### PR TITLE
fix(cli): preserve paired widget colors on light terminals

### DIFF
--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -460,7 +460,7 @@ def get_active_goodbye(fallback: str = "Goodbye! ⚕") -> str:
 
 
 # Palette resolution order for prompt_toolkit styles: (name, skin color key, fallback). A
-# fallback starting with "@" names an earlier entry (so a missing key inherits its remapped value).
+# fallback starting with "@" names an earlier entry in the same palette.
 _STYLE_PALETTE = (
     ("prompt", "prompt", ""), ("input_rule", "input_rule", "#CD7F32"),
     ("title", "banner_title", "#FFD700"), ("text", "banner_text", "#FFF8DC"),
@@ -511,12 +511,18 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
         return {}
     # `prompt` is unset by default so typed text inherits the terminal's foreground (readable
     # on light and dark schemes); skins opt into a colored prompt symbol via `prompt` in YAML.
-    # Every read goes through skin.get_color (cli.py wraps it for light-mode remapping).
+    # Only text on the terminal's own background uses its light-mode remap. Widgets
+    # that paint a background must resolve both colors from the authored palette;
+    # remapping their ink first leaves dark text on a dark menu/status bar.
     palette: Dict[str, str] = {}
+    surface_palette: Dict[str, str] = {}
     for name, key, fallback in _STYLE_PALETTE:
         palette[name] = skin.get_color(key, palette[fallback[1:]] if fallback.startswith("@") else fallback)
-    # This badge paints both sides; foreground-only light remapping destroys its contrast.
-    palette["badge_bg"] = skin.colors.get(
-        "status_bar_strong", skin.colors.get("banner_title", "#FFD700"))
-    palette["badge_fg"] = skin.colors.get("status_bar_bg", "#1a1a2e")
-    return {cls: tpl.format(**palette) for cls, tpl in _STYLE_TEMPLATES.items()}
+        surface_palette[name] = skin.colors.get(
+            key, surface_palette[fallback[1:]] if fallback.startswith("@") else fallback)
+    surface_palette["badge_bg"] = surface_palette["status_strong"]
+    surface_palette["badge_fg"] = surface_palette["status_bg"]
+    return {
+        cls: tpl.format(**(surface_palette if "bg:" in tpl else palette))
+        for cls, tpl in _STYLE_TEMPLATES.items()
+    }

--- a/tests/cli/test_cli_light_mode.py
+++ b/tests/cli/test_cli_light_mode.py
@@ -136,6 +136,46 @@ class TestLightModeRemap:
 class TestSkinConfigHook:
     """Exercise the installed color hook, including self-painted badge colors."""
 
+    @pytest.mark.parametrize("skin_name", ["default", "slate", "daylight"])
+    def test_painted_surfaces_keep_their_colors_on_light_terminals(
+        self, cli_mod, monkeypatch, skin_name
+    ):
+        from prompt_toolkit.styles import Style
+        from hermes_cli.skin_engine import get_active_skin, set_active_skin
+
+        previous = get_active_skin().name
+        instance = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+        instance._tui_style_base = {}
+        try:
+            set_active_skin(skin_name)
+            monkeypatch.setattr(cli_mod, "_LIGHT_MODE_CACHE", False)
+            dark_styles = instance._build_tui_style_dict()
+            monkeypatch.setattr(cli_mod, "_LIGHT_MODE_CACHE", True)
+            light_styles = instance._build_tui_style_dict()
+            dark = Style.from_dict(dark_styles)
+            light = Style.from_dict(light_styles)
+            for name, value in dark_styles.items():
+                if "bg:" not in value:
+                    continue
+                before = dark.get_attrs_for_style_str(f"class:{name}")
+                after = light.get_attrs_for_style_str(f"class:{name}")
+                assert (after.color, after.bgcolor) == (before.color, before.bgcolor), name
+            assert light_styles["prompt"] == get_active_skin().get_color("prompt")
+        finally:
+            set_active_skin(previous)
+
+    def test_painted_surface_fallbacks_do_not_inherit_remapped_ink(self, cli_mod, monkeypatch):
+        from hermes_cli import skin_engine
+
+        skin = skin_engine.SkinConfig(name="minimal", colors={"banner_text": "#FFF8DC"})
+        monkeypatch.setattr(skin_engine, "_active_skin", skin)
+        monkeypatch.setattr(cli_mod, "_LIGHT_MODE_CACHE", False)
+        dark = skin_engine.get_prompt_toolkit_style_overrides()
+        monkeypatch.setattr(cli_mod, "_LIGHT_MODE_CACHE", True)
+        light = skin_engine.get_prompt_toolkit_style_overrides()
+        for name in ("status-bar", "completion-menu", "voice-status", "subagent-dock"):
+            assert light[name] == dark[name], name
+
     @pytest.mark.parametrize("skin_name", ["default", "sisyphus"])
     def test_badge_preserves_its_paired_colors_in_light_mode(
         self, cli_mod, monkeypatch, skin_name

--- a/website/docs/user-guide/features/skins.md
+++ b/website/docs/user-guide/features/skins.md
@@ -266,6 +266,7 @@ Hermes Mod respects the `HERMES_HOME` environment variable, so it works with [pr
 - Built-in skins load from `hermes_cli/skin_engine.py`.
 - Unknown skins automatically fall back to `default`.
 - `/skin` updates the active CLI theme immediately for the current session.
+- In the classic CLI, light-terminal adaptation applies to text on the terminal background. Completion menus, status bars, and other widgets with their own background keep their skin's foreground/background pair so the text stays readable.
 - User skins in `~/.hermes/skins/` take precedence over built-in skins with the same name.
 - Skin changes via `/skin` are session-only. To make a skin your permanent default, set it in `config.yaml`.
 - The `banner_logo` and `banner_hero` fields support Rich console markup (e.g., `[bold #FF0000]text[/]`) for colored ASCII art.


### PR DESCRIPTION
## What does this PR do?

Fixes unreadable completion menus and status bars in the classic CLI on light terminals. With the default skin, menu text becomes `#1A1A1A` on `#1a1a2e`; slate has the same problem (`#24292F` on `#151C2F`).

The light-mode hook remaps foregrounds in `SkinConfig.get_color()` before style generation pairs them with a widget background. The later background check in `_build_tui_style_dict()` therefore sees colors that have already been remapped.

Resolve styles with an explicit background from the original skin palette, including their fallback chains. Text on the terminal background keeps the existing light-mode adaptation. This also replaces the session badge's special case with the same rule used by menus, status bars, the subagent dock, and voice status.

## Related Issues

Related to #31403 (dark text on a dark footer) and #47210 (unreadable CLI menus and status bars on light Ghostty backgrounds).

This patch fixes foreground remapping for classic CLI widgets with an explicit background. It does not change terminal background detection or the separate Ink TUI renderer.

## Type of Change

- [x] Bug fix

## How to Test

1. Start the classic CLI in a light terminal with the default skin. `HERMES_LIGHT=1 hermes --cli` can force the detection result for reproduction.
2. Type `/` and inspect both selected and unselected menu entries and the status bar.
3. Repeat with `/skin slate`, then with a dark terminal. Widgets should retain their skin colors in either mode, while text on the terminal background still adapts.

Validation on macOS, Python 3.11:

```sh
scripts/run_tests.sh \
  tests/cli/test_cli_light_mode.py \
  tests/cli/test_cli_skin_integration.py \
  tests/hermes_cli/test_skin_engine.py \
  tests/hermes_cli/test_skin_cmd.py \
  --file-retries 0 -j 2
```

- 56 passed, 0 failed.
- The new regression cases produce 3 failures and 1 pass on the unpatched baseline (`6e07eb4838`).
- `scripts/check-windows-footguns.py` and `git diff --check` passed.
- The full suite was not run.

## Checklist

- [x] Read the contributing guide and searched existing PRs.
- [x] Conventional commit; changes limited to this fix, regression tests, and skin documentation.
- [x] Added regression coverage for default, slate, daylight, and missing-color fallbacks.
- [x] Tested on macOS; no platform-specific code or dependencies added.
- [ ] Full test suite.

## Screenshots

Default and slate with the same light terminal background. These show actual prompt_toolkit PTY output from a reproduction using the CLI's style builder and slash-command completer, replayed in xterm.js. The terminal settings are identical before and after; the status label is sample text.

Before:

![Before: dark menu text and status text on dark widget backgrounds](https://raw.githubusercontent.com/MoonMao42/hermes-agent/92c5edbdc714c23b0ce8d3bc7b2b5830a9166fa4/before.png)

After:

![After: menu and status text retain their paired skin colors](https://raw.githubusercontent.com/MoonMao42/hermes-agent/92c5edbdc714c23b0ce8d3bc7b2b5830a9166fa4/after.png)
