### PR TITLE
fix(matrix): accept is_voice kwarg in send_voice

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1557,7 +1557,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def send_voice(
         self, chat_id: str, audio_path: str, caption: Optional[str] = None, reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        metadata: Optional[Dict[str, Any]] = None, **kwargs) -> SendResult:
         """Upload audio as an MSC3245 voice message. Voice bubbles need Ogg/Opus but callers pass any
         format (e.g. TTS output), so transcode here — best-effort: without ffmpeg the original is sent."""
         converted_path: Optional[str] = None

--- a/tests/gateway/test_matrix_voice.py
+++ b/tests/gateway/test_matrix_voice.py
@@ -264,3 +264,48 @@ class TestMatrixSendVoiceMSC3245:
             if os.path.exists(converted_path):
                 os.unlink(converted_path)
 
+    @pytest.mark.asyncio
+    async def test_send_voice_accepts_is_voice_kwarg_from_dispatcher(self):
+        """Regression test: the shared media dispatcher (base.py) calls
+        ``send_voice(..., is_voice=is_voice)``. Every other platform adapter
+        accepts that kwarg (``**kwargs``); the Matrix override did not, so the
+        dispatcher raised ``TypeError: send_voice() got an unexpected keyword
+        argument 'is_voice'`` and every Matrix voice message was dropped.
+
+        This mirrors the dispatcher call exactly — it must not raise."""
+        with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
+            f.write(b"fake ogg opus data")
+            temp_path = f.name
+
+        sent_content = None
+
+        async def mock_send_message_event(room_id, event_type, content):
+            nonlocal sent_content
+            sent_content = content
+            return "$sent_event"
+
+        self.adapter._client.send_message_event = mock_send_message_event
+
+        with patch(
+            "plugins.platforms.matrix.adapter._matrix_transcode_voice_to_ogg",
+            return_value=None,
+        ), patch(
+            "plugins.platforms.matrix.adapter._matrix_voice_metadata_for_file",
+            return_value={"duration": 1000, "waveform": [0, 512, 1024]},
+        ):
+            # is_voice=... is what the dispatcher passes.
+            result = await self.adapter.send_voice(
+                chat_id="!room:example.org",
+                audio_path=temp_path,
+                caption="Voice from TTS",
+                is_voice=True,
+            )
+
+        try:
+            assert result.success, "send_voice should report success"
+            assert sent_content is not None, "A voice message should have been sent"
+            assert "org.matrix.msc3245.voice" in sent_content
+        finally:
+            os.unlink(temp_path)
+
+


### PR DESCRIPTION
# fix(matrix): accept is_voice kwarg in send_voice

## Summary

Every Matrix voice message was silently dropped with:

```
[Matrix] Error sending media: MatrixAdapter.send_voice() got an unexpected keyword argument 'is_voice'
```

The shared media dispatcher in `gateway/platforms/base.py` calls
`send_voice(..., is_voice=is_voice)` for **every** platform. All other
adapters accept that kwarg via `**kwargs`, but the Matrix override had a
fixed signature, so the dispatcher raised a `TypeError` on every send.
TTS audio was generated correctly on disk but never reached the user.

## Fix

Add `**kwargs` to `MatrixAdapter.send_voice` to match the base-class
contract (`gateway/platforms/base.py` `send_voice` already carries
`**kwargs`). One line.

## Regression test

`tests/gateway/test_matrix_voice.py::test_send_voice_accepts_is_voice_kwarg`
mirrors the dispatcher call exactly — calls `send_voice(..., is_voice=True)`
and asserts it does not raise. Fails on the unpatched code, passes with the
fix.

## Reproduction (on unpatched main)

1. Send any voice message over Matrix (e.g. a TTS reply).
2. `journalctl --user -u hermes-gateway | grep "Error sending media"` shows
   the `is_voice` TypeError on every attempt.
3. User receives the audio file (if sent as a normal file) but never the
   voice bubble.

## Verification

- Local patch applied to a running Hermes install; user confirmed voice
  message received after gateway restart.
- `python -m py_compile` passes on both changed files.
