### PR TITLE
fix(openviking): update forget URIs and fail closed on identity

### DIFF
--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -168,9 +168,10 @@ memory URI.
 
 `viking_forget` is intentionally narrow. It only accepts concrete user memory
 file URIs, such as
-`viking://user/default/peers/hermes/memories/preferences/mem_abc123.md` (any
-explicit user id works; `viking://~/...` input is passed through untouched for
-deployments where the server expands the home alias). Files
+`viking://user/default/peers/hermes/memories/preferences/mem_abc123.md`, or the
+`viking://~/...` self alias. Under `viking://user/...` the user id is required
+and must match the calling identity; the uid-less `viking://user/memories/...`
+and `viking://user/peers/...` shorthands are deprecated and rejected. Files
 directly under `memories/`, such as `viking://user/default/memories/profile.md`,
 are also allowed because OpenViking supports them. The tool rejects directories,
 resources, skills, sessions, generated summary files, and URIs with query

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -9,11 +9,11 @@ Context database by Volcengine (ByteDance) with filesystem-style knowledge hiera
   then `openviking-server doctor`)
 - OpenViking server running and reachable from Hermes
 
-OpenViking 0.2.10 or newer is recommended. For backward compatibility,
-Hermes can identify older servers that expose the legacy status-only health
-response, but only when anonymous OpenAPI metadata also identifies the service
-as OpenViking. OpenViking 0.2.6 and earlier are deprecated for this integration;
-upgrade them to receive the current health contract and compatibility fixes.
+OpenViking 0.2.14 or newer is required. Hermes can identify older servers that
+expose the legacy status-only health response, but those releases do not provide
+the authenticated-user identity contract required by this integration.
+The `viking://~` home alias requires OpenViking 0.4.16 or newer for user and
+admin credentials, and OpenViking 0.4.17 or newer for root or local development.
 
 ## Setup
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -490,7 +490,7 @@ def _is_windows_absolute_path(value: str) -> bool:
     return len(value) >= 3 and value[0].isalpha() and value[1] == ":" and value[2] in {"/", "\\"}
 
 
-def _validate_forget_memory_uri(raw_uri: Any) -> tuple[Optional[str], Optional[str]]:
+def _validate_forget_memory_uri(raw_uri: Any, *, user_space: Optional[str] = None) -> tuple[Optional[str], Optional[str]]:
     uri = raw_uri.strip() if isinstance(raw_uri, str) else ""
     if not uri:
         return None, "uri is required"
@@ -502,11 +502,17 @@ def _validate_forget_memory_uri(raw_uri: Any) -> tuple[Optional[str], Optional[s
     if uri.endswith("/") or not uri.endswith(".md"):
         return None, "viking_forget only deletes concrete .md memory files"
     parts = [part for part in uri[len("viking://") :].split("/") if part]
-    # ``memories`` segment index for the user / user-uid / peer / uid-peer layouts.
-    memories_idx = next((idx for idx, peer_at in ((1, None), (2, None), (3, 1), (4, 2))
-                         if parts[:1] == ["user"] and len(parts) > idx and parts[idx] == "memories" and (peer_at is None or parts[peer_at] == "peers")), None)
+    # ``memories`` index for ``<scope>/[peers/<agent>/]memories/``; under ``user`` the uid is
+    # required, since the uid-less shorthands are deprecated upstream.
+    offsets = ((1, None), (3, 1)) if parts[:1] == ["~"] else ((2, None), (4, 2)) if parts[:1] == ["user"] else ()
+    memories_idx = next((idx for idx, peer_at in offsets
+                         if len(parts) > idx and parts[idx] == "memories" and (peer_at is None or parts[peer_at] == "peers")), None)
     if memories_idx is None or len(parts) < memories_idx + 2:
         return None, "viking_forget only deletes user memory file URIs"
+    # An explicit uid can name someone else's space; the server answers PERMISSION_DENIED either way.
+    if parts[0] == "user" and user_space and parts[1] != user_space:
+        return None, (f"viking_forget only deletes your own memories; use viking://user/{user_space}/... "
+                      "or viking://~/... instead")
     if uri.rsplit("/", 1)[-1] in _GENERATED_MEMORY_SUMMARY_FILENAMES:
         return None, "viking_forget cannot delete generated memory summary files"
     return uri, None
@@ -2635,7 +2641,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
         })
 
     def _tool_forget(self, args: dict) -> str:
-        uri, error = _validate_forget_memory_uri(args.get("uri"))
+        # _resolve_user_space, not _user_space: its "default" fallback is a guess, not an identity.
+        uri, error = _validate_forget_memory_uri(args.get("uri"), user_space=_resolve_user_space(self._client))
         if error:
             return tool_error(error)
         result = self._unwrap_result(self._client.delete("/api/v1/fs", params={"uri": uri, "recursive": False}))

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -99,9 +99,9 @@ _CONFIG_SCHEMA = [
 # Typed settings (config.yaml primary, env override) keyed by config key.
 _SETTING_SPECS = {f["key"]: f for f in _CONFIG_SCHEMA if "type" in f}
 _RECALL_SETTING_KEYS = tuple(k for k in _SETTING_SPECS if k.startswith("recall_"))
-# Explicit-uid URIs (viking://user/<uid>/...) work under every auth mode; the `~`
-# alias only expands for USER/ADMIN roles and is rejected with 400 under dev/ROOT,
-# so the user space is resolved client-side from /api/v1/system/status.
+# Explicit-uid URIs (viking://user/<uid>/...) work under every auth mode and
+# supported OpenViking version. The `~` alias requires OpenViking 0.4.16+ for
+# USER/ADMIN roles and 0.4.17+ for ROOT, so internal paths remain explicit.
 _SESSION_START_SUFFIXES = ("memories/profile.md", "memories/preferences", "memories/entities")
 _SESSION_START_LIST_PARAMS = {"output": "agent", "recursive": True, "abs_limit": 512, "node_limit": 512}
 # Built-in memory tool `target` -> mirror subdir (user facts -> preferences, agent notes -> patterns).
@@ -128,7 +128,7 @@ _FIX_ENDPOINT = "OpenViking memory is temporarily unavailable; correct the endpo
 _HTTPX_MISSING = "httpx not installed — OpenViking plugin disabled"
 _LEGACY_OPENVIKING_IDENTITY_DETAIL = (
     "returned OpenViking's legacy health response, but its anonymous OpenAPI metadata did not identify OpenViking. "
-    "If this is OpenViking 0.2.6 or earlier, upgrade to OpenViking 0.2.10 or newer."
+    "If this is OpenViking 0.2.6 or earlier, upgrade to OpenViking 0.2.14 or newer."
 )
 _PENDING_SESSIONS_RELATIVE_DIR = Path("openviking") / "pending_sessions"
 _RUN_LOCKS_RELATIVE_DIR = Path("openviking") / "runs"
@@ -509,10 +509,14 @@ def _validate_forget_memory_uri(raw_uri: Any, *, user_space: Optional[str] = Non
                          if len(parts) > idx and parts[idx] == "memories" and (peer_at is None or parts[peer_at] == "peers")), None)
     if memories_idx is None or len(parts) < memories_idx + 2:
         return None, "viking_forget only deletes user memory file URIs"
-    # An explicit uid can name someone else's space; the server answers PERMISSION_DENIED either way.
-    if parts[0] == "user" and user_space and parts[1] != user_space:
-        return None, (f"viking_forget only deletes your own memories; use viking://user/{user_space}/... "
-                      "or viking://~/... instead")
+    # An explicit uid can name someone else's space. Do not send a destructive
+    # request unless the server has confirmed that this uid belongs to the caller.
+    if parts[0] == "user":
+        if not user_space:
+            return None, "viking_forget could not verify the current OpenViking user identity; retry or use viking://~/..."
+        if parts[1] != user_space:
+            return None, (f"viking_forget only deletes your own memories; use viking://user/{user_space}/... "
+                          "or viking://~/... instead")
     if uri.rsplit("/", 1)[-1] in _GENERATED_MEMORY_SUMMARY_FILENAMES:
         return None, "viking_forget cannot delete generated memory summary files"
     return uri, None
@@ -2429,9 +2433,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
         reload mid-write can't borrow a later peer; an empty peer there is intentional.
         getattr(): hand-wired providers (``__new__``) may lack ``_client`` / ``_agent``.
         """
-        # Explicit-uid URIs are canonical under every auth mode; the uid-less `viking://user/peers/...`
-        # shorthand was removed upstream (#4196) and `viking://~/...` only expands for USER/ADMIN roles, not
-        # dev/ROOT.
+        # Explicit-uid URIs are canonical across supported OpenViking versions. The
+        # uid-less shorthand was removed upstream, and `viking://~` is newer.
         active_client = client if client is not None else getattr(self, "_client", None)
         agent = str(getattr(active_client, "_agent", getattr(self, "_agent", "")) or "").strip()
         peer_prefix = f"peers/{agent}/" if agent else ""

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -502,6 +502,8 @@ def _validate_forget_memory_uri(raw_uri: Any, *, user_space: Optional[str] = Non
     if uri.endswith("/") or not uri.endswith(".md"):
         return None, "viking_forget only deletes concrete .md memory files"
     parts = [part for part in uri[len("viking://") :].split("/") if part]
+    if any(unquote(part) in {".", ".."} for part in parts):
+        return None, "viking_forget does not accept dot path segments"
     # ``memories`` index for ``<scope>/[peers/<agent>/]memories/``; under ``user`` the uid is
     # required, since the uid-less shorthands are deprecated upstream.
     offsets = ((1, None), (3, 1)) if parts[:1] == ["~"] else ((2, None), (4, 2)) if parts[:1] == ["user"] else ()

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -12,6 +12,7 @@ from hermes_cli import __version__ as _HERMES_VERSION
 from plugins.memory.openviking import (
     OpenVikingMemoryProvider,
     _VikingClient,
+    _validate_forget_memory_uri,
 )
 
 _EXPECTED_USER_AGENT = f"openviking-memory-hermes/{_HERMES_VERSION}"
@@ -728,6 +729,56 @@ def test_get_tool_schemas_omits_profile_and_keeps_narrow_forget_tools():
     assert "viking_forget" in names
 
 
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "viking://user/zayn/memories/profile.md",
+        "viking://user/zayn/memories/preferences/mem_abc123.md",
+        "viking://user/zayn/peers/hermes/memories/preferences/mem_abc123.md",
+        # Self alias.
+        "viking://~/memories/profile.md",
+        "viking://~/memories/preferences/mem_abc123.md",
+        "viking://~/peers/hermes/memories/preferences/mem_abc123.md",
+    ],
+)
+def test_validate_forget_memory_uri_accepts_canonical(uri):
+    assert _validate_forget_memory_uri(uri) == (uri, None)
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        # Deprecated uid-less shorthands.
+        "viking://user/memories/preferences/mem_abc123.md",
+        "viking://user/peers/hermes/memories/preferences/mem_abc123.md",
+        # Non-memory scopes and generated summaries.
+        "viking://user/zayn/sessions/s1/mem_abc123.md",
+        "viking://resources/docs/note.md",
+        "viking://user/zayn/memories/preferences/.abstract.md",
+        # Directories, non-markdown, query/fragment.
+        "viking://user/zayn/memories/preferences/",
+        "viking://user/zayn/memories/preferences/mem_abc123.txt",
+        "viking://user/zayn/memories/preferences/mem_abc123.md?force=1",
+    ],
+)
+def test_validate_forget_memory_uri_rejects_non_canonical(uri):
+    resolved, error = _validate_forget_memory_uri(uri)
+    assert resolved is None and error
+
+
+def test_validate_forget_memory_uri_rejects_other_user_space():
+    mine = "viking://user/zayn/memories/preferences/mem_abc123.md"
+    theirs = "viking://user/someone-else/memories/preferences/mem_abc123.md"
+
+    assert _validate_forget_memory_uri(mine, user_space="zayn") == (mine, None)
+    assert _validate_forget_memory_uri("viking://~/memories/preferences/mem_abc123.md", user_space="zayn")[1] is None
+
+    resolved, error = _validate_forget_memory_uri(theirs, user_space="zayn")
+    assert resolved is None and "your own memories" in error
+    # Unverified identity leaves the check to the server rather than blocking a legitimate delete.
+    assert _validate_forget_memory_uri(theirs, user_space=None) == (theirs, None)
+
+
 def test_viking_client_delete_uses_identity_headers(monkeypatch):
     client = _VikingClient(
         "https://example.com",
@@ -744,18 +795,18 @@ def test_viking_client_delete_uses_identity_headers(monkeypatch):
         return SimpleNamespace(
             status_code=200,
             text="",
-            json=lambda: {"status": "ok", "result": {"uri": "viking://~/memories/x.md"}},
+            json=lambda: {"status": "ok", "result": {"uri": "viking://user/zayn/memories/x.md"}},
             raise_for_status=lambda: None,
         )
 
     monkeypatch.setattr(client._httpx, "delete", capture_delete)
 
-    assert client.delete("/api/v1/fs", params={"uri": "viking://~/memories/x.md"}) == {
+    assert client.delete("/api/v1/fs", params={"uri": "viking://user/zayn/memories/x.md"}) == {
         "status": "ok",
-        "result": {"uri": "viking://~/memories/x.md"},
+        "result": {"uri": "viking://user/zayn/memories/x.md"},
     }
     assert captured["url"] == "https://example.com/api/v1/fs"
-    assert captured["kwargs"]["params"] == {"uri": "viking://~/memories/x.md"}
+    assert captured["kwargs"]["params"] == {"uri": "viking://user/zayn/memories/x.md"}
     assert captured["kwargs"]["headers"]["Authorization"] == "Bearer test-key"
     assert captured["kwargs"]["headers"]["X-OpenViking-Actor-Peer"] == "hermes"
     assert captured["kwargs"]["headers"]["User-Agent"] == _EXPECTED_USER_AGENT

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -767,6 +767,23 @@ def test_validate_forget_memory_uri_rejects_non_canonical(uri):
     assert resolved is None and error
 
 
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "viking://user/alice/memories/./x.md",
+        "viking://user/alice/memories/../../user/bob/memories/x.md",
+        "viking://user/alice/memories/%2e/x.md",
+        "viking://user/alice/memories/%2e%2e/x.md",
+        "viking://~/memories/../x.md",
+    ],
+)
+def test_validate_forget_memory_uri_rejects_dot_segments(uri):
+    resolved, error = _validate_forget_memory_uri(uri, user_space="alice")
+
+    assert resolved is None
+    assert "dot path segments" in error
+
+
 def test_validate_forget_memory_uri_rejects_other_user_space():
     mine = "viking://user/zayn/memories/preferences/mem_abc123.md"
     theirs = "viking://user/someone-else/memories/preferences/mem_abc123.md"

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -742,7 +742,8 @@ def test_get_tool_schemas_omits_profile_and_keeps_narrow_forget_tools():
     ],
 )
 def test_validate_forget_memory_uri_accepts_canonical(uri):
-    assert _validate_forget_memory_uri(uri) == (uri, None)
+    user_space = "zayn" if uri.startswith("viking://user/") else None
+    assert _validate_forget_memory_uri(uri, user_space=user_space) == (uri, None)
 
 
 @pytest.mark.parametrize(
@@ -775,8 +776,22 @@ def test_validate_forget_memory_uri_rejects_other_user_space():
 
     resolved, error = _validate_forget_memory_uri(theirs, user_space="zayn")
     assert resolved is None and "your own memories" in error
-    # Unverified identity leaves the check to the server rather than blocking a legitimate delete.
-    assert _validate_forget_memory_uri(theirs, user_space=None) == (theirs, None)
+    resolved, error = _validate_forget_memory_uri(theirs, user_space=None)
+    assert resolved is None and "verify the current OpenViking user" in error
+
+
+def test_tool_forget_rejects_explicit_user_when_identity_unavailable():
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.get.side_effect = RuntimeError("identity probe unavailable")
+
+    result = json.loads(provider._tool_forget({
+        "uri": "viking://user/alice/memories/preferences/mem_abc123.md",
+    }))
+
+    assert "error" in result
+    assert "identity" in result["error"].lower()
+    provider._client.delete.assert_not_called()
 
 
 def test_viking_client_delete_uses_identity_headers(monkeypatch):
@@ -1060,7 +1075,7 @@ def test_legacy_health_requires_openviking_openapi_identity_before_auth(monkeypa
     assert valid is False
     assert role is None
     assert "0.2.6 or earlier" in message
-    assert "0.2.10 or newer" in message
+    assert "0.2.14 or newer" in message
     assert events == ["health", "openapi"]
 
 


### PR DESCRIPTION
## Summary

Supersedes #106558 and preserves @ZaynJarvis's original commit and authorship.

- accept `viking://~/...` memory files in `viking_forget`
- reject the removed `viking://user/memories/...` and `viking://user/peers/...` shorthands
- reject explicit `viking://user/<id>/...` deletes when the ID differs from the authenticated OpenViking user
- fail closed when Hermes cannot verify the authenticated user before an explicit-user delete
- reject literal and percent-encoded dot path segments before sending a delete request
- document the OpenViking 0.2.14 identity requirement and the 0.4.16/0.4.17 home-alias version boundaries

OpenViking expands `viking://~` at the request boundary and returns canonical `viking://user/<user_id>/...` URIs. Hermes continues to use explicit-user URIs for internal write and session paths.

The dot-segment check is strict client-side validation and defense in depth. Supported OpenViking versions also reject literal traversal segments in the storage layer.

## Test plan

- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/plugins/memory/test_openviking_provider.py tests/openviking_plugin`
- `uv run --extra dev ruff check plugins/memory/openviking/__init__.py tests/plugins/memory/test_openviking_provider.py`
- `git diff --check upstream/main...HEAD`

All 133 focused tests pass.
