### PR TITLE
feat(feishu): add collapsible progress cards

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -27,6 +27,8 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # Delete tool-progress / "⏳ Working" bubbles after a SUCCESSFUL final response where deletion is
     # supported (Telegram); failed runs keep them as breadcrumbs.
     "cleanup_progress": False,
+    # Render progress summaries with a platform-native card where supported.
+    "progress_card": False,
     # Working-state text on text-rendering indicators (Slack assistant status): "full"/true = verb +
     # argument preview, "verb" = verb only (keeps paths out of shared channels), "off"/false = static.
     "live_status": "full",
@@ -157,6 +159,7 @@ _NORMALISERS: dict[str, Any] = {
     "busy_steer_ack_enabled": _norm_bool,
     "thinking_progress": _norm_bool,
     "cleanup_progress": _norm_cleanup_progress,
+    "progress_card": _norm_bool,
     "live_status": _norm_tristate("full", "off", {"full", "verb", "off"}, extra_truthy={"all"}),
     "tool_progress_grouping": _norm_choice(("accumulate", "separate")),
     "reasoning_style": _norm_choice(("code", "blockquote", "subtext")),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4340,6 +4340,7 @@ class GatewayRunner(
         resolve_display_setting: Any = None
         progress_mode: Any = None
         progress_grouping: Any = None
+        progress_card: Any = None
         _display_surface_mode: Any = None
         tool_progress_enabled: Any = None
         _live_status_mode: Any = None

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2622,6 +2622,7 @@ class GatewayTurnMixin:
         progress_mode = _env_tp if _env_tp and not _tool_progress_configured else (_resolved_tp or _env_tp or "all")
         # "accumulate" (edit one bubble) or "separate" (one msg per tool)
         progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
+        progress_card = bool(resolve_display_setting(user_config, platform_key, "progress_card"))
         _generic_status_recent: List[str] = []
         _generic_status_catalog = resolve_status_phrase_catalog(user_config, platform_key)
 
@@ -2686,21 +2687,21 @@ class GatewayTurnMixin:
         return self._RunAgentDisplay(
             user_config=user_config, platform_key=platform_key, enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets, resolve_display_setting=resolve_display_setting,
-            progress_mode=progress_mode, progress_grouping=progress_grouping,
+            progress_mode=progress_mode, progress_grouping=progress_grouping, progress_card=progress_card,
             _display_surface_mode=_display_surface_mode,
             tool_progress_enabled=tool_progress_enabled, _live_status_mode=_live_status_mode,
             _live_status_adapter=_live_status_adapter, log_mode_enabled=log_mode_enabled,
             log_queue=queue.Queue() if log_mode_enabled else None,
             interim_assistant_messages_enabled=interim_assistant_messages_enabled,
             _thinking_enabled=_thinking_enabled, _native_slack_task_cards=_native_slack_task_cards,
-            needs_progress_queue=tool_progress_enabled or _thinking_enabled or _native_slack_task_cards,
+            needs_progress_queue=tool_progress_enabled or _thinking_enabled or _native_slack_task_cards or progress_card,
             _generic_status_phrase=_generic_status_phrase,
         )
 
     # _RunAgentDisplay fields copied verbatim onto the TurnContext.
     _DISPLAY_TO_TURN_CTX = (
         "_live_status_adapter", "_live_status_mode", "_thinking_enabled", "progress_mode",
-        "progress_grouping", "tool_progress_enabled", "log_queue", "resolve_display_setting",
+        "progress_grouping", "progress_card", "tool_progress_enabled", "log_queue", "resolve_display_setting",
         "user_config", "enabled_toolsets", "disabled_toolsets", "log_mode_enabled",
         "interim_assistant_messages_enabled", "needs_progress_queue", "_native_slack_task_cards",
     )
@@ -3722,6 +3723,20 @@ class GatewayTurnMixin:
         turn_ctx._progress_metadata, turn_ctx._progress_reply_to, _status_thread_metadata = (
             self._run_agent_progress_threading(source, event_message_id, _native_slack_task_cards)
         )
+        if turn_ctx.progress_card:
+            turn_ctx._progress_metadata = dict(turn_ctx._progress_metadata or {})
+            turn_ctx._progress_card_state = {
+                "status": "running", "stages": ["正在执行任务"], "tools": [], "tool_count": 0,
+            }
+            turn_ctx._progress_metadata.update({
+                "_interim_send": True,
+                "_progress_send": True,
+                "_progress_card": True,
+                "_progress_card_state": turn_ctx._progress_card_state,
+            })
+            _status_thread_metadata = dict(_status_thread_metadata or {})
+            _status_thread_metadata["_progress_card"] = True
+            _status_thread_metadata["_progress_card_state"] = turn_ctx._progress_card_state
         # Bridges: sync step/event/status callbacks → async hooks.emit and adapter.send.
         turn_ctx._loop_for_step = asyncio.get_running_loop()
         turn_ctx._hooks_ref = self.hooks
@@ -3865,6 +3880,14 @@ class GatewayTurnMixin:
 
             # Interrupted OR queued message (/queue)?
             result = turn_ctx.result_holder[0]
+            if turn_ctx._progress_card_state is not None:
+                outcome = result if isinstance(result, dict) else response if isinstance(response, dict) else {}
+                turn_ctx._progress_card_state["status"] = (
+                    "failed" if outcome.get("failed") or outcome.get("error")
+                    else "stopped" if outcome.get("interrupted") or outcome.get("stopped")
+                    else "failed" if outcome.get("completed") is False
+                    else "completed"
+                )
             adapter = self._adapter_for_source(source)
             await self._run_agent_finalize_streaming_tts(turn_ctx, adapter)
             pending_event, pending = await self._run_agent_drain_pending(result, adapter, source, session_key)

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -111,6 +111,12 @@ class TurnRunner:
             ctx.log_queue.put(f"{ts}  {tool_name}:{preview_str}".rstrip())
         if not ctx.progress_queue or not ctx._run_still_current():
             return
+        if (
+            ctx._progress_card_state is not None
+            and event_type == "tool.started"
+            and tool_name != "_thinking"
+        ):
+            ctx.progress_queue.put({"type": "tool.started"})
         if event_type == "tool.completed" and not ctx.long_tool_hint_fired[0]:
             self._progress_onboarding_hint(kwargs)
             return
@@ -253,7 +259,10 @@ class TurnRunner:
                 code = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
             elif code is None:
                 code = f"{emoji} {tool_name}: \"{preview}\"" if preview else f"{emoji} {tool_name}..."
-            ctx.progress_queue.put(code)
+            ctx.progress_queue.put(
+                {"type": "tool.summary", "summary": code}
+                if ctx._progress_card_state is not None else code
+            )
             return None
         if code is not None:
             return code
@@ -275,6 +284,9 @@ class TurnRunner:
         ctx = self._ctx
         sc = self._stream_consumer()
         native = sc is not None and getattr(sc, "accepts_tool_progress", False)
+        if ctx._progress_card_state is not None:
+            ctx.progress_queue.put({"type": "tool.summary", "summary": msg})
+            return
         if msg == ctx.last_progress_msg[0]:
             ctx.repeat_count[0] += 1
             if native:
@@ -471,6 +483,7 @@ class TurnRunner:
         _progress_len_fn: Any
         _PROGRESS_TEXT_LIMIT: int
         _edit_accepts_metadata: bool
+        _edit_accepts_finalize: bool
 
     def _progress_edit_state(self, adapter) -> "TurnRunner._ProgressEditState":
         ctx = self._ctx
@@ -494,12 +507,16 @@ class TurnRunner:
             _PROGRESS_TEXT_LIMIT=max(1, raw_limit - (64 if raw_limit > 128 else 0)),
             # Overflow edits pass metadata (Telegram topic/thread routing) only when edit_message takes it.
             _edit_accepts_metadata=bool(ctx._progress_metadata) and _accepts_keyword(adapter.edit_message, "metadata"),
+            _edit_accepts_finalize=_accepts_keyword(adapter.edit_message, "finalize"),
         )
 
-    async def _edit_progress_message(self, st, message_id: str, content: str):
+    async def _edit_progress_message(self, st, message_id: str, content: str, *, finalize: bool = False):
         ctx = self._ctx
         kwargs = {"chat_id": ctx.source.chat_id, "message_id": message_id, "content": content}
-        if getattr(st.adapter, "REQUIRES_EDIT_FINALIZE", False):
+        if st._edit_accepts_finalize and (
+            getattr(st.adapter, "REQUIRES_EDIT_FINALIZE", False)
+            or (finalize and getattr(st.adapter, "REQUIRES_PROGRESS_FINALIZE", False))
+        ):
             kwargs["finalize"] = True
         if st._edit_accepts_metadata:
             kwargs["metadata"] = ctx._progress_metadata
@@ -566,11 +583,33 @@ class TurnRunner:
     def _reset_progress_bubble(self, st) -> None:
         """Content bubble landed — close the tool-progress bubble so the next tool starts fresh
         below it; else tool edits hit the ORIGINAL message above (out of order)."""
+        if self._ctx._progress_card_state is not None:
+            return
         st.progress_msg_id, st.progress_lines = None, []
         self._ctx.last_progress_msg[0], self._ctx.repeat_count[0] = None, 0
 
     def _progress_absorb(self, st, raw) -> Any:
         """Fold a queue item into the bubble buffer; returns the line to render this tick."""
+        state = self._ctx._progress_card_state
+        if state is not None and isinstance(raw, dict):
+            summary = re.sub(r"\s+", " ", str(raw.get("summary") or "")).strip()
+            if len(summary) > 240:
+                summary = summary[:237].rstrip() + "..."
+            if raw.get("type") == "stage" and summary:
+                if not state["stages"] or state["stages"][-1] != summary:
+                    state["stages"].append(summary)
+                    state["stages"] = state["stages"][-6:]
+            elif raw.get("type") == "tool.started":
+                state["tool_count"] += 1
+            elif raw.get("type") == "tool.summary":
+                if summary:
+                    state["tools"].append(summary)
+                    state["tools"] = state["tools"][-8:]
+            rendered = "\n".join([
+                *state["stages"], f"已调用 {state['tool_count']} 次工具", *state["tools"],
+            ])
+            st.progress_lines[:] = [rendered]
+            return rendered
         if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
             _, base_msg, count = raw
             if not st.progress_lines:
@@ -580,10 +619,12 @@ class TurnRunner:
         st.progress_lines.append(raw)
         return raw
 
-    async def _flush_progress_edit(self, st) -> None:
+    async def _flush_progress_edit(self, st, *, finalize: bool = False) -> None:
         if st.can_edit and st.progress_lines and st.progress_msg_id:
             with suppress(Exception):
-                await self._edit_progress_message(st, st.progress_msg_id, self._progress_text(st.progress_lines))
+                await self._edit_progress_message(
+                    st, st.progress_msg_id, self._progress_text(st.progress_lines), finalize=finalize
+                )
 
     async def _drain_progress_on_cancel(self, st) -> None:
         ctx = self._ctx
@@ -602,7 +643,9 @@ class TurnRunner:
         # Final edit with all remaining tools (only if editing works)
         if st.can_edit and st.progress_lines and st.progress_msg_id:
             await self._roll_progress_overflow_if_needed(st)
-        await self._flush_progress_edit(st)
+        await self._flush_progress_edit(
+            st, finalize=bool(ctx._progress_card_state and ctx._progress_card_state.get("status") == "completed")
+        )
 
     async def _progress_restore_typing(self, st) -> None:
         ctx = self._ctx
@@ -616,9 +659,16 @@ class TurnRunner:
         Transient network errors (ConnectError, timeouts) must not disable editing; only permanent
         failures (not found, permissions) set can_edit=False. Flood control backs off but keeps editing.
         """
+        card_state = self._ctx._progress_card_state
+        if card_state is not None and card_state.get("update_failed"):
+            return True
         if st.can_edit and st.progress_msg_id is not None:
             result = await self._edit_progress_message(st, st.progress_msg_id, "\n".join(st.progress_lines))
             if result.success:
+                return True
+            if card_state is not None:
+                card_state["update_failed"] = True
+                logger.warning("[%s] Progress card update failed; preserving the original card", st.adapter.name)
                 return True
             if getattr(result, "retryable", False):
                 logger.debug("[%s] Transient edit failure — keeping can_edit=True", st.adapter.name)
@@ -890,10 +940,14 @@ class TurnRunner:
                 if not already_streamed:
                     stts.on_delta(text)
                     stts.on_delta(None)
-            if stream_consumer is not None:
+            if ctx._progress_card_state is not None and not already_streamed and str(text or "").strip():
+                ctx.progress_queue.put({"type": "stage", "summary": text})
+            elif stream_consumer is not None:
                 stream_consumer.on_segment_break() if already_streamed else stream_consumer.on_commentary(text)
             elif not already_streamed and ctx._status_adapter and str(text or "").strip():
-                self._send_status_text(text, ctx._status_thread_metadata, "interim_assistant_callback scheduling error")
+                self._send_status_text(
+                    text, ctx._status_thread_metadata, "interim_assistant_callback scheduling error"
+                )
 
         return stream_consumer, stream_delta_cb, interim_assistant_cb, want_interim_messages
 

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -21,6 +21,7 @@ class TurnContext:
     _thinking_enabled: bool = False
     progress_mode: str = "off"
     progress_grouping: str = "grouped"
+    progress_card: bool = False
     tool_progress_enabled: bool = False
     progress_queue: Any = None
     log_queue: Any = None
@@ -35,6 +36,7 @@ class TurnContext:
     _cleanup_progress: bool = False
     _cleanup_msg_ids: List[str] = field(default_factory=list)
     _progress_metadata: Optional[dict] = None
+    _progress_card_state: Optional[dict] = None
     _progress_reply_to: Optional[Any] = None
     message: Optional[str] = None  # the only rebindable field
     # turn parameters / config snapshots (read-only in run_sync)

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -64,7 +64,7 @@ _LARK_SDK_IMPORTS = (
         "CreateFileRequest", "CreateFileRequestBody", "CreateImageRequest", "CreateImageRequestBody",
         "CreateMessageRequest", "CreateMessageRequestBody", "GetChatRequest", "GetMessageRequest",
         "GetMessageResourceRequest", "P2ImMessageMessageReadV1", "ReplyMessageRequest", "ReplyMessageRequestBody",
-        "UpdateMessageRequest", "UpdateMessageRequestBody",
+        "PatchMessageRequest", "PatchMessageRequestBody", "UpdateMessageRequest", "UpdateMessageRequestBody",
     )),
     ("lark_oapi.core", ("AccessTokenType", "HttpMethod")),
     ("lark_oapi.core.const", ("FEISHU_DOMAIN", "LARK_DOMAIN")),
@@ -1197,8 +1197,12 @@ class FeishuAdapter(BasePlatformAdapter):
 
     supports_code_blocks = True  # Feishu renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
+    REQUIRES_PROGRESS_FINALIZE = True
 
     MAX_MESSAGE_LENGTH = 8000
+    # Card JSON adds structural overhead around the markdown body. Keep the
+    # existing message budget while leaving room for the Card 2.0 envelope.
+    PROGRESS_CARD_TEXT_LIMIT = 6000
     CHAT_LOCK_MAX_SIZE: int = 1000  # distinct chat IDs kept in _chat_locks before LRU eviction
     _SPLIT_THRESHOLD = 4000  # chunk near Feishu's ~4096-char client split → continuation almost certain
 
@@ -1562,6 +1566,35 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         formatted = self.format_message(content)
+        card_state = (metadata or {}).get("_progress_card_state")
+        if isinstance(card_state, dict) and card_state.get("delivery_aborted"):
+            return SendResult(success=False, error="Progress card delivery was aborted after an uncertain failure")
+        if self._uses_progress_card(metadata):
+            try:
+                response = await self._feishu_send_with_retry(
+                    chat_id=chat_id,
+                    msg_type="interactive",
+                    payload=self._build_progress_card_payload(formatted, metadata=metadata),
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+                result = self._finalize_send_result(response, "progress card send failed")
+                if result.success:
+                    return result
+                if isinstance(card_state, dict):
+                    card_state["delivery_mode"] = "plain"
+                logger.warning(
+                    "[Feishu] Progress card send rejected (code=%s); falling back to ordinary message",
+                    getattr(response, "code", "unknown"),
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[Feishu] Progress card send failed (%s); aborting progress delivery to avoid duplicates",
+                    type(exc).__name__,
+                )
+                if isinstance(card_state, dict):
+                    card_state["delivery_aborted"] = True
+                return SendResult(success=False, error=str(exc))
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         # Decide markdown-vs-text once for the whole message: a chunk of a long
         # markdown reply may be plain prose that fails the per-chunk regex and would
@@ -1606,7 +1639,10 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.error("[Feishu] Send error: %s", exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
-    async def edit_message(self, chat_id: str, message_id: str, content: str, *, finalize: bool = False) -> SendResult:
+    async def edit_message(
+        self, chat_id: str, message_id: str, content: str, *, finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
         """Edit a previously sent Feishu text/post message."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
@@ -1619,7 +1655,27 @@ class FeishuAdapter(BasePlatformAdapter):
             response = await self._run_blocking(self._client.im.v1.message.update, request)
             return self._finalize_send_result(response, "update failed")
 
+        async def _patch_card(payload: str) -> SendResult:
+            body = self._build_patch_message_body(content=payload)
+            request = self._build_patch_message_request(message_id=message_id, request_body=body)
+            response = await self._run_blocking(self._client.im.v1.message.patch, request)
+            return self._finalize_send_result(response, "card patch failed")
+
         try:
+            if self._uses_progress_card(metadata):
+                try:
+                    result = await _patch_card(
+                        self._build_progress_card_payload(content, finalize=finalize, metadata=metadata),
+                    )
+                    if result.success:
+                        result.message_id = message_id
+                    return result
+                except Exception as exc:
+                    logger.warning(
+                        "[Feishu] Progress card update failed (%s); preserving the original card",
+                        type(exc).__name__,
+                    )
+                    return SendResult(success=False, error=str(exc))
             msg_type, payload = self._build_outbound_payload(content)
             result = await _update(msg_type, payload)
             if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
@@ -1633,6 +1689,57 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
+
+    @staticmethod
+    def _uses_progress_card(metadata: Optional[Dict[str, Any]]) -> bool:
+        return bool(
+            metadata
+            and metadata.get("_interim_send") is True
+            and metadata.get("_progress_send") is True
+            and metadata.get("_progress_card") is True
+            and (metadata.get("_progress_card_state") or {}).get("delivery_mode") != "plain"
+        )
+
+    @classmethod
+    def _build_progress_card_payload(
+        cls, content: str, *, finalize: bool = False, metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        if len(content) > cls.PROGRESS_CARD_TEXT_LIMIT:
+            content = content[: cls.PROGRESS_CARD_TEXT_LIMIT - 1].rstrip() + "…"
+        structured_state = (metadata or {}).get("_progress_card_state")
+        state = structured_state if isinstance(structured_state, dict) else {}
+        status = state.get("status") or ("completed" if finalize else "running")
+        status_text = {
+            "running": "⏳ 任务进行中", "completed": "✓ 任务已完成",
+            "failed": "⚠ 任务执行失败", "stopped": "• 任务已终止",
+        }.get(status, "⏳ 任务进行中")
+        stages = (
+            state.get("stages") or ["正在执行任务"]
+            if isinstance(structured_state, dict)
+            else ([content] if content.strip() else [])
+        )
+        stage_lines = [
+            f"{'✓' if status == 'completed' or index < len(stages) - 1 else '●'} {stage}"
+            for index, stage in enumerate(stages)
+        ] or ["● 正在执行任务"]
+        tools = state.get("tools") or []
+        tool_count = int(state.get("tool_count") or 0)
+        elements = [
+            {"tag": "markdown", "content": f"**{status_text}**"},
+            {"tag": "markdown", "content": "\n".join(stage_lines)},
+        ]
+        if tool_count:
+            elements.append({
+                "tag": "collapsible_panel", "expanded": False,
+                "header": {"title": {"tag": "plain_text", "content": f"已调用 {tool_count} 次工具"}},
+                "elements": [{"tag": "markdown", "content": "\n".join(f"</> {tool}" for tool in tools)}],
+            })
+        card = {
+            "schema": "2.0",
+            "config": {"width_mode": "fill"},
+            "body": {"elements": elements},
+        }
+        return json.dumps(card, ensure_ascii=False)
 
     # Template attrs for the shared _format_exec_approval core. The card
     # header carries the title, so the text core starts at the code fence.
@@ -3836,6 +3943,14 @@ class FeishuAdapter(BasePlatformAdapter):
     @staticmethod
     def _build_update_message_request(message_id: str, request_body: Any) -> Any:
         return _sdk_build(UpdateMessageRequest, message_id=message_id, request_body=request_body)
+
+    @staticmethod
+    def _build_patch_message_body(*, content: str) -> Any:
+        return _sdk_build(PatchMessageRequestBody, content=content)
+
+    @staticmethod
+    def _build_patch_message_request(message_id: str, request_body: Any) -> Any:
+        return _sdk_build(PatchMessageRequest, message_id=message_id, request_body=request_body)
 
     @staticmethod
     def _build_create_message_body(*, receive_id: str, msg_type: str, content: str, uuid_value: str) -> Any:

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -326,4 +326,3 @@ class TestLiveStatusSetting:
 
         assert resolve_display_setting({}, "slack", "live_status") == "full"
 
-

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -288,6 +288,107 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
             json.dumps({"text": "可以用 粗体 和 斜体。"}, ensure_ascii=False),
         )
 
+    @staticmethod
+    def _progress_metadata():
+        state = {
+            "status": "running",
+            "stages": ["理解需求", "核对更新协议"],
+            "tools": ["🔍 搜索 SDK", "💻 运行定向测试"],
+            "tool_count": 2,
+        }
+        return {
+            "_interim_send": True,
+            "_progress_send": True,
+            "_progress_card": True,
+            "_progress_card_state": state,
+        }
+
+    @staticmethod
+    def _success(message_id="om_progress"):
+        return SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id=message_id),
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_progress_card_delivery_contract(self):
+        from gateway.config import PlatformConfig
+        from gateway.display_config import resolve_display_setting
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        patch_message = Mock(return_value=self._success())
+        update_message = Mock(return_value=self._success())
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(
+                patch=patch_message, update=update_message,
+            )))
+        )
+        adapter._feishu_send_with_retry = AsyncMock(side_effect=[
+            self._success("om_plain"), self._success("om_progress"), self._success("om_final"),
+        ])
+        metadata = self._progress_metadata()
+
+        plain = asyncio.run(adapter.send("oc_chat", "默认进度"))
+        sent = asyncio.run(adapter.send("oc_chat", "fallback", metadata=metadata))
+        metadata["_progress_card_state"]["status"] = "completed"
+        edited = asyncio.run(adapter.edit_message(
+            "oc_chat", sent.message_id, "fallback", finalize=True, metadata=metadata,
+        ))
+        ordinary_edited = asyncio.run(adapter.edit_message("oc_chat", "om_text", "普通更新"))
+        patch_message.return_value = SimpleNamespace(success=lambda: False, code=230099, msg="invalid card")
+        failed_patch = asyncio.run(adapter.edit_message(
+            "oc_chat", sent.message_id, "fallback", metadata=metadata,
+        ))
+        final = asyncio.run(adapter.send("oc_chat", "最终答案"))
+
+        self.assertFalse(resolve_display_setting({}, "feishu", "progress_card"))
+        self.assertTrue(plain.success and sent.success and edited.success and ordinary_edited.success and final.success)
+        self.assertFalse(failed_patch.success)
+        calls = adapter._feishu_send_with_retry.await_args_list
+        self.assertEqual([call.kwargs["msg_type"] for call in calls], ["text", "interactive", "text"])
+        card = json.loads(calls[1].kwargs["payload"])
+        self.assertEqual(card["schema"], "2.0")
+        self.assertNotIn("header", card)
+        self.assertIn("任务进行中", card["body"]["elements"][0]["content"])
+        self.assertIn("理解需求", card["body"]["elements"][1]["content"])
+        panel = card["body"]["elements"][2]
+        self.assertEqual(panel["tag"], "collapsible_panel")
+        self.assertFalse(panel["expanded"])
+        self.assertEqual(panel["header"]["title"]["content"], "已调用 2 次工具")
+        self.assertIn("运行定向测试", panel["elements"][0]["content"])
+        self.assertEqual(edited.message_id, "om_progress")
+        request = patch_message.call_args_list[0].args[0]
+        self.assertEqual(request.message_id, "om_progress")
+        patched_card = json.loads(request.request_body.content)
+        self.assertIn("任务已完成", patched_card["body"]["elements"][0]["content"])
+        self.assertEqual(update_message.call_count, 1)
+        self.assertEqual(update_message.call_args.args[0].request_body.msg_type, "text")
+
+    def test_progress_card_structured_state_never_promotes_tool_content_to_stage(self):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        metadata = self._progress_metadata()
+        metadata["_progress_card_state"].update({
+            "stages": [],
+            "tools": ["💻 terminal: first command"],
+            "tool_count": 1,
+        })
+        card = json.loads(FeishuAdapter._build_progress_card_payload(
+            "正在执行任务\n已调用 1 次工具\n💻 terminal: first command",
+            metadata=metadata,
+        ))
+
+        stage = card["body"]["elements"][1]["content"]
+        panel = card["body"]["elements"][2]
+        self.assertEqual(stage, "● 正在执行任务")
+        self.assertNotIn("terminal", stage)
+        self.assertIn("terminal: first command", panel["elements"][0]["content"])
+
+        metadata["_progress_card_state"]["status"] = "failed"
+        failed_card = json.loads(FeishuAdapter._build_progress_card_payload("ignored", metadata=metadata))
+        self.assertIn("任务执行失败", failed_card["body"]["elements"][0]["content"])
+
 
 class TestAdapterModule(unittest.TestCase):
     def test_load_settings_uses_sdk_defaults_for_invalid_ws_reconnect_values(self):
@@ -2523,5 +2624,3 @@ class TestChatLockEviction(unittest.TestCase):
 
         adapter = self._make_adapter()
         self.assertIsInstance(adapter._chat_locks, _collections.OrderedDict)
-
-

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -133,6 +133,8 @@ class SmallLimitProgressAdapter(ProgressCaptureAdapter):
 
 
 class MetadataEditProgressCaptureAdapter(ProgressCaptureAdapter):
+    REQUIRES_PROGRESS_FINALIZE = True
+
     async def edit_message(
         self, chat_id, message_id, content, *, finalize: bool = False, metadata=None
     ) -> SendResult:
@@ -142,6 +144,7 @@ class MetadataEditProgressCaptureAdapter(ProgressCaptureAdapter):
                 "message_id": message_id,
                 "content": content,
                 "metadata": metadata,
+                "finalize": finalize,
             }
         )
         return SendResult(success=True, message_id=message_id)
@@ -456,6 +459,57 @@ class DelayedInterimAgent:
         }
 
 
+class CardProgressAgent:
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None, **kwargs):
+        self.interim_assistant_callback("理解用户问题")
+        self.tool_progress_callback("tool.started", "terminal", "first command", {})
+        time.sleep(0.4)
+        self.interim_assistant_callback("核对更新协议")
+        self.tool_progress_callback("tool.started", "browser_navigate", "https://example.com", {})
+        time.sleep(0.4)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+class FailedCardProgressAgent:
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None, **kwargs):
+        self.tool_progress_callback("tool.started", "terminal", "failing command", {})
+        time.sleep(0.4)
+        return {
+            "final_response": "failed", "messages": [], "api_calls": 1,
+            "completed": False, "failed": True,
+        }
+
+
+class StoppedCardProgressAgent:
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None, **kwargs):
+        self.tool_progress_callback("tool.started", "terminal", "interrupted command", {})
+        time.sleep(0.4)
+        return {
+            "final_response": "stopped", "messages": [], "api_calls": 1,
+            "completed": False, "interrupted": True,
+        }
+
+
+class RepeatedCardToolAgent:
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None, **kwargs):
+        self.tool_progress_callback("tool.started", "terminal", "first command", {})
+        self.tool_progress_callback("tool.started", "terminal", "second command", {})
+        time.sleep(0.4)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
 def _make_runner(adapter):
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
@@ -479,6 +533,143 @@ def _make_runner(adapter):
         stt_enabled=False,
     )
     return runner
+
+
+@pytest.mark.asyncio
+async def test_feishu_progress_metadata_marks_card_lane_and_finalizes(monkeypatch, tmp_path):
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "display": {
+                    "platforms": {
+                        "feishu": {
+                            "tool_progress": "all",
+                            "progress_card": True,
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = CardProgressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = MetadataEditProgressCaptureAdapter(platform=Platform.FEISHU)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    source = SessionSource(platform=Platform.FEISHU, chat_id="oc_chat", chat_type="dm")
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-feishu-card",
+        session_key="agent:main:feishu:dm:oc_chat",
+        event_message_id="om_user",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent
+    metadata = adapter.sent[0]["metadata"]
+    assert metadata["_interim_send"] is True
+    assert metadata["_progress_send"] is True
+    assert metadata["_progress_card"] is True
+    assert metadata["_progress_card_state"]["stages"] == [
+        "正在执行任务", "理解用户问题", "核对更新协议",
+    ]
+    assert metadata["_progress_card_state"]["tool_count"] == 2
+    assert len(metadata["_progress_card_state"]["tools"]) == 2
+    assert metadata["_progress_card_state"]["status"] == "completed"
+    assert len(adapter.sent) == 1
+    assert adapter.edits
+    assert adapter.edits[-1]["message_id"] == "progress-1"
+    assert adapter.edits[-1]["finalize"] is True
+
+    fake_run_agent.AIAgent = FailedCardProgressAgent
+    failed_adapter = MetadataEditProgressCaptureAdapter(platform=Platform.FEISHU)
+    failed_runner = _make_runner(failed_adapter)
+    failed_result = await failed_runner._run_agent(
+        message="fail",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-feishu-card-failed",
+        session_key="agent:main:feishu:dm:oc_chat:failed",
+        event_message_id="om_user_2",
+    )
+    assert failed_result["failed"] is True
+    failed_state = failed_adapter.sent[0]["metadata"]["_progress_card_state"]
+    assert failed_state["status"] == "failed"
+    assert failed_adapter.edits[-1]["finalize"] is False
+
+    fake_run_agent.AIAgent = StoppedCardProgressAgent
+    stopped_adapter = MetadataEditProgressCaptureAdapter(platform=Platform.FEISHU)
+    stopped_runner = _make_runner(stopped_adapter)
+    stopped_result = await stopped_runner._run_agent(
+        message="stop",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-feishu-card-stopped",
+        session_key="agent:main:feishu:dm:oc_chat:stopped",
+        event_message_id="om_user_3",
+    )
+    assert stopped_result["interrupted"] is True
+    stopped_state = stopped_adapter.sent[0]["metadata"]["_progress_card_state"]
+    assert stopped_state["status"] == "stopped"
+
+
+@pytest.mark.parametrize("tool_progress", ["off", "log", "new"])
+@pytest.mark.asyncio
+async def test_feishu_progress_card_counts_every_tool_start(monkeypatch, tmp_path, tool_progress):
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({
+            "display": {"platforms": {"feishu": {
+                "tool_progress": tool_progress, "progress_card": True,
+            }}},
+        }),
+        encoding="utf-8",
+    )
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = RepeatedCardToolAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = MetadataEditProgressCaptureAdapter(platform=Platform.FEISHU)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=SessionSource(platform=Platform.FEISHU, chat_id="oc_chat", chat_type="dm"),
+        session_id=f"sess-feishu-card-{tool_progress}",
+        session_key=f"agent:main:feishu:dm:oc_chat:{tool_progress}",
+        event_message_id="om_user",
+    )
+
+    assert result["final_response"] == "done"
+    state = adapter.sent[0]["metadata"]["_progress_card_state"]
+    assert state["tool_count"] == 2
+    assert state["stages"] == ["正在执行任务"]
+    assert len(state["tools"]) == (0 if tool_progress in {"off", "log"} else 1)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -470,6 +470,7 @@ class TestSegmentBreakOnToolBoundary:
         consumer.finish()
         await task
 
+
         # The fallback should send the post-tool response via
         # _send_fallback_final.
         await consumer._send_fallback_final(post_tool_response)
@@ -1487,4 +1488,3 @@ class TestFlushPendingSync:
 
         consumer.finish()
         await task
-

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2162,6 +2162,9 @@ display:
       tool_progress: verbose  # detailed progress on Telegram
     slack:
       tool_progress: 'off'    # quiet in shared Slack workspace
+    feishu:
+      tool_progress: all
+      progress_card: true     # visible stages + collapsed tool summaries; default false
 ```
 
 From the CLI, use the canonical path — `hermes config set display.platforms.telegram.streaming false`. The shorthand `hermes config set platforms.telegram.streaming false` is accepted too: because per-platform *display* settings (`streaming`, `show_reasoning`, `tool_progress`, …) are only ever read from `display.platforms`, `config set`/`get`/`unset` redirect that shorthand to the canonical key and print a note. Connection keys under the top-level `platforms.<name>` block (`token`, `enabled`, `reply_to_mode`, `extra`) are not redirected.
@@ -2173,6 +2176,8 @@ Signal is listed as a valid platform key because the setting can be saved per pl
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
 
 `show_commentary` (default `true`) controls Codex Responses models' commentary channel — the polished progress narration these models produce alongside their private reasoning. When enabled, each completed commentary message is delivered as a visible mid-turn update (on the gateway this also requires `interim_assistant_messages`). Set it to `false` if the extra narration annoys you: commentary then falls back to the reasoning channel and is only shown when `show_reasoning` is enabled.
+
+On Feishu, `display.platforms.feishu.progress_card: true` keeps one interactive progress message: visible, shortened commentary stages appear above a collapsed “Tools called N times” panel containing trimmed tool summaries. Hidden reasoning is never included, and the final answer remains a separate ordinary message. Interactive updates use Feishu's card PATCH API; if an update fails, Hermes leaves the existing card in place instead of risking a duplicate. A card rejected before creation falls back once to the ordinary text/post progress message.
 
 ## Privacy
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1297,11 +1297,16 @@ display:
       tool_progress: verbose  # 在 Telegram 上详细进度
     slack:
       tool_progress: 'off'    # 在共享 Slack 工作区中保持安静
+    feishu:
+      tool_progress: all
+      progress_card: true     # 可见阶段 + 折叠工具摘要，默认 false
 ```
 
 没有覆盖的平台回退到全局 `tool_progress` 值。有效平台键：`telegram`、`discord`、`slack`、`signal`、`whatsapp`、`matrix`、`mattermost`、`email`、`sms`、`homeassistant`、`dingtalk`、`feishu`、`wecom`、`weixin`、`bluebubbles`、`qqbot`。旧版 `display.tool_progress_overrides` 键仍可加载以向后兼容，但已弃用，并在首次加载时迁移到 `display.platforms`。
 
 `interim_assistant_messages` 仅限 gateway。启用后，Hermes 将已完成的轮次中 assistant 更新作为单独的聊天消息发送。这与 `tool_progress` 无关，不需要 gateway 流式传输。
+
+在飞书中设置 `display.platforms.feishu.progress_card: true` 后，Gateway 会用同一条交互卡片消息展示进度：主面板直接显示经过裁剪的可见 commentary 阶段，底部“已调用 N 次工具”折叠区展示裁剪后的工具摘要。卡片不读取或展示模型隐藏思维链；最终答案仍作为独立普通消息发送。交互卡片更新使用飞书 PATCH 接口；更新失败时保留原卡片，不新发重复进度。若卡片在创建前被明确拒绝，则仅回退一次到普通 text/post 进度消息。
 
 ## 隐私
 


### PR DESCRIPTION
## Summary

- add an opt-in Feishu progress card for Gateway task updates
- keep task stages visible while folding tool summaries behind an accurate call count
- update the same interactive message with PATCH and preserve separate final answers
- represent completed, failed, and stopped outcomes without exposing hidden reasoning

## Configuration

Set `display.platforms.feishu.progress_card` to `true`. Existing Feishu text/post behavior remains the default.

## Validation

- `scripts/run_tests.sh tests/gateway/test_run_progress_topics.py tests/gateway/test_stream_consumer.py tests/gateway/test_display_config.py` — 120 passed, 1 skipped
- `scripts/run_tests.sh tests/gateway/test_feishu.py -k progress_card_delivery_contract` — 1 passed
- Ruff — passed
- plugin compatibility pointer check — passed
- `git diff --check` — passed

## Notes

The card only renders Gateway's bounded commentary and tool summaries. It does not read or expose private model reasoning. Card send failures fall back to the existing ordinary message path; update failures remain observable and do not create duplicate final answers.
