### PR TITLE
fix(desktop): offer Start new session on the stranded-resume dead end (partial #106217)

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -15,8 +15,6 @@ import { COMPOSER_HEART_CONFIG, HeartField } from '@/components/chat/vibe-hearts
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { $sessionTileDragging, $sessionTileEdgeHover } from '@/components/pane-shell/tree/store'
 import { PromptOverlays } from '@/components/prompt-overlays'
-import { Button } from '@/components/ui/button'
-import { ErrorState } from '@/components/ui/error-state'
 import { TitleMenuTrigger } from '@/components/ui/title-menu-trigger'
 import { type HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -67,6 +65,7 @@ import { type DroppedFile, partitionDroppedFiles } from './hooks/use-composer-ac
 import { type DragKind, useFileDropZone } from './hooks/use-file-drop-zone'
 import { shouldShowIntro } from './intro-visibility'
 import { ProfileTag } from './profile-tag'
+import { ResumeExhaustedOverlay } from './resume-exhausted-overlay'
 import { isRouteSessionMismatch } from './route-session-state'
 import { useRuntimeMessageRepository } from './runtime-repository'
 import { ScrollToBottomButton } from './scroll-to-bottom-button'
@@ -699,19 +698,7 @@ const ChatViewContent = memo(function ChatViewContent({
             sessionKey={threadKey}
           />
           {resumeExhausted && routedSessionId && (
-            <div className="absolute inset-0 z-10 grid place-items-center bg-(--ui-chat-surface-background) px-8 py-10">
-              <ErrorState
-                className="max-w-sm"
-                description={t.desktop.resumeStrandedBody}
-                title={t.desktop.resumeStrandedTitle}
-              >
-                <div className="grid justify-items-center">
-                  <Button onClick={() => onRetryResume(routedSessionId)} size="sm" variant="outline">
-                    {t.desktop.resumeRetry}
-                  </Button>
-                </div>
-              </ErrorState>
-            </div>
+            <ResumeExhaustedOverlay onRetryResume={onRetryResume} sessionId={routedSessionId} />
           )}
           {showChatBar && <ScrollToBottomButton sessionId={activeSessionId} />}
           {/* Vibe hearts rise from the composer only when no pet is out (else

--- a/apps/desktop/src/app/chat/resume-exhausted-overlay.test.tsx
+++ b/apps/desktop/src/app/chat/resume-exhausted-overlay.test.tsx
@@ -1,0 +1,46 @@
+// Stranded resume overlay (#106217 remainder): the full-window
+// "Couldn't load this session" state hides the composer and used to offer
+// only Retry — a wall with no way out. It must offer Start new session
+// (the existing fresh-draft path) next to Retry. No lease/takeover touch:
+// this only navigates away from the stranded route.
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const requestFreshSession = vi.hoisted(() => vi.fn())
+
+vi.mock('@/store/profile', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  requestFreshSession: () => requestFreshSession()
+}))
+
+import { ResumeExhaustedOverlay } from './resume-exhausted-overlay'
+
+afterEach(() => {
+  cleanup()
+  requestFreshSession.mockClear()
+})
+
+describe('stranded resume overlay escape (#106217)', () => {
+  it('offers Start new session next to Retry instead of a retry-only dead end', async () => {
+    const onRetryResume = vi.fn()
+
+    render(<ResumeExhaustedOverlay onRetryResume={onRetryResume} sessionId="session-1" />)
+
+    expect(await screen.findByRole('button', { name: 'Start new session' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy()
+
+    screen.getByRole('button', { name: 'Start new session' }).click()
+    expect(requestFreshSession).toHaveBeenCalledTimes(1)
+    expect(onRetryResume).not.toHaveBeenCalled()
+  })
+
+  it('keeps Retry resuming the stranded session', async () => {
+    const onRetryResume = vi.fn()
+
+    render(<ResumeExhaustedOverlay onRetryResume={onRetryResume} sessionId="session-1" />)
+
+    screen.getByRole('button', { name: 'Retry' }).click()
+    expect(onRetryResume).toHaveBeenCalledWith('session-1')
+    expect(requestFreshSession).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/resume-exhausted-overlay.tsx
+++ b/apps/desktop/src/app/chat/resume-exhausted-overlay.tsx
@@ -1,0 +1,40 @@
+// Full-window fallback for a routed session whose resume exhausted every
+// retry (#106217 remainder). The overlay covers the thread AND the composer
+// is hidden underneath it, so a Retry-only action row is a wall with no way
+// out — the same dead-end class as the live-owner refusal. Offer Start new
+// session (the existing fresh-draft path, same copy as the turn-error card)
+// next to Retry. No lease/takeover touch: this only navigates away from the
+// stranded route; the failed session and its owner are left intact.
+import { Button } from '@/components/ui/button'
+import { ErrorState } from '@/components/ui/error-state'
+import { useI18n } from '@/i18n'
+import { requestFreshSession } from '@/store/profile'
+
+export function ResumeExhaustedOverlay({
+  onRetryResume,
+  sessionId
+}: {
+  onRetryResume: (sessionId: string) => void
+  sessionId: string
+}) {
+  const { t } = useI18n()
+
+  return (
+    <div className="absolute inset-0 z-10 grid place-items-center bg-(--ui-chat-surface-background) px-8 py-10">
+      <ErrorState
+        className="max-w-sm"
+        description={t.desktop.resumeStrandedBody}
+        title={t.desktop.resumeStrandedTitle}
+      >
+        <div className="grid justify-items-center gap-1.5">
+          <Button onClick={() => requestFreshSession()} size="sm" variant="outline">
+            {t.assistant.thread.errorStartNewSession}
+          </Button>
+          <Button onClick={() => onRetryResume(sessionId)} size="sm" variant="outline">
+            {t.desktop.resumeRetry}
+          </Button>
+        </div>
+      </ErrorState>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary (Partial, not Closes #106217)

Remainder after #106597, which fixed the inline turn-error card (SESSION_NOT_OWNED -> Start new session, Retry hidden). The other dead end from the same issue is still a wall: when a routed session's resume exhausts every retry, Desktop paints a full-window "Couldn't load this session" overlay while the composer stays hidden, with **Retry as the only action**. This PR adds **Start new session** next to Retry on that overlay, reusing the existing fresh-draft path (`requestFreshSession`, same i18n copy as the card).

## Boundary with #106597

- #106597: inline turn-error card, reason-code classifier, `errorStartNewSession` keys. Untouched here.
- This PR: stranded-resume overlay only (extracted to `ResumeExhaustedOverlay` so it is testable; `chat/index.tsx` net -13 lines). No new i18n keys — reuses `assistant.thread.errorStartNewSession`.
- Still out of scope: confirmed takeover / lease deletion. There is no safe backend attach API for Desktop (only cooperative `shared_runtime_url` owners), and `session_already_owned_message` explicitly forbids deleting a live owner's lease. The refusal text still tells the user to close the session in its owning surface.

## Test plan

- New `resume-exhausted-overlay.test.tsx`: Start new session fires `requestFreshSession` without resuming; Retry still resumes the stranded id. Sabotage run (button removed): new test fails as expected.
- Related suites green (`vitest --project ui --maxWorkers=1 --no-file-parallelism`): overlay (2) + `assistant-message` + `use-prompt-actions` = 141 passed; `thread-loading` + `use-route-resume` = 22 passed.
- `npm run typecheck` clean; `eslint` clean on touched files (one pre-existing warning elsewhere in `chat/index.tsx` left alone).

Partial #106217