### PR TITLE
fix(gateway): scope completion lookup to source profile

### DIFF
--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -1077,11 +1077,39 @@ class GatewayNotificationsMixin:
                 self._completion_deliveries_inflight.add(identity)
             return seen
 
-    async def _classify_completion_target(self, parent_session_id: str) -> str:
+    async def _classify_completion_target(
+        self, parent_session_id: str, *, source: Optional[SessionSource] = None,
+    ) -> str:
         """Classify an async-completion target before adapter acceptance: ``"deliver"`` (spawning
         session live or compression-rotated with a live continuation; the resolver still retargets),
         ``"terminal"`` (parent gone for good — unknown / user boundary like /new; drop the durable row
-        rather than falsely ack), ``"retry"`` (DB unavailable / rotation mid-flight; release the claim)."""
+        rather than falsely ack), ``"retry"`` (DB unavailable / rotation mid-flight; release the claim).
+
+        A multiplexed gateway must read the parent from the profile that created the event. The runner's
+        session DB resolves from the active runtime scope, so enter the event source's scope before the
+        lookup instead of using the gateway's unscoped default-profile handle.
+        """
+        if source is not None:
+            from gateway.profile_routing import ProfileRouteRejected
+            from gateway.run import _async_profile_runtime_scope
+            resolve_profile_home = getattr(self, "_resolve_profile_home_for_source", None)
+            if not callable(resolve_profile_home):
+                logger.debug(
+                    "Async-completion target %s cannot resolve its source profile; retrying delivery",
+                    parent_session_id,
+                )
+                return "retry"
+            try:
+                profile_home = cast(Path, resolve_profile_home(source))
+            except ProfileRouteRejected:
+                logger.warning(
+                    "Async-completion target %s has a rejected profile route; retrying delivery",
+                    parent_session_id,
+                )
+                return "retry"
+            async with _async_profile_runtime_scope(profile_home):
+                return await self._classify_completion_target(parent_session_id)
+
         from gateway.run import _USER_BOUNDARY_END_REASONS
         session_db = getattr(self, "_session_db", None)
         if session_db is None:
@@ -1127,13 +1155,13 @@ class GatewayNotificationsMixin:
         """Unavailable owners/transports must not spend a durable delivery attempt."""
         from gateway.wake import adapter_supports_push
 
+        source = await asyncio.to_thread(self._build_process_event_source, evt)
         parent_session_id = str(evt.get("parent_session_id") or "").strip()
         if parent_session_id:
-            verdict = await self._classify_completion_target(parent_session_id)
+            verdict = await self._classify_completion_target(parent_session_id, source=source)
             if verdict != "deliver":
                 # Definitively closed targets still need the normal terminal disposition.
                 return verdict == "terminal"
-        source = await asyncio.to_thread(self._build_process_event_source, evt)
         if source is not None:
             platform = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
             adapter = self._resolve_injection_adapter(platform, source)
@@ -1192,7 +1220,8 @@ class GatewayNotificationsMixin:
         # can still fail closed inside the message pipeline AFTER the adapter accepted, which would falsely
         # acknowledge the durable row as delivered. Verify the target here, before acceptance, and give
         # drops an honest durable disposition.
-        verdict = await self._classify_completion_target(parent_session_id)
+        source = await asyncio.to_thread(self._build_process_event_source, evt)
+        verdict = await self._classify_completion_target(parent_session_id, source=source)
         if verdict == "terminal":
             if evt_type == "async_delegation":
                 logger.warning(

--- a/tests/gateway/test_multiplex_completion_profile_scope.py
+++ b/tests/gateway/test_multiplex_completion_profile_scope.py
@@ -1,0 +1,89 @@
+"""Regression: async completions read their spawning profile's session store.
+
+A multiplexed gateway's default runtime scope points at the root ``state.db``.
+An async completion is routed from its persisted SessionSource, so its preflight
+must enter that source profile's scope before checking the parent session.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway import run as run_module
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from hermes_constants import get_hermes_home
+
+
+@pytest.mark.asyncio
+async def test_completion_classifier_reads_source_profile_db(tmp_path, monkeypatch):
+    """A trading completion finds its live parent in trading, not default."""
+    default_home = tmp_path / "default"
+    trading_home = tmp_path / "profiles" / "trading"
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    default_db = SimpleNamespace(get_session=AsyncMock(return_value=None))
+    trading_db = SimpleNamespace(get_session=AsyncMock(return_value={"ended_at": None}))
+
+    runner = object.__new__(GatewayRunner)
+    runner._session_db_pinned = run_module._SESSION_DB_UNPINNED
+    runner._resolve_profile_home_for_source = lambda source: trading_home
+
+    def open_active_db(raise_on_error=False):
+        del raise_on_error
+        return trading_db if Path(get_hermes_home()) == trading_home else default_db
+
+    runner._open_session_db_for_active_scope = open_active_db
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        profile="trading",
+    )
+
+    assert await runner._classify_completion_target("sess-trading", source=source) == "deliver"
+    trading_db.get_session.assert_awaited_once_with("sess-trading")
+    default_db.get_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_readiness_passes_event_source_to_classifier():
+    """The async-delegation gate must scope its parent lookup from the event."""
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        profile="trading",
+    )
+    runner = object.__new__(GatewayRunner)
+    runner._build_process_event_source = lambda evt: source
+    runner._classify_completion_target = AsyncMock(return_value="retry")
+    event = {"type": "async_delegation", "parent_session_id": "sess-trading"}
+
+    assert await runner._completion_delivery_ready(event) is False
+    runner._classify_completion_target.assert_awaited_once_with(
+        "sess-trading", source=source,
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_preflight_passes_event_source_to_classifier():
+    """The process-completion preflight uses the same source-scoped lookup."""
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        profile="trading",
+    )
+    runner = object.__new__(GatewayRunner)
+    runner._build_process_event_source = lambda evt: source
+    runner._classify_completion_target = AsyncMock(return_value="deliver")
+    event = {"type": "completion", "parent_session_id": "sess-trading"}
+
+    claim = await runner._preflight_completion_delivery(event)
+    assert claim.proceed is True
+    runner._classify_completion_target.assert_awaited_once_with(
+        "sess-trading", source=source,
+    )


### PR DESCRIPTION
## Summary

Fix async delegation completion preflight for multiplexed gateway profiles.

The completion event already carries (or can reconstruct) its spawning `SessionSource`, but the preflight classifier used the gateway's unscoped session DB. On a multiplexed gateway this is the default-profile `state.db`, so a live parent session in another profile was incorrectly treated as permanently gone and its durable completion was dropped.

This patch:
- enters the source profile's `_async_profile_runtime_scope` before reading the parent session;
- passes the resolved source through both completion preflight paths; and
- adds regression coverage for source-scoped DB selection and both call paths.

## Validation

- `pytest -q tests/gateway/test_multiplex_completion_profile_scope.py tests/gateway/test_completion_delivery.py tests/gateway/test_completion_session_boundary.py tests/gateway/test_relay_final_delivery_incident.py tests/gateway/test_relay_delivery_followups.py`
- `ruff check gateway/run_notifications.py tests/gateway/test_multiplex_completion_profile_scope.py`
- `python -m compileall -q gateway/run_notifications.py tests/gateway/test_multiplex_completion_profile_scope.py`
- `git diff --check`

The regression test fails before the change because `_classify_completion_target` has no source/profile scope and therefore cannot select the profile state DB.

## Scope

No configuration, session data, or profile routing rules are changed.
