### PR TITLE
plugins: chrome renderer hook for input rules and status bar (consumer: cuttlefish-theme)

### DIFF
--- a/hermes_cli/cli_status_bar_mixin.py
+++ b/hermes_cli/cli_status_bar_mixin.py
@@ -1086,6 +1086,27 @@ class CLIStatusBarMixin:
         except Exception:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
 
+    def _apply_chrome_status_background(self, fragments, width: int):
+        from hermes_cli.plugins import get_plugin_manager
+        bg = get_plugin_manager().render_chrome("status_bar_bg", width, {
+            "session_id": getattr(self, "session_id", None),
+            "skin": getattr(getattr(self, "skin", None), "name", None) or "default",
+        })
+        if bg is None:
+            return fragments
+        bg_cells = []
+        for style, text in bg:
+            bg_cells.extend([style] * self._status_bar_display_width(text))
+        out = []
+        cell = 0
+        for style, text in fragments:
+            for char in text:
+                cells = max(1, self._status_bar_display_width(char))
+                bg_style = bg_cells[cell] if cell < len(bg_cells) else ""
+                out.append((f"{style} {bg_style}".strip() if bg_style else style, char))
+                cell += cells
+        return out
+
     def _get_status_bar_fragments(self):
         if (
             not self._status_bar_visible
@@ -1131,7 +1152,7 @@ class CLIStatusBarMixin:
             if total_width > width:
                 plain_text = "".join(text for _, text in frags)
                 return [(_SB, self._trim_status_bar_text(plain_text, width))]
-            return frags
+            return self._apply_chrome_status_background(frags, width)
         except Exception:
             return [(_SB, f" {self._build_status_bar_text()} ")]
 

--- a/hermes_cli/cli_tui_mixin.py
+++ b/hermes_cli/cli_tui_mixin.py
@@ -2008,6 +2008,20 @@ class CLITuiMixin:
             Window(FormattedTextControl(fragments_fn), wrap_lines=True),
             filter=Condition(lambda: getattr(self, state_attr) is not None))
 
+    def _tui_chrome_fragments(self, surface: str, width: int):
+        from hermes_cli.plugins import get_plugin_manager
+        from hermes_cli.skin_engine import get_active_skin
+        skin = get_active_skin()
+        skin_name = getattr(skin, "name", None) or getattr(self, "skin", None) or "default"
+        return get_plugin_manager().render_chrome(surface, width, {
+            "session_id": getattr(self, "session_id", None),
+            "skin": skin_name,
+        })
+
+    def _tui_has_chrome_renderer(self) -> bool:
+        from hermes_cli.plugins import get_plugin_manager
+        return bool(get_plugin_manager()._chrome_renderers)
+
     def _tui_build_layout(self, kb):
         """Build the TUI widgets, Layout and Style; registers wrapper keybindings on ``kb``."""
         cli_ref = self
@@ -2039,12 +2053,26 @@ class CLITuiMixin:
         command_palette_widget = self._tui_overlay_widget(
             self._get_command_palette_display_fragments, "_command_palette_state")
         # Rules above/below the input; narrow terminals hide the bottom one to recover a row.
-        input_rule_top = Window(
-            char='─', height=lambda: cli_ref._tui_input_rule_height("top"), style='class:input-rule',
-        )
-        input_rule_bot = Window(
-            char='─', height=lambda: cli_ref._tui_input_rule_height("bottom"), style='class:input-rule',
-        )
+        if self._tui_has_chrome_renderer():
+            def _rule(surface):
+                return lambda: cli_ref._tui_chrome_fragments(
+                    surface, cli_ref._get_tui_terminal_width()) or [
+                        ('class:input-rule', '─' * cli_ref._get_tui_terminal_width())]
+            input_rule_top = Window(
+                content=FormattedTextControl(_rule("input_rule_top")),
+                height=lambda: cli_ref._tui_input_rule_height("top"),
+            )
+            input_rule_bot = Window(
+                content=FormattedTextControl(_rule("input_rule_bot")),
+                height=lambda: cli_ref._tui_input_rule_height("bottom"),
+            )
+        else:
+            input_rule_top = Window(
+                char='─', height=lambda: cli_ref._tui_input_rule_height("top"), style='class:input-rule',
+            )
+            input_rule_bot = Window(
+                char='─', height=lambda: cli_ref._tui_input_rule_height("bottom"), style='class:input-rule',
+            )
         image_bar = Window(
             content=FormattedTextControl(self._tui_image_bar_fragments),
             height=Condition(lambda: bool(cli_ref._attached_images)))

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -894,6 +894,15 @@ class PluginContext:
         """Register a lifecycle hook callback (unknown names warn but are still stored)."""
         return self._track_callback("hook", hook_name, callback, self._manager._hooks, VALID_HOOKS)
 
+    def register_chrome_renderer(self, callback: Callable) -> PluginRegistration:
+        """Register the plugin-owned renderer for TUI chrome surfaces."""
+        if not callable(callback):
+            raise TypeError("chrome renderer must be callable")
+        return self._register_entry(
+            "chrome_renderer", "default", self._manager._chrome_renderers,
+            {"callback": callback, "disabled": False},
+            "Plugin %s registered chrome renderer",)
+
     def register_middleware(self, kind: str, callback: Callable) -> PluginRegistration:
         """Register behavior-changing middleware (request kinds rewrite the payload, execution kinds
         wrap the callback). Unknown kinds warn but are stored."""
@@ -1127,6 +1136,7 @@ class PluginManager(PluginLoaderMixin, PluginDispatchMixin, PluginLedgerMixin):
         # (matcher, callback, plugin_name), platform handler factories (lowercase platform -> list).
         self._plugins: Dict[str, LoadedPlugin] = {}
         self._hooks: Dict[str, List[Callable]] = {}
+        self._chrome_renderers: Dict[str, dict] = {}
         # Fallback hooks registered by a memory provider before general discovery.
         self._memory_hook_registrations: Dict[Tuple[str, str], List[PluginRegistration]] = {}
         self._middleware: Dict[str, List[Callable]] = {}

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -19,8 +19,40 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Union
 
 from hermes_cli.middleware import OBSERVER_SCHEMA_VERSION
+from prompt_toolkit.utils import get_cwidth
 
 logger = logging.getLogger("hermes_cli.plugins")
+
+_CHROME_SURFACES = frozenset({"input_rule_top", "input_rule_bot", "status_bar_bg"})
+
+
+def _normalize_chrome_fragments(fragments: Any, width: int) -> list[tuple[str, str]]:
+    """Clamp renderer fragments to exactly *width* prompt-toolkit cells."""
+    from prompt_toolkit.utils import get_cwidth
+
+    width = max(0, int(width))
+    out: list[tuple[str, str]] = []
+    remaining = width
+    for item in fragments if isinstance(fragments, (list, tuple)) else ():
+        if remaining <= 0 or not isinstance(item, (list, tuple)) or len(item) != 2:
+            continue
+        style, text = str(item[0]), str(item[1])
+        if get_cwidth(text) <= remaining:
+            out.append((style, text))
+            remaining -= get_cwidth(text)
+            continue
+        clipped = ""
+        for char in text:
+            cells = get_cwidth(char)
+            if cells > remaining:
+                break
+            clipped += char
+            remaining -= cells
+        if clipped:
+            out.append((style, clipped))
+    if remaining:
+        out.append(("", " " * remaining))
+    return out
 
 # Allowlist of agent-turn hot-path hooks bounded by plugins.hook_callback_timeout (fail-open:
 # abandon without join — joining reintroduced a shutdown hang). Unlisted hooks run synchronously.
@@ -162,6 +194,28 @@ class PluginDispatchMixin:
             name: value for name, value in payload.items()
             if name in parameters and parameters[name].kind in keyword_kinds
         })
+
+    def render_chrome(self, surface: str, width: int, ctx: dict) -> list[tuple[str, str]] | None:
+        """Render plugin chrome, returning ``None`` for the built-in fallback."""
+        if surface not in _CHROME_SURFACES:
+            raise ValueError(f"unknown chrome surface: {surface}")
+        entry = self._chrome_renderers.get("default")
+        if not entry or entry.get("disabled"):
+            return None
+        try:
+            result = entry["callback"](surface, width, ctx)
+        except Exception:
+            entry["disabled"] = True
+            logger.warning("Chrome renderer failed; disabling it for this session", exc_info=True)
+            return None
+        if result is None:
+            return None
+        raw_width = sum(get_cwidth(str(item[1])) for item in result
+                        if isinstance(item, (list, tuple)) and len(item) == 2)
+        if raw_width != width:
+            logger.debug("Chrome renderer returned %d cells for %s; normalizing to %d",
+                         raw_width, surface, width)
+        return _normalize_chrome_fragments(result, width)
 
     def invoke_hook(self, hook_name: str, **kwargs: Any) -> List[Any]:
         """Call all callbacks for *hook_name*; return their non-``None`` results.

--- a/tests/hermes_cli/test_chrome_renderer.py
+++ b/tests/hermes_cli/test_chrome_renderer.py
@@ -1,0 +1,59 @@
+import logging
+
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+from hermes_cli.plugins_dispatch import _normalize_chrome_fragments
+
+
+def _ctx(manager):
+    return PluginContext(PluginManifest(name="fake-chrome", version="1"), manager)
+
+
+def test_chrome_renderer_registration_is_tracked_and_unregistered():
+    manager = PluginManager(scope_key="/tmp/chrome-test")
+    ctx = _ctx(manager)
+    handle = ctx.register_chrome_renderer(lambda surface, width, info: [("class:a", "x" * width)])
+    assert manager.render_chrome("input_rule_top", 4, {"session_id": None, "skin": "default"})
+    handle.dispose()
+    assert manager.render_chrome("input_rule_top", 4, {}) is None
+
+
+def test_none_renderer_preserves_default_fallback():
+    manager = PluginManager(scope_key="/tmp/chrome-test")
+    _ctx(manager).register_chrome_renderer(lambda surface, width, info: None)
+    assert manager.render_chrome("input_rule_bot", 3, {}) is None
+
+
+def test_renderer_exception_falls_back_and_disables(caplog):
+    calls = []
+    manager = PluginManager(scope_key="/tmp/chrome-test")
+
+    def broken(surface, width, info):
+        calls.append(1)
+        raise RuntimeError("boom")
+
+    _ctx(manager).register_chrome_renderer(broken)
+    with caplog.at_level(logging.WARNING):
+        assert manager.render_chrome("input_rule_top", 3, {}) is None
+        assert manager.render_chrome("input_rule_top", 3, {}) is None
+    assert calls == [1]
+    assert "disabling it" in caplog.text
+
+
+def test_prompt_toolkit_rule_control_renders_multiple_styles():
+    from prompt_toolkit.layout.controls import FormattedTextControl
+
+    manager = PluginManager(scope_key="/tmp/chrome-test")
+    _ctx(manager).register_chrome_renderer(
+        lambda surface, width, info: [("class:red", "x"), ("class:blue", "x"), ("class:green", " " * (width - 2))]
+    )
+    control = FormattedTextControl(lambda: manager.render_chrome("input_rule_top", 8, {}))
+    line = control.create_content(8, 1).get_line(0)
+    assert {style for style, _ in line} >= {"class:red", "class:blue"}
+
+
+def test_renderer_fragments_are_normalized_to_cell_width():
+    from prompt_toolkit.utils import get_cwidth
+
+    result = _normalize_chrome_fragments([("a", "１２３"), ("b", "tail")], 4)
+    assert sum(get_cwidth(text) for _, text in result) == 4
+    assert result == [("a", "１２")]

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -524,6 +524,7 @@ def register(ctx):
 - Called exactly once at startup
 - `ctx.register_tool()` puts your tool in the registry — the model sees it immediately
 - `ctx.register_hook()` subscribes to lifecycle events
+- `ctx.register_chrome_renderer(fn)` registers a renderer for `input_rule_top`, `input_rule_bot`, and `status_bar_bg`. The callable receives `(surface, width, ctx)` where `ctx` includes `session_id` and `skin`, and returns prompt-toolkit `(style, text)` fragments or `None` to preserve the built-in chrome. Hermes normalizes fragments to the requested cell width; an exception logs once and disables the renderer for the session. The registration is unloaded with the plugin, and later registrations replace earlier ones.
 - `ctx.register_cli_command()` registers a CLI subcommand (e.g. `hermes my-plugin <subcommand>`)
 - `ctx.register_command()` registers an in-session slash command (e.g. `/myplugin <args>` inside CLI / gateway chat) — see [Register slash commands](#register-slash-commands) below
 - `ctx.dispatch_tool(name, arguments)` — call any other tool (built-in or from another plugin) with the parent agent's context (approvals, credentials, task_id) wired up automatically. Useful from slash-command handlers that need to invoke `terminal`, `read_file`, or any other tool as if the model had called it directly.


### PR DESCRIPTION
## Problem
Skins are single-colour per style class, so a theme plugin cannot paint per-cell chrome.

## Contract
Adds `ctx.register_chrome_renderer(fn)` for `input_rule_top`, `input_rule_bot`, and `status_bar_bg`. The renderer receives `(surface, width, ctx)` with `session_id` and active `skin`, returns prompt_toolkit fragments or `None`, and later registrations win.

## Guarantees
Existing behavior remains unchanged without a renderer. Fragments are normalized to the requested cell width. Renderer exceptions are logged once and disable that renderer for the session. Registrations are tracked and removed on plugin unload. Prompt-caching invariants are untouched; this is pure rendering.

## Consumer
Concrete consumer: [cuttlefish-theme](https://github.com/wisechef-ai/cuttlefish-theme).

## Tests
- chrome registration/unregistration lifecycle
- `None` fallback
- exception fallback and session disable
- cell-width normalization
- prompt_toolkit multi-style rule render smoke test
