### PR TITLE
fix(deepseek): align model catalog & context length with live /v1/models

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -339,9 +339,12 @@ DEFAULT_CONTEXT_LENGTHS = {
     # Google / Gemma ("gemma4" is Ollama-style naming, e.g. gemma4:31b-cloud)
     "gemini": 1048576,
     "gemma-4": 256000, "gemma4": 256000, "gemma-4-31b": 256000, "gemma-3": 131072, "gemma": 8192,
-    # DeepSeek — V4 family is 1M; deepseek-chat/-reasoner alias v4-flash modes.
+    # DeepSeek — V4 family is 1M; deepseek-chat/-reasoner alias v4-flash modes. The live
+    # /v1/models catalog (2026-09) lists exactly ``deepseek-flash`` + ``deepseek-v4-pro``;
+    # ``deepseek-v4-flash`` is an accepted legacy alias of ``deepseek-flash``.
     # https://api-docs.deepseek.com/zh-cn/quick_start/pricing
-    "deepseek-v4-pro": 1_000_000, "deepseek-v4-flash": 1_000_000, "deepseek-chat": 1_000_000,
+    "deepseek-v4-pro": 1_000_000, "deepseek-v4-flash": 1_000_000, "deepseek-flash": 1_000_000,
+    "deepseek-chat": 1_000_000,
     "deepseek-reasoner": 1_000_000, "deepseek": 128000,
     # Meta; Muse Spark family (1.1/1.2/1.3, -contributor(-free), meta/ prefixed) is 1M per OpenRouter,
     # models.dev and api.commandcode.ai /models — keep the "muse-spark" prefix (bare "muse" would match

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -20,7 +20,9 @@ _REASONING_STALE_TIMEOUT_FLOORS: dict[int, tuple[str, ...]] = {
         # NVIDIA Nemotron behind hosted NIM: documented 60-180s upstream idle kill.
         "nemotron-3-ultra", "nemotron-3-super",
         # DeepSeek R1 / V4 (reasoning_content streamed before final content).
-        "deepseek-r1", "deepseek-reasoner", "deepseek-v4-flash", "deepseek-v4-pro",
+        # ``deepseek-flash`` is the live canonical id for the Flash tier (v4-flash is its
+        # accepted legacy alias) — both must sit here or the stale detector trips the breaker.
+        "deepseek-r1", "deepseek-reasoner", "deepseek-v4-flash", "deepseek-flash", "deepseek-v4-pro",
         # OpenAI o-series: each variant enumerated so bare ``o1`` cannot over-match ``olmo-1``.
         "o1", "o1-mini", "o1-pro", "o1-preview", "o3", "o3-pro",
         # Mythos-class named models (claude-fable-5): 1M ctx + 128K output, a heavier thinking

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -1499,7 +1499,7 @@ class GoalManager:
                 f"judge API unreachable {n_tx} turns in a row (check auxiliary.goal_judge provider/key in config.yaml)",
                 "continue", reason,
                 f"⏸ Goal paused — judge API returned errors ({n_tx} turns). Check the goal_judge provider/key in "
-                + _JUDGE_CONFIG_HINT.format(provider="deepseek", model="deepseek-v4-flash"),
+                + _JUDGE_CONFIG_HINT.format(provider="deepseek", model="deepseek-flash"),
             )
         if n_parse >= DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES:
             return self._pause_decision(

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -87,13 +87,15 @@ _LOWERCASE_MODEL_PROVIDERS: frozenset[str] = frozenset({
     "xiaomi"})
 
 # DeepSeek's direct API only accepts first-class V-series IDs after the 2026-07-24 cut-off (HTTP 400
-# otherwise). Both retired aliases map to deepseek-v4-flash per the official docs (thinking mode is
-# controlled by extra_body.thinking on the profile), so saved configs can't keep sending them.
+# otherwise). The live /v1/models catalog lists exactly ``deepseek-flash`` + ``deepseek-v4-pro``
+# (2026-09); ``deepseek-v4-flash`` is an accepted legacy alias of ``deepseek-flash``, so both pass
+# through and anything else is normalized onto the canonical Flash id (thinking mode is controlled by
+# extra_body.thinking on the profile) so saved configs can't keep sending retired names.
 _DEEPSEEK_RETIRED_ALIASES: frozenset[str] = frozenset({
     "deepseek-chat", "deepseek-reasoner"})
 
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-v4-pro", "deepseek-v4-flash"})
+    "deepseek-v4-pro", "deepseek-flash", "deepseek-v4-flash"})
 
 # First-class V-series IDs incl. future ``deepseek-v5-*`` and dated variants
 # (``deepseek-v4-flash-20260423``): verified real model ids, NOT aliases of ``deepseek-chat``.
@@ -103,11 +105,11 @@ _DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v\d+([-.].+)?$")
 def _normalize_for_deepseek(model_name: str) -> str:
     """Map a model input to a DeepSeek-accepted id: canonicals and ``deepseek-v<digit>…`` pass
     through (future V-series work without a release); retired aliases and everything else become
-    ``deepseek-v4-flash``."""
+    ``deepseek-flash``."""
     bare = _strip_vendor_prefix(model_name).lower()
     if bare in _DEEPSEEK_CANONICAL_MODELS or _DEEPSEEK_V_SERIES_RE.match(bare):
         return bare
-    return "deepseek-v4-flash"
+    return "deepseek-flash"
 
 
 def _strip_vendor_prefix(model_name: str) -> str:

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -205,7 +205,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-sonnet-4-6", "claude-opus-4-5-20251101", "claude-sonnet-4-5-20250929",
         "claude-opus-4-20250514", "claude-sonnet-4-20250514", "claude-haiku-4-5-20251001",
     ],
-    "deepseek": ["deepseek-v4-pro", "deepseek-v4-flash"],
+    "deepseek": ["deepseek-v4-pro", "deepseek-flash"],
     "xiaomi": ["mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "mimo-v2-flash"],
     "tencent-tokenhub": list(_TENCENT_MODELS),
     "tencent-tokenplan": list(_TENCENT_MODELS),

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -42,8 +42,8 @@ class DeepSeekProfile(ProviderProfile):
 deepseek = DeepSeekProfile(
     name="deepseek", aliases=("deepseek-chat",), env_vars=("DEEPSEEK_API_KEY",), display_name="DeepSeek",
     description="DeepSeek — native DeepSeek API", signup_url="https://platform.deepseek.com/",
-    fallback_models=("deepseek-v4-pro", "deepseek-v4-flash"), base_url="https://api.deepseek.com/v1",
-    default_aux_model="deepseek-v4-flash",
+    fallback_models=("deepseek-v4-pro", "deepseek-flash"), base_url="https://api.deepseek.com/v1",
+    default_aux_model="deepseek-flash",
 )
 
 register_provider(deepseek)

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -114,17 +114,20 @@ class TestDeepseekVSeriesPassThrough:
 # ── DeepSeek post-2026-07-24 alias remapping ───────────────────────────
 
 class TestDeepseekCanonicalAndReasonerMapping:
-    """Retired aliases and fuzzy names rewrite to deepseek-v4-flash.
+    """Retired aliases and fuzzy names rewrite to ``deepseek-flash``.
 
     DeepSeek cut off ``deepseek-chat`` / ``deepseek-reasoner`` on
-    2026-07-24; sending them on the wire returns HTTP 400.
+    2026-07-24; sending them on the wire returns HTTP 400. Its live
+    ``/v1/models`` catalog lists exactly ``deepseek-flash`` +
+    ``deepseek-v4-pro``, so the canonical Flash id is the rewrite target
+    (``deepseek-v4-flash`` is an accepted legacy alias, not the canonical name).
     """
 
 
     def test_provider_path_rewrites_reasoner(self):
         assert (
             normalize_model_for_provider("deepseek-reasoner", "deepseek")
-            == "deepseek-v4-flash"
+            == "deepseek-flash"
         )
 
     @pytest.mark.parametrize("model", [
@@ -134,8 +137,17 @@ class TestDeepseekCanonicalAndReasonerMapping:
         "deepseek-reasoning-preview",
         "deepseek-cot-experimental",
     ])
-    def test_reasoner_keywords_map_to_v4_flash(self, model):
-        assert _normalize_for_deepseek(model) == "deepseek-v4-flash"
+    def test_reasoner_keywords_map_to_canonical_flash(self, model):
+        assert _normalize_for_deepseek(model) == "deepseek-flash"
+
+
+    def test_canonical_flash_passes_through_unchanged(self):
+        """The id DeepSeek's live catalog advertises must not be rewritten."""
+        assert _normalize_for_deepseek("deepseek-flash") == "deepseek-flash"
+        assert (
+            normalize_model_for_provider("deepseek-flash", "deepseek")
+            == "deepseek-flash"
+        )
 
 
 # ── Regression: issue #78796 ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

DeepSeek's direct API now advertises exactly **two** models on `/v1/models`:

- `deepseek-flash`
- `deepseek-v4-pro`

`deepseek-v4-flash` is an *accepted legacy alias* of `deepseek-flash` — it still works if sent
on the wire, but it is **not** the canonical name the API reports. Hermes' curated/static tables
and several hardcoded paths still treat `deepseek-v4-flash` (and the retired `deepseek-chat`,
`deepseek-reasoner`) as first-class, which causes three user-visible problems:

1. **`/model` picker lists a less-correct id** — curated DeepSeek list is
   `["deepseek-v4-pro", "deepseek-v4-flash"]`, but the live catalog wants `deepseek-flash`.
2. **`deepseek-flash` context length is wrong** — `agent/model_metadata.py` had entries for
   `deepseek-v4-pro`/`deepseek-v4-flash` (both 1M) but **no entry for `deepseek-flash`**.
   With provider=deepseek + model=deepseek-flash it falls through to the bare `"deepseek": 128000`
   bucket, so Hermes truncates/spacers at 128K even though the model supports 1M.
3. **`deepseek-flash` misses the reasoning-timeout floor** — `agent/reasoning_timeouts.py` listed
   `deepseek-v4-flash` but not `deepseek-flash`, so long-thinking runs on the canonical Flash id
   were not protected by the 600s floor / stale-detector.

## Change

- `hermes_cli/models_catalog_static.py`: DeepSeek curated list `["deepseek-v4-pro", "deepseek-flash"]`.
- `plugins/model-providers/deepseek/__init__.py`: `fallback_models` + `default_aux_model` → `deepseek-flash`.
- `agent/model_metadata.py`: add `"deepseek-flash": 1_000_000` to `DEFAULT_CONTEXT_LENGTHS`.
- `agent/reasoning_timeouts.py`: add `deepseek-flash` to the 600s floor list.
- `hermes_cli/model_normalize.py`: keep `deepseek-v4-flash` as an accepted alias (pass-through),
  but make the canonical fallback target `deepseek-flash`.
- `hermes_cli/goals.py`: judge-config hint string updated to the canonical id (cosmetic).
- `tests/hermes_cli/test_model_normalize.py`: update assertions + add a regression test that
  `deepseek-flash` passes through unchanged and rewrites target `deepseek-flash`.

Note: the retired `deepseek-chat`/`deepseek-reasoner` still map to the Flash tier (now named
`deepseek-flash`).

## Verification

- Live `GET https://api.deepseek.com/v1/models` confirmed the two canonical ids.
- Live probe of the non-canonical ids returns `400 ... The supported API model names are
  deepseek-flash, deepseek-v4-pro`.
- `scripts/run_tests.sh tests/hermes_cli/test_model_normalize.py tests/agent/test_model_metadata.py`
  → **145 passed, 0 failed**.
- `provider_model_ids('deepseek')` now returns `['deepseek-v4-pro', 'deepseek-flash']`.
- `get_model_context_length('deepseek-flash', ...)` → `1_000_000`; reasoning floor → `600s`.
