### PR TITLE
feat(mcp): add Contracko to optional MCP catalog

### DIFF
--- a/optional-mcps/contracko/manifest.yaml
+++ b/optional-mcps/contracko/manifest.yaml
@@ -1,0 +1,31 @@
+manifest_version: 1
+
+name: contracko
+description: Search and review contracts, track renewal dates, and import agreements with Contracko.
+source: https://contracko.com/mcp/contract-management
+
+transport:
+  type: http
+  url: https://app.contracko.com/mcp
+
+auth:
+  type: oauth
+
+suggest:
+  keywords:
+    - contracko
+  hosts:
+    - contracko.com
+
+post_install: |
+  A Contracko account and workspace with MCP access are required.
+  On first connection, authenticate in the browser and choose your workspace.
+  Start with read-only access for contract searches and reviews. Importing or
+  changing records requires separate write permission and user confirmation.
+
+  Contract data used by Hermes is sent to the AI provider running the session.
+  Review that provider's data settings before working with confidential contracts.
+
+  Restart your Hermes session after authentication so the tools are loaded.
+  To change which tools Hermes exposes, run:
+    hermes mcp configure contracko


### PR DESCRIPTION
## What does this PR do?

Proposes Contracko for the optional MCP catalog. Contracko is a hosted contract-management service for searching and reviewing agreements, tracking notice/renewal dates, and importing contracts.

Uses the existing remote HTTP/native OAuth pattern from the Linear entry. No local server, dependency, runtime change, or vendored skills.

## Related Issue

None. Searched existing issues, PRs and catalog entries for Contracko; no duplicate found.

## Type of Change

- [x] ✨ New feature (optional catalog entry)

## Changes Made

- Add `optional-mcps/contracko/manifest.yaml` with the existing public endpoint `https://app.contracko.com/mcp` and OAuth authentication.
- Add product-specific suggestion triggers.
- Explain account/workspace requirements, read-only starting permissions, separate write permission, and AI-provider data handling.

## How to Test

1. Run `hermes mcp install contracko` with a Contracko account and workspace that has MCP access.
2. Complete browser OAuth using read-only permissions, then restart Hermes.
3. Verify connection validation, contract search and review. Confirm write operations are not available without write permission.

Static review performed: checked the manifest version, name, HTTP URL, OAuth declaration, and field structure against the current Linear catalog entry.

**End-to-end Hermes OAuth is not verified.** A local attempt stopped at OAuth client registration with HTTP 429 before browser consent. No authenticated tool call completed. This submission does not claim to fix or diagnose that response. Full Hermes tests were not run for this catalog-only change.

## Checklist

- [x] Read the Contributing Guide.
- [x] Conventional commit used.
- [x] Checked existing PRs and issues for duplicates.
- [x] Only the proposed catalog manifest is changed.
- [ ] Full test suite run.
- [ ] End-to-end client test passed.
- [x] No new config keys, runtime tool schemas, dependencies or platform-specific commands.

## Screenshots / Logs

No credentials or customer data included. OAuth registration result: `Registration failed: 429`.
