### PR TITLE
fix(agent): never dispatch tool calls with synthesized empty-object args

### DIFF
--- a/agent/turn_tool_validation.py
+++ b/agent/turn_tool_validation.py
@@ -137,8 +137,12 @@ def validate_tool_calls(
     # Reset retry counter on successful tool call validation
     agent._invalid_tool_retries = 0
 
-    # Validate tool call arguments are valid JSON; empty strings become empty
-    # objects (common model quirk).
+    # Validate tool call arguments are valid JSON. Empty/whitespace args are NOT
+    # normalized to "{}" here (#105189): that fabricated an invocation the
+    # model never emitted and dispatched side-effecting tools with empty args,
+    # bypassing the executor's "tool was not executed" invariant. They take
+    # the invalid-JSON path below (bounded retry, then error results surfaced
+    # to the model) instead.
     invalid_json_args = []
     for tc in tool_calls:
         args = tc.function.arguments
@@ -148,7 +152,10 @@ def validate_tool_calls(
         if args is not None and not isinstance(args, str):
             tc.function.arguments = args = str(args)
         if not args or not args.strip():
-            tc.function.arguments = "{}"
+            # A mixed-batch invalid-name call never executes (error result later);
+            # don't let its missing args trigger the whole-turn JSON retry.
+            if not (_mixed_invalid_batch and tc.function.name not in valid_names):
+                invalid_json_args.append((tc.function.name, "empty arguments: expected a JSON object"))
             continue
         try:
             json.loads(args)
@@ -162,9 +169,12 @@ def validate_tool_calls(
         invalid_names = {n for n, _ in invalid_json_args}
         # Routers may rewrite finish_reason "length" → "tool_calls", hiding
         # truncation; args not ending in } or ] (stripped) were cut off
-        # mid-stream.
+        # mid-stream. Empty args carry no truncation evidence (a model quirk
+        # for arg-less tools as often as a drop), so they are excluded here
+        # and take the bounded-retry path instead (#105189).
         _truncated = any(
-            not (tc.function.arguments or "").rstrip().endswith(("}", "]"))
+            (tc.function.arguments or "").strip()
+            and not (tc.function.arguments or "").rstrip().endswith(("}", "]"))
             for tc in tool_calls if tc.function.name in invalid_names
         )
         if _truncated:

--- a/tests/run_agent/test_105189_empty_args_never_dispatch.py
+++ b/tests/run_agent/test_105189_empty_args_never_dispatch.py
@@ -1,0 +1,124 @@
+"""#105189: empty tool-call arguments must never be dispatched with synthesized `{}`.
+
+A mid-tool-call stream drop can deliver zero argument bytes (routers may still
+stamp a non-None ``finish_reason``). ``validate_tool_calls`` used to rewrite
+``""`` to ``"{}"`` and return ``"ok"``, so a side-effecting tool
+(e.g. ``browser_exec``) executed with fabricated empty args — bypassing the
+``_parse_tool_arguments`` invariant (``agent/tool_executor.py``: invalid args
+mean "tool was not executed").
+
+Locked behavior: empty/whitespace args take the invalid-JSON path (bounded
+retry, then error results surfaced to the model) and the call is never
+dispatched with synthesized args.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.turn_tool_validation import validate_tool_calls
+
+
+def _tc(call_id, name, arguments):
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _agent(**overrides):
+    agent = MagicMock()
+    agent.valid_tool_names = {"browser_exec", "read_file"}
+    agent._invalid_tool_retries = 0
+    agent._invalid_json_retries = 0
+    agent._uniquify_tool_call_ids = MagicMock()
+    agent._build_assistant_message = MagicMock(
+        return_value={"role": "assistant", "content": "x"}
+    )
+    for key, value in overrides.items():
+        setattr(agent, key, value)
+    return agent
+
+
+def _validate(agent, *tool_calls):
+    assistant_message = SimpleNamespace(content="", tool_calls=list(tool_calls))
+    messages = []
+    verdict = validate_tool_calls(
+        agent,
+        assistant_message,
+        "tool_calls",
+        messages=messages,
+        conversation_history=[],
+        api_call_count=1,
+        effective_task_id="task-1",
+    )
+    return verdict, assistant_message, messages
+
+
+def test_empty_args_are_not_silently_rewritten_to_empty_object():
+    agent = _agent()
+    verdict, assistant_message, _ = _validate(
+        agent, _tc("call-1", "browser_exec", "")
+    )
+    assert verdict.action != "ok"
+    assert assistant_message.tool_calls[0].function.arguments == "", (
+        "empty args must reach neither the handler as '{}' nor the transcript "
+        "rewritten; they take the retry/error path instead"
+    )
+
+
+def test_whitespace_args_are_not_dispatched():
+    agent = _agent()
+    verdict, assistant_message, _ = _validate(
+        agent, _tc("call-1", "browser_exec", "   ")
+    )
+    assert verdict.action != "ok"
+    assert assistant_message.tool_calls[0].function.arguments == "   "
+
+
+def test_empty_args_are_retried_not_refused_as_truncation():
+    # "" carries no truncation evidence (it does not end mid-object); it must
+    # take the bounded-retry path ("continue"), not the outright truncation
+    # refusal ("return" with "Response truncated...").
+    agent = _agent()
+    verdict, _, _ = _validate(agent, _tc("call-1", "browser_exec", ""))
+    assert verdict.action == "continue"
+    assert verdict.result is None
+
+
+def test_empty_args_retry_exhaustion_surfaces_error_to_model():
+    agent = _agent(_invalid_json_retries=2)
+    verdict, _, messages = _validate(agent, _tc("call-1", "browser_exec", ""))
+    assert verdict.action == "continue"
+    tool_results = [m for m in messages if m.get("role") == "tool"]
+    assert len(tool_results) == 1
+    assert "empty object" in tool_results[0]["content"]
+    assert agent._invalid_json_retries == 0
+
+
+def test_valid_sibling_still_runs_after_empty_args_eventually_rejected():
+    # Mixed-shape batch: the empty-args call must not poison validation of a
+    # sibling with complete args — the whole batch takes the retry path and
+    # neither call is dispatched with fabricated args yet.
+    agent = _agent()
+    verdict, assistant_message, _ = _validate(
+        agent,
+        _tc("call-1", "browser_exec", ""),
+        _tc("call-2", "read_file", '{"path": "/tmp/foo"}'),
+    )
+    assert verdict.action == "continue"
+    assert assistant_message.tool_calls[0].function.arguments == ""
+    assert (
+        assistant_message.tool_calls[1].function.arguments
+        == '{"path": "/tmp/foo"}'
+    )
+
+
+def test_genuinely_truncated_args_still_refused_outright():
+    # Non-empty args cut off mid-object keep the old outright-refusal path.
+    agent = _agent()
+    verdict, _, _ = _validate(
+        agent, _tc("call-1", "browser_exec", '{"code": "# Fill email')
+    )
+    assert verdict.action == "return"
+    assert "truncated" in (verdict.result or {}).get("final_response", "").lower()


### PR DESCRIPTION
## 根因

流中断发生在 tool call 中间、但 `finish_reason` 非空时（如路由改写 `length`→`tool_calls`、非流式响应零参数字节），`validate_tool_calls`（`agent/turn_tool_validation.py`）把空/空白参数静默改写成 `"{}"` 并返回 `"ok"` 放行。执行器看到合法 JSON 对象便不再触发 `_parse_tool_arguments` 的 “tool was not executed” 不变量，副作用工具（如 `browser_exec`）带着伪造的空参数被真实执行。

流式 `finish_reason=None` 的零字节/с截断情形基线已有 partial-stub 防护（#80498 相关测试全绿），本次补的是校验层的最后缺口。

## 修复

- 空/空白参数不再合成 `{}`，改走 invalid-JSON 路径：有界重试（3 次）→ 恢复性 tool error 结果回传模型（提示无参工具显式传 `{}`），永不分发合成参数。
- 空参数计入 invalid 后，不再被截断启发式误判为截断而直接 refuse（无截断证据），仍走重试路径；非空截断参数保持原有直接 refuse。
- 单共享函数内修复，所有调用方（sequential/concurrent/segmented）一次性覆盖。

## 测试

- 新增 `tests/run_agent/test_105189_empty_args_never_dispatch.py`（6 用例，TDD 先红后绿）：空/空白参数 verdict 非 ok 且不被改写；走 continue 重试而非截断 refuse；重试耗尽后错误回传模型；真截断仍直接 refuse。
- 回归：`test_malformed_tool_arguments`（执行器不变量）、`test_partial_stream_finish_reason`、`test_anthropic_mid_tool_call_drop`、`test_tool_call_args_sanitizer`、`test_repair_tool_call_arguments`、`test_streaming_tool_call_repair`、`test_canon_args_memo_parity`、`test_message_sanitization_policy`、`test_tool_arg_coercion`、`test_message_sequence_repair`、`test_run_agent`（283✓）全绿；仅有的 4 个失败（`test_streaming` 3 个 +`test_run_agent` 1 个）均为本机缺 `anthropic` 可选包的环境问题，基线同复现，与本次改动无关。

Closes #105189