### PR TITLE
fix(gateway-windows): capture PID start time at discovery, not kill time

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1284,24 +1284,32 @@ def _windows_stop_drain_timeout() -> float:
     return max(1.0, min(configured, 30.0))
 
 
-def _force_terminate_known_gateway_pids(pids: list[int]) -> int:
-    """Force-kill known gateway PIDs without a broad process sweep."""
+def _force_terminate_known_gateway_pids(pids: list[tuple[int, int | None]]) -> int:
+    """Force-kill known gateway PIDs without a broad process sweep.
+
+    ``pids`` carries each PID's start time as captured at *discovery* time (see
+    ``_collect_gateway_stop_pids``). We must not re-read the start time here: between
+    discovery and this call the drain wait can run up to ``_windows_stop_drain_timeout()``
+    seconds, and re-reading at kill time would fingerprint whatever process currently holds
+    the PID rather than the gateway we originally found — defeating the identity guard against
+    PID reuse (see #99558).
+    """
     try:
-        from gateway.status import _pid_exists, get_process_start_time, terminate_pid
+        from gateway.status import _pid_exists, terminate_pid
     except ImportError:
         return 0
 
     own_pid = os.getpid()
     killed = 0
     seen: set[int] = set()
-    for pid in pids:
+    for pid, expected_start_time in pids:
         if pid <= 0 or pid == own_pid or pid in seen:
             continue
         seen.add(pid)
         try:
             if not _pid_exists(pid):
                 continue
-            terminate_pid(pid, force=True, expected_start_time=get_process_start_time(pid))
+            terminate_pid(pid, force=True, expected_start_time=expected_start_time)
             killed += 1
         except ProcessLookupError:
             continue
@@ -1312,15 +1320,26 @@ def _force_terminate_known_gateway_pids(pids: list[int]) -> int:
     return killed
 
 
-def _collect_gateway_stop_pids(primary_pid: int | None = None) -> list[int]:
-    """Collect gateway PIDs for the active profile, preserving primary first."""
-    pids: list[int] = []
+def _collect_gateway_stop_pids(primary_pid: int | None = None) -> list[tuple[int, int | None]]:
+    """Collect gateway PIDs for the active profile, preserving primary first.
+
+    Captures each PID's start time here, at discovery time, rather than leaving it to be
+    re-read later at kill time — the whole point of the start-time guard is to catch a PID
+    that got reassigned to a different process during the drain wait between discovery and
+    kill (see ``_force_terminate_known_gateway_pids``).
+    """
+    from gateway.status import get_process_start_time
+
+    pids: list[tuple[int, int | None]] = []
+    seen: set[int] = set()
     if primary_pid is not None and primary_pid > 0:
-        pids.append(primary_pid)
+        pids.append((primary_pid, get_process_start_time(primary_pid)))
+        seen.add(primary_pid)
     try:
         for pid in _gateway_pids():
-            if pid > 0 and pid not in pids:
-                pids.append(pid)
+            if pid > 0 and pid not in seen:
+                pids.append((pid, get_process_start_time(pid)))
+                seen.add(pid)
     except Exception:
         pass
     return pids
@@ -1350,7 +1369,8 @@ def stop() -> None:
             print(f"⚠ schtasks /End returned code {code}: {err.strip()}")
 
     # No generic process sweep: starts are profile-scoped and stop must stay bounded even if wedged.
-    stop_pids.extend(pid for pid in _collect_gateway_stop_pids() if pid not in stop_pids)
+    known_pids = {p for p, _ in stop_pids}
+    stop_pids.extend(entry for entry in _collect_gateway_stop_pids() if entry[0] not in known_pids)
     killed = _force_terminate_known_gateway_pids(stop_pids)
     if killed:
         stopped_any = True

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -17,6 +17,69 @@ _BREAKAWAY_MARKER = "_HERMES_GATEWAY_BREAKAWAY"
 
 
 
+def test_collect_gateway_stop_pids_captures_start_time_at_discovery(monkeypatch):
+    """``_collect_gateway_stop_pids`` must fingerprint each PID when it is found, not leave
+    that to whoever kills it later — the drain wait between discovery and kill is exactly the
+    window a recycled PID needs to slip through (see #99558)."""
+
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [222])
+    monkeypatch.setattr("gateway.status.get_process_start_time", lambda pid: {111: 100, 222: 200}[pid])
+
+    result = gateway_windows._collect_gateway_stop_pids(primary_pid=111)
+
+    assert result == [(111, 100), (222, 200)]
+
+
+def test_collect_gateway_stop_pids_dedupes_primary_against_scan(monkeypatch):
+    """The primary PID must not be captured twice even if the scan also finds it."""
+
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [111, 333])
+    monkeypatch.setattr("gateway.status.get_process_start_time", lambda pid: {111: 100, 333: 300}[pid])
+
+    result = gateway_windows._collect_gateway_stop_pids(primary_pid=111)
+
+    assert result == [(111, 100), (333, 300)]
+
+
+def test_force_terminate_known_gateway_pids_uses_discovery_time_not_kill_time(monkeypatch):
+    """The whole point of the start-time guard is to catch a PID that changed hands between
+    discovery and kill. We prove this by making a live re-read return a different value (999)
+    than the discovery-time value baked into the input tuple (100): if the code ever re-fetches
+    at kill time instead of trusting what it was handed, the sentinel leaks into the call and
+    this assertion catches it — independent of whether ``get_process_start_time`` even happens
+    to be imported at kill time (see #99558)."""
+
+    calls = []
+
+    def fake_terminate_pid(pid, *, force, expected_start_time):
+        calls.append((pid, force, expected_start_time))
+
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+    monkeypatch.setattr("gateway.status.terminate_pid", fake_terminate_pid)
+    monkeypatch.setattr("gateway.status.get_process_start_time", lambda pid: 999)
+
+    killed = gateway_windows._force_terminate_known_gateway_pids([(111, 100)])
+
+    assert killed == 1
+    assert calls == [(111, True, 100)]  # 100 = discovery-time value, never the 999 sentinel
+
+
+def test_force_terminate_known_gateway_pids_dedupes_by_pid(monkeypatch):
+    """Same PID appearing twice (e.g. primary + rescan overlap) must only be killed once."""
+
+    calls = []
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+    monkeypatch.setattr(
+        "gateway.status.terminate_pid",
+        lambda pid, *, force, expected_start_time: calls.append(pid),
+    )
+
+    killed = gateway_windows._force_terminate_known_gateway_pids([(111, 100), (111, 100)])
+
+    assert killed == 1
+    assert calls == [111]
+
+
 def test_schtasks_encoding_falls_back_to_utf8(monkeypatch):
     """A broken/empty locale must not leave us without a decoder (issue #38172)."""
 


### PR DESCRIPTION
## What does this PR do?

Fixes a PID-reuse TOCTOU in the Windows gateway stop/restart path. `_force_terminate_known_gateway_pids` fetched `expected_start_time` via `get_process_start_time(pid)` immediately before calling `terminate_pid(force=True, ...)` - i.e. at kill time, not at the moment the PID was identified as the gateway to stop. Between discovery and kill, `_drain_gateway_pid` waits up to 30s; if the PID gets reassigned to an unrelated process during that window, the old code fingerprinted the new process at kill time, defeating the identity guard.

Fix: capture each PID's start time in `_collect_gateway_stop_pids`, at discovery time, and thread it through instead of re-reading it at kill time.

## Related Issue

No existing issue - found via direct code audit, no open PR touches this path. Related to #99558 (adds the identity-guard mechanism this PR closes a residual gap in) - not a duplicate of it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway_windows.py`: `_collect_gateway_stop_pids` now returns `list[tuple[int, int | None]]`, capturing the start time at discovery instead of leaving it to the caller; `_force_terminate_known_gateway_pids` now uses the supplied start time directly instead of re-fetching it at kill time.
- `tests/hermes_cli/test_gateway_windows.py`: 4 new regression tests locking in discovery-time capture (sabotage-verified against the pre-fix code).

## How to Test

1. `pytest tests/hermes_cli/test_gateway_windows.py -k "collect_gateway_stop_pids or force_terminate_known_gateway_pids" -v` - 4 new tests pass.
2. Revert the `hermes_cli/gateway_windows.py` changes only (keep tests) and re-run - all 4 fail, confirming they exercise the fix.
3. `pytest tests/hermes_cli/test_gateway_windows.py -v` - full file, no regressions in the other 9 tests.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway-windows): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A - no user-facing docs, no config keys, no CONTRIBUTING/AGENTS changes, no tool schema changes
- [x] Cross-platform impact considered - Windows-only code path (`gateway_windows.py`), no effect on POSIX `launchd_*`/`systemd_*` mirrors

## Screenshots / Logs

Ran `pytest tests/hermes_cli/test_gateway_windows.py -v` locally: 4 new tests PASSED, 9 passed / 4 skipped total (windows_only markers, not applicable on WSL host).
