### PR TITLE
fix(aux): recognize Kimi weekly (7-day) usage limit as payment error

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2992,6 +2992,7 @@ _PAYMENT_KEYWORDS = (
     "too many tokens per day", "daily limit", "tokens per day", "daily quota", "resource exhausted",
     "resource_exhausted", "resource-exhausted", "resourceexhausted",
     "weekly usage limit", "weekly limit",
+    "weekly (7-day) usage limit",
 )
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1419,9 +1419,39 @@ class TestIsPaymentError:
         exc.status_code = 404
         assert _is_payment_error(exc) is False
 
+    def test_403_generic_forbidden_is_not_payment(self):
+        """Generic 403 without billing/quota keywords stays fail-open (#107067)."""
+        exc = Exception("Error code: 403 - {'error': {'type': 'permission_error'}}")
+        exc.status_code = 403
+        assert _is_payment_error(exc) is False
 
+    def test_kimi_weekly_7day_usage_limit_403_is_payment(self):
+        exc = Exception(
+            "Error code: 403 - {'error': {'type': 'permission_error', "
+            "'message': \"You've reached your weekly (7-day) usage limit. "
+            "Your quota will reset when the current 7-day window ends.\"}, "
+            "'type': 'error'}"
+        )
+        exc.status_code = 403
+        assert _is_payment_error(exc) is True
 
+    def test_weekly_usage_limit_403_still_payment(self):
+        """Existing exact substring must keep matching after the Kimi phrase add."""
+        exc = Exception("You've reached your weekly usage limit.")
+        exc.status_code = 403
+        assert _is_payment_error(exc) is True
 
+    def test_500_weekly_7day_usage_limit_is_not_payment(self):
+        """Weekly keywords must not newly classify statuses outside the payment gate."""
+        exc = Exception("You've reached your weekly (7-day) usage limit.")
+        exc.status_code = 500
+        assert _is_payment_error(exc) is False
+
+    def test_403_bare_weekly_is_not_payment(self):
+        """Bare 'weekly' without a quota phrase must not trip payment matching."""
+        exc = Exception("Weekly digest is temporarily unavailable")
+        exc.status_code = 403
+        assert _is_payment_error(exc) is False
 
     # ── Daily / monthly quota exhaustion (#26803) ────────────────────────────
 


### PR DESCRIPTION
## Summary
- Auxiliary `_is_payment_error` missed Kimi's 403 phrasing `weekly (7-day) usage limit` because `_PAYMENT_KEYWORDS` only had uninterrupted `weekly usage limit` / `weekly limit` substrings, so the aux fallback ladder never walked `fallback_chain`.
- Add the exact interpolated phrase to `_PAYMENT_KEYWORDS` and cover positive + fail-open CONTROLs (generic 403, status 500, bare `weekly`, existing weekly substring).

Fixes #107067

## Proof
- RED (pre-fix): `test_kimi_weekly_7day_usage_limit_403_is_payment` failed (`_is_payment_error` False).
- GREEN (post-fix): focused `TestIsPaymentError` / Kimi weekly filters — 14 passed.

## Test plan
- [x] Focused RED then GREEN via `scripts/run_tests.sh tests/agent/test_auxiliary_client.py -k 'kimi_weekly_7day or weekly_7day or TestIsPaymentError'`
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)