### PR TITLE
fix(state): keep v3 Telegram topic migration atomic

### DIFF
--- a/hermes_state_telegram.py
+++ b/hermes_state_telegram.py
@@ -117,6 +117,9 @@ class SessionTelegramTopicsMixin:
         See #76423.
         """
         def _do(conn):
+            # executescript() implicitly commits _execute_write's transaction.
+            # Keep both table swaps, indexes and the version marker in one
+            # transaction so a failed upgrade rolls back and can be retried.
             for table, columns, ddl in _TOPIC_TABLES:
                 conn.execute(f"CREATE TABLE IF NOT EXISTS {table} ({ddl})")
                 have = {row[1] for row in conn.execute(f"PRAGMA table_info('{table}')")}
@@ -125,21 +128,22 @@ class SessionTelegramTopicsMixin:
                 # v1/v2 → v3. SQLite can't ALTER a PK or FK, so rebuild (also supplies v2's
                 # ON DELETE CASCADE). Legacy rows land in "default" only.
                 legacy_columns = columns.replace("profile_name, ", "", 1)
-                conn.executescript(f"""
-                    CREATE TABLE {table}_new ({ddl});
-                    INSERT INTO {table}_new ({columns})
-                        SELECT 'default', {legacy_columns} FROM {table};
-                    DROP TABLE {table};
-                    ALTER TABLE {table}_new RENAME TO {table};
-                    """)
+                conn.execute(f"CREATE TABLE {table}_new ({ddl})")
+                conn.execute(
+                    f"INSERT INTO {table}_new ({columns}) "
+                    f"SELECT 'default', {legacy_columns} FROM {table}"
+                )
+                conn.execute(f"DROP TABLE {table}")
+                conn.execute(f"ALTER TABLE {table}_new RENAME TO {table}")
             # Indexes after any rebuild: the user index needs profile_name.
-            conn.executescript("""
-                CREATE UNIQUE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_session
-                ON telegram_dm_topic_bindings(session_id);
-
-                CREATE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_user
-                ON telegram_dm_topic_bindings(profile_name, user_id, chat_id);
-                """)
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_session "
+                "ON telegram_dm_topic_bindings(session_id)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_telegram_dm_topic_bindings_user "
+                "ON telegram_dm_topic_bindings(profile_name, user_id, chat_id)"
+            )
             conn.execute(
                 "INSERT INTO state_meta (key, value) VALUES (?, ?) "
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",

--- a/tests/test_telegram_topic_migration_atomic.py
+++ b/tests/test_telegram_topic_migration_atomic.py
@@ -1,0 +1,145 @@
+"""Topic upgrades must publish both tables and their version marker atomically."""
+
+import sqlite3
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture(params=[1, 2], ids=["v1", "v2"])
+def legacy_db(tmp_path, request):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id="topic-session", source="telegram", user_id="u1")
+    cascade = "ON DELETE CASCADE" if request.param == 2 else ""
+
+    def seed(conn):
+        conn.execute("""
+            CREATE TABLE telegram_dm_topic_mode (
+                chat_id TEXT PRIMARY KEY, user_id TEXT NOT NULL,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                activated_at REAL NOT NULL, updated_at REAL NOT NULL,
+                has_topics_enabled INTEGER, allows_users_to_create_topics INTEGER,
+                capability_checked_at REAL, intro_message_id TEXT, pinned_message_id TEXT
+            )
+        """)
+        conn.execute("""
+            INSERT INTO telegram_dm_topic_mode
+                (chat_id, user_id, activated_at, updated_at) VALUES ('c1', 'u1', 1, 1)
+        """)
+        conn.execute(f"""
+            CREATE TABLE telegram_dm_topic_bindings (
+                chat_id TEXT NOT NULL, thread_id TEXT NOT NULL, user_id TEXT NOT NULL,
+                session_key TEXT NOT NULL,
+                session_id TEXT NOT NULL REFERENCES sessions(id) {cascade},
+                managed_mode TEXT NOT NULL DEFAULT 'auto',
+                linked_at REAL NOT NULL, updated_at REAL NOT NULL,
+                PRIMARY KEY (chat_id, thread_id)
+            )
+        """)
+        conn.execute("""
+            INSERT INTO telegram_dm_topic_bindings
+            VALUES ('c1', 't1', 'u1', 'k1', 'topic-session', 'auto', 1, 1)
+        """)
+        conn.execute("""
+            CREATE INDEX idx_telegram_dm_topic_bindings_user
+            ON telegram_dm_topic_bindings(user_id, chat_id)
+        """)
+        conn.execute(
+            "INSERT INTO state_meta VALUES ('telegram_dm_topic_schema_version', ?)",
+            (str(request.param),),
+        )
+
+    db._execute_write(seed)
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def topic_snapshot(conn):
+    schema = conn.execute("""
+        SELECT type, name, sql FROM sqlite_master
+        WHERE tbl_name LIKE 'telegram_dm_topic_%' ORDER BY type, name
+    """).fetchall()
+    rows = {
+        name: [tuple(row) for row in conn.execute(f'SELECT * FROM "{name}"')]
+        for kind, name, _ in schema if kind == "table"
+    }
+    version = conn.execute("""
+        SELECT value FROM state_meta WHERE key = 'telegram_dm_topic_schema_version'
+    """).fetchone()
+    return [tuple(row) for row in schema], rows, tuple(version)
+
+
+@pytest.mark.parametrize("action,target", [
+    (sqlite3.SQLITE_ALTER_TABLE, "telegram_dm_topic_mode_new"),
+    (sqlite3.SQLITE_ALTER_TABLE, "telegram_dm_topic_bindings_new"),
+    (sqlite3.SQLITE_CREATE_INDEX, "idx_telegram_dm_topic_bindings_session"),
+    (sqlite3.SQLITE_INSERT, "state_meta"),
+])
+def test_failed_migration_restores_legacy_state_and_can_retry(legacy_db, action, target):
+    db = legacy_db
+    before = topic_snapshot(db._conn)
+    denied = []
+
+    def deny_statement(code, arg1, arg2, *_):
+        if code == action and target in (arg1, arg2):
+            denied.append(target)
+            return sqlite3.SQLITE_DENY
+        return sqlite3.SQLITE_OK
+
+    # SQLite's own authorizer faults the real DDL, including executescript on
+    # the unfixed path; a proxy intercepting execute() would miss that path.
+    db._conn.set_authorizer(deny_statement)
+    try:
+        with pytest.raises(sqlite3.DatabaseError, match="not authorized"):
+            db.apply_telegram_topic_migration()
+    finally:
+        db._conn.set_authorizer(None)
+
+    assert denied
+    assert topic_snapshot(db._conn) == before
+    db.apply_telegram_topic_migration()
+    assert db.is_telegram_topic_mode_enabled(chat_id="c1", user_id="u1")
+    assert db.get_telegram_topic_binding(chat_id="c1", thread_id="t1")["session_id"] == "topic-session"
+
+
+def test_migration_keeps_other_writers_out_until_commit(legacy_db):
+    db = legacy_db
+    contender = SessionDB(db_path=db.db_path)
+    contender._conn.execute("PRAGMA busy_timeout=0")
+    write_attempts = []
+
+    def compete_at_swap(code, *_):
+        if code == sqlite3.SQLITE_ALTER_TABLE:
+            try:
+                contender._conn.execute("BEGIN IMMEDIATE")
+            except sqlite3.OperationalError as exc:
+                write_attempts.append(str(exc))
+            else:
+                contender._conn.rollback()
+                write_attempts.append("writer entered during migration")
+        return sqlite3.SQLITE_OK
+
+    db._conn.set_authorizer(compete_at_swap)
+    try:
+        db.apply_telegram_topic_migration()
+        assert write_attempts
+        assert all("locked" in error for error in write_attempts)
+        # After commit the second connection can both read the complete schema
+        # and acquire the write lock, on WAL and rollback-journal databases.
+        assert topic_snapshot(contender._conn) == topic_snapshot(db._conn)
+        contender._conn.execute("BEGIN IMMEDIATE")
+        contender._conn.rollback()
+    finally:
+        db._conn.set_authorizer(None)
+        contender.close()
+
+    assert db.get_meta("telegram_dm_topic_schema_version") == "3"
+    assert db.is_telegram_topic_mode_enabled(chat_id="c1", user_id="u1", profile_name="default")
+    assert db.get_telegram_topic_binding(chat_id="c1", thread_id="t1", profile_name="default")["session_id"] == "topic-session"
+    assert db.get_telegram_topic_binding(chat_id="c1", thread_id="t1", profile_name="other") is None
+    after = topic_snapshot(db._conn)
+    db.apply_telegram_topic_migration()
+    assert topic_snapshot(db._conn) == after


### PR DESCRIPTION
## What does this PR do?

Fixes #86483. When a Telegram `/topic` opt-in upgrades a legacy database, `executescript()` commits the transaction opened by `_execute_write()` before rebuilding the topic tables. A subsequent failure can strand a replacement table, lose the original table, or publish schema changes without their version marker. Another connection can also acquire the write lock during the upgrade.

Use individual `execute()` calls so both v3 table rebuilds, both indexes and the version marker stay in the existing `BEGIN IMMEDIATE` transaction. Failed upgrades restore the old schema and data; successful upgrades retain profile isolation and the existing foreign-key behavior.

### Relationship to #42004

This intentionally carries forward @synapsesx's #42004, preserving the original commit author. The original transaction fix is theirs. Its commit `f391d23e8ae1e528eb8cfe62f07562b1a96dcf24` was cherry-picked without committing, then adapted after conflicts: the code now lives in `hermes_state_telegram.py`, and the migration now rebuilds **two** tables from v1/v2 to the profile-aware v3 schema. The original PR remains open for maintainers to decide on.

The regression coverage is new: SQLite's actual authorizer injects failures even on the old `executescript()` path, and a real second connection probes write-lock exclusion. The predecessor's unconditional scratch-table cleanup is intentionally omitted because a table left by an older failed migration may contain recoverable data. This PR prevents new partial migrations; it does not attempt recovery of already damaged stores.

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_state_telegram.py`: replace both uses of `executescript()` in the migration with individual statements under the existing transaction.
- `tests/test_telegram_topic_migration_atomic.py`: two invariant tests, parameterized into 10 cases over the v1 and v2 schemas. Inject failures after each table drop, at index creation and at the version write; assert complete rollback and successful retry. Probe a competing writer during each swap, then verify visibility and lock acquisition after commit, profile isolation, and idempotence.

## How to Test

Use the repository's isolated runner with the development environment activated (or set `HERMES_PYTHON` to its Python executable):

```sh
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
  tests/test_telegram_topic_migration_atomic.py \
  tests/gateway/test_telegram_topic_profile_isolation_76423.py \
  tests/gateway/test_telegram_topic_mode.py \
  tests/gateway/test_telegram_topic_profile_routing_76423.py \
  tests/gateway/test_telegram_prune_stale_topic_binding_31501.py \
  tests/test_hermes_state.py -j 4 -q -ra --tb=short
```

Locally executed results:

- **Before the fix**, the new test file on base `6e07eb48387044dbcaf12490931c2b8ca7ec8653`: **10 failed**. Rollback failed to restore schema/data/version, and the competing writer acquired the lock mid-migration.
- **After the fix**, the six-file command above: **303 passed, 0 failed, 2 skipped**, with automatic retries disabled. All 10 new cases passed.
- `ruff check .`: passed (three pre-existing invalid-`noqa` warnings in unrelated files).
- `python scripts/check_compat_pointers.py`: passed.
- `git diff --check`: passed.

Environment: native macOS 27.0, Python 3.11.15, SQLite 3.50.4. The project's SQLite safety policy selected DELETE journaling; this local run does not establish WAL-mode coverage. The initial sandboxed run had one additional failure because process inspection was prohibited during an existing malformed-database repair test. That test passed with process inspection allowed, followed by the complete six-file run above in the same environment. All database fixtures are temporary; no live Telegram gateway or user database was touched.

## Checklist

- [x] Read the contributing guide and repository instructions.
- [x] Conventional Commit; only changes related to this fix.
- [x] Searched existing PRs; this explicitly carries forward #42004 and preserves credit.
- [x] Added behavioral regression tests and proved them failing on the base implementation.
- [x] Executed relevant tests on the native platform and the repository lint/compatibility checks.
- [ ] Full repository test suite — not run locally; upstream CI remains to be evaluated.
- [x] Documentation/config/tool schemas: no public contract changes; added the transaction rationale beside the code.
- [x] Considered cross-platform impact: stdlib SQLite transaction behavior; no OS-specific implementation added.

AI assistance: prepared with Codex; the reproductions and checks reported above were actually executed locally. Original fix credit belongs to @synapsesx.
