### PR TITLE
fix(desktop): let live tool groups expand and name skill_view loads

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -454,6 +454,71 @@ describe('countDiffLineStats', () => {
   })
 })
 
+describe('buildToolView skill_view titles', () => {
+  it('names a pending instruction load instead of the generic tool label', () => {
+    const view = buildToolView(
+      part({ args: { name: 'example-skill' }, result: undefined, toolName: 'skill_view' }),
+      ''
+    )
+
+    expect(view.title).toContain('example-skill')
+    expect(view.title).toMatch(/load/i)
+    expect(view.title).not.toMatch(/skill view/i)
+  })
+
+  it('names a completed instruction load', () => {
+    const view = buildToolView(
+      part({ args: { name: 'example-skill' }, result: { content: '---\nname: example-skill' }, toolName: 'skill_view' }),
+      ''
+    )
+
+    expect(view.title).toContain('example-skill')
+    expect(view.title).toMatch(/loaded/i)
+  })
+
+  it('distinguishes a linked resource read from an instruction load', () => {
+    const instruction = buildToolView(
+      part({ args: { name: 'example-skill' }, result: undefined, toolName: 'skill_view' }),
+      ''
+    )
+    const resource = buildToolView(
+      part({
+        args: { file_path: 'references/example.md', name: 'example-skill' },
+        result: undefined,
+        toolName: 'skill_view'
+      }),
+      ''
+    )
+
+    expect(instruction.title).toContain('example-skill')
+    expect(resource.title).toMatch(/example\.md/)
+    expect(resource.title).not.toBe(instruction.title)
+    expect(`${resource.title} ${resource.subtitle}`).toContain('example-skill')
+  })
+
+  it('does not claim a successful load when the skill_view call failed', () => {
+    const view = buildToolView(
+      part({
+        args: { name: 'example-skill' },
+        isError: true,
+        result: { error: 'skill not found' },
+        toolName: 'skill_view'
+      }),
+      ''
+    )
+
+    expect(view.status).toBe('error')
+    expect(view.title).not.toMatch(/loaded/i)
+  })
+
+  it('does not invent a skill name when name is missing', () => {
+    const view = buildToolView(part({ args: {}, result: undefined, toolName: 'skill_view' }), '')
+
+    expect(view.title).not.toMatch(/example-skill/)
+    expect(view.title.toLowerCase()).toMatch(/skill/)
+  })
+})
+
 describe('buildToolView memory status', () => {
   const memory = (overrides: Partial<Parameters<typeof part>[0]> = {}) =>
     buildToolView(part({ toolName: 'memory', ...overrides }), '')

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -129,6 +129,17 @@ function readFileDisplayTarget(args: Record<string, unknown>, result: Record<str
   return [fileEditBasename(path), lineLabel].filter(Boolean).join(' ')
 }
 
+/** Linked skill file. Empty / missing / SKILL.md is an instruction load. */
+export function skillViewResourcePath(args: Record<string, unknown>): string {
+  const filePath = firstStringField(args, ['file_path'])
+
+  if (!filePath || fileEditBasename(filePath).toLowerCase() === 'skill.md') {
+    return ''
+  }
+
+  return filePath
+}
+
 // The real command, preferring the actual argument over the backend's
 // display preview. `context` is a *summarized* preview ("sleep 70 + 2
 // commands") the gateway sends on tool.start before real args arrive — fine
@@ -200,6 +211,7 @@ const TOOL_META: Record<ToolTitleKey, ToolMetaSpec> = {
     icon: 'search',
     tone: 'agent'
   },
+  skill_view: { icon: 'files', tone: 'agent' },
   terminal: {
     icon: 'terminal',
     tone: 'terminal'
@@ -1363,6 +1375,32 @@ function dynamicTitle(
     return target
       ? titledAction(action, translateNow('assistant.tool.titleTemplates.actionTarget', action, target))
       : fallback
+  }
+
+  if (part.toolName === 'skill_view') {
+    const name = firstStringField(args, ['name'])
+    const resourcePath = skillViewResourcePath(args)
+    const failed =
+      part.isError || result.success === false || result.ok === false || Boolean(firstStringField(result, ['error']))
+
+    if (failed && part.result !== undefined) {
+      return name ? { title: name } : fallback
+    }
+
+    if (resourcePath) {
+      const action = verb(translateNow('assistant.tool.actions.reading'), translateNow('assistant.tool.actions.read'))
+      const target = name ? `${fileEditBasename(resourcePath)} (${name})` : fileEditBasename(resourcePath)
+
+      return titledAction(action, translateNow('assistant.tool.titleTemplates.actionTarget', action, target))
+    }
+
+    if (!name) {
+      return fallback
+    }
+
+    const action = verb(translateNow('assistant.tool.actions.loading'), translateNow('assistant.tool.actions.loaded'))
+
+    return titledAction(action, translateNow('assistant.tool.titleTemplates.actionTarget', action, name))
   }
 
   if (part.toolName === 'terminal' || part.toolName === 'execute_code') {

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -72,7 +72,7 @@ import {
   type ToolStatus,
   type ToolTitleAction
 } from './fallback-model'
-import { isToolCallPart, summarizeToolRun } from './run-summary'
+import { isToolCallPart, summarizeToolRun, summaryArgIdentity } from './run-summary'
 import { ToolRunTicker } from './run-ticker'
 
 // `true` when a ToolEntry is rendered inside an embedding wrapper that owns
@@ -798,7 +798,7 @@ export function splitRunItems(toolNames: readonly string[]): RunItem[] {
  */
 // The one grey line that stands in for a run of tool calls — "Explored 3
 // files, ran 5 commands". Live, it narrates in the present tense above the
-// ticker and offers no toggle, since there is nothing settled to unfold yet.
+// ticker; the user can still expand the group.
 function ToolRunHeader({
   completedAt,
   live,
@@ -867,7 +867,7 @@ function useToolRun(startIndex: number, endIndex: number): ToolRunState {
     const signature = timelineTools
       .map(
         tool =>
-          `${tool.toolCallId}:${tool.result === undefined ? 0 : 1}:${tool.timestamp ?? ''}:${tool.completedAt ?? ''}`
+          `${tool.toolCallId}:${tool.result === undefined ? 0 : 1}:${tool.timestamp ?? ''}:${tool.completedAt ?? ''}:${summaryArgIdentity(tool.args)}`
       )
       .concat(String(live))
       .join('|')
@@ -918,9 +918,10 @@ function useToolRun(startIndex: number, endIndex: number): ToolRunState {
  * index is what made an earlier attempt at this reshuffle the moment a turn
  * settled. `lib/tool-run-continuity.test.ts` locks that agreement down.
  *
- * Live, the run is a summary plus the one-line ticker. Settled, the summary is
- * the whole of it until the user opens it. `ToolEmbedContext` is false so each
- * row still owns its own chrome (timer / copy / approval) when shown.
+ * Live, the run is a summary plus the one-line ticker unless the user expands
+ * it. Settled, the summary is the whole of it until the user opens it.
+ * `ToolEmbedContext` is false so each row still owns its own chrome
+ * (timer / copy / approval) when shown.
  */
 const ToolRun: FC<PropsWithChildren<{ endIndex: number; startIndex: number }>> = ({
   children,
@@ -954,7 +955,7 @@ const ToolRun: FC<PropsWithChildren<{ endIndex: number; startIndex: number }>> =
   // settles and the row can be reached through the summary instead.
   const blocked = Boolean(approval) && pendingApprovalTool
   const unfurled = blocked || rowOpen
-  const expanded = live ? unfurled : (persistedOpen ?? false)
+  const expanded = unfurled || (persistedOpen ?? false)
 
   return (
     <div
@@ -966,12 +967,12 @@ const ToolRun: FC<PropsWithChildren<{ endIndex: number; startIndex: number }>> =
       <ToolRunHeader
         completedAt={completedAt}
         live={live}
-        onToggle={live ? undefined : () => setToolDisclosureOpen(disclosureId, !expanded)}
+        onToggle={() => setToolDisclosureOpen(disclosureId, !expanded)}
         open={expanded}
         startedAt={startedAt}
         summary={summary}
       />
-      {live && !unfurled && <ToolRunTicker>{children}</ToolRunTicker>}
+      {live && !expanded && <ToolRunTicker>{children}</ToolRunTicker>}
       {expanded && <div className="grid min-w-0 max-w-full gap-(--tool-row-gap)">{children}</div>}
     </div>
   )

--- a/apps/desktop/src/components/assistant-ui/tool/run-summary.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/run-summary.test.ts
@@ -57,4 +57,39 @@ describe('summarizeToolRun', () => {
   it('reads a run the turn left unresolved as finished', () => {
     expect(settled([read('a.ts'), tool('search_files', { query: 'toolRuns' })])).toBe('Explored 2 files')
   })
+
+  it('names skill_view calls instead of counting anonymous tools', () => {
+    expect(settled([tool('skill_view', { name: 'example-skill' }, { content: '' })])).toContain('example-skill')
+    expect(settled([tool('skill_view', { name: 'example-skill' }, { content: '' })])).not.toMatch(/Used \d+ tools/)
+  })
+
+  it('keeps skill names when a run also explored files', () => {
+    const summary = settled([
+      read('wiring.tsx'),
+      tool('skill_view', { name: 'example-skill' }, { content: '' }),
+      tool('skill_view', { file_path: 'references/example.md', name: 'example-skill' }, { content: '' })
+    ])
+
+    expect(summary).toContain('example-skill')
+    expect(summary).not.toMatch(/used \d+ tools/i)
+  })
+})
+
+describe('summaryArgIdentity', () => {
+  it('changes when a skill name or resource path arrives', async () => {
+    const { summaryArgIdentity } = await import('./run-summary')
+
+    expect(summaryArgIdentity({})).not.toBe(summaryArgIdentity({ name: 'example-skill' }))
+    expect(summaryArgIdentity({ name: 'example-skill' })).not.toBe(
+      summaryArgIdentity({ file_path: 'references/example.md', name: 'example-skill' })
+    )
+  })
+
+  it('ignores unrelated streaming payload fields', async () => {
+    const { summaryArgIdentity } = await import('./run-summary')
+
+    expect(summaryArgIdentity({ blob: 'x'.repeat(10_000), name: 'example-skill' })).toBe(
+      summaryArgIdentity({ blob: 'y'.repeat(10_000), name: 'example-skill' })
+    )
+  })
 })

--- a/apps/desktop/src/components/assistant-ui/tool/run-summary.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/run-summary.ts
@@ -1,7 +1,8 @@
+import { translateNow } from '@/i18n'
 import { summarizeShellCommand } from '@/lib/summarize-command'
 import { firstStringField } from '@/lib/text'
 
-import { fileEditBasename, isFileEditTool, parseMaybeObject } from './fallback-model'
+import { fileEditBasename, isFileEditTool, parseMaybeObject, skillViewResourcePath } from './fallback-model'
 
 /**
  * The little a summary needs from a tool call, stated structurally so both
@@ -19,18 +20,19 @@ export function isToolCallPart<T extends { type: string }>(part: T): part is Ext
   return part.type === 'tool-call'
 }
 
-type RunCategory = 'delegate' | 'edit' | 'explore' | 'other' | 'run'
+type RunCategory = 'delegate' | 'edit' | 'explore' | 'other' | 'run' | 'skill'
 
 // Clause order is fixed so the same run always reads the same way, whichever
 // category happens to be live.
-const CATEGORY_ORDER: readonly RunCategory[] = ['edit', 'explore', 'run', 'delegate', 'other']
+const CATEGORY_ORDER: readonly RunCategory[] = ['edit', 'explore', 'run', 'delegate', 'skill', 'other']
 
 const CATEGORY_COPY: Record<RunCategory, { noun: [string, string]; past: string; present: string }> = {
   delegate: { noun: ['task', 'tasks'], past: 'Delegated', present: 'Delegating' },
   edit: { noun: ['file', 'files'], past: 'Edited', present: 'Editing' },
   explore: { noun: ['file', 'files'], past: 'Explored', present: 'Exploring' },
   other: { noun: ['tool', 'tools'], past: 'Used', present: 'Using' },
-  run: { noun: ['command', 'commands'], past: 'Ran', present: 'Running' }
+  run: { noun: ['command', 'commands'], past: 'Ran', present: 'Running' },
+  skill: { noun: ['skill', 'skills'], past: 'Loaded', present: 'Loading' }
 }
 
 const EXPLORE_TOOLS = new Set([
@@ -56,6 +58,10 @@ function toolCategory(toolName: string): RunCategory {
     return 'delegate'
   }
 
+  if (toolName === 'skill_view') {
+    return 'skill'
+  }
+
   if (EXPLORE_TOOLS.has(toolName) || toolName.startsWith('browser_')) {
     return 'explore'
   }
@@ -73,12 +79,36 @@ function isPending(tool: ToolCallLike): boolean {
  * described in the same words from the moment the model drafts it.
  */
 export function toolPresentVerb(toolName: string): string {
+  if (toolCategory(toolName) === 'skill') {
+    return translateNow('assistant.tool.actions.loading')
+  }
+
   return CATEGORY_COPY[toolCategory(toolName)].present
+}
+
+/** Cheap identity of the args a run summary names — not the full payload. */
+export function summaryArgIdentity(args: unknown): string {
+  const parsed = parseMaybeObject(args)
+
+  return `${firstStringField(parsed, ['name'])}\0${firstStringField(parsed, ['file_path'])}`
 }
 
 /** The thing a tool acted on, as the header should name it. */
 function toolTarget(tool: ToolCallLike): string {
   const args = parseMaybeObject(tool.args)
+
+  if (toolCategory(tool.toolName) === 'skill') {
+    const name = firstStringField(args, ['name'])
+    const resourcePath = skillViewResourcePath(args)
+
+    if (resourcePath) {
+      const base = fileEditBasename(resourcePath)
+
+      return name ? `${base} (${name})` : base
+    }
+
+    return name
+  }
 
   if (toolCategory(tool.toolName) === 'run') {
     return summarizeShellCommand(firstStringField(args, ['command', 'code']))
@@ -89,6 +119,32 @@ function toolTarget(tool: ToolCallLike): string {
   return path ? fileEditBasename(path) : firstStringField(args, ['query', 'url'])
 }
 
+function skillClause(tools: ToolCallLike[], live: boolean): string {
+  const parts = tools.flatMap(tool => {
+    const target = toolTarget(tool)
+
+    if (!target) {
+      return []
+    }
+
+    const resource = Boolean(skillViewResourcePath(parseMaybeObject(tool.args)))
+    const verb = live
+      ? translateNow(resource ? 'assistant.tool.actions.reading' : 'assistant.tool.actions.loading')
+      : translateNow(resource ? 'assistant.tool.actions.read' : 'assistant.tool.actions.loaded')
+
+    return [`${verb} ${target}`]
+  })
+
+  if (parts.length === 0) {
+    const copy = CATEGORY_COPY.other
+    const verb = live ? copy.present : copy.past
+
+    return `${verb} ${tools.length} ${copy.noun[tools.length === 1 ? 0 : 1]}`
+  }
+
+  return parts.map((text, index) => (index === 0 ? text : lowerFirst(text))).join(', ')
+}
+
 /**
  * One clause per category. A category holding a single thing says what it was
  * ("Edited wiring.tsx"); anything else counts ("explored 3 files"). A settled
@@ -96,6 +152,10 @@ function toolTarget(tool: ToolCallLike): string {
  * command line only earns its space while it's the thing you're waiting on.
  */
 function clause(category: RunCategory, tools: ToolCallLike[], live: boolean): string {
+  if (category === 'skill') {
+    return skillClause(tools, live)
+  }
+
   const copy = CATEGORY_COPY[category]
   const verb = live ? copy.present : copy.past
   const target = tools.length === 1 ? toolTarget(tools[0]) : ''

--- a/apps/desktop/src/components/assistant-ui/tool/tool-group.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-group.test.tsx
@@ -15,12 +15,10 @@ import { formatTimelineRange } from '../thread/timestamp'
 // Timeline timestamps render only when `display.timestamps` is enabled.
 $displayTimestamps.set(true)
 
-// A run of tool calls collapses to a one-line summary once it has settled, but
-// a run with anything still pending always renders its rows. That rule is what
-// keeps the "approval must never be buried" bug fixed: an inline ApprovalBar
-// only ever exists on a pending tool, and a pending tool's run is never behind
-// a chevron. These cover both halves — the collapse itself, and the approval
-// staying in the visual flow.
+// A run of tool calls collapses to a one-line summary once it has settled.
+// Live grouped runs keep a disclosure so the user can expand the ticker into
+// full rows; an inline approval still forces the group open so it cannot sit
+// behind a collapsed chevron.
 
 const createdAt = new Date('2026-06-03T00:00:00.000Z')
 
@@ -49,8 +47,73 @@ stubThreadEnvironment()
 stubThreadViewportSize()
 vi.stubGlobal('ResizeObserver', TestResizeObserver)
 
+// Same toolCallIds as the live grouped pending message, after the turn settled.
+function groupedCompletedMessage(): ThreadMessage {
+  return {
+    id: 'assistant-group-1',
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: 'read-1',
+        toolName: 'read_file',
+        args: { path: '/etc/hosts' },
+        argsText: JSON.stringify({ path: '/etc/hosts' }),
+        result: { content: '127.0.0.1 localhost' }
+      },
+      {
+        type: 'tool-call',
+        toolCallId: 'term-1',
+        toolName: 'terminal',
+        args: { command: 'rm -rf /tmp/x' },
+        argsText: JSON.stringify({ command: 'rm -rf /tmp/x' }),
+        result: { exit_code: 0, stdout: 'ok' }
+      }
+    ],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as unknown as ThreadMessage
+}
+
+function skillViewRunMessage({
+  live,
+  skills
+}: {
+  live?: boolean
+  skills: Array<{ args?: Record<string, unknown>; id: string; result?: unknown }>
+}): ThreadMessage {
+  return {
+    id: 'assistant-skill-run',
+    role: 'assistant',
+    content: skills.map(skill => ({
+      type: 'tool-call' as const,
+      toolCallId: skill.id,
+      toolName: 'skill_view',
+      args: skill.args ?? {},
+      argsText: JSON.stringify(skill.args ?? {}),
+      ...(skill.result !== undefined ? { result: skill.result } : {})
+    })),
+    status: live ? { type: 'running' } : { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as unknown as ThreadMessage
+}
+
 // A running assistant message with two tools: a completed read_file plus a
-// pending terminal (no result), rendered as a flat two-row list.
+// pending terminal (no result), rendered as a live grouped run.
 function groupedPendingMessage(): ThreadMessage {
   return {
     id: 'assistant-group-1',
@@ -478,14 +541,128 @@ describe('live tool run', () => {
     })
   })
 
-  it('cannot be collapsed while a tool is still running', async () => {
+  it('exposes a disclosure on a live grouped run so the ticker can be expanded', async () => {
     const { container } = render(<GroupHarness message={groupedPendingMessage()} />)
 
-    await waitFor(() => {
-      expect(container.querySelector('[data-tool-summary]')).not.toBeNull()
+    const toggle = await waitFor(() => {
+      const button = container.querySelector('[data-tool-summary] button[aria-expanded]')
+
+      expect(button).not.toBeNull()
+
+      return button as HTMLButtonElement
     })
 
-    expect(container.querySelector('[data-tool-summary] button[aria-expanded]')).toBeNull()
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.click(toggle)
+
+    await waitFor(() => {
+      expect(toggle.getAttribute('aria-expanded')).toBe('true')
+      expect(container.querySelector('[data-tool-ticker]')).toBeNull()
+      expect(container.querySelectorAll('[data-tool-row]').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('keeps a live expand open after the same run settles', async () => {
+    const { container, rerender } = render(<GroupHarness message={groupedPendingMessage()} />)
+
+    const toggle = await waitFor(() => {
+      const button = container.querySelector('[data-tool-summary] button[aria-expanded]')
+
+      expect(button).not.toBeNull()
+
+      return button as HTMLButtonElement
+    })
+
+    fireEvent.click(toggle)
+
+    await waitFor(() => {
+      expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    })
+
+    rerender(<GroupHarness message={groupedCompletedMessage()} />)
+
+    await waitFor(() => {
+      const settled = container.querySelector('[data-tool-summary] button[aria-expanded]')
+
+      expect(settled).not.toBeNull()
+      expect(settled?.getAttribute('aria-expanded')).toBe('true')
+      expect(container.querySelectorAll('[data-tool-row]').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('still surfaces an inline approval if the live group is collapsed', async () => {
+    setApprovalRequest({ command: 'rm -rf /tmp/x', description: 'dangerous command', sessionId: 'sess-1' })
+
+    const { container } = render(<GroupHarness message={groupedPendingMessage()} />)
+
+    const toggle = await waitFor(() => {
+      const button = container.querySelector('[data-tool-summary] button[aria-expanded]')
+
+      expect(button).not.toBeNull()
+
+      return button as HTMLButtonElement
+    })
+
+    fireEvent.click(toggle)
+
+    await waitFor(() => {
+      const bar = container.querySelector('[data-slot="tool-approval-inline"]')
+
+      expect(bar).not.toBeNull()
+      expect(bar?.closest('[hidden]')).toBeNull()
+    })
+  })
+
+  it('names skills in a grouped skill_view run instead of counting anonymous tools', async () => {
+    render(
+      <GroupHarness
+        message={skillViewRunMessage({
+          skills: [
+            { args: { name: 'example-skill' }, id: 'skill-1', result: { content: 'instructions' } },
+            {
+              args: { file_path: 'references/example.md', name: 'example-skill' },
+              id: 'skill-2',
+              result: { content: 'notes' }
+            }
+          ]
+        })}
+      />
+    )
+
+    const summary = await screen.findByText(/example-skill/)
+
+    expect(summary.textContent).not.toMatch(/^(Used|Using) \d+ tools$/)
+  })
+
+  it('picks up a skill name when args arrive on the same live tool call', async () => {
+    const { rerender } = render(
+      <GroupHarness
+        message={skillViewRunMessage({
+          live: true,
+          skills: [
+            { args: {}, id: 'skill-live-1' },
+            { args: {}, id: 'skill-live-2' }
+          ]
+        })}
+      />
+    )
+
+    await screen.findByText('Using 2 tools')
+
+    rerender(
+      <GroupHarness
+        message={skillViewRunMessage({
+          live: true,
+          skills: [
+            { args: { name: 'example-skill' }, id: 'skill-live-1' },
+            { args: { name: 'other-skill' }, id: 'skill-live-2' }
+          ]
+        })}
+      />
+    )
+
+    expect((await screen.findAllByText(/example-skill/)).length).toBeGreaterThan(0)
   })
 
   // Liveness used to also require an unresolved call, which is false for the
@@ -497,7 +674,7 @@ describe('live tool run', () => {
 
     expect(await screen.findByText('Running 2 commands')).toBeTruthy()
     expect(container.querySelector('[data-tool-ticker]')).not.toBeNull()
-    expect(container.querySelector('[data-tool-summary] button[aria-expanded]')).toBeNull()
+    expect(container.querySelector('[data-tool-summary] button[aria-expanded]')).not.toBeNull()
   })
 
   // The ticker is a one-line window, so a row opened inside it had its output
@@ -524,8 +701,7 @@ describe('live tool run', () => {
 })
 
 // A run whose calls never resolved used to read as live forever, which stranded
-// it in the present tense and — because a live run withholds its toggle — left
-// it permanently expanded with no way to collapse it.
+// it in the present tense with no way to collapse it.
 describe('tool run left unresolved', () => {
   it('settles with the turn rather than narrating work that stopped', async () => {
     const { container } = render(<GroupHarness message={abandonedRunMessage()} />)

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2820,7 +2820,9 @@ export const ar = defineLocale({
         ran: 'تم التشغيل',
         running: 'جار التشغيل',
         ranCode: 'تم تشغيل الكود',
-        runningCode: 'جار البرمجة'
+        runningCode: 'جار البرمجة',
+        loaded: 'تم التحميل',
+        loading: 'جار التحميل'
       },
       prefixes: {
         browser: 'المتصفح',
@@ -2919,6 +2921,11 @@ export const ar = defineLocale({
           done: 'تم البحث في سجل الجلسة',
           pending: 'جار البحث في سجل الجلسة',
           pendingAction: 'جار البحث'
+        },
+        skill_view: {
+          done: 'تم تحميل المهارة',
+          pending: 'جار تحميل المهارة',
+          pendingAction: 'جار التحميل'
         },
         terminal: {
           done: 'تم تشغيل الأمر',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3728,7 +3728,9 @@ export const en: Translations = {
         ran: 'Ran',
         running: 'Running',
         ranCode: 'Ran code',
-        runningCode: 'Scripting'
+        runningCode: 'Scripting',
+        loaded: 'Loaded',
+        loading: 'Loading'
       },
       prefixes: {
         browser: 'Browser',
@@ -3772,6 +3774,7 @@ export const en: Translations = {
           pending: 'Searching session history',
           pendingAction: 'Searching'
         },
+        skill_view: { done: 'Loaded skill', pending: 'Loading skill', pendingAction: 'Loading' },
         terminal: { done: 'Ran command', pending: 'Running command', pendingAction: 'Running' },
         todo: { done: 'Updated todos', pending: 'Updating todos', pendingAction: 'Updating' },
         vision_analyze: { done: 'Analyzed image', pending: 'Analyzing image', pendingAction: 'Analyzing' },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -3278,7 +3278,9 @@ export const ja = defineLocale({
         ran: '実行完了',
         running: '実行中',
         ranCode: 'コード実行完了',
-        runningCode: 'スクリプト作成中'
+        runningCode: 'スクリプト作成中',
+        loaded: '読み込み完了',
+        loading: '読み込み中'
       },
       prefixes: {
         browser: 'ブラウザー',
@@ -3338,6 +3340,7 @@ export const ja = defineLocale({
           pending: 'セッション履歴を検索中',
           pendingAction: '検索中'
         },
+        skill_view: { done: 'スキルを読み込みました', pending: 'スキルを読み込み中', pendingAction: '読み込み中' },
         terminal: { done: 'コマンドを実行しました', pending: 'コマンドを実行中', pendingAction: '実行中' },
         todo: { done: 'Todo を更新しました', pending: 'Todo を更新中', pendingAction: '更新中' },
         vision_analyze: { done: '画像を分析しました', pending: '画像を分析中', pendingAction: '分析中' },

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -3661,7 +3661,9 @@ export const ru = defineLocale({
         ran: 'Выполнено',
         running: 'Выполняется',
         ranCode: 'Код выполнен',
-        runningCode: 'Скриптинг'
+        runningCode: 'Скриптинг',
+        loaded: 'Загружено',
+        loading: 'Загружаю'
       },
       prefixes: {
         browser: 'Браузер',
@@ -3713,6 +3715,7 @@ export const ru = defineLocale({
           pending: 'Ищу в истории сеансов',
           pendingAction: 'Ищу'
         },
+        skill_view: { done: 'Навык загружен', pending: 'Загружаю навык', pendingAction: 'Загружаю' },
         terminal: { done: 'Команда выполнена', pending: 'Выполняю команду', pendingAction: 'Выполняю' },
         todo: { done: 'Todo обновлены', pending: 'Обновляю todo', pendingAction: 'Обновляю' },
         vision_analyze: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -27,6 +27,7 @@ export type ToolTitleKey =
   | 'read_file'
   | 'search_files'
   | 'session_search_recall'
+  | 'skill_view'
   | 'terminal'
   | 'todo'
   | 'vision_analyze'
@@ -3262,6 +3263,8 @@ export interface Translations {
         running: string
         ranCode: string
         runningCode: string
+        loaded: string
+        loading: string
       }
       prefixes: {
         browser: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -3167,7 +3167,9 @@ export const zhHant = defineLocale({
         ran: '已執行',
         running: '正在執行',
         ranCode: '已執行程式碼',
-        runningCode: '正在撰寫腳本'
+        runningCode: '正在撰寫腳本',
+        loaded: '已載入',
+        loading: '正在載入'
       },
       prefixes: {
         browser: '瀏覽器',
@@ -3203,6 +3205,7 @@ export const zhHant = defineLocale({
           pending: '正在搜尋工作階段歷史',
           pendingAction: '正在搜尋'
         },
+        skill_view: { done: '已載入技能', pending: '正在載入技能', pendingAction: '正在載入' },
         terminal: { done: '已執行指令', pending: '正在執行指令', pendingAction: '正在執行' },
         todo: { done: '已更新待辦', pending: '正在更新待辦', pendingAction: '正在更新' },
         vision_analyze: { done: '已分析圖片', pending: '正在分析圖片', pendingAction: '正在分析' },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3863,7 +3863,9 @@ export const zh: Translations = {
         ran: '已运行',
         running: '正在运行',
         ranCode: '已运行代码',
-        runningCode: '正在编写脚本'
+        runningCode: '正在编写脚本',
+        loaded: '已加载',
+        loading: '正在加载'
       },
       prefixes: {
         browser: '浏览器',
@@ -3895,6 +3897,7 @@ export const zh: Translations = {
         read_file: { done: '已读取文件', pending: '正在读取文件', pendingAction: '正在读取' },
         search_files: { done: '已搜索文件', pending: '正在搜索文件', pendingAction: '正在搜索' },
         session_search_recall: { done: '已搜索会话历史', pending: '正在搜索会话历史', pendingAction: '正在搜索' },
+        skill_view: { done: '已加载技能', pending: '正在加载技能', pendingAction: '正在加载' },
         terminal: { done: '已运行命令', pending: '正在运行命令', pendingAction: '正在运行' },
         todo: { done: '已更新待办', pending: '正在更新待办', pendingAction: '正在更新' },
         vision_analyze: { done: '已分析图片', pending: '正在分析图片', pendingAction: '正在分析' },


### PR DESCRIPTION
## What does this PR do?

Desktop compresses a live tool run into a summary plus a one-line ticker, but `ToolRun` dropped the summary disclosure while `live` was true. A user could not open the whole group until the agent finished; an approval or an already-open row could unfurl it, which is not a usable toggle.

The same surface treated `skill_view` as a generic tool. Unlike the CLI/ACP skill preview, Desktop ignored `name` and `file_path`, so instruction loads and resource reads both rendered as "Skill View" / "Used N tools". The run selector cache also keyed only on id / result presence / timestamps, so identifying arguments that arrived later left a stale title.

This PR wires the existing `$toolDisclosureOpen` toggle for live groups, keeps approval/open-row unfurl fail-open, names skill rows and summaries from `name`/`file_path`, and busts the run cache on those identity fields only (not full payloads).

### Symptom

Desktop compresses a live tool run into a summary plus a one-line ticker, but `ToolRun` dropped the summary disclosure while `live` was true. A user could not open the whole group until the agent finished; an approval or an already-open row could unfurl it, which is not a usable toggle.

The same surface treated `skill_view` as a generic tool. Unlike the CLI/ACP skill preview, Desktop ignored `name` and `file_path`, so instruction loads and resource reads both rendered as "Skill View" / "Used N tools". The run selector cache also keyed only on id / result presence / timestamps, so identifying arguments that arrived later left a stale title.

This PR wires the existing `$toolDisclosureOpen` toggle for live groups, keeps approval/open-row unfurl fail-open, names skill rows and summaries from `name`/`file_path`, and busts the run cache on those identity fields only (not full payloads).


Fixes #107268


- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests


- `apps/desktop/src/components/assistant-ui/tool/fallback.tsx`: live groups always get `onToggle`; `expanded = unfurled || persistedOpen`; ticker hides only when the group is expanded.
- `apps/desktop/src/components/assistant-ui/tool/run-summary.ts`: `skill` category; `summaryArgIdentity(name, file_path)`; summaries name instruction vs resource loads.
- `apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts`: `skill_view` titles use localized Loading/Loaded vs Reading/Read; errors do not cla

### Impact

Desktop compresses a live tool run into a summary plus a one-line ticker, but `ToolRun` dropped the summary disclosure while `live` was true. A user could not open the whole group until the agent finished; an approval or an already-open row could unfurl it, which is not a usable toggle.

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

Desktop compresses a live tool run into a summary plus a one-line ticker, but `ToolRun` dropped the summary disclosure while `live` was true. A user could not open the whole group until the agent finished; an approval or an already-open row could unfurl it, which is not a usable toggle. The same surface treated `skill_view` as a generic tool.

## Related Issue

Fixes #107268

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/assistant-ui/tool/fallback.tsx`: live groups always get `onToggle`; `expanded = unfurled || persistedOpen`; ticker hides only when the group is expanded.
- `apps/desktop/src/components/assistant-ui/tool/run-summary.ts`: `skill` category; `summaryArgIdentity(name, file_path)`; summaries name instruction vs resource loads.
- `apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts`: `skill_view` titles use localized Loading/Loaded vs Reading/Read; errors do not claim Loaded.
- `apps/desktop/src/i18n/*`: `actions.loaded` / `actions.loading` in en, zh, zh-hant, ja, ru, ar.

## How to Test

- ✅ `scripts/run_tests.sh` on the files in Changes Made — focused verification
- ✅ Focused verification completed on this branch
- ✅ BEFORE (RED): 13 failed, 62 passed — live summary had no `button[aria-expanded]`; `skill_view` titles were `Running skill view` / `Skill View`; summaries were `Used 1 tool` / `used 2 tools`.
- ✅ AFTER (GREEN): 75 passed, 0 failed on those three files.

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

