### PR TITLE
fix(tui-gateway): preserve background jobs across client disconnects

### DIFF
--- a/tests/tui_gateway/test_background_process_lifetime.py
+++ b/tests/tui_gateway/test_background_process_lifetime.py
@@ -1,0 +1,368 @@
+"""Automatic session cleanup must wait for owned terminal work and its handoff."""
+
+import json
+import os
+from pathlib import Path
+import shlex
+import sys
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from tui_gateway import server
+from tools.process_registry import process_registry
+
+
+class _Timer:
+    def __init__(self, delay, callback):
+        self.delay, self.callback = delay, callback
+
+    def start(self):
+        pass
+
+    def cancel(self):
+        pass
+
+
+def _child_command(directory):
+    program = (
+        "import pathlib,time; "
+        f"p=pathlib.Path({str(directory)!r}); "
+        "p.joinpath('started').touch(); "
+        "deadline=time.monotonic()+30\n"
+        "while not p.joinpath('release').exists() and time.monotonic()<deadline:\n"
+        " p.joinpath('progress').write_text(str(time.monotonic()),encoding='utf-8'); time.sleep(.02)\n"
+        "print('BACKGROUND_RESULT',flush=True)"
+    )
+    return shlex.join([sys.executable, "-c", program])
+
+
+def _wait_for(predicate, label, timeout=10):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(.02)
+    raise AssertionError(label() if callable(label) else label)
+
+
+@pytest.mark.parametrize("reaper", ["orphan", "lru", "ttl", "explicit"])
+@pytest.mark.parametrize("ownership", ["owned", "foreign", "transferred"])
+@pytest.mark.parametrize("notify", [False, True])
+def test_automatic_reap_waits_for_owned_terminal_work(tmp_path, monkeypatch, reaper, ownership, notify):
+    from agent.client_lifecycle import ClientLifecycleMixin
+    import tools.process_registry as registry_module
+
+    registry = registry_module.ProcessRegistry()
+    monkeypatch.setattr(registry_module, "process_registry", registry)
+    monkeypatch.setattr(sys.modules[__name__], "process_registry", registry)
+    kill_receipts = []
+    kill = registry.kill_process
+
+    def record_kill(*args, **kwargs):
+        result = kill(*args, **kwargs)
+        kill_receipts.append(result)
+        return result
+
+    monkeypatch.setattr(registry, "kill_process", record_kill)
+
+    sid = "background-owner"
+    agent = SimpleNamespace(session_id=sid, _process_owner_task_ids={"owner-turn"})
+    agent.close = lambda: ClientLifecycleMixin._close_task_resources(agent, sid)
+    session = dict(agent=agent, session_key=sid, history=[], history_lock=threading.Lock(),
+                   running=False, transport=server._detached_ws_transport, source="desktop",
+                   created_at=0, last_active=0)
+    monkeypatch.setattr(server, "_sessions", {sid: session})
+    monkeypatch.setattr(server, "_pending_ws_reaps", {})
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 20)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    child = process_registry.spawn_local(
+        _child_command(tmp_path), cwd=str(tmp_path), task_id="default", session_key=sid,
+        owner_task_id="owner-turn" if ownership == "owned" else "other-turn")
+    child.notify_on_complete = notify
+    exit_observed, publish_exit = threading.Event(), threading.Event()
+    move_to_finished = process_registry._move_to_finished
+
+    def finish(process):
+        if process is child and notify and ownership != "foreign" and reaper != "explicit":
+            exit_observed.set()
+            assert publish_exit.wait(10), "test did not release completion publication"
+        move_to_finished(process)
+
+    monkeypatch.setattr(process_registry, "_move_to_finished", finish)
+    try:
+        _wait_for(lambda: (tmp_path / "started").exists(), "child did not start")
+        if ownership == "transferred":
+            assert process_registry.transfer_ownership(
+                child.id, from_owner="other-turn", to_owner="owner-turn",
+                to_task_id="default", to_session_key=sid) is child
+
+        def reap():
+            if reaper == "explicit":
+                server._close_session_by_id(sid)
+            elif reaper == "orphan":
+                server._schedule_ws_orphan_reap(sid)
+                server._pending_ws_reaps[sid].callback()
+            else:
+                predicate = (lambda s: server._session_is_lru_evictable(sid, s)) if reaper == "lru" else (
+                    lambda s: server._session_is_evictable(sid, s, time.time()))
+                server._close_session_by_id(sid, end_reason="lru_evict" if reaper == "lru" else "idle_timeout",
+                                            predicate=predicate)
+
+        reap()
+        assert (sid in server._sessions) is (ownership != "foreign" and reaper != "explicit")
+        if reaper == "explicit" and ownership != "foreign":
+            assert child._completion_event.wait(10), kill_receipts
+            assert child.termination_source == "agent_close"
+            assert child.completion_reason == "killed"
+            return
+        assert not child.exited, "automatic cleanup killed a live terminal job"
+        if ownership == "owned" and reaper == "orphan" and not notify:
+            from tools import process_registry_lifecycle
+
+            def unavailable(*args):
+                raise RuntimeError("temporary ownership lookup failure")
+
+            with monkeypatch.context() as transient:
+                transient.setattr(process_registry_lifecycle, "has_owned_work", unavailable)
+                reap()
+                assert sid in server._sessions, "indeterminate ownership authorized cleanup"
+        (tmp_path / "release").touch()
+        if notify and ownership != "foreign":
+            assert exit_observed.wait(10), "reader did not observe process exit"
+            reap()
+            assert sid in server._sessions, "cleanup crossed exit-to-publication boundary"
+            publish_exit.set()
+        assert child._completion_event.wait(10), "child did not finish"
+        assert child.exit_code == 0
+        assert "BACKGROUND_RESULT" in child.output_buffer
+        if ownership != "foreign":
+            if notify:
+                from tools.process_registry_notifications import format_process_notification
+
+                # A read-only poll must not suppress or acknowledge the continuation.
+                assert process_registry.poll(child.id)["status"] == "exited"
+                reap()
+                assert sid in server._sessions, "pending notification lost its owner"
+                events = process_registry.drain_notifications(owns_event=lambda e: e.get("session_id") == child.id,
+                                                              skip_poll_observed=False)
+                ready = [event for event, _ in events]
+                assert len(ready) == 1
+                admitted = []
+
+                def submit(*args, **kwargs):
+                    session["running"] = False
+                    admitted.append(args[3])
+                    return len(admitted) > 1
+
+                monkeypatch.setattr(server, "_run_prompt_submit", submit)
+                deferred = []
+                server._notif_handle_ready(sid, session, ready, set(), process_registry,
+                                          format_process_notification, deferred)
+                assert deferred == ready, "refused admission lost the completion"
+                reap()
+                assert sid in server._sessions
+                server._notif_handle_ready(sid, session, deferred, set(), process_registry,
+                                          format_process_notification, [])
+                assert len(admitted) == 2
+            reap()
+            assert sid not in server._sessions, "completed work made the session immortal"
+    finally:
+        publish_exit.set()
+        server._cancel_ws_orphan_reap(sid)
+        server._close_session_by_id(sid)
+        process_registry.kill_process(child.id, source="test", consume_output=True)
+
+
+def _offline_agent_factory(directory, use_pty):
+    from openai.types.chat import ChatCompletion
+    from run_agent import AIAgent
+
+    def make(sid, key, **kwargs):
+        agent = AIAgent(
+            api_key="test-key", base_url="http://127.0.0.1:1/v1", provider="openai-compat",
+            model="test-model", api_mode="chat_completions", max_iterations=6,
+            enabled_toolsets=["terminal"], quiet_mode=True, skip_context_files=True,
+            skip_memory=True, save_trajectories=False, session_id=key,
+            session_db=kwargs.get("session_db") or server._get_db(), platform="desktop")
+        agent._disable_streaming = True
+        calls = []
+
+        def respond(api_kwargs, **unused):
+            calls.append(api_kwargs)
+            pending = Path(directory, "provider-calls.tmp")
+            pending.write_text(json.dumps(calls, default=str), encoding="utf-8")
+            pending.replace(Path(directory, "provider-calls.json"))
+            message = {"role": "assistant", "content": "Launched background work"}
+            if len(calls) == 1:
+                message.update(content=None, tool_calls=[{
+                    "id": "launch-job", "type": "function", "function": {"name": "terminal", "arguments": json.dumps({
+                        "command": _child_command(directory), "background": True, "notify": True,
+                        "pty": use_pty})}}])
+            elif len(calls) >= 3:
+                message["content"] = "Observed BACKGROUND_RESULT"
+            return ChatCompletion.model_validate({
+                "id": f"response-{len(calls)}", "object": "chat.completion", "created": 1,
+                "model": "test-model", "choices": [{"index": 0, "message": message,
+                    "finish_reason": "tool_calls" if len(calls) == 1 else "stop"}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20}})
+
+        agent._interruptible_api_call = respond
+        agent._interruptible_streaming_api_call = respond
+        return agent
+    return make
+
+
+@pytest.mark.parametrize("isolated", [False, True])
+@pytest.mark.parametrize("use_pty", [False, pytest.param(True, marks=pytest.mark.macos_only, id="macos-pty"),
+                                   pytest.param(True, marks=pytest.mark.linux_only, id="linux-pty")])
+def test_real_websocket_background_completion_survives_disconnect(tmp_path, monkeypatch, isolated, use_pty):
+    import socket
+    from fastapi import FastAPI, WebSocket
+    import uvicorn
+    from websockets.sync.client import connect
+    from tui_gateway.host_supervisor import HostSupervisor
+    from tui_gateway.ws import handle_ws
+    from hermes_state import SessionDB
+
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text("approvals:\n  mode: 'off'\nterminal:\n  env_type: local\n", encoding="utf-8")
+    db = SessionDB(db_path=home / "state.db")
+
+    monkeypatch.setattr(server, "_sessions", {})
+    monkeypatch.setattr(server, "_pending_ws_reaps", {})
+    monkeypatch.setattr(server, "_db", db)
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", .2)
+    monkeypatch.setattr(server, "_make_agent", _offline_agent_factory(tmp_path, use_pty))
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda *a: None)
+    monkeypatch.setattr(server, "_load_dashboard_process_isolation_config", lambda: {"turn_isolation": isolated})
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    supervisor = None
+    host_frames = []
+    if isolated:
+        # Keep the serving session lazy so this case exercises the child-owned
+        # path instead of racing the optional in-process agent pre-warm.
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+        supervisor = HostSupervisor(
+            argv=[sys.executable, str(Path(__file__).resolve()), "host", str(tmp_path), str(int(use_pty))],
+            registry_path=tmp_path / "host.json", env={"HERMES_HOME": os.environ["HERMES_HOME"]},
+            expected_hermes_home=os.environ["HERMES_HOME"], rpc_sink=server._relay_compute_host_rpc,
+            heartbeat_secs=.1, autostart=False)
+        monkeypatch.setattr(server, "_compute_host_supervisor", supervisor)
+        monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda *a: supervisor)
+        handle_frame = supervisor._handle_host_frame
+
+        def observe_frame(frame):
+            if frame.get("type") in {"turn.end", "turn.error"}:
+                host_frames.append(frame)
+            return handle_frame(frame)
+
+        monkeypatch.setattr(supervisor, "_handle_host_frame", observe_frame)
+    app = FastAPI()
+
+    @app.websocket("/api/ws")
+    async def endpoint(ws: WebSocket):
+        await handle_ws(ws)
+
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    url = f"ws://127.0.0.1:{sock.getsockname()[1]}/api/ws"
+    uv = uvicorn.Server(uvicorn.Config(app, log_level="error", lifespan="off", loop="asyncio"))
+    worker = threading.Thread(target=uv.run, kwargs={"sockets": [sock]}, daemon=True)
+    worker.start()
+    sequence = 0
+
+    def rpc(ws, method, params):
+        nonlocal sequence
+        sequence += 1
+        ws.send(json.dumps({"jsonrpc": "2.0", "id": sequence, "method": method, "params": params}))
+        while True:
+            for line in ws.recv(timeout=15).splitlines():
+                reply = json.loads(line)
+                if reply.get("id") == sequence:
+                    assert "error" not in reply, reply
+                    return reply["result"]
+
+    try:
+        _wait_for(lambda: uv.started, "WebSocket server did not start")
+        with connect(url, max_queue=None) as ws:
+            created = rpc(ws, "session.create", {"source": "desktop", "cwd": str(tmp_path)})
+            sid = created["session_id"]
+            session = server._sessions[sid]
+            submitted = rpc(ws, "prompt.submit", {"session_id": sid, "text": "Run the finite background job"})
+            assert bool(submitted.get("turn_isolation")) is isolated
+            _wait_for(lambda: (tmp_path / "started").exists() and not session["running"],
+                      lambda: {"error": "foreground did not finish after launching the real terminal child",
+                               "running": session["running"], "history": session["history"],
+                               "host_stderr": supervisor._stderr_tail if supervisor else [],
+                               "host_frames": host_frames,
+                               "calls": (tmp_path / "provider-calls.json").read_text(encoding="utf-8")
+                               if (tmp_path / "provider-calls.json").exists() else "none"}, timeout=20)
+            stored_id = session["session_key"]
+            if isolated:
+                assert session["agent"] is None
+                assert supervisor.is_running()
+        _wait_for(lambda: server._ws_session_is_detached(session), "WebSocket did not detach")
+        progress = (tmp_path / "progress").read_text(encoding="utf-8")
+        # Long enough to cross ten shortened grace periods, using the actual timers.
+        threading.Event().wait(2)
+        assert sid in server._sessions, "orphan timer reclaimed the owner of the running job"
+        assert (tmp_path / "progress").read_text(encoding="utf-8") != progress, "background child stopped making progress"
+        if isolated:
+            assert supervisor.has_background_work(sid, session["_compute_host_session_token"])
+            assert not supervisor.has_background_work(sid, "foreign-session-generation")
+            with monkeypatch.context() as observation:
+                def no_startup(*args):
+                    raise AssertionError("cleanup attempted host startup/configuration")
+                observation.setattr(server, "_get_compute_host_supervisor", no_startup)
+                assert server._compute_host_has_background_work(sid, session)
+        with connect(url, max_queue=None) as ws:
+            resumed = rpc(ws, "session.resume", {"session_id": stored_id})
+            assert resumed["session_id"] == sid
+            assert server._sessions[sid] is session
+        _wait_for(lambda: server._ws_session_is_detached(session), "reconnected client did not detach")
+        (tmp_path / "release").touch()
+        _wait_for(lambda: len(json.loads((tmp_path / "provider-calls.json").read_text(encoding="utf-8"))) >= 3,
+                  "completion did not reach a continuation turn")
+        _wait_for(lambda: "Observed BACKGROUND_RESULT" in json.dumps(
+            server._get_db().get_messages_as_conversation(stored_id)), "completion was not persisted")
+        _wait_for(lambda: sid not in server._sessions, "settled completion retained an idle session forever")
+        with connect(url) as ws:
+            rpc(ws, "session.resume", {"session_id": stored_id})
+            history = server._get_db().get_messages_as_conversation(stored_id)
+            assert sum(m.get("content") == "Observed BACKGROUND_RESULT" for m in history) == 1
+        calls = json.loads((tmp_path / "provider-calls.json").read_text(encoding="utf-8"))
+        assert len(calls) == 3
+        assert calls[0]["messages"][0] == calls[2]["messages"][0], "completion rebuilt the cached system prefix"
+    finally:
+        (tmp_path / "release").touch()
+        for sid in list(server._sessions):
+            server._cancel_ws_orphan_reap(sid)
+            server._close_session_by_id(sid)
+        for stop, poller in server._notification_pollers:
+            stop.set()
+            poller.join(5)
+        if supervisor is not None:
+            supervisor.shutdown()
+        uv.should_exit = True
+        worker.join(5)
+        sock.close()
+        db.close()
+
+
+if __name__ == "__main__":
+    from tui_gateway.compute_host import run_host
+
+    server._make_agent = _offline_agent_factory(Path(sys.argv[2]), bool(int(sys.argv[3])))
+    server._sync_agent_model_with_config = lambda *a: None
+    # The real serving RPC already holds the lease. Current main tries to
+    # acquire it again in the child and refuses the turn before any model call.
+    # Model this parent-authorized admission here; this test does NOT certify
+    # the separate cross-process lease protocol. All job/notification/teardown
+    # behavior and the host pipes below are production code.
+    server._ensure_active_session_slot = lambda *a: None
+    run_host(stdout=sys.__stdout__)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -410,6 +410,7 @@ class ProcessSession:
     # session was closed at a user boundary (/new) instead of injecting into the NEW one.
     parent_session_id: str = ""
     notify_on_complete: bool = False            # Queue agent notification on exit
+    notification_delivered: bool = False        # Owning UI admitted the completion turn (not a poll/read)
     watch_patterns: List[str] = field(default_factory=list)
     _watch_hits: int = field(default=0, repr=False)          # total matches delivered
     _watch_suppressed: int = field(default=0, repr=False)    # matches dropped by rate limit

--- a/tools/process_registry_lifecycle.py
+++ b/tools/process_registry_lifecycle.py
@@ -1,0 +1,37 @@
+"""Owner-lifetime observations for the UI backend's automatic session cleanup."""
+
+
+def has_owned_work(registry, owner_task_ids) -> bool:
+    """In-memory only: callers may hold lifecycle locks; never probe a PID here.
+
+    A reader can mark exited before moving/publishing its result. Keep the owner
+    through that transition and, for notify jobs, until the continuation accepts
+    the result. Polling is observation, not notification delivery.
+    """
+    owners = frozenset(owner_task_ids)
+    with registry._lock:
+        if any(s.owner_task_id in owners for s in registry._running.values()):
+            return True
+        return any(s.owner_task_id in owners and (
+            not s._completion_event.is_set() or (
+                s.notify_on_complete and not s.notification_delivered
+                and s.id not in registry._completion_consumed))
+            for s in registry._finished.values())
+
+
+def refresh_owned_work(registry, owner_task_ids) -> None:
+    """Refresh recovered processes outside the UI lifecycle locks."""
+    owners = frozenset(owner_task_ids)
+    with registry._lock:
+        detached = [s for s in registry._running.values() if s.owner_task_id in owners and s.detached]
+    for session in detached:
+        registry._refresh_detached_session(session)
+
+
+def acknowledge_notifications(registry, events) -> None:
+    """Admission receipt, separate from wait/log consumption of process output."""
+    with registry._lock:
+        for event in events:
+            session = registry._finished.get(event.get("session_id"))
+            if session is not None:
+                session.notification_delivered = True

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -63,6 +63,7 @@ class ComputeHost:
         heartbeat_secs: int | float | None = None) -> None:
         self._stdout = stdout or sys.stdout
         self._write_lock = threading.Lock()
+        self._background_state_lock = threading.Lock()
         self._executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=max_workers or _default_workers(), thread_name_prefix="compute-host-turn")
         self._closed = threading.Event()
@@ -91,7 +92,14 @@ class ComputeHost:
 
     def _reply(self, kind: str, sid: str, request_id: Any, **extra: Any) -> None:
         """Emit a per-session frame keyed by the request it answers."""
-        self.emit({"type": kind, "sid": sid, "request_id": request_id, **extra})
+        frame = {"type": kind, "sid": sid, "request_id": request_id, **extra}
+        if kind in {"turn.end", "turn.error"}:
+            # Publish ownership before the serving process makes the turn idle.
+            with self._background_state_lock:
+                frame["background_work"] = self._background_work_snapshot()
+                self.emit(frame)
+        else:
+            self.emit(frame)
 
     def close(self) -> None:
         self._closed.set()
@@ -289,6 +297,8 @@ class ComputeHost:
                     session[key] = str(frame[key])
         else:
             session = self._build_server_session(server, frame, sid)
+        if frame.get("session_token"):
+            session["_compute_host_session_token"] = frame["session_token"]
         if isinstance(frame.get("attached_images"), list):
             session["attached_images"] = list(frame.get("attached_images") or [])
         return session
@@ -439,14 +449,37 @@ class ComputeHost:
         with self._turn_futures_lock:
             return [f for f in self._turn_futures if not f.done()]
 
+    def _background_work_snapshot(self) -> dict:
+        from tui_gateway import server
+        from tools.process_registry import process_registry
+        from tools.process_registry_lifecycle import refresh_owned_work
+
+        with server._sessions_lock:
+            sessions = list(server._sessions.items())
+        work = {}
+        for sid, session in sessions:
+            token = session.get("_compute_host_session_token")
+            if not token or session.get("_finalized"):
+                continue
+            pending = True
+            try:
+                refresh_owned_work(process_registry, getattr(session.get("agent"), "_process_owner_task_ids", ()))
+                pending = server._session_has_background_work(sid, session)
+            except Exception:
+                logging.getLogger(__name__).debug("compute host background work unavailable sid=%s", sid, exc_info=True)
+            work[sid] = {"session_token": token, "pending": pending, "running": bool(session.get("running"))}
+        return work
+
     def _heartbeat_loop(self) -> None:
         while not self._closed.wait(self._heartbeat_secs):
             active_turns = len(self._live_turns())
             with self._progress_lock:
                 counter = self._progress_counter
-            self.emit({
-                "type": "hb", "active_turns": active_turns, "progress_counter": counter,
-                "rss_mb": _rss_mb(os.getpid())})
+            # A heartbeat sampled before turn.end must not overwrite newer work.
+            with self._background_state_lock:
+                self.emit({
+                    "type": "hb", "active_turns": active_turns, "progress_counter": counter,
+                    "rss_mb": _rss_mb(os.getpid()), "background_work": self._background_work_snapshot()})
 
     def _parent_guard_loop(self) -> None:
         while not self._closed.wait(1.0):

--- a/tui_gateway/compute_host_bridge.py
+++ b/tui_gateway/compute_host_bridge.py
@@ -52,10 +52,11 @@ def _compute_host_turn_frame(
     queued_prompt_generation: int | None = None, display_kind: str | None = None) -> dict:
     with session["history_lock"]:
         history = list(session.get("history", []))
+        session_token = session.setdefault("_compute_host_session_token", uuid.uuid4().hex)
         history_version = int(session.get("history_version", 0))
         attached_images = list(image_paths if image_paths is not None else session.get("attached_images", []))
     return {
-        "type": "turn.start", "sid": sid, "request_id": rid,
+        "type": "turn.start", "sid": sid, "request_id": rid, "session_token": session_token,
         "session_key": session.get("session_key") or sid, "text": text,
         **({"display_kind": display_kind} if display_kind else {}), "history": history,
         "history_version": history_version, "cols": int(session.get("cols", 80) or 80),
@@ -67,6 +68,15 @@ def _compute_host_turn_frame(
         "service_tier_override": session.get("create_service_tier_override"),
         "source": _session_source(session), "attached_images": attached_images,
         "queued_prompt_generation": queued_prompt_generation}
+
+
+def _compute_host_has_background_work(sid: str, session: dict) -> bool:
+    token = session.get("_compute_host_session_token")
+    # Reapers may hold session locks: inspect the existing host only, without
+    # loading configuration, acquiring its startup lock, or spawning a host.
+    supervisor = _compute_host_supervisor
+    return bool(token and supervisor is not None and supervisor.has_background_work(
+        sid, token, include_running=not session.get("running")))
 
 
 def _metadata_mirror(session: dict | None) -> dict:

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -156,6 +156,7 @@ class HostSupervisor:
         self._late_control_handlers: dict[str, tuple[float, Callable[[dict], None]]] = {}
         self._stderr_tail: list[str] = []
         self._last_progress_counter = 0
+        self._background_work: dict[str, dict] = {}
         if autostart:
             self.start()
 
@@ -167,6 +168,12 @@ class HostSupervisor:
     def is_running(self) -> bool:
         proc = self._proc
         return proc is not None and proc.poll() is None and not self._stopped_respawning
+
+    def has_background_work(self, sid: str, session_token: str, *, include_running: bool = False) -> bool:
+        """Cached host-owned work only; never start a host or wait for IPC from a reaper."""
+        state = self._background_work.get(sid, {})
+        return bool(self.is_running() and state.get("session_token") == session_token
+                    and (state.get("pending") or (include_running and state.get("running"))))
 
     def start(self) -> None:
         with self._lock:
@@ -311,6 +318,7 @@ class HostSupervisor:
             raise RuntimeError("compute host respawn disabled after crash loop")
         self._hello_event.clear()
         self._hello = {}
+        self._background_work = {}
         env = {**hermes_subprocess_env(inherit_credentials=True), **os.environ, **(self.env or {})}
         env["HERMES_COMPUTE_HOST_HEARTBEAT_SECS"] = str(self.heartbeat_secs)
         root = str(_repo_root())
@@ -378,7 +386,7 @@ class HostSupervisor:
             except json.JSONDecodeError:
                 logger.warning("compute host emitted invalid json: %r", raw[:200])
                 continue
-            if isinstance(frame, dict):
+            if isinstance(frame, dict) and self._proc is proc:
                 self._handle_host_frame(frame)
 
     def _drain_stderr(self, proc: subprocess.Popen[str]) -> None:
@@ -397,12 +405,16 @@ class HostSupervisor:
             self._hello = dict(frame)
             self._hello_event.set()
         elif ftype == "hb":
+            if isinstance(frame.get("background_work"), dict):
+                self._background_work = frame["background_work"]
             self._last_progress_counter = int(frame.get("progress_counter") or self._last_progress_counter)
             logger.debug("compute host heartbeat: %s", frame)
         elif ftype == "rpc":
             if isinstance(frame.get("message"), dict):
                 self.rpc_sink(frame["message"])
         elif ftype in ("turn.end", "turn.error"):
+            if isinstance(frame.get("background_work"), dict):
+                self._background_work = frame["background_work"]
             with self._lock:
                 pending = self._pending_turns.pop(request_id, None)
             if pending is not None and pending[1] is not None:

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -407,6 +407,22 @@ def _interrupt_session_turn(sid: str, session: dict, *, request_id: str | None =
     return use_compute_host
 
 
+def _session_has_background_work(sid: str, session: dict) -> bool:
+    if _session_has_active_delegations(sid, session):
+        return True
+    try:
+        from tools.process_registry import process_registry
+        from tools.process_registry_lifecycle import has_owned_work
+        if has_owned_work(process_registry, getattr(session.get("agent"), "_process_owner_task_ids", ())):
+            return True
+        if session.get("_compute_host_active"):
+            return _compute_host_has_background_work(sid, session)
+        return False
+    except Exception:
+        logger.debug("Failed to query owned background work for UI session %s", sid, exc_info=True)
+        return True  # Unknown ownership must not authorize destructive cleanup.
+
+
 def _session_has_active_delegations(sid: str, session: dict | None = None) -> bool:
     """True when UI session ``sid`` still owns live background work — by live UI sid AND, when the TUI owns the durable
     lifecycle (never for gateway-viewer tabs), by session_key so a delegation from an earlier tab keeps it alive.
@@ -542,7 +558,7 @@ def _schedule_ws_orphan_reap(
                 current.pop("_client_gone_interrupt_polls", None)
                 _pending_ws_reaps.pop(sid, None)
                 return
-            if _session_has_active_delegations(sid, current):
+            if _session_has_background_work(sid, current):
                 reschedule_delay = _WS_ORPHAN_REAP_GRACE_S
             elif not current.get("running"):
                 session = _pop_session_by_id(sid)

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -136,11 +136,11 @@ def _notif_log_failure(what: str, exc: BaseException) -> None:
     print(f"[tui_gateway] {what}: {type(exc).__name__}: {exc}", file=sys.stderr)
 
 
-def _notif_submit(rid: str, sid: str, session: dict, text: str, what: str, **kwargs) -> None:
+def _notif_submit(rid: str, sid: str, session: dict, text: str, what: str, **kwargs) -> bool:
     """message.start + _run_prompt_submit for a claimed (running=True) turn; releases on failure."""
     try:
         _emit("message.start", sid)
-        _run_prompt_submit(rid, sid, session, text, **kwargs)
+        return _run_prompt_submit(rid, sid, session, text, **kwargs) is not False
     except Exception as exc:
         _notif_log_failure(what, exc)
         _notif_release_turn(session)
@@ -448,6 +448,7 @@ def _notif_handle_event(sid, session, evt, emitted, registry, fmt, deferred, com
 
 def _notif_dispatch_completions(sid, session, notifications, registry, deferred):
     from tools.process_registry_notifications import ProcessNotificationBatch
+    from tools.process_registry_lifecycle import acknowledge_notifications
     from tools.async_delegation import claim_event_delivery, complete_event_delivery, release_event_delivery
 
     if not notifications:
@@ -463,14 +464,19 @@ def _notif_dispatch_completions(sid, session, notifications, registry, deferred)
     text = ProcessNotificationBatch(tuple((event, text) for event, text, _claim in claimed)).render(registry)
     if text is None:
         _notif_release_turn(session)
+    started = False
     try:
         if text is not None:
-            _notif_submit(f"__notif__{int(time.time() * 1000)}", sid, session, text,
-                          "completion batch dispatch failed")
+            started = _notif_submit(f"__notif__{int(time.time() * 1000)}", sid, session, text,
+                                    "completion batch dispatch failed")
     except Exception:
         for event, _text, claim in claimed:
             release_event_delivery(event, claim)
+    if text is not None and not started:
+        for event, _text, _claim in claimed:
+            (deferred.append if deferred is not None else registry.completion_queue.put)(event)
         return
+    acknowledge_notifications(registry, (event for event, _text, _claim in claimed))
     for event, _text, claim in claimed:
         complete_event_delivery(event, claim)
 
@@ -557,6 +563,11 @@ def _notification_poller_loop(stop_event: threading.Event, sid: str, session: di
         sid, session, events, emitted, process_registry, format_process_notification, deferred)
     last_kanban_poll = last_loop_poll = 0.0
     while not stop_event.is_set() and not session.get("_finalized"):
+        try:
+            from tools.process_registry_lifecycle import refresh_owned_work
+            refresh_owned_work(process_registry, getattr(session.get("agent"), "_process_owner_task_ids", ()))
+        except Exception:
+            logger.debug("Owned process refresh failed for UI session %s", sid, exc_info=True)
         now = time.monotonic()
         try:
             _poll_bot_live_delivery_once(sid, session)

--- a/tui_gateway/session_reaper.py
+++ b/tui_gateway/session_reaper.py
@@ -149,10 +149,10 @@ def _transport_is_dead(transport) -> bool:
 
 def _session_is_lru_evictable(sid: str, session: dict) -> bool:
     """Shared hard exemptions for both reapers (the LRU cap applies them WITHOUT the age gate: eligible the moment
-    it loses its client): never evict a session mid-turn, awaiting input, still building, owning live delegated
-    work, or on a live transport. Lazy watch sessions never start a build, so their unset agent_ready must not
+    it loses its client): never evict a session mid-turn, awaiting input, still building, owning background
+    work or its pending completion, or on a live transport. Lazy watch sessions never start a build, so their unset agent_ready must not
     make them immortal."""
-    if session.get("running") or _session_pending_kind(sid) or _session_has_active_delegations(sid, session):
+    if session.get("running") or _session_pending_kind(sid) or _session_has_background_work(sid, session):
         return False
     ready = session.get("agent_ready")
     if ready is not None and not ready.is_set() and not session.get("lazy"):


### PR DESCRIPTION
## What does this PR do?

Keep a Desktop/TUI session alive across a WebSocket disconnect while it still owns background terminal work, even after its foreground turn has finished.

For example, an agent launches a background terminal job and replies that it has started. If the laptop then disconnects, orphan cleanup treats the session as idle and closes the agent, killing the child with `termination_source=agent_close`. We reproduced this on an installed backend after **20.06 seconds** disconnected.

This patch protects the owner through execution and admission of any requested completion continuation. Normal idle cleanup resumes afterward; explicit session close and process termination keep their existing behavior.

## Related Issue

Refs #41225, specifically the Remote Gateway URL case where the foreground turn has ended but a background terminal child is still working. This does not claim to resolve every disconnect case in that issue.

Complements the active-turn and reconnect protections in #100504, #104262, and #104924, and the Desktop lease work in #105985.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/process_registry_lifecycle.py` and `process_registry.py`: check exact process ownership, including transfers and the exit/publication transition; separate completion admission from read-only polling.
- `tui_gateway/session_lifecycle.py` and `session_reaper.py`: apply the same background-work protection to orphan, LRU, and TTL cleanup.
- `tui_gateway/session_notifications.py`: refresh recovered owned jobs outside lifecycle locks and retry completions whose continuation was not admitted.
- `tui_gateway/compute_host.py`, `compute_host_bridge.py`, and `host_supervisor.py`: mirror background ownership over existing host frames, scoped to the session generation. Cleanup reads cached state without starting a host or waiting for IPC.
- `tests/tui_gateway/test_background_process_lifetime.py`: two parameterized invariant tests covering real child processes, WebSockets, completion persistence, ownership transfers, races, and explicit teardown.

## How to Test

With the documented `.[all,dev]` extras installed:

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/tui_gateway/test_background_process_lifetime.py -q
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j 4 tests/tui_gateway/ -q
```

Manual reproduction:

1. Connect to a remote backend and launch a finite terminal job with `background=true` and `notify=true`.
2. Wait for the foreground reply to finish, then disconnect the client beyond the orphan grace period while the job is still running.
3. Verify that the child keeps progressing and reconnect resumes the same live session.
4. Disconnect again, let the job finish, and verify one saved completion continuation followed by eventual idle cleanup.

## Checklist

- [x] Read the contribution/subsystem guides; used Conventional Commits.
- [x] Searched open and merged related PRs; kept the change scoped to this lifecycle boundary.
- [x] Added invariant tests and manually verified on macOS arm64 with Python 3.11.15.
- [x] Updated relevant docstrings; no public configuration, RPC, tool-schema, or dependency changes.
- [x] Considered cross-platform behavior; platform-specific cases use repository markers.
- [ ] All repository tests pass: full-run failures and baseline comparisons are disclosed below.
- [ ] Native Linux/Windows verification.

## Screenshots / Logs

**Installed-backend evidence**, using normal timeouts, real terminal children, normal authentication, and a local HTTP model fixture; no production monkeypatches:

| Scenario | Observed result |
| --- | --- |
| Unpatched installed backend | Child killed after **20.06 seconds** disconnected; orphan-reap and agent-close evidence. |
| Patched pipe and PTY runs | Each survived **120 seconds** disconnected, reattached to the same runtime, and persisted one completion while detached. |
| Patched existing remote service | Same result through its authenticated Remote Gateway endpoint. |
| Physical laptop sleep | Laptop-held WebSocket detached for approximately **355 seconds**. The same child and runtime survived; reconnect succeeded. macOS recorded **89 seconds of deep sleep** within that interval. |
| Completion after the sleep test | Child exited normally after another detach; **one** completion continuation was saved, then the idle owner was reclaimed. |

During the physical-sleep test, an independent remote observer recorded 273 samples over 547 seconds. Every sample showed the child and backend alive, with strictly increasing progress. The server logged disconnect code 1006 and detached one session; child progress continued past the normal 20-second orphan deadline while the laptop was still asleep. The 355 seconds measure server-detected disconnection to reconnect, not deep-sleep duration.

These are summarized measurements. Machine names, addresses, user paths, conversation identifiers, and personal project names are omitted. The laptop test used a protocol client against the actual remote backend; Desktop's reconnect UI and a full Codex workload were not exercised.

**Automated verification:** on submitted commit `8c2d29bb0f8d4d294d6eb5e77d1cf7bc1b46fbf9`, based on `1675f1f2c25ce164f07c42e829f2c17a723db94f`, the new regressions plus reconnect-race and isolated foreground-activity tests produced **59 passed, 0 failed, 2 Linux PTY cases skipped**.

<details>
<summary>Broader test results and limitations</summary>

The following runs used base `a6474766c8bdbe5d47b9265ab087c5033e142ee1`, with runner retries disabled. The later rebase preserved the patch unchanged.

| Check | Result |
| --- | --- |
| Exact regression file on unchanged base | 16 failed, 12 passed, 2 skipped |
| Regression file with the fix | 28 passed, 2 Linux PTY cases skipped |
| Gateway directory with the fix | 1,118 passed, 0 failed, 10 skipped |
| Full repository run | 46,413 passed, 172 failed, 519 skipped; 8 setup errors in one additional file |

Of the 172 failures, 164 reproduced on unchanged base. The other eight passed in focused reruns; their original failures remain recorded. All eight setup errors reproduced on base with the same broken Node executable selected by the full run. This is not a full-suite pass. Ruff, compatibility-pointer, and whitespace checks passed; the Windows checker reported two unchanged findings in `host_supervisor.py`.

Provider responses are fixtures. The isolated-host test cases use real subprocesses and pipes but explicitly model parent-authorized admission: an unmodified live probe hit a separate duplicate-session-lease refusal before its first main model call. Those cases verify ownership and cleanup after admission, not that lease protocol. Installed disconnect/sleep tests used `dashboard.turn_isolation: false`. Backend restart durability is outside this patch; native Linux/Windows checks remain pending.

</details>

Happy to provide more sanitized logs, reproduction details, or the failure-by-failure baseline comparison if helpful.
