### PR TITLE
feat(tools): terminal results surface mid-command environment recreation (port lobehub/lobehub#19329)

### DIFF
--- a/tests/tools/test_terminal_environment_recreated_notice.py
+++ b/tests/tools/test_terminal_environment_recreated_notice.py
@@ -1,0 +1,56 @@
+"""The model must be told when the backend replaced its container/sandbox
+mid-command (ported from lobehub/lobehub#19329): silent recovery leaves the
+agent assuming background processes and unsynced files survived."""
+
+import json
+
+from tools.environments import docker as docker_env
+from tools.environments.local import LocalEnvironment
+from tools.terminal_tool_result import finalize_foreground_result
+
+
+def test_execute_folds_recreation_flag_once():
+    """A pending recreation mark surfaces as ``environment_recreated: True``
+    on the next execute() result and is consumed — the following command
+    reports a clean result. Exercises the real BaseEnvironment.execute path."""
+    env = LocalEnvironment(cwd=".", timeout=30)
+    try:
+        env._mark_recreated()
+        result = env.execute("echo hi")
+        assert result["returncode"] == 0
+        assert result.get("environment_recreated") is True
+
+        result2 = env.execute("echo again")
+        assert "environment_recreated" not in result2
+    finally:
+        env.cleanup()
+
+
+def test_docker_recovery_marks_pending_and_finalizer_warns(monkeypatch):
+    """Docker's out-of-band recovery sets the pending mark, and the tool-layer
+    finalizer turns the flag into a model-facing warning — omitted entirely
+    when the backend never flagged a recreation."""
+    env = docker_env.DockerEnvironment.__new__(docker_env.DockerEnvironment)
+    env._container_id = "old"
+    env._labels = {}
+    env._image = ""
+    monkeypatch.setattr(
+        docker_env.DockerEnvironment, "_find_reusable_container",
+        lambda self, *a: ("newcid", "running"))
+    monkeypatch.setattr(docker_env.DockerEnvironment, "init_session", lambda self: None)
+    assert env._recreate_container() is True
+    assert getattr(env, "_recreated_notice_pending", False) is True
+
+    common: dict = dict(
+        command="echo hi", env=env, env_type="docker", effective_task_id="t",
+        task_id="t", session_id="s", session_key="k", workdir=None,
+        command_cwd=None, approval_note=None)
+
+    flagged = json.loads(finalize_foreground_result(
+        result={"output": "hi", "returncode": 0, "environment_recreated": True}, **common))
+    assert "recreated" in flagged.get("environment_recreated", "")
+    assert "may be lost" in flagged["environment_recreated"]
+
+    clean = json.loads(finalize_foreground_result(
+        result={"output": "hi", "returncode": 0}, **common))
+    assert "environment_recreated" not in clean

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -476,6 +476,15 @@ class BaseEnvironment(ABC):
         trigger their FileSyncManager here; bind-mount backends and Local don't."""
         pass
 
+    def _mark_recreated(self) -> None:
+        """Flag that the live container/sandbox was replaced while serving the
+        current command. ``execute`` folds the flag into the result as
+        ``environment_recreated`` so the tool layer can warn the model that
+        background processes died and non-persisted files may be gone —
+        without this the recovery is silent and the model keeps assuming the
+        old workspace state (lobehub/lobehub#19329 class)."""
+        self._recreated_notice_pending = True
+
     # --- Unified execute() ---
     def execute(
         self,
@@ -566,6 +575,9 @@ class BaseEnvironment(ABC):
             {"output": f"[Command timed out after {effective_timeout}s]", "returncode": 124}
             if bounded.timed_out else bounded.value)
         self._update_cwd(result)
+        if getattr(self, "_recreated_notice_pending", False):
+            self._recreated_notice_pending = False
+            result["environment_recreated"] = True
         return result
 
     def _kill_spawned_tree(self, spawned) -> None:

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -918,6 +918,7 @@ class DockerEnvironment(BaseEnvironment):
             return False
 
         logger.info("Recovery successful — new container %s", (self._container_id or "")[:12])
+        self._mark_recreated()
         return True
 
     def execute(self, command: str, cwd: str = "", **kwargs) -> dict:

--- a/tools/environments/vercel_sandbox.py
+++ b/tools/environments/vercel_sandbox.py
@@ -265,6 +265,7 @@ class VercelSandboxEnvironment(BaseEnvironment):
                     return
                 logger.warning("Vercel: sandbox entered state %s for task %s; recreating", status, self._task_id)
             self._close_sandbox_client(sandbox)
+            self._mark_recreated()
         self._attach_fresh_sandbox(requested_cwd)
 
     def _run_checked(self, script: str, label: str) -> None:

--- a/tools/terminal_tool_result.py
+++ b/tools/terminal_tool_result.py
@@ -76,6 +76,18 @@ _EXIT_CODE_SEMANTICS: dict[str, dict[int, str]] = {
     "git": {1: "Non-zero exit (often normal — e.g. 'git diff' returns 1 when files differ)"},
 }
 
+# Model-facing warning attached when the backend replaced its container/sandbox
+# mid-command (out-of-band removal, terminal sandbox state). Persistent-filesystem
+# state was restored, but background processes and anything outside the synced
+# paths are gone (ported from lobehub/lobehub#19329).
+_ENV_RECREATED_NOTE = (
+    "The execution environment was recreated while running this command "
+    "(the previous container/sandbox was gone). Persistent files were restored "
+    "where the backend supports it, but background processes and any files "
+    "outside persisted paths from earlier commands may be lost — verify state "
+    "before relying on prior work."
+)
+
 
 def _interpret_exit_code(command: str, exit_code: int) -> str | None:
     """Note for a non-zero exit code that is informational rather than an
@@ -251,6 +263,7 @@ def finalize_foreground_result(
     # metadata is present only when output overflowed the capture window.
     optional_fields: list[tuple[str, Any]] = [
         ("cwd", changed_cwd),
+        ("environment_recreated", _ENV_RECREATED_NOTE if result.get("environment_recreated") else None),
         *_redact_spill_file(result.get("full_output_path"), result.get("output_total_chars"), command),
         ("verification_evidence", _verification_evidence(
             command, command_cwd, session_id or task_id or effective_task_id or "default",


### PR DESCRIPTION
Terminal tool results now warn the model when the execution environment was recreated mid-command, instead of recovering silently.

Ported from lobehub/lobehub#19329 ("surface sandbox recreation in tool results"), adapted to hermes environment backends and the tool-result JSON contract.

## Symptom

When the persistent Docker container is removed out-of-band (idle reaper, `docker prune`, OOM, daemon restart) or a Vercel sandbox hits a terminal state, the backend recreates it and retries transparently. That recovery is correct — but it was **invisible to the model**: the retried command returns an ordinary-looking result, so the agent keeps assuming background processes and non-persisted files from earlier commands still exist, then builds on state that is gone.

## Change

- `tools/environments/base.py` — `_mark_recreated()` hook + one-shot fold into `execute()`'s result as `environment_recreated: True`.
- `tools/environments/docker.py` — `_recreate_container()` marks on successful recovery.
- `tools/environments/vercel_sandbox.py` — `_ensure_sandbox_ready()` marks when it discards a dead/terminal sandbox before attaching a fresh one.
- `tools/terminal_tool_result.py` — `finalize_foreground_result()` renders the flag as a model-facing `environment_recreated` warning field ("background processes and files outside persisted paths may be lost — verify state before relying on prior work"). Omitted entirely on clean runs, so unaffected results are byte-identical.

## Ours vs theirs

LobeHub threads a `sessionExpiredAndRecreated` flag from its sandbox service through tool runtimes into model-visible output, with copy asking the agent to confirm before regenerating prior work. Hermes already has the recovery mechanics (docker out-of-band recovery #36631, Vercel terminal-state reattach) but not the surfacing — this PR ports exactly the missing half: signal from the provider's own recovery path (never inferred from command errors, matching their key decision), one-shot, warn-only.

## Validation

| Check | Result |
|---|---|
| New invariant tests (2) | red on `origin/main` files, green with fix (A/B verified by checking out base copies of the 4 touched files) |
| E2E through real tool dispatch (`tools.terminal_tool._handle_terminal`, temp `HERMES_HOME`, real LocalEnvironment) | positive: `environment_recreated` warning present after `_mark_recreated()`; negative: absent on next command |
| `scripts/run_tests.sh tests/tools/` | only pre-existing failures (`test_modal_snapshot_isolation`, `test_web_tools_config`, `test_execution_flag_detection`) — identical failures reproduced on unmodified `origin/main` in a clean worktree |
| ruff / windows-footguns / compat pointers / `git diff --check` | clean |

**Live repro:** before — `env._mark_recreated()` + terminal call on base code returns plain JSON with no hint the sandbox was replaced; after — the same call returns `"environment_recreated": "The execution environment was recreated while running this command … may be lost — verify state before relying on prior work."`, and the immediately following command carries no field.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9d1d3/-sh6yCNAY4mLfPPZo-pTD_kMNPe418.png)
