### PR TITLE
fix(discord): instrument safe slash reconciliation

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2405,6 +2405,35 @@ class DiscordAdapter(BasePlatformAdapter):
         if interval > 0:
             await asyncio.sleep(interval)
 
+    def _log_command_sync_interruption(
+        self, kind: str, *, timeout_seconds: Optional[float] = None
+    ) -> None:
+        diagnostics = getattr(self, "_command_sync_diagnostics", None) or {}
+        started_at = diagnostics.get("started_at")
+        elapsed = time.perf_counter() - started_at if started_at is not None else 0.0
+        timeout_field = (
+            f" timeout_seconds={timeout_seconds:.0f}" if timeout_seconds is not None else ""
+        )
+        logger.warning(
+            "[%s] slash_reconcile_%s%s desired=%s existing=%s unchanged=%s "
+            "updated=%s recreated=%s created=%s deleted=%s mutations_started=%s "
+            "mutations_completed=%s active_mutation=%s elapsed_seconds=%.3f",
+            self.name,
+            kind,
+            timeout_field,
+            diagnostics.get("desired", 0),
+            diagnostics.get("existing", "unknown"),
+            diagnostics.get("unchanged", 0),
+            diagnostics.get("updated", 0),
+            diagnostics.get("recreated", 0),
+            diagnostics.get("created", 0),
+            diagnostics.get("deleted", 0),
+            diagnostics.get("mutations_started", 0),
+            diagnostics.get("mutations_completed", 0),
+            diagnostics.get("active_mutation", "none"),
+            elapsed,
+        )
+
     async def _run_post_connect_initialization(self) -> None:
         """Finish non-critical startup work after Discord is connected."""
         if not self._client:
@@ -2471,11 +2500,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 summary["deleted"],
             )
         except asyncio.TimeoutError:
-            logger.warning(
-                "[%s] Slash command sync timed out — Discord rate-limit bucket "
-                "may be saturated; will retry on next reconnect",
-                self.name,
-            )
+            self._log_command_sync_interruption("timeout", timeout_seconds=600)
         except asyncio.CancelledError:
             raise
         except Exception as e:  # pragma: no cover - defensive logging
@@ -3237,6 +3262,26 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _safe_sync_slash_commands(self) -> Dict[str, int]:
         """Diff existing global commands and only mutate the commands that changed."""
+        self._command_sync_diagnostics = {
+            "started_at": time.perf_counter(),
+            "desired": 0,
+            "existing": "unknown",
+            "unchanged": 0,
+            "updated": 0,
+            "recreated": 0,
+            "created": 0,
+            "deleted": 0,
+            "mutations_started": 0,
+            "mutations_completed": 0,
+            "active_mutation": "none",
+        }
+        try:
+            return await self._safe_sync_slash_commands_inner()
+        except asyncio.CancelledError:
+            self._log_command_sync_interruption("cancelled")
+            raise
+
+    async def _safe_sync_slash_commands_inner(self) -> Dict[str, int]:
         if not self._client:
             return {
                 "total": 0,
@@ -3253,11 +3298,20 @@ class DiscordAdapter(BasePlatformAdapter):
             raise RuntimeError("Discord application ID is unavailable for slash command sync")
 
         desired_payloads = [command.to_dict(tree) for command in tree.get_commands()]
+        self._command_sync_diagnostics["desired"] = len(desired_payloads)
         desired_by_key = {
             (int(payload.get("type", 1) or 1), str(payload.get("name", "") or "").lower()): payload
             for payload in desired_payloads
         }
         existing_commands = await tree.fetch_commands()
+        self._command_sync_diagnostics["existing"] = len(existing_commands)
+        logger.info(
+            "[%s] slash_reconcile_fetch_complete desired=%d existing=%d elapsed_seconds=%.3f",
+            self.name,
+            len(desired_payloads),
+            len(existing_commands),
+            time.perf_counter() - self._command_sync_diagnostics["started_at"],
+        )
         existing_by_key = {
             (
                 int(getattr(getattr(command, "type", None), "value", getattr(command, "type", 1)) or 1),
@@ -3274,12 +3328,35 @@ class DiscordAdapter(BasePlatformAdapter):
         http = self._client.http
         mutation_count = 0
 
-        async def mutate(call, *args):
+        async def mutate(mutation_type, call, *args):
             nonlocal mutation_count
+            diagnostics = self._command_sync_diagnostics
+            diagnostics["mutations_started"] += 1
+            ordinal = diagnostics["mutations_started"]
+            diagnostics["active_mutation"] = mutation_type
+            logger.info(
+                "[%s] slash_reconcile_mutation_start ordinal=%d type=%s elapsed_seconds=%.3f",
+                self.name,
+                ordinal,
+                mutation_type,
+                time.perf_counter() - diagnostics["started_at"],
+            )
             if mutation_count:
                 await self._sleep_between_command_sync_mutations()
+            mutation_started_at = time.perf_counter()
             result = await call(*args)
             mutation_count += 1
+            diagnostics["mutations_completed"] = mutation_count
+            diagnostics["active_mutation"] = "none"
+            logger.info(
+                "[%s] slash_reconcile_mutation_complete ordinal=%d type=%s "
+                "elapsed_seconds=%.3f duration_seconds=%.3f",
+                self.name,
+                ordinal,
+                mutation_type,
+                time.perf_counter() - diagnostics["started_at"],
+                time.perf_counter() - mutation_started_at,
+            )
             return result
 
         # Delete obsolete commands FIRST to stay under Discord's 100-command
@@ -3292,14 +3369,16 @@ class DiscordAdapter(BasePlatformAdapter):
         obsolete_keys = set(existing_by_key.keys()) - set(desired_by_key.keys())
         for key in obsolete_keys:
             current = existing_by_key.pop(key)
-            await mutate(http.delete_global_command, app_id, current.id)
+            await mutate("delete_obsolete", http.delete_global_command, app_id, current.id)
             deleted += 1
+            self._command_sync_diagnostics["deleted"] = deleted
 
         for key, desired in desired_by_key.items():
             current = existing_by_key.pop(key, None)
             if current is None:
-                await mutate(http.upsert_global_command, app_id, desired)
+                await mutate("create", http.upsert_global_command, app_id, desired)
                 created += 1
+                self._command_sync_diagnostics["created"] = created
                 continue
 
             current_existing_payload = self._existing_command_to_payload(current)
@@ -3307,16 +3386,38 @@ class DiscordAdapter(BasePlatformAdapter):
             desired_payload = self._canonicalize_app_command_payload(desired)
             if current_payload == desired_payload:
                 unchanged += 1
+                self._command_sync_diagnostics["unchanged"] = unchanged
                 continue
+
+            differing_fields = sorted(
+                field
+                for field in current_payload
+                if current_payload[field] != desired_payload[field]
+            )
+            logger.info(
+                "[%s] slash_reconcile_diff command_type=%d command_name=%s "
+                "differing_fields=%s contexts_desired=%s contexts_existing=%s "
+                "integration_types_desired=%s integration_types_existing=%s",
+                self.name,
+                key[0],
+                key[1],
+                ",".join(differing_fields),
+                desired_payload.get("contexts") if desired_payload.get("contexts") is not None else "default",
+                current_payload.get("contexts") if current_payload.get("contexts") is not None else "default",
+                desired_payload.get("integration_types") if desired_payload.get("integration_types") is not None else "default",
+                current_payload.get("integration_types") if current_payload.get("integration_types") is not None else "default",
+            )
 
             if self._patchable_app_command_payload(current_existing_payload) == self._patchable_app_command_payload(desired):
-                await mutate(http.delete_global_command, app_id, current.id)
-                await mutate(http.upsert_global_command, app_id, desired)
+                await mutate("recreate_delete", http.delete_global_command, app_id, current.id)
+                await mutate("recreate_create", http.upsert_global_command, app_id, desired)
                 recreated += 1
+                self._command_sync_diagnostics["recreated"] = recreated
                 continue
 
-            await mutate(http.edit_global_command, app_id, current.id, desired)
+            await mutate("update", http.edit_global_command, app_id, current.id, desired)
             updated += 1
+            self._command_sync_diagnostics["updated"] = updated
 
         return {
             "total": len(desired_payloads),

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -440,7 +440,9 @@ async def test_safe_sync_slash_commands_only_mutates_diffs():
 
 
 @pytest.mark.asyncio
-async def test_post_connect_initialization_retries_fingerprint_after_timeout(tmp_path, monkeypatch):
+async def test_post_connect_initialization_retries_fingerprint_after_timeout(
+    tmp_path, monkeypatch, caplog
+):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
     monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
 
@@ -496,6 +498,7 @@ async def test_post_connect_initialization_retries_fingerprint_after_timeout(tmp
     assert timed_out_entry["fingerprint"] == desired_fingerprint
     assert "last_success_at" not in timed_out_entry
     assert "summary" not in timed_out_entry
+    assert "slash_reconcile_timeout timeout_seconds=600" in caplog.text
 
     await adapter._run_post_connect_initialization()
 
@@ -503,6 +506,75 @@ async def test_post_connect_initialization_retries_fingerprint_after_timeout(tmp
     recovered_entry = json.loads(state_path.read_text(encoding="utf-8"))["999"]
     assert recovered_entry["last_success_at"] >= recovered_entry["last_attempt_at"]
     assert recovered_entry["summary"] == summary
+
+
+@pytest.mark.parametrize(
+    ("expanded_field", "expanded_default"),
+    [
+        ("contexts", [0, 1, 2]),
+        ("integration_types", [0, 1]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_safe_sync_reports_discord_expanded_defaults(
+    expanded_field, expanded_default, caplog
+):
+    """Discord expands omitted install/context defaults on round-trip.
+
+    Keep this as a mismatch reproduction until semantic normalization is
+    deliberately implemented: the safe sync recreates the command, and its
+    diagnostics must make the exact non-secret default expansion visible.
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    desired = {
+        "name": "status",
+        "description": "sensitive-description-must-not-be-logged",
+        "type": 1,
+        "options": [],
+    }
+    existing_payload = {**desired, expanded_field: expanded_default}
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            return dict(desired)
+
+    class _ExistingCommand:
+        id = 42
+        name = "status"
+        type = SimpleNamespace(value=1)
+
+        def to_dict(self):
+            return {
+                "id": self.id,
+                "application_id": 999,
+                **existing_payload,
+            }
+
+    fake_http = SimpleNamespace(
+        upsert_global_command=AsyncMock(),
+        edit_global_command=AsyncMock(),
+        delete_global_command=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        tree=SimpleNamespace(
+            get_commands=lambda: [_DesiredCommand()],
+            fetch_commands=AsyncMock(return_value=[_ExistingCommand()]),
+        ),
+        http=fake_http,
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+    caplog.set_level("INFO", logger="plugins.platforms.discord.adapter")
+
+    summary = await adapter._safe_sync_slash_commands()
+
+    assert summary["recreated"] == 1
+    assert "slash_reconcile_fetch_complete desired=1 existing=1" in caplog.text
+    assert f"differing_fields={expanded_field}" in caplog.text
+    assert f"{expanded_field}_desired=default" in caplog.text
+    assert f"{expanded_field}_existing={expanded_default}" in caplog.text
+    assert "sensitive-description-must-not-be-logged" not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -706,4 +778,3 @@ class TestPrivilegedIntentsRequiredFatal:
         assert "Message Content Intent" in (adapter.fatal_error_message or "")
         assert "discord.com/developers/applications" in (adapter.fatal_error_message or "")
         assert adapter._bot_task is None
-

--- a/tests/gateway/test_discord_sync_limit.py
+++ b/tests/gateway/test_discord_sync_limit.py
@@ -1,5 +1,7 @@
 """Test Discord slash command sync respects the 100-command hard limit."""
 
+import asyncio
+
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 import sys
@@ -138,3 +140,31 @@ async def test_safe_sync_deletes_before_creating():
         f"Deletions must happen before creations to avoid exceeding 100-command limit. "
         f"Last delete at index {last_delete_idx}, first create at index {first_create_idx}"
     )
+
+
+@pytest.mark.asyncio
+async def test_safe_sync_cancellation_reports_progress(adapter, caplog):
+    entered_mutation = asyncio.Event()
+
+    async def blocked_upsert(*args):
+        entered_mutation.set()
+        await asyncio.Event().wait()
+
+    adapter._client.tree.fetch_commands = AsyncMock(return_value=[])
+    adapter._client.tree.get_commands = MagicMock(
+        return_value=[_FakeTreeCommand(name="new-command")]
+    )
+    adapter._client.http.upsert_global_command.side_effect = blocked_upsert
+    caplog.set_level("INFO", logger="plugins.platforms.discord.adapter")
+
+    task = asyncio.create_task(adapter._safe_sync_slash_commands())
+    await entered_mutation.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert "slash_reconcile_mutation_start ordinal=1 type=create" in caplog.text
+    assert "slash_reconcile_cancelled" in caplog.text
+    assert "mutations_started=1 mutations_completed=0" in caplog.text
+    assert "active_mutation=create" in caplog.text


### PR DESCRIPTION
## Summary

- add credential-free structured diagnostics to safe Discord slash reconciliation
- report fetched desired/existing counts and per-command differing field names
- include only canonical, non-secret values for `contexts` and `integration_types`
- report mutation progress plus factual cancellation and timeout summaries

## Scope

Instrumentation only. This deliberately does not normalize omitted versus Discord-expanded defaults, change mutation pacing, or otherwise alter reconciliation behavior.

The branch is based on `v2026.8.31` (`hermes-agent` 0.21.0, `29112bef`) to match the deployed source revision.

## Reproduction

Regression coverage first demonstrates that omitted `contexts` versus `[0, 1, 2]`, and omitted `integration_types` versus `[0, 1]`, still select recreate. The new logs diagnose those comparisons by field without emitting descriptions, options, permissions, credentials, or account data.

## Tests

- `scripts/run_tests.sh tests/gateway/test_discord_connect.py tests/gateway/test_discord_sync_limit.py` — 17 passed
- `.venv/bin/ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_connect.py tests/gateway/test_discord_sync_limit.py` — passed
- full `scripts/run_tests.sh` — 23,133 passed, 208 skipped, 14 unrelated failures across 3,493 files; no failures in the changed Discord files. The remaining failures were macOS platform/timing/full-suite environment issues, including unsupported Linux socket behavior, an overlong temporary Unix-socket path, and parallel CLI-update tests mutating the checkout virtualenv.
