### PR TITLE
fix(model-switch): narrow built-in/canonical picker rows to a curated models shortlist when discovery is off

### DIFF
--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -498,6 +498,23 @@ def _discover_flag(entry: dict):
     return discover
 
 
+def _apply_configured_models(user_providers: dict, slug: str, model_ids: list) -> list:
+    """Fold a ``providers.<slug>.models`` block into a built-in/canonical row's catalog.
+
+    The declared ids extend the discovered catalog by default; ``discover_models: false``
+    marks the block as an intentional shortlist that narrows the row to it instead — the
+    same semantics custom-endpoint rows already honor.
+    """
+    from hermes_cli.model_switch import _declared_model_ids
+    configured = user_providers.get(slug) if isinstance(user_providers, dict) else None
+    if not isinstance(configured, dict):
+        return list(model_ids)
+    configured_models = _declared_model_ids(configured.get("models"))
+    if configured_models and not _discover_flag(configured):
+        return list(configured_models)
+    return list(dict.fromkeys([*configured_models, *model_ids]))
+
+
 def _display_prefix(name: str) -> str:
     """Text before the per-model separator Hermes's own writer uses ("—" / " - ")."""
     return next((name.split(sep)[0].strip() for sep in ("—", " - ") if sep in name), name)
@@ -708,7 +725,6 @@ class _PickerBuild:
 
 def _lap_builtin_rows(b: _PickerBuild, data: dict, user_providers: dict) -> None:
     """Section 1: models.dev-mapped providers with api_key auth."""
-    from hermes_cli.model_switch import _declared_model_ids
     from agent.models_dev import get_provider_info
     for hermes_id, mdev_id, pconfig, env_vars in _iter_builtin_candidates(data, b.excluded, b.seen_slugs):
         if not (_any_env(env_vars) or _raw_pool_usable(hermes_id)):
@@ -716,9 +732,7 @@ def _lap_builtin_rows(b: _PickerBuild, data: dict, user_providers: dict) -> None
         model_ids = _live_or_curated_ids(hermes_id, b.curated)
         # A providers.<built-in>.models block extends the discovered catalog; section 3 cannot
         # emit it later because this row owns the slug.
-        configured = user_providers.get(hermes_id) if isinstance(user_providers, dict) else None
-        configured_models = _declared_model_ids(configured.get("models")) if isinstance(configured, dict) else []
-        model_ids = list(dict.fromkeys([*configured_models, *model_ids]))
+        model_ids = _apply_configured_models(user_providers, hermes_id, model_ids)
         pinfo = get_provider_info(mdev_id)
         display_name = pconfig.name if pconfig and pconfig.name else (pinfo.name if pinfo else mdev_id)
         b.add_builtin_row(
@@ -809,7 +823,7 @@ def _lap_overlay_rows(b: _PickerBuild, data: dict) -> None:
         b.seen_slugs.add(pid.lower())
 
 
-def _lap_canonical_rows(b: _PickerBuild) -> None:
+def _lap_canonical_rows(b: _PickerBuild, user_providers: dict) -> None:
     """Section 2b: CANONICAL_PROVIDERS missed by sections 1/2."""
     from hermes_cli.auth import PROVIDER_REGISTRY
     from hermes_cli.models import CANONICAL_PROVIDERS
@@ -836,6 +850,7 @@ def _lap_canonical_rows(b: _PickerBuild) -> None:
             model_ids = _aws_live_or_curated_ids(cp.slug, b.curated)
         else:
             model_ids = _live_or_curated_ids(cp.slug, b.curated, merge_models_dev=False)
+        model_ids = _apply_configured_models(user_providers, cp.slug, model_ids)
         b.add_builtin_row(
             cp.slug, cp.label, cp.slug == b.current_provider, model_ids, "canonical", uncapped_ok=False)
 
@@ -1097,7 +1112,7 @@ def list_authenticated_providers(
 
     _lap_builtin_rows(b, data, user_providers)
     _lap_overlay_rows(b, data)
-    _lap_canonical_rows(b)
+    _lap_canonical_rows(b, user_providers or {})
     if user_providers and isinstance(user_providers, dict):
         _lap_user_provider_rows(b, user_providers)
     _lap_bare_custom_row(b, custom_providers)

--- a/tests/hermes_cli/test_model_switch_curated_builtin_rows.py
+++ b/tests/hermes_cli/test_model_switch_curated_builtin_rows.py
@@ -1,0 +1,128 @@
+"""Built-in/canonical picker rows honor a curated ``providers.<id>.models`` shortlist.
+
+Custom-endpoint rows already narrow to the configured list when
+``discover_models: false``; built-in (models.dev-mapped) and canonical rows
+only *prepended* it, so a ~105-model live catalog swallowed a 6-model
+shortlist (#107106). These tests pin the narrowed semantics for both laps
+and the default extend behavior when discovery stays on.
+"""
+
+import agent.models_dev as md
+import hermes_cli.models as hm
+import hermes_cli.models_catalog_static as models_catalog_static
+import pytest
+from hermes_cli import model_switch
+from hermes_cli import model_switch_providers as providers_mod
+
+
+def _isolate_canonical(monkeypatch, *, slug, key_var, live_models):
+    """Restrict every picker input to one canonical provider row.
+
+    Empties the models.dev map / overlays so sections 1-2 stay silent, points
+    the canonical list at *slug*, gates it on *key_var* and stubs the live
+    catalog to *live_models* (what ``cached_provider_model_ids`` would return).
+    """
+    monkeypatch.setattr(md, "PROVIDER_TO_MODELS_DEV", {})
+    monkeypatch.setattr(md, "fetch_models_dev", lambda *a, **k: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    canonical = [models_catalog_static.ProviderEntry(slug, slug.title(), "desc")]
+    monkeypatch.setattr(hm, "CANONICAL_PROVIDERS", canonical)
+    monkeypatch.setattr(models_catalog_static, "CANONICAL_PROVIDERS", canonical)
+    monkeypatch.setattr(
+        hm, "cached_provider_model_ids", lambda *a, **k: list(live_models)
+    )
+    monkeypatch.setattr(hm, "clear_provider_models_cache", lambda *a, **k: None)
+    monkeypatch.setenv(key_var, "sk-test")
+
+
+def _canonical_row(rows, slug):
+    return next(r for r in rows if r["slug"] == slug and r["source"] == "canonical")
+
+
+_LIVE = [f"live/model-{i}" for i in range(12)]
+_SHORTLIST = ["keep/model-a", "keep/model-b", "keep/model-c"]
+
+
+def test_canonical_row_narrows_to_curated_models_when_discovery_off(monkeypatch):
+    _isolate_canonical(
+        monkeypatch, slug="deepinfra", key_var="DEEPINFRA_API_KEY", live_models=_LIVE
+    )
+
+    rows = model_switch.list_authenticated_providers(
+        current_provider="deepinfra",
+        user_providers={
+            "deepinfra": {"discover_models": False, "models": dict.fromkeys(_SHORTLIST)}
+        },
+        max_models=50,
+    )
+    row = _canonical_row(rows, "deepinfra")
+    assert row["models"] == _SHORTLIST
+    assert row["total_models"] == 3
+
+
+def test_canonical_row_extends_catalog_by_default(monkeypatch):
+    _isolate_canonical(
+        monkeypatch, slug="deepinfra", key_var="DEEPINFRA_API_KEY", live_models=_LIVE
+    )
+
+    rows = model_switch.list_authenticated_providers(
+        current_provider="deepinfra",
+        user_providers={"deepinfra": {"models": dict.fromkeys(_SHORTLIST)}},
+        max_models=50,
+    )
+    row = _canonical_row(rows, "deepinfra")
+    assert row["models"][:3] == _SHORTLIST
+    assert len(row["models"]) == len(_LIVE) + len(_SHORTLIST)
+
+
+def test_canonical_dict_metadata_without_flag_does_not_narrow(monkeypatch):
+    _isolate_canonical(
+        monkeypatch, slug="deepinfra", key_var="DEEPINFRA_API_KEY", live_models=_LIVE
+    )
+
+    rows = model_switch.list_authenticated_providers(
+        current_provider="deepinfra",
+        user_providers={
+            "deepinfra": {"models": {m: {"context_length": 8192} for m in _SHORTLIST}}
+        },
+        max_models=50,
+    )
+    row = _canonical_row(rows, "deepinfra")
+    assert len(row["models"]) == len(_LIVE) + len(_SHORTLIST)
+
+
+def test_builtin_row_narrows_to_curated_models_when_discovery_off(monkeypatch):
+    """Section-1 (models.dev-mapped) rows share the same shortlist semantics."""
+    monkeypatch.setattr(md, "PROVIDER_TO_MODELS_DEV", {"togetherai": "togetherai"})
+    monkeypatch.setattr(
+        md,
+        "fetch_models_dev",
+        lambda *a, **k: {
+            "togetherai": {"name": "Together AI", "env": ["TOGETHERAI_API_KEY"]}
+        },
+    )
+
+    class _PInfo:
+        name = "Together AI"
+
+    monkeypatch.setattr(md, "get_provider_info", lambda _pid: _PInfo())
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr(hm, "CANONICAL_PROVIDERS", [])
+    monkeypatch.setattr(models_catalog_static, "CANONICAL_PROVIDERS", [])
+    monkeypatch.setattr(hm, "cached_provider_model_ids", lambda *a, **k: list(_LIVE))
+    monkeypatch.setattr(hm, "clear_provider_models_cache", lambda *a, **k: None)
+    monkeypatch.setenv("TOGETHERAI_API_KEY", "sk-test")
+
+    rows = model_switch.list_authenticated_providers(
+        current_provider="togetherai",
+        user_providers={
+            "togetherai": {
+                "discover_models": False,
+                "models": dict.fromkeys(_SHORTLIST),
+            }
+        },
+        max_models=50,
+    )
+    row = next(r for r in rows if r["slug"] == "togetherai")
+    assert row["models"] == _SHORTLIST
+    assert row["total_models"] == 3


### PR DESCRIPTION
Fixes #107106

### Problem

Custom-endpoint picker rows already narrow to the configured list when `discover_models: false`, but built-in (models.dev-mapped) and canonical rows only **prepended** the configured ids onto the live catalog, so a curated shortlist drowned (DeepInfra: 6 curated + 105 live = 105 shown). `_lap_canonical_rows` never received `user_providers`, so a `providers.deepinfra.models` block was invisible there.

### Fix

- New `_apply_configured_models(user_providers, slug, model_ids)` folds the `providers.<slug>.models` block for both laps: declared ids extend the catalog by default; with `discover_models: false` they become the authoritative narrow — the same semantics section-3/4 rows already honor.
- `_lap_canonical_rows` now takes `user_providers` (threaded from the caller).
- Dict-shaped `models:` without the flag stays per-model metadata (no narrow), consistent with `_models_config_is_allowlist`.

### Tests

`tests/hermes_cli/test_model_switch_curated_builtin_rows.py` (new): canonical narrow, canonical default-extend, dict-metadata no-narrow, built-in narrow. Mutation-checked: the narrow tests fail on unpatched `main`. Full neighboring suites pass (custom_providers 70, list_picker/routing/user_providers 18, inventory/section3 24).