### PR TITLE
fix(cli): let cron job badges wrap so the job title survives narrow widths

### DIFF
--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -1107,8 +1107,8 @@ export default function CronPage() {
             <Card key={jobKey}>
               <CardContent className="flex items-start gap-4 py-4">
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
-                    <span className="font-medium text-sm truncate">
+                  <div className="flex flex-wrap items-center gap-2 mb-1">
+                    <span className="font-medium text-sm truncate min-w-0">
                       {title}
                     </span>
                     <Badge tone={STATUS_TONE[state] ?? "secondary"}>


### PR DESCRIPTION
## What and why

On a phone the Cron tab shows scheduled jobs with no names.

The job header is a single non-wrapping flex row carrying the title plus up to seven badges (state, last result, profile, delivery target, skills, mode, model, toolsets). The badges are content-sized and refuse to shrink, so on a narrow viewport they take the whole row: they overflow the card, slide under the action buttons, and the title — the one element that can shrink — is squeezed to zero width.

The result at 375px is a list of cards where every job is identified only by a row of clipped badges. `truncate` is already on the title and does nothing, because inside a flex row it needs `min-w-0` to have any effect.

## The change

Two utility classes on the existing markup, no structural change:

- `flex-wrap` on the header row, so the badges fall to the next line instead of consuming the title's width.
- `min-w-0` on the title span, so its existing `truncate` applies when a single long name still needs clipping.

## How to test

Open the dashboard at a 375px-wide viewport (device toolbar, or just narrow the window) with at least one scheduled job that carries several badges — a job with a delivery target, a pinned model and a skill shows the problem clearly:

```bash
hermes cron create "every day at 09:00" "<prompt>" --deliver telegram
```

Before: the job card shows badges only, clipped at the right edge, overlapping the pause/run/edit/delete buttons. After: the job name is on its own line, the badges wrap onto following lines, and the action buttons stay in the top-right corner.

Desktop layout is unchanged — the row only wraps once it actually runs out of width.

## Platforms tested

macOS 15 (Darwin 24.6.0), Chromium at 375x812 and at desktop width, against a dashboard with three real scheduled jobs. `tsc --noEmit`, `eslint`, `vitest run src/pages` (7 passed) and `npm run build` all clean.
