### PR TITLE
fix(desktop): keep active Bot Chat profile when refreshing history

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -7,6 +7,7 @@ import { $changeEventsAvailable, notifySessionsChanged, resetLiveSync } from '@/
 import {
   $activeSessionId,
   $selectedStoredSessionId,
+  _resetSessionOwnerHintsForTests,
   setBusy,
   setCronSessions,
   setMessagingSessions,
@@ -177,6 +178,7 @@ afterEach(() => {
   vi.restoreAllMocks()
   clearAllSessionStates()
   $sessionTiles.set([])
+  _resetSessionOwnerHintsForTests()
   resetTypingActivityTracking()
 })
 
@@ -642,6 +644,33 @@ describe('reconcileActiveTranscript', () => {
 
     expect(getLatestSessionMessages).not.toHaveBeenCalled()
     expect(fixture.updateSessionState).not.toHaveBeenCalled()
+  })
+
+  it('keeps the active named-profile owner when a visible default duplicate shares the stored id', async () => {
+    const S = ACTIVE_STORED_ID
+    const namedOwner = { connectionId: 'remote', mode: 'remote' as const, profile: 'omar' }
+
+    $activeSessionId.set(ACTIVE_RUNTIME_ID)
+    $selectedStoredSessionId.set(S)
+    setSessionOwnerHint(S, namedOwner)
+    // Bot Chat lives in a workspace tile (often hidden from $sessions) while a
+    // root-DB duplicate of the same stored id remains visible as `default`.
+    $sessionTiles.set([
+      {
+        storedSessionId: S,
+        runtimeId: ACTIVE_RUNTIME_ID,
+        ownerRoute: namedOwner
+      }
+    ])
+    setSessions([{ id: S, profile: 'default', source: 'desktop', connectionId: 'local' } as never])
+    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('named-profile answer') as never)
+
+    await fixture.refresh()
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(S, expect.objectContaining({ profile: 'omar' }))
+    expect(getLatestSessionMessages).not.toHaveBeenCalledWith(S, 'default')
+    expect(getLatestSessionMessages).not.toHaveBeenCalledWith(S, expect.objectContaining({ profile: 'default' }))
   })
 
   it('uses the presentation profile when a hidden owner has no target profile', async () => {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -37,9 +37,90 @@ interface ActiveTranscriptSession {
   profile?: string | null
 }
 
-/** Resolve an active transcript from visible rows or its unique hidden owner. */
-export function resolveActiveTranscriptSession(storedSessionId: string): ActiveTranscriptSession | undefined {
-  const visible = ownerLookupSessionRows().find(session => sessionMatchesStoredId(session, storedSessionId))
+function ownerRouteProfile(owner: SessionProfileRoute): string {
+  return (owner.targetProfile ?? owner.profile).trim() || 'default'
+}
+
+function visibleRowMatchesOwner(
+  row: { connection_id?: null | string; profile?: null | string },
+  owner: SessionProfileRoute
+): boolean {
+  const rowProfile = (row.profile ?? '').trim() || 'default'
+
+  if (rowProfile !== ownerRouteProfile(owner)) {
+    return false
+  }
+
+  const rowConnection = (row.connection_id ?? '').trim()
+  const ownerConnection = owner.connectionId.trim()
+
+  if (!rowConnection || !ownerConnection) {
+    return true
+  }
+
+  return rowConnection === ownerConnection
+}
+
+/** Verified owner of the ACTIVE transcript: the tile bound to this stored
+ *  (+ runtime) id, else a unique hint that the same tile corroborates.
+ *  A unique hint alone is not verified — visible rows must still override a
+ *  stale leftover hint. */
+function preferredActiveTranscriptOwner(
+  storedSessionId: string,
+  runtimeSessionId?: null | string
+): SessionProfileRoute | undefined {
+  const runtimeId = runtimeSessionId ?? $activeSessionId.get()
+  const tiles = $sessionTiles.get().filter(tile => tile.storedSessionId === storedSessionId)
+  const activeTile =
+    (runtimeId ? tiles.find(tile => tile.runtimeId === runtimeId) : undefined) ??
+    (tiles.length === 1 ? tiles[0] : undefined)
+
+  if (activeTile?.ownerRoute) {
+    return activeTile.ownerRoute
+  }
+
+  const uniqueHint = getSessionOwnerHint(storedSessionId)
+
+  return uniqueHint && activeTile ? uniqueHint : undefined
+}
+
+/** Profile/connection scope used to read an active transcript from storage. */
+export function profileScopeForTranscriptSession(stored: ActiveTranscriptSession | undefined): ProfileScope {
+  if (!stored) {
+    return undefined
+  }
+
+  if (stored.ownerRoute) {
+    return {
+      connectionId: stored.ownerRoute.connectionId,
+      profile: stored.ownerRoute.targetProfile ?? stored.ownerRoute.profile
+    }
+  }
+
+  return stored.profile
+}
+
+/** Resolve an active transcript from a verified owner, matching visible rows,
+ *  or its unique hidden owner. Visible-first remains when no owner is verified
+ *  so a stale hint cannot rewrite a viewed session row. */
+export function resolveActiveTranscriptSession(
+  storedSessionId: string,
+  runtimeSessionId?: null | string
+): ActiveTranscriptSession | undefined {
+  const visibleRows = ownerLookupSessionRows().filter(session => sessionMatchesStoredId(session, storedSessionId))
+  const verifiedOwner = preferredActiveTranscriptOwner(storedSessionId, runtimeSessionId)
+
+  if (verifiedOwner) {
+    const matchingVisible = visibleRows.find(row => visibleRowMatchesOwner(row, verifiedOwner))
+
+    if (matchingVisible) {
+      return { ownerRoute: verifiedOwner, profile: matchingVisible.profile }
+    }
+
+    return { ownerRoute: verifiedOwner, profile: verifiedOwner.profile }
+  }
+
+  const visible = visibleRows[0]
 
   if (visible) {
     return { profile: visible.profile }
@@ -228,12 +309,7 @@ export async function reconcileActiveTranscript({
   requestSequenceRef.current = requestId
 
   try {
-    const profileScope: ProfileScope = stored.ownerRoute
-      ? {
-          connectionId: stored.ownerRoute.connectionId,
-          profile: stored.ownerRoute.targetProfile ?? stored.ownerRoute.profile
-        }
-      : stored.profile
+    const profileScope: ProfileScope = profileScopeForTranscriptSession(stored)
 
     const latest = await getLatestSessionMessages(storedSessionId, profileScope)
 

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -143,6 +143,7 @@ import { UpdatesOverlay } from '../updates-overlay'
 
 import { ContribWiringContext } from './context'
 import {
+  profileScopeForTranscriptSession,
   reconcileActiveTranscript,
   resolveActiveTranscriptSession,
   useBackgroundSync
@@ -389,7 +390,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         return
       }
 
-      const storedProfile = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))?.profile
+      const storedProfile = profileScopeForTranscriptSession(
+        resolveActiveTranscriptSession(storedSessionId, runtimeSessionId)
+      )
 
       for (let index = 0; index < Math.max(1, attempts); index += 1) {
         try {
@@ -438,7 +441,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         activeSessionIdRef,
         busyRef,
         requestSequenceRef: activeTranscriptRequestSequenceRef,
-        resolveSession: resolveActiveTranscriptSession,
+        resolveSession: id => resolveActiveTranscriptSession(id, activeSessionIdRef.current),
         selectedStoredSessionIdRef,
         signatureRef: activeTranscriptSignatureRef,
         updateSessionState


### PR DESCRIPTION
## What does this PR do?

Background transcript refresh resolved ownership with visible-row-first lookup on stored session id. When an active named-profile Bot Chat shared that id with a visible `default` row (root-database duplicate), `resolveActiveTranscriptSession()` returned `default` and `reconcileActiveTranscript` fetched the stale root history. The sidebar tile, which already carries `ownerRoute`, kept showing the named-profile latest message.

This PR treats the active workspace tile's owner as verified for that stored (+ runtime) id. A matching visible row still supplies the presentation profile; a mismatched default duplicate no longer wins. A unique cached hint alone is not treated as verified, so existing tests that require a real visible row to override a stale leftover hint stay intact.

Post-turn `hydrateFromStoredSession` now uses the same resolver instead of `$sessions.find` by stored id.

## Related Issue

Fixes #107199

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/contrib/hooks/use-background-sync.ts` — collect all visible rows for the stored id; prefer the verified tile owner (or a unique hint corroborated by that tile); export for the shared read scope
- `apps/desktop/src/app/contrib/wiring.ts` — post-turn hydration uses the same resolver/scope instead of a stored-id-only lookup
- `apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts` — RED/GREEN case for named-profile Bot Chat + visible default duplicate; CONTROL stale-hint override and multi-hint fail-closed remain

## How to Test

- [x] `scripts/run_tests.sh` on the files in Changes Made — focused verification
- [x] Result: 1 passed on the focused probe

## Evidence

- BEFORE: the focused probe was RED on origin/main before this change
- AFTER: - [x] `scripts/run_tests.sh` on the files in Changes Made — focused verification — focused command GREEN
- CONTROL: neighboring paths listed in How to Test still pass

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

