### PR TITLE
fix(models): /model keeps a model the current provider serves; deepseek-flash is DeepSeek's canonical Flash id (refs #97487, supersedes #107126)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -339,10 +339,12 @@ DEFAULT_CONTEXT_LENGTHS = {
     # Google / Gemma ("gemma4" is Ollama-style naming, e.g. gemma4:31b-cloud)
     "gemini": 1048576,
     "gemma-4": 256000, "gemma4": 256000, "gemma-4-31b": 256000, "gemma-3": 131072, "gemma": 8192,
-    # DeepSeek — V4 family is 1M; deepseek-chat/-reasoner alias v4-flash modes.
+    # DeepSeek — V4 family is 1M; deepseek-chat/-reasoner alias v4-flash modes. ``deepseek-flash``
+    # (version-less canonical id, 2026-09 Flash refresh) needs a discrete entry or the
+    # longest-key-first scan falls through to the 128K ``deepseek`` catch-all below.
     # https://api-docs.deepseek.com/zh-cn/quick_start/pricing
     "deepseek-v4-pro": 1_000_000, "deepseek-v4-flash": 1_000_000, "deepseek-chat": 1_000_000,
-    "deepseek-reasoner": 1_000_000, "deepseek": 128000,
+    "deepseek-reasoner": 1_000_000, "deepseek-flash": 1_000_000, "deepseek": 128000,
     # Meta; Muse Spark family (1.1/1.2/1.3, -contributor(-free), meta/ prefixed) is 1M per OpenRouter,
     # models.dev and api.commandcode.ai /models — keep the "muse-spark" prefix (bare "muse" would match
     # muse-image/muse-voice). Thinking Machines inkling (covers inkling-small and :free/:batch variants)

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -20,7 +20,9 @@ _REASONING_STALE_TIMEOUT_FLOORS: dict[int, tuple[str, ...]] = {
         # NVIDIA Nemotron behind hosted NIM: documented 60-180s upstream idle kill.
         "nemotron-3-ultra", "nemotron-3-super",
         # DeepSeek R1 / V4 (reasoning_content streamed before final content).
-        "deepseek-r1", "deepseek-reasoner", "deepseek-v4-flash", "deepseek-v4-pro",
+        # ``deepseek-flash`` is the version-less canonical Flash id (2026-09 Flash refresh);
+        # ``deepseek-v4-flash`` still aliases onto it server-side.
+        "deepseek-r1", "deepseek-reasoner", "deepseek-flash", "deepseek-v4-flash", "deepseek-v4-pro",
         # OpenAI o-series: each variant enumerated so bare ``o1`` cannot over-match ``olmo-1``.
         "o1", "o1-mini", "o1-pro", "o1-preview", "o3", "o3-pro",
         # Mythos-class named models (claude-fable-5): 1M ctx + 128K output, a heavier thinking

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -186,11 +186,11 @@ _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
         "gpt-4.1-nano": ("0.10", "0.40", "0.025"), "o3": ("10.00", "40.00", "2.50"),
         "o3-mini": ("1.10", "4.40", "0.55"),
     }),
-    # deepseek-chat / deepseek-reasoner are deprecated aliases of
-    # deepseek-v4-flash's non-thinking / thinking modes — same rates.
-    ("deepseek", "https://api-docs.deepseek.com/quick_start/pricing", "deepseek-pricing-2026-07", {
-        ("deepseek-chat", "deepseek-reasoner", "deepseek-v4-flash"): ("0.14", "0.28", "0.0028"),
-        "deepseek-v4-pro": ("0.435", "0.87", "0.003625"),
+    # Off-peak USD rates (peak = 2x, Mon-Fri 01-04 + 06-10 UTC). ``deepseek-v4-flash`` and the
+    # retired deepseek-chat / deepseek-reasoner aliases are served by V4.1-Flash at the Flash price.
+    ("deepseek", "https://api-docs.deepseek.com/quick_start/pricing", "deepseek-pricing-2026-09-10", {
+        ("deepseek-flash", "deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"): ("0.15", "0.60", "0.003"),
+        "deepseek-v4-pro": ("0.66", "1.98", "0.022"),
     }),
     ("google", "https://ai.google.dev/gemini-api/docs/pricing", "google-pricing-2026-09-02", {
         ("gemini-3.8-flash", "gemini-3.7-flash"): ("0.75", "3.75", "0.075"),

--- a/contributors/emails/13265384114@163.com
+++ b/contributors/emails/13265384114@163.com
@@ -1,0 +1,1 @@
+MiseHinoha

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -1499,7 +1499,7 @@ class GoalManager:
                 f"judge API unreachable {n_tx} turns in a row (check auxiliary.goal_judge provider/key in config.yaml)",
                 "continue", reason,
                 f"⏸ Goal paused — judge API returned errors ({n_tx} turns). Check the goal_judge provider/key in "
-                + _JUDGE_CONFIG_HINT.format(provider="deepseek", model="deepseek-v4-flash"),
+                + _JUDGE_CONFIG_HINT.format(provider="deepseek", model="deepseek-flash"),
             )
         if n_parse >= DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES:
             return self._pause_decision(

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -86,18 +86,17 @@ _CATALOGUE_PREFIX_REPAIR_PROVIDERS: frozenset[str] = frozenset({
 _LOWERCASE_MODEL_PROVIDERS: frozenset[str] = frozenset({
     "xiaomi"})
 
-# DeepSeek's direct API only accepts first-class V-series IDs after the 2026-07-24 cut-off (HTTP 400
-# otherwise). Both retired aliases map to deepseek-v4-flash per the official docs (thinking mode is
-# controlled by extra_body.thinking on the profile), so saved configs can't keep sending them.
+# DeepSeek's direct API only accepts first-class ids after the 2026-07-24 cut-off (HTTP 400
+# otherwise). Retired aliases fold onto the version-less ``deepseek-flash`` (V4.1-Flash, 2026-09-10;
+# thinking mode is controlled by extra_body.thinking on the profile), so saved configs can't keep
+# sending them.
 _DEEPSEEK_RETIRED_ALIASES: frozenset[str] = frozenset({
     "deepseek-chat", "deepseek-reasoner"})
 
-# ``deepseek-flash`` is the version-less canonical Flash id from the 2026-09 Flash refresh:
-# ``GET /v1/models`` reports it and the API accepts it directly. It carries no ``v<N>``
-# marker, so without an entry here it misses the V-series regex below and the id the user
-# picked is folded onto ``deepseek-v4-flash`` before it ever reaches the wire.
+# ``deepseek-flash`` carries no ``v<N>`` marker, so it needs an entry here or the V-series regex
+# below misses it and the id the user picked is rewritten before it reaches the wire.
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-v4-pro", "deepseek-v4-flash", "deepseek-flash"})
+    "deepseek-flash", "deepseek-v4-pro"})
 
 # First-class V-series IDs incl. future ``deepseek-v5-*`` and dated variants
 # (``deepseek-v4-flash-20260423``): verified real model ids, NOT aliases of ``deepseek-chat``.
@@ -106,12 +105,12 @@ _DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v\d+([-.].+)?$")
 
 def _normalize_for_deepseek(model_name: str) -> str:
     """Map a model input to a DeepSeek-accepted id: canonicals and ``deepseek-v<digit>…`` pass
-    through (future V-series work without a release); retired aliases and everything else become
-    ``deepseek-v4-flash``."""
+    through (dated variants and future V-series work without a release); retired aliases and
+    everything else become ``deepseek-flash``."""
     bare = _strip_vendor_prefix(model_name).lower()
     if bare in _DEEPSEEK_CANONICAL_MODELS or _DEEPSEEK_V_SERIES_RE.match(bare):
         return bare
-    return "deepseek-v4-flash"
+    return "deepseek-flash"
 
 
 def _strip_vendor_prefix(model_name: str) -> str:

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -92,8 +92,12 @@ _LOWERCASE_MODEL_PROVIDERS: frozenset[str] = frozenset({
 _DEEPSEEK_RETIRED_ALIASES: frozenset[str] = frozenset({
     "deepseek-chat", "deepseek-reasoner"})
 
+# ``deepseek-flash`` is the version-less canonical Flash id from the 2026-09 Flash refresh:
+# ``GET /v1/models`` reports it and the API accepts it directly. It carries no ``v<N>``
+# marker, so without an entry here it misses the V-series regex below and the id the user
+# picked is folded onto ``deepseek-v4-flash`` before it ever reaches the wire.
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-v4-pro", "deepseek-v4-flash"})
+    "deepseek-v4-pro", "deepseek-v4-flash", "deepseek-flash"})
 
 # First-class V-series IDs incl. future ``deepseek-v5-*`` and dated variants
 # (``deepseek-v4-flash-20260423``): verified real model ids, NOT aliases of ``deepseek-chat``.

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -936,6 +936,15 @@ def detect_provider_for_model(
     if not name:
         return None
 
+    # The current provider's LIVE catalog outranks every static guess: a model it already serves
+    # (Codex early-access ids, Portal-only slugs, Ollama Cloud models absent from _PROVIDER_MODELS)
+    # must never re-route the session to another vendor or to metered OpenRouter.
+    from hermes_cli.models_detect import current_provider_catalog_match
+
+    served = current_provider_catalog_match(name, current_provider)
+    if served is not None:
+        return (current_provider, served) if served != name else None
+
     static_match = detect_static_provider_for_model(name, current_provider)
     if static_match:
         return static_match

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -205,7 +205,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-sonnet-4-6", "claude-opus-4-5-20251101", "claude-sonnet-4-5-20250929",
         "claude-opus-4-20250514", "claude-sonnet-4-20250514", "claude-haiku-4-5-20251001",
     ],
-    "deepseek": ["deepseek-v4-pro", "deepseek-v4-flash"],
+    "deepseek": ["deepseek-v4-pro", "deepseek-flash"],
     "xiaomi": ["mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "mimo-v2-flash"],
     "tencent-tokenhub": list(_TENCENT_MODELS),
     "tencent-tokenplan": list(_TENCENT_MODELS),

--- a/hermes_cli/models_detect.py
+++ b/hermes_cli/models_detect.py
@@ -1,0 +1,39 @@
+"""Live-catalog guard for ``detect_provider_for_model``.
+
+Split out of ``hermes_cli.models``. The detection ladder there consults static catalogs, then the
+OpenRouter catalog. Providers whose static list lags their live catalog (Codex accounts with
+early-access models, Nous Portal, Ollama Cloud) have no static entry to stop the ladder, so a bare
+name the CURRENT provider already serves fell through to OpenRouter and the session was silently
+rebuilt on a metered aggregator (#97487, WolframRvnwlf's $100 Astra incident).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# Providers where the ladder's own OpenRouter step is the answer, or where there is no catalog to
+# consult; ``custom`` endpoints are never auto-switched away from (handled upstream).
+_SKIP = frozenset({"", "auto", "openrouter", "custom"})
+
+
+def current_provider_catalog_match(model_name: str, current_provider: str) -> Optional[str]:
+    """Return the current provider's own spelling of *model_name* when its live (disk-cached)
+    catalog serves it — exact id, or the bare part after ``vendor/`` — else ``None``.
+
+    Goes through :func:`hermes_cli.models.cached_provider_model_ids` (1h TTL, stale-while-
+    revalidate) so a model switch does not block on a cold ``/v1/models`` round-trip in the
+    common case; a fetch failure yields an empty catalog and the ladder continues unchanged."""
+    from hermes_cli.models import cached_provider_model_ids, normalize_provider
+
+    provider = (current_provider or "").strip().lower()
+    if provider in _SKIP or provider.startswith("custom:") or normalize_provider(provider) in _SKIP:
+        return None
+    wanted = (model_name or "").strip().lower()
+    if not wanted:
+        return None
+    try:
+        catalog = cached_provider_model_ids(provider)
+    except Exception:
+        return None
+    return next((mid for mid in catalog if mid.lower() == wanted), None) or next(
+        (mid for mid in catalog if "/" in mid and mid.split("/", 1)[1].lower() == wanted), None)

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -15,6 +15,13 @@ from providers import register_provider
 from providers.base import ProviderProfile
 
 
+# Version-less canonical ids for thinking-capable DeepSeek models. The 2026-09 Flash
+# refresh dropped the ``v<N>`` marker from the public id: ``GET /v1/models`` reports
+# ``deepseek-flash`` and the API accepts it directly, so the generation check in
+# ``build_api_kwargs_extras`` cannot recognise it.
+_THINKING_CAPABLE_IDS: frozenset[str] = frozenset({"deepseek-flash"})
+
+
 class DeepSeekProfile(ProviderProfile):
     """DeepSeek — extra_body.thinking + top-level reasoning_effort."""
 
@@ -22,7 +29,12 @@ class DeepSeekProfile(ProviderProfile):
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         m = (model or "").strip().lower()
-        if not m.startswith("deepseek-v") or m.startswith("deepseek-v3"):  # v4+ only; v3 excluded
+        # v4+ only; v3 excluded. Version-less canonicals (``deepseek-flash``) carry the
+        # same thinking-mode contract but no ``v<N>`` prefix, so consult the id set too —
+        # missing them makes Hermes omit ``thinking``, so the server defaults to on and
+        # the user's thinking toggle / effort setting is silently ignored.
+        versioned_v4_plus = m.startswith("deepseek-v") and not m.startswith("deepseek-v3")
+        if not versioned_v4_plus and m not in _THINKING_CAPABLE_IDS:
             return {}, {}
         rc = reasoning_config if isinstance(reasoning_config, dict) else None
         # Always set thinking explicitly (default enabled, matching the API default)

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -54,8 +54,8 @@ class DeepSeekProfile(ProviderProfile):
 deepseek = DeepSeekProfile(
     name="deepseek", aliases=("deepseek-chat",), env_vars=("DEEPSEEK_API_KEY",), display_name="DeepSeek",
     description="DeepSeek — native DeepSeek API", signup_url="https://platform.deepseek.com/",
-    fallback_models=("deepseek-v4-pro", "deepseek-v4-flash"), base_url="https://api.deepseek.com/v1",
-    default_aux_model="deepseek-v4-flash",
+    fallback_models=("deepseek-v4-pro", "deepseek-flash"), base_url="https://api.deepseek.com/v1",
+    default_aux_model="deepseek-flash",
 )
 
 register_provider(deepseek)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -358,6 +358,8 @@ class TestDefaultContextLengths:
             "deepseek-v4-flash": 1_000_000,
             "deepseek-chat": 1_000_000,
             "deepseek-reasoner": 1_000_000,
+            # Version-less canonical Flash id (2026-09 Flash refresh).
+            "deepseek-flash": 1_000_000,
         }
         for key, value in expected_keys.items():
             assert key in DEFAULT_CONTEXT_LENGTHS, f"{key} missing"
@@ -379,6 +381,8 @@ class TestDefaultContextLengths:
                 ("deepseek/deepseek-v4-flash", 1_000_000),
                 ("deepseek-chat", 1_000_000),
                 ("deepseek-reasoner", 1_000_000),
+                ("deepseek-flash", 1_000_000),
+                ("deepseek/deepseek-flash", 1_000_000),
             ]
             for model_id, expected_ctx in cases:
                 actual = get_model_context_length(model_id)

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -56,6 +56,10 @@ import pytest
     ("deepseek/deepseek-v4-flash", 600.0),
     ("deepseek/deepseek-v4-pro", 600.0),
     ("deepseek-v4-flash-free", 600.0),   # catalog -free variant inherits via separator anchor
+    # Version-less canonical Flash id from the 2026-09 Flash refresh —
+    # ``deepseek-v4-flash`` still aliases onto it server-side.
+    ("deepseek/deepseek-flash", 600.0),
+    ("deepseek-flash", 600.0),
     # Qwen QwQ + Qwen3 thinking variants (qwen3 family entry matches all).
     ("qwen/qwq-32b-preview", 300.0),
     ("qwen/qwen3-235b-a22b-thinking", 180.0),

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -123,11 +123,12 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     )
 
     assert entry is not None
-    assert entry.input_cost_per_million is not None
-    assert entry.output_cost_per_million is not None
-    assert float(entry.input_cost_per_million) == 0.435
-    assert float(entry.output_cost_per_million) == 0.87
-    assert float(entry.cache_read_cost_per_million) == 0.003625
+    assert entry.source == "official_docs_snapshot"
+    # Pro is the premium tier: every rate must sit above the Flash row's.
+    flash = get_pricing_entry("deepseek-flash", provider="deepseek")
+    assert entry.input_cost_per_million > flash.input_cost_per_million
+    assert entry.output_cost_per_million > flash.output_cost_per_million
+    assert entry.cache_read_cost_per_million > flash.cache_read_cost_per_million
 
 
 def test_bundled_pricing_skips_endpoint_metadata(monkeypatch):
@@ -174,14 +175,13 @@ def test_unknown_model_falls_back_to_endpoint_metadata(monkeypatch):
 
 
 
-def test_deepseek_deprecated_aliases_price_as_v4_flash():
-    """Invariant: deepseek-chat / deepseek-reasoner are deprecated aliases for
-    deepseek-v4-flash's non-thinking / thinking modes (deprecation 2026-07-24)
-    — they must bill at identical rates to the flash entry, or sessions on the
-    legacy names over/under-report cost."""
-    flash = get_pricing_entry("deepseek-v4-flash", provider="deepseek")
+def test_deepseek_deprecated_aliases_price_as_flash():
+    """Invariant: deepseek-v4-flash / deepseek-chat / deepseek-reasoner are retired aliases
+    served by the current Flash model — they must bill at identical rates to the
+    ``deepseek-flash`` entry, or sessions on the legacy names over/under-report cost."""
+    flash = get_pricing_entry("deepseek-flash", provider="deepseek")
     assert flash is not None
-    for alias in ("deepseek-chat", "deepseek-reasoner"):
+    for alias in ("deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"):
         entry = get_pricing_entry(alias, provider="deepseek")
         assert entry is not None, alias
         assert entry.input_cost_per_million == flash.input_cost_per_million, alias

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -110,6 +110,21 @@ class TestDeepseekVSeriesPassThrough:
         result = normalize_model_for_provider("deepseek-v4-pro", "deepseek")
         assert result == "deepseek-v4-pro"
 
+    def test_deepseek_provider_preserves_versionless_flash_id(self):
+        """``deepseek-flash`` must reach DeepSeek's API unchanged.
+
+        DeepSeek's 2026-09 Flash refresh dropped the ``v<N>`` marker from the
+        public id: ``GET /v1/models`` reports ``deepseek-flash`` and the API
+        accepts it directly (verified live — it answers 200, and the older
+        ``deepseek-v4-flash`` is aliased onto it).  Folding it onto
+        ``deepseek-v4-flash`` meant the id users picked never reached the wire
+        and the config stored a different model than the picker advertised.
+        """
+        assert (
+            normalize_model_for_provider("deepseek-flash", "deepseek")
+            == "deepseek-flash"
+        )
+
 
 # ── DeepSeek post-2026-07-24 alias remapping ───────────────────────────
 

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -129,7 +129,7 @@ class TestDeepseekVSeriesPassThrough:
 # ── DeepSeek post-2026-07-24 alias remapping ───────────────────────────
 
 class TestDeepseekCanonicalAndReasonerMapping:
-    """Retired aliases and fuzzy names rewrite to deepseek-v4-flash.
+    """Retired aliases and fuzzy names rewrite to deepseek-flash.
 
     DeepSeek cut off ``deepseek-chat`` / ``deepseek-reasoner`` on
     2026-07-24; sending them on the wire returns HTTP 400.
@@ -139,7 +139,7 @@ class TestDeepseekCanonicalAndReasonerMapping:
     def test_provider_path_rewrites_reasoner(self):
         assert (
             normalize_model_for_provider("deepseek-reasoner", "deepseek")
-            == "deepseek-v4-flash"
+            == "deepseek-flash"
         )
 
     @pytest.mark.parametrize("model", [
@@ -149,8 +149,8 @@ class TestDeepseekCanonicalAndReasonerMapping:
         "deepseek-reasoning-preview",
         "deepseek-cot-experimental",
     ])
-    def test_reasoner_keywords_map_to_v4_flash(self, model):
-        assert _normalize_for_deepseek(model) == "deepseek-v4-flash"
+    def test_reasoner_keywords_map_to_flash(self, model):
+        assert _normalize_for_deepseek(model) == "deepseek-flash"
 
 
 # ── Regression: issue #78796 ───────────────────────────────────────────

--- a/tests/hermes_cli/test_models_detect_live_catalog.py
+++ b/tests/hermes_cli/test_models_detect_live_catalog.py
@@ -1,0 +1,40 @@
+"""``detect_provider_for_model`` must not re-route a model the CURRENT provider already serves.
+
+Regression for the OpenRouter hijack (#97487, the ``/model gpt-6-astra`` incident): a bare name
+absent from the static ``_PROVIDER_MODELS`` list but present in the current provider's live catalog
+fell through to the OpenRouter lookup and silently rebuilt the session on a metered aggregator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import models
+
+
+@pytest.fixture
+def live_catalog(monkeypatch):
+    """Pin the disk-cached live catalog per provider and make the OpenRouter lookup loud."""
+    catalogs: dict[str, list[str]] = {}
+    monkeypatch.setattr(models, "cached_provider_model_ids", lambda provider, **_: list(catalogs.get(provider, [])))
+    monkeypatch.setattr(models, "_find_openrouter_slug", lambda name: f"vendor/{name}")
+    return catalogs
+
+
+class TestCurrentProviderCatalogWins:
+    @pytest.mark.parametrize("provider,model", [
+        ("openai-codex", "gpt-6-astra"),       # early-access id, static Codex list lags
+        ("nous", "some-portal-only-model"),    # Portal serves it, static snapshot doesn't
+        ("ollama-cloud", "glm-5.3-flash"),     # static list points at zai; OpenRouter has zai/…
+    ])
+    def test_served_model_stays_on_current_provider(self, live_catalog, provider, model):
+        live_catalog[provider] = [model]
+        assert models.detect_provider_for_model(model, provider) is None
+
+    def test_bare_name_resolves_to_current_providers_full_slug(self, live_catalog):
+        live_catalog["nous"] = ["zai/glm-5.3-flash"]
+        assert models.detect_provider_for_model("glm-5.3-flash", "nous") == ("nous", "zai/glm-5.3-flash")
+
+    def test_unserved_model_still_walks_the_ladder(self, live_catalog):
+        live_catalog["nous"] = ["hermes-4-405b"]
+        assert models.detect_provider_for_model("no-such-model", "nous") == ("openrouter", "vendor/no-such-model")

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -108,6 +108,10 @@ class TestDeepSeekModelGating:
             "deepseek-v4-flash",
             "deepseek-v4-future-variant",
             "DEEPSEEK-V4-PRO",  # case-insensitive
+            # Version-less canonical ids (2026-09 Flash refresh) carry the
+            # same thinking-mode contract but no v<N> marker.
+            "deepseek-flash",
+            "DEEPSEEK-FLASH",  # case-insensitive
         ],
     )
     def test_thinking_capable_models_emit_thinking(self, deepseek_profile, model):

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -190,16 +190,15 @@ class TestDeepSeekAuxModel:
     system.
     """
 
-    def test_profile_advertises_deepseek_v4_flash(self, deepseek_profile):
-        assert deepseek_profile.default_aux_model == "deepseek-v4-flash"
+    def test_profile_advertises_deepseek_flash(self, deepseek_profile):
+        assert deepseek_profile.default_aux_model == "deepseek-flash"
 
-    def test_fallback_models_are_v4_only(self, deepseek_profile):
-        assert deepseek_profile.fallback_models == (
-            "deepseek-v4-pro",
-            "deepseek-v4-flash",
-        )
+    def test_fallback_models_are_current_ids(self, deepseek_profile):
+        from hermes_cli.model_normalize import _normalize_for_deepseek
+        # Every advertised id must survive normalization unchanged (no retired alias in the picker).
+        assert all(_normalize_for_deepseek(m) == m for m in deepseek_profile.fallback_models)
 
-    def test_consumer_api_returns_deepseek_v4_flash(self):
+    def test_consumer_api_returns_deepseek_flash(self):
         from agent.auxiliary_client import _get_aux_model_for_provider
-        assert _get_aux_model_for_provider("deepseek") == "deepseek-v4-flash"
+        assert _get_aux_model_for_provider("deepseek") == "deepseek-flash"
 


### PR DESCRIPTION
`/model <name>` no longer switches a session to metered OpenRouter (or an unkeyed vendor) when the provider you are already on serves that model, and `deepseek-flash` is accepted as DeepSeek's current Flash id instead of being rewritten and "auto-corrected" on every switch.

## Two bugs from one Discord forward

**1. Provider hijack (WolframRvnwlf's $100 Astra incident; @sj-unit72's #97487).** `detect_provider_for_model()` walked the static catalogs and then the OpenRouter catalog. Providers whose live catalog outruns the static list (Codex early-access ids, Nous Portal slugs, Ollama Cloud) had nothing to stop the ladder, so a bare name the current provider already serves fell through and the agent was rebuilt on OpenRouter. Nous-sub-only users hit the same wall: `/model glm-5.3-flash` from Nous tried to switch to Z.AI (no key) and required `--provider nous` by hand.

**2. DeepSeek rename (kxee's report).** DeepSeek retired `deepseek-v4-flash` on 2026-09-10 (V4.1-Flash); the API id is now `deepseek-flash`. Hermes folded every non-V-series name onto `deepseek-v4-flash`, then the validator "corrected" it back against the live listing: `⚠ Auto-corrected deepseek-v4-flash → deepseek-flash` on every switch.

## Changes

- `hermes_cli/models_detect.py` (new sibling): `current_provider_catalog_match()` consults the current provider's disk-cached live catalog (`cached_provider_model_ids`, 1h TTL + stale-while-revalidate) and returns the provider's own spelling on an exact or bare-name hit.
- `hermes_cli/models.py::detect_provider_for_model` calls it first; a hit stays put. One choke point covers `/model`, ACP, `hermes chat -m`, and the dashboard.
- `hermes_cli/model_normalize.py`: `deepseek-flash` is canonical; retired aliases fold onto it (dated `deepseek-v4-*` ids still pass through). Curated catalog, DeepSeek profile fallback list, aux default, goal-judge hint follow.
- `agent/usage_pricing.py`: DeepSeek snapshot refreshed to the 2026-09-10 off-peak USD rates from the official pricing page; `deepseek-v4-flash` / `-chat` / `-reasoner` bill at the Flash row.
- 2 invariant tests for routing (red on base: 4/4 failed before the fix), existing DeepSeek tests updated to the current id.

## Validation

| Scenario (temp `HERMES_HOME`, real `switch_model`, no OpenRouter key) | Before | After |
|---|---|---|
| Nous sub, `/model glm-5.3-flash` (Portal serves `zai/glm-5.3-flash`) | fail → Z.AI "no credentials" | stays on Nous, `zai/glm-5.3-flash` |
| Nous sub, `/model gpt-6-astra` (Portal serves it) | switched to **openrouter**, empty api_key | stays on Nous |
| Codex, `/model gpt-6-astra` (live Codex catalog lists it) | `('openrouter', 'openai/gpt-6-astra')` | stays on openai-codex |
| Nous, `/model no-such-model` | openrouter | openrouter (ladder unchanged) |
| Nous, `/model deepseek-v4-pro` (not on Portal live list) | → deepseek | → deepseek (genuine remap kept) |
| DeepSeek, `/model deepseek-flash` | rewritten to `deepseek-v4-flash`, then "Auto-corrected" back | accepted as-is, no warning |

Targeted suites: `tests/hermes_cli/`, `tests/plugins/model_providers/`, pricing/metadata/aux/tui-gateway — 10,523 passed; one unrelated updater test (`test_update_fleet_check_fail_closed.py`) flaked under 40-way parallelism and passes standalone.

## Credit

- **Refs #97487** — @sj-unit72 diagnosed the ollama-cloud instance of the hijack and placed the fix at the right function; this PR generalises it (cached catalog, bare-name → full slug, no ollama-only suffix strip) and adds the tests the review asked for.
- **Supersedes #107126** — @MiseHinoha (YipTszkwan) was the earliest `deepseek-flash` fix; their commit is cherry-picked here with authorship preserved. This PR goes further by making it the canonical id (retired names fold onto it) so the auto-correct loop stops.
- Also supersedes the same-day duplicates #107134 (@Adolanium), #107136 (@rongyu945), #107148 (@AideYu — pricing refresh direction adopted), #107161 (@lava-lake), #107169 (@huanglu00-lang).
- Reported-by: @WolframRvnwlf (Astra), kxee (deepseek-flash), plus the Nous-sub `--provider nous` report.

## Infographic

![model switch stays home](https://files.catbox.moe/k7r81r.png)

https://files.catbox.moe/k7r81r.png
