### PR TITLE
fix(cron): expand ${VAR} env refs in job runtime overrides at fire time

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -38,7 +38,11 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import (
-    _expand_env_vars, load_config, resolve_cron_model_drift_defaults)
+    _ENV_REF_RE,
+    _expand_env_vars,
+    load_config,
+    resolve_cron_model_drift_defaults,
+)
 from hermes_cli.fallback_config import get_fallback_chain
 from hermes_time import now as _hermes_now
 from agent.interrupt_compat import request_hard_interrupt
@@ -1351,6 +1355,26 @@ def _snapshot_pin(job: dict, axis: str, current: str, job_id: str) -> str:
     return snapshot
 
 
+_ENV_REF_OVERRIDE_FIELDS = ("model", "provider", "base_url")
+
+
+def _expand_job_env_refs(job: dict, job_id: str) -> dict:
+    """Expand ``${VAR}`` / ``${env:VAR}`` refs in a job's runtime override fields against the
+    per-run environment (dotenv is reloaded just before this). Operates on a shallow copy so the
+    stored job keeps the templates — the resolved values are never persisted back, exactly like
+    the per-run ``api_key`` expansion (#9682), so a later env change applies next tick. Unresolved
+    refs stay verbatim; preflight reports them by field name."""
+    expanded = dict(job)
+    for field in _ENV_REF_OVERRIDE_FIELDS:
+        raw = expanded.get(field)
+        if isinstance(raw, str) and _ENV_REF_RE.search(raw):
+            expanded[field] = _expand_env_vars(raw)
+            if expanded[field] != raw:
+                logger.debug(
+                    "Job '%s': expanded env ref in field '%s'", job_id, field)
+    return expanded
+
+
 def _load_cron_job_config(job: dict, job_id: str, job_name: str) -> _CronJobConfig:
     """Load config.yaml and resolve the run's model: per-job override > cron.model (fleet default) >
     creation snapshot > HERMES_MODEL > config ``model:``. Re-read every tick (no cache) so
@@ -2250,6 +2274,7 @@ def run_job(
         if scope.workdir:
             logger.info("Job '%s': using task-scoped workdir %s", job_id, scope.workdir)
         _reload_dotenv_and_publish_delivery_target(job)
+        job = _expand_job_env_refs(job, job_id)
 
         jc = _load_cron_job_config(job, job_id, job_name)
         _cfg = jc.cfg

--- a/cron/scheduler_preflight.py
+++ b/cron/scheduler_preflight.py
@@ -314,6 +314,7 @@ def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
     follows the alert-once pattern from the dead-pin auto-pause (#73506).
     """
     for name, check in (
+        ("env_refs", lambda: _preflight_check_env_refs(job)),
         ("provider_key", lambda: _preflight_check_provider_key(job, cfg)),
         ("skills", lambda: _preflight_check_skills(job)),
         ("delivery", lambda: _preflight_check_delivery(job))):
@@ -324,6 +325,22 @@ def _preflight_job_config(job: dict, cfg: dict) -> Optional[str]:
             continue
         if reason:
             return reason
+    return None
+
+
+def _preflight_check_env_refs(job: dict) -> Optional[str]:
+    """After the per-run expansion, a field still matching ``${...}`` references an unset
+    variable — running would ship the literal placeholder to the provider (opaque 404). Name the
+    field so the operator can fix the environment without decoding a provider error."""
+    from hermes_cli.config import _ENV_REF_RE
+
+    for field in _sched._ENV_REF_OVERRIDE_FIELDS:
+        value = job.get(field)
+        if isinstance(value, str) and _ENV_REF_RE.search(value):
+            return (
+                f"unresolved env reference in field '{field}': {value!r} — set the "
+                "variable in the profile .env (or hardcode the value) so the job can run."
+            )
     return None
 
 

--- a/tests/cron/test_cron_job_env_refs.py
+++ b/tests/cron/test_cron_job_env_refs.py
@@ -1,0 +1,147 @@
+"""Cron job runtime overrides expand ``${VAR}`` refs at fire time (#107157).
+
+Background: ``config.yaml`` values are expanded by ``hermes_cli.config._expand_env_vars`` but
+``jobs.json`` string fields were never in that path — a job pinned with
+``"model": "${GB10_LLM_DEFAULT}"`` shipped the literal placeholder to the provider (HTTP 404
+"model does not exist"). The per-run dotenv reload already runs before model resolution, so the
+values are available at the seam; what was missing is the expansion itself.
+
+Contract (mirrors the per-run ``api_key`` expansion, #9682):
+  - ``run_job()`` expands ``${VAR}`` / ``${env:VAR}`` in the job's runtime override fields
+    (``model``, ``provider``, ``base_url``) on a shallow copy; the stored job keeps the templates
+    so a later env change applies next tick.
+  - A ref that is still unresolved after expansion blocks in preflight with the field named,
+    instead of an opaque provider 404.
+
+These tests exercise the full ``run_job`` path (real imports, mocked AIAgent +
+resolve_runtime_provider against a temp HERMES_HOME).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Ensure project root is importable.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.scheduler import run_job
+
+
+def _base_job(**overrides):
+    job = {
+        "id": "envref-test",
+        "name": "envref test",
+        "prompt": "hello",
+        "model": None,
+        "provider": None,
+        "provider_snapshot": None,
+        "model_snapshot": None,
+        "base_url": None,
+    }
+    job.update(overrides)
+    return job
+
+
+def _run(job, tmp_path, monkeypatch=None):
+    """Drive run_job against a temp config.yaml; returns ``(success, error, resolve_kwargs)``."""
+    (tmp_path / "config.yaml").write_text(
+        "model:\n  default: fallback-model\n  provider: openrouter\n"
+    )
+
+    resolve_kwargs = {}
+
+    def _resolve(**kwargs):
+        resolve_kwargs.update(kwargs)
+        return {
+            "api_key": "test-key",
+            "base_url": "https://example.invalid/v1",
+            "provider": kwargs.get("requested") or "openrouter",
+            "api_mode": "chat_completions",
+        }
+
+    fake_db = MagicMock()
+    with (
+        patch("cron.scheduler._hermes_home", tmp_path),
+        patch("cron.scheduler._get_hermes_home", return_value=tmp_path),
+        patch("cron.scheduler_delivery._resolve_origin", return_value=None),
+        patch("hermes_cli.env_loader.load_hermes_dotenv"),
+        patch("hermes_cli.env_loader.reset_secret_source_cache"),
+        patch("hermes_state_registry.acquire", return_value=fake_db),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=_resolve
+        ),
+        patch("run_agent.AIAgent") as mock_agent_cls,
+    ):
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent_cls.return_value = mock_agent
+        success, _output, _final, error = run_job(job)
+    return success, error, (resolve_kwargs or None)
+
+
+class TestJobEnvRefExpansion:
+    def test_model_and_provider_refs_expand_before_provider_resolution(self, tmp_path):
+        job = _base_job(model="${ENVREF_MODEL}", provider="${ENVREF_PROVIDER}")
+        import os
+
+        os.environ["ENVREF_MODEL"] = "glm-4.7"
+        os.environ["ENVREF_PROVIDER"] = "zai"
+        try:
+            success, error, resolve_kwargs = _run(job, tmp_path)
+        finally:
+            del os.environ["ENVREF_MODEL"]
+            del os.environ["ENVREF_PROVIDER"]
+        assert success is True, error
+        assert resolve_kwargs is not None
+        assert resolve_kwargs["target_model"] == "glm-4.7"
+        assert resolve_kwargs["requested"] == "zai"
+
+    def test_env_colon_ref_form_expands(self, tmp_path):
+        job = _base_job(model="${env:ENVREF_MODEL_V2}")
+        import os
+
+        os.environ["ENVREF_MODEL_V2"] = "kimi-k2"
+        try:
+            success, error, resolve_kwargs = _run(job, tmp_path)
+        finally:
+            del os.environ["ENVREF_MODEL_V2"]
+        assert success is True, error
+        assert resolve_kwargs is not None
+        assert resolve_kwargs["target_model"] == "kimi-k2"
+
+    def test_stored_job_template_is_not_mutated(self, tmp_path):
+        job = _base_job(model="${ENVREF_MODEL}")
+        import os
+
+        os.environ["ENVREF_MODEL"] = "glm-4.7"
+        try:
+            success, error, _kwargs = _run(job, tmp_path)
+        finally:
+            del os.environ["ENVREF_MODEL"]
+        assert success is True, error
+        assert job["model"] == "${ENVREF_MODEL}", (
+            "run_job must expand on a copy: persisting the resolved value would "
+            "freeze the job on one env value and leak secrets into jobs.json"
+        )
+
+    def test_unresolved_ref_blocks_with_named_field(self, tmp_path):
+        import os
+
+        job = _base_job(model="${ENVREF_DEFINITELY_UNSET_VAR_107157}")
+        os.environ.pop("ENVREF_DEFINITELY_UNSET_VAR_107157", None)
+        success, error, resolve_kwargs = _run(job, tmp_path)
+        assert success is False
+        assert error is not None
+        assert "[blocked_config]" in error
+        assert "unresolved env reference in field 'model'" in error
+        assert resolve_kwargs is None, (
+            "no provider resolution may happen for a blocked job"
+        )
+
+    def test_plain_values_are_untouched(self, tmp_path):
+        job = _base_job(model="plain-model-name", provider="openrouter")
+        success, error, resolve_kwargs = _run(job, tmp_path)
+        assert success is True, error
+        assert resolve_kwargs is not None
+        assert resolve_kwargs["target_model"] == "plain-model-name"
+        assert resolve_kwargs["requested"] == "openrouter"


### PR DESCRIPTION
## Summary

`jobs.json` runtime override fields (`model`, `provider`, `base_url`) now expand `${VAR}` / `${env:VAR}` references at fire time, matching `config.yaml` semantics (`hermes_cli.config._expand_env_vars`).

Fixes #107157.

## Root cause

`config.yaml` values go through `_expand_env_vars` when the scheduler loads them (`_load_cron_job_config`), but `job.get("model")` / `job.get("provider")` are read from `jobs.json` verbatim and were never in that path. A job pinned with `"model": "${GB10_LLM_DEFAULT}"` shipped the literal placeholder to `resolve_runtime_provider` → provider 404 "model does not exist". The per-run dotenv reload (`_reload_dotenv_and_publish_delivery_target`) already runs *before* model resolution, so the values are available at the seam — the expansion itself was missing.

Note: #15890's "implemented on main" covered the `config.yaml` side; the `jobs.json` fields were never in that path.

## Changes

1. **`cron/scheduler.py`** — `_expand_job_env_refs()`: right after the per-run dotenv reload, `run_job()` expands refs in the override fields on a **shallow copy**. The stored job keeps the templates: the resolved values are never persisted back, exactly like the per-run `api_key` expansion (#9682), so a later env change applies on the next tick.
2. **`cron/scheduler_preflight.py`** — new `env_refs` check (runs first, before the read-only `provider_key` probe which itself calls the resolver with the literal value): a field that still matches `${...}` after expansion references an unset variable, so the job blocks with `unresolved env reference in field 'model': ...` instead of an opaque provider 404. Fail-open, like every other preflight check.

## What's deliberately out of scope

The unquoted-placeholder JSON salvage (the "database corrupted" brick) — that's the `load_jobs()` store-repair contract (auto-repair paths deliberately never guess), and per-job salvage of syntactically-invalid JSON deserves its own discussion.

## Testing

- Reproduced on main via the full `run_job` path: literal `${GB10_LLM_DEFAULT}` reached `resolve_runtime_provider` as `target_model`.
- New spec `tests/cron/test_cron_job_env_refs.py` (full `run_job` path, real imports, mocked `AIAgent` / `resolve_runtime_provider`): expansion reaches the runtime for both `${VAR}` and `${env:VAR}` forms; stored template is not mutated; unresolved ref blocks with the named field and no provider resolution; plain values untouched. Mutation-verified (disabling the expansion call reddens 3 tests).
- Regression neighborhood green: `test_preflight_config`, `test_cron_provider_pin`, `test_run_one_job`, `test_jobs` (115).
- `ruff check` clean; format drift on touched files is byte-identical to clean main.
