### PR TITLE
fix(opencode-go): send thinking controls for the deepseek-flash slug

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -27,7 +27,11 @@ def _flat_model_name(model: str | None) -> str:
 
 def _is_deepseek_thinking_model(model: str | None) -> bool:
     m = _flat_model_name(model)
-    return (m.startswith("deepseek-v") and not m.startswith("deepseek-v3")) or m == "deepseek-reasoner"
+    return (m.startswith("deepseek-v") and not m.startswith("deepseek-v3")) or m in (
+        "deepseek-reasoner",
+        # OpenCode Go serves V4.1 Flash as the short slug "deepseek-flash".
+        "deepseek-flash",
+    )
 
 
 def _is_glm_5_2_model(model: str | None) -> bool:

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -182,6 +182,27 @@ class TestOpenCodeGoDeepSeekThinking:
             assert extra_body == {}
             assert top_level == {"reasoning_effort": "max"}
 
+    def test_go_short_slug_for_v41_flash_gets_effort(self, opencode_go_profile):
+        """OpenCode Go serves V4.1 Flash as "deepseek-flash" (no V prefix).
+
+        Before the fix the thinking check missed this slug, so the effort
+        was silently dropped and the relay used its server default.
+        """
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="deepseek-flash",
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "high"}
+
+    def test_prefixed_v41_flash_spelling_gets_effort(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="deepseek/deepseek-v4.1-flash",
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "high"}
+
 
 class TestOpenCodeGoGLM52Reasoning:
     """GLM-5.2 uses its native high/max reasoning_effort knob on OpenCode Go."""


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

OpenCode Go serves DeepSeek V4.1 Flash as `deepseek-flash` with no V prefix. The Go profile thinking check only matched `deepseek-v*` ids, so it missed this slug. The requested effort was silently dropped and the relay fell back to its server default. This adds the slug to the thinking check. Prefixed spellings like `deepseek/deepseek-v4.1-flash` already worked because the check strips the vendor part first.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

No linked issue. I searched open PRs and issues for v4.1 and found none. The fix is small and covered by new tests below.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `plugins/model-providers/opencode-zen/__init__.py`: `_is_deepseek_thinking_model` also matches the `deepseek-flash` slug
- `tests/plugins/model_providers/test_opencode_go_profile.py`: new cases for the short slug and the prefixed v4.1 spelling

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Call `build_api_kwargs_extras` on the `opencode-go` profile with `model="deepseek-flash"` and effort `high`. Before the fix it returned `{}, {}`. Now it returns `{"reasoning_effort": "high"}`.
2. The new short slug test fails on the base commit and passes with the fix (checked by stashing the source change).
3. Ran `pytest tests/plugins/model_providers/` — 246 passed.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

Note: full `pytest tests/` was not run locally. The provider suite above passes and the full suite runs in CI.

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, wire behavior now matches what is already documented for DeepSeek thinking
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — string matching only, no platform impact
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A
