### PR TITLE
fix(auxiliary): recognize OpenRouter budget limits

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2992,6 +2992,7 @@ _PAYMENT_KEYWORDS = (
     "too many tokens per day", "daily limit", "tokens per day", "daily quota", "resource exhausted",
     "resource_exhausted", "resource-exhausted", "resourceexhausted",
     "weekly usage limit", "weekly limit",
+    "budget limit exceeded", "key limit exceeded",
 )
 
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -89,6 +89,7 @@ _BILLING_PATTERNS = (
     "credits exhausted", "credits have been exhausted", "requires available credits",
     "account balance is too low", "no usable credits", "top up your credits", "payment required",
     "billing hard limit", "exceeded your current quota", "account is deactivated", "plan does not include",
+    "budget limit exceeded",
     "out of extra usage", "out of funds", "run out of funds", "balance_depleted",
     "model_not_supported_on_free_tier", "not available on the free tier",
 )

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1413,6 +1413,28 @@ class TestIsPaymentError:
         setattr(exc, "status_code", 403)
         assert _is_payment_error(exc) is True
 
+    @pytest.mark.parametrize("message", [
+        "Budget limit exceeded (monthly limit). Contact your org admin.",
+        "Key limit exceeded (total limit). Contact your org admin.",
+    ])
+    def test_openrouter_account_limits_are_payment(self, message):
+        exc = Exception(message)
+        exc.status_code = 403
+
+        assert _is_payment_error(exc) is True
+
+    def test_request_rate_limit_is_not_mistaken_for_payment(self):
+        exc = Exception("Request limit exceeded; retry after 60 seconds")
+        exc.status_code = 429
+
+        assert _is_payment_error(exc) is False
+
+    def test_budget_limit_is_still_status_gated(self):
+        exc = Exception("Budget limit exceeded (monthly limit)")
+        exc.status_code = 401
+
+        assert _is_payment_error(exc) is False
+
 
     def test_404_generic_not_found_is_not_payment(self):
         exc = Exception("Not Found")
@@ -1881,6 +1903,46 @@ class TestAuxiliaryFallbackLayering:
         mock_chain.assert_called()
         assert fallback_client.chat.completions.create.called
         # Main agent fallback should NOT be needed when chain succeeds
+        mock_main.assert_not_called()
+
+    def test_openrouter_monthly_budget_triggers_configured_fallback(self):
+        primary_client = MagicMock()
+        budget_error = Exception(
+            "Error code: 403 - Budget limit exceeded (monthly limit). "
+            "Contact your org admin."
+        )
+        budget_error.status_code = 403
+        primary_client.chat.completions.create.side_effect = budget_error
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = _DummyResponse(
+            "fallback response"
+        )
+
+        with patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(primary_client, "openrouter/model"),
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("openrouter", "openrouter/model", None, None, None),
+        ), patch(
+            "agent.auxiliary_client._try_configured_fallback_chain",
+            return_value=(
+                fallback_client,
+                "fallback-model",
+                "fallback_chain[0](custom)",
+            ),
+        ) as mock_chain, patch(
+            "agent.auxiliary_client._try_main_agent_model_fallback"
+        ) as mock_main:
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "compress this session"}],
+            )
+
+        assert result.choices[0].message.content == "fallback response"
+        assert mock_chain.call_args.args[:2] == ("compression", "openrouter")
+        assert mock_chain.call_args.kwargs["reason"] == "payment error"
         mock_main.assert_not_called()
 
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -217,6 +217,22 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.billing
         assert result.retryable is False
 
+    def test_openrouter_monthly_budget_403_is_billing(self):
+        e = MockAPIError(
+            "Budget limit exceeded (monthly limit). Contact your org admin.",
+            status_code=403,
+        )
+        result = classify_api_error(e, provider="openrouter")
+
+        assert result.reason == FailoverReason.billing
+        assert result.should_fallback is True
+
+    def test_unrelated_budget_403_stays_auth(self):
+        e = MockAPIError("Monthly budget report is unavailable", status_code=403)
+        result = classify_api_error(e, provider="openrouter")
+
+        assert result.reason == FailoverReason.auth
+
 
 
 
@@ -1710,5 +1726,4 @@ class TestServerInjectedParameterRejection:
         result = classify_api_error(e, provider="custom", model="m")
         assert result.reason == FailoverReason.format_error
         assert result.retryable is False
-
 


### PR DESCRIPTION
Fixes #107166

## Summary
- classify OpenRouter's exact `Budget limit exceeded` 403 as billing instead of authentication
- align the auxiliary payment gate with the main classifier for both budget-limit and key-limit exhaustion
- preserve ordinary request-rate-limit handling and the existing HTTP status gate
- add focused classifier, false-positive, status-gate, and configured-fallback regression coverage

The match intentionally uses the narrow provider body phrases rather than a generic `limit exceeded` keyword, which would incorrectly route transient request-rate limits through the payment fallback path.

## Validation
- reproduced current behavior before the patch: monthly budget 403 → main `auth`, auxiliary `False`
- focused runtime matrix after the patch:
  - monthly budget 403 → main `billing`, auxiliary `True`
  - key limit 403 → main `billing`, auxiliary `True`
  - request-limit 429 with retry guidance → main `rate_limit`, auxiliary `False`
  - unrelated monthly-budget wording on 403 → main `auth`, auxiliary `False`
- exercised `call_llm(task="compression")` through the configured fallback path; it returned the fallback response with reason `payment error`
- `python -m py_compile` passed for both implementation and test files
- `git diff --check` passed

The full pytest/ruff suite is left to CI because the available runner did not contain the repository's development dependencies.

## Duplicate check
Immediately before push, I rechecked issue comments, open/closed PR search, related branches, and recent code. No overlapping implementation or competing claim was present. This is adjacent to #107067/#107079 but covers a distinct OpenRouter budget body and also fixes the main-agent classifier.