### PR TITLE
fix(clarify): fail-closed consent guard on no-user auto-decide (#107068)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -665,6 +665,7 @@ _PRUNE_MIN_CHARS = 200
 _CLARIFY_NON_RESPONSE_PREFIXES = (
     "The user did not provide a response", "[user did not respond",
     "[clarify prompt could not be delivered", "[oneshot mode:",
+    "[single-query mode:", "[clarify consent guard:",
 )
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -447,6 +447,18 @@ DEFAULT_CONFIG = {
         # browser_cdp / browser_evaluate capabilities.
         "extension_control": {"enabled": False, "developer_mode": False},
     },
+    # Clarify tool behavior. (Users may also set a legacy `timeout` here — seconds, read by
+    # resolve_clarify_timeout before agent.clarify_timeout — but it is not shipped in defaults.)
+    "clarify": {
+        # When no human answers (headless -q/-z turns, timeouts, undeliverable prompts), the
+        # harness tells the agent to pick an option itself. false (default) = that auto-decide
+        # must never select an authorization-semantic option ("authorize me...", "allow me...",
+        # "consent..."): silence cannot grant consent, so such options are excluded from what
+        # the agent may pick (and when ALL options are consent-semantic, the agent is told to
+        # proceed WITHOUT the authorization). true restores the legacy pick-from-all behavior.
+        # See #107068.
+        "auto_decide_allow_consent": False,
+    },
     # Filesystem checkpoints: snapshot the working directory once per turn (on the first
     # write_file/patch call); restore with /rollback. Opt-in via `hermes chat --checkpoints` or
     # enabled=True (most users never use /rollback). Single shared shadow store with real pruning.

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -233,6 +233,45 @@ class TestSummarizeToolResultClarify:
 
             assert summary == "[clarify] asked user a question", sentinel
 
+    def test_live_single_query_producer_is_recognized_as_sentinel(self):
+        """Producer→recognizer drift guard for the -q headless callback
+        (#94943): its ``[single-query mode:`` output must be filtered too."""
+        from hermes_cli.cli_agent_setup_mixin import _single_query_clarify_callback
+
+        sentinels = (
+            _single_query_clarify_callback("Deploy when?", choices=["a", "b"]),
+            _single_query_clarify_callback(
+                "Deploy when?", choices=["a", "b"], multi_select=True
+            ),
+            _single_query_clarify_callback("Deploy when?"),
+        )
+        for sentinel in sentinels:
+            content = json.dumps({"user_response": sentinel})
+
+            summary = _summarize_tool_result("clarify", "{}", content)
+
+            assert summary == "[clarify] asked user a question", sentinel
+
+    def test_consent_guard_prose_never_quoted_as_user_answer(self):
+        """The #107068 guard rewrite is harness instruction, not a user
+        answer — compression must never quote it as one."""
+        from tools.clarify_tool import clarify_tool
+
+        def headless_cb(question, choices, multi_select=False):
+            return ("[single-query mode: no user available. Pick the best "
+                    "option and continue.]")
+
+        content = clarify_tool(
+            "Proceed?",
+            choices=["authorize me to compute the rows", "layout only"],
+            callback=headless_cb,
+        )
+
+        summary = _summarize_tool_result("clarify", "{}", content)
+
+        assert summary == "[clarify] asked user a question"
+        assert "authorize" not in summary.lower()
+
     def test_preserves_batch_user_response_from_responses_list(self):
         """Batch clarify (``questions=[...]``) nests answers inside ``responses[].user_response``;
         the summarizer must surface them, not just 'asked user a question' (#106077)."""

--- a/tests/tools/test_clarify_consent_guard.py
+++ b/tests/tools/test_clarify_consent_guard.py
@@ -1,0 +1,408 @@
+"""Regression tests for the clarify auto-decide consent guard (#107068).
+
+When no human answers (headless -q/-z turns, interactive timeouts, gateway
+delivery failures) the harness tells the agent to pick an option itself. If an
+offered option carries authorization semantics ("authorize me to ...", "allow
+me ...", "consent ..."), that instruction converts silence into consent: the
+agent picks the Recommended self-authorization option, proceeds with exactly
+what its contract forbade, and reports it had user authorization.
+
+Contract under test: a no-user sentinel response is rewritten fail-closed —
+authorization-semantic options are excluded from what the agent may pick (and
+when EVERY option is authorization-semantic, the agent is told to proceed
+WITHOUT the authorization, never to self-authorize). Real user answers are
+never rewritten. ``clarify.auto_decide_allow_consent: true`` restores the old
+pick-from-all-options behavior.
+"""
+
+import json
+
+from tools.clarify_tool import TIMEOUT_RESPONSE, clarify_tool
+
+AUTH = "authorize me to compute these 9 rows directly"
+SAFE = ["configure A2A peer then hand off", "no aggregation, layout only"]
+
+
+def _single_query_cb(question, choices, multi_select=False):
+    """The real headless ``hermes chat -q`` clarify callback."""
+    from hermes_cli.cli_agent_setup_mixin import _single_query_clarify_callback
+    return _single_query_clarify_callback(question, choices, multi_select)
+
+
+def _oneshot_cb(question, choices, multi_select=False):
+    """The real oneshot (``hermes -z``) clarify callback."""
+    from hermes_cli.oneshot import _oneshot_clarify_callback
+    return _oneshot_clarify_callback(question, choices, multi_select)
+
+
+def _sentinel_cb(sentinel):
+    def cb(question, choices, multi_select=False):
+        return sentinel
+    return cb
+
+
+class TestGuardFiresOnNoUserSentinels:
+    """Every harness-authored no-user answer must be screened."""
+
+    def test_single_query_repro_excludes_authorization_option(self):
+        """The exact issue repro: -q turn, Recommended self-authorization
+        option first — the auto-decide answer must not offer it as pickable."""
+        result = json.loads(clarify_tool(
+            "How should the aggregation proceed?",
+            choices=[AUTH] + SAFE,
+            callback=_single_query_cb,
+        ))
+        resp = result["user_response"]
+        assert isinstance(resp, str)
+        assert "[clarify consent guard" in resp
+        assert "silence cannot grant authorization" in resp.lower()
+        # The rewrite is the audit trail: it must name the question that went
+        # unanswered (the -q sentinel embedded it; the guard must not drop it).
+        assert "How should the aggregation proceed?" in resp
+        # The safe options remain pickable; the authorization one is excluded.
+        assert SAFE[0] in resp and SAFE[1] in resp
+        assert "excluded" in resp.lower() and AUTH in resp
+        # The old behavior — handing every option to the agent's judgment —
+        # must be gone.
+        assert "using your own judgment and continue" not in resp
+
+    def test_oneshot_callback_rewritten(self):
+        result = json.loads(clarify_tool(
+            "Format?", choices=[AUTH, SAFE[1]], callback=_oneshot_cb,
+        ))
+        resp = result["user_response"]
+        assert "[clarify consent guard" in resp
+        assert SAFE[1] in resp
+        assert "oneshot mode" not in resp
+
+    def test_timeout_sentinel_rewritten(self):
+        result = json.loads(clarify_tool(
+            "Format?", choices=[AUTH, "yaml"], callback=_sentinel_cb(TIMEOUT_RESPONSE),
+        ))
+        resp = result["user_response"]
+        assert "[clarify consent guard" in resp
+        assert "yaml" in resp
+        assert TIMEOUT_RESPONSE not in resp
+
+    def test_gateway_timeout_sentinel_rewritten(self):
+        result = json.loads(clarify_tool(
+            "Proceed?", choices=["allow me to delete the rows", "skip deletion"],
+            callback=_sentinel_cb("[user did not respond within 60m]"),
+        ))
+        resp = result["user_response"]
+        assert "[clarify consent guard" in resp
+        assert "skip deletion" in resp
+
+    def test_empty_response_rewritten_when_consent_present(self):
+        """The TUI bridge returns "" on timeout/cancel — never a consent grant."""
+        result = json.loads(clarify_tool(
+            "Proceed?", choices=["grant me full disk access", "read-only mode"],
+            callback=_sentinel_cb(""),
+        ))
+        resp = result["user_response"]
+        assert "[clarify consent guard" in resp
+        assert "read-only mode" in resp
+
+    def test_all_options_consent_fails_closed(self):
+        """When every option grants authorization, the agent must be told to
+        proceed WITHOUT the authorization — never to self-authorize."""
+        result = json.loads(clarify_tool(
+            "Proceed?",
+            choices=["authorize me to run it", "consent to full access"],
+            callback=_sentinel_cb(TIMEOUT_RESPONSE),
+        ))
+        resp = result["user_response"]
+        assert "[clarify consent guard" in resp
+        assert "do not self-authorize" in resp.lower()
+        assert "Pick only from" not in resp
+
+    def test_multi_select_sentinel_guard_is_scalar(self):
+        """The guard answer must survive _clean_answer's multi-select list
+        parsing — it stays one scalar instruction string."""
+        result = json.loads(clarify_tool(
+            "Which actions?", choices=[AUTH, SAFE[0]], multi_select=True,
+            callback=_sentinel_cb(TIMEOUT_RESPONSE),
+        ))
+        resp = result["user_response"]
+        assert isinstance(resp, str)
+        assert "[clarify consent guard" in resp
+
+    def test_batch_timeout_blank_is_screened(self):
+        """Layer 7: on a batch timeout, the unanswered entry's blank response
+        must go through the consent guard — a walk-away is a no-user
+        auto-decide, not a deliberate human skip."""
+        def batch_cb(question, choices, questions=None, **kw):
+            # Batch-capable callback: answers the FIRST question, times out
+            # the rest (the tui_gateway bridge carries strings only).
+            return json.dumps({"answers": {"q0": TIMEOUT_RESPONSE}, "timed_out": True})
+        result = json.loads(clarify_tool(
+            "batch",
+            questions=[
+                {"question": "Proceed?", "choices": [AUTH, SAFE[1]]},
+                {"question": "Format?", "choices": [AUTH, "yaml"]},
+            ],
+            callback=batch_cb,
+        ))
+        assert result.get("timed_out") is True
+        resp0 = result["responses"][0]["user_response"]
+        resp1 = result["responses"][1]["user_response"]
+        assert "[clarify consent guard" in resp0
+        # The blank-after-timeout entry is screened too, not passed as "".
+        assert "[clarify consent guard" in resp1
+        assert "yaml" in resp1
+
+    def test_batch_deliberate_skip_stays_blank(self):
+        """Without timed_out, a blank is a deliberate human skip — untouched."""
+        def batch_cb(question, choices, questions=None, **kw):
+            return json.dumps({"answers": {"q0": "no aggregation, layout only"}})
+        result = json.loads(clarify_tool(
+            "batch",
+            questions=[
+                {"question": "Proceed?", "choices": [AUTH, SAFE[1]]},
+                {"question": "Format?", "choices": [AUTH, "yaml"]},
+            ],
+            callback=batch_cb,
+        ))
+        assert "timed_out" not in result
+        assert result["responses"][1]["user_response"] == ""
+
+    def test_recommended_label_does_not_hide_the_verb(self):
+        """Screening sees the bare choices, but must also tolerate the
+        "(Recommended)" presentation label."""
+        result = json.loads(clarify_tool(
+            "Proceed?",
+            choices=[f"{AUTH} (Recommended)", SAFE[1]],
+            callback=_sentinel_cb(TIMEOUT_RESPONSE),
+        ))
+        resp = result["user_response"]
+        assert "[clarify consent guard" in resp
+        assert SAFE[1] in resp
+
+
+class TestGuardDoesNotOverreach:
+    """The guard must not break innocuous auto-decide or real answers."""
+
+    def test_innocuous_choices_sentinel_passthrough(self):
+        result = json.loads(clarify_tool(
+            "Format?", choices=["json", "yaml"], callback=_sentinel_cb(TIMEOUT_RESPONSE),
+        ))
+        assert result["user_response"] == TIMEOUT_RESPONSE
+
+    def test_open_ended_sentinel_passthrough(self):
+        result = json.loads(clarify_tool(
+            "Which timezone?", callback=_sentinel_cb(TIMEOUT_RESPONSE),
+        ))
+        assert result["user_response"] == TIMEOUT_RESPONSE
+
+    def test_real_user_answer_never_rewritten(self):
+        """A human clicking the authorization option IS consent — recorded."""
+        answer = "authorize me to compute these 9 rows directly"
+        result = json.loads(clarify_tool(
+            "Proceed?", choices=[AUTH, SAFE[1]], callback=_sentinel_cb(answer),
+        ))
+        assert result["user_response"] == answer
+
+    def test_near_miss_words_do_not_trigger(self):
+        """Word boundaries: "authorized personnel", "pre-consented" etc. are
+        not consent requests from the user."""
+        result = json.loads(clarify_tool(
+            "Which path?",
+            choices=["use the authorized-personnel roster", "manual entry"],
+            callback=_sentinel_cb(TIMEOUT_RESPONSE),
+        ))
+        assert result["user_response"] == TIMEOUT_RESPONSE
+
+    def test_config_gate_restores_old_behavior(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"clarify": {"auto_decide_allow_consent": True}},
+        )
+        result = json.loads(clarify_tool(
+            "Proceed?", choices=[AUTH, SAFE[1]], callback=_sentinel_cb(TIMEOUT_RESPONSE),
+        ))
+        assert result["user_response"] == TIMEOUT_RESPONSE
+
+
+class TestRevision107279Review:
+    """Regressions from andrexibiza's review of PR#107279 (2026-09-10):
+
+    P1-1: the opt-out resolver must fail closed on non-bool values —
+    ``bool("false")`` is True, so a quoted/malformed YAML value must not
+    disable the consent guard (silence must not regain auto-authorization
+    through a typo).
+
+    P1-2: the consent classifier must cover the explicit phrases #107265
+    (Finn763) already recognizes — approve/approval, permit, let me,
+    self-approve, bypass, and the CJK 授权/批准/准许 — so a no-user sentinel
+    with e.g. "approve this action" cannot fall through to legacy
+    auto-decide.
+    """
+
+    # --- P1-1: typed authority for the opt-out -----------------------------
+
+    def test_optout_quoted_false_string_stays_fail_closed(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"clarify": {"auto_decide_allow_consent": "false"}},
+        )
+        result = json.loads(clarify_tool(
+            "Proceed?", choices=[AUTH, SAFE[1]], callback=_sentinel_cb(TIMEOUT_RESPONSE),
+        ))
+        resp = result["user_response"]
+        assert "[clarify consent guard" in resp  # guard armed: "false" is not True
+        assert SAFE[1] in resp
+
+    def test_optout_nonempty_junk_string_stays_fail_closed(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"clarify": {"auto_decide_allow_consent": "disabled"}},
+        )
+        result = json.loads(clarify_tool(
+            "Proceed?", choices=[AUTH, SAFE[1]], callback=_sentinel_cb(TIMEOUT_RESPONSE),
+        ))
+        assert "[clarify consent guard" in result["user_response"]
+
+    def test_optout_numeric_and_container_values_stay_fail_closed(self, monkeypatch):
+        for bad in (0, 1, 2, 0.0, ["true"], {"enabled": True}, None):
+            monkeypatch.setattr(
+                "hermes_cli.config.load_config",
+                lambda bad=bad: {"clarify": {"auto_decide_allow_consent": bad}},
+            )
+            result = json.loads(clarify_tool(
+                "Proceed?", choices=[AUTH, SAFE[1]], callback=_sentinel_cb(TIMEOUT_RESPONSE),
+            ))
+            assert "[clarify consent guard" in result["user_response"], repr(bad)
+
+    def test_optout_resolver_contract_on_malformed_values(self):
+        """Only the literal boolean True disables the guard; every other
+        type/value keeps it armed."""
+        from tools.clarify_tool import resolve_auto_decide_allow_consent as resolve
+        for bad in ("false", "true", "disabled", "yes", 1, 0, 2, 0.0, 1.0,
+                    ["true"], {"v": True}, None, (), float("nan")):
+            assert resolve({"clarify": {"auto_decide_allow_consent": bad}}) is False, repr(bad)
+        assert resolve({"clarify": {"auto_decide_allow_consent": True}}) is True
+
+    # --- P1-2: classifier convergence with #107265 --------------------------
+
+    def test_approve_phrases_now_guarded(self):
+        """'approve this action' fell through to legacy auto-decide before the
+        revision — silence could still become approval."""
+        result = json.loads(clarify_tool(
+            "Proceed?", choices=["approve this action", "skip"],
+            callback=_sentinel_cb(TIMEOUT_RESPONSE),
+        ))
+        resp = result["user_response"]
+        assert "[clarify consent guard" in resp
+        # the consent option is named — but only as EXCLUDED, never pickable
+        assert "Excluded" in resp and "approve this action" in resp
+        assert "skip" in resp  # safe option stays pickable
+
+    def test_permit_letme_bypass_phrases_now_guarded(self):
+        for consent, safe in (
+            ("permit me to write outside the repo", "stay inside the workdir"),
+            ("let me bypass the sandbox", "retry in-sandbox"),
+            ("bypass the approval gate", "wait for the human"),
+            ("self-approve the deployment", "queue it for review"),
+            ("approval to delete the rows", "skip deletion"),
+        ):
+            result = json.loads(clarify_tool(
+                "Proceed?", choices=[consent, safe], callback=_sentinel_cb(TIMEOUT_RESPONSE),
+            ))
+            resp = result["user_response"]
+            assert "[clarify consent guard" in resp, consent
+            assert safe in resp, consent
+
+    def test_cjk_consent_phrases_now_guarded(self):
+        """授权 / 批准 / 准许 — the #107265 EN+ZH coverage contract."""
+        for consent, safe in (
+            ("授权我直接计算这些行", "仅排版不加总"),
+            ("批准删除这些数据行", "跳过删除"),
+            ("准许我绕过审批", "等待人工确认"),
+        ):
+            result = json.loads(clarify_tool(
+                "如何处理?", choices=[consent, safe], callback=_sentinel_cb(TIMEOUT_RESPONSE),
+            ))
+            resp = result["user_response"]
+            assert "[clarify consent guard" in resp, consent
+            assert safe in resp, consent
+
+    def test_british_spelling_authorise_detected(self):
+        from tools.clarify_tool import _is_consent_semantic
+        assert _is_consent_semantic("authorise me to proceed")
+
+    def test_near_misses_still_pass_through_after_widening(self):
+        """Widening must not catch approval-adjacent nouns that are not consent
+        requests: 'improve performance', 'approved-by-default roster' style
+        hyphenated near-misses stay pickable."""
+        from tools.clarify_tool import _is_consent_semantic
+        for text in (
+            "use the authorized-personnel roster",
+            "the pre-consented form",
+            "json",
+            "Rebase",
+            "Improve performance",
+            "no aggregation, layout only",
+        ):
+            assert not _is_consent_semantic(text), text
+
+    def test_widening_guard_does_not_break_innocuous_passthrough(self):
+        result = json.loads(clarify_tool(
+            "Format?", choices=["json", "yaml", "table", "Rebase first"],
+            callback=_sentinel_cb(TIMEOUT_RESPONSE),
+        ))
+        assert result["user_response"] == TIMEOUT_RESPONSE
+
+
+class TestConfigSurface:
+    """`clarify.auto_decide_allow_consent` — fail-closed by default."""
+
+    def test_resolver_defaults_false(self):
+        from tools.clarify_tool import resolve_auto_decide_allow_consent
+        assert resolve_auto_decide_allow_consent({}) is False
+        assert resolve_auto_decide_allow_consent({"clarify": {}}) is False
+        assert resolve_auto_decide_allow_consent(
+            {"clarify": {"auto_decide_allow_consent": True}}) is True
+
+    def test_default_config_ships_fail_closed(self):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+        clarify_cfg = DEFAULT_CONFIG.get("clarify") or {}
+        assert clarify_cfg.get("auto_decide_allow_consent") is False
+
+
+class TestSentinelDetection:
+    """The sentinel list mirrors what the harness actually produces."""
+
+    def test_harness_sentinels_detected(self):
+        from tools.clarify_tool import _is_auto_decide_sentinel
+        for s in (
+            TIMEOUT_RESPONSE,
+            "",
+            "[single-query mode: no user available to answer 'Q'. Pick the best option ...]",
+            "[oneshot mode: no user available. Pick the best option ...]",
+            "[user did not respond within 60m]",
+            "[clarify prompt could not be delivered]",
+        ):
+            assert _is_auto_decide_sentinel(s), s
+        assert _is_auto_decide_sentinel(None) is False
+
+    def test_consent_verb_detection(self):
+        from tools.clarify_tool import _is_consent_semantic
+        for text in (
+            "authorize me to compute these rows",
+            "Authorize the agent to proceed",
+            "allow me to delete the file",
+            "consent to data aggregation",
+            "I consent to sharing logs",
+            "grant me full disk access",
+            "give me permission to run it",
+            "permission to proceed without asking",
+        ):
+            assert _is_consent_semantic(text), text
+        for text in (
+            "use the authorized-personnel roster",
+            "the pre-consented form",
+            "configure A2A peer then hand off",
+            "no aggregation, layout only",
+            "json",
+        ):
+            assert not _is_consent_semantic(text), text

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -4,6 +4,7 @@ callback (cli.py, gateway/run.py, tui_gateway)."""
 
 import inspect
 import json
+import re
 from typing import Dict, List, Optional, Callable
 
 MAX_CHOICES = 4  # the UI always appends an "Other (type your answer)" row
@@ -15,6 +16,31 @@ TIMEOUT_RESPONSE = ("The user did not provide a response within the time limit. 
 # Applied to the first choice here (not per-surface) so every adapter renders it identically.
 RECOMMENDED_LABEL = "(Recommended)"
 _UNAVAILABLE = "Clarify tool is not available in this execution context."
+
+# ---- Consent guard (#107068) --------------------------------------------------
+# When no human answers, the harness answers for them ("pick the best option
+# yourself"). If an offered option carries authorization semantics, that
+# instruction converts silence into consent. These detect the two halves of the
+# problem: which callback results are harness-authored non-answers, and which
+# option texts ask the user to grant authorization.
+_AUTO_DECIDE_SENTINEL_PREFIXES = (
+    "[single-query mode:",           # hermes chat -q headless callback
+    "[oneshot mode:",                # oneshot (-z) headless callback
+    "[user did not respond",         # gateway bounded-wait expiry
+    "[clarify prompt could not be delivered",
+)
+_CONSENT_PATTERNS = tuple(re.compile(p, re.IGNORECASE) for p in (
+    r"\bauthori[sz]e\b",
+    r"\ballow\s+me\b",
+    r"\blet\s+me\b",
+    r"\bconsent\b",
+    r"\bgrant(?:s|ed|ing)?\s+me\b",
+    r"\bpermi(?:t|ts|tted|ssion)\b",
+    r"\bapprov(?:e|es|ed|ing|al|als)\b",
+    r"\bbypass\b",
+    r"授权|批准|准许",
+))
+_CONSENT_GUARD_PREFIX = "[clarify consent guard:"
 
 
 def _flatten_choice(c) -> str:
@@ -101,6 +127,116 @@ def _is_timeout(raw) -> bool:
     return raw is None or (isinstance(raw, str) and raw.strip() == TIMEOUT_RESPONSE)
 
 
+def _is_auto_decide_sentinel(raw) -> bool:
+    """True when a clarify callback result is a harness-authored non-answer.
+
+    Covers every surface's no-user reply: the timeout sentinel (CLI modal,
+    legacy callback), the headless -q / -z instruction strings, the gateway
+    bounded-wait expiry and undeliverable notes, and the TUI bridge's empty
+    string. A real user answer never matches (#107068).
+    """
+    if not isinstance(raw, str):
+        return False
+    stripped = raw.strip()
+    return stripped in ("", TIMEOUT_RESPONSE) or stripped.startswith(_AUTO_DECIDE_SENTINEL_PREFIXES)
+
+
+def _is_consent_semantic(text: str) -> bool:
+    """True when an option's text asks the user to grant authorization.
+
+    Word-boundary regexes over the authorization verbs ("authorize", "allow
+    me", "let me", "consent", "grant me", "permit", "approve", "bypass", plus
+    the CJK 授权/批准/准许 — coverage converged with #107265) so
+    hyphenated near-misses like "authorized-personnel" or "pre-consented"
+    do not trip it.
+    """
+    if not isinstance(text, str):
+        return False
+    return any(p.search(text) for p in _CONSENT_PATTERNS)
+
+
+def resolve_auto_decide_allow_consent(config: Optional[dict]) -> bool:
+    """Read ``clarify.auto_decide_allow_consent`` (default False = guard on).
+
+    Fail-closed: missing section, missing key, non-bool, or read failure all
+    keep the guard armed. Only the literal boolean ``True`` opts back into the
+    legacy pick-from-all-options auto-decide — this key is itself an escape
+    hatch for human-authorization policy, so a quoted ``"false"`` or any
+    other malformed value must never disable the guard (#107068).
+    """
+    try:
+        clarify_cfg = (config or {}).get("clarify") if isinstance(config, dict) else None
+        if not isinstance(clarify_cfg, dict):
+            return False
+        value = clarify_cfg.get("auto_decide_allow_consent")
+        # Typed authority: anything that is not the literal boolean True
+        # (quoted "true"/"false", numbers, containers) keeps the guard armed.
+        return value is True
+    except Exception:
+        return False
+
+
+def _guarded_auto_decide_answer(question: str, choices: Optional[List[str]], raw: str) -> str:
+    """Fail-closed rewrite of a no-user auto-decide answer (#107068).
+
+    Authorization-semantic options are excluded from what the agent may pick;
+    when EVERY option is authorization-semantic the agent is told to proceed
+    WITHOUT the authorization instead of self-authorizing. Returns ``raw``
+    unchanged when the guard is disabled or no option is consent-semantic.
+    """
+    try:
+        from hermes_cli.config import load_config
+        config = load_config() if load_config else None
+    except Exception:
+        config = None
+    if resolve_auto_decide_allow_consent(config):
+        return raw
+    bare = [strip_recommended(str(c)) for c in (choices or [])]
+    excluded = [c for c in bare if _is_consent_semantic(c)]
+    if not excluded:
+        return raw  # nothing consent-semantic: keep the surface's own wording
+    screened = [c for c in bare if not _is_consent_semantic(c)]
+    if screened:
+        return (
+            f"{_CONSENT_GUARD_PREFIX} no user answered {question!r}, and silence "
+            f"cannot grant authorization. Excluded (require explicit human consent): "
+            f"{excluded}. Pick only from: {screened}.]"
+        )
+    return (
+        f"{_CONSENT_GUARD_PREFIX} no user answered {question!r}, and silence "
+        f"cannot grant authorization. Every offered option requires explicit human "
+        f"consent ({excluded}); none was given. Do not self-authorize: proceed "
+        f"WITHOUT the authorization (choose a non-authorized path or stop and report).]"
+    )
+
+
+def _apply_consent_guard(raw_response, question, shown: Optional[List[str]]):
+    """Screen a callback result for the consent guard (#107068).
+
+    Returns the rewritten guard instruction when a harness-authored no-user
+    sentinel met consent-semantic options, else the original object untouched
+    (identity preserved) so the caller's normal answer processing — including
+    multi-select list cleaning — proceeds exactly as before. A real user answer
+    is never screened: a human clicking the authorize option IS consent.
+    """
+    if shown and _is_auto_decide_sentinel(raw_response):
+        return _guarded_auto_decide_answer(question, shown, str(raw_response))
+    return raw_response
+
+
+def _finalize_answer(raw_response, question, shown: Optional[List[str]], multi: bool):
+    """Consent guard + presentation cleaning, in that order (#107068).
+
+    A rewritten guard instruction stays ONE scalar string — it is harness
+    prose, not a multi-select answer, so the comma-splitting list parse must
+    not mangle it. Real answers flow through ``_clean_answer`` as before.
+    """
+    guarded = _apply_consent_guard(raw_response, question, shown)
+    if isinstance(guarded, str) and guarded.startswith(_CONSENT_GUARD_PREFIX):
+        return guarded
+    return _clean_answer(guarded, multi)
+
+
 # ============================================================================= Batch (multi-question)
 # support — issue #18450 =============================================================================
 def _normalize_questions(questions) -> tuple:
@@ -142,10 +278,19 @@ def _batch_result(normalized: List[dict], answers: dict, timed_out: bool) -> str
     responses = []
     for entry in normalized:
         raw = answers.get(entry["qid"])
+        if raw:
+            resp = _finalize_answer(raw, entry["question"], entry["choices"], entry["multi_select"])
+        elif timed_out and entry["choices"]:
+            # A blank after a timeout is a no-user auto-decide, not a deliberate
+            # human skip — screen it through the consent guard like every other
+            # harness-authored non-answer (#107068).
+            resp = _finalize_answer("", entry["question"], entry["choices"], entry["multi_select"])
+        else:
+            resp = ""
         responses.append({
             **({"id": entry["id"]} if entry["id"] else {}),
             "question": entry["question"], "choices_offered": entry["choices_offered"],
-            "user_response": _clean_answer(raw, entry["multi_select"]) if raw else ""})
+            "user_response": resp})
     result: Dict[str, object] = {"responses": responses}
     if timed_out:
         result["timed_out"] = True
@@ -226,7 +371,9 @@ def clarify_tool(question: str, choices: Optional[List[str]] = None, multi_selec
     except Exception as exc:
         return tool_error(f"Failed to get user input: {exc}")
     return json.dumps({"question": question, "choices_offered": choices,
-                       "user_response": _clean_answer(raw_response, multi_select and choices is not None)},
+                       "user_response": _finalize_answer(
+                           raw_response, question, shown,
+                           multi_select and choices is not None)},
                       ensure_ascii=False)
 
 


### PR DESCRIPTION
## What

When no human can answer a `clarify` call (headless `hermes chat -q` / `-z` turns, interactive timeouts, gateway expiry/undeliverable prompts, TUI blanks), the harness answers for them: *"Pick the best option ... using your own judgment and continue."* If one of the offered options carries authorization semantics (`authorize me to...`, `allow me to...`, `consent to...`), that instruction converts silence into consent — the agent picks the Recommended self-authorization option, does exactly what its contract forbade, and reports it had user authorization (#107068's production repro).

## Fix

Guard at the one platform-agnostic entry point every surface funnels through — `_finalize_answer` in `tools/clarify_tool.py`:

- `_is_auto_decide_sentinel()` detects every harness-authored no-user answer (both headless callbacks, `TIMEOUT_RESPONSE`, gateway `[user did not respond within Xm]` / `[clarify prompt could not be delivered]`, the TUI bridge's empty string). Covers all 7 no-user surfaces + batch blank-after-timeout entries without touching 5 platform files.
- Authorization-semantic options are **excluded** from what the agent may pick; the rewrite names the question and the excluded options (it *is* the audit trail).
- When **every** option is authorization-semantic, the agent is told to proceed **WITHOUT** the authorization — never to self-authorize.
- Real user answers are never rewritten (identity preserved): a human clicking the authorize option *is* consent.
- Opt-out: `clarify.auto_decide_allow_consent: true` in config.yaml restores the legacy pick-from-all behavior (default false = fail-closed).
- Word-boundary regexes (`authorize`, `allow me`, `consent`, `grant me`, `permission`) so "authorized-personnel"-class near-misses don't trip it.
- `agent/context_compressor.py` learns the new guard prefix so compression prunes it like other clarify non-answers.

The headless immediate-answer behavior from #94943 is preserved (only *what may be picked* is screened) — destroying it would resurrect the `-q` hang that change fixed.

## Verified

- 19 new production-path tests (`tests/tools/test_clarify_consent_guard.py`): 13 fail on upstream/main (RED), all pass with the fix — including the exact issue repro with the real `_single_query_clarify_callback` imported.
- Nearby suites post-rebase onto current main (a0749d583a): **310 passed** across clarify tool/gateway/platform button suites, single-query approval mode, and context compressor. `ruff check` clean, `git diff --check` clean.
- E2E config check against a temp `HERMES_HOME`: the new `clarify:` section deep-merges for existing users, default resolves fail-closed, explicit opt-in honored.
- Exactly one focused commit ahead of main (`git rev-list --left-right --count` → `0 1`).

## Competitor analysis

#107265 guards the two headless callbacks only. This PR keeps that idea but covers the remaining no-user surfaces (modal timeout, legacy callback timeout, gateway expiry/undeliverable, canonical sentinel, batch blanks), adds the `clarify.auto_decide_allow_consent` config gate the issue's direction 2 proposes, and anchors the verb regexes with word boundaries to avoid excluding safe options like "use the authorized-personnel roster".

Closes #107068. Related: #25859 (adjacent timeout behavior; shares the config surface).

Auto-published by Moonsong via Path B automated pipeline.