### PR TITLE
feat(desktop): link radio credits directly to artist profiles

### DIFF
--- a/apps/desktop/src/contrib/radio-artist-links.test.ts
+++ b/apps/desktop/src/contrib/radio-artist-links.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createPluginContext } from './plugin'
+
+interface ArtistModule {
+  artistProfile: (relations: unknown[]) => string | null
+  resolveArtist: (name: string, signal: AbortSignal, ctx: ReturnType<typeof createPluginContext>) => Promise<string | null>
+  trackCredit: (source: unknown) => { artist: string; title: string }
+}
+
+// Use the same plain-ESM delivery form as bundled discovery, without reading source text.
+const modules = import.meta.glob<ArtistModule>('../plugins/radio/plugin.js', { eager: true })
+const { artistProfile, resolveArtist, trackCredit } = Object.values(modules)[0]
+const ctx = createPluginContext('radio-artist-test')
+const signal = () => new AbortController().signal
+const json = (data: unknown) => ({ ok: true, json: async () => data })
+
+afterEach(() => {
+  ctx.storage.remove('local.artistRequestAt')
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('Radio artist credits', () => {
+  it('separates only a credited artist and accepts direct artist destinations, never track or search links', () => {
+    expect(trackCredit({ title: 'AC-DC - Thunderstruck' })).toEqual({ artist: 'AC-DC', title: 'Thunderstruck' })
+    expect(trackCredit({ artist: 'AC-DC', title: 'Live - Part Two' })).toEqual({ artist: 'AC-DC', title: 'Live - Part Two' })
+    expect(trackCredit({ title: 'Unstructured broadcast' }).artist).toBe('')
+    expect(trackCredit(null).artist).toBe('')
+
+    const spotify = 'https://open.spotify.com/artist/5V8x0GqH9GCBPl1fYeOhuB'
+    const bandcamp = 'https://davdralleon.bandcamp.com/'
+    const relation = (type: string, resource: string) => ({ type, url: { resource } })
+    expect(artistProfile([
+      relation('bandcamp', bandcamp),
+      relation('free streaming', spotify)
+    ])).toBe(spotify)
+    expect(artistProfile([
+      relation('free streaming', 'https://open.spotify.com/track/5V8x0GqH9GCBPl1fYeOhuB'),
+      relation('free streaming', 'https://open.spotify.com/search/Dav'),
+      relation('bandcamp', `${bandcamp}track/song`),
+      relation('official homepage', 'javascript:alert(1)')
+    ])).toBeNull()
+    expect(artistProfile([relation('bandcamp', bandcamp)])).toBe(bandcamp)
+  })
+
+  it('resolves exact artist profiles, rejects ambiguity, and falls back after an unavailable provider', async () => {
+    const apple = 'https://music.apple.com/us/artist/hello-meteor/1080606463'
+    const row = { wrapperType: 'artist', artistName: 'Hello Meteor', artistLinkUrl: `${apple}?uo=4` }
+    const fetch = vi.fn().mockResolvedValueOnce(json({ results: [row] }))
+    vi.stubGlobal('fetch', fetch)
+    expect(await resolveArtist('Hello Meteor', signal(), ctx)).toBe(apple)
+    const request = new URL(fetch.mock.calls[0][0])
+    expect(request.searchParams.get('entity')).toBe('musicArtist')
+    expect(request.searchParams.get('term')).toBe('Hello Meteor')
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    fetch.mockResolvedValueOnce(json({ results: [row, { ...row, artistLinkUrl: 'https://music.apple.com/us/artist/hello-meteor/2' }] }))
+    expect(await resolveArtist('Hello Meteor', signal(), ctx)).toBeNull()
+    expect(fetch).toHaveBeenCalledTimes(2)
+
+    const id = '08d6699f-ec17-434c-a922-3684531840d1'
+    const spotify = 'https://open.spotify.com/artist/5V8x0GqH9GCBPl1fYeOhuB'
+    vi.stubGlobal('navigator', { locks: {
+      request: async (_name: string, _options: unknown, callback: () => Promise<unknown>) => callback()
+    } })
+    fetch.mockRejectedValueOnce(new Error('Apple unavailable'))
+      .mockResolvedValueOnce(json({ artists: [{ name: 'Dav Dralleon', id, score: 100 }] }))
+      .mockResolvedValueOnce(json({ relations: [{ type: 'free streaming', url: { resource: spotify } }] }))
+    expect(await resolveArtist('Dav Dralleon', signal(), ctx)).toBe(spotify)
+    expect(fetch.mock.calls.at(-1)?.[0]).toContain(`/artist/${id}?inc=url-rels`)
+  })
+})

--- a/apps/desktop/src/plugins/radio/README.md
+++ b/apps/desktop/src/plugins/radio/README.md
@@ -36,7 +36,13 @@ Both waveform sizes use real audio samples, with two dim previous traces.
 Silence stays flat; reduced motion freezes the display. Streams that cannot
 be analysed retry without CORS and show an activity indicator, not invented
 levels. Nightride and EVE Radio song metadata is fetched while the picker is
-open and playback is active.
+open and playback is active. Artist names link directly to their profile, never
+search results or a song. Apple's public artist lookup resolves unambiguous exact
+names to Apple Music profiles. MusicBrainz is a fallback for Spotify, Bandcamp,
+or official artist homepages. Missing or ambiguous matches stay plain text, with
+no dead link or reserved icon gap. Artist names are sent to these services only
+while the picker shows live metadata; results are cached for a day. MusicBrainz
+requests are paced across windows. No account or API key is needed.
 
 Audio connects directly to broadcasters. Searches send the typed station query
 to Radio Browser. There are no accounts, keys, analytics, recording, or

--- a/apps/desktop/src/plugins/radio/plugin.js
+++ b/apps/desktop/src/plugins/radio/plugin.js
@@ -23,7 +23,7 @@ const EN = {
   live: 'Live', paused: 'Paused', connecting: 'Connecting', error: 'Stream unavailable', retry: 'Try again',
   search: 'Find a station…', volume: 'Volume', audioOnly: 'Audio playing · visualizer unavailable',
   mute: 'Mute radio', unmute: 'Unmute radio', save: 'Pin station', unsave: 'Unpin station',
-  visit: 'Visit station website',
+  visit: 'Visit station website', artistProfile: 'Visit artist profile',
   noResults: 'No stations found', searchHint: 'Search by station name. Try jazz, ambient, or house.',
   searchError: 'Station search is unavailable. Your presets still work.', searching: 'Searching stations',
   directory: 'Search powered by Radio Browser', note: 'Live radio · next switches stations',
@@ -35,9 +35,9 @@ const EN = {
 }
 const LOCALES = {
   en: EN,
-  ja: { ...EN, audioOnly: '再生中 · 波形を表示できません', radio: 'ラジオ', browse: 'ステーションを選択', play: 'ラジオを再生', pause: 'ラジオを一時停止', next: '次のステーション', live: 'ライブ', paused: '一時停止', connecting: '接続中', error: '再生できません', retry: '再試行', search: 'ステーションを検索…', volume: '音量', mute: 'ミュート', unmute: 'ミュート解除', save: 'ステーションを固定', unsave: '固定を解除', visit: '公式サイトを開く', noResults: '見つかりませんでした', searchHint: '名前で検索。jazz、ambient、house など。', searchError: '検索できません。おすすめは再生できます。', searching: '検索中', directory: 'Radio Browser による検索', note: 'ライブ放送 · 次へでステーションを切り替え', streamError: '接続できませんでした。再試行するか別のステーションを選んでください。', close: 'ラジオを閉じる', nowPlaying: '再生中', elsewhere: '別のウィンドウで再生中', 'chillsynthDescription': 'やさしい集中 · 暖かなシンセ', 'nightrideDescription': 'シンセウェーブ · 深夜', 'darksynthDescription': 'ダークな電子音 · 高揚感', 'spacesynthDescription': '宇宙的シンセ · レトロな未来', 'paradise-mainDescription': '多彩な選曲 · 人がキュレーション', 'paradise-mellowDescription': 'ゆったりした時間' },
-  zh: { ...EN, audioOnly: '正在播放 · 无法显示波形', radio: '电台', browse: '选择电台', play: '播放电台', pause: '暂停电台', next: '下一个电台', live: '直播', paused: '已暂停', connecting: '正在连接', error: '无法播放', retry: '重试', search: '搜索电台…', volume: '音量', mute: '静音', unmute: '取消静音', save: '置顶电台', unsave: '取消置顶', visit: '访问电台网站', noResults: '没有找到电台', searchHint: '按名称搜索，例如 jazz、ambient 或 house。', searchError: '暂时无法搜索，精选电台仍可使用。', searching: '正在搜索', directory: '搜索由 Radio Browser 提供', note: '直播电台 · 下一首将切换电台', streamError: '无法连接，请重试或选择其他电台。', close: '关闭电台', nowPlaying: '正在播放', elsewhere: '已暂停，正在其他窗口播放', 'chillsynthDescription': '轻松专注 · 温暖合成器', 'nightrideDescription': '合成器浪潮 · 深夜', 'darksynthDescription': '暗黑电子 · 充满能量', 'spacesynthDescription': '宇宙合成器 · 复古未来', 'paradise-mainDescription': '多元风格 · 人工精选', 'paradise-mellowDescription': '放慢节奏' },
-  'zh-hant': { ...EN, audioOnly: '播放中 · 無法顯示波形', radio: '電台', browse: '選擇電台', play: '播放電台', pause: '暫停電台', next: '下一個電台', live: '直播', paused: '已暫停', connecting: '正在連線', error: '無法播放', retry: '重試', search: '搜尋電台…', volume: '音量', mute: '靜音', unmute: '取消靜音', save: '釘選電台', unsave: '取消釘選', visit: '造訪電台網站', noResults: '找不到電台', searchHint: '按名稱搜尋，例如 jazz、ambient 或 house。', searchError: '暫時無法搜尋，精選電台仍可使用。', searching: '正在搜尋', directory: '搜尋由 Radio Browser 提供', note: '直播電台 · 下一首會切換電台', streamError: '無法連線，請重試或選擇其他電台。', close: '關閉電台', nowPlaying: '正在播放', elsewhere: '已暫停，正在其他視窗播放', 'chillsynthDescription': '輕鬆專注 · 溫暖合成器', 'nightrideDescription': '合成器浪潮 · 深夜', 'darksynthDescription': '暗黑電子 · 充滿能量', 'spacesynthDescription': '宇宙合成器 · 復古未來', 'paradise-mainDescription': '多元風格 · 人工精選', 'paradise-mellowDescription': '放慢節奏' }
+  ja: { ...EN, artistProfile: 'アーティストのプロフィールを開く', audioOnly: '再生中 · 波形を表示できません', radio: 'ラジオ', browse: 'ステーションを選択', play: 'ラジオを再生', pause: 'ラジオを一時停止', next: '次のステーション', live: 'ライブ', paused: '一時停止', connecting: '接続中', error: '再生できません', retry: '再試行', search: 'ステーションを検索…', volume: '音量', mute: 'ミュート', unmute: 'ミュート解除', save: 'ステーションを固定', unsave: '固定を解除', visit: '公式サイトを開く', noResults: '見つかりませんでした', searchHint: '名前で検索。jazz、ambient、house など。', searchError: '検索できません。おすすめは再生できます。', searching: '検索中', directory: 'Radio Browser による検索', note: 'ライブ放送 · 次へでステーションを切り替え', streamError: '接続できませんでした。再試行するか別のステーションを選んでください。', close: 'ラジオを閉じる', nowPlaying: '再生中', elsewhere: '別のウィンドウで再生中', 'chillsynthDescription': 'やさしい集中 · 暖かなシンセ', 'nightrideDescription': 'シンセウェーブ · 深夜', 'darksynthDescription': 'ダークな電子音 · 高揚感', 'spacesynthDescription': '宇宙的シンセ · レトロな未来', 'paradise-mainDescription': '多彩な選曲 · 人がキュレーション', 'paradise-mellowDescription': 'ゆったりした時間' },
+  zh: { ...EN, artistProfile: '访问艺人主页', audioOnly: '正在播放 · 无法显示波形', radio: '电台', browse: '选择电台', play: '播放电台', pause: '暂停电台', next: '下一个电台', live: '直播', paused: '已暂停', connecting: '正在连接', error: '无法播放', retry: '重试', search: '搜索电台…', volume: '音量', mute: '静音', unmute: '取消静音', save: '置顶电台', unsave: '取消置顶', visit: '访问电台网站', noResults: '没有找到电台', searchHint: '按名称搜索，例如 jazz、ambient 或 house。', searchError: '暂时无法搜索，精选电台仍可使用。', searching: '正在搜索', directory: '搜索由 Radio Browser 提供', note: '直播电台 · 下一首将切换电台', streamError: '无法连接，请重试或选择其他电台。', close: '关闭电台', nowPlaying: '正在播放', elsewhere: '已暂停，正在其他窗口播放', 'chillsynthDescription': '轻松专注 · 温暖合成器', 'nightrideDescription': '合成器浪潮 · 深夜', 'darksynthDescription': '暗黑电子 · 充满能量', 'spacesynthDescription': '宇宙合成器 · 复古未来', 'paradise-mainDescription': '多元风格 · 人工精选', 'paradise-mellowDescription': '放慢节奏' },
+  'zh-hant': { ...EN, artistProfile: '造訪藝人主頁', audioOnly: '播放中 · 無法顯示波形', radio: '電台', browse: '選擇電台', play: '播放電台', pause: '暫停電台', next: '下一個電台', live: '直播', paused: '已暫停', connecting: '正在連線', error: '無法播放', retry: '重試', search: '搜尋電台…', volume: '音量', mute: '靜音', unmute: '取消靜音', save: '釘選電台', unsave: '取消釘選', visit: '造訪電台網站', noResults: '找不到電台', searchHint: '按名稱搜尋，例如 jazz、ambient 或 house。', searchError: '暫時無法搜尋，精選電台仍可使用。', searching: '正在搜尋', directory: '搜尋由 Radio Browser 提供', note: '直播電台 · 下一首會切換電台', streamError: '無法連線，請重試或選擇其他電台。', close: '關閉電台', nowPlaying: '正在播放', elsewhere: '已暫停，正在其他視窗播放', 'chillsynthDescription': '輕鬆專注 · 溫暖合成器', 'nightrideDescription': '合成器浪潮 · 深夜', 'darksynthDescription': '暗黑電子 · 充滿能量', 'spacesynthDescription': '宇宙合成器 · 復古未來', 'paradise-mainDescription': '多元風格 · 人工精選', 'paradise-mellowDescription': '放慢節奏' }
 }
 
 // Disk plugins are not scanned by Tailwind. Only plugin layout lives here;
@@ -56,6 +56,9 @@ const CSS = `
 .hermes-radio-track{display:flex;align-items:center;gap:5px;height:19px;min-width:0;font-size:11px;line-height:16px;color:var(--ui-text-secondary)}
 .hermes-radio-track-text{overflow:hidden;white-space:nowrap;text-overflow:ellipsis;min-width:0}
 .hermes-radio-track[data-track=true]{color:var(--ui-text-primary)}
+.hermes-radio-artist{min-width:0;max-width:55%;flex-shrink:1;font-size:inherit;font-weight:inherit}
+.hermes-radio-artist>span{overflow:hidden;text-overflow:ellipsis}
+.hermes-radio-track-separator{flex-shrink:0;color:var(--ui-text-quaternary)}
 .hermes-radio-bar .radio-name{max-width:112px;min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;text-align:left}
 .hermes-radio-bar .hermes-radio-action{width:16px;height:16px;padding:0;flex-shrink:0}
 .hermes-radio-action-icon{display:flex;align-items:center;justify-content:center;width:12px;height:12px;flex-shrink:0;overflow:hidden}
@@ -394,7 +397,87 @@ function SmallAction({ label, icon, onClick, size = 'micro', pressed, className,
   }) })
 }
 
-function Signal({ player }) {
+function trackCredit(source) {
+  const raw = typeof source?.title === 'string' ? source.title.trim() : ''
+  const explicit = source?.artist || source?.metadata?.artist
+  const parts = raw.match(/^(.+?)\s[-–—]\s(.+)$/)
+  const artist = typeof explicit === 'string' ? explicit.trim() : parts?.[1].trim() || ''
+  // Only separate an explicit artist prefix when it actually matches.
+  const title = parts && parts[1].trim() === artist ? parts[2].trim() : raw
+  return { artist: raw ? artist : '', title }
+}
+
+async function artistRequest(path, signal, ctx) {
+  // The lock and persisted timestamp pace lookups across desktop windows.
+  return navigator.locks.request('hermes:radio:artist-lookup', { signal }, async () => {
+    const delay = Math.max(0, 1100 - (Date.now() - ctx.storage.get('local.artistRequestAt', 0)))
+    if (delay) await new Promise(resolve => setTimeout(resolve, delay))
+    signal.throwIfAborted()
+    ctx.storage.set('local.artistRequestAt', Date.now())
+    const response = await fetch(`https://musicbrainz.org/ws/2/${path}`, {
+      signal: AbortSignal.any([signal, AbortSignal.timeout(15000)]), credentials: 'omit',
+      headers: { 'User-Agent': 'HermesRadio/1.0 (https://github.com/NousResearch/hermes-agent)' }
+    })
+    if (!response.ok) throw new Error(`Artist lookup: HTTP ${response.status}`)
+    return response.json()
+  })
+}
+
+function artistProfile(relations) {
+  const links = (relations ?? []).filter(item => !item.ended).flatMap(item => {
+    const href = httpsUrl(item.url?.resource)
+    if (!href) return []
+    const url = new URL(href)
+    if (url.hostname === 'open.spotify.com' && /^\/artist\/[a-zA-Z0-9]{22}\/?$/.test(url.pathname)) return [{ href, rank: 0 }]
+    if (item.type === 'bandcamp' && /^[^.]+\.bandcamp\.com$/.test(url.hostname) && url.pathname === '/') return [{ href, rank: 1 }]
+    if (item.type === 'official homepage' && !['open.spotify.com', 'bandcamp.com'].includes(url.hostname)) return [{ href, rank: 2 }]
+    return []
+  })
+  return links.sort((a, b) => a.rank - b.rank)[0]?.href ?? null
+}
+
+function normalizedArtist(name) {
+  return name.normalize('NFKC').trim().toLowerCase()
+}
+
+async function resolveArtist(artist, signal, ctx) {
+  // Apple's public artist search supplies direct profile URLs without API keys.
+  // Prefer it over a slow/unavailable MusicBrainz lookup; never use song results.
+  const params = new URLSearchParams({ term: artist, entity: 'musicArtist', limit: '10' })
+  try {
+    const result = await fetchJson(`https://itunes.apple.com/search?${params}`, signal)
+    const matches = (result.results ?? []).filter(item => item.wrapperType === 'artist' && normalizedArtist(item.artistName) === normalizedArtist(artist))
+    if (matches.length > 1) return null
+    if (matches.length === 1) {
+      const href = httpsUrl(matches[0].artistLinkUrl)
+      if (href) {
+        const url = new URL(href)
+        if (url.hostname === 'music.apple.com' && /^\/[a-z]{2}\/artist\/[^/]+\/\d+$/.test(url.pathname)) {
+          url.search = ''
+          return url.href
+        }
+      }
+    }
+  } catch (error) {
+    if (signal.aborted) throw error
+  }
+  return resolveMusicBrainzArtist(artist, signal, ctx)
+}
+
+async function resolveMusicBrainzArtist(artist, signal, ctx) {
+  const escaped = artist.replace(/[+\-!(){}\[\]^"~*?:\\/&|]/g, '\\$&')
+  const params = new URLSearchParams({ query: `artist:"${escaped}"`, fmt: 'json', limit: '5' })
+  const result = await artistRequest(`artist/?${params}`, signal, ctx)
+  const matches = (result.artists ?? []).filter(item => normalizedArtist(item.name) === normalizedArtist(artist))
+  // Never turn the top fuzzy match or an ambiguous artist name into a credit.
+  if (matches.length !== 1 || matches[0].score !== 100 || result.artists.length === 5) return null
+  const id = matches[0].id
+  if (!/^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$/.test(id)) return null
+  const profile = await artistRequest(`artist/${id}?inc=url-rels&fmt=json`, signal, ctx)
+  return artistProfile(profile.relations)
+}
+
+function Signal({ player, ctx }) {
   const t = usePluginI18n(ID)
   const station = useValue(player.station)
   const status = useValue(player.status)
@@ -414,12 +497,29 @@ function Signal({ player }) {
   const sources = metadata.data?.icestats?.source
   const source = (Array.isArray(sources) ? sources : sources ? [sources] : []).find(source => source.listenurl?.endsWith(stream.pathname))
   const track = status === 'live' && typeof source?.title === 'string' ? source.title : ''
+  const credit = trackCredit(track ? source : null)
+  const artist = useQuery({
+    queryKey: [ID, 'artist-profile', credit.artist],
+    queryFn: ({ signal }) => resolveArtist(credit.artist, signal, ctx),
+    enabled: Boolean(credit.artist), staleTime: 86400000, gcTime: 86400000,
+    retry: 1, retryDelay: 3000, refetchOnWindowFocus: false
+  })
+  const artistUrl = credit.artist ? artist.data : null
   const text = status === 'live' ? track || (mode === 'activity' ? t('audioOnly') : '') : t(status)
   return jsxs('div', { className: 'hermes-radio-signal', children: [
     jsx(Waveform, { player }),
     jsxs('div', { className: 'hermes-radio-track', 'data-track': Boolean(track), role: 'status', children: [
       status === 'connecting' && jsx(GlyphSpinner, { ariaLabel: t('connecting') }),
-      jsx(Tip, { label: text || undefined, children: jsx('span', { className: 'hermes-radio-track-text', children: text }) })
+      credit.artist && (artistUrl ? jsx(Tip, { label: `${t('artistProfile')}: ${credit.artist}`, children: jsx(Button, {
+        variant: 'text', size: 'inline', asChild: true, className: 'hermes-radio-artist',
+        children: jsxs('a', { href: artistUrl, target: '_blank', rel: 'noopener noreferrer',
+          'aria-label': `${t('artistProfile')}: ${credit.artist}`,
+          onClick: event => { event.preventDefault(); void ctx.os.openExternal(artistUrl) },
+          children: [jsx('span', { children: credit.artist }), jsx(icons.ExternalLink, { style: { width: 10, height: 10 }, 'aria-hidden': true })]
+        })
+      }) }) : jsx('span', { className: 'hermes-radio-track-text', children: credit.artist })),
+      credit.artist && jsx('span', { className: 'hermes-radio-track-separator', 'aria-hidden': true, children: '—' }),
+      jsx(Tip, { label: text || undefined, children: jsx('span', { className: 'hermes-radio-track-text', children: credit.artist ? credit.title : text }) })
     ] })
   ] })
 }
@@ -525,7 +625,7 @@ function RadioBar({ player, ctx }) {
       }) }),
       jsx(PopoverContent, { side: 'top', align: 'end', className: 'hermes-radio-panel', 'aria-label': t('radio'), 'data-tour': 'radio-panel', children:
         jsxs('div', { children: [
-          jsx(Stations, { player }), jsx(Signal, { player }), jsx(Transport, { player, ctx })
+          jsx(Stations, { player }), jsx(Signal, { player, ctx }), jsx(Transport, { player, ctx })
         ] })
       })
     ] }),
@@ -533,6 +633,8 @@ function RadioBar({ player, ctx }) {
     jsx(SmallAction, { label: t('next'), icon: NextArrow, onClick: player.next })
   ] })
 }
+
+export { artistProfile, resolveArtist, trackCredit }
 
 export default {
   id: ID,


### PR DESCRIPTION
## What does this PR do?

Makes Radio's artist credit an outbound link to the artist's profile. The song title stays plain text. This follows the bundled Radio plugin in https://github.com/NousResearch/hermes-agent/pull/107072.

## Type of Change

- [x] New feature

## Changes Made

- Resolve exact, unambiguous artist names through Apple's public artist lookup. Fall back to MusicBrainz artist relationships for Spotify, Bandcamp, or official homepages.
- Accept direct artist URLs, not song or search links. Missing or ambiguous matches stay plain text without a dead anchor or invisible-icon gap.
- Keep the existing metadata row and SDK controls. No shell, SDK, backend, dependency, or default-enabled changes.
- Cache artist results for a day in the renderer query cache, pace MusicBrainz requests across windows, and document the lookup's network behavior.
- Add focused coverage for credit parsing, direct-profile URL selection, ambiguity, and provider fallback.

## How to Test

1. Enable Radio and play a metadata-supported station. Open the picker.
2. When an artist resolves, click their name. It should open their artist profile externally; the song title must not become a link.
3. Check an unresolved credit: plain text, no empty icon gap. Pausing must remove stale artist links.

## Verification

- [x] Four targeted tests pass across artist resolution and Radio lifecycle suites.
- [x] Renderer typecheck, changed-test ESLint, JavaScript syntax, and diff whitespace checks pass.
- [x] Live renderer verification resolved Komito to an Apple Music artist URL and exercised the link handler with an intercepted OS opener; no real browser launch was triggered by that probe.
- [x] Checked the returned Komito and Hello Meteor profile pages. Captured the plain-text credit state and verified no icon-sized gap or overlap.
- [ ] Full repository suite and cross-platform verification were not run.

MusicBrainz returned timeouts/503s during live checks; the Apple-first path avoids depending on its availability. Name matching cannot establish every artist identity, so this deliberately leaves missing or ambiguous results unlinked.
