### PR TITLE
fix(desktop): Windows update no longer reports a healthy install as a missing Desktop exe

### DIFF
--- a/hermes_cli/desktop_update_verify.py
+++ b/hermes_cli/desktop_update_verify.py
@@ -69,8 +69,20 @@ def _verify_packaged_entry(resources: Path) -> None:
         raise RuntimeError(f"The updated Desktop renderer entry is invalid: {exc}") from exc
 
 
-def verify_windows_desktop_update(project_root: Path) -> None:
-    """Raise when a zero-exit updater left an incomplete or stale packaged app."""
+def checkout_root() -> Path:
+    """The checkout this module was imported from: the only root the receipt may describe."""
+    return Path(__file__).resolve().parent.parent
+
+
+def verify_windows_desktop_update(project_root: Path | None = None) -> None:
+    """Raise when a zero-exit updater left an incomplete or stale packaged app.
+
+    The root defaults to the imported checkout, never the caller's cwd: the hand-off
+    is spawned from HERMES_HOME by the pre-update Desktop, and a cwd-derived root
+    reported a healthy install as "Desktop executable is missing" (Sep 2026).
+    """
+    if project_root is None:
+        project_root = checkout_root()
     desktop = project_root / "apps" / "desktop"
     executable = _desktop_packaged_executable(desktop)
     if executable is None:

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -1644,7 +1644,7 @@ try {
 
     # A zero-exit update is not proof that the runtime survived the update.
     if ($res.Code -eq 0 -and -not $desktopBuildFailed) {
-        $verifyCode = "import hermes_cli.main; from pathlib import Path; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update(Path.cwd())"
+        $verifyCode = "import hermes_cli.main; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update()"
         $verify = Invoke-HermesStep $pythonExe @("-c", $verifyCode) "verify"
         if ($verify.Code -ne 0) {
             $finalCode = 8

--- a/tests/hermes_cli/test_desktop_update_verify.py
+++ b/tests/hermes_cli/test_desktop_update_verify.py
@@ -51,3 +51,15 @@ def test_current_stamp_does_not_hide_damaged_output(bundle, damage):
         (dist / 'index.html').write_bytes({'empty-index': b'', 'unreadable-index': b'\xff', 'no-module': b'<html></html>'}[damage])
     with pytest.raises((RuntimeError, OSError, ValueError)):
         verify.verify_windows_desktop_update(root)
+
+
+def test_default_root_is_the_imported_checkout_not_cwd(tmp_path, monkeypatch):
+    # The Windows hand-off is spawned from HERMES_HOME; the receipt must describe the checkout anyway.
+    monkeypatch.chdir(tmp_path)
+    seen = {}
+    monkeypatch.setattr(verify, '_desktop_packaged_executable', lambda desktop: seen.setdefault('desktop', desktop) and None)
+    with pytest.raises(RuntimeError, match='executable is missing'):
+        verify.verify_windows_desktop_update()
+    assert seen['desktop'] == verify.checkout_root() / 'apps' / 'desktop'
+    assert (verify.checkout_root() / 'hermes_cli' / 'desktop_update_verify.py').is_file()
+    assert verify.checkout_root() != tmp_path


### PR DESCRIPTION
A successful Windows Desktop update no longer ends in an error dialog claiming "The updated Desktop executable is missing".

## Changes
- `hermes_cli/desktop_update_verify.py`: `verify_windows_desktop_update()` defaults its root to the checkout the module was imported from (`checkout_root()`), never the caller's cwd.
- `scripts/desktop-update/windows.ps1`: the verify step stops passing `Path.cwd()`.
- 1 invariant test: with cwd elsewhere, the receipt still describes the imported checkout.

## Root cause
The hand-off script runs from the pre-update checkout and is spawned from `HERMES_HOME`; e7eaff68 shipped the verify step a day before the cwd pin (#106194), so the receipt looked for `apps/desktop/release` under `~/.hermes`. The update itself had completed (exit 0, gateway restarted, app relaunched from the real `win-unpacked\Hermes.exe`).

## Validation
| Check | Result |
|---|---|
| Live symptom | `desktop-update-handoff.log` 2026-09-08 17:03 and 2026-09-10 00:58: `hermes update exit code: 0` → `verify!| RuntimeError: The updated Desktop executable is missing` → relaunch from `...\apps\desktop\release\win-unpacked\Hermes.exe` succeeded |
| New test on base | red (`IsADirectoryError` / cwd-derived root) |
| New test on branch | green; `tests/hermes_cli/test_desktop_update_verify.py` + `tests/test_desktop_update_windows_cwd.py` 8 passed |
| E2E | from `cwd=/tmp` with temp `HERMES_HOME`, `checkout_root()` resolves to the worktree |

The cwd pin from #106194 remains in place for the other child steps.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9d713/uOCOrpeTtHxjBSEjTgYVM_pyceR4L6.png)
