### PR TITLE
fix(projects): match Windows folder ownership case-insensitively

### DIFF
--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -471,12 +471,13 @@ def project_for_path(conn: sqlite3.Connection, path: str, *, include_archived: b
     folder wins so nested projects resolve to the innermost one."""
     if not str(path or "").strip():
         return None
-    target = _normalize_path(path)
+    target = _primary_path_key(path)
     sql = "SELECT pf.project_id AS pid, pf.path AS folder FROM project_folders pf JOIN projects p ON p.id = pf.project_id"
     if not include_archived:
         sql += " WHERE p.archived = 0"
 
     def owns(folder: str) -> bool:
+        folder = os.path.normcase(folder)
         stem = folder.rstrip("/\\")
         return target == folder or target.startswith(stem + os.sep) or target.startswith(stem + "/")
 

--- a/tests/tui_gateway/test_project_path_case.py
+++ b/tests/tui_gateway/test_project_path_case.py
@@ -1,0 +1,50 @@
+"""Project ownership must use the host's path comparison semantics."""
+
+import pytest
+
+from hermes_cli import projects_db as pdb
+from tui_gateway import server
+
+
+@pytest.mark.windows_only
+@pytest.mark.parametrize("surface", ["rpc", "status"])
+def test_windows_project_lookup_ignores_case_and_keeps_folder_boundaries(
+    tmp_path, surface
+):
+    outer = tmp_path / "MyProject"
+    inner = outer / "Nested"
+    child = inner / "Src"
+    child.mkdir(parents=True)
+    sibling = tmp_path / "MyProjectOther"
+    sibling.mkdir()
+    assert child.samefile(str(child).upper())
+
+    with pdb.connect_closing() as conn:
+        outer_id = pdb.create_project(conn, name="Outer", folders=[str(outer)])
+        inner_id = pdb.create_project(conn, name="Inner", folders=[str(inner)])
+
+        def lookup(path):
+            if surface == "status":
+                return server._project_info_for_cwd(path)
+            response = server._methods["projects.for_cwd"](1, {"cwd": path})
+            assert "error" not in response
+            return response["result"]["project"]
+
+        assert lookup(str(outer).upper())["id"] == outer_id
+        assert lookup(str(child).upper())["id"] == inner_id
+        assert lookup(str(sibling).upper()) is None
+        assert pdb.get_project(conn, inner_id).primary_path == str(inner)
+        pdb.archive_project(conn, inner_id)
+        assert lookup(str(child).upper())["id"] == outer_id
+
+
+@pytest.mark.linux_only
+def test_linux_project_lookup_keeps_case_distinct(tmp_path):
+    upper, lower = tmp_path / "Project", tmp_path / "project"
+    upper.mkdir()
+    lower.mkdir()
+    with pdb.connect_closing() as conn:
+        upper_id = pdb.create_project(conn, name="Upper", folders=[str(upper)])
+        lower_id = pdb.create_project(conn, name="Lower", folders=[str(lower)])
+        assert pdb.project_for_path(conn, str(upper / "src")).id == upper_id
+        assert pdb.project_for_path(conn, str(lower / "src")).id == lower_id


### PR DESCRIPTION
## What does this PR do?

Fix Windows project ownership lookup when the requested folder has different capitalization from its registered path. Registering `MyProject` and resolving the same directory as `MYPROJECT` currently returns no project through both `projects.for_cwd` and the status resolver, even though Windows resolves both spellings to the same directory.

Reuse `_primary_path_key()` for the target and normalize the stored folder's case for comparison in `project_for_path()`. This follows the existing primary-path deduplication convention. Stored spelling, longest-folder selection, archive filtering, and folder boundaries remain unchanged; POSIX comparisons remain case-sensitive.

## Related Issue / Duplicate Check

Found while inspecting Windows project resolution. Searched issues and open/closed PRs for `project_for_path`, `normcase`, and case-insensitive project lookup. No matching fix found. PR #105000 adds marker-based identity across moves but retains the case-sensitive fallback. PR #106677 concerns drive-root normalization, not ownership comparison.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `hermes_cli/projects_db.py`: use host-normalized comparison keys for ownership matching.
- `tests/tui_gateway/test_project_path_case.py`: native Windows regression through real RPC/status handlers and Linux case-distinction coverage.

## How to Test

`scripts/run_tests.sh tests/tui_gateway/test_project_path_case.py tests/tui_gateway/test_projects_rpc.py -j 2`

Native Windows, Python 3.11.15: **37 passed, 0 failed, 1 skipped**. Both Windows regression cases fail on baseline because the handlers return no owning project. The tests create real temporary directories and a per-test Projects database; `Path.samefile()` verifies the different spellings reference the same directory. They also cover nested-project precedence, sibling-prefix exclusion, preserved stored spelling, and archive fallback.

The Linux-only test was skipped on Windows. No local Linux execution, full repository suite, or visible desktop UI verification is claimed. Ruff lint/format for the new test and `git diff --check` pass.

## Checklist

- [x] Read the contributing guide and checked for duplicates.
- [x] Kept the change limited to this bug and its regression coverage.
- [x] Reproduced the failure before the fix and tested on native Windows.
- [x] Considered cross-platform behavior; added a Linux case-distinction test.
- [ ] Full repository test suite passes (not run).
- [x] Config, tool schemas, architecture, and user documentation changes: not applicable.
