### PR TITLE
fix(tools): mount HERMES_HOME persona files into docker terminal containers

### DIFF
--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -10,6 +10,8 @@ from tools.credential_files import (
     clear_credential_files,
     get_credential_file_mounts,
     get_cache_directory_mounts,
+    get_hermes_context_dir_mounts,
+    get_hermes_context_file_mounts,
     get_skills_directory_mount,
     iter_cache_files,
     iter_skills_files,
@@ -472,6 +474,69 @@ class TestCacheDirectoryMounts:
             map_cache_path_to_container(str(upload))
             == "/root/.hermes/images/upload_20260722_181019_1.png"
         )
+
+
+class TestHermesContextMounts:
+    """Tests for persona/context mounts into Docker terminal containers (#100900)."""
+
+    def test_existing_persona_files_mounted(self, tmp_path, monkeypatch):
+        """SOUL.md and friends at the HERMES_HOME root mount into the container."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").write_text("# persona", encoding="utf-8")
+        (hermes_home / "USER.md").write_text("# user", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mounts = get_hermes_context_file_mounts()
+        by_container = {m["container_path"]: m["host_path"] for m in mounts}
+        assert by_container["/root/.hermes/SOUL.md"] == str(hermes_home / "SOUL.md")
+        assert by_container["/root/.hermes/USER.md"] == str(hermes_home / "USER.md")
+
+    def test_missing_context_not_mounted(self, tmp_path, monkeypatch):
+        """An empty home produces no context mounts (no dangling docker -v args)."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert get_hermes_context_file_mounts() == []
+        assert get_hermes_context_dir_mounts() == []
+
+    def test_kind_mismatch_skipped(self, tmp_path, monkeypatch):
+        """A directory named SOUL.md is not returned by the file getter."""
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "SOUL.md").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert get_hermes_context_file_mounts() == []
+
+    def test_scripts_dir_mounted(self, tmp_path, monkeypatch):
+        """The user scripts directory mounts so host scripts stay runnable in the container."""
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "scripts").mkdir(parents=True)
+        (hermes_home / "scripts" / "deploy.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mounts = get_hermes_context_dir_mounts()
+        by_container = {m["container_path"]: m["host_path"] for m in mounts}
+        assert by_container["/root/.hermes/scripts"] == str(hermes_home / "scripts")
+
+    def test_profile_home_dual_mounts(self, tmp_path, monkeypatch):
+        """A profile home mounts to both the default and profile container paths.
+
+        The container-side session may resolve HERMES_HOME to either location
+        depending on whether it carries a profile-scoped override.
+        """
+        hermes_home = tmp_path / ".hermes" / "profiles" / "work"
+        hermes_home.mkdir(parents=True)
+        (hermes_home / "SOUL.md").write_text("# work persona", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mounts = get_hermes_context_file_mounts()
+        container_paths = {m["container_path"] for m in mounts}
+        assert container_paths == {
+            "/root/.hermes/SOUL.md",
+            "/root/.hermes/profiles/work/SOUL.md",
+        }
 
 
 class TestMapCachePathToContainer:

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -538,6 +538,38 @@ class TestHermesContextMounts:
             "/root/.hermes/profiles/work/SOUL.md",
         }
 
+    def test_profiles_component_above_home_not_dual_mounted(self, tmp_path, monkeypatch):
+        """A "profiles" directory above the real home is not a profile root.
+
+        ``tmp_path/profiles/dev/.hermes`` is a default home whose host path
+        merely contains a "profiles" segment; it must not gain a second,
+        wrong container target built from that outer segment.
+        """
+        hermes_home = tmp_path / "profiles" / "dev" / ".hermes"
+        hermes_home.mkdir(parents=True)
+        (hermes_home / "SOUL.md").write_text("# persona", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mounts = get_hermes_context_file_mounts()
+        assert [m["container_path"] for m in mounts] == ["/root/.hermes/SOUL.md"]
+
+    def test_real_profile_below_profiles_named_ancestor_targets_profile_only(
+        self, tmp_path, monkeypatch
+    ):
+        """A real profile home below a coincidental "profiles" ancestor still dual-mounts
+        to the canonical ``profiles/<name>`` container path, not the outer segment."""
+        hermes_home = tmp_path / "profiles" / "dev" / ".hermes" / "profiles" / "work"
+        hermes_home.mkdir(parents=True)
+        (hermes_home / "SOUL.md").write_text("# work persona", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mounts = get_hermes_context_file_mounts()
+        container_paths = {m["container_path"] for m in mounts}
+        assert container_paths == {
+            "/root/.hermes/SOUL.md",
+            "/root/.hermes/profiles/work/SOUL.md",
+        }
+
 
 class TestMapCachePathToContainer:
     """Tests for map_cache_path_to_container() — the backend-agnostic mapper."""

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from io import StringIO
+from pathlib import Path
 import subprocess
 
 import pytest
@@ -490,6 +491,9 @@ def test_snap_compat_drops_only_init_and_no_new_privileges(monkeypatch):
     """#9730: snap-packaged Docker under AppArmor turns ``--init`` and ``no-new-privileges`` into
     "exec: operation not permitted" for every process in the container. The opt-out drops exactly
     those two flags; cap-drop, tmpfs hardening and the privdrop caps are unchanged."""
+    # Pin the persona file: the sandbox HERMES_HOME seeds SOUL.md lazily, which would
+    # otherwise make the persona-mount list differ between the two runs below.
+    Path(os.environ["HERMES_HOME"], "SOUL.md").write_text("# pinned", encoding="utf-8")
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
 
     def run_args(**kw):
@@ -1809,3 +1813,21 @@ def test_docker_env_warnings_never_echo_values(caplog):
     with caplog.at_level(logging.WARNING, logger="tools.environments.docker"):
         docker_env._normalize_env_dict({"TOKEN": ["sk-live-value"], "OK": "1"})
     assert "TOKEN" in caplog.text and "sk-live-value" not in caplog.text
+
+
+def test_persona_context_mount_args_included(tmp_path, monkeypatch):
+    """HERMES_HOME persona files and scripts reach the container read-only (#100900).
+
+    The docker backend mounts only subdirectories by default, so a SOUL.md at
+    the home root stayed invisible and the in-container agent fell back to the
+    seeded default persona.
+    """
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "SOUL.md").write_text("# persona", encoding="utf-8")
+    (hermes_home / "scripts").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    args = docker_env._readonly_skill_mount_args()
+    assert f"{hermes_home / 'SOUL.md'}:/root/.hermes/SOUL.md:ro" in args
+    assert f"{hermes_home / 'scripts'}:/root/.hermes/scripts:ro" in args

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -286,6 +286,59 @@ def get_cache_directory_mounts(container_base: str = "/root/.hermes") -> List[Di
     return [_mount(h, c) for h, c in _cache_dir_roots(container_base, create_missing=True)]
 
 
+# Persona/identity context living at the HERMES_HOME root. Docker terminal
+# containers bind-mount only subdirectories (skills, cache, credential files),
+# so without these mounts the in-container agent never sees the host persona
+# and falls back to the seeded default SOUL.md, and user scripts are
+# unreachable (#100900).
+_HERMES_CONTEXT_FILES: tuple[str, ...] = (
+    "SOUL.md",
+    "USER.md",
+    "MEMORY.md",
+    "IDENTITY.md",
+    "HEARTBEAT.md",
+    "BOOTSTRAP.md",
+    "AGENTS.md",
+)
+_HERMES_CONTEXT_DIRS: tuple[str, ...] = ("scripts",)
+
+
+def _hermes_context_mounts(
+    names: tuple[str, ...], container_base: str, *, is_dir: bool
+) -> List[Dict[str, str]]:
+    """Mount entries for HERMES_HOME-root context files/dirs that exist on the host.
+
+    A profile home (``…/profiles/<name>``) dual-mounts each entry to both the
+    default and the profile-specific container paths, so it stays visible
+    regardless of how the container-side session resolves HERMES_HOME.
+    """
+    home = get_hermes_home()
+    base = container_base.rstrip("/")
+    parts = home.parts
+    targets = [base]
+    if "profiles" in parts:
+        profile_target = f"{base}/{'/'.join(parts[parts.index('profiles'):])}"
+        if profile_target != base:
+            targets.append(profile_target)
+    mounts: List[Dict[str, str]] = []
+    for name in names:
+        host_path = home / name
+        if not (host_path.is_dir() if is_dir else host_path.is_file()):
+            continue
+        mounts.extend(_mount(host_path, f"{target}/{name}") for target in targets)
+    return mounts
+
+
+def get_hermes_context_file_mounts(container_base: str = "/root/.hermes") -> List[Dict[str, str]]:
+    """Bind-mount entries for persona files at the HERMES_HOME root (SOUL.md, ...)."""
+    return _hermes_context_mounts(_HERMES_CONTEXT_FILES, container_base, is_dir=False)
+
+
+def get_hermes_context_dir_mounts(container_base: str = "/root/.hermes") -> List[Dict[str, str]]:
+    """Bind-mount entries for HERMES_HOME context directories (``scripts``)."""
+    return _hermes_context_mounts(_HERMES_CONTEXT_DIRS, container_base, is_dir=True)
+
+
 def _remap_cache_path(path: str, container_base: str, src: str, dst: str, join: Callable[[str, Path], str]) -> Optional[str]:
     """Translate *path* from the *src* side of a cache mount to its *dst* side; None if unmounted."""
     for mount in get_cache_directory_mounts(container_base=container_base):

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Callable, Dict, Iterator, List, Optional, Tuple
 
 from hermes_cli.config import cfg_get
-from hermes_constants import get_hermes_dir, get_hermes_home
+from hermes_constants import get_hermes_dir, get_hermes_home, named_profile_home
 
 from agent.skill_utils import EXCLUDED_SKILL_DIRS
 
@@ -314,10 +314,13 @@ def _hermes_context_mounts(
     """
     home = get_hermes_home()
     base = container_base.rstrip("/")
-    parts = home.parts
     targets = [base]
-    if "profiles" in parts:
-        profile_target = f"{base}/{'/'.join(parts[parts.index('profiles'):])}"
+    profile_home = named_profile_home(home)
+    if profile_home is not None:
+        # Only the ``<root>/profiles/<name>`` suffix names the container-side
+        # profile path; a "profiles" component elsewhere in the host path
+        # (e.g. ``/srv/profiles/dev/.hermes``) must not hijack the target.
+        profile_target = f"{base}/{'/'.join(profile_home.parts[-2:])}"
         if profile_target != base:
             targets.append(profile_target)
     mounts: List[Dict[str, str]] = []

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -437,7 +437,9 @@ def _name_only_env_args(names) -> list[str]:
 _RO_MOUNT_SOURCES = (
     ("get_credential_file_mounts", True, "credential"),
     ("get_skills_directory_mount", False, "skills dir"),
-    ("get_cache_directory_mounts", False, "cache dir"))
+    ("get_cache_directory_mounts", False, "cache dir"),
+    ("get_hermes_context_file_mounts", True, "persona file"),
+    ("get_hermes_context_dir_mounts", False, "persona dir"))
 
 
 def _readonly_skill_mount_args() -> list[str]:

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -439,7 +439,7 @@ _RO_MOUNT_SOURCES = (
     ("get_skills_directory_mount", False, "skills dir"),
     ("get_cache_directory_mounts", False, "cache dir"),
     ("get_hermes_context_file_mounts", True, "persona file"),
-    ("get_hermes_context_dir_mounts", False, "persona dir"))
+    ("get_hermes_context_dir_mounts", False, "scripts dir"))
 
 
 def _readonly_skill_mount_args() -> list[str]:


### PR DESCRIPTION
## What does this PR do?

With `terminal.backend: docker`, the container only bind-mounts subdirectories of HERMES_HOME (skills, cache dirs, credential files). Persona files living at the HERMES_HOME root — `SOUL.md`, `USER.md`, `MEMORY.md`, `IDENTITY.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, `AGENTS.md` — and the `scripts/` directory were invisible inside the container, so the in-container agent fell back to the hard-coded default persona seeded by `_ensure_default_soul_md` and user scripts were unreachable.

This PR adds two mount getters to `tools/credential_files.py` (`get_hermes_context_file_mounts` / `get_hermes_context_dir_mounts`) and registers them in the docker backend's existing `_RO_MOUNT_SOURCES` table, so persona files and `scripts/` mount read-only (`-v host:container:ro`) alongside the existing credential/cache mounts — reusing the same dispatch, kind-check and skip-with-warning path as the other mount sources. A profile home dual-mounts each entry to both the default and the profile-specific container paths, so the persona stays visible regardless of how the container-side session resolves HERMES_HOME. Only paths that actually exist on the host are returned, so a default install adds no mounts.

Note: #101022 previously fixed this and was closed for merge conflicts, not rejected on direction, so this is an independent re-implementation against current main (upstream has since drifted: the old `_resolve_hermes_home` helper no longer exists).

## Related Issue

Fixes #100900

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/credential_files.py`: added `_HERMES_CONTEXT_FILES`/`_HERMES_CONTEXT_DIRS` constants and a shared `_hermes_context_mounts()` helper plus the two public getters, following the module's existing mount-getter pattern.
- `tools/environments/docker.py`: registered the two getters in `_RO_MOUNT_SOURCES` (2 lines, no other backend changes).
- `tests/tools/test_credential_files.py`: new `TestHermesContextMounts` covering existing-file mounts, empty home, kind mismatch, `scripts/` dir and profile dual-mount.
- `tests/tools/test_docker_environment.py`: integration test asserting the persona/`scripts` mounts appear in the generated `docker run` args; pinned the lazily-seeded `SOUL.md` in `test_snap_compat_drops_only_init_and_no_new_privileges` so its exact-args comparison stays deterministic.

## How to Test

1. Point `HERMES_HOME` at a directory containing a custom `SOUL.md` and a `scripts/deploy.sh`.
2. Start a docker terminal session; the startup logs / `docker inspect` output show `-v <home>/SOUL.md:/root/.hermes/SOUL.md:ro` and `-v <home>/scripts:/root/.hermes/scripts:ro`.
3. Observed result: tests pass —
   - `pytest tests/tools/test_credential_files.py tests/tools/test_docker_environment.py -q` → 117 passed
   - `pytest tests/tools/test_docker_*.py tests/tools/test_credential_*.py -q` → 206 passed
   - `test_persona_context_mount_args_included` asserts the generated mounts directly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (mounts are host-path strings resolved by the docker CLI)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
