### PR TITLE
feat(models): add DeepSeek V4.1 Flash to offline fallbacks and Go picker

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -340,8 +340,10 @@ DEFAULT_CONTEXT_LENGTHS = {
     "gemini": 1048576,
     "gemma-4": 256000, "gemma4": 256000, "gemma-4-31b": 256000, "gemma-3": 131072, "gemma": 8192,
     # DeepSeek — V4 family is 1M; deepseek-chat/-reasoner alias v4-flash modes.
+    # V4.1 Flash is 1M too; OpenCode Go serves it as the short slug "deepseek-flash".
     # https://api-docs.deepseek.com/zh-cn/quick_start/pricing
-    "deepseek-v4-pro": 1_000_000, "deepseek-v4-flash": 1_000_000, "deepseek-chat": 1_000_000,
+    "deepseek-v4-pro": 1_000_000, "deepseek-v4-flash": 1_000_000, "deepseek-v4.1-flash": 1_000_000,
+    "deepseek-flash": 1_000_000, "deepseek-chat": 1_000_000,
     "deepseek-reasoner": 1_000_000, "deepseek": 128000,
     # Meta; Muse Spark family (1.1/1.2/1.3, -contributor(-free), meta/ prefixed) is 1M per OpenRouter,
     # models.dev and api.commandcode.ai /models — keep the "muse-spark" prefix (bare "muse" would match

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -21,6 +21,7 @@ _REASONING_STALE_TIMEOUT_FLOORS: dict[int, tuple[str, ...]] = {
         "nemotron-3-ultra", "nemotron-3-super",
         # DeepSeek R1 / V4 (reasoning_content streamed before final content).
         "deepseek-r1", "deepseek-reasoner", "deepseek-v4-flash", "deepseek-v4-pro",
+        "deepseek-v4.1-flash", "deepseek-flash",
         # OpenAI o-series: each variant enumerated so bare ``o1`` cannot over-match ``olmo-1``.
         "o1", "o1-mini", "o1-pro", "o1-preview", "o3", "o3-pro",
         # Mythos-class named models (claude-fable-5): 1M ctx + 128K output, a heavier thinking

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -248,7 +248,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k3", "kimi-k2.7-code", "kimi-k2.6", "kimi-k2.5", "gpt-5.6-luna", "grok-4.5", "glm-5.3",
         "glm-5.3-flash", "glm-5.2", "glm-5.1", "glm-5", "mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro",
         "mimo-v2-omni", "minimax-m3", "minimax-m2.7", "minimax-m2.5", "deepseek-v4-pro",
-        "deepseek-v4-flash", "qwen3.8-max", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus",
+        "deepseek-v4-flash", "deepseek-flash", "qwen3.8-max", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus",
         "qwen3.5-plus", "hy3", "hy3-preview", "muse-spark-1.2-contributor", "muse-spark-1.3-contributor",
     ],
     "kilocode": [

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -356,6 +356,8 @@ class TestDefaultContextLengths:
         expected_keys = {
             "deepseek-v4-pro": 1_000_000,
             "deepseek-v4-flash": 1_000_000,
+            "deepseek-v4.1-flash": 1_000_000,
+            "deepseek-flash": 1_000_000,
             "deepseek-chat": 1_000_000,
             "deepseek-reasoner": 1_000_000,
         }
@@ -375,8 +377,11 @@ class TestDefaultContextLengths:
             cases = [
                 ("deepseek-v4-pro", 1_000_000),
                 ("deepseek-v4-flash", 1_000_000),
+                ("deepseek-v4.1-flash", 1_000_000),
+                ("deepseek-flash", 1_000_000),
                 ("deepseek/deepseek-v4-pro", 1_000_000),
                 ("deepseek/deepseek-v4-flash", 1_000_000),
+                ("deepseek/deepseek-v4.1-flash", 1_000_000),
                 ("deepseek-chat", 1_000_000),
                 ("deepseek-reasoner", 1_000_000),
             ]

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -55,6 +55,8 @@ import pytest
     ("deepseek/deepseek-reasoner", 600.0),
     ("deepseek/deepseek-v4-flash", 600.0),
     ("deepseek/deepseek-v4-pro", 600.0),
+    ("deepseek/deepseek-v4.1-flash", 600.0),
+    ("deepseek-flash", 600.0),   # OpenCode Go slug for V4.1 Flash
     ("deepseek-v4-flash-free", 600.0),   # catalog -free variant inherits via separator anchor
     # Qwen QwQ + Qwen3 thinking variants (qwen3 family entry matches all).
     ("qwen/qwq-32b-preview", 300.0),

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -259,6 +259,7 @@ class TestCopilotNormalization:
         # DeepSeek / MiMo on Go are OpenAI-compatible chat completions.
         assert opencode_model_api_mode("opencode-go", "deepseek-v4-pro") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "deepseek-v4-flash") == "chat_completions"
+        assert opencode_model_api_mode("opencode-go", "deepseek-flash") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "mimo-v2.5") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "kimi-k2.7-code") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "glm-5.2") == "chat_completions"


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

DeepSeek released V4.1 Flash with a 1M context window. OpenCode Go serves it as `deepseek-flash` while NanoGPT uses `deepseek/deepseek-v4.1-flash`. This adds both ids to the offline context table and the reasoning stale-timeout floor, and lists the Go slug in the Go picker. Before this change, cold sessions without a fresh models.dev cache fell back to a 128K window with short timeouts for the new model. The live catalog path already resolves these ids when it is fresh, so this only fixes the offline fallbacks and the picker.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

No linked issue. This is a routine catalog update for a new model release, same shape as the GLM-5.3-Flash picker update. I searched open PRs and issues for v4.1 and found none.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `agent/model_metadata.py`: added `deepseek-v4.1-flash` and `deepseek-flash` with a 1M window to `DEFAULT_CONTEXT_LENGTHS`
- `agent/reasoning_timeouts.py`: added both slugs to the 600s reasoning floor
- `hermes_cli/models_catalog_static.py`: added `deepseek-flash` to the `opencode-go` picker list
- `tests/agent/test_model_metadata.py`, `tests/agent/test_reasoning_stale_timeout_floor.py`, `tests/hermes_cli/test_model_validation.py`: new cases for both ids

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. With no network and an empty models.dev cache, `get_model_context_length("deepseek-v4.1-flash")` returns 1000000 (was 128000 before)
2. `get_reasoning_stale_timeout_floor("deepseek-flash")` returns 600.0 (was None before)
3. `opencode_model_api_mode("opencode-go", "deepseek-flash")` returns `chat_completions`
4. Ran the related suites: `pytest tests/plugins/model_providers/ tests/agent/test_model_metadata.py tests/agent/test_reasoning_stale_timeout_floor.py tests/agent/test_usage_pricing.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_model_normalize.py` — 531 passed

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

Note: full `pytest tests/` was not run locally. The related suites above pass and the full suite runs in CI.

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no documented model list changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure data changes, no platform impact
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A
