### PR TITLE
feat: add ResearchCraft to plugin catalog

### DIFF
--- a/plugin-catalog/researchcraft.yaml
+++ b/plugin-catalog/researchcraft.yaml
@@ -1,0 +1,30 @@
+name: researchcraft
+repo: https://github.com/raktim-mondol/hermes-plugin-researchcraft
+sha: 4bc855e8489cd8abecd8e455470fc3d1ad139f09
+description: >-
+  ResearchCraft scientific research plugin — literature search
+  (Consensus/Parallel/Scite), paper download (Unpaywall), LaTeX compile,
+  lab notebook, scientific file inspection, PDF-to-Markdown, image
+  generation, structured results, workflow templates, scientific figure
+  making (publication-quality matplotlib), and diagram design (39 editorial
+  diagram types). Uses the Hermes main model.
+maintainer: ResearchCraft
+tier: community
+docs_url: https://github.com/raktim-mondol/hermes-plugin-researchcraft
+platforms: []
+capabilities:
+  provides_tools:
+    - consensus_search
+    - parallel_search
+    - scite_search
+    - paper_download
+    - latex_compile
+    - notebook
+    - scientific_result
+    - sci_inspect
+    - pdf_to_markdown
+    - image_generate
+    - workflow
+  provides_hooks: []
+  provides_middleware: []
+  requires_env: []

--- a/plugin-catalog/researchcraft.yaml
+++ b/plugin-catalog/researchcraft.yaml
@@ -23,7 +23,6 @@ capabilities:
     - scientific_result
     - sci_inspect
     - pdf_to_markdown
-    - image_generate
     - workflow
   provides_hooks: []
   provides_middleware: []


### PR DESCRIPTION
## Summary
Adds ResearchCraft as a community-tier plugin in the new `plugin-catalog/` YAML format.

## Changes
- New file `plugin-catalog/researchcraft.yaml` with exact SHA pin (v1.3.0)
- Follows the catalog schema: name, repo, sha, description, maintainer, tier, capabilities
- Declares 10 provided tools (excludes `image_generate` to avoid collision with Hermes built-in)

## Why
The old `plugin_index.json` seed was removed from upstream. The new catalog format is the canonical way to list community plugins.

## Checklist
- [x] Plugin repo is public
- [x] Plugin has a valid plugin.yaml
- [x] Plugin follows the plugin API v1
- [x] Plugin includes a README with installation instructions
- [x] Exact 40-char commit SHA pinned
- [x] Capabilities match what plugin registers