### PR TITLE
fix(agent): preserve canonical docs URL in Anthropic OAuth prompt sanitizer

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -472,6 +472,8 @@ def _apply_claude_code_identity(system, anthropic_tools, anthropic_messages, to_
             text = block.get("text", "")
             for old, new in _OAUTH_SYSTEM_REPLACEMENTS:
                 text = text.replace(old, new)
+            # Preserve the canonical documentation host so docs URLs remain valid and resolvable
+            text = text.replace("claude-code.nousresearch.com", "hermes-agent.nousresearch.com")
             block["text"] = _apply_oauth_prose_aliases(text)
     for tool in anthropic_tools or []:
         if "name" in tool:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1896,3 +1896,38 @@ class TestFinalPayloadHasNoBlankTextBlocks:
         )
         image_blocks = [b for b in tool_result_block["content"] if b.get("type") == "image"]
         assert len(image_blocks) == 1
+
+
+class TestOAuthSystemPromptDocsPreservation:
+    def test_oauth_preserves_canonical_docs_url(self):
+        """The OAuth system prompt sanitizer rewrites product names ('Hermes Agent', 'hermes-agent')
+        to avoid Anthropic content filters, but must preserve the canonical documentation host
+        https://hermes-agent.nousresearch.com/docs intact so docs links remain valid (Fixes #48860)."""
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are Hermes Agent by Nous Research. For help with tools and capabilities, "
+                    "see the documentation at https://hermes-agent.nousresearch.com/docs."
+                ),
+            },
+            {"role": "user", "content": "hello"},
+        ]
+        kwargs = build_anthropic_kwargs(
+            "claude-sonnet-4-6",
+            messages,
+            tools=None,
+            max_tokens=1000,
+            reasoning_config=None,
+            is_oauth=True,
+        )
+        system_blocks = kwargs.get("system", [])
+        assert len(system_blocks) >= 2
+        # First block is the Claude Code prefix
+        # Second block is the sanitized user system prompt
+        text = system_blocks[1]["text"]
+        assert "Claude Code" in text
+        assert "Anthropic" in text
+        assert "https://hermes-agent.nousresearch.com/docs" in text
+        assert "claude-code.nousresearch.com" not in text
+


### PR DESCRIPTION
## Summary
Fixes #48860.

The OAuth system-prompt sanitizer in `agent/anthropic_adapter.py` rewrites product-name references (such as `"Hermes Agent" -> "Claude Code"` and `"hermes-agent" -> "claude-code"`) to avoid server-side content filter rejections on Anthropic OAuth/subscription accounts.

However, replacing `"hermes-agent"` with `"claude-code"` also modified the substring inside the documentation link defined in `agent/prompt_builder.py`:
`https://hermes-agent.nousresearch.com/docs` -> `https://claude-code.nousresearch.com/docs` (which produces an NXDOMAIN failure).

## Changes
- In `_apply_claude_code_identity` (`agent/anthropic_adapter.py`), preserve the canonical documentation host `hermes-agent.nousresearch.com` so documentation links remain valid and resolvable for OAuth users.
- Add unit test coverage in `tests/agent/test_anthropic_adapter.py` verifying that `build_anthropic_kwargs(..., is_oauth=True)` keeps the documentation URL intact while performing required product-name transforms.
