### PR TITLE
fix(desktop): restore minimized sidebar through sidebar controls

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -963,6 +963,39 @@ export function setTreeSideCollapsed(side: TreeSide, collapsed: boolean) {
   }
 }
 
+/** Restore minimized zones without changing their active tab (including Bots). */
+export function restoreMinimizedTreeSide(side: TreeSide): boolean {
+  const tree = $layoutTree.get()
+  const row = rootRow()
+
+  if (!tree || !row) {
+    return false
+  }
+
+  const panes = registry.getArea('panes')
+  let next = tree
+
+  for (const child of row.children) {
+    if (rootChildSide(child, id => panes.find(pane => pane.id === id)) !== side) {
+      continue
+    }
+
+    for (const id of groupLeafIds(child)) {
+      if (findGroup(next, id)?.minimized) {
+        next = setGroupMinimized(next, id, false)
+      }
+    }
+  }
+
+  if (next === tree) {
+    return false
+  }
+
+  commit(next)
+
+  return true
+}
+
 /**
  * Does the layout have a collapsible root side of `side`? ⌘J's normal target is
  * the right sidebar; a layout without one (e.g. a terminal-on-bottom preset)

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -2,7 +2,7 @@ import { atom, computed, type ReadableAtom, type WritableAtom } from 'nanostores
 
 import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '@/app/layout-constants'
 import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
-import { isPaneVisible, revealTreePane } from '@/components/pane-shell/tree/store'
+import { isPaneVisible, restoreMinimizedTreeSide, revealTreePane } from '@/components/pane-shell/tree/store'
 import { matchesQuery } from '@/hooks/use-media-query'
 import { connectionScopedAtom } from '@/lib/connection-scoped'
 import { type Codec, Codecs, persistentAtom } from '@/lib/persisted'
@@ -528,14 +528,26 @@ function revealNarrowPane(id: string, mode: 'close' | 'open' | 'toggle'): boolea
 }
 
 export function setSidebarOpen(open: boolean) {
+  if (open) {
+    restoreMinimizedTreeSide('left')
+  }
+
   setPaneOpen(CHAT_SIDEBAR_PANE_ID, open)
   revealNarrowPane(CHAT_SIDEBAR_PANE_ID, open ? 'open' : 'close')
 }
 
 export function toggleSidebarOpen() {
-  if (!revealNarrowPane(CHAT_SIDEBAR_PANE_ID, 'toggle')) {
-    togglePane(CHAT_SIDEBAR_PANE_ID)
+  if (revealNarrowPane(CHAT_SIDEBAR_PANE_ID, 'toggle')) {
+    return
   }
+
+  if (restoreMinimizedTreeSide('left')) {
+    setPaneOpen(CHAT_SIDEBAR_PANE_ID, true)
+
+    return
+  }
+
+  togglePane(CHAT_SIDEBAR_PANE_ID)
 }
 
 export function toggleFileBrowserOpen() {

--- a/apps/desktop/src/store/sidebar-collapse-persistence.test.ts
+++ b/apps/desktop/src/store/sidebar-collapse-persistence.test.ts
@@ -62,3 +62,36 @@ describe('sidebar collapse persistence', () => {
     expect(s2.leftCollapsed()).toBe(true)
   })
 })
+
+describe('minimized sidebar recovery', () => {
+  it.each([false, true])('restores Bots through the shared toggle with flipped=%s', async flipped => {
+    window.localStorage.clear()
+    vi.resetModules()
+    const { layout, tree, bind } = await loadStores()
+    const { group, split, findGroup } = await import('@/components/pane-shell/tree/model')
+    const { registry } = await import('@/contrib/registry')
+
+    const disposers = [
+      registry.register({ area: 'panes', id: 'sessions', title: 'Sessions', data: { placement: 'left' } }),
+      registry.register({ area: 'panes', id: 'bots', title: 'Bots', data: { placement: 'left' } }),
+      registry.register({ area: 'panes', id: 'workspace', title: 'Main', data: { placement: 'main' } })
+    ]
+
+    try {
+      const sidebar = group(['sessions', 'bots'], { active: 'bots', id: 'sidebar', minimized: true })
+      const main = group(['workspace'])
+      tree.$layoutTree.set(split('row', flipped ? [main, sidebar] : [sidebar, main]))
+      bind()
+      layout.toggleSidebarOpen()
+      expect(layout.$sidebarOpen.get()).toBe(true)
+      expect(findGroup(tree.$layoutTree.get()!, 'sidebar')).toMatchObject({ active: 'bots', minimized: false })
+      layout.toggleSidebarOpen()
+      expect(layout.$sidebarOpen.get()).toBe(false)
+      tree.setTreeGroupMinimized('sidebar', true)
+      layout.setSidebarOpen(true)
+      expect(findGroup(tree.$layoutTree.get()!, 'sidebar')).toMatchObject({ active: 'bots', minimized: false })
+    } finally {
+      disposers.forEach(dispose => dispose())
+    }
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Restore minimized sidebar groups when the user opens the sidebar with the titlebar button or Cmd+B, without switching the active tab from Bots to Sessions.

With Sessions/Bots docked, minimize the group and press Cmd+B. On main at `8068c0943`, the sidebar visibility flag can remain true while the group is minimized, so the toggle hides the side instead of restoring its content. The shared sidebar actions now clear minimized state for the semantic sidebar before opening it. Subsequent toggles still hide and show it normally, including when the sidebar is swapped to the right.

## Related Issue

Related to #106009; this addresses the deterministic minimized-group recovery path, not every possible invalid-width cause in that report.

Related PRs checked: #106095 handles explicit `focus_pane('sessions')` and activates Sessions; this PR handles the shared sidebar open/toggle entry points and preserves the active tab. #93613 addresses Bots workspace behavior while folded, which is separate from restoring the sidebar.

## Type of Change

- [x] Bug fix

## Changes Made

- Add a tree-store action that restores minimized groups on the semantic sidebar without changing active tabs.
- Use it from `setSidebarOpen(true)` and the normal sidebar toggle path.
- Extend the existing persistence tests for both sidebar positions, repeat toggles and explicit open.

## How to Test

1. Dock Sessions and Bots together and select Bots.
2. Minimize the group, then press Cmd+B or click the titlebar sidebar button once. The group should expand with Bots still active.
3. Toggle again to hide, then show the sidebar. Swap the sidebar to the other side and repeat.

Validation on macOS 27.0, Apple Silicon:

- `npx vitest run src/store/sidebar-collapse-persistence.test.ts` from `apps/desktop`: 4 passed. The two added cases fail on the unmodified base and pass with the fix.
- ESLint on the three changed TypeScript files: passed.
- `npx tsc -p . --noEmit` from `apps/desktop`: passed.
- Packaged-app checks on Hermes v0.21.1 / `8068c09`: minimized Bots restored through both Cmd+B and the titlebar button. The local app also had the separate narrow-header patch installed; the regression tests above run on this PR alone.

## Checklist

- [x] Read the contributing guide; used Conventional Commits.
- [x] Searched existing open/merged PRs and issues; related work is identified above.
- [x] Focused change with regression tests.
- [x] Tested on macOS; no OS-specific APIs or new user-facing strings added.
- [ ] Full Python suite (not run; this is a desktop renderer-only change).
- [x] Configuration, tool schemas and architecture documentation: N/A.

## Screenshots / Logs

No private conversation screenshots or user configuration are included. Implementation and verification were assisted by Codex.
