### PR TITLE
fix(desktop): hide fixed titlebar clusters on contributed full pages

### DIFF
--- a/apps/desktop/src/app/routes.titlebar-clusters.test.ts
+++ b/apps/desktop/src/app/routes.titlebar-clusters.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { hidesFixedTitlebarClusters, isOverlayView } from './routes'
+
+describe('hidesFixedTitlebarClusters', () => {
+  it('hides clusters on contributed full pages and overlays', () => {
+    expect(hidesFixedTitlebarClusters('extension')).toBe(true)
+    expect(hidesFixedTitlebarClusters('settings')).toBe(true)
+  })
+
+  it('keeps clusters on chat and first-party workspace pages', () => {
+    expect(hidesFixedTitlebarClusters('chat')).toBe(false)
+    expect(hidesFixedTitlebarClusters('skills')).toBe(false)
+    expect(hidesFixedTitlebarClusters('messaging')).toBe(false)
+    expect(hidesFixedTitlebarClusters('artifacts')).toBe(false)
+  })
+
+  it('does not treat extension as an overlay', () => {
+    expect(isOverlayView('extension')).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -141,6 +141,15 @@ export function isOverlayView(view: AppView): boolean {
   return OVERLAY_VIEWS.has(view)
 }
 
+/** True when TitlebarControls must unmount the app's fixed tool clusters.
+ *  Overlays already own the window; contributed full pages (`extension`)
+ *  bring their own titlebar chrome (`titleBar.center` etc.) and the clusters
+ *  would otherwise sit on top of it. First-party workspace pages
+ *  (skills/messaging/artifacts) keep the clusters. */
+export function hidesFixedTitlebarClusters(view: AppView): boolean {
+  return isOverlayView(view) || view === 'extension'
+}
+
 /** The pathname of a router target. Every classifier below reasons about a
  *  PATH, but callers navigate to full targets (`/skills?tab=mcp`), and an
  *  unstripped query reaches the session-id parser — `/skills?tab=mcp` reads as

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -141,11 +141,11 @@ export function isOverlayView(view: AppView): boolean {
   return OVERLAY_VIEWS.has(view)
 }
 
-/** True when TitlebarControls must unmount the app's fixed tool clusters.
- *  Overlays already own the window; contributed full pages (`extension`)
- *  bring their own titlebar chrome (`titleBar.center` etc.) and the clusters
- *  would otherwise sit on top of it. First-party workspace pages
- *  (skills/messaging/artifacts) keep the clusters. */
+/** True when TitlebarControls must hide the app's fixed tool clusters.
+ *  Overlays already own the window (clusters AND titleBar slots unmount).
+ *  Contributed full pages (`extension`) hide the app clusters but keep the
+ *  titleBar slots so plugin chrome can own that space. First-party workspace
+ *  pages (skills/messaging/artifacts) keep the clusters. */
 export function hidesFixedTitlebarClusters(view: AppView): boolean {
   return isOverlayView(view) || view === 'extension'
 }

--- a/apps/desktop/src/app/shell/titlebar-controls.test.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.test.tsx
@@ -22,27 +22,43 @@ function renderControls(pathname: string) {
 
 const windowControls = () => screen.queryByLabelText('Window controls')
 const appControls = () => screen.queryByLabelText('App controls')
+const pluginChrome = () => screen.queryByText('plugin-chrome')
 
 describe('TitlebarControls fixed clusters', () => {
-  let disposeRoute: () => void
+  let dispose: () => void
 
   beforeEach(() => {
-    disposeRoute = registry.register({
-      area: ROUTES_AREA,
-      data: { path: '/kanban' },
-      id: 'test-kanban-route',
-      render: () => null
-    })
+    dispose = registry.registerMany([
+      {
+        area: ROUTES_AREA,
+        data: { path: '/kanban' },
+        id: 'test-kanban-route',
+        render: () => null
+      },
+      {
+        area: 'titleBar.center',
+        id: 'test-plugin-chrome',
+        render: () => <span>plugin-chrome</span>
+      }
+    ])
   })
 
   afterEach(() => {
-    disposeRoute()
+    dispose()
     cleanup()
   })
 
   it('hides the app clusters on a contributed full-page route', () => {
     renderControls('/kanban')
 
+    expect(windowControls()).toBeNull()
+    expect(appControls()).toBeNull()
+  })
+
+  it('keeps plugin titlebar contributions on a contributed full-page route', () => {
+    renderControls('/kanban')
+
+    expect(pluginChrome()).not.toBeNull()
     expect(windowControls()).toBeNull()
     expect(appControls()).toBeNull()
   })
@@ -59,6 +75,12 @@ describe('TitlebarControls fixed clusters', () => {
 
     expect(windowControls()).toBeNull()
     expect(appControls()).toBeNull()
+  })
+
+  it('hides plugin titlebar contributions on an overlay', () => {
+    renderControls('/settings')
+
+    expect(pluginChrome()).toBeNull()
   })
 
   it('keeps the app clusters on a first-party workspace page', () => {

--- a/apps/desktop/src/app/shell/titlebar-controls.test.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+import { I18nProvider } from '@/i18n'
+
+import { ROUTES_AREA } from '../routes'
+
+import { TitlebarControls } from './titlebar-controls'
+
+function renderControls(pathname: string) {
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <I18nProvider configClient={null} initialLocale="en">
+        <TitlebarControls onOpenSettings={() => {}} />
+      </I18nProvider>
+    </MemoryRouter>
+  )
+}
+
+const windowControls = () => screen.queryByLabelText('Window controls')
+const appControls = () => screen.queryByLabelText('App controls')
+
+describe('TitlebarControls fixed clusters', () => {
+  let disposeRoute: () => void
+
+  beforeEach(() => {
+    disposeRoute = registry.register({
+      area: ROUTES_AREA,
+      data: { path: '/kanban' },
+      id: 'test-kanban-route',
+      render: () => null
+    })
+  })
+
+  afterEach(() => {
+    disposeRoute()
+    cleanup()
+  })
+
+  it('hides the app clusters on a contributed full-page route', () => {
+    renderControls('/kanban')
+
+    expect(windowControls()).toBeNull()
+    expect(appControls()).toBeNull()
+  })
+
+  it('keeps the app clusters on chat', () => {
+    renderControls('/')
+
+    expect(windowControls()).not.toBeNull()
+    expect(appControls()).not.toBeNull()
+  })
+
+  it('hides the app clusters on an overlay', () => {
+    renderControls('/settings')
+
+    expect(windowControls()).toBeNull()
+    expect(appControls()).toBeNull()
+  })
+
+  it('keeps the app clusters on a first-party workspace page', () => {
+    renderControls('/skills')
+
+    expect(windowControls()).not.toBeNull()
+    expect(appControls()).not.toBeNull()
+  })
+})

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/store/layout'
 import { $unreadSessionCount } from '@/store/session-dot-state'
 
-import { appViewForPath, isOverlayView } from '../routes'
+import { appViewForPath, hidesFixedTitlebarClusters } from '../routes'
 
 import {
   TITLEBAR_ICON_BADGE_SCALE,
@@ -235,11 +235,12 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     }
   ]
 
-  // While a full-screen overlay (settings, command center, …) is open it should
+  // While a full-screen overlay (settings, command center, …) or a contributed
+  // full-context plugin page (`extension`, e.g. /kanban) is open it should
   // visually own the window. These control clusters are `fixed` at a higher
-  // z-index than the overlay card, so they'd otherwise bleed over it — hide them
-  // and let the overlay's own chrome (close button, drag region) take over.
-  if (isOverlayView(appViewForPath(location.pathname))) {
+  // z-index than the overlay card / plugin titlebar chrome, so they'd otherwise
+  // bleed over it — hide them and let that surface's own chrome take over.
+  if (hidesFixedTitlebarClusters(appViewForPath(location.pathname))) {
     return null
   }
 

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/store/layout'
 import { $unreadSessionCount } from '@/store/session-dot-state'
 
-import { appViewForPath, hidesFixedTitlebarClusters } from '../routes'
+import { appViewForPath, hidesFixedTitlebarClusters, isOverlayView } from '../routes'
 
 import {
   TITLEBAR_ICON_BADGE_SCALE,
@@ -235,32 +235,43 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     }
   ]
 
-  // While a full-screen overlay (settings, command center, …) or a contributed
-  // full-context plugin page (`extension`, e.g. /kanban) is open it should
-  // visually own the window. These control clusters are `fixed` at a higher
-  // z-index than the overlay card / plugin titlebar chrome, so they'd otherwise
-  // bleed over it — hide them and let that surface's own chrome take over.
-  if (hidesFixedTitlebarClusters(appViewForPath(location.pathname))) {
+  const view = appViewForPath(location.pathname)
+
+  // Overlays own the window. These clusters are `fixed` at a higher z-index
+  // than the overlay card, so they'd otherwise bleed over it — hide them (and
+  // the nested titleBar slots) and let the overlay's own chrome take over.
+  if (isOverlayView(view)) {
     return null
+  }
+
+  const titlebarSlots = (
+    <>
+      <Slot area="titleBar.left" />
+      <Slot area="titleBar.center" />
+      <Slot area="titleBar.right" />
+    </>
+  )
+  const leftClusterClass = cn(
+    titlebarToolClusterClass,
+    'left-(--titlebar-controls-left) top-(--titlebar-controls-top) translate-y-(--titlebar-controls-y-nudge)'
+  )
+
+  // Contributed full-context plugin pages (`extension`) own the titlebar band.
+  // Hide the app's tool clusters but keep plugin slots in the same fixed
+  // position so `titleBar.center` (e.g. kanban's board switcher) stays mounted.
+  if (hidesFixedTitlebarClusters(view)) {
+    return <div className={leftClusterClass}>{titlebarSlots}</div>
   }
 
   const visibleLeftTools = [sidebarTool, ...systemTools, ...leftTools, ...tools].filter(tool => !tool.hidden)
 
   return (
     <>
-      <div
-        aria-label={t.shell.windowControls}
-        className={cn(
-          titlebarToolClusterClass,
-          'left-(--titlebar-controls-left) top-(--titlebar-controls-top) translate-y-(--titlebar-controls-y-nudge)'
-        )}
-      >
+      <div aria-label={t.shell.windowControls} className={leftClusterClass}>
         {visibleLeftTools.map(tool => (
           <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
         ))}
-        <Slot area="titleBar.left" />
-        <Slot area="titleBar.center" />
-        <Slot area="titleBar.right" />
+        {titlebarSlots}
       </div>
 
       <div


### PR DESCRIPTION
## What does this PR do?

`ROUTES_AREA` full pages (e.g. `/kanban`) classify as `extension`, but TitlebarControls only hid the app's fixed tool clusters for overlay views. The clusters stayed mounted on top of the plugin's own titlebar chrome (`titleBar.center` etc.).

This treats `extension` like overlays for **app cluster** ownership only: hide Window/App controls on contributed full pages, keep `titleBar.left/center/right` slots in the same fixed titlebar position so plugin chrome (kanban's board switcher) still mounts. Overlays still `return null` (clusters and slots). `extension` is **not** added to `OVERLAY_VIEWS`, so workspace-pane fronting / find-bar / overlay routing stay unchanged. First-party workspace pages (`skills` / `messaging` / `artifacts`) keep the clusters.

## Related Issue

Fixes #107228

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `apps/desktop/src/app/routes.ts`: add `hidesFixedTitlebarClusters(view)` (`isOverlayView(view) || view === 'extension'`).
- `apps/desktop/src/app/shell/titlebar-controls.tsx`: overlay still returns null; extension hides app clusters but keeps the three titleBar slots.
- `apps/desktop/src/app/shell/titlebar-controls.test.tsx`: RED/GREEN for extension hide-clusters, slot preservation, overlay null, chat/skills CONTROL.
- `apps/desktop/src/app/routes.titlebar-clusters.test.ts`: helper contract, including `isOverlayView('extension') === false`.

## How to Test

```
cd apps/desktop
npx vitest run --project ui src/app/shell/titlebar-controls.test.tsx src/app/routes.titlebar-clusters.test.ts src/app/routes.workspace-reveal.test.ts
```

Proof Receipt (base `8068c09432`):

- BEFORE: `hides the app clusters on a contributed full-page route` failed (`Window controls` still mounted on `/kanban`); after the first fix, `keeps plugin titlebar contributions on a contributed full-page route` failed (`plugin-chrome` unmounted with `return null`)
- AFTER: 31 passed (3 files)
- CONTROL: chat `/` and `/skills` still mount Window/App controls; overlay `/settings` still unmounts clusters and slots; `fronts on a contributed page route` in workspace-reveal still passes

## Related work (not duplicates)

- No open competing PR for #107228 at push time.
- Does not add `extension` to `OVERLAY_VIEWS` (that would stop fronting the workspace pane for plugin pages).

## Review follow-up

- Independent P0 review skipped (2 modules, 150/16 lines, not auth/crypto/state.db, self-review P0=0 after keeping titleBar slots mounted on extension).
- Self-review P0: 0.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run relevant tests locally (desktop vitest ui project; this change is TS, not `pytest tests/`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (vitest/jsdom structure assertions; no live Electron pixel run)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — titlebar cluster hide is view-based, not platform-specific
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Made with [Cursor](https://cursor.com)