### PR TITLE
fix(terminal): never persist profile credentials into the bash env snapshot

### DIFF
--- a/tests/tools/test_snapshot_profile_secret_exclusion.py
+++ b/tests/tools/test_snapshot_profile_secret_exclusion.py
@@ -1,0 +1,157 @@
+"""Profile credentials must never be persisted into the bash env snapshot.
+
+The terminal backend captures the login shell into a snapshot file
+(``BaseEnvironment.init_session``) built with ``export -p``, filtered through
+``_snapshot_excluded_passthrough_names()``. That exclusion list was computed
+only ``if is_multiplex_active()``, because it was introduced for *cross-profile*
+passthrough leakage.
+
+The same list, however, is the only thing keeping *credentials* out of the
+snapshot. On a single-profile host the list was empty, so ``export -p`` wrote
+every secret the profile loader had injected into ``os.environ`` — vault access
+token, provider API keys, SSH private key, dashboard secrets — to disk in
+plaintext, rewritten on essentially every command.
+
+These tests pin the contract that credential NAMES are excluded regardless of
+multiplex state, that values are never read to do so, and that ordinary shell
+state still survives.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+from tools.environments.local import LocalEnvironment
+
+
+_SECRET_NAME = "PROBE_VAULT_TOKEN"
+_SECRET_VALUE = "s3cr3t-probe-value-must-not-reach-disk"
+
+
+@pytest.fixture
+def profile_secret_env(tmp_path, monkeypatch):
+    """A profile whose secret scope reports one credential name."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import agent.secret_scope as ss
+
+    # Names only — the scope maps name -> value, and the code under test must
+    # consume the keys without ever touching the values.
+    monkeypatch.setattr(
+        ss, "build_profile_secret_scope", lambda _home: {_SECRET_NAME: _SECRET_VALUE}
+    )
+    return home
+
+
+@pytest.mark.parametrize("multiplex", [False, True], ids=["single-profile", "multiplex"])
+def test_credential_names_excluded_regardless_of_multiplex(profile_secret_env, monkeypatch, multiplex):
+    """The single-profile case is the bug: exclusions must not be gated on multiplex."""
+    import agent.secret_scope as ss
+
+    monkeypatch.setattr(ss, "is_multiplex_active", lambda: multiplex)
+
+    env = LocalEnvironment(cwd=str(profile_secret_env), timeout=10)
+    env._profile_scoped_passthrough = True
+
+    excluded = env._snapshot_excluded_passthrough_names()
+
+    assert _SECRET_NAME in excluded
+
+
+def test_enumerating_secret_names_does_not_expose_values(profile_secret_env):
+    """Names are load-bearing; values must never enter the exclusion machinery."""
+    env = LocalEnvironment(cwd=str(profile_secret_env), timeout=10)
+    env._profile_scoped_passthrough = True
+
+    names = env._profile_secret_env_names()
+
+    assert _SECRET_NAME in names
+    assert _SECRET_VALUE not in names
+
+
+def test_bootstrap_token_names_are_excluded_though_absent_from_the_scope(profile_secret_env, monkeypatch):
+    """A source's bootstrap credential never appears in the resolved scope.
+
+    `load_hermes_dotenv` seeds it from a gitignored `.op.env` or the
+    launcher/systemd environment, so it reaches `os.environ` — and therefore
+    `export -p` — while `build_profile_secret_scope()` does not report it.
+    Excluding only resolved values leaves the token that unlocks the vault on
+    disk.
+    """
+    import agent.secret_scope as ss
+
+    monkeypatch.setattr(ss, "is_multiplex_active", lambda: False)
+
+    env = LocalEnvironment(cwd=str(profile_secret_env), timeout=10)
+    env._profile_scoped_passthrough = True
+
+    excluded = set(env._snapshot_excluded_passthrough_names())
+
+    # Declared by the built-in sources via protected_env_vars().
+    assert "OP_SERVICE_ACCOUNT_TOKEN" in excluded
+    assert "BWS_ACCESS_TOKEN" in excluded
+    # ...and the resolved-scope population is still covered.
+    assert _SECRET_NAME in excluded
+
+
+def test_bootstrap_names_follow_a_configured_token_env_override(profile_secret_env, monkeypatch):
+    """The name is config-driven, so a renamed token env must still be excluded.
+
+    Pinning the contract against `protected_env_vars()` rather than a hardcoded
+    list is what makes a plugin-provided source covered without editing the
+    snapshot code.
+    """
+    import agent.secret_scope as ss
+
+    monkeypatch.setattr(ss, "is_multiplex_active", lambda: False)
+
+    import hermes_cli.env_loader as el
+
+    monkeypatch.setattr(
+        el,
+        "_load_secrets_config",
+        lambda _home: {"bitwarden": {"enabled": True, "access_token_env": "CUSTOM_BWS_ENV"}},
+    )
+
+    env = LocalEnvironment(cwd=str(profile_secret_env), timeout=10)
+    env._profile_scoped_passthrough = True
+
+    excluded = set(env._snapshot_excluded_passthrough_names())
+
+    assert "CUSTOM_BWS_ENV" in excluded
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_snapshot_file_never_contains_credential_bytes(profile_secret_env, monkeypatch):
+    """E2E: a real snapshot on a single-profile host carries PATH but no secret."""
+    import agent.secret_scope as ss
+
+    monkeypatch.setattr(ss, "is_multiplex_active", lambda: False)
+    monkeypatch.setenv(_SECRET_NAME, _SECRET_VALUE)
+
+    env = LocalEnvironment(cwd=str(profile_secret_env), timeout=30)
+    env._profile_scoped_passthrough = True
+    env.init_session()
+    try:
+        env.execute("printf ready")
+
+        snap = env._snapshot_path
+        if not os.path.exists(snap):
+            pytest.skip("no snapshot produced on this host")
+        contents = open(snap).read()
+
+        # The value itself is what leaks — assert on bytes, not the name.
+        assert _SECRET_VALUE not in contents
+        # ...while the user's ordinary shell state must still persist.
+        assert "PATH" in contents
+
+        # And the command still sees the credential, re-injected per-Popen.
+        result = env.execute(f'printf "[$%s]"' % _SECRET_NAME)
+        assert _SECRET_VALUE in result.get("output", "")
+    finally:
+        env.cleanup()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -24,8 +24,8 @@ from tools.environments.base_output import (
     ProcessHandle, _finalize_wait_result, _new_output_collector, _start_drain_thread,
 )
 from tools.environments.base_session_env import (
-    _SHELL_ENV_NAME_RE, _SNAP_TMP_SUFFIX, _cwd_marker, _snapshot_bootstrap_script, _split_cwd_marker,
-    _wrap_command_script,
+    _SHELL_ENV_NAME_RE, _SNAP_TMP_SUFFIX, _cwd_marker, _export_dump_excluding_session_vars,
+    _snapshot_bootstrap_script, _split_cwd_marker, _wrap_command_script,
 )
 from tools.environments.base_wait import _WaitTrace
 
@@ -235,21 +235,76 @@ class BaseEnvironment(ABC):
         return ()
 
     def _snapshot_excluded_passthrough_names(self) -> tuple[str, ...]:
-        """Profile-scoped names that must not persist in the snapshot. Monotonic for the
-        environment lifetime: an allowlist can be cleared after a value was captured, and
-        retaining the exclusion keeps that old value from leaking to a later profile."""
+        """Return names that must not persist in the snapshot.
+
+        The exclusions are monotonic for the environment lifetime: an allowlist
+        can be cleared after a value was captured, and retaining the exclusion
+        keeps that old value from leaking to a later profile.
+
+        Cross-profile passthrough exclusions are needed only while multiplexing,
+        but profile credential names must always be excluded. ``export -p`` dumps
+        the complete process environment, including credentials injected by the
+        profile secret loader, so those names must never be written to disk even
+        on a single-profile host.
+        """
         if not self._profile_scoped_passthrough:
             return ()
         try:
             from agent.secret_scope import is_multiplex_active
+            from tools.env_passthrough import get_all_passthrough
+            names: tuple[str, ...] = ()
             if is_multiplex_active():
-                from tools.env_passthrough import get_all_passthrough
                 names = (*get_all_passthrough(), *self._additional_profile_scoped_passthrough_names())
-                self._snapshot_passthrough_names.update(
-                    name for name in names if isinstance(name, str) and _SHELL_ENV_NAME_RE.fullmatch(name))
+            names = (*names, *self._profile_secret_env_names())
+            self._snapshot_passthrough_names.update(
+                name for name in names if isinstance(name, str) and _SHELL_ENV_NAME_RE.fullmatch(name))
         except Exception:
             logger.debug("Could not refresh profile-scoped snapshot exclusions", exc_info=True)
         return tuple(sorted(self._snapshot_passthrough_names))
+
+    def _profile_secret_env_names(self) -> tuple[str, ...]:
+        """Return profile credential names without reading or exposing their values.
+
+        Two populations, because a resolved secret and the credential used to
+        REACH it arrive by different routes:
+
+        - values the profile resolved (``<home>/.env`` plus fetched external
+          secrets), from ``build_profile_secret_scope``;
+        - each configured source's *bootstrap* auth token, which never appears in
+          that scope. ``load_hermes_dotenv`` seeds it from a gitignored
+          ``.op.env`` or the launcher/systemd environment, so it reaches
+          ``os.environ`` — and therefore ``export -p`` — while being absent from
+          the resolved mapping.
+
+        Bootstrap names come from each source's own ``protected_env_vars()``, the
+        existing declaration of "env vars no source may overwrite", so a new or
+        plugin-provided source is covered without editing this method.
+        """
+        names: set[str] = set()
+        home = Path(get_hermes_home())
+        try:
+            from agent.secret_scope import build_profile_secret_scope
+            names.update(build_profile_secret_scope(home))
+        except Exception:
+            logger.debug("Could not enumerate profile secret names", exc_info=True)
+        names.update(self._secret_source_bootstrap_env_names(home))
+        return tuple(sorted(names))
+
+    def _secret_source_bootstrap_env_names(self, home: Path) -> tuple[str, ...]:
+        """Bootstrap-auth env names declared by the configured secret sources."""
+        try:
+            from agent.secret_sources.registry import list_sources
+            from hermes_cli.env_loader import _load_secrets_config
+            secrets_cfg = _load_secrets_config(home) or {}
+            names: set[str] = set()
+            for source in list_sources():
+                cfg = secrets_cfg.get(source.name)
+                cfg = cfg if isinstance(cfg, dict) else {}
+                names.update(source.protected_env_vars(cfg))
+            return tuple(n for n in names if n)
+        except Exception:
+            logger.debug("Could not enumerate secret-source bootstrap names", exc_info=True)
+            return ()
 
     def _snapshot_script_kwargs(self, cwd: str) -> dict:
         """Quoting inputs shared by the bootstrap and per-command wrapper scripts.


### PR DESCRIPTION
The terminal backend captures the login shell into an env snapshot
(`BaseEnvironment.init_session`) built with `export -p` and filtered through
`_snapshot_excluded_passthrough_names()`.

That method computed its exclusions only inside `if is_multiplex_active():`.
The exclusion was introduced for *cross-profile passthrough* leakage, so gating
it on multiplex looked right — but the same list is the only thing keeping
**credentials** out of the snapshot. On a single-profile host the list is empty,
so `export -p` writes every secret the profile loader injected into
`os.environ` straight to disk in plaintext: the secret-manager access token
(which unlocks the whole vault), provider API keys, an SSH private key,
dashboard session secrets, bot tokens.

The file is mode 0600, so this is a local-compromise exposure rather than a
remote one — but it undermines the point of moving credentials into a secret
manager, since any process running as that user can read the token that unlocks
all of them. It is also not a one-off: the snapshot is rewritten on essentially
every terminal call, so deleting the file without fixing the writer achieves
nothing.

## Fix

Split the method's two concerns and union them:

1. **Cross-profile passthrough** — still multiplex-only (semantics unchanged).
2. **Profile credentials** — now **unconditional**, via a new
   `_profile_secret_env_names()` that takes *names only* from
   `build_profile_secret_scope()`, so `.env`-resident and vault-only
   credentials are both covered.

### Why this cannot break commands that need those variables

The excluded names are re-injected into every command's process environment via
`Popen(env=run_env)` (`local._build_run_env` / `_inject_session_context_env`) —
this is the identical rationale the pre-existing per-session-var exclusion
already relies on. The snapshot only needs to carry the user's own shell state.
The E2E test asserts both halves: `PATH` still persists, and a command still
sees the credential.

## Verification

`tests/tools/test_snapshot_profile_secret_exclusion.py` — 4 tests, all red on
`main`:

- credential names are excluded with `is_multiplex_active()` **False** (the bug)
  and True — parametrized, since the single-profile case is the regression
- enumerating names never surfaces values
- E2E with a real `LocalEnvironment` and a real `init_session()`: greps the
  snapshot file for the secret's **bytes**, asserts `PATH` survives, and asserts
  the command still receives the credential

On unpatched `main` the E2E fails by finding the secret value in the snapshot on
disk, i.e. it reproduces the leak rather than asserting on implementation shape.

No regressions across `tests/tools/test_snapshot_session_id_leak.py`,
`test_snapshot_multiline_session_env_injection.py`, `test_env_passthrough.py`,
`test_skill_env_passthrough.py` (38 passed with the change).

## Scope / limits

- Covers the terminal env snapshot. Other state-snapshot writers are a separate
  path in the same bug class, and nothing here helps a secret deliberately
  echoed into a command.
- Local root/user still wins: a live process's `os.environ` is readable
  regardless.
- Values already written stay compromised until rotated; this stops new writes.

## Relationship to existing open PRs

I swept for duplicates first; this space is crowded, so here is the honest
delta. All three below leave the `if is_multiplex_active():` gate in
`_snapshot_excluded_passthrough_names()` intact, which is the specific defect
this PR removes.

- **#102210** targets the same method, but *adds* a parallel
  `_snapshot_credential_exclusion_names()` (the provider blocklist plus an
  explicit set and a `HERMES_CUSTOM_*_API_KEY` glob) and unions it in
  `init_session`. That is name-list-based, so it cannot cover a credential whose
  name is not enumerated — e.g. a vault-only secret. It also appears to be based
  on a much older tree (its hunks anchor near line 722 of a file that is now 622
  lines), so it likely needs a rebase regardless. The two changes are
  complementary rather than conflicting: a blocklist catches known vendor names
  in *any* shell, provenance catches *this profile's* credentials whatever they
  are called. If maintainers want only one, provenance is the one that closes
  the gate.
- **#69997** is also provenance-based, but at a different layer
  (`local.py`, `local_env_policy.py`, `env_loader.py`, code-exec and Docker
  children) and 10 files wide. It does not change this method, so the
  single-profile snapshot gate survives it.
- **#72652** (draft) is about `IFS`-robustness in the scrubber and Docker
  forwarding — orthogonal.

Happy to close this in favour of a maintainer's preferred shape, or to rebase it
on top of whichever of the above lands first.