### PR TITLE
fix(desktop): model picker keeps the (provider, model) pair; a shared id on OpenRouter no longer rewrites the pick (#99389, salvage #99575)

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -21,7 +21,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import type { HermesGateway } from '@/hermes'
 import { getLocalModelsStatus } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { catalogProviderMatches, modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
 import { DEFAULT_REASONING_EFFORT, reasoningEffortLabel } from '@/lib/reasoning-effort'
 import { foldIncludes, normalize } from '@/lib/text'
@@ -43,14 +43,6 @@ import { $defaultReasoningEffort } from '@/store/session'
 import type { LocalModelLoadProgress, ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
 
 import { type FastControl, ModelEditSubmenu, resolveFastControl } from './model-edit-submenu'
-
-/** Whether a catalog row represents the session's current provider. Custom
- *  providers report the canonical `custom:<key>` identity from `model.options`
- *  while the row's slug is the bare config key, so exact slug equality never
- *  matches — check the row's alias set too (#87035). */
-function isCurrentProvider(provider: ModelOptionProvider, currentProvider: string): boolean {
-  return provider.slug === currentProvider || (provider.aliases?.includes(currentProvider) ?? false)
-}
 
 // Lets the host dropdown (model-pill, a kanban field trigger, …) hand the panel
 // a way to dismiss itself so clicking a model row commits + closes, while the
@@ -352,14 +344,14 @@ export function ModelCatalogMenu({
   const rowIsCurrent = (row: KbRow) =>
     row.kind === 'moa'
       ? current.provider === 'moa' && row.preset === current.model
-      : isCurrentProvider(row.provider, current.provider) &&
+      : catalogProviderMatches(row.provider, current.provider) &&
         (row.family.id === current.model || row.family.fastId === current.model)
 
   const autoIndex = q
     ? kbRows.length > 0
       ? 0
       : -1
-    : kbRows.findIndex(row => rowIsCurrent(row) || (row.kind === 'family' && row.family.fastId === current.model))
+    : kbRows.findIndex(row => rowIsCurrent(row))
 
   const kbIndex = kbOverride !== null && kbOverride < kbRows.length ? kbOverride : autoIndex
   const kbActiveKey = kbIndex >= 0 ? kbRows[kbIndex].key : null
@@ -387,7 +379,7 @@ export function ModelCatalogMenu({
       return
     }
 
-    if (!rowIsCurrent(row) && row.family.fastId !== current.model) {
+    if (!rowIsCurrent(row)) {
       void selectFamily(row.family, row.provider)
     }
 
@@ -494,7 +486,7 @@ export function ModelCatalogMenu({
                     // The active id may be the base or its -fast sibling; either
                     // way this one family row represents both.
                     const activeId =
-                      isCurrentProvider(group.provider, current.provider) &&
+                      catalogProviderMatches(group.provider, current.provider) &&
                       (current.model === family.id || current.model === family.fastId)
                         ? current.model
                         : null
@@ -752,7 +744,7 @@ function groupModels(
     // stable curated order, so selecting a model can't shuffle the list. While
     // SEARCHING the pin is skipped: a query means "show me matches".
     const activeId =
-      !q && isCurrentProvider(provider, current.provider) && current.model
+      !q && catalogProviderMatches(provider, current.provider) && current.model
         ? allFamilies.find(family => family.id === current.model || family.fastId === current.model)?.id
         : undefined
 

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -465,6 +465,65 @@ describe('ModelMenuPanel provider collapse', () => {
     })
     expect(onSelectModel).not.toHaveBeenCalled()
   })
+
+  it('does not rewrite the provider when Refresh Models lists the same model id elsewhere', async () => {
+    $currentProvider.set('zhipu')
+    $currentModel.set('glm-4.5-air')
+
+    const catalog = {
+      model: 'glm-4.5-air',
+      provider: 'zhipu',
+      providers: [
+        { models: ['glm-4.5-air', 'gpt-5.5'], name: 'OpenRouter', slug: 'openrouter' },
+        { models: ['glm-4.5-air', 'glm-5-turbo'], name: '智谱2', slug: 'zhipu' },
+        MOA_PROVIDER
+      ]
+    }
+
+    getGlobalModelOptions.mockResolvedValue(catalog)
+
+    const { content, onSelectModel } = renderPanel()
+
+    await content.findAllByText(/Glm 4\.5 Air/i)
+    fireEvent.click(await content.findByText('Refresh models'))
+
+    await vi.waitFor(() => {
+      expect(getGlobalModelOptions).toHaveBeenCalledTimes(2)
+    })
+    expect(onSelectModel).not.toHaveBeenCalled()
+  })
+
+  it('marks only the matching provider row current when two providers share a model id', async () => {
+    $currentProvider.set('zhipu')
+    $currentModel.set('glm-4.5-air')
+    getGlobalModelOptions.mockResolvedValue({
+      model: 'glm-4.5-air',
+      provider: 'zhipu',
+      providers: [
+        { models: ['glm-4.5-air', 'gpt-5.5'], name: 'OpenRouter', slug: 'openrouter' },
+        { models: ['glm-4.5-air', 'glm-5-turbo'], name: '智谱2', slug: 'zhipu' },
+        MOA_PROVIDER
+      ]
+    })
+
+    const { content, onSelectModel } = renderPanel()
+
+    const rows = await content.findAllByText(/Glm 4\.5 Air/i)
+    const items = [...new Set(rows.map(row => row.closest('[role="menuitem"]')))]
+
+    expect(items).toHaveLength(2)
+
+    const checked = items.filter(item => item?.querySelector('.codicon-check'))
+    expect(checked).toHaveLength(1)
+    expect(checked[0]?.closest('[role="group"]')?.textContent).toContain('智谱2')
+    expect(
+      items.find(item => !item?.querySelector('.codicon-check'))?.closest('[role="group"]')?.textContent
+    ).toContain('OpenRouter')
+
+    const input = screen.getByRole('textbox', { name: 'Search models' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onSelectModel).not.toHaveBeenCalled()
+  })
 })
 
 describe('ModelMenuPanel refresh reconcile × guarded-switch confirm handshake', () => {

--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -116,7 +116,7 @@ export function ModelMenuPanel({
       // Group / credential swaps can return a catalog that no longer contains
       // the session's current model. The store + currentPickerSelection would
       // otherwise keep painting the stale id (it is not in the new list).
-      const switchTo = reconcileSelectionAfterCatalogRefresh(optionsModel, next.providers)
+      const switchTo = reconcileSelectionAfterCatalogRefresh(optionsModel, next.providers, optionsProvider)
 
       if (switchTo) {
         await onSelectModel({ ...switchTo, sessionId: activeSessionId || null })

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from 'react'
 
 import { getLocalModelsStatus } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { catalogProviderMatches, modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { modelSearchText } from '@/lib/model-search-text'
 import { currentPickerSelection } from '@/lib/model-status-label'
 import { foldIncludes, normalize } from '@/lib/text'
@@ -308,7 +308,7 @@ function ModelResults({
               </div>
             )}
             {models.map(model => {
-              const isCurrent = model === currentModel && provider.slug === currentProvider
+              const isCurrent = model === currentModel && catalogProviderMatches(provider, currentProvider)
               const price = provider.pricing?.[model]
               const locked = unavailable.has(model)
               // Managed local model loading into memory right now: show the

--- a/apps/desktop/src/lib/model-options.test.ts
+++ b/apps/desktop/src/lib/model-options.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getGlobalModelOptions } from '@/hermes'
 
 import {
+  catalogProviderMatches,
   firstSelectableCatalogModel,
   manualPickRemoved,
   modelOptionsQueryKey,
@@ -252,6 +253,22 @@ describe('manualPickRemoved', () => {
   })
 })
 
+describe('catalogProviderMatches', () => {
+  const cloudflare = {
+    aliases: ['custom:cloudflare', 'cloudflare'],
+    models: ['@cf/meta/llama-3.3-70b-instruct-fp8-fast'],
+    name: 'Cloudflare',
+    slug: 'cloudflare'
+  }
+
+  it('matches slug, display name, and custom-provider aliases', () => {
+    expect(catalogProviderMatches(cloudflare, 'cloudflare')).toBe(true)
+    expect(catalogProviderMatches(cloudflare, 'Cloudflare')).toBe(true)
+    expect(catalogProviderMatches(cloudflare, 'custom:cloudflare')).toBe(true)
+    expect(catalogProviderMatches(cloudflare, 'openrouter')).toBe(false)
+  })
+})
+
 describe('reconcileSelectionAfterCatalogRefresh', () => {
   const zhipu = { name: '智谱2', slug: 'zhipu', models: ['glm-4.5-air', 'glm-5-turbo'] }
 
@@ -263,25 +280,72 @@ describe('reconcileSelectionAfterCatalogRefresh', () => {
 
   const moa = { name: 'Mixture of Agents', slug: 'moa', models: ['default'] }
 
+  const openrouter = {
+    models: ['glm-4.5-air', 'gpt-5.5'],
+    name: 'OpenRouter',
+    slug: 'openrouter'
+  }
+
   it('switches to the first new-group model when the current pick is gone', () => {
-    expect(selectionInCatalog([bytea], 'glm-4.5-air')).toBe(false)
+    expect(selectionInCatalog([bytea], 'glm-4.5-air', 'zhipu')).toBe(false)
     expect(firstSelectableCatalogModel([moa, bytea])).toEqual({
       model: 'deepseek-v4-flash',
       provider: 'byteplus'
     })
-    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [moa, bytea])).toEqual({
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [moa, bytea], 'zhipu')).toEqual({
       model: 'deepseek-v4-flash',
       provider: 'byteplus'
     })
   })
 
   it('keeps the current pick when it is still in the refreshed catalog', () => {
-    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [zhipu, moa])).toBeNull()
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [zhipu, moa], 'zhipu')).toBeNull()
+  })
+
+  it('keeps the current provider when the same model id exists on another provider', () => {
+    expect(selectionInCatalog([openrouter, zhipu], 'glm-4.5-air', 'zhipu')).toBe(true)
+    expect(selectionInCatalog([openrouter, zhipu], 'glm-4.5-air', 'openrouter')).toBe(true)
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [openrouter, zhipu], 'zhipu')).toBeNull()
+  })
+
+  it('keeps a custom provider pair when OpenRouter lists the same model id', () => {
+    const model = '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
+
+    const cloudflare = {
+      aliases: ['custom:cloudflare', 'cloudflare'],
+      models: [model],
+      name: 'Cloudflare',
+      slug: 'cloudflare'
+    }
+
+    const openrouterCf = { models: [model, 'gpt-5.5'], name: 'OpenRouter', slug: 'openrouter' }
+
+    expect(selectionInCatalog([openrouterCf, cloudflare], model, 'custom:cloudflare')).toBe(true)
+    expect(reconcileSelectionAfterCatalogRefresh(model, [openrouterCf, cloudflare], 'custom:cloudflare')).toBeNull()
+  })
+
+  it('does not jump to OpenRouter when the current provider is missing but still lists the same model id', () => {
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [openrouter, moa], 'zhipu')).toBeNull()
+  })
+
+  it('keeps the pick when the current provider is present but unconfigured', () => {
+    const emptyZhipu = { models: [], name: '智谱2', slug: 'zhipu' }
+
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [emptyZhipu, openrouter], 'zhipu')).toBeNull()
+  })
+
+  it('falls back when the current provider is populated and dropped the model', () => {
+    const zhipuWithoutAir = { models: ['glm-5-turbo'], name: '智谱2', slug: 'zhipu' }
+
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [zhipuWithoutAir, openrouter], 'zhipu')).toEqual({
+      model: 'glm-5-turbo',
+      provider: 'zhipu'
+    })
   })
 
   it('does not wipe the pick when the refreshed catalog has no selectable models', () => {
-    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [moa])).toBeNull()
-    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [])).toBeNull()
-    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', undefined)).toBeNull()
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [moa], 'zhipu')).toBeNull()
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', [], 'zhipu')).toBeNull()
+    expect(reconcileSelectionAfterCatalogRefresh('glm-4.5-air', undefined, 'zhipu')).toBeNull()
   })
 })

--- a/apps/desktop/src/lib/model-options.ts
+++ b/apps/desktop/src/lib/model-options.ts
@@ -1,6 +1,37 @@
 import { getGlobalModelOptions, type HermesGateway, type ModelOptionsResponse } from '@/hermes'
 import type { ModelOptionProvider } from '@/types/hermes'
 
+type CatalogProviderIdentity = Pick<ModelOptionProvider, 'aliases' | 'name' | 'slug'>
+
+/** True when `currentProvider` is this catalog row — slug, display name, or
+ *  a custom-provider alias (`custom:<key>` vs the bare config key, #87035). */
+export function catalogProviderMatches(provider: CatalogProviderIdentity, currentProvider: string): boolean {
+  if (!currentProvider) {
+    return false
+  }
+
+  return (
+    provider.slug === currentProvider ||
+    provider.name === currentProvider ||
+    (provider.aliases?.includes(currentProvider) ?? false)
+  )
+}
+
+function findCatalogProvider(
+  providers: ModelOptionProvider[] | undefined,
+  provider: string
+): ModelOptionProvider | undefined {
+  if (!providers?.length || !provider) {
+    return undefined
+  }
+
+  return providers.find(row => catalogProviderMatches(row, provider))
+}
+
+function catalogHasModel(providers: ModelOptionProvider[] | undefined, model: string): boolean {
+  return Boolean(model) && (providers?.some(provider => (provider.models ?? []).includes(model)) ?? false)
+}
+
 /**
  * True only when a persisted **manual** composer pick has been removed from the
  * catalog (its provider still ships models, but no longer this one) — so a new
@@ -17,7 +48,7 @@ export function manualPickRemoved(
     return false
   }
 
-  const row = providers.find(p => p.slug === provider || p.name === provider)
+  const row = findCatalogProvider(providers, provider)
 
   if (!row) {
     return false
@@ -36,14 +67,21 @@ export function manualPickRemoved(
 
 const MOA_PROVIDER_SLUG = 'moa'
 
-/** True when `model` appears in any provider's live list. Used after Refresh
- *  Models so a group/catalog swap can tell "still offered" from "gone". */
-export function selectionInCatalog(providers: ModelOptionProvider[] | undefined, model: string): boolean {
-  if (!providers?.length || !model) {
+/** True when THIS provider still lists `model`. Identity is the (provider,
+ *  model) pair: the same id on OpenRouter does not count as the custom /
+ *  first-party pick still being offered. */
+export function selectionInCatalog(
+  providers: ModelOptionProvider[] | undefined,
+  model: string,
+  provider?: string
+): boolean {
+  if (!providers?.length || !model || !provider) {
     return false
   }
 
-  return providers.some(provider => (provider.models ?? []).includes(model))
+  const row = findCatalogProvider(providers, provider)
+
+  return Boolean(row && (row.models ?? []).includes(model))
 }
 
 /** First real (non-MoA) catalog row that still has models. */
@@ -70,14 +108,20 @@ export function firstSelectableCatalogModel(
 }
 
 /**
- * After Refresh Models replaces the catalog: keep the current pick when it is
- * still listed; otherwise switch to the first available model in the new
- * catalog. Returns null when the catalog is empty/unloaded so we never wipe
- * a selection on a failed or still-hydrating refresh.
+ * After Refresh Models replaces the catalog: keep the current **pair** when
+ * that provider still lists the model. Never rewrite the provider just because
+ * another catalog row (OpenRouter, …) exposes the same model id.
+ *
+ * Conservative like `manualPickRemoved` when the current provider is absent or
+ * unconfigured (empty models) — except a fully gone model (group / credential
+ * swap that dropped the id everywhere) still falls back to the first
+ * selectable row. Returns null when the catalog is empty/unloaded so we never
+ * wipe a selection on a failed or still-hydrating refresh.
  */
 export function reconcileSelectionAfterCatalogRefresh(
   currentModel: string,
-  providers: ModelOptionProvider[] | undefined
+  providers: ModelOptionProvider[] | undefined,
+  currentProvider?: string
 ): { model: string; provider: string } | null {
   const next = firstSelectableCatalogModel(providers)
 
@@ -85,7 +129,40 @@ export function reconcileSelectionAfterCatalogRefresh(
     return null
   }
 
-  if (selectionInCatalog(providers, currentModel)) {
+  if (!currentModel) {
+    return next
+  }
+
+  if (currentProvider) {
+    if (selectionInCatalog(providers, currentModel, currentProvider)) {
+      return null
+    }
+
+    const row = findCatalogProvider(providers, currentProvider)
+
+    // Present but empty: re-auth / unconfigured, not "model dropped".
+    if (row && (row.models ?? []).length === 0) {
+      return null
+    }
+
+    // This provider still ships models and dropped this one — fall back.
+    if (row) {
+      return next
+    }
+
+    // Provider missing from the refreshed catalog. Another provider listing
+    // the same id is NOT a reason to switch (the OpenRouter collision).
+    if (catalogHasModel(providers, currentModel)) {
+      return null
+    }
+
+    return next
+  }
+
+  // No provider on the current pair: keep when the id is still offered
+  // anywhere, otherwise fall back. Callers that know the provider must pass it
+  // so a shared id cannot retarget the pick.
+  if (catalogHasModel(providers, currentModel)) {
     return null
   }
 


### PR DESCRIPTION
The Desktop model picker treats a selection as a (provider, model) pair: a model id that also exists on OpenRouter (or any other catalog row) can no longer move the pick, the "current" check mark, or the post-Refresh reconciliation onto a provider the user did not choose.

Salvage of #99575 by @686f6c61 — cherry-picked onto current main with authorship preserved (`550158f3503`); it applied clean, no follow-up commits needed. Fixes #99389 (reported by @dahuangshushu: custom Cloudflare / GMI MiniMax picks jumping to the OpenRouter row).

## Changes (all `apps/desktop`)

- `src/lib/model-options.ts`: `selectionInCatalog(providers, model, provider)` now asks whether THIS provider still lists the model; `reconcileSelectionAfterCatalogRefresh` takes the current provider and keeps the pair when it is still offered. Present-but-empty provider (re-auth / unconfigured) → keep; provider still ships models but dropped this one → fall back; provider missing → another row listing the same id is NOT a reason to switch. New `catalogProviderMatches()` is the single identity helper (slug, display name, or custom alias, #87035).
- `model-menu-panel.tsx`, `model-catalog-menu.tsx`, `model-picker.tsx`: "is current" checks use the pair helper; the keyboard-selection index no longer matches a row by model id alone.
- Tests: Refresh Models with the same id elsewhere does not call `onSelectModel`; two providers sharing an id mark exactly one row current; `selectionInCatalog` pair semantics.

## Validation

| | Before | After |
|---|---|---|
| `zhipu` + `glm-4.5-air`, OpenRouter also lists it, Refresh Models | provider rewritten to openrouter | pick unchanged, `onSelectModel` not called |
| Two rows share an id | both / wrong row checked | only the current provider's row checked |
| `npx vitest run src/lib/model-options.test.ts src/app/shell/model-menu-panel.test.tsx` | — | 54 passed |
| `tsc --noEmit`, eslint on touched files | — | clean |

Companion to #107236 / #107281 on the Python side (backend `/model` routing never switches to an unselected or unkeyed provider). This PR closes the Desktop-only half where the renderer itself re-resolved the pick.

## Infographic

![picker keeps the pair](https://files.catbox.moe/65twy0.png)

https://files.catbox.moe/65twy0.png
