### PR TITLE
fix(simplex): reconcile missed inbound items

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -18,6 +18,7 @@ import os
 import random
 import re
 import time
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -115,8 +116,18 @@ class SimplexAdapter(BasePlatformAdapter):
         self._ws = None  # websockets connection
         self._ws_task: Optional[asyncio.Task] = None
         self._health_task: Optional[asyncio.Task] = None
+        self._health_prime_task: Optional[asyncio.Task] = None
         self._running = False
         self._last_ws_activity = 0.0
+        self._health_item_highwater: Optional[int] = None
+        self._preprime_deferred_item: Optional[int] = None
+        self._seen_chat_items: set[int] = set()
+        self._pending_chat_items: set[int] = set()
+        self._retry_chat_items: set[int] = set()
+        self._delivering_chat_items: set[int] = set()
+        self._max_unreconciled_seen_items = 2000
+        self._seen_chat_item_order = deque()
+        self._max_recent_reconciled_seen_items = 2000
         self._pending_corr_ids: set = set()  # cosmetic echo filter: corrIds we minted, bounded
         self._max_pending_corr = 200
         self._pending_file_transfers: Dict[int, dict] = {}  # awaiting rcvFileComplete, by fileId
@@ -126,6 +137,7 @@ class SimplexAdapter(BasePlatformAdapter):
         self._text_batch_delay = float(os.getenv("HERMES_SIMPLEX_TEXT_BATCH_DELAY", "0.8"))
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        self._pending_text_batch_item_ids: Dict[str, List[int]] = {}
         logger.info(
             "SimpleX adapter initialized: url=%s auto_accept=%s groups=%s",
             self.ws_url, self.auto_accept, "enabled" if self.group_allow_from else "disabled")
@@ -158,6 +170,7 @@ class SimplexAdapter(BasePlatformAdapter):
         self._running = False
         await _cancel_task(self._ws_task)
         await _cancel_task(self._health_task)
+        await _cancel_task(self._health_prime_task)
         if self._ws:
             with contextlib.suppress(Exception):
                 await self._ws.close()
@@ -168,6 +181,9 @@ class SimplexAdapter(BasePlatformAdapter):
                     item.cancel()
         self._pending_text_batch_tasks.clear()
         self._pending_text_batches.clear()
+        self._pending_text_batch_item_ids.clear()
+        self._pending_chat_items.clear()
+        self._delivering_chat_items.clear()
         self._pending_responses.clear()
         self._mark_disconnected()
         logger.info("SimpleX: disconnected")
@@ -181,6 +197,10 @@ class SimplexAdapter(BasePlatformAdapter):
                 logger.debug("SimpleX WS: connecting to %s", self.ws_url)
                 async with _wsclient.connect(self.ws_url, ping_interval=20, ping_timeout=20, close_timeout=10) as ws:
                     self._ws = ws
+                    if self._health_item_highwater is None:
+                        self._health_prime_task = asyncio.create_task(
+                            self._prime_health_cursor(ws)
+                        )
                     backoff = WS_RETRY_DELAY_INITIAL
                     self._last_ws_activity = time.time()
                     logger.info("SimpleX WS: connected")
@@ -203,18 +223,146 @@ class SimplexAdapter(BasePlatformAdapter):
                 if self._running:
                     logger.warning("SimpleX WS: unexpected error: %s (reconnecting in %.0fs)", e, backoff)
             finally:
+                await _cancel_task(self._health_prime_task)
+                self._health_prime_task = None
                 self._ws = None
             if self._running:
                 await asyncio.sleep(backoff + backoff * 0.2 * random.random())
                 backoff = min(backoff * 2, WS_RETRY_DELAY_MAX)
 
+    @staticmethod
+    def _chat_item_id(item: dict) -> Optional[int]:
+        chat_item = item.get("chatItem")
+        if not isinstance(chat_item, dict):
+            return None
+        meta = chat_item.get("meta")
+        if not isinstance(meta, dict):
+            return None
+        item_id = meta.get("itemId")
+        return (
+            item_id
+            if isinstance(item_id, int) and not isinstance(item_id, bool) and item_id > 0
+            else None
+        )
+
+    def _rewind_health_cursor(self, item_id: int) -> None:
+        """Keep reconciliation behind an item until its delivery is settled."""
+        if (
+            self._health_item_highwater is not None
+            and item_id <= self._health_item_highwater
+        ):
+            self._health_item_highwater = max(0, item_id - 1)
+
+    async def _prime_health_cursor(self, ws=None) -> bool:
+        """Snapshot the latest item through the running correlated receiver."""
+        probe_ws = ws or self._ws
+        response = await self._send_command("/_get items count=1", timeout=10.0)
+        response_items = response.get("chatItems") if isinstance(response, dict) else None
+        valid_response = (
+            isinstance(response, dict)
+            and response.get("type") == "chatItems"
+            and isinstance(response_items, list)
+            and all(
+                isinstance(item, dict) and self._chat_item_id(item) is not None
+                for item in response_items
+            )
+        )
+        if not valid_response:
+            if probe_ws:
+                with contextlib.suppress(Exception):
+                    await probe_ws.close()
+            return False
+        assert isinstance(response_items, list)
+        item_ids = [self._chat_item_id(item) for item in response_items]
+        cursor = max(
+            (item_id for item_id in item_ids if item_id is not None), default=0
+        )
+        unsettled = self._pending_chat_items | self._retry_chat_items
+        if self._preprime_deferred_item is not None:
+            unsettled.add(self._preprime_deferred_item)
+        if unsettled:
+            cursor = min(cursor, max(0, min(unsettled) - 1))
+        self._health_item_highwater = cursor
+        self._preprime_deferred_item = None
+        self._prune_reconciled_seen_items()
+        return True
+
+    async def _run_health_check(self) -> bool:
+        """Replay stored items newer than the last reconciled global item ID."""
+        if self._health_item_highwater is None:
+            return False
+
+        page_size = 100
+        max_pages = 10
+        for _ in range(max_pages):
+            cursor = self._health_item_highwater
+            response = await self._send_command(
+                f"/_get items after={cursor} count={page_size}", timeout=10.0
+            )
+            if not isinstance(response, dict) or response.get("type") != "chatItems":
+                return False
+            response_items = response.get("chatItems")
+            if not isinstance(response_items, list):
+                return False
+            ordered_items = []
+            page_ids = set()
+            for item in response_items:
+                item_id = self._chat_item_id(item) if isinstance(item, dict) else None
+                if item_id is None or item_id <= cursor or item_id in page_ids:
+                    return False
+                page_ids.add(item_id)
+                ordered_items.append((item_id, item))
+            ordered_items.sort(key=lambda pair: pair[0])
+            if not ordered_items:
+                return not response_items
+
+            page_max = ordered_items[-1][0]
+            unsettled = self._pending_chat_items | self._retry_chat_items
+            if any(
+                cursor < item_id <= page_max and item_id not in page_ids
+                for item_id in unsettled
+            ):
+                return False
+
+            previous_cursor = cursor
+            for item_id, item in ordered_items:
+                delivered = await self._handle_chat_item(item, replay=True)
+                if delivered is False:
+                    return True
+                unsettled = self._pending_chat_items | self._retry_chat_items
+                if any(pending_id <= item_id for pending_id in unsettled):
+                    return True
+                self._health_item_highwater = item_id
+                self._prune_reconciled_seen_items()
+            if len(response_items) < page_size:
+                return True
+            if (
+                self._health_item_highwater is None
+                or self._health_item_highwater <= previous_cursor
+            ):
+                return False
+
+        logger.info("SimpleX: health replay backlog remains after %d items", page_size * max_pages)
+        return True
+
     async def _health_monitor(self) -> None:
-        """Log (never reconnect on) WebSocket idleness: simplex-chat legitimately stays
-        application-silent for long periods and the client already sends protocol pings."""
+        """Verify daemon responsiveness and reconcile missed inbound events."""
         while self._running:
             await asyncio.sleep(HEALTH_CHECK_INTERVAL)
             if not self._running:
                 break
+            probe_ws = self._ws
+            try:
+                healthy = await self._run_health_check()
+            except Exception:
+                logger.exception("SimpleX: health check failed")
+                healthy = False
+            if not healthy:
+                logger.warning("SimpleX: health check failed, forcing reconnect")
+                if probe_ws and self._ws is probe_ws:
+                    with contextlib.suppress(Exception):
+                        await probe_ws.close()
+                continue
             elapsed = time.time() - self._last_ws_activity
             if elapsed > HEALTH_CHECK_STALE_THRESHOLD:
                 logger.debug("SimpleX: WS application-idle for %.0fs", elapsed)
@@ -246,7 +394,8 @@ class SimplexAdapter(BasePlatformAdapter):
         contact_req_id = (resp.get("contactRequest", {}) or {}).get("contactRequestId")
         if contact_req_id is not None:
             logger.info("SimpleX: auto-accepting contact request %s", _redact_id(str(contact_req_id)))
-            await self._send_command(f"/accept {contact_req_id}")
+            # The event listener must remain free to receive this command's response.
+            await self._send_fire_and_forget(f"/accept {contact_req_id}")
 
     async def _on_rcv_file_descr_ready(self, resp: dict) -> None:
         """XFTP files fire this before newChatItems; start the download now, the chat item arrives later."""
@@ -271,6 +420,13 @@ class SimplexAdapter(BasePlatformAdapter):
         if file_id is None or file_id not in self._pending_file_transfers:
             return
         pending = self._pending_file_transfers.pop(file_id)
+        pending_item_id = self._chat_item_id(pending)
+        if pending_item_id is not None:
+            self._pending_chat_items.discard(pending_item_id)
+            if pending_item_id in self._seen_chat_items:
+                self._retry_chat_items.discard(pending_item_id)
+            else:
+                self._retry_chat_items.add(pending_item_id)
         file_source = file_info.get("fileSource", {}) or {}
         file_path = file_source.get("filePath") if isinstance(file_source, dict) else None
         if file_path:
@@ -290,7 +446,9 @@ class SimplexAdapter(BasePlatformAdapter):
         except Exception:
             logger.exception(err_msg)
 
-    async def _handle_chat_item(self, chat_item: dict) -> None:
+    async def _handle_chat_item(
+        self, chat_item: dict, *, replay: bool = False
+    ) -> Optional[bool]:
         chat_info = chat_item.get("chatInfo", {}) or {}
         chat_item_data = chat_item.get("chatItem", {}) or {}
         chat_type = chat_info.get("type", "")
@@ -333,6 +491,83 @@ class SimplexAdapter(BasePlatformAdapter):
         if not sender_id:
             logger.debug("SimpleX: ignoring message with no sender")
             return
+        # Polling reconciliation can race the live event.  Reject an item that
+        # completed delivery already; deferred/failed items are marked later.
+        item_id = self._chat_item_id(chat_item)
+        if item_id is None:
+            logger.warning("SimpleX: ignoring message with missing or invalid itemId")
+            return False
+        if item_id is not None and item_id in self._seen_chat_items:
+            return True
+        if item_id is not None and item_id in self._delivering_chat_items:
+            return False
+        cursor = self._health_item_highwater
+        if (
+            item_id is not None
+            and not replay
+            and (cursor is None or item_id > cursor)
+            and len(
+                {
+                    seen_id
+                    for seen_id in self._seen_chat_items
+                    if cursor is None or seen_id > cursor
+                }
+                | self._pending_chat_items
+                | self._retry_chat_items
+                | self._delivering_chat_items
+            )
+            >= self._max_unreconciled_seen_items
+        ):
+            if cursor is None:
+                self._preprime_deferred_item = min(
+                    item_id,
+                    self._preprime_deferred_item or item_id,
+                )
+            logger.warning(
+                "SimpleX: reconciliation backlog full; deferring live item %d",
+                item_id,
+            )
+            return False
+        if item_id is not None and item_id in self._pending_chat_items:
+            pending_file = chat_item_data.get("file", {}) or {}
+            pending_source = (
+                pending_file.get("fileSource", {})
+                if isinstance(pending_file, dict)
+                else {}
+            ) or {}
+            file_ready_for_replay = (
+                replay
+                and isinstance(pending_source, dict)
+                and bool(pending_source.get("filePath"))
+            )
+            if not file_ready_for_replay:
+                pending_name = (
+                    pending_file.get("fileName", "")
+                    if isinstance(pending_file, dict)
+                    else ""
+                )
+                pending_id = (
+                    pending_file.get("fileId")
+                    if isinstance(pending_file, dict)
+                    else None
+                )
+                if (
+                    replay
+                    and pending_id is not None
+                    and _is_audio_ext(Path(pending_name).suffix.lower())
+                ):
+                    await self._send_fire_and_forget(f"/freceive {pending_id}")
+                return False
+            ready_file_id = (
+                pending_file.get("fileId")
+                if isinstance(pending_file, dict)
+                else None
+            )
+            if ready_file_id is not None:
+                if self._pending_file_transfers.pop(ready_file_id, None) is None:
+                    return False
+            self._pending_chat_items.discard(item_id)
+            self._retry_chat_items.add(item_id)
         # Attachment: chatItem.chatItem.file (sibling of meta/content/chatDir).
         media_urls: List[str] = []
         media_types: List[str] = []
@@ -349,8 +584,12 @@ class SimplexAdapter(BasePlatformAdapter):
             if not file_path and _is_audio_ext(ext) and file_id is not None:
                 logger.info("SimpleX: voice file %d not yet received, accepting transfer", file_id)
                 self._pending_file_transfers[file_id] = chat_item
+                if isinstance(item_id, int):
+                    self._retry_chat_items.discard(item_id)
+                    self._pending_chat_items.add(item_id)
+                    self._rewind_health_cursor(item_id)
                 await self._send_fire_and_forget(f"/freceive {file_id}")
-                return
+                return False
             if file_path:
                 media_urls.append(file_path)
                 media_types.append(_mime_for_ext(ext))
@@ -371,25 +610,93 @@ class SimplexAdapter(BasePlatformAdapter):
             source=source, text=text or "", message_type=msg_type, media_urls=media_urls,
             media_types=media_types, timestamp=timestamp, raw_message=chat_item)
         logger.debug("SimpleX: message from %s in %s: %s", _redact_id(sender_id), chat_id[:20], (text or "")[:50])
-        if msg_type == MessageType.TEXT and text:  # batch rapid-fire text into one combined message
+        if isinstance(item_id, int):
+            self._retry_chat_items.discard(item_id)
+            self._pending_chat_items.add(item_id)
+            self._rewind_health_cursor(item_id)
+        if msg_type == MessageType.TEXT and text and not replay:
+            key = self._text_batch_key(msg_event)
+            if isinstance(item_id, int):
+                self._pending_text_batch_item_ids.setdefault(key, []).append(item_id)
             self._enqueue_text_event(msg_event)
-        else:
+            return False
+        if isinstance(item_id, int):
+            self._delivering_chat_items.add(item_id)
+        try:
             await self.handle_message(msg_event)
+        except Exception:
+            if isinstance(item_id, int):
+                self._delivering_chat_items.discard(item_id)
+                self._pending_chat_items.discard(item_id)
+                self._retry_chat_items.add(item_id)
+                self._rewind_health_cursor(item_id)
+            raise
+        if isinstance(item_id, int):
+            self._mark_chat_item_delivered(item_id)
+        return True
 
     # Text batching: enqueue lives on BasePlatformAdapter.
 
     def _text_batch_key(self, event: MessageEvent) -> str:
         return f"{event.source.platform.value}:{event.source.chat_id}"
 
+    def _mark_chat_item_delivered(self, item_id: int) -> None:
+        self._delivering_chat_items.discard(item_id)
+        self._pending_chat_items.discard(item_id)
+        self._retry_chat_items.discard(item_id)
+        self._seen_chat_items.add(item_id)
+        self._seen_chat_item_order.append(item_id)
+
+    def _prune_reconciled_seen_items(self) -> None:
+        """Keep unreconciled IDs plus a bounded recent reconciled window."""
+        cursor = self._health_item_highwater
+        if cursor is None:
+            return
+        unreconciled = {
+            item_id for item_id in self._seen_chat_items if item_id > cursor
+        }
+        recent_reconciled = []
+        retained = set()
+        for item_id in reversed(self._seen_chat_item_order):
+            if item_id <= cursor and item_id not in retained:
+                recent_reconciled.append(item_id)
+                retained.add(item_id)
+                if len(recent_reconciled) >= self._max_recent_reconciled_seen_items:
+                    break
+        retained |= unreconciled
+        self._seen_chat_items = retained
+        self._seen_chat_item_order = deque(
+            item_id for item_id in self._seen_chat_item_order if item_id in retained
+        )
+
     async def _flush_text_batch(self, key: str) -> None:
         """Wait for the quiet period then dispatch the aggregated text."""
         current_task = asyncio.current_task()
+        batch_item_ids: List[int] = []
         try:
             await asyncio.sleep(self._text_batch_delay)
             event = self._pending_text_batches.pop(key, None)
             if event:
+                batch_item_ids = self._pending_text_batch_item_ids.pop(key, [])
                 logger.info("[SimpleX] Flushing text batch %s (%d chars)", key, len(event.text or ""))
                 await self.handle_message(event)
+                for item_id in batch_item_ids:
+                    self._mark_chat_item_delivered(item_id)
+        except asyncio.CancelledError:
+            for item_id in batch_item_ids:
+                self._pending_chat_items.discard(item_id)
+                self._retry_chat_items.add(item_id)
+                self._rewind_health_cursor(item_id)
+            raise
+        except Exception:
+            failed_ids = batch_item_ids or self._pending_text_batch_item_ids.pop(
+                key, []
+            )
+            for item_id in failed_ids:
+                self._pending_chat_items.discard(item_id)
+                self._retry_chat_items.add(item_id)
+                self._rewind_health_cursor(item_id)
+            raise
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
@@ -426,6 +733,9 @@ class SimplexAdapter(BasePlatformAdapter):
         try:
             await ws.send(json.dumps({"corrId": corr_id, "cmd": command}))
             return await asyncio.wait_for(fut, timeout=timeout)
+        except asyncio.CancelledError:
+            self._pending_responses.pop(corr_id, None)
+            raise
         except asyncio.TimeoutError:
             logger.warning("SimpleX: command timed out: %s", command[:50])
         except Exception as e:
@@ -434,7 +744,7 @@ class SimplexAdapter(BasePlatformAdapter):
         return None
 
     async def _send_fire_and_forget(self, command: str) -> None:
-        """Send a command the daemon never replies to with a corrId (e.g. ``/freceive``)."""
+        """Send a command whose correlated response is not needed by the caller."""
         await self._send_ws({"corrId": self._make_corr_id(), "cmd": command})
 
     async def _send_items(self, chat_id: str, items: list, error: str) -> SendResult:

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -326,6 +326,17 @@ async def test_standalone_send_defaults_to_local_daemon(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_contact_accept_does_not_block_event_listener_for_response():
+    adapter = _adapter_with_ws()
+    adapter.auto_accept = True
+    adapter._send_fire_and_forget = AsyncMock()
+
+    await adapter._on_contact_request({"contactRequest": {"contactRequestId": 7}})
+
+    adapter._send_fire_and_forget.assert_awaited_once_with("/accept 7")
+
+
+@pytest.mark.asyncio
 async def test_health_monitor_does_not_reconnect_quiet_healthy_ws(monkeypatch):
     from gateway.config import PlatformConfig
     cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
@@ -333,6 +344,7 @@ async def test_health_monitor_does_not_reconnect_quiet_healthy_ws(monkeypatch):
     adapter._running = True
     adapter._last_ws_activity = 0
     adapter._ws = AsyncMock()
+    adapter._run_health_check = AsyncMock(return_value=True)
 
     monkeypatch.setattr(_simplex, "HEALTH_CHECK_INTERVAL", 0.01)
     monkeypatch.setattr(_simplex, "HEALTH_CHECK_STALE_THRESHOLD", 0.01)
@@ -342,7 +354,657 @@ async def test_health_monitor_does_not_reconnect_quiet_healthy_ws(monkeypatch):
     adapter._running = False
     await asyncio.wait_for(task, timeout=1)
 
+    adapter._run_health_check.assert_awaited()
     adapter._ws.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_health_monitor_reconnects_when_daemon_probe_fails(monkeypatch):
+    adapter = _adapter_with_ws()
+    adapter._running = True
+    adapter._run_health_check = AsyncMock(return_value=False)
+
+    monkeypatch.setattr(_simplex, "HEALTH_CHECK_INTERVAL", 0.01)
+
+    task = asyncio.create_task(adapter._health_monitor())
+    await asyncio.sleep(0.03)
+    adapter._running = False
+    await asyncio.wait_for(task, timeout=1)
+
+    adapter._run_health_check.assert_awaited()
+    adapter._ws.close.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stale_health_probe_does_not_close_reconnected_socket(monkeypatch):
+    adapter = _adapter_with_ws()
+    adapter._running = True
+    old_ws = adapter._ws
+    new_ws = AsyncMock()
+
+    async def stale_probe():
+        adapter._ws = new_ws
+        adapter._running = False
+        return False
+
+    adapter._run_health_check = stale_probe
+    monkeypatch.setattr(_simplex, "HEALTH_CHECK_INTERVAL", 0.01)
+
+    await adapter._health_monitor()
+
+    old_ws.close.assert_not_awaited()
+    new_ws.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_health_check_replays_inbound_item_missing_from_live_ws():
+    adapter = _adapter_with_ws()
+    replayed_item = {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 4, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemId": 11},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "text", "text": "missed"},
+            },
+        },
+    }
+    commands = []
+
+    async def fake_send_command(command, timeout=30.0):
+        commands.append(command)
+        return {"type": "chatItems", "chatItems": [replayed_item]}
+
+    adapter._send_command = fake_send_command
+    adapter._health_item_highwater = 10
+    adapter._handle_chat_item = AsyncMock()
+
+    healthy = await adapter._run_health_check()
+
+    assert healthy is True
+    adapter._handle_chat_item.assert_awaited_once_with(replayed_item, replay=True)
+    assert adapter._health_item_highwater == 11
+    assert commands == ["/_get items after=10 count=100"]
+
+
+@pytest.mark.asyncio
+async def test_health_cursor_is_primed_before_live_listener_starts():
+    adapter = _adapter_with_ws()
+    adapter._send_command = AsyncMock(
+        return_value={
+            "type": "chatItems",
+            "chatItems": [{"chatItem": {"meta": {"itemId": 41}}}],
+        }
+    )
+
+    assert await adapter._prime_health_cursor() is True
+    assert adapter._health_item_highwater == 41
+    adapter._send_command.assert_awaited_once_with(
+        "/_get items count=1", timeout=10.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_health_cursor_rejects_malformed_chat_items():
+    adapter = _adapter_with_ws()
+    adapter._send_command = AsyncMock(
+        return_value={"type": "chatItems", "chatItems": None}
+    )
+
+    assert await adapter._prime_health_cursor() is False
+    assert adapter._health_item_highwater is None
+    adapter._ws.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_health_cursor_stays_before_item_that_failed_during_priming():
+    adapter = _adapter_with_ws()
+    adapter._retry_chat_items.add(41)
+    adapter._send_command = AsyncMock(
+        return_value={
+            "type": "chatItems",
+            "chatItems": [{"chatItem": {"meta": {"itemId": 41}}}],
+        }
+    )
+
+    assert await adapter._prime_health_cursor() is True
+    assert adapter._health_item_highwater == 40
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        {"chatItem": {"meta": {"itemId": True}}},
+        {"chatItem": []},
+        {"chatItem": {"meta": []}},
+    ],
+)
+@pytest.mark.asyncio
+async def test_health_page_rejects_malformed_item_before_advancing_cursor(malformed):
+    adapter = _adapter_with_ws()
+    adapter._health_item_highwater = 10
+    adapter._handle_chat_item = AsyncMock()
+    adapter._send_command = AsyncMock(
+        return_value={
+            "type": "chatItems",
+            "chatItems": [
+                {"chatItem": {"meta": {"itemId": 11}}},
+                malformed,
+                {"chatItem": {"meta": {"itemId": 12}}},
+            ],
+        }
+    )
+
+    assert await adapter._run_health_check() is False
+    assert adapter._health_item_highwater == 10
+    adapter._handle_chat_item.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_health_page_does_not_advance_past_missing_retry_item():
+    adapter = _adapter_with_ws()
+    adapter._health_item_highwater = 9
+    adapter._retry_chat_items.add(10)
+    adapter._handle_chat_item = AsyncMock()
+    adapter._send_command = AsyncMock(
+        return_value={
+            "type": "chatItems",
+            "chatItems": [{"chatItem": {"meta": {"itemId": 11}}}],
+        }
+    )
+
+    assert await adapter._run_health_check() is False
+    assert adapter._health_item_highwater == 9
+    adapter._handle_chat_item.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_retry_rewind_is_not_overwritten_by_replay_success():
+    adapter = _adapter_with_ws()
+    adapter._health_item_highwater = 10
+    item = {"chatItem": {"meta": {"itemId": 11}}}
+    adapter._send_command = AsyncMock(
+        return_value={"type": "chatItems", "chatItems": [item]}
+    )
+
+    async def deliver_while_older_item_fails(chat_item, replay=False):
+        adapter._retry_chat_items.add(10)
+        adapter._rewind_health_cursor(10)
+        return True
+
+    adapter._handle_chat_item = AsyncMock(side_effect=deliver_while_older_item_fails)
+
+    assert await adapter._run_health_check() is True
+    assert adapter._health_item_highwater == 9
+    assert adapter._retry_chat_items == {10}
+
+
+def test_seen_items_above_stalled_cursor_are_not_evicted():
+    adapter = _adapter_with_ws()
+    adapter._health_item_highwater = 0
+
+    for item_id in range(1, 2003):
+        adapter._mark_chat_item_delivered(item_id)
+
+    assert 1 in adapter._seen_chat_items
+    assert 2002 in adapter._seen_chat_items
+
+    adapter._max_recent_reconciled_seen_items = 2
+    adapter._health_item_highwater = 1000
+    adapter._prune_reconciled_seen_items()
+    assert 1 not in adapter._seen_chat_items
+    assert 998 not in adapter._seen_chat_items
+    assert 999 in adapter._seen_chat_items
+    assert 1000 in adapter._seen_chat_items
+    assert 1001 in adapter._seen_chat_items
+
+
+@pytest.mark.asyncio
+async def test_live_delivery_is_deferred_when_unreconciled_state_is_full():
+    adapter = _adapter_with_ws()
+    adapter._health_item_highwater = None
+    adapter._max_unreconciled_seen_items = 2
+    adapter._seen_chat_items.update({1, 2})
+    adapter.handle_message = AsyncMock()
+    item = {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 4, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemId": 3},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "text", "text": "later"},
+            },
+        },
+    }
+
+    assert await adapter._handle_chat_item(item) is False
+    adapter.handle_message.assert_not_awaited()
+    assert adapter._seen_chat_items == {1, 2}
+    assert adapter._preprime_deferred_item == 3
+
+    adapter._send_command = AsyncMock(
+        return_value={"type": "chatItems", "chatItems": [item]}
+    )
+    assert await adapter._prime_health_cursor() is True
+    assert adapter._health_item_highwater == 2
+    assert adapter._preprime_deferred_item is None
+
+
+@pytest.mark.parametrize("invalid_id", [None, True, 0, -1])
+@pytest.mark.asyncio
+async def test_live_delivery_rejects_invalid_item_id(invalid_id):
+    adapter = _adapter_with_ws()
+    adapter.handle_message = AsyncMock()
+    item = {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 4, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemId": invalid_id},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "text", "text": "invalid"},
+            },
+        },
+    }
+
+    assert await adapter._handle_chat_item(item) is False
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_health_check_paginates_without_skipping_large_gap():
+    adapter = _adapter_with_ws()
+    adapter._health_item_highwater = 10
+    adapter._handle_chat_item = AsyncMock()
+
+    def item(item_id):
+        return {"chatItem": {"meta": {"itemId": item_id}}}
+
+    responses = iter(
+        [
+            {"type": "chatItems", "chatItems": [item(i) for i in range(11, 111)]},
+            {"type": "chatItems", "chatItems": [item(111)]},
+        ]
+    )
+    commands = []
+
+    async def fake_send_command(command, timeout=30.0):
+        commands.append(command)
+        return next(responses)
+
+    adapter._send_command = fake_send_command
+
+    assert await adapter._run_health_check() is True
+    assert adapter._handle_chat_item.await_count == 101
+    assert adapter._health_item_highwater == 111
+    assert commands == [
+        "/_get items after=10 count=100",
+        "/_get items after=110 count=100",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_health_replay_does_not_duplicate_item_seen_live():
+    adapter = _adapter_with_ws()
+    adapter._text_batch_delay = 0.01
+    adapter.handle_message = AsyncMock()
+    item = {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 4, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemId": 11, "itemTs": "2026-09-10T08:00:00Z"},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "text", "text": "missed"},
+            },
+        },
+    }
+
+    await adapter._handle_chat_item(item)
+    await adapter._handle_chat_item(item)
+    await asyncio.sleep(0.03)
+
+    adapter.handle_message.assert_awaited_once()
+    assert adapter.handle_message.await_args is not None
+    assert adapter.handle_message.await_args.args[0].text == "missed"
+
+
+@pytest.mark.asyncio
+async def test_delayed_live_event_does_not_duplicate_replayed_item():
+    adapter = _adapter_with_ws()
+    adapter._health_item_highwater = 10
+    adapter.handle_message = AsyncMock()
+    item = {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 4, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemId": 11},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "text", "text": "replayed"},
+            },
+        },
+    }
+    adapter._send_command = AsyncMock(
+        return_value={"type": "chatItems", "chatItems": [item]}
+    )
+
+    assert await adapter._run_health_check() is True
+    assert adapter._health_item_highwater == 11
+    assert 11 in adapter._seen_chat_items
+
+    assert await adapter._handle_chat_item(item) is True
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_text_flush_does_not_mark_undelivered_item_seen():
+    adapter = _adapter_with_ws()
+    adapter._text_batch_delay = 0
+    first_started = asyncio.Event()
+
+    async def deliver(event):
+        if event.text == "first":
+            first_started.set()
+            await asyncio.Event().wait()
+
+    adapter.handle_message = AsyncMock(side_effect=deliver)
+
+    def text_item(item_id, text):
+        return {
+            "chatInfo": {
+                "type": "direct",
+                "contact": {"contactId": 4, "localDisplayName": "tester"},
+            },
+            "chatItem": {
+                "chatDir": {"type": "directRcv"},
+                "meta": {"itemId": item_id},
+                "content": {
+                    "type": "rcvMsgContent",
+                    "msgContent": {"type": "text", "text": text},
+                },
+            },
+        }
+
+    await adapter._handle_chat_item(text_item(11, "first"))
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+    await adapter._handle_chat_item(text_item(12, "second"))
+    await asyncio.sleep(0.03)
+
+    assert 11 not in adapter._seen_chat_items
+    assert 11 in adapter._retry_chat_items
+    assert 12 in adapter._seen_chat_items
+
+
+@pytest.mark.asyncio
+async def test_health_cursor_waits_for_pending_live_text_batch():
+    adapter = _adapter_with_ws()
+    adapter._text_batch_delay = 0.01
+    adapter.handle_message = AsyncMock()
+    item = {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 4, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemId": 11, "itemTs": "2026-09-10T08:00:00Z"},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "text", "text": "pending"},
+            },
+        },
+    }
+    adapter._health_item_highwater = 10
+    adapter._send_command = AsyncMock(
+        return_value={"type": "chatItems", "chatItems": [item]}
+    )
+
+    assert await adapter._handle_chat_item(item) is False
+    assert await adapter._run_health_check() is True
+    assert adapter._health_item_highwater == 10
+
+    await asyncio.sleep(0.03)
+    assert 11 in adapter._seen_chat_items
+    assert await adapter._run_health_check() is True
+    assert adapter._health_item_highwater == 11
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_deferred_voice_item_is_not_deduplicated_before_delivery(tmp_path):
+    adapter = _adapter_with_ws()
+    adapter.handle_message = AsyncMock()
+    adapter._send_fire_and_forget = AsyncMock()
+    pending = {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 4, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemId": 11, "itemTs": "2026-09-10T08:00:00Z"},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "voice", "text": ""},
+            },
+            "file": {"fileId": 7, "fileName": "voice.ogg"},
+        },
+    }
+
+    await adapter._handle_chat_item(pending)
+    assert 11 not in adapter._seen_chat_items
+    adapter._send_fire_and_forget.reset_mock()
+    assert await adapter._handle_chat_item(pending, replay=True) is False
+    adapter._send_fire_and_forget.assert_awaited_once_with("/freceive 7")
+
+    voice_path = tmp_path / "voice.ogg"
+    voice_path.write_bytes(b"voice")
+    completed = {
+        "chatItem": {
+            "chatItem": {
+                "file": {
+                    "fileId": 7,
+                    "fileSource": {"filePath": str(voice_path)},
+                }
+            }
+        }
+    }
+    await adapter._on_rcv_file_complete(completed)
+
+    adapter.handle_message.assert_awaited_once()
+    assert 11 in adapter._seen_chat_items
+
+
+@pytest.mark.asyncio
+async def test_health_replay_finishes_voice_when_completion_event_was_missed(tmp_path):
+    adapter = _adapter_with_ws()
+    adapter._health_item_highwater = 10
+    delivery_started = asyncio.Event()
+    release_delivery = asyncio.Event()
+
+    async def deliver(_event):
+        delivery_started.set()
+        await release_delivery.wait()
+
+    adapter.handle_message = AsyncMock(side_effect=deliver)
+    pending = {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 4, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemId": 11, "itemTs": "2026-09-10T08:00:00Z"},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "voice", "text": ""},
+            },
+            "file": {"fileId": 7, "fileName": "voice.ogg"},
+        },
+    }
+    assert await adapter._handle_chat_item(pending) is False
+
+    voice_path = tmp_path / "voice.ogg"
+    voice_path.write_bytes(b"voice")
+    ready = {
+        **pending,
+        "chatItem": {
+            **pending["chatItem"],
+            "file": {
+                "fileId": 7,
+                "fileName": "voice.ogg",
+                "fileSource": {"filePath": str(voice_path)},
+            },
+        },
+    }
+    adapter._send_command = AsyncMock(
+        return_value={"type": "chatItems", "chatItems": [ready]}
+    )
+
+    health_task = asyncio.create_task(adapter._run_health_check())
+    await asyncio.wait_for(delivery_started.wait(), timeout=1)
+    assert 7 not in adapter._pending_file_transfers
+
+    completed = {
+        "chatItem": {
+            "chatItem": {
+                "file": {
+                    "fileId": 7,
+                    "fileSource": {"filePath": str(voice_path)},
+                }
+            }
+        }
+    }
+    await adapter._on_rcv_file_complete(completed)
+    adapter.handle_message.assert_awaited_once()
+
+    release_delivery.set()
+    assert await asyncio.wait_for(health_task, timeout=1) is True
+    assert adapter._health_item_highwater == 11
+    adapter.handle_message.assert_awaited_once()
+    assert 11 not in adapter._pending_chat_items
+
+    await adapter._on_rcv_file_complete(completed)
+    adapter.handle_message.assert_awaited_once()
+    assert 11 not in adapter._retry_chat_items
+
+
+@pytest.mark.asyncio
+async def test_voice_completion_owns_delivery_before_ready_health_replay(tmp_path):
+    adapter = _adapter_with_ws()
+    delivery_started = asyncio.Event()
+    release_delivery = asyncio.Event()
+
+    async def deliver(_event):
+        delivery_started.set()
+        await release_delivery.wait()
+
+    adapter.handle_message = AsyncMock(side_effect=deliver)
+    pending = {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 4, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemId": 11},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "voice", "text": ""},
+            },
+            "file": {"fileId": 7, "fileName": "voice.ogg"},
+        },
+    }
+    assert await adapter._handle_chat_item(pending) is False
+
+    voice_path = tmp_path / "voice.ogg"
+    voice_path.write_bytes(b"voice")
+    completed = {
+        "chatItem": {
+            "chatItem": {
+                "file": {
+                    "fileId": 7,
+                    "fileSource": {"filePath": str(voice_path)},
+                }
+            }
+        }
+    }
+    completion_task = asyncio.create_task(adapter._on_rcv_file_complete(completed))
+    await asyncio.wait_for(delivery_started.wait(), timeout=1)
+
+    ready = {
+        **pending,
+        "chatItem": {
+            **pending["chatItem"],
+            "file": {
+                "fileId": 7,
+                "fileName": "voice.ogg",
+                "fileSource": {"filePath": str(voice_path)},
+            },
+        },
+    }
+    assert await adapter._handle_chat_item(ready, replay=True) is False
+    adapter.handle_message.assert_awaited_once()
+
+    release_delivery.set()
+    await asyncio.wait_for(completion_task, timeout=1)
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_failed_nontext_delivery_is_retryable(tmp_path):
+    adapter = _adapter_with_ws()
+    adapter._health_item_highwater = 12
+    adapter.handle_message = AsyncMock(side_effect=[RuntimeError("temporary"), None])
+    voice_path = tmp_path / "voice.ogg"
+    voice_path.write_bytes(b"voice")
+    item = {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 4, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemId": 12, "itemTs": "2026-09-10T08:00:01Z"},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "voice", "text": ""},
+            },
+            "file": {
+                "fileId": 8,
+                "fileName": "voice.ogg",
+                "fileSource": {"filePath": str(voice_path)},
+            },
+        },
+    }
+
+    with pytest.raises(RuntimeError, match="temporary"):
+        await adapter._handle_chat_item(item)
+    assert 12 not in adapter._seen_chat_items
+    assert 12 in adapter._retry_chat_items
+    assert adapter._health_item_highwater == 11
+
+    await adapter._handle_chat_item(item)
+    assert adapter.handle_message.await_count == 2
+    assert 12 in adapter._seen_chat_items
 
 
 


### PR DESCRIPTION
## Summary

- add a correlated, read-only SimpleX item cursor when the WebSocket listener starts
- periodically reconcile inbound chat items stored by the daemon but missed by the live event stream
- paginate reconciliation without skipping gaps and deduplicate concurrent live/replay delivery
- reconnect only when the daemon command round-trip fails on the same WebSocket
- preserve retries for pending files, text batches, and downstream delivery failures

## Scope

This detects daemon command failures and divergence between the daemon's stored chat items and the adapter's live event stream. It does not claim to prove remote SimpleX network reachability when the local daemon remains responsive but stops ingesting new items.

## Test plan

- `uv run --extra dev pytest tests/gateway/test_simplex_plugin.py -q -o 'addopts='` (44 passed)
- `uv run --extra dev ruff check plugins/platforms/simplex/adapter.py tests/gateway/test_simplex_plugin.py`
- `git diff --check`
- verified the read-only `/_get items` baseline and `after=` pagination commands against a running SimpleX daemon
