### PR TITLE
fix(responses): keep commentary out of reasoning and surface it in CLI

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -428,7 +428,7 @@ def _chat_messages_to_responses_input(
     ``current_issuer_kind``: cross-issuer guard; foreign-stamped items drop, legacy items replay.
     ``native_compaction_eligible``: THIS request carries ``context_management``; gates both replaying ``compaction``
     checkpoints and ``prune_pre_checkpoint_items``. Checkpoints persist across model swaps / compression flips / resume,
-    so without the gate one checkpoint would erase pre-checkpoint history on a model that cannot decrypt it (lossless:
+    so without the gate one checkpoint would erase pre-checkpoint history on a model that cannot decrypt the blob (lossless:
     local history is never truncated).
 
     Earlier (PR #26644, May 2026) we believed xAI's OAuth/SuperGrok ``/v1/responses`` surface rejected
@@ -972,9 +972,13 @@ class _OutputScan:
         message_text = _extract_responses_message_text(item)
         if not message_text:
             return
-        # commentary/analysis text is mid-turn narration, never the final answer: route it
-        # to the reasoning channel; the exact item is still preserved for replay/cache.
-        (self.reasoning_parts if is_commentary_phase else self.content_parts).append(message_text)
+        # Commentary is user-facing progress, not reasoning or a final answer.
+        # Its exact message item below carries interim delivery and replay/cache;
+        # only the analysis phase belongs in the reasoning channel.
+        if normalized_phase == "analysis":
+            self.reasoning_parts.append(message_text)
+        elif normalized_phase != "commentary":
+            self.content_parts.append(message_text)
         item_id = getattr(item, "id", None)
         self.message_items_raw.append(_message_item(
             [{"type": "output_text", "text": message_text}], status=_normalize_responses_message_status(item_status),

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -175,13 +175,10 @@ class CLIAgentSetupMixin:
     """Agent construction + session-resume display methods for ``HermesCLI``."""
 
     def _current_interim_assistant_callback(self):
-        """Keep progress narration independent of reasoning visibility and token streaming."""
+        """Keep progress narration independent of reasoning visibility, token streaming, and tool progress."""
         from cli import CLI_CONFIG
         display = CLI_CONFIG.get("display") or {}
-        if (
-            getattr(self, "tool_progress_mode", "all") == "off"
-            or not display.get("interim_assistant_messages", True)
-        ):
+        if not display.get("interim_assistant_messages", True):
             return None
         return self._on_interim_assistant
 
@@ -295,8 +292,8 @@ class CLIAgentSetupMixin:
 
     def _resolve_fallback_runtime(self, primary_exc):
         """Primary provider resolution failed: on an AuthError try each fallback entry in
-        order and switch to the first that resolves. None when the error is not auth-related
-        or no fallback resolves."""
+        order and switch the CLI's requested_provider/model to the first that resolves.
+        None when the error is not auth-related or no fallback resolves."""
         from cli import _cprint, logger
         from hermes_cli.auth import AuthError
         from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -373,7 +370,7 @@ class CLIAgentSetupMixin:
             select_provider_and_model()
         except (KeyboardInterrupt, EOFError, SystemExit):
             print()
-            _cprint("  Setup cancelled. Run 'hermes model' to try again.")
+            _cprint("  Setup cancelled. Run 'hermes model' any time.")
             return False
         except Exception as exc:
             logger.debug("first-run provider setup failed: %s", exc)
@@ -597,6 +594,14 @@ class CLIAgentSetupMixin:
                 seed_credits_at_session_start(self.agent)
             except Exception:
                 pass
+
+            # Restore conversation history if resuming
+            if self._resumed and self._session_db and not self.conversation_history:
+                if not self._load_resumed_history_late():
+                    return False
+            if self.conversation_history:
+                self.agent.messages = self.conversation_history
+                self.agent._session_messages = self.conversation_history
             self._active_agent_route_signature = _route_signature(effective_model, runtime)
 
             # Force-create DB row on /title intent, then apply title.
@@ -624,7 +629,7 @@ class CLIAgentSetupMixin:
         """Return a safe-resume error without materializing transcript rows.
 
         ``tip_only`` matches call sites that load only the tip session's rows — counting
-        the full lineage there would over-reject compressed sessions with a small
+        the full lineage there would over-reject heavily-compressed sessions with a small
         tip. Generic guard failures fail OPEN; only a genuine over-limit result blocks."""
         if not self._session_db:
             return None

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -174,6 +174,35 @@ def _resume_panel_colors() -> tuple:
 class CLIAgentSetupMixin:
     """Agent construction + session-resume display methods for ``HermesCLI``."""
 
+    def _current_interim_assistant_callback(self):
+        """Keep progress narration independent of reasoning visibility and token streaming."""
+        from cli import CLI_CONFIG
+        display = CLI_CONFIG.get("display") or {}
+        if (
+            getattr(self, "tool_progress_mode", "all") == "off"
+            or not display.get("interim_assistant_messages", True)
+        ):
+            return None
+        return self._on_interim_assistant
+
+    def _on_interim_assistant(self, text: str, *, already_streamed: bool = False) -> None:
+        """Render a completed interim in its own assistant box, never inside reasoning.
+
+        Reuse the normal renderer even with token streaming disabled. Settle both
+        boundaries so commentary cannot make the eventual final look already streamed.
+        The agent owns redaction and per-turn delivery deduplication.
+        """
+        if already_streamed or not isinstance(text, str):
+            return
+        from tools.ansi_strip import sanitize_display_text
+        visible = sanitize_display_text(text).strip()
+        if not visible:
+            return
+        self._flush_reasoning_preview(force=True)
+        self._stream_delta(None)
+        self._stream_delta(visible)
+        self._stream_delta(None)
+
     def _ensure_runtime_credentials(self) -> bool:
         """Re-resolve provider credentials before agent use so key rotation / token
         refresh are picked up without restarting the CLI. False on auth failure."""
@@ -266,8 +295,8 @@ class CLIAgentSetupMixin:
 
     def _resolve_fallback_runtime(self, primary_exc):
         """Primary provider resolution failed: on an AuthError try each fallback entry in
-        order and switch the CLI's requested_provider/model to the first that resolves.
-        None when the error is not auth-related or no fallback resolves."""
+        order and switch to the first that resolves. None when the error is not auth-related
+        or no fallback resolves."""
         from cli import _cprint, logger
         from hermes_cli.auth import AuthError
         from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -344,7 +373,7 @@ class CLIAgentSetupMixin:
             select_provider_and_model()
         except (KeyboardInterrupt, EOFError, SystemExit):
             print()
-            _cprint("  Setup cancelled. Run 'hermes model' any time.")
+            _cprint("  Setup cancelled. Run 'hermes model' to try again.")
             return False
         except Exception as exc:
             logger.debug("first-run provider setup failed: %s", exc)
@@ -535,6 +564,7 @@ class CLIAgentSetupMixin:
                 session_id=self.session_id, platform="cli", session_db=self._session_db,
                 clarify_callback=clarify_callback,
                 reasoning_callback=self._current_reasoning_callback(),
+                interim_assistant_callback=self._current_interim_assistant_callback(),
                 fallback_model=self._fallback_model, thinking_callback=self._on_thinking,
                 checkpoints_enabled=self.checkpoints_enabled,
                 checkpoint_max_snapshots=self.checkpoint_max_snapshots,
@@ -594,7 +624,7 @@ class CLIAgentSetupMixin:
         """Return a safe-resume error without materializing transcript rows.
 
         ``tip_only`` matches call sites that load only the tip session's rows — counting
-        the full lineage there would over-reject heavily-compressed sessions with a small
+        the full lineage there would over-reject compressed sessions with a small
         tip. Generic guard failures fail OPEN; only a genuine over-limit result blocks."""
         if not self._session_db:
             return None

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -594,14 +594,6 @@ class CLIAgentSetupMixin:
                 seed_credits_at_session_start(self.agent)
             except Exception:
                 pass
-
-            # Restore conversation history if resuming
-            if self._resumed and self._session_db and not self.conversation_history:
-                if not self._load_resumed_history_late():
-                    return False
-            if self.conversation_history:
-                self.agent.messages = self.conversation_history
-                self.agent._session_messages = self.conversation_history
             self._active_agent_route_signature = _route_signature(effective_model, runtime)
 
             # Force-create DB row on /title intent, then apply title.

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -191,6 +191,11 @@ class CLIAgentSetupMixin:
         """
         if already_streamed or not isinstance(text, str):
             return
+        # `hermes chat -Q` sets suppress_status_output on the live agent after
+        # construction. Keep its stdout contract without coupling commentary to
+        # tool_progress=off, which is an independent display preference.
+        if getattr(getattr(self, "agent", None), "suppress_status_output", False):
+            return
         from tools.ansi_strip import sanitize_display_text
         visible = sanitize_display_text(text).strip()
         if not visible:

--- a/tests/agent/test_codex_commentary_channels.py
+++ b/tests/agent/test_codex_commentary_channels.py
@@ -1,0 +1,121 @@
+"""Commentary is an assistant message, not a reasoning summary or a final answer."""
+
+from copy import deepcopy
+from types import SimpleNamespace as NS
+
+import pytest
+
+from agent.codex_responses_adapter import (
+    _chat_messages_to_responses_input,
+    _normalize_codex_response,
+)
+
+
+def _message(text, phase, item_id="msg_progress"):
+    return NS(
+        type="message", role="assistant", id=item_id, phase=phase,
+        status="completed", content=[NS(type="output_text", text=text)],
+    )
+
+
+def _reasoning(text="Reasoning summary."):
+    return NS(
+        type="reasoning", id="rs_summary", status="completed",
+        encrypted_content="opaque-replay-state",
+        summary=[NS(type="summary_text", text=text)],
+    )
+
+
+@pytest.mark.parametrize("issuer", [None, "codex_backend", "github_responses", "xai_responses"])
+def test_mixed_response_keeps_commentary_out_of_both_reasoning_and_final(issuer):
+    response = NS(status="completed", output=[
+        _reasoning(),
+        _message("I'll inspect the file.", "commentary"),
+        _message("Analysis summary.", "analysis", "msg_analysis"),
+        _message("The file is correct.", "final_answer", "msg_final"),
+    ])
+    original = deepcopy(response)
+
+    message, finish_reason = _normalize_codex_response(response, issuer_kind=issuer)
+
+    assert finish_reason == "stop"
+    assert message.content == "The file is correct."
+    assert message.reasoning == "Reasoning summary.\n\nAnalysis summary."
+    assert message.reasoning_content is None
+    assert message.reasoning_details is None
+    assert message.codex_message_items == [
+        {
+            "type": "message", "role": "assistant", "status": "completed",
+            "id": item.id, "phase": item.phase,
+            "content": [{"type": "output_text", "text": item.content[0].text}],
+        }
+        for item in response.output if item.type == "message"
+    ]
+    assert message.codex_reasoning_items[0]["encrypted_content"] == "opaque-replay-state"
+    assert response == original
+
+
+@pytest.mark.parametrize("phase", ["commentary", " Commentary ", "COMMENTARY"])
+def test_commentary_only_is_visible_sidecar_not_reasoning_or_final(phase):
+    text = "I'll inspect the file."
+    message, finish_reason = _normalize_codex_response(
+        NS(status="completed", output=[_message(text, phase)], output_text=text),
+        issuer_kind="codex_backend",
+    )
+
+    assert finish_reason == "incomplete"
+    assert message.content == ""
+    assert message.reasoning is None
+    assert message.codex_reasoning_items is None
+    assert message.codex_message_items[0]["phase"] == "commentary"
+    assert message.codex_message_items[0]["content"][0]["text"] == text
+
+
+def test_normalized_commentary_and_encrypted_state_replay_without_reclassification():
+    message, _ = _normalize_codex_response(NS(status="completed", output=[
+        _reasoning(),
+        _message("I'll inspect the file.", "commentary"),
+        _message("The file is correct.", "final_answer", "msg_final"),
+    ]), issuer_kind="codex_backend")
+    history = [
+        {"role": "user", "content": "Check the file."},
+        {"role": "assistant", **vars(message)},
+    ]
+    original = deepcopy(history)
+
+    replay = _chat_messages_to_responses_input(history, current_issuer_kind="codex_backend")
+
+    assert replay == [
+        {"role": "user", "content": "Check the file."},
+        {
+            "type": "reasoning", "encrypted_content": "opaque-replay-state",
+            "summary": [{"type": "summary_text", "text": "Reasoning summary."}],
+        },
+        *message.codex_message_items,
+    ]
+    assert history == original
+
+
+def test_actual_reasoning_is_not_promoted_based_on_user_facing_wording():
+    message, finish_reason = _normalize_codex_response(
+        NS(status="completed", output=[_reasoning("The answer is 42.")]),
+        issuer_kind="codex_backend",
+    )
+
+    assert finish_reason == "incomplete"
+    assert message.content == ""
+    assert message.reasoning == "The answer is 42."
+    assert message.codex_message_items is None
+
+
+def test_xai_response_marker_in_commentary_does_not_turn_progress_into_final():
+    text = "I will inspect <response>the file</response> next."
+    message, finish_reason = _normalize_codex_response(
+        NS(status="completed", output=[_message(text, "commentary")]),
+        issuer_kind="xai_responses",
+    )
+
+    assert finish_reason == "incomplete"
+    assert message.content == ""
+    assert message.reasoning is None
+    assert message.codex_message_items[0]["content"][0]["text"] == text

--- a/tests/cli/test_codex_commentary_channel.py
+++ b/tests/cli/test_codex_commentary_channel.py
@@ -72,6 +72,16 @@ def test_tool_progress_off_keeps_interim_consumer(cli_shell):
     assert printed == []
 
 
+def test_parseable_quiet_suppresses_interim_output(cli_shell):
+    shell, printed, _ = cli_shell
+    shell.agent = SimpleNamespace(suppress_status_output=True)
+
+    shell._on_interim_assistant("Must stay out of -Q stdout.")
+
+    assert printed == []
+    assert shell._stream_started is False
+
+
 def test_explicit_interim_opt_out_does_not_install_consumer(cli_shell):
     shell, printed, cli_mod = cli_shell
     cli_mod.CLI_CONFIG["display"] = {"interim_assistant_messages": False}

--- a/tests/cli/test_codex_commentary_channel.py
+++ b/tests/cli/test_codex_commentary_channel.py
@@ -64,14 +64,17 @@ def test_commentary_renders_as_assistant_independently_of_reasoning_and_streamin
     assert output.count("The file is correct.") == 1
 
 
-@pytest.mark.parametrize("mode,display", [
-    ("off", {}),
-    ("all", {"interim_assistant_messages": False}),
-])
-def test_quiet_and_explicit_interim_opt_out_do_not_install_consumer(cli_shell, mode, display):
+def test_tool_progress_off_keeps_interim_consumer(cli_shell):
+    shell, printed, _ = cli_shell
+    shell.tool_progress_mode = "off"
+
+    assert callable(shell._current_interim_assistant_callback())
+    assert printed == []
+
+
+def test_explicit_interim_opt_out_does_not_install_consumer(cli_shell):
     shell, printed, cli_mod = cli_shell
-    shell.tool_progress_mode = mode
-    cli_mod.CLI_CONFIG["display"] = display
+    cli_mod.CLI_CONFIG["display"] = {"interim_assistant_messages": False}
 
     assert shell._current_interim_assistant_callback() is None
     assert printed == []

--- a/tests/cli/test_codex_commentary_channel.py
+++ b/tests/cli/test_codex_commentary_channel.py
@@ -1,0 +1,164 @@
+"""Classic CLI must consume first-class commentary rather than the reasoning fallback."""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def cli_shell(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import cli as cli_mod
+
+    shell = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+    shell.show_reasoning = False
+    shell.show_timestamps = False
+    shell.streaming_enabled = True
+    shell.verbose = False
+    shell.tool_progress_mode = "all"
+    shell.final_response_markdown = "raw"
+    shell._app = None
+    shell._held_status_lines = []
+    shell._reasoning_shown_this_turn = False
+    shell._reset_stream_state()
+    shell._scrollback_box_width = lambda: 100
+    printed = []
+    monkeypatch.setattr(cli_mod, "_cprint", lambda text="", **kwargs: printed.append(str(text)))
+    monkeypatch.setitem(cli_mod.CLI_CONFIG, "display", {})
+    return shell, printed, cli_mod
+
+
+@pytest.mark.parametrize("show_reasoning", [False, True])
+@pytest.mark.parametrize("streaming_enabled", [False, True])
+def test_commentary_renders_as_assistant_independently_of_reasoning_and_streaming(
+    cli_shell, show_reasoning, streaming_enabled,
+):
+    shell, printed, _ = cli_shell
+    shell.show_reasoning = show_reasoning
+    shell.streaming_enabled = streaming_enabled
+    if show_reasoning:
+        shell._stream_reasoning_delta("Reasoning summary.")
+
+    callback = shell._current_interim_assistant_callback()
+    assert callable(callback)
+    callback("I'll inspect the file.")
+
+    output = "\n".join(printed)
+    assert output.count("I'll inspect the file.") == 1
+    # The interim must be a normal response box, not text in the dim reasoning box.
+    assert "╭" in output
+    if show_reasoning:
+        assert output.index("└") < output.index("I'll inspect the file.")
+    else:
+        assert " Reasoning " not in output
+    assert shell._reasoning_box_opened is False
+    assert shell._stream_started is False
+    assert shell._stream_box_opened is False
+    assert shell._stream_box_live is False
+
+    # A subsequent answer must not be swallowed as an already-rendered final.
+    shell._stream_delta("The file is correct.")
+    shell._stream_delta(None)
+    output = "\n".join(printed)
+    assert output.count("I'll inspect the file.") == 1
+    assert output.count("The file is correct.") == 1
+
+
+@pytest.mark.parametrize("mode,display", [
+    ("off", {}),
+    ("all", {"interim_assistant_messages": False}),
+])
+def test_quiet_and_explicit_interim_opt_out_do_not_install_consumer(cli_shell, mode, display):
+    shell, printed, cli_mod = cli_shell
+    shell.tool_progress_mode = mode
+    cli_mod.CLI_CONFIG["display"] = display
+
+    assert shell._current_interim_assistant_callback() is None
+    assert printed == []
+
+
+def test_already_streamed_interim_is_not_printed_twice(cli_shell):
+    shell, printed, _ = cli_shell
+    shell._stream_delta("Already visible.")
+    shell._on_interim_assistant("Already visible.", already_streamed=True)
+    shell._stream_delta(None)
+
+    assert "\n".join(printed).count("Already visible.") == 1
+
+
+@pytest.mark.parametrize("text", [None, "", " \n\t"])
+def test_empty_interim_does_not_open_a_box(cli_shell, text):
+    shell, printed, _ = cli_shell
+    shell._on_interim_assistant(text)
+    assert printed == []
+    assert shell._stream_started is False
+
+
+def test_interim_sanitizes_terminal_control_sequences(cli_shell):
+    shell, printed, _ = cli_shell
+    shell._on_interim_assistant("\x1b[2JVisible progress.")
+    output = "\n".join(printed)
+    assert "Visible progress." in output
+    assert "\x1b[2J" not in output
+
+
+@pytest.mark.parametrize("streaming_enabled", [False, True])
+def test_init_agent_installs_interim_consumer_even_without_reasoning(cli_shell, monkeypatch, streaming_enabled):
+    shell, _, cli_mod = cli_shell
+    import run_agent
+    import hermes_cli.mcp_startup as mcp_startup
+    import agent.credits_tracker as credits_tracker
+
+    noop = lambda *args, **kwargs: None
+    shell.agent = None
+    shell.model = "gpt-5-codex"
+    shell.streaming_enabled = streaming_enabled
+    shell._session_db = object()
+    shell._resumed = False
+    shell._pending_title = None
+    shell.max_turns = 4
+    shell.enabled_toolsets = []
+    shell.disabled_toolsets = []
+    shell.system_prompt = ""
+    shell.prefill_messages = []
+    shell.reasoning_config = None
+    shell.service_tier = None
+    shell.session_id = "test-commentary"
+    shell._inline_diffs_enabled = False
+    shell.ignore_rules = True
+    shell.pass_session_id = False
+    shell.checkpoints_enabled = False
+    shell.checkpoint_max_snapshots = 1
+    shell.checkpoint_max_total_size_mb = 1
+    shell.checkpoint_max_file_size_mb = 1
+    for name in (
+        "_providers_only", "_providers_ignore", "_providers_order", "_provider_sort",
+        "_provider_require_params", "_provider_data_collection",
+        "_openrouter_min_coding_score", "_fallback_model",
+    ):
+        setattr(shell, name, None)
+    for name in (
+        "finalize_preloaded_skills", "_install_tool_callbacks", "_ensure_tirith_security",
+        "_clarify_callback", "_on_reaction",
+    ):
+        setattr(shell, name, noop)
+    shell._ensure_runtime_credentials = lambda: True
+    monkeypatch.setattr(cli_mod, "_prepare_deferred_agent_startup", noop)
+    monkeypatch.setattr(mcp_startup, "ensure_mcp_discovery_before_agent_build", noop)
+    monkeypatch.setattr(credits_tracker, "seed_credits_at_session_start", noop)
+    # _init_agent updates the process-wide cleanup reference; restore it at teardown.
+    monkeypatch.setattr(cli_mod, "_active_agent_ref", None)
+    captured = {}
+
+    def fake_agent(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace()
+
+    monkeypatch.setattr(run_agent, "AIAgent", fake_agent)
+    assert shell._init_agent(runtime_override={
+        "provider": "openai-codex", "api_mode": "codex_responses",
+        "base_url": "https://chatgpt.com/backend-api/codex", "api_key": "test-key",
+    }) is True
+    assert captured["reasoning_callback"] is None
+    assert captured["interim_assistant_callback"] == shell._on_interim_assistant
+    assert (captured["stream_delta_callback"] is not None) is streaming_enabled

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1895,7 +1895,7 @@ def test_normalize_codex_response_marks_commentary_only_message_as_incomplete(mo
 
     assert finish_reason == "incomplete"
     assert (assistant_message.content or "") == ""
-    assert "inspect the repository" in (assistant_message.reasoning or "")
+    assert assistant_message.reasoning is None
     assert assistant_message.codex_message_items
     assert assistant_message.codex_message_items[0]["phase"] == "commentary"
     assert "inspect the repository" in assistant_message.codex_message_items[0]["content"][0]["text"]
@@ -1912,7 +1912,7 @@ def test_normalize_codex_response_does_not_fallback_to_output_text_for_commentar
 
     assert finish_reason == "incomplete"
     assert (assistant_message.content or "") == ""
-    assert "call the tool" in (assistant_message.reasoning or "")
+    assert assistant_message.reasoning is None
     assert assistant_message.codex_message_items[0]["phase"] == "commentary"
 
 


### PR DESCRIPTION
## Summary

Fix two host-side causes of Responses assistant commentary being treated or displayed as reasoning:

1. The classic Python CLI did not install `interim_assistant_callback` when constructing `AIAgent`. On Codex Responses streams, that made the existing no-consumer compatibility fallback route `phase=commentary` deltas to the reasoning callback. With reasoning hidden, those user-facing updates could disappear; with reasoning shown, they looked like scratchpad text.
2. The shared Responses normalizer (`_OutputScan._message()`) unconditionally grouped `commentary` with `analysis` when populating normalized `reasoning`, even on surfaces that already deliver commentary separately.

This is a protocol/UI fix, not an OAuth change or a prompt workaround. It does not infer an answer from the wording of genuine reasoning.

## Changes

- Install the classic CLI interim callback independently of token streaming, reasoning visibility, and tool-progress display.
- Render completed interims using the existing assistant response renderer, settling reasoning/response boundaries before and after each message so an interim cannot mark a subsequent final as already streamed.
- Respect `display.interim_assistant_messages`, the core `show_commentary` gate, and `already_streamed` deduplication. `tool_progress=off` remains independent and does not suppress assistant commentary.
- Preserve `hermes chat -Q`'s parseable-output contract: `suppress_status_output` prevents the newly wired interim callback from writing commentary to quiet stdout.
- Reuse the existing core redaction/delivery path and sanitize terminal controls before rendering.
- Keep commentary exclusively in the existing `codex_message_items` sidecar instead of duplicating it into `reasoning`. Analysis and actual reasoning items remain reasoning; final-answer extraction remains unchanged.
- Preserve message IDs, phases, statuses, encrypted reasoning replay, and commentary-only continuation behavior.
- Add regression coverage for normalization, replay, actual reasoning-only output, xAI marker isolation, CLI rendering with reasoning/streaming on and off, tool-progress independence, parseable quiet mode, explicit opt-out behavior, duplicate prevention, terminal-control sanitization, and constructor wiring. Update two existing normalization expectations.

## Comparison with official Codex

In [openai/codex `event_mapping.rs` at `968835997714baaff199cfed5f89a2c65d8ca77d`](https://github.com/openai/codex/blob/968835997714baaff199cfed5f89a2c65d8ca77d/codex-rs/core/src/event_mapping.rs), assistant `ResponseItem::Message` becomes `TurnItem::AgentMessage` with its phase preserved; `ResponseItem::Reasoning` becomes a separate `TurnItem::Reasoning`. Commentary is not reclassified as reasoning.

This builds on the first-class commentary delivery introduced in #66115 rather than replacing that infrastructure.

## Relationship to existing work

#61880 independently wires `interim_assistant_callback` into the classic CLI and is direct overlap with the CLI-consumer portion of this PR. That PR is currently conflicted against `main`; this PR additionally fixes the shared Responses normalization bug, preserves the current Codex streaming/replay path, and covers current CLI streaming, quiet-output, and dedup behavior.

The older #59831 addressed the Codex commentary-vs-analysis streaming distinction but was closed without merge. The relevant first-class commentary infrastructure is already present on current `main`; this PR fixes the remaining normalizer/CLI integration gaps rather than reintroducing a parallel channel.

## Scope and compatibility

- The existing low-level no-consumer/explicit-opt-out commentary-to-reasoning streaming fallback is deliberately retained. This PR removes the classic CLI's accidental reliance on it under normal settings.
- The normalization fix applies to the shared Responses adapter, not just the Codex OAuth route.
- The CLI callback also surfaces the existing generic mid-turn assistant-message path; it is not limited to Codex-authenticated models.
- This does not claim to fix a provider that genuinely returns the intended answer only in a reasoning item, nor does it wire every external API-server consumer. No global reasoning-to-final promotion is added.

## Verification

Source-level review of the changed normalization, stream-delivery, CLI callback, and `-Q` quiet-output paths is complete. Full-checkout pytest and live OAuth verification have not been run in this environment. GitHub Actions for this fork PR are currently awaiting maintainer approval (`action_required` with no executed jobs), rather than reporting test failures.

Executed an isolated Python probe of the old/new `_OutputScan._message` logic with synthetic message items: before the change, commentary was appended to reasoning; after the change, only true reasoning/analysis remained there, while message replay data and completion flags were unchanged. This was a focused method probe, not a full normalizer or end-to-end test run.

Added 24 parameterized/regression cases across the two new test modules and updated two existing assertions. The repository tests to run once CI is approved are:

```bash
python -m pytest -q \
  tests/agent/test_codex_commentary_channels.py \
  tests/cli/test_codex_commentary_channel.py \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/test_cli_quiet_stdout_leak.py
```

Manual verification still recommended: classic CLI with Codex OAuth, reasoning shown/hidden, token streaming on/off, commentary followed by tool calls and a final answer, `tool_progress=off`, `hermes chat -Q`, and explicit commentary opt-out.

## Screenshots / logs

Synthetic classifier probe:

```text
BEFORE reasoning: ['Reasoning summary.', "I'll inspect the file.", 'Analysis summary.']
AFTER reasoning: ['Reasoning summary.', 'Analysis summary.']
PASS: channels separated; exact message replay and completion flags unchanged
```

## Checklist

- [ ] I have tested these changes locally in a complete Hermes checkout
- [x] I have added regression tests (execution pending)
- [ ] I have completed live CLI/OAuth verification
- [x] No credentials, authorization behavior, or model prompts changed
