### PR TITLE
fix(models): never auto-switch to a provider the user has no credentials for; keep session custom endpoints; ACP explicit prefix wins (#74143, #59089)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -312,8 +312,11 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         try:
             from hermes_cli.models import detect_provider_for_model, parse_model_input
 
+            raw = new_model
             target_provider, new_model = parse_model_input(new_model, current_provider)
-            if target_provider == current_provider:
+            # An explicit ``provider:model`` prefix is a selection; detection is a fallback for bare
+            # names only and must not second-guess it (#59089).
+            if target_provider == current_provider and new_model == raw:
                 detected = detect_provider_for_model(new_model, current_provider)
                 if detected:
                     target_provider, new_model = detected

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -105,12 +105,13 @@ _DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v\d+([-.].+)?$")
 
 def _normalize_for_deepseek(model_name: str) -> str:
     """Map a model input to a DeepSeek-accepted id: canonicals and ``deepseek-v<digit>…`` pass
-    through (dated variants and future V-series work without a release); retired aliases and
-    everything else become ``deepseek-flash``."""
+    through (dated variants and future V-series work without a release); retired aliases and other
+    ``deepseek-*`` spellings become ``deepseek-flash``. Names outside the family pass through
+    untouched so the validator can reject them instead of silently running Flash."""
     bare = _strip_vendor_prefix(model_name).lower()
     if bare in _DEEPSEEK_CANONICAL_MODELS or _DEEPSEEK_V_SERIES_RE.match(bare):
         return bare
-    return "deepseek-flash"
+    return "deepseek-flash" if bare.startswith("deepseek") else bare
 
 
 def _strip_vendor_prefix(model_name: str) -> str:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -18,7 +18,7 @@ from hermes_cli.providers import (
 from hermes_cli.model_normalize import normalize_model_for_provider
 from agent.models_dev import (
     ModelCapabilities, ModelInfo, get_model_capabilities, get_model_info, list_provider_models)
-from utils import base_url_hostname, base_url_origin
+from utils import base_url_host_matches, base_url_hostname, base_url_origin
 # Re-exported: callers/tests patch hermes_cli.model_switch.<name>.
 from hermes_cli.model_switch_providers import list_authenticated_providers
 
@@ -1309,6 +1309,17 @@ def _creds_for_current_provider(st: _Switch) -> None:
             st.resolve_runtime(requested=st.current_provider)
         except Exception:
             pass
+        # Bare ``custom``/``local`` sessions whose base_url is session-only (not a trusted config
+        # ``model.base_url``) re-resolve to the OpenRouter DEFAULT — a host the user never picked
+        # (#74143). Keep the session endpoint + key then; a config-backed custom URL still wins so
+        # key/endpoint rotation is not pinned to a stale session.
+        if (
+            st.current_provider in {"custom", "local"} and st.current_base_url
+            and (not st.base_url or base_url_host_matches(st.base_url, "openrouter.ai"))
+            and not base_url_host_matches(st.current_base_url, "openrouter.ai")
+        ):
+            st.base_url, st.api_key = st.current_base_url, st.current_api_key
+            st.api_mode = determine_api_mode(st.current_provider, st.base_url)
 
 
 def _resolve_switch_credentials(st: _Switch) -> Optional[ModelSwitchResult]:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -930,8 +930,16 @@ def _resolve_provider_prefix(model_name: str) -> Optional[tuple[str, str]]:
 
 def detect_provider_for_model(
     model_name: str, current_provider: str) -> Optional[tuple[str, str]]:
-    """Auto-detect the best provider for a model name: static catalogs (bare provider name → its
-    default; direct catalog match), then the OpenRouter catalog, then a configured ``vendor/`` prefix."""
+    """Auto-detect the best provider for a model name: the current provider's live catalog, static
+    catalogs (bare provider name → its default; direct catalog match), then the OpenRouter catalog,
+    then a configured ``vendor/`` prefix.
+
+    Never hands back a provider the user holds no credentials for: an unauthenticated guess is
+    skipped and the ladder continues (``None`` = stay on the current provider). Exceptions: the user
+    NAMED the provider (``/model nous``), or there is no current provider yet (``auto``) — then the
+    first guess is returned so the credential step fails loudly instead of silently ignoring input."""
+    from hermes_cli.models_detect import current_provider_catalog_match, provider_has_credentials
+
     name = (model_name or "").strip()
     if not name:
         return None
@@ -939,28 +947,47 @@ def detect_provider_for_model(
     # The current provider's LIVE catalog outranks every static guess: a model it already serves
     # (Codex early-access ids, Portal-only slugs, Ollama Cloud models absent from _PROVIDER_MODELS)
     # must never re-route the session to another vendor or to metered OpenRouter.
-    from hermes_cli.models_detect import current_provider_catalog_match
-
     served = current_provider_catalog_match(name, current_provider)
     if served is not None:
         return (current_provider, served) if served != name else None
 
+    no_selection = (current_provider or "").strip().lower() in {"", "auto"}
+    for candidate in _detection_candidates(name, current_provider):
+        if candidate is None:
+            return None  # the current catalog owns this name
+        if no_selection or candidate[0] == current_provider or provider_has_credentials(candidate[0]):
+            return candidate
+        if _PROVIDER_ALIASES.get(name.lower(), name.lower()) == candidate[0]:
+            return candidate  # explicitly named provider: let the credential step report it
+        logger.debug("Skipping auto-switch of '%s' to %s: no credentials configured", name, candidate[0])
+    # A ``vendor/model`` prefix naming a provider the user DECLARED in ``providers:`` is a selection,
+    # not a guess — hand it back even before its key is wired up.
+    return _resolve_provider_prefix(name)
+
+
+def _detection_candidates(name: str, current_provider: str):
+    """Yield ``(provider, model)`` guesses in ladder order; ``None`` means the current provider's own
+    catalog owns the name (stop, stay)."""
     static_match = detect_static_provider_for_model(name, current_provider)
     if static_match:
-        return static_match
+        yield static_match
     if _model_in_provider_catalog(name.lower(), _provider_keys(current_provider)):
-        return None
+        yield None
+        return
 
     # OpenRouter catalog (exact slug, then bare model part).
     or_slug = _find_openrouter_slug(name)
     if or_slug:
-        if current_provider != "openrouter" or or_slug != name:
-            return ("openrouter", or_slug)
-        return None  # already on openrouter with matching name
+        if current_provider == "openrouter" and or_slug == name:
+            yield None  # already on openrouter with matching name
+            return
+        yield ("openrouter", or_slug)
 
     # Explicit ``vendor/model`` prefix naming a configured provider — AFTER the OpenRouter lookup so
     # aggregator-native slugs (``deepseek/deepseek-chat``) keep their routing.
-    return _resolve_provider_prefix(name)
+    prefixed = _resolve_provider_prefix(name)
+    if prefixed:
+        yield prefixed
 
 
 def _find_openrouter_slug(model_name: str) -> Optional[str]:

--- a/hermes_cli/models_detect.py
+++ b/hermes_cli/models_detect.py
@@ -1,10 +1,15 @@
-"""Live-catalog guard for ``detect_provider_for_model``.
+"""Live-catalog and credential guards for ``detect_provider_for_model``.
 
 Split out of ``hermes_cli.models``. The detection ladder there consults static catalogs, then the
-OpenRouter catalog. Providers whose static list lags their live catalog (Codex accounts with
-early-access models, Nous Portal, Ollama Cloud) have no static entry to stop the ladder, so a bare
-name the CURRENT provider already serves fell through to OpenRouter and the session was silently
-rebuilt on a metered aggregator (#97487, WolframRvnwlf's $100 Astra incident).
+OpenRouter catalog, and its answer used to be applied blindly. Two guards close the class of
+"put the user on a provider they never selected":
+
+* the CURRENT provider's live catalog outranks every static guess (Codex early-access ids, Nous
+  Portal slugs, Ollama Cloud models absent from ``_PROVIDER_MODELS`` — #97487, the $100 Astra
+  incident);
+* an auto-detected TARGET must be a provider the user has credentials for. Guessing a vendor the
+  user never signed into either 401s or, for OpenRouter (whose runtime resolves with an empty key
+  instead of raising), silently bills a metered aggregator.
 """
 
 from __future__ import annotations
@@ -37,3 +42,29 @@ def current_provider_catalog_match(model_name: str, current_provider: str) -> Op
         return None
     return next((mid for mid in catalog if mid.lower() == wanted), None) or next(
         (mid for mid in catalog if "/" in mid and mid.split("/", 1)[1].lower() == wanted), None)
+
+
+def provider_has_credentials(provider: str) -> bool:
+    """Whether *provider* can be switched to without the user typing a key: env/.env key, auth
+    store login, or a usable credential-pool entry. ``custom``/``custom:*`` targets only come out
+    of the ladder when the user declared them in config, so they count as authenticated."""
+    from hermes_cli.auth import get_auth_status, has_usable_secret
+    from hermes_cli.config import get_env_value_prefer_dotenv
+
+    pid = (provider or "").strip().lower()
+    if not pid:
+        return False
+    if pid == "custom" or pid.startswith("custom:"):
+        return True
+    try:
+        if pid == "openrouter" and has_usable_secret(get_env_value_prefer_dotenv("OPENROUTER_API_KEY")):
+            return True
+        status = get_auth_status(pid) or {}
+        if status.get("logged_in") or status.get("configured"):
+            return True
+        from agent.credential_pool import load_pool
+
+        pool = load_pool(pid)
+        return bool(pool.has_credentials() and pool.has_available())
+    except Exception:
+        return False

--- a/hermes_cli/web_server_config.py
+++ b/hermes_cli/web_server_config.py
@@ -426,7 +426,12 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
             canonical = normalize_provider(cur_provider)
             prov_in = cur_provider
         else:
-            canonical = prov_in = "openrouter"
+            from hermes_cli.models_detect import provider_has_credentials
+
+            # Only guess OpenRouter when the user actually holds a key for it; otherwise keep the
+            # pair as sent rather than persisting a provider they never selected.
+            if provider_has_credentials("openrouter"):
+                canonical = prov_in = "openrouter"
 
     if canonical in _KNOWN_PROVIDER_NAMES and not canonical.startswith("custom"):
         try:
@@ -770,11 +775,15 @@ def _infer_provider_on_model_change(model_val: str, prev_provider: str) -> tuple
 
     if "/" in name:
         try:
+            from hermes_cli.models_detect import provider_has_credentials
+
             cur_is_aggregator = normalize_provider(prev_provider) in _AGGREGATOR_PROVIDERS
+            # A vendor slug on a native provider is a guess at an aggregator; never guess one the
+            # user has no key for — that silently writes a metered provider into config.yaml.
+            if not cur_is_aggregator and provider_has_credentials("openrouter"):
+                return "openrouter", name
         except Exception:
-            cur_is_aggregator = False
-        if not cur_is_aggregator:
-            return "openrouter", name
+            pass
     return "", name
 
 

--- a/tests/acp_adapter/test_acp_set_model_explicit_provider.py
+++ b/tests/acp_adapter/test_acp_set_model_explicit_provider.py
@@ -1,0 +1,28 @@
+"""ACP ``session/set_model``: an explicit ``provider:model`` prefix is a selection, never re-detected.
+
+Regression for #59089: ``anthropic:claude-sonnet-5`` while already on anthropic resolved to the same
+provider, so the bare-name fallback ``detect_provider_for_model`` ran and could hand the session to
+OpenRouter because the bare name appears in its catalog.
+"""
+
+from __future__ import annotations
+
+from acp_adapter.server import HermesACPAgent
+
+
+def test_explicit_provider_prefix_skips_detection(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    def hijack(model, current):
+        calls.append((model, current))
+        return ("openrouter", f"anthropic/{model}")
+
+    monkeypatch.setattr("hermes_cli.models.detect_provider_for_model", hijack)
+    assert HermesACPAgent._resolve_model_selection("anthropic:claude-sonnet-5", "anthropic") == (
+        "anthropic", "claude-sonnet-5")
+    assert calls == []
+
+
+def test_bare_name_still_uses_detection(monkeypatch):
+    monkeypatch.setattr("hermes_cli.models.detect_provider_for_model", lambda m, c: ("deepseek", m))
+    assert HermesACPAgent._resolve_model_selection("deepseek-flash", "anthropic") == ("deepseek", "deepseek-flash")

--- a/tests/hermes_cli/test_main_model_custom_provider_normalization.py
+++ b/tests/hermes_cli/test_main_model_custom_provider_normalization.py
@@ -34,7 +34,15 @@ def test_custom_provider_name_canonicalizes_to_durable_slug():
 
 
 def test_unknown_vendor_still_uses_aggregator_fallback():
-    assert _normalize({}, "unconfigured-vendor") == (
-        "openrouter",
-        "vendor/model-a",
-    )
+    with patch("hermes_cli.models_detect.provider_has_credentials", lambda p: p == "openrouter"):
+        assert _normalize({}, "unconfigured-vendor") == (
+            "openrouter",
+            "vendor/model-a",
+        )
+
+
+def test_unknown_vendor_without_openrouter_key_is_not_reassigned():
+    """No key for the guessed aggregator → keep the pair as sent instead of persisting a provider
+    the user never selected."""
+    with patch("hermes_cli.models_detect.provider_has_credentials", lambda p: False):
+        assert _normalize({}, "unconfigured-vendor") == ("unconfigured-vendor", "vendor/model-a")

--- a/tests/hermes_cli/test_model_prefix_routing_87189.py
+++ b/tests/hermes_cli/test_model_prefix_routing_87189.py
@@ -63,7 +63,10 @@ class TestVendorPrefixRouting:
         assert models.detect_provider_for_model("notaprovider/foo-model", "anthropic") is None
 
     def test_openrouter_slug_still_wins_over_prefix_routing(self, monkeypatch):
-        """Aggregator-native slugs keep their existing OpenRouter routing."""
+        """Aggregator-native slugs keep their existing OpenRouter routing (when OpenRouter is
+        authenticated — an unkeyed aggregator is never auto-selected)."""
+        from hermes_cli import models_detect
+        monkeypatch.setattr(models_detect, "provider_has_credentials", lambda p: p == "openrouter")
         monkeypatch.setattr(
             models, "_find_openrouter_slug", lambda _name: "deepseek/deepseek-chat"
         )
@@ -72,6 +75,8 @@ class TestVendorPrefixRouting:
         assert detected == ("openrouter", "deepseek/deepseek-chat")
 
     def test_bare_model_detection_unchanged(self, monkeypatch):
+        from hermes_cli import models_detect
+        monkeypatch.setattr(models_detect, "provider_has_credentials", lambda p: p == "deepseek")
         monkeypatch.setattr(models, "_find_openrouter_slug", lambda _name: None)
         detected = models.detect_provider_for_model("deepseek-chat", "anthropic")
         assert detected == ("deepseek", "deepseek-chat")

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -2220,3 +2220,23 @@ def test_legacy_sentinel_catalog_still_resolves_and_migrates(tmp_path, monkeypat
     assert list(saved["models"]) == _LOCAL_CATALOG
     assert "__discovered_model_catalog__" not in saved["models"]
     assert "__explicit_model_allowlist__" not in saved["models"]
+
+
+def test_same_provider_switch_on_session_only_custom_endpoint_keeps_endpoint(monkeypatch):
+    """#74143: a same-provider ``/model`` on a bare ``custom`` session whose base_url is NOT the
+    trusted config ``model.base_url`` must stay on that endpoint with its key — re-resolving from
+    config fell through to the OpenRouter default and moved the next turn to a host the user never
+    picked."""
+    for var in ("OPENROUTER_API_KEY", "OPENROUTER_BASE_URL", "CUSTOM_BASE_URL", "CUSTOM_API_KEY", "OPENAI_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr("hermes_cli.model_switch.load_config", lambda: {"model": {"provider": "openrouter", "default": "x"}}, raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_api_models",
+        lambda api_key, base_url, **kw: {"models": ["m-a", "m-b"], "url": base_url + "/models", "base_url": base_url,
+                                          "suggested_base_url": None, "used_fallback": False})
+
+    result = switch_model("m-b", "custom", "m-a", "http://10.0.0.5:8000/v1", "session-secret")
+
+    assert result.success
+    assert result.base_url == "http://10.0.0.5:8000/v1"
+    assert result.api_key == "session-secret"

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -144,7 +144,7 @@ class TestDetectProviderForModel:
         with patch(
             "hermes_cli.models.fetch_openrouter_models",
             side_effect=AssertionError("network lookup should not run"),
-        ):
+        ), patch("hermes_cli.models_detect.provider_has_credentials", return_value=True):
             result = detect_provider_for_model("sonnet", "auto")
         assert result is not None
         assert result[0] == "anthropic"

--- a/tests/hermes_cli/test_models_detect_credential_gate.py
+++ b/tests/hermes_cli/test_models_detect_credential_gate.py
@@ -1,0 +1,51 @@
+"""Auto-detection must never hand the user a provider they hold no credentials for.
+
+Regression for the "accidental provider" class: ``/model <name>`` on provider A, where the name is
+only known to provider B (static catalog or OpenRouter), used to switch the session to B even when
+B had no key — an immediate 401 for most vendors, and for OpenRouter (whose runtime resolves with an
+empty key instead of raising) a silent switch onto a metered aggregator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import models
+
+
+@pytest.fixture
+def no_live_catalog(monkeypatch):
+    monkeypatch.setattr(models, "cached_provider_model_ids", lambda provider, **_: [])
+    monkeypatch.setattr(models, "_find_openrouter_slug", lambda name: f"vendor/{name}")
+
+
+@pytest.fixture
+def authed(monkeypatch):
+    """Pin which providers count as authenticated; everything else has no credentials."""
+    from hermes_cli import models_detect
+
+    granted: set[str] = set()
+    monkeypatch.setattr(models_detect, "provider_has_credentials", lambda p: p in granted)
+    return granted
+
+
+class TestNoCredentialsNoSwitch:
+    def test_openrouter_only_model_stays_when_no_openrouter_key(self, no_live_catalog, authed):
+        assert models.detect_provider_for_model("some-model-only-openrouter-has", "deepseek") is None
+
+    def test_openrouter_remap_allowed_with_key(self, no_live_catalog, authed):
+        authed.add("openrouter")
+        assert models.detect_provider_for_model("some-model-only-openrouter-has", "deepseek") == (
+            "openrouter", "vendor/some-model-only-openrouter-has")
+
+    def test_static_vendor_match_requires_that_vendors_credentials(self, no_live_catalog, authed, monkeypatch):
+        monkeypatch.setattr(models, "detect_static_provider_for_model", lambda n, c: ("anthropic", n))
+        assert models.detect_provider_for_model("claude-something", "deepseek") is None
+        authed.add("anthropic")
+        assert models.detect_provider_for_model("claude-something", "deepseek") == ("anthropic", "claude-something")
+
+    def test_explicitly_named_provider_is_not_gated(self, no_live_catalog, authed, monkeypatch):
+        """``/model nous`` names the provider: hand it back so the credential step can prompt/fail
+        loudly instead of silently ignoring the request."""
+        monkeypatch.setattr(models, "detect_static_provider_for_model", lambda n, c: ("nous", "hermes-4-405b"))
+        assert models.detect_provider_for_model("nous", "deepseek") == ("nous", "hermes-4-405b")

--- a/tests/hermes_cli/test_models_detect_live_catalog.py
+++ b/tests/hermes_cli/test_models_detect_live_catalog.py
@@ -35,6 +35,9 @@ class TestCurrentProviderCatalogWins:
         live_catalog["nous"] = ["zai/glm-5.3-flash"]
         assert models.detect_provider_for_model("glm-5.3-flash", "nous") == ("nous", "zai/glm-5.3-flash")
 
-    def test_unserved_model_still_walks_the_ladder(self, live_catalog):
+    def test_unserved_model_still_walks_the_ladder(self, live_catalog, monkeypatch):
+        from hermes_cli import models_detect
+
+        monkeypatch.setattr(models_detect, "provider_has_credentials", lambda p: p == "openrouter")
         live_catalog["nous"] = ["hermes-4-405b"]
         assert models.detect_provider_for_model("no-such-model", "nous") == ("openrouter", "vendor/no-such-model")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3242,6 +3242,7 @@ class TestDenormalizeProviderSwitch:
         """ollama-local + a vendor/model slug → switch to openrouter and drop
         the stale local base_url (the issue's exact repro)."""
         from hermes_cli.web_server_config import _denormalize_config_from_web
+        from unittest.mock import patch as _patch
         from hermes_cli.config import save_config
 
         save_config({
@@ -3253,7 +3254,8 @@ class TestDenormalizeProviderSwitch:
             }
         })
 
-        result = _denormalize_config_from_web({"model": "google/gemini-2.5-flash"})
+        with _patch("hermes_cli.models_detect.provider_has_credentials", lambda p: p == "openrouter"):
+            result = _denormalize_config_from_web({"model": "google/gemini-2.5-flash"})
         model = result["model"]
         assert model["provider"] == "openrouter"
         assert model["default"] == "google/gemini-2.5-flash"
@@ -3265,14 +3267,16 @@ class TestDenormalizeProviderSwitch:
         """An explicit context-length override must persist alongside a
         provider switch."""
         from hermes_cli.web_server_config import _denormalize_config_from_web
+        from unittest.mock import patch as _patch
         from hermes_cli.config import save_config
 
         save_config({"model": {"default": "llama3.2", "provider": "ollama-local"}})
 
-        result = _denormalize_config_from_web({
-            "model": "google/gemini-2.5-flash",
-            "model_context_length": 128000,
-        })
+        with _patch("hermes_cli.models_detect.provider_has_credentials", lambda p: p == "openrouter"):
+            result = _denormalize_config_from_web({
+                "model": "google/gemini-2.5-flash",
+                "model_context_length": 128000,
+            })
         model = result["model"]
         assert model["provider"] == "openrouter"
         assert model["context_length"] == 128000


### PR DESCRIPTION
Hermes never puts a session on a provider the user did not select: auto-detection now skips any target the user holds no credentials for, same-provider switches on a session-only custom endpoint stay on that endpoint, and an explicit `provider:model` prefix over ACP is never re-detected.

Follow-up to #107236 (which fixed the "current provider already serves it" half). This closes the remaining "accidental provider" paths found in the post-merge sweep.

## Root cause

`detect_provider_for_model()` returned whatever the static catalog or OpenRouter catalog said, regardless of whether the user could actually use that provider. Most vendors then 401 at the credential step; OpenRouter's runtime resolves with an **empty key instead of raising**, so the session was rebuilt on a metered aggregator with no error. The dashboard's flat Model field carried two more copies of the same guess.

## Changes

- `hermes_cli/models.py::detect_provider_for_model` walks its ladder as candidates and skips any target without credentials (`hermes_cli/models_detect.py::provider_has_credentials`: env/.env key, auth-store login, or a usable credential-pool entry). Exceptions: the user NAMED the provider (`/model nous`) or there is no current provider yet (`auto`), so the credential step can fail loudly. A `vendor/` prefix naming a provider declared in `providers:` is a selection and always routes.
- `hermes_cli/web_server_config.py`: both OpenRouter fallbacks (`_infer_provider_on_model_change`, `_normalize_main_model_assignment`) apply the same gate before persisting `provider: openrouter` into config.yaml.
- `hermes_cli/model_switch.py::_creds_for_current_provider` (#74143): a bare `custom`/`local` session whose base_url is session-only keeps its endpoint + key when re-resolution comes back empty or on openrouter.ai; a config-backed custom URL still wins.
- `acp_adapter/server.py::_resolve_model_selection` (#59089): detection runs only when `parse_model_input` consumed no prefix.
- `hermes_cli/model_normalize.py`: only `deepseek-*` spellings fold onto `deepseek-flash`; foreign names pass through so the validator rejects them instead of silently running Flash.

## Validation (temp `HERMES_HOME`, real `switch_model`, only a DeepSeek key)

| `/model …` on deepseek | Before | After |
|---|---|---|
| `qwen3.8-max` | switch to opencode-go → 401 "no credentials" | rejected: not in DeepSeek's listing, session untouched |
| `kimi-k2.5` | switch to kimi-coding → 401 | same |
| `mistral-large-latest` / `gemini-3.8-flash` | **openrouter, empty api_key** | rejected, stays on deepseek |
| `claude-opus-4-6` | switch to anthropic → 401 | rejected; with `ANTHROPIC_API_KEY` set → anthropic (remap kept) |
| `gemini-3.8-flash` with `OPENROUTER_API_KEY` | openrouter | openrouter (remap kept when keyed) |
| `nous` (named provider) | Nous "not logged in" | same — named providers still fail loudly |

| Other surfaces | Before | After |
|---|---|---|
| #74143 same-provider `/model` on session-only `http://10.0.0.5:8000/v1` | `base=https://openrouter.ai/api/v1 key=''` | `base=http://10.0.0.5:8000/v1 key=session-secret` |
| ACP `anthropic:claude-sonnet-5` while on anthropic | detect ran, could return openrouter | `('anthropic', 'claude-sonnet-5')`, detect not called |
| Dashboard Model field `openai/gpt-5.5` on ollama-local, no OR key | `provider: openrouter` written | unchanged |

Tests: 5 new invariants, each red on base (2/4 gate, 1 #74143, 1 ACP, live-catalog control updated); 7 existing tests that pinned "switch to OpenRouter/vendor with no key" now grant the credential they assumed. `tests/hermes_cli/` + `tests/acp_adapter/` + model_providers + tui-gateway + aux: 11,165 pass; `test_kanban_gateway_restart_handoff.py` and `test_update_head_moved_gate.py` fail identically on untouched `origin/main` in a scratch worktree (pre-existing, updater environment).

## Credit

- #74143 / #71693 — @fangliquanflq diagnosed the session-only custom → OpenRouter fallthrough; this is the minimal form of that fix at the same-provider credential step.
- #59294 — @AlexFucuson9 diagnosed the ACP explicit-prefix re-detection; same fix expressed as "input unchanged by parsing".
- #48744 (@liuhao1024), #57176 (@hehehe12jj), #19950 (@aideautomation) — earlier "prefer the provider the user is on / is authenticated for" attempts; the credential gate at the shared choke point covers their cases.

Fixes #74143. Fixes #59089. Refs #99389.

## Infographic

![your provider, your choice](https://files.catbox.moe/z9o9dm.png)

https://files.catbox.moe/z9o9dm.png
