### PR TITLE
fix(deepseek): resolve deepseek-flash to 1M and stop rewriting it to the retired id

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -339,10 +339,13 @@ DEFAULT_CONTEXT_LENGTHS = {
     # Google / Gemma ("gemma4" is Ollama-style naming, e.g. gemma4:31b-cloud)
     "gemini": 1048576,
     "gemma-4": 256000, "gemma4": 256000, "gemma-4-31b": 256000, "gemma-3": 131072, "gemma": 8192,
-    # DeepSeek — V4 family is 1M; deepseek-chat/-reasoner alias v4-flash modes.
+    # DeepSeek — V4.1 family is 1M. The first-class id is now ``deepseek-flash``; the older
+    # ``deepseek-v4-flash`` / ``deepseek-chat`` / ``deepseek-reasoner`` still resolve server-side
+    # to V4.1-Flash, so every one of them stays at 1M. Bare ``deepseek`` keeps 128K on purpose:
+    # it is the short catch-all, and _longest_key_match prefers the longer (correct) key.
     # https://api-docs.deepseek.com/zh-cn/quick_start/pricing
     "deepseek-v4-pro": 1_000_000, "deepseek-v4-flash": 1_000_000, "deepseek-chat": 1_000_000,
-    "deepseek-reasoner": 1_000_000, "deepseek": 128000,
+    "deepseek-reasoner": 1_000_000, "deepseek-flash": 1_000_000, "deepseek": 128000,
     # Meta; Muse Spark family (1.1/1.2/1.3, -contributor(-free), meta/ prefixed) is 1M per OpenRouter,
     # models.dev and api.commandcode.ai /models — keep the "muse-spark" prefix (bare "muse" would match
     # muse-image/muse-voice). Thinking Machines inkling (covers inkling-small and :free/:batch variants)

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -87,13 +87,16 @@ _LOWERCASE_MODEL_PROVIDERS: frozenset[str] = frozenset({
     "xiaomi"})
 
 # DeepSeek's direct API only accepts first-class V-series IDs after the 2026-07-24 cut-off (HTTP 400
-# otherwise). Both retired aliases map to deepseek-v4-flash per the official docs (thinking mode is
-# controlled by extra_body.thinking on the profile), so saved configs can't keep sending them.
+# otherwise). Retired aliases and fuzzy names map to the id DeepSeek documents today,
+# ``deepseek-flash`` (V4.1-Flash); thinking mode is controlled by extra_body.thinking on the
+# profile, so saved configs can't keep sending the retired names.
 _DEEPSEEK_RETIRED_ALIASES: frozenset[str] = frozenset({
     "deepseek-chat", "deepseek-reasoner"})
 
+# ``deepseek-flash`` (V4.1) is the first-class id per the official docs; the V4 ids stay listed
+# because the API still accepts them (server-side routed to V4.1-Flash).
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-v4-pro", "deepseek-v4-flash"})
+    "deepseek-flash", "deepseek-v4-pro", "deepseek-v4-flash"})
 
 # First-class V-series IDs incl. future ``deepseek-v5-*`` and dated variants
 # (``deepseek-v4-flash-20260423``): verified real model ids, NOT aliases of ``deepseek-chat``.
@@ -103,11 +106,11 @@ _DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v\d+([-.].+)?$")
 def _normalize_for_deepseek(model_name: str) -> str:
     """Map a model input to a DeepSeek-accepted id: canonicals and ``deepseek-v<digit>…`` pass
     through (future V-series work without a release); retired aliases and everything else become
-    ``deepseek-v4-flash``."""
+    ``deepseek-flash`` — the V4.1 id DeepSeek documents today."""
     bare = _strip_vendor_prefix(model_name).lower()
     if bare in _DEEPSEEK_CANONICAL_MODELS or _DEEPSEEK_V_SERIES_RE.match(bare):
         return bare
-    return "deepseek-v4-flash"
+    return "deepseek-flash"
 
 
 def _strip_vendor_prefix(model_name: str) -> str:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -358,6 +358,7 @@ class TestDefaultContextLengths:
             "deepseek-v4-flash": 1_000_000,
             "deepseek-chat": 1_000_000,
             "deepseek-reasoner": 1_000_000,
+            "deepseek-flash": 1_000_000,
         }
         for key, value in expected_keys.items():
             assert key in DEFAULT_CONTEXT_LENGTHS, f"{key} missing"
@@ -379,6 +380,8 @@ class TestDefaultContextLengths:
                 ("deepseek/deepseek-v4-flash", 1_000_000),
                 ("deepseek-chat", 1_000_000),
                 ("deepseek-reasoner", 1_000_000),
+                ("deepseek-flash", 1_000_000),
+                ("deepseek/deepseek-flash", 1_000_000),
             ]
             for model_id, expected_ctx in cases:
                 actual = get_model_context_length(model_id)

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -114,17 +114,28 @@ class TestDeepseekVSeriesPassThrough:
 # ── DeepSeek post-2026-07-24 alias remapping ───────────────────────────
 
 class TestDeepseekCanonicalAndReasonerMapping:
-    """Retired aliases and fuzzy names rewrite to deepseek-v4-flash.
+    """Retired aliases and fuzzy names rewrite to the current first-class id.
 
     DeepSeek cut off ``deepseek-chat`` / ``deepseek-reasoner`` on
-    2026-07-24; sending them on the wire returns HTTP 400.
+    2026-07-24; sending them on the wire returns HTTP 400. The id DeepSeek
+    documents today is ``deepseek-flash`` (V4.1-Flash), so that is the
+    rewrite target rather than the retired ``deepseek-v4-flash``.
     """
 
 
     def test_provider_path_rewrites_reasoner(self):
         assert (
             normalize_model_for_provider("deepseek-reasoner", "deepseek")
-            == "deepseek-v4-flash"
+            == "deepseek-flash"
+        )
+
+    def test_current_first_class_id_passes_through(self):
+        """``deepseek-flash`` must reach the wire unchanged — it is the id
+        DeepSeek documents today, so rewriting it would be a downgrade."""
+        assert _normalize_for_deepseek("deepseek-flash") == "deepseek-flash"
+        assert (
+            normalize_model_for_provider("deepseek-flash", "deepseek")
+            == "deepseek-flash"
         )
 
     @pytest.mark.parametrize("model", [
@@ -134,8 +145,8 @@ class TestDeepseekCanonicalAndReasonerMapping:
         "deepseek-reasoning-preview",
         "deepseek-cot-experimental",
     ])
-    def test_reasoner_keywords_map_to_v4_flash(self, model):
-        assert _normalize_for_deepseek(model) == "deepseek-v4-flash"
+    def test_reasoner_keywords_map_to_flash(self, model):
+        assert _normalize_for_deepseek(model) == "deepseek-flash"
 
 
 # ── Regression: issue #78796 ───────────────────────────────────────────


### PR DESCRIPTION
DeepSeek's current first-class id is `deepseek-flash` (V4.1-Flash: **1M context**, 384K max
output — https://api-docs.deepseek.com/zh-cn/quick_start/pricing). Two stale spots made Hermes
degrade it:

1. `DEFAULT_CONTEXT_LENGTHS` has no `deepseek-flash` key, so `_longest_key_match` falls through to
   the short `deepseek` catch-all — **128K**. The compressor then starts compacting at ~100K
   against a 1M window. (Observed on a custom-provider route pointed at `api.deepseek.com`: context
   resolved to 128K / `detected` while the model actually serves 1M.)
2. `_normalize_for_deepseek` rewrites the new id back to the retired `deepseek-v4-flash`. The API
   still accepts it (server-side routed to V4.1-Flash), but it is no longer the documented id — and
   the dated-snapshot regex `^deepseek-v\\d+` does not match `deepseek-flash` either.

## Changes

- `deepseek-flash` -> `1_000_000` in `DEFAULT_CONTEXT_LENGTHS`.
- `deepseek-flash` added to `_DEEPSEEK_CANONICAL_MODELS` so it reaches the wire untouched.
- The rewrite target for retired aliases / fuzzy names moves from the retired `deepseek-v4-flash`
  to the current `deepseek-flash`.
- The V4 ids stay at 1M: the API still accepts them.

## Tests

- `tests/hermes_cli/test_model_normalize.py`: the two rewrite-target assertions updated; new
  `test_current_first_class_id_passes_through`.
- `tests/agent/test_model_metadata.py`: the existing 1M contract test now also covers
  `deepseek-flash` and `deepseek/deepseek-flash`.

## Verification

`scripts/run_tests.sh tests/hermes_cli/test_model_*.py tests/agent/test_model_metadata.py`
-> 34 files, **480 passed, 0 failed**.

Branched from `990473a`.
