### PR TITLE
fix(models): accept DeepSeek's version-less deepseek-flash id instead of folding it to the legacy name

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -93,19 +93,26 @@ _DEEPSEEK_RETIRED_ALIASES: frozenset[str] = frozenset({
     "deepseek-chat", "deepseek-reasoner"})
 
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-v4-pro", "deepseek-v4-flash"})
+    "deepseek-flash", "deepseek-v4-pro", "deepseek-v4-flash"})
 
 # First-class V-series IDs incl. future ``deepseek-v5-*`` and dated variants
 # (``deepseek-v4-flash-20260423``): verified real model ids, NOT aliases of ``deepseek-chat``.
 _DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v\d+([-.].+)?$")
 
+# Version-less tier IDs. With V4.1 DeepSeek dropped the ``v<N>`` infix from the official model id:
+# ``GET /models`` serves ``deepseek-flash`` and the pricing page says to use that name (the legacy
+# ``deepseek-v4-flash`` is only temporarily routed to it). Without this the id was silently rewritten
+# back to the legacy name. ``deepseek-pro`` is accepted on the same basis for the announced V4.1 Pro.
+_DEEPSEEK_TIER_RE = re.compile(r"^deepseek-(flash|pro)$")
+
 
 def _normalize_for_deepseek(model_name: str) -> str:
-    """Map a model input to a DeepSeek-accepted id: canonicals and ``deepseek-v<digit>…`` pass
-    through (future V-series work without a release); retired aliases and everything else become
-    ``deepseek-v4-flash``."""
+    """Map a model input to a DeepSeek-accepted id: canonicals, ``deepseek-v<digit>…`` and the
+    version-less ``deepseek-flash`` / ``deepseek-pro`` tier ids pass through (future releases work
+    without a code change); retired aliases and everything else become ``deepseek-v4-flash``."""
     bare = _strip_vendor_prefix(model_name).lower()
-    if bare in _DEEPSEEK_CANONICAL_MODELS or _DEEPSEEK_V_SERIES_RE.match(bare):
+    if (bare in _DEEPSEEK_CANONICAL_MODELS or _DEEPSEEK_V_SERIES_RE.match(bare)
+            or _DEEPSEEK_TIER_RE.match(bare)):
         return bare
     return "deepseek-v4-flash"
 

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -138,6 +138,42 @@ class TestDeepseekCanonicalAndReasonerMapping:
         assert _normalize_for_deepseek(model) == "deepseek-v4-flash"
 
 
+# ── DeepSeek version-less tier ids (V4.1: ``deepseek-flash``) ──────────
+
+class TestDeepseekVersionlessTierIds:
+    """With V4.1 DeepSeek dropped the ``v<N>`` infix from the official id:
+    ``GET /models`` serves ``deepseek-flash`` and the pricing page says to
+    use that name (``deepseek-v4-flash`` is only a temporary route).
+    ``deepseek-flash`` matched neither the canonical set nor the
+    ``deepseek-v<digit>`` regex, so a user who configured it was silently
+    sent on the wire as the legacy id.
+    """
+
+    @pytest.mark.parametrize("model", [
+        "deepseek-flash",
+        "deepseek-pro",
+        "DeepSeek-Flash",
+        "deepseek/deepseek-flash",
+    ])
+    def test_tier_id_passes_through(self, model):
+        assert _normalize_for_deepseek(model) == model.split("/")[-1].lower()
+
+    def test_provider_path_preserves_flash(self):
+        """End-to-end via normalize_model_for_provider — the id the user
+        put in config.yaml is the id that reaches api.deepseek.com."""
+        assert normalize_model_for_provider("deepseek-flash", "deepseek") == "deepseek-flash"
+
+    @pytest.mark.parametrize("model", [
+        "deepseek-foo",
+        "deepseek-flash-lite",
+        "deepseek-pro-max",
+        "deepseek-r1",
+    ])
+    def test_other_names_still_fold_to_v4_flash(self, model):
+        """The tier match is exact — anything else keeps the existing fallback."""
+        assert _normalize_for_deepseek(model) == "deepseek-v4-flash"
+
+
 # ── Regression: issue #78796 ───────────────────────────────────────────
 
 class TestIssue78796NvidiaPrefixRepair:


### PR DESCRIPTION
## What does this PR do?

Makes `hermes_cli/model_normalize.py` accept DeepSeek's new **version-less** official model id `deepseek-flash` (V4.1 Flash, released 2026-09-10) instead of silently rewriting it to the legacy `deepseek-v4-flash`.

**Symptom.** A user follows the DeepSeek docs and sets

```yaml
model:
  provider: deepseek
  default: deepseek-flash
```

but `normalize_model_for_provider("deepseek-flash", "deepseek")` returns the fallback id, so the `model=` that goes out on the wire never matches config. Nothing errors — the id is just quietly rewritten to a name the pricing page describes as a temporary route that will be dropped.

**Root cause.** `_normalize_for_deepseek` only passes through ids that are in `_DEEPSEEK_CANONICAL_MODELS` (`deepseek-v4-pro`, `deepseek-v4-flash`) or match `_DEEPSEEK_V_SERIES_RE = ^deepseek-v\d+([-.].+)?$`. `deepseek-flash` matches neither and hits the catch-all fallback.

**Official source.**
- Pricing page https://api-docs.deepseek.com/quick_start/pricing, model table footnote (1):
  > Use `deepseek-flash` as the model name. The legacy names `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` are still accepted, but the corresponding models have been retired, their requests are served by the DeepSeek-V4.1-Flash model and billed at the Flash price.
- `GET https://api.deepseek.com/models` currently lists `deepseek-flash` and `deepseek-v4-pro` only.

**Why this approach.** Minimal and additive: the id is added to the canonical set, plus an exact `^deepseek-(flash|pro)$` tier match so the announced V4.1 Pro (same naming scheme) works without another code change. Retired-alias handling and the fallback target are unchanged; catalogue / `fallback_models` / `default_aux_model` still point at `deepseek-v4-flash`, which the API still accepts — happy to move those in a follow-up if maintainers want.

## Related Issue

No existing issue found for this. Overlapping open PRs I found after opening this one — flagging them so maintainers can pick one rather than merge three:

- #107126 and #107148 also add `deepseek-flash` to `_DEEPSEEK_CANONICAL_MODELS` (plus metadata / pricing / plugin-profile changes).
- #107134 / #107136 touch catalogue + context length.

What this PR does that those don't: the exact `^deepseek-(flash|pro)$` tier match so the announced V4.1 **Pro** id works without another patch, and negative tests pinning that near-misses (`deepseek-flash-lite`, `deepseek-pro-max`, `deepseek-foo`) still fold. It is also the narrowest footprint (normalizer + its test file only). Happy to close this in favour of one of the others, or fold the tier regex + tests into whichever one maintainers prefer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/model_normalize.py`
  - add `deepseek-flash` to `_DEEPSEEK_CANONICAL_MODELS`
  - add `_DEEPSEEK_TIER_RE = ^deepseek-(flash|pro)$` and check it in `_normalize_for_deepseek`; anchored/exact, so `deepseek-flash-lite`, `deepseek-foo`, `deepseek-r1` … keep the existing fallback
  - update the docstring / rationale comment
- `tests/hermes_cli/test_model_normalize.py`
  - new `TestDeepseekVersionlessTierIds`: `deepseek-flash`, `deepseek-pro`, `DeepSeek-Flash`, `deepseek/deepseek-flash` pass through; end-to-end `normalize_model_for_provider("deepseek-flash", "deepseek") == "deepseek-flash"`; `deepseek-foo` / `deepseek-flash-lite` / `deepseek-pro-max` / `deepseek-r1` still fold to the fallback

## How to Test

1. On `main`, `python -c "from hermes_cli.model_normalize import normalize_model_for_provider as n; print(n('deepseek-flash','deepseek'))"` → prints `deepseek-v4-flash` (bug).
2. On this branch the same command prints `deepseek-flash`; `deepseek-foo` / `deepseek-r1` still print `deepseek-v4-flash`.
3. `python -m pytest tests/hermes_cli/test_model_normalize.py -q` → `32 passed`. Red→green verified: with only the test change on `main` the 5 new cases fail; with the source change they pass and the pre-existing 23 tests are unaffected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_model_normalize.py -q` and all tests pass (full `tests/ -q` not run locally; change is confined to one pure function)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure string logic, N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ python -m pytest tests/hermes_cli/test_model_normalize.py -q
................................                                         [100%]
32 passed in 0.72s
```
