### PR TITLE
fix(image_gen): allow CODEX_CHAT_MODEL override for openai-codex host

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -39,7 +39,24 @@ logger = logging.getLogger(__name__)
 _MAX_ERROR_BODY_CHARS = 500
 
 # Hosts the ``image_generation`` tool call; ``API_MODEL`` does the image work.
+# Override via ``CODEX_CHAT_MODEL`` for accounts without this host (issue #107076).
 _CODEX_CHAT_MODEL = "gpt-5.5"
+
+
+def _resolve_codex_chat_model() -> str:
+    """Host model for the Responses ``image_generation`` tool.
+
+    ``CODEX_CHAT_MODEL`` overrides the default when set and non-empty after
+    strip; whitespace-only is treated as unset so the documented default stays.
+    Orthogonal to ``OPENAI_IMAGE_MODEL`` (tool model, not host).
+    """
+    override = os.environ.get("CODEX_CHAT_MODEL")
+    if override is None:
+        return _CODEX_CHAT_MODEL
+    stripped = override.strip()
+    return stripped or _CODEX_CHAT_MODEL
+
+
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation and image editing "
@@ -181,7 +198,7 @@ def _build_responses_payload(
     nudged by ``instructions``."""
     content: List[Dict[str, Any]] = [{"type": "input_text", "text": prompt}, *(input_images or [])]
     return {
-        "model": _CODEX_CHAT_MODEL,
+        "model": _resolve_codex_chat_model(),
         "store": False,
         "instructions": _CODEX_INSTRUCTIONS,
         "input": [{"type": "message", "role": "user", "content": content}],

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -136,6 +136,7 @@ class TestGenerate:
             ))
             return {"b64": _b64_png(), "source": "final"}
 
+        monkeypatch.delenv("CODEX_CHAT_MODEL", raising=False)
         monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
 
         result = provider.generate("a cat", aspect_ratio="portrait")
@@ -400,6 +401,27 @@ class TestGenerate:
 
 
 class TestRequestShape:
+    def test_codex_host_model_env_override(self, monkeypatch):
+        """Host model for image_generation comes from CODEX_CHAT_MODEL when set."""
+        monkeypatch.setenv("CODEX_CHAT_MODEL", "gpt-5.6-sol")
+        payload = codex_plugin._build_responses_payload(
+            prompt="a cat", size="1024x1024", quality="medium")
+        assert payload["model"] == "gpt-5.6-sol"
+
+    def test_codex_host_model_default_when_env_unset(self, monkeypatch):
+        """Unset CODEX_CHAT_MODEL keeps the documented gpt-5.5 default."""
+        monkeypatch.delenv("CODEX_CHAT_MODEL", raising=False)
+        payload = codex_plugin._build_responses_payload(
+            prompt="a cat", size="1024x1024", quality="medium")
+        assert payload["model"] == "gpt-5.5"
+
+    def test_codex_host_model_whitespace_env_is_unset(self, monkeypatch):
+        """Whitespace-only CODEX_CHAT_MODEL is treated as unset (fail-open)."""
+        monkeypatch.setenv("CODEX_CHAT_MODEL", "   ")
+        payload = codex_plugin._build_responses_payload(
+            prompt="a cat", size="1024x1024", quality="medium")
+        assert payload["model"] == "gpt-5.5"
+
     def test_payload_omits_tool_choice(self):
         """Codex rejects every tool_choice shape for hosted image_generation."""
         payload = codex_plugin._build_responses_payload(


### PR DESCRIPTION
## What does this PR do?

The openai-codex image_gen provider hardcodes the Responses host model as `gpt-5.5`. Codex accounts without access to that host get a permanent HTTP 404 on every `image_generate` call. The tool model already has `OPENAI_IMAGE_MODEL` / config override; the host model did not.

This adds a narrow `CODEX_CHAT_MODEL` env override (strip; whitespace-only = unset) while keeping the default `gpt-5.5` when unset — matching the existing tool-model override pattern without changing product defaults or adding 404 retry / capability classifiers.

## Related Issue

Fixes #107076

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/image_gen/openai-codex/__init__.py`: `_resolve_codex_chat_model()` reads `CODEX_CHAT_MODEL`; `_build_responses_payload` uses it for `"model"`
- `tests/plugins/image_gen/test_openai_codex_provider.py`: override / default / whitespace fail-open cases; existing stream-shape test clears env

## How to Test

1. Focused suite: `./scripts/run_tests.sh tests/plugins/image_gen/test_openai_codex_provider.py`
2. Proof: unset env → payload model `gpt-5.5`; `CODEX_CHAT_MODEL=gpt-5.6-sol` → that host; whitespace env → default
3. Manual (optional): with Codex OAuth lacking `gpt-5.5`, set `CODEX_CHAT_MODEL` to an accessible host and run `image_generate`

## Proof Receipt

- BEFORE (RED): `test_codex_host_model_env_override` AssertionError `gpt-5.5` != `gpt-5.6-sol` (1 failed, 3 passed under host_model/stream filter)
- AFTER (GREEN): same filter 4 passed; full file 31 passed
- CONTROL: default / whitespace fail-open tests keep `gpt-5.5`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Focused tests pass (`test_openai_codex_provider.py`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation — N/A (env override documented in code docstring)
- [x] `cli-config.yaml.example` — N/A (env-only, no new config key)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — N/A (env read only)
- [x] Tool descriptions/schemas — N/A

## Residual risk

Accounts without `CODEX_CHAT_MODEL` still see the hardcoded default (intentional fail-open). Override is env-only; no setup UX. Validity of a given override host remains account-specific.

Made with [Cursor](https://cursor.com)