### PR TITLE
fix(agent): keep early steer on the active turn

### DIFF
--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -134,7 +134,9 @@ def prepare_iteration(
     # break the prompt cache — same contract as apply_pending_steer_to_tool_results).
     _pre_api_steer = agent._drain_pending_steer()
     if _pre_api_steer:
-        _inject_steer_after_newest_tool_result(agent, messages, _pre_api_steer)
+        _inject_steer_after_newest_tool_result(
+            agent, messages, _pre_api_steer, current_turn_user_idx=current_turn_user_idx
+        )
 
     # One-shot run-budget wrap-up notice at 80% of agent.run_budget_seconds, appended to the
     # newest tool result; off with no budget.
@@ -229,10 +231,19 @@ def _previous_tool_round(messages: Any) -> list:
     return []
 
 
-def _inject_steer_after_newest_tool_result(agent: Any, messages: Any, steer_text: str) -> None:
-    """Append the steer marker as a standalone user row after the newest tool message; with no
-    tool message, put the text back so the post-tool-execution drain delivers it later."""
-    for _si in range(len(messages) - 1, -1, -1):
+def _inject_steer_after_newest_tool_result(
+    agent: Any, messages: Any, steer_text: str, *, current_turn_user_idx: Any = None
+) -> None:
+    """Append a steer after the newest tool result in the active turn.
+
+    A steer can arrive while the CLI is still preprocessing an image, before the
+    agent's first API call. In that window the transcript only contains tool
+    results from earlier turns; targeting one would place the steer before the
+    current user message and make it historical context. Requeue until this turn
+    produces a tool result instead.
+    """
+    _lower_bound = current_turn_user_idx if isinstance(current_turn_user_idx, int) else -1
+    for _si in range(len(messages) - 1, _lower_bound, -1):
         _sm = messages[_si]
         if isinstance(_sm, dict) and _sm.get("role") == "tool":
             from agent.prompt_builder import steer_user_row

--- a/tests/agent/test_turn_iteration_prep.py
+++ b/tests/agent/test_turn_iteration_prep.py
@@ -11,7 +11,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from agent.turn_iteration_prep import apply_retry_restarts
+from agent.turn_iteration_prep import (
+    _inject_steer_after_newest_tool_result,
+    apply_retry_restarts,
+)
 from agent.turn_retry_state import TurnRetryState
 
 RESTART_FLAGS = ["restart_with_redirected_messages", "restart_with_rebuilt_messages"]
@@ -64,3 +67,37 @@ def test_restart_refunds_are_bounded_per_turn(flag):
     assert verdicts[-1]._turn_exit_reason.endswith("restart_limit_exceeded")
     # The correction that tripped the redirect cap is handed back as the next user turn.
     assert agent.steered == (["last correction"] if flag == "restart_with_redirected_messages" else [])
+
+
+def test_pre_api_steer_does_not_attach_to_a_historical_tool_result():
+    """A steer queued before the first API call must wait for this turn's tool result."""
+    agent = SimpleNamespace(_pending_steer=None)
+    messages = [
+        {"role": "user", "content": "previous turn"},
+        {"role": "tool", "content": "previous result"},
+        {"role": "user", "content": "current turn with an image"},
+    ]
+
+    _inject_steer_after_newest_tool_result(
+        agent, messages, "correct the image interpretation", current_turn_user_idx=2
+    )
+
+    assert messages[-1]["role"] == "user"
+    assert "correct the image interpretation" not in messages[1]["content"]
+    assert agent._pending_steer == "correct the image interpretation"
+
+
+def test_pre_api_steer_attaches_after_a_tool_result_from_the_active_turn():
+    agent = SimpleNamespace(_pending_steer=None)
+    messages = [
+        {"role": "user", "content": "current turn"},
+        {"role": "tool", "content": "active result"},
+    ]
+
+    _inject_steer_after_newest_tool_result(
+        agent, messages, "use the corrected direction", current_turn_user_idx=0
+    )
+
+    assert messages[-1]["role"] == "user"
+    assert "use the corrected direction" in messages[-1]["content"]
+    assert agent._pending_steer is None


### PR DESCRIPTION
## What does this PR do?

Keeps a /steer queued during image preprocessing from being inserted after a historical tool result. The pre-API drain now only targets tool results produced after the active turn's user message and requeues early steering until that turn has a safe delivery point.

## Related Issue

Fixes #107272

## Type of Change

- [x] Bug fix (non-breaking change)

## Changes Made

- Pass the active turn user index into pre-API steer delivery.
- Requeue steering when only historical tool results exist.
- Add regression coverage for early and active-turn tool-result delivery.

## How to Test

- uv run --with pytest --with concurrent-log-handler pytest tests/agent/test_turn_iteration_prep.py tests/agent/test_compression_busy_steer_anchor.py tests/agent/test_turn_finalizer_cleanup_guard.py -q (16 passed)
- uv run ruff check agent/turn_iteration_prep.py tests/agent/test_turn_iteration_prep.py
- python scripts/check-windows-footguns.py --diff HEAD
- python -m compileall -q agent/turn_iteration_prep.py tests/agent/test_turn_iteration_prep.py
- git diff --check