### PR TITLE
fix(bot-mode): fall back to a private DM directory when the temp root is unusable

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -742,16 +742,20 @@ def test_sweeper_removes_only_stale_dm_files(tmp_path, monkeypatch):
 
 def test_dm_dir_is_private_and_uid_scoped_on_posix(tmp_path, monkeypatch):
     monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bot_mode_dm, "_dm_fallback_dir", lambda: tmp_path / "fallback")
 
     dm_dir = bot_mode_dm._dm_dir()
 
     if hasattr(os, "getuid"):
         assert dm_dir.name == f"{bot_mode_dm._DM_DIR_NAME}-{os.getuid()}"
+        # POSIX contract only: a Windows directory always reports 0o777 and chmod() there
+        # toggles just the read-only bit, so the directory ACL is what protects it.
+        assert dm_dir.stat().st_mode & 0o777 == 0o700
     else:
         assert dm_dir.name == bot_mode_dm._DM_DIR_NAME
-    assert dm_dir.stat().st_mode & 0o777 == 0o700
 
 
+@pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX mode contract")
 def test_dm_dir_repairs_restrictive_owner_mode(tmp_path, monkeypatch):
     monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
     uid = os.getuid() if hasattr(os, "getuid") else None
@@ -774,3 +778,97 @@ def test_dm_dir_rejects_precreated_symlink(tmp_path, monkeypatch):
 
     with pytest.raises(PermissionError, match="not a directory"):
         bot_mode_dm._dm_dir()
+
+
+# --- Unusable temp root: degrade to the private fallback (the reported WinError 5) ---
+
+
+def _deny_canonical(monkeypatch, canonical: Path):
+    """Make only the canonical directory's writability probe fail, WinError 5 shaped."""
+    def probe(path):
+        if Path(path) == canonical:
+            raise PermissionError(13, "Acces refuse", str(path), 5)
+    monkeypatch.setattr(bot_mode_dm, "_probe_writable", probe)
+
+
+def test_dm_dir_falls_back_when_canonical_path_is_not_usable(tmp_path, monkeypatch):
+    """A canonical path that cannot become a directory must degrade, not fail the send."""
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+    fallback = tmp_path / "home" / "cache" / "dm-tmp"
+    monkeypatch.setattr(bot_mode_dm, "_dm_fallback_dir", lambda: fallback)
+    (tmp_path / bot_mode_dm._DM_DIR_NAME).write_text("not a directory", encoding="utf-8")
+
+    assert bot_mode_dm._dm_dir() == fallback
+    assert fallback.is_dir()
+    assert bot_mode_dm._dm_dir() == fallback  # idempotent: one stable fallback, not churn
+
+
+def test_dm_dir_falls_back_when_write_probe_is_denied(tmp_path, monkeypatch):
+    """[WinError 5]: the canonical dir exists but denies creating a file in it."""
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+    fallback = tmp_path / "home" / "cache" / "dm-tmp"
+    monkeypatch.setattr(bot_mode_dm, "_dm_fallback_dir", lambda: fallback)
+    _deny_canonical(monkeypatch, tmp_path / bot_mode_dm._DM_DIR_NAME)
+
+    assert bot_mode_dm._dm_dir() == fallback
+
+
+def test_write_dm_file_uses_the_fallback_when_temp_root_is_denied(tmp_path, monkeypatch):
+    """Regression: a stale ACL on the temp dir must not disable agent-to-agent DMs."""
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+    fallback = tmp_path / "home" / "cache" / "dm-tmp"
+    monkeypatch.setattr(bot_mode_dm, "_dm_fallback_dir", lambda: fallback)
+    _deny_canonical(monkeypatch, tmp_path / bot_mode_dm._DM_DIR_NAME)
+
+    payload = bot_mode_dm._write_dm_file("secret payload")
+
+    assert Path(payload).parent == fallback
+    assert Path(payload).read_text(encoding="utf-8") == "secret payload"
+
+
+def test_dm_dir_fails_closed_when_no_location_is_usable(tmp_path, monkeypatch):
+    """Both locations denied: a named error, never a silent write to an arbitrary path."""
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bot_mode_dm, "_dm_fallback_dir", lambda: tmp_path / "home" / "cache" / "dm-tmp")
+
+    def probe(path):
+        raise PermissionError(13, "Acces refuse", str(path), 5)
+
+    monkeypatch.setattr(bot_mode_dm, "_probe_writable", probe)
+
+    with pytest.raises(PermissionError, match="no usable DM directory"):
+        bot_mode_dm._dm_dir()
+
+
+def test_sweeper_covers_the_fallback_directory(tmp_path, monkeypatch):
+    """Fallback payloads expire too: a later process with a healthy temp root would
+    otherwise never sweep them, breaking the stale-payload bound."""
+    temp_root = tmp_path / "temp"
+    temp_root.mkdir()
+    fallback = tmp_path / "home" / "cache" / "dm-tmp"
+    fallback.mkdir(parents=True)
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(temp_root))
+    monkeypatch.setattr(bot_mode_dm, "_dm_fallback_dir", lambda: fallback)
+
+    stale = fallback / "dm-stale.txt"
+    fresh = fallback / "dm-fresh.txt"
+    for path in (stale, fresh):
+        path.write_text("secret", encoding="utf-8")
+    now = time.time()
+    old = now - bot_mode_dm._DM_STALE_SECONDS - 1
+    os.utime(stale, (old, old))
+
+    bot_mode_dm.cleanup_bot_dm_cache(now=now)
+
+    assert not stale.exists()
+    assert fresh.exists()
+    assert fallback.exists()  # sweeping must not create or remove directories
+
+
+def test_probe_leaves_no_file_behind(tmp_path):
+    """The writability probe must be invisible: no residue in the DM directory."""
+    target = tmp_path / "probe-target"  # dedicated dir: pytest's tmp_path also holds the
+    target.mkdir()                      # suite's isolated HERMES_HOME
+    bot_mode_dm._probe_writable(target)
+
+    assert list(target.iterdir()) == []

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -283,13 +283,33 @@ def _try_relay_delivery(root: Path, raw_target: str, content: str, me: str, *,
         return None
 
 
-def _dm_dir() -> Path:
+def _dm_canonical_dir() -> Path:
+    """The shared-temp-root location: per-uid on POSIX, per-user by ACL on Windows."""
     uid_getter = getattr(os, "getuid", None)
     uid = uid_getter() if callable(uid_getter) else None
-    path = Path(tempfile.gettempdir()) / (f"{_DM_DIR_NAME}-{uid}" if uid is not None else _DM_DIR_NAME)
-    path.mkdir(mode=0o700, exist_ok=True)
-    # Shared POSIX temp roots need a per-user directory. Fail closed if an
-    # attacker pre-created the expected path or replaced it with a symlink.
+    return Path(tempfile.gettempdir()) / (f"{_DM_DIR_NAME}-{uid}" if uid is not None else _DM_DIR_NAME)
+
+
+def _dm_fallback_dir() -> Path:
+    """Private per-user fallback outside the shared temp root.
+
+    Deterministic rather than ``mkdtemp``: ``_dm_dir()`` stays idempotent, housekeeping can
+    find the directory from any process (a fresh process with a healthy temp root would
+    otherwise never sweep it, breaking the stale-payload bound), and no per-call directory
+    churn accumulates in the user's home.
+    """
+    return Path(_default_home()) / "cache" / "dm-tmp"
+
+
+def _assert_usable_dm_dir(path: Path, uid: Optional[int]) -> None:
+    """Fail closed on a pre-created path.
+
+    ``S_ISDIR`` is checked on every platform: it is the only guard against an attacker (or a
+    stray process) pre-creating the expected path as a symlink/junction. The ownership check
+    and the ``0o700`` repair only mean something on POSIX — on Windows ``os.getuid`` is
+    absent and a directory's mode always reads as ``0o777``, so the chmod is cosmetic and the
+    directory ACL is what actually protects the path.
+    """
     info = path.lstat()
     if not stat.S_ISDIR(info.st_mode):
         raise PermissionError(f"DM temp path is not a directory: {path}")
@@ -297,21 +317,86 @@ def _dm_dir() -> Path:
         raise PermissionError(f"DM temp directory is owned by another user: {path}")
     if stat.S_IMODE(info.st_mode) != 0o700:
         path.chmod(0o700)
-    return path
+
+
+def _probe_writable(path: Path) -> None:
+    """Prove *path* can host a payload file, before a real message depends on it.
+
+    An existing directory with a denying ACL (the reported Windows ``[WinError 5]``), a
+    read-only volume, or a full disk all surface here instead of later, mid-send.
+    """
+    fd, probe = tempfile.mkstemp(prefix=".probe-", suffix=".txt", dir=path)
+    os.close(fd)
+    with contextlib.suppress(OSError):
+        os.unlink(probe)
+
+
+def _prepare_dm_dir(path: Path, uid: Optional[int]) -> None:
+    # parents=True: the fallback lives under ``<hermes home>/cache``, which may not exist yet
+    # on a fresh home; the canonical temp-root parent always does.
+    path.mkdir(mode=0o700, exist_ok=True, parents=True)
+    _assert_usable_dm_dir(path, uid)
+    _probe_writable(path)
+
+
+def _dm_dir() -> Path:
+    """Directory holding DM payload files.
+
+    Prefers the canonical shared-temp-root path. If that cannot be prepared — a stale
+    directory whose ACL denies the current user, a pre-created non-directory, an unwritable
+    or full temp volume — fall back to a private per-user directory instead of failing every
+    send. A stale ACL must degrade a message delivery (or fall back to another directory),
+    never disable the whole agent-to-agent messaging layer.
+    """
+    uid_getter = getattr(os, "getuid", None)
+    uid = uid_getter() if callable(uid_getter) else None
+    canonical = _dm_canonical_dir()
+    try:
+        _prepare_dm_dir(canonical, uid)
+        return canonical
+    except OSError as exc:
+        # Debug-level with the exception: an unusable temp dir is a degraded-but-working
+        # condition, and the previous silent swallow here is why the breakage went unnoticed.
+        logger.warning("DM directory %s unusable, falling back to %s: %s", canonical, _dm_fallback_dir(), exc)
+    fallback = _dm_fallback_dir()
+    try:
+        _prepare_dm_dir(fallback, uid)
+    except OSError as exc:
+        raise PermissionError(f"no usable DM directory: {canonical} and {fallback} both failed ({exc})") from exc
+    return fallback
+
+
+def _dm_sweep_locations() -> list[tuple[Path, str]]:
+    """Every directory that can hold DM payload files, canonical first.
+
+    Built without creating anything: housekeeping must not bring directories into existence.
+    The fallback is listed unconditionally — sweeping only ``_dm_dir()`` would leave fallback
+    payloads from an earlier process in place forever once the temp root recovers.
+    """
+    temp_root = Path(tempfile.gettempdir())
+    return [
+        (temp_root, "hermes-dm-*.txt"),
+        (temp_root, "hermes-relay-dm-*.txt"),
+        (_dm_canonical_dir(), "*.txt"),
+        (_dm_fallback_dir(), "*.txt"),
+    ]
 
 
 def cleanup_bot_dm_cache(max_age_hours: float = _DM_STALE_SECONDS / 3600, *, now: float | None = None) -> int:
     """Delete orphaned DM payload files older than *max_age_hours*; returns count.
     Same contract as the other ``cleanup_*_cache`` helpers (hourly gateway housekeeping);
-    legacy temp-root locations from versions predating the dedicated directory are swept too."""
+    legacy temp-root locations from versions predating the dedicated directory are swept too,
+    along with the private fallback directory used when the temp root is unusable."""
     cutoff = (time.time() if now is None else now) - max_age_hours * 3600
-    temp_root = Path(tempfile.gettempdir())
-    locations = [(temp_root, "hermes-dm-*.txt"), (temp_root, "hermes-relay-dm-*.txt")]
-    with contextlib.suppress(OSError):
-        locations.append((_dm_dir(), "*.txt"))
     from tools.bot_relay import unlink_files_older_than
 
-    return sum(unlink_files_older_than(d, pattern, cutoff) for d, pattern in locations)
+    total = 0
+    for directory, pattern in _dm_sweep_locations():
+        # A location can be unreadable (permissions) or absent; neither is fatal, and neither
+        # may abort the sweep of the remaining locations.
+        with contextlib.suppress(OSError):
+            total += unlink_files_older_than(directory, pattern, cutoff)
+    return total
 
 
 def _unlink_dm_file(path: str) -> None:


### PR DESCRIPTION
## Problem

On Windows, every bot-to-bot DM failed with:

```
[WinError 5] Accès refusé: C:\Users\<user>\AppData\Local\Temp\hermes-dm
```

`_dm_dir()` builds a single fixed path (`<tempdir>/hermes-dm`, or `hermes-dm-<uid>` on POSIX) and lets `mkdir`/`mkstemp` raise. A directory left behind by an elevated/other-context process carried an ACL that denied the normal user, so both raised and **every** `message_agent` send failed. Nothing self-healed: the exception propagated as a tool error, and `cleanup_bot_dm_cache()` suppressed the `OSError` on that path, so housekeeping never cleared it either. The breakage went unnoticed for a day.

## Change

- `_dm_dir()` now **probes the canonical directory for writability** (`mkstemp` + unlink) before a real message depends on it.
- When the canonical directory cannot be prepared — denied ACL, pre-created non-directory, unwritable or full temp volume — it **falls back to a deterministic private directory** (`<hermes home>/cache/dm-tmp`) instead of failing the send. A stale ACL degrades one location, it does not disable the messaging layer.
- `cleanup_bot_dm_cache()` lists canonical **and** fallback locations unconditionally, and suppresses errors per location rather than around the whole sweep, so one unreadable directory can neither hide a broken one nor abort the rest.

### Why a deterministic fallback instead of `mkdtemp`

- `_dm_dir()` stays idempotent — callers and tests compare the returned path.
- Housekeeping can find the directory from **any** process. Sweeping only `_dm_dir()` would leave fallback payloads in place forever once the temp root recovers, silently breaking the module's 24h stale-payload bound.
- No per-call directory churn accumulates in the user's home.

### Fail-closed behaviour preserved, split by platform

`S_ISDIR` is checked on **every** platform: it is the only guard against a path pre-created as a symlink/junction. The `st_uid` ownership check and the `0o700` repair stay POSIX-only — on Windows `os.getuid` is absent and a directory's mode always reports `0o777`, so the chmod is cosmetic there and the directory ACL is the real protection.

## Tests

```
tests/tools/test_bot_mode_dm.py  49 passed, 2 skipped
```

On the same machine, the unmodified base commit gives `2 failed, 43 passed` — the two failures are the pre-existing POSIX mode-contract tests (`assert dm_dir.stat().st_mode & 0o777 == 0o700`, which can never hold on Windows: `0o40777 & 0o777 == 0o777`). Those two are now skipped on non-POSIX platforms, where they were already red; the POSIX assertions still run on POSIX.

New coverage: canonical-unusable and `WinError 5` probe-denied both select the fallback; `_write_dm_file` delivers a real payload through it; both-locations-denied raises a named error rather than writing somewhere arbitrary; the sweeper expires fallback payloads; the probe leaves no residue.
