### PR TITLE
fix(terminal): stop the idle reaper from cleaning up an environment mid-call

### DIFF
--- a/tests/tools/test_terminal_inflight_reap_guard.py
+++ b/tests/tools/test_terminal_inflight_reap_guard.py
@@ -1,0 +1,238 @@
+"""Regression coverage: the idle reaper must not tear down an environment mid-call.
+
+``_cleanup_inactive_envs`` reaps any task whose ``_last_activity`` is older than
+``lifetime_seconds`` (``TERMINAL_LIFETIME_SECONDS`` / ``terminal.lifetime_seconds``, default 300).
+``_last_activity`` is only stamped at call boundaries, and only BACKGROUND processes get refreshed
+mid-run (through ``process_registry.has_active_processes``). So a foreground ``terminal`` or remote
+``execute_code`` call that outlives the threshold was reaped while still using its own environment:
+
+* container/remote backends (docker, modal, daytona, ssh, ...): ``env.cleanup()`` stops the sandbox
+  the in-flight call is executing in;
+* local: ``LocalEnvironment.cleanup()`` unlinks the session snapshot and cwd file, so the running
+  command returns but the session's exported shell environment is gone — breaking the terminal
+  tool's own contract that "exported environment variables persist between calls".
+
+The window is wider than the command: the environment is acquired (and stamped) BEFORE the approval
+guards, so a flagged command waiting on approval is idle by this measure too.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from tools import code_execution_tool, terminal_tool as tt
+from tools.terminal_tool_lifecycle import _cleanup_inactive_envs
+
+
+class _FakeEnv:
+    """Cleanup-only stub; ``_ReapingEnv`` below adds the execute side."""
+
+    def __init__(self):
+        self.cleaned = False
+
+    def cleanup(self):
+        self.cleaned = True
+
+
+@pytest.fixture()
+def env_registry(monkeypatch):
+    """Isolate the module-level lifecycle state; yields a register(task_id, idle_for) helper."""
+    monkeypatch.setattr(tt, "_active_environments", {})
+    monkeypatch.setattr(tt, "_last_activity", {})
+    monkeypatch.setattr(tt, "_calls_in_flight", {})
+    monkeypatch.setattr(tt, "_creation_locks", {})
+
+    def register(task_id: str, idle_for: float) -> _FakeEnv:
+        env = _FakeEnv()
+        tt._active_environments[task_id] = env
+        tt._last_activity[task_id] = time.time() - idle_for
+        return env
+
+    return register
+
+
+def test_idle_environment_is_still_reaped(env_registry):
+    """Baseline: the guard must not disable the reaper for genuinely idle tasks."""
+    env = env_registry("t1", idle_for=600)
+
+    _cleanup_inactive_envs(lifetime_seconds=300)
+
+    assert env.cleaned
+    assert "t1" not in tt._active_environments
+
+
+def test_call_in_flight_survives_the_reaper(env_registry):
+    """The whole point: a call longer than lifetime_seconds keeps its environment."""
+    env = env_registry("t1", idle_for=600)
+
+    with tt._call_in_flight("t1"):
+        _cleanup_inactive_envs(lifetime_seconds=300)
+
+        assert not env.cleaned
+        assert tt._active_environments["t1"] is env
+
+
+def test_environment_is_reapable_again_once_the_call_returns(env_registry):
+    """The mark is a hold, not an exemption: the env must not leak past the call."""
+    env = env_registry("t1", idle_for=600)
+    with tt._call_in_flight("t1"):
+        pass
+
+    # Exiting restamps activity, so the countdown starts at call end, not call start.
+    assert time.time() - tt._last_activity["t1"] < 5
+    _cleanup_inactive_envs(lifetime_seconds=300)
+    assert not env.cleaned
+
+    tt._last_activity["t1"] = time.time() - 600
+    _cleanup_inactive_envs(lifetime_seconds=300)
+    assert env.cleaned
+
+
+def test_parallel_calls_refcount_the_mark(env_registry):
+    """Parallel tool calls in one session share a task_id; the first one out must not release it."""
+    env = env_registry("t1", idle_for=600)
+
+    with tt._call_in_flight("t1"):
+        with tt._call_in_flight("t1"):
+            pass
+        tt._last_activity["t1"] = time.time() - 600
+        _cleanup_inactive_envs(lifetime_seconds=300)
+
+    assert not env.cleaned
+    assert tt._calls_in_flight == {}
+
+
+def test_both_the_collapsed_and_the_raw_task_id_are_held(env_registry):
+    """``_lookup_active_env`` stamps whichever of the two keys owns the env, so both are marked:
+    a per-session surface with a CWD-only override collapses to "default" while an env may already
+    be cached under the originating task_id."""
+    collapsed = env_registry("default", idle_for=600)
+    raw = env_registry("session-42", idle_for=600)
+
+    with tt._call_in_flight("default", "session-42"):
+        _cleanup_inactive_envs(lifetime_seconds=300)
+
+    assert not collapsed.cleaned and not raw.cleaned
+
+
+def test_unrelated_tasks_are_unaffected(env_registry):
+    """Holding one task must not keep every other idle sandbox alive."""
+    held = env_registry("t1", idle_for=600)
+    other = env_registry("t2", idle_for=600)
+
+    with tt._call_in_flight("t1"):
+        _cleanup_inactive_envs(lifetime_seconds=300)
+
+    assert not held.cleaned
+    assert other.cleaned
+
+
+def test_none_and_duplicate_ids_are_dropped(env_registry):
+    """``task_id`` is Optional and often equals the collapsed id; neither may corrupt the refcount."""
+    env_registry("t1", idle_for=600)
+
+    with tt._call_in_flight(None, "t1", "t1", ""):
+        assert tt._calls_in_flight == {"t1": 1}
+
+    assert tt._calls_in_flight == {}
+
+
+# ---------------------------------------------------------------------------
+# Through the real entry points, with the reaper firing from inside the call.
+# ---------------------------------------------------------------------------
+
+
+def _sweep_mid_call():
+    """One reaper sweep from inside a call that has been running longer than ``lifetime_seconds``.
+
+    Acquisition stamps ``_last_activity`` when the call STARTS and never again, so age every stamp
+    past the threshold first: that is what the clock does while a long build, a slow script or an
+    approval wait runs. Only the in-flight mark can save the environment now.
+    """
+    for key in list(tt._last_activity):
+        tt._last_activity[key] = time.time() - 600
+    _cleanup_inactive_envs(lifetime_seconds=300)
+
+
+@pytest.fixture()
+def held_env(env_registry, monkeypatch):
+    """A shared environment cached under the COLLAPSED key ``default``, plus a no-op cleanup thread
+    so only the sweeps a test fires can reap it.
+
+    ``session-42`` is the raw tool-call ``task_id``; ``_resolve_container_task_id`` collapses it to
+    ``default`` (no isolation override, no session key), which is where both acquisition paths cache
+    and stamp. A guard that holds the raw id only leaves this environment exposed.
+    """
+    monkeypatch.setattr(tt, "_start_cleanup_thread", lambda: None)
+    env_registry("default", idle_for=0)
+
+
+class _ReapingEnv(_FakeEnv):
+    """Sweeps from inside ``execute`` — a command that outlives ``lifetime_seconds``."""
+
+    def __init__(self, log: list):
+        super().__init__()
+        self.log = log
+        self.calls: list[str] = []
+
+    def execute(self, command, cwd=None, timeout=None, **kwargs):
+        self.calls.append(command)
+        _sweep_mid_call()
+        self.log.append(("execute", self.cleaned))
+        return {"output": "hi", "exit_code": 0}
+
+
+def test_terminal_tool_holds_its_environment_through_approval_and_execution(held_env, monkeypatch):
+    """A foreground command that outlives ``lifetime_seconds`` must keep the environment it is
+    running in. The reaper is fired twice from inside the call — once from the approval guards
+    (a flagged command can wait there for minutes) and once from ``env.execute`` — because the
+    mark has to span both, not just execution."""
+    log: list = []
+    env = _ReapingEnv(log)
+    tt._active_environments["default"] = env
+    real_guards = tt._run_approval_guards
+
+    def guards(*args, **kwargs):
+        _sweep_mid_call()
+        log.append(("approval", env.cleaned))
+        return real_guards(*args, **kwargs)
+
+    monkeypatch.setattr(tt, "_run_approval_guards", guards)
+
+    result = json.loads(tt.terminal_tool(command="echo hi", task_id="session-42"))
+
+    assert [label for label, _ in log] == ["approval", "execute"]
+    assert not any(cleaned for _, cleaned in log)
+    assert not env.cleaned and tt._active_environments["default"] is env
+    assert result["exit_code"] == 0
+
+
+def test_execute_code_remote_holds_the_collapsed_environment_key(held_env):
+    """``_execute_remote``'s own ``effective_task_id`` is just ``task_id or "default"``, while
+    ``_get_or_create_env`` caches and stamps under the collapsed key. Holding the raw id alone let
+    the reaper stop the sandbox the script was running in."""
+    env = _ReapingEnv([])
+    tt._active_environments["default"] = env
+
+    code_execution_tool._execute_remote("print(1)", "session-42", None)
+
+    assert env.calls, "the remote path never reached the environment"
+    assert not env.cleaned
+    assert tt._active_environments["default"] is env
+
+
+def test_mark_is_released_when_the_call_raises(env_registry):
+    """A tool call that dies must not pin its sandbox for the life of the process."""
+    env = env_registry("t1", idle_for=600)
+
+    with pytest.raises(RuntimeError):
+        with tt._call_in_flight("t1"):
+            raise RuntimeError("boom")
+
+    assert tt._calls_in_flight == {}
+    tt._last_activity["t1"] = time.time() - 600
+    _cleanup_inactive_envs(lifetime_seconds=300)
+    assert env.cleaned

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -622,35 +622,43 @@ def _execute_remote(code: str, task_id: Optional[str], enabled_tools: Optional[L
     sandbox_tools, effective_task_id = _sandbox_tools_for(enabled_tools), task_id or "default"
     env, env_type = _get_or_create_env(effective_task_id)
     exec_start = time.monotonic()
-    try:
-        py_check = env.execute("command -v python3 >/dev/null 2>&1 && echo OK", cwd="/", timeout=15)
-        if "OK" not in py_check.get("output", ""):
-            return _error_result(f"Python 3 is not available in the {env_type} terminal "
-                                 "environment. Install Python to use execute_code with remote backends.")
-        # Session-kernel path: one persistent kernel per owner on the
-        # run-to-completion transport. Spawn failure falls OPEN to the per-call
-        # path below so a degraded remote host never blocks execution.
+    # A script that outlives terminal.lifetime_seconds must not have its sandbox reaped
+    # mid-run: the only activity stamp on this path is the one _get_or_create_env just made.
+    # That stamp lands under the COLLAPSED registry key (``default`` / ``profile:…`` /
+    # ``session:…``), which is what _get_or_create_env resolves internally — ``effective_task_id``
+    # here is only ``task_id or "default"``, so marking it alone leaves a shared environment
+    # unprotected. Resolve the same way and hold the key the stamp actually used.
+    from tools.terminal_tool import _call_in_flight, _resolve_container_task_id
+    with _call_in_flight(_resolve_container_task_id(effective_task_id), effective_task_id, task_id):
         try:
-            # --- Session-kernel path (hermes-agent#96873) ------------------- Same always-on model as
-            # local: one persistent kernel per owner, rebuilt on the run-to-completion transport (detached
-            # runner + file cell protocol).
-            from tools.code_kernel_remote import execute_in_remote_kernel
-            kernel_result = execute_in_remote_kernel(
-                code, env=env, env_type=env_type, task_env_id=effective_task_id,
-                sandbox_tools=frozenset(sandbox_tools), timeout=timeout,
-                max_tool_calls=max_tool_calls, reset=bool(reset),
-                idle_exit=int(_cfg.get("kernel_idle_timeout", 1800)),
-            )
-        except Exception:
-            logger.warning("remote session-kernel path failed; falling back to per-call", exc_info=True)
-            kernel_result = None
-        if kernel_result is not None:
-            return _finish_remote_kernel_result(kernel_result, timeout=timeout, exec_start=exec_start)
-        logger.info("remote session kernel unavailable on %s; using per-call path", env_type)
-    except Exception as exc:
-        return _remote_failure(exc, exec_start, 0)
-    return _run_remote_per_call(env, env_type, code, effective_task_id, sandbox_tools,
-                                timeout=timeout, max_tool_calls=max_tool_calls, exec_start=exec_start)
+            py_check = env.execute("command -v python3 >/dev/null 2>&1 && echo OK", cwd="/", timeout=15)
+            if "OK" not in py_check.get("output", ""):
+                return _error_result(f"Python 3 is not available in the {env_type} terminal "
+                                     "environment. Install Python to use execute_code with remote backends.")
+            # Session-kernel path: one persistent kernel per owner on the
+            # run-to-completion transport. Spawn failure falls OPEN to the per-call
+            # path below so a degraded remote host never blocks execution.
+            try:
+                # --- Session-kernel path (hermes-agent#96873) ------------------- Same always-on model as
+                # local: one persistent kernel per owner, rebuilt on the run-to-completion transport (detached
+                # runner + file cell protocol).
+                from tools.code_kernel_remote import execute_in_remote_kernel
+                kernel_result = execute_in_remote_kernel(
+                    code, env=env, env_type=env_type, task_env_id=effective_task_id,
+                    sandbox_tools=frozenset(sandbox_tools), timeout=timeout,
+                    max_tool_calls=max_tool_calls, reset=bool(reset),
+                    idle_exit=int(_cfg.get("kernel_idle_timeout", 1800)),
+                )
+            except Exception:
+                logger.warning("remote session-kernel path failed; falling back to per-call", exc_info=True)
+                kernel_result = None
+            if kernel_result is not None:
+                return _finish_remote_kernel_result(kernel_result, timeout=timeout, exec_start=exec_start)
+            logger.info("remote session kernel unavailable on %s; using per-call path", env_type)
+        except Exception as exc:
+            return _remote_failure(exc, exec_start, 0)
+        return _run_remote_per_call(env, env_type, code, effective_task_id, sandbox_tools,
+                                    timeout=timeout, max_tool_calls=max_tool_calls, exec_start=exec_start)
 
 
 # ---- Main entry point ----

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -25,6 +25,7 @@ import sys
 import time
 import threading
 import atexit
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Optional, Dict, Any, List
 
@@ -169,6 +170,12 @@ PTY: pty=true + background=true for interactive CLIs (they hang without a termin
 # Environment lifecycle state.
 _active_environments: Dict[str, Any] = {}
 _last_activity: Dict[str, float] = {}
+# Tool calls currently holding an environment, refcounted per task_id. ``_last_activity`` is only
+# stamped at call boundaries, so a foreground call that outlives ``lifetime_seconds`` — a long
+# build, or the approval gate waiting on a human — reads as idle to ``_cleanup_inactive_envs`` and
+# has its sandbox reaped mid-call. Background processes already get this exemption through the
+# process registry; this is the same exemption for the calling thread.
+_calls_in_flight: Dict[str, int] = {}
 _env_lock = threading.Lock()
 _creation_locks: Dict[str, threading.Lock] = {}  # Per-task locks for sandbox creation
 _creation_locks_lock = threading.Lock()  # Protects _creation_locks dict itself
@@ -491,6 +498,38 @@ def _lookup_active_env(effective_task_id: str, task_id: Optional[str]):
             _last_activity[key] = time.time()
             return _active_environments[key]
     return None
+
+
+@contextmanager
+def _call_in_flight(*task_ids: Optional[str]):
+    """Hold *task_ids* against the idle reaper for the body of a tool call.
+
+    Every id is registered because the acquisition paths stamp ``_last_activity`` under whichever
+    of the collapsed container id and the raw task_id already owns an env (see
+    ``_lookup_active_env``), and only the stamped one needs the exemption. Refcounted: parallel
+    tool calls in one session share a task_id, so the last one out clears the mark. On exit the
+    activity stamp is refreshed so the idle countdown starts when the call ENDS — otherwise an
+    hour-long call would leave its env eligible for reaping on the very next sweep.
+
+    Must not be entered or exited while holding ``_env_lock``.
+    """
+    keys = tuple(k for k in dict.fromkeys(task_ids) if k)
+    with _env_lock:
+        for key in keys:
+            _calls_in_flight[key] = _calls_in_flight.get(key, 0) + 1
+    try:
+        yield
+    finally:
+        now = time.time()
+        with _env_lock:
+            for key in keys:
+                remaining = _calls_in_flight.get(key, 0) - 1
+                if remaining > 0:
+                    _calls_in_flight[key] = remaining
+                else:
+                    _calls_in_flight.pop(key, None)
+                if key in _last_activity:
+                    _last_activity[key] = now
 
 
 def _resolve_task_host_cwd(config: Dict[str, Any], task_id: Optional[str]) -> Optional[str]:
@@ -1198,41 +1237,45 @@ def terminal_tool(
             command, task_id=task_id, timeout=timeout, background=background, _host_local=_host_local,
         )
         env = _acquire_env(plan, task_id)
-        env_type, cwd, effective_task_id = plan.env_type, plan.cwd, plan.effective_task_id
+        # From here on this task holds an environment. The mark covers the approval gate as
+        # well as execution: a flagged command can sit in the approval wait for minutes
+        # before env.execute is reached, which is long enough to be reaped.
+        with _call_in_flight(plan.effective_task_id, task_id):
+            env_type, cwd, effective_task_id = plan.env_type, plan.cwd, plan.effective_task_id
 
-        # Session key for cwd records: the contextvar doesn't cross tool-worker
-        # threads, so fall back to the raw task_id (the top-level agent's
-        # session_key) as a stable anchor.
-        from tools.approval import get_current_session_key
+            # Session key for cwd records: the contextvar doesn't cross tool-worker
+            # threads, so fall back to the raw task_id (the top-level agent's
+            # session_key) as a stable anchor.
+            from tools.approval import get_current_session_key
 
-        session_key = get_current_session_key(default="") or (task_id or "")
+            session_key = get_current_session_key(default="") or (task_id or "")
 
-        _pre_exec_block(command, env=env, env_type=env_type, cwd=cwd, workdir=workdir, session_key=session_key)
-        # Pre-exec security checks (tirith + dangerous command detection);
-        # force=True means the user already confirmed.
-        verdict = _run_approval_guards(command, env_type, plan.config, force=force)
+            _pre_exec_block(command, env=env, env_type=env_type, cwd=cwd, workdir=workdir, session_key=session_key)
+            # Pre-exec security checks (tirith + dangerous command detection);
+            # force=True means the user already confirmed.
+            verdict = _run_approval_guards(command, env_type, plan.config, force=force)
 
-        pty_disabled = pty and _command_requires_pipe_stdin(command)
-        if plan.promoted_from_foreground_timeout is not None:
-            # Promotion implies notify_on_complete; watch_patterns is a background-only flag the
-            # caller could not have meant for a foreground call, and the two are exclusive anyway.
-            background, notify_on_complete, watch_patterns = True, True, None
-        if background:
-            result = spawn_background_process(
-                command=command, env=env, env_type=env_type, effective_task_id=effective_task_id,
-                task_id=task_id, session_key=session_key, workdir=workdir, cwd=cwd,
-                effective_pty=pty and not pty_disabled, notify_on_complete=notify_on_complete,
-                watch_patterns=watch_patterns, approval_note=verdict.note,
-                pty_disabled_reason=_PTY_DISABLED_REASON if pty_disabled else None,
-            )
+            pty_disabled = pty and _command_requires_pipe_stdin(command)
             if plan.promoted_from_foreground_timeout is not None:
-                result = _with_promoted_note(result, plan.promoted_from_foreground_timeout)
-            return result
-        return _run_foreground(
-            command, env, plan,
-            task_id=task_id, session_id=session_id, session_key=session_key,
-            workdir=workdir, approval_note=verdict.note, clear_interrupt=verdict.approved_run,
-        )
+                # Promotion implies notify_on_complete; watch_patterns is a background-only flag the
+                # caller could not have meant for a foreground call, and the two are exclusive anyway.
+                background, notify_on_complete, watch_patterns = True, True, None
+            if background:
+                result = spawn_background_process(
+                    command=command, env=env, env_type=env_type, effective_task_id=effective_task_id,
+                    task_id=task_id, session_key=session_key, workdir=workdir, cwd=cwd,
+                    effective_pty=pty and not pty_disabled, notify_on_complete=notify_on_complete,
+                    watch_patterns=watch_patterns, approval_note=verdict.note,
+                    pty_disabled_reason=_PTY_DISABLED_REASON if pty_disabled else None,
+                )
+                if plan.promoted_from_foreground_timeout is not None:
+                    result = _with_promoted_note(result, plan.promoted_from_foreground_timeout)
+                return result
+            return _run_foreground(
+                command, env, plan,
+                task_id=task_id, session_id=session_id, session_key=session_key,
+                workdir=workdir, approval_note=verdict.note, clear_interrupt=verdict.approved_run,
+            )
     except _Rejected as r:
         return r.result_json
     except EnvironmentConnectionError as e:

--- a/tools/terminal_tool_lifecycle.py
+++ b/tools/terminal_tool_lifecycle.py
@@ -143,7 +143,7 @@ def _unregister_env(task_id: str):
 def _cleanup_inactive_envs(lifetime_seconds: int = 300):
     """Clean up environments that have been inactive for longer than lifetime_seconds."""
     from tools.terminal_tool import (
-        _active_environments, _creation_locks, _creation_locks_lock, _env_lock,
+        _active_environments, _calls_in_flight, _creation_locks, _creation_locks_lock, _env_lock,
         _last_activity,
     )
     current_time = time.time()
@@ -160,6 +160,12 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
     # Phase 1: unregister stale entries atomically under the lock; phase 2:
     # stop them outside it (see _unregister_env for why).
     with _env_lock:
+        # A task with a call in flight is busy, not idle: its _last_activity was stamped when the
+        # call started and does not move again until it returns, so without this refresh a call
+        # longer than lifetime_seconds reaps the environment out from under itself.
+        for task_id in list(_calls_in_flight):
+            if task_id in _last_activity:
+                _last_activity[task_id] = current_time
         stale = [t for t, last in list(_last_activity.items()) if current_time - last > lifetime_seconds]
         envs_to_stop = [(t, _active_environments.pop(t, None)) for t in stale]
         for t in stale:


### PR DESCRIPTION
## What does this PR do?

`_cleanup_inactive_envs` reaps any task whose `_last_activity` is older than `lifetime_seconds` (default 300). That stamp only moves at call boundaries, and only background processes refresh it mid-run. So a foreground `terminal` or remote `execute_code` call that outlives the threshold gets its environment reaped while it is still running in it. On container and remote backends `env.cleanup()` stops the sandbox mid-call. On local, `LocalEnvironment.cleanup()` unlinks `_snapshot_path` and `_cwd_file` (`tools/environments/local.py:820`): the command finishes, but the session's exported shell environment is gone and the next call rebuilds it from a login shell, against the tool's own "exports persist" contract. The window includes the approval wait, since the environment is acquired before the guards.

Fix: refcount in-flight calls per environment key and have the reaper refresh those tasks, the same exemption background processes already get. `_call_in_flight` is a context manager entered right after the environment is acquired, so it spans the approval gate and execution and cannot leak on an early return.

It holds the keys `_last_activity` is actually stamped under, not just the raw `task_id`: `_get_or_create_env` stamps the collapsed container id (`default`, `profile:...`, `session:...`), so `_execute_remote` now resolves that id the way the cache does. Holding the raw id alone left the common case unprotected (raw `session-42` sharing the `default` environment). Exit restamps activity so the idle countdown starts when the call ends.

Locking unchanged: the context manager takes `_env_lock` itself and is never entered under it; the reaper's refresh runs inside the existing phase-1 critical section.

Authored with AI assistance, reviewed by a human.

## Related Issue

No issue filed. Found by reading the reaper against the call paths that stamp `_last_activity`; happy to open one first if you prefer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py`: `_calls_in_flight`, `@contextmanager _call_in_flight(*task_ids)` (dedupes, refcounts, restamps on exit); `terminal_tool` body wrapped from just after `_acquire_env`. Most `-` lines are re-indentation.
- `tools/code_execution_tool.py`: `_execute_remote` body wrapped from just after `_get_or_create_env`, holding `_resolve_container_task_id(effective_task_id)` plus the raw ids.
- `tools/terminal_tool_lifecycle.py`: `_cleanup_inactive_envs` refreshes in-flight tasks inside the phase-1 lock, next to the background-process refresh.
- `tests/tools/test_terminal_inflight_reap_guard.py`: 10 cases through the real entry points, with the reaper fired from inside the approval guards and from inside `env.execute`, plus the collapsed-id case.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_terminal_inflight_reap_guard.py` (10 passed).
2. Remove the reaper's in-flight refresh: 6 tests fail. Hold only the raw ids in `_execute_remote`: `test_execute_code_remote_holds_the_collapsed_environment_key` fails, with the reaper cleaning the environment the script runs in.
3. Manually: `TERMINAL_LIFETIME_SECONDS=10`, run `terminal(command="sleep 30")`, and check the environment is still registered afterwards (not run here; no long-lived backend on this box).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs
- [x] Only changes related to this fix
- [ ] `pytest tests/ -q`: ran `tests/tools/` (8640 passed, 103 failed); the same 103 fail on unmodified `ecfcbb6`
- [x] Tests added
- [x] Tested on: Linux (CachyOS), Python 3.13

### Documentation & Housekeeping

- [x] Docs: N/A (no user-facing change)
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform: no platform-specific paths touched
- [x] Tool descriptions/schemas: N/A
