### PR TITLE
fix(kanban): fence stale run notifications and preserve summaries

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -53,7 +53,10 @@ def _record_kanban_budget_exhausted(
     from multiple exit paths.
     """
     try:
-        from hermes_cli import kanban_db as _kb
+        raw_run_id = os.environ.get("HERMES_KANBAN_RUN_ID", "")
+        if not raw_run_id.isascii() or not raw_run_id.isdecimal() or int(raw_run_id) <= 0:
+            return
+        expected_run_id = int(raw_run_id)
         from hermes_cli import kanban_db_connect as _kbc
         from hermes_cli import kanban_db_dispatch as _kbd
         _conn = _kbc.connect()
@@ -68,6 +71,7 @@ def _record_kanban_budget_exhausted(
                 outcome="timed_out",
                 release_claim=True,
                 end_run=True,
+                expected_run_id=expected_run_id,
                 event_payload_extra={"budget_used": api_call_count, "budget_max": max_iterations},
             )
         finally:

--- a/gateway/kanban_watchers_notifier.py
+++ b/gateway/kanban_watchers_notifier.py
@@ -289,6 +289,67 @@ def _payload(ev: Any, key: str) -> Any:
     return ev.payload.get(key) if ev.payload and ev.payload.get(key) else None
 
 
+def _fresh_events(conn, task, events):
+    """Reject obsolete failure/decision envelopes using ordered board receipts.
+
+    Timestamps have second precision; lifecycle event IDs fence even an
+    unblock/reblock or two worker generations within the same second.
+    """
+    if task is None:
+        return []
+    guarded = {"timed_out", "crashed", "gave_up", "blocked", "block_loop_detected"}
+    kinds = (*TERMINAL_KINDS, "claimed", "promoted", "reclaimed")
+    latest = conn.execute(
+        "SELECT id FROM task_events WHERE task_id = ? AND kind IN ("
+        + ",".join("?" for _ in kinds) + ") ORDER BY id DESC LIMIT 1",
+        (task.id, *kinds),
+    ).fetchone()
+    latest_run = conn.execute(
+        "SELECT id, outcome, ended_at FROM task_runs WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+        (task.id,),
+    ).fetchone()
+    accepted = []
+    for ev in events:
+        if ev.kind not in guarded:
+            accepted.append(ev)
+            continue
+        if latest is None or ev.id != latest["id"] or task.current_run_id is not None:
+            continue
+        if ev.kind in {"timed_out", "crashed"}:
+            if (latest_run is None or ev.run_id != latest_run["id"]
+                    or latest_run["ended_at"] is None or latest_run["outcome"] != ev.kind
+                    or task.status not in {"ready", "review"}
+                    or _payload(ev, "retry_status") != task.status):
+                continue
+            original = conn.execute(
+                "SELECT id FROM task_events WHERE task_id = ? AND run_id = ? "
+                "AND kind = ? ORDER BY id LIMIT 1", (task.id, ev.run_id, ev.kind),
+            ).fetchone()
+            if original is None or original["id"] != ev.id:
+                continue
+        elif task.status not in {"blocked", "triage"}:
+            continue
+        accepted.append(ev)
+    return accepted
+
+
+def _refresh_delivery(d):
+    from hermes_cli import kanban_db as kb
+    conn = _kbc().connect(board=d.get("board"))
+    try:
+        task = kb.get_task(conn, d["sub"]["task_id"])
+        return task, _fresh_events(conn, task, d["events"])
+    finally:
+        conn.close()
+
+
+def _fmt_timeout(ev, n):
+    used, maximum = _payload(ev, "budget_used"), _payload(ev, "budget_max")
+    detail = f"iteration budget {used}/{maximum}" if maximum else f"max_runtime={int(_payload(ev, 'limit_seconds') or 0)}s"
+    retry = "retry queued" if n.task and n.task.status in {"ready", "review"} else "no automatic retry queued"
+    return f"⏱ {n.head} timed out ({detail}); {retry}", None, None
+
+
 def _clip(ev: Any, key: str, fmt: str, limit: int) -> str:
     """``fmt`` applied to the truncated payload value, or ``""`` when absent."""
     value = _payload(ev, key)
@@ -308,9 +369,9 @@ def _fmt_completed(ev, n) -> tuple:
     wake_handoff = None
     payload_summary = _payload(ev, "summary")
     if payload_summary:
-        wake_handoff = _first_line(str(payload_summary), 200)
+        wake_handoff = str(payload_summary)
     elif n.task and n.task.result:
-        wake_handoff = _first_line(n.task.result, 160)
+        wake_handoff = n.task.result
     handoff = f"\n{wake_handoff}" if wake_handoff is not None else ""
     return f"✔ {n.head} done — {n.title}{handoff}", wake_handoff, None
 
@@ -350,10 +411,8 @@ _EVENT_FORMATTERS: dict[str, Callable[[Any, "_KanbanNotification"], tuple]] = {
     "gave_up": lambda ev, n: (
         f"✖ {n.head} gave up after repeated spawn failures{_clip(ev, 'error', _NL, 200)}", None, None,
     ),
-    "crashed": lambda ev, n: (f"✖ {n.head} worker crashed (pid gone); dispatcher will retry", None, None),
-    "timed_out": lambda ev, n: (
-        f"⏱ {n.head} timed out (max_runtime={int(_payload(ev, 'limit_seconds') or 0)}s); will retry", None, None,
-    ),
+    "crashed": lambda ev, n: (f"✖ {n.head} worker crashed (pid gone); retry queued", None, None),
+    "timed_out": _fmt_timeout,
     "status": lambda ev, n: (f"🔄 {n.head} → {_payload(ev, 'status') or ''}", None, None),
     "review_requested": _fmt_review_requested,
     "changes_requested": _fmt_changes_requested,
@@ -585,6 +644,10 @@ class _KanbanNotification:
         return True
 
     async def deliver(self) -> None:
+        self.task, self.d["events"] = await _to_thread_process_service(_refresh_delivery, self.d)
+        if not self.d["events"]:
+            await self.advance()
+            return
         try:
             self.plat = self.platform_cls(self.platform_str)
         except ValueError:
@@ -603,6 +666,9 @@ class _KanbanNotification:
 
         if not await self._send_pings():
             return
+        # Transport awaits can overlap a human resolving an approval or a
+        # dispatcher claiming the retry. Never wake from the older snapshot.
+        self.task, self.d["events"] = await _to_thread_process_service(_refresh_delivery, self.d)
         # All text pings delivered (or skipped for non-push / wake-only).
         self.build_wake_text()
         wake_kinds, is_push = self.wake_kinds, self.is_push_adapter

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1855,14 +1855,15 @@ def _append_event(
 def _end_run(
     conn: sqlite3.Connection, task_id: str, *, outcome: str, summary: Optional[str] = None,
     error: Optional[str] = None, metadata: Optional[dict] = None, status: Optional[str] = None,
+    expected_run_id: Optional[int] = None,
 ) -> Optional[int]:
     """Close the active run (``status`` defaults to ``outcome``) and clear
     ``current_run_id``; None when no run was active (never-claimed task)."""
     now = int(time.time())
     run_id = _current_run_id(conn, task_id)
-    if run_id is None:
+    if run_id is None or (expected_run_id is not None and run_id != expected_run_id):
         return None
-    conn.execute(
+    cur = conn.execute(
         """
         UPDATE task_runs
            SET status        = ?,
@@ -1879,7 +1880,9 @@ def _end_run(
         """,
         (status or outcome, outcome, summary, error, _json_or_null(metadata), now, run_id),
     )
-    conn.execute("UPDATE tasks SET current_run_id = NULL WHERE id = ?", (task_id,))
+    if cur.rowcount != 1:
+        return None
+    conn.execute("UPDATE tasks SET current_run_id = NULL WHERE id = ? AND current_run_id = ?", (task_id, run_id))
     return run_id
 
 
@@ -2656,8 +2659,8 @@ def _stage_completion_artifacts(conn: sqlite3.Connection, task_id: str, metadata
 def _completed_event_payload(
     result: Optional[str], event_summary: Optional[str], verified_cards: list[str], metadata: Any,
 ) -> dict:
-    """``completed`` event payload: first summary line (400 chars) so gateway
-    notifiers / dashboard WS render without a second round-trip; verified
+    """``completed`` event payload: lossless summary so adapters can chunk at
+    their native delivery limit; verified
     cards; and ``metadata["artifacts"]`` promoted so the notifier can upload
     them as native attachments without fetching the run row."""
     # Mirror CLI's _show_voice_status: include STT/TTS provider availability so the user can tell at a
@@ -2667,7 +2670,7 @@ def _completed_event_payload(
     # ignored the config (#18994).
     payload: dict = {
         "result_len": len(result) if result else 0,
-        "summary": _first_line(event_summary, 400) or None,
+        "summary": event_summary or None,
     }
     if verified_cards:
         payload["verified_cards"] = verified_cards

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -993,6 +993,7 @@ def _record_task_failure(
     force_trip: bool = False,
     release_claim: bool = False,
     end_run: bool = False,
+    expected_run_id: Optional[int] = None,
     event_payload_extra: Optional[dict] = None,
 ) -> bool:
     """Record a non-success outcome and maybe trip the circuit breaker; every
@@ -1017,6 +1018,10 @@ def _record_task_failure(
         ).fetchone()
         if row is None:
             return False
+        if expected_run_id is not None and row["current_run_id"] != expected_run_id:
+            return False
+        if end_run and (row["status"] != "running" or row["current_run_id"] is None):
+            return False
         retry_status = (
             _kb._retry_status_for_run(conn, task_id, row["current_run_id"])
             if release_claim
@@ -1030,6 +1035,29 @@ def _record_task_failure(
             effective_limit, limit_source = int(task_override), "task"
         else:
             effective_limit, limit_source = int(failure_limit), "dispatcher"
+
+        tripped = force_trip or failures >= effective_limit
+        disposition = "blocked" if tripped else retry_status
+        payload = {"error": error, "failures": failures, "retry_status": disposition}
+        if event_payload_extra:
+            payload.update(event_payload_extra)
+        payload["retry_status"] = disposition
+        # Resume phase is distinct from the actual queued disposition. Human
+        # unblocking must restore review even when the breaker stopped retries.
+        payload["resume_status"] = retry_status
+        if tripped:
+            payload.update(effective_limit=effective_limit, limit_source=limit_source,
+                           trigger_outcome=outcome)
+        run_id = None
+        if end_run:
+            # Close before accounting/event append, in the same transaction.
+            # A lost CAS must not spend a retry or announce a stale timeout.
+            run_id = _kb._end_run(
+                conn, task_id, outcome="gave_up" if tripped else outcome,
+                error=error, metadata=payload, expected_run_id=expected_run_id,
+            )
+            if run_id is None:
+                return False
 
         if not (force_trip or failures >= effective_limit):
             if release_claim:
@@ -1049,13 +1077,8 @@ def _record_task_failure(
                 )
             # Timeout/crash path's caller already emitted its own event.
             if end_run:
-                run_id = _kb._end_run(
-                    conn, task_id, outcome=outcome, status=outcome, error=error,
-                    metadata={"failures": failures, "retry_status": retry_status},
-                )
                 _kb._append_event(
-                    conn, task_id, outcome,
-                    {"error": error, "failures": failures, "retry_status": retry_status},
+                    conn, task_id, outcome, payload,
                     run_id=run_id,
                 )
             return False
@@ -1070,29 +1093,14 @@ def _record_task_failure(
             "WHERE id = ? AND status IN ('running', 'ready', 'review')",
             (failures, error, task_id),
         )
-        payload = {
+        payload.update({
             "failures": failures,
             "effective_limit": effective_limit,
             "limit_source": limit_source,
             "error": error,
             "trigger_outcome": outcome,
-            "retry_status": retry_status,
-        }
-        run_id = None
-        if end_run:
-            # Only the spawn path has an open run to close.
-            run_id = _kb._end_run(
-                conn, task_id, outcome="gave_up", status="gave_up", error=error,
-                metadata={
-                    "failures": failures,
-                    "trigger_outcome": outcome,
-                    "effective_limit": effective_limit,
-                    "limit_source": limit_source,
-                    "retry_status": retry_status,
-                },
-            )
-        if event_payload_extra:
-            payload.update(event_payload_extra)
+            "retry_status": "blocked",
+        })
         _kb._append_event(conn, task_id, "gave_up", payload, run_id=run_id)
         return True
 

--- a/tests/gateway/test_kanban_exact_run_notifications.py
+++ b/tests/gateway/test_kanban_exact_run_notifications.py
@@ -1,0 +1,177 @@
+"""Disk-backed finalizer -> board -> notifier regressions, no real messages."""
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from agent.turn_finalizer import _resolve_budget_fallback
+from gateway.config import Platform
+from gateway.kanban_watchers_notifier import _KanbanNotification, _notifier_collect
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_notify as kbn
+
+
+class Transport:
+    def __init__(self):
+        self.sent, self.wakes = [], []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append(text)
+
+    async def handle_message(self, event):
+        self.wakes.append(event.text)
+        event._gateway_accepted = True
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "board.db"))
+    conn = kbc.connect()
+    yield conn
+    conn.close()
+
+
+def claim(conn):
+    tid = kb.create_task(conn, title="Synthetic fixture", assignee="builder")
+    task = kb.claim_task(conn, tid, claimer="test:builder")
+    assert task is not None
+    return tid, task.current_run_id
+
+
+def subscribe(conn, tid):
+    kbn.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="42",
+                       delivery_mode="notify+wake")
+
+
+def finalizer(monkeypatch, tid, rid):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(rid))
+    agent = SimpleNamespace(max_iterations=20, iteration_budget=None)
+    _resolve_budget_fallback(agent, final_response="retained", api_call_count=20,
+                             interrupted=False, failed=False, messages=[],
+                             _pending_verification_response=None,
+                             _pending_verification_response_previewed=False,
+                             _turn_exit_reason="budget_exhausted", logger=logging.getLogger(__name__))
+
+
+def runner(adapter):
+    r = GatewayRunner.__new__(GatewayRunner)
+    r.adapters = {Platform.TELEGRAM: adapter}
+    r._kanban_dispatcher_lock_handle = object()
+    return r
+
+
+def collect(r):
+    return _notifier_collect(r, kb, notifier_profile=None, gc_due=False, gc_retention_days=30)
+
+
+async def deliver(r, ds):
+    for d in ds:
+        await _KanbanNotification(r, d, platform_cls=Platform, sub_fail_counts={}).deliver()
+
+
+def snapshot(conn, tid):
+    return (dict(conn.execute("SELECT * FROM tasks WHERE id=?", (tid,)).fetchone()),
+            [dict(row) for row in conn.execute("SELECT * FROM task_runs WHERE task_id=?", (tid,))],
+            [dict(row) for row in conn.execute("SELECT * FROM task_events WHERE task_id=?", (tid,))])
+
+
+@pytest.mark.parametrize("state", ["done", "review", "blocked", "triage", "successor", "active", "missing", "malformed", "exhausted"])
+def test_finalizer_only_spends_current_active_run(board, monkeypatch, state):
+    tid, rid = claim(board)
+    if state == "done":
+        assert kb.complete_task(board, tid, summary="Retained result", expected_run_id=rid)
+    elif state == "review":
+        assert kb.request_review(board, tid, summary="Review result", expected_run_id=rid)
+    elif state in {"blocked", "triage"}:
+        assert kb.block_task(board, tid, reason="Needs decision", kind="needs_input", expected_run_id=rid)
+        if state == "triage":
+            with kb.write_txn(board):
+                board.execute("UPDATE tasks SET status='triage' WHERE id=?", (tid,))
+    elif state == "successor":
+        finalizer(monkeypatch, tid, rid)
+        assert kb.claim_task(board, tid, claimer="test:successor")
+    elif state == "exhausted":
+        with kb.write_txn(board):
+            board.execute("UPDATE tasks SET max_retries=1 WHERE id=?", (tid,))
+    subscribe(board, tid)  # existing handoff already consumed by origin
+    before = snapshot(board, tid)
+    identity = {"missing": "", "malformed": "not-a-run"}.get(state, rid)
+    finalizer(monkeypatch, tid, identity)
+    adapter = Transport()
+    r = runner(adapter)
+    asyncio.run(deliver(r, collect(r)))
+    if state in {"active", "exhausted"}:
+        after = snapshot(board, tid)
+        assert after[0]["consecutive_failures"] == before[0]["consecutive_failures"] + 1
+        assert after[0]["status"] == ("blocked" if state == "exhausted" else "ready")
+        assert len(adapter.sent) == len(adapter.wakes) == 1
+        if state == "exhausted":
+            assert "retry" not in adapter.sent[0]
+        finalizer(monkeypatch, tid, identity)
+        assert snapshot(board, tid) == after
+        asyncio.run(deliver(r, collect(r)))
+        assert len(adapter.sent) == len(adapter.wakes) == 1
+        if state == "active":
+            event = [e for e in kb.list_events(board, tid) if e.kind == "timed_out"][0]
+            with kb.write_txn(board):
+                kb._append_event(board, tid, "timed_out", event.payload, run_id=rid)
+            before_duplicate = snapshot(board, tid)
+            asyncio.run(deliver(r, collect(r)))
+            assert snapshot(board, tid) == before_duplicate
+            assert len(adapter.sent) == len(adapter.wakes) == 1
+    else:
+        assert snapshot(board, tid) == before
+        assert adapter.sent == adapter.wakes == []
+
+
+@pytest.mark.parametrize("case", ["legacy-null", "ended-run", "replaced", "claim-race", "resolved", "new-approval", "exhausted-crash"])
+def test_obsolete_events_are_silent_but_new_approval_survives(board, monkeypatch, case):
+    tid, rid = claim(board)
+    adapter = Transport()
+    r = runner(adapter)
+    if case in {"resolved", "new-approval"}:
+        subscribe(board, tid)
+        assert kb.block_task(board, tid, reason="Approval A", kind="needs_input", expected_run_id=rid)
+        assert kb.unblock_task(board, tid)
+        if case == "new-approval":
+            assert kb.block_task(board, tid, reason="Approval B", kind="needs_input")
+    elif case == "claim-race":
+        subscribe(board, tid)
+        finalizer(monkeypatch, tid, rid)
+    else:
+        assert kb.complete_task(board, tid, summary="Preserved", expected_run_id=rid)
+        subscribe(board, tid)
+        with kb.write_txn(board):
+            if case == "replaced":
+                board.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+            kb._append_event(board, tid, "timed_out", {"retry_status": "ready"},
+                             run_id=None if case == "legacy-null" else rid)
+        if case == "replaced":
+            successor = kb.claim_task(board, tid, claimer="test:new")
+            assert successor is not None
+            finalizer(monkeypatch, tid, successor.current_run_id)
+            # Old envelope appended after newer run ended must not look current.
+            with kb.write_txn(board):
+                kb._append_event(board, tid, "timed_out", {"retry_status": "ready"}, run_id=rid)
+        if case == "exhausted-crash":
+            with kb.write_txn(board):
+                board.execute("UPDATE tasks SET status='blocked' WHERE id=?", (tid,))
+                kb._append_event(board, tid, "gave_up", {"retry_status": "ready"})
+    ds = collect(r)
+    if case == "claim-race":
+        assert kb.claim_task(board, tid, claimer="test:next")
+    before = snapshot(board, tid)
+    asyncio.run(deliver(r, ds))
+    asyncio.run(deliver(r, collect(r)))
+    assert snapshot(board, tid) == before
+    if case in {"new-approval", "exhausted-crash"}:
+        assert len(adapter.sent) == len(adapter.wakes) == 1
+        assert "retry" not in adapter.sent[0]
+        if case == "new-approval":
+            assert "Approval B" in adapter.sent[0] and "Approval A" not in adapter.sent[0]
+    else:
+        assert adapter.sent == adapter.wakes == []

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -12,6 +12,7 @@ from gateway.run import GatewayRunner
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_db_connect as kbc
 from hermes_cli import kanban_db_notify as kbn
+from hermes_cli import kanban_db_dispatch as kbd
 
 
 class RecordingAdapter:
@@ -315,8 +316,10 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
     try:
         tid = kb.create_task(conn, title="cycle test", assignee="worker")
         kbn.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
-        # First crash — fired by the dispatcher when the worker PID dies.
-        kb._append_event(conn, tid, kind="crashed")
+        claimed = kb.claim_task(conn, tid, claimer="test:first")
+        kbd._record_task_failure(conn, tid, "Synthetic crash", outcome="crashed",
+                                 release_claim=True, end_run=True, failure_limit=3,
+                                 expected_run_id=claimed.current_run_id)
     finally:
         conn.close()
 
@@ -338,10 +341,10 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
             "second crash also notifies the user (issue #21398)."
         )
 
-        # Second crash — same task, same dispatcher (or a respawn). Append
-        # another event to simulate the dispatcher firing crashed a second
-        # time during retry.
-        kb._append_event(conn, tid, kind="crashed")
+        claimed = kb.claim_task(conn, tid, claimer="test:second")
+        kbd._record_task_failure(conn, tid, "Synthetic crash", outcome="crashed",
+                                 release_claim=True, end_run=True, failure_limit=3,
+                                 expected_run_id=claimed.current_run_id)
     finally:
         conn.close()
 
@@ -597,11 +600,10 @@ def test_notifier_delivers_block_loop_detected_triage_ping(tmp_path, monkeypatch
     try:
         tid = kb.create_task(conn, title="loops forever", assignee="worker")
         kbn.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
-        kb._append_event(
-            conn, tid, "block_loop_detected",
-            {"reason": "needs credentials", "kind": "needs_input",
-             "recurrences": 2, "limit": kb.BLOCK_RECURRENCE_LIMIT},
-        )
+        for attempt in range(kb.BLOCK_RECURRENCE_LIMIT):
+            if attempt:
+                assert kb.unblock_task(conn, tid)
+            assert kb.block_task(conn, tid, reason="needs credentials", kind="needs_input")
     finally:
         conn.close()
 
@@ -716,11 +718,10 @@ def test_block_loop_detected_wakes_the_origin_session(tmp_path, monkeypatch):
             chat_type="dm",
             delivery_mode="notify+wake",
         )
-        kb._append_event(
-            conn, tid, "block_loop_detected",
-            {"reason": "needs credentials", "kind": "needs_input",
-             "recurrences": 2, "limit": kb.BLOCK_RECURRENCE_LIMIT},
-        )
+        for attempt in range(kb.BLOCK_RECURRENCE_LIMIT):
+            if attempt:
+                assert kb.unblock_task(conn, tid)
+            assert kb.block_task(conn, tid, reason="needs credentials", kind="needs_input")
     finally:
         conn.close()
 

--- a/tests/gateway/test_kanban_summary_delivery.py
+++ b/tests/gateway/test_kanban_summary_delivery.py
@@ -1,0 +1,67 @@
+"""Completion summaries survive the real Telegram sender with a fake Bot API."""
+import asyncio
+import re
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.kanban_watchers_notifier import _KanbanNotification, _notifier_collect
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_notify as kbn
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+async def summary_flow(tmp_path, monkeypatch, summary):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "summary.db"))
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="Synthetic handoff", assignee="builder")
+        claimed = kb.claim_task(conn, tid, claimer="test:builder")
+        kbn.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="42", delivery_mode="notify+wake")
+        assert kb.complete_task(conn, tid, summary=summary, expected_run_id=claimed.current_run_id)
+        event = [e for e in kb.list_events(conn, tid) if e.kind == "completed"][0]
+        assert event.payload["summary"] == summary
+    finally:
+        conn.close()
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="synthetic-token"))
+    # Test legacy MarkdownV2 transport explicitly, not Bot API capability negotiation.
+    adapter._rich_send_disabled = True
+    adapter._bot = SimpleNamespace(send_message=AsyncMock(return_value=SimpleNamespace(message_id=7)))
+    adapter._retrigger_typing = AsyncMock()
+    wakes = []
+
+    async def handle(event):
+        wakes.append(event.text)
+        event._gateway_accepted = True
+
+    adapter.handle_message = handle
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._kanban_dispatcher_lock_handle = object()
+    ds = _notifier_collect(runner, kb, notifier_profile=None, gc_due=False, gc_retention_days=30)
+    for d in ds:
+        await _KanbanNotification(runner, d, platform_cls=Platform, sub_fail_counts={}).deliver()
+    chunks = [c.kwargs["text"] for c in adapter._bot.send_message.await_args_list]
+    assert chunks
+    assert all(len(c.encode("utf-16-le")) // 2 <= adapter.MAX_MESSAGE_LENGTH for c in chunks)
+    # Decode transport escaping and presentation-only continuation numbering.
+    text = [re.sub(r"\\(.)", r"\1", c) for c in chunks]
+    if len(text) > 1:
+        text = [re.sub(r" \(\d+/\d+\)$", "", c) for c in text]
+    reconstructed = " ".join(text).split("\n", 1)[1]
+    assert reconstructed == summary
+    assert len(wakes) == 1 and summary in wakes[0]
+    assert not _notifier_collect(runner, kb, notifier_profile=None, gc_due=False, gc_retention_days=30)
+
+
+@pytest.mark.parametrize("summary", [
+    "Короткий результат 🐾.",
+    "Проверено: " + "полный полезный текст 🐾 " * 30 + "\nВторая строка: сохранена полностью.",
+    "Длинный результат 🐾 " * 700 + "Конец.",
+])
+def test_summary_reaches_bot_and_wake_losslessly(tmp_path, monkeypatch, summary):
+    asyncio.run(summary_flow(tmp_path, monkeypatch, summary))

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -531,8 +531,17 @@ async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
 
     try:
         tid = kb.create_task(conn, title=f"test {kind} task", assignee="worker1")
+        claimed = kb.claim_task(conn, tid, claimer="test:worker")
+        assert claimed is not None
         kbn.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
-        kb._append_event(conn, tid, kind=kind)
+        from hermes_cli import kanban_db_dispatch as kbd
+        kbd._record_task_failure(
+            conn, tid, "Synthetic worker failure",
+            outcome="timed_out" if kind == "gave_up" else kind,
+            failure_limit=1 if kind == "gave_up" else 2,
+            release_claim=True, end_run=True,
+            expected_run_id=claimed.current_run_id,
+        )
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
@@ -399,7 +399,8 @@ def test_review_retry_still_trips_the_failure_breaker(conn) -> None:
     assert blocked.status == "blocked"
     gave_up = _event(kb.list_events(conn, task_id), "gave_up")
     assert gave_up.payload is not None
-    assert gave_up.payload["retry_status"] == "review"
+    # The breaker preserves the review history, but no retry is queued.
+    assert gave_up.payload["retry_status"] == blocked.status
     assert kb.unblock_task(conn, task_id)
     unblocked = kb.get_task(conn, task_id)
     assert unblocked is not None


### PR DESCRIPTION
## Summary

Fence iteration-budget finalizers to the exact active Kanban run, reject obsolete notification envelopes at dispatch, and preserve complete completion summaries through the existing platform sender.

A late finalizer previously appended a timeout after completion or review handoff, and could affect a successor run. A persisted failure/approval envelope could also outlive the state it described. Independently, completion summaries were cut first in the event producer and again in the notifier, before Telegram's native chunker saw them.

## Changes

- Carry the existing worker run ID into the failure transaction. Validate ownership and complete the run CAS before changing retry accounting or emitting events.
- Recheck lifecycle event ordering, run identity and actual retry disposition before passive notification and again before model wake. Suppress duplicate failure envelopes and resolved approval requests; preserve new requests.
- Preserve review resume phase separately from actual retry disposition after exhaustion.
- Keep full completion summaries in the event, renderer and wake handoff. Use the existing adapter for chunking; no alternate sender.

## Related work and scope

NousResearch/hermes-agent#80320 addresses terminal guards and budget rendering on older modules. This patch adds exact successor-run fencing and dispatch-time freshness, alongside end-to-end summary preservation. NousResearch/hermes-agent#85502 proposes making iteration exhaustion terminal/nonretryable; this patch deliberately preserves the current active-run retry policy. These changes should be coordinated during merge rather than applied as competing retry-policy changes.

This is independent of durable inbound replay work. No gateway rollout or change to retry limits is included. A freshness read cannot retract an already-in-flight network send; this does not promise exactly-once transport.

## Validation

Based on main `1603a073e46e8bc777cd9d096e2fce49887648c2`.

- Canonical runner: `HERMES_PYTHON=$(command -v python3) scripts/run_tests.sh tests/gateway/test_kanban*.py tests/hermes_cli/test_kanban*.py --file-retries 0 -j 6 -q`: 410 passed, 0 failed, 1 Windows-only skip.
- Retained pre-fix behavioral regression run: 18 failures and one passing short-summary control.
- Synthetic disk-backed boards exercise completed/review/blocked/triage/successor states, missing/malformed identity, retry once, exhaustion, duplicate envelopes, collection-to-dispatch claim races, and resolved versus new approvals.
- Real Telegram adapter with fake Bot API exercises short, multiline Unicode and over-limit summaries, reconstructed payload equality and UTF-16 bounds. No real messages or private fixtures are included.
- Full base-to-head scope: nine intended Python source/test files; `git diff --check` and plugin compatibility gate passed.

