### PR TITLE
fix(auth): refuse stale singleton seeding over fresher pooled credentials

### DIFF
--- a/agent/anthropic_credentials.py
+++ b/agent/anthropic_credentials.py
@@ -23,6 +23,7 @@ import subprocess
 import threading
 import time
 from collections import OrderedDict
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -571,15 +572,23 @@ def read_hermes_oauth_credentials() -> Optional[Dict[str, Any]]:
     return data if data is not None and data.get("accessToken") else None
 
 
+# Refresh instant, not access-token expiry: independently minted pairs may have
+# equal or inverted expiresAt values. Match the singleton's camelCase convention.
+HERMES_OAUTH_LAST_REFRESH_KEY = "lastRefresh"
+
+
 def _write_hermes_oauth_credentials(
     access_token: str, refresh_token: Optional[str], expires_at_ms: Optional[int], *, target: Optional[Path] = None
-) -> None:
+) -> str:
     """Commit refreshed hermes_pkce tokens to ~/.hermes/.anthropic_oauth.json (``CredentialPersistError`` on failure).
     ``target`` lets a named profile commit a grant it BORROWED from the global root back to the ROOT singleton
     instead of forking a copy under its own HERMES_HOME; without this write-through the next ``load_pool()``
     re-seeds the stale (consumed) pair from the file over the rotated pool entry."""
+    last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     _commit_private_json(
         target if target is not None else _get_hermes_oauth_file(),
-        {"accessToken": access_token, "refreshToken": refresh_token, "expiresAt": expires_at_ms},
+        {"accessToken": access_token, "refreshToken": refresh_token, "expiresAt": expires_at_ms,
+         HERMES_OAUTH_LAST_REFRESH_KEY: last_refresh},
         "Hermes OAuth credentials",
     )
+    return last_refresh

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -195,31 +195,47 @@ _MARK_OK: Dict[str, Any] = {**_CLEAR_STATUS, "last_status": STATUS_OK}
 # Which payload keys carry token material for a singleton-seeded provider, and
 # which timestamp decides whether that material is fresh.
 #
-# ``_seed_from_singletons`` re-reads the auth.json singleton on every
-# ``load_pool()`` and hands it to ``_upsert_entry``.  A *different* pair is not
-# automatically a *newer* pair: another process can leave an older,
-# already-consumed pair behind, or a write-back can lose a race.  Adopting it
-# would replay a consumed single-use refresh token (``refresh_token_reused``
-# 4xx / portal revocation) and persist the regression to disk — the same defect
-# the ``_sync_*_entry_from_auth_store`` readers guard against, arriving through
-# the seeding door.
+# ``_seed_from_singletons`` re-reads the singleton on every ``load_pool()`` and
+# hands it to ``_upsert_entry``.  A *different* pair is not automatically a
+# *newer* pair: another process can leave an older, already-consumed pair
+# behind, or a write-back can lose a race.  Adopting it would replay a consumed
+# single-use refresh token (``refresh_token_reused`` 4xx / portal revocation)
+# and persist the regression to disk — the same defect the
+# ``_sync_*_entry_from_auth_store`` readers guard against, arriving through the
+# seeding door.
 #
-# Declared per group, not per provider, because one singleton can carry more
-# than one clock: Nous stamps its OAuth pair with ``obtained_at`` and its
-# inference agent key independently with ``agent_key_obtained_at``, so an older
-# pair must not block a legitimately newer key.  Routing/label/metadata keys are
+# Keyed by ``(provider, source)``, not by provider: one provider can seed from
+# several singletons with different authority.  Anthropic seeds both
+# ``hermes_pkce`` (pool-owned: its row persists its own token pair, so the row
+# is a legitimate freshness witness) and ``claude_code`` (borrowed: absent from
+# ``credential_persistence._PERSISTABLE_PROVIDER_SOURCES``, so
+# ``sanitize_borrowed_credential_payload`` strips its tokens before the row
+# reaches auth.json).  Gating a borrowed source would refuse the singleton's
+# material for a row that holds none of its own, stranding it on a cold start —
+# the singleton is its sole authority, so adopting is correct.  ``manual:*``
+# rows are independent credentials with their own refresh-token lifecycle and
+# are never keys here.
+#
+# Declared per group, not per source, because one singleton can carry more than
+# one clock: Nous stamps its OAuth pair with ``obtained_at`` and its inference
+# agent key independently with ``agent_key_obtained_at``, so an older pair must
+# not block a legitimately newer key.  Routing/label/metadata keys are
 # deliberately absent — they are not token material and keep updating.
 #
-# A provider added here inherits the gate at the choke point; no new call-site
-# comparison is needed.
-_SINGLETON_FRESHNESS_GROUPS: Dict[str, Tuple[Tuple[str, frozenset], ...]] = {
-    "openai-codex": (
+# A source added here inherits the gate at the choke point; no new call-site
+# comparison is needed.  It must ALSO have a producer that stamps its timestamp
+# key on every write, or the gate is inert: both sides parse to ``None`` and the
+# payload is returned untouched.  ``anthropic``/``hermes_pkce`` needed
+# ``_write_hermes_oauth_credentials`` to start stamping ``lastRefresh`` before
+# it could be declared here at all.
+_SINGLETON_FRESHNESS_GROUPS: Dict[Tuple[str, str], Tuple[Tuple[str, frozenset], ...]] = {
+    ("openai-codex", "device_code"): (
         ("last_refresh", frozenset({"access_token", "refresh_token", "last_refresh"})),
     ),
-    "xai-oauth": (
+    ("xai-oauth", "device_code"): (
         ("last_refresh", frozenset({"access_token", "refresh_token", "last_refresh"})),
     ),
-    "nous": (
+    ("nous", "device_code"): (
         ("obtained_at", frozenset({
             "access_token", "refresh_token", "expires_at",
             "obtained_at", "expires_in",
@@ -229,11 +245,12 @@ _SINGLETON_FRESHNESS_GROUPS: Dict[str, Tuple[Tuple[str, frozenset], ...]] = {
             "agent_key_expires_in", "agent_key_reused", "agent_key_obtained_at",
         })),
     ),
+    ("anthropic", "hermes_pkce"): (
+        ("last_refresh", frozenset({
+            "access_token", "refresh_token", "expires_at_ms", "last_refresh",
+        })),
+    ),
 }
-
-# Sources seeded *from* a singleton.  ``manual:*`` rows are independent
-# credentials with their own refresh-token lifecycle and are never gated.
-_SINGLETON_SEED_SOURCE = "device_code"
 
 
 def _drop_stale_singleton_token_material(
@@ -247,13 +264,15 @@ def _drop_stale_singleton_token_material(
     Freshness is compared as instants via ``_parse_absolute_timestamp`` (not ISO
     string order), per group.  Missing or unparseable timestamps on either side
     keep the pre-existing adopt behavior for that group, so rotation recovery
-    from an untimestamped store still works.
+    from an untimestamped store still works — which is also the migration
+    window: singletons already on disk carry no stamp until a refresh rewrites
+    them.
 
     Returns ``payload`` unchanged (same object) when nothing is stale, so the
     common path costs one dict lookup.
     """
-    groups = _SINGLETON_FRESHNESS_GROUPS.get(provider)
-    if not groups or source != _SINGLETON_SEED_SOURCE:
+    groups = _SINGLETON_FRESHNESS_GROUPS.get((provider, source))
+    if not groups:
         return payload
 
     stale_keys: Set[str] = set()
@@ -1587,7 +1606,7 @@ class CredentialPool(CredentialPoolAdminMixin):
 
     def _commit_anthropic_rotation(
         self, entry: PooledCredential, refreshed: Dict[str, Any]
-    ) -> None:
+    ) -> Optional[str]:
         """Write a rotated Anthropic pair to its authoritative singleton, or fail closed.
 
         claude_code -> ~/.claude/.credentials.json (so the fallback resolver
@@ -1609,7 +1628,7 @@ class CredentialPool(CredentialPoolAdminMixin):
             if entry.source == "claude_code":
                 ac._write_claude_code_credentials(*args)
             else:
-                ac._write_hermes_oauth_credentials(*args, target=_singleton_target_for_entry(self, entry))
+                return ac._write_hermes_oauth_credentials(*args, target=_singleton_target_for_entry(self, entry))
         except Exception as wexc:
             # Authoritative commit failed: do not mark, persist or return the
             # rotation as successful, and bypass the re-POST recovery path —
@@ -1645,7 +1664,9 @@ class CredentialPool(CredentialPoolAdminMixin):
             refresh_token=refreshed["refresh_token"],
             expires_at_ms=refreshed["expires_at_ms"],
         )
-        self._commit_anthropic_rotation(entry, refreshed)
+        committed_at = self._commit_anthropic_rotation(entry, refreshed)
+        if committed_at is not None:
+            updated = replace(updated, last_refresh=committed_at)
         return updated
 
     def _post_tokens_refresh(self, entry: PooledCredential) -> PooledCredential:
@@ -2426,6 +2447,7 @@ def _seed_anthropic_singletons(seed: _Seeder) -> None:
         return
 
     from agent.anthropic_credentials import (
+        HERMES_OAUTH_LAST_REFRESH_KEY,
         read_claude_code_credentials,
         read_hermes_oauth_credentials,
     )
@@ -2440,6 +2462,7 @@ def _seed_anthropic_singletons(seed: _Seeder) -> None:
                 "access_token": creds.get("accessToken", ""),
                 "refresh_token": creds.get("refreshToken"),
                 "expires_at_ms": creds.get("expiresAt"),
+                "last_refresh": creds.get(HERMES_OAUTH_LAST_REFRESH_KEY),
                 "label": label_from_token(creds.get("accessToken", ""), source_name),
             })
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -192,6 +192,101 @@ _CLEAR_STATUS: Dict[str, Any] = {
 _MARK_OK: Dict[str, Any] = {**_CLEAR_STATUS, "last_status": STATUS_OK}
 
 
+# Which payload keys carry token material for a singleton-seeded provider, and
+# which timestamp decides whether that material is fresh.
+#
+# ``_seed_from_singletons`` re-reads the auth.json singleton on every
+# ``load_pool()`` and hands it to ``_upsert_entry``.  A *different* pair is not
+# automatically a *newer* pair: another process can leave an older,
+# already-consumed pair behind, or a write-back can lose a race.  Adopting it
+# would replay a consumed single-use refresh token (``refresh_token_reused``
+# 4xx / portal revocation) and persist the regression to disk — the same defect
+# the ``_sync_*_entry_from_auth_store`` readers guard against, arriving through
+# the seeding door.
+#
+# Declared per group, not per provider, because one singleton can carry more
+# than one clock: Nous stamps its OAuth pair with ``obtained_at`` and its
+# inference agent key independently with ``agent_key_obtained_at``, so an older
+# pair must not block a legitimately newer key.  Routing/label/metadata keys are
+# deliberately absent — they are not token material and keep updating.
+#
+# A provider added here inherits the gate at the choke point; no new call-site
+# comparison is needed.
+_SINGLETON_FRESHNESS_GROUPS: Dict[str, Tuple[Tuple[str, frozenset], ...]] = {
+    "openai-codex": (
+        ("last_refresh", frozenset({"access_token", "refresh_token", "last_refresh"})),
+    ),
+    "xai-oauth": (
+        ("last_refresh", frozenset({"access_token", "refresh_token", "last_refresh"})),
+    ),
+    "nous": (
+        ("obtained_at", frozenset({
+            "access_token", "refresh_token", "expires_at",
+            "obtained_at", "expires_in",
+        })),
+        ("agent_key_obtained_at", frozenset({
+            "agent_key", "agent_key_expires_at", "agent_key_id",
+            "agent_key_expires_in", "agent_key_reused", "agent_key_obtained_at",
+        })),
+    ),
+}
+
+# Sources seeded *from* a singleton.  ``manual:*`` rows are independent
+# credentials with their own refresh-token lifecycle and are never gated.
+_SINGLETON_SEED_SOURCE = "device_code"
+
+
+def _drop_stale_singleton_token_material(
+    existing: "PooledCredential",
+    provider: str,
+    source: str,
+    payload: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Strip token material that is older than what the entry already holds.
+
+    Freshness is compared as instants via ``_parse_absolute_timestamp`` (not ISO
+    string order), per group.  Missing or unparseable timestamps on either side
+    keep the pre-existing adopt behavior for that group, so rotation recovery
+    from an untimestamped store still works.
+
+    Returns ``payload`` unchanged (same object) when nothing is stale, so the
+    common path costs one dict lookup.
+    """
+    groups = _SINGLETON_FRESHNESS_GROUPS.get(provider)
+    if not groups or source != _SINGLETON_SEED_SOURCE:
+        return payload
+
+    stale_keys: Set[str] = set()
+    pair_stale = False
+    for stamp_key, gated_keys in groups:
+        entry_at = _parse_absolute_timestamp(getattr(existing, stamp_key, None))
+        store_at = _parse_absolute_timestamp(payload.get(stamp_key))
+        if entry_at is None or store_at is None or store_at >= entry_at:
+            continue
+        stale_keys |= gated_keys
+        if "access_token" in gated_keys:
+            pair_stale = True
+
+    # ``_set_nous_agent_key_from_invoke_jwt`` mirrors the access token onto
+    # ``agent_key``, which is what ``runtime_api_key`` actually serves.  If the
+    # incoming key IS the refused access token, refuse it with the pair —
+    # otherwise the stale pair launders itself in through ``agent_key``.
+    incoming_key = payload.get("agent_key")
+    if pair_stale and incoming_key and incoming_key == payload.get("access_token"):
+        for stamp_key, gated_keys in groups:
+            if "agent_key" in gated_keys:
+                stale_keys |= gated_keys
+
+    if not stale_keys:
+        return payload
+    logger.debug(
+        "Pool entry %s: refusing stale singleton token material from auth.json (%s)",
+        existing.id,
+        ", ".join(sorted(stale_keys)),
+    )
+    return {k: v for k, v in payload.items() if k not in stale_keys}
+
+
 def _normalize_pool_auth_type(provider: str, token: Any, auth_type: Any) -> str:
     """Infer pool auth metadata for token formats with one unambiguous meaning."""
     if provider == "anthropic" and isinstance(token, str) and token.startswith("sk-ant-oat"):
@@ -2192,6 +2287,11 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
         return True
 
     existing = entries[existing_idx]
+    # Choke point for singleton freshness: an older auth.json pair must not
+    # displace (or persist over) the fresher one this entry already holds.
+    # Done before ``token_changed`` so a refused pair can't look like a
+    # rotation and clear the entry's exhaustion state.
+    payload = _drop_stale_singleton_token_material(existing, provider, source, payload)
     field_updates: Dict[str, Any] = {}
     extra_updates: Dict[str, Any] = {}
     _field_names = {f.name for f in fields(existing)}

--- a/contributors/emails/daedalus@localhost
+++ b/contributors/emails/daedalus@localhost
@@ -1,0 +1,2 @@
+Kyzcreig
+# Daedalus agent commits authored on behalf of Kyzcreig.

--- a/tests/agent/test_credential_pool_anthropic_seed_freshness.py
+++ b/tests/agent/test_credential_pool_anthropic_seed_freshness.py
@@ -1,0 +1,469 @@
+"""Anthropic ``hermes_pkce`` singleton: producer stamp + seeding freshness gate.
+
+Third file in the series.  ``test_credential_pool_singleton_freshness.py`` covers
+the ``_sync_*_entry_from_auth_store`` readers;
+``test_credential_pool_seed_freshness.py`` covers the seeding-path gate for the
+three ``device_code`` singleton providers.  Neither reaches Anthropic, because
+its singleton could not be gated: ``~/.hermes/.anthropic_oauth.json`` carried
+only ``accessToken``/``refreshToken``/``expiresAt``, and ``expiresAt`` is a token
+EXPIRY, not a refresh instant -- two pairs minted minutes apart can carry the
+same or an inverted ``expiresAt``.  Declaring the group against it would have
+shipped an INERT gate: both sides parse to ``None``, the guard returns the
+payload untouched, and a synthetic test on a stamped fixture would never notice
+that nothing on the live path writes a stamp.
+
+So the producer is fixed first.  ``_write_hermes_oauth_credentials`` -- the sole
+writer of that file, and the commit step of every ``hermes_pkce`` rotation --
+now stamps ``lastRefresh`` with the instant the pair was minted and returns it,
+so the refreshing pool entry can carry the same instant.  Only then is
+``("anthropic", "hermes_pkce")`` declared in ``_SINGLETON_FRESHNESS_GROUPS``.
+
+``claude_code`` is deliberately NOT gated; ``test_claude_code_*`` below pins that
+decision with the measurement behind it.
+
+Everything here is synthetic: no network, no real credentials, isolated
+HOME/HERMES_HOME per test.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import replace as dc_replace
+
+import pytest
+
+from agent import anthropic_credentials as AA
+from agent.credential_pool import STATUS_EXHAUSTED, load_pool
+
+_POOL_ACCESS = "synthetic-pool-access"
+_POOL_REFRESH = "synthetic-pool-refresh"
+_STORE_ACCESS = "synthetic-store-access"
+_STORE_REFRESH = "synthetic-store-refresh"
+
+ENTRY_TIME = "2026-09-10T04:30:00Z"
+OLDER = "2026-07-22T15:28:55Z"
+NEWER = "2026-09-10T05:00:00Z"
+
+_HOUR_MS = 3_600_000
+
+# The one place the payload key name and the table key name have to agree.  A
+# rename on either side turns the gate inert, which is the whole failure mode
+# this file exists to prevent.
+SINGLETON_STAMP_KEY = "lastRefresh"
+ENTRY_STAMP_KEY = "last_refresh"
+
+
+@pytest.fixture
+def anthropic_home(tmp_path, monkeypatch):
+    """Real on-disk HOME/HERMES_HOME with anthropic explicitly configured."""
+    import hermes_cli.auth as auth
+
+    home = tmp_path / "hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for var in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    (home / "auth.json").write_text(
+        json.dumps({"version": 1, "providers": {}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.is_provider_explicitly_configured", lambda pid: True
+    )
+    # Never read the real macOS Keychain entry from a test.
+    monkeypatch.setattr(AA, "_read_claude_code_credentials_from_keychain", lambda: None)
+    assert auth._auth_file_path() == home / "auth.json"
+    return home
+
+
+def _pool_rows(home):
+    store = json.loads((home / "auth.json").read_text(encoding="utf-8"))
+    return store.get("credential_pool", {}).get("anthropic", [])
+
+
+def _write_pkce_singleton(access, refresh, *, stamp, expires_at_ms=None):
+    blob = {
+        "accessToken": access,
+        "refreshToken": refresh,
+        "expiresAt": expires_at_ms
+        if expires_at_ms is not None
+        else int(time.time() * 1000) + _HOUR_MS,
+    }
+    if stamp is not None:
+        blob[SINGLETON_STAMP_KEY] = stamp
+    AA._get_hermes_oauth_file().write_text(json.dumps(blob), encoding="utf-8")
+
+
+def _write_claude_code_singleton(access, refresh, *, stamp):
+    oauth = {
+        "accessToken": access,
+        "refreshToken": refresh,
+        "expiresAt": int(time.time() * 1000) + _HOUR_MS,
+    }
+    if stamp is not None:
+        oauth[SINGLETON_STAMP_KEY] = stamp
+    path = AA.claude_code_credentials_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"claudeAiOauth": oauth}), encoding="utf-8")
+
+
+@pytest.fixture
+def seeded_pkce(anthropic_home):
+    """Seed a ``hermes_pkce`` row from the singleton, then rewrite and reload.
+
+    Both halves go through the real ``load_pool`` -> ``_seed_from_singletons``
+    -> ``_upsert_entry`` path -- the write path this file is about.
+    """
+
+    def build(
+        *,
+        entry_stamp=ENTRY_TIME,
+        store_stamp=OLDER,
+        entry_expires_ms=None,
+        store_expires_ms=None,
+        mutate_entry=None,
+    ):
+        _write_pkce_singleton(
+            _POOL_ACCESS, _POOL_REFRESH,
+            stamp=entry_stamp, expires_at_ms=entry_expires_ms,
+        )
+        pool = load_pool("anthropic")
+        entry = next(e for e in pool.entries() if e.source == "hermes_pkce")
+        assert entry.refresh_token == _POOL_REFRESH
+        if mutate_entry is not None:
+            updated = mutate_entry(entry)
+            pool._replace_entry(entry, updated)
+            pool._persist()
+            entry = updated
+
+        # Another writer regresses (or advances) the singleton.
+        _write_pkce_singleton(
+            _STORE_ACCESS, _STORE_REFRESH,
+            stamp=store_stamp, expires_at_ms=store_expires_ms,
+        )
+
+        reloaded = load_pool("anthropic")
+        row = next(e for e in reloaded.entries() if e.id == entry.id)
+        disk = next(r for r in _pool_rows(anthropic_home) if r["id"] == entry.id)
+        return {"entry": entry, "row": row, "disk": disk}
+
+    return build
+
+
+# ── the producer: the singleton must carry a refresh INSTANT ──────────────
+
+
+def test_writer_stamps_the_singleton_with_a_refresh_instant(anthropic_home):
+    """``_write_hermes_oauth_credentials`` is the choke point that must stamp.
+
+    Without a stamp on this file nothing downstream can distinguish an older
+    pair from a newer one -- ``expiresAt`` is a token expiry, not a mint time.
+    """
+    from agent.credential_pool import _parse_absolute_timestamp
+
+    before = time.time()
+    returned = AA._write_hermes_oauth_credentials("acc", "ref", int(before * 1000))
+    after = time.time()
+
+    on_disk = json.loads(
+        AA._get_hermes_oauth_file().read_text(encoding="utf-8")
+    )
+    assert SINGLETON_STAMP_KEY in on_disk, (
+        "the singleton must carry a refresh instant, or the freshness gate is inert"
+    )
+    stamped = _parse_absolute_timestamp(on_disk[SINGLETON_STAMP_KEY])
+    assert stamped is not None, "the stamp must parse as an instant"
+    assert before - 1 <= stamped <= after + 1
+
+    assert returned == on_disk[SINGLETON_STAMP_KEY], (
+        "the writer must hand the caller the instant it committed, so the "
+        "refreshing pool entry can carry the same one"
+    )
+
+
+def test_writer_stamp_is_a_mint_time_not_the_token_expiry(anthropic_home):
+    """Two pairs written in order must be ordered by the stamp.
+
+    ``expiresAt`` cannot do this: a pair minted later can carry an equal or
+    smaller expiry, which is exactly why a second key was needed.
+    """
+    from agent.credential_pool import _parse_absolute_timestamp
+
+    far_future = int(time.time() * 1000) + 10 * _HOUR_MS
+    first = AA._write_hermes_oauth_credentials("acc1", "ref1", far_future)
+    time.sleep(0.01)
+    # Second write is genuinely later but carries an EARLIER expiry.
+    second = AA._write_hermes_oauth_credentials("acc2", "ref2", far_future - _HOUR_MS)
+
+    assert _parse_absolute_timestamp(second) > _parse_absolute_timestamp(first)
+
+
+def test_writer_preserves_the_existing_singleton_contract(anthropic_home):
+    """The three historical keys must keep their meaning and their casing."""
+    AA._write_hermes_oauth_credentials("acc", "ref", 1_700_000_000_000)
+    on_disk = json.loads(AA._get_hermes_oauth_file().read_text(encoding="utf-8"))
+    assert on_disk["accessToken"] == "acc"
+    assert on_disk["refreshToken"] == "ref"
+    assert on_disk["expiresAt"] == 1_700_000_000_000
+    # camelCase, matching the file's existing convention rather than the
+    # pool's snake_case field name.
+    assert set(on_disk) == {
+        "accessToken", "refreshToken", "expiresAt", SINGLETON_STAMP_KEY,
+    }
+
+
+# ── the gate is NOT inert: the live producer populates the key it reads ────
+
+
+def test_gate_key_is_the_key_the_live_producer_writes(anthropic_home):
+    """Seeding a row from a PRODUCER-WRITTEN file must stamp the entry.
+
+    This is the anti-inertness lock.  It never hand-builds the singleton: the
+    file comes from ``_write_hermes_oauth_credentials`` and the entry comes from
+    ``load_pool``, so a rename on either side of the mapping fails here rather
+    than passing silently on a hand-stamped fixture.
+    """
+    from agent.credential_pool import _SINGLETON_FRESHNESS_GROUPS
+
+    stamp = AA._write_hermes_oauth_credentials(
+        _POOL_ACCESS, _POOL_REFRESH, int(time.time() * 1000) + _HOUR_MS
+    )
+    entry = next(
+        e for e in load_pool("anthropic").entries() if e.source == "hermes_pkce"
+    )
+
+    groups = _SINGLETON_FRESHNESS_GROUPS[("anthropic", "hermes_pkce")]
+    declared_keys = {stamp_key for stamp_key, _gated in groups}
+    assert declared_keys == {ENTRY_STAMP_KEY}
+    for stamp_key in declared_keys:
+        assert getattr(entry, stamp_key) == stamp, (
+            f"the seeded entry must carry {stamp_key}; an unstamped entry makes "
+            "every comparison None and the gate inert"
+        )
+
+
+# ── the defect: an older singleton must not clobber a fresher row ─────────
+
+
+def test_seed_refuses_stale_pair(seeded_pkce):
+    """Older stamp: not adopted in memory, and not persisted to disk."""
+    got = seeded_pkce()
+    assert got["row"].refresh_token == _POOL_REFRESH
+    assert got["row"].access_token == _POOL_ACCESS
+    assert got["disk"]["refresh_token"] == _POOL_REFRESH
+    assert got["row"].last_refresh == ENTRY_TIME
+
+
+def test_seed_refuses_stale_expiry_with_the_pair(seeded_pkce):
+    """``expires_at_ms`` describes the refused access token; it goes with it."""
+    fresh_ms = int(time.time() * 1000) + 4 * _HOUR_MS
+    stale_ms = int(time.time() * 1000) + 9 * _HOUR_MS
+    got = seeded_pkce(entry_expires_ms=fresh_ms, store_expires_ms=stale_ms)
+    assert got["row"].expires_at_ms == fresh_ms, (
+        "adopting the refused pair's expiry would make the kept access token "
+        "look valid for longer than it is"
+    )
+
+
+def test_seed_refuses_stale_pair_across_timezone_offsets(seeded_pkce):
+    """Instants, not ISO string ordering: +02:00 05:00 predates Z 04:00."""
+    got = seeded_pkce(
+        entry_stamp="2026-09-10T04:00:00Z",
+        store_stamp="2026-09-10T05:00:00+02:00",
+    )
+    assert got["row"].refresh_token == _POOL_REFRESH
+    assert got["disk"]["refresh_token"] == _POOL_REFRESH
+
+
+def test_seed_refused_stale_pair_does_not_clear_exhaustion(seeded_pkce):
+    """A refused pair is not a rotation, so the quarantine must survive it."""
+    reset_at = time.time() + 86400
+    got = seeded_pkce(mutate_entry=lambda e: dc_replace(
+        e,
+        last_status=STATUS_EXHAUSTED,
+        last_status_at=time.time(),
+        last_error_reset_at=reset_at,
+    ))
+    assert got["row"].last_status == STATUS_EXHAUSTED
+    assert got["row"].last_error_reset_at == reset_at
+    assert got["disk"]["last_status"] == STATUS_EXHAUSTED
+
+
+# ── preserved behavior: anything not older still lands ────────────────────
+
+
+@pytest.mark.parametrize("store_stamp,entry_stamp", [
+    (NEWER, ENTRY_TIME),
+    (ENTRY_TIME, ENTRY_TIME),
+    (None, ENTRY_TIME),
+    ("not-a-timestamp", ENTRY_TIME),
+    (NEWER, None),
+    (None, None),
+])
+def test_seed_adopts_non_stale_pair(seeded_pkce, store_stamp, entry_stamp):
+    """Strict older-than.
+
+    ``(None, None)`` is the migration window: every singleton already on disk
+    is unstamped, and until it is rewritten by a refresh the gate must stay
+    adopt-by-default rather than freezing the row.
+    """
+    got = seeded_pkce(store_stamp=store_stamp, entry_stamp=entry_stamp)
+    assert got["row"].refresh_token == _STORE_REFRESH
+    assert got["row"].access_token == _STORE_ACCESS
+    assert got["disk"]["refresh_token"] == _STORE_REFRESH
+
+
+def test_seed_adopted_rotation_still_clears_exhaustion(seeded_pkce):
+    """Rotation recovery: a genuinely newer pair clears the stale quarantine."""
+    got = seeded_pkce(
+        store_stamp=NEWER,
+        mutate_entry=lambda e: dc_replace(
+            e,
+            last_status=STATUS_EXHAUSTED,
+            last_status_at=time.time(),
+            last_error_reset_at=time.time() + 86400,
+        ),
+    )
+    assert got["row"].refresh_token == _STORE_REFRESH
+    assert got["row"].last_status is None
+    assert got["row"].last_error_reset_at is None
+
+
+def test_seed_label_updates_despite_stale_pair(seeded_pkce):
+    """Only token material is gated; the derived label keeps flowing.
+
+    ``_upsert_entry`` leaves an already-labelled row alone, so this clears the
+    label first -- otherwise the assertion would pass vacuously.
+    """
+    got = seeded_pkce(mutate_entry=lambda e: dc_replace(e, label=""))
+    assert got["row"].label, "a refused pair must not freeze row metadata"
+    assert got["row"].refresh_token == _POOL_REFRESH
+
+
+# ── the real hazard loop, end to end ──────────────────────────────────────
+
+
+def test_refresh_then_stale_reseed_keeps_the_rotated_pair(
+    anthropic_home, monkeypatch
+):
+    """The defect this card exists for, driven through the production path.
+
+    A pool-level refresh rotates the pair and commits it to the singleton.  A
+    sibling process then writes an OLDER-minted pair over that file (a lost
+    write-back race).  The next ``load_pool()`` must keep the rotated pair
+    rather than replaying the already-consumed one.
+    """
+    rotated = {
+        "access_token": "synthetic-rotated-access",
+        "refresh_token": "synthetic-rotated-refresh",
+        "expires_at_ms": int(time.time() * 1000) + _HOUR_MS,
+    }
+    monkeypatch.setattr(
+        AA, "refresh_anthropic_oauth_pure", lambda refresh_token, **kw: rotated
+    )
+
+    _write_pkce_singleton(_POOL_ACCESS, _POOL_REFRESH, stamp=OLDER)
+    pool = load_pool("anthropic")
+    entry = next(e for e in pool.entries() if e.source == "hermes_pkce")
+
+    refreshed = pool._refresh_entry(entry, force=True)
+    assert refreshed is not None
+    assert refreshed.refresh_token == rotated["refresh_token"]
+    assert refreshed.last_refresh not in (None, "", OLDER), (
+        "a refreshed entry must carry the instant its commit stamped, or the "
+        "gate has nothing to compare the next singleton read against"
+    )
+    pool._persist()
+
+    # Sibling process loses the write-back race and lands an older-minted pair.
+    _write_pkce_singleton("synthetic-sibling-access", "synthetic-sibling-refresh",
+                          stamp=OLDER)
+
+    row = next(
+        e for e in load_pool("anthropic").entries() if e.source == "hermes_pkce"
+    )
+    assert row.refresh_token == rotated["refresh_token"], (
+        "the older-minted sibling pair replayed over a fresher rotation"
+    )
+    assert row.access_token == rotated["access_token"]
+
+
+# ── claude_code is deliberately NOT gated (measured decision) ─────────────
+
+
+def test_claude_code_is_not_declared_in_the_freshness_table():
+    """Pinning the decision, not just today's behavior.
+
+    ``claude_code`` is a BORROWED source: it is absent from
+    ``credential_persistence._PERSISTABLE_PROVIDER_SOURCES``, so
+    ``sanitize_borrowed_credential_payload`` strips ``access_token`` and
+    ``refresh_token`` before its row reaches ``auth.json``.  Measured on this
+    tree: the persisted row keeps only a ``secret_fingerprint``, and every
+    ``load_pool()`` re-hydrates the live pair from the singleton.  A freshness
+    gate REFUSES the singleton's token material -- which for a row that holds
+    none of its own would leave it with nothing at all on a cold start.  The
+    singleton is the sole authority for this source, so adopting whatever it
+    holds is CORRECT, exactly as for ``minimax-oauth``.
+    """
+    from agent.credential_persistence import is_borrowed_credential_source
+    from agent.credential_pool import _SINGLETON_FRESHNESS_GROUPS
+
+    assert is_borrowed_credential_source("claude_code", "anthropic")
+    assert not is_borrowed_credential_source("hermes_pkce", "anthropic")
+    assert ("anthropic", "claude_code") not in _SINGLETON_FRESHNESS_GROUPS
+
+
+def test_claude_code_still_adopts_an_older_singleton(anthropic_home):
+    """The behavioral half of the decision above, through the real path."""
+    _write_claude_code_singleton(_POOL_ACCESS, _POOL_REFRESH, stamp=ENTRY_TIME)
+    entry = next(
+        e for e in load_pool("anthropic").entries() if e.source == "claude_code"
+    )
+    assert entry.refresh_token == _POOL_REFRESH
+
+    _write_claude_code_singleton(_STORE_ACCESS, _STORE_REFRESH, stamp=OLDER)
+    row = next(
+        e for e in load_pool("anthropic").entries() if e.source == "claude_code"
+    )
+    assert row.refresh_token == _STORE_REFRESH, (
+        "gating claude_code would strand a row that persists no tokens of its own"
+    )
+
+
+def test_manual_hermes_pkce_row_is_never_gated(anthropic_home):
+    """``manual:hermes_pkce`` is pool-owned with its own lifecycle.
+
+    It has no singleton (see
+    ``test_manual_hermes_pkce_refresh_does_not_create_duplicate_singleton``),
+    so it must never be matched by the table.
+    """
+    from agent.credential_pool import (
+        PooledCredential,
+        _drop_stale_singleton_token_material,
+    )
+
+    existing = PooledCredential.from_dict("anthropic", {
+        "id": "manual1",
+        "source": "manual:hermes_pkce",
+        "access_token": _POOL_ACCESS,
+        "refresh_token": _POOL_REFRESH,
+        ENTRY_STAMP_KEY: ENTRY_TIME,
+    })
+    payload = {
+        "source": "manual:hermes_pkce",
+        "access_token": _STORE_ACCESS,
+        "refresh_token": _STORE_REFRESH,
+        ENTRY_STAMP_KEY: OLDER,
+    }
+    kept = _drop_stale_singleton_token_material(
+        existing, "anthropic", "manual:hermes_pkce", payload,
+    )
+    assert kept is payload
+
+    # ...and the same payload on the seeded source IS gated, so the assertion
+    # above is about the source and not about the timestamps.
+    gated = _drop_stale_singleton_token_material(
+        existing, "anthropic", "hermes_pkce", payload,
+    )
+    assert "refresh_token" not in gated

--- a/tests/agent/test_credential_pool_seed_freshness.py
+++ b/tests/agent/test_credential_pool_seed_freshness.py
@@ -1,0 +1,422 @@
+"""Stale-pair refusal on the SEEDING path (``load_pool`` -> ``_upsert_entry``).
+
+Sibling of ``test_credential_pool_singleton_freshness.py``, which covers the two
+``_sync_*_entry_from_auth_store`` readers.  Those guards do not sit on the write
+path that ``_seed_from_singletons`` uses: every ``load_pool()`` re-reads the
+auth.json singleton and hands it to ``_upsert_entry``, which adopted (and
+persisted) any differing value regardless of age.  So a stale singleton written
+by another process could clobber a fresher pool row on the next process start —
+the same single-use-refresh-token replay the reader guards exist to prevent,
+arriving through the seeding door.
+
+The gate lives in ``_upsert_entry`` (one comparison, per-provider timestamp
+groups), so all three singleton OAuth providers — and any future one that
+declares its groups — inherit it.
+
+Everything here is synthetic: no network, no real credentials, isolated
+HOME/HERMES_HOME per test.
+"""
+
+from __future__ import annotations
+
+import base64
+import itertools
+import json
+import time
+
+import pytest
+
+
+def _jwt(claims: dict) -> str:
+    def _part(payload: dict) -> str:
+        raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    return f"{_part({'alg': 'none', 'typ': 'JWT'})}.{_part(claims)}.sig"
+
+
+_MINTED = itertools.count()
+
+
+def _access(ttl: int = 4 * 3600) -> str:
+    """Distinct synthetic access token; ``jti`` keeps same-TTL mints unequal."""
+    return _jwt({
+        "sub": "synthetic",
+        "scope": "inference:invoke",
+        "exp": int(time.time()) + ttl,
+        "jti": f"synthetic-{next(_MINTED)}",
+    })
+
+
+ENTRY_TIME = "2026-09-10T04:30:00Z"
+OLDER = "2026-07-22T15:28:55Z"
+NEWER = "2026-09-10T05:00:00Z"
+
+POOL_REFRESH = "synthetic-pool-refresh"
+STORE_REFRESH = "synthetic-store-refresh"
+
+SINGLETON_PROVIDERS = ["openai-codex", "xai-oauth", "nous"]
+
+
+def _singleton_state(
+    provider: str,
+    *,
+    access: str,
+    refresh: str,
+    stamp,
+    agent_key=None,
+    key_stamp=None,
+    inference_base_url: str = "https://inference.nousresearch.com/v1",
+    label=None,
+) -> dict:
+    """auth.json ``providers.<id>`` block for a singleton OAuth provider."""
+    if provider == "nous":
+        state = {
+            "access_token": access,
+            "refresh_token": refresh,
+            "client_id": "hermes-cli",
+            "portal_base_url": "https://portal.nousresearch.com",
+            "inference_base_url": inference_base_url,
+            "token_type": "Bearer",
+            "scope": "inference:invoke",
+            "expires_at": "2026-09-10T05:30:00+00:00",
+            "agent_key": agent_key if agent_key is not None else _access(7200),
+            "agent_key_expires_at": "2026-09-10T05:30:00+00:00",
+        }
+        if stamp is not None:
+            state["obtained_at"] = stamp
+        if key_stamp is not None:
+            state["agent_key_obtained_at"] = key_stamp
+        if label is not None:
+            state["label"] = label
+        return state
+    state = {"tokens": {"access_token": access, "refresh_token": refresh}}
+    if stamp is not None:
+        state["last_refresh"] = stamp
+    if label is not None:
+        state["label"] = label
+    return state
+
+
+def _entry_stamp(entry, provider: str):
+    return entry.last_refresh if provider != "nous" else entry.extra.get("obtained_at")
+
+
+@pytest.fixture
+def seeded(tmp_path, monkeypatch):
+    """Seed a pool row from a singleton, then rewrite the singleton and reload.
+
+    Both halves go through the real ``load_pool`` -> ``_seed_from_singletons``
+    -> ``_upsert_entry`` path — the write path this file is about.
+    """
+    import hermes_cli.auth as auth
+    from agent.credential_pool import load_pool
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    assert auth._auth_file_path() == tmp_path / "hermes" / "auth.json"
+    assert auth._global_auth_file_path() is None
+    path = auth._auth_file_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _write(provider: str, state: dict) -> None:
+        raw: dict = json.loads(path.read_text()) if path.exists() else {"version": 1}
+        providers: dict = raw.setdefault("providers", {})
+        providers[provider] = state
+        path.write_text(json.dumps(raw, indent=2))
+
+    def build(
+        provider: str,
+        *,
+        store_stamp=OLDER,
+        entry_stamp=ENTRY_TIME,
+        store_key_stamp=OLDER,
+        entry_key_stamp=ENTRY_TIME,
+        agent_key_mirrors_access: bool = False,
+        store_url="https://inference.nousresearch.com/v1",
+        store_label=None,
+        mutate_entry=None,
+    ):
+        _write(provider, _singleton_state(
+            provider,
+            access=_access(),
+            refresh=POOL_REFRESH,
+            stamp=entry_stamp,
+            key_stamp=entry_key_stamp,
+        ))
+        pool = load_pool(provider)
+        entry = next(e for e in pool.entries() if e.source == "device_code")
+        assert entry.refresh_token == POOL_REFRESH
+        if mutate_entry is not None:
+            updated = mutate_entry(entry)
+            pool._replace_entry(entry, updated)
+            pool._persist()
+            entry = updated
+
+        # Another writer regresses (or advances) the singleton.
+        store_access = _access()
+        store_key = store_access if agent_key_mirrors_access else _access(7200)
+        _write(provider, _singleton_state(
+            provider,
+            access=store_access,
+            refresh=STORE_REFRESH,
+            stamp=store_stamp,
+            agent_key=store_key,
+            key_stamp=store_key_stamp,
+            inference_base_url=store_url,
+            label=store_label,
+        ))
+
+        reloaded = load_pool(provider)
+        row = next(e for e in reloaded.entries() if e.id == entry.id)
+        disk = next(
+            r for r in json.loads(path.read_text())["credential_pool"][provider]
+            if r["id"] == entry.id
+        )
+        return {
+            "provider": provider,
+            "entry": entry,
+            "row": row,
+            "disk": disk,
+            "store_access": store_access,
+            "store_agent_key": store_key,
+            "path": path,
+        }
+
+    return build
+
+
+# ── the defect: an older singleton must not clobber a fresher row ──────────
+
+
+@pytest.mark.parametrize("provider", SINGLETON_PROVIDERS)
+def test_seed_refuses_stale_pair(seeded, provider):
+    """Older stamp: not adopted in memory, and not persisted to disk."""
+    got = seeded(provider)
+    assert got["row"].refresh_token == POOL_REFRESH
+    assert got["row"].access_token == got["entry"].access_token
+    assert got["disk"]["refresh_token"] == POOL_REFRESH
+    assert _entry_stamp(got["row"], provider) == ENTRY_TIME
+
+
+@pytest.mark.parametrize("provider", SINGLETON_PROVIDERS)
+def test_seed_refuses_stale_pair_across_timezone_offsets(seeded, provider):
+    """Instants, not ISO string ordering: +02:00 05:00 predates Z 04:00."""
+    got = seeded(
+        provider,
+        entry_stamp="2026-09-10T04:00:00Z",
+        store_stamp="2026-09-10T05:00:00+02:00",
+        entry_key_stamp="2026-09-10T04:00:00Z",
+        store_key_stamp="2026-09-10T05:00:00+02:00",
+    )
+    assert got["row"].refresh_token == POOL_REFRESH
+    assert got["disk"]["refresh_token"] == POOL_REFRESH
+
+
+@pytest.mark.parametrize("provider", SINGLETON_PROVIDERS)
+def test_seed_refused_stale_pair_does_not_clear_exhaustion(seeded, provider):
+    """A refused pair is not a rotation, so the quarantine must survive it."""
+    from dataclasses import replace
+
+    from agent.credential_pool import STATUS_EXHAUSTED
+
+    reset_at = time.time() + 86400
+    got = seeded(provider, mutate_entry=lambda e: replace(
+        e,
+        last_status=STATUS_EXHAUSTED,
+        last_status_at=time.time(),
+        last_error_reset_at=reset_at,
+    ))
+    assert got["row"].last_status == STATUS_EXHAUSTED
+    assert got["row"].last_error_reset_at == reset_at
+    assert got["disk"]["last_status"] == STATUS_EXHAUSTED
+
+
+# ── preserved behavior: anything not older still lands ────────────────────
+
+
+@pytest.mark.parametrize("provider", SINGLETON_PROVIDERS)
+@pytest.mark.parametrize("store_stamp,entry_stamp", [
+    (NEWER, ENTRY_TIME),
+    (ENTRY_TIME, ENTRY_TIME),
+    (None, ENTRY_TIME),
+    ("not-a-timestamp", ENTRY_TIME),
+    (NEWER, None),
+])
+def test_seed_adopts_non_stale_pair(seeded, provider, store_stamp, entry_stamp):
+    got = seeded(
+        provider,
+        store_stamp=store_stamp, entry_stamp=entry_stamp,
+        store_key_stamp=store_stamp, entry_key_stamp=entry_stamp,
+    )
+    assert got["row"].refresh_token == STORE_REFRESH
+    assert got["row"].access_token == got["store_access"]
+    assert got["disk"]["refresh_token"] == STORE_REFRESH
+
+
+@pytest.mark.parametrize("provider", SINGLETON_PROVIDERS)
+def test_seed_adopted_rotation_still_clears_exhaustion(seeded, provider):
+    """Rotation recovery: a genuinely newer pair clears the stale quarantine."""
+    from dataclasses import replace
+
+    from agent.credential_pool import STATUS_EXHAUSTED
+
+    got = seeded(
+        provider,
+        store_stamp=NEWER, store_key_stamp=NEWER,
+        mutate_entry=lambda e: replace(
+            e,
+            last_status=STATUS_EXHAUSTED,
+            last_status_at=time.time(),
+            last_error_reset_at=time.time() + 86400,
+        ),
+    )
+    assert got["row"].refresh_token == STORE_REFRESH
+    assert got["row"].last_status is None
+    assert got["row"].last_error_reset_at is None
+
+
+@pytest.mark.parametrize("provider", ["openai-codex", "nous"])
+def test_seed_custom_label_updates_despite_stale_pair(seeded, provider):
+    """Only token material is freshness-gated; a custom label keeps flowing.
+
+    ``_upsert_entry`` leaves an already-labelled row alone, so this clears the
+    label first — otherwise the assertion would pass vacuously.  xAI is absent
+    because its seeding branch never carries ``state["label"]`` (pre-existing,
+    unrelated to freshness); ``base_url`` covers it below.
+    """
+    from dataclasses import replace
+
+    got = seeded(
+        provider,
+        store_label="renamed-by-user",
+        mutate_entry=lambda e: replace(e, label=""),
+    )
+    assert got["row"].label == "renamed-by-user"
+    assert got["row"].refresh_token == POOL_REFRESH
+
+
+@pytest.mark.parametrize("provider", ["openai-codex", "xai-oauth"])
+def test_seed_base_url_updates_despite_stale_pair(seeded, provider):
+    """Routing (``base_url``) is not token material and keeps being repaired.
+
+    Nous is absent: its seeding branch carries ``inference_base_url`` instead —
+    see ``test_seed_routing_metadata_updates_despite_stale_pair``.
+    """
+    from dataclasses import replace
+
+    got = seeded(provider, mutate_entry=lambda e: replace(e, base_url="https://wrong.invalid"))
+    assert got["row"].base_url != "https://wrong.invalid"
+    assert got["row"].refresh_token == POOL_REFRESH
+
+
+@pytest.mark.parametrize("provider", SINGLETON_PROVIDERS)
+def test_seed_manual_row_stays_independent(seeded, provider, tmp_path):
+    """``manual:*`` rows are separate credentials; seeding must not touch them."""
+    from dataclasses import replace
+
+    import hermes_cli.auth as auth
+    from agent.credential_pool import load_pool
+
+    got = seeded(provider, store_stamp=NEWER, store_key_stamp=NEWER,
+                 mutate_entry=lambda e: replace(e, source="manual:device_code"))
+    manual = next(
+        e for e in load_pool(provider).entries() if e.id == got["entry"].id
+    )
+    assert manual.source == "manual:device_code"
+    assert manual.refresh_token == POOL_REFRESH
+    assert manual.access_token == got["entry"].access_token
+    assert auth._auth_file_path() == tmp_path / "hermes" / "auth.json"
+
+
+@pytest.mark.parametrize("provider", SINGLETON_PROVIDERS)
+def test_upsert_never_gates_a_manual_source(provider):
+    """Contract on the shared helper: only singleton-seeded rows are gated.
+
+    No seeding site emits a ``manual:*`` payload today (``_upsert_entry`` matches
+    on exact source, so a ``device_code`` payload can never reach a manual row),
+    which makes the source condition unreachable from
+    ``_seed_from_singletons``.  It is asserted directly here so the condition is
+    proven rather than merely present: a manual row is an independent credential
+    with its own refresh-token lifecycle and must adopt whatever its own writer
+    provides, however that writer stamps it.
+    """
+    from agent.credential_pool import (
+        PooledCredential,
+        _drop_stale_singleton_token_material,
+    )
+
+    stamp_key = "obtained_at" if provider == "nous" else "last_refresh"
+    existing = PooledCredential.from_dict(provider, {
+        "id": "manual1",
+        "source": "manual:device_code",
+        "access_token": _access(),
+        "refresh_token": POOL_REFRESH,
+        stamp_key: ENTRY_TIME,
+    })
+    payload = {
+        "source": "manual:device_code",
+        "access_token": _access(),
+        "refresh_token": STORE_REFRESH,
+        stamp_key: OLDER,
+    }
+    kept = _drop_stale_singleton_token_material(
+        existing, provider, "manual:device_code", payload,
+    )
+    assert kept is payload
+
+    # ...and the same payload on the seeded source IS gated, so the assertion
+    # above is about the source and not about the timestamps.
+    gated = _drop_stale_singleton_token_material(
+        existing, provider, "device_code", payload,
+    )
+    assert "refresh_token" not in gated
+
+
+# ── Nous: per-group boundary survives on the seeding path too ─────────────
+
+
+def test_seed_newer_agent_key_survives_stale_oauth_pair(seeded):
+    got = seeded("nous", store_stamp=OLDER, store_key_stamp=NEWER)
+    assert got["row"].agent_key == got["store_agent_key"]
+    assert got["row"].extra.get("agent_key_obtained_at") == NEWER
+    assert got["row"].refresh_token == POOL_REFRESH
+    assert got["row"].access_token == got["entry"].access_token
+    assert got["disk"]["agent_key"] == got["store_agent_key"]
+    assert got["disk"]["refresh_token"] == POOL_REFRESH
+
+
+def test_seed_refuses_stale_agent_key(seeded):
+    got = seeded("nous", store_stamp=NEWER, store_key_stamp=OLDER)
+    assert got["row"].agent_key == got["entry"].agent_key
+    assert got["row"].extra.get("agent_key_obtained_at") == ENTRY_TIME
+    # ...while the newer OAuth pair still lands.
+    assert got["row"].refresh_token == STORE_REFRESH
+
+
+def test_seed_stale_access_token_cannot_ride_in_as_agent_key(seeded):
+    """Invoke-JWT path mirrors agent_key onto access_token.
+
+    A newer ``agent_key_obtained_at`` must not launder the refused stale
+    access token into ``runtime_api_key``.
+    """
+    got = seeded(
+        "nous",
+        store_stamp=OLDER, store_key_stamp=NEWER,
+        agent_key_mirrors_access=True,
+    )
+    assert got["row"].agent_key != got["store_access"]
+    assert got["row"].agent_key == got["entry"].agent_key
+    assert got["row"].access_token == got["entry"].access_token
+    assert got["row"].runtime_api_key == got["entry"].runtime_api_key
+
+
+def test_seed_routing_metadata_updates_despite_stale_pair(seeded):
+    got = seeded(
+        "nous",
+        store_stamp=OLDER, store_key_stamp=OLDER,
+        store_url="https://inference.nousresearch.com/v2",
+    )
+    assert got["row"].inference_base_url == "https://inference.nousresearch.com/v2"
+    assert got["row"].refresh_token == POOL_REFRESH
+    assert got["row"].agent_key == got["entry"].agent_key


### PR DESCRIPTION
## Problem
`load_pool()` re-reads singleton credentials through `_seed_from_singletons()` and `_upsert_entry()`. A different token pair is not necessarily newer: a stale singleton can overwrite a newer persisted pool row and reintroduce a consumed single-use refresh token.

## Fix
- Gate singleton token-material updates at the shared upsert boundary, before `token_changed` can clear exhaustion.
- Compare actual refresh/mint timestamps, not token expiry. Missing/equal stamps retain existing recovery behavior.
- Keep Nous OAuth-pair and agent-key timestamps independent; routing and labels continue updating.
- Stamp Hermes PKCE's singleton producer with `lastRefresh`, carry it through the existing extracted refresh/seed helpers, and only then enable its guard. Preserve the writer's named-profile/global-root `target` semantics.
- Leave borrowed Claude Code and sole-authority MiniMax singletons ungated.

This PR is confined to the seeding path plus its required Anthropic producer/refresh plumbing. It does not claim to repair every provider's independent pre-refresh singleton-reader path.

## Verification on current upstream
Isolated HOME/HERMES_HOME, synthetic tokens, no live OAuth, explicit module-path assertions:
- Final seed tests against unfixed source: **20 failed, 21 passed** (17 behavioral failures and 3 missing-helper imports).
- Final Anthropic tests against pre-producer source: **11 failed, 9 passed**.
- Both new suites fixed: **61 passed**.
- All credential-pool, Anthropic-agent and Nous/xAI CLI neighbor files: **746 passed, 1 skipped** in 47.40s.
- Ruff and `git diff --check` clean.

Contributor credit is preserved for the original seed change; the Anthropic adaptation credits its original author and retains current upstream's extracted helper architecture rather than restoring old inline implementations.
