### PR TITLE
fix(tools): prefer skill_view over stale session_search recall for skill-covered topics

### DIFF
--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -571,9 +571,13 @@ SESSION_SEARCH_SCHEMA = {
         "args = browse recent sessions. Results are actual DB messages, no LLM. "
         "Searches conversation history ONLY — when the user gave a direct "
         "source (URL, file, contact, live system), inspect that first; never "
-        "conclude 'not found' from history alone. Use for questions about past "
-        "conversations: 'what did we do about X', 'where did we leave Y'. When "
-        "referring the user to a session, write its `link` value verbatim "
+        "conclude 'not found' from history alone. This includes topics covered "
+        "by an installed skill's reference material (e.g. an operational history "
+        "or incident log): if the topic matches a skill, call skill_view to read "
+        "the current file rather than recalling a prior answer here — that answer "
+        "may predate a later update to the skill content. Use for questions about "
+        "past conversations: 'what did we do about X', 'where did we leave Y'. "
+        "When referring the user to a session, write its `link` value verbatim "
         "inline (it renders as a titled link)."
     ),
     "parameters": {

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -614,7 +614,7 @@ SKILLS_LIST_SCHEMA = {
 
 SKILL_VIEW_SCHEMA = {
     "name": "skill_view",
-    "description": "Skills allow for loading information about specific tasks and workflows, as well as scripts and templates. Load a skill's full content or access its linked files (references, templates, scripts). First call returns SKILL.md content plus a 'linked_files' dict showing available references/templates/scripts. To access those, call again with file_path parameter.",
+    "description": "Skills allow for loading information about specific tasks and workflows, as well as scripts and templates. Load a skill's full content or access its linked files (references, templates, scripts). First call returns SKILL.md content plus a 'linked_files' dict showing available references/templates/scripts. To access those, call again with file_path parameter. Skill content is a live source that can change between sessions (e.g. an operational history or incident log gets appended to) — when a question touches a skill's topic, call this to read the current file rather than trusting a remembered answer from session_search, which can surface an answer that predates a later skill update.",
     "parameters": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Problem

`session_search`'s tool description didn't distinguish between "nothing in history" and "this topic is actually covered by an installed skill's reference material." When a user asked about something documented in a skill (e.g. an operational history / incident log that gets appended to over time), the model would sometimes trust a plausible-looking but stale answer recalled via `session_search` instead of calling `skill_view` to re-read the current file — because the skill content had been updated *after* the session that `session_search` was surfacing.

## Fix

Two small, additive wording changes to the existing tool-description strings (no schema/behavior change, no new tool, no new dependency):

- `tools/session_search_tool.py`: `SESSION_SEARCH_SCHEMA`'s description now explicitly calls out that when a topic matches an installed skill's reference material, the model should call `skill_view` to read the current file rather than concluding "not found" (or trusting a remembered answer) from session history alone, since that answer may predate a later update to the skill content.
- `tools/skills_tool.py`: `SKILL_VIEW_SCHEMA`'s description now states that skill content is a live source that can change between sessions, so a question touching a skill's topic should prompt a fresh read via `skill_view` rather than trusting a `session_search` recall that may predate a later update.

## Testing

- `uv sync --extra dev`
- Scoped run of every existing test touching these two tools/behaviors: `tests/tools/test_skills_tool_profile_scope.py`, `tests/tools/test_skill_view_dedup.py`, `tests/tools/test_session_search.py`, `tests/tools/test_skill_view_path_check.py`, `tests/tools/test_skill_view_traversal.py`, `tests/tools/test_skills_tool_discovery_cache.py`, `tests/tools/test_skills_tool.py`, `tests/test_session_search_context_batch.py`, `tests/hermes_cli/test_web_server_session_search.py` — **123 passed, 1 skipped, 0 failed**.
- Live behavioral test on a real deployment: after the fix, asking about a topic never discussed in any chat but covered by an installed skill produced four empty `session_search` calls followed by the model explicitly reasoning "let me check the [skill] directly" and correctly calling `skill_view` for an accurate answer — the fallback-to-source behavior this description change is meant to encourage.
- The full unscoped `pytest tests/ -v` run currently errors on ~33 unrelated pre-existing collection failures in this environment (missing `acp`/`aiohttp`/messaging-adapter extras not installed here) — unrelated to the two files this PR touches, confirmed by scoping to the relevant tests above instead.

## Scope

Two files, 8 insertions / 4 deletions total, wording-only changes to existing tool descriptions. No new tools, no dependency changes.
