### PR TITLE
fix(desktop): route target=_blank links in place in the preview webview (#101190)

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -5,7 +5,7 @@ import { onComposerAttachImagesRequest } from '@/app/chat/composer/focus'
 import { $connection, $selectedStoredSessionId } from '@/store/session'
 
 import { forgetPreviewConsole, previewConsoleState } from './preview-console-store'
-import { PreviewPane } from './preview-pane'
+import { guestWindowOpenTarget, installGuestWindowOpenHandler, PreviewPane } from './preview-pane'
 
 // The consent dialog has its own test file and needs a QueryClientProvider;
 // these tests exercise the pane's console/watch/webview wiring, not the
@@ -639,5 +639,56 @@ describe('PreviewPane console state', () => {
       path: `/api/fs/read-data-url?path=${encodeURIComponent(filePath)}`,
       profile: 'macmini'
     })
+  })
+
+  // target=_blank links were silently dropped: without `allowpopups` Chromium
+  // blocks the popup before any handler runs, and the removed `new-window`
+  // event (gone in Electron 40) never fires (#101190).
+  it('allows guest popups so target=_blank reaches the window-open handler', async () => {
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          target={{ kind: 'url', label: 'Preview', source: 'http://localhost:5174', url: 'http://localhost:5174' }}
+        />
+      )
+    })
+
+    expect(rendered.container.querySelector('webview')?.getAttribute('allowpopups')).not.toBeNull()
+  })
+
+  it.each([
+    ['passes an https link through', 'https://example.com/docs', 'https://example.com/docs'],
+    ['trims the URL', '  https://example.com  ', 'https://example.com'],
+    ['rejects an empty URL', '   ', null],
+    ['rejects javascript: URLs', 'javascript:alert(1)', null],
+    ['rejects data: URLs', 'data:text/html,<h1>x</h1>', null]
+  ])('guestWindowOpenTarget %s', (_case, input, expected) => {
+    expect(guestWindowOpenTarget(input)).toBe(expected)
+  })
+
+  it('routes guest window-opens in place and never opens an OS popup', () => {
+    const navigate = vi.fn()
+    let handler!: (details: { url: string }) => { action: 'deny' }
+
+    const webview = {
+      setWindowOpenHandler: vi.fn((next: typeof handler) => {
+        handler = next
+      })
+    }
+
+    installGuestWindowOpenHandler(webview as never, navigate)
+
+    expect(webview.setWindowOpenHandler).toHaveBeenCalledOnce()
+    expect(handler({ url: 'https://example.com/new' })).toEqual({ action: 'deny' })
+    expect(navigate).toHaveBeenCalledWith('https://example.com/new')
+
+    navigate.mockClear()
+    expect(handler({ url: 'javascript:alert(1)' })).toEqual({ action: 'deny' })
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('installGuestWindowOpenHandler is a no-op without the Electron API', () => {
+    expect(() => installGuestWindowOpenHandler({} as never, vi.fn())).not.toThrow()
   })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -93,6 +93,55 @@ type PreviewWebview = HTMLElement & {
   replaceMisspelling?: (word: string) => void
   selectAll?: () => void
   sendInputEvent?: (event: PreviewInputEvent) => void
+  setWindowOpenHandler?: (handler: (details: { url: string }) => { action: 'deny' }) => void
+}
+
+/**
+ * A guest `window.open` / `target=_blank` URL worth navigating to, or `null`
+ * when there is nothing to go to. Script-bearing schemes run inside the page
+ * rather than navigating it, so they stay denied — the same blocklist the
+ * address bar applies (`normalizePreviewAddress`).
+ */
+export function guestWindowOpenTarget(url: string): string | null {
+  const next = url.trim()
+
+  if (!next) {
+    return null
+  }
+
+  const scheme = /^([a-z0-9+.-]+):/i.exec(next)?.[1]
+
+  if (scheme && /^(data|javascript)$/i.test(scheme)) {
+    return null
+  }
+
+  return next
+}
+
+/**
+ * Route the preview guest's popups back into its own webview. Without the
+ * `allowpopups` attribute Chromium drops `target=_blank` clicks before any
+ * handler runs (#101190) — and the renderer-side `new-window` event #101325
+ * used no longer exists in Electron 40, so this uses the supported
+ * `setWindowOpenHandler` seam instead. Always denies: the URL never reaches
+ * an OS browser (cf. the embedder deny in `window-open-policy.ts`), it just
+ * loads in place with history intact. A setter, not a listener, so it dies
+ * with the element and needs no teardown.
+ */
+export function installGuestWindowOpenHandler(webview: PreviewWebview, navigate: (url: string) => void): void {
+  if (typeof webview.setWindowOpenHandler !== 'function') {
+    return
+  }
+
+  webview.setWindowOpenHandler(({ url }) => {
+    const next = guestWindowOpenTarget(url ?? '')
+
+    if (next) {
+      navigate(next)
+    }
+
+    return { action: 'deny' }
+  })
 }
 
 /** Electron throws if getURL/getTitle run before attach + dom-ready, or after
@@ -1023,8 +1072,23 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     const webview = document.createElement('webview') as PreviewWebview
     webview.className = 'flex h-full w-full flex-1 bg-transparent'
     webview.setAttribute('partition', 'persist:hermes-preview')
+    // Without `allowpopups` Chromium silently drops `target=_blank` clicks
+    // before any handler runs (#101190); the handler below keeps them in-pane.
+    webview.setAttribute('allowpopups', '')
     webview.setAttribute('src', target.url)
     webview.setAttribute('webpreferences', 'contextIsolation=yes,nodeIntegration=no,sandbox=yes')
+
+    // A popup the guest asked for loads in place, keeping history intact — a
+    // dedicated tab is the strip's "+" job, not the page's.
+    installGuestWindowOpenHandler(webview, next => {
+      setCurrentUrl(next)
+
+      if (typeof webview.loadURL === 'function') {
+        void webview.loadURL(next)
+      } else {
+        webview.setAttribute('src', next)
+      }
+    })
 
     const onConsole = (event: Event) => {
       const detail = event as Event & {


### PR DESCRIPTION
Closes #101190

The preview guest is created without `allowpopups`, so Chromium drops `target="_blank` clicks before any handler runs — no tab, no navigation, no error. This adds `allowpopups` and handles popups with the supported `setWindowOpenHandler` seam: deny the OS popup and load the URL in place via `loadURL`, keeping history intact and updating the browser bar through the existing `did-navigate` path. Script-bearing schemes (`javascript:`, `data:`) stay denied, mirroring the address-bar blocklist.

Deliberately not the `#101325` approach: the renderer-side `new-window` event no longer exists in Electron 40, and the embedder deny in `window-open-policy.ts` is untouched — guest popups stay in-pane and never reach an OS browser.

Tests: new cases in `preview-pane.test.tsx` (allowpopups attribute, URL classifier, handler deny+in-place routing, no-Electron no-op). `preview-pane` + related suites: 144 passed; `tsc --noEmit`: clean; eslint on touched files: clean.