### PR TITLE
fix(gateway): preserve Feishu sender IDs in shared sessions

### DIFF
--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1326,15 +1326,21 @@ class GatewayInboundMixin:
             source, group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
         )
-        if _is_shared_multi_user and source.user_name:
+        _feishu_sender_id = source.user_id if source.platform == Platform.FEISHU else None
+        if _is_shared_multi_user and (source.user_name or _feishu_sender_id):
             # Display names are attacker-influenceable: neutralize newlines/control chars or a
             # hostile name masquerades as a fake markdown section (mirrors build_session_context_prompt).
-            _safe_user_name = neutralize_untrusted_inline_text(source.user_name)
+            _safe_user_name = neutralize_untrusted_inline_text(source.user_name or "Feishu user")
             # Slack: expose the CURRENT speaker's verifiable `<@U...>` id so "mention me again" has a
             # trusted target (display names are ambiguous). user_id comes from the envelope, not user-editable.
             # See #17916.
             if source.platform == Platform.SLACK and source.user_id:
                 _safe_user_name = f"{_safe_user_name} | Slack user <@{source.user_id}>"
+            elif _feishu_sender_id:
+                # External Feishu members may have no resolvable contact name. Attribute every
+                # shared-session turn by its envelope ID, including when display names collide.
+                _safe_sender_id = neutralize_untrusted_inline_text(_feishu_sender_id)
+                _safe_user_name = f"{_safe_user_name} | Feishu sender_id={_safe_sender_id}"
             message_text = f"[{_safe_user_name}] {message_text}"
         # After the sender-prefix so the prefix applies only to the trigger message, not the backfill.
         if getattr(event, "channel_context", None):

--- a/tests/gateway/test_shared_group_sender_prefix.py
+++ b/tests/gateway/test_shared_group_sender_prefix.py
@@ -47,3 +47,56 @@ async def test_preprocess_includes_slack_author_mention_for_shared_thread():
     assert result == "[Alice | Slack user <@U123>] mention me again"
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("user_name", [None, "Same display name"])
+@pytest.mark.parametrize("thread_id", [None, "omt_shared"])
+async def test_feishu_shared_session_attributes_each_current_sender(user_name, thread_id):
+    runner = _make_runner(GatewayConfig(group_sessions_per_user=False))
+    history = []
+    sender_ids = ["ou_first_member", "ou_second_member"]
+    for sender_id in sender_ids:
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_team",
+            chat_type="group",
+            user_id=sender_id,
+            user_name=user_name,
+            thread_id=thread_id,
+        )
+        event = MessageEvent(text="show my tasks", source=source)
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=history,
+        )
+        assert f"Feishu sender_id={sender_id}" in result
+        assert result.endswith("show my tasks")
+        assert all(other not in result for other in sender_ids if other != sender_id)
+        history.extend(
+            [
+                {"role": "user", "content": result},
+                {"role": "assistant", "content": "Acknowledged."},
+            ]
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "chat_type,thread_id",
+    [("dm", None), ("group", None), ("group", "omt_private")],
+)
+async def test_feishu_sender_prefix_does_not_change_individual_sessions(chat_type, thread_id):
+    runner = _make_runner(
+        GatewayConfig(group_sessions_per_user=True, thread_sessions_per_user=True)
+    )
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_individual",
+        chat_type=chat_type,
+        user_id="ou_member",
+        user_name=None,
+        thread_id=thread_id,
+    )
+    event = MessageEvent(text="show my tasks", source=source)
+    result = await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+    assert result == event.text


### PR DESCRIPTION
## What does this PR do?

Preserve the current Feishu speaker's ID in shared group and thread messages. With `group_sessions_per_user: false`, a request such as "show my tasks" currently reaches the model with only `[Same display name]`, or with no sender prefix at all when Contact API name resolution is unavailable. `SessionSource.user_id` is already present, but `_prefix_inbound_sender_context` drops it.

Extend the existing per-message prefix, following the Slack path already in this function:

```text
Before, no contact name: show my tasks
After: [Feishu user | Feishu sender_id=ou_member_a] show my tasks

Before, duplicate display names: [Same display name] show my tasks
After: [Same display name | Feishu sender_id=ou_member_b] show my tasks
```

The ID comes from the current event's `SessionSource`, with the existing inline neutralizer applied. It is deliberately labeled `sender_id`: the Feishu adapter prefers tenant-scoped `user_id` and falls back to app-scoped `open_id`, so this patch does not claim every value is an `open_id`.

This is per-turn model context. It preserves the cached system prompt and session keys, adds no API calls or configuration, and does not alter authorization decisions. DM and individually isolated group/thread messages retain their existing behavior.

Suggested priority: **P2** under the repository's labels (degraded behavior with a workaround). Per-user session isolation can mitigate the shared-context ambiguity; no data-loss incident or authorization bypass is claimed here.

## Related Issue

Related to #46721 (surfacing sender IDs in multi-user prefixes). This implements the Feishu-specific case using the existing prefix path rather than the proposed cross-platform configuration option, so it does not close the broader request.

Related work checked:

- #87085 improves contact-name lookup via group members. Stable IDs are still useful when names are unavailable or duplicated.
- #52884 changes the identity block for individually scoped sessions; this patch concerns shared per-turn messages.
- #31301 adds configurable sender relationships and roles, which is a broader feature.
- **#69980 overlaps with this sender-ID goal**, as part of a larger cross-platform sender-envelope and queueing change. This PR offers a small Feishu-specific alternative on current `main`, extending the already-shipped Slack pattern.

## Type of Change

- [x] Bug fix

## Changes Made

- `gateway/run_inbound.py`: include the current Feishu sender ID in shared-session prefixes, including when `user_name` is missing.
- `tests/gateway/test_shared_group_sender_prefix.py`: add two parametrized behavior tests covering successive speakers with missing/duplicate names, shared groups/threads, and unchanged DM/per-user behavior.

## How to Test

Reproduced against `main` at `cfdbbb6e35` on macOS 26.5.1 arm64, Python 3.11.15.

1. Apply only the new tests, leaving production code unchanged:

   ```bash
   scripts/run_tests.sh tests/gateway/test_shared_group_sender_prefix.py -q --tb=short
   ```

   **Before the fix: 4 failed, 4 passed.** All four failures are the missing/duplicate-name cases across shared groups and threads. The tests exercise `GatewayRunner._prepare_inbound_message_text` with real `MessageEvent` and `SessionSource` objects and successive user/assistant history.

2. Apply the production fix and run:

   ```bash
   scripts/run_tests.sh tests/gateway/test_shared_group_sender_prefix.py tests/gateway/test_session.py -q --tb=short
   ```

   **After the fix: 73 passed.** This includes the existing Slack author-prefix test and session-context coverage.

3. Additional checks:

   ```bash
   ruff check gateway/run_inbound.py tests/gateway/test_shared_group_sender_prefix.py
   python scripts/check_compat_pointers.py
   git diff --check
   ```

   All pass.

Additional Feishu adapter coverage returned **77 passed, 1 failed**. The failure is `TestDedupTTL.test_concurrent_dedup_persists_land_in_order`: its `patch.dict(os.environ, {}, clear=True)` clears test-home isolation and loads the developer's existing dedup cache, violating its empty-cache assumption. I restored both changed files and confirmed a completely clean worktree at the same base commit, then reran that exact test through `scripts/run_tests.sh`; it fails identically on unchanged `main`. This PR leaves that separate test-isolation issue untouched. The full repository suite has not been run.

## Checklist

### Code

- [x] Read the Contributing Guide and applicable AGENTS.md instructions.
- [x] Use a Conventional Commit.
- [x] Searched open/merged PRs and issues; overlap is disclosed above.
- [x] Contains only the sender-attribution fix and its tests.
- [ ] Full repository test suite passes (not run; targeted results and baseline failure documented above).
- [x] Added regression tests and demonstrated failure before the fix.
- [x] Tested on macOS 26.5.1 arm64 with Python 3.11.15.

### Documentation & Housekeeping

- [x] Relevant behavior is explained in the inline comment; no new user-facing setup or configuration.
- [x] Configuration example updates: N/A.
- [x] Architecture/workflow documentation updates: N/A.
- [x] Cross-platform impact considered: the change uses existing string/context handling and introduces no OS-specific operations.
- [x] Tool description/schema changes: N/A.
