### PR TITLE
fix(clarify): decline consent-semantic options in headless mode

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -21,12 +21,14 @@ def _single_query_clarify_callback(question: str, choices=None, multi_select=Fal
 
     The oneshot path answers immediately via ``_oneshot_clarify_callback``; single-query turns need the same
     headless behavior (#94943).
+
+    Consent-semantic options are never auto-picked: without a human they are
+    explicitly DECLINED, never treated as consent (#107068).
     """
+    from tools.clarify_tool import headless_clarify_guidance
+
     prefix = f"[single-query mode: no user available to answer {question!r}. "
-    if choices:
-        what = "subset" if multi_select else "option"
-        return f"{prefix}Pick the best {what} from {choices} using your own judgment and continue.]"
-    return f"{prefix}Make the most reasonable assumption you can and continue.]"
+    return headless_clarify_guidance(question, choices, multi_select, prefix)
 
 
 def _current_runtime(cli) -> dict:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -526,11 +526,12 @@ def _close_agent(agent, session_db) -> None:
 
 
 def _oneshot_clarify_callback(question: str, choices=None, multi_select=False) -> str:
-    """Clarify is disabled in oneshot mode — tell the agent to pick a default and proceed."""
-    if choices:
-        what = "subset" if multi_select else "option"
-        return (
-            f"[oneshot mode: no user available. Pick the best {what} from "
-            f"{choices} using your own judgment and continue.]"
-        )
-    return "[oneshot mode: no user available. Make the most reasonable assumption you can and continue.]"
+    """Clarify is disabled in oneshot mode — tell the agent to pick a default and proceed.
+
+    Consent-semantic options are never auto-picked: without a human they are
+    explicitly DECLINED, never treated as consent (#107068).
+    """
+    from tools.clarify_tool import headless_clarify_guidance
+
+    return headless_clarify_guidance(
+        question, choices, multi_select, "[oneshot mode: no user available. ")

--- a/tests/cli/test_single_query_clarify.py
+++ b/tests/cli/test_single_query_clarify.py
@@ -75,3 +75,54 @@ def test_agent_construction_gates_clarify_callback_on_single_query_mode():
         "the clarify_callback wiring no longer consults _single_query_mode — "
         "-q turns would hang on the interactive modal again (#94943)"
     )
+
+
+class TestSingleQueryConsentGuard:
+    """#107068: headless auto-decide must never pick authorization-semantic
+    options — a Recommended "authorize me" row is a silent self-authorization
+    vector when no human is present to answer."""
+
+    _REPRO = [
+        "authorize me to compute these 9 rows directly (Recommended)",
+        "configure A2A peer then hand off",
+        "no aggregation, layout only",
+    ]
+
+    def test_recommended_authorize_option_is_declined_not_picked(self):
+        from hermes_cli.cli_agent_setup_mixin import _single_query_clarify_callback
+
+        result = _single_query_clarify_callback("How to proceed?", choices=list(self._REPRO))
+        assert "authorize me to compute these 9 rows directly" in result  # explicitly marked...
+        assert "DECLINED" in result  # ...as declined without a human...
+        assert "Pick the best option from ['authorize me" not in result  # ...never offered for auto-pick
+        assert "configure A2A peer then hand off" in result  # safe options stay pickable
+
+    def test_all_consent_options_means_stop_not_pick(self):
+        from hermes_cli.cli_agent_setup_mixin import _single_query_clarify_callback
+
+        result = _single_query_clarify_callback(
+            "May I?", choices=["authorize me to proceed (Recommended)", "allow me to continue"]
+        )
+        assert "DECLINED" in result
+        assert "Pick the best" not in result
+        assert "human input is needed" in result
+
+    def test_innocuous_options_keep_exact_legacy_guidance(self):
+        """Non-consent options must keep the byte-identical #94943 guidance."""
+        from hermes_cli.cli_agent_setup_mixin import _single_query_clarify_callback
+
+        result = _single_query_clarify_callback("Format?", choices=["json", "yaml"])
+        assert result.startswith("[single-query mode: no user available")
+        assert "Pick the best option from ['json', 'yaml']" in result
+        assert "DECLINED" not in result
+
+    def test_oneshot_callback_shares_the_guard(self):
+        """The -z path has the same auto-pick shape; the sibling must not stay open."""
+        from hermes_cli.oneshot import _oneshot_clarify_callback
+
+        result = _oneshot_clarify_callback("How to proceed?", choices=list(self._REPRO))
+        assert "DECLINED" in result
+        assert "Pick the best option from ['authorize me" not in result
+        legacy = _oneshot_clarify_callback("Format?", choices=["json", "yaml"])
+        assert "Pick the best option from ['json', 'yaml']" in legacy
+        assert "DECLINED" not in legacy

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -676,3 +676,34 @@ class TestRegistryBatchPassThrough:
         ))
         assert seen["questions"][0]["question"] == "Go?"
         assert result["responses"][0]["user_response"] == "yes"
+
+
+class TestAuthorizationSemanticHeuristic:
+    """#107068: the consent-text detector behind the headless clarify guard."""
+
+    def test_consent_verbs_detected(self):
+        from tools.clarify_tool import is_authorization_semantic
+
+        for text in [
+            "authorize me to compute these 9 rows directly (Recommended)",
+            "authorise me to proceed",
+            "allow me to continue",
+            "consent to self-compute",
+            "grant me permission",
+            "approve this exception",
+            "let me bypass the guard",
+            "授权我直接计算",
+        ]:
+            assert is_authorization_semantic(text), text
+
+    def test_innocuous_options_not_detected(self):
+        from tools.clarify_tool import is_authorization_semantic
+
+        for text in [
+            "json",
+            "configure A2A peer then hand off",
+            "no aggregation, layout only",
+            "Rebase",
+            "Improve performance",
+        ]:
+            assert not is_authorization_semantic(text), text

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -4,6 +4,7 @@ callback (cli.py, gateway/run.py, tui_gateway)."""
 
 import inspect
 import json
+import re
 from typing import Dict, List, Optional, Callable
 
 MAX_CHOICES = 4  # the UI always appends an "Other (type your answer)" row
@@ -47,6 +48,50 @@ def strip_recommended(text: str) -> str:
     if stripped.casefold().endswith(RECOMMENDED_LABEL.casefold()):
         return stripped[: -len(RECOMMENDED_LABEL)].strip()
     return stripped
+
+
+# Authorization verbs that make a clarify option consent-semantic: picking one
+# without a human is self-authorization, not a routing default (#107068).
+# Deliberately narrow (fail-closed only on explicit consent phrasing, EN + ZH);
+# innocuous options ("json", "Rebase", "Improve performance") must not match.
+_CONSENT_RE = re.compile(
+    r"authori[sz]|consent|permit|permission|\ballow\s+me\b|\blet\s+me\b"
+    r"|approv|grant\s+me|self-?approv|bypass|授权|批准|准许",
+    re.IGNORECASE,
+)
+
+
+def is_authorization_semantic(text: object) -> bool:
+    """True when a clarify option asks for human authorization (consent-semantic)."""
+    return bool(text) and bool(_CONSENT_RE.search(strip_recommended(str(text))))
+
+
+def headless_clarify_guidance(question: str, choices, multi_select: bool, prefix: str) -> str:
+    """Headless (no-human) clarify answer shared by the -q and -z callbacks.
+
+    Consent-semantic options are explicitly DECLINED and excluded from the
+    auto-pick list; when every option needs a human, the agent must stop and
+    report instead of picking. Consent-free questions keep the legacy guidance
+    byte-identical.
+    """
+    if not choices:
+        return f"{prefix}Make the most reasonable assumption you can and continue.]"
+    declined = [c for c in choices if is_authorization_semantic(c)]
+    if not declined:
+        what = "subset" if multi_select else "option"
+        return f"{prefix}Pick the best {what} from {choices} using your own judgment and continue.]"
+    safe = [c for c in choices if c not in declined]
+    if safe:
+        what = "subset" if multi_select else "option"
+        return (
+            f"{prefix}Options {declined} require a human and are DECLINED without one — "
+            f"do NOT pick them. Pick the best {what} from {safe} "
+            "using your own judgment and continue.]"
+        )
+    return (
+        f"{prefix}Every option {choices} requires a human and is DECLINED without one — "
+        "do NOT pick any. Stop and report that human input is needed.]"
+    )
 
 
 def _accepts_kwarg(callback, name: str) -> bool:


### PR DESCRIPTION
## 根因

-q（single-query）与 -z（oneshot）的 headless clarify 回调在无人可答时直接让 agent 自行择优继续。若选项中混入 consent 语义的 Recommended 行（如 authorize me），自动择优等于静默自我授权，绕过了人类许可的本意（#107068）。

## 修复

- tools/clarify_tool.py：新增 is_authorization_semantic（EN+ZH 同意措辞启发式，刻意收窄，仅显式许可措辞命中）与共享 headless_clarify_guidance。
- 同意语义选项被明确 DECLINED 并从自动选择列表剔除；全是同意语义时要求停下上报待人工输入；无同意语义时保持 #94943 遗留指引逐字节一致。
- hermes_cli/oneshot.py、hermes_cli/cli_agent_setup_mixin.py：两处 headless 回调共用同一指引，补齐 -z 同形缺口。

## 测试

- 新增 tests/cli/test_single_query_clarify.py::TestSingleQueryConsentGuard（4 用例：推荐授权行被拒、安全项仍可选、全同意则停止、无害选项保持遗留指引、oneshot 同享守卫）。
- 新增 tests/tools/test_clarify_tool.py::TestAuthorizationSemanticHeuristic（同意动词命中/无害项不命中，含中文）。
- 本地：scripts/run_tests.sh 跑 10 个 clarify/oneshot 相关文件，118 tests passed, 0 failed。

## 验证

- git diff 仅 5 个本 issue 文件，+142/-12；分支 fix/107068-descr 基线 5172f22d；head 6ba46ab2846f78df772108155a69b1a61507d6c5。

Closes #107068