### PR TITLE
fix(desktop): registry fallback for all sandbox env vars, ranked above the derived home

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -465,7 +465,16 @@ import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './work
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
 import { resolvePickerDefaultPath, setActiveGatewayProfile, setWslBridgeProfileState } from './wsl-path-bridge'
 
-const USER_DATA_OVERRIDE = process.env.HERMES_DESKTOP_USER_DATA_DIR
+// readWindowsUserEnvVar returns null off-Windows and on any lookup failure, so
+// this is safe to call unconditionally. Mirrors the HERMES_HOME registry
+// fallback below (#45471): a GUI launch with no launcher environment (a bare
+// exe, a stray shortcut, Explorer) must not silently fall through to
+// Electron's own default userData, because that default has no sandbox
+// config and no configured backend connections, and the app then goes looking
+// for `hermes` on PATH -- which can find and run an entirely different,
+// unrelated install's Python backend. Local#1 (2026-09-10).
+const USER_DATA_OVERRIDE =
+  process.env.HERMES_DESKTOP_USER_DATA_DIR || readWindowsUserEnvVar('HERMES_DESKTOP_USER_DATA_DIR')
 
 if (USER_DATA_OVERRIDE) {
   const resolvedUserData = path.resolve(USER_DATA_OVERRIDE)
@@ -784,22 +793,32 @@ function resolveHermesHome() {
     return normalizeHermesHomeRoot(process.env.HERMES_HOME)
   }
 
-  if (USER_DATA_OVERRIDE) {
-    return path.join(path.resolve(USER_DATA_OVERRIDE), 'hermes-home')
-  }
-
   if (IS_WINDOWS) {
     // A GUI app launched from Explorer inherits the environment block captured
     // at login, so a HERMES_HOME set via `setx` AFTER login is invisible in
     // process.env even though the CLI (a fresh shell) sees it. Without this the
     // backend silently falls back to %LOCALAPPDATA%\hermes and reports "No
     // inference provider configured" despite a valid configured home (#45471).
-    // Consult the live User-scoped registry value before the default below.
+    // Consult the live User-scoped registry value.
+    //
+    // This check sits ABOVE the USER_DATA_OVERRIDE derivation on purpose. The
+    // registry value is the stand-in for an explicit HERMES_HOME when the
+    // process environment is stale, so it ranks where the explicit value ranks:
+    // above anything merely derived. Now that USER_DATA_OVERRIDE can itself come
+    // from the registry, leaving this below it would let a derived
+    // <userData>/hermes-home shadow the home the user actually configured, and
+    // split state across two directories depending on how the app was launched.
+    // Every sandbox/test entry point sets HERMES_HOME explicitly, so this cannot
+    // hijack a deliberate sandbox. Local#1 (2026-09-10).
     const fromRegistry = readWindowsUserEnvVar('HERMES_HOME')
 
     if (fromRegistry) {
       return normalizeHermesHomeRoot(fromRegistry)
     }
+  }
+
+  if (USER_DATA_OVERRIDE) {
+    return path.join(path.resolve(USER_DATA_OVERRIDE), 'hermes-home')
   }
 
   if (IS_WINDOWS && process.env.LOCALAPPDATA) {
@@ -913,7 +932,12 @@ const BOOT_FAKE_STEP_MS = (() => {
   return Math.max(120, raw)
 })()
 
-const APP_NAME = process.env.HERMES_DESKTOP_APP_NAME || 'Hermes'
+// Registry fallback, same reasoning as USER_DATA_OVERRIDE above: a bare launch
+// with no launcher environment must not silently become plain "Hermes" and
+// collide with a different, unrelated install of the same name. Local#1
+// (2026-09-10).
+const APP_NAME =
+  process.env.HERMES_DESKTOP_APP_NAME || readWindowsUserEnvVar('HERMES_DESKTOP_APP_NAME') || 'Hermes'
 const HUD_WINDOW_TITLE = `${APP_NAME} HUD`
 const TITLEBAR_HEIGHT = 34
 const MACOS_TRAFFIC_LIGHTS_HEIGHT = 14
@@ -5028,7 +5052,17 @@ function resolveHermesBackend(backendArgs) {
   //    do NOT write a bootstrap marker; the user did this themselves and we
   //    don't want to take ownership of an install we didn't perform.
   //    HERMES_DESKTOP_IGNORE_EXISTING=1 forces the bootstrap path for testing.
-  if (process.env.HERMES_DESKTOP_IGNORE_EXISTING !== '1') {
+  //
+  //    Registry fallback, same as USER_DATA_OVERRIDE/APP_NAME above: this is
+  //    the step that actually runs someone else's Python as this app's
+  //    backend, so of the three sandbox variables this is the one where a
+  //    stale/absent process environment is most consequential -- a bare
+  //    launch with no launcher env previously fell through to whatever
+  //    `hermes` it found on PATH, silently running an unrelated install's
+  //    code (not just its data). Local#1 (2026-09-10).
+  const ignoreExisting =
+    process.env.HERMES_DESKTOP_IGNORE_EXISTING || readWindowsUserEnvVar('HERMES_DESKTOP_IGNORE_EXISTING')
+  if (ignoreExisting !== '1') {
     let hermesCommand = null
     const hermesOverride = process.env.HERMES_DESKTOP_HERMES
 


### PR DESCRIPTION
## What does this PR do?

Extends the HERMES_HOME registry fallback from #45471 to the three sibling desktop sandbox variables (`HERMES_DESKTOP_USER_DATA_DIR`, `HERMES_DESKTOP_APP_NAME`, `HERMES_DESKTOP_IGNORE_EXISTING`), and fixes an ordering bug in `resolveHermesHome()` that adding the first fallback alone would introduce.

**Background.** #45471 made `HERMES_HOME` read the live `HKCU\Environment` value when a GUI launch inherits a stale `process.env` (Explorer, or any shortcut created after the variable was set). The three sibling variables never got the same treatment, so the same staleness reaches them: on a launch with a stale environment, `HERMES_DESKTOP_USER_DATA_DIR` reads as absent → the app opens Electron's default `userData`, which has no configured backend connections → `HERMES_DESKTOP_IGNORE_EXISTING` also reads as absent → the app searches PATH for `hermes` and runs whatever it finds as the backend. On a machine with more than one Hermes install, that means silently running a different install's Python as the backend, while `HERMES_HOME` (already fixed) correctly sends the *data* to the configured home. Reproduced locally with two installs on the same Windows machine.

Fixing only the first half surfaces a second bug: `resolveHermesHome()` checks the `<userData>/hermes-home`-derived path *before* the registry `HERMES_HOME` read. Once `USER_DATA_OVERRIDE` can itself come from the registry, that derivation fires first on a stale-environment launch and shadows the configured home — landing on a third, never-before-used directory instead of either the legacy default or what the user actually configured. This PR reorders the two checks: the registry value is a stand-in for an explicit `HERMES_HOME`, so it should rank where the explicit value ranks, above anything merely derived.

## Related Issue

No existing issue — happy to open one first if you'd prefer that over a direct PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/windows-user-env.ts`: new `readEnvOrWindowsUserVar(name, opts)` — process env first, then the Windows registry fallback, via an injectable `readRegistry` for testing. Exported alongside the existing helpers.
- `apps/desktop/electron/main.ts`:
  - `USER_DATA_OVERRIDE`, `APP_NAME`, and the `ignoreExisting` local in the backend-resolution step now go through `readEnvOrWindowsUserVar` instead of `process.env.X` alone.
  - `resolveHermesHome()`: the registry `HERMES_HOME` check now runs before the `USER_DATA_OVERRIDE` derivation (previously after).
- `apps/desktop/electron/windows-user-env.test.ts`: five new cases for `readEnvOrWindowsUserVar` (env wins over registry, registry fallback when env is stale, empty-string env value treated as absent, both-absent returns `null`, inert off-Windows via the injected reader).

## How to Test

1. On Windows, with two separate Hermes homes on the machine (or simulate with a throwaway `HERMES_HOME` and something else in `PATH`), set `HERMES_DESKTOP_USER_DATA_DIR`, `HERMES_DESKTOP_APP_NAME`, `HERMES_DESKTOP_IGNORE_EXISTING=1`, and `HERMES_HOME` at **user** level (`setx`, not in the current shell) so they're absent from any freshly-launched process's inherited environment. Log out/in, or launch the packaged app from Explorer rather than a shell that was open when the vars were set.
2. Before this patch: the app's data lands in the configured home, but its *backend* is whatever `hermes` it finds on PATH — check the desktop log for `Using existing Hermes Python at <unexpected path>` and confirm that path isn't the one you configured.
3. After this patch: the log should show `Connecting to remote Hermes backend` (if you have a remote configured) or the correct local backend, and no writes anywhere outside the configured `HERMES_HOME`.
4. `npx vitest run --project electron` from `apps/desktop/` — the new tests are in `windows-user-env.test.ts`; the full electron project suite passes at the same rate as `main` (compared directly: identical failing-file set before and after this change, pre-existing and unrelated).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the desktop electron test project and compared against a clean `main` checkout — same failing-file set both times, none of it in the files this PR touches
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no README/docs changes needed; the existing #45471 comment already explains the underlying staleness issue and this PR extends the same fix
- [x] N/A — no config keys added or changed
- [x] N/A — Windows-only fallback behavior, gated the same way the existing HERMES_HOME fallback already is; no macOS/Linux impact
- [x] N/A — no tool schemas changed

## Screenshots / Logs

Desktop log excerpt from a stale-environment launch, before this fix (data correctly isolated, backend was not):

```
[boot] Connecting to remote Hermes backend at http://127.0.0.1:<redacted>
```
became, on the SAME launch route before this fix:
```
[boot] Using existing Hermes Python at <a different install's venv>
Starting Hermes backend via existing Hermes Python at <that same path>
```

After this fix, the same stale-environment launch route consistently logs `Connecting to remote Hermes backend` and writes only under the configured `HERMES_HOME`.
