### PR TITLE
fix(models): honor discover_models=false for built-in/canonical picker rows

### DIFF
--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -715,10 +715,14 @@ def _lap_builtin_rows(b: _PickerBuild, data: dict, user_providers: dict) -> None
             continue
         model_ids = _live_or_curated_ids(hermes_id, b.curated)
         # A providers.<built-in>.models block extends the discovered catalog; section 3 cannot
-        # emit it later because this row owns the slug.
+        # emit it later because this row owns the slug. discover_models: false pins the row to
+        # just the declared list instead, matching the custom-endpoint semantics (#107106).
         configured = user_providers.get(hermes_id) if isinstance(user_providers, dict) else None
         configured_models = _declared_model_ids(configured.get("models")) if isinstance(configured, dict) else []
-        model_ids = list(dict.fromkeys([*configured_models, *model_ids]))
+        if isinstance(configured, dict) and configured_models and not _discover_flag(configured):
+            model_ids = list(configured_models)
+        else:
+            model_ids = list(dict.fromkeys([*configured_models, *model_ids]))
         pinfo = get_provider_info(mdev_id)
         display_name = pconfig.name if pconfig and pconfig.name else (pinfo.name if pinfo else mdev_id)
         b.add_builtin_row(
@@ -809,9 +813,10 @@ def _lap_overlay_rows(b: _PickerBuild, data: dict) -> None:
         b.seen_slugs.add(pid.lower())
 
 
-def _lap_canonical_rows(b: _PickerBuild) -> None:
+def _lap_canonical_rows(b: _PickerBuild, user_providers: dict) -> None:
     """Section 2b: CANONICAL_PROVIDERS missed by sections 1/2."""
     from hermes_cli.auth import PROVIDER_REGISTRY
+    from hermes_cli.model_switch import _declared_model_ids
     from hermes_cli.models import CANONICAL_PROVIDERS
     for cp in CANONICAL_PROVIDERS:
         if _skip(b.seen_slugs, b.excluded, cp.slug):
@@ -836,6 +841,12 @@ def _lap_canonical_rows(b: _PickerBuild) -> None:
             model_ids = _aws_live_or_curated_ids(cp.slug, b.curated)
         else:
             model_ids = _live_or_curated_ids(cp.slug, b.curated, merge_models_dev=False)
+        # discover_models: false + a non-empty providers.<slug>.models narrows this row to the
+        # declared list instead of the live catalog, mirroring section 1 (#107106).
+        configured = user_providers.get(cp.slug) if isinstance(user_providers, dict) else None
+        configured_models = _declared_model_ids(configured.get("models")) if isinstance(configured, dict) else []
+        if isinstance(configured, dict) and configured_models and not _discover_flag(configured):
+            model_ids = list(configured_models)
         b.add_builtin_row(
             cp.slug, cp.label, cp.slug == b.current_provider, model_ids, "canonical", uncapped_ok=False)
 
@@ -1097,7 +1108,7 @@ def list_authenticated_providers(
 
     _lap_builtin_rows(b, data, user_providers)
     _lap_overlay_rows(b, data)
-    _lap_canonical_rows(b)
+    _lap_canonical_rows(b, user_providers)
     if user_providers and isinstance(user_providers, dict):
         _lap_user_provider_rows(b, user_providers)
     _lap_bare_custom_row(b, custom_providers)

--- a/tests/hermes_cli/test_canonical_discover_models.py
+++ b/tests/hermes_cli/test_canonical_discover_models.py
@@ -1,0 +1,40 @@
+"""``discover_models: false`` must narrow CANONICAL_PROVIDERS picker rows (section 2b) to the
+declared ``models:`` list instead of merely prepending it to the live/curated catalog (#107106)."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from hermes_cli.model_switch_providers import _lap_canonical_rows, _PickerBuild
+from hermes_cli.models_catalog_static import ProviderEntry
+
+
+def _run(user_providers):
+    b = _PickerBuild(
+        current_provider="", current_base_url="", current_model="", max_models=None,
+        for_picker=True, force_fresh_nous_tier=False, probe_custom_providers=False,
+        probe_current_custom_provider=False, refresh=False, excluded=set(), curated={})
+    fake_cp_config = SimpleNamespace(api_key_env_vars=["FAKE_PROVIDER_API_KEY"], auth_type="api_key")
+    with (
+        patch("hermes_cli.models.CANONICAL_PROVIDERS", [ProviderEntry("fake-provider", "Fake Provider", "")]),
+        patch("hermes_cli.auth.PROVIDER_REGISTRY", {"fake-provider": fake_cp_config}),
+        patch("hermes_cli.model_switch_providers._live_or_curated_ids", return_value=["live-a", "live-b", "live-c"]),
+        patch.dict("os.environ", {"FAKE_PROVIDER_API_KEY": "test-key"}),
+    ):
+        _lap_canonical_rows(b, user_providers)
+    return next(row for row in b.results if row["slug"] == "fake-provider")
+
+
+def test_discover_models_false_narrows_canonical_row_to_configured_models():
+    row = _run({"fake-provider": {"discover_models": False, "models": {"curated-x": {}, "curated-y": {}}}})
+
+    assert row["models"] == ["curated-x", "curated-y"]
+    assert row["total_models"] == 2
+
+
+def test_discover_models_true_leaves_live_catalog_unchanged():
+    """Unaffected by the fix: with discovery enabled (the default), the row still reflects the
+    live catalog, unlike section 1's builtin rows which prepend declared models."""
+    row = _run({"fake-provider": {"models": {"curated-x": {}}}})
+
+    assert row["models"] == ["live-a", "live-b", "live-c"]
+    assert row["total_models"] == 3

--- a/tests/hermes_cli/test_configured_builtin_models.py
+++ b/tests/hermes_cli/test_configured_builtin_models.py
@@ -5,7 +5,10 @@ from unittest.mock import patch
 from hermes_cli.model_switch import list_authenticated_providers
 
 
-def _provider_row(configured_models, *, max_models=None):
+def _provider_row(configured_models, *, discover_models=None, max_models=None):
+    configured = {"models": configured_models}
+    if discover_models is not None:
+        configured["discover_models"] = discover_models
     with (
         patch(
             "agent.models_dev.fetch_models_dev",
@@ -24,7 +27,7 @@ def _provider_row(configured_models, *, max_models=None):
     ):
         rows = list_authenticated_providers(
             current_provider="deepseek",
-            user_providers={"deepseek": {"models": configured_models}},
+            user_providers={"deepseek": configured},
             max_models=max_models,
         )
     return next(row for row in rows if row["slug"] == "deepseek")
@@ -35,5 +38,14 @@ def test_configured_models_precede_and_deduplicate_discovered_models():
 
     assert row["models"] == ["configured-x", "shared", "live-a"]
     assert row["total_models"] == 3
+
+
+def test_discover_models_false_narrows_builtin_row_to_configured_models():
+    """#107106: discover_models: false must pin the row to the declared list instead of
+    merging it with the live catalog."""
+    row = _provider_row({"configured-x": {}, "shared": {}}, discover_models=False)
+
+    assert row["models"] == ["configured-x", "shared"]
+    assert row["total_models"] == 2
 
 


### PR DESCRIPTION
## What

`discover_models: false` + a curated `providers.<slug>.models` list had no effect on **built-in / canonical** provider rows in the `/model` picker — only on custom-endpoint rows (sections 3/4).

`hermes_cli/model_switch_providers.py`:

- `_lap_builtin_rows` (Section 1, models.dev-mapped built-ins) always merged the declared `models:` list into the live/curated catalog via `dict.fromkeys([*configured_models, *model_ids])`, regardless of `discover_models`.
- `_lap_canonical_rows` (Section 2b, `CANONICAL_PROVIDERS` — e.g. DeepInfra, which is auto-registered from `plugins/model-providers/deepinfra`) didn't even receive `user_providers`, so it never looked at the user's declared models or `discover_models` flag at all.

So a user with:

```yaml
providers:
  deepinfra:
    discover_models: false
    models:
      deepseek-ai/DeepSeek-V4-Flash-0731: {}
      # ... 5 more
```

still saw the full live DeepInfra catalog (~105 models) in `/model` instead of their 6-model shortlist.

## Fix

Both laps now mirror the semantics already used by the custom-endpoint path (`discover_endpoint`/`_discover_flag`): when a row has a non-empty declared `models:` list **and** `discover_models` is explicitly false, the declared list becomes the authoritative (narrowed) set instead of being merged with the live/curated catalog. `_lap_canonical_rows` now takes `user_providers` so it can make this check at all.

When `discover_models` is true (the default), existing behavior (live-only for canonical rows, prepend-and-dedupe for builtin rows) is unchanged.

Fixes #107106

## Test plan

Added regression tests that fail without the fix:

- `tests/hermes_cli/test_configured_builtin_models.py::test_discover_models_false_narrows_builtin_row_to_configured_models`
- `tests/hermes_cli/test_canonical_discover_models.py` (new file): narrowing case + a companion case proving `discover_models: true` is untouched by the change

Verified the new tests fail on the pre-fix code (`TypeError` for the canonical-rows signature change, and a live-catalog-leak assertion failure for the builtin-rows case) and pass after the fix:

```
$ bash scripts/run_tests.sh tests/hermes_cli/test_configured_builtin_models.py tests/hermes_cli/test_canonical_discover_models.py -q
=== Summary: 2 files, 4 tests passed, 0 failed (100% complete) in 1.4s (8 workers) ===
```

Broader related picker suite, all green:

```
$ bash scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_vertex_model_picker.py \
    tests/hermes_cli/test_provider_section3_grouping.py tests/hermes_cli/test_overlay_slug_resolution.py \
    tests/hermes_cli/test_opencode_go_in_model_list.py tests/hermes_cli/test_ollama_cloud_provider.py \
    tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_list_picker_providers.py \
    tests/hermes_cli/test_bedrock_model_picker.py tests/hermes_cli/test_kimi_cn_provider_listing.py \
    tests/hermes_cli/test_model_picker_excluded_providers.py -q
=== Summary: 11 files, 132 tests passed, 0 failed (100% complete) in 24.2s (8 workers) ===
```

`ruff check hermes_cli/model_switch_providers.py tests/hermes_cli/test_configured_builtin_models.py tests/hermes_cli/test_canonical_discover_models.py` → All checks passed.

## AI assistance disclosure

This change was implemented with Claude Code (Claude Sonnet 5), including the diagnosis, fix, and tests. I read and verified the affected code paths on current `main` before writing the patch (the issue's own repro/proposed-fix shape was cross-checked against the live code rather than applied blindly), and ran the test suite and linter myself as shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
