### PR TITLE
fix(custom-provider): gate reasoning wire fields on explicit supports_reasoning:false override

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5969,9 +5969,13 @@ def _project_provider_profile(
         profile = get_provider_profile(provider_norm)
         if profile is not None:
             body = profile.build_extra_body(model=model, base_url=effective_base, reasoning_config=reasoning_config) or {}
+            # provider= (unnormalized, matching the main chat-completions path's
+            # agent.provider) is required so CustomProfile._model_declared_reasoning_incapable
+            # can look up model_overrides.<provider>.<model>.supports_reasoning — without it
+            # the gate can never fire on this call path (see #t_d56d5c00 round 3).
             reasoning_extra, top_level = profile.build_api_kwargs_extras(
                 reasoning_config=reasoning_config, supports_reasoning=reasoning_config is not None,
-                model=model, base_url=effective_base,
+                model=model, base_url=effective_base, provider=provider,
             )
             reasoning_extra = reasoning_extra or {}
             top_level = top_level or {}

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1331,7 +1331,7 @@ def _build_chat_completions_kwargs(agent, api_messages, tools_for_api, reasoning
         cache_scope_id=cache_scope_id, ollama_num_ctx=agent._ollama_num_ctx,
         provider_preferences=_prefs or None, openrouter_min_coding_score=agent.openrouter_min_coding_score,
         supports_reasoning=agent._supports_reasoning_extra_body(),
-        qwen_session_metadata=_qwen_meta)
+        qwen_session_metadata=_qwen_meta, provider=getattr(agent, "provider", None))
     if _profile:
         # Profiles handle per-provider quirks via hooks fed the context above.
         return transport.build_kwargs(provider_profile=_profile, **_common)

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -582,6 +582,26 @@ def _override_for(provider: str, model: str, *, catalog_hit: bool) -> Optional[D
     return explicit if explicit is not None or catalog_hit else _default_model_override(provider)
 
 
+def explicit_supports_reasoning_override(provider: str, model: str) -> Optional[bool]:
+    """User-declared ``supports_reasoning`` for *provider+model*, or None if unset.
+
+    Deliberately narrower than :func:`get_model_capabilities`: that function fills a
+    catalog MISS with a ``False`` default (see ``_UNKNOWN_MODEL_BASE``), which would make
+    every uncatalogued custom/local endpoint look reasoning-incapable and silently drop a
+    configured ``reasoning_effort``. This reports ONLY an explicit
+    ``model_overrides.<provider>.<model>.supports_reasoning`` entry (never a fill-gap
+    ``_default`` and never a catalog-derived value), so a provider profile can gate wire
+    output on "the user told us this model can't take reasoning params" without
+    regressing the common case of no override (#89xxx — custom:ollama-local qwen3-coder
+    400'd on ``reasoning_effort`` because the profile had no way to see the operator's
+    ``supports_reasoning: false`` override).
+    """
+    override = _explicit_model_override(provider, model)
+    if override is None or "supports_reasoning" not in override:
+        return None
+    return bool(override["supports_reasoning"])
+
+
 def _override_int(override: Dict[str, Any], key: str) -> Optional[int]:
     """Coerce an override field to a positive int, warning once on garbage."""
     raw = override.get(key)

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -457,7 +457,7 @@ class ChatCompletionsTransport(ProviderTransport):
             reasoning_config=reasoning_config, supports_reasoning=params.get("supports_reasoning", False),
             qwen_session_metadata=params.get("qwen_session_metadata"), model=model,
             base_url=params.get("base_url"), ollama_num_ctx=params.get("ollama_num_ctx"),
-            session_id=params.get("session_id"),
+            session_id=params.get("session_id"), provider=params.get("provider"),
         )
         api_kwargs.update(top_level_from_profile)
 

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -26,16 +26,40 @@ def _looks_like_ollama_endpoint(base_url: str | None) -> bool:
     return bool(host) and (host == "ollama.com" or host.endswith(".ollama.com") or "ollama" in host.split("."))
 
 
+def _model_declared_reasoning_incapable(provider: str | None, model: str | None) -> bool:
+    """True only when the user's ``model_overrides.<provider>.<model>.supports_reasoning``
+    is explicitly ``false``. Never guesses from a catalog miss — most custom/local models
+    have no models.dev entry at all, and treating "uncatalogued" as "no reasoning" would
+    silently mute the override escape hatch this exists for. See #89xxx: qwen3-coder-30b
+    on custom:ollama-local 400'd with ``think value "high" is not supported for this
+    model`` because the client sent ``reasoning_effort``/``think`` unconditionally —
+    the operator's ``supports_reasoning: false`` override had no wire-shape consumer."""
+    if not provider or not model:
+        return False
+    try:
+        from agent.models_dev import explicit_supports_reasoning_override
+        return explicit_supports_reasoning_override(provider, model) is False
+    except Exception:
+        return False
+
+
 class CustomProfile(ProviderProfile):
     """Custom/Ollama local provider — think=false and num_ctx support."""
 
     def build_api_kwargs_extras(
-        self, *, reasoning_config: dict | None = None, ollama_num_ctx: int | None = None, **ctx: Any
+        self, *, reasoning_config: dict | None = None, ollama_num_ctx: int | None = None,
+        provider: str | None = None, **ctx: Any
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         extra_body: dict[str, Any] = {}
         top_level: dict[str, Any] = {}
         if ollama_num_ctx:
             extra_body["options"] = {"num_ctx": ollama_num_ctx}
+        # A model explicitly declared reasoning-incapable (model_overrides supports_reasoning:
+        # false) never receives a reasoning/think param, even when the agent's global
+        # reasoning_effort is set — the fleet default (e.g. "high") must not reach an
+        # endpoint that 400s on any think/reasoning_effort value (#89xxx).
+        if _model_declared_reasoning_incapable(provider, ctx.get("model")):
+            return extra_body, top_level
         # disabled -> top-level reasoning_effort="none" (Ollama's /v1 ignores
         # extra_body.think) plus think=False only on Ollama URLs; enabled+effort ->
         # top-level reasoning_effort clamped to the OpenAI-compat wire (GLM/ARK,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -467,6 +467,78 @@ class TestBuildCallKwargsMaxTokens:
 
 
 
+class TestAuxiliaryReasoningCapabilityGate:
+    """The auxiliary call path (call_llm/async_call_llm -> _build_call_kwargs ->
+    _project_provider_profile -> profile.build_api_kwargs_extras) must honor a
+    ``model_overrides.<provider>.<model>.supports_reasoning: false`` override exactly
+    like the main chat-completions path does (#t_d56d5c00 round 3).
+
+    Before this fix, ``_project_provider_profile`` called
+    ``profile.build_api_kwargs_extras(...)`` without ``provider=``, so
+    ``CustomProfile._model_declared_reasoning_incapable`` could never look up the
+    override and the client kept sending ``reasoning_effort``/``think`` to a model
+    that 400s on it — the same wire field that produced the fleet-wide crash loop,
+    just reached via compression/title_generation/moa_reference/moa_aggregator/vision
+    instead of a main agent turn.
+    """
+
+    def test_declared_incapable_model_emits_no_reasoning_fields(self, monkeypatch):
+        import agent.models_dev as models_dev
+        from agent.auxiliary_client import _build_call_kwargs
+
+        monkeypatch.setattr(
+            models_dev, "explicit_supports_reasoning_override",
+            lambda provider, model: False if (provider, model) == ("custom:ollama-local", "qwen3-coder-30b-tools-64k") else None,
+        )
+        kwargs = _build_call_kwargs(
+            provider="custom:ollama-local",
+            model="qwen3-coder-30b-tools-64k",
+            messages=[{"role": "user", "content": "hi"}],
+            base_url="http://localhost:11434/v1",
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        extra_body = kwargs.get("extra_body") or {}
+        assert "reasoning_effort" not in kwargs
+        assert "reasoning" not in extra_body
+        assert "think" not in extra_body
+
+    def test_project_provider_profile_passes_provider_through(self, monkeypatch):
+        """Direct unit check on the plumbing itself: the lookup must actually be
+        invoked with the caller's provider id, not skipped for lack of one."""
+        import agent.models_dev as models_dev
+        from agent.auxiliary_client import _project_provider_profile
+
+        calls = []
+
+        def _fake_override(provider, model):
+            calls.append((provider, model))
+            return False if (provider, model) == ("custom:ollama-local", "qwen3-coder-30b-tools-64k") else None
+
+        monkeypatch.setattr(models_dev, "explicit_supports_reasoning_override", _fake_override)
+        projection = _project_provider_profile(
+            "custom:ollama-local", "custom:ollama-local", "qwen3-coder-30b-tools-64k",
+            "http://localhost:11434/v1", {"enabled": True, "effort": "high"},
+        )
+        assert calls, "explicit_supports_reasoning_override was never consulted — provider= didn't reach the gate"
+        assert projection.top_level == {}
+        assert projection.reasoning_extra == {}
+
+    def test_no_override_keeps_existing_auxiliary_behavior(self, monkeypatch):
+        """A model with no explicit override is unaffected on the auxiliary path too."""
+        import agent.models_dev as models_dev
+        from agent.auxiliary_client import _build_call_kwargs
+
+        monkeypatch.setattr(models_dev, "explicit_supports_reasoning_override", lambda provider, model: None)
+        kwargs = _build_call_kwargs(
+            provider="custom:some-other-endpoint",
+            model="glm-5.2",
+            messages=[{"role": "user", "content": "hi"}],
+            base_url="https://ark.example.com/v1",
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kwargs.get("reasoning_effort") == "high"
+
+
 class TestNousTagsScoping:
     def test_tags_injected_when_provider_is_nous(self, monkeypatch):
         import agent.auxiliary_client as aux

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -180,3 +180,98 @@ class TestCustomReasoningWithNumCtx:
         assert eb == {"options": {"num_ctx": 8192}}
         assert tl == {}
 
+
+class TestCustomReasoningCapabilityOverrideGate:
+    """A ``model_overrides.<provider>.<model>.supports_reasoning: false`` override mutes
+    every reasoning/think wire field, even when the agent has a global reasoning_effort
+    (#t_d56d5c00): custom:ollama-local's qwen3-coder-30b-tools-64k has this override
+    declared in config.yaml, but the profile never saw the provider name to look it up —
+    the client kept sending ``reasoning_effort``/``think`` and Ollama 400'd with
+    ``think value "high" is not supported for this model``.
+    """
+
+    def test_declared_incapable_model_gets_no_reasoning_fields(self, custom_profile, monkeypatch):
+        import agent.models_dev as models_dev
+
+        monkeypatch.setattr(
+            models_dev, "explicit_supports_reasoning_override",
+            lambda provider, model: False if (provider, model) == ("custom:ollama-local", "qwen3-coder-30b-tools-64k") else None,
+        )
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="qwen3-coder-30b-tools-64k",
+            base_url="http://localhost:11434/v1",
+            provider="custom:ollama-local",
+        )
+        assert eb == {}
+        assert tl == {}
+
+    def test_declared_incapable_model_ignores_disable_path_too(self, custom_profile, monkeypatch):
+        """Even the disable path (effort=none) must not emit think=False for a model the
+        user has explicitly told us takes no reasoning parameter at all."""
+        import agent.models_dev as models_dev
+
+        monkeypatch.setattr(
+            models_dev, "explicit_supports_reasoning_override",
+            lambda provider, model: False,
+        )
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="qwen3-coder-30b-tools-64k",
+            base_url="http://localhost:11434/v1",
+            provider="custom:ollama-local",
+        )
+        assert eb == {}
+        assert tl == {}
+
+    def test_no_override_keeps_existing_behavior(self, custom_profile, monkeypatch):
+        """A model with no explicit override (the common case) is unaffected — the
+        pre-existing wire-shape contract still applies."""
+        import agent.models_dev as models_dev
+
+        monkeypatch.setattr(models_dev, "explicit_supports_reasoning_override", lambda provider, model: None)
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
+            provider="custom:some-other-endpoint",
+        )
+        assert tl == {"reasoning_effort": "high"}
+        assert eb == {}
+
+    def test_override_true_keeps_existing_behavior(self, custom_profile, monkeypatch):
+        """An explicit ``supports_reasoning: true`` override must not suppress the
+        reasoning wire fields — only an explicit ``false`` gates."""
+        import agent.models_dev as models_dev
+
+        monkeypatch.setattr(models_dev, "explicit_supports_reasoning_override", lambda provider, model: True)
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
+            provider="custom:some-endpoint",
+        )
+        assert tl == {"reasoning_effort": "high"}
+
+    def test_missing_provider_or_model_does_not_gate(self, custom_profile):
+        """No provider/model passed through (defensive) → never suppress; the override
+        lookup itself is skipped, not treated as a positive match."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"}, model=None, provider=None,
+        )
+        assert tl == {"reasoning_effort": "high"}
+
+    def test_lookup_failure_fails_open_to_existing_behavior(self, custom_profile, monkeypatch):
+        """If the override lookup itself raises, never let that regress into silently
+        dropping reasoning params for a model that never asked to be muted."""
+        import agent.models_dev as models_dev
+
+        def _boom(provider, model):
+            raise RuntimeError("config read failed")
+
+        monkeypatch.setattr(models_dev, "explicit_supports_reasoning_override", _boom)
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
+            provider="custom:some-endpoint",
+        )
+        assert tl == {"reasoning_effort": "high"}
+


### PR DESCRIPTION
## Bug

custom:ollama-local's qwen3-coder-30b-tools-64k has `model_overrides.custom:ollama-local.qwen3-coder-30b-tools-64k.supports_reasoning: false` in config.yaml, but `CustomProfile.build_api_kwargs_extras` (plugins/model-providers/custom/__init__.py) had no way to see the provider identity, so it could never look that override up. It always emitted `reasoning_effort`/`think` for the profile's configured `agent.reasoning_effort`, which the endpoint rejected: `HTTP 400: think value "high" is not supported for this model`. That error is non-retryable, so it aborted the agent turn -- and because this was a fallback rung, this fired across a whole fleet's worth of profiles whenever their primary provider rate-limited, producing a crash loop (41 crashes / 31 gave_ups in 15 minutes on one deployment).

## Root cause

`ProviderProfile.build_api_kwargs_extras` (providers/base.py) and its callers never threaded the `provider` string through, so no provider profile could look up its own `model_overrides.<provider>.<model>` entry -- only the generic models.dev capability path (`get_model_capabilities`) could see it, and that path is not consulted for the wire-shape decision in the custom/Ollama profile.

## Fix

1. `agent/models_dev.py`: new `explicit_supports_reasoning_override(provider, model)`. Returns the explicit `model_overrides.<provider>.<model>.supports_reasoning` value only -- never a `_default` fill-gap, never a catalog-derived default. This is deliberately narrower than `get_model_capabilities`, which defaults *uncatalogued* models (the common case for local/custom endpoints) to `supports_reasoning: False` -- using that directly would silently gate reasoning params for every custom endpoint with no override at all.
2. `agent/chat_completion_helpers.py` + `agent/transports/chat_completions.py`: thread `provider=` through `_build_chat_completions_kwargs` -> `_build_kwargs_from_profile` -> `profile.build_api_kwargs_extras(...)`.
3. `plugins/model-providers/custom/__init__.py`: `CustomProfile.build_api_kwargs_extras` now checks `_model_declared_reasoning_incapable(provider, model)` first, before either the disable or enable/effort branch, and returns `({}, {})` (no reasoning/think field of any kind) when the operator has explicitly said the model can't take one. The lookup fails OPEN on any exception, missing provider, or missing model -- this is a targeted mute, not a new default-deny, so profiles with no override keep exactly their current behavior.

## Tests

8 new cases in `tests/plugins/model_providers/test_custom_profile.py`:
- declared-incapable suppresses both the disable path (`effort=none`) and the enable+effort path
- no override / explicit `supports_reasoning: true` / missing provider-or-model / lookup raising an exception all preserve pre-existing behavior (never gate)

Full local run (fresh `origin/main` + this branch):

```
tests/plugins/model_providers/test_custom_profile.py            26 passed
tests/agent/test_models_dev.py                                  69 passed
tests/agent/transports/test_chat_completions.py + tests/providers/ + tests/plugins/model_providers/   391 passed
tests/run_agent/test_run_agent.py -k "reasoning or custom or ollama"   19 passed
```

Also independently verified with a standalone hermetic contract checker built against the config that actually produced the incident (reconstructed from the pre-incident backup, unmodified):
- run against unfixed `main` -> exit 1, reproduces the exact wire payload that 400'd (`{'reasoning_effort': 'high'}`)
- run against this branch -> exit 0, no violations

Same config fixture both runs -- only the source differs.
