### PR TITLE
test(agent): isolate auxiliary OAuth refresh credential lock

### DIFF
--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2746,9 +2746,15 @@ class TestAuxiliaryAuthRefreshRetry:
 
 
 
-    def test_refresh_provider_credentials_force_refreshes_anthropic_oauth_and_evicts_cache(self, monkeypatch):
+    def test_refresh_provider_credentials_force_refreshes_anthropic_oauth_and_evicts_cache(self, monkeypatch, tmp_path):
         stale_client = MagicMock()
         cache_key = ("anthropic", False, None, None, None)
+
+        # The refresh still acquires a real lock even when credential I/O is mocked.
+        monkeypatch.setattr(
+            "agent.anthropic_credentials.claude_code_credentials_path",
+            lambda: tmp_path / ".credentials.json",
+        )
 
         monkeypatch.setenv("ANTHROPIC_TOKEN", "")
         monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "")


### PR DESCRIPTION
## What does this PR do?

Keep the auxiliary Anthropic OAuth refresh test's credential lock inside pytest's temporary directory. The test already mocks credential reads, writes, and token refresh, but `_refresh_oauth_token()` still resolves the real Claude credential path before acquiring its cross-process lock. Running this test can therefore touch `~/.claude/.credentials.lock`; on a sandboxed Windows host it fails with permission denied instead of exercising refresh and cache eviction.

Pass `tmp_path` into the existing test and patch `claude_code_credentials_path()` to point there. The real lock and the existing refresh, credential-write, and stale-client-close assertions remain exercised. No production behavior changes.

## Related Issue

Found while validating an unrelated auxiliary quota fix. Searched issues and PRs for the test name, auxiliary OAuth isolation, and `credentials.lock`; no matching test-isolation fix found.

## Type of Change

- [x] Tests (test isolation)

## Changes Made

- `tests/agent/test_auxiliary_client.py`: isolate the credential path used by `test_refresh_provider_credentials_force_refreshes_anthropic_oauth_and_evicts_cache`.

## How to Test

Run `scripts/run_tests.sh tests/agent/test_auxiliary_client.py -j 1`.

Native Windows, Python 3.11.15: the original test fails when the sandbox denies access to the real-home credential lock. With this patch, all 204 tests in the file pass. `git diff --check` also passes. The full repository suite was not run.

## Checklist

- [x] Read the contributing guide and checked for existing fixes.
- [x] Kept the change limited to one existing test.
- [x] Reproduced the baseline failure and verified the existing behavior assertions after isolation.
- [x] Tested on native Windows; the temporary-path approach is platform independent.
- [ ] Full repository test suite passes (not run).
- [x] Documentation, config keys, tool schemas, and architecture updates: not applicable.
