### PR TITLE
feat(desktop): inspect complete available tool inputs and results

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -9,6 +9,7 @@ import { ThreadTimeline } from '@/components/assistant-ui/thread/timeline'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
 import { UserEditComposer } from '@/components/assistant-ui/thread/user-edit-composer'
 import { UserMessage } from '@/components/assistant-ui/thread/user-message'
+import { ToolInspectionProvider } from '@/components/assistant-ui/tool/tool-inspection'
 import { Intro, type IntroProps } from '@/components/chat/intro'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import type { HermesGateway } from '@/hermes'
@@ -169,27 +170,29 @@ export const Thread = memo(function Thread({
 
   return (
     <ThreadEditContext.Provider value={editContext}>
-      <div className="relative grid h-full min-h-0 max-w-full grid-rows-[minmax(0,1fr)] overflow-hidden bg-transparent contain-[layout_paint]">
-        <ThreadMessageList
-          clampToComposer={clampToComposer}
-          components={messageComponents}
-          emptyPlaceholder={emptyPlaceholder}
-          loadingIndicator={loadingIndicator}
-          sessionId={sessionId}
-          sessionKey={sessionKey}
-        />
-        {loading === 'session' && <CenteredThreadSpinner />}
-        <ThreadTimeline />
-        <ConfirmDialog
-          confirmLabel={copy.restoreConfirm}
-          description={copy.restoreBody}
-          destructive
-          onClose={closeRestoreConfirm}
-          onConfirm={confirmRestore}
-          open={Boolean(restoreConfirmTarget)}
-          title={copy.restoreTitle}
-        />
-      </div>
+      <ToolInspectionProvider scope={editContext}>
+        <div className="relative grid h-full min-h-0 max-w-full grid-rows-[minmax(0,1fr)] overflow-hidden bg-transparent contain-[layout_paint]">
+          <ThreadMessageList
+            clampToComposer={clampToComposer}
+            components={messageComponents}
+            emptyPlaceholder={emptyPlaceholder}
+            loadingIndicator={loadingIndicator}
+            sessionId={sessionId}
+            sessionKey={sessionKey}
+          />
+          {loading === 'session' && <CenteredThreadSpinner />}
+          <ThreadTimeline />
+          <ConfirmDialog
+            confirmLabel={copy.restoreConfirm}
+            description={copy.restoreBody}
+            destructive
+            onClose={closeRestoreConfirm}
+            onConfirm={confirmRestore}
+            open={Boolean(restoreConfirmTarget)}
+            title={copy.restoreTitle}
+          />
+        </div>
+      </ToolInspectionProvider>
     </ThreadEditContext.Provider>
   )
 })

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -429,8 +429,8 @@ describe('clampForDisplay', () => {
 
     expect(clamped.length).toBeLessThan(oversized.length)
     expect(clamped.startsWith('x'.repeat(MAX_TOOL_RENDER_CHARS))).toBe(true)
-    expect(clamped).toContain('5,000 more characters truncated')
-    expect(clamped).toContain('Copy')
+    expect(clamped).toContain('5,000 more characters hidden in this preview')
+    expect(clamped).toContain('open tool details')
   })
 })
 
@@ -444,7 +444,7 @@ describe('prettyJson caps serialized result size', () => {
     const out = prettyJson({ content: huge })
 
     expect(out.length).toBeLessThanOrEqual(MAX_TOOL_RENDER_CHARS + 200)
-    expect(out).toContain('truncated')
+    expect(out).toContain('hidden in this preview')
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/format.ts
@@ -1,3 +1,5 @@
+import { translateNow } from '@/i18n'
+
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
 }
@@ -66,7 +68,7 @@ export function contextValue(value: unknown): string {
 // Each tool result is server-capped (~100KB), but a turn over a big directory
 // stacks many rows; painting/serializing them all floods the renderer (freeze,
 // then OOM). Clamp every inline-painted payload to a bounded slice — the row's
-// Copy button still reads the uncapped `view.detail` for the full output.
+// inspector provides the complete available payload separately.
 export const MAX_TOOL_RENDER_CHARS = 20_000
 
 export function clampForDisplay(value: string, max = MAX_TOOL_RENDER_CHARS): string {
@@ -76,7 +78,7 @@ export function clampForDisplay(value: string, max = MAX_TOOL_RENDER_CHARS): str
 
   const omitted = value.length - max
 
-  return `${value.slice(0, max)}\n\n… ${omitted.toLocaleString()} more characters truncated — use Copy for the full output.`
+  return `${value.slice(0, max)}\n\n… ${translateNow('assistant.tool.inspector.previewLimit', omitted)}`
 }
 
 export function prettyJson(value: unknown): string {

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model/index.ts
@@ -1191,6 +1191,26 @@ export function toolCopyPayload(part: ToolPart, view: ToolView): { label: string
   const args = parseMaybeObject(part.args)
   const result = parseMaybeObject(part.result)
   const detail = view.detail.trim()
+
+  // Copy an explicitly supplied stream/file body verbatim, even when short or
+  // empty. Length is never evidence that a command/path is the right payload.
+  const outputKeys =
+    part.toolName === 'terminal' || part.toolName === 'execute_code'
+      ? ['output', 'stdout', 'stderr']
+      : part.toolName === 'read_file'
+        ? ['content', 'text', 'data', 'body']
+        : []
+
+  for (const key of outputKeys) {
+    if (typeof result[key] === 'string') {
+      return { label: part.toolName === 'read_file' ? copy.file : copy.output, text: result[key] }
+    }
+  }
+
+  if (outputKeys.length && typeof part.result === 'string' && !Object.keys(result).length) {
+    return { label: part.toolName === 'read_file' ? copy.file : copy.output, text: part.result }
+  }
+
   const hasSubstantialOutput = detail.length > 16
 
   if (part.toolName === 'terminal' || part.toolName === 'execute_code') {

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -74,6 +74,7 @@ import {
 } from './fallback-model'
 import { isToolCallPart, summarizeToolRun } from './run-summary'
 import { ToolRunTicker } from './run-ticker'
+import { ToolInspectionButton } from './tool-inspection'
 
 // `true` when a ToolEntry is rendered inside an embedding wrapper that owns
 // the per-row chrome (timer / preview). The flat ToolGroupSlot sets this
@@ -505,41 +506,39 @@ function ToolEntry({ part }: ToolEntryProps) {
   // a completed/failed row that would otherwise sit at the tail of the chat.
   // It goes in the in-flow `action` slot (not `trailing`) so it can't overlap
   // the disclosure caret's hit-target — see the comment above `trailing`.
-  const dismissAction = canDismiss ? (
-    <Tip label={statusCopy.dismiss}>
-      <Button
-        aria-label={statusCopy.dismiss}
-        className={cn(
-          'size-5 rounded-md text-(--ui-text-tertiary) transition-opacity hover:text-(--ui-text-primary) hover:opacity-100',
-          open
-            ? 'opacity-80'
-            : 'opacity-0 group-hover/disclosure-row:opacity-80 group-focus-within/disclosure-row:opacity-80'
-        )}
-        onClick={event => {
-          event.stopPropagation()
-          dismissToolRow(disclosureId)
-        }}
-        size="icon-xs"
-        type="button"
-        variant="ghost"
-      >
-        <Codicon name="close" size="0.75rem" />
-      </Button>
-    </Tip>
-  ) : undefined
+  const dismissAction = (
+    <>
+      <ToolInspectionButton inlineDiff={inlineDiff} part={stablePart} />
+      {canDismiss ? (
+        <Tip label={statusCopy.dismiss}>
+          <Button
+            aria-label={statusCopy.dismiss}
+            className={cn(
+              'size-5 rounded-md text-(--ui-text-tertiary) transition-opacity hover:text-(--ui-text-primary) hover:opacity-100',
+              open
+                ? 'opacity-80'
+                : 'opacity-0 group-hover/disclosure-row:opacity-80 group-focus-within/disclosure-row:opacity-80'
+            )}
+            onClick={event => {
+              event.stopPropagation()
+              dismissToolRow(disclosureId)
+            }}
+            size="icon-xs"
+            type="button"
+            variant="ghost"
+          >
+            <Codicon name="close" size="0.75rem" />
+          </Button>
+        </Tip>
+      ) : null}
+    </>
+  )
 
   if (dismissed) {
     return null
   }
 
-  // A completed file edit with no diff to review is a bare, unexpandable row.
-  // This is almost always a `write_file` create after a reload: only `patch`
-  // persists its diff in the tool result, so creates rehydrate diff-less and
-  // read like dead duplicates of the real diff row. Hide them — but keep
-  // in-flight writes (activity) and failures (errors) visible.
-  if (isFileEdit && !isPending && view.status !== 'error' && !view.inlineDiff) {
-    return null
-  }
+  // Even without a saved diff, the operation has inspectable args/result.
 
   return (
     <div

--- a/apps/desktop/src/components/assistant-ui/tool/tool-inspection-dialog.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-inspection-dialog.tsx
@@ -1,0 +1,184 @@
+import { useMemo, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { CopyButton } from '@/components/ui/copy-button'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { LogView } from '@/components/ui/log-view'
+import { SearchField } from '@/components/ui/search-field'
+import { SegmentedControl } from '@/components/ui/segmented-control'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+
+import type { ToolPart } from './fallback-model/types'
+import {
+  INSPECTION_PAGE_CHARS,
+  type InspectionSection,
+  type InspectionSectionId,
+  inspectionSections,
+  inspectionText,
+  inspectionWindow
+} from './tool-inspection-model'
+
+function InspectionText({ section }: { section: InspectionSection }) {
+  const { t } = useI18n()
+  const copy = t.assistant.tool.inspector
+  const text = useMemo(() => inspectionText(section.value), [section.value])
+  const [offset, setOffset] = useState(0)
+  const [query, setQuery] = useState('')
+  const [match, setMatch] = useState(-1)
+  const [wrap, setWrap] = useState(true)
+  const shown = inspectionWindow(text ?? '', offset)
+
+  // Search is literal and case-sensitive, over the entire selected payload,
+  // not merely the displayed page. No regex execution on untrusted strings.
+  function find(value: string, from = 0, backwards = false) {
+    setQuery(value)
+
+    const index =
+      !value || text === undefined ? -1 : backwards ? text.lastIndexOf(value, from) : text.indexOf(value, from)
+
+    setMatch(index)
+
+    if (index >= 0) {
+      setOffset(Math.max(0, index - 200))
+    }
+  }
+
+  const unavailable = text === undefined
+  const empty = text === ''
+  const highlightStart = Math.max(0, match - shown.start)
+  const highlightEnd = Math.min(shown.text.length, match + query.length - shown.start)
+  const highlighted = query && match >= shown.start && match < shown.end
+
+  return (
+    <div className="grid min-h-0 min-w-0 gap-2">
+      <div className="flex min-w-0 flex-wrap items-center gap-2">
+        <SearchField aria-label={copy.search} onChange={value => find(value)} placeholder={copy.search} value={query} />
+        <Button
+          disabled={!query || match <= 0 || text === undefined || text.lastIndexOf(query, match - 1) < 0}
+          onClick={() => find(query, match - 1, true)}
+          size="sm"
+          variant="ghost"
+        >
+          {copy.previousMatch}
+        </Button>
+        <Button
+          disabled={!query || text === undefined || text.indexOf(query, Math.max(0, match + 1)) < 0}
+          onClick={() => find(query, Math.max(0, match + 1))}
+          size="sm"
+          variant="ghost"
+        >
+          {copy.nextMatch}
+        </Button>
+        <Button aria-pressed={wrap} onClick={() => setWrap(value => !value)} size="sm" variant="ghost">
+          {copy.wrap}
+        </Button>
+        <CopyButton disabled={unavailable || empty} label={copy.copySection} text={text ?? ''} />
+      </div>
+      {query && match < 0 && <p role="status">{copy.noMatch}</p>}
+      <LogView
+        aria-label={copy.sections[section.id]}
+        className={cn(
+          'h-[45vh] min-h-0 text-(--ui-text-secondary)',
+          wrap ? 'whitespace-pre-wrap wrap-anywhere' : 'whitespace-pre break-normal'
+        )}
+        role="region"
+        tabIndex={0}
+      >
+        {unavailable ? (
+          section.value === undefined ? (
+            copy.unavailable
+          ) : (
+            copy.serializationFailed
+          )
+        ) : empty ? (
+          copy.empty
+        ) : highlighted ? (
+          <>
+            {shown.text.slice(0, highlightStart)}
+            <mark>{shown.text.slice(highlightStart, highlightEnd)}</mark>
+            {shown.text.slice(highlightEnd)}
+          </>
+        ) : (
+          shown.text
+        )}
+      </LogView>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          disabled={shown.start === 0}
+          onClick={() => setOffset(Math.max(0, shown.start - INSPECTION_PAGE_CHARS))}
+          size="sm"
+          variant="ghost"
+        >
+          {copy.previousPage}
+        </Button>
+        <span className="text-xs text-muted-foreground" role="status">
+          {copy.range(empty || unavailable ? 0 : shown.start + 1, shown.end, text?.length ?? 0)}
+        </span>
+        <Button
+          disabled={shown.end >= (text?.length ?? 0)}
+          onClick={() => setOffset(shown.end)}
+          size="sm"
+          variant="ghost"
+        >
+          {copy.nextPage}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default function ToolInspectionDialog({
+  part,
+  inlineDiff,
+  onClose,
+  trigger
+}: {
+  part: ToolPart
+  inlineDiff: string
+  onClose: () => void
+  trigger: HTMLButtonElement
+}) {
+  const { t } = useI18n()
+  const copy = t.assistant.tool.inspector
+  const sections = useMemo(() => inspectionSections(part, inlineDiff), [part, inlineDiff])
+  const [selected, setSelected] = useState<InspectionSectionId>(part.result === undefined ? 'args' : 'result')
+  const section = sections.find(value => value.id === selected) ?? sections[0]
+
+  return (
+    <Dialog
+      onOpenChange={open => {
+        if (!open) {
+          onClose()
+        }
+      }}
+      open
+    >
+      <DialogContent
+        className="w-[90vw] max-w-4xl"
+        onCloseAutoFocus={event => {
+          event.preventDefault()
+
+          if (trigger.isConnected) {
+            trigger.focus()
+          }
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>
+            {copy.title} · {part.toolName}
+          </DialogTitle>
+          <DialogDescription>{copy.notice}</DialogDescription>
+        </DialogHeader>
+        <div className="max-w-full overflow-x-auto">
+          <SegmentedControl
+            onChange={setSelected}
+            options={sections.map(value => ({ id: value.id, label: copy.sections[value.id] }))}
+            value={selected}
+          />
+        </div>
+        <InspectionText key={section.id} section={section} />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/tool/tool-inspection-dialog.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-inspection-dialog.tsx
@@ -19,29 +19,60 @@ import {
   inspectionWindow
 } from './tool-inspection-model'
 
+const MAX_SEARCH_MATCHES = 1_000
+
+function searchMatches(text: string | undefined, query: string): { offsets: number[]; truncated: boolean } {
+  if (text === undefined || !query) {
+    return { offsets: [], truncated: false }
+  }
+
+  const offsets: number[] = []
+  let from = 0
+
+  while (offsets.length < MAX_SEARCH_MATCHES) {
+    const index = text.indexOf(query, from)
+
+    if (index < 0) {
+      return { offsets, truncated: false }
+    }
+
+    offsets.push(index)
+    from = index + Math.max(query.length, 1)
+  }
+
+  return { offsets, truncated: text.indexOf(query, from) >= 0 }
+}
+
 function InspectionText({ section }: { section: InspectionSection }) {
   const { t } = useI18n()
   const copy = t.assistant.tool.inspector
   const text = useMemo(() => inspectionText(section.value), [section.value])
   const [offset, setOffset] = useState(0)
   const [query, setQuery] = useState('')
-  const [match, setMatch] = useState(-1)
+  const [activeMatch, setActiveMatch] = useState(0)
   const [wrap, setWrap] = useState(true)
+  const matches = useMemo(() => searchMatches(text, query), [query, text])
+  const normalizedMatch = matches.offsets.length ? Math.min(activeMatch, matches.offsets.length - 1) : 0
+  const match = matches.offsets[normalizedMatch] ?? -1
   const shown = inspectionWindow(text ?? '', offset)
 
-  // Search is literal and case-sensitive, over the entire selected payload,
-  // not merely the displayed page. No regex execution on untrusted strings.
-  function find(value: string, from = 0, backwards = false) {
-    setQuery(value)
+  function moveToMatch(index: number) {
+    const next = matches.offsets[index]
 
-    const index =
-      !value || text === undefined ? -1 : backwards ? text.lastIndexOf(value, from) : text.indexOf(value, from)
-
-    setMatch(index)
-
-    if (index >= 0) {
-      setOffset(Math.max(0, index - 200))
+    if (next === undefined) {
+      return
     }
+
+    setActiveMatch(index)
+    setOffset(Math.max(0, next - 200))
+  }
+
+  function changeQuery(value: string) {
+    setQuery(value)
+    setActiveMatch(0)
+
+    const first = !value || text === undefined ? -1 : text.indexOf(value)
+    setOffset(first >= 0 ? Math.max(0, first - 200) : 0)
   }
 
   const unavailable = text === undefined
@@ -49,22 +80,32 @@ function InspectionText({ section }: { section: InspectionSection }) {
   const highlightStart = Math.max(0, match - shown.start)
   const highlightEnd = Math.min(shown.text.length, match + query.length - shown.start)
   const highlighted = query && match >= shown.start && match < shown.end
+  const matchCount = query
+    ? matches.offsets.length
+      ? `${normalizedMatch + 1}/${matches.offsets.length}${matches.truncated ? '+' : ''}`
+      : '0/0'
+    : ''
 
   return (
     <div className="grid min-h-0 min-w-0 gap-2">
       <div className="flex min-w-0 flex-wrap items-center gap-2">
-        <SearchField aria-label={copy.search} onChange={value => find(value)} placeholder={copy.search} value={query} />
+        <SearchField aria-label={copy.search} onChange={changeQuery} placeholder={copy.search} value={query} />
+        {query && (
+          <span className="shrink-0 text-xs tabular-nums text-muted-foreground" role="status">
+            {matchCount}
+          </span>
+        )}
         <Button
-          disabled={!query || match <= 0 || text === undefined || text.lastIndexOf(query, match - 1) < 0}
-          onClick={() => find(query, match - 1, true)}
+          disabled={!matches.offsets.length}
+          onClick={() => moveToMatch((normalizedMatch - 1 + matches.offsets.length) % matches.offsets.length)}
           size="sm"
           variant="ghost"
         >
           {copy.previousMatch}
         </Button>
         <Button
-          disabled={!query || text === undefined || text.indexOf(query, Math.max(0, match + 1)) < 0}
-          onClick={() => find(query, Math.max(0, match + 1))}
+          disabled={!matches.offsets.length}
+          onClick={() => moveToMatch((normalizedMatch + 1) % matches.offsets.length)}
           size="sm"
           variant="ghost"
         >

--- a/apps/desktop/src/components/assistant-ui/tool/tool-inspection-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-inspection-model.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { INSPECTION_PAGE_CHARS, inspectionSections, inspectionText, inspectionWindow } from './tool-inspection-model'
+
+describe('available inspection payloads', () => {
+  it('retains empty and scalar values without treating them as missing', () => {
+    for (const [value, text] of [
+      [undefined, undefined],
+      ['', ''],
+      [null, 'null'],
+      [false, 'false'],
+      [0, '0'],
+      [[], '[]']
+    ] as const) {
+      expect(inspectionText(value)).toBe(text)
+    }
+
+    const result = { stdout: '', stderr: 'diagnostic', inline_diff: '+line' }
+    const sections = inspectionSections({ type: 'tool-call', toolName: 'terminal', args: { command: 'echo' }, result })
+    expect(sections.find(section => section.id === 'result')?.value).toBe(result)
+    expect(sections.find(section => section.id === 'stdout')?.value).toBe('')
+    expect(sections.find(section => section.id === 'stderr')?.value).toBe('diagnostic')
+    expect(sections.find(section => section.id === 'diff')?.value).toBe('+line')
+  })
+
+  it('bounds very long single lines without splitting surrogate pairs', () => {
+    const text = 'x'.repeat(INSPECTION_PAGE_CHARS - 1) + '😀' + 'y'.repeat(INSPECTION_PAGE_CHARS * 2)
+    const first = inspectionWindow(text, 0)
+    const second = inspectionWindow(text, first.end)
+    expect(first.text.endsWith('😀')).toBe(true)
+    expect(first.text.length).toBeLessThanOrEqual(INSPECTION_PAGE_CHARS + 2)
+    expect(second.text).toBe('y'.repeat(INSPECTION_PAGE_CHARS))
+    expect(inspectionWindow(text, INSPECTION_PAGE_CHARS).text.startsWith('😀')).toBe(true)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool/tool-inspection-model.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-inspection-model.ts
@@ -1,0 +1,90 @@
+import { parseMaybeObject } from './fallback-model/format'
+import type { ToolPart } from './fallback-model/types'
+
+export type InspectionSectionId = 'args' | 'result' | 'metadata' | 'command' | 'stdout' | 'stderr' | 'diff'
+
+export interface InspectionSection {
+  id: InspectionSectionId
+  value: unknown
+}
+
+// Bound even a single enormous line. Paging affects only painting, never the
+// selected value, search range or clipboard payload.
+export const INSPECTION_PAGE_CHARS = 16_000
+
+export function inspectionSections(part: ToolPart, inlineDiff = ''): InspectionSection[] {
+  const args = parseMaybeObject(part.args)
+  const result = parseMaybeObject(part.result)
+
+  const sections: InspectionSection[] = [
+    { id: 'args', value: part.args },
+    { id: 'result', value: part.result },
+    {
+      id: 'metadata',
+      value: {
+        toolName: part.toolName,
+        toolCallId: part.toolCallId,
+        timestamp: part.timestamp,
+        completedAt: part.completedAt,
+        isError: part.isError,
+        // Optional, for the lossless live-result projection. Older transcripts
+        // have only the result, which remains inspectable without this field.
+        display: 'toolResultMetadata' in part ? part.toolResultMetadata : undefined
+      }
+    }
+  ]
+
+  const command = typeof args.command === 'string' ? args.command : args.code
+
+  if (typeof command === 'string') {
+    sections.push({ id: 'command', value: command })
+  }
+
+  for (const id of ['stdout', 'stderr'] as const) {
+    if (typeof result[id] === 'string') {
+      sections.push({ id, value: result[id] })
+    }
+  }
+
+  const diff =
+    typeof result.inline_diff === 'string'
+      ? result.inline_diff
+      : typeof result.diff === 'string'
+        ? result.diff
+        : inlineDiff
+
+  if (diff) {
+    sections.push({ id: 'diff', value: diff })
+  }
+
+  return sections
+}
+
+/** Only the selected section is serialized, after the inspector is opened. */
+export function inspectionText(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return undefined
+  }
+}
+
+export function inspectionWindow(text: string, offset: number) {
+  let start = Math.max(0, Math.min(offset, Math.max(0, text.length - 1)))
+  let end = Math.min(text.length, start + INSPECTION_PAGE_CHARS)
+
+  // Do not paint half a surrogate pair at either edge of the window.
+  if (start > 0 && /[\uDC00-\uDFFF]/.test(text[start]) && /[\uD800-\uDBFF]/.test(text[start - 1])) {
+    start--
+  }
+
+  if (end < text.length && /[\uD800-\uDBFF]/.test(text[end - 1]) && /[\uDC00-\uDFFF]/.test(text[end])) {
+    end++
+  }
+
+  return { start, end, text: text.slice(start, end) }
+}

--- a/apps/desktop/src/components/assistant-ui/tool/tool-inspection.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-inspection.test.tsx
@@ -44,7 +44,7 @@ afterEach(() => {
 
 describe('tool inspection in the normal transcript', () => {
   it('searches and copies past the inline limit independently of long arguments, with bounded painting', async () => {
-    const stdout = 'x'.repeat(25_000) + '\nneedle after the inline limit\n'
+    const stdout = 'x'.repeat(25_000) + '\nneedle after the inline limit\n' + 'y'.repeat(100) + '\nneedle again\n'
     render(<Harness value={message({ stdout, stderr: 'diagnostic' }, { command: 'c'.repeat(30_000) })} />)
     const trigger = await screen.findByRole('button', { name: 'Open tool details' })
     fireEvent.click(trigger)
@@ -57,7 +57,14 @@ describe('tool inspection in the normal transcript', () => {
       target: { value: 'needle' }
     })
     expect(ui.getByRole('region', { name: 'stdout' }).textContent).toContain('needle after the inline limit')
-    expect((ui.getByRole('button', { name: 'Previous match' }) as HTMLButtonElement).disabled).toBe(true)
+    expect(ui.getByText('1/2')).toBeTruthy()
+    fireEvent.click(ui.getByRole('button', { name: 'Next match' }))
+    expect(ui.getByText('2/2')).toBeTruthy()
+    expect(ui.getByRole('region', { name: 'stdout' }).textContent).toContain('needle again')
+    fireEvent.click(ui.getByRole('button', { name: 'Next match' }))
+    expect(ui.getByText('1/2')).toBeTruthy()
+    fireEvent.click(ui.getByRole('button', { name: 'Previous match' }))
+    expect(ui.getByText('2/2')).toBeTruthy()
     expect(ui.getByRole('region', { name: 'stdout' }).textContent?.length).toBeLessThanOrEqual(16_002)
     fireEvent.click(ui.getByRole('button', { name: 'Wrap lines' }))
     expect(ui.getByRole('button', { name: 'Wrap lines' }).getAttribute('aria-pressed')).toBe('false')

--- a/apps/desktop/src/components/assistant-ui/tool/tool-inspection.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-inspection.test.tsx
@@ -1,0 +1,91 @@
+import type { ThreadMessage } from '@assistant-ui/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $toolDisclosureStates, $toolViewMode } from '@/store/tool-view'
+
+import { assistantMessage, stubThreadEnvironment, stubThreadViewportSize, ThreadRuntime } from '../test-utils'
+import { Thread } from '../thread'
+
+import { buildToolView, toolCopyPayload } from './fallback-model'
+
+stubThreadEnvironment()
+stubThreadViewportSize()
+
+const writeText = vi.fn(async (_text: string) => {})
+const originalClipboard = navigator.clipboard
+
+function message(result: unknown, args: unknown = { command: 'printf ok' }): ThreadMessage {
+  return {
+    ...assistantMessage(),
+    content: [{ type: 'tool-call', toolCallId: 'inspect-1', toolName: 'terminal', args, argsText: '{}', result }]
+  } as ThreadMessage
+}
+
+function Harness({ value, sessionId = 'session-a' }: { value: ThreadMessage; sessionId?: string }) {
+  return (
+    <ThreadRuntime messages={[value]}>
+      <Thread sessionId={sessionId} />
+    </ThreadRuntime>
+  )
+}
+
+beforeEach(() => {
+  writeText.mockClear()
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+  $toolViewMode.set('product')
+  $toolDisclosureStates.set({})
+})
+
+afterEach(() => {
+  cleanup()
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: originalClipboard })
+})
+
+describe('tool inspection in the normal transcript', () => {
+  it('searches and copies past the inline limit independently of long arguments, with bounded painting', async () => {
+    const stdout = 'x'.repeat(25_000) + '\nneedle after the inline limit\n'
+    render(<Harness value={message({ stdout, stderr: 'diagnostic' }, { command: 'c'.repeat(30_000) })} />)
+    const trigger = await screen.findByRole('button', { name: 'Open tool details' })
+    fireEvent.click(trigger)
+    const dialog = await screen.findByRole('dialog')
+    const ui = within(dialog)
+    fireEvent.click(ui.getByRole('button', { name: 'Arguments' }))
+    expect(ui.getByRole('region', { name: 'Arguments' }).textContent?.length).toBeLessThanOrEqual(16_002)
+    fireEvent.click(ui.getByRole('button', { name: 'stdout' }))
+    fireEvent.change(ui.getByRole('textbox', { name: 'Find in section (case-sensitive)' }), {
+      target: { value: 'needle' }
+    })
+    expect(ui.getByRole('region', { name: 'stdout' }).textContent).toContain('needle after the inline limit')
+    expect((ui.getByRole('button', { name: 'Previous match' }) as HTMLButtonElement).disabled).toBe(true)
+    expect(ui.getByRole('region', { name: 'stdout' }).textContent?.length).toBeLessThanOrEqual(16_002)
+    fireEvent.click(ui.getByRole('button', { name: 'Wrap lines' }))
+    expect(ui.getByRole('button', { name: 'Wrap lines' }).getAttribute('aria-pressed')).toBe('false')
+    fireEvent.click(ui.getByRole('button', { name: 'Copy section' }))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(stdout))
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(window.document.activeElement).toBe(trigger)
+  })
+
+  it('keeps the opened snapshot after the row disappears but closes it on a session switch', async () => {
+    const { rerender } = render(<Harness value={message({ stdout: 'original' })} />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Open tool details' }))
+    await screen.findByRole('dialog')
+    rerender(<Harness value={assistantMessage()} />)
+    expect(within(screen.getByRole('dialog')).getByRole('region', { name: 'Result' }).textContent).toContain('original')
+    rerender(<Harness sessionId="session-b" value={message({ stdout: 'different session' })} />)
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+  })
+
+  it('copies short and whitespace-bearing output as output, never as a command or path', () => {
+    for (const text of ['ok', '', ' \n ']) {
+      for (const part of [
+        { type: 'tool-call' as const, toolName: 'terminal', args: { command: 'echo ok' }, result: { stdout: text } },
+        { type: 'tool-call' as const, toolName: 'read_file', args: { path: '/tmp/result' }, result: { content: text } }
+      ]) {
+        expect(toolCopyPayload(part, buildToolView(part, '')).text).toBe(text)
+      }
+    }
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool/tool-inspection.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/tool-inspection.tsx
@@ -1,0 +1,79 @@
+import {
+  createContext,
+  lazy,
+  type PropsWithChildren,
+  Suspense,
+  useCallback,
+  useContext,
+  useEffect,
+  useState
+} from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+
+import type { ToolPart } from './fallback-model/types'
+
+const InspectionDialog = lazy(() => import('./tool-inspection-dialog'))
+
+interface InspectionTarget {
+  part: ToolPart
+  inlineDiff: string
+  trigger: HTMLButtonElement
+}
+
+const InspectionContext = createContext<((target: InspectionTarget) => void) | null>(null)
+
+/** A thread-local host survives ticker/list virtualization. No payload is
+ * duplicated into a global store, persisted, or shared between session tiles. */
+export function ToolInspectionProvider({ children, scope }: PropsWithChildren<{ scope: unknown }>) {
+  const [inspection, setInspection] = useState<(InspectionTarget & { scope: unknown }) | null>(null)
+  const open = useCallback((target: InspectionTarget) => setInspection({ ...target, scope }), [scope])
+  const close = useCallback(() => setInspection(null), [])
+
+  useEffect(() => setInspection(null), [scope])
+
+  return (
+    <InspectionContext.Provider value={open}>
+      {children}
+      {inspection && inspection.scope === scope && (
+        <Suspense fallback={null}>
+          <InspectionDialog
+            inlineDiff={inspection.inlineDiff}
+            onClose={close}
+            part={inspection.part}
+            trigger={inspection.trigger}
+          />
+        </Suspense>
+      )}
+    </InspectionContext.Provider>
+  )
+}
+
+export function ToolInspectionButton({ part, inlineDiff }: { part: ToolPart; inlineDiff: string }) {
+  const open = useContext(InspectionContext)
+  const { t } = useI18n()
+  const label = t.assistant.tool.inspector.open
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <Tip label={label}>
+      <Button
+        aria-label={label}
+        onClick={event => {
+          event.stopPropagation()
+          open({ part, inlineDiff, trigger: event.currentTarget })
+        }}
+        size="icon-xs"
+        variant="ghost"
+      >
+        <Codicon name="inspect" size="0.75rem" />
+      </Button>
+    </Tip>
+  )
+}

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2834,6 +2834,36 @@ export const ar = defineLocale({
         runningPrefixedTool: (prefix, action) => `جار تشغيل ${prefix.toLowerCase()} ${action.toLowerCase()}`,
         runningTool: action => `جار تشغيل ${action.toLowerCase()}`
       },
+      inspector: {
+        previewLimit: (count: number) =>
+          `تم إخفاء ${count.toLocaleString()} حرفًا إضافيًا في المعاينة — افتح تفاصيل الأداة لفحص البيانات المتاحة.`,
+        open: 'فتح تفاصيل الأداة',
+        title: 'تفاصيل الأداة',
+        notice:
+          'لقطة للبيانات المتاحة عند الفتح. أغلقها وأعد فتحها للتحديث. لا يمكن استعادة البيانات المقتطعة على الخادم أو غير المحفوظة هنا.',
+        search: 'بحث في القسم (حساس لحالة الأحرف)',
+        previousMatch: 'التطابق السابق',
+        nextMatch: 'التطابق التالي',
+        wrap: 'التفاف الأسطر',
+        copySection: 'نسخ القسم',
+        noMatch: 'لا يوجد تطابق في هذا القسم المتاح.',
+        unavailable: 'لم يتم استلام قيمة.',
+        empty: 'سلسلة فارغة',
+        serializationFailed: 'تعذر تحويل هذه القيمة إلى نص.',
+        previousPage: 'الصفحة السابقة',
+        nextPage: 'الصفحة التالية',
+        range: (start: number, end: number, total: number) =>
+          `${start.toLocaleString()}–${end.toLocaleString()} / ${total.toLocaleString()}`,
+        sections: {
+          args: 'الوسائط',
+          result: 'النتيجة',
+          metadata: 'البيانات الوصفية',
+          command: 'الأمر',
+          stdout: 'stdout',
+          stderr: 'stderr',
+          diff: 'الفروقات'
+        }
+      },
       titles: {
         browser_click: {
           done: 'تم النقر على عنصر الصفحة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3742,6 +3742,36 @@ export const en: Translations = {
         runningPrefixedTool: (prefix, action) => `Running ${prefix.toLowerCase()} ${action.toLowerCase()}`,
         runningTool: action => `Running ${action.toLowerCase()}`
       },
+      inspector: {
+        previewLimit: (count: number) =>
+          `${count.toLocaleString()} more characters hidden in this preview — open tool details to inspect the available payload.`,
+        open: 'Open tool details',
+        title: 'Tool details',
+        notice:
+          'Snapshot of the payload available when opened. Close and reopen to refresh. Backend-truncated or unsaved data cannot be recovered here.',
+        search: 'Find in section (case-sensitive)',
+        previousMatch: 'Previous match',
+        nextMatch: 'Next match',
+        wrap: 'Wrap lines',
+        copySection: 'Copy section',
+        noMatch: 'No match in this available section.',
+        unavailable: 'No value was received.',
+        empty: 'Empty string',
+        serializationFailed: 'This value could not be serialized.',
+        previousPage: 'Previous page',
+        nextPage: 'Next page',
+        range: (start: number, end: number, total: number) =>
+          `${start.toLocaleString()}–${end.toLocaleString()} / ${total.toLocaleString()}`,
+        sections: {
+          args: 'Arguments',
+          result: 'Result',
+          metadata: 'Metadata',
+          command: 'Command',
+          stdout: 'stdout',
+          stderr: 'stderr',
+          diff: 'Diff'
+        }
+      },
       titles: {
         browser_click: { done: 'Clicked page element', pending: 'Clicking page element', pendingAction: 'Clicking' },
         browser_fill: { done: 'Filled form field', pending: 'Filling form field', pendingAction: 'Filling' },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -3292,6 +3292,36 @@ export const ja = defineLocale({
         runningPrefixedTool: (prefix, action) => `${prefix} ${action}を実行中`,
         runningTool: action => `${action}を実行中`
       },
+      inspector: {
+        previewLimit: (count: number) =>
+          `プレビューでは残り ${count.toLocaleString()} 文字を省略しています。ツールの詳細で受信済みのデータを確認できます。`,
+        open: 'ツールの詳細を開く',
+        title: 'ツールの詳細',
+        notice:
+          '開いた時点のデータです。更新するには開き直してください。サーバーで省略されたデータや未保存のデータは復元できません。',
+        search: 'セクション内を検索（大文字小文字を区別）',
+        previousMatch: '前の一致',
+        nextMatch: '次の一致',
+        wrap: '行を折り返す',
+        copySection: 'セクションをコピー',
+        noMatch: 'このセクションに一致はありません。',
+        unavailable: '値を受信していません。',
+        empty: '空の文字列',
+        serializationFailed: '値をテキストに変換できませんでした。',
+        previousPage: '前のページ',
+        nextPage: '次のページ',
+        range: (start: number, end: number, total: number) =>
+          `${start.toLocaleString()}–${end.toLocaleString()} / ${total.toLocaleString()}`,
+        sections: {
+          args: '引数',
+          result: '結果',
+          metadata: 'メタデータ',
+          command: 'コマンド',
+          stdout: 'stdout',
+          stderr: 'stderr',
+          diff: '差分'
+        }
+      },
       titles: {
         browser_click: {
           done: 'ページ要素をクリックしました',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -3675,6 +3675,36 @@ export const ru = defineLocale({
         runningPrefixedTool: (prefix, action) => `Выполняется: ${prefix.toLowerCase()} ${action.toLowerCase()}`,
         runningTool: action => `Выполняется: ${action.toLowerCase()}`
       },
+      inspector: {
+        previewLimit: (count: number) =>
+          `Ещё ${count.toLocaleString()} символов скрыто в превью — откройте детали инструмента для просмотра доступных данных.`,
+        open: 'Открыть детали инструмента',
+        title: 'Детали инструмента',
+        notice:
+          'Снимок данных на момент открытия. Для обновления закройте и откройте снова. Обрезанные на сервере или несохранённые данные здесь восстановить нельзя.',
+        search: 'Поиск в разделе (с учётом регистра)',
+        previousMatch: 'Предыдущее совпадение',
+        nextMatch: 'Следующее совпадение',
+        wrap: 'Перенос строк',
+        copySection: 'Копировать раздел',
+        noMatch: 'В доступном разделе совпадений нет.',
+        unavailable: 'Значение не получено.',
+        empty: 'Пустая строка',
+        serializationFailed: 'Не удалось преобразовать значение в текст.',
+        previousPage: 'Предыдущая страница',
+        nextPage: 'Следующая страница',
+        range: (start: number, end: number, total: number) =>
+          `${start.toLocaleString()}–${end.toLocaleString()} / ${total.toLocaleString()}`,
+        sections: {
+          args: 'Аргументы',
+          result: 'Результат',
+          metadata: 'Метаданные',
+          command: 'Команда',
+          stdout: 'stdout',
+          stderr: 'stderr',
+          diff: 'Diff'
+        }
+      },
       titles: {
         browser_click: {
           done: 'Нажат элемент страницы',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -3275,6 +3275,33 @@ export interface Translations {
         runningPrefixedTool: (prefix: string, action: string) => string
         runningTool: (action: string) => string
       }
+      inspector: {
+        previewLimit: (count: number) => string
+        open: string
+        title: string
+        notice: string
+        search: string
+        previousMatch: string
+        nextMatch: string
+        wrap: string
+        copySection: string
+        noMatch: string
+        unavailable: string
+        empty: string
+        serializationFailed: string
+        previousPage: string
+        nextPage: string
+        range: (start: number, end: number, total: number) => string
+        sections: {
+          args: string
+          result: string
+          metadata: string
+          command: string
+          stdout: string
+          stderr: string
+          diff: string
+        }
+      }
       titles: Record<ToolTitleKey, ToolTitleCopy>
     }
   }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -3181,6 +3181,35 @@ export const zhHant = defineLocale({
         runningPrefixedTool: (prefix, action) => `正在執行${prefix}${action}`,
         runningTool: action => `正在執行 ${action}`
       },
+      inspector: {
+        previewLimit: (count: number) =>
+          `此預覽還隱藏了 ${count.toLocaleString()} 個字元 — 開啟工具詳情以查看可用資料。`,
+        open: '開啟工具詳情',
+        title: '工具詳情',
+        notice: '開啟時可用資料的快照。關閉後重新開啟即可重新整理。無法還原伺服器截斷或未儲存的資料。',
+        search: '在此部分搜尋（區分大小寫）',
+        previousMatch: '上一個符合項目',
+        nextMatch: '下一個符合項目',
+        wrap: '自動換行',
+        copySection: '複製此部分',
+        noMatch: '可用內容中沒有符合項目。',
+        unavailable: '未收到值。',
+        empty: '空字串',
+        serializationFailed: '無法將此值序列化。',
+        previousPage: '上一頁',
+        nextPage: '下一頁',
+        range: (start: number, end: number, total: number) =>
+          `${start.toLocaleString()}–${end.toLocaleString()} / ${total.toLocaleString()}`,
+        sections: {
+          args: '參數',
+          result: '結果',
+          metadata: '中繼資料',
+          command: '命令',
+          stdout: 'stdout',
+          stderr: 'stderr',
+          diff: '差異'
+        }
+      },
       titles: {
         browser_click: { done: '已點擊頁面元素', pending: '正在點擊頁面元素', pendingAction: '正在點擊' },
         browser_fill: { done: '已填寫表單欄位', pending: '正在填寫表單欄位', pendingAction: '正在填寫' },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3877,6 +3877,35 @@ export const zh: Translations = {
         runningPrefixedTool: (prefix, action) => `正在运行${prefix}${action}`,
         runningTool: action => `正在运行 ${action}`
       },
+      inspector: {
+        previewLimit: (count: number) =>
+          `此预览还隐藏了 ${count.toLocaleString()} 个字符 — 打开工具详情以查看可用数据。`,
+        open: '打开工具详情',
+        title: '工具详情',
+        notice: '打开时可用数据的快照。关闭后重新打开即可刷新。无法恢复服务端截断或未保存的数据。',
+        search: '在此部分搜索（区分大小写）',
+        previousMatch: '上一个匹配',
+        nextMatch: '下一个匹配',
+        wrap: '自动换行',
+        copySection: '复制此部分',
+        noMatch: '可用内容中没有匹配项。',
+        unavailable: '未收到值。',
+        empty: '空字符串',
+        serializationFailed: '无法将此值序列化。',
+        previousPage: '上一页',
+        nextPage: '下一页',
+        range: (start: number, end: number, total: number) =>
+          `${start.toLocaleString()}–${end.toLocaleString()} / ${total.toLocaleString()}`,
+        sections: {
+          args: '参数',
+          result: '结果',
+          metadata: '元数据',
+          command: '命令',
+          stdout: 'stdout',
+          stderr: 'stderr',
+          diff: '差异'
+        }
+      },
       titles: {
         browser_click: { done: '已点击页面元素', pending: '正在点击页面元素', pendingAction: '正在点击' },
         browser_fill: { done: '已填写表单字段', pending: '正在填写表单字段', pendingAction: '正在填写' },


### PR DESCRIPTION
## What does this PR do?

Adds a normal-mode **Inspect tool details** action without expanding every tool's full output into the conversation. Users can inspect and copy the complete available payload Desktop received, independently of the 20,000-character inline preview and independently of large arguments.

## Related Issue

Fixes #107269

## Type of Change

- [x] New feature
- [x] Bug fixes and regression tests for short-output copying

## Changes Made

- `tool/tool-inspection.tsx`: a lazy, thread-scoped inspector host outside virtualized tool rows. Retain a snapshot of available payload references while reading, survive row disappearance, and close on session/connection scope change. No new global payload store.
- `tool/tool-inspection-dialog.tsx`: reuse the shared Dialog, SegmentedControl, SearchField, CopyButton and LogView primitives. Separate arguments, result and metadata, plus command/stdout/stderr/diff when supplied. Add literal search over the entire selected text with match counts and cyclic previous/next navigation, wrapping, bounded pages, exact-section copying and focus restoration.
- `tool/tool-inspection-model.ts`: serialize only the selected section on demand. Bound rendered text to a 16 Ki-character window even for a single enormous line; do not split UTF-16 surrogate pairs. Copy and search operate on the available full section, not the current page.
- `tool/fallback.tsx`: make the inspector reachable from ordinary tool rows; retain successful file-operation rows even when no diff is available. Do not fabricate historical file contents or diffs.
- `fallback-model/index.ts`: preserve short, whitespace-only and empty terminal/read-file output for copying instead of silently substituting a command or path.
- Keep the inline limit. Replace the misleading “Copy for full output” truncation hint with a pointer to the inspector. Localize the new controls and limitations in all six locales.

**Data boundary:** “available” means what Desktop received. This does not recover source-truncated, unsaved or already discarded output. The dialog states this explicitly and distinguishes no value from an empty value. Its snapshot remains stable while open; reopening refreshes it from the row.

## How to Test

From `apps/desktop`:

```sh
npx vitest run --project ui --maxWorkers=2 \
  src/components/assistant-ui/tool \
  src/components/assistant-ui/thread/index.test.tsx \
  src/components/assistant-ui/thread/streaming.test.tsx
npx tsc -p . --noEmit
```

**Initial implementation validation:** on a clean Ubuntu 24.04 runner, Node 24.20.0, 124 tests passed in 11 files; renderer TypeScript, changed-file ESLint (`--max-warnings 0`), Prettier and `git diff --check` passed.

[CI job and complete logs](https://github.com/Xipong/hermes-agent/actions/runs/34469356479/job/102845367338). That receipt predates the small follow-up that added match counts and cyclic previous/next navigation; the follow-up includes renderer assertions for the new behavior but has not been rerun through that same validation job yet.

The renderer tests mount the actual Thread/runtime boundary. They exercise a result beyond 25,000 characters alongside arguments over 30,000 characters, search past the inline limit, exact copying, bounded painting, wrapping, dismissal/focus, row disappearance and session switching. Model cases cover empty/missing values and Unicode page boundaries.

The three related changes were also cherry-picked together cleanly before this follow-up: the combined suite passed **231 tests in 16 files**, renderer TypeScript and lint. Replaying the original regression set against unchanged base production code produced 10 failures.

**Not performed:** native packaged-Electron manual testing, macOS/Windows validation, production packaging or the full Python repository suite. No manual screenshots are claimed.

## Independence / Related Work

This is a standalone branch from upstream `main`, not stacked on #107297 or #107298. It tolerates both the existing result representation and the separate display metadata added in #107297. Merging result preservation first is preferable: a viewer cannot recover data already discarded before it opens.

Competing PR #107292 addresses the same inspector issue. This implementation keeps the inspector thread-scoped so it survives row virtualization/remounts and keeps painting bounded to fixed-size pages. A later follow-up adopted two useful UX ideas from #107292 — visible match counts and wrap-around previous/next navigation — without adopting its row-local lifecycle or cumulative rendering model.

The scope is the generic tool-result surface. A full system-log archive and expanded subagent history are deliberately separate from this PR.

## Checklist

- [x] Read contribution and Desktop instructions; conventional commits.
- [x] Searched related work; changes scoped to the inspector and its reachable/correct data surface.
- [x] Added executable model and renderer regressions.
- [x] Localized UI and documented snapshot/source limitations in the interface and code.
- [x] No settings, backend API, tool-schema or persistence changes.
- [ ] Re-run the validation receipt after the match-navigation follow-up.
- [ ] Native Desktop visual/accessibility smoke test.