### PR TITLE
fix(deepseek): accept vendor prefixed model ids in thinking check

### DIFF
--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -21,7 +21,9 @@ class DeepSeekProfile(ProviderProfile):
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        m = (model or "").strip().lower()
+        # Strip an aggregator-style vendor prefix ("deepseek/deepseek-v4-flash")
+        # so thinking controls do not depend on which spelling reached the profile.
+        m = (model or "").strip().lower().rsplit("/", 1)[-1]
         if not m.startswith("deepseek-v") or m.startswith("deepseek-v3"):  # v4+ only; v3 excluded
             return {}, {}
         rc = reasoning_config if isinstance(reasoning_config, dict) else None

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -108,6 +108,8 @@ class TestDeepSeekModelGating:
             "deepseek-v4-flash",
             "deepseek-v4-future-variant",
             "DEEPSEEK-V4-PRO",  # case-insensitive
+            "deepseek/deepseek-v4-pro",  # aggregator spelling reaches the profile
+            "deepseek/deepseek-v4.1-flash",
         ],
     )
     def test_thinking_capable_models_emit_thinking(self, deepseek_profile, model):


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

The DeepSeek profile thinking check looked at the raw model string, so an aggregator spelling like `deepseek/deepseek-v4-pro` missed the gate and got no `thinking` marker. Without the marker DeepSeek defaults to thinking on and later turns can fail when reasoning content is missing. The check now strips the vendor prefix first, the same way the Go profile and model normalization already do.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

No linked issue. I searched open PRs and issues for v4.1 and found none. The fix is small and covered by new tests below.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `plugins/model-providers/deepseek/__init__.py`: strip the `vendor/` prefix before the V series check in `build_api_kwargs_extras`
- `tests/plugins/model_providers/test_deepseek_profile.py`: added `deepseek/deepseek-v4-pro` and `deepseek/deepseek-v4.1-flash` to the thinking capable cases

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Call `build_api_kwargs_extras` on the `deepseek` profile with `model="deepseek/deepseek-v4-pro"` and no reasoning config. Before the fix it returned `{}`. Now it returns `{"thinking": {"type": "enabled"}}`.
2. Both new cases fail on the base commit and pass with the fix (checked by stashing the source change).
3. Ran `pytest tests/plugins/model_providers/ tests/run_agent/test_deepseek_v4_thinking_live.py tests/run_agent/test_deepseek_reasoning_content_echo.py` — 267 passed, 2 skipped (live tests that need credentials).

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

Note: full `pytest tests/` was not run locally. The suites above pass and the full suite runs in CI.

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, wire behavior now matches the profile docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — string matching only, no platform impact
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A
