### PR TITLE
feat(desktop): inspect complete available tool payloads

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -430,7 +430,7 @@ describe('clampForDisplay', () => {
     expect(clamped.length).toBeLessThan(oversized.length)
     expect(clamped.startsWith('x'.repeat(MAX_TOOL_RENDER_CHARS))).toBe(true)
     expect(clamped).toContain('5,000 more characters truncated')
-    expect(clamped).toContain('Copy')
+    expect(clamped).toContain('open Details')
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
@@ -65,8 +65,8 @@ export function contextValue(value: unknown): string {
 
 // Each tool result is server-capped (~100KB), but a turn over a big directory
 // stacks many rows; painting/serializing them all floods the renderer (freeze,
-// then OOM). Clamp every inline-painted payload to a bounded slice — the row's
-// Copy button still reads the uncapped `view.detail` for the full output.
+// then OOM). Clamp every inline-painted payload to a bounded slice — the
+// on-demand Details inspector keeps the available source sections separate.
 export const MAX_TOOL_RENDER_CHARS = 20_000
 
 export function clampForDisplay(value: string, max = MAX_TOOL_RENDER_CHARS): string {
@@ -76,7 +76,7 @@ export function clampForDisplay(value: string, max = MAX_TOOL_RENDER_CHARS): str
 
   const omitted = value.length - max
 
-  return `${value.slice(0, max)}\n\n… ${omitted.toLocaleString()} more characters truncated — use Copy for the full output.`
+  return `${value.slice(0, max)}\n\n… ${omitted.toLocaleString()} more characters truncated — open Details to inspect the available payload.`
 }
 
 export function prettyJson(value: unknown): string {

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-preview-scope.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-preview-scope.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { atom } from 'nanostores'
 import type { ComponentProps, ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -72,5 +72,26 @@ describe('tool row preview recording', () => {
     renderToolRow(node => node)
 
     expect(Object.keys($previewStatusBySession.get())).toEqual([PRIMARY_ID])
+  })
+})
+
+describe('tool details action', () => {
+  it('opens full payload details for a normal row with no expandable summary body', () => {
+    const props = {
+      args: { operations: [{ action: 'add', content: 'Remember this' }], target: 'memory' },
+      result: { current_chars: 120, message: 'Applied 1 operation(s).' },
+      toolCallId: 'call-memory',
+      toolName: 'memory'
+    } as unknown as ComponentProps<typeof ToolFallback>
+
+    const { container } = render(<ToolFallback {...props} />)
+
+    expect(container.querySelector('[data-tool-row] button[aria-expanded]')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Details' }))
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(screen.getByRole('tabpanel').textContent).toContain('Remember this')
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Result' }))
+    expect(screen.getByRole('tabpanel').textContent).toContain('Applied 1 operation(s).')
   })
 })

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -74,6 +74,7 @@ import {
 } from './fallback-model'
 import { isToolCallPart, summarizeToolRun } from './run-summary'
 import { ToolRunTicker } from './run-ticker'
+import { ToolDetailsDialog } from './tool-details'
 
 // `true` when a ToolEntry is rendered inside an embedding wrapper that owns
 // the per-row chrome (timer / preview). The flat ToolGroupSlot sets this
@@ -354,6 +355,7 @@ function ToolEntry({ part }: ToolEntryProps) {
   const messageRunning = useAuiState(selectMessageRunning)
   const embedded = useContext(ToolEmbedContext)
   const toolViewMode = useStore($toolViewMode)
+  const [detailsOpen, setDetailsOpen] = useState(false)
 
   // `ToolFallback` rebuilds the `part` wrapper each render, defeating the memos
   // below and re-running buildToolView (full JSON.stringify of result) on every
@@ -474,8 +476,8 @@ function ToolEntry({ part }: ToolEntryProps) {
     toolViewMode === 'technical'
   )
 
-  // copyAction reads the uncapped view.detail; clampForDisplay below only bounds
-  // what's painted, so the row's Copy button still yields the full output.
+  // Keep the compact row's existing convenience-copy action. The Details
+  // inspector owns exact, independently selectable source payloads.
   const copyAction = useMemo(() => toolCopyPayload(stablePart, view), [stablePart, view])
 
   const diffStats = useMemo(
@@ -601,18 +603,33 @@ function ToolEntry({ part }: ToolEntryProps) {
       {isPending && <PendingToolApproval part={part} />}
       {open && (
         <div className="relative grid w-full min-w-0 max-w-full gap-1.5 overflow-hidden p-1.5">
-          {copyAction.text && (
-            <CopyButton
-              appearance="inline"
-              className="absolute right-4 top-1.5 z-10 h-5 gap-0 rounded-md px-1 opacity-5 transition-opacity group-hover/tool-block:opacity-100 hover:opacity-100 focus-visible:opacity-100"
-              iconClassName="size-3"
-              label={copyAction.label}
-              showLabel={false}
-              side="left"
-              stopPropagation
-              text={copyAction.text}
-            />
-          )}
+          <div className="absolute right-4 top-1.5 z-10 flex items-center gap-0.5 opacity-5 transition-opacity group-hover/tool-block:opacity-100 focus-within:opacity-100 hover:opacity-100">
+            {toolViewMode !== 'technical' && (
+              <Button
+                aria-label={copy.detailsAction}
+                className="h-5 gap-1 rounded-md px-1 text-[0.7rem]"
+                onClick={() => setDetailsOpen(true)}
+                size="xs"
+                type="button"
+                variant="ghost"
+              >
+                <Codicon name="list-tree" size="0.75rem" />
+                {copy.detailsAction}
+              </Button>
+            )}
+            {copyAction.text && (
+              <CopyButton
+                appearance="inline"
+                className="h-5 gap-0 rounded-md px-1"
+                iconClassName="size-3"
+                label={copyAction.label}
+                showLabel={false}
+                side="left"
+                stopPropagation
+                text={copyAction.text}
+              />
+            )}
+          </div>
           {part.toolName === 'terminal' && toolViewMode !== 'technical' && (
             <TerminalTranscript command={view.terminalCommand} exitCode={view.terminalExitCode} />
           )}
@@ -709,6 +726,14 @@ function ToolEntry({ part }: ToolEntryProps) {
             ))}
           {toolViewMode === 'technical' && <ToolPayloadDisclosure args={part.args} result={part.result} />}
         </div>
+      )}
+      {detailsOpen && (
+        <ToolDetailsDialog
+          inlineDiff={view.inlineDiff}
+          onOpenChange={setDetailsOpen}
+          open={detailsOpen}
+          part={stablePart}
+        />
       )}
     </div>
   )

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -530,6 +530,31 @@ function ToolEntry({ part }: ToolEntryProps) {
     </Tip>
   ) : undefined
 
+  const detailsAction =
+    toolViewMode !== 'technical' ? (
+      <Button
+        aria-label={copy.detailsAction}
+        onClick={event => {
+          event.stopPropagation()
+          setDetailsOpen(true)
+        }}
+        size="micro"
+        type="button"
+        variant="ghost"
+      >
+        <Codicon name="list-tree" size="0.75rem" />
+        {copy.detailsAction}
+      </Button>
+    ) : undefined
+
+  const headerAction =
+    detailsAction || dismissAction ? (
+      <span className="flex items-center gap-0.5">
+        {detailsAction}
+        {dismissAction}
+      </span>
+    ) : undefined
+
   if (dismissed) {
     return null
   }
@@ -558,7 +583,7 @@ function ToolEntry({ part }: ToolEntryProps) {
     >
       <div className={cn(open && 'border-b border-(--ui-stroke-tertiary) px-2 py-1.5')}>
         <DisclosureRow
-          action={dismissAction}
+          action={headerAction}
           onToggle={hasExpandableContent ? () => setToolDisclosureOpen(disclosureId, !open) : undefined}
           open={open}
           trailing={trailing}
@@ -604,18 +629,6 @@ function ToolEntry({ part }: ToolEntryProps) {
       {open && (
         <div className="relative grid w-full min-w-0 max-w-full gap-1.5 overflow-hidden p-1.5">
           <div className="absolute right-4 top-1.5 z-10 flex items-center gap-0.5 opacity-5 transition-opacity group-hover/tool-block:opacity-100 focus-within:opacity-100 hover:opacity-100">
-            {toolViewMode !== 'technical' && (
-              <Button
-                aria-label={copy.detailsAction}
-                onClick={() => setDetailsOpen(true)}
-                size="micro"
-                type="button"
-                variant="ghost"
-              >
-                <Codicon name="list-tree" size="0.75rem" />
-                {copy.detailsAction}
-              </Button>
-            )}
             {copyAction.text && (
               <CopyButton
                 appearance="inline"

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -607,9 +607,8 @@ function ToolEntry({ part }: ToolEntryProps) {
             {toolViewMode !== 'technical' && (
               <Button
                 aria-label={copy.detailsAction}
-                className="h-5 gap-1 rounded-md px-1 text-[0.7rem]"
                 onClick={() => setDetailsOpen(true)}
-                size="xs"
+                size="micro"
                 type="button"
                 variant="ghost"
               >

--- a/apps/desktop/src/components/assistant-ui/tool/tool-details.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-details.test.tsx
@@ -51,7 +51,18 @@ describe('findTextMatches', () => {
   it('searches the full selected text beyond the inline render limit', () => {
     const text = `${'x'.repeat(25_000)}Needle${'y'.repeat(25_000)}`
 
-    expect(findTextMatches(text, 'needle')).toEqual([25_000])
+    expect(findTextMatches(text, 'needle')).toEqual([{ end: 25_006, start: 25_000 }])
+  })
+
+  it('searches past 1,000 matches without silently wrapping early', () => {
+    const matches = findTextMatches('x'.repeat(1_500), 'x')
+
+    expect(matches).toHaveLength(1_500)
+    expect(matches[1_000]).toEqual({ end: 1_001, start: 1_000 })
+  })
+
+  it('returns offsets into the original string when Unicode case folding expands', () => {
+    expect(findTextMatches('İx', 'x')).toEqual([{ end: 2, start: 1 }])
   })
 })
 
@@ -141,6 +152,24 @@ describe('ToolDetailsDialog', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
     expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('marks the original character at a Unicode-safe search range', () => {
+    render(
+      <ToolDetailsDialog
+        inlineDiff=""
+        onOpenChange={() => undefined}
+        open
+        part={{ result: { output: 'İx' }, toolName: 'terminal', type: 'tool-call' }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('tab', { name: 'stdout' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search selected section' }), { target: { value: 'x' } })
+
+    const match = screen.getByText('x')
+    expect(match.getAttribute('data-match-offset')).toBe('1')
+    expect(match.textContent).toBe('x')
   })
 
   it('advances through a long single line without growing the mounted payload', () => {

--- a/apps/desktop/src/components/assistant-ui/tool/tool-details.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-details.test.tsx
@@ -56,6 +56,26 @@ describe('findTextMatches', () => {
 })
 
 describe('ToolDetailsDialog', () => {
+  it('snapshots full serialization for each dialog mount', () => {
+    const firstPart = { result: { output: 'first' }, toolName: 'terminal', type: 'tool-call' as const }
+    const secondPart = { result: { output: 'second' }, toolName: 'terminal', type: 'tool-call' as const }
+
+    const { rerender, unmount } = render(
+      <ToolDetailsDialog inlineDiff="" onOpenChange={() => undefined} open part={firstPart} />
+    )
+
+    fireEvent.click(screen.getByRole('tab', { name: 'stdout' }))
+    expect(screen.getByRole('tabpanel').textContent).toBe('first')
+
+    rerender(<ToolDetailsDialog inlineDiff="" onOpenChange={() => undefined} open part={secondPart} />)
+    expect(screen.getByRole('tabpanel').textContent).toBe('first')
+
+    unmount()
+    render(<ToolDetailsDialog inlineDiff="" onOpenChange={() => undefined} open part={secondPart} />)
+    fireEvent.click(screen.getByRole('tab', { name: 'stdout' }))
+    expect(screen.getByRole('tabpanel').textContent).toBe('second')
+  })
+
   it('selects and copies exact short output instead of the command', async () => {
     const writeClipboard = vi.fn().mockResolvedValue(undefined)
     desktopWindow.hermesDesktop = { writeClipboard } as unknown as Window['hermesDesktop']
@@ -80,9 +100,11 @@ describe('ToolDetailsDialog', () => {
     await waitFor(() => expect(writeClipboard).toHaveBeenCalledWith('ok'))
   })
 
-  it('searches beyond the first render window, toggles wrapping and dismisses', () => {
+  it('scrolls each active full-text match into view, toggles wrapping and dismisses', async () => {
     const onOpenChange = vi.fn()
-    const output = `${'a'.repeat(25_000)}far-away-match${'b'.repeat(25_000)}`
+    const scrollIntoView = vi.fn()
+    Element.prototype.scrollIntoView = scrollIntoView
+    const output = `${'a'.repeat(25_000)}far-away-match${'b'.repeat(25_000)}far-away-match`
 
     render(
       <ToolDetailsDialog
@@ -94,17 +116,53 @@ describe('ToolDetailsDialog', () => {
     )
 
     fireEvent.click(screen.getByRole('tab', { name: 'stdout' }))
+    scrollIntoView.mockClear()
     fireEvent.change(screen.getByRole('textbox', { name: 'Search selected section' }), {
       target: { value: 'far-away-match' }
     })
 
-    expect(screen.getByText('1/1')).toBeTruthy()
-    expect(screen.getByRole('tabpanel').textContent).toContain('far-away-match')
+    expect(screen.getByText('1/2')).toBeTruthy()
+    const firstMatch = screen.getByText('far-away-match')
+    expect(firstMatch.getAttribute('data-match-offset')).toBe('25000')
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next match' }))
+    expect(screen.getByText('2/2')).toBeTruthy()
+    const secondMatch = screen.getByText('far-away-match')
+    expect(secondMatch.getAttribute('data-match-offset')).toBe('50014')
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalledTimes(2))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Previous match' }))
+    expect(screen.getByText('1/2')).toBeTruthy()
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalledTimes(3))
 
     fireEvent.click(screen.getByRole('button', { name: 'No wrap' }))
     expect(screen.getByRole('button', { name: 'Wrap' })).toBeTruthy()
 
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
     expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('advances through a long single line without growing the mounted payload', () => {
+    const output = `${'a'.repeat(20_000)}${'b'.repeat(20_000)}tail`
+
+    render(
+      <ToolDetailsDialog
+        inlineDiff=""
+        onOpenChange={() => undefined}
+        open
+        part={{ result: { output }, toolName: 'terminal', type: 'tool-call' }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('tab', { name: 'stdout' }))
+    expect(screen.getByRole('tabpanel').textContent).toBe('a'.repeat(20_000))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next chunk' }))
+    expect(screen.getByRole('tabpanel').textContent).toBe('b'.repeat(20_000))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next chunk' }))
+    expect(screen.getByRole('tabpanel').textContent).toBe('tail')
+    expect(screen.getByRole('tabpanel').textContent?.length).toBeLessThanOrEqual(20_000)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/tool/tool-details.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-details.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { buildToolDetailSections, findTextMatches, ToolDetailsDialog } from './tool-details'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+
+afterEach(() => {
+  cleanup()
+  delete desktopWindow.hermesDesktop
+})
+
+describe('buildToolDetailSections', () => {
+  it('keeps full arguments, results, streams and diff independently selectable', () => {
+    const longResult = `before-${'x'.repeat(25_000)}-needle-after`
+
+    const sections = buildToolDetailSections(
+      {
+        args: { command: 'printf ok', empty: '' },
+        completedAt: 20,
+        result: { diff: '+new', output: longResult, stderr: '' },
+        timestamp: 10,
+        toolCallId: 'call_1',
+        toolName: 'terminal',
+        type: 'tool-call'
+      },
+      ''
+    )
+
+    expect(sections.find(item => item.id === 'arguments')?.copyText).toContain('printf ok')
+    expect(sections.find(item => item.id === 'command')?.copyText).toBe('printf ok')
+    expect(sections.find(item => item.id === 'stdout')?.copyText).toBe(longResult)
+    expect(sections.find(item => item.id === 'stderr')?.state).toBe('empty')
+    expect(sections.find(item => item.id === 'diff')?.copyText).toBe('+new')
+    expect(sections.find(item => item.id === 'result')?.copyText).toContain('needle-after')
+    expect(sections.find(item => item.id === 'metadata')?.copyText).toContain('call_1')
+  })
+
+  it('distinguishes missing values from values supplied as empty strings', () => {
+    const missing = buildToolDetailSections({ toolName: 'terminal', type: 'tool-call' }, '')
+    const empty = buildToolDetailSections({ args: '', result: '', toolName: 'terminal', type: 'tool-call' }, '')
+
+    expect(missing.find(item => item.id === 'arguments')?.state).toBe('unavailable')
+    expect(missing.find(item => item.id === 'result')?.state).toBe('unavailable')
+    expect(empty.find(item => item.id === 'arguments')?.state).toBe('empty')
+    expect(empty.find(item => item.id === 'result')?.state).toBe('empty')
+  })
+})
+
+describe('findTextMatches', () => {
+  it('searches the full selected text beyond the inline render limit', () => {
+    const text = `${'x'.repeat(25_000)}Needle${'y'.repeat(25_000)}`
+
+    expect(findTextMatches(text, 'needle')).toEqual([25_000])
+  })
+})
+
+describe('ToolDetailsDialog', () => {
+  it('selects and copies exact short output instead of the command', async () => {
+    const writeClipboard = vi.fn().mockResolvedValue(undefined)
+    desktopWindow.hermesDesktop = { writeClipboard } as unknown as Window['hermesDesktop']
+
+    render(
+      <ToolDetailsDialog
+        inlineDiff=""
+        onOpenChange={() => undefined}
+        open
+        part={{
+          args: { command: 'echo ok' },
+          result: { exit_code: 0, output: 'ok' },
+          toolName: 'terminal',
+          type: 'tool-call'
+        }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('tab', { name: 'stdout' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Copy stdout' }))
+
+    await waitFor(() => expect(writeClipboard).toHaveBeenCalledWith('ok'))
+  })
+
+  it('searches beyond the first render window, toggles wrapping and dismisses', () => {
+    const onOpenChange = vi.fn()
+    const output = `${'a'.repeat(25_000)}far-away-match${'b'.repeat(25_000)}`
+
+    render(
+      <ToolDetailsDialog
+        inlineDiff=""
+        onOpenChange={onOpenChange}
+        open
+        part={{ result: { output }, toolName: 'terminal', type: 'tool-call' }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('tab', { name: 'stdout' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search selected section' }), {
+      target: { value: 'far-away-match' }
+    })
+
+    expect(screen.getByText('1/1')).toBeTruthy()
+    expect(screen.getByRole('tabpanel').textContent).toContain('far-away-match')
+
+    fireEvent.click(screen.getByRole('button', { name: 'No wrap' }))
+    expect(screen.getByRole('button', { name: 'Wrap' })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool/tool-details.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-details.tsx
@@ -14,7 +14,6 @@ import { cn } from '@/lib/utils'
 import { parseMaybeObject, type ToolPart } from './fallback-model'
 
 const DETAIL_WINDOW_CHARS = 20_000
-const MAX_SEARCH_MATCHES = 1_000
 
 export type ToolDetailSectionId = 'arguments' | 'command' | 'diff' | 'metadata' | 'result' | 'stderr' | 'stdout'
 
@@ -77,27 +76,22 @@ export function buildToolDetailSections(part: ToolPart, inlineDiff: string): Too
   return sections
 }
 
-export function findTextMatches(text: string, query: string): number[] {
-  const needle = query.toLocaleLowerCase()
+export interface TextMatch {
+  end: number
+  start: number
+}
 
-  if (!needle) {
+export function findTextMatches(text: string, query: string): TextMatch[] {
+  if (!query) {
     return []
   }
 
-  const haystack = text.toLocaleLowerCase()
-  const matches: number[] = []
-  let offset = 0
+  const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
-  while (matches.length < MAX_SEARCH_MATCHES) {
-    const index = haystack.indexOf(needle, offset)
-
-    if (index < 0) {
-      break
-    }
-
-    matches.push(index)
-    offset = index + Math.max(needle.length, 1)
-  }
+  const matches = Array.from(text.matchAll(new RegExp(escapedQuery, 'giu')), match => ({
+    end: match.index + match[0].length,
+    start: match.index
+  }))
 
   return matches
 }
@@ -122,7 +116,8 @@ export function ToolDetailsDialog({ inlineDiff, onOpenChange, open, part }: Tool
   const selected = sections.find(item => item.id === selectedId) ?? sections[0]!
   const matches = useMemo(() => findTextMatches(selected.copyText, query), [query, selected.copyText])
   const normalizedMatch = matches.length ? Math.min(activeMatch, matches.length - 1) : 0
-  const matchOffset = matches[normalizedMatch]
+  const match = matches[normalizedMatch]
+  const matchOffset = match?.start
   const maxWindowStart = Math.max(0, selected.copyText.length - DETAIL_WINDOW_CHARS)
 
   const searchStart =
@@ -135,7 +130,7 @@ export function ToolDetailsDialog({ inlineDiff, onOpenChange, open, part }: Tool
 
   const visibleText = selected.copyText.slice(visibleStart, visibleEnd)
   const visibleMatchOffset = matchOffset === undefined ? -1 : matchOffset - visibleStart
-  const visibleMatchLength = Math.min(query.length, visibleText.length - visibleMatchOffset)
+  const visibleMatchLength = Math.min(match ? match.end - match.start : 0, visibleText.length - visibleMatchOffset)
   const hasVisibleMatch = Boolean(query && visibleMatchOffset >= 0 && visibleMatchLength > 0)
   const hasMore = !query && visibleEnd < selected.copyText.length
 

--- a/apps/desktop/src/components/assistant-ui/tool/tool-details.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-details.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { CopyButton } from '@/components/ui/copy-button'
@@ -14,7 +14,6 @@ import { cn } from '@/lib/utils'
 import { parseMaybeObject, type ToolPart } from './fallback-model'
 
 const DETAIL_WINDOW_CHARS = 20_000
-const SEARCH_CONTEXT_CHARS = 2_000
 const MAX_SEARCH_MATCHES = 1_000
 
 export type ToolDetailSectionId = 'arguments' | 'command' | 'diff' | 'metadata' | 'result' | 'stderr' | 'stdout'
@@ -113,27 +112,44 @@ interface ToolDetailsDialogProps {
 export function ToolDetailsDialog({ inlineDiff, onOpenChange, open, part }: ToolDetailsDialogProps) {
   const { t } = useI18n()
   const copy = t.assistant.tool.details
-  const sections = useMemo(() => buildToolDetailSections(part, inlineDiff), [inlineDiff, part])
+  const [sections] = useState(() => buildToolDetailSections(part, inlineDiff))
   const [selectedId, setSelectedId] = useState<ToolDetailSectionId>('arguments')
   const [query, setQuery] = useState('')
   const [activeMatch, setActiveMatch] = useState(0)
   const [wrap, setWrap] = useState(true)
-  const [visibleChars, setVisibleChars] = useState(DETAIL_WINDOW_CHARS)
+  const [windowStart, setWindowStart] = useState(0)
+  const activeMatchRef = useRef<HTMLElement>(null)
   const selected = sections.find(item => item.id === selectedId) ?? sections[0]!
   const matches = useMemo(() => findTextMatches(selected.copyText, query), [query, selected.copyText])
   const normalizedMatch = matches.length ? Math.min(activeMatch, matches.length - 1) : 0
   const matchOffset = matches[normalizedMatch]
-  const searchStart = matchOffset === undefined ? 0 : Math.max(0, matchOffset - SEARCH_CONTEXT_CHARS)
-  const searchEnd = Math.min(selected.copyText.length, searchStart + DETAIL_WINDOW_CHARS)
-  const visibleText = query ? selected.copyText.slice(searchStart, searchEnd) : selected.copyText.slice(0, visibleChars)
-  const hasMore = !query && visibleChars < selected.copyText.length
+  const maxWindowStart = Math.max(0, selected.copyText.length - DETAIL_WINDOW_CHARS)
+
+  const searchStart =
+    matchOffset === undefined
+      ? windowStart
+      : Math.min(maxWindowStart, Math.max(0, matchOffset - Math.floor(DETAIL_WINDOW_CHARS / 2)))
+
+  const visibleStart = query ? searchStart : windowStart
+  const visibleEnd = Math.min(selected.copyText.length, visibleStart + DETAIL_WINDOW_CHARS)
+
+  const visibleText = selected.copyText.slice(visibleStart, visibleEnd)
+  const visibleMatchOffset = matchOffset === undefined ? -1 : matchOffset - visibleStart
+  const visibleMatchLength = Math.min(query.length, visibleText.length - visibleMatchOffset)
+  const hasVisibleMatch = Boolean(query && visibleMatchOffset >= 0 && visibleMatchLength > 0)
+  const hasMore = !query && visibleEnd < selected.copyText.length
+
   const sectionLabel = (id: ToolDetailSectionId) => copy.sections[id]
+
+  useEffect(() => {
+    activeMatchRef.current?.scrollIntoView?.({ block: 'center', inline: 'center' })
+  }, [normalizedMatch, query, selected.id])
 
   const chooseSection = (id: ToolDetailSectionId) => {
     setSelectedId(id)
     setQuery('')
     setActiveMatch(0)
-    setVisibleChars(DETAIL_WINDOW_CHARS)
+    setWindowStart(0)
   }
 
   return (
@@ -186,7 +202,7 @@ export function ToolDetailsDialog({ inlineDiff, onOpenChange, open, part }: Tool
                 type="button"
                 variant="ghost"
               >
-                <ChevronLeft className="size-3.5" />
+                <ChevronLeft />
               </Button>
               <Button
                 aria-label={copy.nextMatch}
@@ -196,7 +212,7 @@ export function ToolDetailsDialog({ inlineDiff, onOpenChange, open, part }: Tool
                 type="button"
                 variant="ghost"
               >
-                <ChevronRight className="size-3.5" />
+                <ChevronRight />
               </Button>
               <Button onClick={() => setWrap(value => !value)} size="xs" type="button" variant="ghost">
                 {wrap ? copy.unwrap : copy.wrap}
@@ -220,7 +236,21 @@ export function ToolDetailsDialog({ inlineDiff, onOpenChange, open, part }: Tool
                   wrap ? 'whitespace-pre-wrap break-words' : 'whitespace-pre break-normal'
                 )}
               >
-                {visibleText}
+                {hasVisibleMatch ? (
+                  <>
+                    {visibleText.slice(0, visibleMatchOffset)}
+                    <mark
+                      className="bg-(--ui-row-active-background) text-inherit"
+                      data-match-offset={matchOffset}
+                      ref={activeMatchRef}
+                    >
+                      {visibleText.slice(visibleMatchOffset, visibleMatchOffset + visibleMatchLength)}
+                    </mark>
+                    {visibleText.slice(visibleMatchOffset + visibleMatchLength)}
+                  </>
+                ) : (
+                  visibleText
+                )}
               </LogView>
             )}
           </div>
@@ -228,12 +258,12 @@ export function ToolDetailsDialog({ inlineDiff, onOpenChange, open, part }: Tool
             <span>{copy.receivedPayload}</span>
             {hasMore ? (
               <Button
-                onClick={() => setVisibleChars(value => value + DETAIL_WINDOW_CHARS)}
+                onClick={() => setWindowStart(value => value + DETAIL_WINDOW_CHARS)}
                 size="xs"
                 type="button"
                 variant="ghost"
               >
-                {copy.loadMore}
+                {copy.nextChunk}
               </Button>
             ) : null}
           </div>

--- a/apps/desktop/src/components/assistant-ui/tool/tool-details.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-details.tsx
@@ -1,0 +1,244 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { CopyButton } from '@/components/ui/copy-button'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { LogView } from '@/components/ui/log-view'
+import { SearchField } from '@/components/ui/search-field'
+import { useI18n } from '@/i18n'
+import { ChevronLeft, ChevronRight } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+
+import { parseMaybeObject, type ToolPart } from './fallback-model'
+
+const DETAIL_WINDOW_CHARS = 20_000
+const SEARCH_CONTEXT_CHARS = 2_000
+const MAX_SEARCH_MATCHES = 1_000
+
+export type ToolDetailSectionId = 'arguments' | 'command' | 'diff' | 'metadata' | 'result' | 'stderr' | 'stdout'
+
+export interface ToolDetailSection {
+  copyText: string
+  id: ToolDetailSectionId
+  state: 'empty' | 'present' | 'unavailable'
+}
+
+function serializeAvailableValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  const serialized = JSON.stringify(value, null, 2)
+
+  return serialized === undefined ? String(value) : serialized
+}
+
+function section(id: ToolDetailSectionId, supplied: boolean, value: unknown): ToolDetailSection {
+  if (!supplied) {
+    return { copyText: '', id, state: 'unavailable' }
+  }
+
+  const copyText = serializeAvailableValue(value)
+
+  return { copyText, id, state: copyText.length === 0 ? 'empty' : 'present' }
+}
+
+function own(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key)
+}
+
+/** Build full-fidelity sections only when the inspector is mounted. */
+export function buildToolDetailSections(part: ToolPart, inlineDiff: string): ToolDetailSection[] {
+  const args = parseMaybeObject(part.args)
+  const result = parseMaybeObject(part.result)
+  const commandKey = own(args, 'command') ? 'command' : own(args, 'code') ? 'code' : null
+  const stdoutKey = own(result, 'stdout') ? 'stdout' : own(result, 'output') ? 'output' : null
+  const diffKey = own(result, 'inline_diff') ? 'inline_diff' : own(result, 'diff') ? 'diff' : null
+
+  const metadata = {
+    toolName: part.toolName,
+    ...(part.toolCallId === undefined ? {} : { toolCallId: part.toolCallId }),
+    ...(part.isError === undefined ? {} : { isError: part.isError }),
+    ...(part.timestamp === undefined ? {} : { timestamp: part.timestamp }),
+    ...(part.completedAt === undefined ? {} : { completedAt: part.completedAt })
+  }
+
+  const sections = [
+    section('arguments', part.args !== undefined, part.args),
+    ...(commandKey ? [section('command', true, args[commandKey])] : []),
+    section('result', part.result !== undefined, part.result),
+    ...(stdoutKey ? [section('stdout', true, result[stdoutKey])] : []),
+    ...(own(result, 'stderr') ? [section('stderr', true, result.stderr)] : []),
+    ...(inlineDiff || diffKey ? [section('diff', true, inlineDiff || (diffKey ? result[diffKey] : ''))] : []),
+    section('metadata', true, metadata)
+  ]
+
+  return sections
+}
+
+export function findTextMatches(text: string, query: string): number[] {
+  const needle = query.toLocaleLowerCase()
+
+  if (!needle) {
+    return []
+  }
+
+  const haystack = text.toLocaleLowerCase()
+  const matches: number[] = []
+  let offset = 0
+
+  while (matches.length < MAX_SEARCH_MATCHES) {
+    const index = haystack.indexOf(needle, offset)
+
+    if (index < 0) {
+      break
+    }
+
+    matches.push(index)
+    offset = index + Math.max(needle.length, 1)
+  }
+
+  return matches
+}
+
+interface ToolDetailsDialogProps {
+  inlineDiff: string
+  onOpenChange: (open: boolean) => void
+  open: boolean
+  part: ToolPart
+}
+
+export function ToolDetailsDialog({ inlineDiff, onOpenChange, open, part }: ToolDetailsDialogProps) {
+  const { t } = useI18n()
+  const copy = t.assistant.tool.details
+  const sections = useMemo(() => buildToolDetailSections(part, inlineDiff), [inlineDiff, part])
+  const [selectedId, setSelectedId] = useState<ToolDetailSectionId>('arguments')
+  const [query, setQuery] = useState('')
+  const [activeMatch, setActiveMatch] = useState(0)
+  const [wrap, setWrap] = useState(true)
+  const [visibleChars, setVisibleChars] = useState(DETAIL_WINDOW_CHARS)
+  const selected = sections.find(item => item.id === selectedId) ?? sections[0]!
+  const matches = useMemo(() => findTextMatches(selected.copyText, query), [query, selected.copyText])
+  const normalizedMatch = matches.length ? Math.min(activeMatch, matches.length - 1) : 0
+  const matchOffset = matches[normalizedMatch]
+  const searchStart = matchOffset === undefined ? 0 : Math.max(0, matchOffset - SEARCH_CONTEXT_CHARS)
+  const searchEnd = Math.min(selected.copyText.length, searchStart + DETAIL_WINDOW_CHARS)
+  const visibleText = query ? selected.copyText.slice(searchStart, searchEnd) : selected.copyText.slice(0, visibleChars)
+  const hasMore = !query && visibleChars < selected.copyText.length
+  const sectionLabel = (id: ToolDetailSectionId) => copy.sections[id]
+
+  const chooseSection = (id: ToolDetailSectionId) => {
+    setSelectedId(id)
+    setQuery('')
+    setActiveMatch(0)
+    setVisibleChars(DETAIL_WINDOW_CHARS)
+  }
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent bodyClassName="overflow-hidden" className="h-[min(42rem,85vh)] max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>{copy.title(part.toolName)}</DialogTitle>
+          <DialogDescription>{copy.description}</DialogDescription>
+        </DialogHeader>
+        <div className="flex min-h-0 flex-1 flex-col gap-2">
+          <div aria-label={copy.sectionsLabel} className="flex shrink-0 gap-1 overflow-x-auto" role="tablist">
+            {sections.map(item => (
+              <Button
+                aria-selected={selected.id === item.id}
+                key={item.id}
+                onClick={() => chooseSection(item.id)}
+                role="tab"
+                size="xs"
+                type="button"
+                variant={selected.id === item.id ? 'secondary' : 'ghost'}
+              >
+                {sectionLabel(item.id)}
+              </Button>
+            ))}
+          </div>
+          <div className="flex shrink-0 flex-wrap items-center justify-between gap-2">
+            <SearchField
+              aria-label={copy.searchPlaceholder}
+              containerClassName="min-w-48 flex-1"
+              onChange={value => {
+                setQuery(value)
+                setActiveMatch(0)
+              }}
+              placeholder={copy.searchPlaceholder}
+              trailingAction={
+                query ? (
+                  <span className="shrink-0 text-[0.65rem] tabular-nums text-(--ui-text-tertiary)">
+                    {matches.length ? `${normalizedMatch + 1}/${matches.length}` : '0/0'}
+                  </span>
+                ) : null
+              }
+              value={query}
+            />
+            <div className="flex items-center gap-1">
+              <Button
+                aria-label={copy.previousMatch}
+                disabled={!matches.length}
+                onClick={() => setActiveMatch((normalizedMatch - 1 + matches.length) % matches.length)}
+                size="icon-xs"
+                type="button"
+                variant="ghost"
+              >
+                <ChevronLeft className="size-3.5" />
+              </Button>
+              <Button
+                aria-label={copy.nextMatch}
+                disabled={!matches.length}
+                onClick={() => setActiveMatch((normalizedMatch + 1) % matches.length)}
+                size="icon-xs"
+                type="button"
+                variant="ghost"
+              >
+                <ChevronRight className="size-3.5" />
+              </Button>
+              <Button onClick={() => setWrap(value => !value)} size="xs" type="button" variant="ghost">
+                {wrap ? copy.unwrap : copy.wrap}
+              </Button>
+              <CopyButton
+                disabled={selected.state !== 'present'}
+                label={copy.copySection(sectionLabel(selected.id))}
+                text={selected.copyText}
+              />
+            </div>
+          </div>
+          <div className="min-h-0 flex-1" role="tabpanel">
+            {selected.state === 'unavailable' ? (
+              <div className="grid h-full place-items-center text-sm text-(--ui-text-tertiary)">{copy.unavailable}</div>
+            ) : selected.state === 'empty' ? (
+              <div className="grid h-full place-items-center text-sm text-(--ui-text-tertiary)">{copy.empty}</div>
+            ) : (
+              <LogView
+                className={cn(
+                  'h-full max-h-none overflow-auto text-(--ui-text-secondary)',
+                  wrap ? 'whitespace-pre-wrap break-words' : 'whitespace-pre break-normal'
+                )}
+              >
+                {visibleText}
+              </LogView>
+            )}
+          </div>
+          <div className="flex shrink-0 items-center justify-between gap-2 text-[0.65rem] text-(--ui-text-tertiary)">
+            <span>{copy.receivedPayload}</span>
+            {hasMore ? (
+              <Button
+                onClick={() => setVisibleChars(value => value + DETAIL_WINDOW_CHARS)}
+                size="xs"
+                type="button"
+                variant="ghost"
+              >
+                {copy.loadMore}
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2803,7 +2803,7 @@ export const ar = defineLocale({
         unavailable: 'غير متوفر',
         empty: 'متوفر، لكنه فارغ',
         receivedPayload: 'هذه هي الحمولة التي استلمها تطبيق سطح المكتب.',
-        loadMore: 'تحميل المزيد',
+        nextChunk: 'المقطع التالي',
         sections: {
           arguments: 'الوسائط',
           command: 'الأمر',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2788,6 +2788,32 @@ export const ar = defineLocale({
       questionProgress: (answered, total) => `تمت الإجابة على ${answered} من ${total}`
     },
     tool: {
+      detailsAction: 'التفاصيل',
+      details: {
+        title: toolName => `تفاصيل ${toolName}`,
+        description:
+          'افحص الحمولة الكاملة التي استلمها تطبيق سطح المكتب. لا يمكن استعادة المحتوى المقتطع في الخلفية أو غير المحفوظ.',
+        sectionsLabel: 'أقسام حمولة الأداة',
+        searchPlaceholder: 'البحث في القسم المحدد',
+        previousMatch: 'المطابقة السابقة',
+        nextMatch: 'المطابقة التالية',
+        wrap: 'التفاف النص',
+        unwrap: 'بدون التفاف',
+        copySection: label => `نسخ ${label}`,
+        unavailable: 'غير متوفر',
+        empty: 'متوفر، لكنه فارغ',
+        receivedPayload: 'هذه هي الحمولة التي استلمها تطبيق سطح المكتب.',
+        loadMore: 'تحميل المزيد',
+        sections: {
+          arguments: 'الوسائط',
+          command: 'الأمر',
+          diff: 'الفروقات',
+          metadata: 'البيانات الوصفية',
+          result: 'النتيجة',
+          stderr: 'الخطأ القياسي',
+          stdout: 'الإخراج القياسي'
+        }
+      },
       copyCode: 'نسخ الكود',
       renderingImage: 'جار عرض الصورة...',
       copyOutput: 'نسخ الإخراج',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3695,6 +3695,32 @@ export const en: Translations = {
       gatewayDisconnected: 'Hermes gateway is not connected'
     },
     tool: {
+      detailsAction: 'Details',
+      details: {
+        title: toolName => `${toolName} details`,
+        description:
+          'Inspect the complete payload available to Desktop. Backend-truncated or unsaved content cannot be recovered here.',
+        sectionsLabel: 'Tool payload sections',
+        searchPlaceholder: 'Search selected section',
+        previousMatch: 'Previous match',
+        nextMatch: 'Next match',
+        wrap: 'Wrap',
+        unwrap: 'No wrap',
+        copySection: label => `Copy ${label.toLowerCase()}`,
+        unavailable: 'Not provided',
+        empty: 'Provided, but empty',
+        receivedPayload: 'This is the payload Desktop received.',
+        loadMore: 'Load more',
+        sections: {
+          arguments: 'Arguments',
+          command: 'Command',
+          diff: 'Diff',
+          metadata: 'Metadata',
+          result: 'Result',
+          stderr: 'stderr',
+          stdout: 'stdout'
+        }
+      },
       copyCode: 'Copy code',
       renderingImage: 'Rendering image',
       copyOutput: 'Copy output',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3710,7 +3710,7 @@ export const en: Translations = {
         unavailable: 'Not provided',
         empty: 'Provided, but empty',
         receivedPayload: 'This is the payload Desktop received.',
-        loadMore: 'Load more',
+        nextChunk: 'Next chunk',
         sections: {
           arguments: 'Arguments',
           command: 'Command',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -3245,6 +3245,32 @@ export const ja = defineLocale({
       lateAnswerHint: 'この質問はもう回答を待っていません。選択肢を選ぶとフォローアップメッセージとして下書きされます。'
     },
     tool: {
+      detailsAction: '詳細',
+      details: {
+        title: toolName => `${toolName} の詳細`,
+        description:
+          'Desktop が受信した完全なペイロードを確認します。バックエンドで切り詰められた、または保存されなかった内容は復元できません。',
+        sectionsLabel: 'ツールペイロードのセクション',
+        searchPlaceholder: '選択したセクションを検索',
+        previousMatch: '前の一致',
+        nextMatch: '次の一致',
+        wrap: '折り返す',
+        unwrap: '折り返さない',
+        copySection: label => `${label}をコピー`,
+        unavailable: '提供されていません',
+        empty: '提供されていますが空です',
+        receivedPayload: 'これは Desktop が受信したペイロードです。',
+        loadMore: 'さらに読み込む',
+        sections: {
+          arguments: '引数',
+          command: 'コマンド',
+          diff: '差分',
+          metadata: 'メタデータ',
+          result: '結果',
+          stderr: '標準エラー',
+          stdout: '標準出力'
+        }
+      },
       copyCode: 'コードをコピー',
       renderingImage: '画像をレンダリング中',
       copyOutput: '出力をコピー',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -3260,7 +3260,7 @@ export const ja = defineLocale({
         unavailable: '提供されていません',
         empty: '提供されていますが空です',
         receivedPayload: 'これは Desktop が受信したペイロードです。',
-        loadMore: 'さらに読み込む',
+        nextChunk: '次の範囲',
         sections: {
           arguments: '引数',
           command: 'コマンド',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -3642,7 +3642,7 @@ export const ru = defineLocale({
         unavailable: 'Не предоставлено',
         empty: 'Предоставлено, но пусто',
         receivedPayload: 'Это данные, полученные Desktop.',
-        loadMore: 'Загрузить ещё',
+        nextChunk: 'Следующий фрагмент',
         sections: {
           arguments: 'Аргументы',
           command: 'Команда',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -3627,6 +3627,32 @@ export const ru = defineLocale({
       gatewayDisconnected: 'Шлюз Hermes не подключён'
     },
     tool: {
+      detailsAction: 'Подробности',
+      details: {
+        title: toolName => `Подробности: ${toolName}`,
+        description:
+          'Просмотр полного пакета данных, полученного Desktop. Усечённые сервером или несохранённые данные восстановить нельзя.',
+        sectionsLabel: 'Разделы данных инструмента',
+        searchPlaceholder: 'Поиск в выбранном разделе',
+        previousMatch: 'Предыдущее совпадение',
+        nextMatch: 'Следующее совпадение',
+        wrap: 'Переносить',
+        unwrap: 'Без переноса',
+        copySection: label => `Копировать: ${label}`,
+        unavailable: 'Не предоставлено',
+        empty: 'Предоставлено, но пусто',
+        receivedPayload: 'Это данные, полученные Desktop.',
+        loadMore: 'Загрузить ещё',
+        sections: {
+          arguments: 'Аргументы',
+          command: 'Команда',
+          diff: 'Изменения',
+          metadata: 'Метаданные',
+          result: 'Результат',
+          stderr: 'stderr',
+          stdout: 'stdout'
+        }
+      },
       copyCode: 'Копировать код',
       renderingImage: 'Рендеринг изображения',
       copyOutput: 'Копировать вывод',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -3227,6 +3227,31 @@ export interface Translations {
       gatewayDisconnected: string
     }
     tool: {
+      detailsAction: string
+      details: {
+        title: (toolName: string) => string
+        description: string
+        sectionsLabel: string
+        searchPlaceholder: string
+        previousMatch: string
+        nextMatch: string
+        wrap: string
+        unwrap: string
+        copySection: (label: string) => string
+        unavailable: string
+        empty: string
+        receivedPayload: string
+        loadMore: string
+        sections: {
+          arguments: string
+          command: string
+          diff: string
+          metadata: string
+          result: string
+          stderr: string
+          stdout: string
+        }
+      }
       copyCode: string
       renderingImage: string
       copyOutput: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -3241,7 +3241,7 @@ export interface Translations {
         unavailable: string
         empty: string
         receivedPayload: string
-        loadMore: string
+        nextChunk: string
         sections: {
           arguments: string
           command: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -3134,6 +3134,31 @@ export const zhHant = defineLocale({
       lateAnswerHint: '此問題已不再等待回答。選擇一個選項會將其起草為後續訊息。'
     },
     tool: {
+      detailsAction: '詳細資料',
+      details: {
+        title: toolName => `${toolName} 詳細資料`,
+        description: '檢查桌面端收到的完整承載內容。後端已截斷或未儲存的內容無法在此復原。',
+        sectionsLabel: '工具承載內容區段',
+        searchPlaceholder: '搜尋所選區段',
+        previousMatch: '上一個相符項目',
+        nextMatch: '下一個相符項目',
+        wrap: '自動換行',
+        unwrap: '不換行',
+        copySection: label => `複製${label}`,
+        unavailable: '未提供',
+        empty: '已提供，但為空',
+        receivedPayload: '這是桌面端收到的承載內容。',
+        loadMore: '載入更多',
+        sections: {
+          arguments: '引數',
+          command: '指令',
+          diff: '差異',
+          metadata: '中繼資料',
+          result: '結果',
+          stderr: '標準錯誤',
+          stdout: '標準輸出'
+        }
+      },
       copyCode: '複製程式碼',
       renderingImage: '正在渲染圖片',
       copyOutput: '複製輸出',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -3148,7 +3148,7 @@ export const zhHant = defineLocale({
         unavailable: '未提供',
         empty: '已提供，但為空',
         receivedPayload: '這是桌面端收到的承載內容。',
-        loadMore: '載入更多',
+        nextChunk: '下一段',
         sections: {
           arguments: '引數',
           command: '指令',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3830,6 +3830,31 @@ export const zh: Translations = {
       gatewayDisconnected: 'Hermes 网关未连接'
     },
     tool: {
+      detailsAction: '详情',
+      details: {
+        title: toolName => `${toolName} 详情`,
+        description: '检查桌面端收到的完整载荷。后端已截断或未保存的内容无法在此恢复。',
+        sectionsLabel: '工具载荷分区',
+        searchPlaceholder: '搜索所选分区',
+        previousMatch: '上一个匹配项',
+        nextMatch: '下一个匹配项',
+        wrap: '自动换行',
+        unwrap: '不换行',
+        copySection: label => `复制${label}`,
+        unavailable: '未提供',
+        empty: '已提供，但为空',
+        receivedPayload: '这是桌面端收到的载荷。',
+        loadMore: '加载更多',
+        sections: {
+          arguments: '参数',
+          command: '命令',
+          diff: '差异',
+          metadata: '元数据',
+          result: '结果',
+          stderr: '标准错误',
+          stdout: '标准输出'
+        }
+      },
       copyCode: '复制代码',
       renderingImage: '正在渲染图片',
       copyOutput: '复制输出',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3844,7 +3844,7 @@ export const zh: Translations = {
         unavailable: '未提供',
         empty: '已提供，但为空',
         receivedPayload: '这是桌面端收到的载荷。',
-        loadMore: '加载更多',
+        nextChunk: '下一段',
         sections: {
           arguments: '参数',
           command: '命令',


### PR DESCRIPTION
## What does this PR do?

Adds an on-demand Desktop inspector for the complete tool payload that reached the renderer. Users can inspect arguments, results, metadata, commands, stdout, stderr, and diffs independently without expanding the compact chat row into an unbounded render.

### Motivation

Desktop currently caps inline tool details at 20,000 characters and combines technical arguments with results before truncation. That can hide a result behind large arguments, while the compact Copy action may choose a command, path, or summary instead of the exact output the user wants.

### Behavior

- Normal-mode expanded tool rows now expose a Details action.
- The dialog separates available arguments, result, metadata, command, stdout, stderr, and diff payloads.
- Search runs against the full selected section, including content beyond the inline limit, while rendering remains bounded to 20,000-character windows.
- Wrapping can be toggled and the selected section can be copied exactly.
- Missing and explicitly empty values are presented differently.
- The dialog states that it shows the payload Desktop received and cannot recover backend-truncated or unsaved content.

### Implementation

The inspector is mounted only when opened, so full payload serialization stays off the streaming and collapsed-row hot paths. It reuses the shared Dialog, SearchField, CopyButton, and LogView primitives, with copy added to all shipped locales.

## Related Issue

Closes #107269

## Type of Change

- [x] New feature

## Changes Made

- `apps/desktop/src/components/assistant-ui/tool/tool-details.tsx` - add lazy section extraction, bounded full-text search, wrapping, exact copy, and dialog UI.
- `apps/desktop/src/components/assistant-ui/tool/fallback.tsx` - expose the normal-mode Details action.
- `apps/desktop/src/i18n/` - localize inspector controls and payload states.
- `apps/desktop/src/components/assistant-ui/tool/tool-details.test.tsx` - cover full payload sections, long-result search, short-output copy, wrapping, and dismissal.

## How to Test

1. Expand a completed tool row in normal mode and open Details.
2. Switch among Arguments, Result, Metadata, and any specialized sections; search for content after the first 20,000 characters, toggle wrapping, copy the selected section, and close the dialog.
3. Run:

```bash
cd apps/desktop
npx vitest run --project ui src/components/assistant-ui/tool/tool-details.test.tsx src/components/assistant-ui/tool/fallback.test.ts src/components/assistant-ui/tool/fallback-model.test.ts
npm run check:lint
```

Result: 50 targeted tests passed; typecheck and lint completed with no errors. Existing repository lint warnings remain unchanged.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the relevant Desktop test suite and all targeted tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; the UI is self-describing and localized
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] I've considered Windows and macOS impact; this is renderer-only behavior using shared primitives
- [x] Tool description and schema updates are N/A; no tool behavior changed

## Screenshots / Logs

N/A
