### PR TITLE
fix(desktop): refuse steer into a session with no live turn

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -2504,6 +2504,36 @@ describe('usePromptActions redirectPrompt', () => {
     expect(await handle!.redirectPrompt('too late')).toBe(false)
   })
 
+  it('refuses to steer a session with no live turn — no echo, no RPC (#105176)', async () => {
+    // The foreground ref still names a session whose turn already settled:
+    // not busy, no stream, not awaiting a response. There is nothing to
+    // redirect, so the steer must NOT echo a bubble into this chat nor RPC an
+    // idle session — returning false lets the caller queue the text for the
+    // conversation whose run is actually live.
+    publishSessionState(RUNTIME_SESSION_ID, createClientSessionState(RUNTIME_SESSION_ID))
+
+    try {
+      const requestGateway = vi.fn(async () => ({ status: 'redirected' }) as never)
+
+      let handle: HarnessHandle | null = null
+      const capturedStates: Record<string, unknown>[] = []
+      await actRender(
+        <Harness
+          onReady={h => (handle = h)}
+          onSeedState={state => capturedStates.push(state)}
+          refreshSessions={async () => undefined}
+          requestGateway={requestGateway}
+        />
+      )
+
+      expect(await handle!.redirectPrompt('stale steer')).toBe(false)
+      expect(requestGateway).not.toHaveBeenCalled()
+      expect(capturedStates).toEqual([])
+    } finally {
+      dropSessionState(RUNTIME_SESSION_ID)
+    }
+  })
+
   it('reports rejection without throwing when the redirect RPC errors', async () => {
     const requestGateway = vi.fn(async () => {
       throw new Error('agent does not support redirect')

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -745,6 +745,21 @@ export function usePromptActions({
         return false
       }
 
+      // #105176: the foreground ref can still name a session whose turn
+      // already settled (a stale busy on the composer fires a steer for it).
+      // Redirecting it would echo the bubble into a chat the user never typed
+      // in and RPC an idle session whose text the backend can cross-deliver
+      // into another session's live run. Refuse before the optimistic insert
+      // so the caller queues the text for the live conversation instead. An
+      // unknown session (no cached state) still goes through: absence of
+      // cache is not evidence of idleness, and the gateway authoritatively
+      // rejects idle redirects.
+      const liveTurn = $sessionStates.get()[sessionId]
+
+      if (liveTurn && !liveTurn.busy && !liveTurn.streamId && !liveTurn.awaitingResponse) {
+        return false
+      }
+
       // Accepted whether the live turn was redirected in place or queued for
       // the next turn (the build window, before the agent is wired) — either
       // way the correction reaches the model, so record it once as a real user


### PR DESCRIPTION
Closes #105176.

Problem: a steer fired while the foreground session's turn had already settled echoed the bubble into that (wrong) chat and RPC'd an idle session, whose text the backend could cross-deliver into another session's live run — never persisted as a user row anywhere.

Approach: single liveness guard in the shared `redirectPrompt` (covers main composer, tile, and queue-panel steer paths — all route through it): when the resolved target has cached state with no live turn (not busy, no streamId, not awaitingResponse), return false before the optimistic insert and before the RPC, so callers queue the text for the live conversation. Unknown sessions (no cached state) still go through; the gateway remains authoritative for idle rejects.

Tests: new regression test refuses-to-steer with no live turn (proven RED pre-fix, GREEN post-fix); full `use-prompt-actions` suite 134 passed; `steer-arrival-order` 4 passed; `tsc --noEmit` clean.

Risk: low — fail-open on unknown state preserves current behavior; only idle-with-known-state steers change (previously phantom bubble + doomed RPC).

Excluded: explicit per-surface steer targets (tile steering while another session is genuinely live still goes to the foreground) — separate enhancement, needs target plumbing across ChatView/ChatBar.