### PR TITLE
fix(desktop): relaunch after update when /home is a symlink

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -318,8 +318,18 @@ stop_ui() { # error/manual outcomes keep the window up briefly so a watching
 # Outcomes mirror decideRelaunchOutcome: relaunch | skew | manual.
 GATE="" GATE_MSG=""
 linux_gate() {
-  local unpacked="$INSTALL_ROOT/apps/desktop/release/linux-unpacked" sb arg
-  case "$RELAUNCH_TARGET" in
+  local unpacked="$INSTALL_ROOT/apps/desktop/release/linux-unpacked" sb arg target="$RELAUNCH_TARGET"
+  # Electron's process.execPath is a realpath; --install-root is often the
+  # symlink form of HERMES_HOME. On Bazzite/Silverblue /home -> /var/home,
+  # so a string prefix match reports a false package-skew and never relaunches.
+  if command -v realpath >/dev/null 2>&1; then
+    unpacked="$(realpath -q "$unpacked" 2>/dev/null || printf '%s' "$unpacked")"
+    target="$(realpath -q "$target" 2>/dev/null || printf '%s' "$target")"
+  else
+    unpacked="$(readlink -f "$unpacked" 2>/dev/null || printf '%s' "$unpacked")"
+    target="$(readlink -f "$target" 2>/dev/null || printf '%s' "$target")"
+  fi
+  case "$target" in
     "$unpacked"/*) ;;
     *) GATE=skew GATE_MSG="Backend updated, but the desktop app package (AppImage/deb/rpm) was not changed. Update or reinstall it to match."; return ;;
   esac

--- a/scripts/desktop-update/repro.sh
+++ b/scripts/desktop-update/repro.sh
@@ -111,6 +111,28 @@ case "$MODE" in
     expect "sibling-prefix dir not fooled"      skew     "$(decide --relaunch-target "$UNPACKED-evil/hermes")"
     expect "no chrome-sandbox (namespace)"      relaunch "$(decide --relaunch-target "$UNPACKED/hermes")"
 
+    # Bazzite/Silverblue: /home -> /var/home. Electron's process.execPath is
+    # the realpath; --install-root is often the symlink path from HERMES_HOME.
+    # String prefix match then reports a false "package skew" and never relaunches.
+    SYMLINK_HOME="$G/home"
+    REAL_HOME="$G/varhome"
+    mkdir -p "$REAL_HOME/hermes-agent/apps/desktop/release/linux-unpacked"
+    ln -s "$REAL_HOME" "$SYMLINK_HOME"
+    touch "$REAL_HOME/hermes-agent/apps/desktop/release/linux-unpacked/hermes"
+    chmod +x "$REAL_HOME/hermes-agent/apps/desktop/release/linux-unpacked/hermes"
+    SYMLINK_UNPACKED="$SYMLINK_HOME/hermes-agent/apps/desktop/release/linux-unpacked"
+    REAL_BIN="$(readlink -f "$REAL_HOME/hermes-agent/apps/desktop/release/linux-unpacked/hermes")"
+    expect "symlink install-root vs realpath exec" relaunch "$(
+      bash "$SCRIPT_DIR/posix.sh" --self-test-gate \
+        --install-root "$SYMLINK_HOME/hermes-agent" \
+        --relaunch-target "$REAL_BIN" | cut -d: -f1
+    )"
+    expect "realpath install-root vs symlink exec" relaunch "$(
+      bash "$SCRIPT_DIR/posix.sh" --self-test-gate \
+        --install-root "$(readlink -f "$SYMLINK_HOME/hermes-agent")" \
+        --relaunch-target "$SYMLINK_UNPACKED/hermes" | cut -d: -f1
+    )"
+
     touch "$UNPACKED/chrome-sandbox"
     expect "sandbox not root/setuid"            manual   "$(decide --relaunch-target "$UNPACKED/hermes")"
     expect "opt-out: --sandbox-fallback"        relaunch "$(decide --relaunch-target "$UNPACKED/hermes" --sandbox-fallback)"


### PR DESCRIPTION
## Bug Description

In-app Desktop update on Linux rebuilds the unpacked app, then the posix hand-off refuses to reopen the window:

```
no relaunch (skew): Backend updated, but the desktop app package (AppImage/deb/rpm) was not changed.
```

Reproduced on Bazzite (ostree): `/home` -> `/var/home`. Same miss 2026-08-29 and 2026-09-10. Backend and `linux-unpacked` *were* updated; only relaunch was skipped.

## Root Cause

`linux_gate` in `scripts/desktop-update/posix.sh` string-prefixes `--relaunch-target` against `$INSTALL_ROOT/apps/desktop/release/linux-unpacked`.

Electron passes `process.execPath` (realpath, `/var/home/.../Hermes`). `--install-root` is often the symlink form of `HERMES_HOME` (`/home/...`). Those strings do not match, so a git-built unpacked app is treated like an unchanged AppImage/deb/rpm.

## Fix

Canonicalize both paths with `realpath` (fallback `readlink -f`) before the prefix match. A real foreign package path still reports skew.

## How to Verify

1. `bash scripts/desktop-update/repro.sh gate` — cases `symlink install-root vs realpath exec` and `realpath install-root vs symlink exec` must be `relaunch`; `appimage (not under unpacked)` must stay `skew`.
2. On a host where `/home` is a symlink:
   `bash scripts/desktop-update/posix.sh --self-test-gate --install-root "$HOME/.hermes/hermes-agent" --relaunch-target "$(readlink -f "$HOME/.hermes/hermes-agent/apps/desktop/release/linux-unpacked/Hermes")"`
   expect `relaunch`.

## Test Plan

- [x] Added regression test for this bug (`repro.sh gate`)
- [x] Existing prefix/skew/opt-out cases still pass
- [x] Manual verification of the fix on Bazzite `/home` vs `/var/home`

## Risk Assessment

Low — comparison is the same prefix check after resolving symlinks; AppImage/deb/rpm installs still skew.
