### PR TITLE
fix(agent): don't attach a pre-API steer to a prior turn's tool result (#107272)

### DIFF
--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -230,15 +230,33 @@ def _previous_tool_round(messages: Any) -> list:
 
 
 def _inject_steer_after_newest_tool_result(agent: Any, messages: Any, steer_text: str) -> None:
-    """Append the steer marker as a standalone user row after the newest tool message; with no
-    tool message, put the text back so the post-tool-execution drain delivers it later."""
+    """Append the steer marker as a standalone user row after the newest tool message OF THE
+    CURRENT TURN; otherwise put the text back so the post-tool-execution drain / next turn
+    delivers it later.
+
+    The newest tool message must belong to the current turn — i.e. sit AFTER the last user row.
+    On a turn's first iteration (e.g. a steer typed while an attached image is still being
+    preprocessed, before the first API call), the newest tool message is the prior turn's result,
+    which precedes the current user prompt. Inserting the steer after it would smear the correction
+    into already-persisted history ahead of the current prompt, where the turn silently ignores it
+    (#107272). So stop the scan at the current user row and re-queue instead — the steer then lands
+    as the next turn, matching the acknowledged 'arrives after the next tool call' contract rather
+    than being lost."""
     for _si in range(len(messages) - 1, -1, -1):
         _sm = messages[_si]
-        if isinstance(_sm, dict) and _sm.get("role") == "tool":
+        if not isinstance(_sm, dict):
+            continue
+        _role = _sm.get("role")
+        if _role == "tool":
             from agent.prompt_builder import steer_user_row
             messages.insert(_si + 1, steer_user_row(steer_text))
             logger.debug("Pre-API-call steer drain: appended user row after tool msg at index %d", _si)
             return
+        if _role == "user":
+            # Reached the current user turn before any tool result: the current turn hasn't produced
+            # one yet, so there is nowhere in it to attach the steer. Re-queue for the next turn
+            # rather than injecting after a stale prior-turn tool result (#107272).
+            break
     from agent.agent_runtime_helpers import _requeue_pending_steer
     _requeue_pending_steer(agent, steer_text)
 

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -682,6 +682,35 @@ class TestPreApiCallSteerDrain:
         agent._pending_steer = _pre_api_steer
         assert agent._pending_steer == "early steer"
 
+    def test_pre_api_drain_restashes_when_newest_tool_is_from_a_prior_turn(self):
+        """A steer typed on a turn's first iteration (e.g. while an attached image is still
+        preprocessing) must NOT be attached to a prior turn's tool result that sits before the
+        current user prompt — it would land in stale history and be silently ignored (#107272).
+
+        The newest tool message here belongs to the PREVIOUS turn (before the current user row),
+        so the steer is re-queued for the next turn instead of injected."""
+        from agent.turn_iteration_prep import _inject_steer_after_newest_tool_result
+
+        agent = _bare_agent()
+        prior_tool_row = {"role": "tool", "content": "prior result", "tool_call_id": "tc0"}
+        messages = [
+            {"role": "user", "content": "earlier prompt"},
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "tc0", "function": {"name": "terminal", "arguments": "{}"}}
+            ]},
+            prior_tool_row,
+            {"role": "assistant", "content": "earlier answer"},
+            # Current turn's user prompt (image already preprocessed): no tool result yet.
+            {"role": "user", "content": "describe this image"},
+        ]
+        before = list(messages)
+        agent.steer("This resembles Markdown's # and ##.")
+        _inject_steer_after_newest_tool_result(agent, messages, agent._drain_pending_steer())
+
+        # History is untouched — nothing was smeared after the prior-turn tool result.
+        assert messages == before
+        # The steer is re-queued so the turn finalizer surfaces it as the next turn.
+        assert agent._pending_steer == "This resembles Markdown's # and ##."
 
 
 class TestSteerMarkerContract:


### PR DESCRIPTION
## What

In the classic CLI, a `/steer` typed while an attached image is still being preprocessed — before the turn's first API call — is acknowledged ("⏩ Steer queued — arrives after the next tool call") but the turn completes without applying it, and nothing indicates it was dropped (#107272).

## Root cause

The steer is accepted into `_pending_steer`, then drained pre-API in `turn_iteration_prep` and handed to `_inject_steer_after_newest_tool_result`, which walks the message list backward and inserts the steer after the newest `role == "tool"` message. That helper is written for **mid-turn** steering (between tool-call iterations), where the newest tool result belongs to the current turn.

On a turn's **first** iteration, there is no current-turn tool result yet. If the session already contains a prior turn's tool result (the issue's repro: "a session that already contains at least one tool result"), that stale tool message sits **before** the current user prompt. The steer is therefore inserted into already-persisted history, ahead of the current turn — exactly the "attached to an earlier turn" case the issue calls out — and the model ignores it as old context.

## Fix

`_inject_steer_after_newest_tool_result` now stops the backward scan at the current **user** row. A tool message only counts as an injection target when it's newer than the last user row (i.e. part of the current turn). Otherwise the steer is re-queued via `_requeue_pending_steer`, so:

- the turn finalizer captures it into `result["pending_steer"]` (existing path), and
- the CLI delivers it as the next turn with `⏩ Delivering leftover /steer as next turn` (existing path, `cli_chat_turn_mixin.py`) — visible, correctly ordered, not lost.

This matches the issue's Expected Behavior ("queue it without attaching it to an earlier turn"). Mid-turn steering is unchanged: there the current-turn tool result is the newest message, so it's found before any user row.

## Tests

`tests/run_agent/test_steer.py::TestPreApiCallSteerDrain`:
- `test_pre_api_drain_restashes_when_newest_tool_is_from_a_prior_turn` — first-iteration steer with a prior-turn tool result before the current user prompt: history is untouched and the steer is re-queued into `_pending_steer`.
- Existing `test_pre_api_drain_appends_user_row_and_leaves_tool_row_untouched` (mid-turn) and `test_pre_api_drain_restashes_when_no_tool_message` still pass.

Full file: 38 passed. `ruff check` clean.

Fixes #107272
