### PR TITLE
fix(desktop): preserve non-object tool results in live transcript

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/changed-files.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/changed-files.ts
@@ -7,7 +7,8 @@ import {
   fileEditPath,
   inlineDiffFromResult,
   isFileEditTool,
-  parseMaybeObject
+  parseMaybeObject,
+  toolPresentation
 } from '@/components/assistant-ui/tool/fallback-model'
 
 export interface ChangedFile {
@@ -21,6 +22,7 @@ export interface ChangedFile {
 
 interface ChangedFilePart {
   args?: unknown
+  presentation?: unknown
   result?: unknown
   toolName?: unknown
   type?: unknown
@@ -41,7 +43,10 @@ export function deriveChangedFiles(parts: readonly unknown[]): ChangedFile[] {
       continue
     }
 
-    const result = parseMaybeObject(part.result)
+    const result = toolPresentation({
+      presentation: parseMaybeObject(part.presentation),
+      result: part.result
+    })
     const diff = inlineDiffFromResult(result)
 
     if (!diff) {

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -488,3 +488,26 @@ describe('buildToolView memory status', () => {
     expect(view.subtitle).toContain('Memory is full')
   })
 })
+
+describe('buildToolView settled tool results', () => {
+  it('does not label a stopped tool without a result as success', () => {
+    const view = buildToolView(
+      part({
+        completedAt: 12,
+        result: undefined,
+        toolName: 'terminal'
+      }),
+      ''
+    )
+
+    expect(view.status).not.toBe('success')
+  })
+
+  it('renders a plain-text tool result as usable output', () => {
+    const view = buildToolView(part({ result: 'ok', toolName: 'terminal' }), '')
+
+    expect(view.status).toBe('success')
+    expect(`${view.detail}\n${view.subtitle}`).toContain('ok')
+    expect(view.detail).not.toMatch(/^\s*\{\s*\}\s*$/)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -694,9 +694,39 @@ function toolErrorText(part: ToolPart, result: Record<string, unknown>): string 
   return ''
 }
 
+/** Event-level hints plus object-result fields. Object-result keys win. */
+export function toolPresentation(part: Pick<ToolPart, 'presentation' | 'result'>): Record<string, unknown> {
+  const hints = isRecord(part.presentation) ? part.presentation : {}
+
+  return {
+    ...hints,
+    ...parseMaybeObject(part.result)
+  }
+}
+
+function scalarResultText(result: unknown): string {
+  if (typeof result === 'string') {
+    return result
+  }
+
+  if (typeof result === 'number' || typeof result === 'boolean') {
+    return String(result)
+  }
+
+  if (result === null) {
+    return 'null'
+  }
+
+  if (Array.isArray(result)) {
+    return formatToolResultSummary(result) || prettyJson(result)
+  }
+
+  return ''
+}
+
 function toolStatus(part: ToolPart, resultRecord: Record<string, unknown>): ToolStatus {
   if (part.result === undefined) {
-    return 'running'
+    return part.completedAt !== undefined ? 'warning' : 'running'
   }
 
   // Explicit success wins over isError / nested-error heuristics. Memory writes
@@ -989,7 +1019,7 @@ function toolSubtitle(
       ? resultRecord.lines.filter((line): line is string => typeof line === 'string').join('\n')
       : ''
 
-    const previewSource = (output || lines).trim()
+    const previewSource = (output || lines || scalarResultText(part.result)).trim()
 
     if (previewSource) {
       const firstMeaningfulLine = previewSource
@@ -1089,6 +1119,12 @@ function toolDetailText(
 
     if (output || lines) {
       return [output, lines].filter(Boolean).join('\n')
+    }
+
+    const scalar = scalarResultText(part.result)
+
+    if (scalar) {
+      return scalar
     }
 
     // A terminal row with no output already shows its command in the `$`
@@ -1302,10 +1338,11 @@ function dynamicTitle(
   result: Record<string, unknown>,
   fallback: ToolTitleParts
 ): ToolTitleParts {
-  const verb = (gerund: string, past: string) => (part.result === undefined ? gerund : past)
+  const awaitingResult = part.result === undefined && part.completedAt === undefined
+  const verb = (gerund: string, past: string) => (awaitingResult ? gerund : past)
 
   const titledAction = (action: string, title: string): ToolTitleParts =>
-    titlePartsFromAction(title, part.result === undefined ? action : undefined)
+    titlePartsFromAction(title, awaitingResult ? action : undefined)
 
   if (part.toolName === 'web_extract') {
     const url = findFirstUrl(args, result)
@@ -1411,7 +1448,7 @@ function dynamicTitle(
 
 export function buildToolView(part: ToolPart, inlineDiff: string): ToolView {
   const argsRecord = parseMaybeObject(part.args)
-  const resultRecord = parseMaybeObject(part.result)
+  const resultRecord = toolPresentation(part)
   const meta = toolMeta(part.toolName)
   const status = toolStatus(part, resultRecord)
   // Skip residual error-heuristic text once status is success (stale isError
@@ -1419,19 +1456,19 @@ export function buildToolView(part: ToolPart, inlineDiff: string): ToolView {
   const error = status === 'success' ? '' : toolErrorText(part, resultRecord)
   // Over-budget memory refusals stay amber — don't claim "Saved".
   const memoryMissed = part.toolName === 'memory' && part.result !== undefined && status !== 'success'
+  const awaitingResult = part.result === undefined && part.completedAt === undefined
 
-  const baseTitle =
-    part.result === undefined
-      ? meta.pending
-      : memoryMissed
-        ? translateNow('assistant.tool.memoryWriteNoted')
-        : meta.done
+  const baseTitle = awaitingResult
+    ? meta.pending
+    : memoryMissed
+      ? translateNow('assistant.tool.memoryWriteNoted')
+      : meta.done
 
   const titleParts = dynamicTitle(
     part,
     argsRecord,
     resultRecord,
-    titlePartsFromAction(baseTitle, part.result === undefined ? meta.pendingAction : undefined)
+    titlePartsFromAction(baseTitle, awaitingResult ? meta.pendingAction : undefined)
   )
 
   const title = titleParts.title

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/types.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/types.ts
@@ -5,6 +5,7 @@ export interface ToolPart {
   args?: unknown
   completedAt?: number
   isError?: boolean
+  presentation?: Record<string, unknown>
   result?: unknown
   timestamp?: number
   toolCallId?: string

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -69,6 +69,7 @@ import {
   toolCopyPayload,
   type ToolPart,
   toolPartDisclosureId,
+  toolPresentation,
   type ToolStatus,
   type ToolTitleAction
 } from './fallback-model'
@@ -359,11 +360,11 @@ function ToolEntry({ part }: ToolEntryProps) {
   // below and re-running buildToolView (full JSON.stringify of result) on every
   // stream delta — the freeze on big `/learn` runs. Re-derive a stable part from
   // the referentially-stable args/result so the memos hold across deltas.
-  const { args, completedAt, isError, result, timestamp, toolCallId, toolName } = part
+  const { args, completedAt, isError, presentation, result, timestamp, toolCallId, toolName } = part
 
   const stablePart = useMemo<ToolPart>(
-    () => ({ args, completedAt, isError, result, timestamp, toolCallId, toolName, type: 'tool-call' }),
-    [args, completedAt, isError, result, timestamp, toolCallId, toolName]
+    () => ({ args, completedAt, isError, presentation, result, timestamp, toolCallId, toolName, type: 'tool-call' }),
+    [args, completedAt, isError, presentation, result, timestamp, toolCallId, toolName]
   )
 
   const disclosureId = toolEntryDisclosureId(messageId, stablePart)
@@ -372,7 +373,7 @@ function ToolEntry({ part }: ToolEntryProps) {
   // Subscribe to this tool's diff only, so a live patch for one tool doesn't
   // re-render every mounted tool row (the factory caches a per-id atom).
   const sideDiff = useStore($toolInlineDiff(toolCallId ?? ''))
-  const inlineDiff = stripInlineDiffChrome(sideDiff) || inlineDiffFromResult(result)
+  const inlineDiff = stripInlineDiffChrome(sideDiff) || inlineDiffFromResult(toolPresentation(stablePart))
   const isFileEdit = isFileEditTool(toolName)
   const defaultOpen = Boolean(inlineDiff)
   const open = useDisclosureOpen(disclosureId, defaultOpen)
@@ -384,14 +385,7 @@ function ToolEntry({ part }: ToolEntryProps) {
   const enterRef = useEnterAnimation(messageRunning && !embedded, `tool-entry:${disclosureId}`)
   const elapsed = useElapsedSeconds(isPending, `tool:${disclosureId}`)
 
-  // Stale parts (no result, but message stopped running) get a synthetic empty
-  // result so buildToolView treats them as completed-no-output. Keyed on
-  // stablePart so it recomputes only when this tool's data changes.
-  const view = useMemo(() => {
-    const p = !isPending && result === undefined ? { ...stablePart, result: {} } : stablePart
-
-    return buildToolView(p, inlineDiff)
-  }, [inlineDiff, isPending, result, stablePart])
+  const view = useMemo(() => buildToolView(stablePart, inlineDiff), [inlineDiff, stablePart])
 
   // Surface a previewable artifact (HTML file / localhost URL) as a compact link
   // in the composer status stack rather than a bulky inline card. Uses the same
@@ -1027,7 +1021,11 @@ export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex:
  * its return type and the underlying ToolEntry stays mounted across
  * group-shape changes.
  */
-type TimelineToolCallProps = ToolCallMessagePartProps & { completedAt?: number; timestamp?: number }
+type TimelineToolCallProps = ToolCallMessagePartProps & {
+  completedAt?: number
+  presentation?: Record<string, unknown>
+  timestamp?: number
+}
 
 export const ToolFallback = ({
   toolCallId,
@@ -1035,10 +1033,21 @@ export const ToolFallback = ({
   args,
   completedAt,
   isError,
+  presentation,
   result,
   timestamp
 }: TimelineToolCallProps) => {
-  const part: ToolPart = { args, completedAt, isError, result, timestamp, toolCallId, toolName, type: 'tool-call' }
+  const part: ToolPart = {
+    args,
+    completedAt,
+    isError,
+    presentation,
+    result,
+    timestamp,
+    toolCallId,
+    toolName,
+    type: 'tool-call'
+  }
 
   return <ToolEntry part={part} />
 }

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -16,6 +16,7 @@ import {
   sealOpenToolParts,
   stripPendingClarifyProjectionForCache,
   toChatMessages,
+  toolPresentation,
   upsertToolPart,
   withUniqueToolCallIdsWithinMessage
 } from './chat-messages'
@@ -766,9 +767,10 @@ describe('upsertToolPart', () => {
     const [part] = parts
 
     expect(part?.type).toBe('tool-call')
-    expect(part && 'result' in part ? part.result : undefined).toMatchObject({
-      inline_diff: '--- a/foo.ts\n+++ b/foo.ts\n@@\n-old\n+new'
-    })
+    expect(part && Object.hasOwn(part, 'result') ? part.result : undefined).toBeUndefined()
+    expect(part ? toolPresentation(part).inline_diff : undefined).toBe(
+      '--- a/foo.ts\n+++ b/foo.ts\n@@\n-old\n+new'
+    )
   })
 
   it('keeps live todo rows stable across sparse progress payloads', () => {
@@ -828,10 +830,8 @@ describe('upsertToolPart', () => {
       'complete'
     )
 
-    const completedResult =
-      completed[0] && 'result' in completed[0] ? (completed[0].result as Record<string, unknown>) : {}
-
-    const clearedResult = cleared[0] && 'result' in cleared[0] ? (cleared[0].result as Record<string, unknown>) : {}
+    const completedResult = completed[0] ? toolPresentation(completed[0]) : {}
+    const clearedResult = cleared[0] ? toolPresentation(cleared[0]) : {}
 
     expect(completedResult.todos).toEqual([{ content: 'Boil water', id: 'boil', status: 'in_progress' }])
     expect(clearedResult.todos).toEqual([])
@@ -885,13 +885,7 @@ describe('upsertToolPart', () => {
 
     const contexts = webParts.map(part => String((part.args as Record<string, unknown>)?.context || ''))
 
-    const summaries = webParts.map(part => {
-      if (!('result' in part) || !part.result || typeof part.result !== 'object') {
-        return ''
-      }
-
-      return String((part.result as Record<string, unknown>).summary || '')
-    })
+    const summaries = webParts.map(part => String(toolPresentation(part).summary || ''))
 
     expect(webParts).toHaveLength(2)
     expect(contexts).toEqual(['tokyo weather', 'reykjavik weather'])
@@ -957,9 +951,8 @@ describe('upsertToolPart', () => {
     expect((part as Extract<ChatMessagePart, { type: 'tool-call' }>).args).toMatchObject({
       context: 'auckland weather today and tomorrow forecast'
     })
-    expect((part as Extract<ChatMessagePart, { type: 'tool-call' }>).result).toMatchObject({
-      summary: 'Did 5 searches in 1.1s'
-    })
+    expect(part ? toolPresentation(part).summary : undefined).toBe('Did 5 searches in 1.1s')
+    expect(part ? toolPresentation(part).duration_s : undefined).toBe(1.1)
   })
 
   it('does not append phantom same-name tool rows for id-less progress updates', () => {
@@ -1026,7 +1019,7 @@ describe('upsertToolPart', () => {
 
     expect(webParts).toHaveLength(1)
     expect(webParts[0].toolCallId).toBe('search-asuncion')
-    expect(webParts[0].result).toMatchObject({ summary: 'Did 5 searches in 1.1s' })
+    expect(toolPresentation(webParts[0]).summary).toBe('Did 5 searches in 1.1s')
   })
 
   it('matches id-less live starts with later identified progress updates', () => {
@@ -1125,10 +1118,7 @@ describe('upsertToolPart', () => {
       .map(part => ({
         id: part.toolCallId,
         query: String((part.args as Record<string, unknown>)?.query || ''),
-        summary:
-          part.result && typeof part.result === 'object'
-            ? String((part.result as Record<string, unknown>).summary || '')
-            : ''
+        summary: String(toolPresentation(part).summary || '')
       }))
 
     expect(webParts).toEqual([
@@ -1173,9 +1163,84 @@ describe('upsertToolPart', () => {
 
     expect(part?.type).toBe('tool-call')
     expect((part as Extract<ChatMessagePart, { type: 'tool-call' }>).result).toMatchObject({
-      data: { web: [{ title: 'Suva forecast' }] },
-      summary: 'Did 1 search in 0.5s'
+      data: { web: [{ title: 'Suva forecast' }] }
     })
+    expect((part as Extract<ChatMessagePart, { type: 'tool-call' }>).result).not.toHaveProperty('summary')
+    expect(part ? toolPresentation(part).summary : undefined).toBe('Did 1 search in 0.5s')
+  })
+
+  it('preserves a plain-text tool result instead of mixing display hints into it', () => {
+    const parts = upsertToolPart(
+      [],
+      { name: 'terminal', tool_id: 'example', result: 'ok', summary: 'done' },
+      'complete'
+    )
+    const result = parts[0] && 'result' in parts[0] ? parts[0].result : undefined
+    expect(result).toBe('ok')
+  })
+
+  it.each([
+    { label: 'array', result: [] as unknown },
+    { label: 'false', result: false as unknown },
+    { label: 'zero', result: 0 as unknown },
+    { label: 'empty string', result: '' as unknown },
+    { label: 'null', result: null as unknown }
+  ])('preserves a $label tool result as the canonical payload', ({ result }) => {
+    const parts = upsertToolPart([], { name: 'terminal', result, summary: 'done', tool_id: 'scalar' }, 'complete')
+    const stored = parts[0] && 'result' in parts[0] ? parts[0].result : undefined
+
+    expect(stored).toEqual(result)
+  })
+
+  it('does not overwrite an object result summary with the outer gateway summary', () => {
+    const parts = upsertToolPart(
+      [],
+      { name: 'terminal', result: { summary: 'inner' }, summary: 'outer', tool_id: 'nested' },
+      'complete'
+    )
+    const stored = parts[0] && 'result' in parts[0] ? parts[0].result : undefined
+
+    expect(stored).toEqual({ summary: 'inner' })
+  })
+
+  it('keeps a stored result when a sparse duplicate complete omits the result key', () => {
+    const completed = upsertToolPart(
+      [],
+      { name: 'terminal', result: 'ok', tool_id: 'dup' },
+      'complete'
+    )
+    const sparse = upsertToolPart(completed, { name: 'terminal', tool_id: 'dup' }, 'complete')
+    const stored = sparse[0] && 'result' in sparse[0] ? sparse[0].result : undefined
+
+    expect(stored).toBe('ok')
+  })
+
+  it('does not invent a result when a completion never received one', () => {
+    const parts = upsertToolPart([], { name: 'terminal', summary: 'done', tool_id: 'empty' }, 'complete')
+
+    expect(parts[0] && Object.hasOwn(parts[0], 'result') ? parts[0].result : undefined).toBeUndefined()
+    expect(parts[0] && 'completedAt' in parts[0] ? parts[0].completedAt : undefined).toBeTypeOf('number')
+  })
+
+  it('keeps distinct identified parallel starts from overwriting one another', () => {
+    const first = upsertToolPart([], { name: 'terminal', result: 'one', tool_id: 'a' }, 'complete')
+    const both = upsertToolPart(first, { name: 'terminal', result: 'two', tool_id: 'b' }, 'complete')
+
+    expect(both).toHaveLength(2)
+    expect(both[0] && 'result' in both[0] ? both[0].result : undefined).toBe('one')
+    expect(both[1] && 'result' in both[1] ? both[1].result : undefined).toBe('two')
+  })
+
+  it('keeps distinct identified completions that never received a result', () => {
+    const first = upsertToolPart([], { name: 'read_file', tool_id: 'a' }, 'complete')
+    const both = upsertToolPart(first, { name: 'read_file', tool_id: 'b' }, 'complete')
+    const tools = both.filter(part => part.type === 'tool-call')
+
+    expect(tools).toHaveLength(2)
+    expect(tools[0]?.toolCallId).toBe('a')
+    expect(tools[1]?.toolCallId).toBe('b')
+    expect(tools[0] && Object.hasOwn(tools[0], 'result') ? tools[0].result : undefined).toBeUndefined()
+    expect(tools[1] && Object.hasOwn(tools[1], 'result') ? tools[1].result : undefined).toBeUndefined()
   })
 })
 
@@ -1426,7 +1491,8 @@ describe('sealOpenToolParts', () => {
 
     const next = sealOpenToolParts(messages)
 
-    expect(next[0].parts[0]).toHaveProperty('result')
+    expect(next[0].parts[0]).not.toHaveProperty('result')
+    expect(next[0].parts[0]).toHaveProperty('completedAt')
   })
 
   it('leaves already-completed tool parts untouched', () => {
@@ -1453,7 +1519,8 @@ describe('sealOpenToolParts', () => {
     const next = sealOpenToolParts(messages)
 
     expect(next[0].parts[0]).toBe(text)
-    expect(next[0].parts[1]).toHaveProperty('result')
+    expect(next[0].parts[1]).not.toHaveProperty('result')
+    expect(next[0].parts[1]).toHaveProperty('completedAt')
   })
 
   it('returns the same array reference when nothing needs sealing', () => {
@@ -1461,5 +1528,14 @@ describe('sealOpenToolParts', () => {
     const messages = [assistantWithParts([done])]
 
     expect(sealOpenToolParts(messages)).toBe(messages)
+  })
+
+  it('does not invent an empty-object success payload for tools that never returned a result', () => {
+    const messages = [assistantWithParts([toolPart()])]
+    const next = sealOpenToolParts(messages)
+    const sealed = next[0].parts[0]
+
+    expect(sealed && Object.hasOwn(sealed, 'result') ? sealed.result : undefined).toBeUndefined()
+    expect(sealed && 'completedAt' in sealed ? sealed.completedAt : undefined).toBeTypeOf('number')
   })
 })

--- a/apps/desktop/src/lib/chat-messages/index.ts
+++ b/apps/desktop/src/lib/chat-messages/index.ts
@@ -19,6 +19,7 @@ export {
   sealOpenToolParts,
   settlePendingClarifyToolCall,
   stripPendingClarifyProjectionForCache,
+  toolPresentation,
   upsertToolPart,
   withUniqueToolCallIdsWithinMessage
 } from './tool-parts'

--- a/apps/desktop/src/lib/chat-messages/tool-parts.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.ts
@@ -184,7 +184,15 @@ function findToolPartIndex(
   for (let index = 0; index < parts.length; index += 1) {
     const part = parts[index]
 
-    if (part.type === 'tool-call' && part.toolName === name && part.result === undefined) {
+    // A complete without a payload used to become `result: {}`. That fake
+    // success is gone, so `completedAt` is what keeps the row out of the
+    // pending pool — otherwise a later identified sibling overwrites it.
+    if (
+      part.type === 'tool-call' &&
+      part.toolName === name &&
+      part.result === undefined &&
+      part.completedAt === undefined
+    ) {
       pendingIndices.push(index)
     }
   }
@@ -264,23 +272,73 @@ function toolArgs(payload: GatewayEventPayload | undefined, prevArgs?: unknown):
   }
 }
 
-function toolResult(
-  payload: GatewayEventPayload | undefined,
-  prevResult?: unknown,
-  prevArgs?: unknown
-): Record<string, unknown> {
-  const parsedResult = parseMaybeJsonObject(payload?.result)
+function canonicalizeToolResult(value: unknown): unknown {
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value)
 
-  return {
-    ...parsedResult,
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed
+      }
+    } catch {
+      return value
+    }
+  }
+
+  return value
+}
+
+function eventPresentation(
+  payload: GatewayEventPayload | undefined,
+  prevPresentation?: unknown,
+  ...carryFrom: unknown[]
+): Record<string, unknown> | undefined {
+  const next = {
+    ...(recordFromUnknown(prevPresentation) ?? {}),
     ...(payload?.inline_diff ? { inline_diff: payload.inline_diff } : {}),
     ...(payload?.summary ? { summary: payload.summary } : {}),
     ...(payload?.message ? { message: payload.message } : {}),
     ...(payload?.preview ? { preview: payload.preview } : {}),
     ...(payload?.duration_s !== undefined ? { duration_s: payload.duration_s } : {}),
-    ...carryTodos(payload, prevResult, prevArgs),
+    ...carryTodos(payload, ...carryFrom),
     ...(payload?.error ? { error: payload.error } : {})
   }
+
+  return Object.keys(next).length > 0 ? next : undefined
+}
+
+function objectResultRecord(result: unknown): Record<string, unknown> {
+  return parseMaybeJsonObject(result)
+}
+
+/** Derived card/diff/todo hints: event-level presentation plus object-result fields.
+ *  Object-result keys win so an inner `summary` is not overwritten by the gateway. */
+export function toolPresentation(
+  part: ChatMessagePart | { presentation?: unknown; result?: unknown }
+): Record<string, unknown> {
+  const hints = recordFromUnknown('presentation' in part ? part.presentation : undefined) ?? {}
+  const result = 'result' in part ? part.result : undefined
+
+  return {
+    ...hints,
+    ...objectResultRecord(result)
+  }
+}
+
+function nextToolResult(
+  payload: GatewayEventPayload | undefined,
+  prev: ChatMessagePart | null,
+  prevResult: unknown
+): { include: true; result: unknown } | { include: false } {
+  if (payload && Object.hasOwn(payload, 'result')) {
+    return { include: true, result: canonicalizeToolResult(payload.result) }
+  }
+
+  if (prev && Object.hasOwn(prev, 'result')) {
+    return { include: true, result: prevResult }
+  }
+
+  return { include: false }
 }
 
 function completeOpenStreamParts(parts: ChatMessagePart[], completedAt: number): ChatMessagePart[] {
@@ -314,7 +372,13 @@ export function upsertToolPart(
   const prev = index >= 0 ? next[index] : null
   const prevArgs = prev && 'args' in prev ? prev.args : undefined
   const prevResult = prev && 'result' in prev ? prev.result : undefined
+  const prevPresentation = prev && 'presentation' in prev ? prev.presentation : undefined
   const args = toolArgs(payload, prevArgs)
+  const resolvedResult = nextToolResult(payload, prev, prevResult)
+  const presentation =
+    phase === 'complete'
+      ? eventPresentation(payload, prevPresentation, prevResult, prevArgs, prevPresentation)
+      : (recordFromUnknown(prevPresentation) ?? undefined)
 
   const id =
     stableId ||
@@ -328,10 +392,11 @@ export function upsertToolPart(
     args: args as never,
     argsText: JSON.stringify(args),
     timestamp: prev?.timestamp ?? occurredAt,
+    ...(presentation ? { presentation } : {}),
     ...(phase === 'complete' && {
       completedAt: occurredAt,
-      result: toolResult(payload, prevResult, prevArgs),
-      isError: Boolean(payload?.error)
+      isError: Boolean(payload?.error),
+      ...(resolvedResult.include ? { result: resolvedResult.result } : {})
     })
   } satisfies ChatMessagePart
 
@@ -579,13 +644,13 @@ export function sealOpenToolParts(messages: ChatMessage[]): ChatMessage[] {
     let partChanged = false
 
     const parts = message.parts.map(part => {
-      if (part.type !== 'tool-call' || Object.hasOwn(part, 'result')) {
+      if (part.type !== 'tool-call' || part.completedAt !== undefined || Object.hasOwn(part, 'result')) {
         return part
       }
 
       partChanged = true
 
-      return { ...part, result: {} }
+      return { ...part, completedAt: part.timestamp ?? 0 }
     })
 
     if (!partChanged) {

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -10,6 +10,8 @@ export interface TimelinePartMetadata {
   timestamp?: number
   /** Unix seconds when this segment stopped or handed off to the next one. */
   completedAt?: number
+  /** Event-level tool display hints. Never a substitute for `result`. */
+  presentation?: Record<string, unknown>
 }
 
 export type ChatMessagePart = Exclude<ThreadMessageLike['content'], string>[number] & TimelinePartMetadata

--- a/apps/desktop/src/lib/todos.ts
+++ b/apps/desktop/src/lib/todos.ts
@@ -248,7 +248,8 @@ export function todosFromMessageContent(content: unknown): null | TodoItem[] {
       continue
     }
 
-    const parsed = parseTodos(part.todos) ?? parseTodos(part.result) ?? parseTodos(part.args)
+    const parsed =
+      parseTodos(part.todos) ?? parseTodos(part.presentation) ?? parseTodos(part.result) ?? parseTodos(part.args)
 
     if (parsed !== null) {
       latest = parsed


### PR DESCRIPTION
## What does this PR do?

Desktop live transcript projection coerced every tool result through `parseMaybeJsonObject()` and then spread gateway display hints (`summary`, `message`, `preview`, …) on top. Plain-text, array, scalar and `null` results such as `"ok"` became a metadata object; an object result's own `summary` could be overwritten by the outer event; a sparse repeat complete erased an already received payload; and `sealOpenToolParts` / the fallback renderer invented `result: {}` for unresolved calls, which `toolStatus` painted as success.

Canonical `part.result` is now the original available payload. Event-level hints live on a derived `presentation` record (object-result keys win). Completions and seals that never received a result omit `result` and stamp `completedAt` instead of fabricating `{}`.

### Symptom

Desktop live transcript projection coerced every tool result through `parseMaybeJsonObject()` and then spread gateway display hints (`summary`, `message`, `preview`, …) on top. Plain-text, array, scalar and `null` results such as `"ok"` became a metadata object; an object result's own `summary` could be overwritten by the outer event; a sparse repeat complete erased an already received payload; and `sealOpenToolParts` / the fallback renderer invented `result: {}` for unresolved calls, which `toolStatus` painted as success.

Canonical `part.result` is now the original available payload. Event-level hints live on a derived `presentation` record (object-result keys win). Completions and seals that never received a result omit `result` and stamp `completedAt` instead of fabricating `{}`.


Fixes #107267


- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests


- `apps/desktop/src/lib/chat-messages/tool-parts.ts`: `nextToolResult` preserves primitives/arrays/null; sparse complete keeps the previous result; `eventPresentation` holds display hints; `sealOpenToolParts` stamps `completedAt` instead of `result: {}`; pending matching also requires `completedAt === undefined` so identified parallel completes do not collapse.
- `apps/desktop/src/components/assistant-ui/tool/fallback.tsx`: stop fabricating `{ result: {} }` for stopped unresolved calls; pass `presentation` through to `buildToolView`.
- `apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts`

### Impact

Desktop live transcript projection coerced every tool result through `parseMaybeJsonObject()` and then spread gateway display hints (`summary`, `message`, `preview`, …) on top. Plain-text, array, scalar and `null` results such as `"ok"` became a metadata object; an object result's own `summary` could be overwritten by the outer event; a sparse repeat complete erased an already received payload; and `sealOpenToolParts` / the fallback renderer invented `result: {}` for unresolved calls, which `toolStatus` painted as success.

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

Desktop live transcript projection coerced every tool result through `parseMaybeJsonObject()` and then spread gateway display hints (`summary`, `message`, `preview`, …) on top. Plain-text, array, scalar and `null` results such as `"ok"` became a metadata object; an object result's own `summary` could be overwritten by the outer event; a sparse repeat complete erased an already received payload; and `sealOpenToolParts` / the fallback renderer invented `result: {}` for unresolved calls, which `toolStatus` painted as success. Canonical `part.result` is now the original available payload.

## Related Issue

Fixes #107267

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/chat-messages/tool-parts.ts`: `nextToolResult` preserves primitives/arrays/null; sparse complete keeps the previous result; `eventPresentation` holds display hints; `sealOpenToolParts` stamps `completedAt` instead of `result: {}`; pending matching also requires `completedAt === undefined` so identified parallel completes do not collapse.
- `apps/desktop/src/components/assistant-ui/tool/fallback.tsx`: stop fabricating `{ result: {} }` for stopped unresolved calls; pass `presentation` through to `buildToolView`.
- `apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts`: `toolPresentation()` merge (hints then object-result); `toolStatus` uses `'warning'` when settled with no result; scalar/array results render as usable output.
- `apps/desktop/src/lib/todos.ts` and `thread/changed-files.ts`: read todos/diffs from the derived presentation so cards still work.

## How to Test

- ✅ `scripts/run_tests.sh` on the files in Changes Made — focused verification
- ✅ Focused verification completed on this branch
- ✅ BEFORE (RED): 12 failed, 111 passed — `result: 'ok'` stored `{ summary: 'done' }`; inner object `summary` overwritten by outer; sparse complete erased `'ok'`; `sealOpenToolParts` invented `{}`; `buildToolView` of `'ok'` did not show the text.
- ✅ AFTER (GREEN): 123 passed, 0 failed on those two files. Adjacent `todos` / `tool-run-continuity` / `fallback.test` also green (174 passed).

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

