### PR TITLE
feat(mcp): add OmniScholar catalog entry

### DIFF
--- a/optional-mcps/omnischolar/manifest.yaml
+++ b/optional-mcps/omnischolar/manifest.yaml
@@ -1,0 +1,60 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: omnischolar
+description: Search literature, read Zotero, inspect citations, and query materials data.
+source: https://github.com/luffysolution-svg/omnischolar
+
+transport:
+  type: stdio
+  command: "uvx"
+  args:
+    - "--from"
+    - "luffysolution-omnischolar==0.1.0"
+    - "omnischolar"
+    - "mcp"
+
+auth:
+  type: none
+
+tools:
+  default_enabled:
+    - omnischolar_status
+    - omnischolar_capabilities
+    - research_sources
+    - literature_search
+    - literature_get
+    - literature_graph
+    - journal_metrics
+    - zotero_collections
+    - zotero_search
+    - zotero_item
+    - ai4scholar_credits
+    - materials_capabilities
+    - materials_search
+    - materials_route_search
+    - materials_get
+    - materials_advanced
+    - chemical_sources
+    - chemical_search
+    - chemical_get
+    - omnischolar_image_models
+    - omnischolar_image_service
+
+suggest:
+  keywords:
+    - omnischolar
+    - literature search
+    - zotero
+    - materials project
+    - scientific research
+
+post_install: |
+  Public literature sources work without credentials. Zotero access is local
+  and read-only. Optional services are configured through OmniScholar's config
+  file and environment variables; see the upstream README before enabling
+  external uploads or paid tools.
+
+  The default tool selection excludes file-writing, upload, and paid tools.
+  Re-run `hermes mcp configure omnischolar` to opt into them.


### PR DESCRIPTION
## What does this PR do?\n\nAdds OmniScholar to the Nous-approved MCP catalog as an exact-version uvx stdio package. The default selection exposes read-only/free research tools while leaving file-writing, upload, and paid tools opt-in.\n\nUpstream: https://github.com/luffysolution-svg/omnischolar\nPyPI: https://pypi.org/project/luffysolution-omnischolar/0.1.0/\n\n## Related Issue\n\nN/A\n\n## Type of Change\n\n- [x] ✨ New feature (non-breaking change that adds functionality)\n\n## Changes Made\n\n- Add optional-mcps/omnischolar/manifest.yaml.\n- Pin luffysolution-omnischolar==0.1.0 and launch omnischolar mcp through uvx.\n- Default-enable 21 read-only/free tools and document how to opt into the remaining tools.\n\n## How to Test\n\n1. Run uvx --from luffysolution-omnischolar==0.1.0 omnischolar --version and confirm omnischolar 0.1.0.\n2. Parse the manifest with hermes_cli.mcp_catalog._parse_manifest; it returns omnischolar, uvx, and 21 defaults.\n3. Run hermes mcp install omnischolar, start a new session, and call omnischolar_status.\n\n## Checklist\n\n### Code\n\n- [x] I've read the Contributing Guide\n- [x] My commit message follows Conventional Commits\n- [x] I searched existing PRs and found no duplicate\n- [x] This PR contains only the catalog entry\n- [ ] Full pytest tests/ -q suite run (not run; catalog parser and exact uvx install were tested directly)\n- [x] Tested on Windows 11\n\n### Documentation & Housekeeping\n\n- [x] Relevant setup and safety notes are included in the manifest\n- [x] cli-config.yaml.example update is N/A\n- [x] CONTRIBUTING.md / AGENTS.md update is N/A\n- [x] Cross-platform impact considered; the entry uses the supported uvx launcher\n- [x] Tool schema changes are N/A