### PR TITLE
fix(memory): bound the external-drift refusal and stop duplicate .bak clutter (#107270)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -499,6 +499,62 @@ class TestExternalDriftGuard:
         assert result["success"] is False
         assert path.stat().st_size == original_size
 
+    def test_repeated_drift_refusal_is_bounded(self, store):
+        """An identical retry against unresolved drift can't loop the turn.
+
+        A drift refusal is a hard blocker (the write can't succeed until the file is made
+        round-trippable), so re-issuing the SAME call got the SAME refusal forever (#107270).
+        Now the refusal is rate-limited like a consolidation failure (#42405): actionable up
+        to the per-turn cap, then a TERMINAL result so the model stops and surfaces the blocker.
+        """
+        store.add("memory", "User likes brevity.")
+        self._plant_drift(store)
+        cap = store._MAX_CONSOLIDATION_FAILURES_PER_TURN
+
+        # Up to the cap: actionable drift refusals, each still naming the backup + remediation.
+        for _ in range(cap):
+            result = store.replace("memory", "User likes", "User prefers concise.")
+            assert result["success"] is False
+            assert result.get("done") is not True
+            assert "drift_backup" in result
+
+        # Past the cap: terminal — no more looping; tells the model to surface it to the user.
+        result = store.replace("memory", "User likes", "User prefers concise.")
+        assert result["success"] is False
+        assert result["done"] is True
+        assert "drift_backup" not in result
+        assert "107270" in result["error"]
+
+        # A fresh turn clears the per-turn counter; the actionable refusal is available again.
+        store.reset_consolidation_failures()
+        result = store.replace("memory", "User likes", "User prefers concise.")
+        assert result.get("done") is not True
+        assert "drift_backup" in result
+
+    def test_repeated_identical_drift_reuses_one_backup(self, store, monkeypatch):
+        """Identical unresolved drift must not spawn a fresh .bak on every refusal (#107270).
+
+        Timestamps are forced to differ so that, without reuse, each refusal would write a
+        distinct ``.bak.<ts>`` and clutter the memory dir.
+        """
+        import tools.memory_tool_store as mod
+        ticks = iter([1000, 2000, 3000, 4000])
+        monkeypatch.setattr(mod.time, "time", lambda: next(ticks))
+
+        store.add("memory", "User likes brevity.")
+        path = self._plant_drift(store)
+
+        def baks():
+            return sorted(path.parent.glob(path.name + ".bak.*"))
+
+        r1 = store.replace("memory", "User likes", "User prefers concise.")
+        r2 = store.replace("memory", "User likes", "User prefers concise.")
+
+        # Same snapshot reused, and exactly one backup on disk despite two refusals.
+        assert r1["drift_backup"] == r2["drift_backup"]
+        assert len(baks()) == 1
+        assert Path(r1["drift_backup"]).read_text() == path.read_text()
+
 
 class TestUnreadableFileDoesNotWipeMemory:
     """A file that exists but can't be read must NOT be treated as empty.

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -108,6 +108,27 @@ class MemoryStore:
             "memory calls — leave memory unchanged for now and continue with your reply to the user. "
             "The fact can be saved in a later turn.")}
 
+    def _drift_failure(self, drift_response: Dict[str, Any]) -> Dict[str, Any]:
+        """Rate-limit the external-drift refusal exactly like a consolidation failure so an
+        identical retry can't loop the turn (#26045 refused unbounded; #107270).
+
+        A drift refusal is a hard blocker — the write cannot succeed until the on-disk file is
+        made round-trippable — so re-issuing the SAME memory call gets the SAME refusal forever.
+        Under the per-turn cap return the actionable drift error (it names the .bak and the
+        remediation); past the cap return a TERMINAL result so the model stops retrying and
+        surfaces the blocker to the user instead of burning the turn. Shares the per-turn counter
+        with consolidation failures — both mean 'a memory op keeps failing this turn, stop'.
+        """
+        self._consolidation_failures += 1
+        if self._consolidation_failures <= self._MAX_CONSOLIDATION_FAILURES_PER_TURN:
+            return drift_response
+        return {"success": False, "done": True, "error": (
+            f"Memory write refused {self._consolidation_failures} times this turn: the file on disk shows "
+            "external drift that won't round-trip through the memory tool, and an identical retry can't "
+            "change that. Stop retrying. Surface this to the user — the .bak snapshot holds their content — "
+            "and ask whether to rewrite the file as a clean §-delimited list of entries or move the extra "
+            "content out; then continue with your reply for now (#107270).")}
+
     def load_from_disk(self):
         """Load MEMORY.md / USER.md and capture the frozen system-prompt snapshot.
         Threat hits are replaced by a ``[BLOCKED: …]`` placeholder in the SNAPSHOT only;
@@ -202,7 +223,7 @@ class MemoryStore:
             bak = None if skip_drift else self._detect_external_drift(target, raw)
             self._set_entries(target, list(dict.fromkeys(self._parse_entries(raw))))
             if bak:
-                return _drift_error(path, bak)
+                return self._drift_failure(_drift_error(path, bak))
             result = mutate(self._entries_for(target), self._char_limit(target))
             if isinstance(result, dict):
                 return result
@@ -409,6 +430,15 @@ class MemoryStore:
                                and max(map(len, parsed), default=0) <= self._char_limit(target)):
             return None
         path = self._path_for(target)
+        # Reuse an existing snapshot with byte-identical content instead of writing a new one:
+        # an identical retry (same unresolved drift) must not spawn a fresh .bak every time and
+        # clutter the memory dir (#107270). Only distinct drift content earns a new snapshot.
+        for existing in sorted(path.parent.glob(path.name + ".bak.*")):
+            try:
+                if existing.read_text(encoding="utf-8") == raw:
+                    return str(existing)
+            except OSError:
+                continue
         bak_path = path.with_suffix(path.suffix + f".bak.{int(time.time())}")
         try:
             bak_path.write_text(raw, encoding="utf-8")


### PR DESCRIPTION
## What

The external-drift guard (#26045) refuses `replace`/`remove` when `MEMORY.md` / `USER.md` won't round-trip through the memory tool, so a session with stale in-memory state can't silently truncate content an external writer appended. That guard is correct and stays. Two side effects of *how it refuses* are the bug in #107270:

1. **The refusal loops.** Consolidation failures are rate-limited per turn (#42405) so the model can't burn a turn retrying; the drift refusal was returned straight from `_mutate` with no such cap. A drift refusal is a hard blocker — an identical `memory(...)` retry gets the identical refusal — so a caller that keeps trying loops on the same call (the issue reports 3+ identical refusals).
2. **`.bak` files pile up.** Every refusal wrote a fresh `MEMORY.md.bak.<ts>` snapshot, so a loop leaves a trail of identical backups cluttering the memory dir.

## Fix

- `_drift_failure` routes the refusal through the same per-turn counter as `_consolidation_failure`: **actionable up to the cap** (still names the `.bak` and the remediation), then a **TERMINAL** result telling the model to stop retrying and surface the blocker to the user — the write can't succeed until the file is made round-trippable, so retrying is pointless.
- `_detect_external_drift` reuses an existing **byte-identical** `.bak` instead of writing a new one; only genuinely-different drift content earns a fresh snapshot.

The round-trip comparison is untouched — a file that genuinely doesn't round-trip is still refused exactly as before. (The issue's "identical to its `.bak`" observation is a red herring: the guard never compares against the `.bak`; it reparses the *current* on-disk file, and the reporter's file almost certainly carried formatting the tool wouldn't emit, e.g. blank lines around the `§` delimiter. Loosening the guard's notion of "clean" is a separate, judgment-heavy call and is deliberately out of scope here.)

## Tests

`tests/tools/test_memory_tool.py::TestExternalDriftGuard`:
- `test_repeated_drift_refusal_is_bounded` — refusals stay actionable up to the cap, then go terminal (`done=True`, no `drift_backup`); a fresh turn (`reset_consolidation_failures`) restores the actionable refusal.
- `test_repeated_identical_drift_reuses_one_backup` — with timestamps forced to differ, two refusals produce **one** `.bak`, and both point at it.

Full file: 53 passed. `ruff check` clean.

Fixes #107270
