### PR TITLE
fix(bot-mode): resolve local display names and Desktop slugs to folder ids

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
@@ -357,6 +357,37 @@ describe('the mention middleware', () => {
     expect(result.text).not.toMatch(/ — on /)
   })
 
+  it('emits the canonical folder id for a renamed local bot slug (#100671)', async () => {
+    // Folder `writer`, display_name `Scribe`: the user tags @scribe, the
+    // backend only accepts the folder id — the annotation must carry it.
+    const { handler } = await contributions({
+      focused: 'builder',
+      profiles: [
+        { display_name: 'Scribe', name: 'writer' },
+        { display_name: 'Builder', name: 'builder' }
+      ]
+    })
+    const result = await handler({ text: 'ask @scribe about the design' })
+
+    expect(result.text).toMatch(/@scribe = agent profile "writer"/)
+    expect(result.text).toMatch(/message_agent target: "writer"/)
+    expect(result.text).not.toMatch(/message_agent target: "scribe"/)
+  })
+
+  it('needs no target annotation when the friendly name matches the folder id', async () => {
+    const { handler } = await contributions({
+      focused: 'writer',
+      profiles: [
+        { display_name: 'Scribe', name: 'writer' },
+        { display_name: 'Builder', name: 'builder' }
+      ]
+    })
+    const result = await handler({ text: 'ask @builder about the design' })
+
+    expect(result.text).toMatch(/@builder = agent profile "builder"/)
+    expect(result.text).not.toMatch(/message_agent target: "builder"/)
+  })
+
   it('teaches no shellout and forbids forwarding the user’s text verbatim', async () => {
     // The class behind #91397 / #91304 / #91339: the renderer used to compose
     // a `hermes -p …` handoff, giving the model a second send path and a way

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -745,17 +745,25 @@ export default {
             const target =
               bot.remoteSource && bot.connectionId ? `${bot.name}@${bot.connectionId}` : botHandle(bot.name)
 
+            // Renamed local bots are tagged by their friendly slug (@scribe
+            // for folder 'writer'): the emitted line must name the canonical
+            // folder id message_agent accepts, not the UI-only slug (#100671).
+            // Show the tag the user actually typed (the friendly slug when one
+            // exists) and annotate the canonical target whenever it differs.
+            const tag = botMentionTag(bot)
+            const shown = tag && tag.toLowerCase() !== handle.toLowerCase() ? tag : handle
+
             // Local rows get the same annotation whenever their UI alias
-            // ('default-this-device') differs from the resolvable handle —
-            // otherwise the agent has only the alias to go on and the local
-            // path rejects it the same way (#97678).
+            // ('default-this-device') or friendly slug ('scribe') differs from
+            // the resolvable handle — otherwise the agent has only the alias
+            // to go on and the local path rejects it the same way (#97678).
             const where = bot.remoteSource
               ? ` — on ${bot.connectionLabel || bot.connectionId} (message_agent target: "${target}")`
-              : handle !== target
+              : handle !== target || shown.toLowerCase() !== target.toLowerCase()
                 ? ` (message_agent target: "${target}")`
                 : ''
 
-            return `@${handle} = agent profile "${bot.name}"${title ? ` ("${title}")` : ''}${where}`
+            return `@${shown} = agent profile "${bot.name}"${title ? ` ("${title}")` : ''}${where}`
           })
 
           const note =

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -195,6 +195,141 @@ def test_unregistered_peer_rejected(tmp_path):
     assert result["peers"] == ["spark"]
 
 
+# ── local alias resolution (#100671) ──────────────────────────────────────────
+
+
+def _managed_home_with_identities(tmp_path, identities) -> Path:
+    """Managed home where each teammate carries display_name / Bot Mode title.
+
+    ``identities``: {folder: {"display_name": ..., "title": ...}}.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir(exist_ok=True)
+    for name, meta in identities.items():
+        d = home / "profiles" / name
+        d.mkdir(parents=True, exist_ok=True)
+        lines = []
+        if meta.get("display_name"):
+            lines.append(f"display_name: {meta['display_name']}")
+        lines.append("description: teammate for tests")
+        lines.append("ui_meta:")
+        lines.append("  hermes-bots:")
+        if meta.get("title"):
+            lines.append(f"    title: {meta['title']}")
+        else:
+            lines.append("    shape: cloud")
+        (d / "profile.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return home
+
+
+def test_resolve_local_name_display_name_and_slug(tmp_path):
+    """@scribe / Scribe resolve to folder `writer`; Builder to `builder`."""
+    home = _managed_home_with_identities(
+        tmp_path, {"writer": {"display_name": "Scribe"}, "builder": {"display_name": "Builder"}}
+    )
+    from tools.bot_mode_probe import _local_alias_map, _roster, _hermes_root
+
+    root = _hermes_root(home)
+    roster_homes = dict(_roster(root))
+    roster = list(roster_homes)
+    alias_map = _local_alias_map(list(roster_homes.items()))
+    for target in ("scribe", "@scribe", "Scribe", "SCRIBE"):
+        assert bot_mode_dm._resolve_local_name(target, roster, alias_map) == "writer"
+    for target in ("Builder", "BUILDER", "@builder", "builder"):
+        assert bot_mode_dm._resolve_local_name(target, roster, alias_map) == "builder"
+    # folder ids still win
+    assert bot_mode_dm._resolve_local_name("writer", roster, alias_map) == "writer"
+
+
+def test_resolve_local_name_punctuated_display_name(tmp_path):
+    """'Dr. Foo' and its Desktop slugs resolve to folder `foo`."""
+    home = _managed_home_with_identities(tmp_path, {"foo": {"display_name": "Dr. Foo"}})
+    from tools.bot_mode_probe import _local_alias_map, _roster, _hermes_root
+
+    root = _hermes_root(home)
+    roster_homes = dict(_roster(root))
+    roster = list(roster_homes)
+    alias_map = _local_alias_map(list(roster_homes.items()))
+    for target in ("Dr. Foo", "dr. foo", "dr-foo", "drfoo", "@dr-foo"):
+        assert bot_mode_dm._resolve_local_name(target, roster, alias_map) == "foo"
+
+
+def test_resolve_local_name_bot_mode_title(tmp_path):
+    """The Bot Mode title is an alias too."""
+    home = _managed_home_with_identities(
+        tmp_path, {"researcher": {"title": "Research Buddy"}}
+    )
+    from tools.bot_mode_probe import _local_alias_map, _roster, _hermes_root
+
+    root = _hermes_root(home)
+    roster_homes = dict(_roster(root))
+    roster = list(roster_homes)
+    alias_map = _local_alias_map(list(roster_homes.items()))
+    for target in ("Research Buddy", "research-buddy", "researchbuddy"):
+        assert bot_mode_dm._resolve_local_name(target, roster, alias_map) == "researcher"
+
+
+def test_resolve_local_name_ambiguous_fails_closed(tmp_path):
+    """One display name on two profiles resolves to neither."""
+    home = _managed_home_with_identities(
+        tmp_path, {"aaa": {"display_name": "Scribe"}, "bbb": {"display_name": "Scribe"}}
+    )
+    from tools.bot_mode_probe import _local_alias_map, _roster, _hermes_root
+
+    root = _hermes_root(home)
+    roster_homes = dict(_roster(root))
+    roster = list(roster_homes)
+    alias_map = _local_alias_map(list(roster_homes.items()))
+    assert bot_mode_dm._resolve_local_name("scribe", roster, alias_map) is None
+    # folder ids stay unambiguous
+    assert bot_mode_dm._resolve_local_name("aaa", roster, alias_map) == "aaa"
+
+
+def test_resolve_local_name_reserved_never_hijacked(tmp_path):
+    """A bot renamed 'Hermes' must not steal the primary profile's alias."""
+    home = _managed_home_with_identities(tmp_path, {"ops": {"display_name": "Hermes"}})
+    from tools.bot_mode_probe import _local_alias_map, _roster, _hermes_root
+
+    root = _hermes_root(home)
+    roster_homes = dict(_roster(root))
+    roster = list(roster_homes)
+    alias_map = _local_alias_map(list(roster_homes.items()))
+    assert bot_mode_dm._resolve_local_name("hermes", roster, alias_map) == "default"
+    assert bot_mode_dm._resolve_local_name("ops", roster, alias_map) == "ops"
+
+
+def test_message_agent_accepts_display_name_and_slug(tmp_path, monkeypatch):
+    """End to end: target 'Scribe'/@scribe delivers into folder `writer`."""
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home_with_identities(
+        tmp_path, {"writer": {"display_name": "Scribe"}, "builder": {"display_name": "Builder"}}
+    )
+    agent = _FakeAgent(home, title="Bot Chat")
+    for target in ("Scribe", "@scribe", "scribe"):
+        calls.clear()
+        result = json.loads(
+            bot_mode_dm.message_agent_tool(target=target, message="hi", agent=agent)
+        )
+        assert result["status"] == "sent", result
+        _mode, _dm_file, transport_argv = _runner_parts(calls[0]["command"])
+        assert transport_argv[1:3] == ["-p", "writer"]
+
+
+def test_message_agent_accepts_punctuated_display_name(tmp_path, monkeypatch):
+    """End to end: 'Dr. Foo' (spaces/punctuation) is a valid target."""
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home_with_identities(tmp_path, {"foo": {"display_name": "Dr. Foo"}})
+    agent = _FakeAgent(home, title="Bot Chat")
+    for target in ("Dr. Foo", "dr-foo"):
+        calls.clear()
+        result = json.loads(
+            bot_mode_dm.message_agent_tool(target=target, message="hi", agent=agent)
+        )
+        assert result["status"] == "sent", result
+        _mode, _dm_file, transport_argv = _runner_parts(calls[0]["command"])
+        assert transport_argv[1:3] == ["-p", "foo"]
+
+
 # ── delivery command shape ───────────────────────────────────────────────────
 
 

--- a/tests/tools/test_bot_mode_probe.py
+++ b/tests/tools/test_bot_mode_probe.py
@@ -94,6 +94,64 @@ def test_roster_lines_carry_roles(tmp_path):
     assert "Deep research and literature review" in section
 
 
+def test_roster_lines_alias_renamed_profile(tmp_path):
+    """#100671: a renamed folder lists its display name + slug (untagged handoff)."""
+    import textwrap as _tw
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    d = home / "profiles" / "writer"
+    d.mkdir(parents=True)
+    (d / "profile.yaml").write_text(
+        _tw.dedent(
+            """\
+            display_name: Scribe
+            ui_meta:
+              hermes-bots:
+                shape: cloud
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    section = bot_mode_probe.get_bot_mode_protocol_section(home)
+    assert "Scribe" in section
+    assert "@scribe" in section
+    assert "`@writer" in section
+
+
+def test_roster_lines_skip_alias_when_name_matches(tmp_path):
+    """display_name == folder id adds no noise."""
+    import textwrap as _tw
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    d = home / "profiles" / "builder"
+    d.mkdir(parents=True)
+    (d / "profile.yaml").write_text(
+        _tw.dedent(
+            """\
+            display_name: Builder
+            ui_meta:
+              hermes-bots:
+                shape: cloud
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    section = bot_mode_probe.get_bot_mode_protocol_section(home)
+    assert "`@builder`" in section
+    assert "aka" not in section
+
+
+def test_mention_name_forms_parity_with_desktop():
+    assert bot_mode_probe._mention_name_forms("Research Buddy") == ["research-buddy", "researchbuddy"]
+    assert bot_mode_probe._mention_name_forms("Dr. Foo") == ["dr-foo", "drfoo"]
+    assert bot_mode_probe._mention_name_forms("Hermes") == []
+    assert bot_mode_probe._mention_name_forms("") == []
+
+
 def test_soul_legacy_protocol_no_longer_suppresses_live_section(tmp_path):
     """Plugin-era SOUL append is stripped at load time; the live roster is the only copy."""
     home = tmp_path / ".hermes"

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -154,12 +154,31 @@ def ensure_message_agent_tool(agent: Any) -> bool:
         return False
 
 
-def _resolve_local_name(target: str, roster: list[str]) -> Optional[str]:
-    """Map a target handle to a profile name ('hermes' → 'default')."""
-    want = target.strip().lower()
+def _resolve_local_name(
+    target: str, roster: list[str], alias_map: dict[str, str | None] | None = None
+) -> Optional[str]:
+    """Map a target handle to a profile name ('hermes' → 'default').
+
+    Beyond folder ids (case-insensitive), resolves friendly aliases when
+    ``alias_map`` is given: ``display_name``, the Bot Mode title, and their
+    Desktop @-slug forms (``'Dr. Foo'`` → ``dr-foo``/``drfoo``). Ambiguous
+    forms (claimed by two profiles) and reserved tokens never resolve —
+    fail closed. Without ``alias_map`` this is the legacy folder-id-only
+    lookup.
+    """
+    want = target.strip().lstrip("@").strip().lower()
+    if not want:
+        return None
     if want == "hermes":
         return "default" if "default" in roster else None
-    return next((name for name in roster if name.lower() == want), None) if want else None
+    direct = next((name for name in roster if name.lower() == want), None)
+    if direct is not None:
+        return direct
+    if alias_map:
+        hit = alias_map.get(want)
+        if hit is not None and hit in roster:
+            return hit
+    return None
 
 
 def _err(message: str, *, roster: list[str] | None = None, peers: list[str] | None = None) -> str:
@@ -228,11 +247,18 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
         return _start_delivery(["hermes", "-p", _self_profile_name(root), "peer", "dm", dm_target], content,
                                f"@{peer_profile or peer_name} on peer '{peer_name}'", stdin_file=True, **delivery)
 
-    # Local teammate.
-    is_local_shape = bool(_LOCAL_TARGET_RE.match(raw_target))
-    if not is_local_shape and "@" not in raw_target:
-        return _roster_err(f"Invalid target: {raw_target!r}.")
-    resolved = _resolve_local_name(raw_target, roster) if is_local_shape else None
+    # Local teammate. Friendly names carry spaces/punctuation ("Dr. Foo") that
+    # never match the handle grammar — resolve those through the live alias
+    # map (folder id + display_name + Bot Mode title + Desktop @-slugs)
+    # before rejecting the shape. Relay handles any '@'-qualified form.
+    from tools.bot_mode_probe import _local_alias_map
+
+    alias_map = _local_alias_map(list(roster_homes.items()))
+    resolved = _resolve_local_name(raw_target, roster, alias_map)
+    if resolved is None:
+        is_local_shape = bool(_LOCAL_TARGET_RE.match(raw_target))
+        if not is_local_shape and "@" not in raw_target:
+            return _roster_err(f"Invalid target: {raw_target!r}.")
     if resolved is None or resolved == me:
         # Unknown locally, or same-name target on ANOTHER connection (this gateway's 'default'
         # messaging the cloud 'default'): every Desktop-connected gateway is reachable via the

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -68,6 +68,99 @@ def _handle(name: str) -> str:
     return "hermes" if name == "default" else name
 
 
+# Tokens the mention charset reserves: a rename must never hijack them
+# (mirrors the Desktop ``mentionNameForms`` filter in
+# ``apps/desktop/src/plugins/hermes-bots/data.ts``).
+_RESERVED_MENTION_FORMS = frozenset({"all", "everyone", "user", "default", "hermes"})
+
+
+def _mention_name_forms(value: object) -> list[str]:
+    """Taggable @-forms for a friendly name: slug + collapsed (Desktop parity).
+
+    ``'Research Buddy'`` → ``['research-buddy', 'researchbuddy']``;
+    ``'Dr. Foo'`` → ``['dr-foo', 'drfoo']``. Reserved tokens drop out so a
+    bot renamed ``'Hermes'`` can never hijack the primary profile's alias.
+    """
+    import re as _re
+
+    name = str(value or "").strip().lower()
+    if not name:
+        return []
+    slug = _re.sub(r"[^a-z0-9_-]+", "-", name).strip("-")
+    collapsed = _re.sub(r"[^a-z0-9_-]+", "", name)
+    forms = [
+        f for f in dict.fromkeys((slug, collapsed)) if f and _re.fullmatch(r"[a-z0-9][a-z0-9_-]*", f)
+    ]
+    return [f for f in forms if f not in _RESERVED_MENTION_FORMS]
+
+
+def _profile_friendly_names(profile_dir: Path) -> list[str]:
+    """Renameable names for a local profile: Bot Mode title + display_name."""
+
+    def _names() -> list[str]:
+        data = _read_yaml_dict(profile_dir / "profile.yaml") or {}
+        out: list[str] = []
+        for raw in ((_bots_meta(data) or {}).get("title"), data.get("display_name")):
+            text = str(raw or "").strip()
+            if text and text not in out:
+                out.append(text)
+        return out
+
+    return _swallow(_names, [])
+
+
+def _local_alias_map(roster: list[tuple[str, Path]]) -> dict[str, str | None]:
+    """Lower-cased alias → canonical folder id (None when ambiguous).
+
+    Keys: folder id, ``hermes`` (→ ``default``), each friendly exact form and
+    its slug/collapsed mention forms. A form claimed by two profiles resolves
+    to None (fail closed, like the Desktop ``byForm`` collision rule).
+    """
+    aliases: dict[str, str | None] = {}
+    for name, profile_dir in roster:
+        claims = {name.lower()}
+        for friendly in _profile_friendly_names(profile_dir):
+            claims.add(friendly.lower())
+            claims.update(_mention_name_forms(friendly))
+        for form in claims:
+            if not form:
+                continue
+            if form in aliases and aliases[form] != name:
+                aliases[form] = None
+            else:
+                aliases.setdefault(form, name)
+    if "default" in (name for name, _d in roster):
+        if "hermes" in aliases and aliases["hermes"] != "default":
+            aliases["hermes"] = None
+        else:
+            aliases.setdefault("hermes", "default")
+    return aliases
+
+
+def _profile_alias_label(name: str, profile_dir: Path) -> str:
+    """``' (aka "Scribe", @scribe)'`` for roster lines; ``''`` when unrenamed."""
+    handle = _handle(name).lower()
+    seen: list[str] = []
+    for friendly in _profile_friendly_names(profile_dir):
+        if not friendly or friendly.lower() in (name.lower(), handle):
+            continue
+        forms = _mention_name_forms(friendly)
+        piece = f'"{friendly}"'
+        slug = forms[0] if forms else ""
+        if slug and slug.lower() not in (name.lower(), handle):
+            piece += f", @{slug}"
+        if piece not in seen:
+            seen.append(piece)
+    return f" (aka {', '.join(seen)})" if seen else ""
+
+
+def _roster_line(name: str, profile_dir: Path) -> str:
+    """One teammate row: ``- `@handle` (aka ...) — role`` (same join as _bullet)."""
+    role = _profile_role(profile_dir)
+    line = f"- `@{_handle(name)}`{_profile_alias_label(name, profile_dir)}"
+    return f"{line} — {role}" if role else line
+
+
 def _roster(root: Path) -> list[tuple[str, Path]]:
     """(name, dir) for the default profile + every named profile, sorted."""
     profiles = root / "profiles"
@@ -196,7 +289,9 @@ def _build_section(home: Path) -> str:
     if not _any_managed(root):
         return ""
 
-    roster_lines = [_bullet(f"@{_handle(name)}", _profile_role(d)) for name, d in _roster(root) if name != me]
+    roster_lines = [
+        _roster_line(name, d) for name, d in _roster(root) if name != me
+    ]
     roster_block = "\n".join(roster_lines) or "- (no teammates yet)"
 
     return (
@@ -297,7 +392,7 @@ def capability_fingerprint(home: str | os.PathLike | None = None) -> str:
         surface["roster"] = sorted(n for n, d in roster if _is_bot_managed(d))
         # Roles are part of the messaging surface: renaming a bot or editing a
         # description must refresh the roster block teammates pick recipients from.
-        surface["roster_roles"] = sorted(f"{n}:{_profile_role(d)}" for n, d in roster)
+        surface["roster_roles"] = sorted(f"{n}:{_profile_role(d)}:{_profile_alias_label(n, d)}" for n, d in roster)
     except Exception:
         surface["roster"] = []
     # Protocol-text version salt: bumping it refreshes every eternal Bot Chat


### PR DESCRIPTION
Closes #100671.

## 根因
本地 Bot Mode 的 message_agent 按 folder id 定址（tools/bot_mode_dm.py _resolve_local_name），只做 folder id 大小写匹配。Desktop 自动补全插入的是友好名 slug（@scribe ← display_name Scribe），而 profile.yaml 的 display_name、Bot Mode title 从未进入解析：@builder 碰巧与 folder id 相同所以能用，@scribe 则报 No teammate named；带标点的展示名（Dr. Foo）连 handle 字符集检查都过不了，直接判 Invalid target。未加 @ 的称呼更 never 触发 mention 中间件，模型只能去读 profiles/<id>/ 下的 SOUL.md 猜队友。

## 修复
- tools/bot_mode_probe.py：新增与桌面 mentionNameForms 同构的 _mention_name_forms（slug＋collapsed、保留词过滤），_profile_friendly_names（Bot Mode title＋display_name），_local_alias_map（folder id＋友好名原文＋slug 形式→folder id；冲突置空 fail closed），花名册行经 _roster_line 追加 (aka "Scribe", @scribe)（display_name 与 folder id 相同大小写时不加噪），capability 指纹同步计入别名。
- tools/bot_mode_dm.py：_resolve_local_name 接受 alias_map（@ 前缀、大小写统一），分发先走别名解析再做字符集拒绝，Dr. Foo 类目标不再误判。
- apps/desktop/src/plugins/hermes-bots/plugin.tsx：mention 中间件对改名本地 bot 展示友好 slug 并标注 message_agent target 为规范 folder id（@scribe → target "writer"）；与 folder id 一致时不加注。
- #94018 的 Bot Chat 门禁未动：cron、subagent、Group: 成员会话、非托管安装仍拒绝。

## 测试
- 新增：tests/tools/test_bot_mode_dm.py 7 项（display_name/slug/大小写、Dr. Foo 及其 slug、title 别名、冲突闭门、保留词不劫持、两条端到端分发断言 -p writer/foo）；tests/tools/test_bot_mode_probe.py 3 项（花名册 aka 行、同名免噪、mention 形式与桌面一致）；plugin.mentions.test.ts 2 项（@scribe 标注 writer、同名免注）。
- 结果：run_tests.sh 下 test_bot_mode_dm 49✓（2 个 dm_dir 权限断言为基线在 Windows 上的既有失败，stash 验证与本改动无关）、test_bot_mode_probe 17✓、test_bot_relay 27✓、payload cache 5✓、refresh_agent_mcp_tools 19✓；桌面 hermes-bots 全套 63 文件 586✓（含新增 2 项）。
- 手工复现：writer/Scribe、builder/Builder、foo/Dr. Foo 三 profile 下，scribe/@scribe/Scribe→writer、Builder→builder、Dr. Foo/dr-foo/drfoo→foo、hermes→default 全部命中，花名册含 aka 行。