### PR TITLE
fix(desktop): scale stranded-reply harvest window to the turn hard cap (partial #105247)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-harvest-bound.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-harvest-bound.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Harvest bound for stranded group replies (#105247): the background watch
+ * must cover the whole legal life of a turn (hard cap + margin), or a reply
+ * landing in a quiet room after the old fixed 5-minute window was dropped.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { atom } = await import('nanostores')
+
+  return {
+    atom,
+    host: { state: { connectionId: { get: () => 'local' } } }
+  }
+})
+
+import { GROUP_TURN_HARD_CAP_MS, groupStrandedHarvestMaxTries } from './group-turns'
+
+describe('groupStrandedHarvestMaxTries', () => {
+  it('covers the hard cap plus a margin at the production interval', () => {
+    const tries = groupStrandedHarvestMaxTries(5000)
+
+    expect(tries * 5000).toBeGreaterThanOrEqual(GROUP_TURN_HARD_CAP_MS + 60000)
+    // 20min cap / 5s + 60s margin = 252 tries (~21min), not the old 60 (5min).
+    expect(tries).toBeGreaterThan(60)
+  })
+
+  it('keeps the old floor for degenerate intervals', () => {
+    expect(groupStrandedHarvestMaxTries(Number.MAX_SAFE_INTEGER)).toBe(60)
+  })
+
+  it('scales with the interval instead of hardcoding tries', () => {
+    const fast = groupStrandedHarvestMaxTries(1000)
+    const slow = groupStrandedHarvestMaxTries(30000)
+
+    expect(fast * 1000).toBeGreaterThanOrEqual(GROUP_TURN_HARD_CAP_MS + 60000)
+    expect(slow * 30000).toBeGreaterThanOrEqual(GROUP_TURN_HARD_CAP_MS + 60000)
+    expect(fast).toBeGreaterThan(slow)
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -19,7 +19,7 @@ import {
 import type { GroupChatRoom, GroupHoldStamp } from './group-chat'
 import { durableGroupChatMembers, followGroupChat, groupMemberKey } from './group-membership'
 import { runGroupContinuationMembers, runGroupRoundMember } from './group-round-members'
-import { harvestStrandedGroupReply } from './group-turns'
+import { groupStrandedHarvestMaxTries, harvestStrandedGroupReply } from './group-turns'
 import { requestForBot } from './routing'
 import type { Attachment, GroupMember, GroupMessage } from './types'
 
@@ -594,9 +594,10 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
 }
 
 /** Bounded background harvest for members whose replies outlived the turn
- *  loop. Polls every 5s for up to 5 minutes; stops early when nothing is
- *  stranded, a new loop takes the room over (it harvests on its own), or the
- *  room record disappears (disband). */
+ *  loop. Polls every 5s until the whole legal life of a turn is covered
+ *  (hard cap + margin, see groupStrandedHarvestMaxTries); stops early when
+ *  nothing is stranded, a new loop takes the room over (it harvests on its
+ *  own), or the room record disappears (disband). */
 async function harvestStrandedUntilSettled(group: string, members: GroupMember[], thread: string) {
   const binding = followGroupChat(group, name => {
     group = name
@@ -604,7 +605,7 @@ async function harvestStrandedUntilSettled(group: string, members: GroupMember[]
 
   try {
     const HARVEST_INTERVAL_MS = 5000
-    const HARVEST_MAX_TRIES = 60
+    const HARVEST_MAX_TRIES = groupStrandedHarvestMaxTries(HARVEST_INTERVAL_MS)
 
     for (let attempt = 0; attempt < HARVEST_MAX_TRIES; attempt++) {
       await new Promise(resolve => window.setTimeout(resolve, HARVEST_INTERVAL_MS))

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.ts
@@ -430,7 +430,15 @@ async function submitGroupTurnPrompt(
 // timeout alone silently dropped long real turns: a 7-minute research run
 // timed out at 3 minutes, read as a pass, and its finished result never
 // reached the room (db's Aug 2026 report).
-const GROUP_TURN_HARD_CAP_MS = 20 * 60000
+export const GROUP_TURN_HARD_CAP_MS = 20 * 60000
+
+/** Harvest bound for stranded replies (#105247): the background watch must
+ *  cover the whole legal life of a turn (hard cap) plus a margin, or a
+ *  reply landing in a quiet room after the old fixed 5-minute window was
+ *  dropped. Floor 60 keeps the previous behavior for degenerate intervals. */
+export function groupStrandedHarvestMaxTries(intervalMs: number): number {
+  return Math.max(60, Math.ceil(GROUP_TURN_HARD_CAP_MS / intervalMs) + Math.ceil(60000 / intervalMs))
+}
 
 /** Mirror a member's pending prompt — clarify question OR command approval —
  *  from its resume snapshot into the room store, keyed


### PR DESCRIPTION
## What Problem This Solves

#105247 Issue 1: `harvestStrandedUntilSettled` (group-rounds.ts) polled every
5s for a fixed 60 tries = 5 minutes. A member turn that is visibly still
working legally runs up to `GROUP_TURN_HARD_CAP_MS` (20 min). If the room
stayed quiet after the base timeout (no new send, no fresh harvest pass), a
reply landing after minute 5 was never delivered.

## Root Cause

The harvest bound was a magic number disconnected from the turn lifecycle it
protects. The cap owner (group-turns.ts) and the watcher (group-rounds.ts)
never shared the constant.

## Changes

- `group-turns.ts`: export `GROUP_TURN_HARD_CAP_MS` + new pure
  `groupStrandedHarvestMaxTries(intervalMs)` = max(60, ceil(hardCap/interval)
  + ceil(60s/interval)). At the production 5s interval: 252 tries (~21 min).
- `group-rounds.ts`: use it instead of the hardcoded 60; doc comment updated.
- `group-harvest-bound.test.ts`: 3 cases (covers cap+margin, old floor,
  interval scaling). Sabotage-verified (bound forced to 60 -> 2 red).

## Evidence

- New suite 3/3 green; full `src/plugins/hermes-bots` suite 64 files /
  587 tests green; `tsc -p . --noEmit` clean.

## Scope

Partial: addresses the Issue 1 (harvest window) half of #105247. Issue 2
(silent member spawn/slot failures + retry + system notice) is not included:
no slot-busy error signature is observable from the desktop tree (zero hits
for slot/busy/pool-exhaustion strings in the plugin), so a transient-error
retry detector would be guesswork. Happy to follow up once the backend
error code is named.
