### PR TITLE
fix(auth): retain fresher xAI and Nous singleton credentials through refresh

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1234,12 +1234,21 @@ class CredentialPool(CredentialPoolAdminMixin):
         try:
             with _auth_store_lock():
                 state = _load_provider_state(_load_auth_store(), self.provider)
-            tokens = state.get("tokens") if isinstance(state, dict) else None
+            if not isinstance(state, dict):
+                return entry
+            tokens = state.get("tokens")
             if not isinstance(tokens, dict):
                 return entry
             store_access = tokens.get("access_token", "")
             store_refresh = tokens.get("refresh_token", "")
             entry_refresh = entry.refresh_token or ""
+            entry_at = _parse_absolute_timestamp(entry.last_refresh)
+            store_at = _parse_absolute_timestamp(state.get("last_refresh"))
+            # A different xAI pair need not be newer. Unknown timestamps retain
+            # rotation recovery; a demonstrably older singleton must not win.
+            if self.provider == "xai-oauth":
+                if entry_at is not None and store_at is not None and store_at < entry_at:
+                    return entry
             # Adopt when either side differs: a fresh refresh_token from
             # another process means our pair is consumed/stale.
             should_adopt = bool(store_access) and (
@@ -1257,6 +1266,11 @@ class CredentialPool(CredentialPoolAdminMixin):
                     entry.id,
                 )
                 should_adopt = True
+            if self.provider == "xai-oauth" and not should_adopt:
+                # Same tokens can still carry a newer watermark. Retain it so
+                # the next read cannot accept an intermediate, stale rotation.
+                if store_at is not None and (entry_at is None or store_at > entry_at):
+                    return self._adopt(entry, last_refresh=state["last_refresh"])
             if should_adopt:
                 logger.debug(
                     "Pool entry %s: syncing %s tokens from auth.json (refreshed by another process)",
@@ -1288,21 +1302,40 @@ class CredentialPool(CredentialPoolAdminMixin):
                 state = _load_provider_state(_load_auth_store(), "nous")
             if not state:
                 return entry
-            comparable = {
-                key: state.get(key)
-                for key in (
-                    "access_token", "refresh_token", "expires_at",
-                    "agent_key", "agent_key_expires_at", "inference_base_url",
-                )
-            }
-            if not any(v not in (None, "") and getattr(entry, k, None) != v for k, v in comparable.items()):
+            def older(clock: str) -> bool:
+                entry_at = _parse_absolute_timestamp(entry.extra.get(clock))
+                store_at = _parse_absolute_timestamp(state.get(clock))
+                return entry_at is not None and store_at is not None and store_at < entry_at
+
+            # OAuth and agent keys rotate independently. Routing has no clock.
+            pair_is_stale = older("obtained_at")
+            key_is_stale = older("agent_key_obtained_at") or (
+                pair_is_stale and bool(state.get("agent_key"))
+                and state.get("agent_key") == state.get("access_token")
+            )
+            fields = ["inference_base_url"]
+            extra_keys = []
+            if not pair_is_stale:
+                fields += ["access_token", "refresh_token", "expires_at"]
+                extra_keys += ["obtained_at", "expires_in"]
+            if not key_is_stale:
+                fields += ["agent_key", "agent_key_expires_at"]
+                extra_keys += ["agent_key_id", "agent_key_expires_in",
+                               "agent_key_reused", "agent_key_obtained_at"]
+            comparable = {key: state.get(key) for key in fields}
+            if not (
+                any(v not in (None, "") and getattr(entry, k, None) != v
+                    for k, v in comparable.items())
+                or any(state.get(k) is not None and entry.extra.get(k) != state[k]
+                       for k in extra_keys)
+            ):
                 return entry
             logger.debug("Pool entry %s: syncing Nous state from auth.json", entry.id)
             field_updates: Dict[str, Any] = dict(_CLEAR_STATUS)
             field_updates.update({k: v for k, v in comparable.items() if v})
             extra_updates = dict(entry.extra)
             extra_updates.update(
-                {k: state[k] for k in _NOUS_EXTRA_STATE_KEYS if state.get(k) is not None}
+                {k: state[k] for k in extra_keys if state.get(k) is not None}
             )
             return self._adopt(entry, extra=extra_updates, **field_updates)
         except Exception as exc:
@@ -1584,7 +1617,10 @@ class CredentialPool(CredentialPoolAdminMixin):
                     if force and entry.runtime_api_key and entry.runtime_api_key != stale_key:
                         logger.debug("Nous entry %s: adopting peer-rotated token, skipping refresh", entry.id)
                         return entry
-                auth_mod.resolve_nous_runtime_credentials(force_refresh=force, stale_access_token=stale_key or None)
+                auth_mod.resolve_nous_runtime_credentials(
+                    force_refresh=force, stale_access_token=stale_key or None,
+                    pool_state=entry.to_dict() if entry.source == "device_code" else None,
+                )
                 updated = self._sync_nous_entry_from_auth_store(entry)
             else:
                 return entry

--- a/hermes_cli/auth_nous.py
+++ b/hermes_cli/auth_nous.py
@@ -815,16 +815,34 @@ class _NousRuntimeResolve:
 
     def __init__(
         self, auth_store: Dict[str, Any], state: Dict[str, Any], state_source_path: Optional[Path],
-        *, force_refresh: bool, stale_access_token: Optional[str], timeout_seconds: float) -> None:
+        *, force_refresh: bool, stale_access_token: Optional[str], timeout_seconds: float,
+        pool_state: Optional[Dict[str, Any]] = None) -> None:
         self.auth_store, self.state, self._source_path = auth_store, state, state_source_path
         self.force_refresh, self.stale_access_token = force_refresh, stale_access_token
         self.timeout_seconds = timeout_seconds
         self.sequence_id = uuid.uuid4().hex[:12]
         self._persisted_state = dict(state)
+        self._pool_state = pool_state
+        self._retain_newer_pool_pair()
         self.persisted_any = False
         self.access_token = state.get("access_token")
         self.refresh_token = state.get("refresh_token")
         self._reload_routing()
+
+    def _retain_newer_pool_pair(self) -> bool:
+        """Keep the newer pool pair inside the locked refresh transaction."""
+        if not self._pool_state:
+            return False
+        from agent.credential_pool import _parse_absolute_timestamp
+
+        pool_at = _parse_absolute_timestamp(self._pool_state.get("obtained_at"))
+        state_at = _parse_absolute_timestamp(self.state.get("obtained_at"))
+        if pool_at is None or state_at is None or pool_at <= state_at:
+            return False
+        for key in ("access_token", "refresh_token", "expires_at", "obtained_at", "expires_in"):
+            if self._pool_state.get(key) is not None:
+                self.state[key] = self._pool_state[key]
+        return True
 
     def _reload_routing(self) -> None:
         (self.portal_base_url, self.stored_inference_base_url, self.inference_base_url,
@@ -863,7 +881,10 @@ class _NousRuntimeResolve:
 
     def merge_shared(self) -> bool:
         """Adopt fresher shared-store tokens (caller holds the shared lock). True when merged."""
-        if not _merge_shared_nous_oauth_state(self.state):
+        merged = _merge_shared_nous_oauth_state(self.state)
+        # A stale shared mirror must not undo the retained pool pair.
+        retained = self._retain_newer_pool_pair()
+        if not (merged or retained):
             return False
         self.access_token = self.state.get("access_token")
         self.refresh_token = self.state.get("refresh_token")
@@ -941,12 +962,15 @@ class _NousRuntimeResolve:
 def resolve_nous_runtime_credentials(
     *, timeout_seconds: float = 15.0, insecure: Optional[bool] = None,
     ca_bundle: Optional[str] = None, force_refresh: bool = False,
-    stale_access_token: Optional[str] = None) -> Dict[str, Any]:
+    stale_access_token: Optional[str] = None,
+    pool_state: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Resolve Nous inference credentials for runtime use (refreshing under the auth-store lock).
 
     ``stale_access_token`` is the bearer that just failed upstream (401): with ``force_refresh``,
     the refresh POST is skipped if the store (re-read under the lock) already holds a *different*
     usable token — a peer won the rotation; adopt it rather than invalidate a sibling's token.
+    ``pool_state`` is a singleton-seeded pool snapshot: only its strictly newer,
+    timestamped OAuth pair can replace the state read inside this transaction.
     """
     from hermes_cli.auth import (
         _assert_nous_inference_jwt_usable, _auth_file_path, _provider_state_transaction,
@@ -957,7 +981,8 @@ def resolve_nous_runtime_credentials(
             raise _nous_err("Hermes is not logged into Nous Portal.", relogin=True)
         run = _NousRuntimeResolve(
             auth_store, state, state_source_path, force_refresh=force_refresh,
-            stale_access_token=stale_access_token, timeout_seconds=timeout_seconds)
+            stale_access_token=stale_access_token, timeout_seconds=timeout_seconds,
+            pool_state=pool_state)
         verify = _resolve_verify(insecure=insecure, ca_bundle=ca_bundle, auth_state=state)
         _oauth_trace(
             "nous_runtime_credentials_start", sequence_id=run.sequence_id,

--- a/tests/agent/test_credential_pool_singleton_freshness.py
+++ b/tests/agent/test_credential_pool_singleton_freshness.py
@@ -1,0 +1,493 @@
+"""Stale-pair refusal for the xAI/Nous singleton auth.json readers.
+
+Sibling of the Codex freshness guard: a singleton mirror must never adopt an
+auth.json token pair that is *older* than the one the pool entry already
+holds, and must never persist that older pair over the fresher one.  Newer,
+same-time, and untimestamped stores keep today's rotation-recovery behavior.
+
+Nous is not Codex: its provider state carries an independently-timestamped
+agent key plus routing metadata.  A stale OAuth pair must not block a
+legitimately newer agent-key/routing update, and a newer agent-key timestamp
+must not be usable to launder the stale access token in through ``agent_key``.
+
+Everything here is synthetic: no network, no real credentials, isolated
+HOME/HERMES_HOME per test.
+"""
+
+from __future__ import annotations
+
+import base64
+import itertools
+import json
+import time
+
+import pytest
+
+
+def _jwt(claims: dict) -> str:
+    def _part(payload: dict) -> str:
+        raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    return f"{_part({'alg': 'none', 'typ': 'JWT'})}.{_part(claims)}.sig"
+
+
+_MINTED = itertools.count()
+
+
+def _access(ttl: int, *, scope: str = "inference:invoke") -> str:
+    """Distinct synthetic access token; ``jti`` keeps same-TTL mints unequal."""
+    return _jwt({
+        "sub": "synthetic",
+        "scope": scope,
+        "exp": int(time.time()) + ttl,
+        "jti": f"synthetic-{next(_MINTED)}",
+    })
+
+
+def _write_store(tmp_path, payload: dict) -> None:
+    home = tmp_path / "hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "auth.json").write_text(json.dumps(payload, indent=2))
+
+
+ENTRY_TIME = "2026-09-10T04:30:00Z"
+OLDER = "2026-07-22T15:28:55Z"
+NEWER = "2026-09-10T05:00:00Z"
+
+
+# ── xAI OAuth ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def xai_pool(tmp_path, monkeypatch):
+    """Real load_pool seeding + real select()/refresh; only the POST is stubbed."""
+    import hermes_cli.auth as auth
+    from agent.credential_pool import load_pool
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    assert auth._auth_file_path() == tmp_path / "hermes" / "auth.json"
+    assert auth._global_auth_file_path() is None
+    calls: list[str] = []
+
+    def _fake_refresh(access_token, refresh_token, **kwargs):
+        calls.append(refresh_token)
+        return {
+            # Beyond XAI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS (1h), otherwise the
+            # rotated token is immediately "expiring" again and re-deferred.
+            "access_token": _access(4 * 3600),
+            "refresh_token": "synthetic-rotated-refresh",
+            "id_token": "",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "last_refresh": NEWER,
+        }
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_xai_oauth_pure", _fake_refresh)
+    path = auth._auth_file_path()
+
+    def build(*, store_time=OLDER, entry_time=ENTRY_TIME, entry_ttl=30,
+              source="device_code"):
+        # entry_ttl=30 puts the seeded entry inside the refresh skew, so the
+        # real select() path exercises refresh; 4h keeps it leasable as-is.
+        # Seed the pool from a singleton that matches the entry we want, so
+        # the entry is materialised by the real seeding path.
+        _write_store(tmp_path, {
+            "version": 1,
+            "providers": {"xai-oauth": {
+                "tokens": {
+                    "access_token": _access(entry_ttl),
+                    "refresh_token": "synthetic-pool-refresh",
+                },
+                "last_refresh": entry_time,
+            }},
+        })
+        pool = load_pool("xai-oauth")
+        entry = next(e for e in pool.entries() if e.source == "device_code")
+        if source != "device_code":
+            from dataclasses import replace
+
+            changed = replace(entry, source=source)
+            pool._replace_entry(entry, changed)
+            pool._persist()
+            entry = changed
+        # Another writer lands a DIFFERENT pair in the singleton.
+        raw = json.loads(path.read_text())
+        raw["providers"]["xai-oauth"] = {
+            "tokens": {
+                "access_token": _access(4 * 3600),
+                "refresh_token": "synthetic-store-refresh",
+            },
+            "last_refresh": store_time,
+        }
+        path.write_text(json.dumps(raw, indent=2))
+        return pool, entry, path, calls
+
+    return build
+
+
+@pytest.mark.parametrize("store_time,entry_time", [
+    (OLDER, ENTRY_TIME),
+    ("2026-09-10T05:00:00+02:00", "2026-09-10T04:00:00Z"),  # tz-offset, not string order
+])
+def test_xai_sync_refuses_stale_pair(xai_pool, store_time, entry_time):
+    pool, entry, path, calls = xai_pool(store_time=store_time, entry_time=entry_time)
+    before = path.read_bytes()
+    assert pool._sync_entry_from_auth_store(entry) is entry
+    assert path.read_bytes() == before
+    assert calls == []
+
+
+def test_xai_stale_store_does_not_spend_stale_refresh_on_select(xai_pool):
+    """Real select() path: refusal must not strand rotation recovery."""
+    pool, entry, path, calls = xai_pool()
+    selected = pool.select()
+    assert selected is not None
+    assert calls == ["synthetic-pool-refresh"]
+    assert selected.refresh_token == "synthetic-rotated-refresh"
+
+
+@pytest.mark.parametrize("store_time,entry_time", [
+    (NEWER, ENTRY_TIME),
+    (ENTRY_TIME, ENTRY_TIME),
+    (None, ENTRY_TIME),
+    ("invalid", ENTRY_TIME),
+    (NEWER, None),
+])
+def test_xai_sync_adopts_non_stale_pair(xai_pool, store_time, entry_time):
+    pool, entry, path, calls = xai_pool(
+        store_time=store_time, entry_time=entry_time, entry_ttl=4 * 3600,
+    )
+    synced = pool._sync_entry_from_auth_store(entry)
+    assert synced is not entry
+    assert synced.refresh_token == "synthetic-store-refresh"
+    persisted = next(e for e in json.loads(path.read_text())["credential_pool"]["xai-oauth"]
+                     if e["id"] == entry.id)
+    assert persisted["refresh_token"] == "synthetic-store-refresh"
+    assert calls == []
+
+
+def test_xai_sync_preserves_timestamp_only_watermark(xai_pool):
+    pool, entry, path, calls = xai_pool(entry_ttl=4 * 3600)
+    raw = json.loads(path.read_text())
+    state = raw["providers"]["xai-oauth"]
+    state["tokens"] = {"access_token": entry.access_token, "refresh_token": entry.refresh_token}
+    state["last_refresh"] = NEWER
+    path.write_text(json.dumps(raw))
+    synced = pool._sync_entry_from_auth_store(entry)
+    assert synced.last_refresh == NEWER
+    persisted = next(e for e in json.loads(path.read_text())["credential_pool"]["xai-oauth"]
+                     if e["id"] == entry.id)
+    assert persisted["last_refresh"] == NEWER
+    raw = json.loads(path.read_text())
+    raw["providers"]["xai-oauth"].update({
+        "last_refresh": ENTRY_TIME,
+        "tokens": {"access_token": _access(4 * 3600), "refresh_token": "intermediate-refresh"},
+    })
+    path.write_text(json.dumps(raw))
+    retained = pool._sync_entry_from_auth_store(synced)
+    assert retained.refresh_token == entry.refresh_token
+    assert retained.last_refresh == NEWER
+    assert calls == []
+
+
+def test_xai_manual_row_stays_independent(xai_pool):
+    """Manual rows are independent credentials; the reader never touches them."""
+    pool, entry, path, calls = xai_pool(
+        store_time=NEWER, entry_time=ENTRY_TIME, source="manual:device_code",
+    )
+    before = path.read_bytes()
+    assert pool._sync_entry_from_auth_store(entry) is entry
+    assert path.read_bytes() == before
+
+
+# ── Nous ───────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def nous_pool(tmp_path, monkeypatch):
+    import hermes_cli.auth as auth
+    from agent.credential_pool import load_pool
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(tmp_path / "shared"))
+    assert auth._auth_file_path() == tmp_path / "hermes" / "auth.json"
+    assert auth._global_auth_file_path() is None
+    path = auth._auth_file_path()
+
+    entry_access = _access(3600)
+
+    def build(*, store_obtained_at=OLDER, entry_obtained_at=ENTRY_TIME,
+              store_key_at=OLDER, entry_key_at=ENTRY_TIME,
+              agent_key_mirrors_access=False, store_url=None,
+              source="device_code", store_access_ttl=3600):
+        _write_store(tmp_path, {
+            "version": 1,
+            "providers": {"nous": {
+                "access_token": entry_access,
+                "refresh_token": "synthetic-pool-refresh",
+                "client_id": "hermes-cli",
+                "portal_base_url": "https://portal.nousresearch.com",
+                "inference_base_url": "https://inference.nousresearch.com/v1",
+                "token_type": "Bearer",
+                "scope": "inference:invoke",
+                "obtained_at": entry_obtained_at,
+                "expires_at": "2026-09-10T05:30:00+00:00",
+                "agent_key": entry_access,
+                "agent_key_expires_at": "2026-09-10T05:30:00+00:00",
+                "agent_key_obtained_at": entry_key_at,
+            }},
+        })
+        pool = load_pool("nous")
+        entry = next(e for e in pool.entries() if e.source == "device_code")
+        if source != "device_code":
+            from dataclasses import replace
+
+            changed = replace(entry, source=source)
+            pool._replace_entry(entry, changed)
+            pool._persist()
+            entry = changed
+        store_access = _access(store_access_ttl)
+        store_agent_key = store_access if agent_key_mirrors_access else _access(7200)
+        raw = json.loads(path.read_text())
+        state = raw["providers"]["nous"]
+        state.update({
+            "access_token": store_access,
+            "refresh_token": "synthetic-store-refresh",
+            "obtained_at": store_obtained_at,
+            "expires_at": "2026-09-10T06:30:00+00:00",
+            "agent_key": store_agent_key,
+            "agent_key_expires_at": "2026-09-10T06:30:00+00:00",
+            "agent_key_obtained_at": store_key_at,
+        })
+        if store_url:
+            state["inference_base_url"] = store_url
+        path.write_text(json.dumps(raw, indent=2))
+        return pool, entry, path, {
+            "access_token": store_access,
+            "agent_key": store_agent_key,
+        }
+
+    return build
+
+
+@pytest.mark.parametrize("clock", ["obtained_at", "agent_key_obtained_at"])
+def test_nous_sync_preserves_timestamp_only_watermark(nous_pool, clock):
+    pool, entry, path, _ = nous_pool()
+    raw = json.loads(path.read_text())
+    state = raw["providers"]["nous"]
+    for key in ("access_token", "refresh_token", "expires_at", "agent_key",
+                "agent_key_expires_at"):
+        state[key] = getattr(entry, key)
+    state["obtained_at"] = ENTRY_TIME
+    state["agent_key_obtained_at"] = ENTRY_TIME
+    state[clock] = NEWER
+    path.write_text(json.dumps(raw))
+    synced = pool._sync_nous_entry_from_auth_store(entry)
+    assert synced.extra[clock] == NEWER
+    persisted = next(e for e in json.loads(path.read_text())["credential_pool"]["nous"]
+                     if e["id"] == entry.id)
+    assert persisted[clock] == NEWER
+    state[clock] = ENTRY_TIME
+    if clock == "obtained_at":
+        state["refresh_token"] = "synthetic-intermediate-refresh"
+    else:
+        state["agent_key"] = "synthetic-intermediate-key"
+    raw = json.loads(path.read_text())
+    raw["providers"]["nous"] = state
+    path.write_text(json.dumps(raw))
+    retained = pool._sync_nous_entry_from_auth_store(synced)
+    assert retained.extra[clock] == NEWER
+    assert retained.refresh_token == entry.refresh_token
+    assert retained.agent_key == entry.agent_key
+
+
+def test_nous_sync_refuses_stale_pair(nous_pool):
+    """Older obtained_at: neither adopted in memory nor persisted to disk."""
+    pool, entry, path, store = nous_pool()
+    before = path.read_bytes()
+    synced = pool._sync_nous_entry_from_auth_store(entry)
+    assert synced.refresh_token == "synthetic-pool-refresh"
+    assert synced.access_token == entry.access_token
+    assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize("store_obtained_at,entry_obtained_at", [
+    (NEWER, ENTRY_TIME),
+    (ENTRY_TIME, ENTRY_TIME),
+    (None, ENTRY_TIME),
+    ("invalid", ENTRY_TIME),
+    (NEWER, None),
+])
+def test_nous_sync_adopts_non_stale_pair(nous_pool, store_obtained_at, entry_obtained_at):
+    pool, entry, path, store = nous_pool(
+        store_obtained_at=store_obtained_at, entry_obtained_at=entry_obtained_at,
+        store_key_at=NEWER,
+    )
+    synced = pool._sync_nous_entry_from_auth_store(entry)
+    assert synced.refresh_token == "synthetic-store-refresh"
+    assert synced.access_token == store["access_token"]
+    persisted = next(e for e in json.loads(path.read_text())["credential_pool"]["nous"]
+                     if e["id"] == entry.id)
+    assert persisted["refresh_token"] == "synthetic-store-refresh"
+
+
+def test_nous_newer_agent_key_survives_stale_oauth_pair(nous_pool):
+    """The metadata boundary: a stale pair must not block a newer agent key."""
+    pool, entry, path, store = nous_pool(store_obtained_at=OLDER, store_key_at=NEWER)
+    synced = pool._sync_nous_entry_from_auth_store(entry)
+    assert synced.agent_key == store["agent_key"]
+    assert synced.agent_key_obtained_at == NEWER
+    # ...and the stale OAuth pair is still refused.
+    assert synced.refresh_token == "synthetic-pool-refresh"
+    assert synced.access_token == entry.access_token
+    persisted = next(e for e in json.loads(path.read_text())["credential_pool"]["nous"]
+                     if e["id"] == entry.id)
+    assert persisted["agent_key"] == store["agent_key"]
+    assert persisted["refresh_token"] == "synthetic-pool-refresh"
+
+
+def test_nous_sync_refuses_stale_agent_key(nous_pool):
+    pool, entry, path, store = nous_pool(store_obtained_at=OLDER, store_key_at=OLDER)
+    synced = pool._sync_nous_entry_from_auth_store(entry)
+    assert synced.agent_key == entry.agent_key
+    assert synced.agent_key_obtained_at == ENTRY_TIME
+
+
+def test_nous_stale_access_token_cannot_ride_in_as_agent_key(nous_pool):
+    """agent_key mirrors access_token on the invoke-JWT path.
+
+    A newer agent_key timestamp must not launder the refused stale access
+    token back into the runtime key.
+    """
+    pool, entry, path, store = nous_pool(
+        store_obtained_at=OLDER, store_key_at=NEWER, agent_key_mirrors_access=True,
+    )
+    synced = pool._sync_nous_entry_from_auth_store(entry)
+    assert synced.agent_key != store["access_token"]
+    assert synced.agent_key == entry.agent_key
+    assert synced.access_token == entry.access_token
+    assert synced.runtime_api_key == entry.runtime_api_key
+
+
+def test_nous_routing_metadata_updates_despite_stale_pair(nous_pool):
+    """Routing metadata is not token material and keeps flowing."""
+    pool, entry, path, store = nous_pool(
+        store_obtained_at=OLDER, store_key_at=OLDER,
+        store_url="https://inference.nousresearch.com/v2",
+    )
+    synced = pool._sync_nous_entry_from_auth_store(entry)
+    assert synced.inference_base_url == "https://inference.nousresearch.com/v2"
+    assert synced.refresh_token == "synthetic-pool-refresh"
+
+
+def test_nous_manual_row_stays_independent(nous_pool):
+    pool, entry, path, store = nous_pool(
+        store_obtained_at=NEWER, store_key_at=NEWER, source="manual:device_code",
+    )
+    before = path.read_bytes()
+    assert pool._sync_nous_entry_from_auth_store(entry) is entry
+    assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize("store_time,shared_time,expected", [
+    (OLDER, None, "synthetic-pool-refresh"),
+    (OLDER, OLDER, "synthetic-pool-refresh"),
+    (OLDER, NEWER, "synthetic-store-refresh"),
+    (NEWER, None, "synthetic-store-refresh"),
+    (None, None, "synthetic-store-refresh"),
+    ("invalid", None, "synthetic-store-refresh"),
+])
+def test_nous_forced_refresh_does_not_spend_stale_refresh_token(
+    nous_pool, monkeypatch, store_time, shared_time, expected,
+):
+    """Real try_refresh_matching() path with only the token POST stubbed."""
+    # An already-usable peer token intentionally skips the POST upstream.
+    # Expire this candidate to exercise actual refresh-token consumption.
+    pool, entry, path, store = nous_pool(store_obtained_at=store_time, store_access_ttl=-30)
+    if shared_time:
+        from hermes_cli.auth import _read_shared_nous_state, _write_shared_nous_state
+
+        shared = dict(json.loads(path.read_text())["providers"]["nous"])
+        shared["obtained_at"] = shared_time
+        _write_shared_nous_state(shared)
+        persisted_shared = _read_shared_nous_state()
+        assert persisted_shared is not None
+        assert persisted_shared["obtained_at"] == shared_time
+    seen: list[str] = []
+
+    def _fake_refresh(*, refresh_token, **kwargs):
+        from hermes_cli.auth import AuthError
+
+        seen.append(refresh_token)
+        if refresh_token != expected:
+            raise AuthError("Consumed token", provider="nous", code="invalid_grant",
+                            relogin_required=True)
+        return {"access_token": _access(7200),
+                "refresh_token": "synthetic-rotated-refresh", "expires_in": 7200}
+
+    monkeypatch.setattr("hermes_cli.auth._refresh_access_token", _fake_refresh)
+    updated = pool.try_refresh_matching(credential_id=entry.id)
+    assert seen == [expected]
+    assert updated is not None
+    assert updated.refresh_token == "synthetic-rotated-refresh"
+    raw = json.loads(path.read_text())
+    assert raw["providers"]["nous"]["refresh_token"] == "synthetic-rotated-refresh"
+    persisted = next(e for e in raw["credential_pool"]["nous"] if e["id"] == entry.id)
+    assert persisted["refresh_token"] == "synthetic-rotated-refresh"
+
+
+def test_nous_refresh_rereads_newer_singleton_inside_transaction(nous_pool, monkeypatch):
+    from contextlib import contextmanager
+
+    import hermes_cli.auth as auth
+
+    pool, entry, path, _ = nous_pool(store_access_ttl=-30)
+    transaction = auth._provider_state_transaction
+    seen = []
+
+    @contextmanager
+    def concurrent_winner(provider):
+        raw = json.loads(path.read_text())
+        raw["providers"]["nous"].update({
+            "obtained_at": NEWER,
+            "refresh_token": "synthetic-winner-refresh",
+        })
+        path.write_text(json.dumps(raw))
+        with transaction(provider) as loaded:
+            yield loaded
+
+    def refresh(*, refresh_token, **kwargs):
+        seen.append(refresh_token)
+        return {"access_token": _access(7200), "refresh_token": "synthetic-rotated-refresh",
+                "expires_in": 7200}
+
+    monkeypatch.setattr(auth, "_provider_state_transaction", concurrent_winner)
+    monkeypatch.setattr(auth, "_refresh_access_token", refresh)
+    updated = pool.try_refresh_matching(credential_id=entry.id)
+    assert seen == ["synthetic-winner-refresh"]
+    assert updated is not None
+    assert updated.refresh_token == "synthetic-rotated-refresh"
+
+
+def test_nous_exhausted_entry_select_refuses_stale_singleton(nous_pool):
+    """The recovery path that clears exhaustion must not adopt an older pair."""
+    from dataclasses import replace
+
+    from agent.credential_pool import STATUS_EXHAUSTED
+
+    pool, entry, path, store = nous_pool()
+    stale_entry = replace(
+        entry,
+        last_status=STATUS_EXHAUSTED,
+        last_status_at=time.time(),
+        last_error_reset_at=time.time() + 86400,
+    )
+    pool._replace_entry(entry, stale_entry)
+    pool._persist()
+    assert pool.select() is None
+    current = next(e for e in pool.entries() if e.id == entry.id)
+    assert current.refresh_token == "synthetic-pool-refresh"
+    assert current.last_status == STATUS_EXHAUSTED


### PR DESCRIPTION
## Problem
A singleton snapshot can be older than the credential pool's already-rotated token pair. Adopting it reintroduces a spent single-use refresh token. Nous has a second failure path: refusing the stale pair in memory does not help if the runtime resolver re-reads and POSTs the stale singleton inside its separate refresh transaction.

## Change
- Refuse strictly older xAI singleton pairs, without changing the Codex shared-reader branch.
- Independently gate Nous OAuth pairs and agent keys; keep routing metadata independent and advance eligible timestamp-only watermarks.
- Carry the retained pool snapshot into the current `_NousRuntimeResolve` transaction under the auth-store lock. Reconcile again after shared-state adoption so an older mirror cannot undo the retained pair.
- Preserve equal/unknown timestamp recovery and newer singleton/shared state. Tests assert the actual refresh token passed to the POST helper, not merely the final pool contents.

## Verification
Based on upstream `fa75692211001f64b2a65557fd498725eb0fe32e`; isolated HOME/HERMES_HOME, synthetic credentials, no live OAuth calls.
- Final reader tests plus existing core pool tests: **93 passed in 8.33s**.
- Final reader test file against unmodified upstream source: **19 failed, 12 passed** (includes changed-interface failures; not all are independent behavioral failures).
- Implementation-time retention-disabled mutation also exercises the real stale-token POST failure.
- Adapted to current shared token-reader and extracted `auth_nous.py` architecture; no old inline resolver bodies restored.
