### PR TITLE
fix(projects): keep blank folder paths from resolving to cwd

### DIFF
--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -106,8 +106,11 @@ def _now() -> int:
 
 
 def _normalize_path(path: str) -> str:
-    """Absolute, user-expanded, separator-normalized path (no trailing sep)."""
-    p = os.path.abspath(os.path.expanduser(str(path).strip()))
+    """Absolute, user-expanded path (no trailing sep), or empty for blank input."""
+    path = str(path).strip()
+    if not path:
+        return ""
+    p = os.path.abspath(os.path.expanduser(path))
     return p.rstrip("/\\") or p
 
 
@@ -238,7 +241,7 @@ def create_project(
     pid = "p_" + secrets.token_hex(4)
     now = _now()
     folder_paths = list(dict.fromkeys(p for p in map(_normalize_path, folders or []) if p))
-    primary = _normalize_path(primary_path) if primary_path else None
+    primary = (_normalize_path(primary_path) or None) if primary_path else None
     if primary and primary not in folder_paths:
         folder_paths.insert(0, primary)
     if primary is None and folder_paths:

--- a/tests/tui_gateway/test_project_empty_paths.py
+++ b/tests/tui_gateway/test_project_empty_paths.py
@@ -1,0 +1,53 @@
+"""Blank project paths must not select the backend's working directory."""
+
+import pytest
+
+from hermes_cli import projects_db as pdb
+from tui_gateway import server
+
+
+@pytest.mark.parametrize("action", ["add_folder", "remove_folder", "set_primary"])
+@pytest.mark.parametrize("path_params", [{}, {"path": ""}, {"path": " \t "}])
+def test_blank_folder_mutations_leave_project_unchanged(
+    tmp_path, monkeypatch, action, path_params
+):
+    cwd, other = tmp_path / "cwd", tmp_path / "other"
+    cwd.mkdir()
+    other.mkdir()
+    monkeypatch.chdir(cwd)
+    folders = [str(other)] + ([str(cwd)] if action != "add_folder" else [])
+    with pdb.connect_closing() as conn:
+        pid = pdb.create_project(conn, name="Project", folders=folders)
+        before = pdb.get_project(conn, pid).to_dict()
+
+        response = server._methods[f"projects.{action}"](1, {"id": pid, **path_params})
+
+        assert pdb.get_project(conn, pid).to_dict() == before
+        if action == "add_folder":
+            assert response["error"]["code"] == 5063
+        else:
+            assert "error" not in response
+
+
+@pytest.mark.parametrize("blank", ["", " \t "])
+def test_blank_paths_never_bind_or_discover_cwd(tmp_path, monkeypatch, blank):
+    monkeypatch.chdir(tmp_path)
+    with pdb.connect_closing() as conn:
+        cwd_id = pdb.create_project(conn, name="Cwd", folders=["."])
+        assert pdb.find_by_primary_path(conn, ".").id == cwd_id
+        assert pdb.find_by_primary_path(conn, blank) is None
+
+        pid = pdb.create_project(
+            conn, name="Unbound", folders=[blank], primary_path=blank
+        )
+        project = pdb.get_project(conn, pid)
+        assert project.folders == []
+        assert project.primary_path is None
+
+        other = str(tmp_path / "other")
+        pid = pdb.create_project(
+            conn, name="Other", folders=[blank, other], primary_path=blank
+        )
+        assert pdb.get_project(conn, pid).primary_path == other
+        assert pdb.record_discovered_repos(conn, [(blank, "blank")]) == 0
+        assert pdb.list_discovered_repos(conn) == []


### PR DESCRIPTION
## What does this PR do?

Prevent blank project-folder paths from resolving to the backend's current working directory. `_normalize_path()` currently passes an empty string to `os.path.abspath()`, bypassing the existing empty-path guard in `add_folder()` and blank-entry filters in project creation and discovery.

For example, a `projects.remove_folder` request with a valid project ID but no `path` removes the cwd's folder association if it is registered. Similarly, blank `add_folder` or `set_primary` requests can add or select that folder. No filesystem deletion is involved.

Preserve blank input as an empty string before making paths absolute, and treat a blank explicit primary path as absent during creation. Existing caller guards/filters then apply across the shared path: add-folder reports its existing invalid-argument error, remove-folder/set-primary make no change, and lookup/discovery ignore blanks. Explicit `.` still selects cwd.

## Related Issue / Duplicate Check

Found during source inspection and reproduced on current main. Searched open/closed issues and PRs for blank/empty project paths, `_normalize_path`, and cwd binding; no matching fix found. Separate from #106677 (drive-root preservation) and #107147 (Windows case comparison).

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `hermes_cli/projects_db.py`: preserve blank normalization and fall back to the first valid folder when an explicit primary path is blank.
- `tests/tui_gateway/test_project_empty_paths.py`: two parameterized behavior tests, covering 11 cases through real RPC handlers and the shared database API.

## How to Test

Run:

```bash
scripts/run_tests.sh tests/tui_gateway/test_project_empty_paths.py tests/tui_gateway/test_projects_rpc.py -j 2
scripts/run_tests.sh tests/hermes_cli/test_projects_cli.py tests/hermes_cli/test_projects_db.py -j 2
```

Native Windows, Python 3.11.15, isolated Hermes home, real temporary directories and SQLite:

- All 11 new cases fail on baseline and pass with the fix. They verify unchanged folder associations for omitted/empty/whitespace inputs, lookup/discovery behavior, primary-folder selection, and explicit `.` semantics.
- New regressions plus existing project RPC tests: **46 passed**.
- Existing CLI tests: **2 passed**.
- Existing DB tests: **5 passed, 2 failed**. Both failures (`test_create_get_list`, `test_per_profile_isolation`) assert literal POSIX paths on Windows. Reproduced the same failures with the production patch removed and a clean diff for `projects_db.py`.
- Overall focused results: **53 passed, 2 pre-existing failures**. The new 11-case regression was rerun successfully immediately before publication.
- New-test Ruff lint/format and `git diff --check` pass.

Full repository suite, Linux/macOS execution, and visible desktop UI verification were not run.

## Checklist

- [x] Read contributing guidance and searched for existing fixes.
- [x] Kept the change limited to the shared bug and its regression coverage.
- [x] Reproduced the failure before fixing it and tested on native Windows.
- [x] Considered cross-platform behavior; tests use native temporary paths without OS emulation.
- [ ] Full repository suite passes (not run; focused baseline failures disclosed above).
- [x] Config, tool schemas, and architecture documentation changes: not applicable.
