### PR TITLE
fix(deps): bump slack-sdk to 3.44.1 — aiohttp Socket Mode connect() retries forever against a closed session

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,9 +197,9 @@ daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
 hindsight = ["hindsight-client==0.6.1"]
 dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
-messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.2", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
+messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.2", "slack-bolt==1.30.0", "slack-sdk==3.44.1", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
-slack = ["slack-bolt==1.30.0", "slack-sdk==3.43.0", "aiohttp==3.14.3"]
+slack = ["slack-bolt==1.30.0", "slack-sdk==3.44.1", "aiohttp==3.14.3"]
 matrix = ["mautrix[encryption]==0.21.1", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0", "aiohttp==3.14.3"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7 (mautrix/aiohttp-socks only cap aiohttp<4 / >=3.10, so pin the patched floor directly)
 # WeCom callback-mode adapter — parses untrusted XML POST bodies from
 # WeCom-controlled callback endpoints, so we use defusedxml (drop-in

--- a/uv.lock
+++ b/uv.lock
@@ -2031,8 +2031,8 @@ requires-dist = [
     { name = "sherpa-onnx", marker = "extra == 'wake'", specifier = "==1.13.4" },
     { name = "slack-bolt", marker = "extra == 'messaging'", specifier = "==1.30.0" },
     { name = "slack-bolt", marker = "extra == 'slack'", specifier = "==1.30.0" },
-    { name = "slack-sdk", marker = "extra == 'messaging'", specifier = "==3.43.0" },
-    { name = "slack-sdk", marker = "extra == 'slack'", specifier = "==3.43.0" },
+    { name = "slack-sdk", marker = "extra == 'messaging'", specifier = "==3.44.1" },
+    { name = "slack-sdk", marker = "extra == 'slack'", specifier = "==3.44.1" },
     { name = "snowballstemmer", specifier = "==3.1.1" },
     { name = "sounddevice", marker = "extra == 'voice'", specifier = "==0.5.5" },
     { name = "sounddevice", marker = "extra == 'wake'", specifier = "==0.5.5" },
@@ -4345,11 +4345,11 @@ wheels = [
 
 [[package]]
 name = "slack-sdk"
-version = "3.43.0"
+version = "3.44.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/75/a4964eb771a0c74d79ee7a3bee6fb5d9718909dd1b675e80d62a6a0ad90a/slack_sdk-3.43.0.tar.gz", hash = "sha256:0553152e46c4259eb69f7464cdadc35ba4802ca10f9f5a849c92cf03d6c2ba07", size = 252769, upload-time = "2026-06-30T18:04:41.59Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/4e/371068dd7281139307e60cd18553b96b9c8c391a4c3040617192713a3cc4/slack_sdk-3.44.1.tar.gz", hash = "sha256:ca19505423789fa2a3189ff486f989f02e49289f008d0a5813df7255b3fb93ea", size = 256661, upload-time = "2026-09-03T14:21:13.879Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/55/42141b8338d46323d5b3c6095201b044c670c20f898643b322ea9b1543a1/slack_sdk-3.43.0-py2.py3-none-any.whl", hash = "sha256:4b6557c65577fc172f685af218b811f9f3b4909e24cddd839ada09565f10c585", size = 315866, upload-time = "2026-06-30T18:04:39.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/fc/67352b742fc6fa520a550581b0284f5757e4e31a32327c2a00276747fd30/slack_sdk-3.44.1-py2.py3-none-any.whl", hash = "sha256:d6f20a0fbe3fecf9cac955c99d686301b48a645b7045472c3a0cdd186d7c42b2", size = 319865, upload-time = "2026-09-03T14:21:12.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Bumps `slack-sdk` from 3.43.0 to 3.44.1 in the `messaging` and `slack` extras, picking up the upstream fix for the aiohttp Socket Mode zombie retry loop: [slackapi/python-slack-sdk#1956](https://github.com/slackapi/python-slack-sdk/pull/1956) (released in [v3.44.1](https://github.com/slackapi/python-slack-sdk/releases/tag/v3.44.1)), which makes `SocketModeClient.connect()` exit its retry loop when `self.closed` is set instead of spinning forever on `Failed to connect (error: Session is closed); Retrying...`.

This addresses the SDK-side root cause discussed in #85574 (and the duplicate reports #96069, #83662, #106849): after a watchdog heal or reconnect, an orphaned `connect()` task from the previous handler generation keeps retrying against a closed aiohttp session indefinitely, logging every `ping_interval` while Slack itself keeps working. Hermes-side mitigations exist (PRs #100597, #106857, #96478, #83693, #85660 and the already-merged #66645), but the upstream 3.44.1 fix removes the underlying failure mode directly and benefits every path at once.

Observed in production on a long-running deployment: 22,000+ `Session is closed` error lines in one profile's rotated logs over ~36 hours (plus thousands more in two other profiles), ending only when an OS package upgrade restarted the gateway processes.

## Related Issue

Relates to #85574 (canonical issue; the SDK-side half of the fix). It does not fully close it — the adapter-side "restart reuses the same dead `AsyncApp`" concern raised there may still need the hermes-side fix tracked in that issue — but it eliminates the SDK's infinite-retry behavior that keeps the wedge alive after the process that owned the session is gone.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `pyproject.toml`: `slack-sdk==3.43.0` → `slack-sdk==3.44.1` in the `messaging` and `slack` extras
- `uv.lock`: regenerated with uv 0.9.28 (same version as `.github/workflows/uv-lockfile-check.yml`); diff is limited to the slack-sdk package block (version, sdist/wheel URLs+hashes) and the two extra specifiers

## How to Test

1. `uv lock --check` → passes (verified with uv 0.9.28)
2. `pip install slack-sdk==3.44.1`, then simulate the wedge: create a `SocketModeClient`, close its `aiohttp_client_session`, and call `connect()` in a task → with 3.43.0 it retries forever logging `Session is closed` every 10s; with 3.44.1 the task exits instead of spinning (verified locally against the real installed package)
3. Healthy path unchanged: normal `connect()` still establishes a session, resets `stale`, and spawns `monitor_current_session`/`receive_messages` as before (verified)
4. `pytest tests/gateway/test_slack_socket_reconnect_heal.py -q` → 3 passed (adapter teardown ordering unaffected)

Tested on Ubuntu 24.04 (VPS), Python 3.11, live gateway deployment with three Slack Socket Mode profiles.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(deps):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — closest are #100597 / #106857 / #83693 (adapter-side orphaned-task mitigations); this PR is the complementary dependency bump
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/ -q` (the suite covering the Slack adapter): **7,955 passed, 8 failed, 47 skipped**; all 8 failures also fail on unmodified `main` with the same ordering (test-isolation flakes in Discord/Teams/Telegram/session-store tests, unrelated to Slack — each passes when run in isolation), and every Slack test passes: `pytest tests/gateway/ -k slack` → **670 passed, 2 skipped**, incl. `test_slack_socket_reconnect_heal.py` (3 passed)
- [ ] I've added tests for my changes — N/A: no behavior change in this repo's code; the fix ships in the upstream dependency
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (dependency version bump only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure version bump)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A