### PR TITLE
fix(qqbot): honor NO_PROXY when opening gateway WebSocket

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -335,7 +335,14 @@ def resolve_proxy_url(
     """Proxy URL: *platform_env_var* (e.g. ``DISCORD_PROXY``) first, then HTTPS_PROXY /
     HTTP_PROXY / ALL_PROXY (any case), then the macOS system proxy — the latter two only when
     ``gateway.trust_env`` is true. None when nothing is found or NO_PROXY matches a target."""
-    value = (os.environ.get(platform_env_var) or "").strip() if platform_env_var else ""
+    value = ""
+    if platform_env_var:
+        # POSIX convention treats lowercase proxy vars as equivalent
+        # (HTTPS_PROXY/https_proxy below get the same treatment).
+        for key in dict.fromkeys((platform_env_var, platform_env_var.lower())):
+            value = (os.environ.get(key) or "").strip()
+            if value:
+                break
     if not value:
         if not gateway_trust_env():  # only the explicit per-platform var is honored
             return None

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -39,7 +39,7 @@ except ImportError:
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
-    gateway_trust_env, BasePlatformAdapter, SendResult,
+    gateway_trust_env, BasePlatformAdapter, SendResult, resolve_proxy_url,
     _ssrf_redirect_guard, cache_document_from_bytes_async, cache_image_from_bytes_async,
 )
 from gateway.platforms.event import MessageEvent, MessageType
@@ -318,10 +318,12 @@ class QQAdapter(BasePlatformAdapter):
 
     async def _open_ws(self, gateway_url: str) -> None:
         await self._close_ws()
-        # Honor proxy env vars for the WebSocket (WSL setups need this).
+        # Shared proxy resolution so NO_PROXY is honored: an explicit proxy=
+        # opts out of aiohttp's env handling, so pre-check the dialed host.
+        # proxy=None falls through to the session's trust_env env lookup.
+        gateway_host = urlparse(gateway_url).hostname
+        ws_proxy = resolve_proxy_url("WSS_PROXY", target_hosts=gateway_host)
         self._session = aiohttp.ClientSession(trust_env=gateway_trust_env())
-        proxy_vars = ("WSS_PROXY", "wss_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy")
-        ws_proxy = next((v for v in map(os.getenv, proxy_vars) if v), None)
         self._ws = await self._session.ws_connect(
             gateway_url, headers={"User-Agent": build_user_agent()}, timeout=CONNECT_TIMEOUT_SECONDS, proxy=ws_proxy,
         )

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -129,6 +129,16 @@ class TestResolveProxyUrl:
 
         assert resolve_proxy_url(target_hosts=["149.154.167.220"]) is None
 
+    def test_platform_env_var_lowercase_form(self, monkeypatch):
+        """``wss_proxy`` (lowercase) is honored like ``WSS_PROXY`` (POSIX convention)."""
+        for key in ("WSS_PROXY", "wss_proxy", "HTTPS_PROXY", "HTTP_PROXY",
+                    "ALL_PROXY", "https_proxy", "http_proxy", "all_proxy",
+                    "NO_PROXY", "no_proxy"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("wss_proxy", "http://127.0.0.1:8888")
+
+        assert resolve_proxy_url("WSS_PROXY") == "http://127.0.0.1:8888"
+
 
 class TestRunAgentProxyDispatch:
     """Test that _run_agent() delegates to proxy when configured."""

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -216,6 +216,157 @@ class TestQQWebSocketProxy:
         assert seen_session_kwargs.get("trust_env") is True
         assert seen_ws_kwargs.get("proxy") == "http://127.0.0.1:7897"
 
+    @pytest.mark.asyncio
+    async def test_open_ws_bypasses_proxy_when_no_proxy_matches_host(self, monkeypatch):
+        """NO_PROXY matching the resolved gateway host → direct (proxy=None)."""
+        from gateway.platforms.qqbot import QQAdapter
+
+        for key in (
+            "WSS_PROXY",
+            "wss_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+        monkeypatch.setenv("NO_PROXY", "api.sgroup.qq.com")
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        seen_ws_kwargs = {}
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+            async def ws_connect(self, *args, **kwargs):
+                seen_ws_kwargs.update(kwargs)
+                return mock.AsyncMock(closed=False)
+
+        with mock.patch("gateway.platforms.qqbot.adapter.aiohttp.ClientSession", side_effect=FakeSession):
+            await adapter._open_ws("wss://api.sgroup.qq.com/websocket")
+
+        assert seen_ws_kwargs.get("proxy") is None
+
+    @pytest.mark.asyncio
+    async def test_open_ws_suffix_no_proxy_matches_gateway_host(self, monkeypatch):
+        """Domain-suffix NO_PROXY (qq.com) bypasses whatever gateway host Tencent returns."""
+        from gateway.platforms.qqbot import QQAdapter
+
+        for key in (
+            "WSS_PROXY",
+            "wss_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+        monkeypatch.setenv("NO_PROXY", "qq.com")
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        seen_ws_kwargs = {}
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+            async def ws_connect(self, *args, **kwargs):
+                seen_ws_kwargs.update(kwargs)
+                return mock.AsyncMock(closed=False)
+
+        with mock.patch("gateway.platforms.qqbot.adapter.aiohttp.ClientSession", side_effect=FakeSession):
+            await adapter._open_ws("wss://api.sgroup.qq.com/websocket")
+
+        assert seen_ws_kwargs.get("proxy") is None
+
+    @pytest.mark.asyncio
+    async def test_open_ws_unrelated_no_proxy_entry_still_proxies(self, monkeypatch):
+        """NO_PROXY for another host (REST token host) must not bypass the WS gateway host."""
+        from gateway.platforms.qqbot import QQAdapter
+
+        for key in (
+            "WSS_PROXY",
+            "wss_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+        monkeypatch.setenv("NO_PROXY", "bots.qq.com")
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        seen_ws_kwargs = {}
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+            async def ws_connect(self, *args, **kwargs):
+                seen_ws_kwargs.update(kwargs)
+                return mock.AsyncMock(closed=False)
+
+        with mock.patch("gateway.platforms.qqbot.adapter.aiohttp.ClientSession", side_effect=FakeSession):
+            await adapter._open_ws("wss://api.sgroup.qq.com/websocket")
+
+        assert seen_ws_kwargs.get("proxy") == "http://127.0.0.1:7897"
+
+    @pytest.mark.asyncio
+    async def test_open_ws_honors_lowercase_wss_proxy(self, monkeypatch):
+        """Lowercase wss_proxy keeps working (pre-helper code read both cases)."""
+        from gateway.platforms.qqbot import QQAdapter
+
+        for key in (
+            "WSS_PROXY",
+            "wss_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("wss_proxy", "http://127.0.0.1:8888")
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+        seen_ws_kwargs = {}
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+            async def ws_connect(self, *args, **kwargs):
+                seen_ws_kwargs.update(kwargs)
+                return mock.AsyncMock(closed=False)
+
+        with mock.patch("gateway.platforms.qqbot.adapter.aiohttp.ClientSession", side_effect=FakeSession):
+            await adapter._open_ws("wss://api.sgroup.qq.com/websocket")
+
+        assert seen_ws_kwargs.get("proxy") == "http://127.0.0.1:8888"
+
 # ---------------------------------------------------------------------------
 # _strip_at_mention
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 根因

gateway/platforms/qqbot/adapter.py _open_ws 把 WSS_PROXY/HTTPS_PROXY 等环境变量直读后以显式 proxy= 传给 aiohttp ws_connect。显式 proxy 会跳过 session trust_env 的环境代理解析，而 NO_PROXY 正是由该解析处理的——于是 NO_PROXY 命中的平台主机仍被路由进代理，代理不可用时无限重连。

## 修复

- _open_ws 改走共享 helper resolve_proxy_url("WSS_PROXY", target_hosts=实际 gateway_url host)，NO_PROXY 命中则传 proxy=None 直连；proxy=None 时回落到 session 的 trust_env 环境解析（aiohttp 自身同样执行 NO_PROXY bypass）。
- resolve_proxy_url 补上小写平台变量（wss_proxy）读取，POSIX 大小写等价，避免相对旧逻辑的回归（#106794 的坑）。
- session 仍用 gateway_trust_env()，遵守 test_no_bare_trust_env_literal_in_adapters（#48820）不变量。

## 测试

- TDD：先加 5 个测试，2 个 NO_PROXY bypass 红测复现（proxy 仍为 127.0.0.1:7897），修复后转绿。
- 新增：NO_PROXY 精确命中直连、后缀 qq.com 命中直连、无关条目仍走代理、小写 wss_proxy 仍生效、helper 小写平台变量。
- 验证：bash scripts/run_tests.sh 相关 7 文件 331 passed / 0 failed / 1 skipped（含 test_qqbot 67、test_proxy_mode 10、test_gateway_trust_env 4 全绿）。
- test_platform_base 14 失败经 stash 对照为基线预存（Windows docker 路径用例），与本改动无关。

## 关联

Closes #106790。Related: #41185（同类早期 open PR，base 已过期）、#106794（已关闭未合并，其小写变量/trust_env 坑已避开）。

残留口径：trust_env=true 且 NO_PROXY 为 host:port/CIDR 写法时，helper 已判 bypass，但 aiohttp 自身 env 回读（urllib proxy_bypass）不识别这类写法，仍可能走代理；精确主机/后缀/大小写/通配符均已覆盖（已实测 urllib 行为）。