### PR TITLE
fix(agent): add "budget limit" to billing detection patterns (#107166)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2991,7 +2991,7 @@ _PAYMENT_KEYWORDS = (
     "reached your session usage limit", "quota exceeded", "quota_exceeded",
     "too many tokens per day", "daily limit", "tokens per day", "daily quota", "resource exhausted",
     "resource_exhausted", "resource-exhausted", "resourceexhausted",
-    "weekly usage limit", "weekly limit",
+    "weekly usage limit", "weekly limit", "budget limit",
 )
 
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -88,7 +88,7 @@ _BILLING_PATTERNS = (
     "insufficient credits", "insufficient_quota", "insufficient balance", "credit balance",
     "credits exhausted", "credits have been exhausted", "requires available credits",
     "account balance is too low", "no usable credits", "top up your credits", "payment required",
-    "billing hard limit", "exceeded your current quota", "account is deactivated", "plan does not include",
+    "billing hard limit", "budget limit", "exceeded your current quota", "account is deactivated", "plan does not include",
     "out of extra usage", "out of funds", "run out of funds", "balance_depleted",
     "model_not_supported_on_free_tier", "not available on the free tier",
 )


### PR DESCRIPTION
Fixes #107166

## Root Cause

OpenRouter's organisation-level monthly budget cap returns HTTP 403 with:
```
Error code: 403 - {'error': {'message': 'Budget limit exceeded (monthly limit). Contact your org admin.', 'code': 403}}
```

Neither `_BILLING_PATTERNS` in `error_classifier.py` nor `_PAYMENT_KEYWORDS` in `auxiliary_client.py` contained `"budget limit"`, causing two failures:

1. **Main agent loop**: `_status_403()` classified it as `auth` instead of `billing`, misleading users with "check your API key" guidance when the real cause is an org-wide budget cap no API key change can clear.
2. **Auxiliary tasks**: Compression, title generation, vision, and approval calls never walked the fallback ladder, causing cascading session failures (a session that can't compress becomes unusable).

## Fix

Added `"budget limit"` to both pattern tuples:

- `agent/error_classifier.py` → `_BILLING_PATTERNS` (main agent loop classification)
- `agent/auxiliary_client.py` → `_PAYMENT_KEYWORDS` (auxiliary fallback trigger)

Both are substring matches, so `"budget limit"` catches `"Budget limit exceeded (monthly limit)"` after `.lower()` normalization.