### PR TITLE
fix(agent): preserve context when summary provider overloads

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -557,12 +557,14 @@ class _SummaryFailureKind:
     streaming_closed: bool
     empty_content: bool
     truncated: bool
+    overloaded: bool
 
     def fallback_reason(self) -> str:
         """Reason string for the one-shot main-model retry log line, most specific first."""
         reasons = (
             (self.json_decode, "returned invalid JSON"), (self.truncated, "returned a truncated summary (output token cap)"),
-            (self.empty_content, "returned empty content"), (self.model_not_found, "unavailable"),
+            (self.empty_content, "returned empty content"), (self.overloaded, "was overloaded"),
+            (self.model_not_found, "unavailable"),
             (self.streaming_closed, "closed stream prematurely"), (self.timeout, "timed out"),
         )
         return next((reason for flagged, reason in reasons if flagged), "failed")
@@ -589,6 +591,8 @@ def _classify_summary_failure(e: Exception) -> _SummaryFailureKind:
         ),
         # Truncated summary: one main-model retry, then ABORT preserving the session.
         truncated=isinstance(e, RuntimeError) and _TRUNCATED_SUMMARY_MARKER in err,
+        overloaded=classify_api_error(e).reason is FailoverReason.overloaded
+        or any(marker in err for marker in ("overloaded", "at capacity", "over capacity")),
     )
 
 
@@ -622,6 +626,13 @@ _TERMINAL_SUMMARY_FAILURES = (
         "Summary generation failed (LLM returned empty content) — aborting compression. %d message(s) "
         "preserved unchanged; the session was NOT rotated. This indicates upstream provider degradation: "
         "retry with /compress once the provider recovers, or continue the conversation as-is.",
+    ),
+    (
+        "_last_summary_overload_failure",
+        "summary_overload_failure",
+        "Summary generation failed because the provider is overloaded — aborting compression. %d message(s) "
+        "preserved unchanged; the session was NOT rotated. Retry with /compress once capacity recovers, "
+        "or continue the conversation as-is.",
     ),
 )
 
@@ -3526,6 +3537,8 @@ Write only the summary body. Do not include any preamble or prefix."""
             self._last_summary_truncated_failure = True
         elif kind.empty_content:
             self._last_summary_empty_content_failure = True
+        elif kind.overloaded:
+            self._last_summary_overload_failure = True
         logger.warning(
             "Failed to generate context summary: %s. Further summary attempts paused for %d seconds.", e,
             _transient_cooldown,

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -171,6 +171,7 @@ _COMPRESSOR_ATTEMPT_STATE_FIELDS = (
     "_cooldown_persist_failed", "_last_summary_error", "_consecutive_timeout_failures", "_last_summary_dropped_count",
     "_last_summary_fallback_used", "_last_compress_aborted", "_last_summary_auth_failure",
     "_last_summary_network_failure", "_last_summary_empty_content_failure", "_last_summary_truncated_failure",
+    "_last_summary_overload_failure",
     "_last_aux_model_failure_error", "_last_aux_model_failure_model", "_summary_model_fallen_back", "summary_model",
     "_last_compression_telemetry", "_active_compression_telemetry", "_compression_telemetry_seed",
     "_proactive_prune_rearm_tokens",

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -930,6 +930,32 @@ class TestAuthFailureAborts:
         assert c._last_compress_aborted is False
         assert c._last_summary_fallback_used is True
 
+    def test_provider_overload_aborts_instead_of_dropping_context(self):
+        """A failed overload summary preserves completed work for a later retry."""
+        err = StubProviderError(
+            "Our servers are currently overloaded. Please try again later.",
+            status_code=503,
+        )
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=False,
+            )
+        c.summary_model = "test/auxiliary"
+        msgs = self._msgs(12)
+        with patch("agent.context_compressor.call_llm", side_effect=err) as mock_call:
+            result = c.compress(msgs, current_tokens=999999, force=True)
+
+        assert mock_call.call_count == 2
+        assert result == msgs
+        assert c._last_compress_aborted is True
+        assert c._last_summary_fallback_used is False
+        assert c._last_summary_dropped_count == 0
+        assert c._last_compression_telemetry["failure_class"] == "summary_overload_failure"
+
 
     def test_403_also_flags_auth_failure(self):
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):


### PR DESCRIPTION
## Summary

- preserve the active transcript when context-summary generation exhausts retries because its provider is overloaded
- keep the existing auxiliary-to-main one-shot fallback before treating overload as terminal
- report overload aborts distinctly instead of claiming that a deterministic fallback was committed

## Root cause

Compression classified the provider's overload response as a generic transient summary failure. Because that class did not set a terminal-abort flag, `compress()` replaced the middle history with a deterministic fallback and the outer boundary committed the shortened transcript. That could hide completed tool work precisely when the next model step had already failed.

## Testing

- `scripts/run_tests.sh tests/agent/test_context_compressor.py` (150 passed)
- `scripts/run_tests.sh tests/agent/test_compression_attempt_telemetry.py tests/agent/test_compression_worker_isolation_76354.py` (7 passed)

Closes #107307
