### PR TITLE
fix(models): keep vendor deepseek-flash instead of rewriting to retired v4-flash

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -93,7 +93,7 @@ _DEEPSEEK_RETIRED_ALIASES: frozenset[str] = frozenset({
     "deepseek-chat", "deepseek-reasoner"})
 
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-v4-pro", "deepseek-v4-flash"})
+    "deepseek-v4-pro", "deepseek-v4-flash", "deepseek-flash"})
 
 # First-class V-series IDs incl. future ``deepseek-v5-*`` and dated variants
 # (``deepseek-v4-flash-20260423``): verified real model ids, NOT aliases of ``deepseek-chat``.

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -22,7 +22,10 @@ class DeepSeekProfile(ProviderProfile):
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         m = (model or "").strip().lower()
-        if not m.startswith("deepseek-v") or m.startswith("deepseek-v3"):  # v4+ only; v3 excluded
+        if "/" in m:
+            m = m.split("/", 1)[1].strip()
+        # v4+ and current vendor flash id; v3 excluded
+        if m != "deepseek-flash" and (not m.startswith("deepseek-v") or m.startswith("deepseek-v3")):
             return {}, {}
         rc = reasoning_config if isinstance(reasoning_config, dict) else None
         # Always set thinking explicitly (default enabled, matching the API default)
@@ -42,8 +45,8 @@ class DeepSeekProfile(ProviderProfile):
 deepseek = DeepSeekProfile(
     name="deepseek", aliases=("deepseek-chat",), env_vars=("DEEPSEEK_API_KEY",), display_name="DeepSeek",
     description="DeepSeek — native DeepSeek API", signup_url="https://platform.deepseek.com/",
-    fallback_models=("deepseek-v4-pro", "deepseek-v4-flash"), base_url="https://api.deepseek.com/v1",
-    default_aux_model="deepseek-v4-flash",
+    fallback_models=("deepseek-v4-pro", "deepseek-flash"), base_url="https://api.deepseek.com/v1",
+    default_aux_model="deepseek-flash",
 )
 
 register_provider(deepseek)

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -138,6 +138,24 @@ class TestDeepseekCanonicalAndReasonerMapping:
         assert _normalize_for_deepseek(model) == "deepseek-v4-flash"
 
 
+class TestDeepseekFlashVendorId:
+    """Vendor id ``deepseek-flash`` is first-class and must not be rewritten
+    to the retired ``deepseek-v4-flash`` alias (#107206).
+    """
+
+    def test_bare_deepseek_flash_is_canonical(self):
+        assert normalize_model_for_provider("deepseek-flash", "deepseek") == "deepseek-flash"
+
+    def test_prefixed_deepseek_flash_strips_but_keeps_flash(self):
+        assert normalize_model_for_provider("deepseek/deepseek-flash", "deepseek") == "deepseek-flash"
+
+    def test_mixed_case_bare_flash_lowercases_and_keeps(self):
+        assert _normalize_for_deepseek("DeepSeek-Flash") == "deepseek-flash"
+
+    def test_retired_reasoner_still_rewrites(self):
+        assert normalize_model_for_provider("deepseek-reasoner", "deepseek") == "deepseek-v4-flash"
+
+
 # ── Regression: issue #78796 ───────────────────────────────────────────
 
 class TestIssue78796NvidiaPrefixRepair:

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -108,6 +108,8 @@ class TestDeepSeekModelGating:
             "deepseek-v4-flash",
             "deepseek-v4-future-variant",
             "DEEPSEEK-V4-PRO",  # case-insensitive
+            "deepseek-flash",  # current vendor flash id (#107206)
+            "deepseek/deepseek-flash",  # prefixed form still V4-class
         ],
     )
     def test_thinking_capable_models_emit_thinking(self, deepseek_profile, model):
@@ -186,16 +188,16 @@ class TestDeepSeekAuxModel:
     system.
     """
 
-    def test_profile_advertises_deepseek_v4_flash(self, deepseek_profile):
-        assert deepseek_profile.default_aux_model == "deepseek-v4-flash"
+    def test_profile_advertises_deepseek_flash(self, deepseek_profile):
+        assert deepseek_profile.default_aux_model == "deepseek-flash"
 
-    def test_fallback_models_are_v4_only(self, deepseek_profile):
+    def test_fallback_models_keep_pro_and_current_flash(self, deepseek_profile):
         assert deepseek_profile.fallback_models == (
             "deepseek-v4-pro",
-            "deepseek-v4-flash",
+            "deepseek-flash",
         )
 
-    def test_consumer_api_returns_deepseek_v4_flash(self):
+    def test_consumer_api_returns_deepseek_flash(self):
         from agent.auxiliary_client import _get_aux_model_for_provider
-        assert _get_aux_model_for_provider("deepseek") == "deepseek-v4-flash"
+        assert _get_aux_model_for_provider("deepseek") == "deepseek-flash"
 


### PR DESCRIPTION
## What does this PR do?

DeepSeek's live catalog now serves `deepseek-flash` + `deepseek-v4-pro`. The DeepSeek normalizer only treated `deepseek-v4-pro` / `deepseek-v4-flash` as canonical, so the vendor's current `deepseek-flash` (and `deepseek/deepseek-flash`) was silently rewritten to the retired `deepseek-v4-flash`. Settings → Model Apply reported success, then reopening showed the retired id.

This PR adds `deepseek-flash` to `_DEEPSEEK_CANONICAL_MODELS` so persist and runtime keep the vendor id. The DeepSeek profile also classifies `deepseek-flash` as V4-class for `extra_body.thinking` (the old `startswith("deepseek-v")` gate would otherwise trade a wrong-model bug for the long-session 400 class), and refreshes `fallback_models` / `default_aux_model` to the current flash id. Retired aliases and unknown ids still rewrite to `deepseek-v4-flash`; saved `deepseek-v4-flash` configs still pass through.

## Related Issue

Fixes #107206

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `hermes_cli/model_normalize.py`: add `deepseek-flash` to `_DEEPSEEK_CANONICAL_MODELS`.
- `plugins/model-providers/deepseek/__init__.py`: treat `deepseek-flash` (including prefixed form) as V4-class for thinking extras; `fallback_models` / `default_aux_model` use `deepseek-flash`.
- `tests/hermes_cli/test_model_normalize.py`: vendor flash id stays canonical; retired `deepseek-reasoner` still rewrites.
- `tests/plugins/model_providers/test_deepseek_profile.py`: thinking gate + aux/fallback pins.

## How to Test

```
# Pre-fix (origin/main @ 8068c09432, new tests only):
#   TestDeepseekFlashVendorId.test_bare_deepseek_flash_is_canonical
#     AssertionError: assert 'deepseek-v4-flash' == 'deepseek-flash'
#   TestDeepseekFlashVendorId.test_prefixed_deepseek_flash_strips_but_keeps_flash
#     AssertionError: assert 'deepseek-v4-flash' == 'deepseek-flash'
#   test_thinking_capable_models_emit_thinking[deepseek-flash]
#     AssertionError: assert {} == {'thinking': {'type': 'enabled'}}
# CONTROL: test_retired_reasoner_still_rewrites already green

scripts/run_tests.sh tests/hermes_cli/test_model_normalize.py tests/plugins/model_providers/test_deepseek_profile.py
# -> 2 files, 55 tests passed
```

## Related work (not duplicates)

- DeepSeek 2026-07-24 alias remap (`deepseek-chat` / `deepseek-reasoner` → `deepseek-v4-flash`) stays; this only stops rewriting the *current* vendor flash id.
- CommandCode aux `deepseek/deepseek-v4-flash` is a different provider and is unchanged.
- Catch-all unknown ids still rewrite to `deepseek-v4-flash` (not a live-catalog pass-through).

## Review follow-up

- Dev self-review P0=0. Independent review skipped (2 production modules, 43-line diff, not auth/crypto/state.db/gateway).
- Saved configs that still name `deepseek-v4-flash` remain canonical.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(models): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run relevant tests locally (see How to Test)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if config keys changed — or N/A
- [x] I've considered cross-platform impact — model-id normalization is provider-side, not OS-specific
- [x] I've updated tool descriptions/schemas if tool behavior changed — or N/A

Made with [Cursor](https://cursor.com)