### PR TITLE
fix(cli): merge startup alias base_url into explicit_base_url

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2684,7 +2684,7 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         # --api-key wins; otherwise a URL-bearing startup alias carries its own credential.
         # See #28660.
         self._explicit_api_key = api_key or _startup_api_key_override or None
-        self._explicit_base_url = base_url
+        self._explicit_base_url = base_url or _startup_base_url_override
 
         # Resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -153,6 +153,43 @@ def test_provider_flag_uses_named_custom_default_model(monkeypatch):
     assert shell.requested_provider == "gmk-lan"
 
 
+def test_model_aliases_base_url_reaches_explicit_base_url(monkeypatch):
+    """A `model_aliases:` entry's own base_url must reach
+    self._explicit_base_url (what _ensure_runtime_credentials() passes as
+    explicit_base_url into resolve_runtime_provider()), not just
+    self.base_url -- issue #107191: it was silently dropped at CLI startup,
+    so the request fell through to the OpenRouter/default runtime instead
+    of the alias's own endpoint."""
+    import hermes_cli.model_switch as ms
+    ms.DIRECT_ALIASES.clear()
+
+    cli = _import_cli()
+    config = {
+        "model_aliases": {
+            "qwen-local": {
+                "model": "Qwen3.6-35B-A3B-UD-IQ2_M.gguf",
+                "provider": "custom",
+                "base_url": "http://localhost:8080/v1",
+                "api_key": None,
+            }
+        },
+    }
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr("hermes_cli.runtime_provider.load_config", lambda: config)
+
+    shell = cli.HermesCLI(model="qwen-local", compact=True, max_turns=1)
+
+    assert shell.model == "Qwen3.6-35B-A3B-UD-IQ2_M.gguf"
+    assert shell._explicit_base_url == "http://localhost:8080/v1"
+    # The CLI flag must still win when both are present (existing precedence:
+    # CLI args > env vars > config file).
+    ms.DIRECT_ALIASES.clear()
+    shell2 = cli.HermesCLI(
+        model="qwen-local", base_url="http://cli-flag-wins:9999/v1", compact=True, max_turns=1
+    )
+    assert shell2._explicit_base_url == "http://cli-flag-wins:9999/v1"
+
+
 def test_explicit_model_wins_over_provider_default_model(monkeypatch):
     """`-m` still wins when `--provider` also names a custom default_model."""
     cli = _import_cli()


### PR DESCRIPTION
Fixes #107191.

## Root cause

`model_aliases:` entries in `config.yaml` with a custom `base_url` resolved `model` and `provider` correctly at CLI startup, but the resolved `base_url` was silently dropped before credential resolution -- the request fell through to the OpenRouter/default runtime and failed with HTTP 401.

`resolve_startup_model_route()` correctly resolves the alias's `base_url` into `_startup_base_url_override`. Two lines later, `self._explicit_base_url` was assigned only from the raw `base_url` parameter (which `hermes chat` doesn't even expose), never merged with `_startup_base_url_override`. `self._explicit_base_url` is what `_ensure_runtime_credentials()` later passes as `explicit_base_url` into `resolve_runtime_provider()` -- since it was empty, routing to the alias's custom endpoint was impossible.

## Fix

The correct merge pattern already exists two lines below in the same function, for `self.base_url`: `base_url or _startup_base_url_override or ...`. Applied the identical pattern to `self._explicit_base_url`, matching the session-resume path in `cli_model_switch_mixin.py` which already does this correctly. The CLI flag still wins when both are present.

## Verification

Verified directly: constructed a `HermesCLI` instance with a `model_aliases:` entry carrying its own `base_url` (the issue's exact repro shape) and confirmed `self._explicit_base_url` now resolves correctly. Also verified the CLI flag still wins when both are present.

Added a regression test following the existing file's established `HermesCLI(...)`/monkeypatched `load_config` pattern. Verified as a genuine regression by reverting just the fix and confirming the test fails with the exact reported symptom.

16/16 pass in the modified test file; 3/3 in a related existing test file (no regression).