### PR TITLE
fix(desktop): hard-settle login-shell PATH probe when grandchild holds stdio

### DIFF
--- a/apps/desktop/electron/shell-path.test.ts
+++ b/apps/desktop/electron/shell-path.test.ts
@@ -145,3 +145,53 @@ test('ensureLoginShellPath never rejects', async () => {
   const result = await ensureLoginShellPath({ env: { SHELL: '/bin/zsh' }, platform: 'darwin', execFileFn })
   assert.equal(result.applied, false)
 })
+
+test('runProbe/applyLoginShellPath settles when execFile callback never fires (grandchild holds stdio)', async () => {
+  // gitstatusd-style grandchild keeps stdout open after execFile's timeout
+  // SIGTERM of the direct child — Node never invokes the callback.
+  const env: any = { SHELL: '/bin/zsh', PATH: '/usr/bin' }
+  const hungExecFile = (_file, _args, _options, _callback) => ({
+    pid: 999999999,
+    stdin: { end() {} }
+  })
+
+  const t0 = Date.now()
+  const result = await applyLoginShellPath({
+    env,
+    platform: 'linux',
+    execFileFn: hungExecFile,
+    timeoutMs: 50
+  })
+  const elapsed = Date.now() - t0
+
+  assert.equal(result.applied, false)
+  assert.equal(result.reason, 'unresolved')
+  assert.equal(env.PATH, '/usr/bin')
+  assert.ok(elapsed < 50 + 1500, `probe hung for ${elapsed}ms`)
+})
+
+test('applyLoginShellPath trusts a stdout sentinel even when the execFile callback never fires', async () => {
+  const env: any = { SHELL: '/bin/zsh', PATH: '/usr/bin' }
+  const execFileFn = (_file, _args, _options, _callback) => ({
+    pid: 999999999,
+    stdin: { end() {} },
+    stdout: {
+      on(event, listener) {
+        if (event === 'data') {
+          queueMicrotask(() => listener(`${START}/opt/homebrew/bin:/usr/bin${END}`))
+        }
+        return this
+      }
+    }
+  })
+
+  const result = await applyLoginShellPath({
+    env,
+    platform: 'linux',
+    execFileFn,
+    timeoutMs: 50
+  })
+
+  assert.equal(result.applied, true)
+  assert.equal(env.PATH, '/opt/homebrew/bin:/usr/bin')
+})

--- a/apps/desktop/electron/shell-path.ts
+++ b/apps/desktop/electron/shell-path.ts
@@ -28,6 +28,29 @@ const PATH_START = '__HERMES_LOGIN_PATH_START__'
 const PATH_END = '__HERMES_LOGIN_PATH_END__'
 const PROBE_COMMAND = "printf '%s' \"" + PATH_START + '${PATH}' + PATH_END + '"'
 const ATTEMPT_TIMEOUT_MS = 5000
+// execFile's timeout only SIGTERMs the direct child. A grandchild that keeps
+// stdout/stderr open (Powerlevel10k gitstatusd, etc.) means the callback
+// never fires. This grace is a wall-clock backstop so boot cannot hang.
+const HARD_SETTLE_GRACE_MS = 500
+
+function killProcessTree(child) {
+  const pid = child?.pid
+
+  try {
+    if (process.platform !== 'win32' && typeof pid === 'number') {
+      process.kill(-pid, 'SIGKILL')
+      return
+    }
+  } catch {
+    // ESRCH / EPERM / unsupported: fall through to a direct kill.
+  }
+
+  try {
+    child?.kill?.('SIGKILL')
+  } catch {
+    // Best-effort — hard-settle must not depend on kill succeeding.
+  }
+}
 
 function loginShellExecutable(env: any = process.env, platform = process.platform) {
   const shell = typeof env?.SHELL === 'string' ? env.SHELL.trim() : ''
@@ -70,28 +93,56 @@ function mergeLoginShellPath(loginPath, currentPath, { delimiter = ':' }: any = 
 function runProbe(shell, flags, execFileFn, timeoutMs): Promise<string | null> {
   return new Promise(resolve => {
     let settled = false
+    let hardTimer = null
+    let partialStdout = ''
 
     const finish = value => {
-      if (!settled) {
-        settled = true
-        resolve(value)
+      if (settled) {
+        return
       }
+
+      settled = true
+
+      if (hardTimer) {
+        clearTimeout(hardTimer)
+        hardTimer = null
+      }
+
+      resolve(value)
     }
 
     try {
       const child = execFileFn(
         shell,
         [...flags, PROBE_COMMAND],
-        { encoding: 'utf8', timeout: timeoutMs, windowsHide: true },
+        {
+          encoding: 'utf8',
+          timeout: timeoutMs,
+          windowsHide: true,
+          // New process group so timeout can SIGKILL the whole tree
+          // (gitstatusd and friends), not just the shell we spawned.
+          detached: process.platform !== 'win32'
+        },
         (_error, stdout) => {
           // A profile script may exit nonzero after the sentinel already
           // printed — trust the sentinel, not the exit code.
-          finish(extractSentinelPath(stdout))
+          finish(extractSentinelPath(stdout ?? partialStdout))
         }
       )
 
       // Interactive shells with a broken rc can block reading stdin.
       child?.stdin?.end?.()
+
+      // If the callback never fires, this is the only view of a printed
+      // sentinel that arrived before a grandchild wedged the pipe.
+      child?.stdout?.on?.('data', chunk => {
+        partialStdout += typeof chunk === 'string' ? chunk : String(chunk)
+      })
+
+      hardTimer = setTimeout(() => {
+        killProcessTree(child)
+        finish(extractSentinelPath(partialStdout))
+      }, timeoutMs + HARD_SETTLE_GRACE_MS)
     } catch {
       finish(null)
     }


### PR DESCRIPTION
## Summary
- Linux desktop boot could hang forever at "Resolving Hermes backend" when the login-shell PATH probe's interactive zsh (e.g. Powerlevel10k gitstatusd) left a grandchild holding stdout/stderr after `execFile`'s timeout SIGTERM'd only the shell — Node never invoked the callback, so `ensureLoginShellPath()` never settled.
- `runProbe` now hard-settles within `timeoutMs + HARD_SETTLE_GRACE_MS`, spawns the probe in its own process group (`detached` on non-Windows), and best-effort `SIGKILL`s the process tree so pipes can close.
- Fail-open unchanged: unresolved probe leaves PATH untouched; Windows still skips probing; successful sentinel capture still merges as before.

## Test plan
- [x] RED: hung `execFile` (callback never fires) timed out on pre-fix
- [x] GREEN: `npx vitest run --config vitest.shell-path.config.ts` → 14 passed (including hung-callback settle + partial-stdout sentinel CONTROL)
- [ ] Manual (optional): Linux + zsh/Powerlevel10k desktop boot advances past "Resolving Hermes backend" within ~6s even if gitstatusd would otherwise wedge

Fixes #107109

Made with [Cursor](https://cursor.com)