### PR TITLE
fix(image_gen): surface unverified Codex image-tool metadata

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -2,7 +2,8 @@
 
 Same catalog/tiers as the ``openai`` plugin (``gpt-image-2`` low/medium/high), routed
 through the Codex Responses API ``image_generation`` tool, so no ``OPENAI_API_KEY`` is
-needed. Output is PNG; source images travel as Responses ``input_image`` parts.
+needed. Output is PNG; source images travel as Responses ``input_image`` parts. Catalog
+selection is a request, not verified engine identity; Codex may echo a different alias.
 
 Do NOT reintroduce an "account capability" classifier keyed on ``Tool choice
 'image_generation' not found in 'tools' parameter``: that 400 is a request-shape
@@ -38,7 +39,7 @@ logger = logging.getLogger(__name__)
 # so it stays diagnosable. See issues #19505, #49008 and #31335.
 _MAX_ERROR_BODY_CHARS = 500
 
-# Hosts the ``image_generation`` tool call; ``API_MODEL`` does the image work.
+# Hosts ``image_generation``; ``API_MODEL`` requests (not verifies) an image model.
 _CODEX_CHAT_MODEL = "gpt-5.5"
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _CODEX_INSTRUCTIONS = (
@@ -278,11 +279,30 @@ def _iter_sse_json(response: Any):
         yield payload
 
 
+def _extract_reported_image_model(event: Any) -> Optional[str]:
+    """Read only ``response.tools`` image_generation.model; never host ``response.model``."""
+    if not isinstance(event, dict):
+        return None
+    response = event.get("response")
+    tools = response.get("tools") if isinstance(response, dict) else None
+    if not isinstance(tools, list):
+        return None
+    for tool in tools:
+        if isinstance(tool, dict) and tool.get("type") == "image_generation":
+            model = tool.get("model")
+            if isinstance(model, str) and model.strip():
+                return model
+    return None
+
+
 def _collect_image_b64(
     token: str, *, prompt: str, size: str, quality: str, input_images: Optional[List[Dict[str, str]]] = None
 ) -> Optional[Dict[str, str]]:
-    """Stream a Codex Responses image_generation call → ``{"b64", "source": "final"|"partial"}`` or
-    ``None``. A partial is kept only when no final arrives; callers must not treat it as success."""
+    """Collect image bytes and optional ``reported_model`` from the same response stream.
+
+    A partial is kept only when no final arrives; callers must not treat it as success.
+    Reported tool configuration is not verified image-engine identity.
+    """
     import httpx
     from agent.codex_headers import codex_cloudflare_headers
 
@@ -298,6 +318,7 @@ def _collect_image_b64(
 
     final_b64: Optional[str] = None
     partial_b64: Optional[str] = None
+    reported_model: Optional[str] = None
     with httpx.Client(timeout=timeout, headers=headers) as http:
         with http.stream("POST", f"{_CODEX_BASE_URL}/responses", json=payload) as response:
             try:
@@ -309,11 +330,15 @@ def _collect_image_b64(
                     f"{_summarize_error_body(exc.response.text)}"
                 ) from exc
             for event in _iter_sse_json(response):
+                reported_model = _extract_reported_image_model(event) or reported_model
                 result_b64, event_partial = _extract_image_candidates(event)
                 final_b64 = result_b64 or final_b64
                 partial_b64 = event_partial or partial_b64
     if final_b64:
-        return {"b64": final_b64, "source": "final"}
+        result = {"b64": final_b64, "source": "final"}
+        if reported_model is not None:
+            result["reported_model"] = reported_model
+        return result
     return {"b64": partial_b64, "source": "partial"} if partial_b64 else None
 
 
@@ -337,7 +362,8 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
             "env_vars": [],
             "post_setup_hint": (
                 "Sign in with `hermes auth codex` (or `hermes setup` → Codex) "
-                "if you haven't already. No API key needed."),
+                "if you haven't already. No API key needed. Image-model selection "
+                "cannot be confirmed on Codex."),
         }
 
     def capabilities(self) -> Dict[str, Any]:
@@ -420,6 +446,12 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
             extra={
                 "size": size, "quality": meta["quality"], "input_image_count": len(input_images),
                 "image_source": image_source, "requested_size": size, "pixel_size": pixel_size,
+                "requested_model": API_MODEL, "reported_model": collected.get("reported_model"),
+                "model_selection_verified": False,
+                "model_selection_note": (
+                    "Exact image model unverified. 'model' is the configured selection; "
+                    "'requested_model' is the sent image-tool model; 'reported_model' is "
+                    "server-reported tool configuration, not proof of the image engine."),
             })
 
 

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import importlib
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -449,6 +450,122 @@ class TestRequestShape:
         # Body is capped, but the actionable wire message still reaches the user.
         assert "tools' parameter" in message
         assert len(message) < len(body)
+
+
+# ── Unverified image-tool metadata (#107233) ────────────────────────────────
+
+
+def _mock_codex_stream(monkeypatch, responses, requests):
+    """Replace only HTTP transport; keep request construction, SSE parsing and saving real."""
+    import httpx
+
+    streams = iter(responses)
+
+    def respond(request):
+        assert str(request.url) == f"{codex_plugin._CODEX_BASE_URL}/responses"
+        requests.append(json.loads(request.content))
+        wire = "".join(f"data: {json.dumps(event)}\n\n" for event in next(streams))
+        return httpx.Response(200, text=wire, headers={"content-type": "text/event-stream"})
+
+    real_client = httpx.Client
+    monkeypatch.setattr(httpx, "Client", lambda *args, **kwargs: real_client(
+        transport=httpx.MockTransport(respond), **kwargs,
+    ))
+
+
+def _final_image_events(*, tools=None):
+    """Successful stream: host ``response.model`` is present and must not become reported_model."""
+    created = {"type": "response.created", "response": {"model": "gpt-5.5"}}
+    completed = {
+        "type": "response.completed",
+        "response": {
+            "model": "gpt-5.5",
+            "output": [{
+                "type": "image_generation_call",
+                "status": "completed",
+                "result": _b64_png(),
+            }],
+        },
+    }
+    if tools is not None:
+        completed["response"]["tools"] = tools
+    return [created, completed]
+
+
+@pytest.mark.parametrize("report", ["alias", "echo", "missing"])
+@pytest.mark.parametrize("with_reference", [False, True], ids=["generate", "edit"])
+def test_success_separates_requested_model_from_unverified_server_report(
+    provider, monkeypatch, tmp_path, report, with_reference,
+):
+    monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+    monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+    reported = {"alias": "gpt-image-2-codex", "echo": "gpt-image-2", "missing": None}[report]
+    tools = [{"type": "function", "name": "unrelated", "model": "not-the-image-model"}]
+    if reported is not None:
+        tools.append({"type": "image_generation", "model": reported})
+    events = _final_image_events(tools=None if report == "missing" else tools)
+    requests: list[Any] = []
+    _mock_codex_stream(monkeypatch, [events], requests)
+    kwargs = {}
+    if with_reference:
+        source = tmp_path / "reference.png"
+        source.write_bytes(bytes.fromhex(_PNG_HEX))
+        kwargs["image_url"] = str(source)
+
+    result = provider.generate("A blue circle on white.", **kwargs)
+
+    assert len(requests) == 1  # A model label must not cause retries or a provider switch.
+    assert requests[0]["tools"][0]["model"] == "gpt-image-2"
+    content = requests[0]["input"][0]["content"]
+    assert any(part["type"] == "input_image" for part in content) == with_reference
+    assert result["success"] is True
+    assert Path(result["image"]).read_bytes() == bytes.fromhex(_PNG_HEX)
+    assert result["provider"] == "openai-codex"
+    assert result["model"] == "gpt-image-2-medium"  # Preserve the existing catalog-selection field.
+    assert result["requested_model"] == "gpt-image-2"
+    assert result["reported_model"] == reported
+    # Even an echoed tool configuration is not verified image-engine identity.
+    assert result["model_selection_verified"] is False
+    assert "unverified" in result["model_selection_note"].lower()
+    assert not result.get("error")
+
+
+@pytest.mark.parametrize("created_tools,completed_tools,expected", [
+    ([{"type": "image_generation", "model": "initial-label"}],
+     [{"type": "image_generation", "model": "final-label"}], "final-label"),
+    ([{"type": "image_generation", "model": "initial-label"}], None, "initial-label"),
+    (None, None, None),
+    (None, {"type": "image_generation", "model": "not-a-tools-list"}, None),
+    (None, [None, {"type": "image_generation", "model": {"unexpected": "object"}}], None),
+    (None, [{"type": "image_generation", "model": "   "}], None),
+])
+def test_reported_model_belongs_to_successful_attempt_not_a_previous_partial(
+    provider, monkeypatch, tmp_path, created_tools, completed_tools, expected,
+):
+    monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+    partial_attempt = [{"type": "response.created", "response": {"tools": [
+        {"type": "image_generation", "model": "discarded-attempt-label"},
+    ]}}, {"type": "response.image_generation_call.partial_image", "partial_image_b64": _b64_png()}]
+    final_attempt = [
+        {"type": "response.created", "response": {"tools": created_tools}},
+        {"type": "response.completed", "response": {
+            "model": "host-model", "tools": completed_tools,
+            "output": [{"type": "image_generation_call", "result": _b64_png()}],
+        }},
+    ]
+    requests: list[Any] = []
+    _mock_codex_stream(monkeypatch, [partial_attempt, final_attempt], requests)
+
+    result = provider.generate("A blue circle on white.")
+
+    assert len(requests) == 2
+    assert result["success"] is True
+    assert result["image_source"] == "final"
+    assert Path(result["image"]).read_bytes() == bytes.fromhex(_PNG_HEX)
+    assert result["reported_model"] == expected
+    assert result["requested_model"] == "gpt-image-2"
+    assert result["model_selection_verified"] is False
+    assert "unverified" in result["model_selection_note"].lower()
 
 
 # ── Plugin entry point ──────────────────────────────────────────────────────

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -248,8 +248,26 @@ backend rejects every `tool_choice` shape for hosted tools, so the request
 relies on instructions to steer the model. When the host model declines to
 invoke the tool, the call fails with `empty_response`. Whether the hosted
 image tool is reachable at all has also been reported to vary between
-accounts. If you need image generation to work deterministically, configure
-the **OpenAI** (API key), **FAL**, or **xAI** backend instead.
+accounts. The backend can also accept an image-model value without honoring
+that selection and return a successful image with a different or opaque tool
+model label, such as `gpt-image-2-codex`.
+
+Successful Codex tool results distinguish:
+
+- `model`: the configured catalog selection (for example `gpt-image-2-medium`), retained for compatibility.
+- `requested_model`: the image-tool model sent to Codex (`gpt-image-2` on this provider).
+- `reported_model`: the last nonempty image-generation model string observed in
+  `response.tools` in the successful attempt, or `null` if none was reported.
+  This is tool-configuration metadata, **not verified image-engine identity**;
+  even a label matching the request may merely echo its configuration.
+- `model_selection_verified`: `false`; `model_selection_note` explains the
+  uncertainty. Hermes does not infer a mapping from an opaque backend alias.
+
+Missing or different model metadata does not discard a usable final image,
+trigger another request, or switch providers.
+
+If you need image generation to work deterministically, configure the
+**OpenAI** (API key), **FAL**, or **xAI** backend instead.
 
 :::
 


### PR DESCRIPTION
## What does this PR do?

The Codex Responses `image_generation` tool does not enforce the client-supplied `model` / `quality` / `size` (issue #107233). `response.completed` echoes a backend-normalized spec (typically `gpt-image-2-codex` / `auto` / `auto`) even for invalid names or an empty tool object, while Hermes currently reports the catalog selection as if it were confirmed.

This PR keeps sending the catalog request unchanged and keeps delivering a successful final image. It records the backend echo as separate, unverified metadata so a user (or a 2.5-catalog PR sitting on top of this) cannot mistake catalog selection for engine identity.

Invariant: catalog `model` stays the configured selection; `requested_model` is the image-tool model actually sent; `reported_model` is the last nonempty `response.tools[].model` with `type == image_generation` on the successful attempt; `model_selection_verified` is always `false`.

### Symptom

The Codex Responses `image_generation` tool does not enforce the client-supplied `model` / `quality` / `size` (issue #107233). `response.completed` echoes a backend-normalized spec (typically `gpt-image-2-codex` / `auto` / `auto`) even for invalid names or an empty tool object, while Hermes currently reports the catalog selection as if it were confirmed.

This PR keeps sending the catalog request unchanged and keeps delivering a successful final image. It records the backend echo as separate, unverified metadata so a user (or a 2.5-catalog PR sitting on top of this) cannot mistake catalog selection for engine identity.

Invariant: catalog `model` stays the configured selection; `requested_model` is the image-tool model actually sent; `reported_model` is the last nonempty `response.tools[].model` with `type == image_generation` on the successful attempt; `model_selection_verified` is always `false`.


Addresses #107233

Related but not fixed here: #106708 / #106717 / #107174 (2.5 catalog and host-model availability) and #106176 (dispatched `model` kwarg).


- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔒 Security fix
- [x] ✅ Tests


- `plugins/image_gen/openai-codex/__init__.py`: parse `response.tools` image-generation model from the same SSE stream; attach `requested_model` / `reported_model` / `model_selection_verified` / `model_selection_note` on success. Do not retry, switch provider, rewrite catalog `model`, or drop a final image when the echo differs.
-

### Impact

The Codex Responses `image_generation` tool does not enforce the client-supplied `model` / `quality` / `size` (issue #107233). `response.completed` echoes a backend-normalized spec (typically `gpt-image-2-codex` / `auto` / `auto`) even for invalid names or an empty tool object, while Hermes currently reports the catalog selection as if it were confirmed.

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

The Codex Responses `image_generation` tool does not enforce the client-supplied `model` / `quality` / `size` (issue #107233). `response.completed` echoes a backend-normalized spec (typically `gpt-image-2-codex` / `auto` / `auto`) even for invalid names or an empty tool object, while Hermes currently reports the catalog selection as if it were confirmed. This PR keeps sending the catalog request unchanged and keeps delivering a successful final image.

## Related Issue

Addresses #107233

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/image_gen/openai-codex/__init__.py`: parse `response.tools` image-generation model from the same SSE stream; attach `requested_model` / `reported_model` / `model_selection_verified` / `model_selection_note` on success. Do not retry, switch provider, rewrite catalog `model`, or drop a final image when the echo differs.
- `tests/plugins/image_gen/test_openai_codex_provider.py`: MockTransport SSE coverage for alias / echo / missing tools, generate vs edit, host-model ignored, function-tool `model` ignored, retry isolation, and fail-open malformed tools.
- `website/docs/user-guide/features/image-generation.md`: document the four fields in the existing Codex best-effort note.

## How to Test

- ✅ `scripts/run_tests.sh` on the files in Changes Made — focused verification
- ✅ Focused verification completed on this branch
- ✅ `scripts/run_tests.sh tests/plugins/image_gen/test_openai_codex_provider.py -q`

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

