### PR TITLE
fix(cli): accept plugin platform bundle entries in platform_toolsets validation

### DIFF
--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -68,7 +68,13 @@ def validate_platform_toolsets(
         for name in raw:
             if not isinstance(name, str) or not name:
                 continue
-            if not is_valid_toolset(name):
+            if name == default and default_valid:
+                # A plugin platform's synthesized bundle (hermes-<platform>) is
+                # rejected by is_valid_toolset() yet resolves to a full toolset;
+                # default_valid already consulted the platform registry.
+                valid_count += 1
+                platform_valid_count += 1
+            elif not is_valid_toolset(name):
                 hint = f" — did you mean '{default}'?" if default_valid else ""
                 warnings.append(f"platform '{platform}' references unknown toolset '{name}'{hint}")
             elif is_allowed_for_platform(name, str(platform)):

--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -197,3 +197,72 @@ def test_populated_platforms_produce_no_empty_list_warning():
     cfg = {"cli": ["hermes-cli"], "telegram": ["hermes-telegram"]}
     warnings = validate_platform_toolsets(cfg, _is_valid)
     assert warnings == []
+
+
+def test_explicit_plugin_platform_bundle_entry_is_valid():
+    # The shipped cli-config.yaml.example documents teams: [hermes-teams];
+    # the synthesized bundle is not in TOOLSETS, but default_valid consulted
+    # the platform registry, so the explicit entry must count as valid.
+    from gateway.platform_registry import PlatformEntry, platform_registry
+    from toolsets import resolve_toolset
+
+    platform = "toolset_validation_bundle"
+    platform_registry.register(
+        PlatformEntry(
+            name=platform,
+            label="Toolset Validation Bundle",
+            adapter_factory=lambda _config: object(),
+            check_fn=lambda: True,
+        )
+    )
+    try:
+        cfg = {platform: [f"hermes-{platform}"], "telegram": ["hermes-telegram"]}
+        warnings = validate_platform_toolsets(cfg, _is_valid)
+
+        assert resolve_toolset(f"hermes-{platform}")
+        assert warnings == []
+    finally:
+        platform_registry.unregister(platform)
+
+
+def test_plugin_platform_bundle_alongside_unknown_name_still_warns():
+    # Only the bundle entry is exempt; genuinely unknown names on the same
+    # list keep their warning, with the bundle as the suggestion.
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    platform = "toolset_validation_bundle"
+    platform_registry.register(
+        PlatformEntry(
+            name=platform,
+            label="Toolset Validation Bundle",
+            adapter_factory=lambda _config: object(),
+            check_fn=lambda: True,
+        )
+    )
+    try:
+        cfg = {platform: [f"hermes-{platform}", "bogus"]}
+        warnings = validate_platform_toolsets(cfg, _is_valid)
+
+        assert any(
+            f"platform '{platform}'" in w
+            and "unknown toolset 'bogus'" in w
+            and f"did you mean 'hermes-{platform}'?" in w
+            for w in warnings
+        )
+        assert not any("no valid toolsets" in w for w in warnings)
+        assert not any("zero valid toolsets" in w for w in warnings)
+    finally:
+        platform_registry.unregister(platform)
+
+
+def test_unregistered_platform_bundle_entry_still_warns():
+    # Registry unaware of the platform: the bundle entry is treated exactly
+    # as before, so a typo like hermes-teams on a non-plugin platform keeps
+    # the unknown-toolset warning and the zero-valid safety net.
+    cfg = {"teams": ["hermes-teams"]}
+    warnings = validate_platform_toolsets(cfg, _is_valid)
+
+    assert any("unknown toolset 'hermes-teams'" in w for w in warnings)
+    assert not any("did you mean 'hermes-teams'?" in w for w in warnings)
+    assert any("platform 'teams'" in w and "no valid toolsets" in w for w in warnings)
+    assert any("zero valid toolsets" in w for w in warnings)


### PR DESCRIPTION
## Summary

`platform_toolsets` entries naming a plugin platform's synthesized bundle (`teams: [hermes-teams]` — verbatim from the shipped `cli-config.yaml.example`) were reported as unknown toolsets, followed by a claim that the platform will have no tools. Both statements are false: the bundle resolves to the full platform toolset via `toolsets.resolve_toolset()` → `_plugin_platform_bundle()`.

Root cause: the two validation paths in `hermes_cli/toolset_validation.py` disagree about plugin platforms. `_platform_default_is_valid()` (used by the null/scalar fallback branch) consults `gateway.platform_registry.is_registered(platform)`, but the per-entry list loop only called the injected `is_valid_toolset` — which resolves to `toolsets.validate_toolset()`, a predicate that never knows about synthesized `hermes-<platform>` bundles. The same string was "valid" as a platform default and "unknown" as an explicit entry, and the "did you mean" hint could echo the exact string it just declared unknown.

Fix: in the list branch, treat an entry equal to the platform's own default as valid when `default_valid` already holds — the same source of truth the null/scalar branch trusts (the platform registry for plugin platforms). Genuinely unknown names on the same list still warn, with the bundle as a now-correct suggestion; the false "no tools" claim disappears for bundle entries. Registry-unaware platforms keep the old behavior entirely (typo case unchanged).

## Testing

- `env -u HERMES_YOLO_MODE .venv/bin/python -m pytest tests/hermes_cli/test_toolset_validation.py -q` → **15 passed** (12 pre-existing + 3 new).
- New regression tests: explicit bundle entry is valid and produces zero warnings; bundle alongside a genuinely unknown name still warns for the unknown one without the "no tools" claim; unregistered platform keeps the old unknown-toolset warning and the zero-valid safety net.
- Mutation check: disabling the new branch (`if False and ...`) turns the first two new tests red.
- `ruff check` clean; `ruff format --diff` complaint count equals the pristine-main baseline (77 = 77).

Fixes #107098
