### PR TITLE
fix(mcp): do not trip circuit breaker on application error responses

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -97,6 +97,20 @@ def _cleanup(mcp_tool_module, name: str) -> None:
         mcp_tool_module._server_breaker_opened_at.pop(name, None)
 
 
+def test_application_error_resets_circuit_breaker(monkeypatch):
+    """A returned MCP application error proves transport health, not an outage."""
+    from tools import mcp_tool
+    from tools.mcp_tool_handlers import _record_call_outcome
+
+    resets = []
+    monkeypatch.setattr(mcp_tool, "_reset_server_error", resets.append)
+    monkeypatch.setattr(mcp_tool, "_bump_server_error", lambda _: pytest.fail("application error tripped breaker"))
+
+    result = '{"error": "application failure"}'
+    assert _record_call_outcome("srv", result) == result
+    assert resets == ["srv"]
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool_handlers.py
+++ b/tools/mcp_tool_handlers.py
@@ -102,8 +102,8 @@ def _result_is_error(result) -> bool:
 
 
 def _record_call_outcome(server_name: str, result) -> Any:
-    """Breaker bookkeeping: an error payload from the tool itself still counts as a strike."""
-    (_core._bump_server_error if _result_is_error(result) else _core._reset_server_error)(server_name)
+    """A completed tools/call round-trip proves transport health; application-level errors do not trip breaker."""
+    _core._reset_server_error(server_name)
     return result
 
 


### PR DESCRIPTION
## What does this PR do?

Prevents completed MCP `tools/call` round-trips that return application errors (JSON payloads with `"error"` or `isError: true`) from counting as transport failures in the MCP circuit breaker.

Currently, `_record_call_outcome()` in `tools/mcp_tool_handlers.py` inspects the returned string and treats any JSON containing an `"error"` key as a failure strike (`_bump_server_error`). After 3 consecutive application errors (e.g. `lean-ctx` refusing out-of-scope paths, or filesystem servers returning "file not found"), the circuit breaker trips and disables the server for 60 seconds.

A completed RPC call proves that transport, stdio process, and JSON-RPC communication are healthy. Only genuine transport dropouts, dead child processes, timeouts, and unhandled exceptions should count as breaker strikes. This change resets the breaker error count on any completed RPC response.

## Related Issue

Fixes #11113
(Also addresses the circuit-breaker issue discussed in #47851)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool_handlers.py`: In `_record_call_outcome()`, reset the server error counter (`_core._reset_server_error(server_name)`) on completed RPC returns instead of striking the breaker when `"error"` is in the payload. Real transport exceptions still route through exception handlers.
- `tests/tools/test_mcp_circuit_breaker.py`: Added unit test `test_application_error_resets_circuit_breaker` verifying that returned application error payloads reset the circuit breaker rather than tripping it.

## How to Test

1. Run the targeted test:
   ```bash
   uv run --extra dev python -m pytest -q tests/tools/test_mcp_circuit_breaker.py::test_application_error_resets_circuit_breaker
   ```
2. Run the MCP circuit breaker test suite:
   ```bash
   uv run --extra dev python -m pytest -q tests/tools/test_mcp_circuit_breaker.py
   ```
   All 8 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux 6.8.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
