### PR TITLE
fix(acp): expose mode and model as configOptions for ACP clients

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -16,10 +16,11 @@ from typing import Any, Callable, Deque, Optional
 
 import acp
 from acp.schema import (
-    AgentCapabilities, AgentMessageChunk, AuthenticateResponse, ClientCapabilities, ForkSessionResponse,
-    Implementation, InitializeResponse, ListSessionsResponse, LoadSessionResponse, McpServerHttp, McpServerSse,
-    McpServerStdio, ModelInfo, NewSessionResponse, PromptCapabilities, PromptResponse, ResumeSessionResponse,
-    SessionCapabilities, SessionForkCapabilities, SessionInfo, SessionInfoUpdate, SessionListCapabilities,
+    AgentCapabilities, AgentMessageChunk, AuthenticateResponse, ClientCapabilities, ConfigOptionUpdate,
+    ForkSessionResponse, Implementation, InitializeResponse, ListSessionsResponse, LoadSessionResponse,
+    McpServerHttp, McpServerSse, McpServerStdio, ModelInfo, NewSessionResponse, PromptCapabilities, PromptResponse,
+    ResumeSessionResponse, SessionCapabilities, SessionConfigOptionSelect, SessionConfigSelectOption,
+    SessionForkCapabilities, SessionInfo, SessionInfoUpdate, SessionListCapabilities,
     SessionMode, SessionModeState, SessionModelState, SessionResumeCapabilities, SetSessionConfigOptionResponse,
     SetSessionModeResponse, SetSessionModelResponse, TextContentBlock, Usage, UsageUpdate, UserMessageChunk,
 )
@@ -40,6 +41,10 @@ from agent.interrupt_compat import request_hard_interrupt
 from tools.approval_context import reset_hermes_interactive_context, set_hermes_interactive_context
 
 logger = logging.getLogger(__name__)
+
+# Sentinel: distinguishes "caller passed no model state" from "caller passed None
+# because the session has no listable models".
+_UNSET: Any = object()
 
 # Runs the synchronous AIAgent off the event loop.
 _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="acp-agent")
@@ -228,6 +233,8 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
 
     _EDIT_APPROVAL_POLICY_CONFIG_ID = "edit_approval_policy"
     _EDIT_APPROVAL_POLICY_DEFAULT = "ask"
+    _MODE_CONFIG_ID = "mode"
+    _MODEL_CONFIG_ID = "model"
     _MODE_DEFAULT = "default"
     # mode id -> (edit approval policy, display name, description)
     _MODES: dict[str, tuple[str, str, str]] = {
@@ -304,6 +311,68 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
             return None
         choice = encode_model_choice(provider, model)
         return SessionModelState(available_models=[ModelInfo(model_id=choice, name=model)], current_model_id=choice)
+
+    def _build_config_options(
+        self, state: SessionState, model_state: SessionModelState | None = _UNSET
+    ) -> list[Any]:
+        """Configuration options exposed to ACP clients (like Zed) as bottom-bar dropdowns/selectors.
+
+        Zed builds the whole bottom bar from ``configOptions`` once it is non-empty and stops
+        rendering the standalone ``modes`` control, so the mode picker MUST be mirrored here
+        alongside the model picker.
+
+        ``model_state`` is accepted precomputed because building it can hit provider ``/models``
+        discovery; callers that already have one must pass it rather than pay for it twice."""
+        if model_state is _UNSET:
+            model_state = self._build_model_state(state)
+        options: list[Any] = []
+        modes_state = self._session_modes(state)
+        options.append(
+            SessionConfigOptionSelect(
+                id=self._MODE_CONFIG_ID,
+                name="Mode",
+                description="Session permission mode",
+                category="mode",
+                type="select",
+                current_value=modes_state.current_mode_id,
+                options=[
+                    SessionConfigSelectOption(value=m.id, name=m.name, description=m.description or None)
+                    for m in modes_state.available_modes
+                ],
+            )
+        )
+        if model_state and model_state.available_models:
+            select_options = [
+                SessionConfigSelectOption(
+                    value=m.model_id,
+                    name=m.name or m.model_id,
+                    description=m.description or None,
+                )
+                for m in model_state.available_models
+            ]
+            current = model_state.current_model_id or ""
+            # Zed renders a blank control when `currentValue` is absent from `options`.
+            # The picker id (provider-normalized) can differ from the session's encoded
+            # choice id, so pin the running model as its own row when it isn't listed.
+            if current not in {o.value for o in select_options}:
+                running = str(state.model or getattr(state.agent, "model", "") or "").strip()
+                if not current:
+                    current = encode_model_choice(getattr(state.agent, "provider", None), running) or running
+                select_options.insert(0, SessionConfigSelectOption(
+                    value=current, name=running or current, description="Current model",
+                ))
+            options.append(
+                SessionConfigOptionSelect(
+                    id=self._MODEL_CONFIG_ID,
+                    name="Model",
+                    description="AI model to use",
+                    category="model",
+                    type="select",
+                    current_value=current,
+                    options=select_options,
+                )
+            )
+        return options
 
     @staticmethod
     def _resolve_model_selection(raw_model: str, current_provider: str) -> tuple[str, str]:
@@ -569,8 +638,10 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
                 )
         self._schedule_available_commands_update(state.session_id)
         self._schedule_soon(lambda: self._send_usage_update(state))
+        model_state = self._build_model_state(state)
         return {
-            "models": self._build_model_state(state),
+            "config_options": self._build_config_options(state, model_state),
+            "models": model_state,
             "modes": self._session_modes(state),
             "field_meta": self._provenance_meta(state.session_id, getattr(state.agent, "session_id", state.session_id)),
         }
@@ -632,8 +703,10 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("Forked session %s -> %s", session_id, state.session_id)
         self._schedule_available_commands_update(state.session_id)
+        model_state = self._build_model_state(state)
         return ForkSessionResponse(
-            session_id=state.session_id, models=self._build_model_state(state), modes=self._session_modes(state)
+            session_id=state.session_id, config_options=self._build_config_options(state, model_state),
+            models=model_state, modes=self._session_modes(state)
         )
 
     async def list_sessions(
@@ -934,6 +1007,12 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
             logger.info(
                 "Session %s: model switched to %s via provider %s", session_id, resolved_model, requested_provider
             )
+            if self._conn:
+                update = ConfigOptionUpdate(
+                    session_update="config_option_update",
+                    config_options=self._build_config_options(state),
+                )
+                await self._send(session_id, update, fail_msg="Failed to send ACP config options update for %s")
             return SetSessionModelResponse()
         logger.warning("Session %s: model switch requested for missing session", session_id)
         return None
@@ -950,19 +1029,36 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         state.mode = normalized_mode
         self.session_manager.save_session(session_id)
         logger.info("Session %s: mode switched to %s", session_id, normalized_mode)
+        if self._conn:
+            update = ConfigOptionUpdate(
+                session_update="config_option_update",
+                config_options=self._build_config_options(state),
+            )
+            await self._send(session_id, update, fail_msg="Failed to send ACP config options update for %s")
         return SetSessionModeResponse()
 
     async def set_config_option(
-        self, config_id: str, session_id: str, value: str, **kwargs: Any
+        self, config_id: str, session_id: str, value: Any, **kwargs: Any
     ) -> SetSessionConfigOptionResponse | None:
-        """Accept ACP config option updates even when Hermes has no typed ACP config surface yet."""
+        """Accept ACP config option updates and update mode/model/policy."""
         state = self.session_manager.get_session(session_id)
         if state is None:
             logger.warning("Session %s: config update requested for missing session", session_id)
             return None
 
-        if str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
-            state.mode = self._EDIT_APPROVAL_POLICY_TO_MODE.get(str(value), self._MODE_DEFAULT)
+        val_str = str(value)
+        if str(config_id) in {self._MODE_CONFIG_ID, self._EDIT_APPROVAL_POLICY_CONFIG_ID}:
+            if val_str in self._MODES:
+                state.mode = val_str
+            else:
+                state.mode = self._EDIT_APPROVAL_POLICY_TO_MODE.get(val_str, self._MODE_DEFAULT)
+            logger.info("Session %s: mode switched to %s (config_option)", session_id, state.mode)
+        elif str(config_id) == self._MODEL_CONFIG_ID:
+            _old, requested_provider, resolved_model = self._switch_model(state, val_str, keep_endpoint=True)
+            logger.info(
+                "Session %s: model switched to %s via provider %s (config_option)",
+                session_id, resolved_model, requested_provider
+            )
         else:
             options = getattr(state, "config_options", None)
             if not isinstance(options, dict):
@@ -971,7 +1067,7 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
             state.config_options = options
         self.session_manager.save_session(session_id)
         logger.info("Session %s: config option %s updated", session_id, config_id)
-        return SetSessionConfigOptionResponse(config_options=[])
+        return SetSessionConfigOptionResponse(config_options=self._build_config_options(state))
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -58,10 +58,13 @@ def agent(mock_manager):
 
 
 @pytest.mark.asyncio
-async def test_new_session_exposes_edit_approvals_as_modes_not_config_options(agent):
+async def test_new_session_exposes_modes_and_config_options(agent):
     resp = await agent.new_session(cwd="/tmp")
 
-    assert resp.config_options is None
+    assert resp.config_options is not None
+    option_ids = [opt.id for opt in resp.config_options]
+    assert "mode" in option_ids
+    assert "model" in option_ids
     assert isinstance(resp.modes, SessionModeState)
     assert resp.modes.current_mode_id == "default"
     assert [(mode.id, mode.name) for mode in resp.modes.available_modes] == [
@@ -72,7 +75,24 @@ async def test_new_session_exposes_edit_approvals_as_modes_not_config_options(ag
 
 
 @pytest.mark.asyncio
-async def test_set_config_option_persists_edit_approval_policy_without_advertising_config(agent):
+async def test_set_config_option_model_switches_session_model(agent):
+    resp = await agent.new_session(cwd="/tmp")
+    with patch.object(agent, "_switch_model", return_value=(None, "openrouter", "deepseek/deepseek-chat")) as switch_mock:
+        update = await agent.set_config_option(
+            "model",
+            resp.session_id,
+            "openrouter:deepseek/deepseek-chat",
+        )
+        assert isinstance(update, SetSessionConfigOptionResponse)
+        switch_mock.assert_called_once_with(
+            agent.session_manager.get_session(resp.session_id),
+            "openrouter:deepseek/deepseek-chat",
+            keep_endpoint=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_persists_edit_approval_policy_and_reflects_mode(agent):
     resp = await agent.new_session(cwd="/tmp")
     update = await agent.set_config_option(
         "edit_approval_policy",
@@ -82,7 +102,8 @@ async def test_set_config_option_persists_edit_approval_policy_without_advertisi
     state = agent.session_manager.get_session(resp.session_id)
 
     assert isinstance(update, SetSessionConfigOptionResponse)
-    assert update.config_options == []
+    mode_opt = next(opt for opt in update.config_options if opt.id == "mode")
+    assert mode_opt.current_value == "accept_edits"
     assert getattr(state, "mode", None) == "accept_edits"
 
 
@@ -390,7 +411,8 @@ class TestSessionConfiguration:
         )
 
         assert mode_result == {}
-        assert config_result["configOptions"] == []
+        assert isinstance(config_result["configOptions"], list)
+        assert len(config_result["configOptions"]) >= 1
 
 
 


### PR DESCRIPTION
## Problem

ACP clients such as Zed build the bottom status bar controls (model selector, mode picker) entirely from the `configOptions` field returned during session lifecycle responses (`session/new`, `session/load`, `session/resume`, `session/fork`).

Hermes previously returned `models` (unstable ACP field) and `modes` but never populated `configOptions`. As a result, Zed showed no model indicator or mode selector at the bottom of the Hermes agent panel — unlike Claude Code, Codex, and other ACP agents.

## Fix

- **`_build_config_options()`** — new method that mirrors both the Mode picker (from `_session_modes`) and the Model picker (from `_build_model_state`) into ACP `SessionConfigOptionSelect` entries. Accepts a precomputed `model_state` to avoid redundant provider `/models` discovery calls.

- **Session responses** — `_session_response_fields`, `fork_session`, and all session lifecycle methods now include `config_options` alongside the existing `models` and `modes` fields.

- **`set_config_option` handler** — recognizes `configId: "mode"` and `configId: "model"` from Zed's dropdown interactions. Mode changes accept both mode ids (`default`/`accept_edits`/`dont_ask`) and legacy edit-approval-policy values. Model changes delegate to `_switch_model`.

- **`set_session_model` / `set_session_mode`** — now push a `config_option_update` notification so the Zed dropdown stays in sync after changes via either the legacy ACP path or the config option path.

- **Current-model fallback** — when the encoded choice id differs from the picker id (e.g. custom provider normalization), the running model is pinned as its own row so `currentValue` always matches a selectable option (prevents blank dropdown).

## Tests

Updated 3 existing tests in `tests/acp/test_server.py` whose assertions expected `config_options` to be `None`/`[]`. Added a new test (`test_set_config_option_model_switches_session_model`) verifying the model-switch path through `set_config_option`.

All 153 ACP tests pass (`scripts/run_tests.sh tests/acp/ tests/acp_adapter/`).

## Note on changed test names

Two existing tests asserted the *opposite* contract (`test_new_session_exposes_edit_approvals_as_modes_not_config_options`, `test_set_config_option_persists_edit_approval_policy_without_advertising_config`). I could not find a rationale in git history for deliberately suppressing `configOptions` — the field was simply never populated. The names and assertions are updated to match the new behavior.