### PR TITLE
feat(kanban): paste images from clipboard into task attachments

### DIFF
--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -51,6 +51,7 @@ import {
   useValue
 } from '@hermes/plugin-sdk'
 import {
+  type ClipboardEvent,
   type CSSProperties,
   type DragEvent as ReactDragEvent,
   type ReactNode,
@@ -75,7 +76,8 @@ import {
   fetchBoards,
   fetchProfiles,
   patchTask,
-  PROFILES_KEY
+  PROFILES_KEY,
+  uploadAttachment
 } from './api'
 import { BoardSwitcher } from './board-switcher'
 import { TaskDrawer } from './drawer'
@@ -88,6 +90,7 @@ import {
   type ArcState,
   arcState,
   Avatar,
+  clipboardImageFiles,
   columnHelp,
   columnLabel,
   errText,
@@ -577,6 +580,8 @@ function NewTaskDialog({
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<null | string>(null)
   const [estimate, setEstimate] = useState<null | TaskEstimate>(null)
+  // Images pasted into the dialog, attached once the task exists.
+  const [pastedFiles, setPastedFiles] = useState<File[]>([])
 
   // Rough effort estimate from the typed title/body (before the task exists),
   // via the auto-routed auxiliary model. Makes a model call — explicit action.
@@ -610,8 +615,23 @@ function NewTaskDialog({
       setError(null)
       setBusy(false)
       setEstimate(null)
+      setPastedFiles([])
     }
   }, [target, boardDefaultKind])
+
+  // Paste an image into the dialog to attach it once the task exists. A paste
+  // with no image (plain text) is left untouched so the title/description
+  // inputs keep their normal behaviour.
+  const onPaste = (event: ClipboardEvent<HTMLDivElement>) => {
+    const files = clipboardImageFiles(event)
+
+    if (files.length === 0) {
+      return
+    }
+
+    event.preventDefault()
+    setPastedFiles(prev => [...prev, ...files])
+  }
 
   const submit = async () => {
     const trimmed = title.trim()
@@ -656,6 +676,23 @@ function NewTaskDialog({
         host.notify({ kind: 'warning', message: warning })
       }
 
+      // Attach pasted images to the freshly-created task (best-effort: the
+      // task exists regardless, and a failed upload just toasts — the file can
+      // still be added from the drawer).
+      if (task && pastedFiles.length > 0) {
+        for (const file of pastedFiles) {
+          try {
+            await uploadAttachment(task.id, {
+              bytes: await file.arrayBuffer(),
+              contentType: file.type || undefined,
+              filename: file.name
+            })
+          } catch (err) {
+            host.notify({ kind: 'warning', message: errText(err) })
+          }
+        }
+      }
+
       await qc.invalidateQueries({ queryKey: ['kanban', 'board'] })
       onClose()
     } catch (err) {
@@ -678,7 +715,7 @@ function NewTaskDialog({
         <DialogHeader>
           <DialogTitle>{target ? k.newTaskIn(columnLabel(k, target)) : k.newTask}</DialogTitle>
         </DialogHeader>
-        <div className="flex max-h-[min(72vh,44rem)] flex-col gap-3 overflow-y-auto pr-0.5">
+        <div className="flex max-h-[min(72vh,44rem)] flex-col gap-3 overflow-y-auto pr-0.5" onPaste={onPaste}>
           <Input
             autoFocus
             onChange={event => setTitle(event.target.value)}
@@ -697,6 +734,28 @@ function NewTaskDialog({
             placeholder={k.descPlaceholder}
             value={bodyText}
           />
+
+          {pastedFiles.length > 0 && (
+            <ul className="flex flex-col gap-1">
+              {pastedFiles.map((file, index) => (
+                <li
+                  className="flex items-center gap-1.5 rounded bg-(--ui-bg-quinary) px-2 py-1 text-[0.75rem] text-(--ui-text-secondary)"
+                  key={`${file.name}-${index}`}
+                >
+                  <Codicon name="file" size="0.75rem" />
+                  <span className="min-w-0 truncate">{file.name}</span>
+                  <button
+                    aria-label={k.delete}
+                    className="ml-auto grid size-5 place-items-center rounded text-(--ui-text-quaternary) transition-colors hover:text-foreground"
+                    onClick={() => setPastedFiles(prev => prev.filter((_, i) => i !== index))}
+                    type="button"
+                  >
+                    <Codicon name="close" size="0.7rem" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
 
           <div className="grid grid-cols-2 gap-3">
             <Field label={k.priority}>

--- a/apps/desktop/src/plugins/kanban/clipboard.test.ts
+++ b/apps/desktop/src/plugins/kanban/clipboard.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { clipboardImageFiles } from './ui'
+
+// The helper reads `clipboardData.items` structurally — a plain mock is enough
+// to exercise extraction, filtering, and null-file handling without jsdom's
+// (incomplete) clipboard implementation.
+const textItem = () => ({ type: 'text/plain', getAsFile: () => null })
+const imageItem = (file: File) => ({ type: 'image/png', getAsFile: () => file })
+
+const event = (items: unknown) => ({ clipboardData: { items } }) as unknown as { clipboardData: DataTransfer }
+const image = (name = 'shot.png') => new File(['png'], name, { type: 'image/png' })
+
+describe('clipboardImageFiles', () => {
+  it('returns an empty list when there is no clipboard data', () => {
+    expect(clipboardImageFiles({ clipboardData: null })).toEqual([])
+  })
+
+  it('returns an empty list for a text-only paste', () => {
+    expect(clipboardImageFiles(event([textItem()]))).toEqual([])
+  })
+
+  it('extracts a pasted image as a File', () => {
+    const file = image()
+
+    expect(clipboardImageFiles(event([imageItem(file)]))).toEqual([file])
+  })
+
+  it('ignores non-image items in a mixed paste', () => {
+    const file = image()
+
+    expect(clipboardImageFiles(event([textItem(), imageItem(file), textItem()]))).toEqual([file])
+  })
+
+  it('drops image items that fail to produce a file', () => {
+    const file = image()
+    const items = [imageItem(file), { type: 'image/png', getAsFile: () => null }]
+
+    expect(clipboardImageFiles(event(items))).toEqual([file])
+  })
+})

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -27,7 +27,7 @@ import {
   useQueryClient,
   useValue
 } from '@hermes/plugin-sdk'
-import { type ReactNode, useEffect, useRef, useState } from 'react'
+import { type ClipboardEvent, type ReactNode, useEffect, useRef, useState } from 'react'
 
 import {
   $boardSlug,
@@ -59,6 +59,7 @@ import {
   ago,
   Avatar,
   Callout,
+  clipboardImageFiles,
   columnLabel,
   duration,
   errText,
@@ -653,6 +654,21 @@ export function TaskDrawer({
     onSuccess: invalidate
   })
 
+  // Paste an image anywhere in the open drawer to attach it — the same upload
+  // path as the attachment button, minus the file-picker hop. A paste that
+  // holds no image (plain text) is left untouched so the comment/description
+  // textareas keep their normal behaviour.
+  const onPaste = (event: ClipboardEvent<HTMLDivElement>) => {
+    const files = clipboardImageFiles(event)
+
+    if (files.length === 0) {
+      return
+    }
+
+    event.preventDefault()
+    files.forEach(file => uploadMut.mutate(file))
+  }
+
   if (!id) {
     return null
   }
@@ -674,7 +690,10 @@ export function TaskDrawer({
   }
 
   return (
-    <div className="absolute inset-y-0 right-0 z-20 flex w-[26rem] flex-col border-l border-(--ui-stroke-tertiary) bg-(--ui-bg-elevated) duration-150 ease-out animate-in fade-in slide-in-from-right-4">
+    <div
+      className="absolute inset-y-0 right-0 z-20 flex w-[26rem] flex-col border-l border-(--ui-stroke-tertiary) bg-(--ui-bg-elevated) duration-150 ease-out animate-in fade-in slide-in-from-right-4"
+      onPaste={onPaste}
+    >
       <header className="flex flex-col gap-2 px-4 pt-3.5 pb-3">
         <div className="flex items-center gap-2">
           {task ? (

--- a/apps/desktop/src/plugins/kanban/ui.tsx
+++ b/apps/desktop/src/plugins/kanban/ui.tsx
@@ -71,6 +71,23 @@ export function errText(err: unknown): string {
   return raw
 }
 
+/** Image files carried by a clipboard paste event. Empty when the clipboard
+ *  held no image — callers must leave a normal text paste untouched in that
+ *  case. Pulls `image/*` items off `clipboardData.items` (the native way to
+ *  get a pasted screenshot) rather than touching the file-picker path. */
+export function clipboardImageFiles(event: { clipboardData: null | DataTransfer }): File[] {
+  const items = event.clipboardData?.items
+
+  if (!items) {
+    return []
+  }
+
+  return Array.from(items)
+    .filter(item => item.type.startsWith('image/'))
+    .map(item => item.getAsFile())
+    .filter((file): file is File => file != null)
+}
+
 /** Backend timestamps are epoch SECONDS; the canonical formatter takes ms. */
 export const ago = (seconds?: null | number): null | string => (seconds ? relativeTime(seconds * 1000) : null)
 


### PR DESCRIPTION
## What & why

Clipboard paste of images into Kanban — no file-picker hop. Today the only way to attach an image is the upload button, which opens a native file dialog. For screenshot-driven workflows (pasting a receipt, error dialog, or diagram into a task) that's unnecessary friction.

This adds **Ctrl/Cmd+V image paste** in two places:

- **Task drawer** — pasting while a task is open attaches the image directly (same upload path as the existing attachment button).
- **New task dialog** — pasted images are queued with a removable preview and attached once the task is created.

A shared `clipboardImageFiles()` helper extracts `image/*` items from `clipboardData.items`. A paste that holds no image (plain text) is left untouched, so the title, description, and comment inputs keep their normal behaviour.

Closes #107061.

## How to test

1. Open the Kanban board.
2. **New task dialog**: press **+** (new task), copy an image to the clipboard (e.g. a screenshot), and press **Ctrl/Cmd+V**. A removable preview row appears. Submit — the task is created and the image shows under *Attachments*.
3. **Task drawer**: open an existing task, press **Ctrl/Cmd+V** with an image on the clipboard — it attaches immediately.
4. Confirm a **text-only** paste into the title/description/comment fields still behaves normally (not swallowed).

## Platforms tested

- Linux (desktop renderer) — unit + plugin suite: `vitest run src/plugins/kanban` → **46 passing**
- `eslint`, `tsc -p . --noEmit`, and `prettier --check` all clean.

## Scope note

This targets the **desktop app's** Kanban plugin (`apps/desktop/src/plugins/kanban/…`). The browser-only web dashboard ships as a pre-built bundle (`plugins/kanban/dashboard/dist/index.js`) whose un-built source isn't in this repo; a paste handler there would be a separate follow-up.
