### PR TITLE
fix(tools): heal a stale local session-cwd record instead of bricking the terminal (#107156)

### DIFF
--- a/gateway/run_agent_cache.py
+++ b/gateway/run_agent_cache.py
@@ -320,6 +320,16 @@ class GatewayAgentCacheMixin:
             store = getattr(self, attr, None)
             if isinstance(store, dict):
                 store.pop(session_key, None)
+        # The per-session cwd record lives module-level in tools.terminal_tool
+        # (not a runner attribute), so the getattr loop above can't reach it.
+        # Drop it here so /new and every other boundary clear the chat's cwd
+        # record too — otherwise a stale record outlives the conversation and a
+        # fresh session inherits it (#107156).
+        try:
+            from tools.terminal_tool import clear_session_cwd
+            clear_session_cwd(session_key)
+        except Exception:
+            logger.debug("Failed to clear session cwd at conversation boundary", exc_info=True)
         self._clear_session_boundary_security_state(session_key)
         logger.debug("Cleared conversation scope for %s (%s)", session_key, reason)
 

--- a/tests/gateway/test_conversation_scope_funnel.py
+++ b/tests/gateway/test_conversation_scope_funnel.py
@@ -53,3 +53,21 @@ def test_funnel_also_clears_boundary_security_state():
     assert OTHER in runner._pending_approvals
     assert KEY not in runner._update_prompt_pending
     assert KEY not in runner._pending_skills_reload_notes
+
+
+def test_funnel_clears_module_level_session_cwd_record(monkeypatch):
+    """The per-session cwd record lives module-level in tools.terminal_tool, not
+    on the runner, so the getattr loop can't reach it. The boundary must still
+    drop it, or a stale record outlives the conversation and a fresh session in
+    the same chat inherits it and bricks on its first command (#107156)."""
+    import tools.terminal_tool as tt
+
+    monkeypatch.setattr(tt, "_session_cwd", {})
+    tt.record_session_cwd(KEY, "/tmp/dead-workspace")
+    tt.record_session_cwd(OTHER, "/tmp/other-workspace")
+
+    runner = _bare_runner()
+    runner._clear_conversation_scope(KEY, reason="test")
+
+    assert tt.get_session_cwd(KEY) is None       # this chat's record dropped
+    assert tt.get_session_cwd(OTHER) == "/tmp/other-workspace"  # others untouched

--- a/tests/tools/test_session_cwd_store.py
+++ b/tests/tools/test_session_cwd_store.py
@@ -221,6 +221,46 @@ class TestCommandCwdReadsTheRecord:
         )
         assert resolved == "/config/default"
 
+
+class TestStaleLocalRecordSelfHeals:
+    """#107156 — on the local backend a recorded cwd that is gone/unenterable
+    must not be baked into ``cd <dead> || exit 126``; fall back to default_cwd so
+    the chat keeps working and the next command re-records a real dir."""
+
+    def test_missing_local_record_falls_back_to_default(self, tmp_path):
+        good = str(tmp_path)  # exists + enterable
+        tt.record_session_cwd("sess-a", str(tmp_path / "gone"))
+        resolved = tt._resolve_command_cwd(
+            workdir=None, default_cwd=good, session_key="sess-a", env_type="local",
+        )
+        assert resolved == good
+
+    def test_usable_local_record_is_kept(self, tmp_path):
+        live = tmp_path / "live"
+        live.mkdir()
+        tt.record_session_cwd("sess-a", str(live))
+        resolved = tt._resolve_command_cwd(
+            workdir=None, default_cwd=str(tmp_path), session_key="sess-a", env_type="local",
+        )
+        assert resolved == str(live)
+
+    def test_explicit_workdir_still_wins_over_the_check(self, tmp_path):
+        tt.record_session_cwd("sess-a", str(tmp_path / "gone"))
+        resolved = tt._resolve_command_cwd(
+            workdir="/explicit", default_cwd=str(tmp_path), session_key="sess-a", env_type="local",
+        )
+        assert resolved == "/explicit"
+
+    def test_missing_record_kept_verbatim_for_remote_backend(self, tmp_path):
+        """A local stat proves nothing about an ssh path — remote backends keep
+        their record and rely on their own existence checks."""
+        remote_path = str(tmp_path / "gone")
+        tt.record_session_cwd("sess-a", remote_path)
+        resolved = tt._resolve_command_cwd(
+            workdir=None, default_cwd=str(tmp_path), session_key="sess-a", env_type="ssh",
+        )
+        assert resolved == remote_path
+
     def test_cd_then_next_command_runs_in_the_new_dir(self, monkeypatch):
         """E2E through terminal_tool: the record round-trips cd state."""
         import json

--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -118,12 +118,20 @@ def test_explicit_workdir_does_not_persist_into_session_cwd(monkeypatch):
     assert all(cwd != "/one/off/dir" for _, cwd in recorded), recorded
 
 
-def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monkeypatch):
-    """Background process launches must also use the recorded session cwd."""
+def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(tmp_path, monkeypatch):
+    """Background process launches must also use the recorded session cwd.
+
+    Real dirs on disk: the local backend now validates a recorded cwd exists
+    before using it (#107156), so the invariant "recorded beats init" is only
+    meaningful for a live directory."""
+    live = tmp_path / "live"
+    init = tmp_path / "init"
+    live.mkdir()
+    init.mkdir()
 
     class FakeEnv:
         env = {}
-        cwd = "/workspace/live"
+        cwd = str(live)
 
     class FakeRegistry:
         def __init__(self):
@@ -141,8 +149,8 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
     monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: FakeEnv()})
     monkeypatch.setattr(terminal_tool, "_last_activity", {})
     monkeypatch.setattr(terminal_tool, "_session_cwd", {})
-    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {task_id: {"cwd": "/workspace/init"}})
-    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _minimal_terminal_config(cwd="/workspace/init"))
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {task_id: {"cwd": str(init)}})
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _minimal_terminal_config(cwd=str(init)))
     monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
     monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda value: value or "default")
     monkeypatch.setattr(
@@ -151,7 +159,7 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
         lambda command, env_type, **kwargs: {"approved": True},
     )
     monkeypatch.setattr(process_registry_mod, "process_registry", registry)
-    terminal_tool.record_session_cwd(task_id, "/workspace/live")
+    terminal_tool.record_session_cwd(task_id, str(live))
 
     result = json.loads(
         terminal_tool.terminal_tool(
@@ -167,7 +175,7 @@ def test_background_command_prefers_recorded_session_cwd_over_init_time_cwd(monk
     # still find and terminate this background process.
     assert registry.calls == [{
         "command": "sleep 1",
-        "cwd": "/workspace/live",
+        "cwd": str(live),
         "task_id": task_id,
         "owner_task_id": task_id,
         "session_key": task_id,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -781,6 +781,25 @@ def _resolve_command_cwd(
             recorded, env_type, default_cwd,
         )
         return default_cwd
+    # Local backend: a recorded cwd can point at a directory that has since been
+    # deleted or become unenterable (e.g. a tool removed its own workdir). Left
+    # verbatim it bakes a leading ``cd <dead> || exit 126`` into every command,
+    # so the command never runs and the record can never self-heal — a bare call
+    # dies before it can re-record — bricking the chat until the gateway
+    # restarts (#107156). Validate it with the same enterable-dir check the env
+    # recovery uses (``isdir`` alone passes ``/root`` for a non-root user) and,
+    # on failure, fall back to ``default_cwd`` so the next successful command
+    # re-records a real directory. Scoped to ``local``: a local stat proves
+    # nothing about an ssh/container path, so those keep their own guards.
+    if recorded and env_type == "local":
+        from tools.environments.local import _cwd_usable
+        if not _cwd_usable(recorded):
+            logger.info(
+                "Recorded session cwd %r is missing/unenterable on the local "
+                "backend; using %r so terminal commands keep working (#107156).",
+                recorded, default_cwd,
+            )
+            return default_cwd
     return recorded or default_cwd
 
 


### PR DESCRIPTION
## Problem

On the `local` backend, once a chat's recorded session cwd points at a directory that has been deleted or become unenterable (in the reported incident, the agent's own cleanup step removed it), **every** subsequent `terminal` call in that chat dies before the command runs:

```
/bin/bash: line 3: cd: /private/tmp/wiki-zh: No such file or directory
exit_code: 126
```

The record is keyed by the chat, not the session, so `/new` does not clear it — a fresh session in the same chat dies on its first command. It clears only on a gateway restart. In the reporter's incident this bricked one chat for ~5 hours across three sessions.

### Root cause (per #107156)

1. `record_session_cwd()` stores whatever cwd a command reports; nothing checks it still exists.
2. `_resolve_command_cwd()` returns the recorded path verbatim for the local backend (the container guard `_is_unusable_container_cwd()` only rejects host/relative paths).
3. `_wrap_command_script()` bakes it into a leading `cd <cwd> || exit 126` on every command.
4. The record can never self-heal: a bare call dies before it re-records, and the one shape that runs (`workdir=`) is excluded from writing the record. `_recover_cwd()` fixes the *process* launch dir but runs too late to change the already-built wrapper.
5. No conversation boundary owns the record — `_session_cwd` is not in `_CONVERSATION_SCOPED_STATE`.

## Fix

- **Validate on read (local only).** In `_resolve_command_cwd()`, when the recorded cwd fails `tools.environments.local._cwd_usable()` (the same enterable-dir check `_resolve_safe_cwd` uses — `isdir` alone passes `/root` for a non-root user), log it and return `default_cwd`. The next successful unscoped command re-records a real directory, so the chat self-heals. Scoped to `local`: a local stat proves nothing about an ssh/container path, so those backends keep their own guards, exactly as the issue asks.
- **Give the record a conversation boundary.** `_session_cwd` lives module-level in `tools.terminal_tool`, so the funnel's `getattr(self, attr)` loop can't reach it; clear it explicitly in `_clear_conversation_scope()` so `/new` and every other boundary drop the per-chat record too.

## Tests

- `tests/tools/test_session_cwd_store.py::TestStaleLocalRecordSelfHeals` — missing local record falls back to default; a usable record is kept; explicit `workdir=` still wins; a missing record is kept verbatim for a remote (`ssh`) backend.
- `tests/gateway/test_conversation_scope_funnel.py::test_funnel_clears_module_level_session_cwd_record` — the boundary drops this chat's record and leaves other chats' records untouched.
- Updated `test_background_command_prefers_recorded_session_cwd_over_init_time_cwd` to use real on-disk dirs, since the local backend now validates existence before using a recorded cwd.

All affected suites pass locally; ruff and the Windows-footgun gate are clean. The arm64-fork-Docker CI job is the known fork-wide failure, unrelated to this change.

Fixes #107156
