### PR TITLE
fix(desktop): cancel interrupted pane and session drags

### DIFF
--- a/apps/desktop/src/app/chat/session-drag.test.ts
+++ b/apps/desktop/src/app/chat/session-drag.test.ts
@@ -70,8 +70,17 @@ function dragTo(source: HTMLElement, x: number, y: number) {
     pointerId: 1
   } as unknown as ReactPointerEvent<HTMLElement>)
 
-  window.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: x, clientY: y }))
-  window.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientX: x, clientY: y }))
+  for (const type of ['pointermove', 'pointerup']) {
+    const event = new MouseEvent(type, {
+      bubbles: true,
+      clientX: x,
+      clientY: y,
+      buttons: type === 'pointermove' ? 1 : 0
+    })
+
+    Object.defineProperty(event, 'pointerId', { value: 1 })
+    window.dispatchEvent(event)
+  }
 }
 
 beforeEach(() => {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/drag-session.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/drag-session.test.ts
@@ -1,0 +1,119 @@
+import type { PointerEvent as ReactPointerEvent } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../store', async () => {
+  const { atom } = await import('nanostores')
+
+  return {
+    $dropHint: atom(null),
+    $treeDragging: atom(null),
+    mergeTreeZones: vi.fn(),
+    moveTreePanes: vi.fn(),
+    reorderTreePanes: vi.fn()
+  }
+})
+vi.mock('@/lib/reorder', () => ({ reorderCommitHaptic: vi.fn(), reorderStepHaptic: vi.fn() }))
+import { $dropHint, $treeDragging } from '../store'
+
+import { startDragSession } from './drag-session'
+
+function pointer(type: string, buttons = 1) {
+  const event = new MouseEvent(type, { bubbles: true, clientX: 20, clientY: 20, buttons })
+  Object.defineProperty(event, 'pointerId', { value: 1 })
+
+  return event
+}
+
+function begin() {
+  const handle = document.createElement('button')
+  document.body.append(handle)
+  handle.setPointerCapture = vi.fn()
+  handle.releasePointerCapture = vi.fn()
+
+  const spec = {
+    onEngage: vi.fn(() => $treeDragging.set('sessions')),
+    resolveMove: vi.fn(() => ({ kind: 'group' as const, groupId: 'main', pos: 'center' as const })),
+    onCommit: vi.fn(),
+    onEnd: vi.fn(),
+    onTap: vi.fn()
+  }
+
+  startDragSession(
+    {
+      button: 0,
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+      currentTarget: handle
+    } as unknown as ReactPointerEvent<HTMLElement>,
+    spec
+  )
+
+  return { handle, spec }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  document.body.style.cursor = 'auto'
+  document.body.style.userSelect = 'text'
+})
+afterEach(() => {
+  window.dispatchEvent(pointer('pointercancel', 0))
+  window.dispatchEvent(pointer('pointerup', 0))
+  vi.runOnlyPendingTimers()
+  vi.useRealTimers()
+  document.body.replaceChildren()
+  $dropHint.set(null)
+  $treeDragging.set(null)
+})
+describe('interrupted drag sessions', () => {
+  it.each(['blur', 'lostpointercapture', 'released-move'])(
+    'cancels on %s without swallowing the next independent click',
+    reason => {
+      const { handle, spec } = begin()
+      window.dispatchEvent(pointer('pointermove'))
+      vi.advanceTimersByTime(32)
+      expect($treeDragging.get()).toBe('sessions')
+      expect(document.body.style.userSelect).toBe('none')
+
+      if (reason === 'blur') {
+        window.dispatchEvent(new Event('blur'))
+      } else if (reason === 'lostpointercapture') {
+        handle.dispatchEvent(pointer('lostpointercapture', 0))
+      } else {
+        window.dispatchEvent(pointer('pointermove', 0))
+      }
+
+      expect($treeDragging.get()).toBeNull()
+      expect($dropHint.get()).toBeNull()
+      expect(document.body.style.cursor).toBe('auto')
+      expect(document.body.style.userSelect).toBe('text')
+      expect(spec.onEnd).toHaveBeenCalledTimes(1)
+      expect(spec.onCommit).not.toHaveBeenCalled()
+      const click = vi.fn()
+      handle.addEventListener('click', click)
+      handle.click()
+      expect(click).toHaveBeenCalledTimes(1)
+      window.dispatchEvent(pointer('pointerup', 0))
+      expect(spec.onEnd).toHaveBeenCalledTimes(1)
+    }
+  )
+  it('preserves taps and normal drops while suppressing only the release click', () => {
+    const tap = begin()
+    window.dispatchEvent(pointer('pointerup', 0))
+    expect(tap.spec.onTap).toHaveBeenCalledTimes(1)
+    const { handle, spec } = begin()
+    window.dispatchEvent(pointer('pointermove'))
+    vi.advanceTimersByTime(32)
+    window.dispatchEvent(pointer('pointerup', 0))
+    expect(spec.onCommit).toHaveBeenCalledWith({ kind: 'group', groupId: 'main', pos: 'center' })
+    expect(spec.onEnd).toHaveBeenCalledTimes(1)
+    const click = vi.fn()
+    handle.addEventListener('click', click)
+    handle.click()
+    expect(click).not.toHaveBeenCalled()
+    vi.runOnlyPendingTimers()
+    handle.click()
+    expect(click).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/drag-session.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/drag-session.ts
@@ -227,6 +227,7 @@ export function startDragSession(e: ReactPointerEvent<HTMLElement>, spec: DragSe
   const restoreCursor = document.body.style.cursor
   const restoreSelect = document.body.style.userSelect
   let engaged = false
+  let finished = false
   let releaseEscapeLayer: (() => void) | null = null
   let releaseGuests: (() => void) | null = null
   let ghost: DragGhost | null = null
@@ -313,11 +314,28 @@ export function startDragSession(e: ReactPointerEvent<HTMLElement>, spec: DragSe
   }
 
   const onMove = (ev: PointerEvent) => {
+    if (ev.pointerId !== pointerId) {
+      return
+    }
+
+    // A native window gesture can consume pointerup. A released pointer
+    // returning to the renderer must cancel, not resume the abandoned drag.
+    if (!(ev.buttons & 1)) {
+      finish(false, false)
+
+      return
+    }
+
     pending = { shift: ev.shiftKey, x: ev.clientX, y: ev.clientY }
     raf ||= requestAnimationFrame(flushMove)
   }
 
-  const finish = (commit: boolean) => {
+  const finish = (commit: boolean, suppressClick = true) => {
+    if (finished) {
+      return
+    }
+    finished = true
+
     if (raf) {
       cancelAnimationFrame(raf)
       raf = 0
@@ -349,9 +367,13 @@ export function startDragSession(e: ReactPointerEvent<HTMLElement>, spec: DragSe
     window.removeEventListener('pointerup', onUp, true)
     window.removeEventListener('pointercancel', onCancel, true)
     window.removeEventListener('keydown', onKey, true)
+    window.removeEventListener('blur', onInterrupted)
+    handle.removeEventListener('lostpointercapture', onLostCapture)
 
     if (engaged) {
-      suppressDragClick(commit)
+      if (suppressClick) {
+        suppressDragClick(commit)
+      }
 
       if (commit) {
         spec.onCommit($dropHint.get())
@@ -365,8 +387,27 @@ export function startDragSession(e: ReactPointerEvent<HTMLElement>, spec: DragSe
     $treeDragging.set(null)
   }
 
-  const onUp = () => finish(true)
-  const onCancel = () => finish(false)
+  const onUp = (ev: PointerEvent) => {
+    if (ev.pointerId === pointerId) {
+      finish(true)
+    }
+  }
+
+  const onCancel = (ev: PointerEvent) => {
+    if (ev.pointerId === pointerId) {
+      finish(false)
+    }
+  }
+
+  // There is no pending release click after focus/capture loss. Arming the
+  // Esc-style click trap here would swallow the user's next unrelated click.
+  const onInterrupted = () => finish(false, false)
+
+  const onLostCapture = (ev: PointerEvent) => {
+    if (ev.pointerId === pointerId) {
+      onInterrupted()
+    }
+  }
 
   // Esc aborts the drag — the target selection vanishes and nothing moves,
   // the universal "never mind" for an in-flight drag. Capture-phase + stop so
@@ -384,6 +425,8 @@ export function startDragSession(e: ReactPointerEvent<HTMLElement>, spec: DragSe
   window.addEventListener('pointerup', onUp, true)
   window.addEventListener('pointercancel', onCancel, true)
   window.addEventListener('keydown', onKey, true)
+  window.addEventListener('blur', onInterrupted)
+  handle.addEventListener('lostpointercapture', onLostCapture)
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/components/pane-shell/tree/renderer/drag-session.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/drag-session.ts
@@ -334,6 +334,7 @@ export function startDragSession(e: ReactPointerEvent<HTMLElement>, spec: DragSe
     if (finished) {
       return
     }
+
     finished = true
 
     if (raf) {


### PR DESCRIPTION
## Summary
Cancel abandoned in-app drag sessions when the window loses focus, the initiating handle loses pointer capture, or a subsequent pointer move reports the primary button already released. Restore cursor/selection state, remove listeners, release guards, and clear drag/drop stores without committing a drop or swallowing the next independent click.

The shared primitive covers pane tabs (including Sessions), pane handles, and sidebar session drags. Normal taps, committed drops, and Escape cancellation keep their existing semantics. Pointer events are scoped to the initiating pointer and teardown is idempotent because releasing capture may itself trigger capture-loss notification.

## RED proof
Command, from `apps/desktop`:
```sh
npx vitest run src/components/pane-shell/tree/renderer/drag-session.test.ts
```
Before the production fix, all three interruption cases failed:
```text
cancels on blur without swallowing the next independent click
cancels on lostpointercapture without swallowing the next independent click
cancels on released-move without swallowing the next independent click
AssertionError: expected 'sessions' to be null
Tests 3 failed | 1 passed (4)
```
After the fix:
```text
Test Files 1 passed (1)
Tests 4 passed (4)
```
The normal tap/drop control passed before and after. Tests execute `startDragSession` and dispatch events; they do not assert source spelling. The existing session-drop fixture now supplies the pointer identity and button state of an actual held-pointer gesture.

## Code path trace
1. A pane tab or session row starts `startDragSession`; movement past the threshold captures the pointer, disables selection, installs a guest-pointer guard and publishes drag state.
2. Previously, only `pointerup`, `pointercancel`, or Escape ended the session. Focus/capture loss was ignored, and a subsequent move with `buttons=0` continued an abandoned drag.
3. Add interruption teardown and a released-button check. Do **not** reuse the Escape release-click trap for interruption: that trap waits for a future pointer release and can consume the next unrelated click.

## Widening audit
- Pane/tab drag and reorder: shared primitive, fixed; normal commit/tap control retained.
- Sidebar session dragging: shared primitive, fixed; existing visible-tab link/split targeting tests pass.
- Escape: continues to suppress the eventual release click; cancellation remains distinct from focus/capture loss.
- Other pointer identities: cannot move, release, or cancel this gesture.
- Native HTML5 file drag/drop and pane resizing: different primitives, unchanged.
- Runtime plugin SDK loading: independent bug, already covered by #107303 / #107301; deliberately not duplicated here.

## Verification
From `apps/desktop`:
- `npx vitest run src/components/pane-shell/tree src/app/chat/session-drag.test.ts`: **32 files, 168 tests passed**.
- `npx tsc -p tsconfig.json --noEmit`: passed.
- ESLint on all three changed files: passed.
- `git diff --check`: passed.

## Scope and native QA limitation
Investigation began with a macOS report of an unresponsive sidebar after interacting with a narrow Sessions titlebar tab. This PR proves and fixes the interrupted-drag lifecycle defect; it does **not** claim to have reproduced the original macOS compositor/window-move sequence. Validation above is Linux/jsdom, not a native macOS end-to-end test. No changes to Electron drag-region geometry are included.

Native follow-up: start dragging a Sessions tab, switch focus or release outside the renderer, return, and verify the next sidebar click works without Escape. Also verify ordinary tab reorder/docking and window dragging remain functional. If the original simple-click symptom persists, inspect native hit-testing separately rather than treating these unit tests as proof of that symptom's resolution.
