### PR TITLE
fix(cli): skip unstattable entries in the managed file listing

### DIFF
--- a/hermes_cli/web_routers/files.py
+++ b/hermes_cli/web_routers/files.py
@@ -362,12 +362,15 @@ async def list_managed_files(request: Request, path: Optional[str] = None):
     if not target.is_dir():
         raise HTTPException(status_code=400, detail="Path is not a directory")
 
+    entries = []
     with _io_errors("Directory is not readable", "Could not read directory"), os.scandir(target) as scan:
-        entries = [
-            _managed_file_entry(policy, Path(entry.path))
-            for entry in scan
-            if not _is_sensitive_path(Path(entry.path))
-        ]
+        for entry in scan:
+            entry_path = Path(entry.path)
+            if _is_sensitive_path(entry_path):
+                continue
+            meta = _managed_file_entry(policy, entry_path, skip_unstattable=True)
+            if meta is not None:
+                entries.append(meta)
 
     entries.sort(key=lambda item: (not item["is_directory"], str(item["name"]).lower()))
     locked_root = policy.locked_root

--- a/hermes_cli/web_server_files.py
+++ b/hermes_cli/web_server_files.py
@@ -7,7 +7,7 @@ import urllib.request
 from dataclasses import dataclass
 from fastapi import HTTPException, Request
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 _MANAGED_FILES_ROOT_ENV = "HERMES_DASHBOARD_FILES_ROOT"
@@ -178,7 +178,15 @@ def _managed_response_meta(policy: ManagedFilesPolicy) -> Dict[str, Any]:
     return {"root": locked_root, "locked_root": locked_root, "can_change_path": policy.can_change_path}
 
 
-def _managed_file_entry(policy: ManagedFilesPolicy, target: Path) -> Dict[str, Any]:
+def _managed_file_entry(
+    policy: ManagedFilesPolicy, target: Path, *, skip_unstattable: bool = False
+) -> Optional[Dict[str, Any]]:
+    """Describe one managed path for the UI.
+
+    ``skip_unstattable`` returns None instead of raising when the path cannot be
+    stat'd. Directory listings pass it: a dangling symlink is an ordinary thing
+    to meet in a home directory, and one dead name must not fail the listing.
+    """
     try:
         resolved = target.resolve()
     except (OSError, RuntimeError):
@@ -189,6 +197,8 @@ def _managed_file_entry(policy: ManagedFilesPolicy, target: Path) -> Dict[str, A
     try:
         st = resolved.stat()
     except OSError as exc:
+        if skip_unstattable:
+            return None
         raise HTTPException(status_code=500, detail=f"Could not stat path: {exc}")
 
     is_dir = resolved.is_dir()

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -420,3 +420,22 @@ def test_credential_dir_trees_blocked_on_subdir_descent(forced_files_client):
     assert [e["name"] for e in mcp_listing.json()["entries"]] == []
 
 
+def test_dangling_symlink_does_not_break_listing(forced_files_client):
+    """A symlink whose target is gone must be skipped, not 500 the whole listing.
+
+    Real case: /root/GEMINI.md pointed into a vault file that a later commit
+    deleted, and the one dead name made the file browser unusable.
+    """
+    client, root = forced_files_client
+
+    root.mkdir(parents=True, exist_ok=True)
+    regular = root / "notes.md"
+    regular.write_text("# notes")
+    dangling = root / "GEMINI.md"
+    dangling.symlink_to(root / "gone.md")
+
+    listing = client.get("/api/files", params={"path": str(root)})
+    assert listing.status_code == 200
+    names = [e["name"] for e in listing.json()["entries"]]
+    assert "notes.md" in names
+    assert "GEMINI.md" not in names


### PR DESCRIPTION
## What and why

`GET /api/files` returns 500 for an entire directory when a single entry cannot be stat'd. `os.scandir` yields a dangling symlink like any other entry, `_managed_file_entry` then calls `resolve().stat()`, and the resulting `OSError` becomes an `HTTPException(500)` that takes every sibling entry down with it.

A broken symlink in `$HOME` is an ordinary thing to meet — a link into a file that a later commit deleted, a checkout that moved, an uninstalled tool. Today one such name makes the whole file browser unusable until the user finds and removes the dead link by hand, without the dashboard telling them which one it is beyond the path in the error string.

Fixes #47154.

## The change

`_managed_file_entry` gains a keyword-only `skip_unstattable` (default `False`) and returns `None` instead of raising when `stat` fails. `list_managed_files` passes it and drops those entries from the listing.

Deliberately narrow:

- Single-path endpoints keep the old behaviour. There a 500 names the problem for the one path the caller asked about instead of silently returning nothing.
- Only the `stat` failure is downgraded. The `400 Invalid path` and `403 Path outside managed files root` checks are untouched, so nothing about the sandbox boundary changes.
- `/api/fs/list` already survives this case (`entry.is_dir(follow_symlinks=False)` plus a surrounding `except OSError`) and is left alone.

## How to test

```bash
mkdir -p /tmp/dangle && cd /tmp/dangle
printf '# notes\n' > notes.md
ln -s /tmp/dangle/gone.md GEMINI.md      # target intentionally absent
hermes dashboard --no-open
```

Browse to `/tmp/dangle` in the Files tab. On `main` the listing is replaced by
`Error: 500: {"detail":"Could not stat path: [Errno 2] No such file or directory: '/tmp/dangle/gone.md'"}`.
With this branch the listing renders and shows `notes.md`, with the dead link omitted.

Automated: `test_dangling_symlink_does_not_break_listing` in `tests/hermes_cli/test_web_server_files.py`. Verified it actually catches the regression — reverting the two source files onto the test gives `assert 500 == 200`.

## Platforms tested

- macOS 15 (Darwin 24.6.0), Python 3.11.15 — `pytest tests/hermes_cli/test_web_server_files.py` 10 passed, `ruff check` clean.
- Ubuntu 24.04 VPS, Python 3.11 — the original report. Reproduced the 500 against a real `$HOME` containing a dangling symlink, then confirmed the patched dashboard lists the directory correctly.
