### PR TITLE
fix(cron): retain pending monitor work and bound safe retries

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1640,7 +1640,7 @@ def _normalized_inference_axes(
     )
 
 
-_MONITOR_COMMIT_POLICIES = {"detection_time", "after_delivery"}
+_MONITOR_COMMIT_POLICIES = {"detection_time", "after_delivery", "safe_retry"}
 
 
 def _normalize_monitor_commit_policy(
@@ -1995,6 +1995,14 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
         raise ValueError(f"Cron job field(s) cannot be updated: {', '.join(sorted(bad_fields))}")
 
     def apply(jobs, i, job):
+        if job.get("monitor_commit_policy") == "safe_retry":
+            from cron import monitor_pending
+            desired = {**job, **updates}
+            if (desired.get("monitor_commit_policy") != "safe_retry"
+                    or monitor_pending._binding(desired) != monitor_pending._binding(job)):
+                pending = monitor_pending.inspect(job)
+                if pending and pending["state"] != "acked":
+                    raise ValueError("Monitor recovery is pending; reconcile its outcome before changing the job")
         _rederive_repeat_for_schedule_change(job, updates)
         _normalize_job_updates(job, updates)
         previous_inference_axes = _normalized_inference_axes(job)

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1640,6 +1640,24 @@ def _normalized_inference_axes(
     )
 
 
+_MONITOR_COMMIT_POLICIES = {"detection_time", "after_delivery"}
+
+
+def _normalize_monitor_commit_policy(
+    value: Optional[str], *, monitor_script: Optional[str], monitor_url: Optional[str],
+) -> Optional[str]:
+    """Validate the optional monitor commit boundary shared by create_job/update_job."""
+    normalized = str(value).strip().lower() if value is not None else ""
+    if not normalized:
+        return None
+    if normalized not in _MONITOR_COMMIT_POLICIES:
+        choices = ", ".join(sorted(_MONITOR_COMMIT_POLICIES))
+        raise ValueError(f"monitor_commit_policy must be one of: {choices}")
+    if not (monitor_script or monitor_url):
+        raise ValueError("monitor_commit_policy requires monitor_script or monitor_url")
+    return normalized
+
+
 def _validate_job_mode_invariants(
     monitor_script: Optional[str],
     monitor_url: Optional[str],
@@ -1706,6 +1724,7 @@ def create_job(
     failure_deliver: Optional[str] = None,
     paused: bool = False,
     paused_reason: Optional[str] = None,
+    monitor_commit_policy: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Create a new cron job and return the stored record.
 
@@ -1714,7 +1733,9 @@ def create_job(
     delivered verbatim, requires ``script``). context_from: job id(s) whose latest output is
     injected. workdir: absolute cwd for tools/scripts. monitor_script/monitor_url: cheap monitor
     source run FIRST each tick; unchanged output suppresses the agent run (mutually exclusive,
-    incompatible with ``no_agent``). reasoning_effort: per-job pin; capability NOT validated."""
+    incompatible with ``no_agent``). monitor_commit_policy: ``detection_time`` (default, eager) or
+    ``after_delivery``, which retries a changed observation until the triggered agent run AND its
+    delivery succeed. reasoning_effort: per-job pin; capability NOT validated."""
     if not isinstance(paused, bool):
         raise ValueError("paused must be a boolean.")
     if paused_reason is not None and not isinstance(paused_reason, str):
@@ -1738,6 +1759,11 @@ def create_job(
     normalized_skills = _normalize_skill_list(skill, skills)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
     normalized_reasoning_effort = _normalize_reasoning_effort(reasoning_effort)
+    normalized_monitor_commit_policy = _normalize_monitor_commit_policy(
+        monitor_commit_policy,
+        monitor_script=f["monitor_script"],
+        monitor_url=f["monitor_url"],
+    )
 
     _validate_job_mode_invariants(f["monitor_script"], f["monitor_url"], f["no_agent"], f["script"])
     prompt_text = _coerce_job_text(prompt).strip()
@@ -1802,6 +1828,7 @@ def create_job(
     for key, value in (
         ("attach_to_session", normalized_attach), ("reasoning_effort", normalized_reasoning_effort),
         ("failure_deliver", f["failure_deliver"]),
+        ("monitor_commit_policy", normalized_monitor_commit_policy),
     ):
         if value is not None:
             job[key] = value
@@ -1973,6 +2000,18 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
         previous_inference_axes = _normalized_inference_axes(job)
         updated = _apply_skill_fields({**job, **updates})
         _reject_terminal_activation(job, updated, job_id)
+        if {"monitor_script", "monitor_url", "monitor_commit_policy"}.intersection(updates):
+            # Re-validate on the MERGED record: clearing the last monitor source must also drop a
+            # policy that is only meaningful for monitor jobs.
+            normalized_policy = _normalize_monitor_commit_policy(
+                updated.get("monitor_commit_policy"),
+                monitor_script=updated.get("monitor_script") or None,
+                monitor_url=updated.get("monitor_url") or None,
+            )
+            if normalized_policy is None:
+                updated.pop("monitor_commit_policy", None)
+            else:
+                updated["monitor_commit_policy"] = normalized_policy
         # Re-check on the MERGED record; scoped to changed fields so legacy records keep loading.
         if {"monitor_script", "monitor_url", "no_agent", "script"}.intersection(updates):
             _validate_job_mode_invariants(

--- a/cron/monitor.py
+++ b/cron/monitor.py
@@ -237,6 +237,11 @@ def commit_monitor_state(job_id: str, new_hash: str, output: str) -> None:
             snapshot_path.unlink(missing_ok=True)
 
     try:
+        # update_job rewrites the job dict and persists jobs.json in one
+        # step; hash and last_changed_at are therefore applied together or
+        # not at all (a failed update_job raises before any partial state
+        # survives). The rollback below only has to cover the snapshot
+        # file, which is why it does not restore a timestamp.
         updated = update_job(
             job_id,
             {

--- a/cron/monitor.py
+++ b/cron/monitor.py
@@ -8,6 +8,12 @@ CHANGE DETECTED" block (capped unified diff + new output) is injected into the p
 failure → an ERROR, never a change, and the stored hash is left untouched. State:
 ``job["monitor_state"]`` in jobs.json (hash + last_changed_at) and
 ``OUTPUT_DIR/<job_id>/monitor_last_output.txt`` (for the diff).
+
+The default commit boundary is detection time. Jobs with
+``monitor_commit_policy="after_delivery"`` defer the hash/snapshot commit until the agent finishes
+AND delivery succeeds, so a failed run re-offers the same observation instead of consuming it. Such
+a job may return the exact marker ``[MONITOR_RETRY]`` to suppress delivery and leave the prior hash
+intact.
 """
 
 from __future__ import annotations
@@ -15,6 +21,8 @@ from __future__ import annotations
 import difflib
 import hashlib
 import logging
+import os
+import uuid
 from dataclasses import dataclass
 from typing import Optional
 
@@ -39,6 +47,8 @@ class MonitorOutcome:
     first_run: bool = False
     context_block: Optional[str] = None
     error: Optional[str] = None
+    new_hash: Optional[str] = None
+    output: Optional[str] = None
 
 
 def hash_monitor_output(output: str) -> str:
@@ -74,13 +84,25 @@ def _read_last_output(job_id: str) -> str:
     return ""
 
 
+def _write_last_output_strict(job_id: str, output: str) -> None:
+    path = _snapshot_path(job_id)
+    from cron.jobs import _ensure_cron_dir
+
+    _ensure_cron_dir(path.parent)
+    temp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        temp_path.write_text(output, encoding="utf-8")
+        os.replace(temp_path, path)
+    finally:
+        try:
+            temp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
 def _write_last_output(job_id: str, output: str) -> None:
     try:
-        from cron.jobs import _ensure_cron_dir
-
-        path = _snapshot_path(job_id)
-        _ensure_cron_dir(path.parent)
-        path.write_text(output, encoding="utf-8")
+        _write_last_output_strict(job_id, output)
     except Exception as exc:
         logger.warning("Monitor: failed to persist last output for %r: %s", job_id, exc)
 
@@ -125,8 +147,10 @@ def job_has_monitor(job: dict) -> bool:
 def check_monitor(job: dict) -> MonitorOutcome:
     """Run the monitor source and decide whether the agent should run.
 
-    On change (or first run) the new hash + snapshot are persisted BEFORE the agent runs — detection
-    time is the state boundary, so a failed agent run doesn't re-alert on the same content forever.
+    By default, on change (or first run) the new hash + snapshot are persisted BEFORE the agent
+    runs — detection time is the state boundary, so a failed agent run doesn't re-alert on the same
+    content forever. ``monitor_commit_policy='after_delivery'`` instead returns the new hash/output
+    to the scheduler for a downstream commit once the agent AND delivery both succeeded.
     On failure nothing is persisted.
     """
     job_id = str(job.get("id") or "")
@@ -163,8 +187,16 @@ def check_monitor(job: dict) -> MonitorOutcome:
             f"### Diff (previous → current)\n\n```diff\n{diff}\n```\n\n" + current
         )
 
-    _persist_monitor_state(job_id, new_hash, output)
-    return MonitorOutcome(ok=True, changed=True, first_run=first_run, context_block=context_block)
+    if job.get("monitor_commit_policy") != "after_delivery":
+        _persist_monitor_state(job_id, new_hash, output)
+    return MonitorOutcome(
+        ok=True,
+        changed=True,
+        first_run=first_run,
+        context_block=context_block,
+        new_hash=new_hash,
+        output=output,
+    )
 
 
 def _persist_monitor_state(job_id: str, new_hash: str, output: str) -> None:
@@ -183,3 +215,45 @@ def _persist_monitor_state(job_id: str, new_hash: str, output: str) -> None:
         )
     except Exception as exc:
         logger.warning("Monitor: failed to persist state for %r: %s", job_id, exc)
+
+
+def commit_monitor_state(job_id: str, new_hash: str, output: str) -> None:
+    """Commit a deferred monitor observation after downstream success."""
+    if not new_hash:
+        raise ValueError("new_hash is required to commit monitor state")
+    from cron.jobs import _hermes_now, update_job
+
+    snapshot_path = _snapshot_path(job_id)
+    old_snapshot_exists = snapshot_path.exists()
+    old_output = (
+        snapshot_path.read_text(encoding="utf-8") if old_snapshot_exists else ""
+    )
+    _write_last_output_strict(job_id, output)
+
+    def rollback_snapshot() -> None:
+        if old_snapshot_exists:
+            _write_last_output_strict(job_id, old_output)
+        else:
+            snapshot_path.unlink(missing_ok=True)
+
+    try:
+        updated = update_job(
+            job_id,
+            {
+                "monitor_state": {
+                    "last_output_hash": new_hash,
+                    "last_changed_at": _hermes_now().isoformat(),
+                }
+            },
+        )
+        if updated is None:
+            raise RuntimeError(f"monitor job {job_id!r} disappeared during commit")
+    except Exception:
+        try:
+            rollback_snapshot()
+        except Exception:
+            logger.exception(
+                "Monitor: failed to roll back snapshot for %r after hash commit failure",
+                job_id,
+            )
+        raise

--- a/cron/monitor.py
+++ b/cron/monitor.py
@@ -49,6 +49,7 @@ class MonitorOutcome:
     error: Optional[str] = None
     new_hash: Optional[str] = None
     output: Optional[str] = None
+    pending_token: Optional[str] = None
 
 
 def hash_monitor_output(output: str) -> str:
@@ -154,7 +155,14 @@ def check_monitor(job: dict) -> MonitorOutcome:
     On failure nothing is persisted.
     """
     job_id = str(job.get("id") or "")
-    ok, output = _run_monitor_source(job)
+    pending = None
+    if job.get("monitor_commit_policy") == "safe_retry":
+        from cron import monitor_pending
+        try:
+            pending = monitor_pending.resume(job)
+        except monitor_pending.RecoveryRequired as exc:
+            return MonitorOutcome(ok=False, error=str(exc))
+    ok, output = (True, pending["output"]) if pending else _run_monitor_source(job)
     if not ok:
         return MonitorOutcome(ok=False, error=output)
 
@@ -162,7 +170,7 @@ def check_monitor(job: dict) -> MonitorOutcome:
     raw_state = job.get("monitor_state")
     last_hash = raw_state.get("last_output_hash") if isinstance(raw_state, dict) else None
 
-    if last_hash is not None and new_hash == last_hash:
+    if pending is None and last_hash is not None and new_hash == last_hash:
         return MonitorOutcome(ok=True, changed=False)
 
     first_run = last_hash is None
@@ -187,7 +195,15 @@ def check_monitor(job: dict) -> MonitorOutcome:
             f"### Diff (previous → current)\n\n```diff\n{diff}\n```\n\n" + current
         )
 
-    if job.get("monitor_commit_policy") != "after_delivery":
+    if job.get("monitor_commit_policy") == "safe_retry" and pending is None:
+        from cron import monitor_pending
+        try:
+            pending = monitor_pending.begin(job, output)
+        except monitor_pending.RecoveryRequired as exc:
+            return MonitorOutcome(ok=False, error=str(exc))
+        if pending is None:
+            return MonitorOutcome(ok=True, changed=False)
+    elif job.get("monitor_commit_policy") not in {"after_delivery", "safe_retry"}:
         _persist_monitor_state(job_id, new_hash, output)
     return MonitorOutcome(
         ok=True,
@@ -196,6 +212,7 @@ def check_monitor(job: dict) -> MonitorOutcome:
         context_block=context_block,
         new_hash=new_hash,
         output=output,
+        pending_token=pending["token"] if pending else None,
     )
 
 

--- a/cron/monitor_pending.py
+++ b/cron/monitor_pending.py
@@ -1,0 +1,205 @@
+"""Durable, bounded monitor attempts; uncertainty never authorizes a replay.
+
+Only safe_retry monitors use this private profile-local store. A running attempt
+surviving its caller is deliberately unresolved, even when its process died.
+"""
+from __future__ import annotations
+
+from contextlib import closing, contextmanager
+import hashlib
+import json
+import os
+import stat
+import sqlite3
+import uuid
+
+from hermes_constants import get_hermes_home
+
+MAX_ATTEMPTS = 2
+MAX_PAYLOAD_BYTES = 262_144
+
+
+class RecoveryRequired(RuntimeError):
+    """An observation is retained and requires outcome reconciliation."""
+
+
+def _binding(job):
+    keys = ("monitor_script", "monitor_url", "script", "prompt", "provider", "model",
+            "provider_snapshot", "model_snapshot", "base_url", "workdir", "deliver", "origin",
+            "skills", "skill", "enabled_toolsets", "context_from", "no_agent")
+    data = json.dumps({k: job.get(k) for k in keys}, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(data.encode()).hexdigest()
+
+
+@contextmanager
+def _store():
+    from cron.jobs import _ensure_cron_dir
+    directory = get_hermes_home() / "cron"
+    _ensure_cron_dir(directory)
+    path = directory / "monitor_pending.db"
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
+        pass
+    else:
+        os.close(fd)
+    metadata = path.lstat()
+    if (not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1
+            or (os.name != "nt" and (metadata.st_mode & 0o077 or metadata.st_uid != os.getuid()))):
+        raise RecoveryRequired("monitor recovery store is not a private regular file")
+    with closing(sqlite3.connect(path, timeout=5)) as db, db:
+        db.row_factory = sqlite3.Row
+        db.execute("PRAGMA synchronous=FULL")
+        db.execute("CREATE TABLE IF NOT EXISTS pending (job TEXT PRIMARY KEY, binding TEXT NOT NULL, "
+                   "hash TEXT NOT NULL, output TEXT NOT NULL, state TEXT NOT NULL, "
+                   "attempts INTEGER NOT NULL, token TEXT NOT NULL, response TEXT, reason TEXT)")
+        db.execute("BEGIN IMMEDIATE")
+        yield db
+
+
+def _row(db, job):
+    row = db.execute("SELECT * FROM pending WHERE job=?", (job["id"],)).fetchone()
+    if row is not None:
+        try:
+            valid = (
+                row["state"] in {"running", "retry", "ready", "unknown", "acked"}
+                and type(row["attempts"]) is int and 1 <= row["attempts"] <= MAX_ATTEMPTS
+                and len(row["token"]) == 32 and all(c in "0123456789abcdef" for c in row["token"])
+                and isinstance(row["output"], str) and len(row["output"].encode()) <= MAX_PAYLOAD_BYTES
+                and hashlib.sha256(row["output"].encode()).hexdigest() == row["hash"]
+                and (row["response"] is None or (
+                    isinstance(row["response"], str) and len(row["response"].encode()) <= MAX_PAYLOAD_BYTES))
+            )
+        except (TypeError, UnicodeError):
+            valid = False
+        if not valid:
+            raise RecoveryRequired("monitor recovery record is invalid; pending data retained")
+    if row is not None and row["state"] != "acked" and row["binding"] != _binding(job):
+        raise RecoveryRequired("monitor recovery configuration changed; pending observation retained")
+    return dict(row) if row is not None else None
+
+
+def _claim(db, row):
+    if row["state"] != "retry" or row["attempts"] >= MAX_ATTEMPTS:
+        raise RecoveryRequired("monitor recovery required: " + row["state"])
+    row.update(state="running", attempts=row["attempts"] + 1, token=uuid.uuid4().hex)
+    db.execute("UPDATE pending SET state=?, attempts=?, token=? WHERE job=?",
+               (row["state"], row["attempts"], row["token"], row["job"]))
+    return row
+
+
+def resume(job):
+    """Claim a positively retryable observation before consulting a newer source."""
+    with _store() as db:
+        row = _row(db, job)
+        if row is None or row["state"] == "acked":
+            return None
+        return _claim(db, row)
+
+
+def begin(job, output):
+    """Persist an observation and claim its first attempt in one transaction."""
+    if len(output.encode()) > MAX_PAYLOAD_BYTES:
+        raise RecoveryRequired("monitor observation exceeds durable payload limit")
+    digest = hashlib.sha256(output.encode("utf-8", errors="replace")).hexdigest()
+    with _store() as db:
+        old = _row(db, job)
+        if old and old["state"] != "acked":
+            raise RecoveryRequired("monitor observation already pending")
+        if old and old["binding"] == _binding(job) and old["hash"] == digest:
+            return None
+        row = {"job": job["id"], "binding": _binding(job), "hash": digest, "output": output,
+               "state": "running", "attempts": 1, "token": uuid.uuid4().hex,
+               "response": None, "reason": None}
+        db.execute("INSERT OR REPLACE INTO pending VALUES (:job,:binding,:hash,:output,:state,"
+                   ":attempts,:token,:response,:reason)", row)
+        return row
+
+
+def settle(job, token, *, response=None, safe_failure=False, completed=False):
+    """Settle generation, never infer safety from an error string or elapsed time."""
+    if response is not None and len(response.encode()) > MAX_PAYLOAD_BYTES:
+        raise RecoveryRequired("monitor response exceeds durable payload limit")
+    with _store() as db:
+        row = _row(db, job)
+        if not row or row["token"] != token or row["state"] != "running":
+            raise RecoveryRequired("monitor attempt ownership changed")
+        if response is not None:
+            state, reason = ("ready", None) if completed else ("unknown", "incomplete_generation")
+        elif safe_failure and row["attempts"] < MAX_ATTEMPTS:
+            state, reason = "retry", "confirmed_pre_effect_failure"
+        else:
+            state, reason = "unknown", "attempt_limit" if safe_failure else "effects_not_excluded"
+        db.execute("UPDATE pending SET state=?, response=?, reason=? WHERE job=? AND token=?",
+                   (state, response, reason, job["id"], token))
+
+
+def acknowledge(job, token):
+    """Called only after successful delivery and the owner-fenced monitor commit."""
+    with _store() as db:
+        row = _row(db, job)
+        if not row or row["token"] != token or row["state"] != "ready":
+            raise RecoveryRequired("monitor acknowledgement ownership changed")
+        db.execute("UPDATE pending SET state='acked', reason=NULL WHERE job=? AND token=?",
+                   (job["id"], token))
+
+
+def inspect(job):
+    """Internal read-back; payloads must not be projected onto public job summaries."""
+    with _store() as db:
+        return _row(db, job)
+
+
+class Attempt:
+    """Observe this built-in agent invocation without treating an error as safety proof."""
+
+    def __init__(self, job):
+        import threading
+        pending = job.get("_monitor_pending_commit") or {}
+        self.token = pending.get("token") if job.get("monitor_commit_policy") == "safe_retry" else None
+        self.job = job
+        self.tools_started = threading.Event()
+        self.started = False
+        self.result = None
+        self.response = None
+
+    def attach(self, agent):
+        if not self.token:
+            return
+        # An external runtime can execute tools before its event stream reports
+        # them. Missing callbacks never prove that its failed turn had no effect.
+        if (getattr(agent, "api_mode", None) == "codex_app_server"
+                or str(getattr(agent, "base_url", "")).lower().startswith(("acp://", "acp+tcp://"))):
+            self.tools_started.set()
+        execute_tools = getattr(agent, "_execute_tool_calls", None)
+        if callable(execute_tools):
+            def guarded_tools(*args, **kwargs):
+                self.tools_started.set()
+                return execute_tools(*args, **kwargs)
+            agent._execute_tool_calls = guarded_tools
+        original = getattr(agent, "tool_start_callback", None)
+
+        def on_start(*args, **kwargs):
+            self.tools_started.set()
+            if original is not None:
+                original(*args, **kwargs)
+
+        agent.tool_start_callback = on_start
+
+    def finish(self, worker):
+        if not self.token:
+            return
+        future = worker.get("future")
+        finished = future is None or future.done()
+        result = self.result or {}
+        requested_retry = (self.response or "").strip() == "[MONITOR_RETRY]"
+        safe_failure = (
+            not self.job.get("script") and not self.tools_started.is_set() and finished
+            and (requested_retry or (
+                result.get("failed") is True
+                and result.get("turn_exit_reason") != "interrupted"))
+        )
+        # A still-running watchdog worker may execute a tool later. Its absence
+        # from a partial transcript is never evidence that retry is safe.
+        settle(self.job, self.token, response=self.response if finished and not requested_retry else None,
+               safe_failure=safe_failure, completed=result.get("completed") is True and result.get("failed") is not True)

--- a/cron/monitor_pending.py
+++ b/cron/monitor_pending.py
@@ -44,8 +44,9 @@ def _store():
     else:
         os.close(fd)
     metadata = path.lstat()
+    owner_uid = os.getuid() if hasattr(os, "getuid") else None
     if (not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1
-            or (os.name != "nt" and (metadata.st_mode & 0o077 or metadata.st_uid != os.getuid()))):
+            or (os.name != "nt" and (metadata.st_mode & 0o077 or metadata.st_uid != owner_uid))):
         raise RecoveryRequired("monitor recovery store is not a private regular file")
     with closing(sqlite3.connect(path, timeout=5)) as db, db:
         db.row_factory = sqlite3.Row

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -470,6 +470,10 @@ from cron.executions import (
 
 # Response marker that suppresses delivery (output is still saved locally for audit).
 SILENT_MARKER = "[SILENT]"
+# Deferred-commit monitors use this exact marker for a transient verification
+# failure: no delivery and no hash commit, so the same observation retries on the
+# next tick instead of being consumed by a run that could not verify it.
+MONITOR_RETRY_MARKER = "[MONITOR_RETRY]"
 
 
 def _is_cron_silence_response(text: str) -> bool:
@@ -526,6 +530,10 @@ _INFLIGHT_MIN_ALLOWANCE_MINUTES = 30.0
 # false "ok" (#60432). Token keying keeps an interruption scoped to that exact execution: a later run of the
 # same job ID (recurring jobs reuse the ID every fire) must not inherit the stale flag.
 _interrupted_job_ids: set = set()
+# Executions that crossed the post-delivery monitor-commit linearization point. A
+# shutdown arriving after this point must not retroactively interrupt them, or the
+# committed hash and the recorded run status would disagree.
+_monitor_commit_in_progress: set = set()
 
 
 class _CancelEventLike(Protocol):
@@ -850,7 +858,21 @@ def mark_running_jobs_interrupted(
         ]
         if only_owners is not None:
             active_fires = [fire for fire in active_fires if (fire[1], fire[2]) in only_owners]
-        registered_ids = {job_id for _t, job_id, _o, _p in active_fires}
+        # Executions past the monitor-commit linearization point are logically complete:
+        # flagging them interrupted would make the run report failure after its hash was
+        # already committed. Keep them out of the flag set but still report the job ID so
+        # shutdown's interrupted-cron notice stays accurate.
+        committing_job_ids = {
+            fire[1]
+            for fire in active_fires
+            if fire[0] is not None and fire[0] in _monitor_commit_in_progress
+        }
+        active_fires = [
+            fire
+            for fire in active_fires
+            if fire[0] is None or fire[0] not in _monitor_commit_in_progress
+        ]
+        registered_ids = {job_id for _t, job_id, _o, _p in active_fires} | committing_job_ids
         if only_owners is None:
             active_fires.extend(
                 (None, job_id, None, _get_hermes_home())
@@ -1287,6 +1309,7 @@ def _run_no_agent_job(
 
 def _apply_monitor_gate(
     job: dict, job_id: str, job_name: str, extra_prompt: Optional[str],
+    defer_monitor_commit: Optional[list] = None,
 ) -> tuple[Optional[tuple], Optional[str]]:
     """Monitor gate (hash-suppressed change detection). Must run BEFORE any agent machinery so an
     unchanged tick costs no LLM/delivery. Returns ``(early_result | None, extra_prompt)``; when
@@ -1318,6 +1341,17 @@ def _apply_monitor_gate(
             True, f"{header}**Status:** no_change (agent run suppressed)\n", SILENT_MARKER, None,
         ), extra_prompt
     # Changed (or first run): inject monitor context via the per-run seam, then normal agent run.
+    if job.get("monitor_commit_policy") == "after_delivery":
+        # Deferred commit: check_monitor deliberately did NOT persist the hash. Stage it so the
+        # bookkeeping tail can commit it only after the agent succeeded AND delivery reported no
+        # error; anything short of that leaves the old hash so this observation retries.
+        pending_commit = {"new_hash": _mon.new_hash, "output": _mon.output}
+        job["_monitor_pending_commit"] = pending_commit
+        if defer_monitor_commit is not None:
+            defer_monitor_commit.append(pending_commit)
+        logger.info(
+            "Job '%s': staged deferred monitor commit hash=%s",
+            job_id, str(_mon.new_hash or "")[:12])
     if _mon.context_block:
         extra_prompt = (
             f"{_mon.context_block}\n\n{extra_prompt}" if extra_prompt else _mon.context_block
@@ -1928,6 +1962,7 @@ _RunResult = tuple[bool, str, str, Optional[str]]
 
 def _prepare_job_prompt(
     job: dict, job_id: str, job_name: str, extra_prompt: Optional[str], cancel_event,
+    defer_monitor_commit: Optional[list] = None,
 ) -> tuple[Optional[_RunResult], Optional[str]]:
     """Run every pre-agent gate and build the prompt. Returns ``(early_result, prompt)``: an early
     result short-circuits ``run_job`` (no_agent job, empty payload, monitor gate, wake gate,
@@ -1953,7 +1988,8 @@ def _prepare_job_prompt(
     if job_payload_is_empty(job):
         return _block_and_pause_job(job_id, job_name, EMPTY_PAYLOAD_ERROR), None
 
-    _early, extra_prompt = _apply_monitor_gate(job, job_id, job_name, extra_prompt)
+    _early, extra_prompt = _apply_monitor_gate(
+        job, job_id, job_name, extra_prompt, defer_monitor_commit)
     if _early is not None:
         return _early, None
 
@@ -2211,6 +2247,7 @@ class _FireAudit:
 def run_job(
     job: dict, *, defer_agent_teardown: Optional[list] = None, extra_prompt: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None, execution_id: Optional[str] = None,
+    defer_monitor_commit: Optional[list] = None,
 ) -> tuple[bool, str, str, Optional[str]]:
     """Execute a single cron job. Returns (success, full_output_doc, final_response, error).
     ``defer_agent_teardown``: if a list, the live agent is appended instead of torn down; the caller
@@ -2226,11 +2263,16 @@ def run_job(
     existing caller is unchanged.
     ``extra_prompt``: optional per-run context from ``cronjob(action='run', prompt=...)`` (#57331). Appended
     to the stored prompt for this fire only — never persisted to the job definition.
+
+    ``defer_monitor_commit``: if a list, a ``monitor_commit_policy='after_delivery'`` job's pending
+    hash/snapshot is appended instead of being persisted at detection time; the caller commits it
+    via ``cron.monitor.commit_monitor_state`` only after delivery succeeded.
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
 
-    early, prompt = _prepare_job_prompt(job, job_id, job_name, extra_prompt, cancel_event)
+    early, prompt = _prepare_job_prompt(
+        job, job_id, job_name, extra_prompt, cancel_event, defer_monitor_commit)
     if early is not None:
         return early
     from run_agent import AIAgent
@@ -2483,11 +2525,14 @@ def run_one_job(
                 execution_token=execution_token))
     finally:
         with _running_lock:
+            _monitor_commit_in_progress.discard(execution_token)
+            _interrupted_job_ids.discard(execution_token)
             executions = _running_fire_owners.get(job["id"])
             if executions is not None:
                 executions.pop(execution_token, None)
                 if not executions:
                     _running_fire_owners.pop(job["id"], None)
+                    _interrupted_job_ids.discard(job["id"])
 
 
 _OWNERSHIP_LOST_INTERRUPTED = "Interrupted by shutdown before terminal completion."
@@ -2612,6 +2657,28 @@ class _RunDelivery:
     incident_acked: bool = False
     failure_incident_id: Optional[str] = None
     side_effect_ownership_lost: bool = False
+    # Delivery failed for real. Separate from ``delivery_error`` because an exception can
+    # stringify to "" (``str(de)`` on a bare custom error), which would read as "no failure"
+    # and let a deferred monitor commit ACK an alert that never left the process.
+    delivery_failed: bool = False
+    # Deferred-commit monitors only: this observation must NOT be acknowledged, so the same
+    # event is re-offered on the next tick.
+    monitor_retry: bool = False
+
+
+def _monitor_event_requires_delivery(pending: Any) -> bool:
+    """True when a staged monitor observation carries ``events.event.requires_delivery``.
+
+    Health/system events must actually reach the operator; if the agent answers ``[SILENT]``
+    (or the job delivers locally) the observation is retried instead of silently acknowledged.
+    """
+    if not isinstance(pending, dict):
+        return False
+    try:
+        doc = json.loads(str(pending.get("output") or ""))
+        return doc.get("events", {}).get("event", {}).get("requires_delivery") is True
+    except (json.JSONDecodeError, AttributeError, TypeError):
+        return False
 
 
 def _save_compose_deliver(
@@ -2653,6 +2720,29 @@ def _save_compose_deliver(
         logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
         d.should_deliver = False
 
+    # Deferred-commit monitors: decide whether this observation may be acknowledged at all.
+    # The exact [MONITOR_RETRY] marker is the agent's "I could not verify this" answer; a
+    # requires_delivery event that was silenced (or routed to a local-only lane) must also
+    # retry rather than be consumed by a run the operator never saw.
+    pending_monitor = job.get("_monitor_pending_commit")
+    requires_delivery = _monitor_event_requires_delivery(pending_monitor)
+    if job.get("monitor_commit_policy") == "after_delivery" and pending_monitor and d.success:
+        d.monitor_retry = (
+            deliver_content.strip().upper() == MONITOR_RETRY_MARKER
+            or (
+                requires_delivery
+                and (
+                    _is_cron_silence_response(deliver_content)
+                    or _normalize_deliver_value(job.get("deliver", "local")) == "local"
+                )
+            )
+        )
+        if d.monitor_retry:
+            logger.info(
+                "Job '%s': monitor retry requested — suppressing delivery and hash commit",
+                job["id"])
+            d.should_deliver = False
+
     if d.should_deliver and fence.lost():
         d.should_deliver = False
         logger.warning("Job '%s': skipping delivery after fire claim ownership loss", job["id"])
@@ -2677,11 +2767,19 @@ def _save_compose_deliver(
                 # on the failure path) honor the job's failure_deliver override (NS-788).
                 for_failure=not d.success,
             )
+            if d.delivery_error is not None:
+                d.delivery_failed = True
+                d.delivery_error = str(d.delivery_error) or "DeliveryError"
     except Exception as de:
         if isinstance(de, _FireClaimLostDuringSideEffect):
             raise
-        d.delivery_error = str(de)
+        d.delivery_failed = True
+        d.delivery_error = str(de) or type(de).__name__
         logger.error("Delivery failed for job %s: %s", job["id"], de)
+    # A required alert that never resolved a target or failed to send must retry, whatever the
+    # agent answered.
+    if requires_delivery and (d.unresolved_origin or d.delivery_failed):
+        d.monitor_retry = True
 
 
 def _finish_interrupted_run(job: dict, execution_id: str, delivery_error: Optional[str]) -> None:
@@ -2704,6 +2802,57 @@ def _finish_interrupted_run(job: dict, execution_id: str, delivery_error: Option
         error="Interrupted by gateway shutdown before terminal completion.")
 
 
+def _commit_deferred_monitor_state(
+    d: _RunDelivery, execution_token: Optional[object], fence: _FireOwnership,
+    staged: Optional[list] = None,
+) -> bool:
+    """Commit a deferred monitor observation. Returns False if ownership was lost first.
+
+    Runs AFTER delivery: the hash advances only when the agent succeeded, no retry was
+    requested, and the notice actually left the process. Anything else leaves the previous
+    hash so the same event is re-offered next tick.
+    """
+    job = d.job
+    pending = job.pop("_monitor_pending_commit", None)
+    if staged:
+        pending = staged[-1]
+    if not (pending and d.success and not d.monitor_retry
+            and not d.delivery_failed and not d.unresolved_origin):
+        logger.info(
+            "Job '%s': deferred monitor commit skipped pending=%s success=%s retry=%s "
+            "delivery_failed=%s unresolved_origin=%s",
+            job["id"], bool(pending), d.success, d.monitor_retry, d.delivery_failed,
+            d.unresolved_origin)
+        return True
+
+    from cron.monitor import commit_monitor_state
+
+    with fence.side_effect_fence() as owns_commit:
+        # Ownership revalidation does file I/O (heartbeat_fire_claim); do it BEFORE taking
+        # _running_lock. Shutdown holds that lock while marking jobs interrupted, so blocking
+        # on the jobs-store fence underneath it would invert the lock order.
+        claim_lost = fence.lost()
+        with _running_lock:
+            # Consume any interrupt flag under the same lock that publishes the commit
+            # marker, so shutdown either wins outright or is excluded from this execution.
+            interrupted_at_commit = (
+                execution_token is not None and execution_token in _interrupted_job_ids
+            ) or job["id"] in _interrupted_job_ids
+            if interrupted_at_commit:
+                if execution_token is not None:
+                    _interrupted_job_ids.discard(execution_token)
+                _interrupted_job_ids.discard(job["id"])
+            if not owns_commit or claim_lost or interrupted_at_commit:
+                return False
+            if execution_token is not None:
+                _monitor_commit_in_progress.add(execution_token)
+        commit_monitor_state(job["id"], pending.get("new_hash"), pending.get("output") or "")
+        logger.info(
+            "Job '%s': deferred monitor commit persisted hash=%s",
+            job["id"], str(pending.get("new_hash") or "")[:12])
+    return True
+
+
 def _finish_completed_run(d: _RunDelivery, fire_owner: Optional[str], execution_id: str) -> bool:
     """mark_job_run (owner-fenced) + execution ledger row for a run that reached delivery."""
     job = d.job
@@ -2718,6 +2867,9 @@ def _finish_completed_run(d: _RunDelivery, fire_owner: Optional[str], execution_
         mark_kwargs["expected_fire_owner"] = fire_owner
     if d.blocked_config:
         mark_kwargs["status"] = "blocked_config"
+    elif d.monitor_retry:
+        # Not "ok": the observation was not acknowledged and will be re-offered.
+        mark_kwargs["status"] = "monitor_retry"
     marked = mark_job_run(job["id"], d.success, d.error, **mark_kwargs)
     if fire_owner is not None and not marked:
         finish_execution(
@@ -2854,6 +3006,9 @@ def _run_one_job_body(
         # hand the agent back instead, and we tear it down below once delivery is done. Defense-in-depth
         # alongside the interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
+        # Staged after-delivery monitor commit(s); see _commit_deferred_monitor_state. Held here
+        # (not only on the job dict) so the pending hash survives any later mutation of `job`.
+        _deferred_monitor_commits: list = []
 
         def _teardown_deferred() -> None:
             # run_job's finally still hands back the agent when it raises; tear it down here so a failed run
@@ -2869,6 +3024,10 @@ def _run_one_job_body(
             "defer_agent_teardown": _deferred_agents,
             "extra_prompt": extra_prompt,
             "execution_id": execution_id}
+        if job.get("monitor_commit_policy") == "after_delivery":
+            # Only deferred-commit monitors need the staging list; keeping it off the default
+            # call keeps the signature that every other caller (and test double) expects.
+            _run_kwargs["defer_monitor_commit"] = _deferred_monitor_commits
         if fire_claim_lost is not None:
             _run_kwargs["cancel_event"] = fire_claim_lost
         try:
@@ -2910,6 +3069,15 @@ def _run_one_job_body(
         if _consume_interrupted_flag(job["id"], execution_token):
             _finish_interrupted_run(job, execution_id, delivery_error)
             return True
+
+        # Post-delivery monitor commit (monitor_commit_policy='after_delivery'). Must run after
+        # the interrupted check and before mark_job_run: the hash may only advance for a run that
+        # both succeeded and delivered, and the recorded status must match what was committed.
+        if not _commit_deferred_monitor_state(
+            d, execution_token, fence, _deferred_monitor_commits
+        ):
+            d.success = False
+            d.error = "Fire claim ownership lost before monitor state commit."
 
         return _finish_completed_run(d, fire_owner, execution_id)
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1346,6 +1346,10 @@ def _apply_monitor_gate(
         # bookkeeping tail can commit it only after the agent succeeded AND delivery reported no
         # error; anything short of that leaves the old hash so this observation retries.
         pending_commit = {"new_hash": _mon.new_hash, "output": _mon.output}
+        # The defer list is the only channel that crosses the process boundary; the job-dict
+        # key is a same-process fallback for callers that don't pass `defer_monitor_commit`,
+        # popped by the decision point in the same execution. Never persist this key — it is
+        # scratch state for one run.
         job["_monitor_pending_commit"] = pending_commit
         if defer_monitor_commit is not None:
             defer_monitor_commit.append(pending_commit)
@@ -2728,7 +2732,7 @@ def _save_compose_deliver(
     requires_delivery = _monitor_event_requires_delivery(pending_monitor)
     if job.get("monitor_commit_policy") == "after_delivery" and pending_monitor and d.success:
         d.monitor_retry = (
-            deliver_content.strip().upper() == MONITOR_RETRY_MARKER
+            deliver_content.strip() == MONITOR_RETRY_MARKER
             or (
                 requires_delivery
                 and (

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1341,11 +1341,13 @@ def _apply_monitor_gate(
             True, f"{header}**Status:** no_change (agent run suppressed)\n", SILENT_MARKER, None,
         ), extra_prompt
     # Changed (or first run): inject monitor context via the per-run seam, then normal agent run.
-    if job.get("monitor_commit_policy") == "after_delivery":
+    if job.get("monitor_commit_policy") in {"after_delivery", "safe_retry"}:
         # Deferred commit: check_monitor deliberately did NOT persist the hash. Stage it so the
         # bookkeeping tail can commit it only after the agent succeeded AND delivery reported no
         # error; anything short of that leaves the old hash so this observation retries.
         pending_commit = {"new_hash": _mon.new_hash, "output": _mon.output}
+        if _mon.pending_token:
+            pending_commit["token"] = _mon.pending_token
         # The defer list is the only channel that crosses the process boundary; the job-dict
         # key is a same-process fallback for callers that don't pass `defer_monitor_commit`,
         # popped by the decision point in the same execution. Never persist this key — it is
@@ -2290,6 +2292,8 @@ def run_job(
     _session_db = None
     _audit: Optional[_FireAudit] = None
     _worker_state: dict = {}
+    from cron.monitor_pending import Attempt
+    monitor_attempt = Attempt(job)
     scope = _CronRunScope(job, job_id, execution_id)
     try:
         scope.enter()
@@ -2311,11 +2315,21 @@ def run_job(
             AIAgent, job, _cfg, setup, workdir=scope.workdir, session_id=_cron_session_id,
             session_db=_session_db)
         _audit = _FireAudit(job, job_id, model)
+        monitor_attempt.attach(agent)
+        monitor_attempt.started = True
 
         result = _run_agent_with_watchdog(
             agent, prompt, job, job_id, job_name, scope.task_id, cancel_event,
             worker_state=_worker_state)
+        monitor_attempt.result = result
+        if monitor_attempt.token and result.get("completed") is not True and result.get("failed") is not True:
+            partial = result.get("final_response")
+            monitor_attempt.response = partial if isinstance(partial, str) and partial else None
+            raise RuntimeError("Monitor generation did not report verified completion")
         final_response = _final_response_from_result(result, job_id, job_name, AIAgent)
+        monitor_attempt.response = final_response
+        if monitor_attempt.token and not final_response.strip():
+            raise RuntimeError("Monitor generation returned no result")
         # Keep final_response clean for delivery logic (empty = no delivery).
         logged_response = final_response if final_response else "(No response generated)"
         output = _run_doc_header(job, job_name, job_id, prompt) + f"## Response\n\n{logged_response}\n"
@@ -2356,6 +2370,7 @@ def run_job(
                     defer_agent_teardown.append(agent)
             else:
                 _teardown_cron_agent(agent, job_id)
+        monitor_attempt.finish(_worker_state)
 
 
 def _teardown_cron_agent(
@@ -2730,7 +2745,9 @@ def _save_compose_deliver(
     # retry rather than be consumed by a run the operator never saw.
     pending_monitor = job.get("_monitor_pending_commit")
     requires_delivery = _monitor_event_requires_delivery(pending_monitor)
-    if job.get("monitor_commit_policy") == "after_delivery" and pending_monitor and d.success:
+    if job.get("monitor_commit_policy") == "safe_retry" and pending_monitor:
+        requires_delivery = requires_delivery or _normalize_deliver_value(job.get("deliver")) != "local"
+    if job.get("monitor_commit_policy") in {"after_delivery", "safe_retry"} and pending_monitor and d.success:
         d.monitor_retry = (
             deliver_content.strip() == MONITOR_RETRY_MARKER
             or (
@@ -2831,6 +2848,14 @@ def _commit_deferred_monitor_state(
 
     from cron.monitor import commit_monitor_state
 
+    if job.get("monitor_commit_policy") == "safe_retry":
+        from cron import monitor_pending
+        retained = monitor_pending.inspect(job)
+        if (not retained or retained["state"] != "ready"
+                or retained["token"] != pending.get("token")
+                or job.get("last_delivery_unverified") or job.get("last_delivery_queued")):
+            raise monitor_pending.RecoveryRequired("monitor delivery outcome requires reconciliation")
+
     with fence.side_effect_fence() as owns_commit:
         # Ownership revalidation does file I/O (heartbeat_fire_claim); do it BEFORE taking
         # _running_lock. Shutdown holds that lock while marking jobs interrupted, so blocking
@@ -2851,6 +2876,8 @@ def _commit_deferred_monitor_state(
             if execution_token is not None:
                 _monitor_commit_in_progress.add(execution_token)
         commit_monitor_state(job["id"], pending.get("new_hash"), pending.get("output") or "")
+        if job.get("monitor_commit_policy") == "safe_retry":
+            monitor_pending.acknowledge(job, pending["token"])
         logger.info(
             "Job '%s': deferred monitor commit persisted hash=%s",
             job["id"], str(pending.get("new_hash") or "")[:12])
@@ -3028,7 +3055,7 @@ def _run_one_job_body(
             "defer_agent_teardown": _deferred_agents,
             "extra_prompt": extra_prompt,
             "execution_id": execution_id}
-        if job.get("monitor_commit_policy") == "after_delivery":
+        if job.get("monitor_commit_policy") in {"after_delivery", "safe_retry"}:
             # Only deferred-commit monitors need the staging list; keeping it off the default
             # call keeps the signature that every other caller (and test double) expects.
             _run_kwargs["defer_monitor_commit"] = _deferred_monitor_commits

--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -938,6 +938,10 @@ def _send_media_via_adapter(
             except TimeoutError:
                 future.cancel()
                 raise
+            if job.get("monitor_commit_policy") == "safe_retry":
+                if not (_confirm_adapter_delivery(result, job_ref["id"], require_message_id=True)):
+                    _note_target_error(job_ref, "media acknowledgement unavailable; outcome unknown", errors)
+                continue
             if result and not getattr(result, "success", True):
                 _note_target_error(
                     job_ref,
@@ -959,7 +963,9 @@ def _result_field(send_result, key: str, default=None):
 
 
 def _confirm_adapter_delivery(
-    send_result, job_id: str = "?", unverified: Optional[list] = None) -> bool:
+    send_result, job_id: str = "?", unverified: Optional[list] = None,
+    *, require_message_id: bool = False,
+) -> bool:
     """Return True only if ``send_result`` unambiguously confirms delivery. ``None`` or no
     ``success`` attr/key is NOT success (would log "delivered" while nothing was sent).
     ``delivered is False`` REJECTS even with truthy ``success`` (the silence-narration filter
@@ -983,6 +989,15 @@ def _confirm_adapter_delivery(
         return False
     if _result_field(send_result, "delivered") is False:
         return False
+    if require_message_id:
+        if _result_field(send_result, "success") is not True:
+            return False
+        message_id = _result_field(send_result, "message_id")
+        if (type(message_id) not in (str, int) or not str(message_id).strip()
+                or (type(message_id) is int and message_id <= 0)):
+            if unverified is not None:
+                unverified.append(True)
+            return False
     if (
         _result_field(send_result, "message_id") is None
         and not _result_field(send_result, "raw_response")
@@ -1243,6 +1258,10 @@ def _live_send_text(
     try:
         send_result = future.result(timeout=60)
     except TimeoutError:
+        if job.get("monitor_commit_policy") == "safe_retry":
+            delivery_errors.append("monitor delivery acknowledgement timed out; outcome unknown")
+            unverified_targets.append(t.where)
+            return False, True, None
         # Slow confirmation != failure; future.cancel() disambiguates. False -> already in flight,
         # cannot be un-sent, standalone resend would DUPLICATE: assume delivered. True -> never
         # started (loop wedged): MUST fall through to standalone or it is silently dropped.
@@ -1268,7 +1287,9 @@ def _live_send_text(
     send_raw_response = _result_field(send_result, "raw_response")
     delivered_message_id = _result_field(send_result, "message_id")
     _evidence_gap: list = []
-    send_success = _confirm_adapter_delivery(send_result, job["id"], _evidence_gap)
+    send_success = _confirm_adapter_delivery(
+        send_result, job["id"], _evidence_gap,
+        require_message_id=job.get("monitor_commit_policy") == "safe_retry")
     if send_success and _evidence_gap:
         unverified_targets.append(t.where)
 
@@ -1421,7 +1442,8 @@ def _deliver_via_live_adapter(
                 route_thread_id if route_thread_id is not None else "-",
                 delivered_message_id if delivered_message_id is not None else "-")
             delivered = True
-            _seed_live_delivery_sessions(t, delivered_message_id)
+            if not (job.get("monitor_commit_policy") == "safe_retry" and timed_out):
+                _seed_live_delivery_sessions(t, delivered_message_id)
     except Exception as e:
         err_msg = f"live adapter delivery to {t.where} failed: {e}"
         if not any(err_msg in err for err in target_errors):
@@ -1461,6 +1483,22 @@ def _standalone_send(
     if not content.strip() and not media_files:
         return _warned(f"standalone send skipped (empty text and no media) for {t.where}")
     coro = _send()
+    if job.get("monitor_commit_policy") == "safe_retry":
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            try:
+                return asyncio.run(coro), None
+            except Exception as exc:
+                return _failed(exc)  # possibly dispatched: never call _send a second time
+        coro.close()  # created but never started; choose the thread lane before dispatch
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
+            return pool.submit(contextvars.copy_context().run, asyncio.run, _send()).result(timeout=30), None
+        except Exception as exc:
+            return _failed(exc)
+        finally:
+            pool.shutdown(wait=False)
     try:
         return asyncio.run(coro), None
     except RuntimeError as run_err:
@@ -1506,6 +1544,10 @@ def _deliver_standalone(
         target_errors.append(err)
         delivery_errors.extend(target_errors)
         return
+    if job.get("monitor_commit_policy") == "safe_retry":
+        if not (_confirm_adapter_delivery(result, job["id"], require_message_id=True)):
+            delivery_errors.append("standalone acknowledgement unavailable; outcome unknown")
+            return
     # Standalone senders report per-file attachment failures in ``warnings`` while returning
     # success; surface them so a vanished attachment doesn't mark the run ok.
     for _w in (result.get("warnings") if isinstance(result, dict) else None) or []:
@@ -1678,6 +1720,8 @@ def _deliver_result(
         from cron.jobs import get_job
         refreshed = get_job(job["id"]) or {}
         job["last_delivery_queued"] = refreshed.get("last_delivery_queued")
+        if job.get("monitor_commit_policy") == "safe_retry":
+            job["last_delivery_unverified"] = refreshed.get("last_delivery_unverified")
         return error
 
     from gateway.config import load_gateway_config
@@ -1766,6 +1810,9 @@ def _deliver_result(
             target_errors=target_errors, delivery_errors=delivery_errors,
             unverified_targets=unverified_targets,
         )
+        if not delivered and t.live_adapter_ready and job.get("monitor_commit_policy") == "safe_retry":
+            delivery_errors.extend(target_errors or ["live delivery outcome unknown"])
+            continue  # failure/exception does not prove that a fallback send is safe
         if not delivered:
             _deliver_standalone(
                 t, cleaned_delivery_content, media_files, target_errors, delivery_errors)

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -544,6 +544,7 @@ _JOB_ARG_FIELDS = (("name", "name"), ("deliver", "deliver"), ("failure_deliver",
                    ("repeat", "repeat"), ("script", "script"), ("workdir", "workdir"),
                    ("model", "model"), ("provider", "model_provider"),
                    ("monitor_script", "monitor_script"), ("monitor_url", "monitor_url"),
+                   ("monitor_commit_policy", "monitor_commit_policy"),
                    ("continuity", "continuity"), ("reasoning_effort", "reasoning_effort"))
 
 
@@ -556,6 +557,7 @@ _JOB_DETAIL_LINES = (
     ("script", "  Script: {}"),
     ("monitor_script", "  Monitor: {} (agent runs only on output change)"),
     ("monitor_url", "  Monitor: {} (agent runs only on output change)"),
+    ("monitor_commit_policy", "  Monitor commit: {}"),
     ("no_agent", "  Mode: no-agent (script stdout delivered directly)"),
     ("continuity", "  Continuity: on (each run sees the previous run's output)"),
     ("workdir", "  Workdir: {}"))

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -60,6 +60,11 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         help="Monitor mode: http(s) URL fetched with a bounded GET each tick "
             "instead of a script. Same hash-suppression semantics as "
             "--monitor-script.")
+    cron_create.add_argument("--monitor-commit-policy",
+        choices=("detection_time", "after_delivery"),
+        help="Monitor state commit boundary. detection_time (default) commits the new hash as "
+            "soon as the change is detected; after_delivery retries the same change until the "
+            "triggered agent run and its delivery succeed.")
     cron_create.add_argument("--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
     )
@@ -123,6 +128,9 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "--monitor-script`). Pass empty string to clear.")
     cron_edit.add_argument("--monitor-url", dest="monitor_url",
         help=("Set/replace the monitor source URL. Pass empty string to clear."))
+    cron_edit.add_argument("--monitor-commit-policy",
+        choices=("detection_time", "after_delivery"),
+        help="Set the monitor state commit boundary.")
     cron_edit.add_argument("--workdir",
         help="Absolute path for the job to run from (injects AGENTS.md etc. and sets terminal cwd). Pass empty string to clear.",
     )

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -61,10 +61,11 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "instead of a script. Same hash-suppression semantics as "
             "--monitor-script.")
     cron_create.add_argument("--monitor-commit-policy",
-        choices=("detection_time", "after_delivery"),
+        choices=("detection_time", "after_delivery", "safe_retry"),
         help="Monitor state commit boundary. detection_time (default) commits the new hash as "
             "soon as the change is detected; after_delivery retries the same change until the "
-            "triggered agent run and its delivery succeed.")
+            "triggered agent run and its delivery succeed. safe_retry retains uncertain outcomes "
+            "and bounds retries after confirmed pre-effect failures.")
     cron_create.add_argument("--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
     )
@@ -129,7 +130,7 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_edit.add_argument("--monitor-url", dest="monitor_url",
         help=("Set/replace the monitor source URL. Pass empty string to clear."))
     cron_edit.add_argument("--monitor-commit-policy",
-        choices=("detection_time", "after_delivery"),
+        choices=("detection_time", "after_delivery", "safe_retry"),
         help="Set the monitor state commit boundary.")
     cron_edit.add_argument("--workdir",
         help="Absolute path for the job to run from (injects AGENTS.md etc. and sets terminal cwd). Pass empty string to clear.",

--- a/tests/computer_use/test_cua_no_overlay.py
+++ b/tests/computer_use/test_cua_no_overlay.py
@@ -11,12 +11,14 @@ probe), not specific config snapshots.
 """
 
 import os
+import sys
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
 from tools.computer_use import cua_backend
 from tools.computer_use import cua_backend_driver
+from tools.computer_use import cua_backend_daemon
 
 
 class TestNoOverlayFlag:
@@ -245,9 +247,17 @@ class TestEmbeddedDaemonOverlayFlag:
             cua_backend.subprocess, "Popen", return_value=process,
         ) as popen, patch.object(
             cua_backend.subprocess, "run", return_value=status,
-        ), patch.object(cua_backend.threading, "Thread"):
+        ), patch.object(cua_backend.threading, "Thread"), patch.object(
+            cua_backend_daemon, "_resolve_cua_driver_app_path", return_value="/fixture/CuaDriver.app",
+        ), patch.object(
+            cua_backend_daemon, "_validate_cua_driver_app_signature",
+        ) as validate_signature:
             daemon.start()
 
         command = popen.call_args.args[0]
-        assert command[:2] == ["/usr/bin/cua-driver", "serve"]
+        if sys.platform == "darwin":
+            assert command[:7] == ["/usr/bin/open", "-n", "-g", "-a", "/fixture/CuaDriver.app", "--args", "serve"]
+            validate_signature.assert_called_once_with("/fixture/CuaDriver.app")
+        else:
+            assert command[:2] == ["/usr/bin/cua-driver", "serve"]
         assert "--no-overlay" in command

--- a/tests/cron/test_cron_live_delivery_confirmation.py
+++ b/tests/cron/test_cron_live_delivery_confirmation.py
@@ -404,3 +404,31 @@ class TestUnverifiedDeliveryIsRecordedOnTheJob:
 def test_scheduler_module_exposes_the_confirmation_helper():
     """Guard the import surface the delivery block depends on."""
     assert callable(sched_delivery._confirm_adapter_delivery)
+
+
+def test_safe_retry_requires_acknowledgement_without_fallback_send():
+    for result, accepted in ((_SendResult(), False),
+                             (_SendResult(message_id=True), False),
+                             (_SendResult(message_id={"id": "bad"}), False),
+                             (_SendResult(success=False), False),
+                             (_SendResult(message_id=1234), True)):
+        job = {**_job(), "monitor_commit_policy": "safe_retry"}
+        error, sent, fallback = _run(job, "summary", result)
+        assert len(sent) == 1 and fallback == []
+        assert (error is None) == accepted
+
+
+def test_safe_retry_timeout_never_resends_when_cancel_would_succeed(monkeypatch):
+    class LostConfirmation(Future):
+        def set_result(self, result):
+            pass  # provider coroutine ran, but its acknowledgement was lost
+        def result(self, timeout=None):
+            raise TimeoutError("confirmation lost")
+        def cancel(self):
+            raise AssertionError("cancellation cannot prove that the provider did nothing")
+
+    monkeypatch.setitem(globals(), "Future", LostConfirmation)
+    job = {**_job(), "monitor_commit_policy": "safe_retry"}
+    error, sent, fallback = _run(job, "summary", _SendResult(message_id=1234))
+    assert len(sent) == 1 and fallback == []
+    assert error and "outcome unknown" in error

--- a/tests/cron/test_file_permissions.py
+++ b/tests/cron/test_file_permissions.py
@@ -105,7 +105,8 @@ class TestConfigFilePermissions(unittest.TestCase):
             self.assertEqual(file_mode, 0o600)
 
     def test_ensure_hermes_home_sets_0700(self):
-        home = Path(self.tmpdir) / ".hermes"
+        # Test an ordinary directory, not macOS /var -> /private/var ownership.
+        home = (Path(self.tmpdir) / ".hermes").resolve()
         with patch("hermes_cli.config.get_hermes_home", return_value=home):
             from hermes_cli.config import ensure_hermes_home
             ensure_hermes_home()

--- a/tests/cron/test_monitor_kind.py
+++ b/tests/cron/test_monitor_kind.py
@@ -22,8 +22,10 @@ enabler: #80774.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import sys
+import threading
 
 import pytest
 
@@ -77,7 +79,12 @@ def _install_agent_stubs(monkeypatch, observed: dict):
         def run_conversation(self, prompt, *_a, **_kw):
             observed["agent_runs"] += 1
             observed["prompts"].append(prompt)
-            return {"final_response": "agent done", "messages": []}
+            if observed.get("raise_error"):
+                raise RuntimeError(str(observed["raise_error"]))
+            return {
+                "final_response": observed.get("final_response", "agent done"),
+                "messages": [],
+            }
 
         def get_activity_summary(self):
             return {"seconds_since_activity": 0.0}
@@ -251,6 +258,99 @@ def test_hash_is_exact_bytes(hermes_env):
     assert hash_monitor_output("a\nb") != hash_monitor_output("a\nb ")
 
 
+def test_deferred_monitor_commit_propagates_snapshot_write_failure(
+    hermes_env, monkeypatch
+):
+    from pathlib import Path
+
+    from cron.jobs import create_job, get_job
+    from cron.monitor import commit_monitor_state
+
+    job = create_job(prompt="p", schedule="every 5m", deliver="local")
+
+    def fail_write(*_args, **_kwargs):
+        raise OSError("simulated snapshot write failure")
+
+    monkeypatch.setattr(Path, "write_text", fail_write)
+
+    with pytest.raises(OSError, match="snapshot write failure"):
+        commit_monitor_state(job["id"], "abc123", "state A")
+
+    assert get_job(job["id"]).get("monitor_state") is None
+
+
+def test_deferred_monitor_commit_rolls_back_snapshot_when_hash_update_fails(
+    hermes_env, monkeypatch
+):
+    import cron.jobs as jobs
+    from cron.jobs import create_job, get_job
+    from cron.monitor import _read_last_output, commit_monitor_state
+
+    job = create_job(prompt="p", schedule="every 5m", deliver="local")
+    commit_monitor_state(job["id"], "a" * 64, "state A")
+
+    def fail_update(*_args, **_kwargs):
+        raise OSError("simulated jobs write failure")
+
+    monkeypatch.setattr(jobs, "update_job", fail_update)
+    with pytest.raises(OSError, match="jobs write failure"):
+        commit_monitor_state(job["id"], "b" * 64, "state B")
+
+    assert _read_last_output(job["id"]) == "state A"
+    assert get_job(job["id"])["monitor_state"]["last_output_hash"] == "a" * 64
+
+
+def test_deferred_monitor_commit_fails_before_write_if_old_snapshot_is_unreadable(
+    hermes_env, monkeypatch
+):
+    from pathlib import Path
+
+    from cron.jobs import create_job, get_job
+    from cron.monitor import _read_last_output, commit_monitor_state
+
+    job = create_job(prompt="p", schedule="every 5m", deliver="local")
+    commit_monitor_state(job["id"], "a" * 64, "state A")
+    real_read_text = Path.read_text
+
+    def fail_snapshot_read(path, *args, **kwargs):
+        if path.name == "monitor_last_output.txt":
+            raise OSError("simulated snapshot read failure")
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_snapshot_read)
+    with pytest.raises(OSError, match="snapshot read failure"):
+        commit_monitor_state(job["id"], "b" * 64, "state B")
+    monkeypatch.setattr(Path, "read_text", real_read_text)
+
+    assert _read_last_output(job["id"]) == "state A"
+    assert get_job(job["id"])["monitor_state"]["last_output_hash"] == "a" * 64
+
+
+def test_after_delivery_policy_records_commit_failure_without_advancing_hash(
+    hermes_env, monkeypatch
+):
+    import cron.monitor as monitor
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+
+    def fail_commit(*_args, **_kwargs):
+        raise OSError("simulated commit failure")
+
+    monkeypatch.setattr(monitor, "commit_monitor_state", fail_commit)
+
+    assert sched.run_one_job(job) is False
+
+    stored = get_job(job["id"])
+    assert stored.get("monitor_state") is None
+    assert stored["last_status"] == "error"
+
+
 def test_unified_diff_is_capped(hermes_env):
     from cron.monitor import MAX_DIFF_CHARS, build_monitor_diff
 
@@ -291,6 +391,560 @@ def test_first_run_always_runs_agent(hermes_env, monkeypatch):
     assert observed["agent_runs"] == 1
     # First run: new output is injected as monitor context.
     assert "state A" in observed["prompts"][0]
+
+
+def test_after_delivery_policy_defers_monitor_hash_commit(hermes_env, monkeypatch):
+    from cron.jobs import get_job, update_job
+    from cron.scheduler import run_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    pending_commits = []
+
+    success, doc, final, error = run_job(
+        job, defer_monitor_commit=pending_commits
+    )
+
+    assert success is True
+    assert error is None
+    assert observed["agent_runs"] == 1
+    assert get_job(job["id"]).get("monitor_state") is None
+    pending = job.get("_monitor_pending_commit")
+    assert pending and pending["new_hash"] and pending["output"] == "state A"
+    assert pending_commits == [pending]
+
+
+def test_after_delivery_policy_commits_after_successful_end_to_end_run(
+    hermes_env, monkeypatch
+):
+    from cron.jobs import get_job, update_job
+    from cron.scheduler import run_one_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+
+    assert run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored["last_status"] == "ok"
+    assert stored["monitor_state"]["last_output_hash"]
+
+
+def test_after_delivery_policy_silent_success_commits_without_delivery(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed = {"final_response": "[SILENT]"}
+    _install_agent_stubs(monkeypatch, observed)
+    deliveries = []
+    monkeypatch.setattr(
+        sched,
+        "_deliver_result",
+        lambda *_a, **_kw: deliveries.append(_a[1]) or None,
+    )
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored["last_status"] == "ok"
+    assert stored["monitor_state"]["last_output_hash"]
+    assert deliveries == []
+
+
+def test_required_delivery_event_rejects_silent_agent_response(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    body = (
+        "echo '{\"version\":4,\"events\":{\"event\":"
+        "{\"event_id\":\"health-1\",\"requires_delivery\":true}}}'\n"
+    )
+    job = _make_monitor_job(hermes_env, body)
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed = {"final_response": "[SILENT]"}
+    _install_agent_stubs(monkeypatch, observed)
+    deliveries = []
+    monkeypatch.setattr(
+        sched,
+        "_deliver_result",
+        lambda *_a, **_kw: deliveries.append(_a[1]) or None,
+    )
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored["last_status"] == "monitor_retry"
+    assert stored.get("monitor_state") is None
+    assert deliveries == []
+
+
+def test_required_delivery_event_rejects_local_only_delivery(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    body = (
+        "echo '{\"version\":4,\"events\":{\"event\":"
+        "{\"event_id\":\"health-1\",\"requires_delivery\":true}}}'\n"
+    )
+    job = _make_monitor_job(hermes_env, body)
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed = {"final_response": "health alert"}
+    _install_agent_stubs(monkeypatch, observed)
+    monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored["last_status"] == "monitor_retry"
+    assert stored.get("monitor_state") is None
+
+
+def test_after_delivery_policy_retry_marker_suppresses_delivery_and_commit(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed = {"final_response": "[MONITOR_RETRY]"}
+    _install_agent_stubs(monkeypatch, observed)
+    deliveries = []
+    monkeypatch.setattr(
+        sched,
+        "_deliver_result",
+        lambda *_a, **_kw: deliveries.append(_a[1]) or None,
+    )
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored["last_status"] == "monitor_retry"
+    assert stored.get("monitor_state") is None
+    assert deliveries == []
+
+
+def test_after_delivery_policy_retry_then_success_commits_and_suppresses_next_tick(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed = {"final_response": "[MONITOR_RETRY]"}
+    _install_agent_stubs(monkeypatch, observed)
+    deliveries = []
+    monkeypatch.setattr(
+        sched,
+        "_deliver_result",
+        lambda *_a, **_kw: deliveries.append(_a[1]) or None,
+    )
+
+    assert sched.run_one_job(job) is True
+    assert get_job(job["id"]).get("monitor_state") is None
+    assert observed["agent_runs"] == 1
+
+    observed["final_response"] = "verified report"
+    assert sched.run_one_job(get_job(job["id"])) is True
+    assert get_job(job["id"])["monitor_state"]["last_output_hash"]
+    assert observed["agent_runs"] == 2
+
+    assert sched.run_one_job(get_job(job["id"])) is True
+    assert observed["agent_runs"] == 2
+    assert deliveries == ["verified report"]
+
+
+def test_plain_cron_treats_monitor_retry_marker_as_normal_output(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import create_job, get_job
+
+    job = create_job(
+        prompt="ordinary job",
+        schedule="every 5m",
+        deliver="local",
+    )
+    observed = {"final_response": "[MONITOR_RETRY]"}
+    _install_agent_stubs(monkeypatch, observed)
+    deliveries = []
+    monkeypatch.setattr(
+        sched,
+        "_deliver_result",
+        lambda *_a, **_kw: deliveries.append(_a[1]) or None,
+    )
+
+    assert sched.run_one_job(job) is True
+
+    assert deliveries == ["[MONITOR_RETRY]"]
+    assert get_job(job["id"])["last_status"] == "ok"
+
+
+def test_default_eager_monitor_treats_retry_marker_as_normal_output(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    observed = {"final_response": "[MONITOR_RETRY]"}
+    _install_agent_stubs(monkeypatch, observed)
+    deliveries = []
+    monkeypatch.setattr(
+        sched,
+        "_deliver_result",
+        lambda *_a, **_kw: deliveries.append(_a[1]) or None,
+    )
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert deliveries == ["[MONITOR_RETRY]"]
+    assert stored["monitor_state"]["last_output_hash"]
+
+
+def test_after_delivery_policy_does_not_commit_on_delivery_failure(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    monkeypatch.setattr(
+        sched,
+        "_deliver_result",
+        lambda *_a, **_kw: "simulated delivery failure",
+    )
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored.get("monitor_state") is None
+    assert stored["last_delivery_error"] == "simulated delivery failure"
+
+
+def test_after_delivery_policy_does_not_commit_on_empty_message_delivery_exception(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+
+    def fail_delivery(*_a, **_kw):
+        raise TimeoutError()
+
+    monkeypatch.setattr(sched, "_deliver_result", fail_delivery)
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored.get("monitor_state") is None
+    assert stored["last_delivery_error"] == "TimeoutError"
+
+
+def test_after_delivery_policy_does_not_commit_when_origin_is_unresolved(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(
+        job["id"],
+        {"monitor_commit_policy": "after_delivery", "deliver": "origin"},
+    )
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored.get("monitor_state") is None
+
+
+def test_after_delivery_policy_fences_monitor_commit_against_owner_loss(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(
+        job["id"],
+        {
+            "monitor_commit_policy": "after_delivery",
+            "fire_claim": {"by": "owner-a", "at": "2026-01-01T00:00:00+00:00"},
+        },
+    )
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    fence_calls = []
+
+    @contextlib.contextmanager
+    def lose_owner_before_commit(_job_id, *, expected_owner):
+        fence_calls.append(expected_owner)
+        # Saving output and delivery still belong to owner-a. The claim is
+        # lost only at the deferred monitor-commit boundary.
+        yield len(fence_calls) <= 2
+
+    monkeypatch.setattr(sched, "fire_claim_fence", lose_owner_before_commit)
+
+    assert sched._run_one_job_body(
+        job,
+        fire_claim_lost=threading.Event(),
+        execution_token=object(),
+    ) is True
+
+    assert len(fence_calls) >= 3
+    assert get_job(job["id"]).get("monitor_state") is None
+
+
+def test_after_delivery_policy_real_fire_owner_commits_without_nested_fence(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(
+        job["id"],
+        {
+            "monitor_commit_policy": "after_delivery",
+            "fire_claim": {"by": "owner-a", "at": "2026-08-20T00:00:00+00:00"},
+        },
+    )
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+
+    assert sched._run_one_job_body(
+        job,
+        fire_claim_lost=threading.Event(),
+        execution_token=object(),
+    ) is True
+
+    stored = get_job(job["id"])
+    assert stored["last_status"] == "ok"
+    assert stored["monitor_state"]["last_output_hash"]
+
+
+def test_after_delivery_policy_rechecks_interrupt_inside_commit_fence(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(
+        job["id"],
+        {
+            "monitor_commit_policy": "after_delivery",
+            "fire_claim": {"by": "owner-a", "at": "2026-01-01T00:00:00+00:00"},
+        },
+    )
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    cancellation = threading.Event()
+    fence_calls = []
+
+    @contextlib.contextmanager
+    def interrupt_at_commit(_job_id, *, expected_owner):
+        fence_calls.append(expected_owner)
+        if len(fence_calls) == 3:
+            cancellation.set()
+        yield True
+
+    monkeypatch.setattr(sched, "fire_claim_fence", interrupt_at_commit)
+
+    assert sched._run_one_job_body(
+        job,
+        fire_claim_lost=cancellation,
+        execution_token=object(),
+    ) is True
+
+    assert len(fence_calls) >= 3
+    assert get_job(job["id"]).get("monitor_state") is None
+
+
+def test_after_delivery_commit_serializes_against_shutdown_interrupt_flag(
+    hermes_env, monkeypatch
+):
+    import cron.monitor as monitor
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(
+        job["id"],
+        {
+            "monitor_commit_policy": "after_delivery",
+            "fire_claim": {"by": "owner-a", "at": "2026-01-01T00:00:00+00:00"},
+        },
+    )
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    commit_entered = threading.Event()
+    allow_commit = threading.Event()
+    interrupt_mark_called = threading.Event()
+
+    def slow_commit(*_args, **_kwargs):
+        commit_entered.set()
+        assert allow_commit.wait(timeout=2)
+
+    def record_mark(_job_id, success, *_args, **_kwargs):
+        if success is False:
+            interrupt_mark_called.set()
+        return True
+
+    monkeypatch.setattr(monitor, "commit_monitor_state", slow_commit)
+    monkeypatch.setattr(sched, "mark_job_run", record_mark)
+
+    @contextlib.contextmanager
+    def in_memory_fire_fence(*_args, **_kwargs):
+        yield True
+
+    monkeypatch.setattr(sched, "fire_claim_fence", in_memory_fire_fence)
+
+    execution_token = object()
+    with sched._running_lock:
+        sched._running_fire_owners.setdefault(job["id"], {})[execution_token] = (
+            "owner-a",
+            hermes_env,
+        )
+
+    run_thread = threading.Thread(
+        target=sched._run_one_job_body,
+        kwargs={
+            "job": job,
+            "fire_claim_lost": threading.Event(),
+            "execution_token": execution_token,
+        },
+    )
+    run_thread.start()
+    assert commit_entered.wait(timeout=2)
+
+    interrupt_thread = threading.Thread(
+        target=sched.mark_running_jobs_interrupted,
+        args=("simulated shutdown",),
+    )
+    interrupt_thread.start()
+    interrupt_reached_terminal_mark_before_commit = interrupt_mark_called.wait(
+        timeout=0.2
+    )
+
+    allow_commit.set()
+    run_thread.join(timeout=3)
+    interrupt_thread.join(timeout=3)
+    with sched._running_lock:
+        sched._running_fire_owners.pop(job["id"], None)
+
+    assert not run_thread.is_alive()
+    assert not interrupt_thread.is_alive()
+    assert interrupt_reached_terminal_mark_before_commit is False
+
+
+def test_after_delivery_commit_stays_linearized_through_terminal_mark(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    execution_token = object()
+    protected_at_mark = []
+
+    def record_mark(_job_id, success, *_args, **_kwargs):
+        if success:
+            protected_at_mark.append(
+                execution_token in sched._monitor_commit_in_progress
+            )
+        return True
+
+    monkeypatch.setattr(sched, "mark_job_run", record_mark)
+
+    assert sched._run_one_job_body(
+        job,
+        fire_claim_lost=threading.Event(),
+        execution_token=execution_token,
+    ) is True
+    sched._monitor_commit_in_progress.discard(execution_token)
+
+    assert protected_at_mark == [True]
+
+
+def test_after_delivery_policy_does_not_commit_on_agent_failure(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed = {"raise_error": "simulated agent failure"}
+    _install_agent_stubs(monkeypatch, observed)
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored.get("monitor_state") is None
+    assert stored["last_status"] == "error"
+
+
+def test_after_delivery_policy_does_not_commit_on_empty_agent_response(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    job = get_job(job["id"])
+    observed = {"final_response": ""}
+    _install_agent_stubs(monkeypatch, observed)
+
+    assert sched.run_one_job(job) is True
+
+    stored = get_job(job["id"])
+    assert stored.get("monitor_state") is None
+    assert stored["last_status"] == "error"
 
 
 def test_unchanged_output_suppresses_agent_run(hermes_env, monkeypatch):

--- a/tests/cron/test_monitor_kind.py
+++ b/tests/cron/test_monitor_kind.py
@@ -135,6 +135,75 @@ def test_create_job_stores_monitor_script(hermes_env):
     assert reloaded.get("monitor_state") is None
 
 
+def test_create_job_persists_after_delivery_commit_policy(hermes_env):
+    from cron.jobs import create_job, get_job
+
+    job = create_job(
+        prompt="React",
+        schedule="every 5m",
+        monitor_script="mon.sh",
+        monitor_commit_policy="after_delivery",
+    )
+
+    assert job["monitor_commit_policy"] == "after_delivery"
+    assert get_job(job["id"])["monitor_commit_policy"] == "after_delivery"
+
+
+def test_update_job_sets_and_clears_monitor_commit_policy(hermes_env):
+    from cron.jobs import create_job, get_job, update_job
+
+    job = create_job(
+        prompt="React",
+        schedule="every 5m",
+        monitor_script="mon.sh",
+    )
+
+    updated = update_job(
+        job["id"], {"monitor_commit_policy": "after_delivery"}
+    )
+    assert updated["monitor_commit_policy"] == "after_delivery"
+    assert get_job(job["id"])["monitor_commit_policy"] == "after_delivery"
+
+    cleared = update_job(job["id"], {"monitor_commit_policy": ""})
+    assert cleared.get("monitor_commit_policy") is None
+
+
+def test_monitor_commit_policy_rejects_invalid_or_non_monitor_jobs(hermes_env):
+    from cron.jobs import create_job, update_job
+
+    with pytest.raises(ValueError, match="monitor_commit_policy must be one of"):
+        create_job(
+            prompt="React",
+            schedule="every 5m",
+            monitor_script="mon.sh",
+            monitor_commit_policy="eventually",
+        )
+
+    with pytest.raises(ValueError, match="requires monitor_script or monitor_url"):
+        create_job(
+            prompt="React",
+            schedule="every 5m",
+            monitor_commit_policy="after_delivery",
+        )
+
+    job = create_job(prompt="React", schedule="every 5m")
+    with pytest.raises(ValueError, match="requires monitor_script or monitor_url"):
+        update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+
+
+def test_update_job_rejects_clearing_monitor_with_after_delivery_policy(hermes_env):
+    from cron.jobs import create_job, update_job
+
+    job = create_job(
+        prompt="React",
+        schedule="every 5m",
+        monitor_script="mon.sh",
+        monitor_commit_policy="after_delivery",
+    )
+    with pytest.raises(ValueError, match="requires monitor_script or monitor_url"):
+        update_job(job["id"], {"monitor_script": ""})
+
+
 def test_create_job_monitor_script_and_url_mutually_exclusive(hermes_env):
     from cron.jobs import create_job
 
@@ -1046,6 +1115,44 @@ def test_monitor_script_failure_is_error_not_change(hermes_env, monkeypatch):
 # ---------------------------------------------------------------------------
 # cronjob tool: API-layer wiring
 # ---------------------------------------------------------------------------
+
+
+def test_cronjob_tool_create_and_update_monitor_commit_policy(hermes_env):
+    from cron.jobs import get_job
+    from tools.cronjob_tools import CRONJOB_SCHEMA, _cronjob_handler
+
+    policy_schema = CRONJOB_SCHEMA["parameters"]["properties"][
+        "monitor_commit_policy"
+    ]
+    assert policy_schema["enum"] == ["detection_time", "after_delivery"]
+
+    _write_script(hermes_env, "mon.sh", "echo hi\n")
+    created = json.loads(
+        _cronjob_handler(
+            {
+                "action": "create",
+                "prompt": "React",
+                "schedule": "every 5m",
+                "monitor": "mon.sh",
+                "monitor_commit_policy": "after_delivery",
+                "deliver": "local",
+            }
+        )
+    )
+    assert created["success"] is True
+    assert get_job(created["job_id"])["monitor_commit_policy"] == "after_delivery"
+
+    updated = json.loads(
+        _cronjob_handler(
+            {
+                "action": "update",
+                "job_id": created["job_id"],
+                "monitor_commit_policy": "detection_time",
+            }
+        )
+    )
+    assert updated["success"] is True
+    assert get_job(created["job_id"])["monitor_commit_policy"] == "detection_time"
 
 
 def test_cronjob_tool_create_with_monitor_script(hermes_env):

--- a/tests/cron/test_monitor_kind.py
+++ b/tests/cron/test_monitor_kind.py
@@ -81,6 +81,8 @@ def _install_agent_stubs(monkeypatch, observed: dict):
             observed["prompts"].append(prompt)
             if observed.get("raise_error"):
                 raise RuntimeError(str(observed["raise_error"]))
+            if "result" in observed:
+                return dict(observed["result"])
             return {
                 "final_response": observed.get("final_response", "agent done"),
                 "messages": [],
@@ -976,6 +978,99 @@ def test_after_delivery_commit_stays_linearized_through_terminal_mark(
     sched._monitor_commit_in_progress.discard(execution_token)
 
     assert protected_at_mark == [True]
+
+
+@pytest.mark.parametrize(
+    "agent_result",
+    [
+        {
+            "failed": True,
+            "completed": False,
+            "error": "HTTP 429",
+            "final_response": "",
+            "messages": [],
+        },
+        {
+            "completed": False,
+            "turn_exit_reason": "interrupted",
+            "final_response": "",
+            "messages": [],
+        },
+    ],
+    ids=("reported-failure", "interrupted-result"),
+)
+def test_after_delivery_retries_agent_reported_failure_results(
+    hermes_env, monkeypatch, agent_result
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+    from cron.monitor import _read_last_output
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    observed = {"result": agent_result}
+    _install_agent_stubs(monkeypatch, observed)
+
+    # A failure RESULT (not a raised exception) must leave the observation
+    # unacknowledged so the identical next tick runs the agent again.
+    assert sched.run_one_job(get_job(job["id"])) is True
+    failed = get_job(job["id"])
+    assert failed.get("monitor_state") is None
+    assert _read_last_output(job["id"]) == ""
+    assert failed["last_status"] == "error"
+    assert observed["agent_runs"] == 1
+
+    observed["result"] = {
+        "failed": False,
+        "completed": True,
+        "final_response": "handled",
+        "messages": [],
+    }
+    assert sched.run_one_job(get_job(job["id"])) is True
+    committed = get_job(job["id"])
+    assert committed["monitor_state"]["last_output_hash"]
+    assert _read_last_output(job["id"]) == "state A"
+    assert observed["agent_runs"] == 2
+
+    # Once the retry succeeds, the next identical observation suppresses.
+    assert sched.run_one_job(get_job(job["id"])) is True
+    assert observed["agent_runs"] == 2
+
+
+def test_after_delivery_failed_change_preserves_prior_hash_and_snapshot(
+    hermes_env, monkeypatch
+):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+    from cron.monitor import _read_last_output
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "after_delivery"})
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+
+    assert sched.run_one_job(get_job(job["id"])) is True
+    committed_a = get_job(job["id"])
+    hash_a = committed_a["monitor_state"]["last_output_hash"]
+    assert _read_last_output(job["id"]) == "state A"
+
+    _write_script(hermes_env, "mon.sh", "echo 'state B'\n")
+    observed["raise_error"] = "HTTP 429"
+    assert sched.run_one_job(get_job(job["id"])) is True
+    failed_b = get_job(job["id"])
+    assert failed_b["monitor_state"]["last_output_hash"] == hash_a
+    assert _read_last_output(job["id"]) == "state A"
+    assert observed["agent_runs"] == 2
+
+    observed.pop("raise_error")
+    assert sched.run_one_job(get_job(job["id"])) is True
+    committed_b = get_job(job["id"])
+    assert committed_b["monitor_state"]["last_output_hash"] != hash_a
+    assert _read_last_output(job["id"]) == "state B"
+    assert observed["agent_runs"] == 3
+
+    assert sched.run_one_job(get_job(job["id"])) is True
+    assert observed["agent_runs"] == 3
 
 
 def test_after_delivery_policy_does_not_commit_on_agent_failure(

--- a/tests/cron/test_monitor_kind.py
+++ b/tests/cron/test_monitor_kind.py
@@ -1219,7 +1219,7 @@ def test_cronjob_tool_create_and_update_monitor_commit_policy(hermes_env):
     policy_schema = CRONJOB_SCHEMA["parameters"]["properties"][
         "monitor_commit_policy"
     ]
-    assert policy_schema["enum"] == ["detection_time", "after_delivery"]
+    assert set(policy_schema["enum"]) == {"detection_time", "after_delivery", "safe_retry"}
 
     _write_script(hermes_env, "mon.sh", "echo hi\n")
     created = json.loads(
@@ -1303,3 +1303,83 @@ def test_cronjob_tool_update_clears_monitor_script(hermes_env):
     )
     assert result.get("success") is True
     assert get_job(created["job_id"]).get("monitor_script") is None
+
+
+def test_safe_retry_keeps_pending_input_and_bounds_pre_effect_attempts(hermes_env, monkeypatch):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+    from cron import monitor_pending
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "safe_retry"})
+    observed = {"result": {"failed": True, "completed": False, "error": "HTTP 429"}}
+    _install_agent_stubs(monkeypatch, observed)
+    assert sched.run_one_job(get_job(job["id"])) is True
+    first = monitor_pending.inspect(get_job(job["id"]))
+    assert first["state"] == "retry"
+    with pytest.raises(ValueError, match="reconcile"):
+        update_job(job["id"], {"monitor_commit_policy": "detection_time"})
+    with pytest.raises(monitor_pending.RecoveryRequired):
+        monitor_pending.resume(dict(get_job(job["id"]), prompt="changed contract"))
+    _write_script(hermes_env, job["monitor_script"], "echo 'state B'\n")
+    observed["result"] = {"completed": True, "final_response": "handled A", "messages": []}
+    assert sched.run_one_job(get_job(job["id"])) is True
+    assert monitor_pending.inspect(get_job(job["id"]))["state"] == "acked"
+    with pytest.raises(monitor_pending.RecoveryRequired):
+        monitor_pending.settle(get_job(job["id"]), first["token"], response="stale")
+    assert "state A" in observed["prompts"][-1]
+    assert "state B" not in observed["prompts"][-1]
+    assert observed["agent_runs"] == 2
+    assert sched.run_one_job(get_job(job["id"])) is True
+    assert "state B" in observed["prompts"][-1]
+    assert sched.run_one_job(get_job(job["id"])) is True
+    assert observed["agent_runs"] == 3  # committed B is now suppressed
+
+    _write_script(hermes_env, job["monitor_script"], "echo 'state C'\n")
+    observed["result"] = {"failed": True, "completed": False, "error": "HTTP 429"}
+    for _ in range(3):
+        sched.run_one_job(get_job(job["id"]))
+    assert observed["agent_runs"] == 5  # two attempts, no unbounded retry
+    assert monitor_pending.inspect(get_job(job["id"]))["state"] == "unknown"
+
+
+def test_safe_retry_never_regenerates_unknown_delivery_or_tool_effects(hermes_env, monkeypatch):
+    import cron.scheduler as sched
+    from cron.jobs import get_job, update_job
+    from cron import monitor_pending
+
+    job = _make_monitor_job(hermes_env, "echo 'state A'\n")
+    update_job(job["id"], {"monitor_commit_policy": "safe_retry"})
+    observed = {"result": {"completed": True, "final_response": "saved summary", "messages": []}}
+    _install_agent_stubs(monkeypatch, observed)
+    sends = []
+    def ambiguous_send(*args, **kwargs):
+        sends.append(args[1])
+        raise TimeoutError("provider acknowledgement unavailable")
+    monkeypatch.setattr(sched, "_deliver_result", ambiguous_send)
+    sched.run_one_job(get_job(job["id"]))
+    retained = monitor_pending.inspect(get_job(job["id"]))
+    assert retained["state"] == "ready" and retained["response"] == "saved summary"
+    sched.run_one_job(get_job(job["id"]))
+    assert observed["agent_runs"] == 1
+    assert sends.count("saved summary") == 1
+
+    # A terminated process and a finished tool-bearing failure both retain work.
+    other = _make_monitor_job(hermes_env, "echo 'other event'\n")
+    update_job(other["id"], {"monitor_commit_policy": "safe_retry"})
+    import run_agent
+    def failed_after_tool(self, *args, **kwargs):
+        observed["agent_runs"] += 1
+        self.tool_start_callback("call", "terminal", {})
+        return {"failed": True, "completed": False, "error": "HTTP 429"}
+    monkeypatch.setattr(run_agent.AIAgent, "run_conversation", failed_after_tool)
+    sched.run_one_job(get_job(other["id"]))
+    assert monitor_pending.inspect(get_job(other["id"]))["state"] == "unknown"
+    sched.run_one_job(get_job(other["id"]))
+    assert observed["agent_runs"] == 2
+    crashed = _make_monitor_job(hermes_env, "echo 'crash event'\n")
+    update_job(crashed["id"], {"monitor_commit_policy": "safe_retry"})
+    crashed = get_job(crashed["id"])
+    monitor_pending.begin(crashed, "crash event")
+    with pytest.raises(monitor_pending.RecoveryRequired):
+        monitor_pending.resume(crashed)

--- a/tests/cron/test_monitor_pending.py
+++ b/tests/cron/test_monitor_pending.py
@@ -1,0 +1,115 @@
+"""Recovery relationships, including crash and competing-attempt boundaries."""
+import importlib
+import pytest
+
+
+@pytest.fixture
+def pending(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import cron.monitor_pending
+    return importlib.reload(cron.monitor_pending)
+
+
+def test_bounded_retry_retains_observation_and_fences_stale_owners(pending):
+    job = {"id": "fixture", "monitor_script": "fixture.py", "prompt": "summarize"}
+    first = pending.begin(job, "event A")
+    with pytest.raises(pending.RecoveryRequired):
+        pending.resume(job)  # A crash is not proof that the first attempt did nothing.
+    with pytest.raises(pending.RecoveryRequired):
+        pending.begin(job, "event B")
+    pending.settle(job, first["token"], safe_failure=True)
+    second = pending.resume(job)
+    assert second["output"] == "event A" and second["token"] != first["token"]
+    with pytest.raises(pending.RecoveryRequired):
+        pending.settle(job, first["token"], response="stale")
+    pending.settle(job, second["token"], safe_failure=True)
+    with pytest.raises(pending.RecoveryRequired):
+        pending.resume(job)
+    assert pending.inspect(job)["output"] == "event A"
+    assert pending.inspect(job)["attempts"] == pending.MAX_ATTEMPTS
+
+
+def test_ready_response_survives_unknown_delivery_and_ack_suppresses_duplicate(pending):
+    job = {"id": "fixture", "monitor_script": "fixture.py", "deliver": "local"}
+    attempt = pending.begin(job, "event A")
+    pending.settle(job, attempt["token"], response="saved summary", completed=True)
+    with pytest.raises(pending.RecoveryRequired):
+        pending.resume(job)  # Includes restart after a partial/unknown delivery.
+    assert pending.inspect(job)["response"] == "saved summary"
+    with pytest.raises(pending.RecoveryRequired):
+        pending.resume(dict(job, deliver="another-target"))
+    pending.acknowledge(job, attempt["token"])
+    assert pending.begin(job, "event A") is None
+    next_attempt = pending.begin(job, "event B")
+    assert next_attempt["output"] == "event B"
+    with pytest.raises(pending.RecoveryRequired):
+        pending.acknowledge(job, attempt["token"])
+
+
+def test_external_runtime_and_tool_middleware_cannot_claim_pre_effect_failure(pending):
+    from types import SimpleNamespace
+    for mode in ("codex_app_server", "chat_completions", "acp"):
+        job = {"id": mode, "monitor_commit_policy": "safe_retry"}
+        row = pending.begin(job, "event")
+        job["_monitor_pending_commit"] = {"token": row["token"]}
+        attempt = pending.Attempt(job)
+        calls = []
+        agent = SimpleNamespace(api_mode=mode, base_url="acp://fixture" if mode == "acp" else "",
+                                _execute_tool_calls=lambda: calls.append("middleware"))
+        attempt.attach(agent)
+        attempt.started = True
+        if mode == "chat_completions":
+            agent._execute_tool_calls()
+            assert calls == ["middleware"]
+        attempt.result = {"failed": True, "turn_exit_reason": "api_error"}
+        attempt.finish({})
+        assert pending.inspect(job)["state"] == "unknown"
+        with pytest.raises(pending.RecoveryRequired):
+            pending.resume(job)
+
+
+def test_real_agent_failure_and_retry_preserve_the_same_observation(monkeypatch):
+    """Actual agent + local HTTP provider; no model service or delivery is contacted."""
+    from tests.agent.test_empty_tool_name_loop_dampening import agent_env, _text_resp
+    context = agent_env.__wrapped__()
+    agent, handler = next(context)
+    try:
+        import cron.monitor_pending as store
+        job = {"id": "native-agent-fixture", "monitor_commit_policy": "safe_retry"}
+        record = store.begin(job, "event A")
+        job["_monitor_pending_commit"] = {"token": record["token"]}
+        attempt = store.Attempt(job)
+        attempt.attach(agent)
+        attempt.started = True
+        original = handler.do_POST
+
+        def rejected(request):
+            request.rfile.read(int(request.headers.get("Content-Length", 0)))
+            body = b'{"error":{"message":"fixture denied","type":"authentication_error"}}'
+            request.send_response(401)
+            request.send_header("Content-Type", "application/json")
+            request.send_header("Content-Length", str(len(body)))
+            request.end_headers()
+            request.wfile.write(body)
+
+        monkeypatch.setattr(handler, "do_POST", rejected)
+        attempt.result = agent.run_conversation("Summarize event A", conversation_history=[], task_id="native-failure")
+        assert attempt.result.get("failed") is True
+        attempt.finish({})
+        record = store.resume(job)
+        assert record["output"] == "event A" and record["attempts"] == 2
+        monkeypatch.setattr(handler, "do_POST", original)
+        handler.response_queue.append(_text_resp("Summary A"))
+        job["_monitor_pending_commit"] = {"token": record["token"]}
+        recovered = store.Attempt(job)
+        recovered.attach(agent)
+        recovered.started = True
+        recovered.result = agent.run_conversation("Summarize event A", conversation_history=[], task_id="native-recovery")
+        recovered.response = recovered.result.get("final_response")
+        recovered.finish({})
+        saved = store.inspect(job)
+        assert saved["state"] == "ready" and saved["response"] == "Summary A"
+    finally:
+        context.close()

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -380,6 +380,7 @@ def test_lost_fire_claim_stops_stale_delivery(monkeypatch):
         job,
         *,
         defer_agent_teardown=None,
+        defer_monitor_commit=None,
         extra_prompt=None,
         cancel_event=None,
         execution_id=None,

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -104,6 +104,40 @@ class TestCronCommandLifecycle:
         out = capsys.readouterr().out
         assert "Updated job" in out
 
+    def test_create_and_edit_monitor_commit_policy(self, tmp_cron_dir, capsys):
+        parser = argparse.ArgumentParser(prog="hermes")
+        subparsers = parser.add_subparsers(dest="command")
+        build_cron_parser(subparsers, cmd_cron=cron_command)
+
+        create_args = parser.parse_args(
+            [
+                "cron",
+                "create",
+                "every 5m",
+                "React",
+                "--monitor-url",
+                "https://example.com/status",
+                "--monitor-commit-policy",
+                "after_delivery",
+            ]
+        )
+        assert cron_command(create_args) == 0
+        job = list_jobs()[0]
+        assert job["monitor_commit_policy"] == "after_delivery"
+
+        edit_args = parser.parse_args(
+            [
+                "cron",
+                "edit",
+                job["id"],
+                "--monitor-commit-policy",
+                "detection_time",
+            ]
+        )
+        assert cron_command(edit_args) == 0
+        assert get_job(job["id"])["monitor_commit_policy"] == "detection_time"
+        assert "Updated job" in capsys.readouterr().out
+
     def test_create_with_multiple_skills(self, tmp_cron_dir, capsys):
         cron_command(
             Namespace(

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -41,6 +41,34 @@ def test_cron_edit_no_agent_tristate():
     assert parser.parse_args(["cron", "edit", "j"]).no_agent is None
 
 
+def test_cron_monitor_commit_policy_create_and_edit_options():
+    parser = _build()
+    created = parser.parse_args(
+        [
+            "cron",
+            "create",
+            "every 5m",
+            "React",
+            "--monitor-url",
+            "https://example.com/status",
+            "--monitor-commit-policy",
+            "after_delivery",
+        ]
+    )
+    assert created.monitor_commit_policy == "after_delivery"
+
+    edited = parser.parse_args(
+        [
+            "cron",
+            "edit",
+            "job-id",
+            "--monitor-commit-policy",
+            "detection_time",
+        ]
+    )
+    assert edited.monitor_commit_policy == "detection_time"
+
+
 def test_cron_accept_hooks_flag_on_run_and_tick():
     parser = _build()
     # --accept-hooks is suppressed-default; present only when passed.

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -220,7 +220,9 @@ def test_unreadable_schema_without_cli_names_the_sqlite3_requirement(
 
     import hermes_cli.session_lost_and_found as laf
 
-    monkeypatch.setattr(laf, "find_sqlite3_cli", lambda: None)
+    # Exercise the real capability reader so its refusal reason is reset;
+    # stubbing only its return leaves an earlier host-probe refusal cached.
+    monkeypatch.setattr(laf.shutil, "which", lambda command: None)
     with pytest.raises(SessionRecoverySourceError) as excinfo:
         recover_session_database(
             source,

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from hermes_cli.update_inventory import UpdatePlan
 from hermes_cli import config as hermes_config
 from hermes_cli import main as hermes_main
 from hermes_cli import update_cmd
@@ -61,7 +62,9 @@ def _patch_gateway_discovery():
     with patch("hermes_cli.gateway.find_gateway_pids", return_value=[]), \
          patch("hermes_cli.gateway.supports_systemd_services", return_value=False), \
          patch("hermes_cli.gateway.find_profile_gateway_processes", return_value=[]), \
-         patch("hermes_cli.update_inventory.collect_runtime_inventory", return_value=None), \
+         patch("hermes_cli.gateway.launchd_gateway_labels_for_install", return_value=[]), \
+         patch("hermes_cli.update_cmd._finish_dashboard_update_cleanup", return_value=None), \
+         patch("hermes_cli.update_inventory.collect_runtime_inventory", side_effect=lambda: UpdatePlan(install_method="git")), \
          patch("hermes_cli.update_inventory.report_unaccounted_runtimes", return_value=False), \
          patch.object(hermes_main, "_fleet_probe_expected_runtimes", lambda *a, **kw: False), \
          patch.object(hermes_main, "_purge_stale_hermes_modules", lambda *a, **kw: None), \

--- a/tests/hermes_cli/test_update_head_moved_gate.py
+++ b/tests/hermes_cli/test_update_head_moved_gate.py
@@ -117,6 +117,12 @@ def _patch_update_deps(monkeypatch, tmp_path, run_side_effect):
     # this machine's real gateways: discovery returns nothing, systemd is
     # unsupported, so the phase is a clean no-op for both snapshots.
     import hermes_cli.gateway as hermes_gateway
+    import hermes_cli.update_inventory as inventory
+    import hermes_cli.update_receipt as receipt
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda *a, **k: None)
+    monkeypatch.setattr(inventory, "collect_runtime_inventory", lambda: inventory.UpdatePlan(install_method="git"))
+    monkeypatch.setattr(receipt, "collect_fleet_versions", lambda *a, **k: [])
+    monkeypatch.setattr(hermes_gateway, "launchd_gateway_labels_for_install", lambda: [])
 
     monkeypatch.setattr(
         hermes_gateway, "find_gateway_pids", lambda all_profiles=False: []

--- a/tests/hermes_cli/test_update_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_launchd_fleet_restart.py
@@ -213,13 +213,17 @@ class TestGetServicePidsScoping:
         monkeypatch.setattr(
             gw, "_locate_launchd_gateway_service", lambda label: located[label]
         )
+        def prefix_scan(command, **kwargs):
+            assert command == ["launchctl", "list"]
+            return subprocess.CompletedProcess(command, 0, "300\t0\tai.hermes.gateway-other-install\n", "")
+        monkeypatch.setattr(gw.subprocess, "run", prefix_scan)
 
     def test_all_profiles_returns_every_gateway_service_pid(self, monkeypatch):
         """The update sweep's exclude-set must protect ALL freshly-restarted
         services, not only the invoking profile's (else the sweep SIGTERMs
         gateways launchd just respawned)."""
         self._wire(monkeypatch)
-        assert gw._get_service_pids(all_profiles=True) == {100, 200}
+        assert gw._get_service_pids(all_profiles=True) == {100, 200, 300}
 
     def test_default_stays_scoped_to_current_profile(self, monkeypatch):
         """Regression guard: default-scope callers (gateway status, cron,
@@ -642,12 +646,15 @@ class TestWaitForLaunchdServicePid:
 
 
 class TestIncompleteWarningMentionsLaunchctl:
+    @pytest.mark.macos_only
     def test_launchd_labels_get_launchctl_hint(self, capsys):
         _warn_incomplete_gateway_fleet_restart(["ai.hermes.gateway-merit-ops"])
         out = capsys.readouterr().out
         assert "Update incomplete" in out
-        assert "launchctl kickstart -k" in out
+        assert "launchctl bootstrap" in out
+        assert "launchctl kickstart -k" not in out
 
+    @pytest.mark.linux_only
     def test_systemd_units_keep_systemctl_hint(self, capsys):
         _warn_incomplete_gateway_fleet_restart(["hermes-gateway-coder"])
         out = capsys.readouterr().out

--- a/tests/scripts/test_contributor_map.py
+++ b/tests/scripts/test_contributor_map.py
@@ -157,7 +157,11 @@ def test_add_contributor_refuses_a_case_collision(tmp_path, monkeypatch):
     monkeypatch.setattr(mod, "EMAILS_DIR", d)
 
     assert mod.add_contributor("agent@example-host.local", "otherperson") == 1
-    assert not (d / "agent@example-host.local").exists()
+    # A differently-cased Path.exists() names the original file on macOS.
+    # Refusal must preserve the exact original entry and its attribution.
+    assert {p.name: p.read_text(encoding="utf-8") for p in d.iterdir()} == {
+        "agent@Example-Host.local": "someone\n",
+    }
 
 
 def test_add_contributor_refuses_case_collision_even_for_same_login(emails_dir, capsys):

--- a/tests/test_guest_durability_barriers.py
+++ b/tests/test_guest_durability_barriers.py
@@ -8,6 +8,7 @@ the guest entry point applies it directly.
 """
 
 import sqlite3
+import sys
 
 import pytest
 
@@ -40,14 +41,17 @@ def test_guest_barriers_apply_configured_synchronous(monkeypatch, tmp_path):
         conn.close()
 
 
-def test_guest_barriers_leave_synchronous_alone_when_unset(monkeypatch, tmp_path):
+def test_guest_barriers_keep_native_safety_default_when_unset(monkeypatch, tmp_path):
     _config(monkeypatch, {})
     conn = sqlite3.connect(tmp_path / "state.db")
     try:
         conn.execute("PRAGMA journal_mode=DELETE")
         conn.execute("PRAGMA synchronous=1")
         apply_durability_barriers(conn)
-        assert conn.execute("PRAGMA synchronous").fetchone()[0] == 1
+        # macOS retains its mandatory FULL barrier even without an override;
+        # other hosts retain the caller's NORMAL setting.
+        assert conn.execute("PRAGMA synchronous").fetchone()[0] == (2 if sys.platform == "darwin" else 1)
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "delete"
     finally:
         conn.close()
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1,6 +1,7 @@
 """Tests for the dangerous command approval module."""
 
 import os
+import shlex
 import threading
 import time
 from pathlib import Path
@@ -93,14 +94,12 @@ class TestDetectDangerousRm:
             assert "delete" in desc.lower()
 
 
-    def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
-        with mock_patch("tempfile.gettempdir", return_value="/tmp"):
+    def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self, tmp_path):
+        canonical_temp = tmp_path.resolve()
+        with mock_patch("tempfile.gettempdir", return_value=str(canonical_temp)):
             for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
-                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
-                    False,
-                    None,
-                    None,
-                )
+                target = shlex.quote(str(canonical_temp / f"{prefix}example.py"))
+                assert detect_dangerous_command(f"rm -f {target}") == (False, None, None)
 
     def test_symlinked_temp_dir_only_exempts_canonical_target(self, tmp_path):
         real_temp = tmp_path / "real-temp"

--- a/tests/tools/test_code_kernel.py
+++ b/tests/tools/test_code_kernel.py
@@ -339,7 +339,7 @@ class TestKernelOwnershipAndLifecycle(unittest.TestCase):
         used to see proc=None as 'dead', replace the registry entry, and
         orphan the winner's process — 110 live kernels under a 4-capped
         process (Sep 2026). Every kernel process must stay registry-owned."""
-        import subprocess
+        import psutil
         import threading
 
         results = []
@@ -353,11 +353,10 @@ class TestKernelOwnershipAndLifecycle(unittest.TestCase):
                 t.join()
         self.assertEqual([r["status"] for r in results], ["success"] * 6)
         self.assertEqual(len(_KERNELS), 1)
-        live = subprocess.run(
-            ["pgrep", "-fc", "-P", str(os.getpid()), "hermes_kernel_runner"],
-            capture_output=True, text=True,
-        ).stdout.strip()
-        self.assertEqual(live, "1")
+        # Inspect real child processes; BSD pgrep has no GNU-only -c flag.
+        live = [child.pid for child in psutil.Process().children()
+                if "hermes_kernel_runner" in " ".join(child.cmdline())]
+        self.assertEqual(len(live), 1)
 
 
 class TestPerCellRpcAuthority(unittest.TestCase):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -413,9 +413,9 @@ class TestDelegateTask(unittest.TestCase):
                 child_db = kwargs["session_db"]
                 self.assertIsInstance(child_db, SessionDB)
                 self.assertIsNot(child_db, parent_db)
-                self.assertEqual(
-                    str(child_db.db_path), str(parent_db.db_path)
-                )
+                # Compare the actual database file: macOS resolves /tmp to
+                # /private/tmp when opening the child's dedicated handle.
+                self.assertTrue(Path(child_db.db_path).samefile(parent_db.db_path))
             finally:
                 if child_db is not None:
                     child_db.close()

--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -32,18 +32,27 @@ def test_real_read_tool_binaries_confirm_option_ownership(
     assert completed.stdout == expected_output
 
 
-@pytest.mark.parametrize(
-    ("tool", "args", "stdin", "needs_tty"),
-    [
-        ("rg", ["--pre", "-payload-marker", "needle", "{input}"], None, False),
-        ("rg", ["--hostname-bin=-payload-marker", "needle", "{input}"], None, False),
-        ("sort", ["--buffer-size=1K", "--compress-program", "-payload-marker"], "{bulk}", False),
-        ("ag", ["--pager=-payload-marker", "needle", "{input}"], None, True),
-        ("man", ["--pager", "-payload-marker", "ls"], None, True),
-        ("man", ["-P", "-payload-marker", "ls"], None, True),
-    ],
-)
-def test_real_binaries_execute_leading_dash_program_payload(
+@pytest.mark.parametrize("args", [
+    ["--pre", "-payload-marker", "needle", "{input}"],
+    ["--hostname-bin=-payload-marker", "needle", "{input}"],
+])
+def test_real_rg_executes_leading_dash_program_payload(tmp_path, args):
+    _assert_leading_dash_program_payload(tmp_path, "rg", args, None, False)
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize(("tool", "args", "stdin", "needs_tty"), [
+    ("sort", ["--buffer-size=1K", "--compress-program", "-payload-marker"], "{bulk}", False),
+    ("ag", ["--pager=-payload-marker", "needle", "{input}"], None, True),
+    ("man", ["--pager", "-payload-marker", "ls"], None, True),
+    ("man", ["-P", "-payload-marker", "ls"], None, True),
+])
+def test_real_gnu_tools_execute_leading_dash_program_payload(tmp_path, tool, args, stdin, needs_tty):
+    # GNU sort/man and util-linux script grammar is not BSD/macOS grammar.
+    _assert_leading_dash_program_payload(tmp_path, tool, args, stdin, needs_tty)
+
+
+def _assert_leading_dash_program_payload(
     tmp_path, tool, args, stdin, needs_tty
 ):
     """A PATH marker proves these binaries do not reparse '-program' as an option."""

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -70,7 +71,7 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(str(Path("/tmp/out.txt").resolve()), "hello world!\n")
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -161,7 +162,7 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(str(Path("/tmp/f.py").resolve()), "foo", "bar", False)
 
 
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_macos_process_exit_race.py
+++ b/tests/tools/test_macos_process_exit_race.py
@@ -1,0 +1,47 @@
+"""A completed group must not turn successful native search into an OS error."""
+import signal
+from types import SimpleNamespace
+
+import pytest
+
+from tools.environments import local
+
+pytestmark = pytest.mark.macos_only
+
+
+@pytest.mark.parametrize(("returncode", "group_state", "allowed"), [
+    (0, "gone", True),
+    (None, "gone", False),
+    (0, "live", False),
+    (0, "denied", False),
+])
+def test_permission_error_requires_reaped_leader_and_absent_group(
+    monkeypatch, returncode, group_state, allowed,
+):
+    import psutil
+    from unittest.mock import Mock
+
+    proc = SimpleNamespace(pid=12345, poll=lambda: returncode)
+    descendants = [object()]
+    monkeypatch.setattr(local.os, "getpgid", lambda pid: proc.pid)
+    monkeypatch.setattr(psutil, "Process", lambda pid: SimpleNamespace(
+        children=lambda recursive: descendants))
+    sweep = Mock()
+    monkeypatch.setattr(local, "_sweep_escaped_descendants", sweep)
+
+    def killpg(pgid, sig):
+        assert pgid == proc.pid
+        if sig == signal.SIGTERM or group_state == "denied":
+            raise PermissionError("signal denied")
+        assert sig == 0
+        if group_state == "gone":
+            raise ProcessLookupError("group gone")
+
+    monkeypatch.setattr(local.os, "killpg", killpg)
+    if allowed:
+        local._kill_process_group_posix(proc)
+        sweep.assert_called_once_with(descendants, proc.pid)
+    else:
+        with pytest.raises(PermissionError, match="signal denied"):
+            local._kill_process_group_posix(proc)
+        sweep.assert_not_called()

--- a/tests/tools/test_search_native_rg.py
+++ b/tests/tools/test_search_native_rg.py
@@ -112,3 +112,34 @@ def test_kill_switch_routes_search_back_to_the_shell(tree, ops_factory, monkeypa
     assert result.total_count == 4
     assert any(c.startswith("test -e") for c in calls)
     assert any("pipefail" in c and "rg" in c for c in calls)
+
+
+@pytest.mark.macos_only
+def test_native_search_retains_group_identity_after_child_exit(tree, ops_factory, monkeypatch):
+    """Force the poll/getpgid race with a real, already reaped child."""
+    import shlex
+    import subprocess
+
+    ops = ops_factory(tree, [])
+    real_popen = subprocess.Popen
+
+    def completed_child(*args, **kwargs):
+        proc = real_popen(*args, **kwargs)
+        proc.wait(timeout=2)
+        real_poll = proc.poll
+        calls = 0
+
+        def stale_poll():
+            nonlocal calls
+            calls += 1
+            return None if calls == 1 else real_poll()
+
+        proc.poll = stale_poll
+        return proc
+
+    monkeypatch.setattr(subprocess, "Popen", completed_child)
+    result = ops._run_rg_native([
+        shlex.quote(sys.executable), "-c", shlex.quote("print('needle')"),
+    ], 5, timeout=2)
+    assert result.exit_code == 0
+    assert result.stdout == "needle\n"

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -383,9 +383,11 @@ class TestTranscribeLocalExtended:
         assert mock_whisper_cls.call_count == 1
 
     def test_config_device_and_compute_type_passed_to_whisper(self, tmp_path):
-        """User-configured device and compute_type should be forwarded to WhisperModel.
+        """User-configured device and compute_type reach the platform-aware loader.
 
         Regression test for #8319: these values were hardcoded to "auto".
+        The loader may apply native safety constraints; this test checks
+        configuration forwarding without pretending to run on another host.
         """
         audio = tmp_path / "test.ogg"
         audio.write_bytes(b"fake")
@@ -398,7 +400,7 @@ class TestTranscribeLocalExtended:
 
         mock_model = MagicMock()
         mock_model.transcribe.return_value = ([mock_segment], mock_info)
-        mock_whisper_cls = MagicMock(return_value=mock_model)
+        mock_loader = MagicMock(return_value=mock_model)
 
         fake_config = {
             "local": {
@@ -408,7 +410,7 @@ class TestTranscribeLocalExtended:
         }
 
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", mock_whisper_cls), \
+             patch("tools.transcription_tools._load_local_whisper_model", mock_loader), \
              patch("tools.transcription_tools._local_model", None), \
              patch("tools.transcription_tools._local_model_name", None), \
              patch("tools.transcription_tools._load_stt_config", return_value=fake_config):
@@ -416,7 +418,7 @@ class TestTranscribeLocalExtended:
             result = _transcribe_local(str(audio), "base")
 
         assert result["success"] is True
-        mock_whisper_cls.assert_called_once_with("base", device="cpu", compute_type="float32")
+        mock_loader.assert_called_once_with("base", device="cpu", compute_type="float32")
 
 
     def test_cuda_out_of_memory_does_not_trigger_cpu_fallback(self, tmp_path):

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -120,11 +120,20 @@ def fake_clock(monkeypatch):
 # detect_audio_environment — WSL / SSH / Docker detection
 # ============================================================================
 
+@pytest.fixture
+def pulse_runtime_dir():
+    # AF_UNIX addresses must fit the host's sun_path, even when pytest's
+    # per-test directory includes a long username and test name.
+    import tempfile
+    with tempfile.TemporaryDirectory(prefix="pulse-") as directory:
+        yield Path(directory)
+
+
 class TestPulseSocketReachable:
-    def test_stale_socket_file_not_reachable(self, monkeypatch, tmp_path):
+    def test_stale_socket_file_not_reachable(self, monkeypatch, pulse_runtime_dir):
         """A socket file with no listener should not count as reachable."""
         import socket as _socket
-        sock_path = tmp_path / "pulse" / "native"
+        sock_path = pulse_runtime_dir / "pulse" / "native"
         sock_path.parent.mkdir(parents=True)
         # Create + bind, then close so the path is a stale socket file.
         s = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
@@ -132,14 +141,14 @@ class TestPulseSocketReachable:
         s.close()
         monkeypatch.delenv("PULSE_SERVER", raising=False)
         monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(pulse_runtime_dir))
         from tools.voice_mode import _pulse_socket_reachable
         assert _pulse_socket_reachable() is False
 
-    def test_listening_socket_reachable_via_xdg_runtime(self, monkeypatch, tmp_path):
+    def test_listening_socket_reachable_via_xdg_runtime(self, monkeypatch, pulse_runtime_dir):
         """A live PulseAudio-style socket under XDG_RUNTIME_DIR is reachable (#35622)."""
         import socket as _socket
-        sock_path = tmp_path / "pulse" / "native"
+        sock_path = pulse_runtime_dir / "pulse" / "native"
         sock_path.parent.mkdir(parents=True)
         server = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
         server.bind(str(sock_path))
@@ -147,7 +156,7 @@ class TestPulseSocketReachable:
         try:
             monkeypatch.delenv("PULSE_SERVER", raising=False)
             monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
-            monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+            monkeypatch.setenv("XDG_RUNTIME_DIR", str(pulse_runtime_dir))
             from tools.voice_mode import _pulse_socket_reachable
             assert _pulse_socket_reachable() is True
         finally:
@@ -1376,6 +1385,7 @@ class TestDefaultInputSamplerate:
             assert wf.getframerate() == 48000
 
 
+@pytest.mark.linux_only
 class TestWSL2PowerShellFallback:
     """Regression tests for WSL2 PowerShell TTS fallback (issue #17608).
 

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -217,14 +217,17 @@ def _install_fake_openwakeword(monkeypatch):
 
 
 def test_openwakeword_ensures_base_models_for_custom_path(monkeypatch):
-    # Regression: a custom ``.onnx`` path used to skip download_models entirely,
+    # Regression: a custom model path used to skip download_models entirely,
     # so a fresh install crashed at load time on a missing melspectrogram.onnx.
     # The base feature models must be ensured for a custom path too.
     calls = _install_fake_openwakeword(monkeypatch)
+    # Fake the runtime dependency, not the host's required inference backend.
+    monkeypatch.setattr(ww, "ensure_tflite_runtime", lambda: True)
+    model_path = "/models/hey_hermes." + ww.default_inference_framework()
     eng = ww._OpenWakeWordEngine(
-        {"provider": "openwakeword", "openwakeword": {"model": "/models/hey_hermes.onnx"}}
+        {"provider": "openwakeword", "openwakeword": {"model": model_path}}
     )
-    assert calls["download"] == [["/models/hey_hermes.onnx"]]
+    assert calls["download"] == [[model_path]]
     assert eng._labels == ["hey_hermes"]
 
 

--- a/tools/cronjob_job_args.py
+++ b/tools/cronjob_job_args.py
@@ -340,7 +340,7 @@ def _validate_context_from_refs(refs: List[Any]) -> Optional[str]:
 # Optional fields echoed by _format_job only when truthy (order = JSON key order).
 _FORMAT_JOB_OPTIONAL_KEYS = (
     "script", "reasoning_effort", "monitor_script", "monitor_url",
-    "monitor_state", "no_agent", "enabled_toolsets", "workdir")
+    "monitor_commit_policy", "monitor_state", "no_agent", "enabled_toolsets", "workdir")
 
 
 def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -572,6 +572,7 @@ def _action_create(a: Dict[str, Any]) -> str:
             no_agent=_no_agent, attach_to_session=a["attach_to_session"],
             monitor_script=_normalize_optional_job_value(a["monitor_script"]),
             monitor_url=_normalize_optional_job_value(a["monitor_url"]),
+            monitor_commit_policy=a["monitor_commit_policy"],
             # CLI-only lane: absent from CRONJOB_SCHEMA and the model dispatch (models don't pick models).
             reasoning_effort=a["reasoning_effort"],
             failure_deliver=_resolve_cron_context_deliver(_normalize_deliver_param(a["failure_deliver"])),
@@ -747,6 +748,9 @@ def _update_script_fields(job: Dict[str, Any], a: Dict[str, Any], updates: Dict[
     if (monitor_script is not None or monitor_url is not None) and (
         _pick(updates, job, "monitor_script") and _pick(updates, job, "monitor_url")):
         return("monitor_script and monitor_url are mutually exclusive — clear one before setting the other.")
+    if a["monitor_commit_policy"] is not None:
+        # update_job validates the value and drops it when no monitor source survives the merge.
+        updates["monitor_commit_policy"] = a["monitor_commit_policy"]
     return None
 
 
@@ -875,6 +879,7 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    monitor_commit_policy: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     failure_deliver: Optional[Union[str, List[str]]] = None,
     task_id: str = None,
@@ -960,6 +965,11 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
                 "type": "string",
                 "description": "Optional change-detector that gates the agent: an http(s) URL (fetched each tick) or a script path (same rules as `script`, run each tick) — cheap, no LLM. Output identical to the previous tick skips the agent run entirely; changed output wakes the agent with a diff injected into the prompt. First tick always runs (baseline). Output must be deterministic (no timestamps) or every tick looks changed. Incompatible with no_agent. On update, '' clears."
             },
+            "monitor_commit_policy": {
+                "type": "string",
+                "enum": ["detection_time", "after_delivery"],
+                "description": "Optional commit boundary for monitor state. detection_time (default) advances the stored hash as soon as the change is detected. after_delivery keeps the prior hash until the triggered agent run AND its delivery succeed, so a transient failure retries the same change next tick instead of losing it. Requires a monitor."
+            },
             "no_agent": {
                 "type": "boolean",
                 "default": False,
@@ -1011,7 +1021,7 @@ def check_cronjob_requirements() -> bool:
 _HANDLER_FORWARDED_ARGS = (
     "job_id", "prompt", "schedule", "name", "repeat", "deliver", "failure_deliver", "skill", "skills", "reason",
     "script", "context_from", "continuity", "enabled_toolsets", "workdir", "no_agent", "attach_to_session",
-    "paused_reason")
+    "monitor_commit_policy", "paused_reason")
 
 
 def _cronjob_handler(args, **kw):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -967,8 +967,8 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
             },
             "monitor_commit_policy": {
                 "type": "string",
-                "enum": ["detection_time", "after_delivery"],
-                "description": "Optional commit boundary for monitor state. detection_time (default) advances the stored hash as soon as the change is detected. after_delivery keeps the prior hash until the triggered agent run AND its delivery succeed, so a transient failure retries the same change next tick instead of losing it. Requires a monitor."
+                "enum": ["detection_time", "after_delivery", "safe_retry"],
+                "description": "Optional commit boundary for monitor state. detection_time (default) advances the stored hash as soon as the change is detected. after_delivery keeps the prior hash until the triggered agent run AND its delivery succeed, so a transient failure retries the same change next tick instead of losing it. safe_retry retains unresolved work and allows at most two attempts only after confirmed pre-effect failures. Requires a monitor."
             },
             "no_agent": {
                 "type": "boolean",

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -668,6 +668,12 @@ def _kill_process_group_posix(proc) -> None:
                 proc.wait(timeout=0.2)
     except ProcessLookupError:
         pass
+    except PermissionError:
+        # macOS can refuse a signal while the last group member exits.
+        # Reap our child and prove the entire group absent; an alive or
+        # inaccessible group still fails, even when its leader has exited.
+        if proc.poll() is None or not _wait_for_group_exit(proc, pgid, 0):
+            raise
     _sweep_escaped_descendants(descendants, pgid)
 
 

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -341,6 +341,9 @@ class SearchMixin:
                 args, cwd=cwd, env=_make_run_env(self.env.env), stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT if merge_stderr else subprocess.DEVNULL,
                 start_new_session=True)
+            # setsid makes this child the group leader. Preserve the identity
+            # even if a short search exits before cleanup can call getpgid.
+            proc._hermes_pgid = proc.pid
         except OSError as exc:
             return ExecuteResult(stdout=f"rg: {exc}", exit_code=2)
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -1163,3 +1163,39 @@ Cron jobs run in a completely fresh agent session. The prompt must contain every
 ## Security
 
 Scheduled task prompts are scanned for prompt-injection and credential-exfiltration patterns at creation and update time. Prompts containing invisible Unicode tricks, SSH backdoor attempts, or obvious secret-exfiltration payloads are blocked.
+
+## Retaining unfinished monitor observations
+
+A monitor normally records a changed source at detection time. Choose a commit
+policy explicitly when the observation must survive a failed agent run:
+
+```bash
+hermes cron edit <job_id> --monitor-commit-policy safe_retry
+```
+
+`safe_retry` retains the exact pending input and allows at most two attempts
+within the job's existing schedule/dispatch limits. An automatic second attempt
+requires a completed, structured agent failure before any tool started. A
+watchdog worker still running, a tool-bearing failure, a restart during an
+attempt, and an uncertain delivery require reconciliation instead. New source
+observations cannot overwrite pending work. The already-generated response is
+retained privately when delivery cannot be confirmed; it is not regenerated.
+
+A timeout does not establish that a send was cancelled before dispatch. In this
+mode the scheduler does not switch from a failed live send to a standalone
+resend, and an acknowledgement-free result does not advance the monitor hash.
+Partial, empty, or incomplete agent results also cannot acknowledge an event.
+The explicit `[MONITOR_RETRY]` response can request a bounded retry only before
+any tool activity.
+
+Pending observations live in the profile's private `cron/monitor_pending.db`.
+Do not delete this file, reset the output hash, or recreate a job to recover it.
+Pause the job and establish the actual execution/delivery outcome before
+reconciliation. Changing the job's inference, source, prompt, destination, or
+commit policy while an observation remains unresolved is rejected.
+
+The default `detection_time` policy and the existing `after_delivery` policy
+remain available. `after_delivery` reoffers a changed source after downstream
+failure without the conservative pending-attempt protection of `safe_retry`.
+
+Native Codex app-server and ACP runtimes do not qualify for automatic pre-effect retry: their external tool activity may precede its notification. Failed outcomes from those runtimes remain pending for reconciliation.


### PR DESCRIPTION
## What does this PR do?

A monitor can mark an observation seen before generation succeeds, losing the next retry. Deferring the hash until delivery helps, but an unknown delivery or tool outcome can cause duplicate generation or effects. This adds opt-in `monitor_commit_policy="safe_retry"`: retain the unfinished observation and generated response, retry only a confirmed pre-effect failure, and hold ambiguous outcomes for reconciliation.

This extends #91289 and preserves its four commits and original authorship. The default remains `detection_time`; existing jobs are not migrated. The inherited `after_delivery` policy remains available.

## Related Issue

Related to #91287 and builds on #91289. The additional contract is retained pending work and bounded, side-effect-aware retry, beyond the existing after-delivery proposal.

## Type of Change

- [x] Bug fix / reliability
- [x] Opt-in functionality and regression coverage

## Changes Made

- `cron/monitor_pending.py`: private profile-local SQLite pending input/response, attempt tokens, a two-attempt limit, and binding to the job's execution settings. New observations cannot overwrite pending work.
- Scheduler/monitor integration: only completed, structured failures before tools may retry. Interrupted workers, unknown tool effects, native app-server/ACP outcomes, or changed job bindings block automatic replay.
- Delivery: require a successful message acknowledgement; a live timeout cannot trigger a standalone resend. Retain the generated response after an uncertain delivery. Pausing remains possible; pending outcomes block policy changes.
- Native cron APIs, CLI, tool schema, and user documentation expose the opt-in policy.
- Native search cleanup: retain process-group identity; tolerate permission errors only after reaping the child and proving the entire group absent. Live/inaccessible groups still fail and descendant cleanup remains intact.
- QA prerequisite fixtures reproduced on baseline are corrected for native filesystem paths, SQLite durability, isolated update inventory, audio socket paths, portable process counting, and official OS CI markers. These fixture changes are explicitly included in this candidate.

## How to Test

1. Run `scripts/run_tests.sh -j 12 -q`. On exact commit `7be3824803793cc533c903e702ccef16f5fd9498`: **3,914 files; 46,593 passed, 0 failed, 556 skipped**, macOS arm64 / Python 3.11 with the locked CI extras.
2. Run the cron, CLI/tool and delivery suites. The tests cover same-input retry, preservation of pending A when B arrives, acknowledgement/suppression, attempt exhaustion, restart in flight, tool effects, incomplete generation, and ambiguous delivery. An actual AIAgent with a local HTTP provider exercises failed generation followed by successful retry.
3. Run `tests/tools/test_macos_process_exit_race.py`, `test_search_native_rg.py`, `test_read_file_utf8_binary_regression.py`, `test_search_auto_multiline.py`, `test_local_interrupt_cleanup.py`, and `test_local_setsid_descendant_sweep.py` through `scripts/run_tests.sh`: **29 passed**. Two deterministic regressions failed before the fix and passed afterward.
4. Ruff on every changed Python file and `git diff --check`: PASS. Native CLI apply/read-back/rollback before execution preserves unrelated fields in an isolated profile.

## Checklist

- [x] Read the contributing guide and checked existing PRs; relationship to #91289 is explicit.
- [x] Conventional commit messages, regression tests, and relevant CLI/tool documentation.
- [x] Canonical full test runner passed on the exact candidate.
- [x] Cross-platform behavior considered; OS-specific tests use native CI markers.
- [x] No credentials, private IDs, runtime histories, or production patches included.

## Limitations

No external model trial or live message delivery was performed; local deterministic tests do not prove repeated external-agent behavior. Historical work is not replayed. There is no automatic reconciliation of an unknown outcome; it remains held. The native CLI rollback was verified before execution, not after ambiguous effects.

The tested base is `6e07eb48387044dbcaf12490931c2b8ca7ec8653`. The five newer upstream commits through `8068c09432d3e7a23d30aa5f4f7d5a17783f8668` have no changed-file overlap and the three-way preview is conflict-free; they are not part of the tested candidate. GitHub CI remains a separate result.
