### PR TITLE
fix(kanban): skip active_pr guard after changes_requested rework

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1134,8 +1134,10 @@ def check_respawn_guard(
     path never increments ``consecutive_failures``), ``"blocker_auth"``
     (quota/auth pattern; the breaker still trips eventually), then for the
     ready lane only ``"recent_success"`` (completed run within the window, unless
-    a re-queue event arrived after it — a deliberate re-run) and ``"active_pr"``
-    (PR URL in a recent comment; re-spawning risks a duplicate PR). The review
+    a re-queue event arrived after it — a deliberate re-run, including
+    ``changes_requested``) and ``"active_pr"``
+    (PR URL in a recent comment; re-spawning risks a duplicate PR, except
+    implementer rework after ``changes_requested``). The review
     lane skips the last two: they are the *inputs* to a review handoff. Stale /
     dead claim locks are NOT a guard reason — the reclaim passes own those.
     """
@@ -1196,7 +1198,8 @@ def check_respawn_guard(
         requeued_after = conn.execute(
             "SELECT 1 FROM task_events "
             "WHERE task_id = ? AND created_at >= ? "
-            "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
+            "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed', "
+            "'changes_requested') "
             "LIMIT 1",
             (task_id, completed_at),
         ).fetchone()
@@ -1204,13 +1207,27 @@ def check_respawn_guard(
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
-    pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, pr_cutoff),
-    ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+    #    Ready-lane rework exception: the latest ended run is the reviewer's
+    #    ``changes_requested`` handoff, so respawning the implementer is the
+    #    point of rework, not a duplicate-PR risk. Other latest outcomes
+    #    (completed / crashed / review_requested / rate_limited / missing)
+    #    keep the existing defer. ``id DESC`` breaks same-second ties with the
+    #    preceding ``review_requested`` run (both close in one wall-clock second).
+    latest_ended = conn.execute(
+        "SELECT outcome FROM task_runs "
+        "WHERE task_id = ? AND ended_at IS NOT NULL "
+        "ORDER BY ended_at DESC, id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if latest_ended is None or latest_ended["outcome"] != "changes_requested":
+        pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+        for c in conn.execute(
+            "SELECT body FROM task_comments "
+            "WHERE task_id = ? AND created_at >= ?",
+            (task_id, pr_cutoff),
+        ).fetchall():
+            if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+                return "active_pr"
 
     return None
 

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -478,6 +478,105 @@ def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
         ) == "rate_limit_cooldown"
 
 
+def test_active_pr_guard_skipped_for_ready_lane_after_changes_requested(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ready-lane rework after ``changes_requested`` must not trip ``active_pr``.
+
+    The implementer opened a PR (URL comment <24h), the reviewer requested
+    changes, and the card is back in ``ready`` assigned to the implementer.
+    That PR link is the *input* to the rework, not a duplicate-PR signal.
+    Without the exemption, ``check_respawn_guard`` returns ``active_pr`` for
+    24h and the implementer never respawns.
+    """
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: True)
+    monkeypatch.setattr(
+        cfgmod, "load_config",
+        lambda *a, **k: {"kanban": {"review_dispatch": True}},
+    )
+    pr_comment = "Opened https://github.com/example/repo/pull/123 for review."
+
+    with kbc.connect() as conn:
+        # CONTROL: ready-lane + PR URL, no changes_requested → still active_pr.
+        control_ready_id = kb.create_task(
+            conn, title="already PRed control", assignee="worker",
+        )
+        kb.add_comment(conn, control_ready_id, author="worker", body=pr_comment)
+
+        # CONTROL: review-lane + fresh PR URL → still skipped (existing B2).
+        control_review_id = kb.create_task(
+            conn, title="review control", assignee="reviewer",
+        )
+        claimed_review = kb.claim_task(conn, control_review_id)
+        assert claimed_review is not None
+        kb.add_comment(conn, control_review_id, author="worker", body=pr_comment)
+        assert kb.request_review(
+            conn, control_review_id, summary="PR ready",
+            expected_run_id=claimed_review.current_run_id,
+        )
+
+        # Lifecycle: implement → PR comment → review → changes_requested → ready.
+        tid = kb.create_task(conn, title="rework after review", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        kb.add_comment(conn, tid, author="worker", body=pr_comment)
+        # Stamp the PR comment in the past so a same-second changes_requested
+        # event is strictly newer (B) if the guard also compares timestamps.
+        _now = int(__import__("time").time())
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE task_comments SET created_at = ? WHERE task_id = ?",
+                (_now - 60, tid),
+            )
+        assert kb.request_review(
+            conn, tid, summary="PR ready for review",
+            reviewer="reviewer",
+            expected_run_id=claimed.current_run_id,
+        )
+        review = kb.claim_review_task(conn, tid)
+        assert review is not None
+        assert kb.request_changes(
+            conn, tid,
+            reason="Please address the review comments.",
+            expected_run_id=review.current_run_id,
+        ) == (True, "worker")
+        rework = kb.get_task(conn, tid)
+        assert rework is not None
+        assert rework.status == "ready"
+        assert rework.assignee == "worker"
+
+        # CONTROL assertions — must pass on pre-fix main and after the fix.
+        assert kbd.check_respawn_guard(conn, control_ready_id) == "active_pr"
+        assert kbd.check_respawn_guard(
+            conn, control_review_id, lane="review",
+        ) is None
+
+        # These assertions fail on pre-fix main (guard returns "active_pr").
+        assert kbd.check_respawn_guard(conn, tid) is None
+        res = kbd.dispatch_once(conn, dry_run=True)
+        spawned_ids = [s[0] for s in res.spawned]
+        guarded = dict(res.respawn_guarded)
+        assert control_review_id in spawned_ids
+        assert control_ready_id not in spawned_ids
+        assert guarded.get(control_ready_id) == "active_pr"
+        assert tid in spawned_ids
+        assert guarded.get(tid) != "active_pr"
+
+        # After changes_requested, a later rate-limited run still defers.
+        _later = int(__import__("time").time())
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_runs (task_id, profile, status, outcome, "
+                "started_at, ended_at) VALUES (?, 'worker', 'rate_limited', "
+                "'rate_limited', ?, ?)",
+                (tid, _later, _later + 5),
+            )
+        assert kbd.check_respawn_guard(conn, tid) == "rate_limit_cooldown"
+
+
 def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(
     kanban_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## What does this PR do?

`check_respawn_guard` already skips `active_pr` for the review lane, because a fresh GitHub PR URL is the *input* to a review handoff (B2). After `changes_requested` the card returns to the **ready** lane so the implementer can rework — and the same PR URL is the input to that spawn. The 24h comment scan still treated it as "a PR was already opened, don't respawn", so the dispatcher emitted `respawn_guarded {reason: active_pr}` for up to 24 hours and `kanban diagnostics` flagged `stranded_in_ready`.

This PR skips `active_pr` when the latest ended run (tie-broken with `id DESC` so a same-second `review_requested` does not hide it) has `outcome == "changes_requested"`. `changes_requested` is also added to the existing `recent_success` re-queue kinds. Ready-lane cards with a PR URL and no such run still defer. `rate_limit_cooldown` and `blocker_auth` stay first.

## Related Issue

Fixes #107165

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔒 Security fix
- [x] ✅ Tests

## Changes Made

- `hermes_cli/kanban_db_dispatch.py`: skip ready-lane `active_pr` when the latest ended run is `changes_requested`; include that event kind in the `recent_success` re-queue list.
- `tests/hermes_cli/test_kanban_review_lifecycle.py`: sibling of B2 covering implementer rework after `request_changes`, plus CONTROL (no CR still `active_pr`, review lane still skipped, later `rate_limited` still defers).

## How to Test

```
cd worktree
python -m pytest \
  tests/hermes_cli/test_kanban_review_lifecycle.py::test_active_pr_guard_skipped_for_ready_lane_after_changes_requested \
  tests/hermes_cli/test_kanban_review_lifecycle.py::test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane \
  tests/hermes_cli/test_kanban_review_lifecycle_complete.py::test_same_card_review_supports_changes_and_approval_without_block_loop \
  -q
# -> 3 passed

# Pre-fix (origin/main 6e07eb4838) the new test was RED:
#   assert kbd.check_respawn_guard(conn, tid) is None
#   AssertionError: assert 'active_pr' is None
```

## Related work (not duplicates)

- Existing B2 regression `test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane` — review-lane exemption only; this PR is the ready-lane rework sibling after `changes_requested`.
- `test_same_card_review_supports_changes_and_approval_without_block_loop` — lifecycle routing; does not cover the respawn guard.

## Review follow-up

- Latest-run tie-break (`ORDER BY ended_at DESC, id DESC`) is scoped to the rework check so the rate-limit `latest_run` query is unchanged.
- Fail-open: `completed` / `crashed` / `review_requested` / `rate_limited` / missing latest run still apply `active_pr`.
- Comments that only say `PR #N` (no full GitHub URL) still do not match `_RESPAWN_GUARD_PR_URL_RE`.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run relevant tests locally (see How to Test)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.6 (darwin 24.6.0)

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if config keys changed — N/A
- [x] I've considered cross-platform impact — dispatcher SQLite guard only
- [x] I've updated tool descriptions/schemas if tool behavior changed — N/A

## Proof / review

- Detection / Fail-open / Forbidden contract covered by focused tests.
- Self-review P0 = 0. Independent code-review skipped (2 files, 126 lines, no auth/crypto/state.db schema/gateway, P0=0).

Made with [Cursor](https://cursor.com)