### PR TITLE
fix(gateway): exit cleanly when the service manager stops the unit

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4934,6 +4934,27 @@ def _start_gateway_configure_logging(verbosity: Optional[int]) -> None:
             root.setLevel(_stderr_level)
 
 
+def _shutdown_signal_is_service_manager_stop(received_signal, ctx: Optional[dict]) -> bool:
+    """True when our own service manager is stopping the unit — ``systemctl stop``/``restart``, or the
+    needrestart sweep that follows ``apt-daily-upgrade``.
+
+    Such a SIGTERM is a planned stop even without a marker. The planned-stop marker is written only by
+    the Hermes CLI, so a manager-initiated stop used to fall through to the "bare kill" branch and exit
+    non-zero: every ``systemctl restart`` marked the unit ``failed``, and the next boot pruned live
+    sessions as "left by a crashed gateway". The non-zero exit buys nothing here either — systemd never
+    auto-restarts a unit it stopped itself, whatever the exit status. The cases the non-zero exit exists
+    for (container, OOM, bare kill) are unaffected: they carry no ``INVOCATION_ID`` — docker's PID 1
+    included — or their parent is not the service manager.
+    """
+    if received_signal != signal.SIGTERM or not ctx:
+        return False
+    if not ctx.get("systemd_invocation_id"):  # set by systemd for its unit's processes only
+        return False
+    # A system unit's parent is PID 1; a user unit's is ``systemd --user``, named systemd as well.
+    parent = ctx.get("parent")
+    return isinstance(parent, dict) and parent.get("name") == "systemd"
+
+
 def _start_gateway_make_shutdown_signal_handler(runner, _signal_initiated_shutdown: list):
     """Build the SIGINT/SIGTERM handler; ``_signal_initiated_shutdown[0]`` records an unplanned signal."""
     def shutdown_signal_handler(received_signal=None):
@@ -4953,15 +4974,22 @@ def _start_gateway_make_shutdown_signal_handler(runner, _signal_initiated_shutdo
             return snapshot_shutdown_context(received_signal)
 
         planned_takeover = bool(_best_effort(_takeover, "Takeover marker check failed: %s"))
+        # Snapshot BEFORE the marker check below consumes the marker, so the forensic line still shows it.
+        _shutdown_ctx = _best_effort(_snapshot, "snapshot_shutdown_context failed: %s")
         planned_stop = received_signal == signal.SIGINT or (
             not planned_takeover and bool(_best_effort(_planned_stop, "Planned stop marker check failed: %s")))
-        _shutdown_ctx = _best_effort(_snapshot, "snapshot_shutdown_context failed: %s")
+        manager_stop = not planned_takeover and not planned_stop and bool(_best_effort(
+            lambda: _shutdown_signal_is_service_manager_stop(received_signal, _shutdown_ctx),
+            "Service-manager stop check failed: %s"))
         sig_name = _shutdown_ctx["signal"] if _shutdown_ctx else None
 
         if planned_takeover:
             logger.info("Received %s as a planned --replace takeover — exiting cleanly", sig_name or "SIGTERM")
         elif planned_stop:
             logger.info("Received %s as a planned gateway stop — exiting cleanly", sig_name or "SIGTERM/SIGINT")
+        elif manager_stop:
+            logger.info("Received %s from the service manager (unit stop/restart) — exiting cleanly",
+                        sig_name or "SIGTERM")
         else:
             # Mirrored onto the runner so _stop_impl suppresses the gateway_state=stopped persist for
             # unexpected signals; operator stops take the `planned_stop` branch and leave it False (DO persist).

--- a/tests/gateway/test_gateway_service_manager_stop.py
+++ b/tests/gateway/test_gateway_service_manager_stop.py
@@ -1,0 +1,115 @@
+"""A SIGTERM from our own service manager must exit cleanly (gateway/run.py).
+
+The planned-stop marker is written only by the Hermes CLI, so a ``systemctl
+stop``/``restart`` — including the needrestart sweep that follows
+``apt-daily-upgrade`` — used to look like a bare external kill: the gateway
+exited non-zero, systemd marked the unit ``failed``, and the next boot pruned
+live sessions as "left by a crashed gateway".
+
+The container / OOM / bare-kill cases the non-zero exit exists for must keep it.
+"""
+
+import asyncio
+import signal
+
+import pytest
+
+from gateway.run import (
+    _shutdown_signal_is_service_manager_stop,
+    _start_gateway_make_shutdown_signal_handler,
+)
+
+_SYSTEMD_CTX = {
+    "signal": "SIGTERM",
+    "ppid": 1,
+    "systemd_invocation_id": "8f2c1d1b9b0a4d5e",
+    "parent": {"pid": 1, "name": "systemd", "cmdline": "/usr/lib/systemd/systemd --system"},
+}
+
+
+def _ctx(**overrides):
+    """A systemd system-unit shutdown context, with per-test overrides."""
+    ctx = {k: (v.copy() if isinstance(v, dict) else v) for k, v in _SYSTEMD_CTX.items()}
+    ctx.update(overrides)
+    return ctx
+
+
+def test_systemd_unit_stop_is_a_service_manager_stop():
+    assert _shutdown_signal_is_service_manager_stop(signal.SIGTERM, _ctx()) is True
+
+
+def test_user_unit_stop_is_a_service_manager_stop():
+    """A user unit's parent is ``systemd --user`` — PID 1 is not the marker of a managed stop."""
+    ctx = _ctx(ppid=920, parent={"pid": 920, "name": "systemd", "cmdline": "/usr/lib/systemd/systemd --user"})
+    assert _shutdown_signal_is_service_manager_stop(signal.SIGTERM, ctx) is True
+
+
+def test_container_pid1_without_invocation_id_is_not():
+    """Docker's PID 1 has no INVOCATION_ID; that SIGTERM must keep the non-zero exit."""
+    ctx = _ctx(parent={"pid": 0})
+    ctx.pop("systemd_invocation_id")
+    assert _shutdown_signal_is_service_manager_stop(signal.SIGTERM, ctx) is False
+
+
+def test_bare_kill_from_a_shell_is_not():
+    assert _shutdown_signal_is_service_manager_stop(
+        signal.SIGTERM, _ctx(parent={"pid": 4242, "name": "bash"})) is False
+
+
+def test_sigint_is_not_a_service_manager_stop():
+    """Ctrl+C is already a planned stop upstream; this probe stays SIGTERM-only."""
+    assert _shutdown_signal_is_service_manager_stop(signal.SIGINT, _ctx()) is False
+
+
+def test_missing_context_is_not():
+    """The snapshot is best-effort and may be None; absent evidence is not a managed stop."""
+    assert _shutdown_signal_is_service_manager_stop(signal.SIGTERM, None) is False
+
+
+class _FakeRunner:
+    """Stand-in for GatewayRunner — the handler only sets a flag and awaits stop()."""
+
+    def __init__(self):
+        self._signal_initiated_shutdown = False
+        self.stopped = False
+
+    async def stop(self):
+        self.stopped = True
+
+
+@pytest.fixture
+def quiet_forensics(monkeypatch):
+    """Keep the handler off /proc and out of subprocesses; each test supplies its own context."""
+    import gateway.shutdown_forensics as forensics
+    import gateway.status as status
+
+    monkeypatch.setattr(status, "consume_takeover_marker_for_self", lambda: False)
+    monkeypatch.setattr(status, "consume_planned_stop_marker_for_self", lambda: False)
+    monkeypatch.setattr(forensics, "format_context_for_log", lambda ctx: "ctx")
+    monkeypatch.setattr(forensics, "spawn_async_diagnostic", lambda *a, **k: None)
+    return forensics
+
+
+async def _run_handler(ctx, forensics, monkeypatch):
+    monkeypatch.setattr(forensics, "snapshot_shutdown_context", lambda received_signal=None: ctx)
+    runner, flag = _FakeRunner(), [False]
+    _start_gateway_make_shutdown_signal_handler(runner, flag)(signal.SIGTERM)
+    await asyncio.sleep(0)  # let the task the handler scheduled for runner.stop() run
+    return runner, flag
+
+
+@pytest.mark.asyncio
+async def test_handler_leaves_systemd_stop_unflagged(quiet_forensics, monkeypatch):
+    """Unflagged means exit 0: the unit stops without being marked failed."""
+    runner, flag = await _run_handler(_ctx(), quiet_forensics, monkeypatch)
+    assert flag[0] is False
+    assert runner._signal_initiated_shutdown is False
+    assert runner.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_handler_still_flags_a_bare_kill(quiet_forensics, monkeypatch):
+    ctx = _ctx(parent={"pid": 4242, "name": "bash"})
+    runner, flag = await _run_handler(ctx, quiet_forensics, monkeypatch)
+    assert flag[0] is True
+    assert runner._signal_initiated_shutdown is True


### PR DESCRIPTION
## Problem

The planned-stop marker is written only by the Hermes CLI (`hermes gateway stop`, `service_manager`). When **systemd itself** stops the unit — `systemctl stop`/`restart`, or the `needrestart` sweep that follows `apt-daily-upgrade` — no marker exists, so `shutdown_signal_handler` classifies the SIGTERM as a bare external kill and the gateway exits non-zero.

Observed on a long-running box (`Restart=always`), where every routine restart looked like a crash:

```
systemd[1]: Stopping hermes-gateway.service...
gateway.run: Shutdown context: signal=SIGTERM under_systemd=yes parent_pid=1 parent_name=systemd
systemd[1]: hermes-gateway.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: hermes-gateway.service: Failed with result 'exit-code'.
```

Three consequences:

1. The unit is marked `failed` on every ordinary restart.
2. The next boot prunes live sessions as `left by a crashed gateway`.
3. Real crashes drown in the noise — on the box above, 5 genuine crashes sat among 19 `status=1/FAILURE` lines.

The rationale in the code is "so systemd `Restart=on-failure` can revive the gateway", but systemd never auto-restarts a unit it stopped itself, whatever the exit status — so the non-zero exit buys nothing on this path.

## Fix

Treat SIGTERM as a planned stop when `INVOCATION_ID` is set **and** our parent is `systemd`. Both signals come from the existing shutdown snapshot; no new probing.

The cases the non-zero exit exists for are untouched, as named in the runner's own comment (`container, OOM, bare kill`): they carry no `INVOCATION_ID` — docker's PID 1 included — or have a different parent. A user unit is covered too, since its parent is `systemd --user` rather than PID 1.

Also moves the shutdown snapshot above the marker check, so the forensic line still reports a marker that the check is about to consume.

## Tests

`tests/gateway/test_gateway_service_manager_stop.py` — system unit, user unit, container PID 1 without `INVOCATION_ID`, bare kill from a shell, SIGINT, and a missing snapshot; plus two handler-level tests asserting the flag that drives the exit code.

Verified the handler test fails without the fix (`assert True is False`) and passes with it.

```
tests/gateway/test_gateway_service_manager_stop.py  8 passed
+ test_gateway_shutdown.py, test_planned_stop_watcher.py            29 passed
+ test_gateway_process_exit.py, test_restart_drain.py,
  test_orphan_exit_grace.py, test_restart_after_turn.py    27 passed, 2 skipped
ruff check                                                    All checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)