### PR TITLE
fix(desktop): paint cached conversations before backend waits

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1096,8 +1096,11 @@ describe('resumeSession failure recovery', () => {
 
   it('paints a durable tail before stored-session resolution settles', async () => {
     const storedLookup = deferred<SessionInfo>()
+    const persistedLookup = deferred<Awaited<ReturnType<typeof getLatestSessionMessages>>>()
+    const resumeLookup = deferred<SessionResumeResponse>()
 
     vi.mocked(getSession).mockReturnValue(storedLookup.promise)
+    vi.mocked(getLatestSessionMessages).mockReturnValue(persistedLookup.promise)
     saveTranscriptTail(
       'stored-1',
       [
@@ -1110,7 +1113,13 @@ describe('resumeSession failure recovery', () => {
       'work'
     )
 
-    const requestGateway = vi.fn(async () => ({}) as never)
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        return resumeLookup.promise as never
+      }
+
+      return {} as never
+    })
 
     let resume: ((storedSessionId: string, replaceRoute?: boolean, ownerRoute?: SessionProfileRoute) => Promise<unknown>) | null =
       null
@@ -1125,8 +1134,33 @@ describe('resumeSession failure recovery', () => {
     expect(settled).toBe(false)
     expect(requestGateway).not.toHaveBeenCalled()
 
-    storedLookup.resolve(storedSession({ id: 'stored-1', profile: 'work' }))
+    storedLookup.resolve(storedSession({ id: 'stored-1', message_count: 1, profile: 'work' }))
+    await waitFor(() => expect(getLatestSessionMessages).toHaveBeenCalled())
+
+    // Metadata and gateway readiness have settled and REST is now pending. The
+    // provisional tail must remain continuously visible rather than flickering
+    // back to the loader between the early paint and authoritative hydration.
+    expect(JSON.stringify($messages.get())).toContain('cached history paints immediately')
+    expect(settled).toBe(false)
+
+    persistedLookup.resolve({
+      messages: [{ content: 'authoritative history replaces cache', role: 'assistant', timestamp: 1 }],
+      session_id: 'stored-1'
+    })
+    resumeLookup.resolve({
+      info: {},
+      message_count: 1,
+      messages: [],
+      messages_omitted: true,
+      resumed: 'stored-1',
+      running: false,
+      session_id: 'runtime-1',
+      session_key: 'stored-1'
+    })
     await pending
+
+    expect(JSON.stringify($messages.get())).toContain('authoritative history replaces cache')
+    expect(JSON.stringify($messages.get())).not.toContain('cached history paints immediately')
     vi.mocked(getSession).mockReset()
   })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -69,6 +69,7 @@ import { $removedSessionIds, $sessionMutationsInFlight } from '@/store/session-r
 import { requestForSessionProfile, type SessionProfileRoute } from '@/store/session-request-router'
 import { $sessionTiles, sessionTileOwnerRoute } from '@/store/session-states'
 import { $sessionSeenCounts, $unreadFinishedMarkers } from '@/store/session-unread'
+import { saveTranscriptTail } from '@/store/transcript-tail-cache'
 
 import sessionResumeActiveTurn from '../../../../../../tests/fixtures/session-resume-active-turn.json'
 import { deferred } from '../../../test/deferred'
@@ -1068,8 +1069,10 @@ function ResumeTimerHarness({
 describe('resumeSession failure recovery', () => {
   afterEach(() => {
     cleanup()
+    window.localStorage.clear()
     setActiveSessionId(null)
     setResumeFailedSessionId(null)
+    setSelectedStoredSessionId(null)
     setMessages([])
     setSessions([])
     $removedSessionIds.set(new Set())
@@ -1090,6 +1093,42 @@ describe('resumeSession failure recovery', () => {
     await waitFor(() => expect(resume).not.toBeNull())
     await resume!('stored-1', true)
   }
+
+  it('paints a durable tail before stored-session resolution settles', async () => {
+    const storedLookup = deferred<SessionInfo>()
+
+    vi.mocked(getSession).mockReturnValue(storedLookup.promise)
+    saveTranscriptTail(
+      'stored-1',
+      [
+        {
+          id: 'cached-assistant',
+          parts: [{ text: 'cached history paints immediately', type: 'text' }],
+          role: 'assistant'
+        }
+      ] as never,
+      'work'
+    )
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean, ownerRoute?: SessionProfileRoute) => Promise<unknown>) | null =
+      null
+
+    render(<ResumeHarness onReady={ready => (resume = ready)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    let settled = false
+    const pending = resume!('stored-1', true, { connectionId: '', profile: 'work' }).finally(() => (settled = true))
+
+    expect(JSON.stringify($messages.get())).toContain('cached history paints immediately')
+    expect(settled).toBe(false)
+    expect(requestGateway).not.toHaveBeenCalled()
+
+    storedLookup.resolve(storedSession({ id: 'stored-1', profile: 'work' }))
+    await pending
+    vi.mocked(getSession).mockReset()
+  })
 
   it('does not resume a tombstoned session after delete', async () => {
     $removedSessionIds.set(new Set(['stored-1']))

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -127,7 +127,8 @@ import {
   dropTranscriptTail,
   dropTranscriptTailEverywhere,
   loadTranscriptTail,
-  saveTranscriptTail
+  saveTranscriptTail,
+  type TranscriptTailScope
 } from '@/store/transcript-tail-cache'
 import { isWatchWindow } from '@/store/windows'
 import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, UsageStats } from '@/types/hermes'
@@ -273,6 +274,17 @@ function reconcileAuthoritativeMessages(
   liveProjection?: Pick<SessionResumeResponse, 'inflight' | 'queued' | 'session_id'>
 ): ChatMessage[] {
   return reconcileAuthoritativeChatMessages(toChatMessages(authoritativeMessages), previousMessages, liveProjection)
+}
+
+function transcriptRestScope(
+  ownerRoute: SessionProfileRoute | undefined,
+  stored: { connection_id?: null | string; profile?: null | string } | undefined,
+  ambientConnectionId: string
+): TranscriptTailScope | undefined {
+  const connectionId = ownerRoute?.connectionId || stored?.connection_id || ambientConnectionId
+  const profile = ownerRoute?.targetProfile || ownerRoute?.profile || stored?.profile || 'default'
+
+  return connectionId ? { connectionId, profile } : ownerRoute?.profile || stored?.profile || undefined
 }
 
 // `session.create` params from the current profile + sticky-UI model/effort/fast,
@@ -918,6 +930,38 @@ export function useSessionActions({
       // chat view drops the error state and shows the loader again.
       setResumeExhaustedSessionId(current => (current === storedSessionId ? null : current))
 
+      const ownerRoute = capturedOwner || getSessionOwnerHint(storedSessionId)
+      // A connection switch clears/reloads the session rows before this path
+      // runs, so an untagged row belongs to the connection that supplied the
+      // current list. Capture that source before the async metadata lookup. If
+      // we reduce it to the profile string `default`, requestForSessionProfile
+      // resolves the local default socket and sends an SSH session id to the
+      // wrong machine ("resume failed: session not found").
+      const ambientConnection = $connection.get()
+
+      const ambientConnectionId =
+        ambientConnection?.mode === 'remote' ? ambientConnection.connectionId?.trim() || '' : ''
+
+      const listedStoredSession = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+
+      // A durable paint is provisional: the authoritative REST transcript
+      // replaces it below. Keep its exact array identity so reconciliation can
+      // distinguish it from live changes made after the paint.
+      let cachedTailPaint: ChatMessage[] | null = null
+
+      const paintCachedTail = (scope: TranscriptTailScope | undefined): void => {
+        if (resumedSameSelectedSession || cachedTailPaint !== null || $messages.get().length > 0) {
+          return
+        }
+
+        const cachedTail = loadTranscriptTail(storedSessionId, scope)
+
+        if (cachedTail && selectedStoredSessionIdRef.current === storedSessionId) {
+          cachedTailPaint = cachedTail
+          setMessages(cachedTail)
+        }
+      }
+
       // A warm cache entry is only trustworthy when it still BELONGS to the
       // session being resumed. A pooled profile backend that gets idle-reaped
       // and respawned (pruneSecondaryGateways) re-mints runtime ids, so a
@@ -959,22 +1003,15 @@ export function useSessionActions({
         }
       }
 
+      // Paint before metadata resolution or a backend/profile dial. Those
+      // awaits can take seconds on a cold or remote owner, while the durable
+      // cache is already scoped by the synchronous owner hint/list row.
+      paintCachedTail(transcriptRestScope(ownerRoute, listedStoredSession, ambientConnectionId))
+
       // Swap the single live gateway to this session's profile before any
       // gateway call (no-op when it's already on that profile / single-profile).
       // resolveStoredSession finds the row by id (cheap), so an uncached pasted
       // id loads as fast as a sidebar click instead of hanging on a list scan.
-      const ownerRoute = capturedOwner || getSessionOwnerHint(storedSessionId)
-      // A connection switch clears/reloads the session rows before this path
-      // runs, so an untagged row belongs to the connection that supplied the
-      // current list. Capture that source before the async metadata lookup. If
-      // we reduce it to the profile string `default`, requestForSessionProfile
-      // resolves the local default socket and sends an SSH session id to the
-      // wrong machine ("resume failed: session not found").
-      const ambientConnection = $connection.get()
-
-      const ambientConnectionId =
-        ambientConnection?.mode === 'remote' ? ambientConnection.connectionId?.trim() || '' : ''
-
       const storedForProfile = await resolveStoredSession(storedSessionId, ownerRoute)
       const sessionProfile = storedForProfile?.profile
 
@@ -1029,17 +1066,7 @@ export function useSessionActions({
       const requestForSession = <T>(method: string, params: Record<string, unknown> = {}): Promise<T> =>
         requestForSessionProfile<T>(sessionOwner, requestGateway, method, params)
 
-      const sessionRestScope = resolvedConnectionId
-        ? {
-            connectionId: resolvedConnectionId,
-            profile: ownerRoute?.targetProfile || ownerRoute?.profile || sessionProfile || 'default'
-          }
-        : storedForProfile?.connection_id
-          ? {
-              connectionId: storedForProfile.connection_id,
-              profile: sessionProfile || 'default'
-            }
-          : sessionProfile
+      const sessionRestScope = transcriptRestScope(ownerRoute, storedForProfile, ambientConnectionId)
 
       // Re-check after the profile-resolve / gateway-swap awaits above: the
       // cache may have changed, and takeWarmCache re-validates belongs-to and
@@ -1472,26 +1499,16 @@ export function useSessionActions({
         setMessages([])
       }
 
-      // Instant paint from the durable tail cache: a cold resume (fresh app
-      // launch, reaped/respawned backend) otherwise shows a loader until the
-      // REST prefetch lands — which on a cold multi-profile boot waits behind
-      // a backend spawn. Painting the persisted tail here makes the wake
-      // visually complete at ~0ms (and satisfies the paint-first hydration
-      // wait). The paint is DISPLAY-ONLY: reconciliation below must treat the
-      // view as empty (see cachedTailPaint), because grafting the REST tail
+      // The durable tail normally painted before owner resolution. If metadata
+      // supplied a previously unknown owner, retry its authoritative scope here.
+      // The paint is DISPLAY-ONLY: reconciliation below must treat the view as
+      // empty (see cachedTailPaint), because grafting the REST tail
       // onto a stale cached tail would duplicate or misorder rows — the
       // authoritative transcript REPLACES the cached paint when it lands.
       // Same-selected re-resumes skip it — their transcript is already live.
-      let cachedTailPaint: ChatMessage[] | null = null
-
-      if (!resumedSameSelectedSession && $messages.get().length === 0) {
-        const cachedTail = loadTranscriptTail(storedSessionId, sessionRestScope)
-
-        if (cachedTail && selectedStoredSessionIdRef.current === storedSessionId) {
-          cachedTailPaint = cachedTail
-          setMessages(cachedTail)
-        }
-      }
+      // Metadata may have supplied an owner absent from the synchronous list;
+      // retry with the authoritative scope when the instant lookup missed.
+      paintCachedTail(sessionRestScope)
 
       // The reconciler's notion of "what was already on screen": a durable
       // cached paint is provisional, not history — report empty so the

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1493,9 +1493,16 @@ export function useSessionActions({
       // warm path can still bail down to here — an empty-transcript drop, or the
       // cache getting purged during the profile-swap await — so the PREVIOUS
       // session's transcript would leak into this cold resume ("switching
-      // sessions shows the same messages"). Clear it so the loader/prefetch
-      // paints fresh; guarded so the normal cold path (already cleared) no-ops.
-      if (!resumedSameSelectedSession && $messages.get().length > 0) {
+      // sessions shows the same messages"). Clear that foreign view, but keep
+      // this session's scoped provisional tail continuously visible until the
+      // authoritative prefetch replaces it.
+      const coldPathMessages = $messages.get()
+
+      if (
+        !resumedSameSelectedSession &&
+        coldPathMessages.length > 0 &&
+        (cachedTailPaint === null || coldPathMessages !== cachedTailPaint)
+      ) {
         setMessages([])
       }
 


### PR DESCRIPTION
## Summary

- paint a scoped durable transcript tail immediately when a conversation is selected
- perform metadata resolution and backend/profile dialing after the first paint
- retry the cache lookup with authoritative owner metadata when the synchronous owner hint was incomplete
- preserve REST as transcript authority and retain the existing stale-selection guard

## User impact

Cold conversation switches currently clear the previous transcript, then wait for stored-session resolution and potentially a backend/profile spawn before reading the existing durable tail cache. On large or remote sessions this leaves a loader visible for seconds even though cached display data is already available locally.

This moves only the provisional cache paint ahead of those awaits. Authoritative REST hydration and runtime resume behavior are unchanged.

## Verification

Target truth: cached history becomes visible before stored-session lookup or gateway work settles. The new hook regression test holds metadata resolution pending and asserts the cached transcript is already painted and no gateway call has started. It does not prove end-to-end frame latency in the packaged Electron app.

- `npx vitest run --project ui src/app/session/hooks/use-session-actions.test.tsx src/store/transcript-tail-cache.test.ts` — 112 passed
- `npx tsc -p . --noEmit`
- `npx eslint src/app/session/hooks/use-session-actions/index.ts src/app/session/hooks/use-session-actions.test.tsx`
- `git diff --check`

Related stability fix: #106838.