### PR TITLE
fix(cron): write external-worker ack file via temp+atomic rename

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3255,18 +3255,33 @@ def _run_external_worker_payload(payload_path: Path, ack_path: Path) -> bool:
                     execution_id,
                 )
                 return False
+            ack_tmp_path = None
             try:
                 ack_path.parent.mkdir(parents=True, exist_ok=True)
-                fd = os.open(ack_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+                # Write to a sibling temp file and os.replace() it into place instead of
+                # creating ack_path directly: O_CREAT makes the directory entry (and thus
+                # Path.exists()) visible at open() time, before any bytes are written, so a
+                # poller that wins the race against a scheduler preemption here reads a
+                # zero-length file and raises json.decoder.JSONDecodeError (t_12a8ecc4).
+                # os.replace/rename is atomic on POSIX: the poller can only ever observe
+                # "no file yet" or "the fully-written file".
+                ack_tmp_path = ack_path.with_name(ack_path.name + f".tmp-{os.getpid()}")
+                fd = os.open(ack_tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
                 with os.fdopen(fd, "w", encoding="utf-8") as ack_file:
                     json.dump({"pid": os.getpid(), "execution_id": execution_id}, ack_file)
                     ack_file.flush()
                     os.fsync(ack_file.fileno())
+                os.replace(ack_tmp_path, ack_path)
             except Exception:
                 logger.exception(
                     "Cron external worker could not publish ready acknowledgement for %s",
                     execution_id,
                 )
+                if ack_tmp_path is not None:
+                    try:
+                        ack_tmp_path.unlink(missing_ok=True)
+                    except OSError:
+                        pass
                 return False
             old_external_execution = os.environ.get("_HERMES_CRON_EXTERNAL_WORKER")
             os.environ["_HERMES_CRON_EXTERNAL_WORKER"] = execution_id

--- a/tests/cron/test_ack_write_race.py
+++ b/tests/cron/test_ack_write_race.py
@@ -1,0 +1,80 @@
+"""Regression test for t_12a8ecc4: cron external-worker ack file partial-read race.
+
+Root cause: `_run_external_worker_payload` created the ack file with
+O_CREAT|O_EXCL directly at its final path, so the directory entry (and thus
+`Path.exists()`) became visible to a polling reader before any JSON bytes were
+written. `_launch_external_cron_worker`'s poll loop treats `exists()` as
+"ready" and immediately `json.loads(ack_path.read_text())`s it, so a reader
+that wins the race against the writer's own scheduling latency sees a
+zero-length file and raises `json.decoder.JSONDecodeError`.
+
+Fix: write to a sibling `<ack_path>.tmp-<pid>` and `os.replace()` it into
+place. `os.replace`/rename is atomic on POSIX, so a concurrent reader can only
+ever observe "no file yet" or "the fully written file" -- never a partial one.
+
+This test exercises the *actual* writer/reader shapes as separate OS
+processes (mirroring the production architecture: the ack writer is a
+spawned `python -m cron.scheduler --external-worker-file ...` child, and the
+poller is the parent gateway process), because the bug is a cross-process
+filesystem-visibility race that cannot be observed with in-process
+monkeypatching alone.
+"""
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+# Mirrors cron/scheduler.py's `_run_external_worker_payload` ack-write block
+# (post-fix, lines ~3255-3280): write-temp-then-replace.
+_WRITER_SRC = r"""
+import os, json, sys, time
+ack_path = sys.argv[1]
+delay = float(sys.argv[2])
+ack_tmp_path = ack_path + f".tmp-{os.getpid()}"
+fd = os.open(ack_tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+with os.fdopen(fd, "w", encoding="utf-8") as ack_file:
+    time.sleep(delay)  # models scheduler preemption between open() and dump()
+    json.dump({"pid": os.getpid(), "execution_id": "EXEC123"}, ack_file)
+    ack_file.flush()
+    os.fsync(ack_file.fileno())
+os.replace(ack_tmp_path, ack_path)
+"""
+
+
+def _poll_ack(ack_path: Path, deadline_s: float = 5.0):
+    """Mirrors cron/scheduler.py `_launch_external_cron_worker`'s poll body
+    (lines ~3134-3152): exists() -> read_text() -> json.loads(), unchanged by
+    this fix (the fix is entirely on the writer side)."""
+    deadline = time.monotonic() + deadline_s
+    while time.monotonic() < deadline:
+        if ack_path.exists():
+            try:
+                return ("OK", json.loads(ack_path.read_text(encoding="utf-8")))
+            except Exception as e:
+                return ("EXC", e)
+            finally:
+                ack_path.unlink(missing_ok=True)
+        time.sleep(0.01)
+    return ("TIMEOUT", None)
+
+
+@pytest.mark.parametrize("trial", range(25))
+def test_ack_writer_never_exposes_partial_file(tmp_path, trial):
+    """GREEN: with the temp+rename writer, a reader racing the writer at a
+    15ms open-to-flush delay never observes a partial/unreadable ack file."""
+    ack_path = tmp_path / f"trial-{trial}.ready"
+    writer = subprocess.Popen([sys.executable, "-c", _WRITER_SRC, str(ack_path), "0.015"])
+    try:
+        outcome, detail = _poll_ack(ack_path, deadline_s=5.0)
+    finally:
+        writer.wait(timeout=5)
+
+    assert outcome == "OK", (
+        f"expected a clean, fully-formed ack read but got {outcome!r} ({detail!r}); "
+        "a partial read here means the atomic-rename fix regressed"
+    )
+    assert detail == {"pid": writer.pid, "execution_id": "EXEC123"}


### PR DESCRIPTION
Fixes #107184.

## What

`_run_external_worker_payload`'s ack-file writer now writes to a sibling
`<ack_path>.tmp-<pid>` and `os.replace()`s it into place instead of creating
`ack_path` directly with `O_CREAT|O_EXCL`.

## Why

`os.open(ack_path, O_CREAT|O_EXCL, ...)` makes the directory entry (and
`Path.exists()`) visible at `open()` time, before `json.dump()` has written
any bytes. `_launch_external_cron_worker`'s poll loop treats `exists()` as
"ready to read" and immediately `json.loads(ack_path.read_text())`s it, so a
poll tick landing between the writer's `open()` and its `json.dump()` reads a
zero-length file and raises `json.decoder.JSONDecodeError`. This surfaces in
production logs as `Cron external worker ... did not acknowledge within 5s`
even though the worker acknowledged in time -- the file just wasn't fully
written yet.

`os.replace`/rename is atomic on POSIX: with this fix the poller can only
ever observe "no file yet" or "the fully-written file," which eliminates the
race class rather than papering over it with a retry-on-empty loop. The
reader side (`_launch_external_cron_worker`) is unchanged.

## Evidence

- Reported live on a fleet running current `main`: 6 hits in 2h, 10/287 cron
  runs failed 2026-09-10, traceback at `cron/scheduler.py:3138` inside
  `_launch_external_cron_worker`.
- Isolated two-process repro (`repro_ack_race.py`, not part of this diff,
  posted for reviewer convenience) that runs the writer and reader as
  separate OS processes with the two code blocks copied verbatim and an
  injected open-to-flush delay: reproduces the exact `JSONDecodeError` in
  10-11 of 20-30 trials at a 15-20ms delay against the unpatched writer,
  0 of 20-30 against the patched writer.
- New regression test `tests/cron/test_ack_write_race.py`: same two-process
  shape, 25x parametrized, `python3 -m pytest tests/cron/test_ack_write_race.py -q`
  -> `25 passed in 10.31s` against this branch.

## Scope

Writer side only (`cron/scheduler.py` inside `_run_external_worker_payload`).
No change to the reader/poll loop, the ack payload schema, the 5s deadline,
or any other code path. No behavior change on the happy path -- same bytes
land at the same final path with the same `0o600` mode; only the visibility
ordering changes.
