### PR TITLE
fix(deepseek): recognise the version-less deepseek-flash model id

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -339,10 +339,12 @@ DEFAULT_CONTEXT_LENGTHS = {
     # Google / Gemma ("gemma4" is Ollama-style naming, e.g. gemma4:31b-cloud)
     "gemini": 1048576,
     "gemma-4": 256000, "gemma4": 256000, "gemma-4-31b": 256000, "gemma-3": 131072, "gemma": 8192,
-    # DeepSeek — V4 family is 1M; deepseek-chat/-reasoner alias v4-flash modes.
+    # DeepSeek — V4 family is 1M; deepseek-chat/-reasoner alias v4-flash modes. ``deepseek-flash``
+    # (version-less canonical id, 2026-09 Flash refresh) needs a discrete entry or the
+    # longest-key-first scan falls through to the 128K ``deepseek`` catch-all below.
     # https://api-docs.deepseek.com/zh-cn/quick_start/pricing
     "deepseek-v4-pro": 1_000_000, "deepseek-v4-flash": 1_000_000, "deepseek-chat": 1_000_000,
-    "deepseek-reasoner": 1_000_000, "deepseek": 128000,
+    "deepseek-reasoner": 1_000_000, "deepseek-flash": 1_000_000, "deepseek": 128000,
     # Meta; Muse Spark family (1.1/1.2/1.3, -contributor(-free), meta/ prefixed) is 1M per OpenRouter,
     # models.dev and api.commandcode.ai /models — keep the "muse-spark" prefix (bare "muse" would match
     # muse-image/muse-voice). Thinking Machines inkling (covers inkling-small and :free/:batch variants)

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -20,7 +20,9 @@ _REASONING_STALE_TIMEOUT_FLOORS: dict[int, tuple[str, ...]] = {
         # NVIDIA Nemotron behind hosted NIM: documented 60-180s upstream idle kill.
         "nemotron-3-ultra", "nemotron-3-super",
         # DeepSeek R1 / V4 (reasoning_content streamed before final content).
-        "deepseek-r1", "deepseek-reasoner", "deepseek-v4-flash", "deepseek-v4-pro",
+        # ``deepseek-flash`` is the version-less canonical Flash id (2026-09 Flash refresh);
+        # ``deepseek-v4-flash`` still aliases onto it server-side.
+        "deepseek-r1", "deepseek-reasoner", "deepseek-flash", "deepseek-v4-flash", "deepseek-v4-pro",
         # OpenAI o-series: each variant enumerated so bare ``o1`` cannot over-match ``olmo-1``.
         "o1", "o1-mini", "o1-pro", "o1-preview", "o3", "o3-pro",
         # Mythos-class named models (claude-fable-5): 1M ctx + 128K output, a heavier thinking

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -192,6 +192,16 @@ _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
         ("deepseek-chat", "deepseek-reasoner", "deepseek-v4-flash"): ("0.14", "0.28", "0.0028"),
         "deepseek-v4-pro": ("0.435", "0.87", "0.003625"),
     }),
+    # DeepSeek V4.1-Flash, released 2026-09-10: the model id is now the version-less
+    # ``deepseek-flash``. Published rates are off-peak USD per 1M (peak is 2x; peak hours
+    # are 01:00-04:00 and 06:00-10:00 UTC, Mon-Fri) — the off-peak column is encoded, as in
+    # the rows above. The retired ``deepseek-v4-flash`` / ``deepseek-v4-flash-vision-exp`` /
+    # ``deepseek-chat`` / ``deepseek-reasoner`` ids are served by V4.1-Flash and billed at
+    # these rates (official docs footnote 1); refreshing their 2026-07 rows belongs to the
+    # wider pricing pass, so this entry only adds the new id.
+    ("deepseek", "https://api-docs.deepseek.com/quick_start/pricing", "deepseek-pricing-2026-09", {
+        "deepseek-flash": ("0.15", "0.60", "0.003"),
+    }),
     ("google", "https://ai.google.dev/gemini-api/docs/pricing", "google-pricing-2026-09-02", {
         ("gemini-3.8-flash", "gemini-3.7-flash"): ("0.75", "3.75", "0.075"),
     }),

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -92,8 +92,12 @@ _LOWERCASE_MODEL_PROVIDERS: frozenset[str] = frozenset({
 _DEEPSEEK_RETIRED_ALIASES: frozenset[str] = frozenset({
     "deepseek-chat", "deepseek-reasoner"})
 
+# ``deepseek-flash`` is the version-less canonical Flash id from the 2026-09 Flash refresh:
+# ``GET /v1/models`` reports it and the API accepts it directly. It carries no ``v<N>``
+# marker, so without an entry here it misses the V-series regex below and the id the user
+# picked is folded onto ``deepseek-v4-flash`` before it ever reaches the wire.
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-v4-pro", "deepseek-v4-flash"})
+    "deepseek-v4-pro", "deepseek-v4-flash", "deepseek-flash"})
 
 # First-class V-series IDs incl. future ``deepseek-v5-*`` and dated variants
 # (``deepseek-v4-flash-20260423``): verified real model ids, NOT aliases of ``deepseek-chat``.

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -86,9 +86,10 @@ _CATALOGUE_PREFIX_REPAIR_PROVIDERS: frozenset[str] = frozenset({
 _LOWERCASE_MODEL_PROVIDERS: frozenset[str] = frozenset({
     "xiaomi"})
 
-# DeepSeek's direct API only accepts first-class V-series IDs after the 2026-07-24 cut-off (HTTP 400
-# otherwise). Both retired aliases map to deepseek-v4-flash per the official docs (thinking mode is
-# controlled by extra_body.thinking on the profile), so saved configs can't keep sending them.
+# DeepSeek's direct API only accepts first-class IDs after the 2026-07-24 cut-off (HTTP 400
+# otherwise). The retired aliases rewrite to the id DeepSeek documents today, ``deepseek-flash``
+# (V4.1-Flash, 2026-09) — see ``_normalize_for_deepseek``. Thinking mode is controlled by
+# extra_body.thinking on the provider profile, so saved configs can't keep sending these names.
 _DEEPSEEK_RETIRED_ALIASES: frozenset[str] = frozenset({
     "deepseek-chat", "deepseek-reasoner"})
 
@@ -107,11 +108,13 @@ _DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v\d+([-.].+)?$")
 def _normalize_for_deepseek(model_name: str) -> str:
     """Map a model input to a DeepSeek-accepted id: canonicals and ``deepseek-v<digit>…`` pass
     through (future V-series work without a release); retired aliases and everything else become
-    ``deepseek-v4-flash``."""
+    ``deepseek-flash`` — the id DeepSeek documents today (V4.1-Flash). ``deepseek-v4-flash`` is
+    itself only a server-side alias onto it now, so rewriting to it stored a name the picker no
+    longer advertises."""
     bare = _strip_vendor_prefix(model_name).lower()
     if bare in _DEEPSEEK_CANONICAL_MODELS or _DEEPSEEK_V_SERIES_RE.match(bare):
         return bare
-    return "deepseek-v4-flash"
+    return "deepseek-flash"
 
 
 def _strip_vendor_prefix(model_name: str) -> str:

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -15,6 +15,13 @@ from providers import register_provider
 from providers.base import ProviderProfile
 
 
+# Version-less canonical ids for thinking-capable DeepSeek models. The 2026-09 Flash
+# refresh dropped the ``v<N>`` marker from the public id: ``GET /v1/models`` reports
+# ``deepseek-flash`` and the API accepts it directly, so the generation check in
+# ``build_api_kwargs_extras`` cannot recognise it.
+_THINKING_CAPABLE_IDS: frozenset[str] = frozenset({"deepseek-flash"})
+
+
 class DeepSeekProfile(ProviderProfile):
     """DeepSeek — extra_body.thinking + top-level reasoning_effort."""
 
@@ -22,7 +29,12 @@ class DeepSeekProfile(ProviderProfile):
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         m = (model or "").strip().lower()
-        if not m.startswith("deepseek-v") or m.startswith("deepseek-v3"):  # v4+ only; v3 excluded
+        # v4+ only; v3 excluded. Version-less canonicals (``deepseek-flash``) carry the
+        # same thinking-mode contract but no ``v<N>`` prefix, so consult the id set too —
+        # missing them makes Hermes omit ``thinking``, so the server defaults to on and
+        # the user's thinking toggle / effort setting is silently ignored.
+        versioned_v4_plus = m.startswith("deepseek-v") and not m.startswith("deepseek-v3")
+        if not versioned_v4_plus and m not in _THINKING_CAPABLE_IDS:
             return {}, {}
         rc = reasoning_config if isinstance(reasoning_config, dict) else None
         # Always set thinking explicitly (default enabled, matching the API default)

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -20,6 +20,10 @@ from providers.base import ProviderProfile
 # ``deepseek-flash`` and the API accepts it directly, so the generation check in
 # ``build_api_kwargs_extras`` cannot recognise it.
 _THINKING_CAPABLE_IDS: frozenset[str] = frozenset({"deepseek-flash"})
+# Dated snapshots of the version-less id (``deepseek-flash-20260910``) mirror the versioned
+# family's ``deepseek-v4-flash-<date>`` form, which the ``deepseek-v`` prefix rule below
+# already covers — so the version-less branch needs a prefix rule of its own.
+_THINKING_CAPABLE_PREFIXES: tuple[str, ...] = ("deepseek-flash-",)
 
 
 class DeepSeekProfile(ProviderProfile):
@@ -29,12 +33,13 @@ class DeepSeekProfile(ProviderProfile):
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         m = (model or "").strip().lower()
-        # v4+ only; v3 excluded. Version-less canonicals (``deepseek-flash``) carry the
-        # same thinking-mode contract but no ``v<N>`` prefix, so consult the id set too —
-        # missing them makes Hermes omit ``thinking``, so the server defaults to on and
-        # the user's thinking toggle / effort setting is silently ignored.
+        # v4+ only; v3 excluded. Version-less canonicals (``deepseek-flash`` and its dated
+        # snapshots) carry the same thinking-mode contract but no ``v<N>`` prefix, so consult
+        # the id set/prefix too — missing them makes Hermes omit ``thinking``, so the server
+        # defaults to on and the user's thinking toggle / effort setting is silently ignored.
         versioned_v4_plus = m.startswith("deepseek-v") and not m.startswith("deepseek-v3")
-        if not versioned_v4_plus and m not in _THINKING_CAPABLE_IDS:
+        versionless = m in _THINKING_CAPABLE_IDS or m.startswith(_THINKING_CAPABLE_PREFIXES)
+        if not versioned_v4_plus and not versionless:
             return {}, {}
         rc = reasoning_config if isinstance(reasoning_config, dict) else None
         # Always set thinking explicitly (default enabled, matching the API default)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -358,6 +358,8 @@ class TestDefaultContextLengths:
             "deepseek-v4-flash": 1_000_000,
             "deepseek-chat": 1_000_000,
             "deepseek-reasoner": 1_000_000,
+            # Version-less canonical Flash id (2026-09 Flash refresh).
+            "deepseek-flash": 1_000_000,
         }
         for key, value in expected_keys.items():
             assert key in DEFAULT_CONTEXT_LENGTHS, f"{key} missing"
@@ -379,6 +381,8 @@ class TestDefaultContextLengths:
                 ("deepseek/deepseek-v4-flash", 1_000_000),
                 ("deepseek-chat", 1_000_000),
                 ("deepseek-reasoner", 1_000_000),
+                ("deepseek-flash", 1_000_000),
+                ("deepseek/deepseek-flash", 1_000_000),
             ]
             for model_id, expected_ctx in cases:
                 actual = get_model_context_length(model_id)

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -56,6 +56,10 @@ import pytest
     ("deepseek/deepseek-v4-flash", 600.0),
     ("deepseek/deepseek-v4-pro", 600.0),
     ("deepseek-v4-flash-free", 600.0),   # catalog -free variant inherits via separator anchor
+    # Version-less canonical Flash id from the 2026-09 Flash refresh —
+    # ``deepseek-v4-flash`` still aliases onto it server-side.
+    ("deepseek/deepseek-flash", 600.0),
+    ("deepseek-flash", 600.0),
     # Qwen QwQ + Qwen3 thinking variants (qwen3 family entry matches all).
     ("qwen/qwq-32b-preview", 300.0),
     ("qwen/qwen3-235b-a22b-thinking", 180.0),

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -130,6 +130,28 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     assert float(entry.cache_read_cost_per_million) == 0.003625
 
 
+def test_deepseek_flash_v41_pricing_entry_exists():
+    """The version-less ``deepseek-flash`` id must price, not show unknown cost.
+
+    V4.1-Flash shipped 2026-09-10 and is the id ``GET /v1/models`` advertises; the
+    legacy ``deepseek-v4-flash`` rows are only server-side aliases onto it.  Rates
+    are the published off-peak tier ($0.15 in / $0.60 out / $0.003 cache read per
+    1M); peak hours bill 2x.
+    """
+    entry = get_pricing_entry(
+        "deepseek-flash",
+        provider="deepseek",
+    )
+
+    assert entry is not None
+    assert entry.input_cost_per_million is not None
+    assert entry.output_cost_per_million is not None
+    assert entry.cache_read_cost_per_million is not None
+    assert float(entry.input_cost_per_million) == 0.15
+    assert float(entry.output_cost_per_million) == 0.60
+    assert float(entry.cache_read_cost_per_million) == 0.003
+
+
 def test_bundled_pricing_skips_endpoint_metadata(monkeypatch):
     """An exact bundled price must not block on the provider's /models API."""
     monkeypatch.setattr(

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -110,6 +110,21 @@ class TestDeepseekVSeriesPassThrough:
         result = normalize_model_for_provider("deepseek-v4-pro", "deepseek")
         assert result == "deepseek-v4-pro"
 
+    def test_deepseek_provider_preserves_versionless_flash_id(self):
+        """``deepseek-flash`` must reach DeepSeek's API unchanged.
+
+        DeepSeek's 2026-09 Flash refresh dropped the ``v<N>`` marker from the
+        public id: ``GET /v1/models`` reports ``deepseek-flash`` and the API
+        accepts it directly (verified live — it answers 200, and the older
+        ``deepseek-v4-flash`` is aliased onto it).  Folding it onto
+        ``deepseek-v4-flash`` meant the id users picked never reached the wire
+        and the config stored a different model than the picker advertised.
+        """
+        assert (
+            normalize_model_for_provider("deepseek-flash", "deepseek")
+            == "deepseek-flash"
+        )
+
 
 # ── DeepSeek post-2026-07-24 alias remapping ───────────────────────────
 

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -129,18 +129,23 @@ class TestDeepseekVSeriesPassThrough:
 # ── DeepSeek post-2026-07-24 alias remapping ───────────────────────────
 
 class TestDeepseekCanonicalAndReasonerMapping:
-    """Retired aliases and fuzzy names rewrite to deepseek-v4-flash.
+    """Retired aliases and fuzzy names rewrite to the current first-class id.
 
     DeepSeek cut off ``deepseek-chat`` / ``deepseek-reasoner`` on
-    2026-07-24; sending them on the wire returns HTTP 400.
+    2026-07-24; sending them on the wire returns HTTP 400.  The id DeepSeek
+    documents today is ``deepseek-flash`` (V4.1-Flash), so that is the rewrite
+    target rather than a legacy name the picker no longer advertises.
     """
 
 
     def test_provider_path_rewrites_reasoner(self):
         assert (
             normalize_model_for_provider("deepseek-reasoner", "deepseek")
-            == "deepseek-v4-flash"
+            == "deepseek-flash"
         )
+
+    def test_retired_chat_alias_rewrites_to_current_id(self):
+        assert _normalize_for_deepseek("deepseek-chat") == "deepseek-flash"
 
     @pytest.mark.parametrize("model", [
         "deepseek-r1",
@@ -149,8 +154,8 @@ class TestDeepseekCanonicalAndReasonerMapping:
         "deepseek-reasoning-preview",
         "deepseek-cot-experimental",
     ])
-    def test_reasoner_keywords_map_to_v4_flash(self, model):
-        assert _normalize_for_deepseek(model) == "deepseek-v4-flash"
+    def test_reasoner_keywords_map_to_flash(self, model):
+        assert _normalize_for_deepseek(model) == "deepseek-flash"
 
 
 # ── Regression: issue #78796 ───────────────────────────────────────────

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -108,6 +108,10 @@ class TestDeepSeekModelGating:
             "deepseek-v4-flash",
             "deepseek-v4-future-variant",
             "DEEPSEEK-V4-PRO",  # case-insensitive
+            # Version-less canonical ids (2026-09 Flash refresh) carry the
+            # same thinking-mode contract but no v<N> marker.
+            "deepseek-flash",
+            "DEEPSEEK-FLASH",  # case-insensitive
         ],
     )
     def test_thinking_capable_models_emit_thinking(self, deepseek_profile, model):

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -112,6 +112,8 @@ class TestDeepSeekModelGating:
             # same thinking-mode contract but no v<N> marker.
             "deepseek-flash",
             "DEEPSEEK-FLASH",  # case-insensitive
+            # Dated snapshots mirror the versioned family's ``-<date>`` form.
+            "deepseek-flash-20260910",
         ],
     )
     def test_thinking_capable_models_emit_thinking(self, deepseek_profile, model):


### PR DESCRIPTION
## What this fixes

DeepSeek's 2026-09 Flash refresh introduced a **version-less canonical model id**. Right now `GET https://api.deepseek.com/v1/models` returns only:

```
deepseek-flash
deepseek-v4-pro
```

`deepseek-flash` is accepted directly, and the older `deepseek-v4-flash` is server-side aliased onto it (a request for `deepseek-v4-flash` comes back with `"model": "deepseek-flash"`). The in-between id `deepseek-v4.1-flash` is rejected with:

```
The supported API model names are deepseek-flash, deepseek-v4-pro
```

Every DeepSeek model-id gate in Hermes keys off the `deepseek-v<N>` prefix, so the new id silently falls through four of them. Each is a real, observable defect — verified against the live API and against the current functions:

| gate | with `deepseek-flash` before this patch | with `deepseek-v4-flash` |
|---|---|---|
| `DeepSeekProfile.build_api_kwargs_extras` | `{} / {}` — no `thinking`, no `reasoning_effort` | `{"thinking": {"type": "enabled"}}` + effort |
| `_normalize_for_deepseek` | folded onto `deepseek-v4-flash` | passthrough |
| `DEFAULT_CONTEXT_LENGTHS` scan | hits the 128K `deepseek` catch-all | 1M |
| `_REASONING_STALE_TIMEOUT_FLOORS` | `None` → 180s default | 600.0 |

Consequences, in user terms:

1. **Thinking controls silently stop working.** A `False` from the profile makes Hermes omit `extra_body.thinking`; DeepSeek then defaults to thinking-on, so the user's thinking toggle does nothing and `reasoning_effort` (`low`/`medium`/`high`/`max`) is dropped.
2. **The picker offers a model the config never stores.** Selecting the id from the live catalog normalizes it back to `deepseek-v4-flash` before it reaches the wire.
3. **Context is capped at 1/8.** 128K instead of the real 1M window, so compaction kicks in far too early.
4. **The stale-stream detector can kill a healthy thinking phase** at 180s instead of the 600s reasoning floor.

## Changes

- `plugins/model-providers/deepseek/__init__.py` — add a `_THINKING_CAPABLE_IDS` set and consult it alongside the version-prefix check.
- `hermes_cli/model_normalize.py` — add `deepseek-flash` to `_DEEPSEEK_CANONICAL_MODELS`. **This one must ship with the profile change**: once the id stops being folded, the profile is the only thing keeping `thinking` on the wire.
- `agent/model_metadata.py` — discrete 1M entry (beats the 128K catch-all on the longest-key-first scan).
- `agent/reasoning_timeouts.py` — add the slug to the 600s floor group.

Regression coverage for all four sites, in the existing test files. `deepseek-v3-*`, unknown ids, and the empty/`None` model behave exactly as before (unknown ids still fold to `deepseek-v4-flash`).

## Verification

- Live API probes against `api.deepseek.com` (models list, both id spellings, image input, the rejected in-between id).
- `scripts/run_tests.sh` on the four touched test files: **180 passed, 0 failed**; plus the whole `tests/plugins/model_providers/` directory and the two adjacent `model_metadata` files: **226 + 39 passed, 0 failed**.

## Note on the refresh itself

The Flash model also now takes image input (documented in the changelog as `deepseek-v4-flash-vision-exp`, which is likewise routed onto `deepseek-flash` today) and the official docs' model list still lags the API. That's context for reviewers — this patch only makes Hermes recognise the id the API already reports; it changes no pricing or capability assumptions.
