### PR TITLE
fix(codex): target hermes-tools in Kanban worker overrides

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -74,8 +74,8 @@ class CodexAppServerClient:
         if owned_task:
             for key in (*KANBAN_ENV_KEYS, "HERMES_KANBAN_DB", "HERMES_KANBAN_BOARD"):
                 if key in os.environ:
-                    cmd += ["-c", f"mcp_servers.hermes-mcp.env.{key}={json.dumps(os.environ[key])}"]
-            cmd += ["-c", f'mcp_servers.hermes-mcp.env.{DELEGATED_CHILD_ENV_MARKER}=""']
+                    cmd += ["-c", f"mcp_servers.hermes-tools.env.{key}={json.dumps(os.environ[key])}"]
+            cmd += ["-c", f'mcp_servers.hermes-tools.env.{DELEGATED_CHILD_ENV_MARKER}=""']
         spawn_env = delegated_child_subprocess_env(spawn_env)
         # Kanban workers must write handoff/status to the board DB outside the
         # workspace: keep the sandbox on, add the Kanban root as writable.

--- a/evals/kanban_scope_probe.py
+++ b/evals/kanban_scope_probe.py
@@ -34,8 +34,8 @@ ch.mkdir()
 (ch / "config.toml").write_text(
     'model="fixture"\nmodel_provider="fixture"\n'
     '[model_providers.fixture]\nname="fixture"\nbase_url="http://127.0.0.1:9/v1"\nwire_api="responses"\n'
-    '[mcp_servers.hermes-mcp]\ncommand=' + json.dumps(sys.executable) + '\nargs=["-m","agent.transports.hermes_tools_mcp_server"]\nstartup_timeout_sec=40\n'
-    '[mcp_servers.hermes-mcp.env]\nPYTHONPATH=' + json.dumps(str(repo)) + '\nHERMES_HOME=' + json.dumps(str(hh)) + '\n'
+    '[mcp_servers.hermes-tools]\ncommand=' + json.dumps(sys.executable) + '\nargs=["-m","agent.transports.hermes_tools_mcp_server"]\nstartup_timeout_sec=40\n'
+    '[mcp_servers.hermes-tools.env]\nPYTHONPATH=' + json.dumps(str(repo)) + '\nHERMES_HOME=' + json.dumps(str(hh)) + '\n'
 )
 report = {}
 with CodexAppServerClient(codex_bin=shutil.which("codex") or "codex", codex_home=str(ch)) as c:
@@ -51,7 +51,7 @@ with CodexAppServerClient(codex_bin=shutil.which("codex") or "codex", codex_home
     status = c.request("mcpServerStatus/list", {"threadId": thread_id}, timeout=50)
     report["mcp_servers"] = [{"name": x.get("name"), "tools": list(x.get("tools", {}))} for x in status.get("data", [])]
     for name, tid in (("foreign", foreign), ("own", own)):
-        report[name] = c.request("mcpServer/tool/call", {"threadId": thread_id, "server": "hermes-mcp", "tool": "kanban_complete", "arguments": {"task_id": tid, "summary": "supervised parent handoff"}}, timeout=50)
+        report[name] = c.request("mcpServer/tool/call", {"threadId": thread_id, "server": "hermes-tools", "tool": "kanban_complete", "arguments": {"task_id": tid, "summary": "supervised parent handoff"}}, timeout=50)
     report["stderr"] = c._stderr_lines[-8:]
 report["readback"] = {"own": kb.get_task(conn, own).status, "foreign": kb.get_task(conn, foreign).status, "integrity": conn.execute("PRAGMA integrity_check").fetchone()[0]}
 print(json.dumps(report, indent=2))

--- a/tests/agent/transports/test_codex_managed_mcp_overrides.py
+++ b/tests/agent/transports/test_codex_managed_mcp_overrides.py
@@ -1,0 +1,147 @@
+"""Worker overrides must target the endpoint the real migration registers."""
+
+from contextlib import ExitStack
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tomllib
+from types import SimpleNamespace
+
+import pytest
+
+from agent.delegation_context import (
+    DELEGATED_CHILD_ENV_MARKER, KANBAN_ENV_KEYS, delegated_child_context, non_dispatcher_owned_context,
+)
+from agent.transports.codex_app_server import CodexAppServerClient, check_codex_binary
+from hermes_cli.codex_runtime_plugin_migration import migrate
+
+
+@pytest.fixture
+def invocation(monkeypatch, tmp_path):
+    home = tmp_path / 'profile'
+    home.mkdir()
+    (home / 'config.yaml').write_text('toolsets: []\n')
+    monkeypatch.setenv('HOME', str(tmp_path))
+    monkeypatch.setenv('HERMES_HOME', str(home))
+    for key in (*KANBAN_ENV_KEYS, DELEGATED_CHILD_ENV_MARKER, 'HERMES_KANBAN_DB', 'HERMES_KANBAN_BOARD'):
+        monkeypatch.delenv(key, raising=False)
+    worker_env = {
+        'HERMES_KANBAN_TASK': '11111111-1111-4111-8111-111111111111',
+        'HERMES_KANBAN_RUN_ID': '42',
+        'HERMES_KANBAN_CLAIM_LOCK': (tmp_path / 'claim.lock').as_posix(),
+        'HERMES_KANBAN_GOAL_MODE': '1',
+        'HERMES_KANBAN_GOAL_MAX_TURNS': '3',
+        'HERMES_KANBAN_DB': (tmp_path / 'board with spaces' / 'kanban.db').as_posix(),
+        'HERMES_KANBAN_BOARD': 'test-board',
+    }
+
+    def build(mode, with_user_server):
+        if mode != 'ordinary':
+            for key, value in worker_env.items():
+                monkeypatch.setenv(key, value)
+        user_servers = {'hermes-mcp': {
+            'command': sys.executable, 'args': ['-c', 'raise SystemExit(0)'],
+            'env': {'USER_MARKER': 'unchanged'},
+        }} if with_user_server else {}
+        codex_home = tmp_path / 'codex'
+        report = migrate({'mcp_servers': user_servers}, codex_home=codex_home,
+                         discover_plugins=False, expose_hermes_tools=True)
+        assert not report.errors
+        config_path = codex_home / 'config.toml'
+        original = config_path.read_bytes()
+        servers = tomllib.loads(original.decode())['mcp_servers']
+        managed_name, = [name for name, cfg in servers.items()
+                        if cfg.get('args') == ['-m', 'agent.transports.hermes_tools_mcp_server']]
+        captured = {}
+
+        class Process:
+            def __init__(self, command, **kwargs):
+                captured.update(command=list(command), env=kwargs['env'].copy())
+                self.stdin = self.stdout = self.stderr = None
+
+        with ExitStack() as stack, monkeypatch.context() as patch:
+            if mode == 'delegated':
+                stack.enter_context(delegated_child_context())
+            elif mode == 'non-worker':
+                stack.enter_context(non_dispatcher_owned_context())
+            patch.setattr(subprocess, 'Popen', Process)
+            client = CodexAppServerClient(codex_bin='record-only', codex_home=str(codex_home))
+            client._closed = True
+            client._reader.join(2)
+            client._stderr_reader.join(2)
+            assert not client._reader.is_alive() and not client._stderr_reader.is_alive()
+        assert config_path.read_bytes() == original
+        return SimpleNamespace(**captured, servers=servers, managed_name=managed_name,
+                               worker_env=worker_env, config_path=config_path, home=home)
+
+    return build
+
+
+@pytest.mark.parametrize('mode', ['ordinary', 'worker', 'delegated', 'non-worker'])
+@pytest.mark.parametrize('with_user_server', [False, True])
+def test_worker_scope_matches_migrated_endpoint(invocation, mode, with_user_server):
+    case = invocation(mode, with_user_server)
+    overrides = {}
+    for index, argument in enumerate(case.command):
+        if argument == '-c' and case.command[index + 1].startswith('mcp_servers.'):
+            for name, config in tomllib.loads(case.command[index + 1])['mcp_servers'].items():
+                overrides.setdefault(name, {}).update(config.get('env', {}))
+    assert set(overrides) == ({case.managed_name} if mode == 'worker' else set())
+    assert not any(key in case.env for key in KANBAN_ENV_KEYS)
+    if mode != 'ordinary':
+        assert case.env[DELEGATED_CHILD_ENV_MARKER] == '1'
+    if with_user_server:
+        assert 'hermes-mcp' not in overrides
+        assert case.servers['hermes-mcp']['env'] == {'USER_MARKER': 'unchanged'}
+
+    endpoint = case.servers[case.managed_name]
+    endpoint_env = {key: case.env[key] for key in endpoint.get('env_vars', []) if key in case.env}
+    endpoint_env.update(endpoint.get('env', {}))
+    endpoint_env.update(overrides.get(case.managed_name, {}))
+    if mode == 'worker':
+        assert all(endpoint_env[key] == value for key, value in case.worker_env.items())
+        assert endpoint_env[DELEGATED_CHILD_ENV_MARKER] == ''
+    else:
+        assert not any(key in endpoint_env for key in KANBAN_ENV_KEYS)
+
+    # Evaluate the tool consumer in a fresh process, not the parent's ContextVars.
+    env = {**case.env, 'HERMES_HOME': str(case.home)}
+    for key in (*KANBAN_ENV_KEYS, DELEGATED_CHILD_ENV_MARKER):
+        env.pop(key, None)
+    env.update(endpoint_env)
+    script = (
+        'import json; from tools.kanban_tools import _check_kanban_mode, _default_task_id; '
+        'print(json.dumps({"available": _check_kanban_mode(), "task": _default_task_id(None)}))'
+    )
+    result = subprocess.run([sys.executable, '-c', script], env=env, cwd=Path(__file__).resolve().parents[3],
+                            capture_output=True, text=True, timeout=15)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {
+        'available': mode == 'worker', 'task': case.worker_env['HERMES_KANBAN_TASK'] if mode == 'worker' else None,
+    }
+
+
+@pytest.fixture(scope='module')
+def codex_cli():
+    binary = shutil.which('codex')
+    if binary is None:
+        pytest.skip('Codex CLI is not installed; producer/consumer tests still run')
+    available, version = check_codex_binary(binary)
+    if not available:
+        pytest.skip(version)
+    return binary
+
+
+@pytest.mark.parametrize('mode', ['ordinary', 'worker'])
+@pytest.mark.parametrize('with_user_server', [False, True])
+@pytest.mark.parametrize('command', [('mcp', 'list', '--json'), ('app-server',)])
+def test_native_codex_accepts_migrated_worker_config(invocation, codex_cli, mode, with_user_server, command):
+    case = invocation(mode, with_user_server)
+    # Immediate EOF: load configuration, but never initialize a model turn or invoke a tool.
+    result = subprocess.run([codex_cli, *command, *case.command[2:]], input='', env=case.env,
+                            capture_output=True, text=True, timeout=15)
+    assert result.returncode == 0, result.stderr
+    if command[0] == 'mcp':
+        assert {server['name'] for server in json.loads(result.stdout)} == set(case.servers)


### PR DESCRIPTION
## What does this PR do?

Kanban workers using `codex_app_server` add `mcp_servers.hermes-mcp.env.*` overrides, but migration registers the callback as `hermes-tools`. With the generated config, this creates an MCP entry without a command or URL, and Codex exits with `invalid transport` in `mcp_servers.hermes-mcp` before a turn starts. If the user already has a server named `hermes-mcp`, the overrides target that unrelated server instead.

Point both overrides at `hermes-tools`. Worker detection, process-environment filtering and sandbox settings stay unchanged; user-defined MCP entries are left alone.

## Type of Change

- [x] Bug fix

## Changes Made

- `agent/transports/codex_app_server.py`: correct the two worker-override targets to match the migrated endpoint.
- `tests/agent/transports/test_codex_managed_mcp_overrides.py`: connect real migration and constructor output to fresh-process Kanban tool checks, plus native Codex configuration and startup checks.

## How to Test

```bash
bash scripts/run_tests.sh -j 2 --file-retries 0 \
  tests/agent/transports/test_codex_managed_mcp_overrides.py
```

The tests cover ordinary calls, dispatcher workers, delegated children and non-worker contexts, with and without a user-defined `hermes-mcp` server. Native checks run `codex mcp list` and `codex app-server` against temporary configuration; app-server receives immediate EOF, without a model turn or tool call.

All **16 cases pass** on macOS with Codex CLI 0.137.0; **four fail** on unmodified main (`49ef015ca3`). The native cases skip when a compatible CLI is unavailable; the eight producer/consumer cases still run.

<details>
<summary>Broader validation</summary>

```bash
bash scripts/run_tests.sh -j 2 --file-retries 0 --file-timeout 180 \
  tests/agent/transports/test_codex_managed_mcp_overrides.py \
  tests/agent/transports/test_codex_app_server_runtime.py \
  tests/agent/transports/test_codex_app_server_session.py \
  tests/agent/transports/test_hermes_tools_mcp_server.py \
  tests/agent/test_codex_app_server_event_bridge.py \
  tests/hermes_cli/test_codex_runtime_plugin_migration.py \
  tests/hermes_cli/test_codex_runtime_switch.py \
  tests/hermes_cli/test_kanban_review_surfaces.py \
  tests/hermes_cli/test_kanban_worker_spawn_toolsets.py \
  tests/hermes_cli/test_signal_handler_kanban_worker.py \
  tests/hermes_cli/test_kanban_worker_terminal_cwd.py \
  tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py \
  tests/hermes_cli/test_kanban_worker_session_source.py \
  tests/hermes_cli/test_pin_kanban_board_env.py \
  tests/tools/test_hermes_subprocess_env.py \
  tests/tools/test_kanban_descendant_scope.py \
  tests/cron/test_cron_kanban_env_isolation.py
```

**202 passed, 2 skipped**, using isolated homes and no file retries. The same selection on the unmodified baseline gives 198 passed, the four expected failures and the same two skips: one Linux-only case and one requiring the optional ACP extra.

Full-repository Ruff, Windows-footgun, compatibility-pointer and diff checks pass. The new test file is Ty-clean; the changed production file retains one unchanged pre-existing diagnostic.

The full repository suite, native Linux/Windows, and live model/MCP tool sessions were not run.

</details>

## Checklist

- [x] Read the contributing guide and checked related PRs.
- [x] Added failing-before regression tests and preservation controls.
- [x] Kept the change scoped and tested it on macOS.
