### PR TITLE
feat(desktop): close Kanban with a button or Escape

### DIFF
--- a/apps/desktop/e2e/kanban-close.spec.ts
+++ b/apps/desktop/e2e/kanban-close.spec.ts
@@ -1,0 +1,163 @@
+import { expect, test } from './test'
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { MOCK_REPLY } from '../../../tests-js/scripts/mock-server'
+
+let fixture: MockBackendFixture
+const HELD_PROMPT = 'Keep running while I inspect the board.'
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend({
+    modelContextLength: 128_000,
+    extraConfig:
+      'platform_toolsets:\n  cli: [terminal]\nagent:\n  coding_context: off\nsecurity:\n  allow_lazy_installs: false',
+    mockServer: { holdFirstStreamForPrompt: HELD_PROMPT }
+  })
+  await waitForAppReady(fixture, 120_000)
+  // Enable the bundled UI in the isolated Electron profile, as Settings does.
+  await fixture.page.evaluate(() => {
+    localStorage.setItem('hermes.desktop.pluginDecisions.v2', JSON.stringify({ kanban: true }))
+  })
+  await fixture.page.reload()
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+})
+
+test('returns to the same chat and gives nested controls the first Escape', async ({}, testInfo) => {
+  const page = fixture.page
+  const closeButton = page.getByRole('banner').getByRole('button', { name: 'Close', exact: true })
+  const composer = page.locator('[contenteditable="true"]').first()
+  await composer.click()
+  await composer.pressSequentially('Keep this conversation while inspecting Kanban.')
+  await page.keyboard.press('Enter')
+  await expect(page.getByText(MOCK_REPLY, { exact: true })).toBeVisible({ timeout: 60_000 })
+  const previousUrl = page.url()
+
+  const openBoard = async () => {
+    await page.getByRole('button', { name: 'Kanban', exact: true }).click()
+    await expect(page.getByRole('heading', { name: 'Kanban', exact: true })).toBeVisible()
+    await expect(page).toHaveURL(/#\/kanban$/)
+  }
+
+  await openBoard()
+  await closeButton.click()
+  await expect(page).toHaveURL(previousUrl)
+  await expect(page.getByText(MOCK_REPLY, { exact: true })).toBeVisible()
+
+  await openBoard()
+  await page.keyboard.press('Escape')
+  await expect(page).toHaveURL(previousUrl)
+
+  await page.keyboard.press('ControlOrMeta+k')
+  await page.getByRole('combobox').fill('Kanban: Open board')
+  await expect(page.getByRole('option', { name: 'Kanban: Open board' })).toBeVisible()
+  await page.keyboard.press('ArrowDown')
+  await page.keyboard.press('Enter')
+  await expect(page.getByRole('dialog')).toHaveCount(0)
+  await expect(page).toHaveURL(/#\/kanban$/)
+  await page.keyboard.press('Escape')
+  await expect(page).toHaveURL(previousUrl)
+
+  await openBoard()
+  await page.getByRole('button', { name: 'Open settings', exact: true }).click()
+  await expect(page).toHaveURL(/#\/settings/)
+  const settings = page.locator('[data-overlay-surface]')
+  await settings.getByRole('button', { name: 'Close settings', exact: true }).click()
+  await expect(page).toHaveURL(/#\/kanban$/)
+  await closeButton.click()
+  await expect(page).toHaveURL(previousUrl)
+
+  await openBoard()
+  await page.getByRole('button', { name: 'New task', exact: true }).first().click()
+  await expect(page.getByRole('dialog')).toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('dialog')).toHaveCount(0)
+  await expect(page).toHaveURL(/#\/kanban$/)
+
+  const search = page.getByRole('textbox', { name: 'Filter cards…' })
+  await search.click()
+  await page.keyboard.press('Escape')
+  await expect(page).toHaveURL(/#\/kanban$/)
+  await page.getByRole('heading', { name: 'Kanban', exact: true }).click()
+  await page.keyboard.press('Escape')
+  await expect(page).toHaveURL(previousUrl)
+
+  await openBoard()
+  await page.getByRole('button', { name: 'New task', exact: true }).first().click()
+  const newTask = page.getByRole('dialog')
+  await newTask.getByPlaceholder('Rough idea — a specifier will flesh it out').fill('A parked task')
+  await newTask.getByRole('combobox').nth(1).click()
+  await page.getByRole('option', { name: "unassigned (parked — won't run)", exact: true }).click()
+  await newTask.getByRole('button', { name: 'Create task', exact: true }).click()
+  await expect(newTask).toHaveCount(0)
+  const card = page.getByText('A parked task', { exact: true })
+  await card.click({ modifiers: ['ControlOrMeta'] })
+  await expect(page.getByRole('button', { name: 'Clear selection (Esc)' })).toBeVisible()
+  await card.click()
+  await expect(page.getByRole('heading', { name: 'A parked task' })).toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('heading', { name: 'A parked task' })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'Clear selection (Esc)' })).toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('button', { name: 'Clear selection (Esc)' })).toHaveCount(0)
+  await expect(page).toHaveURL(/#\/kanban$/)
+  await card.click({ button: 'right' })
+  await expect(page.getByRole('menu')).toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('menu')).toHaveCount(0)
+  await expect(page).toHaveURL(/#\/kanban$/)
+  await card.click({ button: 'right' })
+  await page.getByRole('menuitem', { name: 'Move to Ready', exact: true }).click()
+  await page.getByRole('heading', { name: 'Kanban', exact: true }).click()
+  await page.keyboard.press('Escape')
+  await expect(page).toHaveURL(previousUrl)
+
+  // The live counter is a third entry point into the same route.
+  await page.getByRole('contentinfo').getByRole('button', { name: '1', exact: true }).click()
+  await expect(page).toHaveURL(/#\/kanban$/)
+  await closeButton.click()
+  await expect(page).toHaveURL(previousUrl)
+
+  // A route tile shares the board component but owns a different close action.
+  const openSplitBoard = async () => {
+    await page.getByRole('button', { name: 'Kanban', exact: true }).click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Open in split' }).hover()
+    await page.getByRole('menuitem', { name: 'Right', exact: true }).click()
+    await expect(page.getByRole('heading', { name: 'Kanban', exact: true })).toBeVisible()
+    await expect(page).toHaveURL(previousUrl)
+  }
+
+  await openSplitBoard()
+  await composer.click()
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('heading', { name: 'Kanban', exact: true })).toBeVisible()
+  await closeButton.click()
+  await expect(page.getByRole('heading', { name: 'Kanban', exact: true })).toHaveCount(0)
+  await expect(page.getByText(MOCK_REPLY, { exact: true })).toBeVisible()
+  await openSplitBoard()
+  // The sidebar menu can restore focus to its trigger. Target this pane
+  // explicitly; Escape in the chat above must leave the board alone.
+  await page.getByRole('heading', { name: 'Kanban', exact: true }).click()
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('heading', { name: 'Kanban', exact: true })).toHaveCount(0)
+  await expect(page).toHaveURL(previousUrl)
+
+  // Closing the board must not also stop the conversation behind it.
+  await composer.click()
+  await composer.pressSequentially(HELD_PROMPT)
+  await page.keyboard.press('Enter')
+  await fixture.mock.waitForHeldStream()
+  await openBoard()
+  await page.keyboard.press('Escape')
+  await expect(page).toHaveURL(previousUrl)
+  await expect(page.locator('[data-slot="composer-root"] button[aria-label="Stop"]')).toBeVisible()
+  fixture.mock.releaseHeldStream()
+  await expect(page.getByText(MOCK_REPLY, { exact: true })).toHaveCount(2)
+
+  await openBoard()
+  await page.screenshot({ path: testInfo.outputPath('kanban-close.png') })
+  await closeButton.click()
+  await page.screenshot({ path: testInfo.outputPath('returned-conversation.png') })
+})

--- a/apps/desktop/src/app/chat/route-tile.tsx
+++ b/apps/desktop/src/app/chat/route-tile.tsx
@@ -67,7 +67,7 @@ function RouteTilePane({ path }: { path: string }) {
   if (contrib) {
     return (
       <ContribBoundary id={path}>
-        <ContribRender render={contrib.render} />
+        <ContribRender onClose={() => closeRouteTile(path)} render={contrib.render} />
       </ContribBoundary>
     )
   }

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -184,7 +184,7 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
         <Route
           element={page(
             <ContribBoundary id={route.key}>
-              <ContribRender render={route.render} />
+              <ContribRender onClose={actions.closeContributedRoute} render={route.render} />
             </ContribBoundary>
           )}
           key={route.key}

--- a/apps/desktop/src/app/contrib/types.ts
+++ b/apps/desktop/src/app/contrib/types.ts
@@ -59,6 +59,7 @@ export type ChatActions = Pick<
  * the latest closure.
  */
 export interface WiringActions extends SidebarActions, ChatActions {
+  closeContributedRoute: () => void
   /** Imperative access to the live gateway for controller-owned callbacks.
    *  Rendered surfaces subscribe to the active `$gateway` atom directly. */
   getGateway: () => ComponentProps<typeof ChatView>['gateway']

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -260,6 +260,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const {
     agentsOpen,
     chatOpen,
+    closeContributedRoute,
     closeOverlayToPreviousRoute,
     commandCenterInitialSection,
     commandCenterOpen,
@@ -991,6 +992,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // identity for the app's life (memoized surfaces don't re-render on churn)
   // while every handler still closes over the latest values.
   const nextActions: WiringActions = {
+    closeContributedRoute,
     onAddContextRef: composer.addContextRefAttachment,
     onAddUrl: url => composer.addContextRefAttachment(`@url:${formatRefValue(url)}`, url),
     onArchiveSession: sessionId => void archiveSession(sessionId),

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -82,6 +82,8 @@ const RESERVED_PATHS: ReadonlySet<string> = new Set(APP_ROUTES.map(route => rout
 // (`render` on the contribution itself, like every other area). Contributed
 // paths are reserved exactly like APP_ROUTES so the session-id parser never
 // mistakes them for a session route. Navigate with `host.navigate(path)`.
+// A route's render component may accept optional `{ onClose?: () => void }`
+// props: the host returns to the prior view, or closes only its split tile.
 
 export const ROUTES_AREA = 'routes'
 

--- a/apps/desktop/src/app/shell/hooks/use-overlay-routing.test.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-overlay-routing.test.tsx
@@ -1,0 +1,126 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, useLocation, useNavigate } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { ROUTES_AREA } from '@/app/routes'
+import { registry } from '@/contrib/registry'
+import { $activeGatewayProfile } from '@/store/profile'
+import { setConnection } from '@/store/session'
+
+import { useOverlayRouting } from './use-overlay-routing'
+
+let dispose: () => void
+
+function Harness() {
+  const { closeContributedRoute, closeOverlayToPreviousRoute } = useOverlayRouting()
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  return (
+    <>
+      <output>
+        {location.pathname}
+        {location.search}
+        {location.hash}
+      </output>
+      <button onClick={() => void navigate('/kanban')}>Board</button>
+      <button onClick={() => void navigate('/settings')}>Settings</button>
+      <button onClick={closeOverlayToPreviousRoute}>Close settings</button>
+      <button onClick={closeContributedRoute}>Close board</button>
+    </>
+  )
+}
+
+beforeEach(() => {
+  setConnection(null)
+  $activeGatewayProfile.set('default')
+  dispose = registry.register({
+    area: ROUTES_AREA,
+    id: 'kanban-close-test',
+    data: { path: '/kanban' },
+    render: () => null
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  dispose()
+  setConnection(null)
+  $activeGatewayProfile.set('default')
+})
+
+const click = (name: string) => fireEvent.click(screen.getByRole('button', { name }))
+const route = () => screen.getByRole('status').textContent
+
+describe('closing contributed routes', () => {
+  it('returns to the full original route after a settings round trip, without a return loop', () => {
+    render(
+      <MemoryRouter initialEntries={['/conversation?panel=tools#item']}>
+        <Harness />
+      </MemoryRouter>
+    )
+    click('Board')
+    click('Settings')
+    click('Close settings')
+    expect(route()).toBe('/kanban')
+    click('Close board')
+    expect(route()).toBe('/conversation?panel=tools#item')
+    click('Board')
+    click('Close board')
+    expect(route()).toBe('/conversation?panel=tools#item')
+  })
+
+  it('returns home when launched directly, including when its previous plugin unloads', () => {
+    const removePreviousPage = registry.register({
+      area: ROUTES_AREA,
+      id: 'previous-page',
+      data: { path: '/previous-plugin' },
+      render: () => null
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/previous-plugin']}>
+        <Harness />
+      </MemoryRouter>
+    )
+    click('Board')
+    removePreviousPage()
+    click('Close board')
+    expect(route()).toBe('/')
+    cleanup()
+    render(
+      <MemoryRouter initialEntries={['/kanban']}>
+        <Harness />
+      </MemoryRouter>
+    )
+    click('Close board')
+    expect(route()).toBe('/')
+  })
+
+  it.each(['profile', 'connection'] as const)('discards the return route after a %s switch', scope => {
+    render(
+      <MemoryRouter initialEntries={['/conversation']}>
+        <Harness />
+      </MemoryRouter>
+    )
+    click('Board')
+    act(() => {
+      if (scope === 'profile') {
+        $activeGatewayProfile.set('other')
+      } else {
+        setConnection({
+          connectionId: 'other',
+          baseUrl: 'https://other.example',
+          wsUrl: 'wss://other.example/ws',
+          token: '',
+          logs: [],
+          isFullscreen: false,
+          nativeOverlayWidth: 0,
+          windowButtonPosition: null
+        })
+      }
+    })
+    click('Close board')
+    expect(route()).toBe('/')
+  })
+})

--- a/apps/desktop/src/app/shell/hooks/use-overlay-routing.ts
+++ b/apps/desktop/src/app/shell/hooks/use-overlay-routing.ts
@@ -1,21 +1,29 @@
+import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useLocation, useNavigate } from 'react-router'
 
 import { type CommandCenterSection } from '@/app/command-center'
 import {
   AGENTS_ROUTE,
+  type AppView,
   appViewForPath,
   COMMAND_CENTER_ROUTE,
   isOverlayView,
   NEW_CHAT_ROUTE,
+  routePathname,
   STARMAP_ROUTE
 } from '@/app/routes'
+import { $activeConnectionId } from '@/store/connections'
+import { $activeGatewayProfile } from '@/store/profile'
 
 const SECTIONS = ['sessions', 'system', 'usage'] as const
 
 export function useOverlayRouting() {
   const location = useLocation()
   const navigate = useNavigate()
+  const connectionId = useStore($activeConnectionId)
+  const profile = useStore($activeGatewayProfile)
+  const scope = `${connectionId ?? ''}\0${profile}`
 
   const currentView = appViewForPath(location.pathname)
   const settingsOpen = currentView === 'settings'
@@ -28,16 +36,34 @@ export function useOverlayRouting() {
   const chatOpen = currentView === 'chat'
   const overlayOpen = isOverlayView(currentView)
 
-  // Overlay routes (settings/command-center/agents) stash the underlying path
-  // so closing them returns there instead of bouncing to /.
-  const returnPathRef = useRef(NEW_CHAT_ROUTE)
+  // Keep the underlying route while an overlay is open. Contributed pages
+  // also retain their caller, so closing one doesn't switch chats or bots.
+  const returns = useRef({ scope, paths: [] as Array<{ path: string; view: AppView }> })
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
-    if (!overlayOpen) {
-      returnPathRef.current = `${location.pathname}${location.search}${location.hash}`
+    if (returns.current.scope !== scope) {
+      returns.current = { scope, paths: [] }
     }
-  }, [location.hash, location.pathname, location.search, overlayOpen])
+
+    if (overlayOpen) {
+      return
+    }
+
+    const entry = { path: `${location.pathname}${location.search}${location.hash}`, view: currentView }
+    const paths = returns.current.paths
+    const index = paths.findIndex(item => routePathname(item.path) === location.pathname)
+
+    if (currentView !== 'extension') {
+      returns.current.paths = [entry]
+    } else if (index >= 0) {
+      // Returning from another page, or changing only a query: don't create
+      // a loop back to the page we just closed.
+      paths.splice(index, paths.length - index, entry)
+    } else {
+      paths.push(entry)
+    }
+  }, [currentView, location.hash, location.pathname, location.search, overlayOpen, scope])
 
   const commandCenterInitialSection = useMemo<CommandCenterSection | undefined>(
     () => SECTIONS.find(value => value === new URLSearchParams(location.search).get('section')),
@@ -50,13 +76,31 @@ export function useOverlayRouting() {
   )
 
   const resetOverlayReturnRoute = useCallback(() => {
-    returnPathRef.current = NEW_CHAT_ROUTE
+    returns.current.paths = []
   }, [])
 
-  const closeOverlayToPreviousRoute = useCallback(
-    () => navigate(returnPathRef.current || NEW_CHAT_ROUTE, { replace: true }),
+  const closeToReturnRoute = useCallback(
+    (closePage: boolean) => {
+      const currentScope = `${$activeConnectionId.get() ?? ''}\0${$activeGatewayProfile.get()}`
+      const paths = returns.current.scope === currentScope ? returns.current.paths : []
+
+      if (closePage) {
+        paths.pop()
+      }
+
+      // A plugin may have unloaded since it supplied the return route. Don't
+      // reinterpret its old path as a session id.
+      while (paths.length && appViewForPath(paths.at(-1)!.path) !== paths.at(-1)!.view) {
+        paths.pop()
+      }
+
+      void navigate(paths.at(-1)?.path ?? NEW_CHAT_ROUTE, { replace: true })
+    },
     [navigate]
   )
+
+  const closeOverlayToPreviousRoute = useCallback(() => closeToReturnRoute(false), [closeToReturnRoute])
+  const closeContributedRoute = useCallback(() => closeToReturnRoute(true), [closeToReturnRoute])
 
   const toggleCommandCenter = useCallback(() => {
     if (commandCenterOpen) {
@@ -72,6 +116,7 @@ export function useOverlayRouting() {
   return {
     agentsOpen,
     chatOpen,
+    closeContributedRoute,
     closeOverlayToPreviousRoute,
     commandCenterInitialSection,
     commandCenterOpen,

--- a/apps/desktop/src/contrib/react/boundary.tsx
+++ b/apps/desktop/src/contrib/react/boundary.tsx
@@ -15,13 +15,15 @@ interface ContribBoundaryProps {
 }
 
 interface ContribRenderProps {
-  render: () => ReactNode
+  render: (props: { onClose?: () => void }) => ReactNode
+  /** Route hosts supply their own return/close action; other surfaces omit it. */
+  onClose?: () => void
 }
 
 /** Mount a contribution callback as a component so its hooks and errors belong
  * to the contribution, not to whichever host surface happened to call it. */
-export function ContribRender({ render }: ContribRenderProps) {
-  return createElement(render)
+export function ContribRender({ render, onClose }: ContribRenderProps) {
+  return createElement(render, { onClose })
 }
 
 /**

--- a/apps/desktop/src/plugins/kanban/board-close.test.tsx
+++ b/apps/desktop/src/plugins/kanban/board-close.test.tsx
@@ -1,0 +1,154 @@
+import type { PluginRestOptions } from '@hermes/plugin-sdk'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The harness uses the same contribution and locale boundaries as the host.
+// eslint-disable-next-line no-restricted-imports
+import { ContribRender } from '@/contrib/react/boundary'
+// eslint-disable-next-line no-restricted-imports
+import { registerPluginLocales } from '@/i18n/plugin-i18n'
+
+import { bindApi } from './api'
+import { KanbanBoardPage } from './board'
+import { en, KANBAN_LOCALES } from './i18n'
+import type { KanbanBoard, KanbanTask } from './types'
+
+vi.mock('@/hermes', () => ({ setApiRequestProfile: vi.fn() }))
+
+const task: KanbanTask = { id: 't_close', title: 'Keep this task', status: 'todo' }
+
+const board: KanbanBoard = {
+  columns: [{ name: 'todo', tasks: [task] }],
+  tenants: [],
+  assignees: [],
+  latest_event_id: 0,
+  now: 0
+}
+
+let client: QueryClient
+let disposeApi: () => void
+let disposeLocales: () => void
+let boardResult: () => Promise<KanbanBoard>
+
+beforeEach(() => {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  boardResult = async () => board
+  disposeLocales = registerPluginLocales('kanban', KANBAN_LOCALES)
+  disposeApi = bindApi(
+    async <T,>(path: string, _options?: PluginRestOptions): Promise<T> => {
+      const route = path.split('?')[0]
+
+      const data = {
+        '/boards': { boards: [], current: '' },
+        '/profiles': { profiles: [] },
+        '/orchestration': { default_assignee: '' },
+        '/tasks/t_close': { task, comments: [], events: [], links: { parents: [], children: [] }, runs: [] },
+        '/tasks/t_close/log': { exists: false, content: '', size_bytes: 0, truncated: false }
+      }
+
+      if (route === '/board') {
+        return (await boardResult()) as T
+      }
+
+      if (!(route in data)) {
+        throw new Error(`Unexpected REST request: ${path}`)
+      }
+
+      return data[route as keyof typeof data] as T
+    },
+    { get: (_key, fallback) => fallback, set: vi.fn(), remove: vi.fn() },
+    () => vi.fn()
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  client.clear()
+  disposeApi()
+  disposeLocales()
+  vi.restoreAllMocks()
+})
+
+function openBoard() {
+  const close = vi.fn()
+
+  const result = render(
+    <QueryClientProvider client={client}>
+      <ContribRender onClose={close} render={KanbanBoardPage} />
+    </QueryClientProvider>
+  )
+
+  return { ...result, close }
+}
+
+describe('Kanban close controls', () => {
+  it('uses the host close action for both the header button and Escape', async () => {
+    const { close } = openBoard()
+    await screen.findByText(task.title)
+    const button = screen.getByRole('button', { name: en.close })
+    fireEvent.click(button)
+    expect(close).toHaveBeenCalledTimes(1)
+    fireEvent.keyDown(button, { key: 'Escape' })
+    expect(close).toHaveBeenCalledTimes(2)
+  })
+
+  it('dismisses the drawer, then the selection, then the board', async () => {
+    const { close } = openBoard()
+    const card = await screen.findByText(task.title)
+    fireEvent.click(card, { ctrlKey: true })
+    expect(screen.getByRole('button', { name: en.clearSelection })).toBeTruthy()
+    fireEvent.click(card)
+    await screen.findByRole('heading', { name: task.title })
+
+    fireEvent.keyDown(card, { key: 'Escape' })
+    expect(screen.queryByRole('heading', { name: task.title })).toBeNull()
+    expect(screen.getByRole('button', { name: en.clearSelection })).toBeTruthy()
+    expect(close).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(card, { key: 'Escape' })
+    expect(screen.queryByRole('button', { name: en.clearSelection })).toBeNull()
+    expect(close).not.toHaveBeenCalled()
+    fireEvent.keyDown(card, { key: 'Escape' })
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('leaves search, composition, and keys outside the board alone', async () => {
+    const { close } = openBoard()
+    await screen.findByText(task.title)
+    fireEvent.keyDown(screen.getByRole('textbox', { name: en.filterCards }), { key: 'Escape' })
+    fireEvent.keyDown(screen.getByRole('button', { name: en.close }), {
+      key: 'Escape',
+      isComposing: true
+    })
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(close).not.toHaveBeenCalled()
+  })
+
+  it('lets a nested dialog consume Escape without closing the board', async () => {
+    const { close } = openBoard()
+    await screen.findByText(task.title)
+    fireEvent.click(screen.getByRole('button', { name: en.newTask }))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(close).not.toHaveBeenCalled()
+  })
+
+  it.each(['loading', 'empty', 'error'] as const)('keeps Close available while %s', async state => {
+    boardResult = () =>
+      state === 'loading'
+        ? new Promise(() => {})
+        : state === 'error'
+          ? Promise.reject(new Error('Board unavailable'))
+          : Promise.resolve({ ...board, columns: [] })
+    const { close } = openBoard()
+
+    if (state === 'error') {
+      await screen.findByText('Board unavailable')
+    }
+
+    fireEvent.click(screen.getByRole('button', { name: en.close }))
+    expect(close).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -1079,8 +1079,13 @@ function SelectionBar({
 
 // ── page ─────────────────────────────────────────────────────────────────────
 
-export function KanbanBoardPage() {
+interface KanbanBoardPageProps {
+  onClose?: () => void
+}
+
+export function KanbanBoardPage({ onClose }: KanbanBoardPageProps = {}) {
   const k = useKanban()
+  const pageRef = useRef<HTMLDivElement>(null)
   const qc = useQueryClient()
   const slug = useValue($boardSlug)
   const [archived, setArchived] = useState(false)
@@ -1144,21 +1149,14 @@ export function KanbanBoardPage() {
     })
   }, [board])
 
+  // Let Escape reach this surface immediately after navigation. Native focus
+  // ignores hidden/inert panes; rerenders and background query updates do not
+  // move focus.
   useEffect(() => {
-    if (selected.size === 0) {
-      return
+    if (!pageRef.current?.contains(document.activeElement)) {
+      pageRef.current?.focus({ preventScroll: true })
     }
-
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setSelected(new Set())
-      }
-    }
-
-    window.addEventListener('keydown', onKey)
-
-    return () => window.removeEventListener('keydown', onKey)
-  }, [selected.size])
+  }, [])
 
   const columnNames = board?.columns.map(col => col.name) ?? []
 
@@ -1321,7 +1319,44 @@ export function KanbanBoardPage() {
   }
 
   return (
-    <div className="relative flex h-full flex-col overflow-hidden bg-(--ui-surface-background)">
+    <div
+      className="relative flex h-full flex-col overflow-hidden bg-(--ui-surface-background)"
+      onKeyDown={event => {
+        // Portaled menus/dialogs bubble through React's tree too. They own
+        // Escape, as do text fields and IME composition.
+        if (
+          event.key !== 'Escape' ||
+          event.defaultPrevented ||
+          event.nativeEvent.isComposing ||
+          addStatus ||
+          document.querySelector('[data-overlay-surface]') ||
+          !event.currentTarget.contains(event.target as Node) ||
+          (event.target as HTMLElement).closest('input, textarea, [contenteditable="true"]')
+        ) {
+          return
+        }
+
+        event.preventDefault()
+        event.stopPropagation()
+
+        if (openId) {
+          setOpenId(null)
+        } else if (selected.size) {
+          setSelected(new Set())
+        } else {
+          onClose?.()
+        }
+      }}
+      onPointerDown={event => {
+        // Cards and empty board space are not native focus targets. Keep
+        // keyboard ownership in this board after the user clicks either.
+        if (!(event.target as HTMLElement).closest('button, a, input, textarea, select, [contenteditable="true"]')) {
+          event.currentTarget.focus({ preventScroll: true })
+        }
+      }}
+      ref={pageRef}
+      tabIndex={-1}
+    >
       {/* Page-owned titlebar chrome: exists exactly while this page is mounted. */}
       <Contribute area={TITLEBAR_AREAS.center} id="kanban:board-switcher">
         <BoardSwitcher />
@@ -1360,6 +1395,13 @@ export function KanbanBoardPage() {
             <Codicon name="add" size="0.8rem" />
             {k.newTask}
           </Button>
+          {onClose && (
+            <Tip label={`${k.close} (Esc)`}>
+              <Button aria-label={k.close} onClick={onClose} size="icon-xs" variant="ghost">
+                <Codicon name="close" />
+              </Button>
+            </Tip>
+          )}
         </div>
       </header>
 

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -571,18 +571,6 @@ export function TaskDrawer({
     refetchInterval: running ? 3_000 : 15_000
   })
 
-  // Esc closes the drawer even though it isn't modal (no backdrop to click off).
-  useEffect(() => {
-    if (!id) {
-      return
-    }
-
-    const onKey = (event: KeyboardEvent) => event.key === 'Escape' && onClose()
-    window.addEventListener('keydown', onKey)
-
-    return () => window.removeEventListener('keydown', onKey)
-  }, [id, onClose])
-
   const invalidate = () => {
     void qc.invalidateQueries({ queryKey: taskKey(slug, id!) })
     void qc.invalidateQueries({ queryKey: ['kanban', 'board', slug] })

--- a/apps/desktop/src/plugins/kanban/plugin.tsx
+++ b/apps/desktop/src/plugins/kanban/plugin.tsx
@@ -108,7 +108,7 @@ const plugin: HermesPlugin = {
         id: 'page',
         area: ROUTES_AREA,
         data: { path: '/kanban' } satisfies RouteContribution,
-        render: () => <KanbanBoardPage />
+        render: KanbanBoardPage
       },
       {
         id: 'nav',


### PR DESCRIPTION
## Related Issue

Fixes #102438

## What does this PR do?

The Kanban board currently has no close control. This adds a Close button and an Escape shortcut to return to the previous view. Open dialogs and card details handle Escape before the board does.

Returning keeps the original conversation and full URL, including after opening Settings. Switching connections or profiles clears the return destination; opening Kanban directly falls back to the new-chat page. In a split workspace, closing Kanban removes only its tile.

Related PRs #103966 and #93619 add statusbar and sidebar toggles, respectively. This PR adds controls inside the board and works regardless of which entry point opened it.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/kanban/board.tsx`: reuse the existing Close label and button style. Handle Escape within the focused board: close card details, then clear selection, then close the board. Search fields, composition, and open popups keep their keyboard behavior.
- `apps/desktop/src/app/shell/hooks/use-overlay-routing.ts`: extend the existing return-route tracking to preserve the previous view and discard destinations from another connection/profile or an unloaded plugin.
- `apps/desktop/src/contrib/react/boundary.tsx`, route hosts, and wiring: supply an optional `onClose` callback. The main view returns to its caller; a split tile uses its existing close action.
- Add board and route tests plus an Electron test using the real Python backend, a temporary `HERMES_HOME`, and local mock inference. No new dependencies, RPCs, or settings.

## How to Test

1. Enable Kanban in Desktop Settings → Plugins. From a conversation, open the board using the sidebar, statusbar counter, or command palette. Close or Escape should return to that conversation.
2. Open Settings from the board, close Settings, then close the board. The original conversation should still be the destination.
3. Open card details or select cards. Each Escape should dismiss only the current layer. Typing in the board search should not close it.
4. Open Kanban in a split. Escape in the chat should leave the board alone; Close or Escape within the board should remove only that tile.

With Node 26, workspace dependencies, and the project's Python environment installed:

```bash
cd apps/desktop
npm run test:ui -- --maxWorkers=6
npm run typecheck
npm run lint
npm run build
npx playwright test e2e/kanban-close.spec.ts
cd ../..
git diff --check origin/main...HEAD
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs and documented the adjacent work above.
- [x] My PR contains only changes related to this feature.
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; no Python code changed.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: macOS 26.5.1 arm64, Node 26.8.1.

### Documentation & Housekeeping

- [x] Relevant documentation updated: the optional route close callback is documented in `app/routes.ts`.
- [x] Config example: N/A; no config keys changed.
- [x] Architecture/workflow guide: N/A; this uses the existing contribution and route wiring.
- [x] Cross-platform impact considered: shared renderer code; native Windows and Linux execution was not tested locally.
- [x] Tool descriptions/schemas: N/A; no model tool changed.

## Screenshots / Logs

Local verification:

```text
Desktop UI:       772 files, 7,443 tests passed
Electron E2E:     1 passed
Typecheck:        passed
ESLint:           0 errors; changed files also pass with --max-warnings=0
Prettier:         passed for all changed TypeScript files
Production build: passed
git diff --check: passed
```

The initial six board regressions fail without the implementation. The Electron test exercises all three entry points, Settings return, search, dialogs, card details, selection, context menus, and both split-tile close controls. It also holds a real backend response open while closing Kanban and verifies that the original conversation continues afterward. Playwright records a trace and screenshots of the board and returned conversation.

