### PR TITLE
fix(image_gen): resolve 404 in openai-codex provider and add GPT Image 2.5 support

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -39,11 +39,30 @@ logger = logging.getLogger(__name__)
 _MAX_ERROR_BODY_CHARS = 500
 
 # Hosts the ``image_generation`` tool call; ``API_MODEL`` does the image work.
-_CODEX_CHAT_MODEL = "gpt-5.5"
+_CODEX_CHAT_MODEL = os.getenv("OPENAI_CODEX_CHAT_MODEL", "gpt-5.6-luna")
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation and image editing "
     "requests by using the image_generation tool when provided.")
+
+MODELS = {
+    **{key: {**meta, "api_model": API_MODEL} for key, meta in GPT_IMAGE_2_TIERS.items()},
+    **{
+        model if quality == "auto" else f"{model}-{quality}": {
+            "display": f"GPT Image 2.5 {name} ({quality.title()})",
+            "speed": speed,
+            "strengths": strengths,
+            "api_model": model,
+            "quality": quality,
+        }
+        for model, name, speed, strengths in (
+            ("gpt-image-2.5-flare", "Flare", "Fast", "Everyday image generation and editing"),
+            ("gpt-image-2.5-sunburst", "Sunburst", "Slower", "Precision generation and editing"),
+        )
+        for quality in ("auto", "low", "medium", "high", "xhigh", "max")
+    },
+}
+
 
 _MAX_REFERENCE_IMAGES = 16
 _MAX_INPUT_IMAGE_BYTES = 25 * 1024 * 1024
@@ -76,7 +95,7 @@ def _summarize_error_body(body: str) -> str:
 
 def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     return resolve_static_model(
-        GPT_IMAGE_2_TIERS, DEFAULT_MODEL, env_var="OPENAI_IMAGE_MODEL", config_key="openai-codex")
+        MODELS, DEFAULT_MODEL, env_var="OPENAI_IMAGE_MODEL", config_key="openai-codex")
 
 
 def _read_codex_access_token() -> Optional[str]:
@@ -174,7 +193,8 @@ def _normalize_input_images(
 
 
 def _build_responses_payload(
-    *, prompt: str, size: str, quality: str, input_images: Optional[List[Dict[str, str]]] = None
+    *, prompt: str, size: str, quality: str, input_images: Optional[List[Dict[str, str]]] = None,
+    api_model: str = API_MODEL
 ) -> Dict[str, Any]:
     """Responses body for an image_generation call. No ``tool_choice``: Codex rejects every shape
     for forcing the hosted tool (looks it up as a *function* name), so the host model decides,
@@ -187,7 +207,7 @@ def _build_responses_payload(
         "input": [{"type": "message", "role": "user", "content": content}],
         "tools": [{
             "type": "image_generation",
-            "model": API_MODEL,
+            "model": api_model,
             "size": size,
             "quality": quality,
             "output_format": "png",
@@ -279,7 +299,8 @@ def _iter_sse_json(response: Any):
 
 
 def _collect_image_b64(
-    token: str, *, prompt: str, size: str, quality: str, input_images: Optional[List[Dict[str, str]]] = None
+    token: str, *, prompt: str, size: str, quality: str, input_images: Optional[List[Dict[str, str]]] = None,
+    api_model: str = API_MODEL
 ) -> Optional[Dict[str, str]]:
     """Stream a Codex Responses image_generation call → ``{"b64", "source": "final"|"partial"}`` or
     ``None``. A partial is kept only when no final arrives; callers must not treat it as success."""
@@ -293,7 +314,7 @@ def _collect_image_b64(
         "Content-Type": "application/json",
     })
     payload = _build_responses_payload(
-        prompt=prompt, size=size, quality=quality, input_images=input_images)
+        prompt=prompt, size=size, quality=quality, input_images=input_images, api_model=api_model)
     timeout = httpx.Timeout(300.0, connect=30.0, read=300.0, write=30.0, pool=30.0)
 
     final_b64: Optional[str] = None
@@ -322,7 +343,7 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
 
     provider_id = "openai-codex"
     label = "OpenAI (Codex auth)"
-    models = GPT_IMAGE_2_TIERS
+    models = MODELS
     default_model_id = DEFAULT_MODEL
     price = "varies"
 
@@ -333,7 +354,7 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
         return {
             "name": "OpenAI (Codex auth)",
             "badge": "free",
-            "tag": "gpt-image-2 via ChatGPT/Codex OAuth — no API key required; supports text and image inputs",
+            "tag": "GPT Image 2 and 2.5 Flare/Sunburst via ChatGPT/Codex OAuth — no API key required; supports text and image inputs",
             "env_vars": [],
             "post_setup_hint": (
                 "Sign in with `hermes auth codex` (or `hermes setup` → Codex) "
@@ -361,6 +382,7 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
 
         tier_id, meta = _resolve_model()
         size = size_for(aspect)
+        api_model = meta.get("api_model", API_MODEL)
         fail = error_factory("openai-codex", aspect, model=tier_id, prompt=prompt)
         attempts = _NONFINAL_RETRIES + 1
         try:
@@ -373,7 +395,7 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
             for attempt in range(attempts):
                 collected = _collect_image_b64(
                     token, prompt=prompt, size=size, quality=meta["quality"],
-                    input_images=input_images or None)
+                    input_images=input_images or None, api_model=api_model)
                 if collected and collected.get("source") == "final" and collected.get("b64"):
                     break
                 if attempt < _NONFINAL_RETRIES:
@@ -420,6 +442,7 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
             extra={
                 "size": size, "quality": meta["quality"], "input_image_count": len(input_images),
                 "image_source": image_source, "requested_size": size, "pixel_size": pixel_size,
+                "api_model": api_model,
             })
 
 

--- a/plugins/image_gen/openai-codex/plugin.yaml
+++ b/plugins/image_gen/openai-codex/plugin.yaml
@@ -1,5 +1,5 @@
 name: openai-codex
 version: 1.0.0
-description: "OpenAI image generation backed by ChatGPT/Codex OAuth (gpt-image-2 via the Responses image_generation tool). Saves generated images to $HERMES_HOME/cache/images/."
+description: "OpenAI image generation backed by ChatGPT/Codex OAuth (GPT Image 2 and GPT Image 2.5 Flare/Sunburst via the Responses image_generation tool). Saves generated images to $HERMES_HOME/cache/images/."
 author: NousResearch
 kind: backend

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -59,9 +59,18 @@ class TestMetadata:
     def test_default_model(self, provider):
         assert provider.default_model() == "gpt-image-2-medium"
 
-    def test_list_models_three_tiers(self, provider):
+    def test_picker_matches_resolvable_catalog(self, provider):
         ids = [m["id"] for m in provider.list_models()]
-        assert ids == ["gpt-image-2-low", "gpt-image-2-medium", "gpt-image-2-high"]
+        assert set(ids) == set(provider.models)
+        assert provider.default_model() in ids
+        assert "gpt-image-2.5-flare" in ids
+        assert "gpt-image-2.5-sunburst" in ids
+
+    def test_catalog_entries_have_display_speed_strengths(self, provider):
+        for entry in provider.list_models():
+            assert entry["display"].startswith("GPT Image 2")
+            assert entry["speed"]
+            assert entry["strengths"]
 
     def test_setup_schema_has_no_required_env_vars(self, provider):
         schema = provider.get_setup_schema()
@@ -127,7 +136,7 @@ class TestGenerate:
 
         captured = {}
 
-        def _collect(token, *, prompt, size, quality, input_images=None):
+        def _collect(token, *, prompt, size, quality, input_images=None, **kwargs):
             captured.update(codex_plugin._build_responses_payload(
                 prompt=prompt,
                 size=size,
@@ -141,7 +150,7 @@ class TestGenerate:
         result = provider.generate("a cat", aspect_ratio="portrait")
         assert result["success"] is True
 
-        assert captured["model"] == "gpt-5.5"
+        assert captured["model"] == "gpt-5.6-luna"
         assert captured["store"] is False
         assert captured["input"][0]["type"] == "message"
         assert captured["input"][0]["role"] == "user"
@@ -161,6 +170,30 @@ class TestGenerate:
         # Progressive previews disabled: partial frames were being saved as
         # finals and presented as smeared/unfinished images.
         assert tool["partial_images"] == 0
+
+    def test_codex_stream_request_shape_gpt_image_2_5(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", "gpt-image-2.5-flare")
+
+        captured = {}
+
+        def _collect(token, *, prompt, size, quality, input_images=None, api_model="gpt-image-2"):
+            captured.update(codex_plugin._build_responses_payload(
+                prompt=prompt,
+                size=size,
+                quality=quality,
+                input_images=input_images,
+                api_model=api_model,
+            ))
+            return {"b64": _b64_png(), "source": "final"}
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        result = provider.generate("a cat", aspect_ratio="landscape")
+        assert result["success"] is True
+        assert result["api_model"] == "gpt-image-2.5-flare"
+        assert captured["tools"][0]["model"] == "gpt-image-2.5-flare"
+
 
     def test_capabilities_advertise_image_inputs(self, provider):
         caps = provider.capabilities()


### PR DESCRIPTION
## Problem
When using the `openai-codex` image generation provider, calls to the Codex Responses API currently fail unconditionally with HTTP 404:
```
Codex Responses API returned HTTP 404: The model `gpt-5.5` does not exist or you do not have access to it.
```
This is caused by `_CODEX_CHAT_MODEL = "gpt-5.5"` hardcoded in `plugins/image_gen/openai-codex/__init__.py`. The `gpt-5.5` model identifier is rejected by the backend endpoint (`https://chatgpt.com/backend-api/codex/responses`). Additionally, the recently released `gpt-image-2.5-flare` and `gpt-image-2.5-sunburst` models were omitted from this provider.

## Solution
1. **Fix Host Chat Model (HTTP 404)**:
   - Make the host model configurable via `OPENAI_CODEX_CHAT_MODEL`, defaulting to `gpt-5.6-luna`.
2. **Support GPT Image 2.5 (Flare / Sunburst)**:
   - Expand the model catalog with `gpt-image-2.5-flare` and `gpt-image-2.5-sunburst` across all quality tiers (`auto`, `low`, `medium`, `high`, `xhigh`, `max`), matching the standard `openai` provider.
   - Pass the selected `api_model` through `_build_responses_payload` and `_collect_image_b64` so the underlying hosted `image_generation` tool correctly receives the requested model rather than falling back to `gpt-image-2`.
3. **Tests & Docs**:
   - Update `tests/plugins/image_gen/test_openai_codex_provider.py` to cover catalog resolution and the request payload shape for `gpt-image-2.5-flare`. All 30 unit tests pass.
   - Update `plugin.yaml` description.

## Verification
- **Unit Tests**: Ran `pytest tests/plugins/image_gen/test_openai_codex_provider.py` (30 passed).
- **Regression Tests**: Ran alongside `test_openai_provider.py` (all 78 tests passed).
- **Live Verification**: Verified against the live backend endpoint using OAuth credentials; confirmed `gpt-5.6-luna` host model + `gpt-image-2.5-flare` successfully generates a full PNG response (`source: "final"`).
