### PR TITLE
fix(agent): add "7-day usage limit" to payment keywords (#107067)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2991,7 +2991,7 @@ _PAYMENT_KEYWORDS = (
     "reached your session usage limit", "quota exceeded", "quota_exceeded",
     "too many tokens per day", "daily limit", "tokens per day", "daily quota", "resource exhausted",
     "resource_exhausted", "resource-exhausted", "resourceexhausted",
-    "weekly usage limit", "weekly limit",
+    "weekly usage limit", "weekly limit", "7-day usage limit",
 )
 
 


### PR DESCRIPTION
Fixes #107067

## Root Cause

Kimi coding plan weekly quota exhaustion returns HTTP 403 with:
```
"You've reached your weekly (7-day) usage limit. Your quota will reset when the current 7-day window ends."
```

`_PAYMENT_KEYWORDS` in `auxiliary_client.py` contained `"weekly usage limit"` and `"weekly limit"`, but Kimi inserts `(7-day)` between "weekly" and "usage", producing `"weekly (7-day) usage limit"`. The substring `_contains_any` check fails on both keywords.

Result: `_is_payment_error()` returns `False` for Kimi 403 quota exhaustion, and auxiliary fallback never triggers. Compression, title generation, vision, and approval tasks fail outright while the main model happily falls back via `fallback_providers`.

## Fix

Added `"7-day usage limit"` to `_PAYMENT_KEYWORDS`. This catches the Kimi error variant while remaining specific enough to avoid false positives on unrelated messages containing "7-day".