### PR TITLE
fix(dashboard-auth): verify-stage token denials trigger re-login, not a misleading 503; headless gateway gets a Desktop-app hint

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -85,9 +85,36 @@ def _render_active_theme_bootstrap_css() -> str:
 _IMMUTABLE_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable"
 _NO_STORE = {"Cache-Control": "no-store, no-cache, must-revalidate"}
 _HEADLESS_MSG = (
-    "Headless backend (hermes serve): web UI disabled — use "
-    "`hermes dashboard` for the browser UI."
+    "Headless backend (hermes serve): web UI disabled — open the Hermes Desktop "
+    "app and add this URL as a remote gateway (Settings → Gateways); operators "
+    "use `hermes dashboard` for the browser UI."
 )
+
+
+def _headless_navigation_hint(url: str) -> str:
+    """HTML for a top-level browser navigation to a headless gateway URL.
+
+    Users pasting a ``hermes serve`` URL into a browser used to land on raw JSON with no
+    hint where the UI actually lives; the auth already succeeded at that point, so the
+    message should say so and point at the Desktop app. No token is included — this is
+    only served to requests that carry ``Sec-Fetch-Mode: navigate`` (real navigations);
+    fetch()/API/Desktop clients keep the JSON contract.
+    """
+    from html import escape
+
+    return (
+        "<!doctype html><html><head><meta charset=\"utf-8\">"
+        "<title>Hermes gateway — no web UI</title></head>"
+        "<body style=\"font-family:-apple-system,'Segoe UI',Roboto,sans-serif;"
+        "max-width:42rem;margin:4rem auto;padding:0 1rem;line-height:1.6;color:#1f2937\">"
+        "<h2>This is a Hermes gateway endpoint</h2>"
+        "<p>Your connection and sign-in are working — but a <code>hermes serve</code> gateway "
+        "intentionally has no web page. The UI is the <strong>Hermes Desktop</strong> app:</p>"
+        "<p style=\"margin-left:1rem\">Settings &rarr; Gateways &rarr; Gateway URL:<br>"
+        f"<code>{escape(url)}</code></p>"
+        "<p>Operators: the browser dashboard is a separate command, <code>hermes dashboard</code>.</p>"
+        "</body></html>"
+    )
 
 
 def mount_spa(application: FastAPI):
@@ -110,7 +137,7 @@ def mount_spa(application: FastAPI):
     if os.environ.get("HERMES_SERVE_HEADLESS") == "1":
 
         @application.get("/{full_path:path}")
-        async def no_frontend(full_path: str):
+        async def no_frontend(request: Request, full_path: str):
             # Desktop token handshake: the Electron shell boots by fetching `/` and reading
             # ``window.__HERMES_SESSION_TOKEN__`` for /api/ws auth. When headless 404'd every
             # path, a renderer whose spawn token no longer matched (e.g. after `hermes update`)
@@ -125,6 +152,15 @@ def mount_spa(application: FastAPI):
                     "window.__HERMES_AUTH_REQUIRED__=false;"
                     f"</script></head><body>{_HEADLESS_MSG}</body></html>",
                     headers=_NO_STORE,
+                )
+            # Top-level browser navigations (a user pasting the gateway URL) get the
+            # friendly hint instead of raw JSON; fetch()/API/Desktop clients keep the
+            # JSON contract (Sec-Fetch-Mode is cors/no-cors for fetch(), navigate for
+            # real navigations — the Electron token fetch is a fetch(), not a
+            # navigation, so it is unaffected).
+            if request.headers.get("sec-fetch-mode", "").lower() == "navigate":
+                return HTMLResponse(
+                    _headless_navigation_hint(str(request.url)), status_code=404, headers=_NO_STORE
                 )
             return JSONResponse({"error": _HEADLESS_MSG}, status_code=404)
         return

--- a/plugins/dashboard_auth/_shared.py
+++ b/plugins/dashboard_auth/_shared.py
@@ -196,16 +196,18 @@ def verify_jwt(
     Unreachable JWKS → ``ProviderError`` (503); a bearer that is not one of our JWTs
     (opaque peer key, foreign kid) → ``InvalidCodeError`` (None / next provider); folding
     both into 503 broke peer-key bearers. Expiry raises ``InvalidCodeError`` (verify_session
-    maps it to None); any other claim failure raises ``ProviderError`` with the unverified
-    iss/aud appended so operators can spot config drift.
+    maps it to None). Every other decode-time rejection — wrong audience/issuer, bad
+    signature, missing claims — raises ``InvalidCodeError`` too: the IdP answered and the
+    token is simply *not ours*, a confirmed denial that must drive re-login (verify_session
+    → None, refresh → RefreshExpiredError via the caller's ``bad_request_exc`` mapping), not
+    the misleading 503 "provider unreachable". The unverified iss/aud are appended so
+    operators can still spot config drift.
     """
     import jwt  # lazy — keeps startup fast for the ungated path
 
     try:
         signing_key = jwks_client.get_signing_key_from_jwt(token)
     except Exception as exc:
-        # Unreachable JWKS -> ProviderError (503); a bearer that is not one of our JWTs (opaque peer key,
-        # foreign kid) -> InvalidCodeError (None / next provider). Folding both into 503 produced #94558.
         # Unreachable JWKS -> ProviderError (503); a bearer that is not one of our JWTs (opaque peer key,
         # foreign kid) -> InvalidCodeError (None / next provider). Folding both into 503 produced #94558.
         raise classify_jwks_lookup_error(exc) from exc
@@ -216,8 +218,9 @@ def verify_jwt(
     except jwt.ExpiredSignatureError as exc:
         raise InvalidCodeError(f"{label} expired: {exc}") from exc
     except jwt.InvalidTokenError as exc:
-        # Decoding without verification is safe here: verification already failed and
-        # these values are surfaced for diagnostics only, never trusted.
+        # A claim-level denial, not an outage: the IdP answered (JWKS fetched, token parsed)
+        # but the token isn't ours. Decoding without verification is safe here: verification
+        # already failed and these values are surfaced for diagnostics only, never trusted.
         details = ""
         try:
             unverified = jwt.decode(token, options={"verify_signature": False, "verify_exp": False})
@@ -226,7 +229,7 @@ def verify_jwt(
                 f"expected iss={issuer!r} aud={audience!r}]")
         except Exception:
             pass
-        raise ProviderError(f"{label} verification failed: {exc}{details}") from exc
+        raise InvalidCodeError(f"{label} verification failed: {exc}{details}") from exc
 
 
 # ---- Shared provider skeletons ----
@@ -250,7 +253,8 @@ class JwtOAuthProvider(DashboardAuthProvider):
     """Authorization-code + PKCE provider whose session token is a JWT we verify ourselves
     (nous: Portal access token; self-hosted: OIDC ID token). Subclasses set ``_client_id`` and
     implement: ``_jwks_uri() -> str``; ``_claims_for(token) -> claims`` (raises
-    ``InvalidCodeError`` on expiry/foreign token, ``ProviderError`` otherwise);
+    ``InvalidCodeError`` for any verified-not-ours token — expiry, foreign aud/iss, opaque
+    bearer — and ``ProviderError`` only for genuine IDP outages);
     ``_grant(data, *, bad_request_exc, headers=None, previous_refresh_token="") -> Session``;
     ``_refresh_request(refresh_token) -> (form_data, extra_headers)``;
     ``_session(token, refresh_token, claims) -> Session``."""

--- a/plugins/dashboard_auth/nous/__init__.py
+++ b/plugins/dashboard_auth/nous/__init__.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 
-from hermes_cli.dashboard_auth import LoginStart, ProviderError, Session
+from hermes_cli.dashboard_auth import InvalidCodeError, LoginStart, ProviderError, Session
 from plugins.dashboard_auth._shared import (
     JwtOAuthProvider,
     SkipRegistration,
@@ -86,7 +86,14 @@ class NousDashboardAuthProvider(JwtOAuthProvider):
             idp="Portal", endpoint="Portal token endpoint", token_key="access_token",
             missing_msg="Portal token response missing access_token")
         # Rotating RT the caller MUST persist back to the cookie.
-        return self._session(access_token, refresh_token_from(payload), self._claims_for(access_token))
+        try:
+            claims = self._claims_for(access_token)
+        except InvalidCodeError as exc:
+            # Verify-stage denial inside a grant (expired / foreign token): map to the
+            # caller's bad_request_exc so the refresh scan rejects this provider
+            # (RefreshExpiredError) instead of crashing on an uncaught InvalidCodeError.
+            raise bad_request_exc(str(exc)) from exc
+        return self._session(access_token, refresh_token_from(payload), claims)
 
 
     def _claims_for(self, access_token: str) -> Dict[str, Any]:

--- a/plugins/dashboard_auth/self_hosted/__init__.py
+++ b/plugins/dashboard_auth/self_hosted/__init__.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, Optional
 
 import httpx
 
-from hermes_cli.dashboard_auth import LoginStart, ProviderError, Session
+from hermes_cli.dashboard_auth import InvalidCodeError, LoginStart, ProviderError, Session
 from plugins.dashboard_auth._shared import (
     JSON_HEADERS,
     TOKEN_ENDPOINT_TIMEOUT_SEC as _TOKEN_ENDPOINT_TIMEOUT_SEC,
@@ -160,7 +160,14 @@ class SelfHostedOIDCProvider(JwtOAuthProvider):
                 "OIDC token response missing id_token — ensure the 'openid' "
                 "scope is configured and the client is allowed to receive an "
                 "ID token."))
-        claims = self._verify_id_token(id_token)
+        try:
+            claims = self._verify_id_token(id_token)
+        except InvalidCodeError as exc:
+            # Verify-stage denial (expiry / wrong aud-iss / foreign key) inside a grant:
+            # map to the caller's bad_request_exc so the refresh scan rejects this
+            # provider (RefreshExpiredError) instead of crashing on an uncaught
+            # InvalidCodeError; the auth-code path keeps its 400.
+            raise bad_request_exc(str(exc)) from exc
         # Prefer a freshly-issued RT, else keep the previous (some IDPs don't rotate).
         return self._session(id_token, refresh_token_from(payload, previous_refresh_token), claims)
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5414,3 +5414,37 @@ def test_mount_spa_dynamic_web_dist_recheck(tmp_path, monkeypatch):
     res2 = client.get("/")
     assert res2.status_code == 200
     assert "Test" in res2.text
+
+
+class TestHeadlessNoFrontendLanding:
+    """`hermes serve` is headless: a real browser navigation to the gateway URL gets a
+    friendly HTML hint (auth already succeeded; the UI is the Desktop app) instead of raw
+    JSON, while fetch()/API/Desktop clients keep the JSON contract (Sec-Fetch-Mode is
+    cors/no-cors for fetch(), navigate only for top-level navigations — the Electron
+    token handshake fetch is unaffected either way: it only reads the ungated token page
+    at the root, which is served before the navigation check)."""
+
+    @staticmethod
+    def _client(monkeypatch):
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+
+        monkeypatch.setenv("HERMES_SERVE_HEADLESS", "1")
+        app = FastAPI()
+        _web_server_dashboard.mount_spa(app)
+        return TestClient(app)
+
+    def test_browser_navigation_gets_html_hint(self, monkeypatch):
+        client = self._client(monkeypatch)
+        resp = client.get("/anything", headers={"Sec-Fetch-Mode": "navigate"})
+        assert resp.status_code == 404
+        # The hint points at the Desktop app and echoes the gateway URL.
+        assert "Hermes Desktop" in resp.text
+        assert "http://testserver/anything" in resp.text
+        assert not resp.text.lstrip().startswith("{")
+
+    def test_fetch_clients_keep_json_404(self, monkeypatch):
+        client = self._client(monkeypatch)
+        resp = client.get("/anything")  # no Sec-Fetch-Mode → fetch()/API contract
+        assert resp.status_code == 404
+        assert resp.json()["error"] == _web_server_dashboard._HEADLESS_MSG

--- a/tests/plugins/dashboard_auth/test_nous_provider.py
+++ b/tests/plugins/dashboard_auth/test_nous_provider.py
@@ -550,11 +550,12 @@ class TestVerifySession:
         token = _mint_token(rsa_keypair, ttl_seconds=-1)
         assert provider.verify_session(access_token=token) is None
 
-    def test_wrong_audience_raises_provider_error(self, provider, rsa_keypair):
+    def test_wrong_audience_returns_none(self, provider, rsa_keypair):
+        # A wrong-audience token is a confirmed denial (the IdP answered, the token
+        # isn't ours): verify_session must return None so middleware refreshes /
+        # re-logins instead of answering the misleading 503 "provider unreachable".
         token = _mint_token(rsa_keypair, aud="agent:other-instance")
-        with pytest.raises(ProviderError, match="verification failed"):
-            provider.verify_session(access_token=token)
-
+        assert provider.verify_session(access_token=token) is None
 
     def test_verification_failure_message_surfaces_token_claims(
         self, provider, rsa_keypair
@@ -562,8 +563,8 @@ class TestVerifySession:
         """Operators need to see the actual iss/aud the token carries to debug
         config drift between HERMES_DASHBOARD_PORTAL_URL/CLIENT_ID and Portal."""
         token = _mint_token(rsa_keypair, iss="https://evil.example")
-        with pytest.raises(ProviderError) as excinfo:
-            provider.verify_session(access_token=token)
+        with pytest.raises(InvalidCodeError) as excinfo:
+            provider._claims_for(token)
         msg = str(excinfo.value)
         # Both the observed (token) and expected (configured) values appear.
         assert "'https://evil.example'" in msg
@@ -658,6 +659,21 @@ class TestRefreshAndRevoke:
         assert kwargs["data"]["client_id"] == "agent:inst123"
         assert kwargs["data"]["refresh_token"] == "rt_old_value"
         assert kwargs["headers"]["x-nous-refresh-token"] == "rt_old_value"
+
+    def test_refresh_verify_denial_maps_to_refresh_expired(self, provider, rsa_keypair):
+        """A verify-stage denial inside the refresh grant (exchange OK, but the granted
+        token isn't ours) maps to RefreshExpiredError so the middleware refresh scan
+        rejects this provider instead of crashing on an uncaught InvalidCodeError."""
+        access_token = _mint_token(rsa_keypair, aud="agent:other-instance")
+        mock_resp = self._mock_post(
+            200,
+            {"access_token": access_token, "token_type": "Bearer", "refresh_token": "rt2"},
+        )
+        with patch(
+            "plugins.dashboard_auth._shared.httpx.post", return_value=mock_resp
+        ):
+            with pytest.raises(RefreshExpiredError, match="verification failed"):
+                provider.refresh_session(refresh_token="rt_old")
 
 
     def test_revoke_is_noop(self, provider):

--- a/tests/plugins/dashboard_auth/test_self_hosted_provider.py
+++ b/tests/plugins/dashboard_auth/test_self_hosted_provider.py
@@ -547,19 +547,37 @@ class TestVerifySession:
         token = _mint_id_token(rsa_keypair, ttl_seconds=-1)
         assert provider.verify_session(access_token=token) is None
 
-    def test_wrong_audience_raises(self, provider, rsa_keypair):
+    def test_wrong_audience_returns_none(self, provider, rsa_keypair):
+        # A wrong-audience token is a confirmed denial: the IdP answered (JWKS fetched,
+        # token parsed) but the token isn't ours. verify_session must return None so the
+        # middleware refreshes / re-logins instead of answering the misleading 503
+        # "provider unreachable" (folding denials into ProviderError produced exactly
+        # that against a desktop reusing one session across same-issuer gateways).
         token = _mint_id_token(rsa_keypair, aud="some-other-client")
-        with pytest.raises(ProviderError, match="verification failed"):
-            provider.verify_session(access_token=token)
-
+        assert provider.verify_session(access_token=token) is None
 
     def test_failure_message_surfaces_claims(self, provider, rsa_keypair):
         token = _mint_id_token(rsa_keypair, iss="https://evil.example")
-        with pytest.raises(ProviderError) as excinfo:
-            provider.verify_session(access_token=token)
+        with pytest.raises(InvalidCodeError) as excinfo:
+            provider._verify_id_token(token)
         msg = str(excinfo.value)
         assert "'https://evil.example'" in msg
         assert f"'{_ISSUER}'" in msg
+
+    def test_refresh_verify_denial_maps_to_refresh_expired(self, rsa_keypair):
+        """A verify-stage denial inside the refresh grant maps to RefreshExpiredError so
+        the middleware refresh scan rejects this provider instead of crashing on an
+        uncaught InvalidCodeError."""
+        provider = _make_provider(rsa_keypair)
+        id_token = _mint_id_token(rsa_keypair, aud="some-other-client")
+        mock_resp = _mock_post(
+            200, {"id_token": id_token, "token_type": "Bearer", "refresh_token": "rt2"}
+        )
+        with patch(
+            "plugins.dashboard_auth.self_hosted.httpx.post", return_value=mock_resp
+        ):
+            with pytest.raises(RefreshExpiredError, match="verification failed"):
+                provider.refresh_session(refresh_token="rt_old")
 
 
     def test_jwks_unreachable_raises(self, provider, rsa_keypair):


### PR DESCRIPTION
## Summary

Two related gateway-auth UX fixes, from a real deployment incident (fm-prod-3, 2026-09-10 — a Hermes Desktop reusing one OIDC session across two same-issuer gateways):

**1. Claim-level token denials now drive re-login instead of a misleading 503.**

`verify_jwt` raised `ProviderError` for every decode-time rejection except expiry, so a token minted for a *different* client on the same IdP surfaced as `503 {"detail": "Auth provider 'self-hosted' unreachable"}` — while the IdP was reachable and had answered; the token was simply not ours (audience mismatch). Operators only saw the real reason in `errors.log`: `"ID token verification failed: Audience doesn't match"`.

- `verify_jwt`: wrong audience/issuer, bad signature, missing claims → `InvalidCodeError` (the diagnostic unverified iss/aud is still appended). `verify_session` returns `None` per protocol → middleware refreshes / re-logins instead of answering 503.
- `JwtOAuthProvider` grants (self-hosted + nous) map a verify-stage `InvalidCodeError` to the caller's `bad_request_exc` (`InvalidCodeError` for the auth-code path, `RefreshExpiredError` for refresh) so the middleware refresh scan rejects that provider instead of crashing on an uncaught exception.
- JWKS transport failures remain `ProviderError` (503) — unreachable means unreachable (the #94558 separation is preserved).

**2. Headless `hermes serve` answers browser navigations with a Desktop-app hint.**

Opening a `hermes serve` URL in a browser always ended on the raw `{"error": "Headless backend ..."}` JSON even after auth succeeded, leaving gateway users with an unexplained 404. The catch-all now returns a small HTML hint (points at Hermes Desktop → Settings → Gateways, echoes the gateway URL) for top-level navigations (`Sec-Fetch-Mode: navigate`); fetch()/API/Desktop clients keep the JSON contract, and the ungated token-handshake page at the root is untouched (#94227, #95575).

## Test plan

- `tests/plugins/dashboard_auth/` — 113 passed (incl. new: wrong-audience `verify_session` → None; refresh-stage denial maps to `RefreshExpiredError`; diagnostic iss/aud surfaces on `_verify_id_token`/`_claims_for`)
- `tests/hermes_cli/test_web_server.py` — 190 passed (incl. new `TestHeadlessNoFrontendLanding`: navigate → HTML hint + echoed URL, non-navigate → unchanged JSON 404)
- middleware/token-auth/gate/cookies/audit suites — 99 passed