### PR TITLE
fix(dashboard): use theme colors for model badges

### DIFF
--- a/web/src/components/ModelInfoCard.tsx
+++ b/web/src/components/ModelInfoCard.tsx
@@ -91,12 +91,12 @@ export function ModelInfoCard({
             </span>
           )}
           {caps.supports_vision && (
-            <span className="inline-flex items-center gap-1 bg-blue-500/10 px-2 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400">
+            <span className="inline-flex items-center gap-1 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
               <Eye className="h-2.5 w-2.5" /> Vision
             </span>
           )}
           {caps.supports_reasoning && (
-            <span className="inline-flex items-center gap-1 bg-purple-500/10 px-2 py-0.5 text-xs font-medium text-purple-600 dark:text-purple-400">
+            <span className="inline-flex items-center gap-1 bg-muted px-2 py-0.5 text-xs font-medium text-text-secondary">
               <Brain className="h-2.5 w-2.5" /> Reasoning
             </span>
           )}

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -179,12 +179,12 @@ function CapabilityBadges({
         </span>
       )}
       {capabilities.supports_vision && (
-        <span className="inline-flex items-center gap-1 bg-blue-500/10 px-1.5 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400">
+        <span className="inline-flex items-center gap-1 bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary">
           <Eye className="h-2.5 w-2.5" /> Vision
         </span>
       )}
       {capabilities.supports_reasoning && (
-        <span className="inline-flex items-center gap-1 bg-purple-500/10 px-1.5 py-0.5 text-xs font-medium text-purple-600 dark:text-purple-400">
+        <span className="inline-flex items-center gap-1 bg-muted px-1.5 py-0.5 text-xs font-medium text-text-secondary">
           <Brain className="h-2.5 w-2.5" /> Reasoning
         </span>
       )}
@@ -417,7 +417,7 @@ function ModelCard({
                 </span>
               )}
               {mainAuxTask && (
-                <span className="inline-flex items-center bg-purple-500/10 px-1.5 py-0.5 text-display text-xs font-medium tracking-wider text-purple-600 dark:text-purple-400">
+                <span className="inline-flex items-center bg-muted px-1.5 py-0.5 text-display text-xs font-medium tracking-wider text-text-secondary">
                   aux · {mainAuxTask}
                 </span>
               )}


### PR DESCRIPTION
## What does this PR do?

Replaces the five inert light/dark palette pairs used by the Models dashboard badges with existing semantic theme tokens. Vision follows the primary theme color; Reasoning and AUX use the readable secondary-text/muted pairing. This fixes dark-theme contrast without globally enabling Tailwind's `dark` variant or changing the Nous Blue light theme.

## Related Issue

Fixes #107322

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Update capability badges in `web/src/components/ModelInfoCard.tsx`.
- Update capability and AUX badges in `web/src/pages/ModelsPage.tsx`.
- Keep the change presentation-only; no theme, API, or behavior contract changes.

## How to Test

1. `npm run typecheck --workspace web`
2. Focused ESLint on the two changed files
3. `npm run build --workspace web`

## Checklist

- [x] Read the Contributing Guide
- [x] Conventional Commit
- [x] Searched all PR states for duplicates
- [x] Focused diff only
- [x] Web typecheck and production build pass
- [x] Windows 11
- [x] Documentation/config/tool-schema changes N/A

## Screenshots / Logs

Typecheck and production build pass. Focused ESLint has no errors and retains one pre-existing warning at `ModelsPage.tsx:1221`, outside this diff.