### PR TITLE
fix(moonshot): stop stamping a synthetic type on if/then/else nodes

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -19,7 +19,9 @@ _SCHEMA_MAP_KEYS = frozenset({"properties", "patternProperties", "$defs", "defin
 # Values are lists of schemas.
 _SCHEMA_LIST_KEYS = frozenset({"anyOf", "oneOf", "allOf", "prefixItems"})
 # Values are a single nested schema (additionalProperties may also be a bool).
-_SCHEMA_NODE_KEYS = frozenset({"items", "contains", "not", "additionalProperties", "propertyNames"})
+_SCHEMA_NODE_KEYS = frozenset(
+    {"items", "contains", "not", "additionalProperties", "propertyNames", "if", "then", "else"}
+)
 
 _SCALAR_TYPES = frozenset({"string", "integer", "number", "boolean"})
 # bool before int: bool is an int subclass.
@@ -103,7 +105,9 @@ def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
     A type list collapses to its first concrete member; otherwise
     ``properties``/``required``/``additionalProperties`` → object,
     ``items``/``prefixItems`` → array, ``enum`` → type of its first value,
-    else ``string`` (safest scalar).
+    else ``string`` (safest scalar). A bare ``if``/``then``/``else`` node
+    constrains whatever instance it is attached to rather than describing
+    its own type, so it is left untyped instead of defaulting to ``string``.
     """
     node_type = node.get("type")
     if isinstance(node_type, list):
@@ -119,6 +123,8 @@ def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
     elif isinstance(node.get("enum"), list) and node["enum"]:
         sample = node["enum"][0]
         inferred = next((t for cls, t in _ENUM_SAMPLE_TYPES if isinstance(sample, cls)), "string")
+    elif "if" in node or "then" in node or "else" in node:
+        return node
     else:
         inferred = "string"
     return {**node, "type": inferred}

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -92,6 +92,30 @@ class TestMissingTypeFilled:
         assert out["properties"]["payload"]["$ref"] == "#/$defs/Payload"
 
 
+class TestConditionalSchemaNotGivenSyntheticType:
+    """A bare if/then/else conditional constrains the enclosing instance; it
+    does not describe its own type, so it must not be defaulted to "string"."""
+
+    def test_if_then_node_is_not_given_synthetic_type(self):
+        params = {
+            "oneOf": [
+                {"required": ["prompt"], "not": {"required": ["goal"]}},
+                {"required": ["goal"], "not": {"required": ["prompt"]}},
+            ],
+            "allOf": [
+                {
+                    "if": {"required": ["goal"]},
+                    "then": {"properties": {"mode": {"enum": ["build", "edit"]}}},
+                }
+            ],
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        conditional = out["allOf"][0]
+        assert "type" not in conditional
+        # Nested schemas under then/if still get repaired.
+        assert conditional["then"]["properties"]["mode"]["type"] == "string"
+
+
 class TestAnyOfParentType:
     """Rule 2: type must not appear at the anyOf parent level.
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Moonshot/Kimi schema repair path (`agent/moonshot_schema.py`) so a bare `if`/`then`/`else` conditional node no longer gets a synthetic `type` stamped on it.

`_repair_schema`'s recursion set (`_SCHEMA_NODE_KEYS`) didn't include `if`/`then`/`else`, so a conditional wrapper like:

```json
{"if": {"required": ["goal"]}, "then": {"properties": {"mode": {"enum": ["build", "edit"]}}}}
```

was never recursed into, and then fell through `_fill_missing_type`'s default branch, which stamped `"type": "string"` on it (the "safest scalar" fallback for a node with none of `properties`/`required`/`items`/`enum`). But the wrapper actually constrains an object instance — the real tool-call arguments — so stamping `type: "string"` on it corrupts the schema: every real (object) argument now fails validation against it. Because `if`/`then`/`else` weren't recursed into at all, anything nested under them (e.g. the `mode` enum above) also silently skipped every Moonshot repair (type inference, enum null-stripping, required-array guarantee).

This is the `agent/moonshot_schema.py` piece of #107141 ("mutex/conditional constraints inside oneOf/allOf/if/then/else get corrupted by schema repair"), reproducing the issue's own observation that "the `allOf[0]` node was given a nonsense top-level `type: 'string'` by the moonshot fallback."

Note: the other two files the issue names, `tools/mcp_tool_schema.py` and `tools/schema_sanitizer.py`, already have an open, more extensive fix in #104548, which I verified resolves that half of the bug (tested locally against the issue's exact repro — required is preserved and no bogus `type`/`properties` coercion happens in `oneOf`/`not` branches). This PR only touches the third file, `agent/moonshot_schema.py`, which #104548 does not modify and which still reproduces the corruption described in the issue.

## Related Issue

Fixes #107141 (partially — the `agent/moonshot_schema.py` portion; the `tools/mcp_tool_schema.py` / `tools/schema_sanitizer.py` portion is covered by #104548)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/moonshot_schema.py`:
  - Add `if`, `then`, `else` to `_SCHEMA_NODE_KEYS` so `_repair_schema` recurses into them instead of copying them raw.
  - `_fill_missing_type`: leave a node untyped (instead of defaulting to `"string"`) when its only content is `if`/`then`/`else` — such a node constrains whatever instance it's attached to, it doesn't describe its own shape.
- `tests/agent/test_moonshot_schema.py`: new `TestConditionalSchemaNotGivenSyntheticType`, using the issue's own `oneOf`/`not`/`if`/`then` reproduction shape, asserting the conditional wrapper stays untyped and that schemas nested under `then` still get repaired (the `mode` enum gets its `type` filled).

## How to Test

```bash
python3 -m pytest tests/agent/test_moonshot_schema.py -q
```

**Red (bug present):** reverting only `agent/moonshot_schema.py` to `HEAD` (test file kept) and running the new test:

```
FAILED tests/agent/test_moonshot_schema.py::TestConditionalSchemaNotGivenSyntheticType::test_if_then_node_is_not_given_synthetic_type
AssertionError: assert 'type' not in {'if': {'required': ['goal']}, 'then': {'properties': {'mode': {'enum': ['build', 'edit']}}}, 'type': 'string'}
```

**Green (fixed):** full suite passes:

```
$ python3 -m pytest tests/agent/test_moonshot_schema.py -q
......................................                                   [100%]
38 passed in 0.42s
```

Also ran the broader schema-adjacent suite for regressions:

```
$ python3 -m pytest tests/agent/ -q -k "schema or moonshot"
........................................................................ [ 80%]
.................                                                        [100%]
89 passed, 1 skipped, 6627 deselected in 15.15s
```

`ruff check agent/moonshot_schema.py tests/agent/test_moonshot_schema.py` → All checks passed!

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (see note above on #104548 covering the other two files)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_moonshot_schema.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (CI runner)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed by this fix

---

*This PR was prepared with AI assistance (Claude).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
