### PR TITLE
fix(deepseek): honor effort none as thinking disabled alongside enabled false (#107238)

### DIFF
--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -39,11 +39,14 @@ class DeepSeekProfile(ProviderProfile):
         rc = reasoning_config if isinstance(reasoning_config, dict) else None
         # Always set thinking explicitly (default enabled, matching the API default)
         # to avoid the reasoning_content echo trap on subsequent turns.
-        if rc is not None and rc.get("enabled") is False:
+        # Disabled covers both ``{"enabled": False}`` (parse_reasoning_effort("none"))
+        # and ``{"effort": "none"}`` — some surfaces only set effort, so check both.
+        effort_raw = (rc.get("effort") or "").strip().lower() if rc is not None else ""
+        if rc is not None and (rc.get("enabled") is False or effort_raw == "none"):
             return {"thinking": {"type": "disabled"}}, {}
         top_level: dict[str, Any] = {}
         # No effort -> omit reasoning_effort so DeepSeek applies its server default.
-        effort = (rc.get("effort") or "").strip().lower() if rc is not None else ""
+        effort = effort_raw
         if effort and effort != "none":
             clamped = clamp_effort(effort, DEEPSEEK_V4_EFFORTS, DEEPSEEK_V4_OVERRIDES)
             if clamped in DEEPSEEK_V4_EFFORTS:


### PR DESCRIPTION
Fixes #107238

**Bug:** Desktop shows Thinking: Off but requests still sent `thinking: {"type": "enabled"}" — 68% thinking tokens wasted.

**Root cause:** DeepSeek plugin only checked `rc.get("enabled") is False` to emit `disabled`. Some surfaces (CLI `--reasoning none`, desktop per-session effort=none, and any caller passing `{"effort": "none"}` without the enabled flag) were missed — they fell through to the default `enabled` branch. TUI gateway `parse_reasoning_effort("none")` correctly returns `{"enabled": False}`, but direct effort-only dicts were not covered.

**Fix:** Check both signals: `enabled is False OR effort == "none"` (case-insensitive), mirroring the Gemini thinking-config pattern (`_build_gemini_thinking_config` checks both). Reuses the effort string computation to avoid a redundant strip+lower.

**Tests:** Targeted manual matrix (10 cases: enabled False, effort none/NONE, both, high, None, v3 non-thinking, flash variant) all pass; existing reasoning/model_normalize suites green (64 tests).