### PR TITLE
fix(model): route DeepSeek to the canonical deepseek-flash id

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -339,9 +339,11 @@ DEFAULT_CONTEXT_LENGTHS = {
     # Google / Gemma ("gemma4" is Ollama-style naming, e.g. gemma4:31b-cloud)
     "gemini": 1048576,
     "gemma-4": 256000, "gemma4": 256000, "gemma-4-31b": 256000, "gemma-3": 131072, "gemma": 8192,
-    # DeepSeek — V4 family is 1M; deepseek-chat/-reasoner alias v4-flash modes.
+    # DeepSeek — V4 generation is 1M; deepseek-flash is the canonical id of DeepSeek-V4.1-Flash
+    # (2026-09-10) and the retired V4 names are served by it.
     # https://api-docs.deepseek.com/zh-cn/quick_start/pricing
-    "deepseek-v4-pro": 1_000_000, "deepseek-v4-flash": 1_000_000, "deepseek-chat": 1_000_000,
+    "deepseek-v4-pro": 1_000_000, "deepseek-flash": 1_000_000, "deepseek-v4-flash": 1_000_000,
+    "deepseek-chat": 1_000_000,
     "deepseek-reasoner": 1_000_000, "deepseek": 128000,
     # Meta; Muse Spark family (1.1/1.2/1.3, -contributor(-free), meta/ prefixed) is 1M per OpenRouter,
     # models.dev and api.commandcode.ai /models — keep the "muse-spark" prefix (bare "muse" would match

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -19,8 +19,8 @@ _REASONING_STALE_TIMEOUT_FLOORS: dict[int, tuple[str, ...]] = {
     600: (
         # NVIDIA Nemotron behind hosted NIM: documented 60-180s upstream idle kill.
         "nemotron-3-ultra", "nemotron-3-super",
-        # DeepSeek R1 / V4 (reasoning_content streamed before final content).
-        "deepseek-r1", "deepseek-reasoner", "deepseek-v4-flash", "deepseek-v4-pro",
+        # DeepSeek R1 / V4 / V4.1 (reasoning_content streamed before final content).
+        "deepseek-r1", "deepseek-reasoner", "deepseek-flash", "deepseek-v4-flash", "deepseek-v4-pro",
         # OpenAI o-series: each variant enumerated so bare ``o1`` cannot over-match ``olmo-1``.
         "o1", "o1-mini", "o1-pro", "o1-preview", "o3", "o3-pro",
         # Mythos-class named models (claude-fable-5): 1M ctx + 128K output, a heavier thinking

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -186,11 +186,16 @@ _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
         "gpt-4.1-nano": ("0.10", "0.40", "0.025"), "o3": ("10.00", "40.00", "2.50"),
         "o3-mini": ("1.10", "4.40", "0.55"),
     }),
-    # deepseek-chat / deepseek-reasoner are deprecated aliases of
-    # deepseek-v4-flash's non-thinking / thinking modes — same rates.
-    ("deepseek", "https://api-docs.deepseek.com/quick_start/pricing", "deepseek-pricing-2026-07", {
-        ("deepseek-chat", "deepseek-reasoner", "deepseek-v4-flash"): ("0.14", "0.28", "0.0028"),
-        "deepseek-v4-pro": ("0.435", "0.87", "0.003625"),
+    # deepseek-flash is the canonical id of DeepSeek-V4.1-Flash (2026-09-10). The retired names
+    # deepseek-v4-flash / deepseek-chat / deepseek-reasoner are still accepted but served by the
+    # same model at the same Flash price. Docs publish peak/off-peak rates (off-peak = half; peak =
+    # 01:00-04:00 + 06:00-10:00 UTC Mon-Fri) and Hermes has no time-of-day pricing, so the PEAK
+    # rate is encoded — a displayed cost never under-reports the bill.
+    # deepseek-v4-pro is retired in favour of Flash from 2026-09-14 (requests route to Flash).
+    ("deepseek", "https://api-docs.deepseek.com/quick_start/pricing", "deepseek-pricing-2026-09-10", {
+        ("deepseek-flash", "deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"):
+            ("0.30", "1.20", "0.006"),
+        "deepseek-v4-pro": ("1.32", "3.96", "0.044"),
     }),
     ("google", "https://ai.google.dev/gemini-api/docs/pricing", "google-pricing-2026-09-02", {
         ("gemini-3.8-flash", "gemini-3.7-flash"): ("0.75", "3.75", "0.075"),

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -1499,7 +1499,7 @@ class GoalManager:
                 f"judge API unreachable {n_tx} turns in a row (check auxiliary.goal_judge provider/key in config.yaml)",
                 "continue", reason,
                 f"⏸ Goal paused — judge API returned errors ({n_tx} turns). Check the goal_judge provider/key in "
-                + _JUDGE_CONFIG_HINT.format(provider="deepseek", model="deepseek-v4-flash"),
+                + _JUDGE_CONFIG_HINT.format(provider="deepseek", model="deepseek-flash"),
             )
         if n_parse >= DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES:
             return self._pause_decision(

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -86,14 +86,26 @@ _CATALOGUE_PREFIX_REPAIR_PROVIDERS: frozenset[str] = frozenset({
 _LOWERCASE_MODEL_PROVIDERS: frozenset[str] = frozenset({
     "xiaomi"})
 
-# DeepSeek's direct API only accepts first-class V-series IDs after the 2026-07-24 cut-off (HTTP 400
-# otherwise). Both retired aliases map to deepseek-v4-flash per the official docs (thinking mode is
-# controlled by extra_body.thinking on the profile), so saved configs can't keep sending them.
+# DeepSeek's direct API only accepts first-class IDs — anything else returns HTTP 400 with
+# "The supported API model names are deepseek-flash, deepseek-v4-pro". ``deepseek-flash`` is the
+# canonical id of DeepSeek-V4.1-Flash (released 2026-09-10, replacing the V4 generation);
+# ``deepseek-v4-flash`` and the older ``deepseek-chat``/``deepseek-reasoner`` are retired names
+# that DeepSeek still serves — and bills at the Flash price — but can be cut off the way
+# ``deepseek-chat``/``deepseek-reasoner`` were on 2026-07-24, so nothing may leave on them.
+# Thinking mode is controlled by extra_body.thinking on the provider profile.
 _DEEPSEEK_RETIRED_ALIASES: frozenset[str] = frozenset({
     "deepseek-chat", "deepseek-reasoner"})
 
+# Retired ids that must reach the API under their current name. Must be consulted BEFORE the
+# V-series pass-through below, otherwise the retired name wins on the prefix match.
+_DEEPSEEK_RENAMED_MODELS: dict[str, str] = {
+    "deepseek-v4-flash": "deepseek-flash",
+}
+
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-v4-pro", "deepseek-v4-flash"})
+    "deepseek-v4-pro", "deepseek-flash"})
+
+_DEEPSEEK_FALLBACK_MODEL = "deepseek-flash"
 
 # First-class V-series IDs incl. future ``deepseek-v5-*`` and dated variants
 # (``deepseek-v4-flash-20260423``): verified real model ids, NOT aliases of ``deepseek-chat``.
@@ -102,12 +114,15 @@ _DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v\d+([-.].+)?$")
 
 def _normalize_for_deepseek(model_name: str) -> str:
     """Map a model input to a DeepSeek-accepted id: canonicals and ``deepseek-v<digit>…`` pass
-    through (future V-series work without a release); retired aliases and everything else become
-    ``deepseek-v4-flash``."""
+    through (future V-series work without a release); renamed ids follow their rename, and retired
+    aliases / fuzzy names become ``deepseek-flash``."""
     bare = _strip_vendor_prefix(model_name).lower()
+    renamed = _DEEPSEEK_RENAMED_MODELS.get(bare)
+    if renamed:
+        return renamed
     if bare in _DEEPSEEK_CANONICAL_MODELS or _DEEPSEEK_V_SERIES_RE.match(bare):
         return bare
-    return "deepseek-v4-flash"
+    return _DEEPSEEK_FALLBACK_MODEL
 
 
 def _strip_vendor_prefix(model_name: str) -> str:

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -204,7 +204,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-sonnet-4-6", "claude-opus-4-5-20251101", "claude-sonnet-4-5-20250929",
         "claude-opus-4-20250514", "claude-sonnet-4-20250514", "claude-haiku-4-5-20251001",
     ],
-    "deepseek": ["deepseek-v4-pro", "deepseek-v4-flash"],
+    "deepseek": ["deepseek-flash", "deepseek-v4-pro"],
     "xiaomi": ["mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "mimo-v2-flash"],
     "tencent-tokenhub": list(_TENCENT_MODELS),
     "tencent-tokenplan": list(_TENCENT_MODELS),

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -4,7 +4,9 @@ V4 defaults to thinking ON when ``extra_body.thinking`` is unset, and then
 requires ``reasoning_content`` to be echoed back on later turns (HTTP 400 after
 the first tool call otherwise). This profile sets ``thinking`` explicitly and
 maps effort onto DeepSeek's ``reasoning_effort``; V3 models are left untouched.
-Retired ``deepseek-chat``/``deepseek-reasoner`` IDs are remapped in
+``deepseek-flash`` is the versionless id of DeepSeek-V4.1-Flash (2026-09-10) and
+belongs to that same thinking-capable family; retired ``deepseek-v4-flash`` /
+``deepseek-chat`` / ``deepseek-reasoner`` IDs are remapped in
 ``hermes_cli.model_normalize`` before reaching here.
 """
 
@@ -14,6 +16,16 @@ from agent.reasoning_effort import DEEPSEEK_V4_EFFORTS, DEEPSEEK_V4_OVERRIDES, c
 from providers import register_provider
 from providers.base import ProviderProfile
 
+# Versionless ids of the V4-generation thinking models, which the "deepseek-v" prefix gate below
+# would otherwise miss.
+_V4_THINKING_IDS: frozenset[str] = frozenset({"deepseek-flash"})
+
+
+def _is_thinking_capable(m: str) -> bool:
+    """V4 generation and later — ``deepseek-v4*`` (plus future ``deepseek-v5*``) and the
+    versionless ``deepseek-flash`` id of V4.1-Flash. V3 and unknown ids stay untouched."""
+    return m in _V4_THINKING_IDS or (m.startswith("deepseek-v") and not m.startswith("deepseek-v3"))
+
 
 class DeepSeekProfile(ProviderProfile):
     """DeepSeek — extra_body.thinking + top-level reasoning_effort."""
@@ -22,7 +34,7 @@ class DeepSeekProfile(ProviderProfile):
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         m = (model or "").strip().lower()
-        if not m.startswith("deepseek-v") or m.startswith("deepseek-v3"):  # v4+ only; v3 excluded
+        if not _is_thinking_capable(m):
             return {}, {}
         rc = reasoning_config if isinstance(reasoning_config, dict) else None
         # Always set thinking explicitly (default enabled, matching the API default)
@@ -42,8 +54,8 @@ class DeepSeekProfile(ProviderProfile):
 deepseek = DeepSeekProfile(
     name="deepseek", aliases=("deepseek-chat",), env_vars=("DEEPSEEK_API_KEY",), display_name="DeepSeek",
     description="DeepSeek — native DeepSeek API", signup_url="https://platform.deepseek.com/",
-    fallback_models=("deepseek-v4-pro", "deepseek-v4-flash"), base_url="https://api.deepseek.com/v1",
-    default_aux_model="deepseek-v4-flash",
+    fallback_models=("deepseek-flash", "deepseek-v4-pro"), base_url="https://api.deepseek.com/v1",
+    default_aux_model="deepseek-flash",
 )
 
 register_provider(deepseek)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -355,6 +355,7 @@ class TestDefaultContextLengths:
 
         expected_keys = {
             "deepseek-v4-pro": 1_000_000,
+            "deepseek-flash": 1_000_000,
             "deepseek-v4-flash": 1_000_000,
             "deepseek-chat": 1_000_000,
             "deepseek-reasoner": 1_000_000,
@@ -373,8 +374,10 @@ class TestDefaultContextLengths:
              mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
              mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
             cases = [
+                ("deepseek-flash", 1_000_000),
                 ("deepseek-v4-pro", 1_000_000),
                 ("deepseek-v4-flash", 1_000_000),
+                ("deepseek/deepseek-flash", 1_000_000),
                 ("deepseek/deepseek-v4-pro", 1_000_000),
                 ("deepseek/deepseek-v4-flash", 1_000_000),
                 ("deepseek-chat", 1_000_000),

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -114,8 +114,9 @@ def test_deepseek_v4_pro_pricing_entry_exists():
 
     Before this fix, deepseek-v4-pro sessions showed as unknown cost
     in hermes insights because the _OFFICIAL_DOCS_PRICING table had no
-    entry for that model.  See #24218.  Rates track the 2026-07 price cut
-    ($1.74/$3.48 → $0.435/$0.87).
+    entry for that model.  See #24218.  Rates track the 2026-09-10 docs
+    page (peak / per 1M: $1.32 in, $3.96 out, $0.044 cache-hit); the model
+    is retired in favour of deepseek-flash from 2026-09-14.
     """
     entry = get_pricing_entry(
         "deepseek-v4-pro",
@@ -125,9 +126,9 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     assert entry is not None
     assert entry.input_cost_per_million is not None
     assert entry.output_cost_per_million is not None
-    assert float(entry.input_cost_per_million) == 0.435
-    assert float(entry.output_cost_per_million) == 0.87
-    assert float(entry.cache_read_cost_per_million) == 0.003625
+    assert float(entry.input_cost_per_million) == 1.32
+    assert float(entry.output_cost_per_million) == 3.96
+    assert float(entry.cache_read_cost_per_million) == 0.044
 
 
 def test_bundled_pricing_skips_endpoint_metadata(monkeypatch):
@@ -174,14 +175,14 @@ def test_unknown_model_falls_back_to_endpoint_metadata(monkeypatch):
 
 
 
-def test_deepseek_deprecated_aliases_price_as_v4_flash():
-    """Invariant: deepseek-chat / deepseek-reasoner are deprecated aliases for
-    deepseek-v4-flash's non-thinking / thinking modes (deprecation 2026-07-24)
-    — they must bill at identical rates to the flash entry, or sessions on the
-    legacy names over/under-report cost."""
-    flash = get_pricing_entry("deepseek-v4-flash", provider="deepseek")
+def test_deepseek_retired_names_price_as_flash():
+    """Invariant: deepseek-v4-flash / deepseek-chat / deepseek-reasoner are retired
+    names served by deepseek-flash (deepseek-chat/reasoner cut off 2026-07-24;
+    deepseek-v4-flash retired 2026-09-10) — they must bill at identical rates to
+    the canonical flash entry, or sessions on the legacy names over/under-report cost."""
+    flash = get_pricing_entry("deepseek-flash", provider="deepseek")
     assert flash is not None
-    for alias in ("deepseek-chat", "deepseek-reasoner"):
+    for alias in ("deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"):
         entry = get_pricing_entry(alias, provider="deepseek")
         assert entry is not None, alias
         assert entry.input_cost_per_million == flash.input_cost_per_million, alias

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -95,8 +95,8 @@ class TestCustomProviderIsNotAVendorIdentity:
 # ── DeepSeek V-series pass-through (bug: V4 models silently folded to V3) ──
 
 class TestDeepseekVSeriesPassThrough:
-    """DeepSeek's V-series IDs (``deepseek-v4-pro``, ``deepseek-v4-flash``,
-    and future ``deepseek-v<N>-*`` variants) are first-class model IDs
+    """DeepSeek's IDs (``deepseek-flash`` — the canonical id of V4.1-Flash since 2026-09-10 —
+    ``deepseek-v4-pro``, and future ``deepseek-v<N>-*`` variants) are first-class model IDs
     accepted directly by DeepSeek's Chat Completions API. Earlier code
     folded every non-reasoner name into ``deepseek-chat``, which on
     aggregators (Nous portal, OpenRouter via DeepInfra) routes to V3 —
@@ -110,21 +110,35 @@ class TestDeepseekVSeriesPassThrough:
         result = normalize_model_for_provider("deepseek-v4-pro", "deepseek")
         assert result == "deepseek-v4-pro"
 
+    def test_deepseek_provider_preserves_versionless_flash(self):
+        """``deepseek-flash`` is the name DeepSeek now publishes; it must reach the
+        API unchanged instead of being folded back to the retired ``deepseek-v4-flash``."""
+        assert normalize_model_for_provider("deepseek-flash", "deepseek") == "deepseek-flash"
+        assert _normalize_for_deepseek("deepseek/deepseek-flash") == "deepseek-flash"
+
 
 # ── DeepSeek post-2026-07-24 alias remapping ───────────────────────────
 
 class TestDeepseekCanonicalAndReasonerMapping:
-    """Retired aliases and fuzzy names rewrite to deepseek-v4-flash.
+    """Retired / renamed aliases and fuzzy names rewrite to ``deepseek-flash``.
 
     DeepSeek cut off ``deepseek-chat`` / ``deepseek-reasoner`` on
-    2026-07-24; sending them on the wire returns HTTP 400.
+    2026-07-24, and retired the ``deepseek-v4-flash`` name (its requests are
+    served by DeepSeek-V4.1-Flash and billed at the Flash price) on
+    2026-09-10. Nothing may leave on a retired name.
     """
 
 
     def test_provider_path_rewrites_reasoner(self):
         assert (
             normalize_model_for_provider("deepseek-reasoner", "deepseek")
-            == "deepseek-v4-flash"
+            == "deepseek-flash"
+        )
+
+    def test_retired_v4_flash_name_follows_the_rename(self):
+        assert (
+            normalize_model_for_provider("deepseek-v4-flash", "deepseek")
+            == "deepseek-flash"
         )
 
     @pytest.mark.parametrize("model", [
@@ -134,8 +148,8 @@ class TestDeepseekCanonicalAndReasonerMapping:
         "deepseek-reasoning-preview",
         "deepseek-cot-experimental",
     ])
-    def test_reasoner_keywords_map_to_v4_flash(self, model):
-        assert _normalize_for_deepseek(model) == "deepseek-v4-flash"
+    def test_reasoner_keywords_map_to_deepseek_flash(self, model):
+        assert _normalize_for_deepseek(model) == "deepseek-flash"
 
 
 # ── Regression: issue #78796 ───────────────────────────────────────────

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -105,9 +105,11 @@ class TestDeepSeekModelGating:
         "model",
         [
             "deepseek-v4-pro",
+            "deepseek-flash",
             "deepseek-v4-flash",
             "deepseek-v4-future-variant",
             "DEEPSEEK-V4-PRO",  # case-insensitive
+            "DEEPSEEK-FLASH",   # canonical versionless id, case-insensitive
         ],
     )
     def test_thinking_capable_models_emit_thinking(self, deepseek_profile, model):
@@ -186,16 +188,16 @@ class TestDeepSeekAuxModel:
     system.
     """
 
-    def test_profile_advertises_deepseek_v4_flash(self, deepseek_profile):
-        assert deepseek_profile.default_aux_model == "deepseek-v4-flash"
+    def test_profile_advertises_deepseek_flash(self, deepseek_profile):
+        assert deepseek_profile.default_aux_model == "deepseek-flash"
 
-    def test_fallback_models_are_v4_only(self, deepseek_profile):
+    def test_fallback_models_are_flash_then_pro(self, deepseek_profile):
         assert deepseek_profile.fallback_models == (
+            "deepseek-flash",
             "deepseek-v4-pro",
-            "deepseek-v4-flash",
         )
 
-    def test_consumer_api_returns_deepseek_v4_flash(self):
+    def test_consumer_api_returns_deepseek_flash(self):
         from agent.auxiliary_client import _get_aux_model_for_provider
-        assert _get_aux_model_for_provider("deepseek") == "deepseek-v4-flash"
+        assert _get_aux_model_for_provider("deepseek") == "deepseek-flash"
 


### PR DESCRIPTION
## Bug Description

DeepSeek renamed its Flash line on **2026-09-10**. The API now serves exactly two first-class ids, and the Hermes alias table has the mapping pointed the wrong way:

```
$ curl -s https://api.deepseek.com/v1/models -H "Authorization: Bearer $DEEPSEEK_API_KEY" | jq -r '.data[].id'
deepseek-flash
deepseek-v4-pro

$ # unknown id → the server names its own whitelist:
{"error":{"message":"The supported API model names are deepseek-flash, deepseek-v4-pro, but you passed deepseek-does-not-exist."}}

$ # retired id → the server rewrites it to the canonical one:
deepseek-v4-flash   -> HTTP 200, response model='deepseek-flash'
deepseek-chat       -> HTTP 200, response model='deepseek-flash'
deepseek-reasoner   -> HTTP 200, response model='deepseek-flash'
```

The official Models & Pricing page, footnote (1):

> Use **deepseek-flash** as the model name. The legacy names `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` are still accepted, but the corresponding models have been retired, their requests are served by the **DeepSeek-V4.1-Flash** model and billed at the Flash price.

So `deepseek-flash` is the canonical id of DeepSeek-V4.1-Flash and `deepseek-v4-flash` is the retired name — the opposite of what `_normalize_for_deepseek` assumes. Concretely, on current `main`:

- `normalize_model_for_provider("deepseek-flash", "deepseek")` → `"deepseek-v4-flash"`. The `/model` picker offers `deepseek-flash` from the provider's live catalog, and selecting it silently sends the retired name — the canonical id is unreachable.
- The status bar therefore shows a name DeepSeek no longer publishes (and flips from the configured value to it after the first turn, once the agent normalizes `agent.model`).
- The provider profile gates explicit `extra_body.thinking` on `m.startswith("deepseek-v")`, so the versionless id would miss it.
- Context-length / pricing rows have no `deepseek-flash` entry, and the flash pricing row is the pre-V4.1 snapshot.

Nothing is broken *yet* only because DeepSeek keeps serving retired names; it cut `deepseek-chat` / `deepseek-reasoner` off with HTTP 400 on 2026-07-24, so a retired name on the wire is debt.

Fixes nothing (no issue filed for it that I could find — happy to move this under one if it exists).

## Root Cause

`hermes_cli/model_normalize.py` encodes the 2026-07 rename (`deepseek-chat` / `deepseek-reasoner` → `deepseek-v4-flash`) and treats every non-`deepseek-v<N>` name as a fuzzy alias that must become `deepseek-v4-flash`. DeepSeek's 2026-09-10 release renames the Flash line again — to a versionless id — which that rule folds back into the retired name.

## Fix

- `hermes_cli/model_normalize.py` — `deepseek-flash` joins the canonical set; a `_DEEPSEEK_RENAMED_MODELS` table maps the retired `deepseek-v4-flash` to it (consulted before the `deepseek-v<digit>` pass-through, which would otherwise win on the prefix match); the fallback for retired/fuzzy names is now `deepseek-flash`. `deepseek-v4-pro` and future `deepseek-v5-*` still pass through untouched.
- `plugins/model-providers/deepseek/__init__.py` — the thinking gate becomes `_is_thinking_capable()`, which accepts the versionless id, so `deepseek-flash` still gets the explicit `extra_body.thinking` marker the profile sends to avoid the `reasoning_content` echo trap. `fallback_models` / `default_aux_model` move to `deepseek-flash`.
- `agent/model_metadata.py` — `deepseek-flash` is 1M context.
- `agent/usage_pricing.py` — row refreshed from the 2026-09-10 docs page. Note: the page publishes peak **and** off-peak rates (off-peak = half of peak; peak = 01:00-04:00 + 06:00-10:00 UTC Mon-Fri) and the table has no time-of-day support, so the **peak** rate is encoded — a displayed cost never under-reports. Happy to switch to off-peak if you'd rather track the standard rate.
- `agent/reasoning_timeouts.py` — `deepseek-flash` gets the 600s reasoning floor alongside the other DeepSeek reasoning ids.
- `hermes_cli/models_catalog_static.py`, `hermes_cli/goals.py` — static catalog order and the judge-config hint string move to the canonical id.
- Tests: expectations move to the canonical id, plus two behaviour contracts — `deepseek-flash` reaches the API unchanged, and `deepseek-v4-flash` follows the rename.

## How to Verify

1. `scripts/run_tests.sh tests/hermes_cli/test_model_normalize.py` — `deepseek-flash` passes through; `deepseek-v4-flash` / `deepseek-chat` / `deepseek-reasoner` become `deepseek-flash`.
2. Against the real API (any DeepSeek key):
   ```
   curl -s https://api.deepseek.com/v1/models -H "Authorization: Bearer $KEY" | jq -r '.data[].id'
   # deepseek-flash / deepseek-v4-pro
   ```
   then `POST /chat/completions` with `{"model": "deepseek-v4-flash", ...}` — the response echoes `model: "deepseek-flash"`, i.e. the server treats the id Hermes was sending as the retired alias.
3. `python -c "from hermes_cli.model_normalize import normalize_model_for_provider as n; print(n('deepseek-flash','deepseek'))"` on `main` → `deepseek-v4-flash`; with this branch → `deepseek-flash`.
4. Transport wire shape with the patch: `model=deepseek-flash`, `reasoning_effort=<effort>`, `extra_body={'thinking': {'type': 'enabled'}}`.

## Test Plan

- [x] Added regression tests for this bug (`plan: pass-through for the canonical id`, `retired name follows the rename`, thinking wire shape for the versionless id)
- [x] Existing tests still pass — `scripts/run_tests.sh` over the 19 touched/adjacent test files: **918 passed, 0 failed** (test_model_normalize, test_deepseek_profile, test_usage_pricing, test_model_metadata, test_doctor, test_auxiliary_client, test_inventory, test_catalog_variants, test_model_switch_custom_providers, test_model_validation, test_goals, test_provider_groups, test_list_picker_providers, test_reasoning_stale_timeout_floor, test_system_prompt, test_title_generator, test_delegate_request_overrides, test_model_prefix_routing_87189, test_opencode_go_flat_namespace)
- [x] Manual verification of the fix against the live DeepSeek API (transcripts above)

## Risk Assessment

**Low.** The change is confined to the `deepseek` provider path plus two data tables. Blast radius:

- `deepseek-v4-flash` users now send `deepseek-flash` — the same model, billed at the same Flash price per the docs footnote, so no behaviour change beyond the name on the wire.
- Other providers that resell `deepseek-v4-flash` (OpenRouter, opencode-go, Nous portal, Fireworks, …) are untouched: they key off their own ids and never enter `_normalize_for_deepseek`.
- `deepseek-v4-pro` is unchanged here; note it is itself retired for Flash routing from **2026-09-14 12:00 Beijing** (docs footnote 2) — deliberately left out of scope.
- Pricing numbers change for DeepSeek rows (peak vs the old snapshot), so cost displays move; that trade-off is deliberate and documented in the row comment.
