### PR TITLE
fix(gateway): route pre-turn image pre-analysis with a conversation affinity scope

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2061,7 +2061,14 @@ def _iteration_summary_chat_kwargs(agent, api_messages: list) -> dict:
                 extra_body["plugins"] = [{"id": "pareto-router", "min_coding_score": _ps}]
     if extra_body:
         summary_kwargs["extra_body"] = extra_body
-    return summary_kwargs
+    # Same relay-affinity invariant as build_api_kwargs(): the max-iterations recap is a real
+    # OpenCode request, so an OpenCode target must carry x-opencode-session or the relay answers
+    # 400 MissingSessionID and the recap is replaced by the error text.
+    from agent.opencode_affinity import merge_opencode_session_headers
+    return merge_opencode_session_headers(
+        summary_kwargs, getattr(agent, "provider", None), getattr(agent, "base_url", None),
+        getattr(agent, "session_id", None),
+    )
 
 
 def _summary_text(agent, response, **normalize_kwargs) -> str:

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 import asyncio
 import concurrent.futures
 import dataclasses
+import hashlib
 import json
 import os
 import re
@@ -33,6 +34,15 @@ if TYPE_CHECKING:  # string annotations only; never imported at runtime (cycle)
 
 # Log-record parity with the origin module.
 logger = logging.getLogger("gateway.run")
+
+
+def _vision_affinity_scope(session_key: str) -> str:
+    """Opaque, stable OpenCode routing scope for pre-turn auxiliary calls.
+
+    Hashed on purpose: a session key embeds platform user/chat ids and this value travels to the
+    provider as a routing token. Only per-conversation consistency matters, not legibility.
+    """
+    return "img-" + hashlib.sha256(str(session_key or "").encode("utf-8")).hexdigest()[:24]
 
 
 class GatewayInboundMixin:
@@ -1395,9 +1405,25 @@ class GatewayInboundMixin:
             logger.debug("vision enrichment: session runtime resolution failed", exc_info=True)
 
         from agent.auxiliary_client import scoped_runtime_main
+        from agent.portal_tags import (
+            get_affinity_scope, get_conversation_context, reset_conversation_context,
+            set_conversation_context,
+        )
 
-        with scoped_runtime_main(vision_runtime):
-            return await self._enrich_message_with_vision(message_text, image_paths)
+        # Pre-analysis runs BEFORE the turn binds its conversation scope (agent/turn_facade.py), and
+        # an OpenCode target (opencode-go/zen) 400s without a non-empty ``x-opencode-session``
+        # ("MissingSessionID") — every image would degrade to the "couldn't quite see it" hint. Bind an
+        # opaque scope derived from this conversation's session key so the aux call routes like the turn
+        # it belongs to. Only when nothing is bound already: this path must not clobber a live scope.
+        scope_token = None
+        if not (get_affinity_scope() or get_conversation_context()):
+            scope_token = set_conversation_context(_vision_affinity_scope(session_key))
+        try:
+            with scoped_runtime_main(vision_runtime):
+                return await self._enrich_message_with_vision(message_text, image_paths)
+        finally:
+            if scope_token is not None:
+                reset_conversation_context(scope_token)
 
     async def _echo_stt_transcripts(
         self, adapter, source: SessionSource, transcripts: List[str], *, metadata=None, log_context: str = "Transcript"

--- a/tests/agent/test_opencode_session_affinity.py
+++ b/tests/agent/test_opencode_session_affinity.py
@@ -60,3 +60,15 @@ def test_auxiliary_calls_share_the_main_turn_session_key():
         assert "x-opencode-session" not in (other.get("extra_headers") or {})
     finally:
         aux._RUNTIME_MAIN_CONTEXT.reset(token)
+
+
+def test_iteration_limit_summary_carries_the_session_header():
+    """The max-iterations recap is a chat-completions request like any other."""
+    from agent.chat_completion_helpers import _iteration_summary_chat_kwargs
+
+    agent = _agent("opencode-go", "glm-5", "https://opencode.ai/zen/go/v1")
+    kwargs = _iteration_summary_chat_kwargs(agent, _MSGS)
+    assert kwargs["extra_headers"]["x-opencode-session"] == "sess-affinity-1"
+
+    other = _agent("openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1")
+    assert "x-opencode-session" not in (_iteration_summary_chat_kwargs(other, _MSGS).get("extra_headers") or {})

--- a/tests/gateway/test_vision_preanalysis_affinity.py
+++ b/tests/gateway/test_vision_preanalysis_affinity.py
@@ -1,0 +1,79 @@
+"""Pre-turn image pre-analysis must route as the conversation it belongs to.
+
+An OpenCode target (opencode-go/zen) rejects a request without a non-empty
+``x-opencode-session`` ("MissingSessionID"). The gateway's pre-analysis runs BEFORE the agent turn
+binds its conversation scope, so the aux vision call used to go out headerless and every image
+degraded to the "couldn't quite see it" hint. These are the behaviour contracts for the fix.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from agent import auxiliary_client as aux
+from agent.portal_tags import (
+    get_affinity_scope,
+    get_conversation_context,
+    reset_conversation_context,
+    set_conversation_context,
+)
+from gateway.config import Platform
+from gateway.run_inbound import GatewayInboundMixin
+from gateway.session import SessionSource
+
+_BASE_URL = "https://opencode.ai/zen/go/v1"
+_MSGS = [{"role": "user", "content": "describe this"}]
+
+
+class _Runner(GatewayInboundMixin):
+    """Minimal stand-in: text routing, a resolved OpenCode runtime, captured header."""
+
+    def __init__(self) -> None:
+        self.captured_header = None
+        self.captured_scope = None
+
+    async def _decide_image_input_mode(
+        self, *, source=None, session_key=None, user_config=None, provider=None, model=None,
+    ) -> str:
+        return "text"
+
+    def _resolve_session_agent_runtime(self, *, source=None, session_key=None, user_config=None):
+        return "deepseek-flash", {"provider": "opencode-go", "base_url": _BASE_URL}
+
+    async def _enrich_message_with_vision(self, user_text: str, image_paths: list) -> str:
+        kwargs = aux._build_call_kwargs("opencode-go", "deepseek-flash", _MSGS, base_url=_BASE_URL)
+        self.captured_header = (kwargs.get("extra_headers") or {}).get("x-opencode-session")
+        self.captured_scope = get_conversation_context()
+        return "enriched"
+
+
+_SOURCE = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", user_id="6789")
+
+
+def _run(runner: _Runner) -> str:
+    return asyncio.run(runner._enrich_inbound_images(
+        source=_SOURCE, session_key="telegram:12345", message_text="hi", image_paths=["/tmp/x.jpg"],
+    ))
+
+
+def test_preanalysis_sends_a_routable_affinity_header():
+    runner = _Runner()
+    assert _run(runner) == "enriched"
+    assert runner.captured_header, "pre-analysis aux call went out without x-opencode-session"
+
+
+def test_preanalysis_scope_is_released_afterwards():
+    runner = _Runner()
+    _run(runner)
+    assert get_conversation_context() is None and get_affinity_scope() is None
+
+
+def test_preanalysis_does_not_clobber_a_live_scope():
+    token = set_conversation_context("live-conversation")
+    try:
+        runner = _Runner()
+        _run(runner)
+        assert runner.captured_header == "live-conversation"
+        assert get_conversation_context() == "live-conversation"
+    finally:
+        reset_conversation_context(token)


### PR DESCRIPTION
## Summary

Pre-turn image pre-analysis in the gateway runs its auxiliary vision call **without** the OpenCode conversation-affinity header, so on an `opencode-go` / `opencode-zen` target the request is rejected and every inbound image silently degrades to the `"couldn't quite see it"` placeholder.

`agent/opencode_affinity.py` states the header cannot drift per code path — but its key resolves from `get_affinity_scope() or get_conversation_context() or session_id`, and the gateway's enrichment path has none of the three bound yet, so `opencode_session_headers()` returns `{}` and no header is sent at all.

## Root cause

`GatewayRunner._enrich_inbound_images()` (text image routing) calls `_enrich_message_with_vision()` **before** `AIAgent.run_conversation()`, and it is the turn that binds the conversation scope (`agent/turn_facade.py`: `set_conversation_context(...)` / `set_affinity_scope(...)`). The aux call therefore goes out headerless:

```
errors.log: 400 {"type":"MissingSessionID","message":"Error from provider (Console Go): Request is missing x-opencode-session ..."}
agent.log:  Image routing: text (mode=text). Pre-analyzing 1 image(s) via vision_analyze.
tools.vision_tools: Error analyzing image: Error code: 400 - ... MissingSessionID
```

`vision_analyze_tool` then returns `success: False`, which is exactly the branch that emits the `couldn't quite see it` note.

Reachable whenever text routing is active: an explicit `auxiliary.vision.*` backend (which forces `text` under `agent.image_input_mode: auto`, see `agent/image_routing.py`) or a text-only main model.

## Fix

Bind an opaque scope derived from the conversation's session key for the duration of the enrichment call, and release it afterwards. The value is hashed because a session key embeds platform user/chat ids and it travels to the provider as a routing token; only per-conversation consistency is required. An already-bound scope is never clobbered (the gateway can hold a live one).

## Test plan

`tests/gateway/test_vision_preanalysis_affinity.py` — three behaviour contracts:

- pre-analysis sends a non-empty `x-opencode-session` (built through the real `auxiliary_client` kwargs path, so it fails on the unfixed code),
- the scope is released after the call,
- a live scope is preserved and not overwritten.

```
scripts/run_tests.sh tests/gateway/test_vision_preanalysis_affinity.py tests/agent/test_opencode_session_affinity.py
=== 2 files, 9 tests passed, 0 failed ===
```

Verified against a live setup: with the patch applied, the same image that previously failed now analyzes cleanly through `opencode-go/deepseek-flash`.
