### PR TITLE
fix(desktop): keep left titlebar tabs from clipping beside window controls

### DIFF
--- a/apps/desktop/src/components/pane-shell/geometry.test.ts
+++ b/apps/desktop/src/components/pane-shell/geometry.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { TITLEBAR_DRAG_FILL_INSET, titlebarDragFillStart } from './geometry'
+
+describe('titlebarDragFillStart', () => {
+  it('is 0 when the zone already starts past the control cluster', () => {
+    expect(titlebarDragFillStart(98, 96, 260)).toBe(0)
+  })
+
+  it('cuts the fill so it starts after the cluster when the zone slides under it', () => {
+    expect(titlebarDragFillStart(98, 96, 28)).toBe(166)
+  })
+})
+
+describe('TITLEBAR_DRAG_FILL_INSET', () => {
+  it('references the published titlebar and workspace CSS vars', () => {
+    expect(TITLEBAR_DRAG_FILL_INSET).toContain('--titlebar-controls-left')
+    expect(TITLEBAR_DRAG_FILL_INSET).toContain('--titlebar-controls-width')
+    expect(TITLEBAR_DRAG_FILL_INSET).toContain('--workspace-left')
+  })
+})

--- a/apps/desktop/src/components/pane-shell/geometry.ts
+++ b/apps/desktop/src/components/pane-shell/geometry.ts
@@ -41,6 +41,22 @@ export function intersect(a: Rect, b: Rect): Rect | null {
   return { x, y, width: right - x, height: bottom - y }
 }
 
+/**
+ * CSS length that starts a titlebar drag fill after the fixed window-control
+ * cluster. When the zone already begins past the cluster (`--workspace-left`
+ * ≥ cluster right edge) this is 0. Cut the strip — Electron's no-drag
+ * carve-out of fixed/transformed elements is unreliable.
+ *
+ * start = max(0, controlsLeft + controlsWidth - workspaceLeft)
+ */
+export const TITLEBAR_DRAG_FILL_INSET =
+  'max(0px, calc(var(--titlebar-controls-left, 0px) + var(--titlebar-controls-width, 0px) - var(--workspace-left, 0px)))'
+
+/** Pixel form of `TITLEBAR_DRAG_FILL_INSET` for callers with resolved lengths. */
+export function titlebarDragFillStart(controlsLeft: number, controlsWidth: number, workspaceLeft: number): number {
+  return Math.max(0, controlsLeft + controlsWidth - workspaceLeft)
+}
+
 // ---------------------------------------------------------------------------
 // Native window controls rect
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
@@ -79,6 +79,100 @@ describe('TreeGroup', () => {
     expect(strip.style).toHaveProperty('WebkitAppRegion', '')
   })
 
+  it('keeps panel tabs in the titlebar for a top-edge zone that is not the left edge', () => {
+    disposePane = registry.register({
+      area: 'panes',
+      data: { placement: 'main' },
+      id: 'terminal',
+      title: 'Terminal',
+      render: () => <div>Terminal</div>
+    })
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+    render(<TreeGroup node={terminalGroup(false)} topEdge />)
+    const header = container!.querySelector('[data-panel-header]')!
+    const strip = header.querySelector<HTMLElement>('[data-zone-tabstrip]')!
+    expect(header.contains(strip)).toBe(true)
+    expect(strip.className).toContain('h-full')
+    expect(strip.className).toContain('[-webkit-app-region:drag]')
+  })
+
+  it('does not put a scroll-clipped tab strip in the left titlebar band beside Minimize', () => {
+    disposePane = registry.register({
+      area: 'panes',
+      data: { placement: 'main' },
+      id: 'sessions',
+      title: 'SESSIONS',
+      render: () => <div>Sessions</div>
+    })
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+    render(
+      <TreeGroup
+        leftEdge
+        node={{
+          active: 'sessions',
+          id: 'sessions-zone',
+          minimized: false,
+          panes: ['sessions'],
+          tabStrip: 'always',
+          type: 'group'
+        }}
+        topEdge
+      />
+    )
+
+    const header = container!.querySelector('[data-panel-header]')!
+    const tab = container!.querySelector('[data-tree-tab="sessions"]')!
+    const minimize = container!.querySelector('button[aria-label="Minimize"]')
+    const strip = header.querySelector<HTMLElement>('[data-zone-tabstrip]')
+    const tablist = tab.closest('[role="tablist"]')
+    const clusterSpacer = [...header.querySelectorAll('div')].some(el =>
+      el.className.includes('--titlebar-controls-width')
+    )
+    const titlebarStrip = Boolean(strip?.className.includes('h-full'))
+    const tablistScrolls = Boolean(tablist?.className.includes('overflow-x-auto'))
+    const truncates = Boolean(tab.querySelector('.truncate'))
+
+    expect(tab.textContent).toContain('SESSIONS')
+    // Left-edge titlebar must not host a truncated overflow-x-auto tablist in
+    // the same flex row as the in-flow --titlebar-controls-width spacer.
+    expect(clusterSpacer && titlebarStrip && tablistScrolls && truncates).toBe(false)
+    if (minimize && strip?.contains(minimize)) {
+      expect(titlebarStrip && clusterSpacer).toBe(false)
+    }
+  })
+
+  it('cuts the titlebar drag filler so it cannot cover the window-control cluster', () => {
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+    render(
+      <TreeGroup
+        node={{
+          active: 'gone',
+          id: 'empty-zone',
+          minimized: false,
+          panes: ['gone'],
+          type: 'group'
+        }}
+        topEdge
+      />
+    )
+
+    const header = container!.querySelector('[data-panel-header]')!
+    const filler =
+      header.querySelector('[data-titlebar-drag-fill]') ??
+      [...header.querySelectorAll('div')].find(
+        el =>
+          el.className.includes('flex-1') &&
+          el.className.includes('-webkit-app-region:drag') &&
+          el.childElementCount === 0
+      )
+
+    expect(filler).toBeTruthy()
+    expect(filler!.getAttribute('data-titlebar-drag-fill')).not.toBeNull()
+    const css = `${filler!.className} ${filler!.getAttribute('style') ?? ''}`
+    expect(css).toMatch(/--titlebar-controls-left/)
+    expect(css).toMatch(/--titlebar-controls-width/)
+  })
+
   it('points the docked-zone chevron in the collapse or restore action direction', () => {
     disposePane = registry.register({
       area: 'panes',

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -34,7 +34,7 @@ import { cn } from '@/lib/utils'
 import { closeAllOpenSessionTiles } from '@/store/session-states'
 
 import { $layoutEditMode } from '../../edit-mode'
-import { useWindowControlsOverlap } from '../../geometry'
+import { TITLEBAR_DRAG_FILL_INSET, useWindowControlsOverlap } from '../../geometry'
 import { emptyPaneLifecycleState, reconcilePaneLifecycle } from '../../pane-lifecycle'
 import { hiddenPaneProps, PaneGroupContext, PaneLifecycleContext, PaneVisibleContext } from '../../pane-visibility'
 import {
@@ -357,6 +357,12 @@ export function TreeGroup({
   const verticalCollapse = Boolean(node.minimized) && parentAxis === 'row' && !isEmpty && shown.length <= 1
   // A minimized group IS its header, so it shows one regardless.
   const headerVisible = !isEmpty && !verticalCollapse && (Boolean(node.minimized) || stripVisible)
+  // Left-edge titlebar shares the traffic lights + control cluster; laying
+  // the tab strip in that same flex row leaves crumbs (~26px in a 260px
+  // sidebar) and clips labels (SESSIONS → ONS). Keep the spacers in the
+  // band and drop the strip to the normal h-7 header. topEdge && !leftEdge
+  // still hosts tabs in the titlebar (bbe212de9b).
+  const tabsInTitlebar = topEdge && !leftEdge
 
   // Keep the activated tab — and, on the last one, the trailing "+" — inside
   // the strip's scroll window. Opening a tab past the right edge otherwise
@@ -500,23 +506,52 @@ export function TreeGroup({
           bounds, strip refs, focus ownership and split geometry as the body. */}
       {(headerVisible || topEdge) && (
         <div
-          className="flex min-w-0 shrink-0 bg-(--ui-sidebar-surface-background)"
+          className="flex min-w-0 shrink-0 flex-col bg-(--ui-sidebar-surface-background)"
           data-panel-header=""
-          style={topEdge ? { height: TITLEBAR_HEIGHT } : undefined}
         >
-          {topEdge && leftEdge && (
-            <div className="flex shrink-0">
-              <div className="w-(--titlebar-controls-left,14px) [-webkit-app-region:drag]" data-window-drag-handle="" />
-              <div className="relative w-(--titlebar-controls-width,96px)">
-                <div
-                  className="absolute inset-x-0 top-0 h-(--titlebar-controls-top,5px) [-webkit-app-region:drag]"
-                  data-window-drag-handle=""
-                />
-              </div>
-              <div className="w-3 [-webkit-app-region:drag]" data-window-drag-handle="" />
+          {topEdge && !(headerVisible && tabsInTitlebar) && (
+            <div className="flex min-w-0" data-titlebar-band="" style={{ height: TITLEBAR_HEIGHT }}>
+              {leftEdge && (
+                <div className="flex shrink-0">
+                  <div className="w-(--titlebar-controls-left,14px) [-webkit-app-region:drag]" data-window-drag-handle="" />
+                  <div className="relative w-(--titlebar-controls-width,96px)">
+                    <div
+                      className="absolute inset-x-0 top-0 h-(--titlebar-controls-top,5px) [-webkit-app-region:drag]"
+                      data-window-drag-handle=""
+                    />
+                  </div>
+                  <div className="w-3 [-webkit-app-region:drag]" data-window-drag-handle="" />
+                </div>
+              )}
+              {/* Cut so the fill never covers the fixed window-control cluster.
+                  Electron's no-drag carve-out of fixed/transformed elements is
+                  unreliable — same invariant as the pre-bbe212de9b drag strips. */}
+              <div
+                className="min-w-0 flex-1 [-webkit-app-region:drag]"
+                data-titlebar-drag-fill=""
+                style={{ marginLeft: TITLEBAR_DRAG_FILL_INSET }}
+              />
+              {rightEdge && (
+                <div className="flex shrink-0">
+                  <div
+                    className="w-6"
+                    data-window-drag-handle=""
+                    style={{ WebkitAppRegion: dragging ? 'no-drag' : 'drag' } as CSSProperties}
+                  />
+                  <div className="w-[calc(var(--titlebar-tools-right,0.75rem)+var(--titlebar-tools-width,24px))] [-webkit-app-region:no-drag]" />
+                </div>
+              )}
             </div>
           )}
-          {headerVisible ? (
+          {headerVisible && (
+            <div
+              className="flex min-w-0"
+              style={
+                tabsInTitlebar
+                  ? { height: TITLEBAR_HEIGHT, marginLeft: TITLEBAR_DRAG_FILL_INSET }
+                  : undefined
+              }
+            >
             <ZoneMenu {...zoneMenu}>
               <PaneTabStrip
                 className="flex-1"
@@ -537,7 +572,7 @@ export function TreeGroup({
                 }}
                 ref={stripRef}
                 style={{ cursor: 'grab', WebkitAppRegion: dragging ? 'no-drag' : undefined } as CSSProperties}
-                titlebar={topEdge}
+                titlebar={tabsInTitlebar}
                 trailing={
                   <>
                     {minimizable && (
@@ -694,17 +729,16 @@ export function TreeGroup({
                 )}
               </PaneTabStrip>
             </ZoneMenu>
-          ) : (
-            <div className="min-w-0 flex-1 [-webkit-app-region:drag]" />
-          )}
-          {topEdge && rightEdge && (
-            <div className="flex shrink-0">
-              <div
-                className="w-6"
-                data-window-drag-handle=""
-                style={{ WebkitAppRegion: dragging ? 'no-drag' : 'drag' } as CSSProperties}
-              />
-              <div className="w-[calc(var(--titlebar-tools-right,0.75rem)+var(--titlebar-tools-width,24px))] [-webkit-app-region:no-drag]" />
+              {tabsInTitlebar && rightEdge && (
+                <div className="flex shrink-0">
+                  <div
+                    className="w-6"
+                    data-window-drag-handle=""
+                    style={{ WebkitAppRegion: dragging ? 'no-drag' : 'drag' } as CSSProperties}
+                  />
+                  <div className="w-[calc(var(--titlebar-tools-right,0.75rem)+var(--titlebar-tools-width,24px))] [-webkit-app-region:no-drag]" />
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -781,7 +815,11 @@ export function TreeGroup({
             className="absolute inset-x-0 bottom-0 z-50 flex cursor-grab items-center justify-center outline-1 -outline-offset-2 outline-dashed backdrop-blur-[2px]"
             onPointerDown={e => startPaneDrag(activeId, e, undefined, undefined, active?.title ?? activeId)}
             style={{
-              top: topEdge ? TITLEBAR_HEIGHT : headerVisible ? 28 : 0,
+              top: topEdge
+                ? TITLEBAR_HEIGHT + (headerVisible && leftEdge ? 28 : 0)
+                : headerVisible
+                  ? 28
+                  : 0,
               background:
                 'color-mix(in srgb, var(--ui-accent) 6%, color-mix(in srgb, var(--ui-bg-chrome) 55%, transparent))',
               outlineColor: 'color-mix(in srgb, var(--ui-accent) 55%, transparent)'


### PR DESCRIPTION
## What does this PR do?

Regression from `bbe212de9b` (keep panel tabs in the titlebar): on macOS the left zone's titlebar band inserts in-flow spacers for the traffic lights and the fixed window-control cluster (`--titlebar-controls-left` + `--titlebar-controls-width` + `w-3`, ~206px). In a ~260px Sessions sidebar that leaves ~26px for the tab strip. `overflow-x-auto` then clips `SESSIONS` to `ONS`, and the zone-collapse chevron sits beside that fragment.

Clicking the chevron collapses the sidebar. The next zone's header filler was a naked `flex-1` `-webkit-app-region:drag` strip with no carve-out, so it slid under the fixed `[aria-label="Window controls"]` cluster and swallowed Hide sidebar / Settings / Layout editor / HUD clicks. Electron's no-drag carve-out of fixed/transformed elements is unreliable — the old titlebar cut its drag strips geometrically.

This keeps `bbe212de9b` for non-left top-edge zones (tabs stay in the titlebar). The left-edge titlebar hosts only the control spacers plus a geometrically cut drag fill; that zone's tabs render in the normal `h-7` header below, so labels are not scroll-clipped beside Minimize.

## Related Issue

Fixes #107196

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx`: left-edge titlebar no longer shares a flex row with a truncated overflow tab strip; drag filler cut via `TITLEBAR_DRAG_FILL_INSET`.
- `apps/desktop/src/components/pane-shell/geometry.ts`: `titlebarDragFillStart` / `TITLEBAR_DRAG_FILL_INSET` (`max(0, controlsLeft + controlsWidth - workspaceLeft)`).
- `apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx`: RED/GREEN for D1 (no clipped left titlebar strip) and D2 (drag fill carve-out); CONTROL that non-left top-edge zones still host titlebar tabs.
- `apps/desktop/src/components/pane-shell/geometry.test.ts`: inset math for cluster-clear vs under-cluster workspace origins.

## How to Test

```
cd apps/desktop
npx vitest run --project ui src/components/pane-shell/tree/renderer/tree-group.test.tsx src/components/pane-shell/geometry.test.ts
```

Proof Receipt (base `8068c09432`):

- BEFORE (tests on origin/main tree, same assertions): 2 failed (clipped titlebar strip; missing `data-titlebar-drag-fill`), 5 existing CONTROL passed
- AFTER: 10 passed (2 files)
- CONTROL: `keeps a top-edge strip inside its panel…` and `keeps panel tabs in the titlebar for a top-edge zone that is not the left edge` stayed green

Manual (macOS desktop): left Sessions zone ~260px — tab label `SESSIONS` is fully readable in the zone header below the titlebar, not `ONS` beside Minimize. Collapse then restore: Hide sidebar / Settings / Layout editor / HUD still accept clicks without ⌘R.

## Related work (not duplicates)

- `bbe212de9b` introduced titlebar panel tabs; this does not revert that for `topEdge && !leftEdge` zones.
- No open competing PR for #107196 at push time.

## Review follow-up

- Left-edge tabs always sit in the `h-7` header even if the user widens the sidebar enough for tabs+chevron. That is allowed (MAY stay in the titlebar, not MUST) and avoids a magic `zoneWidth < 260` gate.
- Independent P0 review: 0. Self-review P0: 0.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run relevant tests locally (desktop vitest ui project; this change is TS, not `pytest tests/`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (vitest/jsdom structure assertions; no live Electron pixel run)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — Windows overlay is top-right; left-edge spacer path is macOS traffic-lights + cluster. Drag-fill inset uses the same CSS vars on all platforms.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Made with [Cursor](https://cursor.com)