### PR TITLE
fix(desktop): resolve plugin SDK namespaces lazily so disk plugins load in production builds

### DIFF
--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -13,21 +13,37 @@ import * as jsxRuntime from 'react/jsx-runtime'
 
 import * as sdk from './index'
 
-const GLOBALS = {
-  __HERMES_PLUGIN_SDK__: sdk,
-  __HERMES_REACT__: React,
-  __HERMES_REACT_JSX__: jsxRuntime,
-  __HERMES_REACT_JSX_DEV__: jsxDevRuntime
-} as const
+// Resolved LAZILY, never as a module-scope literal. This module sits in an
+// import cycle — `sdk/index` → `contrib/*` → `contrib/runtime-loader` →
+// `sdk/runtime` — so a module-scope `{ __HERMES_PLUGIN_SDK__: sdk, … }` is
+// evaluated BEFORE `sdk/index`'s own body runs. In the bundled app that read
+// yields `undefined` (the bundler emits the namespace as a hoisted `var`), so
+// `Object.keys(GLOBALS.__HERMES_PLUGIN_SDK__)` threw
+// "Cannot convert undefined or null to object" and EVERY runtime (disk)
+// plugin failed to load. Reading them at call time — installPluginSdk() and
+// the shim builder only ever run once the app is up — gets the live
+// namespaces.
+function pluginNamespaces() {
+  return {
+    __HERMES_PLUGIN_SDK__: sdk,
+    __HERMES_REACT__: React,
+    __HERMES_REACT_JSX__: jsxRuntime,
+    __HERMES_REACT_JSX_DEV__: jsxDevRuntime
+  }
+}
+
+type PluginGlobalKey = keyof ReturnType<typeof pluginNamespaces>
 
 export function installPluginSdk(): void {
-  Object.assign(globalThis, GLOBALS)
+  Object.assign(globalThis, pluginNamespaces())
 }
 
 /** Build a shim ESM blob that re-exports a global namespace's live members.
  *  Export names come from the namespace itself, so the list can't drift. */
-function shimUrl(globalKey: keyof typeof GLOBALS): string {
-  const names = Object.keys(GLOBALS[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
+function shimUrl(globalKey: PluginGlobalKey): string {
+  const names = Object.keys(pluginNamespaces()[globalKey]).filter(
+    name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name)
+  )
 
   const source =
     `const m = globalThis.${globalKey};\n` +


### PR DESCRIPTION
## What breaks

In a **production (bundled) build** of the desktop app, *every* plugin loaded from disk fails to load: `$HERMES_HOME/desktop-plugins/<id>/plugin.js` and the `desktop/plugin.js` half of a unified package alike. Capabilities → Plugins → *Desktop plugins* shows the row as `failed` with:

```
Cannot convert undefined or null to object
```

It is not plugin-specific — the throw happens **before any plugin code runs**, so there is no plugin-side workaround.

## Root cause

`apps/desktop/src/sdk/runtime.ts` captured the SDK namespaces in a **module-scope object literal**:

```ts
const GLOBALS = {
  __HERMES_PLUGIN_SDK__: sdk,
  __HERMES_REACT__: React,
  __HERMES_REACT_JSX__: jsxRuntime,
  __HERMES_REACT_JSX_DEV__: jsxDevRuntime
} as const
```

That module sits in an import cycle:

```
sdk/index  ->  @/contrib/*  ->  contrib/runtime-loader  ->  sdk/runtime  ->  sdk/index
```

- **Dev (unbundled ESM):** the cycle still yields a live namespace object, so `Object.keys(sdk)` works — which is why this is invisible in dev, in vitest, and in review.
- **Production bundle:** the namespace becomes a hoisted `var`, and the bundler may order the two top-level statements either way. In the shipped 0.20.4 bundle it emits them like this (byte offsets inside one minified chunk):

| statement | offset |
|---|---|
| `var Lg={__HERMES_PLUGIN_SDK__:Db,__HERMES_REACT__:J,__HERMES_REACT_JSX__:Y,…}` | 158,782 |
| `var Db=t({…})` — the plugin-SDK namespace itself | 228,399 |

So `Lg.__HERMES_PLUGIN_SDK__` is `undefined` when the literal is evaluated (`var` ⇒ no TDZ error), and the first `Object.keys(GLOBALS[globalKey])` inside `shimUrl()` throws exactly `TypeError: Cannot convert undefined or null to object`.

## Why every disk plugin dies

`loadRuntimePlugin()` runs `installPluginSdk()` and then `unsupportedImports(source)` → `sdkImportMap()` → `shimUrl()` **for every source, before evaluating it**, so the failure is content-independent.

## Reproduction (production build only)

1. Build `apps/desktop` for production and run the packaged app.
2. Drop any `plugin.js` into `~/.hermes/desktop-plugins/<id>/`.
3. Start the app (or hit *Reload desktop plugins*).

`desktop.log` shows:

```
[renderer console:main] [plugins] runtime load failed (<id>) TypeError: Cannot convert
undefined or null to object (…/app.asar.unpacked/dist/assets/sdk-<hash>.js:5)
```

## The fix

Resolve the namespaces at **call time** — `installPluginSdk()` and the shim builder only ever run once the app is up, so reading them there is always safe and statement ordering stops mattering. `installPluginSdk()` now reads a fresh `pluginNamespaces()`, and `shimUrl()` reads it per call.

## Testing note (honest)

A vitest unit test **cannot** catch this: in the dev module graph the namespace object is live, so the old code passes too — the regression is bundler-ordering-only. Two options, reviewer's call: rely on the structural fix (module scope no longer captures the namespaces at all), or add a production-build smoke test that loads a fixture plugin through `loadRuntimePlugin()` and asserts it registers, which is the faithful reproducer.

## Impact

Any user updating to a build with this ordering loses **every** on-disk desktop plugin. Same-shape siblings worth an audit while you are here: any other module-scope capture of a value from the `sdk/index` ↔ `contrib` cycle.

Fixes #107304
