### PR TITLE
fix(mcp): resolve name collisions when registering a lazy server from the schema cache

### DIFF
--- a/tests/tools/test_mcp_lazy_start.py
+++ b/tests/tools/test_mcp_lazy_start.py
@@ -334,3 +334,55 @@ class TestResolveServerLazy:
 
     def test_explicit_false(self):
         assert _mcp_discovery._resolve_server_lazy("s", {"command": "npx", "lazy": False}) is False
+
+
+from tools.mcp_tool_schema import _build_utility_schemas
+from tools.registry import ToolRegistry
+
+
+def _cached_tool_schema(name, description):
+    return {"name": name, "description": description,
+            "inputSchema": {"type": "object", "properties": {}},
+            "annotations": {"readOnlyHint": True}}
+
+
+def _cache_entry_with(tools, utility_keys=()):
+    return {"fingerprint": "abc", "tools": tools,
+            "utility_tools": [e for e in _build_utility_schemas("srv")
+                              if e["handler_key"] in utility_keys]}
+
+
+class TestLazyRegistrationResolvesNameCollisions:
+    """The cache path resolves name collisions exactly like the live path.
+
+    ``_register_candidates`` has three call sites; the live path
+    (``_register_server_tools``) and the shared-scope path both pass their
+    candidates through ``_resolve_name_collisions`` first. The lazy path did
+    not, so a server booted with ``lazy: true`` from the schema cache skipped
+    collision resolution entirely and the last candidate silently won.
+    """
+
+    def _register(self, entry):
+        registry = ToolRegistry()
+        with patch("tools.registry.registry", registry), \
+             patch("tools.mcp_tool_registration._track_mcp_tool_server"):
+            return registry, _mcp_registration._register_from_cache_sync("srv", {}, entry)
+
+    def test_cached_native_tool_wins_over_generated_utility(self):
+        """A generated utility must not replace the server's own tool of the same name."""
+        registry, registered = self._register(
+            _cache_entry_with([_cached_tool_schema("read_resource", "Native read-resource tool")],
+                              utility_keys=("read_resource",)))
+
+        assert registered == ["mcp__srv__read_resource"]
+        assert registry.get_schema("mcp__srv__read_resource")["description"] == "Native read-resource tool"
+
+    def test_cached_normalization_collision_skips_all_ambiguous_tools(self):
+        """Two native names that normalize to one registry name are skipped, not raced."""
+        registry, registered = self._register(
+            _cache_entry_with([_cached_tool_schema("read-file", "HYPHEN tool"),
+                               _cached_tool_schema("read_file", "UNDERSCORE tool"),
+                               _cached_tool_schema("safe_tool", "fine")]))
+
+        assert registered == ["mcp__srv__safe_tool"]
+        assert registry.get_entry("mcp__srv__read_file") is None

--- a/tools/mcp_tool_registration.py
+++ b/tools/mcp_tool_registration.py
@@ -473,7 +473,8 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
     candidates = _tool_candidates(name, cached_tools, _make_tool_filter(name, config), tool_timeout)
     candidates += _utility_candidates(name, utility_tools_from_cache_entry(entry), tool_timeout)
     registered = _register_candidates(
-        name, candidates, check_fn=_make_check_fn(name), scope=_core._mcp_registry_scope, lazy=True)
+        name, _resolve_name_collisions(name, candidates),
+        check_fn=_make_check_fn(name), scope=_core._mcp_registry_scope, lazy=True)
     if registered:
         with _core._lock:
             _core._lazy_server_configs[name] = dict(config)


### PR DESCRIPTION
## What does this PR do?

`_register_candidates` has three call sites. Two of them pass their candidate list through `_resolve_name_collisions` first — the live path at `tools/mcp_tool_registration.py:368-370` (`_register_server_tools`) and the shared-scope path at `:449-451`. The lazy path at `:475-476` (`_register_from_cache_sync`) passes `candidates` raw, so a server booted with `lazy: true` from the schema cache never runs collision resolution at all.

Nothing downstream catches it. Every candidate for one server carries the same toolset name `mcp-{name}`, so the ownership pre-check in `_register_candidates` (`existing_toolset != toolset_name`, `:300`) never fires, and `registry.register()` takes its "same-toolset re-registration stays allowed" path (`tools/registry.py:640-653`) and overwrites. Last candidate wins.

Two consequences, both of which the live path already refuses:

1. **A generated utility replaces the server's own tool.** Utility candidates are appended after native ones (`:474`), so a server that exposes a native `read_resource` gets the generated `read_resource` stub in the registry instead — the same defect fixed for the live path in #87112, whose regression test is `tests/tools/test_mcp_tool.py:897`. The agent is then advertised the utility's `{uri}` schema in place of the native tool's, and the first call runs the utility handler.
2. **Two native tools that normalize to one registry name get an arbitrary handler** (`read-file` / `read_file` → `mcp__srv__read_file`) instead of the documented fail-closed skip (`tests/tools/test_mcp_tool.py:868`). The returned `registered` list also contains the name twice, and that list is stored into `_lazy_server_tool_names` and counted as `lazy_registered` at `tools/mcp_tool_discovery.py:290`.

A single live boot primes this: `_write_schema_cache` (`:337-354`) persists the filtered native tools *and* the `_select_utility_schemas` rows, and neither list has been through collision resolution at that point. So the same boot that correctly keeps the native tool writes the cache entry that destroys it on the next `lazy: true` start.

Blast radius, stated honestly: `_ensure_lazy_server_connected` (`tools/mcp_tool_discovery.py:135-175`) re-registers live and deregisters phantom cached names, so the wrong entry can self-heal on the first real call to that server. The window is boot → first call, during which the tool snapshot handed to the model already carries the wrong schema; a lazy server that is never called keeps the wrong entry for the whole session.

## Related Issue

No open issue. #87112 (merged) is the live-path half of the same defect; this is its cache-path sibling.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool_registration.py` — `_register_from_cache_sync` wraps its candidates in `_resolve_name_collisions`, matching the other two call sites.
- `tests/tools/test_mcp_lazy_start.py` — two regression tests mirroring `tests/tools/test_mcp_tool.py:868` and `:897` against the cache path.

## How to Test

Both new tests fail on `main` and pass with the one-line change. No network, no child process.

```
# main @ f44b0fd342, test added, fix NOT applied
$ scripts/run_tests.sh tests/tools/test_mcp_lazy_start.py -q
>       assert registered == ["mcp__srv__read_resource"]
E       AssertionError: Left contains one more item: 'mcp__srv__read_resource'
>       assert registered == ["mcp__srv__safe_tool"]
E       AssertionError: assert ['mcp__srv__r...v__safe_tool'] == ['mcp__srv__safe_tool']
=== Summary: 1 files, 17 tests passed, 2 failed ===
```

## Validation

| check | command | result |
| --- | --- | --- |
| new tests fail on the defect | `scripts/run_tests.sh tests/tools/test_mcp_lazy_start.py -q` (fix reverted) | 17 passed, **2 failed** |
| MCP suites with the fix | `scripts/run_tests.sh tests/tools/test_mcp_lazy_start.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_schema_cache.py -q` | **133 passed, 0 failed** (131 before + 2 new) |
| lint | `ruff check tools/mcp_tool_registration.py tests/tools/test_mcp_lazy_start.py` | `All checks passed!` |
| wider suite | `scripts/run_tests.sh tests/tools/ -q` | 18 files / 76 tests fail on this host, **none of them MCP** — `daytona`, `modal`, `discord`, `whatsapp`, `voice`, `video_generation` and friends, all missing external services locally. I cannot honestly tick "all tests pass"; the failing set is identical with and without this change. |

Tested on macOS 15 (darwin 25.3.0), branched from `f44b0fd342`.
