### PR TITLE
fix(cron): expand ${VAR} placeholders in per-job model/provider

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1355,7 +1355,7 @@ def _load_cron_job_config(job: dict, job_id: str, job_name: str) -> _CronJobConf
     """Load config.yaml and resolve the run's model: per-job override > cron.model (fleet default) >
     creation snapshot > HERMES_MODEL > config ``model:``. Re-read every tick (no cache) so
     ``hermes cron edit --model`` applies next tick."""
-    model = job.get("model") or os.getenv("HERMES_MODEL") or ""
+    model = _expand_env_vars(job.get("model")) or os.getenv("HERMES_MODEL") or ""
     _cron_default_provider = ""
     _cfg: dict = {}
     _model_cfg: Any = {}
@@ -1494,7 +1494,7 @@ def _resolve_job_runtime(job: dict, job_id: str, jc: _CronJobConfig) -> tuple[di
     from hermes_cli.auth import AuthError
 
     model = jc.model
-    requested = job.get("provider") or jc.cron_default_provider or None
+    requested = _expand_env_vars(job.get("provider")) or jc.cron_default_provider or None
     if not requested:
         global_provider = (
             str(jc.model_cfg.get("provider") or "").strip() if isinstance(jc.model_cfg, dict) else "")

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -220,3 +220,31 @@ class TestRuntimeResolutionTargetModel:
         assert success is True, error
         assert resolve_kwargs["target_model"] == "my-pinned-model"
         assert resolve_kwargs["requested"] == "openrouter"
+
+
+class TestJobEnvVarExpansion:
+    """Per-job model/provider support ``${VAR}`` expansion like config.yaml (#107157): a job saved
+    with ``"model": "${SOME_VAR}"`` must resolve to the env value at fire time, not pass the
+    literal placeholder to the provider."""
+
+    def test_model_and_provider_env_refs_expand_before_firing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TEST_CRON_MODEL_VAR", "expanded-model")
+        monkeypatch.setenv("TEST_CRON_PROVIDER_VAR", "expanded-provider")
+        job = _base_job(model="${TEST_CRON_MODEL_VAR}", provider="${TEST_CRON_PROVIDER_VAR}")
+        success, error, agent_kwargs, resolve_kwargs = _run(
+            job, tmp_path, current_provider="openrouter", current_model="other-model")
+
+        assert success is True, error
+        assert agent_kwargs["model"] == "expanded-model"
+        assert resolve_kwargs["requested"] == "expanded-provider"
+
+    def test_unresolved_env_ref_kept_verbatim(self, tmp_path, monkeypatch):
+        """Same policy as config.yaml: an unset var keeps the literal placeholder (not silently
+        dropped or crashed on) so the resulting provider error stays diagnosable."""
+        monkeypatch.delenv("TEST_CRON_MODEL_VAR_UNSET", raising=False)
+        job = _base_job(model="${TEST_CRON_MODEL_VAR_UNSET}", provider="openrouter")
+        success, error, agent_kwargs, _resolve_kwargs = _run(
+            job, tmp_path, current_provider="openrouter", current_model="other-model")
+
+        assert success is True, error
+        assert agent_kwargs["model"] == "${TEST_CRON_MODEL_VAR_UNSET}"


### PR DESCRIPTION
## What

`config.yaml` supports `${VAR}` / `${env:VAR}` references, expanded via `hermes_cli/config.py::_expand_env_vars`. Per-job `model` / `provider` fields in `~/.hermes/cron/jobs.json` did not get the same treatment: `cron/scheduler.py` read `job.get("model")` and `job.get("provider")` verbatim when resolving what to fire a job with, so a job saved with

```json
"model": "${GB10_LLM_DEFAULT}",
"provider": "${GB10_LLM_PROVIDER}"
```

fired with the literal placeholder string, and the provider rejected it (`HTTP 404: The model ${GB10_LLM_DEFAULT} does not exist`).

## Why

`_load_cron_job_config` already imports and calls `_expand_env_vars` on the config.yaml dict it reads for the fleet-wide/global model default (`cron/scheduler.py:1371`) — the per-job override just wasn't going through the same function. This applies the same expansion at the two places a job's own `model` / `provider` are read before firing:

- `cron/scheduler.py::_load_cron_job_config` — per-job `model`
- `cron/scheduler.py::_resolve_job_runtime` — per-job `provider`

Unresolved refs are kept verbatim (same policy as config.yaml), so an unset var still produces a diagnosable error message instead of silently vanishing.

Scope note: this fixes the primary reported bug (quoted `${VAR}` silently passed through literally). The issue's second ask — turning an *unquoted* `${VAR}` in jobs.json (which is invalid JSON, not a valid string) into a clear per-field error instead of the fatal "Cron database corrupted and unrepairable" — is a separate, larger change to the JSON-parsing/repair path in `cron/jobs.py::load_jobs`/`_parse_jobs_file` and is left out of this minimal fix.

## How to test

Added `TestJobEnvVarExpansion` to `tests/cron/test_cron_provider_pin.py`, exercising the full `run_job` path (matching the existing `TestSnapshotIsTheEffectivePin` style):

- `test_model_and_provider_env_refs_expand_before_firing`: job with `model="${TEST_CRON_MODEL_VAR}"`, `provider="${TEST_CRON_PROVIDER_VAR}"` and those env vars set → asserts the agent/resolver were called with the *expanded* values.
- `test_unresolved_env_ref_kept_verbatim`: unset var → placeholder stays literal (matches config.yaml behavior).

Confirmed the first test fails without the fix:

```
$ git checkout HEAD~1 -- cron/scheduler.py   # (equivalent: reverted the two-line change)
$ pytest tests/cron/test_cron_provider_pin.py -k EnvVarExpansion -q
F.
AssertionError: assert '${TEST_CRON_MODEL_VAR}' == 'expanded-model'
1 failed, 1 passed, 9 deselected in 1.42s
```

With the fix restored:

```
$ pytest tests/cron/test_cron_provider_pin.py -q
...........
11 passed in 2.17s
```

Full cron suite (unaffected):

```
$ pytest tests/cron/ -q
1212 passed, 19 skipped in 80.78s
```

Lint:

```
$ ruff check cron/scheduler.py tests/cron/test_cron_provider_pin.py
All checks passed!
```

## Platforms tested

Linux (CI container), via the repo's `pytest`/`ruff` toolchain — no platform-specific code paths touched.

Fixes #107157

---
This PR was prepared with AI assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
