### PR TITLE
fix(tools): make DaemonThreadPoolExecutor compatible with Python 3.14 (#107121)

### DIFF
--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -36,8 +36,12 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         return super().submit(_run_with_context, *args, **kwargs)
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
+        # Mirrors CPython's implementation with two changes:
         # daemon=True and no _threads_queues registration.
+        # Supports both CPython 3.8-3.13 (initializer/initargs) and
+        # 3.14+ (WorkerContext via _create_worker_context) so the pool
+        # works even when the entry-point is launched with a system
+        # Python 3.14 (e.g. shebang resolving to /usr/bin/python).
         if self._idle_semaphore.acquire(timeout=0):
             return
 
@@ -46,11 +50,18 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            # Carry the active profile into the review thread so MEMORY.md / skill review writes land in the
-            # right profile (#54937).
-            t = threading.Thread(
-                name=thread_name, target=_worker, daemon=True,
-                args=(weakref.ref(self, weakref_cb), self._work_queue, self._initializer, self._initargs),
-            )
+            # Python 3.14 removed _initializer/_initargs in favour of
+            # WorkerContext (_create_worker_context/_resolve_work_item_task)
+            # and changed _worker signature to (executor_ref, ctx, queue).
+            if hasattr(self, "_create_worker_context"):  # pyright: ignore[reportAttributeAccessIssue]
+                t = threading.Thread(
+                    name=thread_name, target=_worker, daemon=True,
+                    args=(weakref.ref(self, weakref_cb), self._create_worker_context(), self._work_queue),  # pyright: ignore[reportAttributeAccessIssue]
+                )
+            else:
+                t = threading.Thread(
+                    name=thread_name, target=_worker, daemon=True,
+                    args=(weakref.ref(self, weakref_cb), self._work_queue, self._initializer, self._initargs),
+                )
             t.start()
             self._threads.add(t)


### PR DESCRIPTION
Fixes #107121

Python 3.14 removed `ThreadPoolExecutor._initializer`/`_initargs` and replaced them with `WorkerContext` (`_create_worker_context`) and a changed `_worker(executor_ref, ctx, queue)` signature. The daemon pool's `_adjust_thread_count` still referenced the old attributes, causing `AttributeError: 'DaemonThreadPoolExecutor' has no attribute '_initializer'` when the CLI entry point resolves to a system Python 3.14 (e.g. `/usr/bin/python` shebang at `~/.local/bin/hermes`).

Branch on `hasattr(_create_worker_context)` to use the correct worker-creation path for both 3.8–3.13 and 3.14+.

Tested: `tests/tools/test_daemon_pool.py` passes (4/4) and simulated 3.14 branching verified.

Note: the shebang issue is mitigated by the runtime fix; users on 3.14 will no longer crash. Long-term the installer should ensure the entry point resolves to the venv interpreter (pyproject caps `requires-python <3.14` pending Rust wheel availability), but this pool fix is the immediate correctness requirement.