### PR TITLE
fix(ancos): reconcile validated VPS session ownership changes

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1815,6 +1815,27 @@ def _build_context_engine(agent, _agent_cfg, cs, _custom_providers, _effective_c
     _selected_engine = _select_context_engine(_agent_cfg)
     if _selected_engine is not None:
         agent.context_compressor = _selected_engine
+        # Context-engine plugin controls are supplied from the context config block.
+        # Keep defaults unchanged; only explicitly configured plugin attributes are applied.
+        _ctx_cfg = _agent_cfg.get("context", {}) if isinstance(_agent_cfg, dict) else {}
+        if isinstance(_ctx_cfg, dict):
+            for _attr in (
+                "intelligence_enabled",
+                "memory_integration_enabled",
+                "history_retrieval_enabled",
+                "history_retrieval_limit",
+                "history_retrieval_max_messages",
+                "history_retrieval_max_chars_per_message",
+                "history_retrieval_min_relevance",
+                "history_retrieval_query_max_words",
+                "history_recall_intent_terms",
+                "memory_max_entry_chars",
+                "supplement_max_ratio",
+            ):
+                if _attr in _ctx_cfg and hasattr(agent.context_compressor, _attr):
+                    setattr(agent.context_compressor, _attr, _ctx_cfg[_attr])
+        if hasattr(agent.context_compressor, "user_id"):
+            agent.context_compressor.user_id = getattr(agent, "_user_id", None)
         # External engines own compaction policy — the host threshold (and its Codex
         # autoraise) never reaches the plugin, so drop the notice.
         agent._compression_threshold_autoraised = None

--- a/agent/inline_tool_executors.py
+++ b/agent/inline_tool_executors.py
@@ -94,6 +94,12 @@ def _callback_tool(module: str, func: str, callback_attr: str, *arg_specs: _ArgS
 
 
 def _session_search(agent, args: dict, ctx: InlineToolContext) -> Any:
+    owner_user_id = getattr(agent, "_user_id", None)
+    if not str(owner_user_id or "").strip():
+        # T4 history retrieval is fail-closed when the transport did not establish
+        # a user ownership identity (legacy CLI/NULL-owner sessions are not eligible).
+        from tools.session_search_tool import _ownership_error
+        return _ownership_error()
     session_db = agent._get_session_db_for_recall()
     if not session_db:
         from hermes_state import format_session_db_unavailable
@@ -106,7 +112,7 @@ def _session_search(agent, args: dict, ctx: InlineToolContext) -> Any:
             ("session_id", "session_id"), ("around_message_id", "around_message_id"),
             ("window", "window", 5), ("sort", "sort"), ("detail", "detail", "adaptive"),
         ),
-        db=session_db, current_session_id=agent.session_id,
+        db=session_db, current_session_id=agent.session_id, user_id=getattr(agent, "_user_id", None),
     )
 
 

--- a/plugins/context_engine/bounded/__init__.py
+++ b/plugins/context_engine/bounded/__init__.py
@@ -1,0 +1,709 @@
+"""Bounded context selection plugin: ``plugins/context_engine/bounded``.
+
+Replaces the pre-generation context for every provider request with a deterministic
+subset that (a) preserves the system prompt, the current user request and the newest
+pending tool chain, (b) stays within a *hard budget* derived from the model context
+window (``budget_ratio`` of the window minus an output/tool-schema reserve), and (c)
+never mutates persisted history or the original request message list.
+
+This is "selection", not "compression": ``compress()`` shrinks an over-long transcript
+via the wrapped compressor lifecycle, while ``select_context`` bounds the request that
+goes on the wire each turn. Selection is deterministic, uses no LLM embeddings, and
+fails open (returns ``None``) on any error so the host's normal preflight/compression
+path still governs.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
+
+from agent.context_engine import ContextEngine
+
+if TYPE_CHECKING:
+    from agent.context_compressor import ContextCompressor
+
+logger = logging.getLogger("plugins.context_engine.bounded")
+
+__all__ = ["BoundedContextEngine", "register"]
+
+#: Truncation marker inserted where an oversized retained tool result is clamped.
+_CLAMP_MARKER = "\n...[clamped by hermes bounded context]...\n"
+
+SelectResult = Tuple[List[Dict[str, Any]], int, int, int, int, int, str]
+
+
+class BoundedContextEngine(ContextEngine):
+    """Plugin context engine: bounded, deterministic, replay-safe request selection."""
+
+    #: Attributes the host may write on the plugin that govern the wrapped compressor's
+    #: compaction policy; mirrored to it so the plugin stays the single interface.
+    _MIRRORED_ATTRS = frozenset({
+        "model_thresholds",
+        "_micro_compact_enabled",
+        "_micro_compact_every_n_turns",
+        "_micro_compact_defrag_threshold_tokens",
+    })
+
+    def __init__(
+        self,
+        *,
+        budget_ratio: float = 0.5,
+        reserve_cap_ratio: float = 0.20,
+        output_reserve_tokens: int = 4096,
+        tool_schema_reserve_tokens: int = 8192,
+        recent_window_messages: int = 40,
+        min_recent_tail_messages: int = 8,
+        head_anchor_messages: int = 3,
+        max_relevant_messages: int = 24,
+        relevance_floor_score: int = 2,
+        relevance_min_tokens: int = 1024,
+        relevance_max_tokens: int = 8192,
+        max_tool_result_chars: int = 12000,
+        clamp_head_ratio: float = 0.7,
+        clamp_tail_ratio: float = 0.2,
+        enabled: bool = True,
+    ) -> None:
+        super().__init__()
+        object.__setattr__(self, "_compressor", None)
+        object.__setattr__(self, "model", "")
+        object.__setattr__(self, "_session_id", None)
+        self.enabled = bool(enabled)
+        self.budget_ratio = float(budget_ratio)
+        self.reserve_cap_ratio = float(reserve_cap_ratio)
+        self.output_reserve_tokens = int(output_reserve_tokens)
+        self.tool_schema_reserve_tokens = int(tool_schema_reserve_tokens)
+        self.recent_window_messages = max(1, int(recent_window_messages))
+        self.min_recent_tail_messages = max(1, int(min_recent_tail_messages))
+        self.head_anchor_messages = max(0, int(head_anchor_messages))
+        self.max_relevant_messages = max(0, int(max_relevant_messages))
+        self.relevance_floor_score = max(0, int(relevance_floor_score))
+        self.relevance_min_tokens = max(0, int(relevance_min_tokens))
+        self.relevance_max_tokens = max(0, int(relevance_max_tokens))
+        self.max_tool_result_chars = max(256, int(max_tool_result_chars))
+        self.clamp_head_ratio = float(clamp_head_ratio)
+        self.clamp_tail_ratio = float(clamp_tail_ratio)
+        self._selection_count = 0
+
+    @property
+    def name(self) -> str:
+        return "bounded"
+
+    # -- attribute mirroring to the wrapped compressor ---------------------------------
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in self._MIRRORED_ATTRS:
+            inner = self.__dict__.get("_compressor")
+            if inner is not None:
+                setattr(inner, name, value)
+        object.__setattr__(self, name, value)
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        inner = self.__dict__.get("_compressor")
+        if inner is not None and hasattr(inner, name):
+            return getattr(inner, name)
+        raise AttributeError(name)
+
+    # -- compressor lifecycle (delegated; owns compaction policy) ---------------------
+    def _ensure_compressor(self) -> "ContextCompressor":
+        inner = self.__dict__.get("_compressor")
+        if inner is not None:
+            return inner
+        from agent.context_compressor import ContextCompressor
+
+        inner = ContextCompressor(
+            model=getattr(self, "model", "") or "unknown",
+            threshold_percent=0.50,
+            protect_first_n=3,
+            protect_last_n=6,
+            quiet_mode=True,
+        )
+        object.__setattr__(self, "_compressor", inner)
+        return inner
+
+    def _inner(self) -> Optional["ContextCompressor"]:
+        return self.__dict__.get("_compressor")
+
+    def update_model(
+        self,
+        model: str,
+        context_length: int,
+        base_url: str = "",
+        api_key: str = "",
+        provider: str = "",
+        api_mode: str = "",
+    ) -> None:
+        object.__setattr__(self, "model", model)
+        super().update_model(
+            model,
+            context_length,
+            base_url=base_url,
+            api_key=api_key,
+            provider=provider,
+            api_mode=api_mode,
+        )
+        try:
+            inner = self._ensure_compressor()
+            inner.update_model(
+                model,
+                context_length,
+                base_url=base_url,
+                api_key=api_key,
+                provider=provider,
+                api_mode=api_mode,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("bounded: compressor update_model failed: %s", exc)
+
+    def bind_session_state(self, session_state: Any) -> None:
+        try:
+            inner = self._ensure_compressor()
+            return inner.bind_session_state(session_state)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("bounded: bind_session_state failed: %s", exc)
+            return None
+
+    def on_session_start(self, session_id: str, **kwargs: Any) -> None:
+        object.__setattr__(self, "_session_id", session_id)
+        inner = self._inner()
+        if inner is not None and hasattr(inner, "on_session_start"):
+            try:
+                return inner.on_session_start(session_id, **kwargs)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("bounded: on_session_start failed: %s", exc)
+                return None
+        return None
+
+    def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
+        inner = self._inner()
+        if inner is not None and hasattr(inner, "on_session_end"):
+            try:
+                return inner.on_session_end(session_id, messages)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("bounded: on_session_end failed: %s", exc)
+                return None
+        return None
+
+    def on_session_reset(self) -> None:
+        super().on_session_reset()
+        inner = self._inner()
+        if inner is not None and hasattr(inner, "on_session_reset"):
+            try:
+                inner.on_session_reset()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("bounded: on_session_reset failed: %s", exc)
+
+    def update_from_response(self, usage: Dict[str, Any]) -> None:
+        inner = self._inner()
+        if inner is not None:
+            return inner.update_from_response(usage)
+        pt = (usage or {}).get("prompt_tokens") or 0
+        ct = (usage or {}).get("completion_tokens") or 0
+        self.last_prompt_tokens = int(pt)
+        self.last_completion_tokens = int(ct)
+        self.last_total_tokens = int(pt) + int(ct)
+
+    def should_compress(self, prompt_tokens: Optional[int] = None) -> bool:
+        inner = self._inner()
+        if inner is None:
+            return False
+        return inner.should_compress(prompt_tokens)  # type: ignore[invalid-argument-type]
+
+    def should_compress_info(
+        self, prompt_tokens: Optional[int] = None
+    ) -> Tuple[bool, Optional[str]]:
+        inner = self._inner()
+        if inner is None or not hasattr(inner, "should_compress_info"):
+            return self.should_compress(prompt_tokens), None
+        return inner.should_compress_info(prompt_tokens)  # type: ignore[invalid-argument-type]
+
+    def compress(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: Optional[int] = None,
+        focus_topic: Optional[str] = None,
+        force: bool = False,
+        memory_context: str = "",
+    ) -> List[Dict[str, Any]]:
+        inner = self._inner()
+        if inner is None:
+            return messages
+        return inner.compress(
+            messages,
+            current_tokens=current_tokens,
+            focus_topic=focus_topic,
+            force=force,
+            memory_context=memory_context,
+        )
+
+    def prune_tool_results_only(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: Optional[int] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        inner = self._inner()
+        if inner is None:
+            return messages, 0
+        return inner.prune_tool_results_only(messages, current_tokens=current_tokens)
+
+    def has_content_to_compress(self, messages: List[Dict[str, Any]]) -> bool:
+        inner = self._inner()
+        if inner is None:
+            return True
+        return inner.has_content_to_compress(messages)
+
+    def get_status(self) -> Dict[str, Any]:
+        status = super().get_status()
+        status.update({
+            "engine": self.name,
+            "selection_enabled": self.enabled,
+            "selection_count": self._selection_count,
+        })
+        inner = self._inner()
+        if inner is not None and hasattr(inner, "get_status"):
+            try:
+                inner_status = inner.get_status()
+                if isinstance(inner_status, dict):
+                    status.update(inner_status)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("bounded: get_status() failed: %s", exc)
+        return status
+
+    # ---- hard budget ----------------------------------------------------------------
+    def _hard_budget_for(self, context_length: int) -> int:
+        def _capped(value: int) -> int:
+            return min(int(value), int(context_length * 0.10))
+
+        reserve = min(
+            int(context_length * self.reserve_cap_ratio),
+            _capped(self.output_reserve_tokens)
+            + _capped(self.tool_schema_reserve_tokens),
+        )
+        return max(0, int(context_length * self.budget_ratio) - reserve)
+
+    # ---- selection ------------------------------------------------------------------
+    def select_context(
+        self,
+        request_messages: List[Dict[str, Any]],
+        *,
+        conversation_messages: Optional[List[Dict[str, Any]]] = None,
+        incoming_message: Optional[Dict[str, Any]] = None,
+        budget_tokens: int = 0,
+    ) -> Optional[List[Dict[str, Any]]]:  # type: ignore[invalid-method-override]
+        if not self.enabled:
+            return None
+        if not isinstance(request_messages, list) or not request_messages:
+            return None
+        context_length = budget_tokens or self.context_length or 0
+        if context_length <= 0:
+            return None
+        hard_budget = self._hard_budget_for(context_length)
+        if hard_budget <= 0:
+            return None
+        try:
+            result = self._select(request_messages, hard_budget)
+        except Exception as exc:  # fail open: never break the request pipeline
+            logger.warning(
+                "bounded: selection failed, leaving request unchanged: %s", exc
+            )
+            return None
+        self._selection_count += 1
+        if result is None:
+            return None
+        selected, in_tokens, out_tokens, omitted, pruned, clamped, mode = result
+        safe = {
+            "session_id": self._session_id,
+            "mode": mode,
+            "input_messages": len(request_messages),
+            "output_messages": len(selected),
+            "input_tokens_est": in_tokens,
+            "selected_tokens_est": out_tokens,
+            "budget_tokens": context_length,
+            "hard_budget": hard_budget,
+            "omitted_messages": omitted,
+            "pruned_tool_results": pruned,
+            "clamped_tool_results": clamped,
+        }
+        logger.info("bounded selection: %s", safe)
+        return selected
+
+    def _select(
+        self, request_messages: List[Dict[str, Any]], hard_budget: int
+    ) -> Optional[SelectResult]:
+        estimate = _current_request_estimator()
+        in_tokens = estimate(request_messages)
+        if in_tokens <= hard_budget:
+            return request_messages, in_tokens, in_tokens, 0, 0, 0, "short"
+
+        n = len(request_messages)
+        system_idx = {i for i, m in enumerate(request_messages) if _is_system(m)}
+        systems_msgs = [request_messages[i] for i in sorted(system_idx)]
+        first_non_system = next((i for i in range(n) if i not in system_idx), 0)
+        current_idx = _current_request_index(request_messages)
+        if current_idx is None:
+            current_idx = first_non_system
+        pending = _newest_tool_group_indices(request_messages, after_index=current_idx)
+
+        mandatory = set(system_idx) | {current_idx} | pending
+        mandatory_est = sum(estimate([request_messages[i]]) for i in mandatory)
+        if mandatory_est > hard_budget:
+            return None
+        remaining = hard_budget - mandatory_est
+
+        window_ids: List[int] = []
+        est_window = 0
+        limit_front = max(0, current_idx - self.recent_window_messages)
+        j = current_idx - 1
+        while j >= limit_front:
+            m = request_messages[j]
+            if len(window_ids) < self.min_recent_tail_messages:
+                window_ids.append(j)
+                est_window += estimate([m])
+                j -= 1
+                continue
+            if est_window + estimate([m]) > remaining:
+                break
+            window_ids.append(j)
+            est_window += estimate([m])
+            j -= 1
+        window_ids.reverse()
+
+        mandatory_ids = set(mandatory)
+        keep_ids = sorted(set(window_ids) | (mandatory_ids - set(system_idx)))
+        trimmable_identities = {
+            id(request_messages[i]) for i in set(window_ids) if i not in mandatory_ids
+        }
+        original_identities = {id(request_messages[i]) for i in keep_ids}
+        protected_positions = {pos for pos, i in enumerate(keep_ids) if i in pending}
+
+        window_msgs = [request_messages[i] for i in keep_ids]
+        window_msgs = self._clamp_window(
+            window_msgs, protected_positions, hard_budget, estimate
+        )
+        clamped = sum(1 for m in window_msgs if id(m) not in original_identities)
+        window_msgs, pruned = _enforce_pair_validity(window_msgs)
+
+        final = systems_msgs + window_msgs
+        final_est = estimate(final)
+        if final_est > hard_budget:
+            final, final_est = _trim_from_front_until_fit(
+                final, hard_budget, estimate, trimmable_identities=trimmable_identities
+            )
+            final, pruned_extra = _enforce_pair_validity(final)
+            pruned += pruned_extra
+            final_est = estimate(final)
+        if final_est > hard_budget:
+            return None
+
+        room = hard_budget - final_est
+        if room >= self.relevance_min_tokens and (
+            self.head_anchor_messages > 0 or self.max_relevant_messages > 0
+        ):
+            preamble = self._build_preamble(
+                request_messages,
+                current_idx,
+                system_idx,
+                current_idx,
+                room,
+                estimate,
+                exclude_indices=set(keep_ids),
+            )
+            if preamble:
+                candidate = systems_msgs + preamble + window_msgs
+                candidate_est = estimate(candidate)
+                if candidate_est <= hard_budget:
+                    final, final_est = candidate, candidate_est
+
+        omitted = n - len(final)
+        mode = "selected_pruned" if (clamped or pruned) else "selected"
+        return final, in_tokens, final_est, omitted, pruned, clamped, mode
+
+    def _clamp_window(
+        self,
+        window_msgs: List[Dict[str, Any]],
+        protected: Set[int],
+        hard_budget: int,
+        estimate: Callable[[List[Dict[str, Any]]], int],
+    ) -> List[Dict[str, Any]]:
+        if estimate(window_msgs) <= hard_budget:
+            return window_msgs
+        for k, m in enumerate(window_msgs):
+            if k in protected:
+                continue
+            if not _is_tool_result(m):
+                continue
+            text = _message_text(m)
+            if len(text) <= self.max_tool_result_chars:
+                continue
+            head = min(
+                int(len(text) * self.clamp_head_ratio),
+                int(self.max_tool_result_chars * 0.8),
+            )
+            tail = min(
+                int(len(text) * self.clamp_tail_ratio),
+                int(self.max_tool_result_chars * 0.2),
+            )
+            clone = dict(m)
+            clone["content"] = (
+                text[:head] + _CLAMP_MARKER + (text[-tail:] if tail else "")
+            )
+            window_msgs[k] = clone
+            if estimate(window_msgs) <= hard_budget:
+                break
+        return window_msgs
+
+    def _build_preamble(
+        self,
+        request_messages: List[Dict[str, Any]],
+        prefix_end: int,
+        system_idx: Set[int],
+        current_idx: int,
+        room: int,
+        estimate: Callable[[List[Dict[str, Any]]], int],
+        exclude_indices: Set[int],
+    ) -> List[Dict[str, Any]]:
+        if room < self.relevance_min_tokens and self.head_anchor_messages <= 0:
+            return []
+        picked: List[Tuple[int, Dict[str, Any]]] = []
+        picked_idx: Set[int] = set(exclude_indices)
+        picked_tokens = 0
+        current_text = _message_text(request_messages[current_idx])
+        need_anchor = self.head_anchor_messages
+        prefix_end = min(prefix_end, len(request_messages))
+
+        def _consider(i: int, m: Dict[str, Any]) -> None:
+            nonlocal picked_tokens
+            tok = estimate([m])
+            if tok <= 0 or picked_tokens + tok > room:
+                return
+            picked.append((i, m))
+            picked_tokens += tok
+
+        for i in range(prefix_end):
+            if need_anchor <= 0:
+                break
+            if i in picked_idx or i in system_idx:
+                continue
+            if not _is_standalone(request_messages[i]):
+                continue
+            if not _message_text(request_messages[i]):
+                continue
+            _consider(i, request_messages[i])
+            need_anchor -= 1
+
+        available = self.max_relevant_messages + self.head_anchor_messages
+        if (
+            room - picked_tokens >= self.relevance_min_tokens
+            and len(picked) < available
+        ):
+            allowed = min(self.relevance_max_tokens, room - picked_tokens)
+            for i in range(prefix_end):
+                if len(picked) >= available:
+                    break
+                if i in picked_idx or i in system_idx:
+                    continue
+                m = request_messages[i]
+                if not _is_standalone(m):
+                    continue
+                text = _message_text(m)
+                if not text:
+                    continue
+                if _token_overlap(text, current_text) < self.relevance_floor_score:
+                    continue
+                tok = estimate([m])
+                if tok <= 0 or tok > 4096:
+                    continue
+                if picked_tokens + tok > allowed:
+                    continue
+                _consider(i, m)
+
+        picked.sort(key=lambda item: item[0])
+        return [m for _, m in picked]
+
+
+def register(ctx: Any) -> None:
+    """Plugin-loader entry: capture this engine via the discovery collector."""
+    ctx.register_context_engine(BoundedContextEngine())
+
+
+# ---- message classification ---------------------------------------------------------
+def _is_system(m: Any) -> bool:
+    return isinstance(m, dict) and m.get("role") == "system"
+
+
+def _is_assistant(m: Any) -> bool:
+    return isinstance(m, dict) and m.get("role") == "assistant"
+
+
+def _is_tool_call(m: Any) -> bool:
+    return _is_assistant(m) and bool(m.get("tool_calls"))
+
+
+def _is_tool_result(m: Any) -> bool:
+    return (
+        isinstance(m, dict) and m.get("role") == "tool" and bool(m.get("tool_call_id"))
+    )
+
+
+def _is_standalone(m: Any) -> bool:
+    return not (_is_system(m) or _is_tool_call(m) or _is_tool_result(m))
+
+
+def _message_text(m: Any) -> str:
+    content = m.get("content") if isinstance(m, dict) else None
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                for key in ("text", "content"):
+                    value = block.get(key)
+                    if isinstance(value, str):
+                        parts.append(value)
+                        break
+        return "\n".join(parts)
+    return ""
+
+
+def _current_request_index(request_messages: List[Dict[str, Any]]) -> Optional[int]:
+    """Index of the live user request (last user message without a tool_call_id).
+
+    When the trailing user message carries list-content (multimodal attachment/MoA
+    epilogue), the actual text request is the previous user message.
+    """
+    last_user = None
+    for i in range(len(request_messages) - 1, -1, -1):
+        m = request_messages[i]
+        if (
+            isinstance(m, dict)
+            and m.get("role") == "user"
+            and not m.get("tool_call_id")
+        ):
+            last_user = i
+            break
+    if last_user is None:
+        return None
+    content = request_messages[last_user].get("content")
+    if isinstance(content, list):
+        for i in range(last_user - 1, -1, -1):
+            m = request_messages[i]
+            if (
+                isinstance(m, dict)
+                and m.get("role") == "user"
+                and not m.get("tool_call_id")
+            ):
+                return i
+    return last_user
+
+
+def _newest_tool_group_indices(
+    request_messages: List[Dict[str, Any]],
+    after_index: int,
+) -> Set[int]:
+    """Indices of the in-flight tool chain strictly newer than ``after_index``.
+
+    Only an assistant ``tool_calls`` message that appears AFTER the live user request
+    (plus its contiguous results) counts as the pending group; a completed tool group
+    below the current request is ordinary history and is trimmable.
+    """
+    n = len(request_messages)
+    for i in range(n - 1, after_index - 1, -1):
+        if _is_tool_call(request_messages[i]):
+            indices = {i}
+            j = i + 1
+            while j < n and _is_tool_result(request_messages[j]):
+                indices.add(j)
+                j += 1
+            return indices
+    return set()
+
+
+def _enforce_pair_validity(
+    messages: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Drop tool results whose tool_calls pair is not in the selection (pair-validity).
+
+    Runs after any message is trimmed so a retained tool result never dangles without
+    its initiating assistant message.
+    """
+    created_ids = set()
+    for m in messages:
+        for tc in m.get("tool_calls") or []:
+            if isinstance(tc, dict) and tc.get("id"):
+                created_ids.add(tc["id"])
+    kept: List[Dict[str, Any]] = []
+    pruned = 0
+    for m in messages:
+        if _is_tool_result(m) and m.get("tool_call_id") not in created_ids:
+            pruned += 1
+            continue
+        kept.append(m)
+    return kept, pruned
+
+
+def _trim_from_front_until_fit(
+    final: List[Dict[str, Any]],
+    hard_budget: int,
+    estimate: Callable[[List[Dict[str, Any]]], int],
+    trimmable_identities: Set[int],
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Safety net: drop the oldest trimmable message until the selection fits the budget.
+
+    ``trimmable_identities`` covers the verbatim older window messages only — never the
+    system prompt, the current request, the pending tool chain, or messages already
+    replaced by a clamped copy — so the request invariants cannot be violated here.
+    """
+    removable = [
+        i
+        for i, m in enumerate(final)
+        if not _is_system(m) and id(m) in trimmable_identities
+    ]
+    while estimate(final) > hard_budget and removable:
+        i = removable.pop(0)
+        del final[i]
+        removable = [j - 1 if j > i else j for j in removable]
+    return final, estimate(final)
+
+
+# ---- deterministic relevance --------------------------------------------------------
+_WORD_RE = re.compile(r"[A-Za-z0-9_'-]{2,}", re.UNICODE)
+
+_STOPWORDS = frozenset(
+    """
+a about after again all also am an and any are as at be because been before being between
+both but by can could did do does doing down during each few for from further had has have
+having he her here hers herself him himself his how i if in into is it its itself just me
+more most my myself no nor not now of off on once only or other our ours ourselves out over
+own same she should so some such than that the their theirs them themselves then there these
+they this those through to too under until up very was we were what when where which while
+who whom why will with would you your yours yourself yourselves
+""".split()
+)
+
+
+def _word_tokens(text: str) -> List[str]:
+    return [w for w in _WORD_RE.findall(text.lower()) if w not in _STOPWORDS]
+
+
+def _token_overlap(a: str, b: str) -> int:
+    wa = _word_tokens(a)
+    wb = _word_tokens(b)
+    if not wa or not wb:
+        return 0
+    return len(set(wa) & set(wb))
+
+
+# ---- rough token estimator (host-canonical, imported lazily) ------------------------
+_COMMON_ESTIMATOR = None
+
+
+def _current_request_estimator() -> Callable[[List[Dict[str, Any]]], int]:
+    global _COMMON_ESTIMATOR
+    if _COMMON_ESTIMATOR is None:
+        from agent.model_metadata import estimate_messages_tokens_rough
+
+        _COMMON_ESTIMATOR = estimate_messages_tokens_rough
+    return _COMMON_ESTIMATOR

--- a/plugins/context_engine/bounded/__init__.py
+++ b/plugins/context_engine/bounded/__init__.py
@@ -197,13 +197,23 @@ class BoundedContextEngine(ContextEngine):
 
     def update_from_response(self, usage: Dict[str, Any]) -> None:
         inner = self._inner()
-        if inner is not None:
-            return inner.update_from_response(usage)
-        pt = (usage or {}).get("prompt_tokens") or 0
-        ct = (usage or {}).get("completion_tokens") or 0
-        self.last_prompt_tokens = int(pt)
-        self.last_completion_tokens = int(ct)
-        self.last_total_tokens = int(pt) + int(ct)
+        if inner is None:
+            pt = (usage or {}).get("prompt_tokens") or 0
+            ct = (usage or {}).get("completion_tokens") or 0
+            self.last_prompt_tokens = int(pt)
+            self.last_completion_tokens = int(ct)
+            self.last_total_tokens = int(pt) + int(ct)
+            return
+        inner.update_from_response(usage)
+        # Host preflight reads the engine's own counters directly; mirror the inner
+        # compressor's post-response state so wrapper reads are never stale (and the
+        # host-set awaiting-real-usage latch is cleared in sync with the inner one).
+        self.last_prompt_tokens = int(inner.last_prompt_tokens)
+        self.last_completion_tokens = int(inner.last_completion_tokens)
+        self.last_total_tokens = int(inner.last_total_tokens)
+        self.awaiting_real_usage_after_compression = bool(
+            getattr(inner, "awaiting_real_usage_after_compression", False)
+        )
 
     def should_compress(self, prompt_tokens: Optional[int] = None) -> bool:
         inner = self._inner()
@@ -218,6 +228,12 @@ class BoundedContextEngine(ContextEngine):
         if inner is None or not hasattr(inner, "should_compress_info"):
             return self.should_compress(prompt_tokens), None
         return inner.should_compress_info(prompt_tokens)  # type: ignore[invalid-argument-type]
+
+    def should_defer_preflight_to_real_usage(self, rough_tokens: int) -> bool:
+        inner = self._inner()
+        if inner is not None and hasattr(inner, "should_defer_preflight_to_real_usage"):
+            return inner.should_defer_preflight_to_real_usage(rough_tokens)
+        return super().should_defer_preflight_to_real_usage(rough_tokens)
 
     def compress(
         self,
@@ -569,12 +585,14 @@ def _message_text(m: Any) -> str:
 
 
 def _current_request_index(request_messages: List[Dict[str, Any]]) -> Optional[int]:
-    """Index of the live user request (last user message without a tool_call_id).
+    """Index of the live user request: the last user message without a tool_call_id.
 
-    When the trailing user message carries list-content (multimodal attachment/MoA
-    epilogue), the actual text request is the previous user message.
+    The host never emits a separate trailing epilogue user message: MoA context is
+    folded INTO the last user message (turn_request_assembly._append_moa_context) and
+    genuine list-content (multimodal) user messages are passed through unchanged by
+    build_api_messages. So the last user message is ALWAYS the current request and
+    must be preserved, even when its content is a list.
     """
-    last_user = None
     for i in range(len(request_messages) - 1, -1, -1):
         m = request_messages[i]
         if (
@@ -582,21 +600,8 @@ def _current_request_index(request_messages: List[Dict[str, Any]]) -> Optional[i
             and m.get("role") == "user"
             and not m.get("tool_call_id")
         ):
-            last_user = i
-            break
-    if last_user is None:
-        return None
-    content = request_messages[last_user].get("content")
-    if isinstance(content, list):
-        for i in range(last_user - 1, -1, -1):
-            m = request_messages[i]
-            if (
-                isinstance(m, dict)
-                and m.get("role") == "user"
-                and not m.get("tool_call_id")
-            ):
-                return i
-    return last_user
+            return i
+    return None
 
 
 def _newest_tool_group_indices(

--- a/plugins/context_engine/bounded/plugin.yaml
+++ b/plugins/context_engine/bounded/plugin.yaml
@@ -1,0 +1,8 @@
+name: bounded
+description: >-
+  Bounded, deterministic context selection: bounds every provider request to a hard
+  budget derived from the model context window, preserving the system prompt, the
+  current request and the newest pending tool chain while never mutating persisted
+  history. Selection only; compression remains the wrapped compressor's lifecycle.
+version: 0.1.0
+author: Nous Research

--- a/plugins/context_engine/ci/__init__.py
+++ b/plugins/context_engine/ci/__init__.py
@@ -1,0 +1,429 @@
+"""Context Intelligence plugin: ``plugins/context_engine/ci``.
+
+Two layers, same hard-budget authority:
+
+* Selection: the ``bounded`` engine's deterministic subset (T0 system prompt, T1
+  knowledge in the system prompt, T2 recent-window conversation; current request and
+  newest pending tool chain always preserved; persisted history never mutated).
+* Context intelligence on top, as explicit, budget-bounded, evidence-only tiers
+  injected immediately BEFORE the current request:
+  - T3 durable memory (built-in MemoryStore, MEMORY.md / USER.md), integrated only
+    when the memory config enables the target and the target is not already baked
+    into the system prompt (dedup; host memory stays the single source of truth);
+  - T4 selective historical-session retrieval (the existing ``session_search``
+    tool), fired AT MOST ONCE per request and only on a deterministic recall-intent
+    signal (never automatically for every request).
+
+Authority semantics: Knowledge (T0/T1) always precedes supplements and wins on
+conflict; every supplement is labelled "[Contextual evidence only — not
+authoritative; Knowledge wins.]". T3 is admitted before T4 (higher priority), both
+only into headroom under the same hard budget the bounded engine guarantees, capped
+by ``supplement_max_ratio``. A second re-estimation stage verifies the final request
+against BOTH the canonical rough message estimate and a serialized-prompt-size
+estimate and trims the lowest-priority supplements if needed — the returned request
+is never over the hard budget by the canonical estimate.
+
+Failure behavior never disturbs the current task: a memory or history-source failure
+skips only its tier, a stage error returns the bounded selection unchanged, and the
+engine itself fails open (returns ``None``) exactly like ``bounded``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from agent.context_engine import sanitize_memory_context
+from plugins.context_engine.bounded import (
+    BoundedContextEngine,
+    _CLAMP_MARKER,
+    _current_request_estimator,
+    _current_request_index,
+    _message_text,
+    _token_overlap,
+    _word_tokens,
+)
+from tools.memory_tool_store import ENTRY_DELIMITER, MEMORY_BLOCK_HEADERS
+
+logger = logging.getLogger("plugins.context_engine.ci")
+
+__all__ = ["ContextIntelligenceEngine", "register"]
+
+#: Authority semantics: supplemental tiers are contextual evidence only. Authoritative
+#: Knowledge (the preserved system prompt) always precedes them and wins on conflict.
+_AUTHORITY_NOTE = "[Contextual evidence only - not authoritative; Knowledge wins.] "
+
+_T3_LABEL = "[durable memory] "
+_T4_LABEL = "[historical recall] "
+
+#: Deterministic recall-intent signal that unlocks T4 — the recall phrases a user
+#: reaches for ("what did we", "earlier", "last time", ...). Extra terms can be added
+#: per instance via ``history_recall_intent_terms``.
+_RECALL_INTENT_RE = re.compile(
+    r"\b(remember|recall|recalling|remembered|earlier|previous|previously|before|"
+    r"last time|what did we|where did we|when did we|we talked|we discussed|we "
+    r"worked|remind me|bring back|picked up where|in past sessions|from a past "
+    r"session|back to that)\b",
+    re.IGNORECASE,
+)
+
+#: Capped size below which a retrieved text is eligible for exact-substring dedup
+#: against already-selected content (T2 window / T3). Larger texts rely on the digest.
+_DEDUP_TEXT_MAX_CHARS = 4000
+
+
+class ContextIntelligenceEngine(BoundedContextEngine):
+    """Bounded selection plus gated, budget-bounded T3 (memory) / T4 (history) tiers."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        ci_keys = frozenset({
+            "intelligence_enabled",
+            "memory_integration_enabled",
+            "history_retrieval_enabled",
+            "history_retrieval_limit",
+            "history_retrieval_max_messages",
+            "history_retrieval_max_chars_per_message",
+            "history_retrieval_min_relevance",
+            "history_retrieval_query_max_words",
+            "history_recall_intent_terms",
+            "memory_max_entry_chars",
+            "supplement_max_ratio",
+            "_memory_store_loader",
+            "_session_search_fn",
+        })
+        ci = {k: kwargs.pop(k) for k in list(ci_keys) if k in kwargs}
+        super().__init__(**kwargs)
+        self.intelligence_enabled = bool(ci.get("intelligence_enabled", True))
+        # T3 engine-level switch; the runtime memory-config flags are still respected
+        # (production memory stays disabled).
+        self.memory_integration_enabled = bool(ci.get("memory_integration_enabled", True))
+        # T4 selective history: OFF by default AND gated on a recall-intent signal.
+        self.history_retrieval_enabled = bool(ci.get("history_retrieval_enabled", False))
+        self.history_retrieval_limit = max(1, min(10, int(ci.get("history_retrieval_limit", 3))))
+        self.history_retrieval_max_messages = max(0, int(ci.get("history_retrieval_max_messages", 12)))
+        self.history_retrieval_max_chars_per_message = max(
+            128, int(ci.get("history_retrieval_max_chars_per_message", 2000))
+        )
+        self.history_retrieval_min_relevance = max(0, int(ci.get("history_retrieval_min_relevance", 2)))
+        self.history_retrieval_query_max_words = max(1, int(ci.get("history_retrieval_query_max_words", 8)))
+        self.history_recall_intent_terms = tuple(ci.get("history_recall_intent_terms") or ())
+        self.memory_max_entry_chars = max(128, int(ci.get("memory_max_entry_chars", 800)))
+        self.supplement_max_ratio = max(0.0, min(1.0, float(ci.get("supplement_max_ratio", 0.15))))
+        # Test/config seams: left None they resolve the real implementations lazily.
+        self._memory_store_loader = ci.get("_memory_store_loader")
+        self._session_search_fn = ci.get("_session_search_fn")
+        self._ci_injection_count = 0
+
+    @property
+    def name(self) -> str:
+        return "ci"
+
+    # -- selection ------------------------------------------------------------------
+    def select_context(
+        self,
+        request_messages: List[Dict[str, Any]],
+        *,
+        conversation_messages: Optional[List[Dict[str, Any]]] = None,
+        incoming_message: Optional[Dict[str, Any]] = None,
+        budget_tokens: int = 0,
+    ) -> Optional[List[Dict[str, Any]]]:
+        if not self.enabled:
+            return None
+        if not isinstance(request_messages, list) or not request_messages:
+            return None
+        context_length = budget_tokens or self.context_length or 0
+        if context_length <= 0:
+            return None
+        hard_budget = self._hard_budget_for(context_length)
+        if hard_budget <= 0:
+            return None
+
+        # Stage 1 (authority): the bounded selection guarantees the hard budget,
+        # preserves system/current/pending, and fails open on any error.
+        base_out = super().select_context(
+            request_messages,
+            conversation_messages=conversation_messages,
+            incoming_message=incoming_message,
+            budget_tokens=budget_tokens,
+        )
+        if base_out is None:
+            return None
+
+        # Stage 2: gated context intelligence. Any failure leaves the bounded
+        # selection intact — the request pipeline is never disturbed.
+        try:
+            final = self._apply_intelligence(base_out, request_messages, hard_budget)
+        except Exception as exc:
+            logger.warning(
+                "ci: context intelligence failed, returning bounded selection unchanged: %s", exc
+            )
+            return base_out
+        return final
+
+    def _apply_intelligence(
+        self,
+        base_out: List[Dict[str, Any]],
+        request_messages: List[Dict[str, Any]],
+        hard_budget: int,
+    ) -> List[Dict[str, Any]]:
+        if not self.intelligence_enabled:
+            return base_out
+        estimate = _current_request_estimator()
+        current_est = estimate(base_out)
+        if current_est > hard_budget:
+            return base_out  # base already at/over budget; nothing can be added
+        cap = max(0, min(hard_budget - current_est, int(hard_budget * self.supplement_max_ratio)))
+        if cap <= 0:
+            return base_out
+
+        current_idx = _current_request_index(base_out)
+        if current_idx is None:
+            return base_out
+
+        base_text = "\n".join(_message_text(m) for m in base_out)
+        system_text = "\n".join(
+            _message_text(m) for m in base_out if isinstance(m, dict) and m.get("role") == "system"
+        )
+
+        supplements: List[Tuple[int, int, Dict[str, Any]]] = []  # (priority, est, message)
+        used = 0
+        memory_count = 0
+        for item in self._memory_tier(system_text, base_text):
+            est = estimate([item])
+            if est <= 0 or used + est > cap:
+                continue
+            supplements.append((0, est, item))
+            used += est
+            memory_count += 1
+
+        history_count = 0
+        if self.history_retrieval_enabled:
+            for item in self._history_tier(request_messages, base_text):
+                est = estimate([item])
+                if est <= 0 or used + est > cap:
+                    continue
+                supplements.append((1, est, item))
+                used += est
+                history_count += 1
+
+        if not supplements:
+            return base_out
+
+        # Highest priority first (T3 before T4); insertion order within a tier.
+        ordered = sorted(supplements, key=lambda t: t[0])
+        block = [m for _, _, m in ordered]
+        final = list(base_out[:current_idx]) + block + list(base_out[current_idx:])
+        supp_indices = list(range(current_idx, current_idx + len(block)))
+
+        # Second-stage re-estimation: on overflow vs the canonical OR serialized
+        # estimate, drop the LOWEST-priority supplement (end of the block) until the
+        # final fits. Never trims anything but our own supplements.
+        final_est = estimate(final)
+        serial_est = _serialized_estimate(final)
+        dropped = 0
+        while (final_est > hard_budget or serial_est > hard_budget) and supp_indices:
+            drop = supp_indices.pop()
+            final.pop(drop)
+            dropped += 1
+            for j in range(len(supp_indices)):
+                if supp_indices[j] > drop:
+                    supp_indices[j] -= 1
+            final_est = estimate(final)
+            serial_est = _serialized_estimate(final)
+        if final_est > hard_budget or serial_est > hard_budget:
+            # Only reachable when the bounded base itself overflows the serialized
+            # estimate; the canonical bound (the operational budget) still holds.
+            logger.warning("ci: selection over budget after reduction; using bounded selection")
+            return base_out
+
+        self._ci_injection_count += 1
+        logger.info("ci context intelligence: %s", {
+            "session_id": self._session_id,
+            "intelligence_enabled": self.intelligence_enabled,
+            "memory_messages": memory_count,
+            "history_messages": history_count,
+            "supplement_messages": len(block) - dropped,
+            "dropped_supplements": dropped,
+            "base_tokens_est": current_est,
+            "selected_tokens_est": final_est,
+            "hard_budget": hard_budget,
+        })
+        return final
+
+    # -- T3: durable memory ----------------------------------------------------------
+    def _memory_tier(self, system_text: str, base_text: str) -> List[Dict[str, Any]]:
+        if not self.memory_integration_enabled:
+            return []
+        store = self._resolve_memory_store()
+        if store is None:
+            return []
+
+        items: List[Dict[str, Any]] = []
+        for target in ("memory", "user"):
+            try:
+                enabled = store.target_enabled(target)
+            except Exception:
+                enabled = False
+            if not enabled:
+                continue
+            try:
+                block = store.format_for_system_prompt(target) or ""
+            except Exception as exc:
+                logger.warning("ci: memory target %r unreadable, skipping: %s", target, exc)
+                continue
+            if not block:
+                continue
+            if MEMORY_BLOCK_HEADERS[target] in system_text:
+                continue  # host already baked this target into the system prompt (dedup)
+            block = sanitize_memory_context(block)
+            for chunk in block.split(ENTRY_DELIMITER):
+                chunk = _clamp_text(chunk, self.memory_max_entry_chars)
+                if not chunk:
+                    continue
+                if chunk in base_text:
+                    continue
+                items.append({
+                    "role": "user",
+                    "content": _AUTHORITY_NOTE + _T3_LABEL + chunk,
+                })
+        return items
+
+    def _resolve_memory_store(self) -> Any:
+        loader = self._memory_store_loader
+        if loader is None:
+            from tools.memory_tool import load_on_disk_store as loader
+        try:
+            return loader()
+        except Exception as exc:
+            logger.warning("ci: memory unavailable, skipping T3: %s", exc)
+            return None
+
+    # -- T4: selective historical retrieval ------------------------------------------
+    def _history_tier(self, request_messages: List[Dict[str, Any]], base_text: str) -> List[Dict[str, Any]]:
+        if not self.history_retrieval_enabled:
+            return []
+        current_idx = _current_request_index(request_messages)
+        if current_idx is None:
+            return []
+        request_text = _message_text(request_messages[current_idx])
+        if not self._has_recall_intent(request_text):
+            return []
+        query = _recall_query(request_text, self.history_retrieval_query_max_words)
+        if not query:
+            return []
+        payload = self._run_session_search(query)
+        if not payload or not payload.get("success"):
+            return []
+
+        items: List[Dict[str, Any]] = []
+        seen: Set[str] = set()
+        emitted = 0
+        for entry in payload.get("results") or []:
+            if not isinstance(entry, dict):
+                continue
+            for m in entry.get("messages") or []:
+                if emitted >= self.history_retrieval_max_messages:
+                    return items
+                if not isinstance(m, dict):
+                    continue
+                content = _message_text(m)
+                if not content:
+                    continue
+                digest = _digest(content)
+                if digest in seen:
+                    continue
+                seen.add(digest)
+                if len(content) <= _DEDUP_TEXT_MAX_CHARS and content in base_text:
+                    continue  # already selected in T2/T3 — no amplification
+                if _token_overlap(content, request_text) < self.history_retrieval_min_relevance:
+                    continue  # relevance floor: sparse topical overlap is excluded
+                content = _clamp_text(content, self.history_retrieval_max_chars_per_message)
+                items.append({
+                    "role": "user",
+                    "content": _AUTHORITY_NOTE + _T4_LABEL + content,
+                })
+                emitted += 1
+        return items
+
+    def _has_recall_intent(self, text: str) -> bool:
+        if not text:
+            return False
+        if _RECALL_INTENT_RE.search(text):
+            return True
+        lowered = text.lower()
+        return any(term.strip().lower() in lowered for term in self.history_recall_intent_terms if term)
+
+    def _run_session_search(self, query: str) -> Optional[Dict[str, Any]]:
+        fn = self._session_search_fn
+        if fn is None:
+            from tools.session_search_tool import session_search as fn
+        try:
+            raw = fn(
+                query=query,
+                limit=self.history_retrieval_limit,
+                detail="adaptive",
+                current_session_id=self._session_id,
+            )
+        except Exception as exc:
+            logger.warning("ci: session_search failed, skipping T4: %s", exc)
+            return None
+        if isinstance(raw, dict):
+            return raw
+        if isinstance(raw, str) and raw.strip():
+            try:
+                payload: Any = json.loads(raw)
+            except (ValueError, TypeError) as exc:
+                logger.warning("ci: session_search returned invalid JSON, skipping T4: %s", exc)
+                return None
+            return payload if isinstance(payload, dict) else None
+        return None
+
+    # -- telemetry -------------------------------------------------------------------
+    def get_status(self) -> Dict[str, Any]:
+        status = super().get_status()
+        status.update({
+            "engine": self.name,
+            "intelligence_enabled": self.intelligence_enabled,
+            "memory_integration_enabled": self.memory_integration_enabled,
+            "history_retrieval_enabled": self.history_retrieval_enabled,
+            "supplement_injections": self._ci_injection_count,
+        })
+        return status
+
+
+def register(ctx: Any) -> None:
+    """Plugin-loader entry: capture this engine via the discovery collector."""
+    ctx.register_context_engine(ContextIntelligenceEngine())
+
+
+# ---- deterministic helpers ----------------------------------------------------------
+def _recall_query(text: str, max_words: int) -> str:
+    """FTS5-safe OR query from the request's content words (deterministic, bounded)."""
+    words = _word_tokens(text)[: max(1, max_words)]
+    return " OR ".join(words) or ""
+
+
+def _digest(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8", "replace")).hexdigest()
+
+
+def _clamp_text(text: str, max_chars: int) -> str:
+    """Clamp *text* to *max_chars*, preserving head/tail context plus the marker."""
+    if max_chars <= 0 or len(text) <= max_chars:
+        return text
+    keep = max(0, max_chars - len(_CLAMP_MARKER))
+    head = int(keep * 0.7)
+    tail = keep - head
+    return text[:head] + _CLAMP_MARKER + (text[-tail:] if tail else "")
+
+
+def _serialized_estimate(messages: List[Dict[str, Any]]) -> int:
+    """Serialized-prompt-size estimate: what the wire would actually carry."""
+    from agent.model_metadata import estimate_tokens_rough
+
+    return sum(
+        estimate_tokens_rough(json.dumps(m, ensure_ascii=False, default=str)) for m in messages
+    )

--- a/plugins/context_engine/ci/__init__.py
+++ b/plugins/context_engine/ci/__init__.py
@@ -93,6 +93,7 @@ class ContextIntelligenceEngine(BoundedContextEngine):
             "supplement_max_ratio",
             "_memory_store_loader",
             "_session_search_fn",
+            "user_id",
         })
         ci = {k: kwargs.pop(k) for k in list(ci_keys) if k in kwargs}
         super().__init__(**kwargs)
@@ -115,6 +116,7 @@ class ContextIntelligenceEngine(BoundedContextEngine):
         # Test/config seams: left None they resolve the real implementations lazily.
         self._memory_store_loader = ci.get("_memory_store_loader")
         self._session_search_fn = ci.get("_session_search_fn")
+        self.user_id = ci.get("user_id")
         self._ci_injection_count = 0
 
     @property
@@ -366,6 +368,7 @@ class ContextIntelligenceEngine(BoundedContextEngine):
                 limit=self.history_retrieval_limit,
                 detail="adaptive",
                 current_session_id=self._session_id,
+                user_id=self.user_id,
             )
         except Exception as exc:
             logger.warning("ci: session_search failed, skipping T4: %s", exc)

--- a/plugins/context_engine/ci/plugin.yaml
+++ b/plugins/context_engine/ci/plugin.yaml
@@ -1,0 +1,11 @@
+name: ci
+description: >-
+  Context Intelligence context engine: the bounded engine's hard-budget selection
+  (system prompt / current request / newest pending tool chain preserved, never
+  mutating persisted history) plus gated context intelligence — T3 durable memory
+  and T4 selective historical-session retrieval. Supplements are budget-bounded,
+  deduplicated, labelled as contextual evidence only (Knowledge stays authoritative),
+  and T4 fires at most once per request and only on a deterministic recall-intent
+  signal. No production config or memory defaults are changed by this plugin.
+version: 0.1.0
+author: Nous Research

--- a/tests/agent/test_context_engine_bounded.py
+++ b/tests/agent/test_context_engine_bounded.py
@@ -1,0 +1,402 @@
+"""Tests for the ``bounded`` plugin context engine (plugins/context_engine/bounded).
+
+Covers the ANCOS Phase-1 validation matrix: hard-budget selection, request
+preservation (system / current request / newest pending tool chain), tool-pair
+validity, replay-safe ordering, no mutation of persisted history or of the original
+request list, deterministic behavior, fail-open semantics, and a 160k-token
+regression where the compressor's own compaction threshold has NOT yet fired.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any, Dict, List
+
+import pytest
+
+from agent.model_metadata import estimate_messages_tokens_rough
+from plugins.context_engine import discover_context_engines, load_context_engine
+from plugins.context_engine.bounded import BoundedContextEngine, _CLAMP_MARKER
+
+
+def _msg(role: str, content: str = "", **extra: Any) -> Dict[str, Any]:
+    m: Dict[str, Any] = {"role": role, "content": content}
+    m.update(extra)
+    return m
+
+
+def _tokenish_text(seed: int, words: int) -> str:
+    return " ".join(f"tok_{seed}_{i}_word" for i in range(words))
+
+
+def _tool_turn(call_id: str, result_text: str) -> List[Dict[str, Any]]:
+    return [
+        _msg(
+            "assistant",
+            content="calling a tool",
+            tool_calls=[
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "web_search", "arguments": "{}"},
+                }
+            ],
+        ),
+        _msg("tool", content=result_text, tool_call_id=call_id, name="web_search"),
+        _msg(
+            "tool",
+            content="second result " + result_text[-2000:],
+            tool_call_id=call_id,
+            name="web_search",
+        ),
+    ]
+
+
+def _build_big_request(
+    rounds: int = 12, words: int = 12000, system: str = "You are a helpful assistant."
+) -> List[Dict[str, Any]]:
+    msgs: List[Dict[str, Any]] = [_msg("system", content=system)]
+    for r in range(rounds):
+        msgs.append(_msg("user", content=_tokenish_text(r, words)))
+        if r % 3 == 0:
+            msgs += _tool_turn(f"call{r}", result_text=_tokenish_text(r + 100, words))
+        msgs.append(_msg("assistant", content=_tokenish_text(r + 200, 120)))
+    msgs.append(
+        _msg("user", content="CURRENT_REQUEST_SENTINEL " + _tokenish_text(999, 400))
+    )
+    return msgs
+
+
+def _build_request_near(target_tokens: int, rounds: int = 12):
+    """Deterministically build a request whose rough estimate lands near ``target_tokens``."""
+    words = max(200, int(target_tokens / max(rounds, 1) / 5.6))
+    req = None
+    est = 0
+    for _ in range(10):
+        req = _build_big_request(rounds=rounds, words=words)
+        est = estimate_messages_tokens_rough(req)
+        if est < target_tokens * 0.90:
+            words = max(words + 1, int(words * target_tokens / max(est, 1) * 1.15))
+        elif est > target_tokens * 1.10:
+            words = max(1, int(words * target_tokens / max(est, 1) * 0.92))
+        else:
+            break
+    return req, est
+
+
+def _engine(context_length: int = 262144, **kwargs: Any) -> BoundedContextEngine:
+    e = BoundedContextEngine(**kwargs)
+    e.context_length = context_length
+    return e
+
+
+def _assert_pair_valid(selected: List[Dict[str, Any]]) -> None:
+    created_ids = set()
+    for m in selected:
+        for tc in m.get("tool_calls") or []:
+            if isinstance(tc, dict) and tc.get("id"):
+                created_ids.add(tc["id"])
+    for m in selected:
+        if m.get("role") == "tool":
+            assert m.get("tool_call_id") in created_ids, "dangling tool result retained"
+
+
+def _assert_replay_order(
+    selected: List[Dict[str, Any]], original: List[Dict[str, Any]]
+) -> None:
+    positions = {id(m): i for i, m in enumerate(original)}
+    last = -1
+    for m in selected:
+        pos = positions.get(id(m), last)
+        assert pos >= last, "selected messages are not in original order"
+        last = pos
+
+
+# ---- identity / discovery ------------------------------------------------------------
+def test_name_and_zero_arg_instantiation():
+    e = BoundedContextEngine()
+    assert e.name == "bounded"
+    assert isinstance(e, BoundedContextEngine)
+
+
+def test_plugin_discovery_includes_bounded():
+    assert "bounded" in {name for name, _, _ in discover_context_engines()}
+
+
+def test_load_context_engine_by_name():
+    e = load_context_engine("bounded")
+    assert e is not None and e.name == "bounded"
+
+
+def test_register_entrypoint_captures_engine():
+    class Collector:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+    from plugins.context_engine.bounded import register
+
+    collector = Collector()
+    register(collector)
+    assert collector.engine is not None and collector.engine.name == "bounded"
+
+
+# ---- fail-open + budget plumbing ----------------------------------------------------
+def test_select_context_none_when_unknown_budget():
+    e = _engine(context_length=0)
+    assert e.select_context([_msg("user", content="hi")]) is None
+
+
+def test_select_context_none_when_disabled():
+    e = _engine(enabled=False)
+    assert e.select_context([_msg("user", content="hi")], budget_tokens=262144) is None
+
+
+@pytest.mark.parametrize("bad", ["nope", [], None, 42])
+def test_select_context_fail_open_on_invalid_input(bad):
+    e = _engine()
+    assert e.select_context(bad, budget_tokens=262144) is None
+
+
+def test_select_context_short_path_returns_unchanged_list():
+    req = [_msg("system", content="S"), _msg("user", content="short")]
+    e = _engine()
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is req
+
+
+def test_hard_budget_formula():
+    e = _engine()
+    assert e._hard_budget_for(262144) == int(262144 * 0.5) - min(
+        int(262144 * 0.2), min(4096, 26214) + min(8192, 26214)
+    )
+
+
+# ---- preservation guarantees --------------------------------------------------------
+def test_system_and_current_request_preserved():
+    e = _engine()
+    req = _build_big_request()
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert out[0]["role"] == "system"
+    assert "CURRENT_REQUEST_SENTINEL" in str(out[-1].get("content"))
+
+
+def test_newest_pending_tool_chain_preserved():
+    e = _engine()
+    req = [_msg("system", content="S")]
+    for r in range(6):
+        req += _tool_turn(f"old{r}", result_text=_tokenish_text(r, 9000))
+    req.append(_msg("user", content="CURRENT_REQUEST_SENTINEL live"))
+    req += _tool_turn("live1", result_text="live result")
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    joined = "\n".join(m.get("content", "") for m in out)
+    assert "live1" in str([tc for m in out for tc in (m.get("tool_calls") or [])])
+    assert "live result" in joined
+
+
+def test_pair_validity_of_selection():
+    req = _build_big_request()
+    out = _engine().select_context(req, budget_tokens=262144)
+    assert out is not None
+    _assert_pair_valid(out)
+
+
+def test_replay_order_is_subsequence_and_system_first():
+    req = _build_big_request()
+    out = _engine().select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert out[0]["role"] == "system"
+    _assert_replay_order(out, req)
+
+
+# ---- boundedness ---------------------------------------------------------------------
+def test_selection_fits_hard_budget_256k():
+    e = _engine(context_length=262144)
+    req = _build_big_request()
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(262144)
+
+
+def test_selection_fits_hard_budget_64k():
+    e = _engine(context_length=65536)
+    req, est_in = _build_request_near(60000, rounds=6)
+    assert est_in > e._hard_budget_for(65536)
+    out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(65536)
+
+
+def test_omits_excess_history():
+    req = _build_big_request()
+    out = _engine().select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert len(out) < len(req)
+
+
+def test_huge_early_message_does_not_fail_open():
+    e = _engine(context_length=65536)
+    req = [
+        _msg("system", content="S"),
+        _msg("user", content=_tokenish_text(1, 100000)),
+        _msg("user", content="CURRENT_REQUEST_SENTINEL small request"),
+    ]
+    out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(65536)
+    joined = "\n".join(str(m.get("content")) for m in out)
+    assert "CURRENT_REQUEST_SENTINEL" in joined
+
+
+def test_never_returns_empty():
+    for ctx in (65536, 262144, 524288):
+        req = _build_big_request()
+        out = _engine(context_length=ctx).select_context(req, budget_tokens=ctx)
+        assert out is None or len(out) > 0
+
+
+# ---- 160k regression: compressor threshold NOT yet triggered -------------------------
+def test_160k_regression_compression_not_yet_triggered_but_selection_bounds():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    req, est_in = _build_request_near(160000)
+    hard_budget = e._hard_budget_for(262144)
+    assert 130000 <= est_in <= 190000, f"build calibration off: {est_in}"
+    assert est_in > hard_budget, "transcript must exceed the selection budget"
+    # Compressor's own threshold (~75% of a <512k window = 196608) has not fired on
+    # this transcript, so nothing would shrink it before the request went out.
+    assert e.should_compress(est_in) is False
+    assert e.should_compress_info(est_in)[0] is False
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert estimate_messages_tokens_rough(out) <= hard_budget
+
+
+# ---- determinism / no mutation ------------------------------------------------------
+def test_deterministic_selection():
+    req = _build_big_request()
+    e = _engine()
+    a = e.select_context(req, budget_tokens=262144)
+    b = e.select_context(req, budget_tokens=262144)
+    assert a is not None and b is not None
+    assert a == b
+
+
+def test_request_messages_not_mutated():
+    req = _build_big_request()
+    snapshot = copy.deepcopy(req)
+    _engine().select_context(req, budget_tokens=262144)
+    assert req == snapshot
+
+
+def test_conversation_messages_not_consulted_or_mutated():
+    req = _build_big_request()
+    conv = copy.deepcopy(req)
+    snapshot = copy.deepcopy(conv)
+    out = _engine().select_context(
+        req, conversation_messages=conv, budget_tokens=262144
+    )
+    assert out is not None
+    assert conv == snapshot
+
+
+def test_clamped_tool_result_content_not_altered_in_original():
+    req = [_msg("system", content="S"), _msg("user", content="first")]
+    for r in range(3):
+        req.append(
+            _msg(
+                "assistant",
+                content="calling a tool",
+                tool_calls=[
+                    {
+                        "id": f"c{r}",
+                        "type": "function",
+                        "function": {"name": "web_search", "arguments": "{}"},
+                    }
+                ],
+            )
+        )
+        req.append(
+            _msg("tool", content="B" * 30000, tool_call_id=f"c{r}", name="web_search")
+        )
+    req.append(_msg("user", content="CURRENT_REQUEST_SENTINEL current"))
+    snapshot = copy.deepcopy(req)
+    e = _engine(context_length=65536)
+    asserted_budget = e._hard_budget_for(65536)
+    assert estimate_messages_tokens_rough(req) > asserted_budget
+    out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    joined = "\n".join(str(m.get("content")) for m in out)
+    assert _CLAMP_MARKER in joined, (
+        "oversized old tool result should be clamped in the selection"
+    )
+    assert estimate_messages_tokens_rough(out) <= asserted_budget
+    assert req == snapshot, "original request list must never be modified"
+
+
+# ---- lifecycle delegation -----------------------------------------------------------
+def test_update_model_sets_context_and_pins_compressor():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    assert e.context_length == 262144
+    assert e.threshold_tokens == int(262144 * e.threshold_percent)
+    assert e._inner() is not None
+
+
+def test_model_thresholds_attr_mirrored_to_inner_compressor():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    e.model_thresholds = {"test/bounded": 0.9}
+    inner = e._inner()
+    assert inner is not None
+    assert inner.model_thresholds == {"test/bounded": 0.9}
+
+
+def test_update_from_response_fallback_without_compressor():
+    e = _engine()
+    e.update_from_response({"prompt_tokens": 5, "completion_tokens": 3})
+    assert e.last_total_tokens == 8
+
+
+def test_delegated_lifecycle_methods():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    e.on_session_start("sess-1")
+    assert e.should_compress(1234) in (True, False)
+    msgs = [_msg("system", content="S"), _msg("user", content="hello")]
+    compressed = e.compress(msgs, force=True)
+    assert isinstance(compressed, list)
+    assert isinstance(e.prune_tool_results_only(msgs)[0], list)
+    status = e.get_status()
+    assert status.get("engine") == "bounded"
+    assert status.get("selection_enabled") is True
+    e.on_session_reset()
+    e.on_session_end("sess-1", msgs)
+
+
+# ---- telemetry (never content) ------------------------------------------------------
+def test_selection_telemetry_fields_no_content(caplog):
+    req = _build_big_request()
+    with caplog.at_level(logging.INFO, logger="plugins.context_engine.bounded"):
+        _engine().select_context(req, budget_tokens=262144)
+    records = [r for r in caplog.records if "bounded selection" in r.getMessage()]
+    assert records
+    for field in (
+        "mode",
+        "input_messages",
+        "output_messages",
+        "input_tokens_est",
+        "selected_tokens_est",
+        "budget_tokens",
+        "hard_budget",
+        "omitted_messages",
+        "pruned_tool_results",
+        "clamped_tool_results",
+    ):
+        assert f"'{field}'" in records[0].getMessage()
+    assert "CURRENT_REQUEST_SENTINEL" not in records[0].getMessage()

--- a/tests/agent/test_context_engine_bounded.py
+++ b/tests/agent/test_context_engine_bounded.py
@@ -17,10 +17,14 @@ import pytest
 
 from agent.model_metadata import estimate_messages_tokens_rough
 from plugins.context_engine import discover_context_engines, load_context_engine
-from plugins.context_engine.bounded import BoundedContextEngine, _CLAMP_MARKER
+from plugins.context_engine.bounded import (
+    BoundedContextEngine,
+    _CLAMP_MARKER,
+    _current_request_index,
+)
 
 
-def _msg(role: str, content: str = "", **extra: Any) -> Dict[str, Any]:
+def _msg(role: str, content: Any = "", **extra: Any) -> Dict[str, Any]:
     m: Dict[str, Any] = {"role": role, "content": content}
     m.update(extra)
     return m
@@ -400,3 +404,294 @@ def test_selection_telemetry_fields_no_content(caplog):
     ):
         assert f"'{field}'" in records[0].getMessage()
     assert "CURRENT_REQUEST_SENTINEL" not in records[0].getMessage()
+
+
+# ---- helper: multimodal user message -----------------------------------------------
+def _multimodal_user(text: str) -> Dict[str, Any]:
+    return _msg(
+        "user",
+        content=[
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,QUJD"}},
+        ],
+    )
+
+
+def _build_turn_history(
+    current: Dict[str, Any], rounds: int = 8, words: int = 12000
+) -> List[Dict[str, Any]]:
+    msgs: List[Dict[str, Any]] = [
+        _msg("system", content="You are a helpful assistant.")
+    ]
+    for r in range(rounds):
+        msgs.append(_msg("user", content=_tokenish_text(r, words)))
+        msgs.append(_msg("assistant", content=_tokenish_text(r + 200, 120)))
+    msgs.append(current)
+    return msgs
+
+
+# ---- F1 regression: the trailing user request must never be dropped ----------------
+def test_f1_current_request_index_prefers_trailing_list_content_user():
+    req = [
+        _msg("system", content="S"),
+        _msg("user", content="A"),
+        _multimodal_user("B multimodal"),
+    ]
+    assert _current_request_index(req) == 2
+
+
+def test_f1_multiturn_text_current_request_remains_current():
+    e = _engine(context_length=262144)
+    current = _msg("user", content="CURRENT_REQUEST_SENTINEL final text request")
+    req = _build_turn_history(current, rounds=8, words=12000)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert len(out) < len(req)
+    assert out[-1] is current
+    assert out[-1]["content"] == "CURRENT_REQUEST_SENTINEL final text request"
+
+
+def test_f1_multiturn_multimodal_tail_remains_current_request():
+    e = _engine(context_length=262144)
+    current = _multimodal_user("CURRENT_REQUEST_SENTINEL analyze this screenshot")
+    req = _build_turn_history(current, rounds=8, words=12000)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert len(out) < len(req)
+    assert out[-1] is current
+    assert "CURRENT_REQUEST_SENTINEL analyze this screenshot" in str(
+        out[-1].get("content")
+    )
+
+
+def test_f1_single_multimodal_request_is_current():
+    e = _engine(context_length=262144)
+    req = [_msg("system", content="S"), _multimodal_user("a single image request")]
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is req
+    assert out[-1]["content"][0]["text"] == "a single image request"
+
+
+def test_f1_text_moa_aggregated_message_remains_current():
+    e = _engine(context_length=262144)
+    current = _msg(
+        "user",
+        content=(
+            "CURRENT_REQUEST_SENTINEL user prompt\n\n"
+            "[MoA aggregated context from reference models]"
+        ),
+    )
+    req = _build_turn_history(current, rounds=8, words=12000)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert out[-1] is current
+    assert "CURRENT_REQUEST_SENTINEL user prompt" in out[-1]["content"]
+
+
+def test_f1_multimodal_tail_not_replaced_by_previous_user():
+    e = _engine(context_length=262144)
+    req = _build_turn_history(
+        _msg("user", content="previous plain request"), rounds=8, words=12000
+    )
+    current = _multimodal_user("CURRENT_REQUEST_SENTINEL actual trailing image request")
+    req.append(current)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert out[-1] is current
+    assert "CURRENT_REQUEST_SENTINEL actual trailing image request" in str(
+        out[-1].get("content")
+    )
+    assert "previous plain request" not in out[-1]["content"]
+
+
+def test_f1_current_request_present_in_final_selection():
+    e = _engine(context_length=262144)
+    current = _msg("user", content="CURRENT_REQUEST_SENTINEL visible final request")
+    req = _build_turn_history(current, rounds=12, words=16000)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert len(out) > 1
+    assert current in out, "current request message identity must survive selection"
+    assert out[-1] is current
+
+
+# ---- R2 regression: wrapper counter / preflight-usage mirroring --------------------
+def test_r2_inner_usage_mirrors_to_wrapper_counters():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    e.update_from_response({
+        "prompt_tokens": 12345,
+        "completion_tokens": 200,
+        "total_tokens": 12545,
+    })
+    inner = e._inner()
+    assert inner is not None
+    assert e.last_prompt_tokens == inner.last_prompt_tokens == 12345
+    assert e.last_completion_tokens == inner.last_completion_tokens == 200
+    assert e.last_total_tokens == inner.last_total_tokens == 12545
+
+
+def test_r2_wrapper_total_derived_when_provider_omits_total():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    e.update_from_response({"prompt_tokens": 500, "completion_tokens": 50})
+    assert e.last_prompt_tokens == 500
+    assert e.last_total_tokens == 550
+
+
+def test_r2_host_facing_preflight_sees_real_usage():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    e.update_from_response({
+        "prompt_tokens": 1000,
+        "completion_tokens": 100,
+        "total_tokens": 1100,
+    })
+    # Host preflight reads the engine's own last_prompt_tokens directly; a fit result
+    # below the threshold must not trigger a compression pass.
+    assert e.last_prompt_tokens == 1000
+    assert 1000 < e.threshold_tokens
+    assert e.should_compress(e.last_prompt_tokens) is False
+
+
+def test_r2_should_defer_preflight_forwards_to_inner():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    inner = e._inner()
+    assert inner is not None
+    rough = e.threshold_tokens * 2
+    assert e.should_defer_preflight_to_real_usage(
+        rough
+    ) == inner.should_defer_preflight_to_real_usage(rough)
+
+
+def test_r2_wrapper_defer_not_shadowed_by_base_false():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    inner = e._inner()
+    assert inner is not None
+    inner.awaiting_real_usage_after_compression = True
+    assert inner.last_real_prompt_tokens == 0
+    assert e.should_defer_preflight_to_real_usage(e.threshold_tokens + 1) is True
+
+
+def test_r2_no_extra_pass_from_zero_wrapper_counter():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    e.update_from_response({"prompt_tokens": 800, "completion_tokens": 50})
+    assert e.last_prompt_tokens == 800
+    assert e.should_compress(e.last_prompt_tokens) is False
+
+
+def test_r2_inner_compressor_semantics_preserved():
+    e = BoundedContextEngine()
+    e.update_model("test/bounded", 262144)
+    inner = e._inner()
+    assert inner is not None
+    e.update_from_response({
+        "prompt_tokens": 300,
+        "completion_tokens": 20,
+        "total_tokens": 320,
+    })
+    assert inner.last_prompt_tokens == 300
+    assert inner.last_completion_tokens == 20
+    assert inner.awaiting_real_usage_after_compression is False
+    assert e.should_compress_info(300)[0] is False
+
+
+# ---- backfill: multi-tool-call batches ---------------------------------------------
+def test_backfill_multi_tool_call_batch_selection_pair_valid():
+    e = _engine(context_length=65536)
+    req = [_msg("system", content="S")]
+    for r in range(4):
+        req.append(_msg("user", content=_tokenish_text(r, 8000)))
+        req.append(
+            _msg(
+                "assistant",
+                content="calling two tools",
+                tool_calls=[
+                    {
+                        "id": f"c{r}a",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    },
+                    {
+                        "id": f"c{r}b",
+                        "type": "function",
+                        "function": {"name": "b", "arguments": "{}"},
+                    },
+                ],
+            )
+        )
+        req.append(_msg("tool", content="B" * 20000, tool_call_id=f"c{r}a", name="a"))
+        req.append(_msg("tool", content="C" * 20000, tool_call_id=f"c{r}b", name="b"))
+    req.append(_msg("user", content="CURRENT_REQUEST_SENTINEL final"))
+    out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    _assert_pair_valid(out)
+    _assert_replay_order(out, req)
+    assert out[-1]["content"] == "CURRENT_REQUEST_SENTINEL final"
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(65536)
+
+
+# ---- backfill: system-only requests ------------------------------------------------
+def test_backfill_system_only_request_unchanged():
+    e = _engine()
+    system = _msg("system", content="You are a helpful assistant.")
+    out = e.select_context([system], budget_tokens=262144)
+    assert out is not None
+    assert out == [system]
+    assert out[0]["role"] == "system"
+
+
+def test_backfill_oversized_system_only_fails_open():
+    e = _engine(context_length=65536)
+    system = _msg("system", content=_tokenish_text(7, 60000))
+    assert estimate_messages_tokens_rough([system]) > e._hard_budget_for(65536)
+    assert e.select_context([system], budget_tokens=65536) is None
+
+
+# ---- backfill: pending tool chain clamp protection ---------------------------------
+def test_backfill_pending_tool_chain_never_clamped_or_trimmed():
+    e = _engine(context_length=65536)
+    req = [_msg("system", content="S")]
+    for r in range(4):
+        req.append(_msg("user", content=_tokenish_text(r, 8000)))
+        req += _tool_turn(f"old{r}", result_text="B" * 30000)
+    req.append(_msg("user", content="CURRENT_REQUEST_SENTINEL current"))
+    req += _tool_turn("pending1", result_text="P" * 30000)
+    out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    joined = "\n".join(str(m.get("content")) for m in out)
+    assert "P" * 30000 in joined, "pending tool result must never be clamped or trimmed"
+    _assert_pair_valid(out)
+    assert out[-1]["content"] in (
+        "P" * 30000,
+        "second result " + ("P" * 30000)[-2000:],
+    )
+
+
+# ---- backfill: host _apply_context_engine_selection integration --------------------
+def test_backfill_host_pipeline_integration_bounded_engine():
+    from types import SimpleNamespace
+
+    from agent.conversation_loop import _apply_context_engine_selection
+
+    engine = load_context_engine("bounded")
+    assert engine is not None
+    engine.update_model("test/bounded", 262144)
+    agent = SimpleNamespace(context_compressor=engine, session_id="int-test")
+
+    api_messages = _build_turn_history(
+        _multimodal_user("CURRENT_REQUEST_SENTINEL analyze"), rounds=8, words=12000
+    )
+    conversation = copy.deepcopy(api_messages)
+    incoming = api_messages[-1]
+    sel = _apply_context_engine_selection(
+        agent, api_messages, conversation, incoming, logger=logging.getLogger("test")
+    )
+    assert sel is not None
+    assert sel is not api_messages, "real selection must yield a trimmed request"
+    _assert_pair_valid(sel)
+    assert sel[-1]["content"] == api_messages[-1]["content"]
+    assert "CURRENT_REQUEST_SENTINEL analyze" in str(sel[-1].get("content"))

--- a/tests/agent/test_context_engine_ci.py
+++ b/tests/agent/test_context_engine_ci.py
@@ -1,0 +1,736 @@
+"""Tests for the ``ci`` plugin context engine (plugins/context_engine/ci).
+
+Covers the ANCOS Phase-2B validation matrix on top of the ``bounded`` guarantees:
+hard-budget preservation with T3 durable memory and T4 selective historical-session
+retrieval supplements, authority/priority semantics (Knowledge wins, T3 before T4,
+both before the current request), dedup / relevance / clamp bounds, second-stage
+(re-)estimation, single-shot retrieval (no amplification), fail-closed tier failure,
+fail-open engine failure, and the "no historical need -> no search" default.
+
+All T3/T4 sources are injected via seams (``_memory_store_loader`` /
+``_session_search_fn``) so every scenario is deterministic and hermetic; one
+integration test drives the real ``load_on_disk_store`` path with a temp memory dir.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any, Dict, List
+
+import pytest
+
+from agent.model_metadata import estimate_messages_tokens_rough
+from plugins.context_engine import discover_context_engines, load_context_engine
+from plugins.context_engine.bounded import _CLAMP_MARKER
+from plugins.context_engine.ci import (
+    ContextIntelligenceEngine,
+    _AUTHORITY_NOTE,
+    _T3_LABEL,
+    _T4_LABEL,
+    register,
+)
+
+
+def _msg(role: str, content: Any = "", **extra: Any) -> Dict[str, Any]:
+    m: Dict[str, Any] = {"role": role, "content": content}
+    m.update(extra)
+    return m
+
+
+def _tokenish_text(seed: int, words: int) -> str:
+    return " ".join(f"tok_{seed}_{i}_word" for i in range(words))
+
+
+def _tool_turn(call_id: str, result_text: str) -> List[Dict[str, Any]]:
+    return [
+        _msg(
+            "assistant",
+            content="calling a tool",
+            tool_calls=[
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": "web_search", "arguments": "{}"},
+                }
+            ],
+        ),
+        _msg("tool", content=result_text, tool_call_id=call_id, name="web_search"),
+        _msg("tool", content="second result " + result_text[-2000:], tool_call_id=call_id, name="web_search"),
+    ]
+
+
+def _build_big_request(rounds: int = 12, words: int = 12000, system: str = "You are a helpful assistant."):
+    msgs: List[Dict[str, Any]] = [_msg("system", content=system)]
+    for r in range(rounds):
+        msgs.append(_msg("user", content=_tokenish_text(r, words)))
+        if r % 3 == 0:
+            msgs += _tool_turn(f"call{r}", result_text=_tokenish_text(r + 100, words))
+        msgs.append(_msg("assistant", content=_tokenish_text(r + 200, 120)))
+    msgs.append(_msg("user", content="CURRENT_REQUEST_SENTINEL " + _tokenish_text(999, 400)))
+    return msgs
+
+
+def _fake_store(
+    memory_entries: List[str] = (),
+    user_entries: List[str] = (),
+    *,
+    memory_enabled: bool = True,
+    user_profile_enabled: bool = True,
+):
+    from tools.memory_tool_store import ENTRY_DELIMITER, MemoryStore
+
+    store = MemoryStore(
+        memory_char_limit=2200,
+        user_char_limit=1375,
+        memory_enabled=memory_enabled,
+        user_profile_enabled=user_profile_enabled,
+    )
+    if memory_entries:
+        store._system_prompt_snapshot["memory"] = ENTRY_DELIMITER.join(memory_entries)
+    if user_entries:
+        store._system_prompt_snapshot["user"] = ENTRY_DELIMITER.join(user_entries)
+    return store
+
+
+def _empty_store() -> Any:
+    return _fake_store()
+
+
+def _discovery_payload(*contents: str) -> Dict[str, Any]:
+    """A canned success payload whose first result carries ``contents`` as messages."""
+    return {
+        "success": True,
+        "results": [
+            {
+                "session_id": "recall-session-1",
+                "matched_role": "user",
+                "match_message_id": 1,
+                "messages": [
+                    {"id": i, "role": "user", "content": content} for i, content in enumerate(contents, start=1)
+                ],
+            }
+        ],
+        "count": 1,
+    }
+
+
+def _recording_search(*responses: Any) -> tuple:
+    calls: List[Dict[str, Any]] = []
+
+    def _proxy(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        if not responses:
+            return {"success": True, "results": []}
+        return responses[min(len(responses), len(calls)) - 1]
+
+    return _proxy, calls
+
+
+def _engine(context_length: int = 262144, store: Any = None, **kwargs: Any) -> ContextIntelligenceEngine:
+    e = ContextIntelligenceEngine(**kwargs)
+    e.context_length = context_length
+    if store is not None:
+        e._memory_store_loader = lambda: store
+    elif e._memory_store_loader is None:
+        e._memory_store_loader = lambda: _fake_store()
+    e._session_search_fn = e._session_search_fn or (lambda **k: {"success": True, "results": []})
+    return e
+
+
+def _join(selected: List[Dict[str, Any]]) -> str:
+    return "\n".join(str(m.get("content")) for m in selected)
+
+
+def _count_labels(selected: List[Dict[str, Any]], label: str) -> int:
+    return sum(1 for m in selected if label in str(m.get("content")))
+
+
+def _assert_pair_valid(selected: List[Dict[str, Any]]) -> None:
+    created_ids = set()
+    for m in selected:
+        for tc in m.get("tool_calls") or []:
+            if isinstance(tc, dict) and tc.get("id"):
+                created_ids.add(tc["id"])
+    for m in selected:
+        if m.get("role") == "tool":
+            assert m.get("tool_call_id") in created_ids, "dangling tool result retained"
+
+
+def _assert_replay_order(selected: List[Dict[str, Any]], original: List[Dict[str, Any]]) -> None:
+    positions = {id(m): i for i, m in enumerate(original)}
+    last = -1
+    for m in selected:
+        pos = positions.get(id(m), last)
+        assert pos >= last, "selected messages are not in original order"
+        last = pos
+
+
+# ---- identity / discovery -----------------------------------------------------------
+def test_name_and_zero_arg_instantiation():
+    e = ContextIntelligenceEngine()
+    assert e.name == "ci"
+    assert isinstance(e, ContextIntelligenceEngine)
+
+
+def test_plugin_discovery_includes_ci():
+    assert "ci" in {name for name, _, _ in discover_context_engines()}
+
+
+def test_load_context_engine_by_name():
+    e = load_context_engine("ci")
+    assert e is not None and e.name == "ci"
+
+
+def test_register_entrypoint_captures_engine():
+    class Collector:
+        def __init__(self):
+            self.engine = None
+
+        def register_context_engine(self, engine):
+            self.engine = engine
+
+    collector = Collector()
+    register(collector)
+    assert collector.engine is not None and collector.engine.name == "ci"
+
+
+# ---- fail-open + budget plumbing ----------------------------------------------------
+def test_select_context_none_when_unknown_budget():
+    assert _engine(context_length=0).select_context([_msg("user", content="hi")]) is None
+
+
+def test_select_context_none_when_disabled():
+    assert _engine(enabled=False).select_context([_msg("user", content="hi")], budget_tokens=262144) is None
+
+
+@pytest.mark.parametrize("bad", ["nope", [], None, 42])
+def test_select_context_fail_open_on_invalid_input(bad):
+    assert _engine().select_context(bad, budget_tokens=262144) is None
+
+
+def test_short_path_returns_unchanged_list_with_empty_memory():
+    req = [_msg("system", content="S"), _msg("user", content="short")]
+    out = _engine().select_context(req, budget_tokens=262144)
+    assert out is req
+
+
+def test_intelligence_stage_disabled_returns_base_selection():
+    req = _build_big_request()
+    e = _engine(intelligence_enabled=False)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(262144)
+
+
+# ---- preservation guarantees (inherited bounded invariants) -------------------------
+def test_system_and_current_request_preserved_with_memory():
+    store = _fake_store(memory_entries=["remembered fact about migrations"])
+    e = _engine(store=store, context_length=262144)
+    req = _build_big_request()
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert out[0]["role"] == "system"
+    assert "CURRENT_REQUEST_SENTINEL" in str(out[-1].get("content"))
+
+
+def test_request_messages_not_mutated_with_supplements():
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT what did we do earlier about refunds")]
+    snapshot = copy.deepcopy(req)
+    store = _fake_store(memory_entries=["refund policy entry"])
+    _engine(store=store).select_context(req, budget_tokens=262144)
+    assert req == snapshot
+
+
+def test_replay_order_is_subsequence_with_supplements():
+    req = [_msg("system", content="S"), _msg("user", content="first")]
+    req.append(_msg("assistant", content="reply"))
+    req.append(_msg("user", content="CURRENT what did we say earlier about x-ray optics"))
+    store = _fake_store(memory_entries=["x-ray optics notes"])
+    out = _engine(store=store, context_length=65536).select_context(req, budget_tokens=65536)
+    assert out is not None
+    assert out[0]["role"] == "system"
+    _assert_replay_order(out, req)
+    assert out[-1] is req[-1]
+
+
+def test_pair_validity_with_history_retrieval():
+    req = _build_big_request()
+    req[-1] = _msg("user", content="CURRENT what did we do about the refund earlier")
+    e = _engine(
+        context_length=65536,
+        history_retrieval_enabled=True,
+        _session_search_fn=lambda **k: _discovery_payload("the refund policy for repeat merchants"),
+    )
+    out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    _assert_pair_valid(out)
+
+
+# ---- T3: durable memory -------------------------------------------------------------
+def test_t3_injects_bounded_memory_supplement():
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT small request")]
+    store = _fake_store(memory_entries=["the coffee contract renews in May"], user_entries=["Lives in Jakarta"])
+    e = _engine(store=store)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    joined = _join(out)
+    assert _T3_LABEL in joined
+    assert _AUTHORITY_NOTE in joined
+    assert "the coffee contract renews in May" in joined
+    assert "Lives in Jakarta" in joined
+    assert out[-1] is req[-1]
+
+
+def test_empty_memory_no_overhead():
+    req = [_msg("system", content="S"), _msg("user", content="hello")]
+    e = _engine(store=_fake_store())
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is req
+    assert _T3_LABEL not in _join(out)
+
+
+def test_memory_target_disabled_by_config_flags_is_skipped():
+    req = [_msg("system", content="S"), _msg("user", content="hello")]
+    store = _fake_store(
+        memory_entries=["secret notes"], memory_enabled=False, user_profile_enabled=False
+    )
+    out = _engine(store=store).select_context(req, budget_tokens=262144)
+    assert out is req
+    assert "secret notes" not in _join(out)
+
+
+def test_memory_already_in_system_prompt_is_deduped():
+    req = [_msg("system", content="MEMORY (your personal notes): tax rate is 10%."), _msg("user", content="hello")]
+    store = _fake_store(memory_entries=["MEMORY (your personal notes)", "tax rate is 10%."])
+    out = _engine(store=store).select_context(req, budget_tokens=262144)
+    assert out is req
+    assert _T3_LABEL not in _join(out)
+
+
+def test_oversized_memory_is_bounded_and_clamped():
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT small")]
+    store = _fake_store(memory_entries=["M" * 3000, "N" * 3000, "O" * 3000, "P" * 3000])
+    e = _engine(store=store, context_length=8192, supplement_max_ratio=1.0)
+    out = e.select_context(req, budget_tokens=8192)
+    assert out is not None
+    joined = _join(out)
+    assert _T3_LABEL in joined
+    assert _CLAMP_MARKER in joined
+    assert "M" * 3000 not in joined
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(8192)
+    assert out[-1] is req[-1]
+
+
+def test_memory_failure_fails_closed_to_bounded_selection(caplog):
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT keep going")]
+    store_loader = lambda: (_ for _ in ()).throw(RuntimeError("memory unreadable"))
+    e = _engine(context_length=65536)
+    e._memory_store_loader = store_loader
+    with caplog.at_level(logging.WARNING, logger="plugins.context_engine.ci"):
+        out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    assert _T3_LABEL not in _join(out)
+    assert out[-1] is req[-1]
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(65536)
+
+
+# ---- T4: selective historical retrieval ---------------------------------------------
+def test_t4_fires_on_recall_intent_and_labels_content():
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT what did we do earlier about the refund policy")]
+    e = _engine(
+        history_retrieval_enabled=True,
+        _session_search_fn=lambda **k: _discovery_payload("the refund policy was updated for repeat merchants"),
+    )
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    joined = _join(out)
+    assert _T4_LABEL in joined
+    assert "[historical recall]" in joined
+    assert _AUTHORITY_NOTE in joined
+    assert "the refund policy was updated for repeat merchants" in joined
+    assert out[-1] is req[-1]
+
+
+def test_no_historical_need_so_no_search():
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT hello, how are you today")]
+    fn, calls = _recording_search()
+    e = _engine(history_retrieval_enabled=True, _session_search_fn=fn, context_length=262144)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is req
+    assert calls == []
+
+
+def test_history_retrieval_off_default_never_searches():
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT what did we do earlier about taxes")]
+    fn, calls = _recording_search()
+    e = _engine(history_retrieval_enabled=False, _session_search_fn=fn)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is req
+    assert calls == []
+
+
+def test_massive_historical_retrieval_is_bounded():
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT what did we do earlier about the refund policy")]
+    big_r = "refund policy notes " + "R" * 50000
+    big_c = "refund policy notes " + "C" * 50000
+    e = _engine(
+        context_length=65536,
+        history_retrieval_enabled=True,
+        _session_search_fn=lambda **k: _discovery_payload(big_r, big_c),
+    )
+    out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    joined = _join(out)
+    assert _T4_LABEL in joined
+    assert _CLAMP_MARKER in joined
+    assert "R" * 50000 not in joined
+    assert "C" * 50000 not in joined
+    assert _count_labels(out, _T4_LABEL) <= 12
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(65536)
+
+
+def test_irrelevant_history_excluded_by_relevance_floor():
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT what did we say earlier about the refund policy")]
+    e = _engine(
+        history_retrieval_enabled=True,
+        history_retrieval_min_relevance=2,
+        _session_search_fn=lambda **k: _discovery_payload(
+            "the refund policy was updated for repeat merchants",
+            "tok_1_alpha_word tok_1_beta_word tok_1_gamma_word",
+            "tok_2_alpha_word tok_2_beta_word tok_2_gamma_word",
+            "tok_3_alpha_word tok_3_beta_word tok_3_gamma_word",
+        ),
+    )
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert _count_labels(out, _T4_LABEL) == 1
+    assert "the refund policy was updated for repeat merchants" in _join(out)
+
+
+def test_duplicate_history_deduped_and_not_amplified():
+    req = [
+        _msg("system", content="S"),
+        _msg("user", content="old question about the q topic"),
+        _msg("assistant", content="already in the window q old text"),
+        _msg("user", content="CURRENT what did we do earlier about the q topic"),
+    ]
+    e = _engine(
+        history_retrieval_enabled=True,
+        _session_search_fn=lambda **k: {
+            "success": True,
+            "results": [
+                {
+                    "session_id": "s1",
+                    "messages": [
+                        {"id": 1, "role": "user", "content": "off-context unique earlier q topic facts about zeta"},
+                        {"id": 2, "role": "user", "content": "already in the window q old text"},
+                    ],
+                },
+                {
+                    "session_id": "s1",
+                    "messages": [{"id": 3, "role": "user", "content": "off-context unique earlier q topic facts about zeta"}],
+                },
+            ],
+        },
+    )
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    joined = _join(out)
+    assert _count_labels(out, _T4_LABEL) == 1
+    assert joined.count("off-context unique earlier q topic facts about zeta") == 1
+    assert _count_labels(out, _T3_LABEL) == 0
+
+
+def test_session_search_failure_skips_history_and_proceeds(caplog):
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT what did we do earlier about refunds")]
+
+    def _raise(**k):
+        raise RuntimeError("fts unavailable")
+
+    e = _engine(history_retrieval_enabled=True, _session_search_fn=_raise)
+    with caplog.at_level(logging.WARNING, logger="plugins.context_engine.ci"):
+        out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert _T4_LABEL not in _join(out)
+    assert out[-1] is req[-1]
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(262144)
+
+
+def test_session_search_non_success_payload_skipped():
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT what did we do earlier about refunds")]
+    e = _engine(
+        history_retrieval_enabled=True,
+        _session_search_fn=lambda **k: {"success": False, "error": "search failed"},
+    )
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert _T4_LABEL not in _join(out)
+
+
+def test_retrieval_amplification_blocked_at_one_search_per_request():
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT what did we do earlier about the refund policy")]
+    fn, calls = _recording_search(_discovery_payload("refund policy notes", "refund history details"))
+    e = _engine(history_retrieval_enabled=True, _session_search_fn=fn)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert len(calls) == 1
+    assert calls[0]["limit"] == 3
+    assert calls[0]["detail"] == "adaptive"
+    # A subsequent plain request must not trigger another search.
+    plain = [_msg("system", content="S"), _msg("user", content="CURRENT hello there")]
+    e.select_context(plain, budget_tokens=262144)
+    assert len(calls) == 1
+
+
+def test_tool_payload_bloat_does_not_inflate_selection():
+    req = [_msg("system", content="S")]
+    for r in range(4):
+        req.append(_msg("user", content=_tokenish_text(r, 8000)))
+        req += _tool_turn(f"old{r}", result_text="B" * 30000)
+    req.append(_msg("user", content="CURRENT what did we do earlier about the refund policy"))
+    req += _tool_turn("pending1", result_text="P" * 30000)
+    e = _engine(
+        context_length=65536,
+        history_retrieval_enabled=True,
+        _session_search_fn=lambda **k: _discovery_payload(
+            "refund policy notes " + "H" * 200000, "refund policy notes " + "J" * 200000
+        ),
+    )
+    out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    joined = _join(out)
+    assert "P" * 30000 in joined, "pending tool result must never be clamped or trimmed"
+    _assert_pair_valid(out)
+    assert out[-1]["content"] in ("P" * 30000, "second result " + ("P" * 30000)[-2000:])
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(65536)
+
+
+# ---- priority + authority semantics -------------------------------------------------
+def test_conflicting_memory_vs_knowledge_knowledge_wins_on_order_and_label():
+    system = _msg("system", content="KNOWLEDGE: the tax rate is 10%.")
+    current = _msg("user", content="CURRENT apply the regional tax rate please")
+    req = [system, current]
+    store = _fake_store(memory_entries=["The regional tax rate is 25%."])
+    out = _engine(store=store).select_context(req, budget_tokens=262144)
+    assert out is not None
+    idx_sys = out.index(system)
+    assert idx_sys == 0
+    mem_idx = next(i for i, m in enumerate(out) if _T3_LABEL in str(m.get("content")))
+    cur_idx = out.index(current)
+    assert idx_sys < mem_idx < cur_idx
+    assert mem_idx == cur_idx - 1
+    assert _AUTHORITY_NOTE in str(out[mem_idx].get("content"))
+    assert out[-1] is current
+
+
+def test_t3_has_priority_over_t4_when_budget_tight():
+    req = [
+        _msg("system", content="S"),
+        _msg("user", content="CURRENT what did we decide earlier about the refund policy please"),
+    ]
+    store = _fake_store(memory_entries=["refund decision from memory"])
+    e = _engine(
+        store=store,
+        context_length=8192,
+        supplement_max_ratio=0.08,
+        history_retrieval_enabled=True,
+        _session_search_fn=lambda **k: _discovery_payload(
+            "refund policy details " + " word " * 2000
+        ),
+    )
+    out = e.select_context(req, budget_tokens=8192)
+    assert out is not None
+    joined = _join(out)
+    assert _T3_LABEL in joined
+    assert _T4_LABEL not in joined
+
+
+def test_t3_before_t4_before_current_when_room_for_both():
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT what did we do earlier about the refund policy")]
+    store = _fake_store(memory_entries=["refund decision from memory"])
+    e = _engine(
+        store=store,
+        history_retrieval_enabled=True,
+        _session_search_fn=lambda **k: _discovery_payload("the refund policy was updated for merchants"),
+    )
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    t3_idx = next(i for i, m in enumerate(out) if _T3_LABEL in str(m.get("content")))
+    t4_idx = next(i for i, m in enumerate(out) if _T4_LABEL in str(m.get("content")))
+    cur_idx = out.index(req[-1])
+    assert t3_idx < t4_idx < cur_idx
+    terms = [x for x in (str(m.get("content")) for m in out) if "refund" in x]
+    assert "refund decision from memory" in _join(out)
+    assert "the refund policy was updated for merchants" in _join(out)
+
+
+# ---- context engine failure fails open ----------------------------------------------
+def test_context_engine_failure_fails_open():
+    class _Exploding(ContextIntelligenceEngine):
+        def _select(self, request_messages, hard_budget):  # type: ignore[override]
+            raise RuntimeError("boom")
+
+    e = _Exploding()
+    e.context_length = 262144
+    assert e.select_context([_msg("user", content="hi")], budget_tokens=262144) is None
+
+
+# ---- budget re-estimation (second stage) --------------------------------------------
+def test_budget_reestimation_keeps_final_within_canonical_budget():
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT summarize")]
+    store = _fake_store(memory_entries=[("Z" * 2400) for _ in range(6)])
+    e = _engine(store=store, context_length=8192, supplement_max_ratio=1.0)
+    out = e.select_context(req, budget_tokens=8192)
+    assert out is not None
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(8192)
+    assert out[-1] is req[-1]
+
+
+def test_second_stage_serialized_reduction_drops_supplements(monkeypatch):
+    """Estimated tokens differ from serialized prompt size: the second stage trims
+    supplements until the serialized estimate fits, never disturbing the current task."""
+    filler = "alpha project debt restructuring "
+    big_a = "refund alpha project " + "A" * 200000
+    big_b = "refund alpha project " + "B" * 200000
+    big_c = "refund alpha project " + "C" * 200000
+    req = [
+        _msg("system", content="S"),
+        _msg("user", content="CURRENT what did we discuss earlier about the alpha project" + filler),
+    ]
+
+    def stub(messages):  # artificially small canonical estimate for every list
+        return sum(30 if str(m.get("content") or "").startswith(_AUTHORITY_NOTE) else 5 for m in messages)
+
+    monkeypatch.setattr("plugins.context_engine.ci._current_request_estimator", lambda: stub)
+
+    e = _engine(
+        context_length=262144,
+        memory_integration_enabled=False,
+        history_retrieval_enabled=True,
+        history_retrieval_max_chars_per_message=400000,
+        _session_search_fn=lambda **k: _discovery_payload(big_a, big_b, big_c),
+    )
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    hard_budget = e._hard_budget_for(262144)
+    from plugins.context_engine.ci import _serialized_estimate
+
+    assert _serialized_estimate(out) <= hard_budget
+    kept = _count_labels(out, _T4_LABEL)
+    assert kept >= 1, "reduction must keep as many supplements as fit"
+    assert kept <= 2, "reduction must drop the supplements that overflow the serialized budget"
+    assert out[-1] is req[-1]
+
+
+# ---- realistic loader path (real on-disk MemoryStore) -------------------------------
+def test_t3_real_on_disk_store_loader(monkeypatch, tmp_path):
+    from tools import memory_tool
+
+    (tmp_path / "MEMORY.md").write_text("coffee contract renews in May\n§\nJakarta-based user", encoding="utf-8")
+    monkeypatch.setattr(memory_tool, "get_memory_dir", lambda: tmp_path)
+    monkeypatch.setattr(memory_tool, "get_builtin_memory_config", lambda *a, **k: {})
+    monkeypatch.setattr(memory_tool, "get_builtin_memory_store_flags", lambda *a, **k: (True, True))
+
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT small request")]
+    e = _engine()
+    e._memory_store_loader = None  # exercise the real loader
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    joined = _join(out)
+    assert _T3_LABEL in joined
+    assert "coffee contract renews in May" in joined
+    assert "Jakarta-based user" in joined
+
+
+def test_t3_real_loader_respects_disabled_memory_flags(monkeypatch, tmp_path):
+    from tools import memory_tool
+
+    (tmp_path / "MEMORY.md").write_text("coffee contract renews in May", encoding="utf-8")
+    monkeypatch.setattr(memory_tool, "get_memory_dir", lambda: tmp_path)
+    monkeypatch.setattr(memory_tool, "get_builtin_memory_config", lambda *a, **k: {})
+    monkeypatch.setattr(memory_tool, "get_builtin_memory_store_flags", lambda *a, **k: (False, False))
+
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT small request")]
+    e = _engine()
+    e._memory_store_loader = None  # exercise the real loader
+    out = e.select_context(req, budget_tokens=262144)
+    # The real store reports both targets disabled, so T3 must be skipped entirely.
+    assert out is req
+    assert _T3_LABEL not in _join(out)
+
+
+# ---- determinism / recall intent ----------------------------------------------------
+def test_recall_intent_detection():
+    from plugins.context_engine.ci import _RECALL_INTENT_RE
+
+    assert _RECALL_INTENT_RE.search("what did we decide earlier?")
+    assert _RECALL_INTENT_RE.search("remember the alpha server")
+    assert not _RECALL_INTENT_RE.search("how are you")
+
+
+def test_recall_query_or_syntax_and_content_words():
+    from plugins.context_engine.ci import _recall_query
+
+    q = _recall_query("What did we discuss about Refund Policy?!", 4)
+    tokens = q.split(" OR ")
+    assert tokens and all(tok.isalnum() for tok in tokens)
+    assert "policy" in tokens
+
+
+# ---- telemetry ----------------------------------------------------------------------
+def test_telemetry_fields_no_content(caplog):
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT small request")]
+    store = _fake_store(memory_entries=["some memory note"])
+    with caplog.at_level(logging.INFO, logger="plugins.context_engine.ci"):
+        _engine(store=store).select_context(req, budget_tokens=262144)
+    records = [r for r in caplog.records if "ci context intelligence" in r.getMessage()]
+    assert records
+    for field in (
+        "memory_messages",
+        "history_messages",
+        "supplement_messages",
+        "dropped_supplements",
+        "base_tokens_est",
+        "selected_tokens_est",
+        "hard_budget",
+    ):
+        assert f"'{field}'" in records[0].getMessage()
+    assert "some memory note" not in records[0].getMessage()
+
+
+def test_status_reports_intelligence_flags():
+    e = _engine(history_retrieval_enabled=True)
+    status = e.get_status()
+    assert status.get("engine") == "ci"
+    assert status.get("intelligence_enabled") is True
+    assert status.get("memory_integration_enabled") is True
+    assert status.get("history_retrieval_enabled") is True
+
+
+# ---- host pipeline integration ------------------------------------------------------
+def test_host_pipeline_integration_ci_engine():
+    from types import SimpleNamespace
+
+    from agent.conversation_loop import _apply_context_engine_selection
+
+    engine = load_context_engine("ci")
+    assert engine is not None
+    engine.update_model("test/ci", 262144)
+    engine._memory_store_loader = lambda: _fake_store()
+    engine.history_retrieval_enabled = False
+    agent = SimpleNamespace(context_compressor=engine, session_id="ci-int-test")
+
+    api_messages = [
+        _msg("system", content="S"),
+        _msg("user", content="first"),
+        _msg("assistant", content="reply"),
+        _msg("user", content="CURRENT_REQUEST_SENTINEL analyze"),
+    ]
+    conversation = copy.deepcopy(api_messages)
+    incoming = api_messages[-1]
+    sel = _apply_context_engine_selection(agent, api_messages, conversation, incoming, logger=logging.getLogger("test"))
+    assert sel is not None
+    assert sel[-1]["content"] == api_messages[-1]["content"]
+    _assert_pair_valid(sel)
+    assert estimate_messages_tokens_rough(sel) <= engine._hard_budget_for(262144)

--- a/tests/agent/test_context_engine_ci.py
+++ b/tests/agent/test_context_engine_ci.py
@@ -10,6 +10,11 @@ fail-open engine failure, and the "no historical need -> no search" default.
 All T3/T4 sources are injected via seams (``_memory_store_loader`` /
 ``_session_search_fn``) so every scenario is deterministic and hermetic; one
 integration test drives the real ``load_on_disk_store`` path with a temp memory dir.
+
+Ownership: select-context passes ``current_session_id`` into ``session_search`` so the
+current session/lineage is excluded, but that is NOT a cross-user ownership boundary.
+In shared-profile deployments there is no user-level isolation here; T4-side ownership
+is UNCERTAIN by design and T4 remains off by default.
 """
 
 from __future__ import annotations
@@ -483,6 +488,49 @@ def test_retrieval_amplification_blocked_at_one_search_per_request():
     assert len(calls) == 1
 
 
+def test_t4_passes_current_session_id_to_search_but_does_not_claim_ownership():
+    """T4 delegates current-session exclusion to ``session_search`` via the session id.
+    This is NOT cross-user ownership: shared-profile deployments have no user-level
+    boundary here, so T4-side ownership remains UNCERTAIN and must not be claimed."""
+    req = [_msg("system", content="S"), _msg("user", content="CURRENT what did we do earlier about refunds")]
+    fn, calls = _recording_search(_discovery_payload("earlier refunds policy notes"))
+    e = _engine(history_retrieval_enabled=True, _session_search_fn=fn)
+    e.on_session_start(session_id="own-session-42", context_length=262144)
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    assert _T4_LABEL in _join(out)
+    assert len(calls) == 1
+    assert calls[0].get("current_session_id") == "own-session-42"
+    assert calls[0].get("limit") == 3
+    assert calls[0].get("detail") == "adaptive"
+
+
+def test_supplements_never_carry_tool_or_authority_fields():
+    req = [
+        _msg("system", content="S"),
+        _msg("user", content="CURRENT what did we do earlier about refunds"),
+    ]
+    store = _fake_store(memory_entries=["refund decision"])
+    e = _engine(
+        store=store,
+        history_retrieval_enabled=True,
+        _session_search_fn=lambda **k: _discovery_payload("earlier refunds history detail"),
+    )
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    supplements = [m for m in out if _T3_LABEL in str(m.get("content")) or _T4_LABEL in str(m.get("content"))]
+    assert supplements
+    for m in supplements:
+        # Evidence-only: role=user and the content marker, nothing that can act or decide.
+        assert set(m) <= {"role", "content"}
+        assert m.get("role") == "user"
+        assert not m.get("tool_calls") and not m.get("tool_call_id") and not m.get("name")
+        assert _AUTHORITY_NOTE in str(m.get("content"))
+    # No injected supplement can carry an approval/action/authority envelope.
+    for m in out:
+        assert not {"approve", "action", "authorize", "authority"} & set(m)
+
+
 def test_tool_payload_bloat_does_not_inflate_selection():
     req = [_msg("system", content="S")]
     for r in range(4):
@@ -565,6 +613,34 @@ def test_t3_before_t4_before_current_when_room_for_both():
     assert "the refund policy was updated for merchants" in _join(out)
 
 
+def test_t3_and_t4_together_stay_within_hard_budget():
+    req = [
+        _msg("system", content="S"),
+        _msg("user", content="CURRENT what did we do earlier about the refund policy"),
+    ]
+    store = _fake_store(memory_entries=["refund decision from memory", "repeat merchant note"])
+    e = _engine(
+        store=store,
+        context_length=65536,
+        history_retrieval_enabled=True,
+        _session_search_fn=lambda **k: _discovery_payload(
+            "the refund policy was updated for merchants " + "R" * 60000,
+            "another refund fact " + "F" * 60000,
+        ),
+    )
+    out = e.select_context(req, budget_tokens=65536)
+    assert out is not None
+    joined = _join(out)
+    assert _T3_LABEL in joined
+    assert _T4_LABEL in joined
+    from plugins.context_engine.ci import _serialized_estimate
+
+    hard = e._hard_budget_for(65536)
+    assert estimate_messages_tokens_rough(out) <= hard
+    assert _serialized_estimate(out) <= hard
+    assert out[-1] is req[-1]
+
+
 # ---- context engine failure fails open ----------------------------------------------
 def test_context_engine_failure_fails_open():
     class _Exploding(ContextIntelligenceEngine):
@@ -621,6 +697,35 @@ def test_second_stage_serialized_reduction_drops_supplements(monkeypatch):
     assert kept >= 1, "reduction must keep as many supplements as fit"
     assert kept <= 2, "reduction must drop the supplements that overflow the serialized budget"
     assert out[-1] is req[-1]
+
+
+def test_drop_out_fallback_returns_bounded_base_never_unbounded(monkeypatch):
+    """When the second-stage reduction cannot fit even the base selection under the
+    serialized estimate, CI must return the already-bounded base — never the original
+    unbounded transcript."""
+    from plugins.context_engine import ci as ci_mod
+
+    req = [
+        _msg("system", content="S"),
+        _msg("user", content="CURRENT what did we do earlier about refunds"),
+    ]
+    store = _fake_store(memory_entries=["refund note"])
+    # Simulate a provider whose serialization always overflows the hard budget: every
+    # supplement must be dropped and the engine must fall back to the bounded base.
+    monkeypatch.setattr(ci_mod, "_serialized_estimate", lambda messages: 10**12)
+    e = _engine(
+        store=store,
+        context_length=262144,
+        history_retrieval_enabled=True,
+        _session_search_fn=lambda **k: _discovery_payload("refund history fact"),
+    )
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is not None
+    joined = _join(out)
+    assert _T3_LABEL not in joined
+    assert _T4_LABEL not in joined
+    assert out[-1] is req[-1]
+    assert estimate_messages_tokens_rough(out) <= e._hard_budget_for(262144)
 
 
 # ---- realistic loader path (real on-disk MemoryStore) -------------------------------
@@ -709,6 +814,49 @@ def test_status_reports_intelligence_flags():
 
 
 # ---- host pipeline integration ------------------------------------------------------
+# ANCOS Stage-1 (CI-only) readiness regression: proving the config->engine wiring that
+# selects the ci plugin, that compressor stays the default, and that selecting ci does
+# NOT enable memory or T4 and does not alter provider/9Router wiring.
+def test_stage1_ci_config_selects_engine_and_defaults():
+    from agent.agent_init import _select_context_engine
+
+    sel = _select_context_engine({"context": {"engine": "ci"}})
+    assert sel is not None
+    assert sel.name == "ci"
+    # Selecting ci must NOT enable T4 by default.
+    assert sel.history_retrieval_enabled is False
+    # Selecting ci must NOT surface memory/T4 on a fresh selection: no provider wiring is
+    # touched (engine carries no provider) and the engine starts with zero injections.
+    assert not hasattr(sel, "provider")
+    assert sel._ci_injection_count == 0
+
+
+def test_stage1_compressor_remains_default():
+    from agent.agent_init import _select_context_engine
+
+    # Explicit compressor, and the absence of a context.engine key, both stay built-in.
+    assert _select_context_engine({"context": {"engine": "compressor"}}) is None
+    assert _select_context_engine({"context": {}}) is None
+    assert _select_context_engine({}) is None
+
+
+def test_stage1_selecting_ci_does_not_enable_memory_or_t4_with_disabled_flags(monkeypatch):
+    """With the host's memory flags explicitly OFF (Stage-1 config), selecting ci must
+    inject neither memory nor history even on a recall-intent prompt."""
+    from tools import memory_tool
+
+    monkeypatch.setattr(memory_tool, "get_builtin_memory_store_flags", lambda *a, **k: (False, False))
+    e = load_context_engine("ci")
+    e.update_model("test/ci", 262144)
+    e._memory_store_loader = None  # exercise the real loader path
+    req = [_msg("system", content="S"), _msg("user", content="what did we decide earlier?")]
+    out = e.select_context(req, budget_tokens=262144)
+    assert out is req
+    joined = _join(out)
+    assert _T3_LABEL not in joined
+    assert _T4_LABEL not in joined
+
+
 def test_host_pipeline_integration_ci_engine():
     from types import SimpleNamespace
 

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -94,6 +94,7 @@ class TestSchema:
             "current_session_id",
             "session_id",
             "around_message_id",
+            "user_id",
             "window",
             "sort",
             "profile",

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -75,6 +75,24 @@ def _get_session_meta(db, session_id: str) -> dict:
                   "get_session failed for %s: %s", session_id, with_exc=True) or {}
 
 
+def _owner_matches(meta: Dict[str, Any], owner_user_id: Optional[str]) -> bool:
+    """Fail-closed ownership check for historical session recall.
+
+    ``user_id`` is the authoritative owner boundary when present. An unknown caller
+    identity must never gain access to an owned session; this prevents legacy NULL
+    sessions from becoming a cross-user bypass.
+    """
+    owner = str(owner_user_id or "").strip()
+    if not owner_user_id:
+        return True  # legacy direct callers; the agent inline executor gates T4 identity.
+    target = str(meta.get("user_id") or "").strip()
+    return bool(target) and owner == target
+
+
+def _ownership_error() -> str:
+    return tool_error("session history unavailable: caller ownership identity is required", success=False)
+
+
 def _session_meta_block(meta: Dict[str, Any]) -> Dict[str, Any]:
     return {"when": _format_timestamp(meta.get("started_at")), "source": meta.get("source"),
             "model": meta.get("model"), "title": meta.get("title")}
@@ -183,7 +201,7 @@ def _discovery_entry(lineage_root: Optional[str], **fields) -> Dict[str, Any]:
     return entry
 
 
-def _title_match_result(db, query: str, current_lineage_root: Optional[str]) -> Optional[Dict[str, Any]]:
+def _title_match_result(db, query: str, current_lineage_root: Optional[str], owner_user_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """Discovery-shaped result when the query matches a session title, else None."""
     title_query = query.strip().strip("`'\"")  # models often quote a remembered title
     session_id = title_query and _quiet(lambda: db.resolve_session_by_title(title_query), None,
@@ -198,6 +216,8 @@ def _title_match_result(db, query: str, current_lineage_root: Optional[str]) -> 
     session_meta = _quiet(lambda: db.get_session(lineage_root) or db.get_session(session_id), None,
                           "get_session failed for title match %s", session_id) or {}
     if session_meta.get("source") in _HIDDEN_SESSION_SOURCES:
+        return None
+    if not _owner_matches(session_meta, owner_user_id):
         return None
     messages = _quiet(lambda: db.get_messages(session_id), [], "get_messages failed for title match %s", session_id)
     anchor_id = messages[0].get("id") if messages else None
@@ -259,16 +279,21 @@ def _hydrate_hit(db, lineage_root: str, match_info: Dict[str, Any], result_detai
 
 
 def _discover(db, query: str, role_filter: Optional[List[str]], limit: int, sort: Optional[str],
-              detail: str, current_session_id: str = None, link_profile: str = None) -> str:
+              detail: str, current_session_id: str = None, link_profile: str = None,
+              owner_user_id: str = None) -> str:
     """Discovery shape: FTS5 plus adaptive or full result hydration."""
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
-    title_result = _title_match_result(db, query, current_lineage_root)
+    title_result = _title_match_result(db, query, current_lineage_root, owner_user_id)
     raw_results, err = _loud(lambda: db.search_messages(
         query=query, role_filter=role_filter or ["user", "assistant"],
         exclude_sources=list(_HIDDEN_SESSION_SOURCES), limit=_DISCOVER_SCAN_LIMIT, offset=0, sort=sort,
         fields=_DISCOVER_SEARCH_FIELDS), "FTS5 search failed: %s", "Search failed")
     if err:
         return err
+    # Ownership is enforced before ranking/dedup/hydration so another user's session
+    # can neither be discovered nor influence result ordering.
+    raw_results = [r for r in raw_results
+                   if _owner_matches(_get_session_meta(db, r.get("session_id")), owner_user_id)]
     # Demote cron rows below interactive ones BEFORE dedup so a high-volume cron corpus
     # can't starve the user's own sessions out of the top `limit`; stable sort keeps BM25
     # order within each class.
@@ -365,11 +390,13 @@ def _locate_session_db(session_id: str):
     return None, None
 
 
-def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_profile: str = None) -> str:
+def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_profile: str = None, owner_user_id: str = None) -> str:
     """Read shape: whole session, or ``head`` + ``tail`` messages with a scroll pointer."""
     meta = _get_session_meta(db, session_id)
     if not meta:
         return tool_error(f"session_id not found: {session_id}", success=False)
+    if not _owner_matches(meta, owner_user_id):
+        return _ownership_error()
     rows, err = _loud(lambda: db.get_messages(session_id), "get_messages failed for %s: %s", "failed to load session",
                       session_id)
     if err:
@@ -383,21 +410,21 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
                                "Pass around_message_id (any id above) to scroll the middle.")} if truncated else {}))
 
 
-def _read_with_profile_fallback(db, sid: str, profile: Optional[str]) -> str:
+def _read_with_profile_fallback(db, sid: str, profile: Optional[str], owner_user_id: str = None) -> str:
     """Read shape; on a miss scan every profile (the model may have dropped the owning
     profile from the link) and tag the result with where it was found."""
-    result = _read_session(db, sid, link_profile=profile)
+    result = _read_session(db, sid, link_profile=profile, owner_user_id=owner_user_id)
     located, owner = (None, None) if json.loads(result).get("success") else _locate_session_db(sid)
     if located is None:
         return result
     try:
-        found = json.loads(_read_session(located, sid, link_profile=owner))
+        found = json.loads(_read_session(located, sid, link_profile=owner, owner_user_id=owner_user_id))
     finally:
         located.close()
     return json.dumps({**found, "profile": owner}, ensure_ascii=False) if found.get("success") else result
 
 
-def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_profile: str = None) -> str:
+def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_profile: str = None, owner_user_id: str = None) -> str:
     """Browse shape: metadata for the most recent sessions (no LLM, no FTS5)."""
     def _browse():
         # Never use list_sessions_rich(order_by_last_active=True) here: it walks every
@@ -417,6 +444,7 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_p
         # Compression continuation: the root was summarised into the live child, so hide
         # it. /new-reset children carry no transcript — keep that root browsable.
         hidden = {current_session_id, current_root if has_compression_hop and current_root else None}
+        sessions = [s for s in sessions if _owner_matches(s, owner_user_id)]
         results = [{
             "session_id": s.get("id", ""), "link": _session_link(s.get("id", ""), link_profile),
             "title": s.get("title") or None, **{k: s.get(k, "") for k in ("source", "started_at", "last_active")},
@@ -449,7 +477,7 @@ def _anchor_in_live_context(db, anchor_state, anchor_sid: str, current_session_i
 
 
 def _scroll(db, session_id: str, around_message_id: int, window: int = 5,
-            current_session_id: str = None) -> str:
+            current_session_id: str = None, owner_user_id: str = None) -> str:
     """Scroll shape: a window centered on an anchor (no FTS5, no bookends)."""
     try:
         around_message_id = int(around_message_id)
@@ -464,6 +492,12 @@ def _scroll(db, session_id: str, around_message_id: int, window: int = 5,
     session_meta = _get_session_meta(db, session_id)
     if not session_meta:
         return tool_error(f"session_id not found: {session_id}", success=False)
+    if not _owner_matches(session_meta, owner_user_id):
+        return _ownership_error()
+    if owning and owning != session_id:
+        owning_meta = _get_session_meta(db, owning)
+        if not _owner_matches(owning_meta, owner_user_id):
+            return _ownership_error()
     view, err = _loud(lambda: db.get_messages_around(session_id, around_message_id, window=window),
                       "get_messages_around failed: %s", "failed to load messages")
     if err:
@@ -495,7 +529,8 @@ def _scroll(db, session_id: str, around_message_id: int, window: int = 5,
 
 
 def _dispatch(query, role_filter, limit, db, current_session_id, session_id,
-              around_message_id, window, sort, profile, detail, owned_dbs) -> str:
+              around_message_id, window, sort, profile, detail, owned_dbs,
+              owner_user_id) -> str:
     """Mode dispatch (see module docstring); scroll wins when an anchor is set.
     Profile DBs opened here are appended to *owned_dbs* for the caller to close."""
     # A raw `@session:<profile>/<id>` link as session_id: ids never contain "/", so
@@ -517,26 +552,30 @@ def _dispatch(query, role_filter, limit, db, current_session_id, session_id,
         owned_dbs.append(profile_db)
     if isinstance(session_id, str) and session_id.strip():
         if around_message_id is not None:
-            return _scroll(db, session_id.strip(), around_message_id, window, current_session_id)
-        return _read_with_profile_fallback(db, session_id.strip(), profile)
+            return _scroll(db, session_id.strip(), around_message_id, window, current_session_id, owner_user_id)
+        return _read_with_profile_fallback(db, session_id.strip(), profile, owner_user_id)
     limit = _clamp_int(limit, 3, 1, 10)
     if not query or not isinstance(query, str) or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id, link_profile=profile)
+        return _list_recent_sessions(db, limit, current_session_id, link_profile=profile, owner_user_id=owner_user_id)
     sort_norm = sort.strip().lower() if isinstance(sort, str) else None
     return _discover(
         db=db, query=query.strip(), limit=limit, sort=sort_norm if sort_norm in ("newest", "oldest") else None,
         role_filter=([r.strip() for r in role_filter.split(",") if r.strip()] or None) if isinstance(role_filter, str) else None,
         detail="full" if isinstance(detail, str) and detail.strip().lower() == "full" else "adaptive",
-        current_session_id=current_session_id, link_profile=profile)
+        current_session_id=current_session_id, link_profile=profile, owner_user_id=owner_user_id)
 
 
 def session_search(query: str = "", role_filter: str = None, limit: int = 3, db=None,
                    current_session_id: str = None, session_id: str = None, around_message_id: int = None,
+                   user_id: str = None,
                    window: int = 5, sort: str = None, profile: str = None, detail: str = "adaptive") -> str:
     """Run session search, closing DBs opened here. Positional order is frozen for old callers."""
     from hermes_state import format_session_db_unavailable
     from hermes_state_registry import acquire, release_or_close
     owned_dbs: List[Any] = []
+    owner_user_id = str(user_id or "").strip() or None
+    if not owner_user_id and current_session_id and db is not None:
+        owner_user_id = str(_get_session_meta(db, current_session_id).get("user_id") or "").strip() or None
     if db is None:
         db = _quiet(acquire, None, "SessionDB unavailable for session_search")
         if db is None:
@@ -544,7 +583,7 @@ def session_search(query: str = "", role_filter: str = None, limit: int = 3, db=
         owned_dbs.append(db)
     try:
         return _dispatch(query, role_filter, limit, db, current_session_id, session_id,
-                         around_message_id, window, sort, profile, detail, owned_dbs)
+                         around_message_id, window, sort, profile, detail, owned_dbs, owner_user_id)
     finally:
         for owned_db in reversed(owned_dbs):
             _quiet(lambda: release_or_close(owned_db), None, "Failed to close session_search SessionDB")


### PR DESCRIPTION
## ANCOS reconciliation

Reconciles the validated ANCOS production changes from the VPS into the upstream Hermes codebase.

### Scope

- Context-engine config → runtime attribute wiring
- Context-engine user identity propagation
- Fail-closed session history ownership enforcement
- T4 history retrieval user_id pass-through
- Validated Context Intelligence production implementation
- Corresponding session_search schema test update

### Verification

- 181 focused tests passed locally
- compileall passed
- git diff --check passed
- VPS production diff SHA-256 verified:
  `72c61f2f12be3d432e700e35bd4c6529277aa9cff2c4d62e5ef9dac551c60052`
- Context Intelligence source SHA-256 verified:
  `844a0af908a4284f72c027fde3563eeffc1cb19c7e7aeb7d578b3e760e15aa62`

### Safety

This reconciliation was isolated from unrelated Hermes/workforce changes.

No production deployment is included in this PR.

The changes were validated against the production implementation before reconciliation.