### PR TITLE
fix(tools): silent MCP OAuth refresh before browser authorize on resource 401

### DIFF
--- a/tests/tools/test_mcp_oauth_bidirectional.py
+++ b/tests/tools/test_mcp_oauth_bidirectional.py
@@ -312,6 +312,181 @@ async def _noop_redirect(_url: str) -> None:
     return None
 
 
+@pytest.mark.asyncio
+async def test_401_with_usable_refresh_silently_refreshes_before_browser(tmp_path, monkeypatch):
+    """#107059: a resource 401 with a usable refresh token must NOT open a browser tab.
+
+    The server can reject an access token before its local expiry (restart/boot
+    with a stale token). The wrapper must attempt one silent refresh and retry
+    the resource with the new bearer before the SDK's authorization-code branch
+    (``redirect_handler`` -> browser tab) is allowed to run.
+    """
+    from tools.mcp_tool import sdk_httpx
+    httpx = sdk_httpx()
+    from mcp.shared.auth import (
+        OAuthClientInformationFull, OAuthClientMetadata, OAuthMetadata, OAuthToken,
+    )
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="old_access",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="old_refresh",
+        )
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=storage,
+        redirect_handler=_browser_must_not_open,
+        callback_handler=_noop_callback,
+    )
+    provider.context.oauth_metadata = OAuthMetadata(
+        issuer="https://example.com",
+        authorization_endpoint="https://example.com/authorize",
+        token_endpoint="https://example.com/token",
+    )
+
+    req = httpx.Request("POST", "https://example.com/mcp")
+    flow = provider.async_auth_flow(req)
+    outbound = await flow.__anext__()
+
+    fake_401 = httpx.Response(
+        401,
+        request=outbound,
+        headers={"www-authenticate": 'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"'},
+    )
+
+    # Must be a refresh POST, not a metadata-discovery GET / browser authorize.
+    refresh_request = await flow.asend(fake_401)
+    assert refresh_request.method == "POST"
+    assert "example.com/token" in str(refresh_request.url)
+    assert b"grant_type=refresh_token" in refresh_request.content
+
+    retry = await flow.asend(
+        httpx.Response(
+            200,
+            request=refresh_request,
+            json={
+                "access_token": "new_access",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "new_refresh",
+            },
+        )
+    )
+    assert retry is req
+    assert retry.headers["authorization"] == "Bearer new_access"
+
+    with pytest.raises(StopAsyncIteration):
+        await flow.asend(httpx.Response(200, request=retry))
+
+
+@pytest.mark.asyncio
+async def test_401_failed_refresh_falls_back_to_sdk_discovery(tmp_path, monkeypatch):
+    """#107059: when silent refresh fails, the SDK browser fallback must stay intact."""
+    from tools.mcp_tool import sdk_httpx
+    httpx = sdk_httpx()
+    from mcp.shared.auth import (
+        OAuthClientInformationFull, OAuthClientMetadata, OAuthMetadata, OAuthToken,
+    )
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="old_access",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="old_refresh",
+        )
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+    provider.context.oauth_metadata = OAuthMetadata(
+        issuer="https://example.com",
+        authorization_endpoint="https://example.com/authorize",
+        token_endpoint="https://example.com/token",
+    )
+
+    req = httpx.Request("POST", "https://example.com/mcp")
+    flow = provider.async_auth_flow(req)
+    outbound = await flow.__anext__()
+
+    fake_401 = httpx.Response(
+        401,
+        request=outbound,
+        headers={"www-authenticate": 'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"'},
+    )
+
+    refresh_request = await flow.asend(fake_401)
+    assert refresh_request.method == "POST"
+
+    # Refresh rejected -> wrapper must hand the 401 to the SDK, which yields
+    # its metadata-discovery GET (browser re-auth path preserved).
+    next_request = await flow.asend(httpx.Response(400, request=refresh_request))
+    assert isinstance(next_request, httpx.Request)
+
+    await flow.aclose()
+
+
+async def _browser_must_not_open(_url: str) -> None:
+    """Fail loudly if the SDK authorization-code branch opens a browser tab."""
+    raise AssertionError("browser authorize must not run when silent refresh can recover (#107059)")
+
+
 async def _noop_callback() -> tuple[str, str | None]:
     """Callback handler that won't be invoked in these tests."""
     raise AssertionError(

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -243,6 +243,22 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
                     await inner.aclose()
                     retry_after_concurrent_auth = True
                     break
+                # A resource 401 is not proof the refresh credential is dead: the server can reject an
+                # access token before its local expiry (restart/boot with a stale token). Attempt one
+                # silent refresh before the SDK falls into authorization-code flow and opens a browser
+                # tab (#107059). Refresh needs a discovered token endpoint — without metadata
+                # `_refresh_token` would guess `{server_url}/token` (wrong for split-origin providers)
+                # and a failed guess wipes good tokens, so fall through to SDK discovery instead.
+                if (getattr(incoming, "status_code", None) == 401 and self.context.can_refresh_token()
+                        and getattr(getattr(self.context, "oauth_metadata", None), "token_endpoint", None)):
+                    refresh_request = await self._refresh_token()
+                    refresh_response = yield refresh_request
+                    await self._maybe_flag_poisoned_client(refresh_response)
+                    if await self._handle_refresh_response(refresh_response):
+                        self._add_auth_header(request)
+                        await inner.aclose()
+                        retry_after_concurrent_auth = True
+                        break
                 # Sniff the response for a dead-client-registration signal before handing it back to the SDK
                 # (best-effort, GH#36767).
                 await self._maybe_flag_poisoned_client(incoming)


### PR DESCRIPTION
## 根因

资源服务器可在本地 access token 未过期时返回 401（重启/隔夜后用过期 token 首次调用）。`HermesMCPOAuthProvider.async_auth_flow` 把 401 直接透传给 SDK 内层生成器，而 SDK 的 401 分支不试 refresh token，直奔元数据发现 + 授权码流程，`redirect_handler` 打开浏览器授权页——即使磁盘上的 refresh token 随后（或并发）静默刷新成功，该页也已孤立（canva 案例：refresh 200、mcp 200，但授权页照样弹出）。

## 修复

`tools/mcp_oauth_manager.py`：收到资源 401 且 `can_refresh_token()` 为真、且已有已发现的 `token_endpoint`（`_initialize` 预取或持久化恢复）时，先 yield 一次 refresh POST；成功则关闭内层流、用新 bearer 重试原请求，仅刷新失败/无凭证/无元数据时才落回 SDK 原有发现 + 浏览器流程。与已关闭未合并的 #107064 同思路，但保留其删掉的回退覆盖，并加元数据门控：无元数据时 `_refresh_token` 会猜 `{server_url}/token`（split-origin 会 404），且失败会清空正常 token，故直接走 SDK 发现。

## 测试

- 新增 `test_401_with_usable_refresh_silently_refreshes_before_browser`：401 → 断言先出 refresh POST（含 grant_type=refresh_token，发往 token_endpoint），200 回包后原请求带新 bearer 重试，全程 redirect_handler 若被调用即失败。先红（基线返回发现 GET）后绿。
- 新增 `test_401_failed_refresh_falls_back_to_sdk_discovery`：refresh 被 400 拒绝 → 断言回落到 SDK 发现请求，浏览器回退路径保留。
- 既有 `test_hermes_provider_forwards_401_triggers_refresh`（无元数据场景）未动，继续覆盖无元数据回退。

## 验证

`HERMES_PYTHON=D:/code/hermes-agent/.venv/Scripts/python.exe bash scripts/run_tests.sh tests/tools/test_mcp_oauth_bidirectional.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_integration.py tests/tools/test_mcp_oauth_cold_load_expiry.py -v`：4 文件 32 测试全绿。

Closes #107059