### PR TITLE
fix(deepseek): recognise `deepseek-flash` as a first-class model id

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -192,6 +192,14 @@ _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
         ("deepseek-chat", "deepseek-reasoner", "deepseek-v4-flash"): ("0.14", "0.28", "0.0028"),
         "deepseek-v4-pro": ("0.435", "0.87", "0.003625"),
     }),
+    # V4.1-Flash (2026-09-10) renames the flash line to the bare id `deepseek-flash`;
+    # `deepseek-v4-flash` / `-vision-exp` and the deepseek-chat/reasoner aliases now
+    # resolve to it. Off-peak CNY rates per 1M (cache hit / miss / output) 0.02 / 1 / 4;
+    # peak hours (Mon-Fri 09-12, 14-18) bill 2x. Encoded off-peak, same USD ratio as above.
+    ("deepseek", "https://api-docs.deepseek.com/quick_start/pricing", "deepseek-pricing-2026-09", {
+        ("deepseek-flash", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp",
+         "deepseek-chat", "deepseek-reasoner"): ("0.14", "0.56", "0.0028"),
+    }),
     ("google", "https://ai.google.dev/gemini-api/docs/pricing", "google-pricing-2026-09-02", {
         ("gemini-3.8-flash", "gemini-3.7-flash"): ("0.75", "3.75", "0.075"),
     }),

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -93,7 +93,7 @@ _DEEPSEEK_RETIRED_ALIASES: frozenset[str] = frozenset({
     "deepseek-chat", "deepseek-reasoner"})
 
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-v4-pro", "deepseek-v4-flash"})
+    "deepseek-v4-pro", "deepseek-v4-flash", "deepseek-flash"})
 
 # First-class V-series IDs incl. future ``deepseek-v5-*`` and dated variants
 # (``deepseek-v4-flash-20260423``): verified real model ids, NOT aliases of ``deepseek-chat``.

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -111,6 +111,17 @@ class TestDeepseekVSeriesPassThrough:
         assert result == "deepseek-v4-pro"
 
 
+    def test_deepseek_provider_preserves_bare_flash_id(self):
+        """`deepseek-flash` (the current V4.1 flash id) is first-class too.
+
+        It matches neither the V-series regex nor the canonical set, so it
+        fell through to the retired-slug fallback and every request went out
+        as `deepseek-v4-flash` even when the user selected the published id.
+        """
+        result = normalize_model_for_provider("deepseek-flash", "deepseek")
+        assert result == "deepseek-flash"
+
+
 # ── DeepSeek post-2026-07-24 alias remapping ───────────────────────────
 
 class TestDeepseekCanonicalAndReasonerMapping:


### PR DESCRIPTION
## What

`deepseek-flash` — the id DeepSeek publishes today for the V4.1 flash line — is silently rewritten to the retired slug `deepseek-v4-flash` before the request leaves Hermes.

## Why it happens

`hermes_cli/model_normalize.py::_normalize_for_deepseek` accepts a name when it is in `_DEEPSEEK_CANONICAL_MODELS` or matches `_DEEPSEEK_V_SERIES_RE` (`^deepseek-v\d+([-.].+)?$`). The bare `deepseek-flash` matches neither, so it lands on the `return "deepseek-v4-flash"` fallback.

## Reproduction (live API, 2026-09-10)

- `curl https://api.deepseek.com/models` lists exactly `deepseek-flash` and `deepseek-v4-pro`.
- `deepseek-v4-flash`, `deepseek-v4-flash-vision-exp` and the beta id `deepseek-v4.1-flash-expires-on-0910` still return HTTP 200, and every response carries `model: deepseek-flash` — they are aliases of the same (retired-name) model.
- With `model.default: deepseek-flash`, a one-shot run (`hermes -z "…"`) is recorded by the session usage table as `model=deepseek-v4-flash, provider=deepseek`. The same run routed through a custom provider (which passes names through verbatim) records `deepseek-flash` — i.e. the rewrite happens in the deepseek normalization branch, not upstream of it.
- New test, fix reverted: `AssertionError: assert 'deepseek-v4-flash' == 'deepseek-flash'`.

Impact: usage/cost rows are mislabelled today, and every call breaks the day DeepSeek stops accepting the legacy ids — while the user's config names the correct, published model.

## Fix

Add `deepseek-flash` to `_DEEPSEEK_CANONICAL_MODELS`. Retired-alias behaviour (`deepseek-chat` / `deepseek-reasoner` / fuzzy names → `deepseek-v4-flash`) is deliberately unchanged here.

Follow-up for a maintainer's call: the fallback target is itself a retired slug, so the next retirement of `deepseek-v4-flash` needs a matching update. I kept this PR to the pass-through bug instead of also re-pointing the fallback.

## Pricing (second commit)

`deepseek-flash` appears in no `_SNAPSHOTS` row, so usage for the current flash model resolves to `cost_source=none` — no estimate at all. Adds a 2026-09 deepseek row covering `deepseek-flash` plus the retired ids it replaces, at the published off-peak CNY rates (cache hit / miss / output: 0.02 / 1 / 4 per 1M) converted at the same USD ratio as the existing 2026-07 row → `0.14 / 0.56 / 0.0028`. Peak hours (Mon-Fri 09-12, 14-18) bill 2x and the snapshot format has no time-of-day buckets, hence off-peak. `deepseek-v4-pro` keeps its 2026-07 row (still a distinct backend until V4.1 Pro ships).

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_model_normalize.py` → 24 passed with the fix; the new test is red on base.
- `scripts/run_tests.sh tests/agent/test_usage_pricing.py` → 50 passed.
