### PR TITLE
fix(deepseek): resolve the dotted v4.1 slug to its real 1M window

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -341,8 +341,12 @@ DEFAULT_CONTEXT_LENGTHS = {
     "gemma-4": 256000, "gemma4": 256000, "gemma-4-31b": 256000, "gemma-3": 131072, "gemma": 8192,
     # DeepSeek — V4 family is 1M; deepseek-chat/-reasoner alias v4-flash modes. ``deepseek-flash``
     # (version-less canonical id, 2026-09 Flash refresh) needs a discrete entry or the
-    # longest-key-first scan falls through to the 128K ``deepseek`` catch-all below.
+    # longest-key-first scan falls through to the 128K ``deepseek`` catch-all below. The
+    # 4.1 refresh (``deepseek-v4.1-flash``, 1,048,576 per OpenRouter/models.dev) needs the same
+    # treatment: ``deepseek-v4-flash`` is not a substring of it, so without the entry a relay
+    # alias like ``deepseek-v4.1-flash-tk`` resolves to 128K.
     # https://api-docs.deepseek.com/zh-cn/quick_start/pricing
+    "deepseek-v4.1-flash": 1_048_576,
     "deepseek-v4-pro": 1_000_000, "deepseek-v4-flash": 1_000_000, "deepseek-chat": 1_000_000,
     "deepseek-reasoner": 1_000_000, "deepseek-flash": 1_000_000, "deepseek": 128000,
     # Meta; Muse Spark family (1.1/1.2/1.3, -contributor(-free), meta/ prefixed) is 1M per OpenRouter,
@@ -1303,6 +1307,7 @@ _PRE_CATALOG_STALE_KEYS = frozenset({
     "grok-4.3", "grok-4.6",  # 1M / 500K; "grok-4" catch-all persisted 256,000
     "grok-4-fast", "grok-4.20",  # 2M; fell through to the 256K fallback
     "qwen3.6-plus",  # 1M; "qwen" catch-all persisted 131,072
+    "deepseek-v4.1-flash",  # 1M; dotted slug missed "deepseek-v4-flash", so "deepseek" persisted 128,000
 })
 
 

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -23,6 +23,8 @@ _REASONING_STALE_TIMEOUT_FLOORS: dict[int, tuple[str, ...]] = {
         # ``deepseek-flash`` is the version-less canonical Flash id (2026-09 Flash refresh);
         # ``deepseek-v4-flash`` still aliases onto it server-side.
         "deepseek-r1", "deepseek-reasoner", "deepseek-flash", "deepseek-v4-flash", "deepseek-v4-pro",
+        # 4.1 refresh (2026-09): a discrete slug, not a substring of `deepseek-v4-flash`.
+        "deepseek-v4.1-flash",
         # OpenAI o-series: each variant enumerated so bare ``o1`` cannot over-match ``olmo-1``.
         "o1", "o1-mini", "o1-pro", "o1-preview", "o3", "o3-pro",
         # Mythos-class named models (claude-fable-5): 1M ctx + 128K output, a heavier thinking

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -189,7 +189,7 @@ _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
     # Off-peak USD rates (peak = 2x, Mon-Fri 01-04 + 06-10 UTC). ``deepseek-v4-flash`` and the
     # retired deepseek-chat / deepseek-reasoner aliases are served by V4.1-Flash at the Flash price.
     ("deepseek", "https://api-docs.deepseek.com/quick_start/pricing", "deepseek-pricing-2026-09-10", {
-        ("deepseek-flash", "deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"): ("0.15", "0.60", "0.003"),
+        ("deepseek-flash", "deepseek-v4-flash", "deepseek-v4.1-flash", "deepseek-chat", "deepseek-reasoner"): ("0.15", "0.60", "0.003"),
         "deepseek-v4-pro": ("0.66", "1.98", "0.022"),
     }),
     ("google", "https://ai.google.dev/gemini-api/docs/pricing", "google-pricing-2026-09-02", {

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -390,6 +390,22 @@ class TestDefaultContextLengths:
                     f"{model_id}: expected {expected_ctx}, got {actual}"
                 )
 
+    def test_deepseek_v4_1_refresh_does_not_fall_back_to_128k(self):
+        """The 4.1 refresh is a discrete slug, not a substring of ``deepseek-v4-flash``.
+
+        Without a catalog entry the longest-key-first scan falls through to the
+        legacy 128K ``deepseek`` catch-all, so a relay alias such as
+        ``deepseek-v4.1-flash-tk`` silently reports a 128K window.
+        """
+        from agent.model_metadata import get_model_context_length
+        from unittest.mock import patch as mock_patch
+
+        with mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
+            for model_id in ("deepseek-v4.1-flash", "deepseek-v4.1-flash-tk"):
+                assert get_model_context_length(model_id) == 1_048_576, model_id
+
 
 
 
@@ -1709,6 +1725,13 @@ class TestGenericPreCatalogStaleGuard:
         assert _stale_pre_catalog_cache_entry("qwen3.6-plus", 131_072)
         assert _stale_pre_catalog_cache_entry("alibaba/qwen3.6-plus", 131_072)
         assert not _stale_pre_catalog_cache_entry("qwen3.6-plus", 1_048_576)
+        # deepseek-v4.1-flash (1M): the dotted slug missed "deepseek-v4-flash", so pre-fix
+        # builds persisted the 128,000 "deepseek" catch-all.
+        assert _stale_pre_catalog_cache_entry("deepseek-v4.1-flash", 128_000)
+        assert _stale_pre_catalog_cache_entry("deepseek-v4.1-flash-tk", 128_000)
+        assert not _stale_pre_catalog_cache_entry("deepseek-v4.1-flash", 1_048_576)
+        # Legacy DeepSeek slugs keep their genuine 128K window.
+        assert not _stale_pre_catalog_cache_entry("deepseek-v3.2", 128_000)
         # A 256K value for qwen3.6-plus is above the "qwen" catch-all —
         # could be a genuine probe result, so it is NOT dropped.
         assert not _stale_pre_catalog_cache_entry("qwen3.6-plus", 262_144)

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -60,6 +60,9 @@ import pytest
     # ``deepseek-v4-flash`` still aliases onto it server-side.
     ("deepseek/deepseek-flash", 600.0),
     ("deepseek-flash", 600.0),
+    # 4.1 refresh (2026-09) — a discrete slug, not a substring of `deepseek-v4-flash`.
+    ("deepseek/deepseek-v4.1-flash", 600.0),
+    ("deepseek-v4.1-flash-tk", 600.0),
     # Qwen QwQ + Qwen3 thinking variants (qwen3 family entry matches all).
     ("qwen/qwq-32b-preview", 300.0),
     ("qwen/qwen3-235b-a22b-thinking", 180.0),

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -150,6 +150,15 @@ def test_bundled_pricing_skips_endpoint_metadata(monkeypatch):
     assert entry.source == "official_docs_snapshot"
 
 
+def test_deepseek_v4_1_flash_pricing_matches_flash_tier():
+    """The 4.1 refresh bills at the Flash rate, not "unknown cost" (see #24218 class)."""
+    entry = get_pricing_entry("deepseek-v4.1-flash", provider="deepseek")
+    assert entry is not None
+    assert entry.source == "official_docs_snapshot"
+    flash = get_pricing_entry("deepseek-flash", provider="deepseek")
+    assert entry.input_cost_per_million == flash.input_cost_per_million
+
+
 def test_unknown_model_falls_back_to_endpoint_metadata(monkeypatch):
     """Models absent from the bundled table still use endpoint pricing."""
     monkeypatch.setattr(


### PR DESCRIPTION
Fixes context-window resolution for the dotted V4.1 slug `deepseek-v4.1-flash` (reported as **128K** instead of its real 1M window).

**Root cause.** `DEFAULT_CONTEXT_LENGTHS` matches by substring. The catalog ships `deepseek-v4-flash`, and `"deepseek-v4-flash" in "deepseek-v4.1-flash"` is `False` because `v4.1` != `v4`. The slug therefore fell through to the family catch-all `"deepseek": 128000`. It never reached the 256K probe-down fallback, so nothing flagged the resolved value as suspiciously low — the wrong answer looked plausible.

Observed on a relay alias (CPA/TokenHarbor `deepseek-v4.1-flash-tk`, upstream `deepseek-v4.1-flash:free`), where the endpoint's `/v1/models` reports no `context_length`, so the catalog is the only source. Upstream truth: OpenRouter/models.dev `deepseek/deepseek-v4.1-flash` = `context: 1048576`, `release_date: 2026-09-10`.

## Changes

- `agent/model_metadata.py` — add `"deepseek-v4.1-flash": 1_048_576`. It needs its own entry: the dotted slug is not a substring of `deepseek-v4-flash`, and normalization (`_normalize_model_version`) only maps dots on the *comparison* side, so it cannot bridge `v4.1` -> `v4`.
- `agent/model_metadata.py` (`_PRE_CATALOG_STALE_KEYS`) — add `deepseek-v4.1-flash` so a `128,000` value persisted by earlier builds is discarded and re-resolved instead of being served from the step-1 cache forever.
- `agent/reasoning_timeouts.py` — the dotted slug needs its own 600s entry too; `.` is a separator anchor, but `deepseek-v4-flash` still does not match it, so V4.1 sessions got no reasoning stale-timeout floor.
- `agent/usage_pricing.py` — V4.1 bills at the Flash tier; without the key these sessions show as unknown cost (#24218 class).

## Tests

Invariant tests, all proven red on base (verified by reverting the catalog key / slug / price key in-process):

| Base | Fixed |
|---|---|
| `get_model_context_length("deepseek-v4.1-flash") == 128000` | `1_048_576` |
| `get_model_context_length("deepseek-v4.1-flash-tk") == 128000` | `1_048_576` |
| `get_reasoning_stale_timeout_floor("deepseek-v4.1-flash-tk") is None` | `600.0` |
| `get_pricing_entry("deepseek-v4.1-flash", provider="deepseek") is None` | Flash rates |

Also extends `test_absorbed_pr_37684_models` with the stale-cache cases (`128_000` dropped, `1_048_576` kept, legacy `deepseek-v3.2` 128K untouched).

Note: this overlaps #107250 (same root cause, opened independently the same day); happy to close mine in favour of that one if it lands first.