### PR TITLE
fix(gateway): transfer durable batches to recoverable outputs

### DIFF
--- a/docs/durable-ingress-transfer.md
+++ b/docs/durable-ingress-transfer.md
@@ -1,0 +1,56 @@
+# Durable input-to-output transfer
+
+The normalized gateway event is persisted before ordinary-message admission. Its
+original platform identity, reply anchor, routing and incoming attachments survive
+queueing and batching. This boundary is after platform normalization: it does not
+claim to make a platform's polling acknowledgement transactional with admission.
+
+## Ownership invariant
+
+One logical response has one authoritative delivery-ledger row. Every contributing
+input has a transactional link to that row before its spool record is retired.
+Already-transferred input does not invoke the model again; unfinished input still
+recovers. A fresh identity with identical text remains a new request. Mixed batches
+are rebuilt from their untransferred members rather than assigning old members to
+a second output. There is no text-similarity classifier or alternate sender.
+
+The output retains normalized text, ordered attachment dispatch units, reply/routing
+metadata and per-component completion. Normal, queued and already-streamed final
+paths use the existing delivery owner. Recovery skips confirmed components and
+reuses attachment dispatch. Failed turns do not upload generated attachments.
+Missing or denied paths remain failed rather than silently completing the output.
+
+Successful platform receipt IDs are associated with the authoritative output.
+Fresh reply ingress resolves these IDs within session/platform/chat/thread scope.
+Unknown or ambiguous receipts stay unknown. Typed original identities and prior
+output disposition enter the new turn and existing transcript display metadata;
+cached prompts and old messages are not rewritten.
+
+## Persistence and rollback
+
+Schema initialization adds an input-link table, a nullable output payload and a
+receipt table. Legacy text-only output rows remain readable. Receipt rows expire
+with their output; input-link tombstones prevent re-execution after content
+retention and currently have no pruning policy.
+
+Older code can open the extended database but cannot recover attachment manifests
+or honor component completion. Drain or explicitly reconcile pending manifests
+before downgrade. Preserve spool/database evidence for reconciliation.
+
+## Limits and verification
+
+A send accepted by the platform before its receipt is persisted is ambiguous.
+Retry may repeat accepted content without rerunning the model. Partial success
+inside a multi-chunk send or image batch is also ambiguous. This is not exactly-once
+external delivery. Attachment paths are retained, not immutable byte snapshots;
+deleted or replaced files require explicit handling. Automatic TTS is not covered
+by a complete crash-recovery guarantee.
+
+Synthetic disk-backed tests use real gateway/ledger/compaction implementations and
+fake transports. They cover duplicate and mixed-batch admission, fresh identical
+text, crash/record/send boundaries, failed attachment recovery, exact-route receipt
+lookup, and retained identity through compaction and reopening. Fake provider
+responses establish plumbing only, not semantic behavior of a language model.
+Policy-level quality of answers to follow-ups, repeated URLs and complaints needs
+separate model evaluation. Runtime rollout and historical reconciliation are
+operator decisions, not consequences of applying this source patch.

--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -157,6 +157,10 @@ def _connect() -> sqlite3.Connection:
 def _initialize_schema(conn: sqlite3.Connection) -> None:
     from hermes_state_wal import apply_wal_with_fallback
     apply_wal_with_fallback(conn, db_label="state.db (delivery_ledger)")
+    conn.execute("""CREATE TABLE IF NOT EXISTS delivery_input_links (
+        session_key TEXT NOT NULL, inbound_id TEXT NOT NULL,
+        obligation_id TEXT NOT NULL,
+        PRIMARY KEY (session_key, inbound_id))""")
     conn.execute(
         """CREATE TABLE IF NOT EXISTS delivery_obligations (
             obligation_id TEXT PRIMARY KEY,
@@ -175,13 +179,19 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
             adapter_profile TEXT
         )"""
     )
-    if "adapter_profile" not in {row[1] for row in conn.execute("PRAGMA table_info(delivery_obligations)")}:
+    for column in ("adapter_profile", "output_payload"):
+        if column in {row[1] for row in conn.execute("PRAGMA table_info(delivery_obligations)")}:
+            continue
         try:
-            conn.execute("ALTER TABLE delivery_obligations ADD COLUMN adapter_profile TEXT")
+            conn.execute(f"ALTER TABLE delivery_obligations ADD COLUMN {column} TEXT")
         except sqlite3.OperationalError as exc:
             # Concurrent first-use connections can both observe the old schema.
             if "duplicate column" not in str(exc).lower():
                 raise
+    conn.execute("""CREATE TABLE IF NOT EXISTS delivery_receipts (
+        obligation_id TEXT NOT NULL, message_id TEXT NOT NULL,
+        PRIMARY KEY (obligation_id, message_id))""")
+    conn.execute("CREATE INDEX IF NOT EXISTS delivery_receipt_message ON delivery_receipts(message_id)")
 
 
 @contextmanager
@@ -245,34 +255,180 @@ def _owner_alive(pid: Any, started_at: Any) -> bool:
         return True
 
 
-def compute_obligation_id(session_key: str, message_ref: str, content: str) -> str:
-    """Stable id: same turn + same content re-records idempotently, while distinct threads/topics on one
-    chat never collide (session_key carries platform/chat/thread; ``message_ref`` = inbound message id)."""
-    return hashlib.sha256(f"{session_key}|{message_ref}|{content}".encode("utf-8", "replace")).hexdigest()[:24]
+def compute_obligation_id(
+    session_key: str,
+    message_ref: str,
+    content: str,
+    *,
+    stable_inbound_id: str | None = None,
+) -> str:
+    """Return the canonical delivery identity for one terminal response.
+
+    Ordinary callers retain the historical trigger-message-plus-content id.
+    A durably queued inbound turn supplies ``stable_inbound_id`` instead: the
+    agent may regenerate different wording after a crash, but it must retain
+    one outbound owner rather than create a second reply obligation.
+    """
+    stable_inbound_id = str(stable_inbound_id or "").strip()
+    if stable_inbound_id:
+        payload = f"{session_key}|inbound:{stable_inbound_id}"
+    else:
+        payload = f"{session_key}|{message_ref}|{content}"
+    return hashlib.sha256(payload.encode("utf-8", "replace")).hexdigest()[:24]
 
 
-def record_obligation(*, obligation_id: str, session_key: str, platform: str, chat_id: str,
-                      thread_id: Optional[str], content: str, adapter_profile: Optional[str] = None) -> None:
-    """Record a final response as owed to the platform (state='pending')."""
-    now, (pid, started) = time.time(), _owner_stamp()
+def obligation_state(obligation_id: str) -> Optional[str]:
+    """Return the existing outbound owner's state without claiming it."""
+    if not obligation_id:
+        return None
     with _DB_LOCK, _transaction() as conn:
-        conn.execute(
+        row = conn.execute(
+            "SELECT state FROM delivery_obligations WHERE obligation_id=?",
+            (obligation_id,),
+        ).fetchone()
+    return str(row[0]) if row else None
+
+
+def inbound_transfer_state(session_key: str, inbound_id: str) -> Optional[str]:
+    """Resolve a batch member through the ledger, including legacy one-input rows."""
+    with _DB_LOCK, _transaction() as conn:
+        row = conn.execute(
+            """SELECT COALESCE(o.state, 'transferred') FROM delivery_input_links i
+               LEFT JOIN delivery_obligations o ON o.obligation_id=i.obligation_id
+               WHERE i.session_key=? AND i.inbound_id=?""",
+            (session_key, inbound_id)).fetchone()
+    if row:
+        return str(row[0])
+    return obligation_state(compute_obligation_id(session_key, "", "", stable_inbound_id=inbound_id))
+
+
+def record_obligation(
+    *,
+    obligation_id: str,
+    session_key: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str],
+    content: str,
+    adapter_profile: Optional[str] = None,
+    preserve_existing: bool = False,
+    inbound_ids: Optional[List[str]] = None,
+    output_payload: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Record a final response as owed to the platform (state='pending').
+
+    ``preserve_existing`` is used only for durable inbound transfer ids.  A
+    second execution of the same inbound turn must leave its original outbound
+    response intact, not overwrite it with newly generated wording.
+    """
+    now = time.time()
+    stored_profile = str(adapter_profile).strip() if adapter_profile else "default"
+    pid, started = _owner_stamp()
+    with _DB_LOCK, _transaction() as conn:
+        # One transaction transfers the output and ALL original batch members.
+        for inbound_id in inbound_ids or []:
+            linked = conn.execute(
+                "SELECT obligation_id FROM delivery_input_links WHERE session_key=? AND inbound_id=?",
+                (session_key, inbound_id)).fetchone()
+            if linked and linked[0] != obligation_id:
+                raise ValueError("input already belongs to another output")
+        statement = (
+            """INSERT OR IGNORE INTO delivery_obligations
+               (obligation_id, session_key, platform, chat_id, thread_id,
+                content, state, attempts, created_at, updated_at,
+                owner_pid, owner_started_at, adapter_profile)
+               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?, ?)"""
+            if preserve_existing else
             """INSERT OR REPLACE INTO delivery_obligations
                (obligation_id, session_key, platform, chat_id, thread_id,
                 content, state, attempts, created_at, updated_at,
                 owner_pid, owner_started_at, adapter_profile)
-               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?, ?)""",
-            (obligation_id, session_key, platform, str(chat_id), str(thread_id) if thread_id else None,
-             content, now, now, pid, started, str(adapter_profile).strip() if adapter_profile else "default"))
+               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?, ?)"""
+        )
+        cursor = conn.execute(
+            statement,
+            (obligation_id, session_key, platform, str(chat_id),
+             str(thread_id) if thread_id else None, content, now, now,
+             pid, started, stored_profile),
+        )
+        created = bool(cursor.rowcount)
+        if created and output_payload is not None:
+            conn.execute("UPDATE delivery_obligations SET output_payload=? WHERE obligation_id=?",
+                         (json.dumps(output_payload), obligation_id))
+        for inbound_id in inbound_ids or []:
+            conn.execute("INSERT OR IGNORE INTO delivery_input_links VALUES (?, ?, ?)",
+                         (session_key, inbound_id, obligation_id))
     _prune()
+    return created
 
 
 def mark_attempting(obligation_id: str) -> None:
     _update_state(obligation_id, "attempting")
 
 
-def mark_delivered(obligation_id: str) -> None:
-    _update_state(obligation_id, "delivered")
+def output_payload(obligation_id: str) -> Optional[Dict[str, Any]]:
+    with _DB_LOCK, _transaction() as conn:
+        row = conn.execute("SELECT output_payload FROM delivery_obligations WHERE obligation_id=?",
+                           (obligation_id,)).fetchone()
+    return json.loads(row[0]) if row and row[0] else None
+
+
+def record_component_receipt(obligation_id: str, component: Optional[int] = None,
+                             message_ids: Optional[List[str]] = None) -> None:
+    """Commit a confirmed component and its receipts together; text is component None.
+
+    Old rows have no manifest and retain their text-only completion semantics.
+    An accepted send with a lost receipt remains an ambiguous retry, never proof.
+    """
+    with _DB_LOCK, _transaction() as conn:
+        row = conn.execute("SELECT output_payload FROM delivery_obligations WHERE obligation_id=?",
+                           (obligation_id,)).fetchone()
+        if not row:
+            return
+        payload = json.loads(row[0]) if row[0] else None
+        complete = True
+        if payload is not None:
+            if component is None:
+                payload["text_complete"] = True
+            else:
+                payload["attachments"][component]["complete"] = True
+            complete = payload["text_complete"] and all(
+                item.get("complete", False) for item in payload["attachments"])
+        for message_id in message_ids or []:
+            if isinstance(message_id, (str, int)) and str(message_id):
+                conn.execute("INSERT OR IGNORE INTO delivery_receipts VALUES (?, ?)",
+                             (obligation_id, str(message_id)))
+        conn.execute("""UPDATE delivery_obligations SET output_payload=?,
+                        state=CASE WHEN ? THEN 'delivered' ELSE state END, updated_at=?
+                        WHERE obligation_id=?""",
+                     (json.dumps(payload) if payload is not None else None,
+                      complete, time.time(), obligation_id))
+
+
+def mark_delivered(obligation_id: str, message_ids: Optional[List[str]] = None) -> None:
+    record_component_receipt(obligation_id, message_ids=message_ids)
+
+
+def resolve_reply_receipt(session_key: str, platform: str, chat_id: str,
+                          thread_id: Optional[str], message_id: str) -> Optional[Dict[str, Any]]:
+    """Exact route + receipt association, independent of quotes and compressed text.
+
+    session_key includes the canonical profile/route scope. Ambiguous matches and
+    old rows without a real receipt stay unknown.
+    """
+    with _DB_LOCK, _transaction() as conn:
+        rows = conn.execute("""SELECT o.obligation_id, o.state FROM delivery_receipts r
+            JOIN delivery_obligations o ON o.obligation_id=r.obligation_id
+            WHERE r.message_id=? AND o.session_key=? AND o.platform=? AND o.chat_id=?
+              AND COALESCE(o.thread_id, '')=?""",
+            (str(message_id), session_key, platform, str(chat_id), str(thread_id or ""))).fetchall()
+        if len(rows) != 1:
+            return None
+        oid, state = rows[0]
+        members = conn.execute("SELECT inbound_id FROM delivery_input_links WHERE obligation_id=? ORDER BY inbound_id",
+                               (oid,)).fetchall()
+    return {"obligation_id": oid, "delivery_state": state,
+            "inbound_ids": [row[0] for row in members]}
 
 
 def mark_failed(obligation_id: str, error: str = "") -> None:
@@ -503,6 +659,8 @@ def _prune(now: Optional[float] = None) -> None:
                                     ELSE 2
                                   END, updated_at ASC
                          LIMIT ?)""", (total - _MAX_ROWS,))
+            conn.execute("""DELETE FROM delivery_receipts WHERE obligation_id NOT IN
+                            (SELECT obligation_id FROM delivery_obligations)""")
     except Exception:
         logger.debug("delivery ledger prune failed", exc_info=True)
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1663,6 +1663,10 @@ def merge_pending_message_event(pending_messages: Dict[str, MessageEvent], sessi
     replace."""
     existing = pending_messages.get(session_key)
     if existing:
+        existing_ids = {m["inbound_id"] for m in existing.original_inputs() if m["inbound_id"]}
+        incoming_ids = {m["inbound_id"] for m in event.original_inputs() if m["inbound_id"]}
+        if incoming_ids and incoming_ids <= existing_ids:
+            return
         existing_type = getattr(existing, "message_type", None)
         existing_is_photo = existing_type == MessageType.PHOTO
         incoming_is_photo = event.message_type == MessageType.PHOTO
@@ -1679,6 +1683,7 @@ def merge_pending_message_event(pending_messages: Dict[str, MessageEvent], sessi
         # A photo burst always absorbs; otherwise merge only when media is involved on either
         # side. Captions merge in every absorbing case.
         if both_photo or existing.media_urls or incoming_has_media:
+            existing.absorb_input_identity(event)
             if both_photo or incoming_has_media:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
@@ -1697,6 +1702,7 @@ def merge_pending_message_event(pending_messages: Dict[str, MessageEvent], sessi
             return
         both_text = existing_type == MessageType.TEXT and event.message_type == MessageType.TEXT
         if merge_text and both_text:
+            existing.absorb_input_identity(event)
             if event.text:
                 existing.text = _append_text(existing.text, event.text)
             return
@@ -3506,6 +3512,13 @@ class BasePlatformAdapter(ABC):
                            expected_session_key, session_key)
             return
         # On-entry self-heal: clear a guard whose owner task already exited.
+        if not event.internal and not event.is_command():
+            from gateway.shutdown_flush import record_durable_inbound_event, _has_durable_outbound_transfer
+            if not record_durable_inbound_event(session_key, event):
+                return
+            if _has_durable_outbound_transfer(session_key, event.metadata.get("_hermes_durable_inbound_id", "")):
+                event._gateway_accepted = True
+                return
         if session_key in self._active_sessions:
             self._heal_stale_session_lock(session_key)
         if session_key in self._active_sessions:
@@ -3569,6 +3582,16 @@ class BasePlatformAdapter(ABC):
         # (or collapse distinct wakes into one turn). Its caller can retry admission.
         if event.internal and session_key in self._pending_messages:
             return
+        if not getattr(event, "internal", False):
+            try:
+                from gateway.shutdown_flush import record_durable_inbound_event
+
+                if not record_durable_inbound_event(session_key, event):
+                    logger.error("[%s] Rejecting queued input without durable record for %s", self.name, session_key)
+                    return
+            except Exception:
+                logger.exception("[%s] Durable pending-input record failed for %s", self.name, session_key)
+                return
         # Photo bursts/albums: queue without interrupting; they run after the current task.
         if event.message_type == MessageType.PHOTO:
             logger.debug("[%s] Queuing photo follow-up for session %s without interrupt", self.name, session_key)
@@ -3636,7 +3659,8 @@ class BasePlatformAdapter(ABC):
 
     async def _play_tts_file(
         self, event: MessageEvent, text_content: str, tts_path: str, first: bool,
-        metadata: Dict[str, Any], record_delivery: Callable) -> bool:
+        metadata: Dict[str, Any], record_delivery: Callable,
+        obligation_id: Optional[str] = None) -> bool:
         """Play one synthesized TTS file. Returns True when the ORIGINAL reply text rode
         along as a Telegram caption (first file, ≤1024 chars) so the text send is skipped."""
         caption = None
@@ -3645,41 +3669,71 @@ class BasePlatformAdapter(ABC):
         tts_result = await self.play_tts(
             chat_id=event.source.chat_id, audio_path=tts_path, caption=caption, metadata=metadata)
         record_delivery(tts_result)
+        if caption and obligation_id is not None:
+            await self._finalize_delivery_obligation(
+                obligation_id, tts_result, event, self._final_delivery_adapter(event.source))
+        elif caption and getattr(tts_result, "success", False):
+            with contextlib.suppress(Exception):
+                from gateway.shutdown_flush import acknowledge_durable_inbound_event
+
+                acknowledge_durable_inbound_event(event)
         return bool(caption and getattr(tts_result, "success", False))
 
     async def _record_delivery_obligation(
         self, event: MessageEvent, session_key: str, text_content: str,
-        delivery_adapter: "BasePlatformAdapter", is_ephemeral_response: bool) -> Optional[str]:
+        delivery_adapter: "BasePlatformAdapter", is_ephemeral_response: bool, *,
+        attachments: Optional[list] = None, metadata: Optional[dict] = None,
+        reply_to: Optional[str] = None) -> tuple[Optional[str], bool]:
         """Ledger the final response BEFORE the send so a crash before platform ACK redelivers on
         next boot; best-effort, skips slash-command and ephemeral replies. Returns the obligation id
-        or None."""
+        and whether an existing outbound owner already transferred a durable inbound turn. A durable
+        inbound identity takes precedence over regenerated response text."""
+        event = getattr(event, "terminal_event", None) or event
         if is_ephemeral_response or str(event.text or "").lstrip().startswith(
             ("/", self.typed_command_prefix or "!")):
-            return None
+            return None, False
         try:
             from gateway.delivery_ledger import (
                 compute_obligation_id, ledger_enabled, mark_attempting, record_obligation)
+            from gateway.shutdown_flush import (
+                acknowledge_durable_inbound_event, durable_inbound_obligation_id)
             if not await asyncio.to_thread(ledger_enabled):
-                return None
+                return None, False
             source = event.source
+            inbound_id = durable_inbound_obligation_id(event)
+            inbound_ids = [m["inbound_id"] for m in event.original_inputs() if m["inbound_id"]]
             # ``ledger_message_id`` wins when set: a queued chain's final answers the last message
             # of the chain, not the event that opened it (see ``MessageEvent.ledger_message_id``).
             _ledger_id = getattr(event, "ledger_message_id", None)
             if _ledger_id is None:
                 _ledger_id = getattr(event, "message_id", "")
             obligation_id = compute_obligation_id(
-                session_key, str(_ledger_id or ""), text_content)
-            await asyncio.to_thread(
+                session_key, str(_ledger_id or ""), text_content,
+                stable_inbound_id=inbound_id or None)
+            created = await asyncio.to_thread(
                 record_obligation, obligation_id=obligation_id, session_key=session_key,
                 platform=str(getattr(source.platform, "value", source.platform)),
                 chat_id=source.chat_id, thread_id=getattr(source, "thread_id", None),
                 content=text_content,
-                adapter_profile=getattr(delivery_adapter, "_owner_profile", None))
-            await asyncio.to_thread(mark_attempting, obligation_id)
-            return obligation_id
+                adapter_profile=getattr(delivery_adapter, "_owner_profile", None),
+                preserve_existing=bool(inbound_id), inbound_ids=inbound_ids,
+                output_payload={"version": 1, "attachments": attachments or [],
+                                "text_complete": not bool(text_content),
+                                "metadata": metadata or {}, "reply_to": reply_to,
+                                "session_key": session_key})
+            if inbound_id:
+                if not created:
+                    return obligation_id, True
+                acknowledge_durable_inbound_event(event)
+            if created:
+                await asyncio.to_thread(mark_attempting, obligation_id)
+            return obligation_id, False
         except Exception:
             logger.debug("delivery ledger record failed", exc_info=True)
-            return None
+            if event.metadata.get("_hermes_durable_inbound_id"):
+                # Never send an unowned response after a failed durable transfer.
+                raise
+            return None, False
 
     async def _finalize_delivery_obligation(
         self, obligation_id: str, result: Any, event: MessageEvent,
@@ -3692,7 +3746,7 @@ class BasePlatformAdapter(ABC):
         try:
             from gateway.delivery_ledger import is_flood_error, mark_delivered, mark_failed
             if getattr(result, "success", False):
-                await asyncio.to_thread(mark_delivered, obligation_id)
+                await asyncio.to_thread(mark_delivered, obligation_id, self._delivery_receipt_ids(result))
                 return
             error = str(getattr(result, "error", "") or "")
             await asyncio.to_thread(mark_failed, obligation_id, error)
@@ -3710,6 +3764,91 @@ class BasePlatformAdapter(ABC):
                              profile=getattr(delivery_adapter, "_owner_profile", None))
         except Exception:
             logger.debug("delivery ledger update failed", exc_info=True)
+
+    @staticmethod
+    def _delivery_receipt_ids(result: Any) -> list:
+        ids = getattr(result, "continuation_message_ids", None)
+        ids = list(ids) if isinstance(ids, (list, tuple)) else []
+        raw = getattr(result, "raw_response", None)
+        if isinstance(raw, dict) and isinstance(raw.get("message_ids"), (list, tuple)):
+            ids.extend(raw["message_ids"])
+        message_id = getattr(result, "message_id", None)
+        if isinstance(message_id, (str, int)) and str(message_id) and message_id != "__no_edit__":
+            ids.append(str(message_id))
+        return list(dict.fromkeys(str(mid) for mid in ids
+                                  if isinstance(mid, (str, int)) and str(mid) and mid != "__no_edit__"))
+
+    @staticmethod
+    def _delivery_manifest(media_files: list, local_files: list, images: list,
+                           force_document: bool) -> list:
+        """Persist dispatch units, not copies of the response. Missing files stay owed."""
+        manifest = [{"images": images, "complete": False}] if images else []
+        photos = [(p, v) for p, v in media_files
+                  if not v and not force_document and Path(p).suffix.lower() in _IMAGE_EXTS]
+        local_photos = [p for p in local_files
+                        if not force_document and Path(p).suffix.lower() in _IMAGE_EXTS]
+        if photos or local_photos:
+            manifest.append({"media_files": photos, "local_files": local_photos,
+                             "force_document": force_document, "complete": False})
+        for path, voice in media_files:
+            if (path, voice) in photos:
+                continue
+            manifest.append({"media_files": [[path, voice]], "local_files": [],
+                             "force_document": force_document, "complete": False})
+        for path in local_files:
+            if path in local_photos:
+                continue
+            manifest.append({"media_files": [], "local_files": [path],
+                             "force_document": force_document, "complete": False})
+        return manifest
+
+    async def _deliver_ledger_attachments(self, obligation_id: str, event: MessageEvent,
+                                           record_delivery: Optional[Callable] = None) -> bool:
+        """Normal attachment dispatch, with durable per-component confirmation.
+
+        Revalidate on recovery: retaining a path is not permission to bypass the
+        media policy or upload a replaced symlink. A rejected path stays failed.
+        """
+        from gateway.delivery_ledger import output_payload, record_component_receipt, mark_failed
+        payload = await asyncio.to_thread(output_payload, obligation_id)
+        if payload is None:
+            return True
+        for index, item in enumerate(payload["attachments"]):
+            if item.get("complete"):
+                continue
+            results = []
+            metadata = payload["metadata"]
+            if "images" in item:
+                await self._send_image_batch(event, item["images"], metadata, 0, results.append)
+            else:
+                media, local = [], []
+                for path, voice in item["media_files"]:
+                    safe = _validated_delivery_path(path, payload["session_key"], "MEDIA directive path")
+                    if safe:
+                        media.append((safe, voice))
+                for path in item["local_files"]:
+                    safe = _validated_delivery_path(path, payload["session_key"], "local attachment")
+                    if safe:
+                        local.append(safe)
+                if len(media) + len(local) != len(item["media_files"]) + len(item["local_files"]):
+                    results.append(SendResult(success=False, error="attachment unavailable or denied"))
+                else:
+                    await self._deliver_media_attachments(
+                        event, media, local, force_document_attachments=item["force_document"],
+                        human_delay=0, metadata=metadata, record_delivery=results.append)
+            for result in results:
+                if record_delivery:
+                    record_delivery(result)
+            if not results or not all(getattr(result, "success", False) for result in results):
+                error = next((str(getattr(r, "error", "") or "attachment send failed")
+                              for r in results if not getattr(r, "success", False)), "attachment send failed")
+                await asyncio.to_thread(mark_failed, obligation_id, error)
+                logger.error("[%s] response_delivery_dropped: attachment dispatch failed (%s)",
+                             self.name, error)
+                return False
+            receipts = [mid for result in results for mid in self._delivery_receipt_ids(result)]
+            await asyncio.to_thread(record_component_receipt, obligation_id, index, receipts)
+        return True
 
     async def _deliver_media_attachments(
         self, event: MessageEvent, media_files: list, local_files: list, *,
@@ -3782,6 +3921,7 @@ class BasePlatformAdapter(ABC):
     async def send_final_ledgered(
         self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any], *,
         reply_to: Optional[str], is_ephemeral_response: bool = False,
+        obligation_id: Optional[str] = None,
     ) -> "tuple[SendResult, BasePlatformAdapter]":
         """The delivery-ledger bracket every final text goes through, on the CURRENT transport
         (a reconnect may have replaced this adapter): record the obligation before the send,
@@ -3789,12 +3929,21 @@ class BasePlatformAdapter(ABC):
         transport) leaves a ledger row the boot sweep / runtime redelivery can act on. ``event``
         supplies the source and the ledger identity (``ledger_message_id`` or ``message_id``).
         Returns the result with the adapter that sent it: that adapter owns ``result.message_id``
-        (an ephemeral delete must go to the same transport)."""
+        (an ephemeral delete must go to the same transport). ``obligation_id`` reuses the
+        pre-recorded owner from the normal lane instead of creating a second row."""
         delivery_adapter = self._final_delivery_adapter(event.source)
         logger.info("[%s] Sending response (%d chars) to %s", delivery_adapter.name,
                     len(text_content), event.source.chat_id)
-        obligation_id = await self._record_delivery_obligation(
-            event, session_key, text_content, delivery_adapter, is_ephemeral_response)
+        if obligation_id is None:
+            obligation_id, outbound_already_owned = await self._record_delivery_obligation(
+                event, session_key, text_content, delivery_adapter, is_ephemeral_response,
+                metadata=metadata, reply_to=reply_to)
+            if outbound_already_owned:
+                logger.info(
+                    "[%s] Existing outbound obligation owns durable inbound turn for %s",
+                    self.name, session_key,
+                )
+                return SendResult(success=True), delivery_adapter
         result = await delivery_adapter._send_with_retry(
             chat_id=event.source.chat_id, content=text_content, reply_to=reply_to, metadata=metadata)
         if obligation_id is not None:
@@ -3803,12 +3952,23 @@ class BasePlatformAdapter(ABC):
 
     async def _send_final_text(
         self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any],
-        is_ephemeral_response: bool, ephemeral_ttl: int, record_delivery: Callable) -> None:
-        """Normal-lane final: the ledger bracket plus the message-id owner's ephemeral delete."""
+        is_ephemeral_response: bool, ephemeral_ttl: int, record_delivery: Callable,
+        obligation_id: Optional[str] = None) -> None:
+        """Normal-lane final: reuse a pre-recorded obligation when supplied, then apply the ledger
+        bracket plus the message-id owner's ephemeral delete."""
+        send_kwargs = {}
+        if obligation_id is not None:
+            send_kwargs["obligation_id"] = obligation_id
         result, delivery_adapter = await self.send_final_ledgered(
             event, session_key, text_content, metadata,
-            reply_to=_reply_anchor_for_event(event), is_ephemeral_response=is_ephemeral_response)
+            reply_to=_reply_anchor_for_event(event), is_ephemeral_response=is_ephemeral_response,
+            **send_kwargs)
         record_delivery(result)
+        if obligation_id is None and result.success:
+            with contextlib.suppress(Exception):
+                from gateway.shutdown_flush import acknowledge_durable_inbound_event
+
+                acknowledge_durable_inbound_event(event)
         if ephemeral_ttl and ephemeral_ttl > 0 and result.success and result.message_id:
             delivery_adapter._schedule_ephemeral_delete(event.source.chat_id, result.message_id, ephemeral_ttl)
 
@@ -3977,6 +4137,21 @@ class BasePlatformAdapter(ABC):
                 text_content, media_files = extracted.text_content, extracted.media_files
                 # Final content gets notify=True; typing metadata stays unmarked (thread-strict).
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                obligation_id, outbound_already_owned = await self._record_delivery_obligation(
+                    event, session_key, text_content, self, is_ephemeral_response,
+                    attachments=self._delivery_manifest(
+                        self.extract_media(response)[0], extracted.local_files, extracted.images,
+                        extracted.force_document_attachments),
+                    metadata=_final_thread_metadata, reply_to=_reply_anchor_for_event(event))
+                if outbound_already_owned:
+                    logger.info(
+                        "[%s] Existing outbound obligation owns durable inbound turn for %s",
+                        self.name, session_key,
+                    )
+                    response = None
+                    text_content = ""
+                    media_files = []
+                    extracted = _ExtractedResponse("", [], [], [], False, "")
                 _tts_paths, _tts_requested_path = [], None
                 if self._wants_auto_tts(
                         event, session_key, interrupt_event, text_content, media_files):
@@ -3987,7 +4162,7 @@ class BasePlatformAdapter(ABC):
                     try:
                         _tts_caption_delivered |= await self._play_tts_file(
                             event, text_content, _tts_path, _tts_index == 0, _final_thread_metadata,
-                            _record_delivery)
+                            _record_delivery, obligation_id)
                     finally:
                         with contextlib.suppress(OSError):
                             os.remove(_tts_path)
@@ -3997,11 +4172,21 @@ class BasePlatformAdapter(ABC):
                 if text_content and not _tts_caption_delivered:
                     await self._send_final_text(
                         event, session_key, text_content, _final_thread_metadata,
-                        is_ephemeral_response, _ephemeral_ttl, _record_delivery)
-                await self._deliver_attachments(
-                    event, extracted, _final_thread_metadata,
-                    anything_sent=delivery_attempted or _tts_caption_delivered,
-                    record_delivery=_record_delivery)
+                        is_ephemeral_response, _ephemeral_ttl, _record_delivery, obligation_id)
+                if obligation_id and not outbound_already_owned:
+                    await self._deliver_ledger_attachments(obligation_id, event, _record_delivery)
+                    if not (text_content or extracted.images or extracted.local_files or media_files):
+                        # Preserve the existing empty-extraction diagnostic; this
+                        # path has no remaining attachment to send a second time.
+                        await self._deliver_attachments(
+                            event, extracted, _final_thread_metadata,
+                            anything_sent=delivery_attempted or _tts_caption_delivered,
+                            record_delivery=_record_delivery)
+                elif not outbound_already_owned:
+                    await self._deliver_attachments(
+                        event, extracted, _final_thread_metadata,
+                        anything_sent=delivery_attempted or _tts_caption_delivered,
+                        record_delivery=_record_delivery)
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
             # Clean up the per-turn streaming-TTS flag.
             self._streaming_tts_completed_turns.discard(self._streaming_tts_turn_key(

--- a/gateway/platforms/event.py
+++ b/gateway/platforms/event.py
@@ -84,6 +84,71 @@ class MessageEvent:
     # so untrusted payload text stays conversational. Kept last for positional compat.
     allow_gateway_control: bool = True
 
+    # Captured before batching mutates text/media; input links, not output copies.
+    input_members: List[Dict[str, Any]] = field(default_factory=list)
+    terminal_event: Optional["MessageEvent"] = field(default=None, repr=False, compare=False)
+    # Derived at canonical ingress, never trusted from platform metadata.
+    ingress_provenance: List[Dict[str, Any]] = field(default_factory=list, repr=False, compare=False)
+
+    def original_inputs(self) -> List[Dict[str, Any]]:
+        if self.input_members:
+            return self.input_members
+        return [{
+            "inbound_id": self.metadata.get("_hermes_durable_inbound_id", ""),
+            "message_id": self.message_id, "platform_update_id": self.platform_update_id,
+            "timestamp": self.timestamp.isoformat() if self.timestamp else None,
+            "reply_to_message_id": self.reply_to_message_id, "internal": self.internal,
+            "reply_to_text": self.reply_to_text, "text": self.text,
+            "media_urls": list(self.media_urls), "media_types": list(self.media_types),
+            "media_text_inlined": list(self.media_text_inlined),
+            "message_type": self.message_type.value,
+            "reply_to_author_id": self.reply_to_author_id,
+            "reply_to_author_name": self.reply_to_author_name,
+            "reply_to_is_own_message": self.reply_to_is_own_message,
+        }]
+
+    def retain_inputs(self, members: List[Dict[str, Any]]) -> None:
+        """Rebuild a mixed replay batch from only the untransferred originals.
+
+        Keep this event object: queued/recursive callers hold its identity for
+        the terminal transfer. Never retain a replied-to anchor from a removed
+        member, or enrich an already-answered attachment a second time.
+        """
+        if not members:
+            raise ValueError("cannot rebuild an empty input batch")
+        first = members[0]
+        self.input_members = list(members)
+        self.text = "\n\n".join(m["text"] for m in members if m.get("text"))
+        self.media_urls = [url for m in members for url in m.get("media_urls", [])]
+        self.media_types = [kind for m in members for kind in m.get("media_types", [])]
+        self.media_text_inlined = []
+        for member in members:
+            flags = list(member.get("media_text_inlined", []))
+            self.media_text_inlined.extend(flags + [None] * (len(member.get("media_urls", [])) - len(flags)))
+        self.message_type = MessageType(first.get("message_type", "text"))
+        if any(m.get("message_type") == "photo" for m in members):
+            self.message_type = MessageType.PHOTO
+        for name in ("message_id", "platform_update_id", "reply_to_message_id", "reply_to_text",
+                     "reply_to_author_id", "reply_to_author_name"):
+            setattr(self, name, first.get(name))
+        self.reply_to_is_own_message = first.get("reply_to_is_own_message", False)
+        self.internal = first.get("internal", False)
+        if first.get("timestamp"):
+            self.timestamp = datetime.fromisoformat(first["timestamp"])
+        self.metadata = {**self.metadata, "_hermes_durable_inbound_id": first["inbound_id"]}
+        self.metadata.pop("_hermes_durable_inbound_path", None)
+        self.ledger_message_id = None
+        for name in ("_gateway_pending_stt_text", "_gateway_pending_stt_transcripts"):
+            if hasattr(self, name):
+                delattr(self, name)
+
+    def absorb_input_identity(self, other: "MessageEvent") -> None:
+        members = self.original_inputs() + other.original_inputs()
+        self.input_members = list({
+            (m["inbound_id"] or (m["message_id"], m["platform_update_id"], m["timestamp"])): m
+            for m in members
+        }.values())
+
     # Process-local admission receipt, never routing metadata or execution acknowledgement.
     _gateway_accepted: bool = field(default=False, init=False, repr=False, compare=False)
 

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -278,11 +278,21 @@ class GatewayBusySessionMixin:
         "gateway_session_id", "gateway_session_strict",
     )
 
-    def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
+    def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> bool:
         from gateway.platforms.base import merge_pending_message_event
         adapter = self._adapter_for_source(event.source)
         if not adapter:
-            return
+            return False
+        if not getattr(event, "internal", False):
+            try:
+                from gateway.shutdown_flush import record_durable_inbound_event
+
+                if not record_durable_inbound_event(session_key, event):
+                    logger.error("Rejecting queued input without durable record for session %s", session_key)
+                    return False
+            except Exception:
+                logger.exception("Durable pending-input record failed for session %s", session_key)
+                return False
         # FIFO so each follow-up gets its own turn in arrival order (the single pending slot used to
         # be silently OVERWRITTEN). Photo bursts still merge into the head slot (album semantics).
         pending_slot = getattr(adapter, "_pending_messages", None)
@@ -312,16 +322,22 @@ class GatewayBusySessionMixin:
                 merge_text=event.message_type == MessageType.TEXT,
             )
             event._gateway_accepted = True
-            return
+            return True
 
         if self._queue_depth(session_key, adapter=adapter) >= self._BUSY_QUEUE_MAX_PENDING:
             logger.warning(
                 "Dropping busy-mode follow-up for session %s — pending queue at cap (%d).",
                 session_key, self._BUSY_QUEUE_MAX_PENDING,
             )
-            return
+            if not getattr(event, "internal", False):
+                with contextlib.suppress(Exception):
+                    from gateway.shutdown_flush import acknowledge_durable_inbound_event
+
+                    acknowledge_durable_inbound_event(event)
+            return False
 
         self._enqueue_fifo(session_key, event, adapter)
+        return True
 
     async def _prepare_busy_steer_text(self, event: MessageEvent) -> str:
         """Steerable text for a busy follow-up, transcribing voice-message media first.
@@ -406,8 +422,11 @@ class GatewayBusySessionMixin:
         if not adapter:
             return
         if self._queue_during_drain_enabled(effective_mode):
-            self._queue_or_replace_pending_event(session_key, event)
-            message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+            accepted = self._queue_or_replace_pending_event(session_key, event)
+            message = (
+                f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+                if accepted else "⚠️ Gateway could not safely queue that message; please send it again after it is back."
+            )
         else:
             message = f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
         await self._send_busy_reply(event, adapter, message)
@@ -702,8 +721,16 @@ class GatewayBusySessionMixin:
         effective_mode, redirected = _steer.effective_mode, _steer.redirected
         # Queue as the next turn — skipped after a successful steer/redirect (the text is already in
         # the run and must NOT replay). FIFO gives each text its own turn (raw merge would join them).
+        queued = True
         if not _steer.steered and not redirected:
-            self._queue_or_replace_pending_event(session_key, event)
+            queued = self._queue_or_replace_pending_event(session_key, event)
+        if not queued:
+            await self._send_busy_ack_reply(
+                event, adapter,
+                "⚠️ I could not safely queue that follow-up while the current request is running. "
+                "Please send it again after the current turn finishes.",
+            )
+            return True
         # Store the message so it's processed as the next turn after the current run finishes (or is
         # interrupted). Skip this for a successful steer — the text already landed inside the run and must
         # NOT also be replayed as a next-turn user message. Route through _queue_or_replace_pending_event

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1618,6 +1618,32 @@ class GatewayInboundMixin:
         # Prefer the caller's resolved session key so this write key matches the consume key at the
         # run_conversation site; derive it here only for tests and legacy standalone callers.
         session_key = session_key or self._session_key_for_source(source)
+        from gateway.delivery_ledger import inbound_transfer_state, resolve_reply_receipt
+        members = event.original_inputs()
+        provenance = []
+        for member in members:
+            state = (inbound_transfer_state(session_key, member["inbound_id"])
+                     if member["inbound_id"] else None)
+            provenance.append({**member, "delivery_state": state,
+                               "kind": "internal_notification" if member["internal"] else "owner_message"})
+            if member.get("reply_to_message_id"):
+                provenance[-1]["prior_output"] = resolve_reply_receipt(
+                    session_key, str(getattr(source.platform, "value", source.platform)),
+                    source.chat_id, source.thread_id, member["reply_to_message_id"])
+        if provenance and all(item["delivery_state"] for item in provenance):
+            # The stored output, not another model turn, owns recovery.
+            return None
+        if any(item["delivery_state"] for item in provenance):
+            # A restored batch may mix old transfers with genuinely new input.
+            # Remove the old members from both model work and the next output's
+            # ownership links; otherwise recording that output conflicts with
+            # their authoritative earlier output.
+            members = [member for member, item in zip(members, provenance)
+                       if item["delivery_state"] is None]
+            event.retain_inputs(members)
+            provenance = [item for item in provenance if item["delivery_state"] is None]
+            message_text = event.text
+            _pending_stt_prepared = False
         # Reset only this session's per-call buffer; other sessions may be concurrently preparing.
         self._consume_pending_native_image_paths(session_key)
 
@@ -1635,7 +1661,13 @@ class GatewayInboundMixin:
                 return None
         # After expansion: the quoted reply is someone else's text and stays literal — an
         # ``@file:`` inside it must never read a local file on the replier's behalf.
-        return self._prepend_inbound_reply_context(event, source, message_text)
+        message_text = self._prepend_inbound_reply_context(event, source, message_text)
+        event.ingress_provenance = provenance
+        if event.input_members or any(m["inbound_id"] for m in members):
+            import json
+            message_text = ("[Gateway ingress provenance]\n" +
+                            json.dumps(provenance, ensure_ascii=False) + "\n\n" + message_text)
+        return message_text
 
     async def _prepare_profile_scoped_inbound_message_text(
         self, *, event: MessageEvent, source: SessionSource, history: List[Dict[str, Any]],

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -318,6 +318,7 @@ class GatewayNotificationsMixin:
         metadata: Optional[Dict[str, Any]] = None, event_message_id: Optional[str] = None,
         text_already_delivered: bool = False, deliver_media: bool = True, stream_consumer=None,
         session_key: Optional[str] = None, inbound_message_id: Optional[str] = None,
+        inbound_event: Optional[MessageEvent] = None,
     ) -> None:
         """Deliver a queued response using the normal text+attachment split.
 
@@ -326,6 +327,23 @@ class GatewayNotificationsMixin:
         ``event_message_id`` reply anchor); see ``_send_queued_final_text``. Without a key the send
         stays unledgered."""
         from gateway.run import _strip_response_attachments_for_direct_send
+        obligation_id = None
+        transfer_event = inbound_event or MessageEvent(
+            text="", source=source, ledger_message_id=inbound_message_id)
+        from gateway.platforms.base import SendResult
+        if session_key and isinstance(adapter, BasePlatformAdapter):
+            media_files, _ = adapter.extract_media(response)
+            manifest = adapter._delivery_manifest(media_files, [], [], "[[as_document]]" in response) if deliver_media else []
+            obligation_id, already_owned = await adapter._record_delivery_obligation(
+                transfer_event, session_key,
+                _strip_response_attachments_for_direct_send(response, adapter), adapter, False,
+                attachments=manifest, metadata=metadata, reply_to=event_message_id)
+            if already_owned:
+                return
+            if text_already_delivered and obligation_id:
+                await adapter._finalize_delivery_obligation(
+                    obligation_id, SendResult(success=True, message_id=getattr(stream_consumer, "message_id", None)),
+                    transfer_event, adapter)
         if not text_already_delivered:
             text_content = _strip_response_attachments_for_direct_send(response, adapter)
             if text_content:
@@ -344,6 +362,9 @@ class GatewayNotificationsMixin:
                         )
                         if getattr(_edit_res, "success", False):
                             _reconciled = True
+                            if obligation_id:
+                                await adapter._finalize_delivery_obligation(
+                                    obligation_id, _edit_res, transfer_event, adapter)
                             logger.info(
                                 "Queued-lane final reconciled by editing message %s in place (no duplicate send).",
                                 _sc_msg_id,
@@ -366,10 +387,13 @@ class GatewayNotificationsMixin:
                 if not _reconciled:
                     await self._send_queued_final_text(
                         adapter, source, text_content, metadata, event_message_id, session_key,
-                        inbound_message_id)
+                        inbound_message_id, inbound_event=transfer_event, obligation_id=obligation_id)
         # Failed turns deliver their (normalized failure) text but must not upload attachments as if
         # they succeeded — mirrors the ``not agent_result.get("failed")`` completed-turn guard.
         if not deliver_media:
+            return
+        if obligation_id:
+            await adapter._deliver_ledger_attachments(obligation_id, transfer_event)
             return
         await self._deliver_media_from_response(
             response, MessageEvent(text="", source=source, message_id=event_message_id), adapter,
@@ -380,6 +404,7 @@ class GatewayNotificationsMixin:
         self, adapter, source: SessionSource, text_content: str, metadata: Optional[Dict[str, Any]],
         event_message_id: Optional[str], session_key: Optional[str],
         inbound_message_id: Optional[str] = None,
+        inbound_event: Optional[MessageEvent] = None, obligation_id: Optional[str] = None,
     ):
         """Send a queued-lane final through the same ledger bracket as the normal final
         (``send_final_ledgered``). This lane used to call ``adapter.send`` bare and discard the
@@ -391,8 +416,9 @@ class GatewayNotificationsMixin:
         the base contract and sends without a session key keep the plain send."""
         if session_key and isinstance(adapter, BasePlatformAdapter):
             result, _ = await adapter.send_final_ledgered(
-                MessageEvent(text="", source=source, ledger_message_id=inbound_message_id),
-                session_key, text_content, _mark_notify_metadata(metadata), reply_to=event_message_id)
+                inbound_event or MessageEvent(text="", source=source, ledger_message_id=inbound_message_id),
+                session_key, text_content, _mark_notify_metadata(metadata), reply_to=event_message_id,
+                obligation_id=obligation_id)
         else:
             result = await adapter.send(source.chat_id, text_content, metadata=metadata)
         if not getattr(result, "success", False):

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -90,6 +90,26 @@ class GatewayStartupMixin:
             drained += 1
         return drained
 
+    def _restore_durable_inbound_queue(self) -> int:
+        """Add persisted inbound obligations to the existing startup queue without acknowledging them.
+
+        Adapter admission is only RAM ownership.  The spool stays until final
+        output transfers to the delivery ledger (or a ledger-disabled send is
+        confirmed), so a second restart cannot lose the original user turn.
+        """
+        try:
+            from gateway.shutdown_flush import recover_durable_inbound_events
+
+            events = recover_durable_inbound_events()
+        except Exception:
+            logger.exception("Could not restore durable inbound queue")
+            return 0
+        for event in events:
+            self._queue_startup_restore_event(event)
+        if events:
+            logger.info("Restored %d durable inbound message(s) into startup queue", len(events))
+        return len(events)
+
     def _start_startup_warmup(self) -> None:
         """Kick off the boot turn-machinery warm-up so it overlaps the network-bound platform
         connects; ``_finish_startup_restore`` awaits it (bounded)."""
@@ -365,7 +385,7 @@ class GatewayStartupMixin:
         # No early return on an empty claim: the boot sweep may have ADOPTED flood-refused rows that are
         # not due yet, and those still need their timer armed below.
         try:
-            from gateway.delivery_ledger import RECOVERED_MARKER, mark_delivered, mark_failed
+            from gateway.delivery_ledger import RECOVERED_MARKER, mark_delivered, mark_failed, output_payload
         except Exception:
             logger.debug("delivery ledger import failed", exc_info=True)
             return 0
@@ -383,7 +403,24 @@ class GatewayStartupMixin:
                 content = row.get("marker", RECOVERED_MARKER) + content
             metadata = {"thread_id": row["thread_id"]} if row.get("thread_id") else None
             try:
-                result = await adapter.send(chat_id=row["chat_id"], content=content, metadata=metadata)
+                payload = await asyncio.to_thread(output_payload, row["obligation_id"])
+                if payload is not None:
+                    metadata = payload["metadata"]
+                from gateway.platforms.base import SendResult
+                result = SendResult(success=True)
+                if payload is None or not payload["text_complete"]:
+                    kwargs = {"reply_to": payload["reply_to"]} if payload and payload.get("reply_to") else {}
+                    result = await adapter.send(chat_id=row["chat_id"], content=content, metadata=metadata, **kwargs)
+                    if getattr(result, "success", False):
+                        await asyncio.to_thread(mark_delivered, row["obligation_id"],
+                                                BasePlatformAdapter._delivery_receipt_ids(result))
+                if payload and getattr(result, "success", False):
+                    source = SessionSource(platform=Platform(row["platform"]), chat_id=row["chat_id"],
+                                           thread_id=row.get("thread_id"))
+                    complete = await adapter._deliver_ledger_attachments(
+                        row["obligation_id"], MessageEvent(text="", source=source))
+                    if not complete:
+                        continue  # attachment sender retained the specific failure
             except Exception as send_err:
                 logger.warning("obligation %s: redelivery send raised: %s", row["obligation_id"], send_err)
                 result = None
@@ -1248,6 +1285,7 @@ class GatewayStartupMixin:
         )
         # Auto-resume restart-interrupted sessions (ledger-answered ones were cleared above); a failed
         # auto-resume stays visible on the next user message.
+        self._restore_durable_inbound_queue()
         self._schedule_resume_pending_sessions()
         await self._finish_startup_restore()
         # Surface state.db init failures to messaging platforms before the user loses data.

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1612,6 +1612,8 @@ class GatewayTurnMixin:
             _user_entry["display_kind"] = prepared.persist_user_display_kind
         if prepared.persistence_owner:
             _user_entry["display_metadata"] = {"gateway_input_owner": prepared.persistence_owner}
+        if event.ingress_provenance:
+            _user_entry.setdefault("display_metadata", {})["original_inputs"] = event.ingress_provenance
         if getattr(event, "message_id", None):
             _user_entry["message_id"] = str(event.message_id)
         return _user_entry
@@ -1731,7 +1733,11 @@ class GatewayTurnMixin:
         # skip when the agent failed: the error text is new content streaming didn't show.
         if agent_result.get("already_sent") and not agent_result.get("failed"):
             if response and adapter:
-                await self._deliver_media_from_response(response, event, adapter)
+                from gateway.platforms.base import SendResult
+                await self._deliver_queued_first_response(
+                    response, source, adapter, metadata=self._event_thread_metadata(event, source),
+                    session_key=session_key, inbound_event=event, text_already_delivered=True,
+                    stream_consumer=SendResult(success=True, message_id=agent_result.get("delivery_message_id")))
             # Streaming delivered the body, but the footer was held back (`not already_sent` gate).
             if _footer_line and adapter:
                 try:
@@ -1965,11 +1971,13 @@ class GatewayTurnMixin:
                 session_id=_run_start_session_id, session_key=session_key,
                 run_generation=run_generation, event_message_id=self._reply_anchor_for_event(event),
                 inbound_message_id=str(event.message_id) if event.message_id else None,
+                inbound_event=event,
                 channel_prompt=event.channel_prompt, moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=prepared.persist_user_message,
                 persist_user_timestamp=prepared.persist_user_timestamp,
                 persist_user_display_kind=prepared.persist_user_display_kind,
-                persist_user_display_metadata={"gateway_input_owner": prepared.persistence_owner},
+                persist_user_display_metadata={"gateway_input_owner": prepared.persistence_owner,
+                                               "original_inputs": event.ingress_provenance},
                 message_type=event.message_type,
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
@@ -1979,6 +1987,7 @@ class GatewayTurnMixin:
             # message's id or it collides with an earlier turn's row carrying the same text. Reply
             # routing is untouched: the anchor still comes from this event.
             if isinstance(agent_result, dict):
+                event.terminal_event = agent_result.get("queued_terminal_event")
                 _terminal_inbound = agent_result.get("queued_terminal_inbound_id")
                 if _terminal_inbound:
                     event.ledger_message_id = str(_terminal_inbound)
@@ -3395,6 +3404,7 @@ class GatewayTurnMixin:
                     # The text send records a delivery-ledger obligation under this key, keyed on
                     # the raw inbound id (the anchor above is only the reply target).
                     session_key=session_key, inbound_message_id=turn_ctx.inbound_message_id,
+                    inbound_event=turn_ctx.inbound_event,
                 )
             except Exception as e:
                 logger.warning("Failed to send first response before queued message: %s", e)
@@ -3513,6 +3523,8 @@ class GatewayTurnMixin:
             source=next_source, session_id=session_id, session_key=next_session_key,
             run_generation=run_generation, _interrupt_depth=_interrupt_depth + 1,
             event_message_id=next_message_id, inbound_message_id=next_inbound_id,
+            inbound_event=pending_event,
+            persist_user_display_metadata={"original_inputs": getattr(pending_event, "ingress_provenance", [])} if pending_event else None,
             channel_prompt=next_channel_prompt, message_type=next_message_type,
         )
         merged = _preserve_queued_followup_history_offset(result, followup_result)
@@ -3524,6 +3536,8 @@ class GatewayTurnMixin:
         # so only fill the key while it is still absent: the innermost turn wins.
         if isinstance(merged, dict) and "queued_terminal_inbound_id" not in merged:
             merged = {**merged, "queued_terminal_inbound_id": next_inbound_id}
+        if isinstance(merged, dict) and "queued_terminal_event" not in merged:
+            merged = {**merged, "queued_terminal_event": pending_event}
         return merged
 
     async def _run_agent_cleanup_turn_tasks(
@@ -3674,6 +3688,12 @@ class GatewayTurnMixin:
                 _sk, _streamed, _previewed, _content_delivered, _transformed, len(_final),
             )
 
+        if response.get("already_sent") and _sc is not None:
+            # Only the confirmed terminal consumer supplies receipt identity.
+            message_id = getattr(_sc, "message_id", None)
+            if isinstance(message_id, (str, int)) and message_id != "__no_edit__":
+                response["delivery_message_id"] = str(message_id)
+
     def _run_agent_schedule_bubble_cleanup(self, response: Any, _cleanup_adapter: Any, turn_ctx: TurnContext) -> None:
         """Schedule deletion of tracked temporary progress bubbles after the final response lands.
 
@@ -3811,6 +3831,7 @@ class GatewayTurnMixin:
         persist_user_message: Optional[Any] = None, persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None, message_type: Optional[str] = None,
         persist_user_display_metadata: Optional[dict] = None,
+        inbound_event: Optional[MessageEvent] = None,
     ) -> Dict[str, Any]:
         """Run the agent; returns the full run_conversation result dict.
 
@@ -3830,6 +3851,7 @@ class GatewayTurnMixin:
             run_generation=run_generation, context_prompt=context_prompt, history=history,
             session_id=session_id, _interrupt_depth=_interrupt_depth,
             event_message_id=event_message_id, inbound_message_id=inbound_message_id,
+            inbound_event=inbound_event,
             channel_prompt=channel_prompt, moa_config=moa_config,
             persist_user_message=persist_user_message,
             persist_user_timestamp=persist_user_timestamp,

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -12,10 +12,12 @@ deletes each file on success), ``flush_agent_history_to_file`` (DB flush raised)
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import itertools
 import json
 import logging
 import os
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -30,6 +32,11 @@ TRANSCRIPT_CAP_DROP_REASON = "transcript_cap_drop"
 # Monotonic tiebreaker so same-second spool files replay in drop order.
 _TRANSCRIPT_SPOOL_SEQ = itertools.count()
 
+DURABLE_INBOUND_REASON = "durable_inbound"
+_DURABLE_INBOUND_ID_KEY = "_hermes_durable_inbound_id"
+_DURABLE_INBOUND_PATH_KEY = "_hermes_durable_inbound_path"
+_DURABLE_INBOUND_LOCK = threading.Lock()
+
 
 def _get_flush_dir():
     """Return the pending-messages flush directory under the active HERMES_HOME."""
@@ -41,10 +48,15 @@ def _get_flush_dir():
     return flush_dir
 
 
-def _write_payload(flush_dir: Path, payload: Dict[str, Any]) -> Path:
+def _write_payload(
+    flush_dir: Path,
+    payload: Dict[str, Any],
+    *,
+    file_name: str | None = None,
+) -> Path:
     """Atomically write one private, uniquely named recovery payload; return its path."""
     from utils import atomic_json_write
-    final_path = flush_dir / f"pending-{uuid.uuid4().hex}.json"
+    final_path = flush_dir / (file_name or f"pending-{uuid.uuid4().hex}.json")
     atomic_json_write(final_path, payload, mode=0o600, default=str)
     if os.name == "posix":
         # Persist the directory entry too; keep the published file (the only recovery copy) even if
@@ -61,6 +73,314 @@ def _write_payload(flush_dir: Path, payload: Dict[str, Any]) -> Path:
             finally:
                 os.close(directory_fd)
     return final_path
+
+
+def _json_safe_value(value: Any) -> Any:
+    """Return a JSON-safe value without losing a user turn to rich metadata."""
+    try:
+        json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _durable_inbound_id(session_key: str, event: Any) -> str:
+    """Give one inbound event a stable, private spool identity.
+
+    Platform message/update ids are stable across a restart.  Some adapters do
+    not expose either, so keep one generated id on the in-memory event before
+    its first acknowledgement.
+    """
+    metadata = getattr(event, "metadata", None)
+    if isinstance(metadata, dict):
+        existing = str(metadata.get(_DURABLE_INBOUND_ID_KEY) or "").strip()
+        if existing:
+            return existing
+    source = getattr(event, "source", None)
+    identity = "|".join(
+        str(value or "")
+        for value in (
+            session_key,
+            getattr(getattr(source, "platform", None), "value", None),
+            getattr(source, "chat_id", None),
+            getattr(source, "thread_id", None),
+            getattr(event, "message_id", None),
+            getattr(event, "platform_update_id", None),
+            getattr(event, "timestamp", None),
+        )
+    )
+    value = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+    if isinstance(metadata, dict):
+        metadata[_DURABLE_INBOUND_ID_KEY] = value
+    return value
+
+
+def durable_inbound_obligation_id(event: Any) -> str:
+    """Return the already-persisted inbound identity, never a new one.
+
+    ``record_durable_inbound_event`` is the sole owner that creates this id.
+    Consumers may use it to derive the matching outbound delivery identity,
+    but must not invent a second inbound identity after dispatch begins.
+    """
+    metadata = getattr(event, "metadata", None)
+    if not isinstance(metadata, dict):
+        return ""
+    return str(metadata.get(_DURABLE_INBOUND_ID_KEY) or "").strip()
+
+
+def _next_durable_inbound_sequence(flush_dir: Path) -> int:
+    """Allocate the next persisted FIFO sequence from surviving records.
+
+    Wall time can move backwards after NTP/RTC correction, so ``time_ns`` is
+    not an arrival ordering authority.  A gateway owns this private spool
+    exclusively; under that process contract, scanning its small bounded
+    pending set gives a restart-stable monotonic sequence without another
+    queue or database.
+    """
+    highest = 0
+    for path in flush_dir.glob("inbound-*.json"):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if payload.get("reason") != DURABLE_INBOUND_REASON:
+                continue
+            highest = max(highest, int(payload.get("arrival_sequence", 0)))
+        except (OSError, ValueError, TypeError, json.JSONDecodeError):
+            continue
+    return highest + 1
+
+
+def _has_durable_outbound_transfer(session_key: str, inbound_obligation_id: str) -> bool:
+    """Whether an existing delivery-ledger row owns this inbound turn.
+
+    The delivery ledger is the only outbound owner.  Its stable-id helper is
+    deliberately reused here so a crash after its durable write but before
+    inbound unlink never causes the agent to regenerate a second reply.
+    """
+    if not session_key or not inbound_obligation_id:
+        return False
+    try:
+        from gateway.delivery_ledger import (
+            inbound_transfer_state,
+            ledger_enabled,
+        )
+
+        if not ledger_enabled():
+            return False
+
+        # Exhausted delivery is still transferred, not permission to rerun tools.
+        return inbound_transfer_state(session_key, inbound_obligation_id) is not None
+    except Exception:
+        logger.debug("Could not resolve durable outbound transfer", exc_info=True)
+        return False
+
+
+def _serialise_inbound_event(event: Any) -> Optional[dict]:
+    """Serialise the normalized event shape required to replay it safely."""
+    source = getattr(event, "source", None)
+    platform = getattr(getattr(source, "platform", None), "value", None)
+    chat_id = getattr(source, "chat_id", None)
+    if not platform or not chat_id:
+        return None
+    source_fields = (
+        "chat_id", "chat_name", "chat_type", "user_id", "user_name",
+        "thread_id", "chat_topic", "user_id_alt", "chat_id_alt", "is_bot",
+        "scope_id", "guild_id", "parent_chat_id", "message_id",
+        "role_authorized", "profile", "auto_thread_created",
+        "auto_thread_initial_name", "prospective_thread_id",
+    )
+    event_fields = (
+        "input_members",
+        "text", "user_id", "user_name", "message_id", "platform_update_id",
+        "media_urls", "media_types", "media_text_inlined", "reply_to_message_id",
+        "reply_to_text", "reply_to_author_id", "reply_to_author_name",
+        "reply_to_is_own_message", "prompt_response", "auto_skill",
+        "channel_prompt", "channel_context", "internal", "allow_gateway_control",
+    )
+    return {
+        "source": {
+            "platform": platform,
+            **{
+                field: _json_safe_value(getattr(source, field, None))
+                for field in source_fields
+            },
+        },
+        "message_type": getattr(getattr(event, "message_type", None), "value", "text"),
+        "timestamp": getattr(getattr(event, "timestamp", None), "isoformat", lambda: None)(),
+        "metadata": _json_safe_value(getattr(event, "metadata", {}) or {}),
+        **{
+            field: _json_safe_value(getattr(event, field, None))
+            for field in event_fields
+        },
+    }
+
+
+def record_durable_inbound_event(session_key: str, event: Any) -> bool:
+    """Persist an accepted queued inbound event before its acknowledgement.
+
+    Returning ``False`` means the caller must not claim the message was queued:
+    the only authoritative copy would still be volatile memory.
+    """
+    try:
+        data = _serialise_inbound_event(event)
+        if data is None:
+            return False
+        obligation_id = _durable_inbound_id(session_key, event)
+        flush_dir = _get_flush_dir()
+        # A hash is an identity, not an arrival sequence.  Nor is wall time:
+        # NTP/RTC correction can move it backwards.  The durable FIFO sequence
+        # survives restart and the id remains the dedupe key.
+        with _DURABLE_INBOUND_LOCK:
+            matches = list(flush_dir.glob(f"inbound-*-{obligation_id}.json"))
+            legacy_path = flush_dir / f"inbound-{obligation_id}.json"
+            if legacy_path.exists():
+                matches.append(legacy_path)
+            if matches:
+                existing_path = sorted(matches)[0]
+                metadata = getattr(event, "metadata", None)
+                if isinstance(metadata, dict):
+                    metadata[_DURABLE_INBOUND_PATH_KEY] = existing_path.name
+                return True
+            arrival_sequence = _next_durable_inbound_sequence(flush_dir)
+            final_path = flush_dir / (
+                f"inbound-{arrival_sequence:020d}-{obligation_id}.json"
+            )
+            _write_payload(
+                flush_dir,
+                {
+                    "session_key": session_key,
+                    "reason": DURABLE_INBOUND_REASON,
+                    "obligation_id": obligation_id,
+                    "arrival_sequence": arrival_sequence,
+                    "ts": int(time.time()),
+                    "data": data,
+                },
+                file_name=final_path.name,
+            )
+        metadata = getattr(event, "metadata", None)
+        if isinstance(metadata, dict):
+            metadata[_DURABLE_INBOUND_PATH_KEY] = final_path.name
+        return True
+    except Exception as exc:
+        logger.warning("Unable to durably queue inbound event for %s: %s", session_key, exc)
+        return False
+
+
+def _deserialise_inbound_event(data: Any) -> Any:
+    """Rebuild a normalized MessageEvent from a durable inbound payload."""
+    if not isinstance(data, dict):
+        raise ValueError("inbound payload data is not an object")
+    source_data = data.get("source")
+    if not isinstance(source_data, dict):
+        raise ValueError("inbound payload has no source")
+    from datetime import datetime
+    from gateway.config import Platform
+    from gateway.platforms.event import MessageEvent, MessageType
+    from gateway.session import SessionSource
+
+    platform = Platform(str(source_data.get("platform") or ""))
+    source_kwargs = {key: value for key, value in source_data.items() if key != "platform"}
+    source = SessionSource(platform=platform, **source_kwargs)
+    raw_timestamp = data.get("timestamp")
+    try:
+        timestamp = datetime.fromisoformat(raw_timestamp) if raw_timestamp else datetime.now()
+    except (TypeError, ValueError):
+        timestamp = datetime.now()
+    message_type = MessageType(str(data.get("message_type") or "text"))
+    event_kwargs = {
+        key: data.get(key)
+        for key in (
+            "input_members",
+            "text", "user_id", "user_name", "message_id", "platform_update_id",
+            "media_urls", "media_types", "media_text_inlined", "reply_to_message_id",
+            "reply_to_text", "reply_to_author_id", "reply_to_author_name",
+            "reply_to_is_own_message", "prompt_response", "auto_skill",
+            "channel_prompt", "channel_context", "internal", "allow_gateway_control",
+        )
+        if key in data
+    }
+    event_kwargs["metadata"] = data.get("metadata") or {}
+    return MessageEvent(source=source, message_type=message_type, timestamp=timestamp, **event_kwargs)
+
+
+def recover_durable_inbound_events() -> list[Any]:
+    """Load durable queued input without acknowledging it yet.
+
+    Dispatching to an adapter merely transfers an event to RAM.  The record
+    stays until a durable outbound response obligation exists (or that response
+    is confirmed delivered when the ledger is disabled).  Invalid payloads
+    stay on disk for an explicit operator failure rather than being silently
+    lost.
+    """
+    try:
+        candidates = sorted(_get_flush_dir().glob("inbound-*.json"))
+    except Exception as exc:
+        logger.warning("Cannot scan durable inbound queue: %s", exc)
+        return []
+    events = []
+    for path in candidates:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if payload.get("reason") != DURABLE_INBOUND_REASON:
+                continue
+            event = _deserialise_inbound_event(payload.get("data"))
+            metadata = getattr(event, "metadata", None)
+            if isinstance(metadata, dict):
+                metadata[_DURABLE_INBOUND_ID_KEY] = str(payload["obligation_id"])
+                metadata[_DURABLE_INBOUND_PATH_KEY] = path.name
+            if _has_durable_outbound_transfer(
+                str(payload.get("session_key") or ""),
+                str(payload.get("obligation_id") or ""),
+            ):
+                # The matching outbound row is already authoritative.  This
+                # is the recovery half of the one inbound→outbound transfer;
+                # never re-run the user turn just because the previous process
+                # died before it unlinked the inbound file.
+                acknowledge_durable_inbound_event(event)
+                continue
+            try:
+                arrival_sequence = int(payload.get("arrival_sequence"))
+            except (TypeError, ValueError):
+                # Compatibility ordering for the short-lived time-ns format
+                # and older hash-named records. New writes never use wall time.
+                arrival_sequence = int(payload.get("arrival_ns", payload.get("ts", 0)))
+            events.append((arrival_sequence, path.name, event))
+        except Exception as exc:
+            logger.warning("Cannot restore durable inbound event %s: %s", path, exc)
+    return [event for _arrival_sequence, _name, event in sorted(events)]
+
+
+def acknowledge_durable_inbound_event(event: Any) -> None:
+    """Remove one durable input only after its terminal response/transfer."""
+    event = getattr(event, "terminal_event", None) or event
+    if getattr(event, "input_members", None):
+        from types import SimpleNamespace
+        for member in event.input_members:
+            acknowledge_durable_inbound_event(SimpleNamespace(metadata={
+                _DURABLE_INBOUND_ID_KEY: member["inbound_id"]}))
+        return
+    metadata = getattr(event, "metadata", None)
+    obligation_id = str(metadata.get(_DURABLE_INBOUND_ID_KEY) or "") if isinstance(metadata, dict) else ""
+    if not obligation_id:
+        return
+    try:
+        flush_dir = _get_flush_dir()
+        file_name = (
+            str(metadata.get(_DURABLE_INBOUND_PATH_KEY) or "")
+            if isinstance(metadata, dict) else ""
+        )
+        if file_name and Path(file_name).name == file_name:
+            (flush_dir / file_name).unlink(missing_ok=True)
+            return
+        # Compatibility with records written before arrival-order filenames.
+        legacy_path = flush_dir / f"inbound-{obligation_id}.json"
+        if legacy_path.exists():
+            legacy_path.unlink()
+            return
+        for path in flush_dir.glob(f"inbound-*-{obligation_id}.json"):
+            path.unlink(missing_ok=True)
+    except Exception as exc:
+        logger.warning("Unable to acknowledge durable inbound event %s: %s", obligation_id, exc)
+
 
 
 def _flush_value(flush_dir: Path, kind: str, session_key: str, value: Any, **extra: Any) -> bool:
@@ -82,8 +402,12 @@ def flush_pending_to_file(pending: Dict[str, Any], *, reason: str = "shutdown") 
         return 0
     flush_dir, ts, flushed = _get_flush_dir(), int(time.time()), 0
     for session_key, value in list(pending.items()):
-        if value is not None:
-            flushed += _flush_value(flush_dir, "pending", session_key, value, reason=reason, ts=ts)
+        if value is None:
+            continue
+        metadata = getattr(value, "metadata", None)
+        if isinstance(metadata, dict) and metadata.get(_DURABLE_INBOUND_ID_KEY):
+            continue
+        flushed += _flush_value(flush_dir, "pending", session_key, value, reason=reason, ts=ts)
     if flushed:
         logger.info("Flushed %d pending message(s) to %s (reason=%s)", flushed, flush_dir, reason)
     return flushed

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -50,6 +50,7 @@ class TurnContext:
     event_message_id: Optional[str] = None
     # Raw inbound platform id (not the event_message_id reply anchor); stamped on the user turn.
     inbound_message_id: Optional[str] = None
+    inbound_event: Any = None
     moa_config: Optional[dict] = None
     persist_user_message: Optional[Any] = None
     persist_user_timestamp: Optional[float] = None

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -143,6 +143,44 @@ class TestObligationId:
         assert a != dl.compute_obligation_id("sk1", "msg1", "other")
         assert len(a) == 24
 
+    def test_durable_inbound_identity_ignores_regenerated_wording(self):
+        """One queued user input has one outbound owner across a restart."""
+        first = dl.compute_obligation_id(
+            "sk1", "msg1", "first generated answer", stable_inbound_id="in-1"
+        )
+        replay = dl.compute_obligation_id(
+            "sk1", "msg1", "different regenerated answer", stable_inbound_id="in-1"
+        )
+        assert first == replay
+
+
+def test_preserved_inbound_transfer_never_overwrites_original_reply():
+    oid = dl.compute_obligation_id("sk1", "", "", stable_inbound_id="in-1")
+    assert dl.record_obligation(
+        obligation_id=oid,
+        session_key="sk1",
+        platform="telegram",
+        chat_id="1",
+        thread_id=None,
+        content="canonical reply",
+        preserve_existing=True,
+    )
+    dl.mark_delivered(oid)
+    assert not dl.record_obligation(
+        obligation_id=oid,
+        session_key="sk1",
+        platform="telegram",
+        chat_id="1",
+        thread_id=None,
+        content="regenerated reply must not replace the first",
+        preserve_existing=True,
+    )
+    with dl._connect() as conn:
+        row = conn.execute(
+            "SELECT content, state FROM delivery_obligations WHERE obligation_id=?", (oid,)
+        ).fetchone()
+    assert row == ("canonical reply", "delivered")
+
 
 class TestSweep:
     def test_live_owner_rows_never_claimed(self):

--- a/tests/gateway/test_delivery_ledger_producer.py
+++ b/tests/gateway/test_delivery_ledger_producer.py
@@ -8,12 +8,14 @@ block the send.
 """
 
 import asyncio
+import json
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from gateway import delivery_ledger as dl
+from gateway import shutdown_flush
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, SendResult
 from gateway.platforms.event import MessageEvent, MessageType
@@ -111,6 +113,109 @@ class TestProducerHook:
         assert len(rows) == 1
         assert rows[0][1] == "delivered"
         assert rows[0][2] == "final answer"
+
+    @pytest.mark.asyncio
+    async def test_durable_inbound_is_retained_until_outbound_transfer(self, tmp_path, monkeypatch):
+        """The real adapter path acks only after creating the durable reply row."""
+        adapter = _Adapter()
+        event = _event()
+        flush_dir = tmp_path / "pending_messages"
+        flush_dir.mkdir()
+        monkeypatch.setattr(shutdown_flush, "_get_flush_dir", lambda: flush_dir)
+        assert shutdown_flush.record_durable_inbound_event(
+            "agent:main:slack:channel:C1", event
+        )
+
+        await _run(adapter, event)
+
+        assert adapter.sent == ["final answer"]
+        assert _rows()[0][1] == "delivered"
+        assert shutdown_flush.recover_durable_inbound_events() == []
+
+    @pytest.mark.asyncio
+    async def test_empty_terminal_keeps_durable_inbound_for_visible_retry(
+        self, tmp_path, monkeypatch
+    ):
+        """No text means no durable terminal reply transfer to acknowledge."""
+        adapter = _Adapter()
+        event = _event()
+        flush_dir = tmp_path / "pending_messages"
+        flush_dir.mkdir()
+        monkeypatch.setattr(shutdown_flush, "_get_flush_dir", lambda: flush_dir)
+        assert shutdown_flush.record_durable_inbound_event(
+            "agent:main:slack:channel:C1", event
+        )
+
+        await _run(adapter, event, response=None)
+
+        assert adapter.sent == []
+        assert [restored.text for restored in shutdown_flush.recover_durable_inbound_events()] == [
+            "hello agent"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_tts_caption_marks_the_existing_outbound_transfer_delivered(
+        self, tmp_path, monkeypatch
+    ):
+        """Voice-caption delivery is terminal even when it skips a text send."""
+        adapter = _Adapter()
+        adapter.platform = Platform.TELEGRAM
+        adapter._should_auto_tts_for_chat = lambda _chat_id: True
+        event = _event()
+        event.message_type = MessageType.VOICE
+        flush_dir = tmp_path / "pending_messages"
+        flush_dir.mkdir()
+        monkeypatch.setattr(shutdown_flush, "_get_flush_dir", lambda: flush_dir)
+        audio = tmp_path / "answer.ogg"
+        audio.write_bytes(b"voice")
+        monkeypatch.setattr("tools.tts_tool.check_tts_requirements", lambda: True)
+        monkeypatch.setattr(
+            "tools.tts_tool.text_to_speech_tool",
+            lambda **_kwargs: json.dumps({"success": True, "file_path": str(audio)}),
+        )
+        adapter.play_tts = AsyncMock(return_value=SendResult(success=True, message_id="voice-1"))
+        assert shutdown_flush.record_durable_inbound_event(
+            "agent:main:slack:channel:C1", event
+        )
+
+        await _run(adapter, event, response="spoken answer")
+
+        adapter.play_tts.assert_awaited_once()
+        assert adapter.sent == []
+        assert _rows()[0][1] == "delivered"
+        assert shutdown_flush.recover_durable_inbound_events() == []
+
+    @pytest.mark.asyncio
+    async def test_durable_inbound_survives_crash_during_background_dispatch(
+        self, tmp_path, monkeypatch
+    ):
+        """handle_message returning after task spawn is not an acknowledgement."""
+        adapter = _Adapter()
+        event = _event()
+        flush_dir = tmp_path / "pending_messages"
+        flush_dir.mkdir()
+        monkeypatch.setattr(shutdown_flush, "_get_flush_dir", lambda: flush_dir)
+        assert shutdown_flush.record_durable_inbound_event(
+            "agent:main:slack:channel:C1", event
+        )
+
+        started = asyncio.Event()
+        never = asyncio.Event()
+
+        async def blocked_handler(_event):
+            started.set()
+            await never.wait()
+
+        adapter._message_handler = blocked_handler
+        await adapter.handle_message(event)
+        await asyncio.wait_for(started.wait(), timeout=1)
+        assert [restored.text for restored in shutdown_flush.recover_durable_inbound_events()] == [
+            "hello agent"
+        ]
+
+        for task in list(adapter._session_tasks.values()):
+            task.cancel()
+        await asyncio.gather(*list(adapter._session_tasks.values()), return_exceptions=True)
 
     @pytest.mark.asyncio
     async def test_send_failure_leaves_failed_row(self):

--- a/tests/gateway/test_durable_batch_transfer.py
+++ b/tests/gateway/test_durable_batch_transfer.py
@@ -1,0 +1,149 @@
+"""Disk-backed incident regression: one output owns every original batch input."""
+from datetime import datetime
+import inspect
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway import delivery_ledger as dl, shutdown_flush as spool
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult, merge_pending_message_event
+from gateway.platforms.event import MessageEvent
+from gateway.session import SessionSource
+from gateway.run import GatewayRunner
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+@pytest.fixture
+def world(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(dl, "ledger_enabled", lambda *a, **k: True)
+    monkeypatch.setattr(dl, "_owner_alive", lambda *a: False)
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fixture", extra={}))
+    adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True, message_id="out"))
+    adapter.edit_message = AsyncMock(return_value=SendResult(success=True, message_id="out"))
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="fixture-chat", user_id="fixture-owner")
+    return adapter, source, "agent:main:telegram:dm:fixture-chat"
+
+
+def inputs(source, key, count=5):
+    events = [MessageEvent(text="same fresh question", source=source, message_id=f"member-{i}",
+                           platform_update_id=i, timestamp=datetime(2026, 1, 1, 0, 0, i),
+                           reply_to_message_id=f"prior-{i}") for i in range(count)]
+    pending = {}
+    for event in events:
+        assert spool.record_durable_inbound_event(key, event)
+        merge_pending_message_event(pending, key, event, merge_text=True)
+    return events, pending[key]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["before_record", "after_record", "after_send", "failed_send"])
+async def test_batch_transfer_restart(world, monkeypatch, boundary):
+    adapter, source, key = world
+    events, batch = inputs(source, key)
+    ids = [spool.durable_inbound_obligation_id(e) for e in events]
+    if boundary == "before_record":
+        assert len(spool.recover_durable_inbound_events()) == len(ids)
+        assert dl.sweep_recoverable() == []
+        return
+    if boundary == "after_record":
+        monkeypatch.setattr(spool, "acknowledge_durable_inbound_event", lambda e: None)
+        await adapter._record_delivery_obligation(batch, key, "authoritative response", adapter, False)
+    else:
+        if boundary == "failed_send":
+            adapter._send_with_retry.return_value = SendResult(success=False, error="rejected")
+        await adapter.send_final_ledgered(batch, key, "authoritative response", {}, reply_to=None)
+    assert spool.recover_durable_inbound_events() == [], "answered batch members must not execute again"
+    recovered = dl.sweep_recoverable()
+    assert len(recovered) == (0 if boundary == "after_send" else 1)
+    with dl._transaction() as conn:
+        assert conn.execute("SELECT count(*) FROM delivery_obligations").fetchone()[0] == 1
+    # A fresh same-text identity is not a replay, even after a successful batch.
+    fresh = MessageEvent(text=events[0].text, source=source, message_id="fresh")
+    assert spool.record_durable_inbound_event(key, fresh)
+    assert [e.message_id for e in spool.recover_durable_inbound_events()] == ["fresh"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streamed", [False, True])
+async def test_queued_transfer_keeps_original_envelope(world, streamed):
+    adapter, source, key = world
+    events, batch = inputs(source, key)
+    runner = object.__new__(GatewayRunner)
+    runner._deliver_media_from_response = AsyncMock()
+    envelope = ({"inbound_event": batch} if "inbound_event" in
+                inspect.signature(runner._deliver_queued_first_response).parameters else {})
+    await runner._deliver_queued_first_response(
+        "authoritative response", source, adapter, session_key=key,
+        inbound_message_id=batch.message_id, **envelope,
+        text_already_delivered=streamed, deliver_media=False)
+    assert spool.recover_durable_inbound_events() == []
+    assert dl.sweep_recoverable() == []
+    assert adapter._send_with_retry.await_count == (0 if streamed else 1)
+
+
+@pytest.mark.asyncio
+async def test_restored_provenance_and_same_identity_admission(world):
+    import json
+
+    adapter, source, key = world
+    events, batch = inputs(source, key)
+    restored = spool._deserialise_inbound_event(spool._serialise_inbound_event(batch))
+    runner = object.__new__(GatewayRunner)
+    runner._pending_native_image_paths = {}
+    runner.config = SimpleNamespace()
+    text = await runner._prepare_inbound_message_text(
+        event=restored, source=source, history=[], session_key=key)
+    assert text is not None
+    provenance = json.loads(text.split("\n", 2)[1])
+    assert [m["message_id"] for m in provenance] == [e.message_id for e in events]
+    assert [m["reply_to_message_id"] for m in provenance] == [e.reply_to_message_id for e in events]
+    assert all(m["delivery_state"] is None for m in provenance)
+    await adapter.send_final_ledgered(batch, key, "answer", {}, reply_to=None)
+    assert await runner._prepare_inbound_message_text(
+        event=restored, source=source, history=[], session_key=key) is None
+    fresh = MessageEvent(text=events[0].text, source=source, message_id="new-followup")
+    assert spool.record_durable_inbound_event(key, fresh)
+    assert await runner._prepare_inbound_message_text(
+        event=fresh, source=source, history=[], session_key=key)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("depth", [0, 2])
+async def test_recursive_chain_transfers_terminal_batch(world, depth):
+    from unittest.mock import MagicMock
+    from gateway.turn_context import TurnContext
+
+    adapter, source, key = world
+    events, batch = inputs(source, key)
+    opening = MessageEvent(text="opening", source=source, message_id="opening")
+    assert spool.record_durable_inbound_event(key, opening)
+    runner = object.__new__(GatewayRunner)
+    runner._MAX_INTERRUPT_DEPTH = 8
+    runner._is_goal_continuation_event = MagicMock(return_value=False)
+    runner._session_key_for_source = MagicMock(return_value=key)
+    runner._prepare_profile_scoped_inbound_message_text = AsyncMock(return_value="followup")
+    runner._reply_anchor_for_event = MagicMock(return_value=None)
+    runner._adapter_for_source = MagicMock(return_value=None)
+    runner._refresh_agent_cache_message_count = AsyncMock()
+    runner._deliver_media_from_response = AsyncMock()
+    runner._pop_post_delivery_callback = MagicMock(return_value=None)
+    terminal = {"final_response": "terminal", "messages": []}
+    if depth:
+        terminal["queued_terminal_event"] = batch
+        terminal["queued_terminal_inbound_id"] = batch.message_id
+    runner._run_agent = AsyncMock(return_value=terminal)
+    ctx = TurnContext(source=source, session_id="sid", session_key=key,
+                      inbound_event=opening, inbound_message_id=opening.message_id,
+                      _interrupt_depth=depth, history=[])
+    result = await runner._run_agent_queued_followup(
+        ctx, adapter, "pending", batch,
+        {"final_response": "first"}, {"messages": []}, None)
+    assert runner._run_agent.await_args.kwargs["inbound_event"] is batch
+    opening.terminal_event = result["queued_terminal_event"]
+    await adapter.send_final_ledgered(opening, key, result["final_response"], {}, reply_to=None)
+    assert spool.recover_durable_inbound_events() == []
+    with dl._transaction() as conn:
+        assert conn.execute("SELECT count(*) FROM delivery_obligations").fetchone()[0] == 2

--- a/tests/gateway/test_durable_ingress_provenance.py
+++ b/tests/gateway/test_durable_ingress_provenance.py
@@ -1,0 +1,206 @@
+"""Canonical ingress/compaction plumbing, not a model-meaning evaluation.
+
+Synthetic IDs and fake summaries deliberately provide no semantic evidence for
+report rows 5/6/9. Receipt association must come from disk ownership, not quotes.
+"""
+import asyncio
+import copy
+import json
+import socket
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway import delivery_ledger as dl, shutdown_flush as spool
+from gateway.platforms.event import MessageEvent
+from gateway.run import GatewayRunner
+from tests.gateway.test_durable_batch_transfer import inputs, world  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def no_network(monkeypatch):
+    def refused(*args, **kwargs):
+        raise AssertionError("network is forbidden in synthetic replay fixtures")
+
+    monkeypatch.setattr(socket.socket, "connect", refused)
+    monkeypatch.setattr(socket.socket, "connect_ex", refused)
+    # This constructor preflight may probe auxiliary providers. It is not the
+    # compaction persistence path under test, and must never contact a provider.
+    monkeypatch.setattr("agent.conversation_compression.check_compression_model_feasibility",
+                        lambda agent: None)
+
+
+def ingress_runner():
+    runner = object.__new__(GatewayRunner)
+    runner.config = SimpleNamespace()
+    runner._pending_native_image_paths = {}
+    return runner
+
+
+def scalar_values(value):
+    if isinstance(value, dict):
+        return [item for child in value.values() for item in scalar_values(child)]
+    if isinstance(value, list):
+        return [item for child in value for item in scalar_values(child)]
+    return [value]
+
+
+@pytest.mark.asyncio
+async def test_adapter_suppresses_answered_redelivery_but_admits_fresh_identity(world):
+    adapter, source, key = world
+    event = MessageEvent(text="repeat deliberately", source=source, message_id="first")
+    assert spool.record_durable_inbound_event(key, event)
+    saved = spool._serialise_inbound_event(event)
+    await adapter.send_final_ledgered(event, key, "already answered", {}, reply_to=None)
+    adapter._message_handler = AsyncMock(return_value=None)
+    await adapter.handle_message(spool._deserialise_inbound_event(saved))
+    assert adapter._message_handler.await_count == 0
+    fresh = MessageEvent(text=event.text, source=source, message_id="second")
+    await adapter.handle_message(fresh)
+    await asyncio.gather(*list(adapter._session_tasks.values()))
+    assert adapter._message_handler.await_count == 1
+    assert adapter._message_handler.await_args.args[0].message_id == fresh.message_id
+    # No terminal answer was produced for the fresh request; restart must keep it.
+    assert [e.message_id for e in spool.recover_durable_inbound_events()] == [fresh.message_id]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("internal", [False, True])
+async def test_batched_ingress_exposes_original_typed_members_without_history_mutation(world, internal):
+    _, source, key = world
+    events, batch = inputs(source, key)
+    if internal:
+        # Internal events are not durable owner work. Preserve this distinction
+        # even if the pending envelope has explicit batched provenance.
+        batch.input_members = [{**m, "internal": True, "inbound_id": ""}
+                               for m in batch.original_inputs()]
+        batch.internal = True
+    before = copy.deepcopy(batch.original_inputs())
+    history = [{"role": "user", "content": "earlier"}, {"role": "assistant", "content": "answer"}]
+    saved_history = copy.deepcopy(history)
+    text = await ingress_runner()._prepare_inbound_message_text(
+        event=batch, source=source, history=history, session_key=key)
+    provenance = json.loads(text.split("\n", 2)[1])
+    assert history == saved_history
+    assert len(provenance) == len(before)
+    for actual, original in zip(provenance, before):
+        assert {name: actual[name] for name in original} == original
+        assert actual["kind"] == ("internal_notification" if internal else "owner_message")
+        assert actual["delivery_state"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("compact", [False, True])
+@pytest.mark.parametrize("known_receipt", [False, True])
+async def test_fresh_reply_resolves_delivered_output_after_disk_compaction(world, tmp_path, compact, known_receipt):
+    from hermes_state import SessionDB
+    from agent.conversation_compression import compress_context
+    from tests.run_agent.test_in_place_compaction import _make_agent
+
+    adapter, source, key = world
+    _, batch = inputs(source, key)
+    original_members = copy.deepcopy(batch.original_inputs())
+    await adapter.send_final_ledgered(batch, key, "prior result", {}, reply_to=None)
+    with dl._transaction() as conn:
+        oid = conn.execute("SELECT obligation_id FROM delivery_obligations").fetchone()[0]
+    db_path = tmp_path / "conversation.db"
+    db = SessionDB(db_path=db_path)
+    sid = "synthetic-replay-session"
+    db.create_session(sid, "telegram", model="test/model")
+    history = [{"role": "user", "content": "prior work"},
+               {"role": "assistant", "content": "prior result"}]
+    for item in history:
+        db.append_message(session_id=sid, **item)
+    if compact:
+        agent = _make_agent(db, sid, in_place=True)
+        compress_context(agent, history * 4, approx_tokens=100_000, system_message="fixed system")
+        assert agent._last_compaction_in_place is True
+    db.close()
+    reopened = SessionDB(db_path=db_path)
+    history = reopened.get_messages_as_conversation(sid)
+    assert history
+    if compact:
+        assert any(not row.get("active", 1) for row in reopened.get_messages(sid, include_inactive=True))
+    reopened.close()
+    followup = MessageEvent(text="Investigate the repeated response, not the old work.",
+                            source=source, message_id="new-complaint",
+                            reply_to_message_id="out" if known_receipt else "unknown-receipt",
+                            # Untrusted quoted words may NOT supply authoritative disposition.
+                            reply_to_text="delivered", reply_to_is_own_message=True)
+    assert spool.record_durable_inbound_event(key, followup)
+    # A real disk spool reload, not a constructed replacement identity.
+    restored = spool.recover_durable_inbound_events()[0]
+    text = await ingress_runner()._prepare_inbound_message_text(
+        event=restored, source=source, history=history, session_key=key)
+    assert text is not None, "a fresh complaint is not a duplicate input"
+    provenance = json.loads(text.split("\n", 2)[1])
+    assert provenance[0]["message_id"] == followup.message_id
+    assert provenance[0]["reply_to_message_id"] == followup.reply_to_message_id
+    # Do not prescribe a new API/schema: the typed provenance must associate the
+    # authoritative output and every original input somewhere in its structure.
+    values = scalar_values(provenance)
+    if known_receipt:
+        assert oid in values, "known platform receipt must resolve to the authoritative output"
+        assert all(member["inbound_id"] in values for member in original_members)
+        # Exclude the quote when checking a machine disposition, to reject copying.
+        assert any(value == "delivered" for value in scalar_values([
+            {k: v for k, v in item.items() if k not in {"text", "reply_to_text"}}
+            for item in provenance]))
+    else:
+        assert oid not in values, "unknown receipts cannot infer prior ownership from text"
+
+
+@pytest.mark.asyncio
+async def test_no_change_internal_notification_stays_silent(world):
+    adapter, source, key = world
+    event = MessageEvent(text="unchanged internal status", source=source, message_id="internal-only",
+                         internal=True, allow_gateway_control=False)
+    adapter._message_handler = AsyncMock(return_value=None)
+    adapter._active_sessions[key] = asyncio.Event()
+    await adapter._process_message_background(event, key)
+    adapter._send_with_retry.assert_not_awaited()
+    assert spool.recover_durable_inbound_events() == []
+    assert dl.sweep_recoverable() == []
+
+
+@pytest.mark.asyncio
+async def test_compaction_keeps_retained_complaint_identity_metadata(world, tmp_path):
+    from hermes_state import SessionDB
+    from agent.conversation_compression import compress_context
+    from tests.run_agent.test_in_place_compaction import _make_agent
+
+    _, source, key = world
+    _, complaint = inputs(source, key, count=2)
+    text = await ingress_runner()._prepare_inbound_message_text(
+        event=complaint, source=source, history=[], session_key=key)
+    provenance = json.loads(text.split("\n", 2)[1])
+    # display_metadata is the existing lossless transcript API, not a new
+    # ingress API. Compression must preserve metadata of retained messages.
+    retained = {"role": "user", "content": text,
+                "platform_message_id": complaint.message_id,
+                "display_metadata": {"original_inputs": provenance}}
+    recent = [retained, {"role": "assistant", "content": "Investigating repetition."}]
+    path = tmp_path / "compaction.db"
+    db = SessionDB(db_path=path)
+    sid = "retained-complaint"
+    db.create_session(sid, "telegram", model="test/model")
+    for item in recent:
+        db.append_message(session_id=sid, **item)
+    agent = _make_agent(db, sid, in_place=True)
+    agent.context_compressor.compress = lambda *args, **kwargs: copy.deepcopy(recent)
+    compress_context(agent, recent * 4, approx_tokens=100_000, system_message="stable")
+    assert agent._last_compaction_in_place is True
+    db.close()
+    reopened = SessionDB(db_path=path)
+    rows = reopened.get_messages(sid)
+    originals = reopened.get_messages(sid, include_inactive=True)
+    reopened.close()
+    archived = [row for row in originals if not row.get("active", 1)]
+    assert any(row.get("platform_message_id") == complaint.message_id for row in archived)
+    current = next(row for row in rows if row["role"] == "user")
+    assert current.get("platform_message_id") == complaint.message_id
+    metadata = current.get("display_metadata")
+    if isinstance(metadata, str):
+        metadata = json.loads(metadata)
+    assert metadata == retained["display_metadata"]

--- a/tests/gateway/test_durable_mixed_admission.py
+++ b/tests/gateway/test_durable_mixed_admission.py
@@ -1,0 +1,84 @@
+"""Replay filtering must not discard the fresh tail of a partially answered batch."""
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway import delivery_ledger as dl, shutdown_flush as spool
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult, merge_pending_message_event
+from gateway.platforms.event import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+@pytest.fixture
+def world(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(dl, "ledger_enabled", lambda *a, **k: True)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="synthetic", user_id="owner")
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fixture", extra={}))
+    adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True, message_id="receipt"))
+    runner = object.__new__(GatewayRunner)
+    runner._pending_native_image_paths = {}
+    runner.config = SimpleNamespace()
+    return source, adapter, runner, "agent:main:telegram:dm:synthetic"
+
+
+def event(source, identity, text):
+    return MessageEvent(text=text, source=source, message_id=identity,
+                        timestamp=datetime(2026, 1, 1), reply_to_message_id="reply-" + identity)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("attachments", [False, True])
+async def test_partial_batch_executes_and_transfers_only_fresh_members(world, tmp_path, attachments):
+    source, adapter, runner, key = world
+    old = event(source, "old", "obsolete instruction")
+    fresh = event(source, "fresh", "current question")
+    if attachments:
+        for item in (old, fresh):
+            path = tmp_path / (item.message_id + ".txt")
+            path.write_text("synthetic attachment", encoding="utf-8")
+            item.media_urls = [str(path)]
+            item.media_types = ["text/plain"]
+            item.media_text_inlined = [True]
+    for item in (old, fresh):
+        assert spool.record_durable_inbound_event(key, item)
+    await adapter.send_final_ledgered(old, key, "previous answer", {}, reply_to=None)
+    old_id = spool.durable_inbound_obligation_id(old)
+    pending = {key: spool._deserialise_inbound_event(spool._serialise_inbound_event(old))}
+    merge_pending_message_event(pending, key, fresh, merge_text=True)
+    batch = pending[key]
+    text = await runner._prepare_inbound_message_text(
+        event=batch, source=source, history=[], session_key=key)
+    assert text is not None
+    assert [m["message_id"] for m in batch.original_inputs()] == [fresh.message_id]
+    assert batch.reply_to_message_id == fresh.reply_to_message_id
+    assert batch.text == fresh.text
+    assert batch.media_urls == fresh.media_urls
+    assert batch.media_text_inlined == fresh.media_text_inlined
+    await adapter.send_final_ledgered(batch, key, "current answer", {}, reply_to=None)
+    assert spool.recover_durable_inbound_events() == []
+    assert dl.inbound_transfer_state(key, old_id) == "delivered"
+    with dl._transaction() as conn:
+        assert conn.execute("SELECT count(*) FROM delivery_obligations").fetchone()[0] == 2
+    assert adapter._send_with_retry.await_count == 2
+
+
+def test_repeated_pending_identity_is_not_appended(world):
+    source, _, _, key = world
+    original = event(source, "one", "same text")
+    original_text = original.text
+    assert spool.record_durable_inbound_event(key, original)
+    duplicate = spool._deserialise_inbound_event(spool._serialise_inbound_event(original))
+    pending = {key: original}
+    merge_pending_message_event(pending, key, duplicate, merge_text=True)
+    assert pending[key].text == original_text
+    assert len(pending[key].original_inputs()) == 1
+    fresh = event(source, "two", original.text)
+    assert spool.record_durable_inbound_event(key, fresh)
+    merge_pending_message_event(pending, key, fresh, merge_text=True)
+    assert len(pending[key].original_inputs()) == 2

--- a/tests/gateway/test_durable_output_recovery.py
+++ b/tests/gateway/test_durable_output_recovery.py
@@ -1,0 +1,238 @@
+"""Replay contract against real disk owners; every transport is synthetic.
+
+The child interpreter reopens the spool/SQLite and runs the production recovery
+sender. No parent-process adapter, pending queue, or ledger connection survives.
+"""
+import asyncio
+import json
+import os
+import socket
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway import delivery_ledger as dl, shutdown_flush as spool
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.event import MessageEvent
+from gateway.run import GatewayRunner
+from plugins.platforms.telegram.adapter import TelegramAdapter
+from tests.gateway.test_durable_batch_transfer import inputs, world  # noqa: F401
+
+
+class Crash(BaseException):
+    """Simulate process death without being swallowed as a transport exception."""
+
+
+def refuse_network(*args, **kwargs):
+    raise AssertionError("network is forbidden in synthetic replay fixtures")
+
+
+@pytest.fixture(autouse=True)
+def no_network(monkeypatch):
+    monkeypatch.setattr(socket.socket, "connect", refuse_network)
+    monkeypatch.setattr(socket.socket, "connect_ex", refuse_network)
+
+
+def recovery_snapshot(home):
+    os.environ["HERMES_HOME"] = home
+    socket.socket.connect = refuse_network
+    socket.socket.connect_ex = refuse_network
+    sent, documents = [], []
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fixture", extra={}))
+
+    async def send(chat_id, content, **kwargs):
+        sent.append({"chat_id": chat_id, "content": content, **kwargs})
+        return SendResult(success=True, message_id="recovery-text")
+
+    async def document(**kwargs):
+        if not Path(kwargs["file_path"]).is_file():
+            return SendResult(success=False, error="missing attachment")
+        documents.append(kwargs)
+        return SendResult(success=True, message_id="recovery-file")
+
+    adapter.send = send
+    adapter._send_with_retry = send
+    adapter.send_document = document
+    runner = object.__new__(GatewayRunner)
+    runner._obligation_adapter = AsyncMock(return_value=adapter)
+    runner._arm_flood_timers_for_waiting_rows = AsyncMock()
+    # The simulated dead producer is still our live pytest parent. Only its
+    # liveness probe is replaced; the real atomic claim and sender are exercised.
+    dl._owner_alive = lambda *args: False
+    pending = spool.recover_durable_inbound_events()
+    claimed = dl.sweep_recoverable()
+    asyncio.run(runner._redeliver_claimed_obligations(claimed))
+    with dl._transaction() as conn:
+        rows = conn.execute("SELECT obligation_id, state FROM delivery_obligations").fetchall()
+        links = conn.execute("SELECT inbound_id, obligation_id FROM delivery_input_links").fetchall()
+    return {"pending": [e.original_inputs() for e in pending], "claimed": claimed,
+            "sent": sent, "documents": documents, "rows": rows, "links": links}
+
+
+def restart(home):
+    code = ("import json,sys; "
+            "from tests.gateway.test_durable_output_recovery import recovery_snapshot; "
+            "print(json.dumps(recovery_snapshot(sys.argv[1])))")
+    result = subprocess.run([sys.executable, "-c", code, str(home)],
+                            capture_output=True, text=True, check=True)
+    return json.loads(result.stdout.splitlines()[-1])
+
+
+def runner_for(adapter):
+    runner = object.__new__(GatewayRunner)
+    runner._thread_metadata_for_source = lambda *args: {}
+    runner._reply_anchor_for_event = lambda event: event.reply_to_message_id
+    return runner
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["before_record", "record_failed", "record_before_ack",
+                                      "ack_before_send", "send_before_receipt", "after_send", "refused"])
+async def test_restart_dispatch_preserves_every_member(world, tmp_path, monkeypatch, boundary):
+    adapter, source, key = world
+    events, batch = inputs(source, key)
+    originals = [dict(member) for member in batch.original_inputs()]
+    if boundary == "record_failed":
+        monkeypatch.setattr(dl, "record_obligation", lambda **kwargs: (_ for _ in ()).throw(OSError("disk full")))
+    if boundary == "record_before_ack":
+        monkeypatch.setattr(spool, "acknowledge_durable_inbound_event", lambda event: (_ for _ in ()).throw(Crash()))
+    if boundary == "ack_before_send":
+        adapter._send_with_retry.side_effect = Crash()
+    if boundary == "send_before_receipt":
+        adapter._finalize_delivery_obligation = AsyncMock(side_effect=Crash())
+    if boundary == "refused":
+        adapter._send_with_retry.return_value = SendResult(success=False, error="rejected")
+    if boundary != "before_record":
+        try:
+            await adapter.send_final_ledgered(batch, key, "saved output", {}, reply_to=None)
+        except (Crash, OSError):
+            assert boundary in {"record_failed", "record_before_ack", "ack_before_send", "send_before_receipt"}
+    snapshot = restart(tmp_path)
+    if boundary in {"before_record", "record_failed"}:
+        assert [m for group in snapshot["pending"] for m in group] == originals
+        assert snapshot["links"] == snapshot["rows"] == snapshot["sent"] == []
+        adapter._send_with_retry.assert_not_awaited()
+    else:
+        assert snapshot["pending"] == []
+        assert len(snapshot["rows"]) == 1
+        oid, state = snapshot["rows"][0]
+        assert state == "delivered"
+        assert dict(snapshot["links"]) == {m["inbound_id"]: oid for m in originals}
+        assert len(snapshot["sent"]) == (0 if boundary == "after_send" else 1)
+        if boundary == "send_before_receipt":
+            # Accepted transport with no persisted receipt is ambiguous, not
+            # an exactly-once guarantee: redelivery carries the restart marker.
+            assert snapshot["claimed"][0]["needs_marker"] is True
+    fresh = MessageEvent(text=events[0].text, source=source, message_id="intentional-repeat")
+    assert spool.record_durable_inbound_event(key, fresh)
+    assert "intentional-repeat" in [e.message_id for e in spool.recover_durable_inbound_events()]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streamed", [False, True])
+@pytest.mark.parametrize("failure", ["crash_before_media", "refused_media", "missing_file"])
+async def test_queued_media_survives_text_success_and_restart(world, tmp_path, streamed, failure):
+    adapter, source, key = world
+    _, batch = inputs(source, key)
+    document = tmp_path / "deliverable.txt"
+    document.write_text("synthetic deliverable", encoding="utf-8")
+    runner = runner_for(adapter)
+    if failure == "crash_before_media":
+        adapter.send_document = AsyncMock(side_effect=Crash())
+    else:
+        adapter.send_document = AsyncMock(return_value=SendResult(success=False, error="refused"))
+    if failure == "missing_file":
+        document.unlink()
+    try:
+        await runner._deliver_queued_first_response(
+            f"result\nMEDIA:{document}", source, adapter, session_key=key,
+            inbound_event=batch, text_already_delivered=streamed,
+            stream_consumer=SimpleNamespace(message_id="stream-receipt") if streamed else None,
+            metadata={})
+    except Crash:
+        pass
+    snapshot = restart(tmp_path)
+    assert snapshot["pending"] == [], "recover the output, never rerun the answered inputs"
+    if failure == "missing_file":
+        assert snapshot["rows"][0][1] != "delivered", "missing attachment cannot silently complete"
+    else:
+        assert [item["file_path"] for item in snapshot["documents"]] == [str(document)]
+        assert snapshot["sent"] == [], "confirmed text must not be sent twice to recover media"
+        assert snapshot["rows"][0][1] == "delivered"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streamed", [False, True])
+async def test_failed_queued_turn_never_uploads_artifacts(world, tmp_path, streamed):
+    adapter, source, key = world
+    _, batch = inputs(source, key)
+    artifact = tmp_path / "not-a-success.txt"
+    artifact.write_text("partial", encoding="utf-8")
+    adapter.send_document = AsyncMock()
+    await runner_for(adapter)._deliver_queued_first_response(
+        f"failed\nMEDIA:{artifact}", source, adapter, session_key=key,
+        inbound_event=batch, text_already_delivered=streamed, deliver_media=False)
+    adapter.send_document.assert_not_awaited()
+    assert restart(tmp_path)["documents"] == []
+
+
+def test_shutdown_flush_keeps_unfinished_originals_and_media(world, tmp_path):
+    _, source, key = world
+    attachment = tmp_path / "input.txt"
+    attachment.write_text("fixture", encoding="utf-8")
+    event = MessageEvent(text="unfinished", source=source, message_id="pending-with-file",
+                         media_urls=[str(attachment)], media_types=["text/plain"],
+                         media_text_inlined=[True], reply_to_message_id="anchor")
+    assert spool.record_durable_inbound_event(key, event)
+    assert spool.flush_pending_to_file({key: event}) == 0  # already durably owned
+    snapshot = restart(tmp_path)
+    assert snapshot["pending"] == [event.original_inputs()]
+    assert snapshot["rows"] == []
+    assert attachment.read_text(encoding="utf-8") == "fixture"
+
+
+@pytest.mark.asyncio
+async def test_recursive_terminal_recovers_only_unconfirmed_attachment(world, tmp_path):
+    from gateway.turn_context import TurnContext
+
+    adapter, source, key = world
+    _, batch = inputs(source, key)
+    first, second = tmp_path / "first.txt", tmp_path / "second.txt"
+    for path in (first, second):
+        path.write_text("synthetic", encoding="utf-8")
+    opening = MessageEvent(text="opening", source=source, message_id="opening")
+    assert spool.record_durable_inbound_event(key, opening)
+    runner = runner_for(adapter)
+    runner._MAX_INTERRUPT_DEPTH = 8
+    runner._is_goal_continuation_event = MagicMock(return_value=False)
+    runner._session_key_for_source = MagicMock(return_value=key)
+    runner._prepare_profile_scoped_inbound_message_text = AsyncMock(return_value="followup")
+    runner._adapter_for_source = MagicMock(return_value=None)
+    runner._refresh_agent_cache_message_count = AsyncMock()
+    runner._pop_post_delivery_callback = MagicMock(return_value=None)
+    terminal = {"final_response": f"terminal\nMEDIA:{first}\nMEDIA:{second}", "messages": [],
+                "queued_terminal_event": batch, "queued_terminal_inbound_id": batch.message_id}
+    runner._run_agent = AsyncMock(return_value=terminal)
+    ctx = TurnContext(source=source, session_id="sid", session_key=key,
+                      inbound_event=opening, inbound_message_id=opening.message_id,
+                      _interrupt_depth=2, history=[])
+    result = await runner._run_agent_queued_followup(
+        ctx, adapter, "pending", batch, {"final_response": "opening answer"}, {"messages": []}, None)
+    assert runner._run_agent.await_args.kwargs["inbound_event"] is batch
+    adapter.send_document = AsyncMock(side_effect=[
+        SendResult(success=True, message_id="first-file-receipt"),
+        SendResult(success=False, error="refused")])
+    await runner._deliver_queued_first_response(
+        result["final_response"], source, adapter, session_key=key,
+        inbound_event=result["queued_terminal_event"], metadata={})
+    assert [call.kwargs["file_path"] for call in adapter.send_document.await_args_list] == [str(first), str(second)]
+    snapshot = restart(tmp_path)
+    assert snapshot["pending"] == []
+    assert len(snapshot["rows"]) == 2  # opening output plus ONE terminal output
+    assert [item["file_path"] for item in snapshot["documents"]] == [str(second)]
+    assert snapshot["sent"] == []

--- a/tests/gateway/test_shutdown_flush.py
+++ b/tests/gateway/test_shutdown_flush.py
@@ -11,10 +11,16 @@ import pytest
 
 from gateway.shutdown_flush import (
     _serialise_value,
+    acknowledge_durable_inbound_event,
     flush_overflow_to_file,
     flush_pending_to_file,
+    record_durable_inbound_event,
+    recover_durable_inbound_events,
     recover_pending_to_db,
 )
+from gateway.config import Platform
+from gateway.platforms.event import MessageEvent
+from gateway.session import SessionSource
 
 
 def _make_flush_dir(tmp_path: Path) -> Path:
@@ -148,6 +154,64 @@ def test_serialise_object_with_text():
     assert result is not None
     assert result["text"] == "msg"
     assert result["session_id"] == "sid"
+
+
+def test_durable_queued_inbound_round_trips_once_before_ack(tmp_path, monkeypatch):
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr("gateway.shutdown_flush._get_flush_dir", lambda: flush_dir)
+    event = MessageEvent(
+        text="finish the original request too",
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="123", user_id="456"),
+        message_id="789",
+    )
+
+    assert record_durable_inbound_event("agent:main:telegram:dm:123", event)
+    assert record_durable_inbound_event("agent:main:telegram:dm:123", event)
+    assert len(list(flush_dir.glob("inbound-*.json"))) == 1
+    restored = recover_durable_inbound_events()
+    assert [item.text for item in restored] == ["finish the original request too"]
+    acknowledge_durable_inbound_event(restored[0])
+    assert recover_durable_inbound_events() == []
+
+
+def test_durable_inbound_replays_in_arrival_order_not_hash_order(tmp_path, monkeypatch):
+    import gateway.shutdown_flush as shutdown_flush
+
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(shutdown_flush, "_get_flush_dir", lambda: flush_dir)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", user_id="456")
+    for text, message_id in (("first", "z"), ("second", "a"), ("third", "m")):
+        assert record_durable_inbound_event(
+            "agent:main:telegram:dm:123",
+            MessageEvent(text=text, source=source, message_id=message_id),
+        )
+    assert [item.text for item in recover_durable_inbound_events()] == [
+        "first", "second", "third",
+    ]
+
+
+def test_recovery_transfers_existing_outbound_reply_without_rerunning_input(tmp_path, monkeypatch):
+    from gateway import delivery_ledger as ledger
+    import gateway.shutdown_flush as shutdown_flush
+
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(shutdown_flush, "_get_flush_dir", lambda: flush_dir)
+    monkeypatch.setattr(ledger, "_db_path", lambda: tmp_path / "state.db")
+    session_key = "agent:main:telegram:dm:123"
+    event = MessageEvent(
+        text="finish the original request",
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="123", user_id="456"),
+        message_id="789",
+    )
+    assert record_durable_inbound_event(session_key, event)
+    inbound_id = shutdown_flush.durable_inbound_obligation_id(event)
+    outbound_id = ledger.compute_obligation_id(session_key, "", "", stable_inbound_id=inbound_id)
+    assert ledger.record_obligation(
+        obligation_id=outbound_id, session_key=session_key, platform="telegram", chat_id="123",
+        thread_id=None, content="canonical first reply", preserve_existing=True,
+    )
+    assert recover_durable_inbound_events() == []
+    assert ledger.obligation_state(outbound_id) == "pending"
 
 
 def test_get_flush_dir_uses_get_hermes_home(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Transfer every durable batch member to one authoritative recoverable output before retiring inbound spool records. Preserve original identities and route-scoped reply receipts through queueing, recovery and compaction. Recover confirmed text/attachment components through the existing sender without rerunning the model for already-transferred input.

This is a standalone PR against main. The independent Kanban lifecycle/summary change in NousResearch/hermes-agent#107315 touches disjoint files; neither PR requires the other.

## Verification

On exact head be05a4f16e088e93900fbe251b06018ed5ce744d, the canonical per-file runner passed 387 tests across 36 files (0 failures). Coverage includes disk-backed crash/restart, mixed batches, fresh identical text, attachment failure/recovery, scoped reply receipts, compaction, queued/streamed finals, media and multiplex routing. Tests use synthetic identities and fake transports; no real messages or provider calls.

The combined integration acceptance run passed 526 tests with one platform skip before an additional media-diagnostic compatibility repair. Broad gateway testing exposed two media diagnostics regressions, now repaired and covered by the passing exact-head suite. It also exposed browser-control failures outside this change; a fresh upstream-baseline run reproduced one browser-control failure. A completely green full gateway suite is not claimed.

Retained pre-fix disk-backed replay regressions fail before the implementation and pass after it. Scope includes source, synthetic tests and design documentation only; no generated artifacts, runtime configuration, personal fixtures or archives.

## Boundaries and risks

- A platform accepting a send before its receipt is persisted remains ambiguous; retry may duplicate external content. This is not an exactly-once transport guarantee.
- Partial chunk/image-batch sends and automatic TTS have remaining crash ambiguity.
- Attachment manifests retain paths, not immutable bytes.
- Input-link tombstones currently have no pruning policy.
- Reconcile pending attachment manifests before downgrade; older code cannot interpret component completion.
- Fake provider tests prove provenance plumbing, not semantic answer quality for follow-ups, repeated URLs or complaints. Those model-evaluation gates remain separate.

No runtime rollout, historical reconciliation, or merge is included.

