### PR TITLE
docs(browser): add a "which mode do I need?" callout at the top of the page

### DIFF
--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -20,6 +20,16 @@ Hermes Agent includes a full browser automation toolset with multiple backend op
 
 In all modes, the agent can navigate websites, interact with page elements, fill forms, and extract information.
 
+:::tip Which mode do I need?
+Most setups need none of the configuration below. Pick the first line that matches you:
+
+- **You just want the agent to browse the web.** Do nothing. With no cloud key set and no `/browser connect` endpoint, Hermes drives a packaged Chromium through the Browser Use CLI by default; `agent-browser` resolves itself on first use. Your own Chrome is never touched. See [Browser Use mode](#browser-use-mode-default).
+- **You want the agent to use your existing logins.** Set `browser.use_real_profile: true` in `~/.hermes/config.yaml`. See [Real profile browsing](#real-profile-browsing-use-your-own-logins).
+- **You want to attach to a Chrome, Brave, Chromium, or Edge window you can watch.** Run `/browser connect` with nothing after it. It is a CLI slash command: type it in `hermes` or `hermes chat` in a terminal, not in a Discord, Telegram, or WebUI chat. It auto-launches or attaches to a local browser at `http://127.0.0.1:9222`; the `ws://host:port` argument is only for a browser running somewhere else. See [Local Chromium-family browser via CDP](#local-chromium-family-browser-via-cdp-browser-connect).
+- **You have a paid Nous Portal subscription.** Pick **Nous Subscription** as the browser provider via `hermes tools`. No separate API keys are needed.
+- **You want a cloud browser with anti-bot tooling.** Add the provider key from [Setup](#setup) and select the provider in `hermes tools` → Browser Automation.
+:::
+
 ## Overview
 
 Pages are represented as **accessibility trees** (text-based snapshots), making them ideal for LLM agents. Interactive elements get ref IDs (like `@e1`, `@e2`) that the agent uses for clicking and typing.


### PR DESCRIPTION
### What
- Adds a `:::tip Which mode do I need?` admonition directly under the eight-item backend list on `user-guide/features/browser.md`.
- Five one-line entries (plain browsing / own logins / attach to a visible browser / Nous subscription / cloud anti-bot), each pointing at the existing section that already documents it.
- States on the first screen that `/browser connect` takes no argument in the common case, and that it is a CLI slash command (the gateway note already lives ~470 lines down).
- No behaviour claims that are not already on the page; every sentence is a restatement of an existing line with an anchor link.

### Why
The page opens with eight backend options and only says "this is the default, zero config" under the Browser Use mode heading, after the cloud-provider setup blocks. New users read the list as "I must choose one", pick `/browser connect` because it sounds local, then hit the argument question and the gateway-vs-CLI question. Latest report: a newcomer in a community thread on 2026-09-10 who abandoned the attempt at exactly that step. A first-screen router removes the whole class.

Verified against `main` at cfdbbb6 (2026-09-10). Independent of #106585 (Chrome 136+ paragraph, further down the same file); no overlapping hunks.