### PR TITLE
fix(desktop): regrow the transcript when a parked scroll restore is stranded

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list-session-scroll.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list-session-scroll.test.tsx
@@ -169,4 +169,59 @@ describe('list session-scroll restore', () => {
     // resulting reader position. Here the abandoned target must not return.
     expect(vp.scrollTop).not.toBe(2000 - CLIENT_H - 800)
   })
+
+  it('spends pages to regrow toward a saved offset the mounted window cannot cover', async () => {
+    // Heavy turns so the transcript is windowed by the render budget; a saved
+    // offset far below the mounted window must auto-spend pages (the same
+    // Show-earlier path) instead of stranding at the clamped top.
+    const heavy = 'x'.repeat(5000)
+    const messages = Array.from({ length: 60 }, (_, i) => [
+      {
+        id: `u-${i}`,
+        role: 'user',
+        content: [{ type: 'text', text: heavy }],
+        attachments: [],
+        createdAt,
+        metadata: { custom: {} }
+      } as ThreadMessage,
+      {
+        id: `a-${i}`,
+        role: 'assistant',
+        content: [{ type: 'text', text: heavy }],
+        status: { type: 'complete', reason: 'stop' },
+        createdAt,
+        metadata: { unstable_state: null, unstable_annotations: [], unstable_data: [], steps: [], custom: {} }
+      } as ThreadMessage
+    ]).flat()
+
+    // Control: no saved offset — the default window stays capped.
+    const ctl = render(<ScrollHarness messages={messages} sessionKey="ctl" />)
+    const stableGroups = async (container: HTMLElement) => {
+      let count = container.querySelectorAll('[data-slot="aui_message-group"]').length
+
+      for (let round = 0; round < 25; round += 1) {
+        await settleScroll(10)
+        const next = container.querySelectorAll('[data-slot="aui_message-group"]').length
+
+        if (next === count) {
+          return count
+        }
+
+        count = next
+      }
+
+      return count
+    }
+
+    const ctlGroups = await stableGroups(ctl.container)
+    ctl.unmount()
+
+    // Deep saved offset — the regrow effect spends pages toward it.
+    saveThreadScrollPosition('regrow', { fromBottom: 999999, kind: 'offset' })
+    const deep = render(<ScrollHarness messages={messages} sessionKey="regrow" />)
+    const deepGroups = await stableGroups(deep.container)
+
+    expect(ctlGroups).toBeGreaterThan(0)
+    expect(deepGroups).toBeGreaterThan(ctlGroups)
+  })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -127,6 +127,12 @@ export const shouldClampTranscriptBudget = (hidden: boolean, renderBudget: numbe
 // still well under the measured 780ms single-jump freeze.
 const BACKFILL_STEP = 290
 
+// Auto-spent budget pages while a parked reading offset waits for the tree
+// to cover it (see the grow effect). The real bound is the transcript
+// itself; this only stops a truncated-window fetch that never lands from
+// re-arming forever.
+const PARKED_OFFSET_MAX_PAGES = 96
+
 export const transcriptBackfillFrameCount = (
   firstPaint = FIRST_PAINT_BUDGET,
   step = BACKFILL_STEP,
@@ -496,6 +502,11 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // load in progress, not a reading position anyone chose — never anchor to it.
   const loadSettledRef = useRef(false)
   const cancelRestoreRef = useRef<(() => void) | null>(null)
+  // Pages auto-spent toward the current parked offset; reset at each park.
+  const autoGrowPagesRef = useRef(0)
+  // Bumped when the settle loop parks an offset, so the grow effect below
+  // re-runs with fresh state even when no other dependency changed.
+  const [restoreGrowTick, setRestoreGrowTick] = useState(0)
   const isRunning = useAuiState(s => s.thread.isRunning)
   // Session the settle loop last armed for, so a re-arm within the same load
   // is distinguishable from a switch to a different transcript.
@@ -513,6 +524,17 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     const el = scrollRef.current
 
     if (!el || !loadSettledRef.current) {
+      return
+    }
+
+    // A following view can be caught mid-catch-up: an earlier prepend slid
+    // the content down while the stick's re-pin hasn't landed yet, so
+    // sh - scrollTop measures a transient overshoot. Parking that value
+    // strands the view exactly that far above the bottom once the stick
+    // catches up. Following means the bottom is the destination.
+    if (el.getAttribute('data-following') === 'true' && threadScrollStateFromMetrics(el).kind !== 'bottom') {
+      restoreFromBottomRef.current = el.clientHeight
+
       return
     }
 
@@ -859,6 +881,12 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
           // can't be overwritten by a mid-load anchor measurement. The restore
           // effect flips settled once it consumes the parked value.
           restoreFromBottomRef.current = target.fromBottom + node.clientHeight
+          // Reset the auto-spend counter and wake the grow effect below: the
+          // parked offset needs the tree to grow, and once the render has
+          // topped out nothing else re-runs the growth check. The tick makes
+          // the effect re-read fresh budget/render state.
+          autoGrowPagesRef.current = 0
+          setRestoreGrowTick(tick => tick + 1)
         } else {
           loadSettledRef.current = true
         }
@@ -1006,6 +1034,56 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     }
     // renderBudget covers DOM pages; groups.length covers store-window expands.
   }, [scrollRef, renderBudget, groups.length])
+
+  // A parked offset deeper than the tree needs the transcript to GROW, and
+  // nothing else keeps growing it — the budget backfill tops out at one pane
+  // page and only a user click used to spend more. Spend pages in the same
+  // order as "Show earlier" (DOM budget first, then the store window) until
+  // the tree covers the parked offset; each committed budget re-runs this
+  // effect for the next page. Without this the view stays stranded at the
+  // clamped top and, because the load never counts as settled, the recorded
+  // position never refreshes — every switch back strands it at the same
+  // spot. The parked ref must survive these spends untouched: it is
+  // re-applied (never re-measured), so no anchor is taken here.
+  useLayoutEffect(() => {
+    const el = scrollRef.current
+    const restoreFromBottom = restoreFromBottomRef.current
+
+    if (!el || restoreFromBottom == null || el.scrollHeight >= restoreFromBottom) {
+      return
+    }
+
+    // Wait for the stepped backfill to top out first: while it is still
+    // climbing the tree may cover the offset on its own, and racing it would
+    // only hoard pages. A hidden pane stays put entirely — its budget is
+    // clamped to the live tail and the reveal re-runs this effect.
+    if (renderBudget < paneBudget || !paneVisible) {
+      return
+    }
+
+    const action = resolveShowEarlierAction(hiddenCount, olderAvailable)
+
+    if (!action || autoGrowPagesRef.current >= PARKED_OFFSET_MAX_PAGES) {
+      return
+    }
+
+    autoGrowPagesRef.current += 1
+    startTransition(() => setRenderBudget(budget => budget + paneBudget))
+
+    if (action === 'window') {
+      expandWindow()
+    }
+  }, [
+    restoreGrowTick,
+    scrollRef,
+    renderBudget,
+    groups.length,
+    hiddenCount,
+    olderAvailable,
+    paneBudget,
+    expandWindow,
+    paneVisible
+  ])
 
   // The row array is memoized on the inputs the rows actually read. This
   // component re-renders on every isAtBottom flip — and use-stick-to-bottom


### PR DESCRIPTION
## What does this PR do?

Leaving a long session mid-read and switching back can strand the Desktop transcript at the clamped top: the settle loop parks the saved reading offset (`fromBottom + clientHeight`) waiting for the remounted tree to grow past it, but nothing grows the tree beyond one pane page — only a user Show-earlier click used to spend more. The parked offset then never becomes reachable, the load never counts as settled, and the recorded position never refreshes, so every switch back strands the view at the top again.

This makes the parked restore spend pages the same way the Show-earlier button does (DOM render budget first, then the store window) until the tree covers the parked offset, at which point the existing consume path lands the viewport at the recorded reading position.

It also fixes a related strand-on-fresh-open case: `anchorBeforePrepend` could park a transient overshoot measured mid-catch-up while the view was following the bottom, dragging a freshly opened transcript up off the bottom once the stick re-pinned.

## Related Issue

No tracking issue — reliable reproduction steps are below.

Related open PRs (same broad area, different phases): #103365 and #70478 address the original per-session position-memory gap; this fixes the remaining strand on top of the parked-offset restore machinery that shipped after them.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/components/assistant-ui/thread/list.tsx`
  - New grow `useLayoutEffect`, woken by a tick bumped at the park site: spends budget pages through the same `resolveShowEarlierAction` order as Show earlier until `scrollHeight` covers the parked `restoreFromBottomRef`, bounded by `PARKED_OFFSET_MAX_PAGES`. It waits for the stepped backfill to top out first (the tree may cover the offset on its own), leaves hidden panes untouched (their budget is clamped to the live tail; the reveal re-runs the effect), and never re-measures the parked value.
  - `anchorBeforePrepend` now re-parks to the live edge when the view is following (`data-following="true"`) instead of measuring a transient `scrollHeight - scrollTop`.
- `apps/desktop/src/components/assistant-ui/thread/list-session-scroll.test.tsx`
  - New test: a saved offset below the mounted window spends pages — the mounted group count grows past the capped control's count.

## How to Test

1. Open a long session, scroll deep (or use Show earlier a few times and scroll up), switch to another session, switch back.
   - Before: the viewport strands at the clamped top and never moves; the stored position stays stale, so every switch back repeats the strand.
   - After: the transcript regrows over a few seconds and the view lands at the recorded position; repeat switches hold.
2. Fresh-open a long session: before, it could jump up off the bottom about a second in (stale anchor); after, it stays pinned to the bottom.
3. `vitest run src/components/assistant-ui/thread` — 193 passed, including the new case and the existing scroll-restore tests.

Verified on a live dev instance with CDP-driven reproduction scripts (deep-scroll leave/return; fresh-open) before and after, plus the unit suite above.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(desktop):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` — not applicable to a desktop-renderer fix; ran the desktop unit suite instead
- [x] I've added tests for my changes
