### PR TITLE
fix(cron): preserve completed work across slow fenced delivery

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -87,6 +87,7 @@ _jobs_lock_state = threading.local()
 _fire_fence_locks: Dict[str, threading.RLock] = {}
 _fire_fence_locks_guard = threading.Lock()
 _fire_fence_lock_state = threading.local()
+_protected_fire_owners: Dict[str, str] = {}
 
 # Upper bound on waiting for the cross-process .jobs.lock. Every cron function funnels through
 # _jobs_lock(), so blocking forever on a wedged sibling process would freeze the ticker and every
@@ -361,7 +362,40 @@ def fire_claim_fence(job_id: str, *, expected_owner: str):
             job = next((item for item in load_jobs() if item.get("id") == job_id), None)
             claim = job.get("fire_claim") if isinstance(job, dict) else None
             owns_claim = isinstance(claim, dict) and claim.get("by") == expected_owner
-        yield owns_claim
+        if not owns_claim:
+            yield False
+            return
+        store = _current_cron_store()
+        key = f"{os.getpid()}::{store.cron_dir.resolve()}::{job_id}"
+        with _fire_fence_locks_guard:
+            previous = _protected_fire_owners.get(key)
+            _protected_fire_owners[key] = expected_owner
+        body_error = None
+        try:
+            yield True
+        except BaseException as exc:
+            body_error = exc
+            raise
+        finally:
+            try:
+                # Delivery can outlive the lease. Refresh before releasing its
+                # real fence so a waiting claimant cannot reclaim that gap.
+                token = _cron_store_override.set(store)
+                try:
+                    _with_job(job_id, lambda jobs, _i, job: _refresh_claim(
+                        jobs, job.get("fire_claim"), expected_owner), False)
+                finally:
+                    _cron_store_override.reset(token)
+            except BaseException:
+                if body_error is None:
+                    raise
+                logger.exception("Could not renew fire claim while unwinding its side effect")
+            finally:
+                with _fire_fence_locks_guard:
+                    if previous is None:
+                        _protected_fire_owners.pop(key, None)
+                    else:
+                        _protected_fire_owners[key] = previous
 
 
 # Fields that must never change after creation: ``id`` is a path component under OUTPUT_DIR, so an
@@ -2591,12 +2625,38 @@ def claim_job_for_fire(
 
 
 def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
-    """Refresh an active ``fire_claim`` without extending another owner's lease: an execution may
-    outlive the TTL, and the owner check stops a stale runner from refreshing a recovered claim."""
-    def apply(jobs, _i, job):
-        return _refresh_claim(jobs, job.get("fire_claim"), expected_owner)
+    """Renew ownership, or confirm that its side-effect fence still protects it.
 
-    return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
+    A delivery's real cross-process fence excludes replacement owners. Do not
+    time out against that same worker's delivery lock: its context refreshes
+    the lease before unlocking. All other renewals retain the fail-closed fence.
+    """
+    key = f"{os.getpid()}::{_current_cron_store().cron_dir.resolve()}::{job_id}"
+
+    def protected_owner():
+        with _fire_fence_locks_guard:
+            protected = _protected_fire_owners.get(key) == expected_owner
+        if not protected:
+            return None
+        job = get_job(job_id)
+        claim = job.get("fire_claim") if isinstance(job, dict) else None
+        return isinstance(claim, dict) and claim.get("by") == expected_owner
+
+    protected = protected_owner()
+    if protected is not None:
+        return protected
+
+    with _fire_job_lock(job_id) as acquired:
+        if not acquired:
+            # Delivery may have entered its fence after the first lookup.
+            protected = protected_owner()
+            if protected is not None:
+                return protected
+            # Unavailable locking is not proof that the owner changed. The
+            # scheduler retries transient exceptions within its existing grace.
+            raise RuntimeError("Fire claim heartbeat could not acquire its fence")
+        return _with_job(job_id, lambda jobs, _i, job: _refresh_claim(
+            jobs, job.get("fire_claim"), expected_owner), False)
 
 
 # Completed one-shots are retained in jobs.json (final status stays inspectable) and pruned by

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -7,6 +7,7 @@ claim for a given fire. Single-machine deployments always win (unaffected).
 These exercise the real store against a temp HERMES_HOME (no mocks) per the
 E2E-over-mocks discipline for file-touching code.
 """
+import contextlib
 import threading
 import time
 
@@ -104,7 +105,8 @@ def test_mark_job_run_clears_claim(temp_home):
     assert claim_job_for_fire(jid) is True
 
 
-def test_fire_claim_heartbeat_refreshes_only_expected_owner(temp_home, monkeypatch):
+@pytest.mark.parametrize("exit_error", [None, RuntimeError, KeyboardInterrupt])
+def test_fire_claim_heartbeat_refreshes_only_expected_owner(temp_home, monkeypatch, exit_error):
     from datetime import datetime, timedelta
 
     import cron.jobs as jobs
@@ -130,6 +132,42 @@ def test_fire_claim_heartbeat_refreshes_only_expected_owner(temp_home, monkeypat
         job["id"],
         expected_owner="replacement-owner",
     ) is False
+
+    # Protected heartbeats are read-only, but even a failed long side effect
+    # must leave a fresh lease before releasing its fence to other claimants.
+    late = claimed_at + timedelta(seconds=jobs.FIRE_CLAIM_TTL_SECONDS + 60)
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: late)
+    expected = pytest.raises(exit_error, match="fixture exit") if exit_error else contextlib.nullcontext()
+    original_refresh = jobs._refresh_claim
+
+    def failing_refresh(*_args):
+        raise OSError("fixture disk failure")
+
+    with expected:
+        with jobs.fire_claim_fence(job["id"], expected_owner=claimed["by"]) as owned:
+            assert owned
+            before = (temp_home / "cron" / "jobs.json").read_bytes()
+            assert jobs.heartbeat_fire_claim(job["id"], expected_owner=claimed["by"])
+            assert (temp_home / "cron" / "jobs.json").read_bytes() == before
+            with jobs.fire_claim_fence(job["id"], expected_owner=claimed["by"]) as nested:
+                assert nested
+            with jobs.use_cron_store(temp_home / "other-profile"):
+                assert not jobs.heartbeat_fire_claim(job["id"], expected_owner=claimed["by"])
+            assert jobs.heartbeat_fire_claim(job["id"], expected_owner=claimed["by"])
+            if exit_error:
+                if exit_error is KeyboardInterrupt:
+                    monkeypatch.setattr(jobs, "_refresh_claim", failing_refresh)
+                raise exit_error("fixture exit")
+    monkeypatch.setattr(jobs, "_refresh_claim", original_refresh)
+    stored = jobs.get_job(job["id"])
+    assert isinstance(stored, dict)
+    assert stored["fire_claim"]["at"] == late.isoformat()
+    assert jobs.claim_job_for_fire(job["id"]) is False
+    # The protected-owner shortcut must be gone after normal AND exceptional exit.
+    with monkeypatch.context() as unavailable:
+        unavailable.setattr(jobs, "_acquire_flock", lambda *_: False)
+        with pytest.raises(RuntimeError, match="could not acquire"):
+            jobs.heartbeat_fire_claim(job["id"], expected_owner=claimed["by"])
 
 
 def test_reclaimed_fire_uses_new_owner_token(temp_home, monkeypatch):

--- a/tests/cron/test_delivery_fire_heartbeat.py
+++ b/tests/cron/test_delivery_fire_heartbeat.py
@@ -1,0 +1,177 @@
+"""Delivery must not make a live fire cancel its own completed work."""
+
+import contextlib
+import logging
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+
+@pytest.mark.parametrize("entry_race", [False, True])
+@pytest.mark.parametrize("delivery_error", [None, "fixture transport failed"])
+def test_slow_delivery_does_not_reclassify_completed_run(
+    tmp_path, monkeypatch, entry_race, delivery_error,
+):
+    from cron import executions, jobs, scheduler
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    heartbeat_at_lock = tmp_path / "heartbeat-at-lock"
+    script = "print('completed artifact')\n"
+    if entry_race:
+        script = (
+            "import time\nfrom pathlib import Path\n"
+            f"ready = Path({str(heartbeat_at_lock)!r})\n"
+            "deadline = time.monotonic() + 5\n"
+            "while not ready.exists():\n"
+            "    assert time.monotonic() < deadline, 'heartbeat never reached lock'\n"
+            "    time.sleep(0.01)\n" + script
+        )
+    (scripts / "complete.py").write_text(script)
+    job = jobs.create_job(
+        prompt="", schedule="every 5m", name="slow-delivery",
+        script="complete.py", no_agent=True, deliver="telegram:fixture",
+    )
+    claimed = jobs.claim_job_for_fire(job["id"], return_job=True)
+    assert isinstance(claimed, dict)
+    # Run the real in-process worker, not a systemd service on the test host.
+    monkeypatch.setattr(scheduler, "_launch_external_cron_worker", lambda _job: False)
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.01)
+    delivering = threading.Event()
+    heartbeat_done = threading.Event()
+    false_cancel_logged = threading.Event()
+    renewals = []
+    delivered = []
+    real_heartbeat = jobs.heartbeat_fire_claim
+    real_fire_lock = jobs._fire_job_lock
+    worker_thread = threading.current_thread()
+
+    @contextlib.contextmanager
+    def observe_fire_lock(job_id):
+        # Pause the heartbeat after its first protected-owner lookup, before
+        # real acquisition. Delivery can then win the actual lock race.
+        if threading.current_thread() is not worker_thread:
+            heartbeat_at_lock.touch()
+            assert delivering.wait(5), "delivery never entered its fence"
+        with real_fire_lock(job_id) as acquired:
+            yield acquired
+
+    if entry_race:
+        monkeypatch.setattr(jobs, "_fire_job_lock", observe_fire_lock)
+
+    def observe_heartbeat(*args, **kwargs):
+        renewed = real_heartbeat(*args, **kwargs)
+        if delivering.is_set():
+            renewals.append(renewed)
+            heartbeat_done.set()
+        return renewed
+
+    class LossObserver(logging.Handler):
+        def emit(self, record):
+            if "fire claim ownership lost; interrupting stale run" in record.getMessage():
+                false_cancel_logged.set()
+
+    def slow_transport(_job, content, **_kwargs):
+        delivering.set()
+        assert heartbeat_done.wait(5), "heartbeat never ran during delivery"
+        if not renewals[-1]:
+            assert false_cancel_logged.wait(5), "claim failure was not handled"
+        # Keep the transport in flight beyond the shortened lock window even
+        # when the corrected heartbeat no longer waits on that lock.
+        threading.Event().wait(0.1)
+        delivered.append(content)
+        delivering.clear()
+        return delivery_error
+
+    handler = LossObserver()
+    scheduler.logger.addHandler(handler)
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", observe_heartbeat)
+    # Only the outbound transport is a fixture; script, fences, heartbeat,
+    # artifact and execution/job persistence all execute their production path.
+    monkeypatch.setattr(scheduler, "_deliver_result", slow_transport)
+    try:
+        assert scheduler.run_one_job(claimed) is True
+    finally:
+        scheduler.logger.removeHandler(handler)
+    stored = jobs.get_job(job["id"])
+    execution = executions.latest_executions([job["id"]])[job["id"]]
+    assert delivered == ["completed artifact"]
+    assert isinstance(stored, dict)
+    assert stored["last_status"] == ("delivery_failed" if delivery_error else "ok"), stored["last_error"]
+    assert execution["status"] == "completed", execution["error"]
+    assert stored["last_delivery_error"] == delivery_error
+    assert execution["delivery_outcome"] == ("failed" if delivery_error else "delivered")
+    # A later stale completion cannot reclassify an already-terminal attempt.
+    assert executions.finish_execution(
+        execution["id"], success=False, error="late claim loss",
+    ) is None
+    assert executions.get_execution(execution["id"]) == execution
+    assert stored["fire_claim"] is None
+    assert renewals and all(renewals)
+    outputs = list((tmp_path / "cron" / "output" / job["id"]).glob("*.md"))
+    assert len(outputs) == 1 and "completed artifact" in outputs[0].read_text()
+
+
+@pytest.mark.linux_only
+def test_real_sigterm_mid_script_still_records_interrupted(tmp_path, monkeypatch):
+    """A real signal enters the worker cancellation path; no live gateway involved."""
+    from cron import executions, jobs
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    started = tmp_path / "script-started"
+    worker_code = """
+import os, signal, threading
+from pathlib import Path
+from cron import jobs, scheduler
+home = Path(os.environ['HERMES_HOME'])
+scripts = home / 'scripts'
+scripts.mkdir()
+started = home / 'script-started'
+(scripts / 'blocking.py').write_text(
+    'import os, time\\nfrom pathlib import Path\\n'
+    + f'Path({str(started)!r}).write_text(str(os.getpid()))\\n'
+    + 'time.sleep(30)\\nprint("must not succeed")\\n'
+)
+job = jobs.create_job(prompt='', schedule='every 5m', name='interrupt-fixture',
+                      script='blocking.py', no_agent=True, deliver='local')
+claimed = jobs.claim_job_for_fire(job['id'], return_job=True)
+cancel = threading.Event()
+signal.signal(signal.SIGTERM, lambda *_: cancel.set())
+scheduler._launch_external_cron_worker = lambda _job: False
+assert scheduler.run_one_job(claimed, cancel_event=cancel) is True
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", worker_code], stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE, text=True,
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while (not started.exists() or not started.read_text()) and process.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert started.exists(), "script did not reach its running phase"
+
+        process.send_signal(signal.SIGTERM)
+        stdout, stderr = process.communicate(timeout=10)
+        assert process.returncode == 0, stdout + stderr
+        stored, = jobs.load_jobs()
+        execution = executions.latest_executions([stored["id"]])[stored["id"]]
+        assert stored["last_status"] == "error"
+        assert "Interrupted" in stored["last_error"]
+        assert execution["status"] == "failed"
+        assert "Interrupted" in execution["error"]
+        assert stored["fire_claim"] is None
+    finally:
+        if process.poll() is None:
+            # Let the worker cancel/reap its own script through its live handle.
+            process.terminate()
+            try:
+                process.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.communicate(timeout=5)


### PR DESCRIPTION
## What does this PR do?

Prevents successful cron work from being persisted as `Interrupted by shutdown before terminal completion.` merely because its own delivery held the fire fence longer than the heartbeat's acquisition timeout.

Reproduced against main `8068c09432d3e7a23d30aa5f4f7d5a17783f8668`, using the real scheduler, an actual Python job script, real locks/heartbeat, saved Markdown output, JSON job store and SQLite execution ledger under a temporary `HERMES_HOME`. Only outbound delivery and systemd launch are test boundaries; no LLM/network service is needed.

### Exact failure path

On that base, `cron/jobs.py::heartbeat_fire_claim` routes through `_under_fire_fence`; delivery already holds that lock. The failed acquisition returns `False`, and `cron/scheduler.py:2378–2387` treats it as confirmed ownership loss. After delivery, `_record_fire_ownership_lost` at `cron/scheduler.py:2496–2502` calls `mark_job_run(..., False, "Interrupted...")` and `finish_execution(..., success=False)`.

Precisely: the script has succeeded, but the execution ledger is still **running**, not already committed as completed. It is falsely finalized as failed. Existing write-once SQLite terminal-state protection remains unchanged and is also asserted by the regression.

## Changes made

- Keep the real per-job side-effect and owner-mutation fences; do not move renewal writes outside those fences.
- During a verified active side effect, heartbeat checks the durable exact token without waiting on its own busy fence or writing the store. Protection is scoped by PID, resolved cron store and job.
- Recheck protection after failed acquisition to cover delivery entering between the initial lookup and lock attempt. Unconfirmed lock unavailability uses the existing transient-error grace path; confirmed missing/replacement ownership remains false.
- Refresh the lease before releasing the protected fence. Restore nested protection and captured store context; always clean up registration.
- Preserve an original body exception, including `KeyboardInterrupt`, if exit refresh also fails. A secondary persistence error must not disguise shutdown as an ordinary delivery failure.

## Related work

This overlaps reports/approaches in #104286, #106745, #100418 and #97565; it is not a claim of first discovery. Compared with the inspected #104286 implementation, this candidate exercises actual lock contention and closes the expired-lease handoff gap before unlocking. Unlike the inspected #106745 implementation, it retains the renewal fire fence: `_jobs_lock` deliberately degrades to process-only locking, so dropping the fire fence weakens the existing same-job CAS boundary. Offered as a complete reviewed candidate/test contribution for maintainers to consolidate.

## How to test / executed evidence

Reviewed candidate: `e92594ed5d977a602db5023af4ff6235326a4d72`.

1. On unfixed main with the new regression file:
   `scripts/run_tests.sh tests/cron/test_delivery_fire_heartbeat.py --file-retries 0 -j 1 --tb=short`
   Result: **4 failed, 1 passed**. All delayed-delivery variants fail with the false interruption; the real SIGTERM counter already passes. Original implementation was restored only in the isolated worktree for this check, then the candidate was restored with matching SHA-256.
2. On the candidate:
   `scripts/run_tests.sh tests/cron/test_delivery_fire_heartbeat.py tests/cron/test_claim_job_for_fire.py tests/cron/test_shutdown_interrupt.py tests/cron/test_script_claim_heartbeat.py --file-retries 0 -j 2 --tb=short`
   Result: **66 passed, 0 failed**.
3. Full required scope:
   `scripts/run_tests.sh tests/cron/ -j 2 --tb=short`
   Result: **101 files; 1235 passed, 0 failed, 1 skipped; 77.2 seconds; no FLAKY retries**. The skip is Windows-only on this Linux host.

Coverage includes delayed success/failure × delivery-entry race, saved artifacts and delivery outcomes, immutable terminal attempts, lease expiry, nested/profile isolation, original shutdown exception plus refresh failure, genuine owner replacement and real SIGTERM mid-script. The SIGTERM test uses a fixture signal handler to enter real scheduler cancellation: it is not a deployed gateway signal-handler E2E.

Independent, separate-context source review of the exact commit: **SHIP, correctness 9/10, residual risk 2/10**, with no remaining material findings. The reviewer did not rerun tests; execution evidence above is separate.

## Scope and limits

Bug fix only: `cron/jobs.py` and `tests/cron/`. No settings, environment variables, dependencies, live jobs, gateways or historical failure records changed. No runtime update/restart/deployment performed. This does not claim to fix pre-existing whole-store fail-open CRUD consistency or exactly-once remote delivery across a process crash. Full repository tests and non-Linux runtime behavior were not exercised locally.
