### PR TITLE
fix(desktop): keep streamed trailing text when final restates earlier text

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/trailing-text-after-tool.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/trailing-text-after-tool.test.tsx
@@ -1,0 +1,143 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { chatMessageText } from '@/lib/chat-messages'
+import { clearSessionTodos } from '@/store/todos'
+import type { RpcEvent } from '@/types/hermes'
+
+import { type MessageStreamHarness, renderMessageStream } from './test-harness'
+
+// #105927: a turn ending with text AFTER a tool call
+// (assistant(tool_calls) -> tool result -> assistant(text, stop)) must render
+// the trailing text in the live view, not only after reload/hydration.
+const SID = 'session-1'
+
+let stream: MessageStreamHarness
+
+function mountStream() {
+  stream = renderMessageStream(SID)
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}) {
+  act(() => stream.handleEvent({ payload, session_id: SID, type }))
+}
+
+function getState(): ClientSessionState {
+  return stream.state()
+}
+
+function assistantMessages(): string[] {
+  return getState()
+    .messages.filter(m => m.role === 'assistant' && !m.hidden)
+    .map(m => chatMessageText(m))
+}
+
+function allLiveText(): string {
+  return assistantMessages().join('\n')
+}
+
+const toolStart = () => emit('tool.start', { name: 'terminal', tool_id: 'tool-1', args: { command: 'ls' } })
+const toolComplete = () =>
+  emit('tool.complete', { name: 'terminal', tool_id: 'tool-1', args: { command: 'ls' }, result: 'file.txt' })
+
+describe('trailing assistant text after a tool call (#105927)', () => {
+  beforeEach(() => {
+    clearSessionTodos(SID)
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearSessionTodos(SID)
+    vi.restoreAllMocks()
+  })
+
+  it('renders trailing text streamed as deltas after tool.complete', async () => {
+    mountStream()
+    await emit('message.start', {})
+
+    toolStart()
+    toolComplete()
+
+    await emit('message.delta', { text: 'Here is the conclusion.' })
+    await emit('message.complete', { text: 'Here is the conclusion.' })
+
+    expect(allLiveText()).toContain('Here is the conclusion.')
+  })
+
+  it('renders trailing text that arrives only in the terminal frame (no deltas)', async () => {
+    mountStream()
+    await emit('message.start', {})
+
+    toolStart()
+    toolComplete()
+
+    await emit('message.complete', { text: 'Here is the conclusion.' })
+
+    expect(allLiveText()).toContain('Here is the conclusion.')
+  })
+
+  it('renders trailing text after an interim-sealed pre-tool narration', async () => {
+    mountStream()
+    await emit('message.start', {})
+
+    await emit('message.delta', { text: 'Let me check.' })
+    toolStart()
+    toolComplete()
+    await emit('message.interim', { text: 'Let me check.', already_streamed: true })
+
+    await emit('message.delta', { text: 'Here is the conclusion.' })
+    await emit('message.complete', { text: 'Here is the conclusion.' })
+
+    expect(allLiveText()).toContain('Let me check.')
+    expect(allLiveText()).toContain('Here is the conclusion.')
+  })
+
+  it('renders chunked trailing deltas after tool.complete', async () => {
+    mountStream()
+    await emit('message.start', {})
+
+    toolStart()
+    toolComplete()
+
+    await emit('message.delta', { text: 'Here is ' })
+    await emit('message.delta', { text: 'the conclusion.' })
+    await emit('message.complete', { text: 'Here is the conclusion.' })
+
+    expect(allLiveText()).toContain('Here is the conclusion.')
+  })
+
+  it('keeps streamed trailing text when the terminal frame restates only earlier narration (#105927)', async () => {
+    mountStream()
+    await emit('message.start', {})
+
+    await emit('message.delta', { text: 'Let me check.' })
+    toolStart()
+    toolComplete()
+
+    await emit('message.delta', { text: 'Here is the conclusion.' })
+    // Terminal frame carries only the pre-tool narration while the streamed
+    // tail already holds the conclusion: the live view must not delete the
+    // newer trailing segment (reload rehydrates it from stored rows).
+    await emit('message.complete', { text: 'Let me check.' })
+
+    expect(allLiveText()).toContain('Here is the conclusion.')
+  })
+
+  it('replaces streamed text when the terminal frame rewrites it (authoritative final wins)', async () => {
+    // Boundary of the #105927 fix: a terminal frame that says something NEW
+    // (not restated on screen) still supersedes the streamed draft — e.g. a
+    // rewrite after a retry. Only a terminal that restates on-screen text
+    // keeps the richer streamed tail.
+    mountStream()
+    await emit('message.start', {})
+
+    toolStart()
+    toolComplete()
+
+    await emit('message.delta', { text: 'draft conclusion' })
+    await emit('message.complete', { text: 'Final rewritten conclusion.' })
+
+    expect(allLiveText()).toContain('Final rewritten conclusion.')
+  })
+})

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -1266,6 +1266,22 @@ describe('mergeFinalAssistantText', () => {
     expect(result.filter(p => p.type === 'text')).toHaveLength(1)
     expect(result.filter(p => p.type === 'text')[0]).toMatchObject({ text: 'already on screen' })
   })
+
+  it('keeps streamed trailing text when the final restates only earlier text (#105927)', () => {
+    const parts = [
+      { type: 'text' as const, text: 'Let me check.' },
+      { type: 'tool-call' as const, toolCallId: 'tc1', toolName: 'terminal', args: {} as never, argsText: '{}' },
+      { type: 'text' as const, text: 'Here is the conclusion.' }
+    ]
+
+    const result = mergeFinalAssistantText(parts, 'Let me check.')
+
+    expect(result.map(part => part.type)).toEqual(['text', 'tool-call', 'text'])
+    expect(result.filter(p => p.type === 'text').map(p => (p as { text: string }).text)).toEqual([
+      'Let me check.',
+      'Here is the conclusion.'
+    ])
+  })
 })
 
 describe('collectUnspokenTurnSpeech', () => {

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -163,6 +163,12 @@ export function dedupeRepeatedTextInParts(parts: ChatMessagePart[]): ChatMessage
  *   NOT swallow a longer reasoning block that merely starts with it (#61447).
  * - Keeps all other part types (tool-call, image, etc.).
  * - Appends the final text as a new text part.
+ * - Keeps the streamed parts untouched when the final text restates text
+ *   already on screen (the final is equal to or contained in the streamed
+ *   text). The streamed tail is newer than the frame: wiping it would delete a
+ *   trailing segment the frame doesn't cover — e.g. a turn ending with text
+ *   after a tool call whose terminal frame restates only earlier narration
+ *   (#105927: live lost the conclusion until reload rehydrated it from rows).
  */
 export function mergeFinalAssistantText(
   parts: ChatMessagePart[],
@@ -186,7 +192,11 @@ export function mergeFinalAssistantText(
 
   // An authoritative final that is exactly the concatenation of streamed text
   // confirms the content without erasing text↔reasoning activity boundaries.
-  if (streamedText && streamedText === dedupeReference) {
+  // The same holds when the final only restates on-screen text (a subset of
+  // what streamed): the streamed tail already holds everything the frame
+  // says, plus newer segments the frame doesn't cover — deleting them would
+  // drop the turn's trailing text from the live view (#105927).
+  if (streamedText && dedupeReference && streamedText.includes(dedupeReference)) {
     return parts
   }
 


### PR DESCRIPTION
## 根因
mergeFinalAssistantText 仅在终端帧与流式拼接完全相等时才保留流式部分。当回合以工具调用后的尾文本结尾、而终端帧只复述 earlier 旁白时，旧逻辑把已在屏幕上的结论尾段整个抹掉，live 视图丢结论，直到 reload 从存储行 rehydrate 才恢复。

修复：终端帧文本被流式文本包含（复述屏上内容）时视为确认，直接保留更丰富的流式部分；终端帧带来新内容时仍以其为准（authoritative final 覆盖草稿）。

## 测试
- apps/desktop/src/lib/chat-messages.test.ts：新增 mergeFinalAssistantText 单测——final 只复述 earlier 文本时保留 tool-call 后的尾文本。
- apps/desktop/src/app/session/hooks/use-message-stream/trailing-text-after-tool.test.tsx：新增 6 个用例——delta 流式尾文本、仅终端帧尾文本、interim 密封后尾文本、分块 delta、复述 earlier 时保留尾文本、改写时 final 获胜。

## 验证
- 上述单测与 hook 集成测试通过。
- 未动其他逻辑，仅 #105927 相关三文件。

Closes #105927