### PR TITLE
kanban: exempt implementer-actionable PRs from the active_pr respawn guard

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -8,6 +8,7 @@ late-bound via ``_kb`` (import-cycle breaking) so monkeypatching
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import re
 import signal
@@ -70,6 +71,120 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
     r"https?://github\.com/[^/\s]+/[^/\s]+/pull/\d+",
     re.IGNORECASE,
 )
+
+# Parses owner/repo/number back out of a matched PR URL.
+_PR_URL_PARTS_RE = re.compile(
+    r"https?://github\.com/(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/pull/(?P<number>\d+)",
+    re.IGNORECASE,
+)
+
+# Per-process cache of guard verdicts: pr_url -> (applies, cached_at). The
+# dispatcher re-checks the same handful of PR URLs every tick; an uncached
+# ``gh`` call per task per tick makes dispatch unusably slow.
+_PR_GUARD_CACHE: dict[str, tuple[bool, float]] = {}
+_PR_GUARD_CACHE_TTL = 120  # seconds
+
+# ``conclusion`` values (CheckRun shape) that mean the check failed.
+_PR_CHECK_FAILURE_CONCLUSIONS = {
+    "FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE",
+}
+# ``state`` values (StatusContext shape) that mean the check failed.
+_PR_CHECK_FAILURE_STATES = {"FAILURE", "ERROR"}
+
+
+def _fetch_pr_status(owner: str, repo: str, number: str) -> Optional[dict]:
+    """Return {'state','reviewDecision','statusCheckRollup'} for a PR, or None.
+
+    None means indeterminate (no ``gh``, network failure, non-zero exit, bad JSON).
+    Isolated as a module-level function so tests can monkeypatch it without a
+    network or a GitHub account.
+    """
+    try:
+        proc = subprocess.run(
+            [
+                "gh", "pr", "view", str(number),
+                "--repo", f"{owner}/{repo}",
+                "--json", "state,reviewDecision,statusCheckRollup",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            env={**os.environ, "PAGER": "cat", "GH_PAGER": "cat"},
+        )
+        if proc.returncode != 0:
+            return None
+        data = json.loads(proc.stdout)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _rollup_has_failure(rollup: Any) -> bool:
+    """True when any status-check entry is in a failed terminal state.
+
+    Derived from the entry's own fields (never a whitelist of check names): a
+    CheckRun carries ``conclusion``, a StatusContext carries ``state``. An
+    unknown/missing value on a still-running check is NOT a failure.
+    """
+    if not isinstance(rollup, list):
+        return False
+    for entry in rollup:
+        if not isinstance(entry, dict):
+            continue
+        conclusion = (entry.get("conclusion") or "").upper()
+        if conclusion in _PR_CHECK_FAILURE_CONCLUSIONS:
+            return True
+        state = (entry.get("state") or "").upper()
+        if state in _PR_CHECK_FAILURE_STATES:
+            return True
+    return False
+
+
+def _active_pr_guard_applies(pr_url: str) -> bool:
+    """True when this PR is a reason to SUPPRESS respawn.
+
+    The guard exists to stop a duplicate-PR storm while a PR is green and
+    awaiting review/merge. It must NOT fire when the PR is in a state that
+    only the implementer can clear, or the card deadlocks (t_108177c6: 4h of
+    respawn_guarded while #4774 sat on CHANGES_REQUESTED).
+
+    Guard applies  -> True
+    Exempt         -> False, when:
+      * PR is not OPEN (MERGED / CLOSED: finished work, guarding freezes the card)
+      * reviewDecision == "CHANGES_REQUESTED"
+      * any statusCheckRollup entry is a failure
+    Indeterminate status (fetch returned None, or URL is unparsable) -> True
+    (fail CLOSED: keep the old conservative behaviour; a network blip must not
+    stampede duplicate workers onto a task whose PR is genuinely in flight).
+    """
+    now = time.time()
+    cached = _PR_GUARD_CACHE.get(pr_url)
+    if cached is not None and (now - cached[1]) < _PR_GUARD_CACHE_TTL:
+        return cached[0]
+
+    applies = _compute_active_pr_guard(pr_url)
+    _PR_GUARD_CACHE[pr_url] = (applies, now)
+    return applies
+
+
+def _compute_active_pr_guard(pr_url: str) -> bool:
+    """Uncached verdict for :func:`_active_pr_guard_applies`."""
+    m = _PR_URL_PARTS_RE.match(pr_url)
+    if m is None:
+        return True
+    status = _fetch_pr_status(m.group("owner"), m.group("repo"), m.group("number"))
+    if status is None:
+        return True
+
+    if (status.get("state") or "").upper() != "OPEN":
+        return False
+    if (status.get("reviewDecision") or "").upper() == "CHANGES_REQUESTED":
+        return False
+    if _rollup_has_failure(status.get("statusCheckRollup")):
+        return False
+    return True
 
 
 @dataclass
@@ -1135,7 +1250,11 @@ def check_respawn_guard(
     (quota/auth pattern; the breaker still trips eventually), then for the
     ready lane only ``"recent_success"`` (completed run within the window, unless
     a re-queue event arrived after it — a deliberate re-run) and ``"active_pr"``
-    (PR URL in a recent comment; re-spawning risks a duplicate PR). The review
+    (PR URL in a recent comment; re-spawning risks a duplicate PR). ``"active_pr"``
+    is EXEMPT when the PR is one only the implementer can clear — not OPEN
+    (merged/closed), ``CHANGES_REQUESTED``, or with a failing status check — since
+    guarding those deadlocks the card; an indeterminate PR status fails closed and
+    still guards. The review
     lane skips the last two: they are the *inputs* to a review handoff. Stale /
     dead claim locks are NOT a guard reason — the reclaim passes own those.
     """
@@ -1209,7 +1328,10 @@ def check_respawn_guard(
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
         (task_id, pr_cutoff),
     ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+        if not c["body"]:
+            continue
+        match = _RESPAWN_GUARD_PR_URL_RE.search(c["body"])
+        if match and _active_pr_guard_applies(match.group(0)):
             return "active_pr"
 
     return None

--- a/tests/hermes_cli/test_kanban_respawn_guard_active_pr.py
+++ b/tests/hermes_cli/test_kanban_respawn_guard_active_pr.py
@@ -32,10 +32,16 @@ def kanban_home(tmp_path, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def clear_pr_guard_cache():
-    """Verdicts are cached per-process; don't leak between cases."""
-    kbd._PR_GUARD_CACHE.clear()
+    """Verdicts are cached per-process; don't leak between cases.
+
+    ``getattr`` with a default so this file still COLLECTS against a build that
+    predates the fix — otherwise the regression case would fail as a collection
+    error, which proves nothing about behaviour. On unpatched code the
+    assertions below are what must go red.
+    """
+    getattr(kbd, "_PR_GUARD_CACHE", {}).clear()
     yield
-    kbd._PR_GUARD_CACHE.clear()
+    getattr(kbd, "_PR_GUARD_CACHE", {}).clear()
 
 
 def _task_with_pr_comment(conn) -> str:

--- a/tests/hermes_cli/test_kanban_respawn_guard_active_pr.py
+++ b/tests/hermes_cli/test_kanban_respawn_guard_active_pr.py
@@ -1,0 +1,130 @@
+"""The ``active_pr`` respawn guard must exempt implementer-actionable PRs.
+
+Card t_108177c6 looped ``respawn_guarded {"reason":"active_pr"}`` for 4+ hours
+while its PR sat OPEN on a CHANGES_REQUESTED verdict: only the implementer could
+clear it, and the guard was what kept the implementer from being respawned.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+
+
+PR_URL = "https://github.com/NousResearch/hermes-agent/pull/4774"
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture(autouse=True)
+def clear_pr_guard_cache():
+    """Verdicts are cached per-process; don't leak between cases."""
+    kbd._PR_GUARD_CACHE.clear()
+    yield
+    kbd._PR_GUARD_CACHE.clear()
+
+
+def _task_with_pr_comment(conn) -> str:
+    task_id = kb.create_task(conn, title="ship the thing", assignee="a")
+    kb.add_comment(conn, task_id, "worker", f"Opened PR: {PR_URL}")
+    conn.commit()
+    return task_id
+
+
+def _stub_status(monkeypatch, status):
+    monkeypatch.setattr(
+        kbd, "_fetch_pr_status", lambda owner, repo, number: status,
+    )
+
+
+def test_changes_requested_pr_does_not_guard_respawn(kanban_home, monkeypatch):
+    """The deadlock repro: only the implementer can clear CHANGES_REQUESTED."""
+    _stub_status(monkeypatch, {
+        "state": "OPEN",
+        "reviewDecision": "CHANGES_REQUESTED",
+        "statusCheckRollup": [{"conclusion": "SUCCESS"}],
+    })
+    with kbc.connect() as conn:
+        task_id = _task_with_pr_comment(conn)
+        assert kbd.check_respawn_guard(conn, task_id) is None
+
+
+def test_green_pr_awaiting_review_still_guards(kanban_home, monkeypatch):
+    """The guard's designed case: a green PR waiting on a reviewer."""
+    _stub_status(monkeypatch, {
+        "state": "OPEN",
+        "reviewDecision": "REVIEW_REQUIRED",
+        "statusCheckRollup": [
+            {"conclusion": "SUCCESS"}, {"state": "SUCCESS"},
+        ],
+    })
+    with kbc.connect() as conn:
+        task_id = _task_with_pr_comment(conn)
+        assert kbd.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_failing_check_pr_does_not_guard_respawn(kanban_home, monkeypatch):
+    """A red CI run is implementer-actionable too."""
+    _stub_status(monkeypatch, {
+        "state": "OPEN",
+        "reviewDecision": "REVIEW_REQUIRED",
+        "statusCheckRollup": [
+            {"conclusion": None, "status": "IN_PROGRESS"},
+            {"conclusion": "FAILURE"},
+        ],
+    })
+    with kbc.connect() as conn:
+        task_id = _task_with_pr_comment(conn)
+        assert kbd.check_respawn_guard(conn, task_id) is None
+
+
+def test_merged_pr_does_not_guard_respawn(kanban_home, monkeypatch):
+    """Finished work: guarding on it just freezes the card."""
+    _stub_status(monkeypatch, {
+        "state": "MERGED",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": [],
+    })
+    with kbc.connect() as conn:
+        task_id = _task_with_pr_comment(conn)
+        assert kbd.check_respawn_guard(conn, task_id) is None
+
+
+def test_indeterminate_pr_status_fails_closed(kanban_home, monkeypatch):
+    """No ``gh`` / network blip must not stampede duplicate workers."""
+    _stub_status(monkeypatch, None)
+    with kbc.connect() as conn:
+        task_id = _task_with_pr_comment(conn)
+        assert kbd.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_pr_verdict_is_cached_within_ttl(kanban_home, monkeypatch):
+    """Second check inside the TTL reuses the verdict instead of re-fetching."""
+    _stub_status(monkeypatch, {
+        "state": "OPEN",
+        "reviewDecision": "CHANGES_REQUESTED",
+        "statusCheckRollup": [],
+    })
+    with kbc.connect() as conn:
+        task_id = _task_with_pr_comment(conn)
+        assert kbd.check_respawn_guard(conn, task_id) is None
+
+        def _boom(owner, repo, number):
+            raise AssertionError("cached verdict must be reused")
+
+        monkeypatch.setattr(kbd, "_fetch_pr_status", _boom)
+        assert kbd.check_respawn_guard(conn, task_id) is None


### PR DESCRIPTION
## Problem (measured)

Card `t_108177c6` looped `respawn_guarded {"reason":"active_pr"}` every 60-90s for 4+
hours while its PR sat OPEN on a `CHANGES_REQUESTED` verdict. Two review rounds produced
zero commits: only the implementer can make requested changes, and the `active_pr` guard
was the exact thing preventing the implementer from being respawned. The loop only broke
when a human manually closed the PR — the card was claimed 62s later.

```
$ sqlite3 ~/.hermes/kanban.db "select kind,payload,datetime(created_at,'unixepoch','localtime') from task_events where task_id='t_108177c6' order by id desc limit 15"
respawn_guarded|{"reason": "active_pr"}|2026-09-10 04:59:14
respawn_guarded|{"reason": "active_pr"}|2026-09-10 04:58:04
respawn_guarded|{"reason": "active_pr"}|2026-09-10 04:57:02
respawn_guarded|{"reason": "active_pr"}|2026-09-10 04:55:52
commented|{"author": "reviewer", "len": 1601}|2026-09-10 04:59:58
claimed|{"lock": ...,"run_id": 1216}|2026-09-10 05:00:16   <-- only after the PR was closed
```

Root cause, `hermes_cli/kanban_db_dispatch.py:1206` (pre-fix): the guard returned
`"active_pr"` for *any* GitHub PR URL matched in a recent comment. It never looked at the
PR's state at all — not open/merged, not the review decision, not CI.

## Change

`check_respawn_guard` now classifies the PR before guarding on it:

- `_fetch_pr_status(owner, repo, number)` — `gh pr view --json state,reviewDecision,statusCheckRollup`,
  20s timeout, `PAGER/GH_PAGER=cat`. Any failure (no `gh`, network, non-zero exit, bad
  JSON) returns `None`. Module-level so tests monkeypatch it without a network or account.
- `_active_pr_guard_applies(pr_url)` — guard **holds** only for a PR that is OPEN, not
  `CHANGES_REQUESTED`, and with no failing check. Exempt (respawn allowed) when the PR is
  MERGED/CLOSED, has `reviewDecision == CHANGES_REQUESTED`, or any `statusCheckRollup`
  entry is failing. **Indeterminate status fails CLOSED** and still guards, preserving the
  old conservative behaviour on a network blip.
- Failing-check detection is derived from each rollup entry's own fields, never a
  hand-maintained list of check names: `conclusion ∈ {FAILURE, TIMED_OUT, CANCELLED,
  ACTION_REQUIRED, STARTUP_FAILURE}` (CheckRun) or `state ∈ {FAILURE, ERROR}`
  (StatusContext), case-insensitive. A still-running check with no conclusion is not a
  failure.
- `_PR_GUARD_CACHE` (120s TTL, keyed by PR URL) — dispatch re-checks the same handful of
  URLs every tick; an uncached `gh` call per task per tick makes the dispatcher unusable.

AC4 respected: this is **not** widened into always-respawn. A green PR awaiting review is
still guarded — see the mutation proof below.

## Verification (run by me, in a clean worktree off `origin/main` 67764dc086)

Note: this fork has no CI runners, so there are no Actions run URLs to paste. The RED/GREEN
evidence below is verbatim local output; commands included so it is reproducible.

### RED — behavioural, no stubs, real `gh`

`/tmp/probe_red.py` puts a real MERGED PR URL (`NousResearch/hermes-agent#107321`,
confirmed `MERGED` via `gh pr list --state merged`) in a task comment and asserts the card
respawns. Source file reverted to `origin/main`, probe unchanged:

```
$ git checkout origin/main -- hermes_cli/kanban_db_dispatch.py
$ python -m pytest /tmp/probe_red.py -q
>           assert kbd.check_respawn_guard(conn, task_id) is None
E           AssertionError: assert 'active_pr' is None
FAILED ../../../../tmp/probe_red.py::test_changes_requested_pr_must_respawn
1 failed in 2.69s
```

### GREEN — same probe, fix restored

```
$ git checkout HEAD -- hermes_cli/kanban_db_dispatch.py
$ python -m pytest /tmp/probe_red.py -q
.                                                                        [100%]
1 passed in 3.83s
```

### The committed test file

`tests/hermes_cli/test_kanban_respawn_guard_active_pr.py` — 6 cases, both required
assertions in the same file: CHANGES_REQUESTED respawns, green-awaiting-review still
guards, failing check respawns, MERGED respawns, indeterminate fails closed, verdict is
cached within TTL.

```
$ python -m pytest tests/hermes_cli/test_kanban_respawn_guard_active_pr.py -q
......                                                                   [100%]
6 passed in 9.32s
```

Against `origin/main` (source reverted, tests kept) all 6 fail.

### Mutation proof — the guard is real, not decorative

Widened `_compute_active_pr_guard` to `return False` (i.e. "always respawn", the thing AC4
forbids):

```
$ python -m pytest tests/hermes_cli/test_kanban_respawn_guard_active_pr.py -q
FAILED ...::test_green_pr_awaiting_review_still_guards
FAILED ...::test_indeterminate_pr_status_fails_closed
2 failed, 4 passed in 4.56s
```

Reverted -> green again. The suite fails on both the widening direction and the deadlock
direction, so neither can regress silently.

### No regression

```
$ python -m pytest tests/hermes_cli/test_kanban_respawn_guard_active_pr.py \
    tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_review_lifecycle.py -q
......s..................................................                [100%]
56 passed, 1 skipped in 68.79s
```

## What I did NOT verify

- **No CI run URLs.** I do not have push access to `NousResearch/hermes-agent` (`gh repo view
  --json viewerPermission` -> `READ`), so the branch is on the `dzianisv/hermes-agent` fork,
  which has no Actions runners. AC3 asked for two run URLs; local verbatim RED/GREEN above
  is the substitute. Someone with write access should push this branch to origin to get CI.
- **The live dispatcher was not exercised end-to-end.** I proved `check_respawn_guard` at
  the function level with a real `gh` lookup, not by watching a real deadlocked card get
  respawned by a running dispatcher tick — reproducing that requires a card parked on a
  CHANGES_REQUESTED PR, which does not currently exist on the board (`gh pr list --state
  open --json reviewDecision` returned no CHANGES_REQUESTED PRs at the time of writing).
- **`_fetch_pr_status` subprocess path is covered only indirectly** — via the unstubbed
  probe run above (real `gh`, real merged PR). Its error branches are exercised through
  `_compute_active_pr_guard`'s `None` handling, not through forced subprocess failures.
- Tests were run with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` because an unrelated broken
  `deepeval` plugin in the user site-packages crashes collection on this host.
