### PR TITLE
fix(agent): strip OpenRouter routing suffix before reasoning gate lookup (#106493)

### DIFF
--- a/agent/reasoning_params.py
+++ b/agent/reasoning_params.py
@@ -72,14 +72,17 @@ class ReasoningParamsMixin:
         # allowlist repeatedly went stale one vendor at a time. Unknown falls back to the static list.
         try:
             from hermes_cli.models_reasoning_caps import openrouter_model_reasoning_capabilities, warm_openrouter_reasoning_caps_async
-            caps = openrouter_model_reasoning_capabilities(self.model)
+            # Strip OpenRouter routing suffix (:floor, :nitro, :free, :batch, ...)
+            # before catalog lookup — suffixes only change routing, not capabilities.
+            _model_for_caps = self.model.split(":")[0] if self.model and ":" in self.model else self.model
+            caps = openrouter_model_reasoning_capabilities(_model_for_caps)
             if caps is None:
                 warm_openrouter_reasoning_caps_async()  # cache cold — warm in the background, never block
         except Exception:
             caps = None
         if caps is not None:
             return bool(caps.get("supports_reasoning"))
-        model = (self.model or "").lower()
+        model = (self.model or "").lower().split(":")[0]
         return any(model.startswith(prefix) for prefix in _OPENROUTER_REASONING_PREFIXES)
 
     def _lmstudio_reasoning_options_cached(self) -> list[str]:


### PR DESCRIPTION
Fixes #106493

## Root Cause

OpenRouter model IDs can carry routing-variant suffixes (`:floor`, `:nitro`, `:free`, `:batch`) that only change how OpenRouter picks a provider — they do not change the model's capabilities.

`_supports_reasoning_extra_body()` passed the full model ID (e.g. `z-ai/glm-flash-latest:floor`) to both:

1. **Live-catalog lookup**: `openrouter_model_reasoning_capabilities("z-ai/glm-flash-latest:floor")` — the suffixed ID doesn't match the catalog entry `z-ai/glm-flash-latest`, so `caps` is `None`.
2. **Static prefix fallback**: `"z-ai/glm-flash-latest:floor".startswith("z-ai/")` → `False` because the model string starts with `z-ai/glm-...` but `_OPENROUTER_REASONING_PREFIXES` doesn't include `"z-ai/"`.

Result: `supports_reasoning` resolves to `False` and Hermes never sends `extra_body.reasoning` for suffixed models, even when reasoning is mandatory on the OpenRouter side.

## Fix

Strip the routing suffix (everything after the first `:`) from the model ID before both lookups:

```python
_model_for_caps = self.model.split(":")[0] if self.model and ":" in self.model else self.model
```

This is applied in:
- The `openrouter_model_reasoning_capabilities()` call
- The static `_OPENROUTER_REASONING_PREFIXES` prefix check

Model IDs without suffixes are unaffected (no `:` → no split).