### PR TITLE
fix(memory): recreate mem0's entities collection on embedding dim change

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -155,9 +155,21 @@ class OSSBackend(Mem0Backend):
             self._memory = Memory.from_config(config)
 
     @staticmethod
+    def _stale_collection_names(provider: str, collection_name: str) -> tuple[str, ...]:
+        """Every collection mem0 derives from ``collection_name``, including the entities one.
+
+        mem0 builds a second collection for entity-boosted search alongside the
+        configured one (``_entity_collection_name`` in ``mem0/memory/main.py``).
+        The separator mirrors that helper so the two stay in lockstep.
+        """
+        separator = "-" if provider == "s3_vectors" else "_"
+        return (collection_name, f"{collection_name}{separator}entities")
+
+    @staticmethod
     def _recreate_collection_if_dims_changed(provider: str, vs_config: dict, expected_dims: int) -> None:
-        """Delete stale vector collection when embedding dimensions change."""
+        """Delete stale vector collections when embedding dimensions change."""
         collection_name = vs_config.get("collection_name", "mem0")
+        names = OSSBackend._stale_collection_names(provider, collection_name)
         with suppress(Exception):
             if provider == "qdrant":
                 from qdrant_client import QdrantClient
@@ -169,15 +181,18 @@ class OSSBackend(Mem0Backend):
                 else:
                     return
                 with closing(client):
-                    if not client.collection_exists(collection_name):
-                        return
-                    vectors = client.get_collection(collection_name).config.params.vectors
-                    # Named-vector collections expose a dict; unnamed expose an object with .size.
-                    if isinstance(vectors, dict):
-                        vectors = next(iter(vectors.values()), None)
-                    current_dims = getattr(vectors, "size", None)
-                    if current_dims is not None and current_dims != expected_dims:
-                        client.delete_collection(collection_name)
+                    for name in names:
+                        # Per-collection guard: one collection failing must not skip the rest.
+                        with suppress(Exception):
+                            if not client.collection_exists(name):
+                                continue
+                            vectors = client.get_collection(name).config.params.vectors
+                            # Named-vector collections expose a dict; unnamed expose an object with .size.
+                            if isinstance(vectors, dict):
+                                vectors = next(iter(vectors.values()), None)
+                            current_dims = getattr(vectors, "size", None)
+                            if current_dims is not None and current_dims != expected_dims:
+                                client.delete_collection(name)
             elif provider == "pgvector":
                 import psycopg2
                 from psycopg2 import sql as pgsql
@@ -185,10 +200,13 @@ class OSSBackend(Mem0Backend):
                 with closing(psycopg2.connect(**conn_params)) as conn:
                     conn.autocommit = True
                     with closing(conn.cursor()) as cur:
-                        cur.execute("SELECT atttypmod FROM pg_attribute WHERE attrelid = %s::regclass AND attname = 'vector'", (collection_name,))
-                        row = cur.fetchone()
-                        if row and row[0] > 0 and row[0] != expected_dims:
-                            cur.execute(pgsql.SQL("DROP TABLE IF EXISTS {}").format(pgsql.Identifier(collection_name)))
+                        for name in names:
+                            # Per-collection guard: an absent table raises on ::regclass.
+                            with suppress(Exception):
+                                cur.execute("SELECT atttypmod FROM pg_attribute WHERE attrelid = %s::regclass AND attname = 'vector'", (name,))
+                                row = cur.fetchone()
+                                if row and row[0] > 0 and row[0] != expected_dims:
+                                    cur.execute(pgsql.SQL("DROP TABLE IF EXISTS {}").format(pgsql.Identifier(name)))
 
     def search(self, query: str, *, filters: dict, top_k: int = 10, rerank: bool = False) -> list[dict]:
         return _unwrap_results(self._memory.search(query, filters=filters, top_k=top_k))

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -621,6 +621,67 @@ class TestOSSBackend:
 httpx = pytest.importorskip("httpx")
 
 
+class _FakeQdrantCollection:
+
+    def __init__(self, size):
+        self.config = SimpleNamespace(params=SimpleNamespace(vectors=SimpleNamespace(size=size)))
+
+
+class _FakeQdrantClient:
+    """Minimal QdrantClient stand-in recording which collections get dropped."""
+
+    def __init__(self, dims_by_collection):
+        self._dims = dict(dims_by_collection)
+        self.deleted = []
+        self.closed = False
+
+    def collection_exists(self, name):
+        return name in self._dims
+
+    def get_collection(self, name):
+        return _FakeQdrantCollection(self._dims[name])
+
+    def delete_collection(self, name):
+        self.deleted.append(name)
+        self._dims.pop(name, None)
+
+    def close(self):
+        self.closed = True
+
+
+class TestRecreateCollectionIfDimsChanged:
+    """The dim-change guard must also cover mem0's derived entities collection."""
+
+    def _run(self, monkeypatch, dims_by_collection, expected_dims=1024, provider="qdrant"):
+        client = _FakeQdrantClient(dims_by_collection)
+        module = types.ModuleType("qdrant_client")
+        module.QdrantClient = lambda **kwargs: client
+        monkeypatch.setitem(sys.modules, "qdrant_client", module)
+        OSSBackend._recreate_collection_if_dims_changed(
+            provider, {"collection_name": "mem0", "path": "/tmp/qdrant"}, expected_dims
+        )
+        return client
+
+    def test_entities_collection_name_tracks_mem0_separator(self):
+        # Mirrors _entity_collection_name in mem0/memory/main.py.
+        assert OSSBackend._stale_collection_names("qdrant", "mem0") == ("mem0", "mem0_entities")
+        assert OSSBackend._stale_collection_names("s3_vectors", "mem0") == ("mem0", "mem0-entities")
+
+    def test_stale_entities_collection_is_dropped_with_the_main_one(self, monkeypatch):
+        client = self._run(monkeypatch, {"mem0": 768, "mem0_entities": 768})
+        assert client.deleted == ["mem0", "mem0_entities"]
+        assert client.closed
+
+    def test_entities_collection_dropped_even_when_main_is_absent(self, monkeypatch):
+        # The pre-fix guard returned early here, stranding the entities collection.
+        client = self._run(monkeypatch, {"mem0_entities": 768})
+        assert client.deleted == ["mem0_entities"]
+
+    def test_matching_dims_drops_nothing(self, monkeypatch):
+        client = self._run(monkeypatch, {"mem0": 1024, "mem0_entities": 1024})
+        assert client.deleted == []
+
+
 class _StubServer:
     """Records requests and serves the real self-hosted server's response shapes."""
 


### PR DESCRIPTION
## What does this PR do?

`OSSBackend._recreate_collection_if_dims_changed` drops the vector collection when the configured embedding model's dimensionality no longer matches what's stored. But mem0 doesn't keep just one collection — alongside the configured `collection_name` it derives a second one for entity-boosted search (`_entity_collection_name` in `mem0/memory/main.py`, i.e. `mem0_entities` for the default `mem0`).

The guard only ever looked at the main collection, so after an embedding-model change the entities collection was left at the old dimensionality. mem0 then writes 1024-d vectors into a 768-d entities collection, and every entity read and write fails — quietly, because the whole guard runs under `suppress(Exception)`. The symptom is memory that appears to work (the main collection was correctly recreated) while entity search silently returns nothing.

There's a second, sharper case: the pre-fix code did `if not client.collection_exists(collection_name): return`. If the main collection was already gone but the entities collection wasn't, the function returned before touching the stale one — so the guard skipped exactly the collection it needed to drop.

This extends the existing guard to cover both collections, for both the `qdrant` and `pgvector` paths.

## Related Issue

No existing issue — I searched open and merged PRs and issues for the entities-collection / embedding-dimension symptom and found nothing covering it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/mem0/_backend.py`
  - New `_stale_collection_names(provider, collection_name)` helper returning both the configured collection and its derived entities collection. The separator mirrors mem0's own `_entity_collection_name` (`-` for `s3_vectors`, `_` otherwise) so the two stay in lockstep.
  - `_recreate_collection_if_dims_changed` now iterates both names on the `qdrant` and `pgvector` paths instead of only the configured one.
  - Each collection is checked under its own `suppress(Exception)`. Previously a single failure aborted the whole guard; now one collection erroring cannot skip the other. This also removes the early `return` that stranded the entities collection when the main one was absent.
- `tests/plugins/memory/test_mem0_backend.py`
  - New `TestRecreateCollectionIfDimsChanged` with a minimal `QdrantClient` stand-in recording which collections get dropped.

## How to Test

Reproduction, without this patch:

1. Configure the mem0 OSS backend with a qdrant vector store and an embedding model of one dimensionality (e.g. a 768-d model). Let it write memories, so both `mem0` and `mem0_entities` are created at 768-d.
2. Switch the configured embedding model to one with a different dimensionality (e.g. 1024-d) and restart.
3. `mem0` is correctly dropped and recreated at 1024-d, but `mem0_entities` is still 768-d. Entity writes and reads now fail against it, and the failure is swallowed — memory looks healthy but entity search returns nothing.

With this patch, step 3 drops both collections and mem0 recreates them at the new dimensionality.

Automated coverage, four new cases:

```
pytest tests/plugins/memory/test_mem0_backend.py -k RecreateCollection -q
```

- entities collection name tracks mem0's separator for both `qdrant` and `s3_vectors`
- a stale entities collection is dropped alongside the main one
- the entities collection is still dropped when the main one is absent (the early-return regression)
- matching dimensions drop nothing

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — see note below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64), Python 3.11

> Note on the test checkbox, so the box isn't ticked for something I didn't do: I ran the affected module, `tests/plugins/memory/test_mem0_backend.py` — **18 passed**, which is the full file including the 4 new cases. I did not run the entire `tests/` suite locally, so I've left that box unticked rather than claim it. Happy to run it if you'd like the full result.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on the touched functions updated; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A, no platform-specific primitives; pure client-library calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool surface changed
