### PR TITLE
fix(desktop): stop setting LC_CTYPE=UTF-8 on Linux

### DIFF
--- a/apps/desktop/electron/terminal-ipc.ts
+++ b/apps/desktop/electron/terminal-ipc.ts
@@ -156,7 +156,10 @@ export function registerTerminalIpc({
     delete env.COLORFGBG
 
     env.COLORTERM = 'truecolor'
-    env.LC_CTYPE = env.LC_CTYPE || 'UTF-8'
+    // macOS accepts the bare charset name "UTF-8"; glibc does not, and bash
+    // warns: setlocale: LC_CTYPE: cannot change locale (UTF-8). Prefer LANG or C.UTF-8 on Linux.
+    env.LC_CTYPE =
+      env.LC_CTYPE || (process.platform === 'darwin' ? 'UTF-8' : env.LANG || 'C.UTF-8')
     env.TERM = 'xterm-256color'
     env.TERM_PROGRAM = 'Hermes'
     env.TERM_PROGRAM_VERSION = app.getVersion()


### PR DESCRIPTION
## Summary
- Hermes Desktop's integrated terminal defaulted `LC_CTYPE` to the bare value `UTF-8`.
- That is a macOS charset shorthand; glibc has no locale named `UTF-8`, so interactive bash prints:
  `bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory`
- On non-darwin platforms, default to `LANG` when set, otherwise `C.UTF-8`. Keep `UTF-8` on macOS.

## Test plan
- [x] Reproduced warning with `LC_CTYPE=UTF-8` interactive bash on Linux
- [x] Confirmed Hermes Desktop embedded terminal showed the warning on Omarchy/Arch Linux
- [x] After patch + Desktop restart, warning is gone
- [ ] CI / reviewer smoke: open Desktop terminal on Linux and macOS