### PR TITLE
fix(desktop): keep narrow sidebar tabs below window controls

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -206,7 +206,9 @@ Sizes: `default`, `xs`, `overlay` (titlebar glyph counts).
 
 Top-edge panels extend into the native titlebar band. Their tab strips remain
 inside their own zones so tab drops, focus, and split boundaries use the same
-geometry. Lower panels keep local headers. Empty header space moves the window;
+geometry. Lower panels keep local headers. Edge panels at 420px or narrower place their
+tabs on a second row below the window controls, retaining the full tab and
+restore hit targets while resizing. Empty header space moves the window;
 tabs and actions remain no-drag, with native-control space reserved from the
 existing traffic-light and Window Controls Overlay measurements.
 

--- a/apps/desktop/e2e/pane-tab-clearance.spec.ts
+++ b/apps/desktop/e2e/pane-tab-clearance.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from './test'
+import { setupMockBackend, waitForAppReady } from './fixtures'
+
+// Uses the real panel, stylesheet, and native titlebar reservations. jsdom
+// cannot detect clipped tabs or the content subtree's zero titlebar height.
+test('sidebar tabs remain clickable while resizing on either window edge', async () => {
+  const fixture = await setupMockBackend()
+  try {
+    await waitForAppReady(fixture, 120_000)
+    const page = fixture.page
+    const zone = page.locator('[data-tree-group]').filter({ has: page.locator('[data-tree-tab="sessions"]') })
+    for (const flipped of [false, true]) {
+      if (flipped) await page.getByRole('button', { name: 'Swap sidebar sides', exact: true }).click()
+      for (const width of [245, 470]) {
+        // Constrain the actual track, as a sash does, without coupling this
+        // header regression to pointer-drag thresholds or persisted widths.
+        await zone.evaluate((element, width) => {
+          Object.assign(element.parentElement!.style, {
+            flex: `0 0 ${width}px`,
+            minWidth: `${width}px`,
+            maxWidth: `${width}px`
+          })
+        }, width)
+        for (const tab of [zone.locator('[data-tree-tab="sessions"]'), zone.getByRole('tab', { name: /^bots$/i })]) {
+          await tab.click({ trial: true })
+          const tabBox = (await tab.boundingBox())!
+          const zoneBox = (await zone.boundingBox())!
+          expect(tabBox.x).toBeGreaterThanOrEqual(zoneBox.x)
+          expect(tabBox.x + tabBox.width).toBeLessThanOrEqual(zoneBox.x + zoneBox.width)
+          if (width < 300) {
+            const controlBox = (await page
+              .locator(flipped ? '[aria-label="App controls"]' : '[aria-label="Window controls"]')
+              .boundingBox())!
+            expect(tabBox.y).toBeGreaterThanOrEqual(controlBox.y + controlBox.height)
+          }
+        }
+        await zone.getByRole('button', { name: 'Minimize', exact: true }).click({ trial: true })
+      }
+    }
+  } finally {
+    await fixture.cleanup()
+  }
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -425,7 +425,7 @@ export function TreeGroup({
 
   return (
     <div
-      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-(--ui-editor-surface-background)"
+      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-(--ui-editor-surface-background) [container-type:inline-size] [container-name:pane-zone]"
       data-tree-group={node.id}
       data-window-top={topEdge || undefined}
       // Advertises the visible tab strip so panes can drop their own
@@ -440,7 +440,12 @@ export function TreeGroup({
         setMenuPane((e.target as HTMLElement).closest('[data-tree-tab]')?.getAttribute('data-tree-tab') ?? undefined)
       }}
       ref={ref}
-      style={wcOverlap ? { paddingTop: wcOverlap.y + wcOverlap.height } : undefined}
+      style={
+        {
+          '--pane-titlebar-height': `${TITLEBAR_HEIGHT}px`,
+          paddingTop: wcOverlap ? wcOverlap.y + wcOverlap.height : undefined
+        } as CSSProperties
+      }
     >
       {wcOverlap && (
         <div
@@ -500,12 +505,13 @@ export function TreeGroup({
           bounds, strip refs, focus ownership and split geometry as the body. */}
       {(headerVisible || topEdge) && (
         <div
-          className="flex min-w-0 shrink-0 bg-(--ui-sidebar-surface-background)"
+          className="relative flex min-w-0 shrink-0 bg-(--ui-sidebar-surface-background)"
           data-panel-header=""
-          style={topEdge ? { height: TITLEBAR_HEIGHT } : undefined}
+          data-titlebar-tabs={topEdge && headerVisible && (leftEdge || rightEdge) ? true : undefined}
+          style={topEdge ? { height: `var(--panel-header-height, ${TITLEBAR_HEIGHT}px)` } : undefined}
         >
           {topEdge && leftEdge && (
-            <div className="flex shrink-0">
+            <div className="flex shrink-0" data-titlebar-reserve="left">
               <div className="w-(--titlebar-controls-left,14px) [-webkit-app-region:drag]" data-window-drag-handle="" />
               <div className="relative w-(--titlebar-controls-width,96px)">
                 <div
@@ -698,7 +704,7 @@ export function TreeGroup({
             <div className="min-w-0 flex-1 [-webkit-app-region:drag]" />
           )}
           {topEdge && rightEdge && (
-            <div className="flex shrink-0">
+            <div className="flex shrink-0" data-titlebar-reserve="right">
               <div
                 className="w-6"
                 data-window-drag-handle=""
@@ -772,16 +778,17 @@ export function TreeGroup({
       {editMode && !dragging && !isEmpty && !node.minimized && (
         <ZoneMenu {...zoneMenu}>
           <div
+            className="absolute inset-x-0 bottom-0 z-50 flex cursor-grab items-center justify-center outline-1 -outline-offset-2 outline-dashed backdrop-blur-[2px]"
             // z-50: pane CONTENT may carry its own stacked chrome (the
             // terminal rail is z-40) — the edit veil must cover all of it.
             // The scrim mixes the accent over the CHROME BG (not transparent)
             // so it properly dims content in dark themes instead of leaving a
             // barely-tinted wash; the light blur reads as "edit mode" the same
             // way the zone editor's backdrop does.
-            className="absolute inset-x-0 bottom-0 z-50 flex cursor-grab items-center justify-center outline-1 -outline-offset-2 outline-dashed backdrop-blur-[2px]"
+            data-pane-edit-veil=""
             onPointerDown={e => startPaneDrag(activeId, e, undefined, undefined, active?.title ?? activeId)}
             style={{
-              top: topEdge ? TITLEBAR_HEIGHT : headerVisible ? 28 : 0,
+              top: topEdge ? `var(--panel-header-height, ${TITLEBAR_HEIGHT}px)` : headerVisible ? 28 : 0,
               background:
                 'color-mix(in srgb, var(--ui-accent) 6%, color-mix(in srgb, var(--ui-bg-chrome) 55%, transparent))',
               outlineColor: 'color-mix(in srgb, var(--ui-accent) 55%, transparent)'

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -274,7 +274,7 @@ export function TreeSplit({
           element,
           index,
           initial: side.fixed ? side.size : sizeOf(element),
-          // A minimized rail is its 28px strip: it neither donates nor takes,
+          // A minimized zone keeps its rendered strip: it neither donates nor takes,
           // and its remembered weight must survive the gesture so restoring
           // it brings back the size it had before it was folded.
           minimized: child.type === 'group' && Boolean(child.minimized),
@@ -704,7 +704,11 @@ export function TreeSplit({
               collapsed
                 ? { display: 'none' }
                 : minimized
-                  ? { flex: `0 0 ${MINIMIZED_TRACK}` }
+                  ? {
+                      // Rows keep a narrow rail; columns follow the rendered
+                      // strip height, including two-row top-edge headers.
+                      flex: `0 0 ${horizontal ? MINIMIZED_TRACK : 'auto'}`
+                    }
                   : {
                       // One flexbox formula for everything: a sized zone is
                       // grow-0 shrink-1 from its preferred basis (it yields

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -3543,3 +3543,30 @@ html:has([data-hud-shell]) [data-slot='popover-content'] {
 [data-hud-shell] [data-slot='composer-bounds'] *::-webkit-scrollbar {
   display: none;
 }
+
+/* Narrow top-edge zones keep their tabs below the window controls.
+   Container queries respond to sash movement without rerendering transcripts.
+   ponytail: 420px covers the current control clusters; measure reservations if plugins add titlebar controls. */
+@container pane-zone (max-width: 420px) {
+  [data-titlebar-tabs] {
+    --panel-header-height: calc(var(--pane-titlebar-height, 34px) * 2);
+    padding-top: var(--pane-titlebar-height, 34px);
+  }
+
+  [data-titlebar-tabs] > [data-titlebar-reserve] {
+    position: absolute;
+    top: 0;
+    height: var(--pane-titlebar-height, 34px);
+  }
+
+  [data-titlebar-tabs] > [data-titlebar-reserve='left'] {
+    left: 0;
+  }
+  [data-titlebar-tabs] > [data-titlebar-reserve='right'] {
+    right: 0;
+  }
+
+  [data-titlebar-tabs] ~ [data-pane-edit-veil] {
+    --panel-header-height: calc(var(--pane-titlebar-height, 34px) * 2);
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Keep Sessions/Bots tabs and the minimize/restore action usable when a top-edge sidebar is resized narrower than its window-control reservations plus tab strip.

At 245px on macOS, the titlebar controls consume most of the available width, clipping the tabs. Top-edge groups at either window edge now put their single-line tab strip below the controls when the group is at most 420px wide. Wider groups retain the existing single-row header. A CSS container query follows sash resizing without adding resize state or rerendering transcripts.

## Related Issue

Observed and reproduced locally on macOS; no dedicated issue is claimed as fixed.

Related: #106703 adds an optional general Wrap Tabs setting. This PR separates the window controls from the tab strip in narrow edge groups; it does not wrap tabs themselves or add a setting. Both changes touch TreeGroup/header sizing and would need reconciliation if both are merged.

## Type of Change

- [x] Bug fix

## Changes Made

- Reserve a second header row for narrow top-edge groups, keeping window controls in their original band.
- Use a dedicated pane-titlebar height because the content subtree can inherit `--titlebar-height: 0px`.
- Align the layout-edit overlay with the taller header and let vertically stacked minimized tracks use their rendered header height.
- Document the narrow-header behavior and add one Electron regression test using the existing mock-backend fixture.

## How to Test

1. With Sessions and Bots docked, resize the sidebar to approximately 245px. Both tabs and the minimize action should remain fully visible and clickable below the window controls.
2. Expand it to 470px: the header should return to one row.
3. Swap sidebar sides and repeat.

Validation on macOS 27.0, Apple Silicon, from `apps/desktop`:

- `npx vitest run src/components/pane-shell/tree/renderer/tree-group.test.tsx src/components/pane-shell/tree/renderer/tree-split-cascade-resize.test.tsx`: 7 passed.
- `npx playwright test e2e/pane-tab-clearance.spec.ts --reporter=list`: 1 passed in a real Electron window using the existing isolated mock backend. Checks the actual Sessions/Bots tabs and minimize action at 245px and 470px on both sides.
- The same Electron test fails on the unmodified base on the narrow-header geometry assertion (tab top 0px overlaps the control band ending at 29px).
- Renderer and E2E TypeScript checks, ESLint on changed renderer files, and `npm run build --ignore-scripts`: passed.
- Packaged-app manual check: 245px sidebar keeps both tabs visible; resizing back to 320px works. That local app also had the separate sidebar-recovery patch installed; the automated checks above run on this PR alone.

## Checklist

- [x] Read the contributing guide; used Conventional Commits.
- [x] Searched existing open/merged PRs and issues; related work is identified above.
- [x] Focused change with a real renderer regression test and updated DESIGN.md.
- [x] Tested on macOS; Windows/Linux native titlebar behavior has not been manually verified.
- [ ] Full Python suite (not run; this is a desktop renderer-only change).
- [x] Configuration, tool schemas and architecture workflow changes: N/A.

## Screenshots / Logs

No private conversation screenshots or user configuration are included. Implementation and verification were assisted by Codex.
