### PR TITLE
fix(profiles): serialize cold skill-count scans

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -10,6 +10,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -566,6 +567,7 @@ def _served_by_running_multiplexer(profile_name: str) -> bool:
 # signature changes (skill add/remove) or after a short TTL (deep edits).
 _SKILL_COUNT_CACHE: dict[str, tuple[float, float, int]] = {}
 _SKILL_COUNT_TTL_SECONDS = 30.0
+_SKILL_COUNT_SCAN_LOCK = threading.Lock()
 
 
 def _skills_dir_signature(skills_dir: Path) -> float:
@@ -595,13 +597,21 @@ def _count_skills(profile_dir: Path) -> int:
         return 0
     key = str(skills_dir)
     signature = _skills_dir_signature(skills_dir)
-    now = time.time()
     cached = _SKILL_COUNT_CACHE.get(key)
-    if cached is not None and cached[0] == signature and (now - cached[1]) < _SKILL_COUNT_TTL_SECONDS:
+    if cached is not None and cached[0] == signature and (time.time() - cached[1]) < _SKILL_COUNT_TTL_SECONDS:
         return cached[2]
-    count = sum(1 for md in skills_dir.rglob("SKILL.md") if not is_excluded_skill_path(md))
-    _SKILL_COUNT_CACHE[key] = (signature, now, count)
-    return count
+    # HTTP and RPC callers share this cache. Concurrent recursive scans amplify
+    # filesystem/GIL contention even when they traverse different profiles.
+    with _SKILL_COUNT_SCAN_LOCK:
+        signature = _skills_dir_signature(skills_dir)
+        now = time.time()
+        cached = _SKILL_COUNT_CACHE.get(key)
+        if cached is not None and cached[0] == signature and (now - cached[1]) < _SKILL_COUNT_TTL_SECONDS:
+            return cached[2]
+        count = sum(1 for md in skills_dir.rglob("SKILL.md") if not is_excluded_skill_path(md))
+        # A slow scan must not publish an already-expired cache entry.
+        _SKILL_COUNT_CACHE[key] = (signature, time.time(), count)
+        return count
 
 
 # profile.yaml — per-profile metadata (description, role, etc.)

--- a/tests/hermes_cli/test_profile_skill_count_concurrency.py
+++ b/tests/hermes_cli/test_profile_skill_count_concurrency.py
@@ -1,0 +1,95 @@
+"""Profile scans share work across dashboard and RPC callers."""
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import threading
+
+import pytest
+
+from hermes_cli import profiles
+
+SKILL_NAME = "SKILL.md"
+SKILL_TEXT = "---\nname: example\ndescription: Example skill\n---\n"
+WAIT_SECONDS = 5
+CONTENTION_SECONDS = 2
+CALLERS = 4
+
+
+@pytest.mark.parametrize("distinct_profiles", [False, True])
+def test_skill_scans_are_serialized_and_reuse_completed_counts(tmp_path, monkeypatch, distinct_profiles):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(profiles, "_SKILL_COUNT_CACHE", {})
+    roots = [tmp_path / str(i if distinct_profiles else 0) for i in range(CALLERS)]
+    cached_root = tmp_path / "cached"
+    for root in set(roots) | {cached_root}:
+        skill = root / "skills" / "category" / "example" / SKILL_NAME
+        skill.parent.mkdir(parents=True)
+        skill.write_text(SKILL_TEXT)
+    assert profiles._count_skills(cached_root) == 1
+    scan_entered = threading.Event()
+    overlapping_scan = threading.Event()
+    release_scan = threading.Event()
+    counter_lock = threading.Lock()
+    active = peak = scans = 0
+    original_rglob = Path.rglob
+
+    def held_scan(path, pattern):
+        nonlocal active, peak, scans
+        with counter_lock:
+            active += 1
+            scans += 1
+            peak = max(peak, active)
+            if active > 1:
+                overlapping_scan.set()
+        scan_entered.set()
+        try:
+            assert release_scan.wait(WAIT_SECONDS)
+            yield from original_rglob(path, pattern)
+        finally:
+            with counter_lock:
+                active -= 1
+
+    monkeypatch.setattr(Path, "rglob", held_scan)
+    with ThreadPoolExecutor(max_workers=CALLERS + 1) as executor:
+        futures = [executor.submit(profiles._count_skills, roots[0])]
+        try:
+            assert scan_entered.wait(WAIT_SECONDS)
+            futures.extend(executor.submit(profiles._count_skills, root) for root in roots[1:])
+            cached = executor.submit(profiles._count_skills, cached_root)
+            assert cached.result(timeout=CONTENTION_SECONDS) == 1
+            overlapping_scan.wait(CONTENTION_SECONDS)
+        finally:
+            release_scan.set()
+        counts = [future.result(timeout=WAIT_SECONDS) for future in futures]
+    assert counts == [1] * CALLERS
+    assert peak == 1
+    assert scans == len(set(roots))
+
+
+def test_slow_scan_result_is_fresh_when_published(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(profiles, "_SKILL_COUNT_CACHE", {})
+    root = tmp_path / "profile"
+    skill = root / "skills" / "example" / SKILL_NAME
+    skill.parent.mkdir(parents=True)
+    skill.write_text(SKILL_TEXT)
+    clock = [100.0]
+    scans = 0
+    original_rglob = Path.rglob
+
+    def slow_scan(path, pattern):
+        nonlocal scans
+        scans += 1
+        clock[0] += profiles._SKILL_COUNT_TTL_SECONDS + 1
+        yield from original_rglob(path, pattern)
+
+    monkeypatch.setattr(profiles.time, "time", lambda: clock[0])
+    monkeypatch.setattr(Path, "rglob", slow_scan)
+    assert profiles._count_skills(root) == 1
+    assert profiles._count_skills(root) == 1
+    assert scans == 1
+    clock[0] += profiles._SKILL_COUNT_TTL_SECONDS + 1
+    assert profiles._count_skills(root) == 1
+    assert scans == 2


### PR DESCRIPTION
## What does this PR do?

Prevent concurrent profile enumeration from starting overlapping recursive skill-count scans, and keep a slow scan from publishing an already-expired cache entry.

The signature/TTL cache in `_count_skills()` is present on the tested base (`cfdbbb6e35010ace89fbe8243ee82fa4de143e10`), but checking the cache and filling it are not synchronized. Concurrent HTTP and TUI/Desktop RPC callers can all observe a cold or expired entry and independently traverse the same tree. Scans of different profile trees also contend within the same process. This was investigated after profile enumeration and Kanban board reads stalled together in a multi-profile dashboard.

There is a second amplification mechanism: the existing timestamp is captured before traversal. A scan taking longer than the TTL stores a result that is already expired, so the next caller immediately scans again.

## Related Issue

Fixes #107151

## Related work and scope

This extends the cache introduced in #54770; it does not replace its signature invalidation or endpoint offloading.

I checked the related open traversal changes in #53482, #97176 and #101314, and the broader work in #53435 and #68111. This patch changes scan ownership and cache publication time, not directory pruning, unreadable-directory handling, HTTP timeouts or Desktop reconnect behavior. It deliberately leaves the walker and the set of counted skills unchanged. The nearby traversal PRs may need a textual conflict resolution in this function.

## Type of Change

- [x] Bug fix
- [x] Regression tests

## Changes Made

- `hermes_cli/profiles.py`: serialize cold skill scans at the common counter, recheck the signature/cache after acquiring the lock, and timestamp the result after traversal.
- Preserve the lock-free valid-cache path: an unrelated slow scan does not hold up an already-cached count.
- `tests/hermes_cli/test_profile_skill_count_concurrency.py`: two invariant tests, three parametrized cases, using real temporary skill trees with an event-held traversal and a controlled clock.

The lock is process-local and scoped to this counter's scans. It is not an HTTP admission controller or a hard filesystem timeout. Callers needing an uncached count may wait for the active scan; valid cache hits do not. Exceptions retain their existing behavior and release the lock through the context manager.

## How to Test

Run through the canonical isolated runner:

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j 2 \
  tests/hermes_cli/test_profile_skill_count_concurrency.py \
  tests/hermes_cli/test_profiles.py \
  tests/hermes_cli/test_cron_profile_enumeration_lightweight.py \
  tests/hermes_cli/test_web_profiles_off_loop.py \
  tests/hermes_cli/test_profiles_sidebar_cache.py \
  tests/hermes_cli/test_profiles_sidebar_scope.py \
  tests/hermes_cli/test_web_server_profile_unification.py \
  tests/hermes_cli/test_web_server_skills_profiles.py \
  tests/hermes_cli/test_profile_distribution.py \
  tests/hermes_cli/test_web_server_cron_profiles.py \
  tests/agent/test_skill_utils.py \
  tests/tui_gateway/test_profiles_list_canonical_session.py \
  tests/tui_gateway/test_profiles_list_worker_session.py
```

Result on Linux/WSL2, Python 3.11.15: **266 passed, 0 failed, 2 Windows-only tests skipped**.

The initial three regression cases were run against unmodified base `cfdbbb6e35` and failed: overlapping scan peak was 4 rather than 1, and two consecutive calls rescanned twice when the first scan exceeded its TTL. The additional warm-cache assertion was also proven red against the intermediate implementation that locked before checking the cache; the final implementation passes it.

`ruff check hermes_cli/profiles.py tests/hermes_cli/test_profile_skill_count_concurrency.py` and `git diff --check` pass.

## Checklist

- [x] Reviewed the relevant contribution and testing guidance.
- [x] Searched open, closed and merged related PRs; the remaining concurrency/cache-publication gap is still present on the tested base.
- [x] One narrowly scoped, cryptographically signed commit; no unrelated changes.
- [x] Regression tests added and run before and after the fix.
- [x] Tested on Linux/WSL2 with Python 3.11.15.
- [ ] Full repository test suite, Windows and macOS execution: not run locally.
- [x] No new dependencies, configuration keys, API fields or tool schemas.

Posted for GP by his AI assistant
