### PR TITLE
fix(kanban): honor requeues after PR comments

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1122,6 +1122,19 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
         )
 
 
+def _has_explicit_requeue_since(
+    conn: sqlite3.Connection, task_id: str, since: int,
+) -> bool:
+    """Whether an explicit operator/dispatcher requeue occurred at or after ``since``."""
+    return conn.execute(
+        "SELECT 1 FROM task_events "
+        "WHERE task_id = ? AND created_at >= ? "
+        "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
+        "LIMIT 1",
+        (task_id, since),
+    ).fetchone() is not None
+
+
 def check_respawn_guard(
     conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
 ) -> Optional[str]:
@@ -1135,9 +1148,10 @@ def check_respawn_guard(
     (quota/auth pattern; the breaker still trips eventually), then for the
     ready lane only ``"recent_success"`` (completed run within the window, unless
     a re-queue event arrived after it — a deliberate re-run) and ``"active_pr"``
-    (PR URL in a recent comment; re-spawning risks a duplicate PR). The review
-    lane skips the last two: they are the *inputs* to a review handoff. Stale /
-    dead claim locks are NOT a guard reason — the reclaim passes own those.
+    (PR URL in a recent comment with no later explicit requeue; re-spawning risks
+    a duplicate PR). The review lane skips the last two: they are the *inputs* to
+    a review handoff. Stale / dead claim locks are NOT a guard reason — the
+    reclaim passes own those.
     """
     row = conn.execute(
         "SELECT last_failure_error FROM tasks WHERE id = ?",
@@ -1193,23 +1207,23 @@ def check_respawn_guard(
     ).fetchone()
     if recent_completed:
         completed_at = int(recent_completed["ended_at"] or 0)
-        requeued_after = conn.execute(
-            "SELECT 1 FROM task_events "
-            "WHERE task_id = ? AND created_at >= ? "
-            "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
-            "LIMIT 1",
-            (task_id, completed_at),
-        ).fetchone()
-        if not requeued_after:
+        if not _has_explicit_requeue_since(conn, task_id, completed_at):
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    As with recent success, a later explicit requeue is a deliberate rerun.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT body, created_at FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ? "
+        "ORDER BY created_at DESC, id DESC",
         (task_id, pr_cutoff),
     ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+        if (
+            c["body"]
+            and _RESPAWN_GUARD_PR_URL_RE.search(c["body"])
+            and not _has_explicit_requeue_since(conn, task_id, int(c["created_at"]))
+        ):
             return "active_pr"
 
     return None

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -478,6 +478,56 @@ def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
         ) == "rate_limit_cooldown"
 
 
+@pytest.mark.parametrize("event_kind", ["status", "promoted", "unblocked", "reclaimed"])
+def test_active_pr_guard_yields_to_later_explicit_requeue(
+    kanban_home: Path, event_kind: str
+) -> None:
+    """An operator action after a PR comment deliberately re-runs the task."""
+    now = int(__import__("time").time())
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="rerun merged PR", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+                "VALUES (?, 'done', 'completed', ?, ?)",
+                (task_id, now - 30, now - 20),
+            )
+            conn.execute(
+                "INSERT INTO task_comments (task_id, author, body, created_at) "
+                "VALUES (?, 'worker', ?, ?)",
+                (task_id, "Opened https://github.com/example/repo/pull/456", now - 10),
+            )
+            conn.execute(
+                "INSERT INTO task_events (task_id, kind, payload, created_at) "
+                "VALUES (?, ?, NULL, ?)",
+                (task_id, event_kind, now - 5),
+            )
+
+        assert kbd.check_respawn_guard(conn, task_id) is None
+
+
+def test_active_pr_guard_ignores_explicit_requeue_before_pr_comment(
+    kanban_home: Path,
+) -> None:
+    """A later PR comment supersedes an earlier requeue and still prevents duplication."""
+    now = int(__import__("time").time())
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="PR followed requeue", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_events (task_id, kind, payload, created_at) "
+                "VALUES (?, 'unblocked', NULL, ?)",
+                (task_id, now - 10),
+            )
+            conn.execute(
+                "INSERT INTO task_comments (task_id, author, body, created_at) "
+                "VALUES (?, 'worker', ?, ?)",
+                (task_id, "Opened https://github.com/example/repo/pull/789", now - 5),
+            )
+
+        assert kbd.check_respawn_guard(conn, task_id) == "active_pr"
+
+
 def test_review_dispatch_preserves_task_skills_and_adds_reviewer_skill(
     kanban_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- keep the recent-PR guard for ordinary duplicate-spawn protection
- let a later explicit `status`, `promoted`, `unblocked`, or `reclaimed` event requeue the item
- preserve the guard when the requeue event predates the PR comment
- keep review-lane and existing auth/rate-limit protections unchanged

## Verification

- `uv run --extra dev python -m pytest -q tests/hermes_cli/test_kanban_review_lifecycle.py`
- 24 passed