### PR TITLE
fix(security): route secrets-file output to the ENV redaction pass regardless of read command

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -642,21 +642,15 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     return text
 
 
-# Commands whose stdout is an env-var dump: terminal redaction runs the
-# ENV-assignment pass (code_file=False) for these so opaque tokens with no vendor
-# prefix are masked; everything else uses code_file=True (``MAX_TOKENS=100``).
-# Commands whose stdout is an environment-variable dump (KEY=value lines), NOT source code.
-# ``MY_SERVICE_TOKEN=abc123randomstring``) are still masked. For all other commands, code_file=True is used
-# to avoid mangling legitimate source/config dumps (``MAX_TOKENS=100``, ``"apiKey": "x"`` fixtures,
-# ``postgresql://{user}`` f-string templates). See issue #43025.
+# Commands whose stdout is an env-var dump (``env``/``printenv``/…): the
+# ENV-assignment pass (code_file=False) must run so opaque tokens with no vendor
+# prefix (``MY_SERVICE_TOKEN=abc123randomstring``) are masked rather than echoed
+# verbatim. Every other command keeps code_file=True to avoid mangling source /
+# config dumps (``MAX_TOKENS=100``, ``"apiKey": "x"`` fixtures,
+# ``postgresql://{user}`` f-string templates) — the one other exception being a
+# command that references a secrets file, handled by ``_command_reads_env_file``
+# below. See issue #43025.
 _ENV_DUMP_COMMANDS = frozenset({"env", "printenv", "set", "export", "declare"})
-
-# Commands that read file contents to stdout. A ``.env`` target is a credential
-# dump (per AGENTS.md ``.env`` holds only secrets), so the ENV pass must run.
-_FILE_READ_COMMANDS = frozenset({
-    "cat", "head", "tail", "type", "bat", "less", "more", "nl",
-    "zcat", "tac", "view", "batcat",
-})
 
 
 def _command_segments(command: str) -> list[str]:
@@ -665,21 +659,20 @@ def _command_segments(command: str) -> list[str]:
 
 
 def _command_reads_env_file(command: str | None) -> bool:
-    """True if ``command`` reads a ``.env``-style file (by basename) to stdout.
-    Defense-in-depth, not a boundary: indirect reads (``sudo cat .env``, ``$(cat
-    .env)``, ``sed``/``awk``) are not detected, matching ``is_env_dump_command``."""
+    """Detect literal env-file path references in shell commands or executed source.
+
+    Reader-independent: wrappers, one-liners, substitutions and redirects can
+    all expose assignments. Split syntax delimiters without consuming Windows
+    path separators. This is a lexical hint, not data-flow analysis: computed
+    paths and symlink targets are not resolved; templates stay excluded by the
+    exact basename lookup.
+    """
     if not command:
         return False
-    for seg in _command_segments(command):
-        tokens = seg.split()  # not shlex: it mangles Windows paths (``C:\Users\...\.env``)
-        if not tokens or tokens[0] not in _FILE_READ_COMMANDS:
-            continue
-        for arg in tokens[1:]:
-            if arg.startswith("-"):
-                continue
-            basename = arg.strip("\"'").rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
-            if basename.lower() in _ENV_FILE_BASENAMES:
-                return True
+    for arg in re.split(r"[\s\"'`|;&<>(){}\[\],=]+", command):
+        basename = arg.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+        if basename.lower() in _ENV_FILE_BASENAMES:
+            return True
     return False
 
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -898,7 +898,6 @@ class TestTerminalOutputRedaction:
         assert not _command_reads_env_file("cat README.md")
         assert not _command_reads_env_file("cat .envrc.bak")  # .bak not in list
         assert not _command_reads_env_file("python app.py")
-        assert not _command_reads_env_file("echo .env")  # echo is not a file-read cmd
         assert not _command_reads_env_file("")
         assert not _command_reads_env_file(None)
 
@@ -1178,3 +1177,29 @@ class TestValueAwareGatingCorpus:
         result = redact_sensitive_text(block, force=True)
         assert prose_line in result
         assert "A9f3kZq7Lm2Xw8Rt4Yv6" not in result
+
+
+@pytest.mark.parametrize("reader", [
+    'grep KEY {path}', 'grep -n API_KEY {path}', 'sed -n 1,20p {path}',
+    "awk -F= '{{print}}' {path}", 'sort {path}',
+    'python3 -c "print(open(\'{path}\').read())"',
+    "perl -pe '' {path}", "ruby -e 'puts File.read(\"{path}\")'",
+    'node -e "console.log(require(\'fs\').readFileSync(\'{path}\',\'utf8\'))"',
+    'xxd {path}', 'od {path}', 'strings {path}', 'cut -f1 {path}',
+    'diff /dev/null {path}', 'column {path}', 'base64 {path}',
+    'sudo cat {path}', 'sort <{path}', 'echo $(sort {path})',
+    'echo `sort {path}`', 'true; sort {path} | head', 'true && sort {path}',
+])
+def test_env_file_output_routing_contract(reader):
+    """Reader identity must not decide whether opaque assignments are secrets."""
+    from agent.redact import redact_terminal_output
+
+    value = 'q7Vm2R9xK4pL8wN6zB3d'
+    output = f'TAVILY_API_KEY={value}\nDEBUG=true\n'
+    for path in ('.env', 'config/.ENV.local', r'C:\config\.envrc'):
+        result = redact_terminal_output(output, reader.format(path=path), force=True)
+        assert value not in result
+        assert 'DEBUG=true' in result
+    for path in ('source.py', '.env.example', '.env.sample', '.env.template',
+                 '.env.dist', '.envrc.bak', '.env/source.py'):
+        assert redact_terminal_output(output, reader.format(path=path), force=True) == output

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -924,3 +924,41 @@ class TestRpcTokenAuthorization(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+@pytest.mark.parametrize('filename', ['.env', '.env.local', '.env.example', 'source.txt'])
+def test_execute_code_env_file_output_contract(tmp_path, filename):
+    """Real registry dispatch and kernel I/O preserve fixtures but mask env dumps."""
+    value = 'q7Vm2R9xK4pL8wN6zB3d'
+    output = f'COMMANDCODE_API_KEY={value}\nMAX_TOKENS=100\n'
+    path = tmp_path / filename
+    path.write_text(output)
+    code = f'print(open({str(path)!r}).read(), end="")'
+    result = json.loads(registry.dispatch('execute_code', {'code': code}, task_id='redact-contract'))
+    assert result['status'] == 'success', result
+    if filename in ('.env', '.env.local'):
+        assert value not in result['output']
+        assert 'MAX_TOKENS=100' in result['output']
+    else:
+        assert result['output'] == output
+
+
+@pytest.mark.parametrize('persistent', [True, False])
+def test_execute_code_remote_env_file_output_contract(monkeypatch, persistent):
+    """Both remote transports must carry source context to output cleaning."""
+    import tools.code_execution_tool as execution
+    import tools.code_kernel_remote as remote
+
+    value = 'q7Vm2R9xK4pL8wN6zB3d'
+    output = f'DISCORD_BOT_TOKEN={value}\n'
+    env = MagicMock()
+    env.execute.return_value = {'output': 'OK\n' + output, 'returncode': 0}
+    monkeypatch.setattr(execution, '_get_or_create_env', lambda _: (env, 'docker'))
+    monkeypatch.setattr(execution, '_ship_file_to_remote', lambda *a: None)
+    monkeypatch.setattr(execution, '_rpc_poll_loop', lambda *a: None)
+    monkeypatch.setattr(remote, 'execute_in_remote_kernel', lambda *a, **kw:
+                        {'status': 'success', 'stdout': output} if persistent else None)
+    for filename in ('.env', '.env.example', 'source.txt'):
+        result = json.loads(execution._execute_remote(f'print(open({filename!r}).read())', 'redact', []))
+        assert result['status'] == 'success', result
+        assert (value not in result['output']) == (filename == '.env')

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -478,13 +478,15 @@ def _format_interrupted_output(stdout_text: str) -> str:
     return f"{stdout_text}\n{marker}" if stdout_text else marker
 
 
-def _clean_output(stdout_text: str) -> Tuple[str, Dict[str, Any]]:
-    """Shared output pipeline: byte-cap (with spill), ANSI strip, secret redaction. code_file=True:
-    output often echoes source/config — skip ENV/JSON/f-string false positives, still mask credentials."""
+def _clean_output(stdout_text: str, code: str = "") -> Tuple[str, Dict[str, Any]]:
+    """Cap, strip ANSI and redact output; enable assignments only for env-file references.
+    Other snippets may echo source/config fixtures and must retain code_file=True.
+    """
     from tools.ansi_strip import strip_ansi
-    from agent.redact import redact_sensitive_text
+    from agent.redact import _command_reads_env_file, redact_sensitive_text
     stdout_text, metadata = _truncate_stdout_text(stdout_text)
-    return redact_sensitive_text(strip_ansi(stdout_text), code_file=True), metadata
+    return redact_sensitive_text(
+        strip_ansi(stdout_text), code_file=not _command_reads_env_file(code)), metadata
 
 
 def _with_timeout_notice(stdout_text: str, timeout_msg: str) -> str:
@@ -509,10 +511,10 @@ _REMOTE_EXIT_STATUS = {124: "timeout", 130: "interrupted"}
 
 
 def _remote_result(status: str, raw_stdout: str, exec_start: float, fields: Dict[str, Any],
-                   kernel: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+                   kernel: Optional[Dict[str, Any]] = None, *, code: str = "") -> Dict[str, Any]:
     """Common remote reply shape: status, cleaned output, *fields*, duration, optional kernel
     info, then truncation metadata (key order is part of the result contract)."""
-    stdout_text, stdout_metadata = _clean_output(raw_stdout)
+    stdout_text, stdout_metadata = _clean_output(raw_stdout, code)
     result: Dict[str, Any] = {"status": status, "output": stdout_text, **fields,
                               "duration_seconds": round(time.monotonic() - exec_start, 2)}
     if kernel is not None:
@@ -527,7 +529,7 @@ def _apply_timeout(result: Dict[str, Any], timeout_msg: str) -> None:
 
 
 def _finish_remote_kernel_result(kernel_result: Dict[str, Any], *,
-                                 timeout: int, exec_start: float) -> str:
+                                 timeout: int, exec_start: float, code: str = "") -> str:
     """Post-process a remote-kernel cell result into the tool's JSON reply. Timeout messaging
     mirrors the local kernel contract (kernel killed, state lost, next call fresh)."""
     stdout_text = kernel_result.get("stdout", "") or ""
@@ -539,7 +541,7 @@ def _finish_remote_kernel_result(kernel_result: Dict[str, Any], *,
         stdout_text = stdout_text + "\n--- stderr ---\n" + stderr_text + traceback_text
     result = _remote_result(kernel_result.get("status", "error"), stdout_text, exec_start,
                             {"tool_calls_made": kernel_result.get("tool_calls_made", 0)},
-                            kernel=kernel_result.get("kernel", {"remote": True}))
+                            kernel=kernel_result.get("kernel", {"remote": True}), code=code)
     if result["status"] == "timeout":
         _apply_timeout(result, f"Cell timed out after {timeout}s; the remote session kernel was "
                                "killed and its state was lost. The next call starts fresh.")
@@ -599,7 +601,7 @@ def _run_remote_per_call(env, env_type: str, code: str, effective_task_id: str,
         except Exception:
             logger.debug("Failed to clean up remote sandbox %s", sandbox_dir)
     result = _remote_result(status, stdout_text, exec_start,
-                            {"exit_code": exit_code, "tool_calls_made": tool_call_counter[0]})
+                            {"exit_code": exit_code, "tool_calls_made": tool_call_counter[0]}, code=code)
     if status == "timeout":
         _apply_timeout(result, f"Script timed out after {timeout}s and was killed.")
         logger.warning("execute_code (remote) timed out after %ss (limit %ss) with %d tool calls",
@@ -645,7 +647,7 @@ def _execute_remote(code: str, task_id: Optional[str], enabled_tools: Optional[L
             logger.warning("remote session-kernel path failed; falling back to per-call", exc_info=True)
             kernel_result = None
         if kernel_result is not None:
-            return _finish_remote_kernel_result(kernel_result, timeout=timeout, exec_start=exec_start)
+            return _finish_remote_kernel_result(kernel_result, timeout=timeout, exec_start=exec_start, code=code)
         logger.info("remote session kernel unavailable on %s; using per-call path", env_type)
     except Exception as exc:
         return _remote_failure(exc, exec_start, 0)

--- a/tools/code_kernel.py
+++ b/tools/code_kernel.py
@@ -679,13 +679,14 @@ def _with_stderr(stdout_text: str, stderr_text: str) -> str:
 
 def _cell_result(kernel: SessionKernel, key: Tuple, status: str, payload: Dict[str, Any], *,
                  timeout: int, sandbox_tools: frozenset, reused: bool,
-                 state_reset: bool, exec_start: float) -> Dict[str, Any]:
+                 state_reset: bool, exec_start: float, code: str = "") -> Dict[str, Any]:
     """Assemble the tool result for one settled cell (disposing the kernel where the contract says so)."""
     from tools.code_execution_tool import _sandbox_failure_hint, _truncate_stdout_text
-    from agent.redact import redact_sensitive_text
+    from agent.redact import _command_reads_env_file, redact_sensitive_text
     from tools.ansi_strip import strip_ansi
+    code_file = not _command_reads_env_file(code)
     def clean(text: str) -> str:
-        return redact_sensitive_text(strip_ansi(text), code_file=True)
+        return redact_sensitive_text(strip_ansi(text), code_file=code_file)
     if status in ("timeout", "interrupted"):
         # No safe way to interrupt one cell in place: kill the kernel, report the loss, respawn next call.
         _REGISTRY.discard(key, kernel)
@@ -789,7 +790,7 @@ def _run_cell(kernel: SessionKernel, key: Tuple, code: str, *, task_id: str, chi
             result = _cell_result(
                 kernel, key, status, payload,
                 timeout=timeout, sandbox_tools=sandbox_tools, reused=reused,
-                state_reset=state_reset, exec_start=exec_start,
+                state_reset=state_reset, exec_start=exec_start, code=code,
             )
             return json.dumps(result, ensure_ascii=False)
         except Exception as exc:  # pragma: no cover - defensive parity with per-call


### PR DESCRIPTION
## What does this PR do?

`security.redact_secrets` (on by default) masks *opaque* credentials — values with no vendor-prefix regex, e.g. `TAVILY_API_KEY=tvly-dev-…`, `COMMANDCODE_API_KEY=…`, `DISCORD_BOT_TOKEN=…` — only when the generic ENV-assignment pass runs. For terminal output that pass is gated on `agent/redact.py::_command_reads_env_file()`, which requires **the segment's leading token to be one of `_FILE_READ_COMMANDS`** (`cat`, `head`, `tail`, `type`, `bat`, `less`, `more`, `nl`, `zcat`, `tac`, `view`, `batcat`) **and** an argument basename in `_ENV_FILE_BASENAMES`.

So reader *identity* decides whether a secrets-file dump is treated as secrets. Every other way of getting a `.env` to stdout falls through to `code_file=True` (which correctly skips the ENV pass to avoid source-code false positives — that is the #33801 / #15934 contract), and the opaque values reach the model verbatim. `execute_code` additionally had no switch at all: both of its output paths hardcoded `code_file=True` (#95509).

This PR makes the detection reader-independent and routes both surfaces through it, without touching the false-positive protection that `code_file=True` exists for.

## Related Issue

Fixes #95509

Follow-up to #61352, which introduced the `.env` detection in a reader-dependent form.

### Relationship to #95515

#95515 (open) fixes #95509 by enabling the ENV pass **unconditionally** on `execute_code` output, accepting `MAX_TOKENS=100` → `MAX_TOKENS=***` and relaxing two existing sentinel assertions. This PR takes the narrower route for that same surface: the ENV pass is enabled only when the executed source actually references a `.env`-style basename, so the #33801 false-positive contract is preserved. It also fixes the larger terminal half, which no open PR covers. Happy to drop the `execute_code` hunk and keep only the terminal change if #95515 lands first.

### Known trade-offs

- The detection is a lexical hint, not data flow: any command *mentioning* an env-file basename routes its output through the ENV pass. `echo .env` therefore matches where it previously did not (that one assertion in `TestTerminalOutputRedaction` was updated). Output that is not a `KEY=value`/JSON assignment is unaffected — `echo .env` → `.env`, `ls -la .env` → unchanged, `MAX_TOKENS=100` → unchanged (the pattern's word-boundary guard).
- The residual cost is the one `code_file=False` already accepts elsewhere: for a command that mentions a secrets file, a JSON-shaped line whose key contains a secret keyword is masked too (e.g. grep'ing docs for the string `.env` turns `"apiKey": "test"` into `"apiKey": "***"`). That is strictly narrower than the unconditional switch in #95515 (where *every* `execute_code` snippet gets the ENV pass).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `agent/redact.py` — `_command_reads_env_file()` is now reader-independent: any `|`/`;`/`&`-separated segment whose tokens include an `_ENV_FILE_BASENAMES` basename (from `agent/file_safety._BLOCKED_PROJECT_ENV_BASENAMES`, single source of truth) marks the dump, whether the value came from `cat`, `grep`, `sed`, `awk`, `sort`, `python -c`, `perl`, `ruby`, `node`, `xxd`, `od`, `strings`, `cut`, `diff`, `column`, `base64`, `sudo cat`, a `<` redirect, `$(…)`/backtick substitution, or a `;`/`&&` sequence. `_FILE_READ_COMMANDS` and `_ENV_FILE_EXCLUDE_SUFFIXES` are removed (template exclusion is now implicit — `.env.example` is not an exact `_ENV_FILE_BASENAMES` match); the now-stale comment above `_ENV_DUMP_COMMANDS` was corrected.
- `tools/code_execution_tool.py` — `_clean_output()` takes the executed source and enables the ENV pass only when it references an env-file basename; `_remote_result()` / `_finish_remote_kernel_result()` / `_run_remote_per_call()` thread the source through.
- `tools/code_kernel.py` — `_cell_result()` (local kernel path) does the same via the same predicate.
- Tests: `tests/agent/test_redact.py` — one parametrized contract test over 22 reader shapes × 3 path forms (positive) and 7 non-secrets paths (negative, output must be byte-identical). `tests/tools/test_code_execution.py` — two tests: a real `registry.dispatch('execute_code', …)` round trip against a temp `.env` (local kernel path), and a transport-level test for both remote paths.

## How to Test

```bash
scripts/run_tests.sh tests/agent/test_redact.py           # 138 passed, 0 failed
scripts/run_tests.sh tests/tools/test_code_execution.py   # 50 passed, 0 failed
scripts/run_tests.sh tests/tools/                         # 8891 passed, 68 failed, 143 skipped
```

Red/green evidence — the same test files were run against `origin/main` @ 8068c09432 (base) and this branch, same interpreter, `TZ=UTC`/`LANG=C.UTF-8`/temp `HERMES_HOME`:

| Tests | Base | This branch |
|---|---|---|
| `test_env_file_output_routing_contract` (22 params) | 22 failed | 22 passed |
| `test_execute_code_env_file_output_contract` (4 params) | 2 failed, 2 passed | 4 passed |
| `test_execute_code_remote_env_file_output_contract` (2 params) | 2 failed | 2 passed |
| `tests/agent/test_redact.py` (whole file) | 22 failed / 116 passed | 138 passed |
| `tests/tools/test_code_execution.py` (whole file) | 50 passed | 50 passed |

Whole `tests/tools/` directory, base vs. branch: the failing set is identical (16 files, all pre-existing — `test_daytona_environment`, `test_image_generation`, `test_video_generation_tool_surface_matrix`, …) except for

1. the new tests above, which fail on base and pass here, and
2. two timing-race tests (`test_delegate_timeout_cleanup.py::test_timeout_does_not_close_child_while_worker_is_unwinding`, `test_mcp_death_supervisor.py::test_a_server_that_survived_teardown_stays_registered`) that the runner flagged `⚠ FLAKY` (passed on retry) and that pass 5/5 in isolation on **both** trees — load-induced, unrelated to this change.

Manual repro (synthetic values; no real credential is printed) — `redact_terminal_output(output, cmd)` over `TAVILY_API_KEY=<opaque>` / `COMMANDCODE_API_KEY=<opaque>` / `DISCORD_BOT_TOKEN=<opaque>`:

| command | base | this branch |
|---|---|---|
| `cat ~/.hermes/.env`, `head -5 …` | masked | masked |
| `grep KEY ~/.hermes/.env` | **leaked** | masked |
| `grep -n API_KEY …`, `sed -n 1,20p …` | **leaked** | masked |
| `awk -F= '{print}' …`, `sort …` | **leaked** | masked |
| `python3 -c "print(open('.env').read())"` | **leaked** | masked |
| `cut -d= -f1 …`, `base64 …` | **leaked** | masked (routing) |
| `cat /tmp/notes.txt` (no env-file reference) | unmasked (by design) | unmasked (unchanged) |
| `execute_code` printing a `.env` | **leaked** | masked |

Deliberately out of scope: output that no longer contains readable `KEY=value` assignments — `base64`/`xxd`/`od` *output*, or `cut -d= -f2` value-only output. Routing is fixed for those commands (the ENV pass now runs), but an encoded or value-only transform cannot be masked by an assignment-based pass; that needs entropy detection, which is a separate design question (#363 explored it).

### Sibling call paths checked

| Surface | Verdict |
|---|---|
| `tools/terminal_tool_result.py` (foreground + spill file) | covered — both call `redact_terminal_output` |
| `tools/process_registry*.py` (background poll/log/wait) | covered — `redact_terminal_output`; the `code_file=True` calls there redact the *command* string, not stdout (correct) |
| `tools/code_execution_tool.py` local kernel + remote kernel + remote per-call | covered by this PR |
| `tools/code_kernel.py` `_cell_result` | covered by this PR |
| `agent/moa_loop.py` | not applicable — redacts model text, not tool stdout |
| `tools/file_tools.py` | already uses `file_read=True` (non-reusable sentinel) |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate — no open PR covers the terminal-side reader-dependent detection; #95515 covers part of the `execute_code` half with a broader trigger (see above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64), Python 3.12

Not claimed: a full `pytest tests/ -q` run. I ran `scripts/run_tests.sh` on the two changed test files and on the whole `tests/tools/` directory, and diffed the failing set against base as described above.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings/comments updated in `agent/redact.py` and `tools/code_execution_tool.py`; no user-facing doc describes this check — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `shlex` is deliberately avoided (it mangles `C:\Users\…\.env`); the test matrix includes `C:\config\.envrc`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no schema change)
