### PR TITLE
fix(gateway): distinguish update restarts from unexpected ones

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2533,6 +2533,32 @@ _INTERRUPT_REASON_SSE_DISCONNECT = "SSE client disconnected"
 _INTERRUPT_REASON_GATEWAY_SHUTDOWN = "Gateway shutting down"
 _INTERRUPT_REASON_GATEWAY_RESTART = "Gateway restarting"
 
+# HERMES_HOME markers that tell a *planned update* restart apart from a crash.
+# ``fleet_restart_pending`` is dropped by ``hermes update`` after the pull and
+# cleared once the fleet is back (hermes_cli.update_cmd_fleet); the in-chat
+# ``/update`` flow owns ``.update_pending.json``.  Either one means the restart
+# the user is about to see was asked for, so the lifecycle notifications should
+# read as an update instead of the generic "your task was interrupted" warning.
+# Names are pinned against their writers by test_update_restart_notification.py.
+_UPDATE_MARKER_FLEET_RESTART = "fleet_restart_pending"
+_UPDATE_MARKER_CHAT_PENDING = ".update_pending.json"
+# An abandoned marker (update killed before it could clear it) must not
+# mislabel a genuine crash restart hours later.
+_UPDATE_MARKER_MAX_AGE_SECONDS = 3600.0
+
+
+def _planned_update_marker() -> Optional[Path]:
+    """Return the fresh update marker driving this restart, if any."""
+    for name in (_UPDATE_MARKER_FLEET_RESTART, _UPDATE_MARKER_CHAT_PENDING):
+        path = _hermes_home / name
+        try:
+            age = time.time() - path.stat().st_mtime
+        except OSError:
+            continue
+        if age <= _UPDATE_MARKER_MAX_AGE_SECONDS:
+            return path
+    return None
+
 
 def _reap_gateway_turn_processes(
     task_id: str, process_baseline, *, source: str,

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -752,7 +752,14 @@ class GatewayNotificationsMixin:
         """
         delivered: set[tuple[str, str, Optional[str]]] = set()
         skipped = skip_targets or set()
-        message = "♻️ Gateway online — Hermes is back and ready."
+        from gateway.run import _planned_update_marker
+        # Close the loop on the "updating" notice sent before we exited, so the
+        # pair reads as one planned event rather than two unexplained ones.
+        message = (
+            "⬆️ Update complete — Hermes is back on the new version and ready."
+            if _planned_update_marker() is not None
+            else "♻️ Gateway online — Hermes is back and ready."
+        )
         for platform, platform_cfg, home, transport in self._home_channel_transports():
             if not platform_cfg.gateway_restart_notification:
                 logger.info(

--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -928,11 +928,18 @@ class GatewayShutdownMixin:
 
         Called at the start of stop() while adapters are connected; send failures never block shutdown.
         """
+        from gateway.run import _planned_update_marker
         restart_source = self._restart_command_source if self._restart_requested else None
         msg = "⚠️ Gateway shutting down — Your current task will be interrupted."
         if self._restart_requested:
+            # An update-driven restart was asked for — say so, rather than
+            # sending the same ⚠️ wording a crash restart sends.
             msg = (
-                "⚠️ Gateway restarting — Your current task will be interrupted. "
+                "⬆️ Updating Hermes — planned restart, back in a moment. "
+                "Your current task will be interrupted; send any message once "
+                "I'm back and I'll try to resume where you left off."
+                if _planned_update_marker() is not None
+                else "⚠️ Gateway restarting — Your current task will be interrupted. "
                 "Send any message after restart and I'll try to resume where you left off."
             )
         restart_key = None

--- a/tests/gateway/test_update_restart_notification.py
+++ b/tests/gateway/test_update_restart_notification.py
@@ -1,0 +1,169 @@
+"""Tests for update-aware gateway lifecycle messaging.
+
+A restart driven by ``hermes update`` / ``/update`` was asked for, so it must
+not be announced with the same ⚠️ wording a crash restart uses — otherwise a
+user watching the home channel reads a planned upgrade as the gateway falling
+over, and learns to ignore the warning that matters when it really is a crash.
+"""
+
+import os
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import HomeChannel, Platform
+from gateway.platforms.base import SendResult
+from gateway.session import build_session_key
+from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+
+_PLANNED_RESTART = "⬆️ Updating Hermes"
+_PLANNED_ONLINE = "⬆️ Update complete — Hermes is back on the new version and ready."
+_GENERIC_RESTART = "⚠️ Gateway restarting — Your current task will be interrupted. "
+_GENERIC_ONLINE = "♻️ Gateway online — Hermes is back and ready."
+
+
+# ── marker names stay pinned to their writers ──────────────────────────────
+
+
+def test_fleet_restart_marker_name_matches_its_writer():
+    """The CLI owns this filename; a rename there must not silently mute us."""
+    from hermes_cli.update_cmd_fleet import _FLEET_RESTART_PENDING_NAME
+
+    assert gateway_run._UPDATE_MARKER_FLEET_RESTART == _FLEET_RESTART_PENDING_NAME
+
+
+def test_chat_update_marker_name_matches_its_writer():
+    from gateway.run import GatewayRunner
+
+    assert GatewayRunner._update_paths().pending.name == gateway_run._UPDATE_MARKER_CHAT_PENDING
+
+
+# ── marker detection ───────────────────────────────────────────────────────
+
+
+def test_planned_update_marker_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    assert gateway_run._planned_update_marker() is None
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        gateway_run._UPDATE_MARKER_FLEET_RESTART,
+        gateway_run._UPDATE_MARKER_CHAT_PENDING,
+    ],
+)
+def test_planned_update_marker_detects_either_writer(tmp_path, monkeypatch, name):
+    """Both ``hermes update`` (CLI fleet restart) and in-chat ``/update`` count."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / name).write_text("started=1\n")
+
+    marker = gateway_run._planned_update_marker()
+    assert marker is not None and marker.name == name
+
+
+def test_planned_update_marker_ignores_stale_marker(tmp_path, monkeypatch):
+    """An abandoned marker must not relabel a genuine crash restart later."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    stale = tmp_path / gateway_run._UPDATE_MARKER_FLEET_RESTART
+    stale.write_text("started=1\n")
+    old = time.time() - gateway_run._UPDATE_MARKER_MAX_AGE_SECONDS - 60
+    os.utime(stale, (old, old))
+
+    assert gateway_run._planned_update_marker() is None
+
+
+# ── shutdown notification ──────────────────────────────────────────────────
+
+
+async def _shutdown_message(runner, adapter) -> str:
+    source = make_restart_source(chat_id="chat-1")
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    return adapter.send.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_restart_notification_says_update_when_marker_present(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / gateway_run._UPDATE_MARKER_FLEET_RESTART).write_text("started=1\n")
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+
+    message = await _shutdown_message(runner, adapter)
+
+    assert message.startswith(_PLANNED_RESTART)
+    assert "⚠️" not in message
+    # The resume hint has to survive the reword — it is the actionable half.
+    assert "resume where you left off" in message
+
+
+@pytest.mark.asyncio
+async def test_restart_notification_unchanged_without_marker(tmp_path, monkeypatch):
+    """Baseline: an unexplained restart keeps the warning wording."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+
+    message = await _shutdown_message(runner, adapter)
+
+    assert message.startswith(_GENERIC_RESTART)
+    assert _PLANNED_RESTART not in message
+
+
+@pytest.mark.asyncio
+async def test_shutdown_without_restart_ignores_update_marker(tmp_path, monkeypatch):
+    """A terminal shutdown is not coming back — never call it an update."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / gateway_run._UPDATE_MARKER_FLEET_RESTART).write_text("started=1\n")
+    runner, adapter = make_restart_runner()
+
+    message = await _shutdown_message(runner, adapter)
+
+    assert message == "⚠️ Gateway shutting down — Your current task will be interrupted."
+
+
+# ── startup notification ───────────────────────────────────────────────────
+
+
+def _with_home(runner):
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+
+
+@pytest.mark.asyncio
+async def test_startup_notification_reports_update_completion(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / gateway_run._UPDATE_MARKER_FLEET_RESTART).write_text("started=1\n")
+    runner, adapter = make_restart_runner()
+    _with_home(runner)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "home-42", None)}
+    assert adapter.send.await_args.args[1] == _PLANNED_ONLINE
+
+
+@pytest.mark.asyncio
+async def test_startup_notification_unchanged_without_marker(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    _with_home(runner)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "home-42", None)}
+    assert adapter.send.await_args.args[1] == _GENERIC_ONLINE


### PR DESCRIPTION
## What

A gateway restart driven by `hermes update` (or in-chat `/update`) is announced with exactly the same wording as a crash restart:

```
⚠️ Gateway restarting — Your current task will be interrupted. Send any message after restart …
♻️ Gateway online — Hermes is back and ready.
```

Nothing in that sequence says an update happened. A user watching the home channel reads a planned upgrade as the gateway falling over — and, worse, learns to ignore the ⚠️ that matters when it really *is* a crash.

## How

Both update paths already leave a HERMES_HOME breadcrumb that is present for exactly the duration of the restart, so no new state is introduced:

- `fleet_restart_pending` — dropped by `hermes update` after the pull, cleared once the fleet is back (`hermes_cli/update_cmd_fleet.py`)
- `.update_pending.json` — the in-chat `/update` flow's existing marker

`gateway/run.py` gains `_planned_update_marker()`, and the two lifecycle notifications read the marker instead of assuming the worst:

```
⬆️ Updating Hermes — planned restart, back in a moment. Your current task will be interrupted; send any message once I'm back and I'll try to resume where you left off.
⬆️ Update complete — Hermes is back on the new version and ready.
```

Everything else keeps its current wording byte-for-byte: no marker, a terminal shutdown (not coming back, so never called an update), and the chat-`/restart` reply. A marker older than an hour is ignored, so an update killed before it could clear its breadcrumb cannot mislabel a genuine crash restart later.

## How to test

Manual, on a systemd deployment with a home channel configured:

1. `hermes update` with a session running → the chat gets the `⬆️ Updating Hermes` notice instead of `⚠️ Gateway restarting`.
2. When the gateway comes back → `⬆️ Update complete`.
3. `systemctl --user restart hermes-gateway` (no update) → unchanged `⚠️` / `♻️` wording.

Automated — `tests/gateway/test_update_restart_notification.py` (11 cases):

```
pytest tests/gateway/test_update_restart_notification.py tests/gateway/test_restart_notification.py \
       tests/gateway/test_restart_resume_pending.py tests/gateway/test_gateway_shutdown.py
# 79 passed
```

Coverage includes both reworded notifications, the unchanged baselines ("no marker" and "terminal shutdown"), the staleness bound, and two guards pinning the marker filenames against their actual writers (`_FLEET_RESTART_PENDING_NAME` and `GatewayRunner._update_paths().pending`) so a rename on either side can't silently mute this. Verified the four positive cases fail when `_planned_update_marker()` is neutered.

## Platforms tested

macOS 15 (arm64), Python 3.12. The changed paths are platform-agnostic — a marker-file stat plus string selection; the marker writers are unchanged.
