### PR TITLE
fix(desktop): atomically publish and verify macOS updates

### DIFF
--- a/hermes_cli/desktop_macos_update.py
+++ b/hermes_cli/desktop_macos_update.py
@@ -1,0 +1,647 @@
+"""Private macOS handoff: validate, exchange, observe adoption, retain rollback.
+
+Reader evidence covers the updater's effective UID and libproc-exposed vnode
+regions. Other users, unexposed VM submaps/pagers, and launches after the final
+scan are outside that observation. This is not a launch lock or crash recovery.
+"""
+from __future__ import annotations
+
+import ast
+import argparse
+import ctypes
+import datetime
+import errno
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import plistlib
+import re
+import signal
+import stat
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from dataclasses import dataclass
+
+
+def command(*args, timeout=30):
+    result = subprocess.run([str(a) for a in args], capture_output=True, timeout=timeout)
+    if result.returncode:
+        raise RuntimeError(f"{Path(args[0]).name} failed ({result.returncode})")
+    return result.stdout.decode("utf-8", errors="strict").strip()
+
+
+def expectation(root):
+    root = Path(root)
+    sha = command("git", "-C", root, "rev-parse", "HEAD^{commit}")
+    if not re.fullmatch(r"[0-9a-f]{40}", sha) or sha == "0" * 40:
+        raise ValueError("source has no real commit")
+    if command("git", "-C", root, "status", "--porcelain", "-uno"):
+        raise ValueError("tracked source differs from expected commit")
+    package = json.loads((root / "apps/desktop/package.json").read_text(encoding="utf-8"))
+    version = None
+    for node in ast.parse((root / "hermes_cli/__init__.py").read_text(encoding="utf-8")).body:
+        if isinstance(node, ast.Assign) and any(isinstance(t, ast.Name) and t.id == "__version__" for t in node.targets):
+            version = ast.literal_eval(node.value)
+    if not isinstance(version, str) or not version:
+        raise ValueError("missing expected backend version")
+    return dict(sha=sha, version=package["version"], identity=package["build"]["appId"],
+                arch=platform.machine(), backend_version=version)
+
+
+@dataclass(frozen=True)
+class Fingerprint:
+    tree: str
+    executable: str
+    archive: str
+    stamp: str
+
+
+def file_hash(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def fingerprint(app):
+    app = Path(app).resolve(strict=True)
+    tree = hashlib.sha256()
+    for path in sorted(app.rglob("*")):
+        info = path.lstat()
+        tree.update(json.dumps([str(path.relative_to(app)), stat.S_IMODE(info.st_mode)]).encode())
+        if path.is_symlink():
+            if not path.resolve(strict=True).is_relative_to(app):
+                raise ValueError("bundle symlink escapes its tree")
+            tree.update(b"L" + os.fsencode(os.readlink(path)))
+        elif stat.S_ISREG(info.st_mode):
+            tree.update(b"F" + file_hash(path).encode())
+        elif stat.S_ISDIR(info.st_mode):
+            tree.update(b"D")
+        else:
+            raise ValueError("unsupported bundle file type")
+    resources = app / "Contents/Resources"
+    return Fingerprint(tree.hexdigest(), file_hash(app / "Contents/MacOS/Hermes"),
+                       file_hash(resources / "app.asar"), file_hash(resources / "install-stamp.json"))
+
+
+def verify_signature(app):
+    command("/usr/bin/codesign", "--verify", "--deep", "--strict", app)
+
+
+def validate(app, expected):
+    app = Path(app)
+    info = plistlib.loads((app / "Contents/Info.plist").read_bytes())
+    if (info.get("CFBundleIdentifier") != expected["identity"]
+            or info.get("CFBundleExecutable") != "Hermes"
+            or info.get("CFBundleShortVersionString") != expected["version"]):
+        raise ValueError("candidate bundle identity or version mismatch")
+    exe = app / "Contents/MacOS/Hermes"
+    if not os.access(exe, os.X_OK) or expected["arch"] not in command("/usr/bin/lipo", "-archs", exe).split():
+        raise ValueError("candidate architecture mismatch")
+    stamp = json.loads((app / "Contents/Resources/install-stamp.json").read_text(encoding="utf-8"))
+    if (type(stamp.get("schemaVersion")) is not int or stamp["schemaVersion"] != 1
+            or stamp.get("commit") != expected["sha"] or stamp.get("dirty") is not False
+            or stamp.get("source") not in ("ci", "local")):
+        raise ValueError("candidate stamp is stale, dirty, unsupported or fallback")
+    built = datetime.datetime.fromisoformat(stamp["builtAt"].replace("Z", "+00:00"))
+    now = datetime.datetime.now(datetime.timezone.utc)
+    if built.tzinfo is None or built.year < 2000 or built > now + datetime.timedelta(seconds=60):
+        raise ValueError("invalid build timestamp")
+    verify_signature(app)
+    return fingerprint(app)
+
+
+def select_candidate(root, expected):
+    candidates = []
+    for app in sorted((Path(root) / "apps/desktop/release").glob("mac*/Hermes.app")):
+        # A mismatched/stale directory must not win by ordering or modification time.
+        try:
+            validate(app, expected)
+        except (ValueError, RuntimeError, OSError, KeyError, TypeError):
+            continue
+        candidates.append(app)
+    if len(candidates) != 1:
+        raise ValueError("missing or ambiguous compatible candidate")
+    return candidates[0]
+
+
+def exchange(left, right):
+    left, right = Path(left), Path(right)
+    if left.stat().st_dev != right.stat().st_dev:
+        raise ValueError("atomic exchange requires the same volume")
+    libc = ctypes.CDLL(None, use_errno=True)
+    swap = libc.renamex_np
+    swap.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint]
+    swap.restype = ctypes.c_int
+    # RENAME_SWAP | RENAME_NOFOLLOW_ANY. No destructive two-rename fallback.
+    if swap(os.fsencode(left), os.fsencode(right), 2 | 16):
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+
+
+def preflight(root, target):
+    root, target = Path(root).resolve(strict=True), Path(target)
+    if target.is_symlink() or any(p.is_symlink() for p in target.parents):
+        raise ValueError("symlinked publication target")
+    target = target.resolve(strict=True)
+    if (target.suffix != ".app" or not target.is_dir()
+            or target.is_relative_to(root) or root.is_relative_to(target)):
+        raise ValueError("unsupported or overlapping source/target layout")
+    with tempfile.TemporaryDirectory(prefix=".hermes-swap-probe-", dir=target.parent) as directory:
+        left, right = Path(directory) / "left", Path(directory) / "right"
+        left.mkdir()
+        right.mkdir()
+        exchange(left, right)
+    return target
+
+
+def native():
+    lib = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+    lib.proc_listpids.argtypes = [ctypes.c_uint, ctypes.c_uint, ctypes.c_void_p, ctypes.c_int]
+    lib.proc_pidinfo.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_int]
+    lib.proc_pidpath.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_uint]
+    return lib
+
+
+@dataclass(frozen=True)
+class Process:
+    pid: int
+    start: tuple
+    parent: int
+    executable: Path | None
+
+
+def process_record(lib, pid):
+    # Darwin proc_bsdinfo ABI, shared by supported arm64/x86_64 macOS.
+    data = ctypes.create_string_buffer(136)
+    ctypes.set_errno(0)
+    count = lib.proc_pidinfo(pid, 3, 0, data, len(data))
+    if count == 0 and ctypes.get_errno() == errno.ESRCH:
+        return None
+    if count != len(data):
+        raise RuntimeError("incomplete process identity scan")
+    status, = struct.unpack_from("=I", data, 4)
+    found, parent, uid = struct.unpack_from("=III", data, 12)
+    if found != pid or uid != os.geteuid():  # windows-footgun: ok — private Darwin observer
+        raise RuntimeError("process identity or credentials changed")
+    if status == 5:  # SZOMB: its address space has already exited.
+        return None
+    start = struct.unpack_from("=QQ", data, 120)
+    path = ctypes.create_string_buffer(4096)
+    ctypes.set_errno(0)
+    count = lib.proc_pidpath(pid, path, len(path))
+    if count == 0 and ctypes.get_errno() == errno.ENOENT:
+        # A removed executable (e.g. another app's completed update) still has
+        # vnode-backed mappings. Observe those; never treat this as an exited PID.
+        return Process(pid, start, parent, None)
+    if count <= 0 or count >= len(path):
+        raise RuntimeError("executable identity unavailable")
+    return Process(pid, start, parent, Path(os.fsdecode(path.value)))
+
+
+def process_table():
+    lib = native()
+    for _ in range(3):
+        needed = lib.proc_listpids(4, os.geteuid(), None, 0)  # windows-footgun: ok — Darwin PROC_UID_ONLY (effective UID)
+        if needed <= 0 or needed > 4_000_000:
+            raise RuntimeError("process enumeration failed")
+        data = ctypes.create_string_buffer(needed + 4096)
+        count = lib.proc_listpids(4, os.geteuid(), data, len(data))  # windows-footgun: ok — private Darwin observer
+        if count == len(data):
+            continue
+        if count <= 0 or count > len(data) or count % 4:
+            raise RuntimeError("malformed process enumeration")
+        rows = {}
+        for pid in struct.unpack_from(f"={count // 4}I", data):
+            if pid:
+                row = process_record(lib, pid)
+                if row is not None:
+                    rows[pid] = row
+        return rows
+    raise RuntimeError("process enumeration overflow")
+
+
+@dataclass
+class Observation:
+    state: str
+    readers: dict
+    processes: dict
+    reason: str = ""
+
+
+def mapped_files(lib, process, deadline):
+    address = 0
+    files = {}
+    for _ in range(100_000):
+        if time.monotonic() > deadline:
+            raise RuntimeError("reader scan timed out")
+        data = ctypes.create_string_buffer(1272)  # proc_regionwithpathinfo
+        ctypes.set_errno(0)
+        count = lib.proc_pidinfo(process.pid, 8, address, data, len(data))
+        error = ctypes.get_errno()
+        if count == 0 and error in (errno.EINVAL, errno.ESRCH):
+            current = process_record(lib, process.pid)
+            if current is None:
+                return {}
+            if error == errno.EINVAL and current.start == process.start:
+                if current.executable is None and not files:
+                    raise RuntimeError("neither executable nor mapped identity available")
+                return files  # Flavor 8's end-of-map; flavor 22 conflates other errors.
+            raise RuntimeError("process changed during reader scan")
+        if count != len(data):
+            raise RuntimeError("incomplete or denied mapped-file scan")
+        start, size = struct.unpack_from("=QQ", data, 80)
+        tag, = struct.unpack_from("=I", data, 32)
+        device, = struct.unpack_from("=I", data, 96)
+        inode, = struct.unpack_from("=Q", data, 104)
+        path = bytes(data[248:1272]).split(b"\0", 1)[0]
+        if not size and start > address and tag == 31 and not inode and not path:
+            # Darwin can return a zero-length hint when the cursor is in a gap.
+            # Requery its exact address; skip no bytes and require forward progress.
+            address = start
+            continue
+        if not size or start + size <= address:
+            raise RuntimeError("malformed mapped-file region")
+        if inode:
+            if not path:
+                raise RuntimeError("mapped vnode path unavailable")
+            files[(device, inode)] = Path(os.fsdecode(path))
+        # A zero vnode covers anonymous memory and kernel-unexposed submaps/pagers;
+        # it is explicitly outside this observer's file-identity guarantee.
+        address = start + size
+    raise RuntimeError("mapped-file scan exceeded region limit")
+
+
+def observe(bundles):
+    bundles = [Path(p) for p in bundles]
+    readers = {p: set() for p in bundles}
+    rows = {}
+    try:
+        identities = {}
+        for bundle in bundles:
+            identities[bundle] = {(s.st_dev, s.st_ino) for p in bundle.rglob("*")
+                                  if p.is_file() for s in [p.stat()]}
+        lib, rows = native(), process_table()
+        deadline = time.monotonic() + 30
+        for pid, row in rows.items():
+            files = mapped_files(lib, row, deadline)
+            current = process_record(lib, pid)
+            if current is None:
+                continue
+            if current.start != row.start or current.executable != row.executable:
+                raise RuntimeError("process changed during reader scan")
+            for bundle in bundles:
+                if (files.keys() & identities[bundle]
+                        or any(path.is_relative_to(bundle) for path in files.values())
+                        or (row.executable is not None and row.executable.is_relative_to(bundle))):
+                    readers[bundle].add(pid)
+        missing_paths = sum(row.executable is None for row in rows.values())
+        note = f"{missing_paths} removed executable paths observed through mapped identities" if missing_paths else ""
+        return Observation("present" if any(readers.values()) else "none", readers, rows, note)
+    except (OSError, RuntimeError, ValueError) as exc:
+        return Observation("unknown", readers, rows, str(exc))
+
+
+def scan_readers(bundles):
+    # A PID may exec between enumeration and inspection. Discard that entire
+    # unknown observation and retry from scratch, at most three times. Never
+    # retry presence, permission errors, malformed data, or other uncertainty.
+    for _ in range(3):
+        result = observe(bundles)
+        if result.state != "unknown" or result.reason != "process changed during reader scan":
+            return result
+    return result
+
+
+class LogCursor:
+    def __init__(self, path):
+        self.path = Path(path)
+        self.identity = None
+        self.prefix = b""
+        self.last_size = 0
+        if self.path.exists():
+            with self.path.open("rb") as stream:
+                info = os.fstat(stream.fileno())
+                self.identity = (info.st_dev, info.st_ino)
+                self.prefix = stream.read()
+                self.last_size = len(self.prefix)
+
+    def read(self):
+        if not self.path.exists() and self.identity is None:
+            return ""
+        with self.path.open("rb") as stream:
+            info = os.fstat(stream.fileno())
+            identity = (info.st_dev, info.st_ino)
+            if self.identity is None:
+                self.identity = identity
+            if identity != self.identity or info.st_size < self.last_size:
+                raise RuntimeError("Desktop log rotated or truncated")
+            data = stream.read()
+        if not data.startswith(self.prefix):
+            raise RuntimeError("Desktop log history changed")
+        self.last_size = len(data)
+        return data[len(self.prefix):].decode("utf-8", errors="strict")
+
+
+def clear_marker(marker, owner):
+    try:
+        lines = Path(marker).read_text(encoding="utf-8").splitlines()
+        if lines and lines[0].strip() == str(owner):
+            Path(marker).unlink()
+    except FileNotFoundError:
+        return
+
+
+def launch_app(app):
+    command("/usr/bin/open", app)
+
+
+def descendants(rows, main):
+    tree = {main.pid: main}
+    for _ in range(len(rows)):
+        added = {pid: row for pid, row in rows.items() if row.parent in tree and pid not in tree}
+        if not added:
+            return tree
+        tree.update(added)
+    raise RuntimeError("cyclic process ancestry")
+
+
+def readiness(text, tree, expected, not_before=0):
+    events = []
+    for line in text.splitlines():
+        match = re.fullmatch(r"\[([^\]]+)\] \[hermes\] (.*)", line)
+        if not match:
+            continue
+        try:
+            stamp = datetime.datetime.fromisoformat(match[1].replace("Z", "+00:00"))
+            if stamp.tzinfo is None or not not_before <= stamp.timestamp() <= time.time() + 1:
+                continue
+        except ValueError:
+            continue
+        events.append(match[2])
+    remote = "[boot] Remote Hermes backend is ready" in events
+    local = "[boot] Hermes backend is ready. Finalizing desktop startup" in events
+    ports = {match[1] for line in events
+             if (match := re.fullmatch(r"HERMES_(?:BACKEND|DASHBOARD)_READY port=(\d+)", line))}
+    if remote and (local or ports) or len(ports) > 1:
+        raise RuntimeError("ambiguous fresh readiness evidence")
+    if remote:
+        return ("remote",)
+    if not local or len(ports) != 1:
+        return None
+    port = int(next(iter(ports)))
+    if not 1 <= port <= 65535:
+        raise RuntimeError("invalid announced port")
+    import psutil
+    listeners = []
+    for pid, row in tree.items():
+        try:
+            for connection in psutil.Process(pid).net_connections(kind="tcp"):
+                if (connection.status == psutil.CONN_LISTEN and connection.laddr.port == port
+                        and connection.laddr.ip in ("127.0.0.1", "::1")):
+                    listeners.append((pid, row.start))
+        except psutil.NoSuchProcess:
+            return None
+        except psutil.AccessDenied as exc:
+            raise RuntimeError("backend listener identity unavailable") from exc
+    if len(listeners) != 1:
+        return None
+    # No proxy or credentials; local health endpoint is public. Its socket must
+    # belong to this launch's descendant, not an unrelated healthy server.
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    try:
+        with opener.open(f"http://127.0.0.1:{port}/api/health", timeout=0.5) as response:
+            body = json.loads(response.read(65536))
+            if response.status != 200 or body.get("version") != expected["backend_version"]:
+                return None
+    except (OSError, ValueError):
+        return None
+    return ("local", port, *listeners[0])
+
+
+def adopt(app, expected, log, retained=None, *, startup=90, stability=10, owned=None):
+    app = Path(app)
+    owned = {} if owned is None else owned
+    bundles = [app] + ([retained] if retained else [])
+    before = scan_readers(bundles)
+    if before.state != "none":
+        raise RuntimeError("launch refused: bundle readers " + before.state)
+    hashes, cursor = validate(app, expected), LogCursor(log)
+    launched_at = time.time()
+    launch_app(app)
+    deadline, stable_since, identity, evidence = time.monotonic() + startup, None, None, None
+    while time.monotonic() < deadline or stable_since is not None:
+        tick = time.monotonic()
+        rows = process_table()
+        mains = [p for p in rows.values() if p.executable == app / "Contents/MacOS/Hermes"
+                 and p.start[0] + p.start[1] / 1_000_000 >= launched_at]
+        if len(mains) > 1:
+            raise RuntimeError("ambiguous canonical Desktop launch")
+        if not mains:
+            if identity is not None:
+                raise RuntimeError("Desktop died during adoption")
+        else:
+            main = mains[0]
+            if identity is not None and (main.pid, main.start) != identity:
+                raise RuntimeError("Desktop process identity changed")
+            identity = (main.pid, main.start)
+            tree = descendants(rows, main)
+            owned.update(tree)
+            renderers = [p for p in tree.values() if p.pid != main.pid and p.executable is not None
+                         and p.executable == app / "Contents/Frameworks/Hermes Helper (Renderer).app/Contents/MacOS/Hermes Helper (Renderer)"]
+            fresh = readiness(cursor.read(), {pid: p for pid, p in tree.items() if pid != main.pid}, expected, launched_at)
+            signature = (fresh, frozenset((p.pid, p.start, p.executable) for p in renderers))
+            if fresh and renderers:
+                if stable_since is None:
+                    stable_since, evidence = tick, signature
+                elif signature != evidence:
+                    raise RuntimeError("backend or renderer changed during stability")
+                if tick - stable_since >= stability:
+                    after = scan_readers(bundles)
+                    if (after.state == "unknown" or (retained and after.readers[retained])
+                            or not after.readers[app].issubset(tree) or main.pid not in after.readers[app]):
+                        raise RuntimeError(f"late or ambiguous bundle readers: {after.state}; {after.reason}")
+                    if validate(app, expected) != hashes:
+                        raise RuntimeError("installed candidate changed during adoption")
+                    final = process_table()
+                    if any(final.get(pid) != p for pid, p in tree.items()):
+                        raise RuntimeError("process tree changed at adoption boundary")
+                    cursor.read()
+                    return main
+            elif stable_since is not None:
+                raise RuntimeError("readiness or renderer lost during stability")
+        # Never sample less frequently than once per second during stability.
+        elapsed = time.monotonic() - tick
+        if stable_since is not None and elapsed > 1:
+            raise RuntimeError("could not sustain one-second stability sampling")
+        interval = 0.8 if stable_since is not None else min(0.8, deadline - time.monotonic())
+        time.sleep(max(0, interval - elapsed))
+    raise RuntimeError("Desktop did not provide fresh adoption evidence within startup deadline")
+
+
+@dataclass
+class Outcome:
+    code: int
+    message: str
+
+
+def require_absent(bundles):
+    observed = scan_readers(bundles)
+    if observed.state != "none":
+        raise RuntimeError(f"bundle readers {observed.state}: {observed.reason}")
+
+
+def stop_owned(owned):
+    lib = native()
+    for pid, original in reversed(list(owned.items())):
+        current = process_record(lib, pid)
+        if current is None:
+            continue
+        if current.start != original.start or current.executable != original.executable:
+            raise RuntimeError("candidate process identity uncertain; not signaling it")
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            continue
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if all(process_record(lib, pid) is None for pid in owned):
+            return
+        time.sleep(0.5)
+    raise RuntimeError("candidate processes did not exit within 30 seconds")
+
+
+def recover(target, retained, old_hashes, old_expected, log, owned):
+    try:
+        stop_owned(owned)
+        require_absent([target, retained])
+        if validate(retained, old_expected) != old_hashes:
+            raise RuntimeError("retained old bundle changed")
+        # Final scan after signature/hashing, immediately before restoration.
+        require_absent([target, retained])
+        exchange(target, retained)
+        if validate(target, old_expected) != old_hashes:
+            raise RuntimeError("restored bundle verification failed")
+    except Exception as exc:
+        return Outcome(7, f"Source/backend advanced; shell recovery uncertain. Manual recovery required: {exc}. Both bundle paths retained: {target}, {retained}")
+    try:
+        adopt(target, old_expected, log, retained)
+        return Outcome(6, f"Source/backend advanced; previous shell restored and reopened. Candidate retained at {retained}.")
+    except Exception as exc:
+        return Outcome(7, f"Source/backend advanced; previous shell restored, reopening unverified. Manual recovery required: {exc}. Candidate retained at {retained}.")
+
+
+def publish_candidate(root, target, owner):
+    target = preflight(root, target)
+    expected = expectation(root)
+    candidate = select_candidate(root, expected)
+    if candidate.resolve().is_relative_to(target) or target.is_relative_to(candidate.resolve()):
+        raise ValueError("overlapping candidate and publication target")
+    old_info = plistlib.loads((target / "Contents/Info.plist").read_bytes())
+    old_stamp = json.loads((target / "Contents/Resources/install-stamp.json").read_text(encoding="utf-8"))
+    old_expected = {**expected, "version": old_info["CFBundleShortVersionString"], "sha": old_stamp["commit"]}
+    old_hashes = validate(target, old_expected)
+    source_hashes = validate(candidate, expected)
+    require_absent([target])
+    directory = Path(tempfile.mkdtemp(prefix=".hermes-exchange-", dir=target.parent))
+    retained = directory / "Hermes.app"
+    # Never sweep prior staging/rollback paths. Even partial copies remain diagnosable.
+    command("/usr/bin/ditto", candidate, retained, timeout=180)
+    if validate(retained, expected) != source_hashes or validate(candidate, expected) != source_hashes:
+        raise RuntimeError("candidate copy/hash mismatch; old shell preserved")
+    if validate(target, old_expected) != old_hashes:
+        raise RuntimeError("old shell changed while staging")
+    require_absent([target, retained])
+    old_inode = target.stat().st_ino
+    candidate_inode = retained.stat().st_ino
+    owned = {}
+    log = Path(root).parent / "logs/desktop.log"
+    try:
+        exchange(target, retained)
+        if validate(target, expected) != source_hashes or fingerprint(retained) != old_hashes:
+            raise RuntimeError("post-exchange bundle identity mismatch")
+        require_absent([target, retained])
+        clear_marker(Path(root).parent / ".hermes-update-in-progress", owner)
+        adopt(target, expected, log, retained, owned=owned)
+        return Outcome(0, f"Updated Desktop adopted. Previous shell retained at {retained}.")
+    except Exception as exc:
+        # A signal can arrive after the native swap but before its wrapper returns.
+        # Determine orientation from directory identity, never from a success flag.
+        try:
+            if target.stat().st_ino == old_inode and retained.stat().st_ino == candidate_inode:
+                return Outcome(5, f"Source/backend advanced; previous shell preserved. Exchange refused: {exc}")
+            if target.stat().st_ino != candidate_inode or retained.stat().st_ino != old_inode:
+                raise RuntimeError("bundle directory identities changed")
+        except Exception as identity_error:
+            return Outcome(7, f"Source/backend advanced; publication state uncertain. Manual recovery required: {identity_error}. Both paths retained: {target}, {retained}")
+        restored = recover(target, retained, old_hashes, old_expected, log, owned)
+        restored.message = f"Candidate adoption failed ({exc}). {restored.message}"
+        return restored
+
+
+def complete(root, target, branch, owner, update_code, message):
+    root, target = Path(root), Path(target)
+    outcome = Outcome(update_code or 5, message)
+    try:
+        if update_code:
+            outcome.message = f"Underlying update failed ({update_code}); shell preserved; source/backend may have advanced. {message}"
+        else:
+            outcome = publish_candidate(root, target, owner)
+    except (OSError, RuntimeError, ValueError, KeyError, TypeError, subprocess.TimeoutExpired) as exc:
+        outcome = Outcome(5, f"Source/backend advanced; previous shell preserved. Publication refused: {exc}")
+    try:
+        clear_marker(root.parent / ".hermes-update-in-progress", owner)
+        result = dict(ok=outcome.code == 0, exit_code=outcome.code, manual=outcome.code != 0,
+                      message=outcome.message, branch=branch, finished_at=int(time.time()))
+        path = root.parent / ".hermes-update-result.json"
+        # Existing result protocol; a failed write cannot become a successful event.
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", dir=root.parent,
+                                         prefix=".hermes-update-result-", delete=False) as stream:
+            json.dump(result, stream)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(stream.name, path)
+    except (OSError, IndexError) as exc:
+        return Outcome(9, f"{outcome.message} Terminal result could not be recorded ({type(exc).__name__}); manual follow-up required.")
+    return outcome
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=["preflight", "complete"])
+    parser.add_argument("root", type=Path)
+    parser.add_argument("target", type=Path)
+    parser.add_argument("--owner", type=int, default=0)
+    parser.add_argument("--branch", default="main")
+    parser.add_argument("--update-code", type=int, default=0)
+    parser.add_argument("--message", default="")
+    args = parser.parse_args()
+    if sys.platform != "darwin":
+        return 5
+
+    def interrupted(signum, frame):
+        raise RuntimeError(f"controlled updater interruption ({signum})")
+
+    for signum in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):  # windows-footgun: ok — Darwin-only entrypoint
+        signal.signal(signum, interrupted)
+    if args.action == "preflight":
+        try:
+            preflight(args.root, args.target)
+            return 0
+        except (OSError, RuntimeError, ValueError) as exc:
+            print(f"Publication refused before update: {exc}")
+            return 5
+    outcome = complete(args.root, args.target, args.branch, args.owner, args.update_code, args.message)
+    print(outcome.message)
+    return outcome.code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -886,9 +886,12 @@ def _desktop_macos_relaunchable_fixup(
         if identity != "-":
             print(
                 f"  (warning: configured macOS signing identity failed: {identity!r}; "
-                "falling back to ad-hoc — TCC grants may need to be re-granted)"
+                "refusing to replace it with an ad-hoc identity)"
             )
+            return False
         print(f"  (warning: stable macOS signing failed ({exc}); using legacy ad-hoc sign)")
+    if identity != "-":
+        return False
     return _macos_legacy_adhoc_resign(codesign, app)
 
 
@@ -1330,7 +1333,19 @@ def _promote_staged_desktop_app(desktop_dir: Path, staging_dir: Path) -> Path:
     # Locally-built apps are ad-hoc signed; make them relaunchable after an
     # in-place self-update. Signs the STAGED bundle so the live app is never
     # half-signed. No-op on non-macOS and on real-identity builds.
-    _desktop_macos_relaunchable_fixup(desktop_dir, release_dir=staging_dir)
+    signing_ok = _desktop_macos_relaunchable_fixup(desktop_dir, release_dir=staging_dir)
+    if sys.platform == "darwin":
+        try:
+            signing_ok = signing_ok and staged_executable is not None and _codesign_verify(
+                "/usr/bin/codesign", staged_executable.parents[2], check=False, timeout=30
+            ).returncode == 0
+        except (OSError, subprocess.TimeoutExpired):
+            signing_ok = False
+    if not signing_ok:
+        _discard_desktop_staging(staging_dir)
+        print("✗ Desktop signing or independent signature verification failed.")
+        print(_PREVIOUS_APP_KEPT)
+        sys.exit(1)
 
     # Windows integrity gate: never declare the rebuild a success on a
     # Hermes.exe Windows cannot load. Verified on the STAGED exe, so a failure

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -341,48 +341,9 @@ linux_gate() {
   GATE=manual GATE_MSG="Update complete, but the rebuilt app can't relaunch itself (its sandbox helper needs root ownership). Reopen Hermes to finish."
 }
 
-mac_swap() {
-  local rebuilt="" c
-  for c in "$INSTALL_ROOT/apps/desktop/release/mac-arm64/Hermes.app" \
-           "$INSTALL_ROOT/apps/desktop/release/mac/Hermes.app"; do
-    [ -d "$c" ] && { rebuilt="$c"; break; }
-  done
-
-  # Transactional swap: stage a full copy, move the old bundle aside, move
-  # the copy in. Every step checked; a failed final move ROLLS BACK so the
-  # user always has a launchable app, and the result file tells the truth.
-  if [ "$FINAL_CODE" -eq 0 ] && [ -n "$rebuilt" ] && [ -d "$RELAUNCH_TARGET" ] && [ "$rebuilt" != "$RELAUNCH_TARGET" ]; then
-    publish_stage "Installing the new app"
-    rm -rf "$RELAUNCH_TARGET.new" "$RELAUNCH_TARGET.old" 2>/dev/null || true
-    if ! /usr/bin/ditto "$rebuilt" "$RELAUNCH_TARGET.new"; then
-      rm -rf "$RELAUNCH_TARGET.new" 2>/dev/null || true
-      DONE_NOTE="Update complete, but the new app could not be staged; the previous version was kept. Run the update again."
-      log "WARNING: bundle copy failed; keeping existing app"
-    elif ! mv "$RELAUNCH_TARGET" "$RELAUNCH_TARGET.old"; then
-      rm -rf "$RELAUNCH_TARGET.new" 2>/dev/null || true
-      DONE_NOTE="Update complete, but the new app could not replace the old one; the previous version was kept. Run the update again."
-      log "WARNING: could not move old bundle aside; keeping existing app"
-    elif ! mv "$RELAUNCH_TARGET.new" "$RELAUNCH_TARGET"; then
-      if mv "$RELAUNCH_TARGET.old" "$RELAUNCH_TARGET"; then
-        rm -rf "$RELAUNCH_TARGET.new" 2>/dev/null || true
-        DONE_NOTE="Update complete, but the new app could not be installed; the previous version was restored. Run the update again."
-        log "WARNING: bundle install failed; rolled back to the previous app"
-      else
-        FINAL_CODE=7 FINAL_MSG="The update finished but installing the new app failed and the previous app could not be restored. Reinstall Hermes (the rebuilt app is at $rebuilt)."
-        log "ERROR: bundle install failed AND rollback failed"
-      fi
-    else
-      rm -rf "$RELAUNCH_TARGET.old" 2>/dev/null || true
-      log "swapped app bundle"
-    fi
-  fi
-}
-
 deliver_outcome() { # the truth-determining half: swap bundles / gate the relaunch
   [ -n "$RELAUNCH_TARGET" ] || return 0
-  if [ "$(uname)" = "Darwin" ]; then
-    mac_swap
-  else
+  if [ "$(uname)" != "Darwin" ]; then
     linux_gate
     if [ "$GATE" != "relaunch" ] && [ "$FINAL_CODE" -eq 0 ]; then
       DONE_NOTE="$GATE_MSG"
@@ -430,6 +391,26 @@ write_result() {
 }
 
 finish() {
+  if [ "$(uname)" = "Darwin" ] && [ -n "$RELAUNCH_TARGET" ]; then
+    # The helper owns publication, launch, recovery and the existing result file.
+    # Never fall through to the legacy launch-acceptance exit handler.
+    trap - EXIT
+    local py="$INSTALL_ROOT/venv/bin/python3" outcome
+    tcc_probe_python "$py" || py="$(command -v python3)"
+    outcome="$("$py" "$SCRIPT_DIR/../../hermes_cli/desktop_macos_update.py" complete \
+      "$INSTALL_ROOT" "$RELAUNCH_TARGET" --owner "$$" --branch "$BRANCH" \
+      --update-code "$FINAL_CODE" --message "$FINAL_MSG" 2>>"$LOG")"
+    FINAL_CODE=$?
+    FINAL_MSG="${outcome:-macOS publication helper failed; shell state unverified. Manual recovery required.}"
+    log "$FINAL_MSG"
+    if [ "$FINAL_CODE" -eq 0 ]; then
+      publish "done" "$FINAL_MSG"; stop_ui
+    else
+      publish "error" "$FINAL_MSG"; stop_ui leave-window
+    fi
+    rm -f "$STATUS" "$STATUS.tmp" "$LOG_DIR/desktop-update-ui-port" 2>/dev/null || true
+    exit "$FINAL_CODE"
+  fi
   # Ordering (gille's reviews, both rounds):
   #   1. deliver the outcome (swap/gate) so the truth exists;
   #   2. durable result + marker removal (the relaunched app consumes the
@@ -722,6 +703,18 @@ start_ui
 
 HERMES_BIN="$INSTALL_ROOT/venv/bin/hermes"
 [ -x "$HERMES_BIN" ] || { FINAL_CODE=3 FINAL_MSG="Update aborted: $HERMES_BIN is missing. The install needs repair (run the Hermes installer or hermes doctor)."; log "$FINAL_MSG"; exit 3; }
+
+# Reject publication into/over the producer tree before the underlying update
+# can rebuild or remove it. This runs even if no candidate has been built yet.
+if [ "$(uname)" = "Darwin" ] && [ -n "$RELAUNCH_TARGET" ]; then
+  MACOS_PY="$INSTALL_ROOT/venv/bin/python3"
+  tcc_probe_python "$MACOS_PY" || MACOS_PY="$(command -v python3)"
+  MACOS_PREFLIGHT="$("$MACOS_PY" "$SCRIPT_DIR/../../hermes_cli/desktop_macos_update.py" preflight \
+    "$INSTALL_ROOT" "$RELAUNCH_TARGET" 2>>"$LOG")" || {
+    FINAL_CODE=5 FINAL_MSG="$MACOS_PREFLIGHT Source/backend update was not run."
+    log "$FINAL_MSG"; exit "$FINAL_CODE"
+  }
+fi
 
 # Heal a venv the reverted TCC anchor left bricked BEFORE invoking the CLI:
 # venv/bin/hermes execs venv/bin/python3, so a dead alias kills every attempt

--- a/tests/hermes_cli/test_desktop_macos_producer.py
+++ b/tests/hermes_cli/test_desktop_macos_producer.py
@@ -1,0 +1,42 @@
+"""macOS candidate promotion must not turn a signing failure into success."""
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import main_desktop as producer
+
+
+pytestmark = pytest.mark.macos_only
+
+
+@pytest.mark.parametrize("fixup_ok", [False, True])
+def test_unverified_signature_never_replaces_release(tmp_path, monkeypatch, fixup_ok):
+    desktop = tmp_path / "apps/desktop"
+    old = desktop / "release/mac-arm64/Hermes.app/Contents/MacOS/Hermes"
+    staged = desktop / ".staging-test/mac-arm64/Hermes.app/Contents/MacOS/Hermes"
+    old.parent.mkdir(parents=True)
+    staged.parent.mkdir(parents=True)
+    old.write_bytes(b"previous working package")
+    staged.write_bytes(b"unsigned invalid executable")
+    # The signing operation is external; promotion and release writes stay real.
+    monkeypatch.setattr(producer, "_desktop_macos_relaunchable_fixup", lambda *a, **k: fixup_ok)
+    with pytest.raises(SystemExit) as error:
+        producer._promote_staged_desktop_app(desktop, desktop / ".staging-test")
+    assert error.value.code != 0
+    assert old.read_bytes() == b"previous working package"
+
+
+def test_configured_identity_failure_does_not_fall_back_to_adhoc(tmp_path, monkeypatch):
+    app = tmp_path / "release/mac-arm64/Hermes.app"
+    exe = app / "Contents/MacOS/Hermes"
+    exe.parent.mkdir(parents=True)
+    exe.write_bytes(b"unsigned")
+    monkeypatch.setattr(producer, "_desktop_macos_local_signing_identity", lambda: "Configured Identity")
+
+    def fail_sign(*args, **kwargs):
+        raise RuntimeError("signer unavailable")
+
+    monkeypatch.setattr(producer, "_desktop_macos_local_codesign", fail_sign)
+    # If called, the legacy signer would report success: observable return must remain false.
+    monkeypatch.setattr(producer, "_macos_legacy_adhoc_resign", lambda *a: True)
+    assert producer._desktop_macos_relaunchable_fixup(tmp_path, publisher_signing_configured=False) is False

--- a/tests/hermes_cli/test_desktop_macos_update.py
+++ b/tests/hermes_cli/test_desktop_macos_update.py
@@ -1,0 +1,855 @@
+"""Behavioral publication gates, using disposable signed Darwin bundles."""
+import datetime
+import importlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import plistlib
+import shutil
+import subprocess
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.macos_only
+
+
+def updater():
+    assert importlib.util.find_spec("hermes_cli.desktop_macos_update"), "missing bounded macOS updater"
+    return importlib.import_module("hermes_cli.desktop_macos_update")
+
+
+def run(*args, **kwargs):
+    return subprocess.run(args, check=True, capture_output=True, **kwargs)
+
+
+def sign(app):
+    run("/usr/bin/codesign", "--force", "--deep", "--sign", "-", str(app))
+
+
+@pytest.fixture
+def bundles(tmp_path, native_program):
+    root = tmp_path / "home/hermes-agent"
+    desktop = root / "apps/desktop"
+    desktop.mkdir(parents=True)
+    package = {"version": "1.2.3", "build": {"appId": "test.hermes.updater." + uuid.uuid4().hex}}
+    (desktop / "package.json").write_text(json.dumps(package))
+    (root / "hermes_cli").mkdir()
+    (root / "hermes_cli/__init__.py").write_text('__version__ = "4.5.6"\n')
+    run("git", "init", "-q", str(root))
+    run("git", "-C", str(root), "add", ".")
+    run("git", "-C", str(root), "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+        "-c", "commit.gpgsign=false", "commit", "-qm", "fixture source")
+    sha = run("git", "-C", str(root), "rev-parse", "HEAD").stdout.decode().strip()
+    candidate = desktop / "release/mac-arm64/Hermes.app"
+    if os.uname().machine != "arm64":
+        candidate = desktop / "release/mac/Hermes.app"
+    resources = candidate / "Contents/Resources"
+    resources.mkdir(parents=True)
+    executable = candidate / "Contents/MacOS/Hermes"
+    executable.parent.mkdir()
+    shutil.copyfile(native_program, executable)
+    executable.chmod(0o755)
+    info = {"CFBundleIdentifier": package["build"]["appId"], "CFBundleExecutable": "Hermes",
+            "CFBundleShortVersionString": package["version"], "CFBundlePackageType": "APPL"}
+    (candidate / "Contents/Info.plist").write_bytes(plistlib.dumps(info))
+    stamp = {"schemaVersion": 1, "commit": sha, "source": "local", "dirty": False,
+             "builtAt": datetime.datetime.now(datetime.timezone.utc).isoformat()}
+    (resources / "install-stamp.json").write_text(json.dumps(stamp))
+    (resources / "app.asar").write_bytes(b"fixture archive")
+    (resources / "app.asar.unpacked/dist").mkdir(parents=True)
+    (resources / "app.asar.unpacked/dist/index.html").write_text("fixture renderer")
+    sign(candidate)
+    target = tmp_path / "Applications/Hermes.app"
+    target.parent.mkdir()
+    shutil.copytree(candidate, target, symlinks=True)
+    return root, candidate, target
+
+
+@pytest.fixture(scope="session")
+def native_program(tmp_path_factory):
+    program = tmp_path_factory.mktemp("native-program") / "fixture"
+    run("/usr/bin/clang", "-x", "c", "-", "-o", str(program),
+        input=b'''#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <libgen.h>
+#include <mach-o/dyld.h>
+int main(int n,char**v){
+ if(n>1){sleep(atoi(v[1]));return 0;}
+ char exe[4096],script[4096],helper[4096]; unsigned size=sizeof(exe);
+ if(_NSGetExecutablePath(exe,&size))return 2;
+ char *dir=dirname(exe);
+ snprintf(script,sizeof(script),"%s/../Resources/fixture-launch.sh",dir);
+ if(access(script,R_OK))return 0;
+ snprintf(helper,sizeof(helper),"%s/../Frameworks/Hermes Helper (Renderer).app/Contents/MacOS/Hermes Helper (Renderer)",dir);
+ if(access(helper,X_OK))snprintf(helper,sizeof(helper),"%s/../Frameworks/Hermes Helper (GPU).app/Contents/MacOS/Hermes Helper (GPU)",dir);
+ if(fork()==0){execl(helper,helper,"120",NULL);_exit(2);}
+ if(fork()==0){execl("/bin/bash","/bin/bash",script,NULL);_exit(2);}
+ sleep(120);return 0;
+}''')
+    return program
+
+
+def test_validate_and_hash_signed_candidate_including_unpacked_assets(bundles):
+    root, candidate, _ = bundles
+    update = updater()
+    expected = update.expectation(root)
+    valid = update.validate(candidate, expected)
+    (candidate / "Contents/Resources/app.asar.unpacked/dist/index.html").write_text("changed")
+    sign(candidate)
+    assert update.validate(candidate, expected).tree != valid.tree
+
+
+@pytest.mark.parametrize("damage", ["commit", "dirty", "schema", "timestamp", "future", "fallback",
+                                     "identity", "executable", "version", "signature", "architecture"])
+def test_invalid_candidate_refused_before_publication(bundles, damage, monkeypatch):
+    root, candidate, target = bundles
+    update = updater()
+    expected = update.expectation(root)
+    original = update.fingerprint(target)
+    stamp_path = candidate / "Contents/Resources/install-stamp.json"
+    stamp = json.loads(stamp_path.read_text())
+    changes = {"commit": {"commit": "a" * 40}, "dirty": {"dirty": True},
+               "schema": {"schemaVersion": 2}, "timestamp": {"builtAt": "invalid"},
+               "future": {"builtAt": "2999-01-01T00:00:00Z"}, "fallback": {"source": "fallback"}}
+    if damage in changes:
+        stamp.update(changes[damage])
+        stamp_path.write_text(json.dumps(stamp))
+        sign(candidate)
+    elif damage in ("identity", "executable", "version"):
+        info_path = candidate / "Contents/Info.plist"
+        info = plistlib.loads(info_path.read_bytes())
+        info[{"identity": "CFBundleIdentifier", "executable": "CFBundleExecutable",
+              "version": "CFBundleShortVersionString"}[damage]] = "wrong"
+        info_path.write_bytes(plistlib.dumps(info))
+        sign(candidate)
+    elif damage == "signature":
+        (candidate / "Contents/MacOS/Hermes").write_bytes(b"bad")
+    else:
+        expected = {**expected, "arch": "incompatible"}
+    with pytest.raises((ValueError, RuntimeError, OSError)):
+        update.validate(candidate, expected)
+    assert update.fingerprint(target) == original
+
+
+def test_select_refuses_ambiguous_or_missing_candidate(bundles):
+    root, candidate, _ = bundles
+    update = updater()
+    expected = update.expectation(root)
+    assert update.select_candidate(root, expected) == candidate
+    duplicate = candidate.parents[1] / "mac-universal/Hermes.app"
+    shutil.copytree(candidate, duplicate)
+    with pytest.raises(ValueError, match="ambiguous"):
+        update.select_candidate(root, expected)
+    shutil.rmtree(duplicate)
+    shutil.rmtree(candidate)
+    with pytest.raises(ValueError):
+        update.select_candidate(root, expected)
+
+
+@pytest.mark.parametrize("layout", ["inside-release", "source-ancestor", "symlink", "not-app"])
+def test_preflight_rejects_unsafe_publication_layout(bundles, layout):
+    root, candidate, target = bundles
+    update = updater()
+    if layout == "inside-release":
+        target = candidate
+    elif layout == "source-ancestor":
+        target = root.parent
+    elif layout == "symlink":
+        link = target.parent / "Link.app"
+        link.symlink_to(target)
+        target = link
+    else:
+        target = target.parent
+    with pytest.raises((ValueError, RuntimeError)):
+        update.preflight(root, target)
+
+
+def test_native_exchange_retains_both_identities_and_refuses_cross_volume(tmp_path, monkeypatch):
+    update = updater()
+    left, right = tmp_path / "left", tmp_path / "right"
+    left.mkdir()
+    right.mkdir()
+    (left / "identity").write_text("old")
+    (right / "identity").write_text("new")
+    update.exchange(left, right)
+    assert (left / "identity").read_text() == "new"
+    assert (right / "identity").read_text() == "old"
+    update.exchange(left, right)
+    assert (left / "identity").read_text() == "old"
+    real_stat = Path.stat
+
+    def different_volume(path, *args, **kwargs):
+        result = real_stat(path, *args, **kwargs)
+        if path == right:
+            fields = list(result)
+            fields[2] += 1
+            return os.stat_result(fields)
+        return result
+
+    monkeypatch.setattr(Path, "stat", different_volume)
+    with pytest.raises(ValueError, match="volume"):
+        update.exchange(left, right)
+    assert (left / "identity").read_text() == "old"
+
+
+def shell_handoff(root, target):
+    """Execute production shell against a stub updater; deny production writes/notifications."""
+    import sys
+    bin_dir = root / "venv/bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("python", "python3"):
+        (bin_dir / name).symlink_to(sys.executable)
+    hermes = bin_dir / "hermes"
+    hermes.write_text('#!/bin/bash\ncase "$*" in *--help*) echo --keep-stash;; *) echo fixture-update;; esac\n')
+    hermes.chmod(0o755)
+    script = Path(__file__).resolve().parents[2] / "scripts/desktop-update/posix.sh"
+    env = {"PATH": os.environ["PATH"], "HOME": str(root.parent),
+           "TMPDIR": str(root.parent), "HERMES_UPDATE_SHIM_GRACE_SECONDS": "0"}
+    policy = '(version 1)(allow default)(deny file-write* (subpath "/Applications") (subpath "/Users/mini/.hermes"))(deny process-exec (literal "/usr/bin/osascript"))'
+    return subprocess.run(["/usr/bin/sandbox-exec", "-p", policy, "/bin/bash", str(script),
+                           "--daemonized", "--install-root", str(root), "--desktop-pid", "0",
+                           "--no-ui", "--relaunch-target", str(target)],
+                          env=env, capture_output=True, text=True, timeout=150)
+
+
+def test_handoff_preserves_historical_rollback(bundles):
+    root, _, target = bundles
+    historical = target.with_name(target.name + ".old")
+    historical.mkdir()
+    (historical / "recovery").write_text("historical recovery")
+    shell_handoff(root, target)
+    assert (historical / "recovery").read_text() == "historical recovery"
+
+
+def test_handoff_launch_acceptance_without_readiness_is_not_success(bundles):
+    root, _, target = bundles
+    completed = shell_handoff(root, target)
+    result = json.loads((root.parent / ".hermes-update-result.json").read_text())
+    assert result["ok"] is False
+    assert result["exit_code"] != 0
+    assert completed.returncode != 0
+
+
+@pytest.mark.parametrize("reader", ["main", "helper", "renderer", "mapped-only"])
+def test_native_observation_finds_exact_bundle_readers(bundles, reader):
+    import sys
+    root, _, target = bundles
+    update = updater()
+    assert hasattr(update, "observe"), "reader observation gate is missing"
+    def observed():
+        import time
+        # Live unrelated processes can exit during a scan. Unknown is safe; retry
+        # a fresh scan, never turn it into absence or accept an incorrect known state.
+        for _ in range(3):
+            result = update.observe([target])
+            if result.state != "unknown":
+                return result
+            time.sleep(0.2)
+        pytest.fail(result.reason)
+
+    assert observed().state == "none"
+    executable = target / "Contents/MacOS/Hermes"
+    if reader in ("helper", "renderer"):
+        helper = target / f"Contents/Frameworks/{reader}.app/Contents/MacOS/{reader}"
+        helper.parent.mkdir(parents=True)
+        shutil.copyfile(executable, helper)
+        helper.chmod(0o755)
+        executable = helper
+    if reader == "mapped-only":
+        process = subprocess.Popen([sys.executable, "-c",
+            "import mmap,os,sys; f=os.open(sys.argv[1],os.O_RDONLY); "
+            "m=mmap.mmap(f,0,access=mmap.ACCESS_READ,trackfd=False); os.close(f); "
+            "print('ready',flush=True); sys.stdin.read()",
+            str(target / "Contents/Resources/app.asar")], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        assert process.stdout.readline() == b"ready\n"
+    else:
+        process = subprocess.Popen([str(executable), "30"])
+    try:
+        found = observed()
+        assert found.state == "present", found
+        assert process.pid in found.readers[target]
+    finally:
+        process.terminate()
+        process.wait(timeout=10)
+        if process.stdin:
+            process.stdin.close()
+            process.stdout.close()
+    assert observed().state == "none"
+
+
+def test_native_scanner_explicit_errors_are_unknown(bundles, monkeypatch):
+    _, _, target = bundles
+    update = updater()
+    assert hasattr(update, "observe"), "reader observation gate is missing"
+
+    def denied():
+        raise PermissionError("fixture denied inspection")
+
+    monkeypatch.setattr(update, "process_table", denied)
+    assert update.observe([target]).state == "unknown"
+
+
+@pytest.mark.parametrize("change", ["rotate", "truncate", "rewrite"])
+def test_log_cursor_rejects_ambiguous_history(tmp_path, change):
+    update = updater()
+    assert hasattr(update, "LogCursor"), "fresh-log evidence gate is missing"
+    log = tmp_path / "desktop.log"
+    log.write_text("old readiness evidence\n")
+    cursor = update.LogCursor(log)
+    with log.open("a") as stream:
+        stream.write("fresh startup\n")
+    assert cursor.read() == "fresh startup\n"
+    if change == "rotate":
+        log.rename(tmp_path / "desktop.log.old")
+        log.write_text("a new log with enough bytes to exceed the old offset\n")
+    else:
+        log.write_text("" if change == "truncate" else "changed prefix with a longer suffix than before\n")
+    with pytest.raises(RuntimeError):
+        cursor.read()
+
+
+def test_fresh_remote_event_requires_canonical_process_and_renderer(bundles, monkeypatch):
+    update = updater()
+    assert hasattr(update, "adopt"), "adoption gate is missing"
+    root, _, target = bundles
+    expected = update.expectation(root)
+    log = root.parent / "logs/desktop.log"
+    log.parent.mkdir()
+    log.write_text("Remote Hermes backend is ready\n")
+    launched = []
+
+    def start(app):
+        launched.append(subprocess.Popen([str(app / "Contents/MacOS/Hermes"), "30"]))
+
+    monkeypatch.setattr(update, "launch_app", start)
+    try:
+        with pytest.raises(RuntimeError):
+            update.adopt(target, expected, log, startup=0.5, stability=0.2)
+    finally:
+        for process in launched:
+            process.terminate()
+            process.wait(timeout=10)
+
+
+def test_marker_cleanup_is_owner_scoped(tmp_path):
+    update = updater()
+    assert hasattr(update, "clear_marker"), "owner-scoped marker handling is missing"
+    marker = tmp_path / ".hermes-update-in-progress"
+    marker.write_text("123\n1000\n")
+    update.clear_marker(marker, 456)
+    assert marker.read_text() == "123\n1000\n"
+    update.clear_marker(marker, 123)
+    assert not marker.exists()
+
+
+def install_launch_fixture(app, log, mode="local", version="4.5.6", helper_kind="Renderer"):
+    """Native shell/renderer + real HTTP child, using the existing log events only."""
+    import shlex
+    import sys
+    resources = app / "Contents/Resources"
+    name = f"Hermes Helper ({helper_kind})"
+    helper = app / f"Contents/Frameworks/{name}.app/Contents/MacOS/{name}"
+    helper.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(app / "Contents/MacOS/Hermes", helper)
+    helper.chmod(0o755)
+    backend = resources / "fixture-backend.py"
+    backend.write_text('''import datetime,http.server,json,pathlib,sys,threading,urllib.request,time
+log=pathlib.Path(sys.argv[1]);mode=sys.argv[2];version=sys.argv[3]
+class Handler(http.server.BaseHTTPRequestHandler):
+ def do_GET(self):
+  data=json.dumps({"ok":True,"version":version}).encode()
+  self.send_response(200);self.end_headers();self.wfile.write(data)
+ def log_message(self,*args):pass
+server=http.server.HTTPServer(("127.0.0.1",0),Handler)
+threading.Thread(target=server.serve_forever,daemon=True).start()
+def write(message):
+ with log.open("a") as f:f.write("["+datetime.datetime.now(datetime.timezone.utc).isoformat()+"] [hermes] "+message+"\\n")
+port=server.server_address[1]
+urllib.request.urlopen("http://127.0.0.1:"+str(port)+"/api/health").read()
+if mode=="local":
+ write("HERMES_BACKEND_READY port="+str(port))
+ write("[boot] Hermes backend is ready. Finalizing desktop startup")
+elif mode=="remote":write("[boot] Remote Hermes backend is ready")
+elif mode=="unrelated":
+ write("HERMES_BACKEND_READY port=1")
+ write("[boot] Hermes backend is ready. Finalizing desktop startup")
+elif mode=="die":
+ write("[boot] Remote Hermes backend is ready");time.sleep(1);sys.exit(0)
+while True:time.sleep(1)
+''')
+    (resources / "fixture-launch.sh").write_text("exec " + " ".join(map(shlex.quote,
+        [sys.executable, str(backend), str(log), mode, version])) + "\n")
+    sign(app)
+
+
+def stop_fixture(app):
+    import psutil
+    # Only this disposable bundle's native processes and their current children.
+    owned = {}
+    for process in psutil.process_iter(["exe"]):
+        if process.info["exe"] and Path(process.info["exe"]).is_relative_to(app):
+            owned[process.pid] = process
+            owned.update({child.pid: child for child in process.children(recursive=True)})
+    for process in reversed(list(owned.values())):
+        try:
+            process.terminate()
+        except psutil.NoSuchProcess:
+            pass
+    _, alive = psutil.wait_procs(list(owned.values()), timeout=5)
+    for process in alive:
+        if process.status() != psutil.STATUS_ZOMBIE:
+            process.kill()
+    psutil.wait_procs(alive, timeout=5)
+
+
+@pytest.mark.parametrize("mode", ["local", "remote"])
+@pytest.mark.live_system_guard_bypass  # LaunchServices reparents our disposable apps to PID 1.
+def test_native_launch_and_mode_appropriate_adoption(bundles, mode):
+    update = updater()
+    assert hasattr(update, "adopt"), "adoption gate is missing"
+    root, _, target = bundles
+    log = root.parent / "logs/desktop.log"
+    log.parent.mkdir()
+    log.write_text("historical log\n")
+    install_launch_fixture(target, log, mode)
+    try:
+        # Real /usr/bin/open and native observation. Production default 90s/10s.
+        adopted = update.adopt(target, update.expectation(root), log)
+        assert adopted.pid > 0
+        assert adopted.executable == target / "Contents/MacOS/Hermes"
+    finally:
+        stop_fixture(target)
+
+
+@pytest.mark.parametrize("failure", ["adoption", "copy", "final-reader", "late-reader", "result-write",
+                                     "after-swap-exception", "recovery-timeout"])
+def test_publication_failures_preserve_recovery_and_never_report_success(bundles, monkeypatch, failure):
+    update = updater()
+    assert hasattr(update, "complete"), "controlled publication and recovery are missing"
+    root, candidate, target = bundles
+    (target / "Contents/Resources/app.asar").write_bytes(b"old distinct archive")
+    sign(target)
+    old = update.fingerprint(target)
+    marker = root.parent / ".hermes-update-in-progress"
+    marker.write_text(f"{os.getpid()}\n1000\n")
+    attempts = []
+    # Deterministic state-machine unit cases; separate native tests exercise the
+    # real observer (including main/helper/renderer and closed-fd mappings).
+    monkeypatch.setattr(update, "observe", lambda paths: update.Observation(
+        "none", {p: set() for p in paths}, {}))
+
+    def adoption(app, *args, **kwargs):
+        attempts.append(update.fingerprint(app))
+        if len(attempts) == 1:
+            raise RuntimeError("fixture candidate adoption failed")
+        return update.Process(99999, (1, 0), 1, app / "Contents/MacOS/Hermes")
+
+    monkeypatch.setattr(update, "adopt", adoption)
+    if failure == "after-swap-exception":
+        real_exchange = update.exchange
+        swapped = 0
+
+        def interrupted(left, right):
+            nonlocal swapped
+            real_exchange(left, right)
+            if left == target:
+                swapped += 1
+                if swapped == 1:
+                    raise RuntimeError("interrupted immediately after exchange")
+
+        monkeypatch.setattr(update, "exchange", interrupted)
+        monkeypatch.setattr(update, "adopt", lambda *args, **kwargs: None)
+    if failure == "recovery-timeout":
+        real_validate = update.validate
+
+        def timeout(app, expected):
+            if attempts and Path(app).parent.name.startswith(".hermes-exchange-"):
+                raise subprocess.TimeoutExpired("codesign", 30)
+            return real_validate(app, expected)
+
+        monkeypatch.setattr(update, "validate", timeout)
+    if failure == "copy":
+        real_command = update.command
+
+        def torn_copy(*args, **kwargs):
+            result = real_command(*args, **kwargs)
+            if args[0] == "/usr/bin/ditto":
+                (Path(args[2]) / "Contents/Resources/app.asar").write_bytes(b"torn")
+            return result
+
+        monkeypatch.setattr(update, "command", torn_copy)
+    if failure in ("final-reader", "late-reader"):
+        real_observe = update.observe
+        calls = 0
+
+        def new_reader(paths):
+            nonlocal calls
+            calls += 1
+            # First scan before staging; second immediately before exchange.
+            if calls >= (2 if failure == "final-reader" else 3):
+                return update.Observation("unknown", {p: set() for p in paths}, {}, "fixture scan uncertainty")
+            return real_observe(paths)
+
+        monkeypatch.setattr(update, "observe", new_reader)
+    if failure == "result-write":
+        (root.parent / ".hermes-update-result.json").mkdir()
+    outcome = update.complete(root, target, "main", os.getpid(), 0, "update completed")
+    assert outcome.code != 0
+    if failure not in ("late-reader", "recovery-timeout"):
+        assert update.fingerprint(target) == old
+    else:
+        assert "manual" in outcome.message.lower()
+    retained = list(target.parent.glob(".hermes-exchange-*/Hermes.app"))
+    if failure in ("adoption", "late-reader", "result-write"):
+        assert len(retained) == 1
+    if failure != "result-write":
+        result = json.loads((root.parent / ".hermes-update-result.json").read_text())
+        assert result["ok"] is False
+        assert result["exit_code"] == outcome.code
+    if failure == "adoption":
+        assert attempts[1] == old
+        assert "restored" in outcome.message.lower()
+
+
+@pytest.mark.live_system_guard_bypass
+def test_gpu_child_cannot_satisfy_renderer_gate(bundles):
+    update = updater()
+    root, _, target = bundles
+    log = root.parent / "logs/desktop.log"
+    log.parent.mkdir()
+    log.write_text("historical log\n")
+    install_launch_fixture(target, log, "remote", helper_kind="GPU")
+    try:
+        with pytest.raises(RuntimeError):
+            update.adopt(target, update.expectation(root), log, startup=4, stability=1)
+    finally:
+        stop_fixture(target)
+
+
+@pytest.mark.parametrize("line", ["[renderer] Error: Remote Hermes backend is ready: false",
+                                  "[boot] Remote Hermes backend is ready: false",
+                                  "Remote Hermes backend is ready"])
+def test_readiness_rejects_diagnostic_lookalikes(line):
+    update = updater()
+    text = "[2026-09-10T10:00:00Z] [hermes] " + line + "\n"
+    assert update.readiness(text, {}, {}) is None
+
+
+@pytest.mark.live_system_guard_bypass
+def test_two_native_updates_retain_unique_rollbacks(bundles):
+    update = updater()
+    root, candidate, target = bundles
+    log = root.parent / "logs/desktop.log"
+    log.parent.mkdir()
+    log.write_text("history\n")
+    install_launch_fixture(candidate, log, "remote")
+    old = update.fingerprint(target)
+    try:
+        first = update.complete(root, target, "main", os.getpid(), 0, "updated")
+        assert first.code == 0, first.message + "\n" + log.read_text()
+        first_hash = update.fingerprint(target)
+        stop_fixture(target)
+        # A subsequent source revision, never the patch's frozen base.
+        (root / "revision").write_text("second update")
+        run("git", "-C", str(root), "add", "revision")
+        run("git", "-C", str(root), "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+            "-c", "commit.gpgsign=false", "commit", "-qm", "next source")
+        stamp_path = candidate / "Contents/Resources/install-stamp.json"
+        stamp = json.loads(stamp_path.read_text())
+        stamp["commit"] = update.expectation(root)["sha"]
+        stamp_path.write_text(json.dumps(stamp))
+        (candidate / "Contents/Resources/app.asar").write_bytes(b"second candidate")
+        sign(candidate)
+        second = update.complete(root, target, "main", os.getpid(), 0, "updated")
+        assert second.code == 0, second.message + "\n" + log.read_text()
+        retained = list(target.parent.glob(".hermes-exchange-*/Hermes.app"))
+        assert len(retained) == 2
+        assert {update.fingerprint(path) for path in retained} == {old, first_hash}
+        result = json.loads((root.parent / ".hermes-update-result.json").read_text())
+        assert result["ok"] is True and result["exit_code"] == 0
+    finally:
+        stop_fixture(target)
+
+
+@pytest.mark.live_system_guard_bypass
+def test_native_controlled_failure_restores_and_reopens_old_shell(bundles, monkeypatch):
+    update = updater()
+    root, candidate, target = bundles
+    log = root.parent / "logs/desktop.log"
+    log.parent.mkdir()
+    log.write_text("history\n")
+    install_launch_fixture(target, log, "remote")
+    install_launch_fixture(candidate, log, "local")
+    old = update.fingerprint(target)
+    real_readiness = update.readiness
+    failed = False
+
+    def interrupt_after_ready(*args, **kwargs):
+        nonlocal failed
+        ready = real_readiness(*args, **kwargs)
+        if ready and not failed:
+            failed = True
+            raise RuntimeError("controlled candidate failure after native readiness")
+        return ready
+
+    monkeypatch.setattr(update, "readiness", interrupt_after_ready)
+    try:
+        outcome = update.complete(root, target, "main", os.getpid(), 0, "updated")
+        assert outcome.code == 6, outcome.message + "\n" + log.read_text()
+        assert failed
+        assert "restored and reopened" in outcome.message
+        assert update.fingerprint(target) == old
+        assert len(list(target.parent.glob(".hermes-exchange-*/Hermes.app"))) == 1
+    finally:
+        stop_fixture(target)
+
+
+@pytest.mark.parametrize("when", ["before", "after"])
+@pytest.mark.live_system_guard_bypass  # Dedicated throwaway repo; child only invokes this private helper.
+def test_sigkill_preserves_canonical_and_retained_bundles(bundles, when):
+    import sys
+    update = updater()
+    root, candidate, target = bundles
+    (target / "Contents/Resources/app.asar").write_bytes(b"old shell")
+    sign(target)
+    old, new = update.fingerprint(target), update.fingerprint(candidate)
+    script = '''import os,signal,sys
+from pathlib import Path
+from hermes_cli import desktop_macos_update as update
+root,target,when=Path(sys.argv[1]),Path(sys.argv[2]),sys.argv[3]
+exchange=update.exchange
+def abrupt(left,right):
+ if left==target and when=="before":os.kill(os.getpid(),signal.SIGKILL)
+ exchange(left,right)
+ if left==target and when=="after":os.kill(os.getpid(),signal.SIGKILL)
+update.exchange=abrupt
+result=update.complete(root,target,"main",os.getpid(),0,"updated")
+print(result)
+'''
+    result = subprocess.run([sys.executable, "-c", script, str(root), str(target), when],
+                            capture_output=True, text=True, timeout=60)
+    assert result.returncode == -9, result.stdout + result.stderr
+    retained = list(target.parent.glob(".hermes-exchange-*/Hermes.app"))
+    assert len(retained) == 1
+    assert update.fingerprint(target) == (old if when == "before" else new)
+    assert update.fingerprint(retained[0]) == (new if when == "before" else old)
+    assert not (root.parent / ".hermes-update-result.json").exists()
+
+
+def test_unsupported_exchange_refuses_before_underlying_update(bundles, monkeypatch):
+    root, candidate, target = bundles
+    update = updater()
+    old = update.fingerprint(target)
+
+    def unsupported(*args):
+        raise OSError("filesystem does not support atomic exchange")
+
+    monkeypatch.setattr(update, "exchange", unsupported)
+    with pytest.raises(OSError):
+        update.preflight(root, target)
+    assert update.fingerprint(target) == old
+    result = shell_handoff(root, candidate)
+    assert result.returncode != 0
+    assert "fixture-update" not in result.stdout
+    assert not list(target.parent.glob(".hermes-exchange-*"))
+
+
+def test_launch_rejection_preserves_old_shell(bundles, monkeypatch):
+    update = updater()
+    root, _, target = bundles
+    original = update.fingerprint(target)
+
+    def rejected(app):
+        raise RuntimeError("LaunchServices refused request")
+
+    monkeypatch.setattr(update, "launch_app", rejected)
+    with pytest.raises(RuntimeError, match="LaunchServices"):
+        update.adopt(target, update.expectation(root), root.parent / "desktop.log")
+    assert update.fingerprint(target) == original
+
+
+def test_unrelated_healthy_port_cannot_supply_local_readiness():
+    import http.server
+    import threading
+    update = updater()
+    class Healthy(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'{"version":"4.5.6"}')
+        def log_message(self, *args):
+            pass
+    server = http.server.HTTPServer(("127.0.0.1", 0), Healthy)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        stamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        text = f"[{stamp}] [hermes] HERMES_BACKEND_READY port={server.server_port}\n"
+        text += f"[{stamp}] [hermes] [boot] Hermes backend is ready. Finalizing desktop startup\n"
+        assert update.readiness(text, {}, {"backend_version": "4.5.6"}) is None
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+@pytest.mark.live_system_guard_bypass
+def test_native_main_death_during_stability_is_not_adoption(bundles, monkeypatch):
+    import signal
+    update = updater()
+    root, _, target = bundles
+    log = root.parent / "logs/desktop.log"
+    log.parent.mkdir()
+    log.write_text("history\n")
+    install_launch_fixture(target, log, "remote")
+    real_readiness = update.readiness
+    owned = {}
+    samples = 0
+
+    def die_after_stability_starts(*args, **kwargs):
+        nonlocal samples
+        ready = real_readiness(*args, **kwargs)
+        if ready:
+            samples += 1
+            if samples == 2:
+                mains = [p for p in owned.values() if p.executable == target / "Contents/MacOS/Hermes"]
+                assert len(mains) == 1
+                os.kill(mains[0].pid, signal.SIGTERM)
+        return ready
+
+    monkeypatch.setattr(update, "readiness", die_after_stability_starts)
+    try:
+        with pytest.raises(RuntimeError, match="Desktop died"):
+            update.adopt(target, update.expectation(root), log, startup=6, stability=3, owned=owned)
+        assert samples >= 2
+    finally:
+        update.stop_owned(owned)
+        stop_fixture(target)
+
+
+@pytest.mark.parametrize("damage", ["permission", "short", "zero", "repeated-guard", "pid-reuse"])
+def test_mapped_scan_rejects_incomplete_or_unstable_records(monkeypatch, damage):
+    import ctypes
+    import errno
+    import struct
+    import time
+    update = updater()
+    process = update.Process(123, (1, 0), 1, Path("/fixture"))
+    cursor_values = []
+    class API:
+        def proc_pidinfo(self, pid, flavor, address, data, length):
+            cursor_values.append(address)
+            if damage in ("permission", "pid-reuse"):
+                ctypes.set_errno(errno.EACCES if damage == "permission" else errno.EINVAL)
+                return 0
+            if damage == "short":
+                return length - 1
+            struct.pack_into("=QQ", data, 80, 4096, 0)
+            struct.pack_into("=I", data, 32, 31 if damage == "repeated-guard" else 0)
+            return length
+    monkeypatch.setattr(update, "process_record", lambda *args: update.Process(123, (2, 0), 1, Path("/fixture")))
+    with pytest.raises(RuntimeError):
+        update.mapped_files(API(), process, time.monotonic() + 2)
+    if damage == "repeated-guard":
+        assert cursor_values == [0, 4096]
+
+
+def test_guard_hint_requeries_exact_address_without_skipping_mapping(monkeypatch):
+    import ctypes
+    import errno
+    import struct
+    import time
+    update = updater()
+    process = update.Process(123, (1, 0), 1, None)
+    cursor_values = []
+    class API:
+        def proc_pidinfo(self, pid, flavor, address, data, length):
+            cursor_values.append(address)
+            if address == 8192:
+                ctypes.set_errno(errno.EINVAL)
+                return 0
+            struct.pack_into("=QQ", data, 80, 4096, 4096 if address == 4096 else 0)
+            struct.pack_into("=I", data, 32, 31)
+            if address == 4096:
+                struct.pack_into("=I", data, 96, 7)
+                struct.pack_into("=Q", data, 104, 8)
+                data[248:257] = b"/mapped\0\0"
+            return length
+    monkeypatch.setattr(update, "process_record", lambda *args: process)
+    assert update.mapped_files(API(), process, time.monotonic() + 2) == {(7, 8): Path("/mapped")}
+    assert cursor_values == [0, 4096, 8192]
+
+
+def test_full_process_enumeration_buffer_is_unknown(bundles, monkeypatch):
+    update = updater()
+    class API:
+        def proc_listpids(self, kind, uid, data, length):
+            return length if data is not None else 4
+    monkeypatch.setattr(update, "native", API)
+    assert update.observe([bundles[2]]).state == "unknown"
+
+
+@pytest.mark.parametrize("when", ["final-scan", "after-exchange"])
+def test_native_reader_arriving_at_exchange_boundary_blocks_mutation(bundles, monkeypatch, when):
+    update = updater()
+    root, candidate, target = bundles
+    (target / "Contents/Resources/app.asar").write_bytes(b"old distinct shell")
+    sign(target)
+    old, new = update.fingerprint(target), update.fingerprint(candidate)
+    actual_gate = update.require_absent
+    readers = []
+    calls = 0
+
+    def reader_arrives(paths):
+        nonlocal calls
+        calls += 1
+        if calls == (2 if when == "final-scan" else 3):
+            bundle = paths[0] if when == "final-scan" else paths[1]
+            readers.append(subprocess.Popen([str(bundle / "Contents/MacOS/Hermes"), "30"]))
+            # Wait for a real native identity, never replace observation with a mock.
+            import time
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                process = update.process_record(update.native(), readers[0].pid)
+                if process and process.executable == bundle / "Contents/MacOS/Hermes":
+                    break
+                time.sleep(0.02)
+        return actual_gate(paths)
+
+    monkeypatch.setattr(update, "require_absent", reader_arrives)
+    try:
+        outcome = update.complete(root, target, "main", os.getpid(), 0, "updated")
+        assert outcome.code != 0 and readers, outcome.message
+        assert "readers present" in outcome.message, outcome.message
+        retained = list(target.parent.glob(".hermes-exchange-*/Hermes.app"))
+        assert len(retained) == 1
+        assert update.fingerprint(target) == (old if when == "final-scan" else new)
+        assert update.fingerprint(retained[0]) == (new if when == "final-scan" else old)
+        if when == "after-exchange":
+            assert "Manual recovery required" in outcome.message
+    finally:
+        for process in readers:
+            process.terminate()
+            process.wait(timeout=10)
+
+
+@pytest.mark.parametrize("reason,final_state,calls", [
+    ("process changed during reader scan", "none", 2),
+    ("process changed during reader scan", "present", 2),
+    ("process changed during reader scan", "unknown", 3),
+    ("incomplete or denied mapped-file scan", "unknown", 1),
+    ("malformed mapped-file region", "unknown", 1),
+])
+def test_rescan_requires_a_complete_fresh_observation(monkeypatch, reason, final_state, calls):
+    update = updater()
+    observed = []
+    def scan(paths):
+        observed.append(paths)
+        state = "unknown" if len(observed) == 1 else final_state
+        return update.Observation(state, {Path("/fixture"): {123} if state == "present" else set()}, {}, reason)
+    monkeypatch.setattr(update, "observe", scan)
+    assert update.scan_readers([Path("/fixture")]).state == final_state
+    assert len(observed) == calls


### PR DESCRIPTION
## What does this PR do?

The macOS handoff previously removed a historical rollback, copied a candidate into a reusable slot, used two renames, and treated LaunchServices acceptance as successful adoption. This change uses a private same-volume slot and Darwin RENAME_SWAP, retains the old bundle, and reports success only after a fresh canonical shell, renderer, and mode-appropriate backend evidence remain stable for ten seconds.

Controlled failures stop only identified candidate processes and restore the previous shell only when readers are observed absent. Uncertain recovery leaves both bundles and reports a nonzero manual outcome. Source/backend code is never rolled back. The producer also honors signing-fixup failure and independently verifies the staged signature without silently downgrading a configured signing identity.

This is intentionally an unmerged draft; no installed application was replaced or activated. Frozen base: `6e07eb48387044dbcaf12490931c2b8ca7ec8653`.

## Related work

Related to #96171 (producer/rebuild preservation) and #102349 (runtime-free remote updates), inspected read-only. This patch does not import their implementations or change those PRs. No equivalent merged fix or material readiness/result contract drift was found at upstream `1603a073e46e8bc777cd9d096e2fce49887648c2`; the inspected package diff adds QR-code dependencies only.

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/desktop_macos_update.py`: candidate/stamp/signature/tree validation, native reader observation and atomic exchange, fresh adoption, controlled restoration, existing result-file publication.
- `hermes_cli/main_desktop.py`: signing-failure handling and independent staged signature verification.
- `scripts/desktop-update/posix.sh`: reject unsafe publication layout before the underlying update; hand publication/relaunch/results to the macOS helper exactly once; preserve the Linux path and existing notification/shim interfaces.
- Two focused behavioral/native test files.

Scope: three production files, **697 added / 42 deleted production lines**; two test files, **897 added lines**. No new public API, receipt, endpoint, journal, LaunchAgent, privileges, gateway operations, or historical recovery cleanup.

## How to Test

On macOS with the project venv and workspace dependencies installed, use disposable test homes. All Python runs used `scripts/run_tests.sh`, one worker, and zero automatic file retries.

```sh
HERMES_TEST_WORKERS=1 HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/hermes_cli/test_desktop_macos_update.py tests/hermes_cli/test_desktop_macos_producer.py tests/hermes_cli/test_desktop_exe_integrity.py tests/hermes_cli/test_update_handoff_desktop_rebuild.py
npm run test:desktop:platforms --workspace apps/desktop -- electron/updater-process.test.ts electron/handoff-result.test.ts electron/update-handoff-marker.test.ts electron/update-marker.test.ts electron/update-gate.test.ts electron/update-prerequisites.test.ts electron/update-remote.test.ts electron/desktop-log-line.test.ts scripts/desktop-update-ui.test.mjs
npm run typecheck --workspace apps/desktop
.venv/bin/ruff check hermes_cli/main_desktop.py hermes_cli/desktop_macos_update.py tests/hermes_cli/test_desktop_macos_update.py tests/hermes_cli/test_desktop_macos_producer.py
.venv/bin/python scripts/check-windows-footguns.py hermes_cli/desktop_macos_update.py hermes_cli/main_desktop.py
bash -n scripts/desktop-update/posix.sh
git diff --check
```

Results on macOS 26.6.2 arm64 / Python 3.13.15 / Node 22.23.1:

- Python: **71 passed, 4 Windows-only skipped**. Includes real main/helper/renderer and closed-FD mapped readers, real exchange, readers arriving immediately before/after exchange, local/remote readiness, process death, controlled restoration/reopening, SIGKILL before/after exchange, and two successive updates with unique rollback retention.
- Desktop updater/result/log suites: **80 passed, 1 skipped**. Desktop typecheck, Ruff, Windows-footgun checks, shell syntax, and diff checks passed.
- Additional unchanged `tests/hermes_cli/test_desktop_update_verify.py`: **6 passed, 1 failed**. `test_readable_packaged_entry_passes` rejects the fixture as stale/incomplete on both this branch and a separate untouched frozen-base worktree. It was not changed. No full monorepo suite was run.
- TDD captured RED then GREEN for the three original defects, validation, observation/adoption, recovery/reporting, and review findings. Representative RED commands were the producer file, the helper file with `-k handoff`, and `-k 'diagnostic_lookalikes or after-swap-exception or recovery-timeout or gpu_child'`.
- Independent adversarial review found and re-reviewed fixes for GPU helper substitution, readiness lookalikes, and recovery exceptions misreporting preservation. The final production artifact and bounded rescan passed re-review.

## Observation and fixture limits

Reader observation is explicitly limited to the updater's effective UID and vnode-backed mappings exposed by libproc. Other users, unexposed VM submaps/pagers, and the scan-to-exchange race are outside the guarantee. This is observed quiescence, not launch exclusion. An identity-changing scan is discarded and retried from scratch at most three times; presence, permission errors, malformed data, and other uncertainty are never retried or accepted. Persistent uncertainty blocks publication/restoration.

Readiness remains observational: local mode associates the fresh READY port with a descendant listener and checks the expected backend version; remote mode uses the application's existing fresh post-health-check boot event. Startup is bounded at 90 seconds, stability at 10 seconds, and candidate exit at 30 seconds. No remote credentials are copied. There is no automatic recovery guarantee after SIGKILL, reboot, or power loss. Hashes prove copy integrity, not independent trust in local builds.

Native fixtures use disposable signed executables, a real descendant HTTP server, existing log events, `/usr/bin/open`, libproc, and RENAME_SWAP. They do not run Electron/AppKit UI lifecycle or a real remote service. They add no stronger handshake or recovery protocol. Shell tests stub actual update/gateway commands and deny production writes/notifications. Earlier native runs recorded safe refusals during process churn and readiness failures; those were not counted as successful adoption. The final complete in-scope Python run passed.

## Checklist

- [x] Read applicable contribution and platform guidance; conventional commit used.
- [x] Searched related open PRs and current upstream implementation.
- [x] Only changes related to this bounded repair.
- [x] Added behavioral tests and exercised native macOS mechanisms.
- [x] Focused tests and independent review completed; limitations above are explicit.
- [ ] Full monorepo test suite — intentionally outside this task's test scope.
- [x] Documentation provided in module contracts and this PR; no new configuration keys, tool schemas, or architecture workflow changes.
- [x] No merge, activation, installed-app/live-checkout/gateway changes, or changes to existing PRs, WIP, rollback bundles, stashes, and `gateway/delivery_events.py`.
