### PR TITLE
fix(desktop): isolate missing plugin-SDK namespaces instead of failing every disk plugin

### DIFF
--- a/apps/desktop/src/sdk/runtime.test.ts
+++ b/apps/desktop/src/sdk/runtime.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { shimSource } from './runtime'
+import { sdkImportMap, shimSource } from './runtime'
 
 describe('plugin SDK shim source', () => {
   it('fails loudly at import time when the namespace is missing, naming the piece', () => {
@@ -18,5 +18,19 @@ describe('plugin SDK shim source', () => {
 
     expect(source).toContain('export const { ping } = m')
     expect(source).not.toContain('not-an-identifier!')
+  })
+
+  it('builds a usable shim URL for every supported specifier without throwing', () => {
+    const createObjectURL = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:fake-shim')
+
+    try {
+      const map = sdkImportMap()
+
+      for (const specifier of ['@hermes/plugin-sdk', 'react', 'react/jsx-runtime', 'react/jsx-dev-runtime']) {
+        expect(map[specifier]).toBe('blob:fake-shim')
+      }
+    } finally {
+      createObjectURL.mockRestore()
+    }
   })
 })

--- a/apps/desktop/src/sdk/runtime.test.ts
+++ b/apps/desktop/src/sdk/runtime.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { shimSource } from './runtime'
+
+describe('plugin SDK shim source', () => {
+  it('fails loudly at import time when the namespace is missing, naming the piece', () => {
+    for (const namespace of [undefined, null]) {
+      const source = shimSource('__HERMES_REACT_JSX_DEV__', namespace, 'react/jsx-dev-runtime')
+
+      expect(source.startsWith('throw new Error(')).toBe(true)
+      expect(source).toContain('react/jsx-dev-runtime')
+      expect(source).toContain('__HERMES_REACT_JSX_DEV__')
+    }
+  })
+
+  it('re-exports live members while skipping default and invalid identifiers', () => {
+    const source = shimSource('__HERMES_PLUGIN_SDK__', { ping: 1, default: 2, 'not-an-identifier!': 3 }, '@hermes/plugin-sdk')
+
+    expect(source).toContain('export const { ping } = m')
+    expect(source).not.toContain('not-an-identifier!')
+  })
+})

--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -20,21 +20,53 @@ const GLOBALS = {
   __HERMES_REACT_JSX_DEV__: jsxDevRuntime
 } as const
 
+/** Specifier -> injected global, longest keys first (matches rewrite order). */
+const SPECIFIER_GLOBALS = {
+  '@hermes/plugin-sdk': '__HERMES_PLUGIN_SDK__',
+  'react/jsx-dev-runtime': '__HERMES_REACT_JSX_DEV__',
+  'react/jsx-runtime': '__HERMES_REACT_JSX__',
+  react: '__HERMES_REACT__'
+} as const satisfies Record<string, keyof typeof GLOBALS>
+
 export function installPluginSdk(): void {
   Object.assign(globalThis, GLOBALS)
 }
 
-/** Build a shim ESM blob that re-exports a global namespace's live members.
- *  Export names come from the namespace itself, so the list can't drift. */
-function shimUrl(globalKey: keyof typeof GLOBALS): string {
-  const names = Object.keys(GLOBALS[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
+/** Shim body for one injected namespace. The namespace rides as a parameter
+ *  (not read off the module table) so the missing-namespace contract is
+ *  unit-testable without a renderer. */
+export function shimSource(
+  globalKey: string,
+  namespace: Record<string, unknown> | null | undefined,
+  specifier: string
+): string {
+  if (!namespace) {
+    // A namespace can go missing when the bundler drops or renames a module
+    // the map assumes (seen in the wild with react/jsx-dev-runtime): fail
+    // LOUDLY at import time, naming the missing piece, instead of throwing
+    // "Cannot convert undefined or null to object" while building the map —
+    // which blocks EVERY disk plugin, including ones that never import the
+    // missing specifier.
+    return `throw new Error(${JSON.stringify(
+      `Cannot load '${specifier}': the ${globalKey} namespace is missing from this app build. Update Hermes Desktop, then reload plugins.`
+    )});\n`
+  }
 
-  const source =
+  const names = Object.keys(namespace).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
+
+  return (
     `const m = globalThis.${globalKey};\n` +
     `export default m.default ?? m;\n` +
     // Guard the destructuring: `export const {  } = m` is a syntax error, so
     // only emit it when the namespace actually has named exports.
     (names.length ? `export const { ${names.join(', ')} } = m;\n` : '')
+  )
+}
+
+/** Build a shim ESM blob that re-exports a global namespace's live members.
+ *  Export names come from the namespace itself, so the list can't drift. */
+function shimUrl(globalKey: keyof typeof GLOBALS, specifier: string): string {
+  const source = shimSource(globalKey, GLOBALS[globalKey] as Record<string, unknown> | undefined, specifier)
 
   return URL.createObjectURL(new Blob([source], { type: 'text/javascript' }))
 }
@@ -43,12 +75,9 @@ let cached: Record<string, string> | null = null
 
 /** Specifier -> shim URL map for the runtime loader (longest keys first). */
 export function sdkImportMap(): Record<string, string> {
-  cached ??= {
-    '@hermes/plugin-sdk': shimUrl('__HERMES_PLUGIN_SDK__'),
-    'react/jsx-dev-runtime': shimUrl('__HERMES_REACT_JSX_DEV__'),
-    'react/jsx-runtime': shimUrl('__HERMES_REACT_JSX__'),
-    react: shimUrl('__HERMES_REACT__')
-  }
+  cached ??= Object.fromEntries(
+    Object.entries(SPECIFIER_GLOBALS).map(([specifier, globalKey]) => [specifier, shimUrl(globalKey, specifier)])
+  )
 
   return cached
 }

--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -13,23 +13,34 @@ import * as jsxRuntime from 'react/jsx-runtime'
 
 import * as sdk from './index'
 
-const GLOBALS = {
-  __HERMES_PLUGIN_SDK__: sdk,
-  __HERMES_REACT__: React,
-  __HERMES_REACT_JSX__: jsxRuntime,
-  __HERMES_REACT_JSX_DEV__: jsxDevRuntime
-} as const
-
 /** Specifier -> injected global, longest keys first (matches rewrite order). */
 const SPECIFIER_GLOBALS = {
   '@hermes/plugin-sdk': '__HERMES_PLUGIN_SDK__',
   'react/jsx-dev-runtime': '__HERMES_REACT_JSX_DEV__',
   'react/jsx-runtime': '__HERMES_REACT_JSX__',
   react: '__HERMES_REACT__'
-} as const satisfies Record<string, keyof typeof GLOBALS>
+} as const
+
+type GlobalKey = (typeof SPECIFIER_GLOBALS)[keyof typeof SPECIFIER_GLOBALS]
+
+/** Read the injected namespaces NOW, not at module evaluation. This module
+ *  sits in an import cycle (sdk/index -> contrib/* -> contrib/runtime-loader
+ *  -> sdk/runtime -> sdk/index), and production bundlers may evaluate a
+ *  module-scope capture before the bindings it references are assigned —
+ *  which is exactly how every disk plugin ended up failing to load. Both
+ *  entry points below run long after module evaluation, so reading here is
+ *  always safe. */
+export function pluginNamespaces(): Record<GlobalKey, Record<string, unknown> | undefined> {
+  return {
+    __HERMES_PLUGIN_SDK__: sdk as unknown as Record<string, unknown>,
+    __HERMES_REACT__: React as unknown as Record<string, unknown>,
+    __HERMES_REACT_JSX__: jsxRuntime as unknown as Record<string, unknown>,
+    __HERMES_REACT_JSX_DEV__: jsxDevRuntime as unknown as Record<string, unknown>
+  }
+}
 
 export function installPluginSdk(): void {
-  Object.assign(globalThis, GLOBALS)
+  Object.assign(globalThis, pluginNamespaces())
 }
 
 /** Shim body for one injected namespace. The namespace rides as a parameter
@@ -65,8 +76,8 @@ export function shimSource(
 
 /** Build a shim ESM blob that re-exports a global namespace's live members.
  *  Export names come from the namespace itself, so the list can't drift. */
-function shimUrl(globalKey: keyof typeof GLOBALS, specifier: string): string {
-  const source = shimSource(globalKey, GLOBALS[globalKey] as Record<string, unknown> | undefined, specifier)
+function shimUrl(globalKey: GlobalKey, specifier: string): string {
+  const source = shimSource(globalKey, pluginNamespaces()[globalKey], specifier)
 
   return URL.createObjectURL(new Blob([source], { type: 'text/javascript' }))
 }


### PR DESCRIPTION
## Symptom

In production desktop builds, every disk plugin fails to load before any plugin code runs:

> `[plugins] runtime load failed (<id>) TypeError: Cannot convert undefined or null to object`
> `(at bundled sdk-*.js: Object.keys <- shimUrl <- sdkImportMap)`

Verified plugin-independent: the last known-good plugin build fails identically, and the same file loads cleanly against a stub host.

## Root cause

The module-scope namespace capture in `apps/desktop/src/sdk/runtime.ts` sits in an import cycle (`sdk/index -> contrib/* -> contrib/runtime-loader -> sdk/runtime -> sdk/index`). Production bundlers may evaluate it before the captured bindings are assigned, so `Object.keys()` throws during map construction. Diagnosis credit to #107303 for the byte-offset forensics proving the ordering.

## Fix (two layers)

1. **Lazy resolution (the actual fix).** Namespaces are read at call time via `pluginNamespaces()` — both entry points (`installPluginSdk`, `shimUrl`) run long after module evaluation, so statement ordering stops mattering.
2. **Loud failure (diagnosability).** If a namespace is ever genuinely absent, `shimSource()` emits a shim that throws at import time, naming the specifier and the missing global — instead of one bad entry killing the map for every unrelated plugin.

## Relation to #107303 / #107309

Same outage, complementary mechanisms now combined here: #107303's lazy resolution (root fix) plus a named per-entry failure instead of #107309's silent empty shim. Happy to close mine in favor of #107303 if maintainers prefer it pure — the shimSource guard ports over in a few lines.

## Tests

- New `apps/desktop/src/sdk/runtime.test.ts` (3 tests): missing namespace yields an import-time throw naming both pieces; present namespaces re-export live members minus `default`/invalid identifiers; the full map builds a usable URL per specifier without throwing. Red on base, green with the fix.
- Neighbors pass: `src/sdk` + `src/contrib/plugin.test.ts` + `src/contrib/runtime-loader.test.ts` (97 tests). Full desktop `tsc --noEmit` clean, eslint clean.