### PR TITLE
fix(file-safety): resolve HERMES_HOME/config per call so multiplex profiles don't poison the write guards (#107327)

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -771,6 +771,84 @@ class TestMultiplexProfileWriteGuardsAreProfileScoped:
         assert err is not None
         assert "Refusing to write to Hermes config file" in err
 
+    def test_config_resolver_failure_stays_bound_to_active_profile(
+        self, tmp_path, monkeypatch
+    ):
+        """Opposite-side regression (PR #107335 review): when the primary config
+        resolver raises, the fallback must derive beta's config from beta's own
+        ``HERMES_HOME`` key — never the subprocess/default home — so beta's
+        ``config.yaml`` stays hard-blocked instead of failing open against an
+        unrelated config, and alpha's config is not spuriously protected under
+        beta's scope."""
+        import tools.file_tools_write_guards as ft
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        a, b = self._profiles(tmp_path)
+        # alpha runs first (would poison a process memo), then the primary
+        # resolver breaks and beta's turn must fall back to beta's own home key.
+        tok = set_hermes_home_override(str(a))
+        try:
+            ft._get_hermes_config_resolved()
+        finally:
+            reset_hermes_home_override(tok)
+
+        def boom():
+            raise RuntimeError("config path unavailable")
+
+        monkeypatch.setattr(ft, "_config_path_resolved", boom)
+
+        tok = set_hermes_home_override(str(b))
+        try:
+            assert ft._get_hermes_config_resolved() == str(
+                (b / "config.yaml").resolve()
+            )
+            err = ft._check_sensitive_path(str(b / "config.yaml"), "default")
+            # beta scope must NOT protect alpha's unrelated config (no wrong-home
+            # compare in either direction).
+            alpha_err = ft._check_sensitive_path(str(a / "config.yaml"), "default")
+        finally:
+            reset_hermes_home_override(tok)
+        assert err is not None
+        assert "Refusing to write to Hermes config file" in err
+        assert alpha_err is None
+
+    def test_home_resolver_failure_keeps_exemption_on_active_profile(
+        self, tmp_path, monkeypatch
+    ):
+        """Opposite-side regression (PR #107335 review): when the primary home
+        resolver raises, the protected-instruction exemption must still resolve
+        against beta's own home (not the process/default home)."""
+        import tools.file_tools_write_guards as ft
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        a, b = self._profiles(tmp_path)
+
+        def boom():
+            raise RuntimeError("home unavailable")
+
+        monkeypatch.setattr(ft, "_hermes_home_real", boom)
+
+        tok = set_hermes_home_override(str(b))
+        try:
+            assert ft._get_real_hermes_home() == os.path.realpath(str(b))
+            # beta's own ~/.hermes tree is exempt from the project-local
+            # instruction gate (governed by its config-level guards instead),
+            # resolved against beta — not alpha or the default home.
+            assert (
+                ft._check_protected_instruction_write(
+                    [str(b / "AGENTS.md")], "default"
+                )
+                is None
+            )
+        finally:
+            reset_hermes_home_override(tok)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -690,5 +690,87 @@ class TestProtectedInstructionFiles:
         assert rendered["choices"] == ["once", "deny"]
 
 
+class TestMultiplexProfileWriteGuardsAreProfileScoped:
+    """#107327: a multiplexed gateway scopes ``HERMES_HOME`` per turn via a
+    contextvar. The home/config path getters must resolve per call, or whichever
+    profile ran first in the process freezes both the protected-instruction gate
+    and the ``config.yaml`` hard-block for every later profile — up to letting a
+    later profile rewrite its own ``config.yaml`` the block exists to protect."""
+
+    def _profiles(self, tmp_path: Path):
+        root = tmp_path / "home"
+        a, b = root / "profiles" / "alpha", root / "profiles" / "beta"
+        for home in (a, b):
+            (home / "workspace").mkdir(parents=True)
+            (home / "config.yaml").write_text(
+                "model:\n  default: original\n", encoding="utf-8"
+            )
+        return a, b
+
+    def test_home_getter_tracks_active_profile_after_a_prior_scope(self, tmp_path):
+        import tools.file_tools_write_guards as ft
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        a, b = self._profiles(tmp_path)
+        # A normal alpha turn resolves (and, on the buggy path, would freeze) home.
+        tok = set_hermes_home_override(str(a))
+        try:
+            assert ft._get_real_hermes_home() == os.path.realpath(str(a))
+        finally:
+            reset_hermes_home_override(tok)
+        # The next turn is beta — the getter must now return beta's home, not alpha's.
+        tok = set_hermes_home_override(str(b))
+        try:
+            assert ft._get_real_hermes_home() == os.path.realpath(str(b))
+        finally:
+            reset_hermes_home_override(tok)
+
+    def test_config_getter_tracks_active_profile_after_a_prior_scope(self, tmp_path):
+        import tools.file_tools_write_guards as ft
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        a, b = self._profiles(tmp_path)
+        tok = set_hermes_home_override(str(a))
+        try:
+            assert ft._get_hermes_config_resolved() == str((a / "config.yaml").resolve())
+        finally:
+            reset_hermes_home_override(tok)
+        tok = set_hermes_home_override(str(b))
+        try:
+            assert ft._get_hermes_config_resolved() == str((b / "config.yaml").resolve())
+        finally:
+            reset_hermes_home_override(tok)
+
+    def test_config_hard_block_refuses_beta_config_even_after_alpha_turn(self, tmp_path):
+        """End-to-end: the ``config.yaml`` hard-block must fire for beta's own
+        config under beta's scope, regardless of alpha having run first."""
+        import tools.file_tools_write_guards as ft
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        a, b = self._profiles(tmp_path)
+        tok = set_hermes_home_override(str(a))
+        try:
+            ft._get_hermes_config_resolved()  # warm the (formerly poisoning) alpha lookup
+        finally:
+            reset_hermes_home_override(tok)
+
+        tok = set_hermes_home_override(str(b))
+        try:
+            err = ft._check_sensitive_path(str(b / "config.yaml"), "default")
+        finally:
+            reset_hermes_home_override(tok)
+        assert err is not None
+        assert "Refusing to write to Hermes config file" in err
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tools/file_tools_write_guards.py
+++ b/tools/file_tools_write_guards.py
@@ -59,8 +59,17 @@ def _get_hermes_config_resolved() -> str | None:
     try:
         return _config_path_resolved()
     except Exception:
+        # Resolver failure must stay bound to the ACTIVE profile's home, not the
+        # subprocess HOME. ``_expand_tilde("~/...")`` follows the subprocess-HOME
+        # contract, which under host ``auto`` mode can be the real/default user
+        # home rather than the active multiplex ``HERMES_HOME`` — comparing
+        # beta's ``config.yaml`` against the default/root config would let the
+        # hard-block fail open on the exception path. Re-derive from the same
+        # ``get_hermes_home()`` key the happy path uses, and substitute no
+        # unrelated home if even that is gone (#107327 follow-up; PR #107335).
         try:
-            return str(Path(_expand_tilde("~/.hermes/config.yaml")).resolve())
+            from hermes_constants import get_hermes_home
+            return str((Path(str(get_hermes_home())) / "config.yaml").resolve())
         except Exception:
             return None
 
@@ -75,8 +84,16 @@ def _get_real_hermes_home() -> str | None:
     try:
         return _hermes_home_real()
     except Exception:
+        # Same active-profile binding on the exception path (see
+        # ``_get_hermes_config_resolved``): re-derive from ``get_hermes_home()``
+        # rather than ``_expand_tilde("~/.hermes")`` so the protected-instruction
+        # exemption resolves against the active profile — not the subprocess /
+        # default home — and substitute no unrelated home if the active security
+        # path cannot be established (PR #107335). A ``None`` here fails closed at
+        # the consumer: the ``~/.hermes`` exemption is skipped, so the gate runs.
         try:
-            return os.path.realpath(_expand_tilde("~/.hermes"))
+            from hermes_constants import get_hermes_home
+            return os.path.realpath(str(get_hermes_home()))
         except Exception:
             return None
 

--- a/tools/file_tools_write_guards.py
+++ b/tools/file_tools_write_guards.py
@@ -24,26 +24,19 @@ _SENSITIVE_PATH_PREFIXES = (
     "/private/var/db/", "/private/var/root/")
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
+# NOTE: these four are a TEST-OVERRIDE surface, not a process cache. Both getters
+# resolve per call in production (below) because ``get_hermes_home()`` /
+# ``get_config_path()`` are per-turn contextvar-scoped: a multiplexed gateway
+# (``gateway.multiplex_profiles: true``) serves many profiles in one process, and
+# a process-wide memo would freeze whichever profile's home/config ran first —
+# making the protected-instruction gate and the ``config.yaml`` hard-block
+# order-dependent, up to letting a later profile rewrite its own ``config.yaml``
+# the block exists to protect (#107327). A test can still pin a value by setting
+# the slot and its ``_loaded`` flag.
 _hermes_config_resolved: str | None = None
 _hermes_config_resolved_loaded = False
 _real_hermes_home_cached: str | None = None
 _real_hermes_home_loaded = False
-
-
-def _cached_lookup(slot: str, flag: str, primary, fallback) -> str | None:
-    """Fill module global *slot* once (guarded by *flag*) from ``primary()``, else
-    ``fallback()``, else None. Module globals so tests can monkeypatch the slots."""
-    g = globals()
-    if not g[flag]:
-        g[flag] = True
-        try:
-            g[slot] = primary()
-        except Exception:
-            try:
-                g[slot] = fallback()
-            except Exception:
-                g[slot] = None
-    return g[slot]
 
 
 def _config_path_resolved() -> str:
@@ -57,15 +50,35 @@ def _hermes_home_real() -> str:
 
 
 def _get_hermes_config_resolved() -> str | None:
-    """Return the resolved absolute path of the Hermes config file (cached)."""
-    return _cached_lookup("_hermes_config_resolved", "_hermes_config_resolved_loaded", _config_path_resolved,
-                          lambda: str(Path(_expand_tilde("~/.hermes/config.yaml")).resolve()))
+    """Resolved absolute path of the Hermes config file for the ACTIVE profile.
+
+    Resolved per call so it tracks the per-turn ``HERMES_HOME`` scope (#107327);
+    a test may pin it via ``_hermes_config_resolved`` + ``_hermes_config_resolved_loaded``."""
+    if _hermes_config_resolved_loaded:
+        return _hermes_config_resolved
+    try:
+        return _config_path_resolved()
+    except Exception:
+        try:
+            return str(Path(_expand_tilde("~/.hermes/config.yaml")).resolve())
+        except Exception:
+            return None
 
 
 def _get_real_hermes_home() -> str | None:
-    """Return the realpath of the authoritative Hermes home (cached)."""
-    return _cached_lookup("_real_hermes_home_cached", "_real_hermes_home_loaded", _hermes_home_real,
-                          lambda: os.path.realpath(_expand_tilde("~/.hermes")))
+    """Realpath of the authoritative Hermes home for the ACTIVE profile.
+
+    Resolved per call so it tracks the per-turn ``HERMES_HOME`` scope (#107327);
+    a test may pin it via ``_real_hermes_home_cached`` + ``_real_hermes_home_loaded``."""
+    if _real_hermes_home_loaded:
+        return _real_hermes_home_cached
+    try:
+        return _hermes_home_real()
+    except Exception:
+        try:
+            return os.path.realpath(_expand_tilde("~/.hermes"))
+        except Exception:
+            return None
 
 
 def _resolved_or_raw(filepath: str, task_id: str) -> str:


### PR DESCRIPTION
## What & why

Fixes #107327.

In a multiplexed gateway (`gateway.multiplex_profiles: true`) every profile turn scopes `HERMES_HOME` through a per-turn contextvar (`gateway/run.py::_profile_runtime_scope` → `set_hermes_home_override`). But `tools/file_tools_write_guards.py` memoised the resolved home and config path in **process-global** module state, filled once by whichever profile ran first. Two security checks derive from that memo:

- **Protected agent-instruction gate** — `_get_real_hermes_home()` exempts a profile's own `~/.hermes` subtree. Frozen at profile A, profile B's own `workspace/AGENTS.md` is measured against A's home, so it is *not* exempt and gets gated (fail-closed where no human channel exists — cron / background review).
- **`config.yaml` hard-block** — `_get_hermes_config_resolved()` is the path the block compares against. Frozen at profile A, profile B's own `config.yaml` no longer matches, so **the block stops refusing** and a prompt-injected agent can rewrite the file the block exists to protect.

The reporter reproduced both end-to-end with the real pre-write checks (`_write_precheck_error`, `write_file_tool`) under the same `set_hermes_home_override` scope the gateway uses — a poisoned order let `write_file_tool(beta/config.yaml)` succeed where the fresh-process control refused it.

## Fix

Resolve both values **per call**. `get_hermes_home()` / `get_config_path()` are contextvar-scoped, so the getters now track the active profile. The guard already pays a `realpath` per call, so the extra cost is negligible (the reporter's own assessment too). The two module slots are kept purely as a **test-override surface** (set the slot + its `_loaded` flag to pin a value); production leaves them unset and resolves live — which additionally removes the cross-test poisoning the process memo could cause. Both getters are fixed, per the issue's note that fixing only the home getter leaves the `config.yaml` block order-dependent.

## Tests

`tests/tools/test_file_write_safety.py::TestMultiplexProfileWriteGuardsAreProfileScoped`:

- `_get_real_hermes_home()` returns beta's home after an alpha turn ran first (not frozen at alpha).
- `_get_hermes_config_resolved()` returns beta's config path after an alpha turn.
- End-to-end: the `config.yaml` hard-block (`_check_sensitive_path`) refuses beta's own `config.yaml` under beta's scope even after an alpha lookup warmed the (formerly poisoning) path.

All existing guard tests pass, including the ones that pin the module slots via monkeypatch. (Two pre-existing `test_file_tools.py` failures — `/tmp` vs `/private/tmp` on macOS — are environmental and reproduce on unmodified `main`.)

The arm64 fork-Docker check is expected to fail on fork PRs and is unrelated.
