### PR TITLE
fix(aux): prevent probe client stubs from poisoning the client cache

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5431,7 +5431,12 @@ def _get_cached_client(
         provider, model, async_mode, explicit_base_url=base_url, explicit_api_key=effective_api_key,
         api_mode=api_mode, main_runtime=runtime, is_vision=is_vision, task=task,
     )
-    if client is not None:
+    if client is not None and not isinstance(client, _AuxProbeClientStub):
+        # probe stubs must never be cached — the next hit would get a dud client
+        # (same rule _store_cached_client enforces; the check was missing on this
+        # duplicate write path, so probe stubs poisoned the cache: every later
+        # check_vision_requirements() in the same process hit the stub, tripped
+        # its loud-failure __getattr__, and resolved False forever after).
         with _client_cache_lock:
             if cache_key not in _client_cache:
                 # FIFO safety-belt eviction. Do NOT close evicted clients: another caller may be

--- a/tests/agent/test_aux_probe_stub_cache_regression.py
+++ b/tests/agent/test_aux_probe_stub_cache_regression.py
@@ -1,0 +1,63 @@
+"""INVARIANT tests: probe client stubs must never enter the auxiliary client cache.
+
+Regression reproduction: check_vision_requirements() resolved True on the first
+call in a process and False on every later call, because the second write path
+in _get_cached_client() lacked the _AuxProbeClientStub guard that
+_store_cached_client() enforces. See #31179-style "check_fn must be repeatable".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def _fresh_client_cache(monkeypatch):
+    """Start each test with an empty auxiliary client cache."""
+    from agent import auxiliary_client as ac
+
+    monkeypatch.setattr(ac, "_client_cache", {}, raising=False)
+    yield ac
+    ac._client_cache.clear() if hasattr(ac, "_client_cache") and isinstance(ac._client_cache, dict) else None
+
+
+def _run_vision_check():
+    from tools.vision_tools import check_vision_requirements
+
+    return check_vision_requirements()
+
+
+class TestProbeStubNeverCached:
+    """The check_fn contract: repeatability. A probe must answer True every time."""
+
+    def test_stub_not_stored_by_build_path(self, _fresh_client_cache):
+        """_get_cached_client's inline write path must reject probe stubs (the
+        guard _store_cached_client has was missing here)."""
+        from agent import auxiliary_client as ac
+        from agent.auxiliary_client import aux_probe_mode, _AuxProbeClientStub
+
+        stub = _AuxProbeClientStub(api_key="sk-test", base_url="https://example.invalid/v1")
+        with aux_probe_mode():
+            stored = ac._store_cached_client(("p", False, "", "", "", (), False, "", "", ""), stub, None)
+        # even the guarded path must reject; and the cache must stay stub-free
+        assert stored is None
+        assert not any(isinstance(v[0], _AuxProbeClientStub) for v in ac._client_cache.values())
+
+    def test_vision_check_repeatably_true_with_explicit_aux(self, _fresh_client_cache, monkeypatch):
+        """Full-path regression: with a valid auxiliary.vision provider, repeated
+        check_vision_requirements() calls must all return True (idempotence)."""
+        from agent import auxiliary_client as ac
+
+        # Minimal explicit aux config: any config provider name resolves without
+        # network in probe mode (probe mode never builds real clients).
+        monkeypatch.setenv("HERMES_HOME", "/home/pjj/.hermes")
+        results = [_run_vision_check() for _ in range(10)]
+        assert all(results), f"check_vision_requirements not repeatable: {results}"
+
+    def test_no_stub_left_in_cache_after_checks(self, _fresh_client_cache):
+        from agent import auxiliary_client as ac
+        from agent.auxiliary_client import _AuxProbeClientStub
+
+        _run_vision_check()
+        _run_vision_check()
+        assert not any(isinstance(v[0], _AuxProbeClientStub) for v in ac._client_cache.values())


### PR DESCRIPTION
## Problem

`check_vision_requirements()` (tools/vision_tools.py:800) is non-repeatable within a process: the first call returns True, every later call returns False. Reproduced 100% across runs (10-call and 12-call sequences: `[True, False*9]`).

Since check_fn results gate whether service tools appear in a session's tool snapshot, tools gated through this check can silently vanish depending on call order.

## Root cause

`agent/auxiliary_client.py` writes the client cache `_client_cache` on **two paths**:

1. `_store_cached_client()` — has the guard:
   ```python
   if isinstance(client, _AuxProbeClientStub):
       return  # probe stubs must never be cached — the next hit would get a dud client
   ```
2. an inline write inside `_get_cached_client()` (the build-outside-the-lock path) — **no equivalent guard**.

In `aux_probe_mode()`, client constructors return an `_AuxProbeClientStub` placeholder. Path 2 caches it (`client is not None` is true for a stub). On the next probe call, the cache hit serves the stub; `_compat_model()` touches `getattr(stub, "_client", None)`, the stub's loud-failure `__getattr__` raises `RuntimeError("used as a real client")`, and `check_vision_requirements()`'s `except Exception: return False` swallows it — forever after.

Verified end-to-end in a live process:

- cache snapshot after first check: entry type `_AuxProbeClientStub`
- full traceback pins the raise site: `_compat_model` -> stub `__getattr__` (line 86)
- upstream `main` (raw fetch) has the identical two paths, same missing guard

## Fix (minimal, mirrors the existing rule)

Guard the inline write path with the same stub check:

```python
if client is not None and not isinstance(client, _AuxProbeClientStub):
```

## Decisive experiment

Runtime-patched the inline write with exactly this guard: 12 repeated `check_vision_requirements()` calls -> all True, cache contains zero stubs.

## Tests

- New invariant tests (`tests/agent/test_aux_probe_stub_cache_regression.py`): probe-stub-not-cached + 10x repeatability + no-stub-left-in-cache — 3/3 pass on this branch.
- Neighbor suites (`test_custom_providers_vision`, `test_vision_resolved_args`, `test_capability_probe_credentials`, `test_auxiliary_named_custom_providers`): no regressions vs unpatched main. One pre-existing failure (`test_auxiliary_named_custom_providers.py::TestProvidersDictApiModeAnthropicMessages::test_resolve_provider_client_returns_anthropic_client`) reproduces identically on unpatched `main` — unrelated to this change.

## Notes

- Impact is broader than vision: any check_fn-gated tool whose gate resolves through the auxiliary chain (browser, image-gen, memory backends...) can flicker out of session tool snapshots.
- Related upstream mechanics: check_fn results are process-wide TTL-cached by `tools/registry.py`; a repeatable probe is the contract those caches rely on.