### PR TITLE
fix(tools): clean up stale index lock after killed git child (#107149)

### DIFF
--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -201,6 +201,17 @@ def _git_env(store: Path, working_dir: str, index_file: Optional[Path] = None) -
     return env
 
 
+def _remove_stale_index_lock(index_file: Optional[Path]) -> None:
+    """Remove a stale .lock file left by a killed git child (#107149)."""
+    if index_file is None:
+        return
+    lock = Path(str(index_file) + ".lock")
+    try:
+        lock.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
 def _git_subprocess(cmd: List[str], env: dict, timeout: int, cwd: Optional[str] = None):
     # creationflags suppresses the per-call conhost flash on Windows (no-op on POSIX).
     # Text mode both replaces undecodable path bytes and normalizes CR/CRLF.
@@ -239,9 +250,11 @@ def _run_git(args: List[str], store: Path, working_dir: str, timeout: int = _GIT
         logger.error("Git command skipped: %s (%s)", " ".join(cmd), msg)
         return False, "", msg
 
+    _remove_stale_index_lock(index_file)
     try:
         result = _git_subprocess(cmd, _git_env(store, str(wd), index_file=index_file), timeout, cwd=str(wd))
     except subprocess.TimeoutExpired:
+        _remove_stale_index_lock(index_file)  # killed child may have left a lock
         msg = f"git timed out after {timeout}s: {' '.join(cmd)}"
         logger.error(msg, exc_info=True)
         return False, "", msg


### PR DESCRIPTION
Fixes #107149

## Root Cause

`checkpoint_manager._run_git` shells out to `git` with a per-project `GIT_INDEX_FILE` (stored at `store/indexes/<hash>`). Git creates `<index_file>.lock` with `O_EXCL` and renames it into place on success. When `subprocess.run(timeout=...)` kills the git child (large repo, slow I/O), the lock file is abandoned — nothing reclaims it.

Every later checkpoint for that work tree fails instantly with `fatal: Unable to create '<store>/indexes/<hash>.lock': File exists`. The issue reporter observed **1,666 consecutive failures across 5+ weeks**.

## Fix

Add `_remove_stale_index_lock(index_file)` helper that deletes `<index>.lock`:

1. **Before** each git command — safe because git creates the lock itself when it needs one; removing a stale lock is always correct.
2. **After** `TimeoutExpired` — the killed child may have left a lock behind.

`Path.unlink(missing_ok=True)` handles the common case (no lock exists) silently. `OSError` is caught for race conditions (another process cleaned it up).

## Testing

- `python3 -m py_compile tools/checkpoint_manager.py` passes
- The helper is a no-op when `index_file is None` (non-checkpoint git calls)
- `unlink(missing_ok=True)` is safe to call even when no lock exists