### PR TITLE
feat(ntfy): outgoing message attachments — image, audio, video, file (issue #46447)

### DIFF
--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -550,14 +550,18 @@ async def _standalone_send(
     if files:
         caption = _cap_to_message_limit(
             (message or "").strip() or None, context="ntfy standalone")
-        # Validate every attachment BEFORE posting any, so a bad file in a batch
-        # doesn't leave a partial delivery.
+        # Validate every attachment BEFORE posting any: a bad path (missing, not a file,
+        # wrong type, oversized) fails the whole batch instead of delivering a prefix of it.
+        # A file that becomes unreadable after this check, or a mid-batch publish failure,
+        # can still leave earlier attachments delivered.
         read_paths = []
+        max_bytes = _attachment_max_bytes(extra, server)
         for path_value, _is_voice in files:
-            path, error = _read_attachment(path_value)
+            path, error = _read_attachment(path_value, max_bytes=max_bytes)
             if error:
                 return {"error": f"ntfy standalone send: {error}"}
             read_paths.append(path)
+        last_message_id: Optional[str] = None
         async with httpx.AsyncClient(timeout=120.0) as client:
             for index, path in enumerate(read_paths):
                 params = _attachment_fields(

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -5,6 +5,11 @@ config.yaml ``platforms.ntfy.extra``: ``server`` (default https://ntfy.sh), ``to
 (default false). Env (read at construct time; ``extra`` wins over env): NTFY_TOPIC, NTFY_SERVER_URL,
 NTFY_TOKEN, NTFY_PUBLISH_TOPIC, NTFY_MARKDOWN ("true"/"1"/"yes"), NTFY_ALLOWED_USERS (topic names),
 NTFY_ALLOW_ALL_USERS (dev only), NTFY_HOME_CHANNEL, NTFY_HOME_CHANNEL_NAME.
+Outgoing attachments (issue #46447): a local file is published as the POST body with a
+``filename`` query param (ntfy's ``X-Filename``; attachment fields ride as query params because
+httpx rejects non-ASCII header values), message text as ``message=`` (``X-Message``); a URL
+attachment publishes with ``attach=`` (``X-Attach``) and an empty body. ntfy.sh caps attachments
+at 15 MB (100 MB total per visitor) and expires them after 3 h.
 Identity: ntfy has no authenticated user; ``title`` is publisher-controlled and NOT used for
 authorization. Each topic is one trusted channel (``user_id`` == topic). Protect it with a read token.
 """
@@ -15,7 +20,8 @@ import logging
 import time
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 try:
     import httpx
@@ -38,6 +44,7 @@ class _FatalStreamError(Exception):
 
 DEFAULT_SERVER = "https://ntfy.sh"
 MAX_MESSAGE_LENGTH = 4096  # ntfy message body limit
+MAX_ATTACHMENT_BYTES = 15 * 1024 * 1024  # ntfy.sh attachment limit (server may differ; it re-checks)
 DEDUP_WINDOW_SECONDS = 300
 DEDUP_MAX_SIZE = 1000
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
@@ -72,6 +79,73 @@ def _publish_headers(token: str, markdown: bool, *, auth_first: bool = True) -> 
     if markdown:
         headers["X-Markdown"] = "true"
     return headers
+
+
+def _attachment_fields(
+    *, message: Optional[str] = None, file_name: Optional[str] = None, attach_url: Optional[str] = None,
+) -> Dict[str, str]:
+    """Attachment publish fields as query params (ntfy accepts the X-Filename/X-Message/X-Attach
+    headers or these ``filename``/``message``/``attach`` aliases). Query params, not headers:
+    httpx rejects non-ASCII header values (``UnicodeEncodeError``) and captions/filenames/URLs
+    can carry emoji or CJK; httpx URL-encodes params as UTF-8."""
+    fields: Dict[str, str] = {}
+    if message is not None:
+        fields["message"] = message
+    if file_name is not None:
+        fields["filename"] = file_name
+    if attach_url is not None:
+        fields["attach"] = attach_url
+    return fields
+
+
+def _attachment_headers(token: str, markdown: bool) -> Dict[str, str]:
+    """Headers for an attachment publish POST: auth (if any), echo tag, optional X-Markdown.
+
+    No ``Content-Type``: the server sniffs the attachment bytes.
+    """
+    auth = _build_auth_header(token)
+    headers = {"X-Tags": _ECHO_TAG}
+    if markdown:
+        headers["X-Markdown"] = "true"
+    return {**auth, **headers}
+
+
+async def _publish_attachment(
+    client, server: str, publish_topic: str, *, headers: Dict[str, str],
+    params: Dict[str, str], body: Optional[bytes],
+) -> SendResult:
+    """One attachment publish POST; never raises for expected failures. The 120 s timeout
+    accommodates multi-MB uploads (text sends use 15 s)."""
+    url = f"{server}/{publish_topic}"
+    try:
+        resp = await client.post(url, content=body, headers=headers, params=params, timeout=120.0)
+        if resp.status_code < 300:
+            return SendResult(success=True, message_id=_response_message_id(resp))
+        logger.warning(
+            "Attachment publish failed HTTP %d: %s", resp.status_code, resp.text[:200])
+        return SendResult(success=False, error=f"HTTP {resp.status_code}: {resp.text[:200]}")
+    except httpx.TimeoutException:
+        return SendResult(success=False, error="Timeout publishing attachment to ntfy")
+    except Exception as e:
+        logger.error("Attachment publish error: %s", e)
+        return SendResult(success=False, error=str(e))
+
+
+def _read_attachment(path_value: Any) -> "Tuple[Path, None] | Tuple[None, str]":
+    """``(path, None)`` or ``(None, error)`` for a local attachment input (str or Path
+    accepted; the base-class contract is str). Error names the concrete problem:
+    missing vs unreadable vs too large."""
+    path = Path(path_value)
+    try:
+        size = path.stat().st_size
+    except FileNotFoundError:
+        return None, "attachment file not found"
+    except OSError as e:
+        return None, f"attachment file unreadable: {e}"
+    if size > MAX_ATTACHMENT_BYTES:
+        return None, (f"attachment exceeds the {MAX_ATTACHMENT_BYTES // (1024 * 1024)} MB "
+                      f"ntfy.sh attachment limit ({size} bytes)")
+    return path, None
 
 
 def _truncate_body(message: str, *, context: str) -> bytes:
@@ -285,7 +359,7 @@ class NtfyAdapter(BasePlatformAdapter):
         self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Publish a message to the configured publish topic."""
-        publish_topic = (metadata or {}).get("publish_topic") or self._publish_topic or chat_id
+        publish_topic = self._resolve_publish_topic(chat_id, metadata)
         if not self._http_client:
             return SendResult(success=False, error="HTTP client not initialized")
         headers = _publish_headers(self._token, bool((self.config.extra or {}).get("markdown", False)))
@@ -310,6 +384,91 @@ class NtfyAdapter(BasePlatformAdapter):
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         return {"name": chat_id, "type": "dm"}
+
+    def _resolve_publish_topic(self, chat_id: str, metadata: Optional[Dict[str, Any]]) -> str:
+        return (metadata or {}).get("publish_topic") or self._publish_topic or chat_id
+
+    def _markdown_enabled(self) -> bool:
+        return bool((self.config.extra or {}).get("markdown", False))
+
+    def _attachment_cap(self, caption: Optional[str]) -> Optional[str]:
+        """Caption for ``message=``: truncated to the 4096-char ntfy message limit."""
+        if caption is None:
+            return None
+        return caption[:MAX_MESSAGE_LENGTH]
+
+    def _require_client(self) -> Optional[SendResult]:
+        if not self._http_client:
+            return SendResult(success=False, error="HTTP client not initialized")
+        return None
+
+    async def _send_file_attachment(
+        self, chat_id: str, file_path: str, *, caption: Optional[str] = None,
+        file_name: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Publish a local file as an attachment (body upload + ``filename`` param)."""
+        not_ready = self._require_client()
+        if not_ready:
+            return not_ready
+        path, error = _read_attachment(file_path)
+        if error:
+            logger.warning("[%s] Attachment send skipped: %s", self.name, error)
+            return SendResult(success=False, error=error)
+        publish_topic = self._resolve_publish_topic(chat_id, metadata)
+        params = _attachment_fields(
+            message=self._attachment_cap(caption), file_name=file_name or path.name)
+        headers = _attachment_headers(self._token, self._markdown_enabled())
+        try:
+            body = path.read_bytes()
+        except OSError as e:
+            return SendResult(success=False, error=f"attachment file unreadable: {e}")
+        return await _publish_attachment(
+            self._http_client, self._server, publish_topic, headers=headers, params=params, body=body)
+
+    async def send_document(
+        self, chat_id: str, file_path: str, caption: Optional[str] = None,
+        file_name: Optional[str] = None, reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None, **kwargs) -> SendResult:
+        """Send a local file as an ntfy attachment; ``caption`` rides as the message text."""
+        return await self._send_file_attachment(
+            chat_id, file_path, caption=caption, file_name=file_name, metadata=metadata)
+
+    async def send_image_file(
+        self, chat_id: str, image_path: str, caption: Optional[str] = None,
+        reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None, **kwargs) -> SendResult:
+        """Send a local image file as an ntfy attachment."""
+        return await self._send_file_attachment(
+            chat_id, image_path, caption=caption, metadata=metadata)
+
+    async def send_video(
+        self, chat_id: str, video_path: str, caption: Optional[str] = None,
+        reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None, **kwargs) -> SendResult:
+        """Send a local video file as an ntfy attachment."""
+        return await self._send_file_attachment(
+            chat_id, video_path, caption=caption, metadata=metadata)
+
+    async def send_voice(
+        self, chat_id: str, audio_path: str, caption: Optional[str] = None,
+        reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None, **kwargs) -> SendResult:
+        """ntfy has no voice-note primitive: the audio file goes out as a normal attachment."""
+        return await self._send_file_attachment(
+            chat_id, audio_path, caption=caption, metadata=metadata)
+
+    async def send_image(
+        self, chat_id: str, image_url: str, caption: Optional[str] = None,
+        reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        """Send an image URL attachment: the ntfy SERVER fetches it (``attach=``), the
+        publish body stays empty. Non-http(s) URLs are refused without a POST."""
+        if not image_url.startswith(("http://", "https://")):
+            return SendResult(success=False, error=f"not an http(s) URL: {image_url[:80]}")
+        not_ready = self._require_client()
+        if not_ready:
+            return not_ready
+        publish_topic = self._resolve_publish_topic(chat_id, metadata)
+        params = _attachment_fields(message=self._attachment_cap(caption), attach_url=image_url)
+        headers = _attachment_headers(self._token, self._markdown_enabled())
+        return await _publish_attachment(
+            self._http_client, self._server, publish_topic, headers=headers, params=params, body=b"")
 
     def _auth_headers(self) -> Dict[str, str]:
         return _build_auth_header(self._token)
@@ -350,9 +509,12 @@ async def _standalone_send(
 ) -> Dict[str, Any]:
     """Out-of-process publish for cron / send_message_tool when no gateway adapter is live.
 
-    ``thread_id``/``media_files`` are signature parity only (ntfy has no thread
-    or attachment primitive). Markdown is honored if ``NTFY_MARKDOWN`` is set
-    OR ``pconfig.extra["markdown"]`` is True.
+    ``thread_id`` is signature parity only (ntfy has no threads). ``media_files`` —
+    ``(path, is_voice)`` tuples — publish as attachments: the message text rides as the
+    ``message=`` caption on the FIRST attachment only (association beyond one file is
+    ambiguous); remaining attachments publish without text. ``force_document`` is a no-op
+    (every ntfy attachment is transferred as a file). Markdown is honored if
+    ``NTFY_MARKDOWN`` is set OR ``pconfig.extra["markdown"]`` is True.
     """
     if not HTTPX_AVAILABLE:
         return {"error": "ntfy standalone send: httpx not installed"}
@@ -366,6 +528,26 @@ async def _standalone_send(
     token = _setting(extra, "token", "NTFY_TOKEN")
     markdown_env = _get_scoped_secret("NTFY_MARKDOWN", "").strip().lower()
     markdown = bool(extra.get("markdown")) or markdown_env in _MARKDOWN_TRUTHY
+    files = [(path, bool(is_voice)) for path, is_voice in (media_files or [])]
+    if files:
+        caption = (message or "").strip()[:MAX_MESSAGE_LENGTH] or None
+        for index, (path_value, _is_voice) in enumerate(files):
+            path, error = _read_attachment(path_value)
+            if error:
+                return {"error": f"ntfy standalone send: {error}"}
+            params = _attachment_fields(
+                message=caption if index == 0 else None, file_name=path.name)
+            headers = _attachment_headers(token, markdown)
+            try:
+                body = path.read_bytes()
+            except OSError as e:
+                return {"error": f"ntfy standalone send: attachment file unreadable: {e}"}
+            async with httpx.AsyncClient(timeout=120.0) as client:
+                result = await _publish_attachment(
+                    client, server, publish_topic, headers=headers, params=params, body=body)
+            if not result.success:
+                return {"error": f"ntfy standalone send: {result.error}"}
+        return {"success": True, "platform": "ntfy", "chat_id": publish_topic}
     headers = _publish_headers(token, markdown, auth_first=False)
     body = _truncate_body(message, context="ntfy standalone")
     try:

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -167,12 +167,14 @@ def _cap_to_message_limit(text: Optional[str], *, context: str) -> Optional[str]
 
 
 def _truncate_body(message: str, *, context: str) -> bytes:
-    """Apply the ntfy 4096-char limit, logging a warning (tagged ``context``) on truncation."""
-    if len(message) > MAX_MESSAGE_LENGTH:
-        logger.warning(
-            "%s: truncating message from %d to %d chars (ntfy limit)",
-            context, len(message), MAX_MESSAGE_LENGTH)
-    return message[:MAX_MESSAGE_LENGTH].encode("utf-8")
+    """Encode ``message`` for a publish body, capped at ntfy's 4096-BYTE limit.
+
+    The limit counts bytes, not characters, and an over-limit body is not rejected: the
+    server silently converts it into a file attachment, so a long CJK/emoji message would
+    arrive as a file instead of a notification. Truncation is logged (tagged ``context``).
+    """
+    capped = _cap_to_message_limit(message, context=context)
+    return (capped or "").encode("utf-8")
 
 
 def _response_message_id(resp) -> str:
@@ -381,11 +383,7 @@ class NtfyAdapter(BasePlatformAdapter):
         if not self._http_client:
             return SendResult(success=False, error="HTTP client not initialized")
         headers = _publish_headers(self._token, bool((self.config.extra or {}).get("markdown", False)))
-        if len(content) > self.MAX_MESSAGE_LENGTH:
-            logger.warning(
-                "[%s] Message truncated from %d to %d chars (ntfy limit)",
-                self.name, len(content), self.MAX_MESSAGE_LENGTH)
-        body = content[:self.MAX_MESSAGE_LENGTH].encode("utf-8")
+        body = _truncate_body(content, context=f"[{self.name}]")
         try:
             resp = await self._http_client.post(
                 f"{self._server}/{publish_topic}", content=body, headers=headers, timeout=15.0)
@@ -606,7 +604,7 @@ def register(ctx) -> None:
             "Use plain text by default — ntfy supports optional markdown "
             "(set markdown: true in config or NTFY_MARKDOWN=true). "
             "Keep responses concise; ntfy is a push notification service "
-            "with a 4096-character per-message limit."
+            "with a 4096-byte per-message limit."
         ))
 
 

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -474,7 +474,9 @@ class NtfyAdapter(BasePlatformAdapter):
         self, chat_id: str, image_url: str, caption: Optional[str] = None,
         reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
         """Send an image URL attachment: the ntfy SERVER fetches it (``attach=``), the
-        publish body stays empty. Non-http(s) URLs are refused without a POST."""
+        publish body stays empty. Non-str URLs and non-http(s) URLs are refused without a POST."""
+        if not isinstance(image_url, str):
+            return SendResult(success=False, error=f"invalid image URL type: {type(image_url).__name__}")
         if not image_url.startswith(("http://", "https://")):
             return SendResult(success=False, error=f"not an http(s) URL: {image_url[:80]}")
         not_ready = self._require_client()

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -573,7 +573,10 @@ async def _standalone_send(
                     client, server, publish_topic, headers=headers, params=params, body=body)
                 if not result.success:
                     return {"error": f"ntfy standalone send: {result.error}"}
-        return {"success": True, "platform": "ntfy", "chat_id": publish_topic}
+                last_message_id = result.message_id
+        return {
+            "success": True, "platform": "ntfy", "chat_id": publish_topic,
+            "message_id": last_message_id}
     headers = _publish_headers(token, markdown, auth_first=False)
     body = _truncate_body(message, context="ntfy standalone")
     try:

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -134,9 +134,13 @@ async def _publish_attachment(
 def _read_attachment(path_value: Any) -> "Tuple[Path, None] | Tuple[None, str]":
     """``(path, None)`` or ``(None, error)`` for a local attachment input (str or Path
     accepted; the base-class contract is str). Error names the concrete problem:
-    missing vs unreadable vs too large."""
+    wrong type vs missing/not-a-file vs unreadable vs too large."""
+    if not isinstance(path_value, (str, Path)):
+        return None, f"invalid attachment path type: {type(path_value).__name__}"
     path = Path(path_value)
     try:
+        if not path.is_file():
+            return None, "attachment file not found or is not a regular file"
         size = path.stat().st_size
     except FileNotFoundError:
         return None, "attachment file not found"
@@ -544,11 +548,16 @@ async def _standalone_send(
     if files:
         caption = _cap_to_message_limit(
             (message or "").strip() or None, context="ntfy standalone")
+        # Validate every attachment BEFORE posting any, so a bad file in a batch
+        # doesn't leave a partial delivery.
+        read_paths = []
+        for path_value, _is_voice in files:
+            path, error = _read_attachment(path_value)
+            if error:
+                return {"error": f"ntfy standalone send: {error}"}
+            read_paths.append(path)
         async with httpx.AsyncClient(timeout=120.0) as client:
-            for index, (path_value, _is_voice) in enumerate(files):
-                path, error = _read_attachment(path_value)
-                if error:
-                    return {"error": f"ntfy standalone send: {error}"}
+            for index, path in enumerate(read_paths):
                 params = _attachment_fields(
                     message=caption if index == 0 else None, file_name=path.name)
                 headers = _attachment_headers(token, markdown)

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -8,8 +8,10 @@ NTFY_ALLOW_ALL_USERS (dev only), NTFY_HOME_CHANNEL, NTFY_HOME_CHANNEL_NAME.
 Outgoing attachments (issue #46447): a local file is published as the POST body with a
 ``filename`` query param (ntfy's ``X-Filename``; attachment fields ride as query params because
 httpx rejects non-ASCII header values), message text as ``message=`` (``X-Message``); a URL
-attachment publishes with ``attach=`` (``X-Attach``) and an empty body. ntfy.sh caps attachments
-at 15 MB (100 MB total per visitor) and expires them after 3 h.
+attachment publishes with ``attach=`` (``X-Attach``) and an empty body. Attachment size: the
+public ntfy.sh server allows 2 MB per attachment, a self-hosted server's shipped default is
+15 MB — the client cap follows the configured server unless ``extra.attachment_max_mb``
+overrides it. ntfy.sh expires attachments after 3 h.
 Identity: ntfy has no authenticated user; ``title`` is publisher-controlled and NOT used for
 authorization. Each topic is one trusted channel (``user_id`` == topic). Protect it with a read token.
 """
@@ -22,6 +24,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlsplit
 
 try:
     import httpx
@@ -44,7 +47,12 @@ class _FatalStreamError(Exception):
 
 DEFAULT_SERVER = "https://ntfy.sh"
 MAX_MESSAGE_LENGTH = 4096  # ntfy message body limit
-MAX_ATTACHMENT_BYTES = 15 * 1024 * 1024  # ntfy.sh attachment limit (server may differ; it re-checks)
+# Attachment caps. The ntfy server default is 15 MB, but the public ntfy.sh allows 2 MB per
+# attachment (20 MB per visitor) — probe: 2 MB accepted, 2 MB + 1 byte rejected with HTTP 413.
+# The server re-checks either way, so the client cap only decides which files fail fast: it must
+# never be more permissive than the server the adapter publishes to.
+DEFAULT_ATTACHMENT_MAX_BYTES = 15 * 1024 * 1024
+PUBLIC_SERVER_ATTACHMENT_MAX_BYTES = 2 * 1024 * 1024
 DEDUP_WINDOW_SECONDS = 300
 DEDUP_MAX_SIZE = 1000
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
@@ -131,10 +139,29 @@ async def _publish_attachment(
         return SendResult(success=False, error=str(e))
 
 
-def _read_attachment(path_value: Any) -> "Tuple[Path, None] | Tuple[None, str]":
+def _attachment_max_bytes(extra: Dict[str, Any], server: str) -> int:
+    """Client-side attachment cap for ``server``: ``extra.attachment_max_mb`` when set (integer
+    MB), else the server's known limit — 2 MB for the public ntfy.sh, 15 MB for a self-hosted
+    server (ntfy's shipped default). A non-numeric override is ignored with a warning rather
+    than failing mid-send; an unusable value must not take the whole send path down.
+    """
+    public = (urlsplit(server).hostname or "").lower() == "ntfy.sh"
+    default = PUBLIC_SERVER_ATTACHMENT_MAX_BYTES if public else DEFAULT_ATTACHMENT_MAX_BYTES
+    configured = extra.get("attachment_max_mb")
+    if configured in (None, ""):
+        return default
+    try:
+        megabytes = int(configured)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring non-numeric attachment_max_mb=%r", configured)
+        return default
+    return megabytes * 1024 * 1024 if megabytes > 0 else default
+
+
+def _read_attachment(path_value: Any, *, max_bytes: int) -> "Tuple[Path, None] | Tuple[None, str]":
     """``(path, None)`` or ``(None, error)`` for a local attachment input (str or Path
     accepted; the base-class contract is str). Error names the concrete problem:
-    wrong type vs missing/not-a-file vs unreadable vs too large."""
+    wrong type vs missing/not-a-file vs unreadable vs too large (over ``max_bytes``)."""
     if not isinstance(path_value, (str, Path)):
         return None, f"invalid attachment path type: {type(path_value).__name__}"
     path = Path(path_value)
@@ -146,9 +173,9 @@ def _read_attachment(path_value: Any) -> "Tuple[Path, None] | Tuple[None, str]":
         return None, "attachment file not found"
     except OSError as e:
         return None, f"attachment file unreadable: {e}"
-    if size > MAX_ATTACHMENT_BYTES:
-        return None, (f"attachment exceeds the {MAX_ATTACHMENT_BYTES // (1024 * 1024)} MB "
-                      f"ntfy.sh attachment limit ({size} bytes)")
+    if size > max_bytes:
+        return None, (f"attachment exceeds the {max_bytes // (1024 * 1024)} MB "
+                      f"attachment limit ({size} bytes)")
     return path, None
 
 
@@ -411,6 +438,10 @@ class NtfyAdapter(BasePlatformAdapter):
         """Caption for ``message=`` — byte-aware cap to ntfy's message limit."""
         return _cap_to_message_limit(caption, context="ntfy attachment caption")
 
+    def _attachment_limit_bytes(self) -> int:
+        """Fail-fast attachment cap for the configured server (see ``_attachment_max_bytes``)."""
+        return _attachment_max_bytes(self.config.extra or {}, self._server)
+
     def _require_client(self) -> Optional[SendResult]:
         if not self._http_client:
             return SendResult(success=False, error="HTTP client not initialized")
@@ -424,7 +455,7 @@ class NtfyAdapter(BasePlatformAdapter):
         not_ready = self._require_client()
         if not_ready:
             return not_ready
-        path, error = _read_attachment(file_path)
+        path, error = _read_attachment(file_path, max_bytes=self._attachment_limit_bytes())
         if error:
             logger.warning("[%s] Attachment send skipped: %s", self.name, error)
             return SendResult(success=False, error=error)

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -544,22 +544,22 @@ async def _standalone_send(
     if files:
         caption = _cap_to_message_limit(
             (message or "").strip() or None, context="ntfy standalone")
-        for index, (path_value, _is_voice) in enumerate(files):
-            path, error = _read_attachment(path_value)
-            if error:
-                return {"error": f"ntfy standalone send: {error}"}
-            params = _attachment_fields(
-                message=caption if index == 0 else None, file_name=path.name)
-            headers = _attachment_headers(token, markdown)
-            try:
-                body = path.read_bytes()
-            except OSError as e:
-                return {"error": f"ntfy standalone send: attachment file unreadable: {e}"}
-            async with httpx.AsyncClient(timeout=120.0) as client:
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            for index, (path_value, _is_voice) in enumerate(files):
+                path, error = _read_attachment(path_value)
+                if error:
+                    return {"error": f"ntfy standalone send: {error}"}
+                params = _attachment_fields(
+                    message=caption if index == 0 else None, file_name=path.name)
+                headers = _attachment_headers(token, markdown)
+                try:
+                    body = path.read_bytes()
+                except OSError as e:
+                    return {"error": f"ntfy standalone send: attachment file unreadable: {e}"}
                 result = await _publish_attachment(
                     client, server, publish_topic, headers=headers, params=params, body=body)
-            if not result.success:
-                return {"error": f"ntfy standalone send: {result.error}"}
+                if not result.success:
+                    return {"error": f"ntfy standalone send: {result.error}"}
         return {"success": True, "platform": "ntfy", "chat_id": publish_topic}
     headers = _publish_headers(token, markdown, auth_first=False)
     body = _truncate_body(message, context="ntfy standalone")

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -148,6 +148,20 @@ def _read_attachment(path_value: Any) -> "Tuple[Path, None] | Tuple[None, str]":
     return path, None
 
 
+def _cap_to_message_limit(text: Optional[str], *, context: str) -> Optional[str]:
+    """Byte-aware cap to ntfy's message limit: it counts BYTES (a 4096-char CJK/emoji
+    caption is up to 4x that), so truncate the UTF-8 encoding at a character boundary."""
+    if text is None:
+        return None
+    encoded = text.encode("utf-8")
+    if len(encoded) <= MAX_MESSAGE_LENGTH:
+        return text
+    logger.warning(
+        "%s: truncating message from %d to %d bytes (ntfy limit)",
+        context, len(encoded), MAX_MESSAGE_LENGTH)
+    return encoded[:MAX_MESSAGE_LENGTH].decode("utf-8", errors="ignore")
+
+
 def _truncate_body(message: str, *, context: str) -> bytes:
     """Apply the ntfy 4096-char limit, logging a warning (tagged ``context``) on truncation."""
     if len(message) > MAX_MESSAGE_LENGTH:
@@ -392,10 +406,8 @@ class NtfyAdapter(BasePlatformAdapter):
         return bool((self.config.extra or {}).get("markdown", False))
 
     def _attachment_cap(self, caption: Optional[str]) -> Optional[str]:
-        """Caption for ``message=``: truncated to the 4096-char ntfy message limit."""
-        if caption is None:
-            return None
-        return caption[:MAX_MESSAGE_LENGTH]
+        """Caption for ``message=`` — byte-aware cap to ntfy's message limit."""
+        return _cap_to_message_limit(caption, context="ntfy attachment caption")
 
     def _require_client(self) -> Optional[SendResult]:
         if not self._http_client:
@@ -530,7 +542,8 @@ async def _standalone_send(
     markdown = bool(extra.get("markdown")) or markdown_env in _MARKDOWN_TRUTHY
     files = [(path, bool(is_voice)) for path, is_voice in (media_files or [])]
     if files:
-        caption = (message or "").strip()[:MAX_MESSAGE_LENGTH] or None
+        caption = _cap_to_message_limit(
+            (message or "").strip() or None, context="ntfy standalone")
         for index, (path_value, _is_voice) in enumerate(files):
             path, error = _read_attachment(path_value)
             if error:

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -355,6 +355,30 @@ class TestAttachmentSend:
         assert result.success is True
         assert client.post.call_args[1]["params"]["message"] == "héllo 🎉"
 
+    def test_caption_truncation(self):
+        """ntfy's 4096 message limit counts BYTES: a caption of 4096 CJK chars is
+        ~12k bytes and must be truncated to fit, at a character boundary."""
+        adapter = self._make_adapter()
+        capped = adapter._attachment_cap("漢" * 4096)  # 3 bytes/char in UTF-8
+        assert capped is not None
+        assert len(capped.encode("utf-8")) <= _ntfy.MAX_MESSAGE_LENGTH
+        assert len(capped) < 4096  # well under the char count that blew the byte budget
+        # ASCII at the byte limit passes through unchanged
+        assert adapter._attachment_cap("a" * 4096) == "a" * 4096
+
+    def test_send_document_cjk_caption_byte_capped(self, tmp_path):
+        """End-to-end: an oversized CJK caption goes out within the byte limit."""
+        media = tmp_path / "c.txt"
+        media.write_bytes(b"x")
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        _run(adapter.send_document("hermes-in", str(media), caption="漢" * 4096))
+
+        sent = client.post.call_args[1]["params"]["message"]
+        assert len(sent.encode("utf-8")) <= _ntfy.MAX_MESSAGE_LENGTH
+
     def test_send_document_without_caption_has_no_message_param(self, tmp_path):
         media = tmp_path / "c.txt"
         media.write_bytes(b"x")

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -313,10 +313,13 @@ class TestSend:
 
 class TestAttachmentSend:
 
-    def _make_adapter(self, topic="hermes-in", publish_topic="", token=""):
+    def _make_adapter(self, topic="hermes-in", publish_topic="", token="", server=None, **extra_kwargs):
         extra: dict = {"topic": topic, "token": token}
         if publish_topic:
             extra["publish_topic"] = publish_topic
+        if server:
+            extra["server"] = server
+        extra.update(extra_kwargs)
         return NtfyAdapter(PlatformConfig(enabled=True, extra=extra))
 
     @staticmethod
@@ -428,7 +431,7 @@ class TestAttachmentSend:
         media = tmp_path / "big.bin"
         media.write_bytes(b"tiny")
         with open(media, "r+b") as f:  # sparse: logical size > limit, ~0 bytes on disk
-            f.truncate(_ntfy.MAX_ATTACHMENT_BYTES + 1)
+            f.truncate(_ntfy.PUBLIC_SERVER_ATTACHMENT_MAX_BYTES + 1)
         adapter = self._make_adapter()
         client = self._mock_client()
         adapter._http_client = client
@@ -436,7 +439,40 @@ class TestAttachmentSend:
         result = _run(adapter.send_document("hermes-in", str(media)))
 
         assert result.success is False
-        assert "15 MB" in result.error
+        assert "2 MB" in result.error
+        client.post.assert_not_called()
+
+    def test_send_document_self_hosted_allows_over_public_limit(self, tmp_path):
+        """The cap follows the server: ntfy's shipped self-hosted default is 15 MB, so a file
+        the public server would 413 is fine against a self-hosted one."""
+        media = tmp_path / "big.bin"
+        media.write_bytes(b"tiny")
+        with open(media, "r+b") as f:  # sparse: only the logical size matters here
+            f.truncate(_ntfy.PUBLIC_SERVER_ATTACHMENT_MAX_BYTES + 1)
+        adapter = self._make_adapter(server="https://ntfy.example.com")
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_document("hermes-in", str(media)))
+
+        assert result.success is True
+        assert client.post.call_count == 1
+
+    def test_attachment_limit_config_override(self, tmp_path):
+        """``extra.attachment_max_mb`` wins over the server default (self-hosted servers
+        configure their own limits, in both directions)."""
+        media = tmp_path / "big.bin"
+        media.write_bytes(b"tiny")
+        with open(media, "r+b") as f:
+            f.truncate(_ntfy.PUBLIC_SERVER_ATTACHMENT_MAX_BYTES + 1)
+        adapter = self._make_adapter(server="https://ntfy.example.com", attachment_max_mb=1)
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_document("hermes-in", str(media)))
+
+        assert result.success is False
+        assert "1 MB" in result.error
         client.post.assert_not_called()
 
     def test_send_document_missing_path_fails_before_post(self):
@@ -584,6 +620,31 @@ class TestAttachmentSend:
         _run(adapter.send_document("hermes-in", str(media)))
 
         assert "Content-Type" not in client.post.call_args[1]["headers"]
+
+
+class TestAttachmentLimitResolution:
+    """``_attachment_max_bytes``: the fail-fast cap must match the publish server (2 MB for the
+    public ntfy.sh — 2 MB accepted / 2 MB + 1 byte HTTP 413 — 15 MB for a self-hosted server's
+    shipped default), with ``extra.attachment_max_mb`` as an explicit override."""
+
+    def test_public_server_uses_ntfy_sh_limit(self):
+        assert _ntfy._attachment_max_bytes({}, "https://ntfy.sh") == \
+            _ntfy.PUBLIC_SERVER_ATTACHMENT_MAX_BYTES
+
+    def test_self_hosted_uses_server_default(self):
+        assert _ntfy._attachment_max_bytes({}, "https://ntfy.mydomain.com") == \
+            _ntfy.DEFAULT_ATTACHMENT_MAX_BYTES
+
+    def test_config_override_in_mb(self):
+        assert _ntfy._attachment_max_bytes({"attachment_max_mb": 50}, "https://ntfy.sh") == \
+            50 * 1024 * 1024
+
+    def test_unusable_override_falls_back_to_the_server_limit(self):
+        """A config typo must not take the send path down."""
+        assert _ntfy._attachment_max_bytes({"attachment_max_mb": "big"}, "https://ntfy.sh") == \
+            _ntfy.PUBLIC_SERVER_ATTACHMENT_MAX_BYTES
+        assert _ntfy._attachment_max_bytes({"attachment_max_mb": 0}, "https://ntfy.sh") == \
+            _ntfy.PUBLIC_SERVER_ATTACHMENT_MAX_BYTES
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -440,6 +440,22 @@ class TestAttachmentSend:
         assert call[1]["params"]["attach"] == "https://example.com/flower.jpg"
         assert call[1]["content"] in (b"", None)
 
+    def test_send_image_url_caption_survives_non_ascii(self):
+        """URL attachments take captions too: non-ASCII caption + non-ASCII URL must
+        ride as UTF-8 query params (the header path would raise UnicodeEncodeError)."""
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_image(
+            "hermes-in", "https://example.com/花.jpg", caption="héllo 🎉"))
+
+        assert result.success is True
+        call = client.post.call_args
+        assert call[1]["params"]["message"] == "héllo 🎉"
+        assert call[1]["params"]["attach"] == "https://example.com/花.jpg"
+        assert call[1]["content"] in (b"", None)
+
     def test_send_image_invalid_url_fails_without_post(self):
         adapter = self._make_adapter()
         client = self._mock_client()

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -804,6 +804,30 @@ class TestStandaloneSend:
             pconfig, "", "caption", media_files=[(str(tmp_path / "gone.bin"), False)]))
         assert "error" in result
 
+    def test_standalone_send_media_returns_message_id(self, monkeypatch, tmp_path):
+        """The media success result carries the last published attachment's id — the text
+        branch returns one, and callers that surface ``message_id`` must not get ``None``."""
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        pconfig = MagicMock()
+        pconfig.extra = {"topic": "hermes-in"}
+        media = tmp_path / "photo.jpg"
+        media.write_bytes(b"\xff\xd8jpg")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"id": "att-9"}
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(_ntfy, "httpx") as mock_httpx:
+            mock_httpx.AsyncClient.return_value = mock_client
+            result = _run(_standalone_send(pconfig, "", "photo", media_files=[(str(media), False)]))
+
+        assert result.get("success") is True
+        assert result.get("message_id") == "att-9"
+
 
 # ---------------------------------------------------------------------------
 # 11. register() — plugin-side metadata

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -486,6 +486,20 @@ class TestAttachmentSend:
         assert result.success is False
         client.post.assert_not_called()
 
+    def test_send_image_non_str_url_fails_not_raises(self):
+        """``send_image`` returns a failed ``SendResult`` for a non-str URL, like the file
+        path helpers do — ``.startswith`` on a non-str would raise ``AttributeError``."""
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        for bad_url in (None, 42):
+            result = _run(adapter.send_image("hermes-in", bad_url))
+            assert result.success is False
+            assert "invalid image URL type" in result.error
+
+        client.post.assert_not_called()
+
     def test_send_voice_posts_audio_bytes(self, tmp_path):
         media = tmp_path / "note.ogg"
         media.write_bytes(b"OggS")

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -286,6 +286,212 @@ class TestSend:
 
 
 # ---------------------------------------------------------------------------
+# 7b. Attachment sends (issue #46447)
+# ---------------------------------------------------------------------------
+
+
+class TestAttachmentSend:
+
+    def _make_adapter(self, topic="hermes-in", publish_topic="", token=""):
+        extra: dict = {"topic": topic, "token": token}
+        if publish_topic:
+            extra["publish_topic"] = publish_topic
+        return NtfyAdapter(PlatformConfig(enabled=True, extra=extra))
+
+    @staticmethod
+    def _mock_client(status_code=200, msg_id="att-123"):
+        mock_resp = MagicMock()
+        mock_resp.status_code = status_code
+        mock_resp.json.return_value = {"id": msg_id}
+        mock_resp.text = "server error"
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=mock_resp)
+        return client
+
+    def test_send_document_string_path(self, tmp_path):
+        """Real callers pass str paths (base-class contract): bytes body, filename
+        param, echo tag, and no text/plain content type (the server sniffs)."""
+        adapter = self._make_adapter(topic="hermes-in", publish_topic="hermes-out")
+        media = tmp_path / "report.pdf"
+        media.write_bytes(b"%PDF-1.4 tiny")
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_document("hermes-in", str(media), caption="Here"))
+
+        assert result.success is True
+        assert result.message_id == "att-123"
+        call = client.post.call_args
+        assert call[0][0].endswith("/hermes-out")
+        assert call[1]["content"] == b"%PDF-1.4 tiny"
+        assert call[1]["params"]["filename"] == "report.pdf"
+        assert call[1]["params"]["message"] == "Here"
+        assert call[1]["headers"]["X-Tags"] == _ntfy._ECHO_TAG
+        assert "Content-Type" not in call[1]["headers"]
+
+    def test_send_document_accepts_path_object(self, tmp_path):
+        media = tmp_path / "doc.txt"
+        media.write_bytes(b"x")
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_document("hermes-in", media))
+
+        assert result.success is True
+        assert client.post.call_args[1]["params"]["filename"] == "doc.txt"
+
+    def test_send_document_caption_survives_non_ascii(self, tmp_path):
+        """httpx rejects non-ASCII header values (UnicodeEncodeError); captions ride
+        as UTF-8 query params instead — an emoji caption must round-trip."""
+        media = tmp_path / "c.txt"
+        media.write_bytes(b"x")
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_document("hermes-in", str(media), caption="héllo 🎉"))
+
+        assert result.success is True
+        assert client.post.call_args[1]["params"]["message"] == "héllo 🎉"
+
+    def test_send_document_without_caption_has_no_message_param(self, tmp_path):
+        media = tmp_path / "c.txt"
+        media.write_bytes(b"x")
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_document("hermes-in", str(media)))
+
+        assert result.success is True
+        assert "message" not in client.post.call_args[1]["params"]
+
+    def test_send_document_file_name_override(self, tmp_path):
+        media = tmp_path / "blob.bin"
+        media.write_bytes(b"x")
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_document("hermes-in", str(media), file_name="pretty-name.png"))
+
+        assert result.success is True
+        assert client.post.call_args[1]["params"]["filename"] == "pretty-name.png"
+
+    def test_send_document_oversized_file_fails_before_post(self, tmp_path):
+        media = tmp_path / "big.bin"
+        media.write_bytes(b"tiny")
+        with open(media, "r+b") as f:  # sparse: logical size > limit, ~0 bytes on disk
+            f.truncate(_ntfy.MAX_ATTACHMENT_BYTES + 1)
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_document("hermes-in", str(media)))
+
+        assert result.success is False
+        assert "15 MB" in result.error
+        client.post.assert_not_called()
+
+    def test_send_document_missing_path_fails_before_post(self):
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_document("hermes-in", "/nonexistent/path/f.bin"))
+
+        assert result.success is False
+        client.post.assert_not_called()
+
+    def test_send_image_url_uses_attach_param(self):
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_image("hermes-in", "https://example.com/flower.jpg"))
+
+        assert result.success is True
+        call = client.post.call_args
+        assert call[1]["params"]["attach"] == "https://example.com/flower.jpg"
+        assert call[1]["content"] in (b"", None)
+
+    def test_send_image_invalid_url_fails_without_post(self):
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_image("hermes-in", "ftp://example.com/f.jpg"))
+
+        assert result.success is False
+        client.post.assert_not_called()
+
+    def test_send_voice_posts_audio_bytes(self, tmp_path):
+        media = tmp_path / "note.ogg"
+        media.write_bytes(b"OggS")
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_voice("hermes-in", str(media)))
+
+        assert result.success is True
+        call = client.post.call_args
+        assert call[1]["content"] == b"OggS"
+        assert call[1]["params"]["filename"] == "note.ogg"
+
+    def test_attachment_metadata_publish_topic_override(self, tmp_path):
+        media = tmp_path / "c.txt"
+        media.write_bytes(b"x")
+        adapter = self._make_adapter(topic="hermes-in", publish_topic="hermes-out")
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_document(
+            "hermes-in", str(media), metadata={"publish_topic": "override-out"}))
+
+        assert result.success is True
+        assert client.post.call_args[0][0].endswith("/override-out")
+
+    def test_tokenless_adapter_omits_authorization_header(self, tmp_path):
+        """Tokenless self-hosted setups must not get a malformed empty
+        Authorization header — mirroring the text-send behavior."""
+        media = tmp_path / "c.txt"
+        media.write_bytes(b"x")
+        adapter = self._make_adapter(token="")
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_document("hermes-in", str(media)))
+
+        assert result.success is True
+        assert "Authorization" not in client.post.call_args[1]["headers"]
+
+    def test_attachment_http_500_is_failure_not_raise(self, tmp_path):
+        media = tmp_path / "c.txt"
+        media.write_bytes(b"x")
+        adapter = self._make_adapter()
+        client = self._mock_client(status_code=500)
+        adapter._http_client = client
+
+        result = _run(adapter.send_document("hermes-in", str(media)))
+
+        assert result.success is False
+        assert "500" in result.error
+
+    def test_attachment_markdown_hint_not_text_content_type(self, tmp_path):
+        media = tmp_path / "c.txt"
+        media.write_bytes(b"x")
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        _run(adapter.send_document("hermes-in", str(media)))
+
+        assert "Content-Type" not in client.post.call_args[1]["headers"]
+
+
+# ---------------------------------------------------------------------------
 # 8. Inbound message processing (identity invariant — security-critical)
 # ---------------------------------------------------------------------------
 
@@ -429,6 +635,79 @@ class TestStandaloneSend:
 
         headers = mock_client.post.call_args[1]["headers"]
         assert headers.get("X-Tags") == _ntfy._ECHO_TAG
+
+    def test_standalone_send_media_file_with_caption(self, monkeypatch, tmp_path):
+        """Cron media delivery: the file publishes as an attachment (body upload +
+        ``filename`` param) and the text rides as the caption on that attachment."""
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        pconfig = MagicMock()
+        pconfig.extra = {"topic": "hermes-in"}
+        media_file = tmp_path / "photo.jpg"
+        media_file.write_bytes(b"\xff\xd8jpg")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"id": "att-1"}
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(_ntfy, "httpx") as mock_httpx:
+            mock_httpx.AsyncClient.return_value = mock_client
+            result = _run(_standalone_send(
+                pconfig, "", "See the photo", media_files=[(str(media_file), False)]))
+
+        assert result.get("success") is True
+        assert mock_client.post.call_count == 1
+        params = mock_client.post.call_args[1]["params"]
+        headers = mock_client.post.call_args[1]["headers"]
+        assert params.get("filename") == "photo.jpg"
+        assert params.get("message") == "See the photo"
+        assert headers.get("X-Tags") == _ntfy._ECHO_TAG
+        assert mock_client.post.call_args[1]["content"] == b"\xff\xd8jpg"
+
+    def test_standalone_send_caption_on_first_attachment_only(self, monkeypatch, tmp_path):
+        """Multi-file cron delivery: the caption must not be duplicated onto every
+        attachment (association beyond one file is ambiguous)."""
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        pconfig = MagicMock()
+        pconfig.extra = {"topic": "hermes-in"}
+        first, second = tmp_path / "a.png", tmp_path / "b.png"
+        first.write_bytes(b"A")
+        second.write_bytes(b"B")
+
+        responses = []
+        for msg_id in ("att-1", "att-2"):
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = {"id": msg_id}
+            responses.append(resp)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=responses)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(_ntfy, "httpx") as mock_httpx:
+            mock_httpx.AsyncClient.return_value = mock_client
+            result = _run(_standalone_send(
+                pconfig, "", "two files",
+                media_files=[(str(first), False), (str(second), False)]))
+
+        assert result.get("success") is True
+        first_call, second_call = mock_client.post.call_args_list
+        assert first_call[1]["params"].get("message") == "two files"
+        assert "message" not in second_call[1]["params"]
+        assert first_call[1]["params"].get("filename") == "a.png"
+        assert second_call[1]["params"].get("filename") == "b.png"
+
+    def test_standalone_send_missing_media_file_errors(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        pconfig = MagicMock()
+        pconfig.extra = {"topic": "hermes-in"}
+        result = _run(_standalone_send(
+            pconfig, "", "caption", media_files=[(str(tmp_path / "gone.bin"), False)]))
+        assert "error" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -428,6 +428,26 @@ class TestAttachmentSend:
         assert result.success is False
         client.post.assert_not_called()
 
+    def test_send_document_directory_path_fails_before_post(self, tmp_path):
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_document("hermes-in", str(tmp_path)))
+
+        assert result.success is False
+        client.post.assert_not_called()
+
+    def test_send_document_none_path_fails_not_raises(self):
+        adapter = self._make_adapter()
+        client = self._mock_client()
+        adapter._http_client = client
+
+        result = _run(adapter.send_document("hermes-in", None))
+
+        assert result.success is False
+        client.post.assert_not_called()
+
     def test_send_image_url_uses_attach_param(self):
         adapter = self._make_adapter()
         client = self._mock_client()

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -257,6 +257,27 @@ class TestSend:
         posted_url = mock_client.post.call_args[0][0]
         assert posted_url.endswith("/override-out")
 
+    def test_send_cjk_body_is_byte_capped(self):
+        """The live reply path shares ntfy's byte limit: an over-limit CJK reply must be
+        truncated, not published as-is (the server turns an oversized body into a file
+        attachment, so the user would get a file instead of a notification)."""
+        adapter = self._make_adapter(topic="hermes-in")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"id": "abc123"}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        adapter._http_client = mock_client
+
+        result = _run(adapter.send("hermes-in", "漢" * 4096))  # 12 KB in UTF-8
+
+        assert result.success is True
+        body = mock_client.post.call_args[1]["content"]
+        assert len(body) <= _ntfy.MAX_MESSAGE_LENGTH
+        assert body.decode("utf-8").startswith("漢")
+
 
     def test_send_handles_timeout(self):
         adapter = self._make_adapter(topic="hermes-in")
@@ -842,6 +863,17 @@ class TestTruncateHelper:
 
     def test_short_message_passes_through(self):
         assert _ntfy._truncate_body("hi", context="test") == b"hi"
+
+    def test_ascii_message_at_limit_passes_through(self):
+        body = _ntfy._truncate_body("a" * _ntfy.MAX_MESSAGE_LENGTH, context="test")
+        assert body == b"a" * _ntfy.MAX_MESSAGE_LENGTH
+
+    def test_cjk_message_is_truncated_to_the_byte_limit(self):
+        """The cap counts BYTES: 4096 CJK characters are ~12 KB, and ntfy answers an
+        over-limit body with a file attachment instead of a notification."""
+        body = _ntfy._truncate_body("漢" * 4096, context="test")
+        assert len(body) <= _ntfy.MAX_MESSAGE_LENGTH
+        assert body.decode("utf-8").startswith("漢")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1741,6 +1741,121 @@ class TestSendViaAdapterStandaloneFallback:
 
         assert result == {"error": "Plugin standalone send failed: boom!"}
 
+class TestNtfyMediaRouting:
+    """ntfy MEDIA attachments deliver natively (issue #46447): through the live
+    gateway adapter's attachment methods, or the plugin standalone sender (cron).
+    The generic text-only gate must neither refuse media-only sends nor add a
+    false 'attachments were omitted' warning."""
+
+    @staticmethod
+    def _fake_gateway_run(runner):
+        fake_gateway_run = ModuleType("gateway.run")
+        fake_gateway_run._gateway_runner_ref = lambda: runner
+        return fake_gateway_run
+
+    @pytest.mark.asyncio
+    async def test_ntfy_media_only_send_delivers_via_live_adapter(self, monkeypatch, tmp_path):
+        from tools.send_message_tool import _send_to_platform
+
+        platform = Platform("ntfy")
+        media = tmp_path / "report.pdf"
+        media.write_bytes(b"%PDF-1.4 tiny")
+        calls = []
+
+        class Adapter:
+            async def send_document(self, chat_id, file_path, caption=None, reply_to=None,
+                                    metadata=None, **kwargs):
+                calls.append({"chat_id": chat_id, "file_path": file_path,
+                              "caption": caption, "metadata": metadata})
+                return SimpleNamespace(success=True, message_id="m1")
+
+        monkeypatch.setitem(sys.modules, "gateway.run", self._fake_gateway_run(
+            SimpleNamespace(adapters={platform: Adapter()})))
+
+        result = await _send_to_platform(
+            platform, SimpleNamespace(extra={"topic": "hermes-in"}), "alerts-channel", "",
+            media_files=[(str(media), False)])
+
+        assert result == {"success": True, "message_id": "m1", "media_delivered": True}
+        assert calls[0]["file_path"] == str(media)
+        assert calls[0]["metadata"] == {"publish_topic": "alerts-channel"}
+
+    @pytest.mark.asyncio
+    async def test_ntfy_text_and_media_caption_rides_attachment(self, monkeypatch, tmp_path):
+        from tools.send_message_tool import _send_to_platform
+
+        platform = Platform("ntfy")
+        media = tmp_path / "clip.mp4"
+        media.write_bytes(b"mp4")
+        text_sends, video_calls = [], []
+
+        class Adapter:
+            async def send(self, *, chat_id, content, metadata=None):
+                text_sends.append(content)
+                return SimpleNamespace(success=True, message_id="t1")
+
+            async def send_video(self, chat_id, video_path, caption=None, reply_to=None,
+                                 metadata=None, **kwargs):
+                video_calls.append({"path": video_path, "caption": caption})
+                return SimpleNamespace(success=True, message_id="v1")
+
+        monkeypatch.setitem(sys.modules, "gateway.run", self._fake_gateway_run(
+            SimpleNamespace(adapters={platform: Adapter()})))
+
+        result = await _send_to_platform(
+            platform, SimpleNamespace(extra={"topic": "hermes-in"}), "alerts-channel", "see clip",
+            media_files=[(str(media), False)])
+
+        assert result == {"success": True, "message_id": "v1", "media_delivered": True}
+        assert video_calls == [{"path": str(media), "caption": "see clip"}]
+        assert text_sends == []  # the caption rode the attachment; no separate text send
+
+    @pytest.mark.asyncio
+    async def test_ntfy_media_only_send_standalone_uses_plugin_sender(self, monkeypatch, tmp_path):
+        from tools.send_message_tool import _send_to_platform
+        from gateway.platform_registry import platform_registry
+
+        platform = Platform("ntfy")
+        media = tmp_path / "note.ogg"
+        media.write_bytes(b"OggS")
+        received = {}
+
+        async def fake_sender(pconfig, chat_id, chunk, **kwargs):
+            received.update(kwargs, chunk=chunk)
+            return {"success": True, "platform": "ntfy"}
+
+        monkeypatch.setattr(
+            platform_registry, "get",
+            lambda name: SimpleNamespace(standalone_sender_fn=fake_sender, send_message_handler=None))
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+
+        result = await _send_to_platform(
+            platform, SimpleNamespace(extra={"topic": "hermes-in"}), "alerts-channel", "",
+            media_files=[(str(media), False)])
+
+        assert result == {"success": True, "platform": "ntfy"}
+        assert received["media_files"] == [(str(media), False)]
+        assert received["chunk"] == ""
+
+    @pytest.mark.asyncio
+    async def test_ntfy_text_only_send_has_no_media_warning(self, monkeypatch):
+        from tools.send_message_tool import _send_to_platform
+
+        platform = Platform("ntfy")
+
+        class Adapter:
+            async def send(self, *, chat_id, content, metadata=None):
+                return SimpleNamespace(success=True, message_id="t1")
+
+        monkeypatch.setitem(sys.modules, "gateway.run", self._fake_gateway_run(
+            SimpleNamespace(adapters={platform: Adapter()})))
+
+        result = await _send_to_platform(
+            platform, SimpleNamespace(extra={"topic": "hermes-in"}), "alerts-channel", "plain text")
+
+        assert result == {"success": True, "message_id": "t1"}
+
+
 class TestSendTelegramThreadNotFoundRetry:
     """Tests for thread-not-found retry behaviour in _send_telegram (#27012)."""
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -582,7 +582,7 @@ _TEXT_SENDERS = {
     "qqbot": lambda pc, cid, chunk, tid: _send_qqbot(pc, cid, chunk),
     "yuanbao": lambda pc, cid, chunk, tid: _send_yuanbao(cid, chunk)}
 
-_MEDIA_PLATFORMS_NOTE = "telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack"
+_MEDIA_PLATFORMS_NOTE = "telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp, ntfy and slack"
 
 
 async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None):
@@ -611,9 +611,10 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         return await _send_chunks(chunks, lambda chunk, is_last: sender(
             platform, pconfig, chat_id, chunk, media_files if is_last else empty_media, thread_id, force_document))
 
-    # Generic path: text only. Buzz delivers media natively via _send_via_adapter, so no warning.
+    # Generic path: text only. Buzz and ntfy deliver media natively via _send_via_adapter
+    # (ntfy: attachment publish, issue #46447), so no warning.
     warning = None
-    if media_files and platform_name != "buzz":
+    if media_files and platform_name not in ("buzz", "ntfy"):
         if not message.strip():
             return {"error": (f"send_message MEDIA delivery is currently only supported for {_MEDIA_PLATFORMS_NOTE}; "
                               f"target {platform_name} had only media attachments")}

--- a/website/docs/user-guide/messaging/ntfy.md
+++ b/website/docs/user-guide/messaging/ntfy.md
@@ -139,6 +139,16 @@ The mobile app supports a subset of CommonMark — bold, italic, lists, links, f
 
 If you only want Hermes to *push* notifications to ntfy (cron summaries, alerts) and never accept messages back, set both `NTFY_TOPIC` and `NTFY_PUBLISH_TOPIC` to the same value and skip `NTFY_ALLOWED_USERS` entirely. With no allowlist, the agent never responds to inbound messages — your phone gets the pushes, but the conversation is one-way.
 
+## Attachments
+
+You can send files, images, audio, and video as attachments. Include `MEDIA:/path/to/file` in the message text to attach a local file. The file is uploaded server-side and included in the published notification.
+
+- Use `[[as_document]]` in the message to force the file to be sent as a document attachment (useful for PDF files that should not be displayed inline).
+- HTTP(S) URLs in the message are attached directly by the ntfy server.
+- Maximum size: 15 MB per attachment on the public ntfy.sh server, 100 MB total per visitor. Self-hosted servers configure their own limits and may disable attachments entirely.
+- Attachments expire after 3 hours on ntfy.sh.
+- The message text you send becomes the attachment caption.
+
 ## Limits
 
 - **Message size**: ntfy caps message bodies at 4096 chars. Hermes truncates with a warning when this is exceeded.

--- a/website/docs/user-guide/messaging/ntfy.md
+++ b/website/docs/user-guide/messaging/ntfy.md
@@ -144,7 +144,7 @@ If you only want Hermes to *push* notifications to ntfy (cron summaries, alerts)
 You can send files, images, audio, and video as attachments. Include `MEDIA:/path/to/file` in the message text to attach a local file. The file is uploaded server-side and included in the published notification.
 
 - Use `[[as_document]]` in the message to force the file to be sent as a document attachment (useful for PDF files that should not be displayed inline).
-- HTTP(S) URLs in the message are attached directly by the ntfy server.
+- Hermes-issued image links (e.g. generated pictures) can be attached by the ntfy server directly via its `X-Attach` mechanism — the server fetches the URL, so the file never transits Hermes.
 - Maximum size: 15 MB per attachment on the public ntfy.sh server, 100 MB total per visitor. Self-hosted servers configure their own limits and may disable attachments entirely.
 - Attachments expire after 3 hours on ntfy.sh.
 - The message text you send becomes the attachment caption.

--- a/website/docs/user-guide/messaging/ntfy.md
+++ b/website/docs/user-guide/messaging/ntfy.md
@@ -143,17 +143,17 @@ If you only want Hermes to *push* notifications to ntfy (cron summaries, alerts)
 
 You can send files, images, audio, and video as attachments. Include `MEDIA:/path/to/file` in the message text to attach a local file. The file is uploaded server-side and included in the published notification.
 
-- Use `[[as_document]]` in the message to force the file to be sent as a document attachment (useful for PDF files that should not be displayed inline).
-- Hermes-issued image links (e.g. generated pictures) can be attached by the ntfy server directly via its `X-Attach` mechanism — the server fetches the URL, so the file never transits Hermes.
-- Maximum size: 15 MB per attachment on the public ntfy.sh server, 100 MB total per visitor. Self-hosted servers configure their own limits and may disable attachments entirely.
+- Use `[[as_document]]` in the message for cross-platform parity: on ntfy every attachment is already delivered as a file, so the marker changes nothing (files are never rendered inline).
+- Hermes-issued image links (e.g. generated pictures) can be attached by the ntfy server directly via its `attach` parameter (`X-Attach`) — the server fetches the URL, so the file never transits Hermes.
+- Maximum size: 2 MB per attachment on the public ntfy.sh server (20 MB total per visitor). A self-hosted server ships with a 15 MB default and may disable attachments entirely. Hermes fails fast locally above the cap for your configured server — set `platforms.ntfy.extra.attachment_max_mb` if your server allows a different size.
 - Attachments expire after 3 hours on ntfy.sh.
 - The message text you send becomes the attachment caption.
 
 ## Limits
 
-- **Message size**: ntfy caps message bodies at 4096 chars. Hermes truncates with a warning when this is exceeded.
+- **Message size**: ntfy caps message bodies at 4096 bytes. Hermes truncates with a warning when this is exceeded.
 - **No typing indicators**: the protocol doesn't expose one; `send_typing` is a no-op.
-- **No threads or attachments**: ntfy is plain push notifications. Long replies stay in the message body, no thread fanout.
+- **No threads**: ntfy is plain push notifications. Long replies stay in the message body, no thread fanout; attachments ride with the message (see Attachments above).
 - **No native user identity**: see the identity-model section above.
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

Implements #46447: outgoing ntfy messages can now carry attachments — image, audio, video, or any file — instead of media being refused with "MEDIA delivery is currently only supported for …".

- **NtfyAdapter** natively implements the base media methods: `send_document` / `send_image_file` / `send_video` / `send_voice` (local file → publish POST body + `filename` param, message text as the `message=` caption) and `send_image` (URL → `attach=` param with empty body; the ntfy server fetches it). Voice notes are delivered as normal attachments (ntfy has no voice-note primitive). Missing files, directories, invalid path types, and files over the configured server's attachment cap fail with a clear `SendResult` before any POST.
- **Standalone/cron path** (`_standalone_send`): `media_files` publish as attachments with the caption on the first file only; every path is validated before any POST, so a bad file in a batch fails the whole batch instead of delivering a prefix of it; one pooled `AsyncClient` per batch. Success carries the last published attachment's `message_id`.
- **send_message routing**: ntfy is excluded from the generic text-only media gate (like buzz) and added to `_MEDIA_PLATFORMS_NOTE`, so MEDIA-tagged sends deliver natively through the live adapter, or the plugin standalone sender when the gateway isn't in-process.
- Attachment fields ride as URL query params (`filename=`, `message=`, `attach=`) rather than headers because httpx raises `UnicodeEncodeError` on non-ASCII header values (captions/filenames can carry emoji or CJK; httpx URL-encodes params as UTF-8). Message bodies — captions and plain sends alike — are capped at ntfy's 4096-**byte** limit at a character boundary: ntfy counts bytes, and an over-limit body is not rejected but silently converted into a *file attachment*.
- Attachment size: the cap follows the configured server — 2 MB for the public ntfy.sh, 15 MB (ntfy's self-hosted default) otherwise — overridable via `platforms.ntfy.extra.attachment_max_mb`.
- `X-Tags` echo tag is preserved on attachment publishes (echo-loop prevention), and no `Content-Type` is set so the server sniffs the attachment bytes.
- Docs: new "Attachments" section in `website/docs/user-guide/messaging/ntfy.md`, limits corrected (attachment sizes, 4096 bytes, `[[as_document]]` is a no-op here).

## Testing

- `tests/gateway/test_ntfy_plugin.py`: 65 passed (attachment sends, non-str URL guard, standalone media + `message_id`, byte cap on both publish paths, attachment-cap resolution per server, path hardening).
- `tests/tools/test_send_message_tool.py`: 51 passed, including 4 new routing tests through the real `_send_to_platform` dispatch (live-adapter delivery, caption-on-attachment, standalone fallback, text-only unaffected).
- Full affected lanes via `scripts/run_tests.sh` (`tests/gateway/` + `tests/tools/` + `test_web_server.py`): 1,396 files, 17,027 passed, 46 failed, 168 skipped on this host (darwin — `linux_only` / `windows_only` tests skip here). All failures are in `tests/tools/` and environment-specific; the same lane set at clean `origin/main` fails the same families (50 failures in 15 files), with the rg/search files varying run to run under 28-way parallelism (`test_search_zero_match_and_multipath.py` 12 vs 6, `test_search_auto_multiline.py` 0 vs 3). Nothing in `tests/gateway/` or `test_web_server.py` fails on either side, and none of the touched files are affected — they are green here (65 / 51 / 6 passed). One flake on this host: `tests/tools/test_code_kernel_remote.py` (failed once, passed on retry; it did not recur in the base run).
- Every fix from the review round has a regression test that bites: reverting the URL type guard, the byte cap and the media `message_id` together fails exactly those new tests and nothing else; reverting the server-aware cap default fails exactly the three attachment-cap tests.

## Notes

- **Attachment size + expiry:** the public ntfy.sh server allows 2 MB per attachment and 20 MB per visitor (probes: 2,097,152 bytes → HTTP 200, 2,097,153 bytes → HTTP 413 `code 41301`) and expires attachments after 3 h. ntfy's *self-hosted* default is 15 MB / 100 MB. Hermes now fails fast locally at the limit for the configured server instead of uploading past it and taking the server's 413; a server with different limits needs `platforms.ntfy.extra.attachment_max_mb`. Effect on existing setups: self-hosted users keep the 15 MB default, ntfy.sh users get a local failure where they previously got a full upload followed by HTTP 413.
- **Review round:** the automated review's findings (`send_image` type safety, partial-delivery comment scope, byte-aware truncation, media `message_id`, `[[as_document]]` docs) are addressed in `3ae261acc8..7efc4c064f`.
- **Open question:** should the cap override live only in `platforms.ntfy.extra` (config.yaml, as now) or also mirror an env var for parity with `NTFY_MARKDOWN`?

Closes #46447
