### PR TITLE
fix(gateway): report selected session provider in status

### DIFF
--- a/gateway/slash_commands_status.py
+++ b/gateway/slash_commands_status.py
@@ -79,11 +79,12 @@ def _quiet_sync(call, default=None):
         return default
 
 
-def _status_model_route(status_agent, persisted_route: dict, session_row: dict, session_entry):
+def _status_model_route(status_agent, persisted_route: dict, session_row: dict, session_entry,
+                        session_override: dict | None = None):
     """``(model, provider, context_used, context_total)`` for /status.
 
-    Order: live/cached agent route -> persisted dominant route -> SessionDB row -> gateway config
-    (only loaded when something is still missing).
+    Order: live/cached agent -> selected session override -> persisted billing -> gateway config.
+    A model switch precedes its first billed call; historical billing cannot describe that selection.
     """
     from gateway.run import _AGENT_PENDING_SENTINEL, _load_gateway_config, _resolve_gateway_model
     context_used = context_total = 0
@@ -95,6 +96,10 @@ def _status_model_route(status_agent, persisted_route: dict, session_row: dict, 
         if ctx is not None:
             context_used = max(0, _int_value(getattr(ctx, "last_prompt_tokens", 0)))
             context_total = _int_value(getattr(ctx, "context_length", 0))
+    # Memory also carries /model --once; the stored override survives gateway restarts.
+    override = session_override if isinstance(session_override, dict) else getattr(session_entry, "model_override", None)
+    if isinstance(override, dict):
+        routes.append((_clean_str(override.get("model")), _clean_str(override.get("provider"))))
     routes.append((_clean_str(persisted_route.get("model")),
                    _clean_str(persisted_route.get("billing_provider"))))
     row_route = (_clean_str(session_row.get("model")), _clean_str(session_row.get("billing_provider")))
@@ -233,7 +238,8 @@ class GatewayStatusCommandsMixin:
         # to SessionDB metadata + last_prompt_tokens so /status stays useful between turns.
         status_agent = agent if is_running else self._cached_agent_for(session_key)
         model_name, provider_name, context_used, context_total = _status_model_route(
-            status_agent, persisted_route, session_row, session_entry
+            status_agent, persisted_route, session_row, session_entry,
+            session_override=(getattr(self, "_session_model_overrides", {}) or {}).get(session_key),
         )
 
         stamp = "%Y-%m-%d %H:%M"

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -190,6 +190,63 @@ async def test_status_command_uses_dominant_persisted_model_route(tmp_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("restore", [False, True])
+@pytest.mark.parametrize("has_history", [False, True])
+async def test_status_reports_selected_route_before_next_inference(tmp_path, monkeypatch, restore, has_history):
+    """A committed selection, including after restart, supersedes defaults and old billing."""
+    from gateway.session import SessionStore
+    from gateway.slash_commands_model import _ModelSwitchContext
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "model:\n  default: deepseek/example\n  provider: openrouter\n", encoding="utf-8"
+    )
+    store = SessionStore(tmp_path / "sessions", GatewayConfig())
+    entry = store.get_or_create_session(_make_source())
+    runner = _make_runner(entry)
+    runner.session_store = store
+    runner._session_db = AsyncSessionDB(store._db)
+    runner._session_model_overrides = {}
+    if has_history:
+        store._db.update_token_counts(entry.session_id, model="deepseek/example",
+                                      billing_provider="openrouter", input_tokens=10, api_call_count=1)
+    result = SimpleNamespace(new_model="gpt-5.6-luna-900k", target_provider="openai-codex",
+                             api_key="", base_url="https://chatgpt.com/backend-api/codex",
+                             api_mode="codex_responses", request_overrides={}, runtime_capabilities={},
+                             provider_label="ChatGPT or Codex Subscription")
+    ctx = _ModelSwitchContext(session_key=entry.session_key, source=_make_source(),
+                              config_path=tmp_path / "config.yaml", persist_global=False,
+                              current_model="deepseek/example")
+    await runner._record_model_switch(result, ctx, source=_make_source(), one_turn=False, picker=True)
+    if restore:
+        runner = _make_runner(entry)
+        runner.session_store = SessionStore(tmp_path / "sessions", GatewayConfig())
+        runner._session_db = AsyncSessionDB(store._db)
+        runner._session_model_overrides = {}
+    status = await runner._handle_status_command(_make_event("/status"))
+    assert "**Model:** `gpt-5.6-luna-900k` (openai-codex)" in status
+    assert "(openrouter)" not in status
+
+
+@pytest.mark.asyncio
+async def test_status_prefers_one_turn_override_until_an_agent_is_running():
+    """One-turn selections are memory-only; an actual resident agent remains authoritative."""
+    entry = SessionEntry(session_key=build_session_key(_make_source()), session_id="sess-once",
+                         created_at=datetime.now(), updated_at=datetime.now(),
+                         platform=Platform.TELEGRAM, chat_type="dm",
+                         model_override={"model": "old-model", "provider": "openrouter"})
+    runner = _make_runner(entry)
+    runner._session_model_overrides = {
+        entry.session_key: {"model": "selected-model", "provider": "openai-codex"}
+    }
+    status = await runner._handle_status_command(_make_event("/status"))
+    assert "**Model:** `selected-model` (openai-codex)" in status
+    runner._running_agents[entry.session_key] = SimpleNamespace(model="actual-model", provider="actual-provider")
+    status = await runner._handle_status_command(_make_event("/status"))
+    assert "**Model:** `actual-model` (actual-provider)" in status
+
+
+@pytest.mark.asyncio
 async def test_agents_command_reports_active_agents_and_processes(monkeypatch):
     session_key = build_session_key(_make_source())
     session_entry = SessionEntry(


### PR DESCRIPTION
Fixes #107084.

After `/model` selects a subscription model, `/status` could combine the selected model name with the profile's OpenRouter default before any inference. With earlier usage, it could instead report an old billed route. The session selection was saved correctly but omitted from status resolution.

Status now prefers the in-memory session override, or its persisted counterpart after restart, when there is no actual resident agent route. This also covers one-turn selections. Live/cached agent routes remain authoritative, and historical billing remains available when no selection exists.

Validation:
- Five regression cases failed on the base revision and pass with this change.
- `scripts/run_tests.sh tests/gateway/test_status_command.py tests/gateway/test_model_switch_persistence.py tests/gateway/test_model_picker_persist.py -q`: 24 passed.
- Ruff and `git diff --check` passed.
- The same focused suite passed against the installed older Hermes runtime after applying this patch. Its previously affected saved session now resolves the selected model with `openai-codex` before inference.
