### PR TITLE
fix(review): normalize routed Codex forks and guard oversized requests

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -203,9 +203,10 @@ def load_background_review_settings() -> tuple[bool, Dict[str, Any]]:
 
 def _resolve_review_runtime(agent: Any, task_cfg: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Resolve provider/model/credentials for the review fork. Default (auto / unset / same as
-    parent): the parent's live runtime with ``routed=False`` (codex_app_server -> codex_responses
-    downgrade applied). When ``auxiliary.background_review.{provider,model}`` names a different
-    concrete model, resolve that runtime and set ``routed=True``."""
+    parent): the parent's live runtime with ``routed=False``. When
+    ``auxiliary.background_review.{provider,model}`` names a different concrete model,
+    resolve that runtime and set ``routed=True``. Normalize codex_app_server to
+    codex_responses on whichever runtime is selected."""
     parent_runtime = agent._current_main_runtime()
     parent_api_mode = parent_runtime.get("api_mode") or None
     parent = {
@@ -233,7 +234,8 @@ def _resolve_review_runtime(agent: Any, task_cfg: Optional[Dict[str, Any]] = Non
         )
         return {
             "provider": rp.get("provider") or task_provider, "model": rp.get("model") or task_model,
-            **{key: rp.get(key) for key in ("api_key", "base_url", "api_mode", "credential_pool", "command")},
+            **{key: rp.get(key) for key in ("api_key", "base_url", "credential_pool", "command")},
+            "api_mode": "codex_responses" if rp.get("api_mode") == "codex_app_server" else rp.get("api_mode"),
             "request_overrides": dict(rp.get("request_overrides") or {}),
             "args": list(rp.get("args") or []), "routed": True,
         }
@@ -876,6 +878,8 @@ def build_cache_parity_fork(
     # Inherit the parent's live runtime: AIAgent.__init__'s env auto-resolution fails for
     # OAuth-only providers, session-scoped creds and credential pools.
     _rt = _resolve_review_runtime(agent, task_cfg)
+    if _rt.get("api_mode") == "codex_app_server":
+        raise ValueError("Detached forks cannot use codex_app_server native tools")
     _routed = bool(_rt.get("routed"))
     review_agent = AIAgent(**_fork_init_kwargs(agent, _rt, _routed, max_iterations))
     review_agent._memory_write_origin = review_agent._memory_write_context = write_origin

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1008,6 +1008,7 @@ class _ReviewForkState:
     review_agent: Any = None
     review_messages: List[Dict] = field(default_factory=list)
     review_usage: Dict[str, Any] = field(default_factory=dict)
+    review_skipped: bool = False
 
 
 def _release_fork_clients(review_agent: Any) -> None:
@@ -1056,7 +1057,7 @@ def _run_review_fork(
     try:
         if review_run is None or review_run.begin_request(st.review_agent):
             # Routed -> digest (cache cold anyway); same model -> full snapshot (warm cache reads).
-            st.review_agent.run_conversation(
+            result = st.review_agent.run_conversation(
                 user_message=(
                     prompt + "\n\nYou can only call " + memory_phrase_prompt +
                     "management tools. Other tools will be denied "
@@ -1064,6 +1065,9 @@ def _run_review_fork(
                 ),
                 conversation_history=_digest_history(messages_snapshot) if _routed else messages_snapshot,
             )
+            st.review_skipped = isinstance(result, dict) and result.get("turn_exit_reason") in {
+                "review_request_oversized", "review_request_size_unavailable",
+            }
     finally:
         clear_thread_tool_whitelist()
         # Attribute usage to the PARENT session. Snapshot BEFORE unregister/close so counters
@@ -1152,7 +1156,7 @@ def _run_review_in_thread(
                 e,
             )
             actions = []
-        _log_review_completion(st.review_usage, _classify_review_result(actions))
+        _log_review_completion(st.review_usage, "skipped" if st.review_skipped else _classify_review_result(actions))
         if actions:
             _publish_review_summary(agent, actions)
     except Exception as e:

--- a/agent/turn_preflight_gate.py
+++ b/agent/turn_preflight_gate.py
@@ -44,7 +44,13 @@ def run_preflight_gate(
         _last_preflight_pressure=None,
     )
 
-    is_review = getattr(agent, "_memory_write_origin", None) == "background_review"
+    # The budget attribute identifies cache-parity forks even when disabled
+    # (None). Write origin excludes /btw; provenance alone also tags the standalone
+    # skill curator, which is not a snapshot review and must keep its own behavior.
+    is_review = (
+        getattr(agent, "_memory_write_origin", None) == "background_review"
+        and hasattr(agent, "_review_input_token_budget")
+    )
     review_threshold = getattr(getattr(agent, "context_compressor", None), "threshold_tokens", None)
 
     def skip_review(reason: str) -> PreflightGateVerdict:

--- a/agent/turn_preflight_gate.py
+++ b/agent/turn_preflight_gate.py
@@ -7,6 +7,7 @@ assembled requests, not raw ``messages``) and the call into
 from __future__ import annotations
 
 import logging
+import math
 from contextlib import suppress
 from typing import Any
 
@@ -42,6 +43,36 @@ def run_preflight_gate(
         _provider_overflow_recovery_pending=_provider_overflow_recovery_pending,
         _last_preflight_pressure=None,
     )
+
+    is_review = getattr(agent, "_memory_write_origin", None) == "background_review"
+    review_threshold = getattr(getattr(agent, "context_compressor", None), "threshold_tokens", None)
+
+    def skip_review(reason: str) -> PreflightGateVerdict:
+        logger.warning(
+            "Background review skipped: reason=%s request_tokens=%s threshold_tokens=%s "
+            "model=%s context_length=%s max_tokens=%s",
+            reason, request_pressure_tokens, review_threshold, getattr(agent, "model", None),
+            getattr(getattr(agent, "context_compressor", None), "context_length", None),
+            getattr(agent, "max_tokens", None),
+        )
+        v.final_response = "Background review skipped: " + reason
+        v.failed = True
+        v._turn_exit_reason = reason
+        v.api_call_count -= 1
+        agent._api_call_count = v.api_call_count
+        with suppress(Exception):
+            agent.iteration_budget.refund()
+        v.action = "break"
+        return v
+
+    if is_review:
+        valid_sizing = all(
+            isinstance(value, (int, float)) and not isinstance(value, bool)
+            and math.isfinite(value) and value > 0
+            for value in (request_pressure_tokens, review_threshold)
+        )
+        if not valid_sizing:
+            return skip_review("review_request_size_unavailable")
 
     _runtime_context_error = _ollama_context_limit_error(agent, request_pressure_tokens)
     if _runtime_context_error:
@@ -87,7 +118,7 @@ def run_preflight_gate(
             f"{_last_preflight_pressure:,}",
             f"{request_pressure_tokens:,}",
         )
-    return run_preflight_compression(
+    v = run_preflight_compression(
         agent, v, compressor=_compressor, request_pressure_tokens=request_pressure_tokens,
         provider_overflow_preflight=_provider_overflow_preflight,
         # An anchored figure is real usage + delta: never deferred. Only a whole-context rough
@@ -100,3 +131,9 @@ def run_preflight_gate(
         user_message=user_message, max_compression_attempts=max_compression_attempts,
         effective_task_id=effective_task_id,
     )
+    # Normal detached compaction may rebuild later requests. Never compare its
+    # stale pre-compaction estimate: the next loop pass reassembles and rechecks.
+    # Request one defers compaction and reaches this guard without a model call.
+    if is_review and v.action == "fallthrough" and request_pressure_tokens >= review_threshold:
+        return skip_review("review_request_oversized")
+    return v

--- a/tests/run_agent/test_background_review_request_size.py
+++ b/tests/run_agent/test_background_review_request_size.py
@@ -1,0 +1,166 @@
+"""Prepared review requests must fit the detached review model's threshold."""
+from unittest.mock import patch
+from contextlib import contextmanager
+from functools import wraps
+
+import pytest
+
+from tests.run_agent.test_background_review_input_budget import (
+    _make_loop_agent, _run_with_responses, _final_response, _tool_response,
+)
+
+
+@contextmanager
+def _pressure(*values):
+    from agent.turn_request_assembly import assemble_api_request
+    values = iter(values)
+
+    @wraps(assemble_api_request)
+    def assemble(*args, **kwargs):
+        request = assemble_api_request(*args, **kwargs)
+        request.request_pressure_tokens = next(values)
+        return request
+
+    with patch("agent.conversation_loop.assemble_api_request", new=assemble):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _restore_review_origin():
+    # These loops run inline instead of on the production disposable thread.
+    from tools.skill_provenance import set_current_write_origin, reset_current_write_origin
+    token = set_current_write_origin("foreground")
+    try:
+        yield
+    finally:
+        reset_current_write_origin(token)
+
+
+@pytest.mark.parametrize("pressure", [1000, 1001, None, -1, float("nan"), True, "100"])
+def test_initial_review_rejects_oversized_or_unavailable_pressure(pressure):
+    agent = _make_loop_agent()
+    agent._memory_write_origin = "background_review"
+    agent._review_defer_compaction_before_first_response = True
+    agent.context_compressor.threshold_tokens = 1000
+    agent.compression_enabled = True
+    with _pressure(pressure), patch.object(agent, "_compress_context") as compress:
+        result = _run_with_responses(agent, [_final_response()])
+    agent.client.chat.completions.create.assert_not_called()
+    compress.assert_not_called()
+    assert result["completed"] is False
+    assert result["api_calls"] == 0
+    assert result["turn_exit_reason"] in {"review_request_oversized", "review_request_size_unavailable"}
+
+
+@pytest.mark.parametrize("origin", [None, "side_question", "background_review"])
+def test_under_limit_and_nonreview_requests_proceed(origin):
+    agent = _make_loop_agent()
+    agent._memory_write_origin = origin
+    agent._review_input_token_budget = 600000
+    agent.context_compressor.threshold_tokens = 1000
+    with _pressure(999 if origin == "background_review" else 1001):
+        result = _run_with_responses(agent, [_final_response()])
+    assert result["completed"] is True
+    assert agent.client.chat.completions.create.call_count == 1
+
+
+@pytest.mark.parametrize("threshold", [None, 0, -1, float("inf"), "bad", True])
+def test_review_missing_threshold_skips(threshold):
+    agent = _make_loop_agent()
+    agent._memory_write_origin = "background_review"
+    agent.context_compressor.threshold_tokens = threshold
+    with _pressure(100):
+        result = _run_with_responses(agent, [_final_response()])
+    agent.client.chat.completions.create.assert_not_called()
+    assert result["turn_exit_reason"] == "review_request_size_unavailable"
+
+
+def test_later_oversized_prepared_request_never_reaches_provider():
+    agent = _make_loop_agent()
+    agent._memory_write_origin = "background_review"
+    agent.context_compressor.threshold_tokens = 1000
+    with _pressure(100, 1001):
+        result = _run_with_responses(agent, [_tool_response(100), _final_response()])
+    assert agent.client.chat.completions.create.call_count == 1
+    assert result["completed"] is False
+    assert result["turn_exit_reason"] == "review_request_oversized"
+
+
+@pytest.mark.parametrize("reason", ["review_request_oversized", "review_request_size_unavailable"])
+def test_skipped_review_reports_skip_and_releases_ownership(reason):
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+    from agent import background_review as review
+    parent = SimpleNamespace(
+        client=None, _background_review_agent=None, _active_children=[],
+        memory_notifications="on", background_review_callback=None,
+    )
+    fork = MagicMock()
+    fork._session_messages = []
+    fork.run_conversation.return_value = {"completed": False, "turn_exit_reason": reason}
+    run = MagicMock()
+    run.cancel_requested.is_set.return_value = False
+    run.begin_request.return_value = True
+    with patch.object(review, "build_cache_parity_fork", return_value=(fork, {}, False)), \
+         patch.object(review, "_review_tool_whitelist", return_value=(set(), set())), \
+         patch.object(review, "_snapshot_review_usage", return_value={}), \
+         patch.object(review, "_record_review_usage_to_parent"), \
+         patch.object(review, "finish_background_review_run") as finish, \
+         patch.object(review, "_log_review_completion") as completion, \
+         patch.object(review, "_set_thread_approval_callback") as approval:
+        review._run_review_in_thread(parent, [], "review", {}, run)
+    completion.assert_called_once_with({}, "skipped")
+    assert parent._background_review_agent is None
+    assert parent._active_children == []
+    finish.assert_called_with(parent, run)
+    fork.release_clients.assert_called_once()
+    approval.assert_called_with(None)
+
+
+@pytest.mark.parametrize("rebuilt_pressure", [900, 1001])
+def test_later_detached_compaction_rebuild_is_checked(rebuilt_pressure):
+    agent = _make_loop_agent()
+    agent._memory_write_origin = "background_review"
+    agent._review_defer_compaction_before_first_response = True
+    agent.compression_enabled = True
+    agent.context_compressor.threshold_tokens = 1000
+    agent.context_compressor.should_compress.side_effect = lambda tokens: tokens >= 1000
+    agent.compression_in_place = True
+
+    def compress(messages, system, **kwargs):
+        return list(messages), system
+
+    with _pressure(100, 1500, rebuilt_pressure), \
+         patch.object(agent, "_compress_context", side_effect=compress) as compression, \
+         patch("agent.turn_preflight.automatic_local_compression_allowed", return_value=True):
+        result = _run_with_responses(agent, [_tool_response(100), _final_response()])
+    compression.assert_called_once()
+    assert agent.client.chat.completions.create.call_count == (2 if rebuilt_pressure < 1000 else 1)
+    assert result["completed"] is (rebuilt_pressure < 1000)
+
+
+def test_routed_fork_uses_own_window_not_parent_capacity():
+    from agent.background_review import build_cache_parity_fork
+    parent = _make_loop_agent()
+    with patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+        "provider": "openai", "model": "review-small", "api_key": "test-key",
+        "api_mode": "chat_completions", "base_url": "https://example.com/v1",
+    }), patch("agent.process_bootstrap.OpenAI"), \
+         patch("model_tools.get_tool_definitions", return_value=[]), \
+         patch("model_tools.check_toolset_requirements", return_value={}), \
+         patch("agent.model_metadata.get_model_context_length", return_value=128000), \
+         patch("agent.context_compressor.get_model_context_length", return_value=128000):
+        fork, _, routed = build_cache_parity_fork(parent, {"provider": "openai", "model": "review-small"}, max_iterations=3)
+    assert routed
+    assert fork.context_compressor is not parent.context_compressor
+    assert fork.context_compressor.context_length == 128000
+    assert fork.context_compressor.threshold_tokens < parent.context_compressor.threshold_tokens
+    fork.client = parent.client
+    fork._cached_system_prompt = "system"
+    fork._disable_streaming = True
+    with _pressure(fork.context_compressor.threshold_tokens):
+        result = _run_with_responses(fork, [_final_response()])
+    fork.client.chat.completions.create.assert_not_called()
+    assert result["turn_exit_reason"] == "review_request_oversized"
+    assert parent.context_compressor.threshold_tokens == 999_999_999
+    fork.release_clients()

--- a/tests/run_agent/test_background_review_request_size.py
+++ b/tests/run_agent/test_background_review_request_size.py
@@ -40,6 +40,7 @@ def _restore_review_origin():
 def test_initial_review_rejects_oversized_or_unavailable_pressure(pressure):
     agent = _make_loop_agent()
     agent._memory_write_origin = "background_review"
+    agent._review_input_token_budget = None
     agent._review_defer_compaction_before_first_response = True
     agent.context_compressor.threshold_tokens = 1000
     agent.compression_enabled = True
@@ -52,12 +53,15 @@ def test_initial_review_rejects_oversized_or_unavailable_pressure(pressure):
     assert result["turn_exit_reason"] in {"review_request_oversized", "review_request_size_unavailable"}
 
 
-@pytest.mark.parametrize("origin", [None, "side_question", "background_review"])
-def test_under_limit_and_nonreview_requests_proceed(origin):
+@pytest.mark.parametrize(("origin", "threshold"), [
+    (None, 1000), (None, None), ("side_question", 1000), ("side_question", None),
+    ("background_review", 1000),
+])
+def test_under_limit_and_nonreview_requests_proceed(origin, threshold):
     agent = _make_loop_agent()
     agent._memory_write_origin = origin
     agent._review_input_token_budget = 600000
-    agent.context_compressor.threshold_tokens = 1000
+    agent.context_compressor.threshold_tokens = threshold
     with _pressure(999 if origin == "background_review" else 1001):
         result = _run_with_responses(agent, [_final_response()])
     assert result["completed"] is True
@@ -68,6 +72,7 @@ def test_under_limit_and_nonreview_requests_proceed(origin):
 def test_review_missing_threshold_skips(threshold):
     agent = _make_loop_agent()
     agent._memory_write_origin = "background_review"
+    agent._review_input_token_budget = None
     agent.context_compressor.threshold_tokens = threshold
     with _pressure(100):
         result = _run_with_responses(agent, [_final_response()])
@@ -78,6 +83,7 @@ def test_review_missing_threshold_skips(threshold):
 def test_later_oversized_prepared_request_never_reaches_provider():
     agent = _make_loop_agent()
     agent._memory_write_origin = "background_review"
+    agent._review_input_token_budget = None
     agent.context_compressor.threshold_tokens = 1000
     with _pressure(100, 1001):
         result = _run_with_responses(agent, [_tool_response(100), _final_response()])
@@ -121,6 +127,7 @@ def test_skipped_review_reports_skip_and_releases_ownership(reason):
 def test_later_detached_compaction_rebuild_is_checked(rebuilt_pressure):
     agent = _make_loop_agent()
     agent._memory_write_origin = "background_review"
+    agent._review_input_token_budget = None
     agent._review_defer_compaction_before_first_response = True
     agent.compression_enabled = True
     agent.context_compressor.threshold_tokens = 1000
@@ -164,3 +171,14 @@ def test_routed_fork_uses_own_window_not_parent_capacity():
     assert result["turn_exit_reason"] == "review_request_oversized"
     assert parent.context_compressor.threshold_tokens == 999_999_999
     fork.release_clients()
+
+
+def test_standalone_curator_is_not_a_snapshot_review_fork():
+    agent = _make_loop_agent()
+    agent._memory_write_origin = "background_review"  # curator's skill-write protection
+    assert not hasattr(agent, "_review_input_token_budget")
+    agent.context_compressor.threshold_tokens = 1000
+    with _pressure(1001):
+        result = _run_with_responses(agent, [_final_response()])
+    assert agent.client.chat.completions.create.call_count == 1
+    assert result["completed"] is True

--- a/tests/run_agent/test_background_review_request_size.py
+++ b/tests/run_agent/test_background_review_request_size.py
@@ -138,8 +138,7 @@ def test_later_detached_compaction_rebuild_is_checked(rebuilt_pressure):
         return list(messages), system
 
     with _pressure(100, 1500, rebuilt_pressure), \
-         patch.object(agent, "_compress_context", side_effect=compress) as compression, \
-         patch("agent.turn_preflight.automatic_local_compression_allowed", return_value=True):
+         patch.object(agent, "_compress_context", side_effect=compress) as compression:
         result = _run_with_responses(agent, [_tool_response(100), _final_response()])
     compression.assert_called_once()
     assert agent.client.chat.completions.create.call_count == (2 if rebuilt_pressure < 1000 else 1)

--- a/tests/run_agent/test_background_review_routing_guard.py
+++ b/tests/run_agent/test_background_review_routing_guard.py
@@ -46,3 +46,34 @@ def test_fork_rejects_residual_native_runtime_before_construction(origin):
         with pytest.raises(ValueError, match="codex_app_server"):
             build_cache_parity_fork(_parent(), {}, max_iterations=3, write_origin=origin)
     constructor.assert_not_called()
+
+
+def test_routed_codex_request_contains_digest_and_medium_wire_effort():
+    from agent import background_review as review
+    from agent.transports.codex import ResponsesApiTransport
+    from unittest.mock import MagicMock
+    parent = _parent()
+    fork = MagicMock()
+    fork._session_messages = []
+    snapshot = [{"role": role, "content": f"history {i}"}
+                for i in range(30) for role in ("user", "assistant")]
+    state = review._ReviewForkState()
+    with patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+        "provider": "openai-codex", "model": "gpt-5.6-sol", "api_mode": "codex_app_server",
+        "api_key": "test-key", "base_url": "https://chatgpt.com/backend-api/codex",
+    }), patch("run_agent.AIAgent", return_value=fork) as constructor, \
+         patch.object(review, "_review_tool_whitelist", return_value=(set(), set())), \
+         patch.object(review, "_record_review_usage_to_parent"):
+        review._run_review_fork(parent, snapshot, "review", {"provider": "openai-codex", "model": "gpt-5.6-sol"}, None, state)
+    kwargs = constructor.call_args.kwargs
+    assert kwargs["api_mode"] == "codex_responses"
+    assert "reasoning_config" not in kwargs
+    history = fork.run_conversation.call_args.kwargs["conversation_history"]
+    assert history == review._digest_history(snapshot)
+    assert history != snapshot
+    request = ResponsesApiTransport().build_kwargs(
+        model=kwargs["model"], messages=history, tools=None,
+        base_url=kwargs["base_url"], reasoning_config=kwargs.get("reasoning_config"),
+    )
+    assert request["reasoning"]["effort"] == "medium"
+    assert "[Earlier conversation digest" in str(request["input"])

--- a/tests/run_agent/test_background_review_routing_guard.py
+++ b/tests/run_agent/test_background_review_routing_guard.py
@@ -22,12 +22,11 @@ def _parent():
 def test_routed_runtime_normalizes_only_native_mode_preserving_fields(mode, pool):
     runtime = dict(provider="openai-codex", model="review", api_key="key", base_url="url",
                    api_mode=mode, credential_pool=pool, command="cmd", args=["arg"],
-                   request_overrides={"extra": True}, max_output_tokens=456)
+                   request_overrides={"extra": True})
     with patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=runtime):
         resolved = _resolve_review_runtime(_parent(), {"provider": "openai-codex", "model": "review"})
     expected = {**runtime, "api_mode": "codex_responses" if mode == "codex_app_server" else mode,
-                "max_tokens": 456, "routed": True}
-    del expected["max_output_tokens"]
+                "routed": True}
     assert resolved == expected
     assert runtime["api_mode"] == mode
 

--- a/tests/run_agent/test_background_review_routing_guard.py
+++ b/tests/run_agent/test_background_review_routing_guard.py
@@ -1,0 +1,48 @@
+"""Review runtime normalization and native-tool boundary regressions."""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.background_review import _resolve_review_runtime, build_cache_parity_fork
+
+
+def _parent():
+    return SimpleNamespace(
+        provider="openai-codex", model="parent", request_overrides={"x": 1},
+        _credential_pool=None, max_tokens=123, acp_command=None, acp_args=[],
+        platform="test", session_id="parent", _memory_store=None, _memory_enabled=False,
+        _user_profile_enabled=False, _cached_system_prompt="system", session_start=None,
+        _current_main_runtime=lambda: {"api_mode": "codex_app_server", "api_key": "parent-key"},
+    )
+
+
+@pytest.mark.parametrize("mode", ["codex_app_server", "anthropic_messages"])
+@pytest.mark.parametrize("pool", [None, object()])
+def test_routed_runtime_normalizes_only_native_mode_preserving_fields(mode, pool):
+    runtime = dict(provider="openai-codex", model="review", api_key="key", base_url="url",
+                   api_mode=mode, credential_pool=pool, command="cmd", args=["arg"],
+                   request_overrides={"extra": True}, max_output_tokens=456)
+    with patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=runtime):
+        resolved = _resolve_review_runtime(_parent(), {"provider": "openai-codex", "model": "review"})
+    expected = {**runtime, "api_mode": "codex_responses" if mode == "codex_app_server" else mode,
+                "max_tokens": 456, "routed": True}
+    del expected["max_output_tokens"]
+    assert resolved == expected
+    assert runtime["api_mode"] == mode
+
+
+def test_same_model_inherits_normalized_runtime():
+    resolved = _resolve_review_runtime(_parent(), {"provider": "openai-codex", "model": "parent"})
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["routed"] is False
+    assert resolved["api_key"] == "parent-key"
+    assert resolved["request_overrides"] == {"x": 1}
+
+
+@pytest.mark.parametrize("origin", ["background_review", "side_question"])
+def test_fork_rejects_residual_native_runtime_before_construction(origin):
+    with patch("agent.background_review._resolve_review_runtime", return_value={"api_mode": "codex_app_server"}), patch("run_agent.AIAgent") as constructor:
+        with pytest.raises(ValueError, match="codex_app_server"):
+            build_cache_parity_fork(_parent(), {}, max_iterations=3, write_origin=origin)
+    constructor.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Fixes two background-review failure modes without changing the foreground Codex runtime:

1. Selecting a different Codex model for `auxiliary.background_review` can leave the detached fork on `codex_app_server`. The inherited/same-model branch already converts this to `codex_responses`, but the different-model branch does not. Apply the same conversion there so the supplied review history and Hermes tool restrictions use the intended detached execution path.
2. A review snapshot or later tool-expanded request can exceed the review model's context threshold before the cumulative input-usage budget can help. Check each prepared review request against its own compressor threshold before provider dispatch, including the first request.

## Related Issue

No dedicated issue. Searched existing open/closed PRs and issues. #105830/#105835 address primary-runtime selection during fallback; #94832 addresses routed reasoning-effort settings. Those are separate from this change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/background_review.py`: normalize routed Codex runtime selection, reject residual app-server mode before detached fork construction, and classify size-guard exits as skipped reviews.
- `agent/turn_preflight_gate.py`: reuse the already-prepared request-pressure estimate and the review agent's `context_compressor.threshold_tokens`. Skip invalid sizing or over-threshold requests, refund the unused call, and preserve existing cleanup.
- Add synthetic regression fixtures in `tests/run_agent/test_background_review_{routing_guard,request_size}.py`.

The guard applies only to snapshot background-review forks, not foreground turns, `/btw`, or standalone curator runs. Later detached compaction still runs normally; rebuilt requests are rechecked on the next loop pass. The guard does not compact the parent, truncate stored transcripts, add a tokenizer/configuration key, or guarantee exact agreement with provider token accounting. Normal review cadence remains unchanged. Existing cumulative review-usage budgets remain separate.

## How to Test

With development dependencies installed:

```sh
python -m pytest tests/run_agent/test_background_review*.py tests/run_agent/test_preflight*.py tests/agent/test_preflight*.py tests/agent/test_engine_preflight_wire.py tests/agent/test_native_preflight_estimate.py -q
```

**106 passed** on macOS with Python 3.11, pytest 9.1.1, and pytest-asyncio 1.3.0, based on upstream `cfdbbb6e35010ace89fbe8243ee82fa4de143e10` plus this branch. The test process emitted a non-failing auxiliary title-generation warning because no provider was configured for that task.

Coverage includes routed/same-model/non-Codex selection, preserved runtime fields, digest forwarding, default Responses medium effort, oversized initial and subsequent requests, invalid estimates, review-model capacity rather than parent capacity, compaction rebuilds, unaffected non-review paths, and skipped-review cleanup.

The same runtime changes were also exercised in a local deployment through an automatic Codex background review using real Responses calls. That deployment has other local patches, so the clean-upstream synthetic test result above is the portable evidence for this PR. No private transcripts, credentials, profile settings, or deployment machinery are included.

## Checklist

- [x] Read the contribution guidance and searched for related PRs.
- [x] Conventional commit messages; only changes related to this fix.
- [x] Added regression tests and ran the focused suites listed above.
- [ ] Full `pytest tests/ -q` suite — not run.
- [x] Tested on macOS; no new platform-specific code or dependencies.
- [x] Updated resolver docstring and explanatory comments.
- [x] Config examples, tool schemas, and architecture instructions: N/A; no new settings or tool capabilities.

AI-assisted contribution, inspected and tested. The routing and guard changes are separate commits if maintainers prefer splitting them.
