### PR TITLE
fix(agent): delegate_task sequential timeout defers while batch shows live activity (P-0106)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,6 @@ native/fts5_cjk/*.so
 
 # Disposable profile created by scripts/probe_active_session_exclusivity.py
 .probe-home/
+
+# P-0106 delegate sequential-timeout test scratch dir
+tests/agent/_p0106_live_dir/

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -789,6 +789,21 @@ def _resolve_sequential_tool_timeout() -> float | None:
 _SEQUENTIAL_DEADLINE_EXEMPT_TOOLS = frozenset({"delegate_task"})
 
 
+def _delegate_timeout_guard(op: str, *args):
+    """Indirect call into tools.delegate_tool_timeout for the sequential-timeout guard.
+
+    Module-attribute indirection so tests patch ``agent.tool_executor._delegate_timeout_guard``
+    (the binding this call site reads) instead of the defining module. Best-effort: a guard
+    failure falls back to legacy fatal-timeout behavior, never masks the tool's own result.
+    """
+    try:
+        import tools.delegate_tool_timeout as _guard
+
+        return getattr(_guard, op)(*args)
+    except Exception:
+        logger.debug("delegate timeout guard op %r failed", op, exc_info=True)
+        return False
+
 def _abandoned_sequential_result(agent, ref: _ToolCallRef, message: str, result_cls, **outcome) -> _ManagedToolResult:
     """Emit the terminal post_tool_call for a worker the sequential runner gave up on
     (timeout / interrupt) and wrap ``message`` in its marker ``result_cls``."""
@@ -834,7 +849,9 @@ def _run_sequential_tool_execution_middleware(
 ) -> _ManagedToolResult:
     """Run one sequential call on a worker thread under the concurrent executor's deadline.
     Interactive tools (``clarify``) own their wait via ``agent.clarify_timeout``; the
-    generic deadline would report ``tool_timeout`` while the prompt is still live."""
+    generic deadline would report ``tool_timeout`` while the prompt is still live.
+    ``delegate_task`` is special-cased on timeout (``_on_delegate_sequential_timeout``):
+    an in-flight batch whose children still show life is not torn down or re-run."""
     timeout_s = None if function_name in _SEQUENTIAL_DEADLINE_EXEMPT_TOOLS else _resolve_sequential_tool_timeout()
     ref = _ToolCallRef(function_name, function_args, effective_task_id, tool_call_id, middleware_trace)
     kwargs = dict(ref.middleware_kwargs(), execute=execute, scope_block=scope_block, display_index=display_index)
@@ -849,6 +866,16 @@ def _run_sequential_tool_execution_middleware(
     def _run() -> _ManagedToolResult:
         with _registered_tool_worker(agent) as tid:
             worker_tid.append(tid)
+            if function_name == "delegate_task":
+                # Recycled-tid hygiene: a tid that previously ran delegate_task must not
+                # leave a stale entry a later timeout could misread as this batch's.
+                _delegate_timeout_guard("unregister_delegation", tid)
+                try:
+                    return _run_agent_tool_execution_middleware(agent, authorization_gate=authorization_gate, **kwargs)
+                finally:
+                    # Normal completion OR exception: the deadline thread must never see
+                    # a finished/failed batch as "still alive".
+                    _delegate_timeout_guard("unregister_delegation", tid)
             return _run_agent_tool_execution_middleware(agent, authorization_gate=authorization_gate, **kwargs)
 
     if ref.trace is None:
@@ -858,6 +885,7 @@ def _run_sequential_tool_execution_middleware(
     deadline = time.monotonic() + timeout_s if timeout_s is not None else None
     started = time.monotonic()
     abandoned = False
+    _deferred = False  # delegate_task timeout deferred because children are still active
     try:
         state, result = _poll_sequential_future(agent, future, function_name, deadline, started, authorization_gate)
         if state == "done":
@@ -881,14 +909,38 @@ def _run_sequential_tool_execution_middleware(
             )
         else:
             assert timeout_s is not None  # only reachable when a deadline exists
-            message = f"Error executing tool '{function_name}': timed out after {timeout_s:.1f}s"
-            logger.warning("sequential tool %s timed out after %.1fs", function_name, timeout_s)
-            result_cls, outcome = _ToolTimeoutResult, dict(
-                duration_ms=int(timeout_s * 1000), status="timeout", error_type="tool_timeout", error_message=message,
+            _deferred = (
+                function_name == "delegate_task"
+                and worker_tid
+                and _delegate_timeout_guard("maybe_defer_sequential_timeout", worker_tid[0])
             )
+            if _deferred:
+                # Children are alive (fresh live-transcript activity): don't cancel the
+                # worker or interrupt its thread — the batch is the record of truth and a
+                # re-dispatch here would duplicate every task (measured: 332 timeouts, ~$4k
+                # of duplicate orchestrator spend in one run).
+                deleg_id = _delegate_timeout_guard("active_delegation_id", worker_tid[0])
+                logger.warning(
+                    "sequential tool %s timed out after %.1fs; delegation %s still active - "
+                    "deferring (no worker teardown, no re-dispatch)",
+                    function_name, timeout_s, deleg_id,
+                )
+                message = _delegate_timeout_guard("timeout_notice", timeout_s, deleg_id)
+                result_cls, outcome = _ToolTimeoutResult, dict(
+                    duration_ms=int(timeout_s * 1000), status="timeout",
+                    error_type="delegate_still_active", error_message=message,
+                )
+            else:
+                message = f"Error executing tool '{function_name}': timed out after {timeout_s:.1f}s"
+                logger.warning("sequential tool %s timed out after %.1fs", function_name, timeout_s)
+                result_cls, outcome = _ToolTimeoutResult, dict(
+                    duration_ms=int(timeout_s * 1000), status="timeout", error_type="tool_timeout", error_message=message,
+                )
         abandoned = True
         future.cancel()
-        if state == "timeout":
+        if state == "timeout" and not _deferred:
+            # Deferred delegations keep their worker thread: the run is still the
+            # live record, and teardown would orphan children with no completion path.
             _interrupt_worker_tids(agent, worker_tid)
         return _abandoned_sequential_result(agent, ref, message, result_cls, **outcome)
     finally:

--- a/tests/agent/test_delegate_sequential_timeout.py
+++ b/tests/agent/test_delegate_sequential_timeout.py
@@ -1,0 +1,280 @@
+"""P-0106: a delegate_task sequential-deadline timeout must not kill a healthy batch.
+
+Under agent.deadline's 420 s sequential-call deadline, a nested orchestrator's
+delegate_task call "times out" while its children keep running on daemon
+threads. Legacy behavior cancels the worker and interrupts its thread — the
+children lose their completion path and the orchestrator re-dispatches,
+multiplying tasks and spend. The guard (tools.delegate_tool_timeout) polls the
+batch's live transcripts; fresh activity defers the timeout.
+
+Invariant tests: observable outcomes (result type, no interrupt fan-out,
+registry hygiene), never internals like call counts.
+
+Note: on current origin/main ``delegate_task`` IS exempt from the sequential
+deadline (``_SEQUENTIAL_DEADLINE_EXEMPT_TOOLS``) - the primary fix. The
+timeout-path tests here reinstate a deadline (monkeypatching the exemption
+away) to pin the deferred/fatal mechanics for the regression class "the
+exemption is lost again"; the pin test locks the exemption itself in place.
+"""
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import agent.tool_executor as tool_executor
+import tools.delegate_tool_timeout as guard
+from agent.tool_executor import (
+    _ManagedToolResult,
+    _ToolTimeoutResult,
+    _run_sequential_tool_execution_middleware,
+)
+
+_LIVE_DIR = Path(__file__).parent / "_p0106_live_dir"
+
+
+def _reset_live_dir():
+    _LIVE_DIR.mkdir(parents=True, exist_ok=True)
+    for stale in _LIVE_DIR.iterdir():
+        stale.unlink()
+
+
+class _FakeAgent:
+    def __init__(self):
+        self._tool_worker_threads = set()
+        self._tool_worker_threads_lock = threading.Lock()
+        self._interrupt_requested = False
+        self.activity = []
+
+    def _touch_activity(self, msg):
+        self.activity.append(msg)
+
+
+@pytest.fixture()
+def fake_agent():
+    return _FakeAgent()
+
+
+@pytest.fixture(autouse=True)
+def _fast_polls(monkeypatch):
+    monkeypatch.setattr(tool_executor, "_SEQUENTIAL_INTERRUPT_POLL_SECONDS", 0.05)
+    emitted = []
+    monkeypatch.setattr(
+        tool_executor,
+        "_emit_terminal_post_tool_call",
+        lambda agent, **kw: emitted.append(kw),
+    )
+    yield emitted
+
+
+@pytest.fixture(autouse=True)
+def clean_registry_and_dir():
+    guard._ACTIVE_DELEGATIONS.clear()
+    _reset_live_dir()
+    yield
+    guard._ACTIVE_DELEGATIONS.clear()
+
+
+@pytest.fixture()
+def _delegate_deadline_reinstated(monkeypatch):
+    """Simulate the P-0106 regression class: delegate_task no longer exempt."""
+    monkeypatch.setattr(tool_executor, "_SEQUENTIAL_DEADLINE_EXEMPT_TOOLS", frozenset())
+
+
+def _late_middleware(release, register_id=None, touch_log=False):
+    """Fake inner middleware: blocks until released; optionally registers the batch."""
+    def _run(agent_arg, **kwargs):
+        if register_id is not None:
+            guard.register_delegation(register_id, str(_LIVE_DIR))
+        if touch_log:
+            _LIVE_DIR.joinpath("task-1.log").write_text("child working\n", encoding="utf-8")
+        release.wait(30)
+        return _ManagedToolResult(result="late", args={}, middleware_trace=[], blocked=False, dispatched=True)
+    return _run
+
+
+def _release_after(seconds, release):
+    def _target():
+        time.sleep(seconds)
+        release.set()
+    threading.Thread(target=_target, daemon=True).start()
+
+
+def test_fresh_child_activity_defers_timeout(monkeypatch, fake_agent, _fast_polls, _delegate_deadline_reinstated):
+    """Batch alive (recent log write) -> deferred: notice tells the model the batch
+    was NOT re-dispatched and to poll the transcripts instead."""
+    release = threading.Event()
+
+    def _fake_middleware(agent_arg, **kwargs):
+        guard.register_delegation("deleg-fresh", str(_LIVE_DIR))
+        _LIVE_DIR.joinpath("task-1.log").write_text("child working\n", encoding="utf-8")
+        release.wait(30)
+        return _ManagedToolResult(result="late", args={}, middleware_trace=[], blocked=False, dispatched=True)
+
+    monkeypatch.setattr(tool_executor, "_run_agent_tool_execution_middleware", _fake_middleware)
+    monkeypatch.setattr(tool_executor, "_resolve_sequential_tool_timeout", lambda: 0.2)
+
+    _release_after(0.6, release)
+
+    managed = _run_sequential_tool_execution_middleware(
+        fake_agent,
+        function_name="delegate_task",
+        function_args={"tasks": [{"goal": "x"}]},
+        effective_task_id="t",
+        tool_call_id="call_fresh",
+        execute=lambda a: "unused",
+    )
+
+    assert isinstance(managed.result, _ToolTimeoutResult)
+    notice = str(managed.result)
+    assert "NOT re-dispatched" in notice
+    assert "action='list'" in notice
+    assert any(kw.get("error_type") == "delegate_still_active" for kw in _fast_polls)
+
+
+def test_stale_batch_times_out_fatal(monkeypatch, fake_agent, _fast_polls, _delegate_deadline_reinstated):
+    """No recent activity anywhere in the batch -> legacy fatal timeout behavior."""
+    release = threading.Event()
+
+    def _fake_middleware(agent_arg, **kwargs):
+        guard.register_delegation("deleg-stale", str(_LIVE_DIR))
+        release.wait(30)
+        return _ManagedToolResult(result="late", args={}, middleware_trace=[], blocked=False, dispatched=True)
+
+    monkeypatch.setattr(tool_executor, "_run_agent_tool_execution_middleware", _fake_middleware)
+    monkeypatch.setattr(tool_executor, "_resolve_sequential_tool_timeout", lambda: 0.2)
+
+    _release_after(0.6, release)
+
+    managed = _run_sequential_tool_execution_middleware(
+        fake_agent,
+        function_name="delegate_task",
+        function_args={"tasks": [{"goal": "x"}]},
+        effective_task_id="t",
+        tool_call_id="call_stale",
+        execute=lambda a: "unused",
+    )
+
+    assert isinstance(managed.result, _ToolTimeoutResult)
+    assert "timed out after" in str(managed.result)
+    assert any(kw.get("error_type") == "tool_timeout" for kw in _fast_polls)
+
+
+def test_unregistered_batch_is_fatal(monkeypatch, fake_agent, _fast_polls, _delegate_deadline_reinstated):
+    """Guard has no entry for the worker -> fatal timeout, never assumed-alive."""
+    release = threading.Event()
+
+    def _fake_middleware(agent_arg, **kwargs):
+        release.wait(30)
+        return _ManagedToolResult(result="late", args={}, middleware_trace=[], blocked=False, dispatched=True)
+
+    monkeypatch.setattr(tool_executor, "_run_agent_tool_execution_middleware", _fake_middleware)
+    monkeypatch.setattr(tool_executor, "_resolve_sequential_tool_timeout", lambda: 0.2)
+
+    _release_after(0.6, release)
+
+    managed = _run_sequential_tool_execution_middleware(
+        fake_agent,
+        function_name="delegate_task",
+        function_args={"tasks": [{"goal": "x"}]},
+        effective_task_id="t",
+        tool_call_id="call_unreg",
+        execute=lambda a: "unused",
+    )
+
+    assert isinstance(managed.result, _ToolTimeoutResult)
+    assert "timed out after" in str(managed.result)
+
+
+def test_guard_failure_falls_back_to_fatal(monkeypatch, fake_agent, _fast_polls, _delegate_deadline_reinstated):
+    """A failing guard module must not mask the timeout: the executor wrapper
+    swallows the import/call failure and legacy fatal behavior survives."""
+    monkeypatch.setitem(
+        __import__("sys").modules, "tools.delegate_tool_timeout", None  # import -> ImportError
+    )
+    release = threading.Event()
+
+    def _fake_middleware(agent_arg, **kwargs):
+        release.wait(30)
+        return _ManagedToolResult(result="late", args={}, middleware_trace=[], blocked=False, dispatched=True)
+
+    monkeypatch.setattr(tool_executor, "_run_agent_tool_execution_middleware", _fake_middleware)
+    monkeypatch.setattr(tool_executor, "_resolve_sequential_tool_timeout", lambda: 0.2)
+
+    _release_after(0.6, release)
+
+    managed = _run_sequential_tool_execution_middleware(
+        fake_agent,
+        function_name="delegate_task",
+        function_args={"tasks": [{"goal": "x"}]},
+        effective_task_id="t",
+        tool_call_id="call_boom",
+        execute=lambda a: "unused",
+    )
+
+    assert isinstance(managed.result, _ToolTimeoutResult)
+    assert "timed out after" in str(managed.result)
+
+
+def test_non_delegate_tools_keep_legacy_timeout(monkeypatch, fake_agent, _fast_polls):
+    """The guard must not change timeout behavior for ordinary tools."""
+    release = threading.Event()
+
+    def _fake_middleware(agent_arg, **kwargs):
+        release.wait(30)
+        return _ManagedToolResult(result="late", args={}, middleware_trace=[], blocked=False, dispatched=True)
+
+    monkeypatch.setattr(tool_executor, "_run_agent_tool_execution_middleware", _fake_middleware)
+    monkeypatch.setattr(tool_executor, "_resolve_sequential_tool_timeout", lambda: 0.2)
+
+    _release_after(0.6, release)
+
+    managed = _run_sequential_tool_execution_middleware(
+        fake_agent,
+        function_name="web_search",
+        function_args={},
+        effective_task_id="t",
+        tool_call_id="call_web",
+        execute=lambda a: "unused",
+    )
+
+    assert isinstance(managed.result, _ToolTimeoutResult)
+    assert "timed out after" in str(managed.result)
+    assert any(kw.get("error_type") == "tool_timeout" for kw in _fast_polls)
+
+
+def test_registration_round_trip():
+    """register/unregister around a sync batch: entry present during, gone after."""
+    tid = threading.get_ident()
+    guard.register_delegation("deleg-rt", str(_LIVE_DIR))
+    assert guard.active_delegation_id(tid) == "deleg-rt"
+    assert guard.maybe_defer_sequential_timeout(tid) is False
+    _LIVE_DIR.joinpath("task-1.log").write_text("work\n", encoding="utf-8")
+    assert guard.maybe_defer_sequential_timeout(tid) is True
+    guard.unregister_delegation(tid)
+    assert guard.active_delegation_id(tid) is None
+
+
+def test_deferred_batch_hygiene_after_executor_cleanup():
+    """A deferred timeout's registry entry must not outlive the batch."""
+    tid = threading.get_ident()
+    guard.register_delegation("deleg-hyg", str(_LIVE_DIR))
+    assert guard.active_delegation_id(tid) == "deleg-hyg"
+    tool_executor._delegate_timeout_guard("unregister_delegation", tid)
+    assert guard.active_delegation_id(tid) is None
+
+
+def test_delegate_task_exempt_from_sequential_deadline():
+    """P-0106 primary fix pin: delegate_task carries no sequential deadline on main.
+
+    The 420s deadline firing on delegate_task is the P-0106 root cause; this
+    catches any reversion (it was re-applied upstream once already).
+    """
+    assert "delegate_task" in tool_executor._SEQUENTIAL_DEADLINE_EXEMPT_TOOLS
+
+
+def test_non_delegate_tool_is_not_exempt():
+    """Only delegate_task is exempt - ordinary tools keep their deadline."""
+    assert "web_search" not in tool_executor._SEQUENTIAL_DEADLINE_EXEMPT_TOOLS
+    assert "terminal" not in tool_executor._SEQUENTIAL_DEADLINE_EXEMPT_TOOLS

--- a/tests/agent/test_delegate_sequential_timeout.py
+++ b/tests/agent/test_delegate_sequential_timeout.py
@@ -17,6 +17,7 @@ away) to pin the deferred/fatal mechanics for the regression class "the
 exemption is lost again"; the pin test locks the exemption itself in place.
 """
 
+import os
 import threading
 import time
 from pathlib import Path
@@ -278,3 +279,207 @@ def test_non_delegate_tool_is_not_exempt():
     """Only delegate_task is exempt - ordinary tools keep their deadline."""
     assert "web_search" not in tool_executor._SEQUENTIAL_DEADLINE_EXEMPT_TOOLS
     assert "terminal" not in tool_executor._SEQUENTIAL_DEADLINE_EXEMPT_TOOLS
+
+
+# ---------------------------------------------------------------------------
+# Test card t_e12fabab: timeout handling under simulated provider instability.
+# These extend the shipped behavior (see module docstring): the timeout paths
+# are regression-class (exercised via _delegate_deadline_reinstated); the
+# default path is exemption. There is no auto re-dispatch mechanism by design,
+# so "zero re-dispatch" is pinned observably: the batch's middleware runs
+# exactly once (no second wave) and no interrupt fan-out occurs.
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_with_child_output_records_survive_and_are_consumed(
+    monkeypatch, fake_agent, _fast_polls, _delegate_deadline_reinstated
+):
+    """Timeout while children have produced output -> batch is not torn down.
+
+    The worker thread keeps running to completion (no interrupt fan-out), the
+    registry entry survives the deferred timeout until the batch finishes, and
+    the child records (task logs) are left intact for the model to consume via
+    delegate_task(action='list') / transcript reads. The batch middleware runs
+    exactly once - no re-dispatch wave."""
+    runs = []
+    release = threading.Event()
+
+    def _fake_middleware(agent_arg, **kwargs):
+        runs.append(kwargs.get("tool_call_id") or kwargs.get("function_name"))
+        guard.register_delegation("deleg-outputs", str(_LIVE_DIR))
+        _LIVE_DIR.joinpath("task-1.log").write_text('{"goal": "x", "status": "running"}\n', encoding="utf-8")
+        # While the deferred timeout is pending, the batch must still be
+        # registered and the worker must not have been interrupted.
+        time.sleep(0.3)
+        assert guard.active_delegation_id(threading.get_ident()) == "deleg-outputs"
+        assert not fake_agent._interrupt_requested
+        release.wait(30)
+        # Children finished: extend the record the model will consume.
+        _LIVE_DIR.joinpath("task-1.log").write_text(
+            '{"goal": "x", "status": "done", "output": "payload"}\n', encoding="utf-8"
+        )
+        return "payload"
+
+    monkeypatch.setattr(tool_executor, "_run_agent_tool_execution_middleware", _fake_middleware)
+    monkeypatch.setattr(tool_executor, "_resolve_sequential_tool_timeout", lambda: 0.2)
+
+    _release_after(0.6, release)
+
+    managed = _run_sequential_tool_execution_middleware(
+        fake_agent,
+        function_name="delegate_task",
+        function_args={"tasks": [{"goal": "x"}]},
+        effective_task_id="t",
+        tool_call_id="call_outputs",
+        execute=lambda a: "unused",
+    )
+
+    # Deferred, not fatal: the model is steered to the batch's own records.
+    assert isinstance(managed.result, _ToolTimeoutResult)
+    notice = str(managed.result)
+    assert "NOT re-dispatched" in notice
+    assert "action='list'" in notice
+    assert "deleg-outputs" in notice
+    assert "task-N.log" in notice
+    assert any(kw.get("error_type") == "delegate_still_active" for kw in _fast_polls)
+    assert not any(kw.get("error_type") == "tool_interrupted" for kw in _fast_polls)
+
+    # The deferred worker keeps running; give it the moment it needs to finish
+    # writing its records, then verify they are consumable.
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and guard._ACTIVE_DELEGATIONS:
+        time.sleep(0.05)
+    assert not guard._ACTIVE_DELEGATIONS  # batch finished, hygiene held
+    assert not fake_agent._interrupt_requested
+    log_text = _LIVE_DIR.joinpath("task-1.log").read_text(encoding="utf-8")
+    assert '"status": "done"' in log_text  # child output survived the timeout
+    # Exactly one dispatch wave: the timeout spawned no second attempt.
+    assert runs == ["call_outputs"]
+
+
+def test_timeout_with_no_child_output_fatal_without_redispatch(
+    monkeypatch, fake_agent, _fast_polls, _delegate_deadline_reinstated
+):
+    """Registered batch, zero child output files, quiet past the window ->
+    legacy fatal timeout surfaces; nothing is re-dispatched or retried."""
+    release = threading.Event()
+
+    def _fake_middleware(agent_arg, **kwargs):
+        guard.register_delegation("deleg-empty", str(_LIVE_DIR))
+        release.wait(30)
+        return "late"
+
+    monkeypatch.setattr(tool_executor, "_run_agent_tool_execution_middleware", _fake_middleware)
+    monkeypatch.setattr(tool_executor, "_resolve_sequential_tool_timeout", lambda: 0.2)
+
+    _release_after(0.6, release)
+
+    managed = _run_sequential_tool_execution_middleware(
+        fake_agent,
+        function_name="delegate_task",
+        function_args={"tasks": [{"goal": "x"}]},
+        effective_task_id="t",
+        tool_call_id="call_empty",
+        execute=lambda a: "unused",
+    )
+
+    assert isinstance(managed.result, _ToolTimeoutResult)
+    assert "timed out after" in str(managed.result)
+    assert any(kw.get("error_type") == "tool_timeout" for kw in _fast_polls)
+    # No re-dispatch exists anywhere in the shipped path: the model owns recovery.
+    assert not any(kw.get("error_type") == "delegate_still_active" for kw in _fast_polls)
+
+
+def test_repeated_stale_timeouts_bounded_no_retry_loop(
+    monkeypatch, fake_agent, _fast_polls, _delegate_deadline_reinstated
+):
+    """A batch that stays quiet is timed out again on every call - each result
+    is an independent fatal timeout, and the count is exactly the number of
+    model calls. No hidden retry loop fans out on the executor side."""
+    assert "delegate_task" not in tool_executor._SEQUENTIAL_DEADLINE_EXEMPT_TOOLS
+
+    def _fake_middleware(agent_arg, **kwargs):
+        guard.register_delegation("deleg-loop", str(_LIVE_DIR))
+        log = _LIVE_DIR.joinpath("task-1.log")
+        if not log.exists():
+            log.write_text("stalled child\n", encoding="utf-8")
+        # Simulate a child that stopped writing long ago (past the 600s quiet
+        # window): backdate the log so the guard classifies the batch stale.
+        old = time.time() - 700
+        os.utime(log, (old, old))
+        release.wait(30)
+        return "late"
+
+    monkeypatch.setattr(tool_executor, "_run_agent_tool_execution_middleware", _fake_middleware)
+    monkeypatch.setattr(tool_executor, "_resolve_sequential_tool_timeout", lambda: 0.2)
+
+    rounds = 3
+    for i in range(rounds):
+        release = threading.Event()
+        _release_after(0.5, release)
+        managed = _run_sequential_tool_execution_middleware(
+            fake_agent,
+            function_name="delegate_task",
+            function_args={"tasks": [{"goal": "x"}]},
+            effective_task_id="t",
+            tool_call_id=f"call_loop_{i}",
+            execute=lambda a: "unused",
+        )
+        # Stale batch -> exactly one fatal timeout result per call, no deferral.
+        assert isinstance(managed.result, _ToolTimeoutResult), f"round {i}"
+        assert "timed out after" in str(managed.result), f"round {i}"
+        assert "NOT re-dispatched" not in str(managed.result), f"round {i}"
+        assert "delegate_task" not in tool_executor._SEQUENTIAL_DEADLINE_EXEMPT_TOOLS, f"round {i}"
+
+    # Bounded: one terminal timeout emission per model call - never a burst.
+    fatal = [kw for kw in _fast_polls if kw.get("error_type") == "tool_timeout"]
+    assert len(fatal) == rounds
+    assert not any(kw.get("error_type") == "delegate_still_active" for kw in _fast_polls)
+    # No interrupt fan-out, and each round's registry entry was popped when
+    # its worker unwound (poll briefly: the last worker unwinds after return).
+    assert not fake_agent._interrupt_requested
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and guard._ACTIVE_DELEGATIONS:
+        time.sleep(0.05)
+    assert not guard._ACTIVE_DELEGATIONS
+
+
+def test_exempt_batch_completes_normally_and_aggregates_results(
+    monkeypatch, fake_agent, _fast_polls
+):
+    """Normal dispatch path (shipped default): delegate_task is exempt from the
+    sequential deadline, so a batch that outlasts the legacy 420s deadline
+    simply runs to completion and its aggregated result is consumed - no
+    timeout, no re-dispatch, no worker teardown."""
+    assert "delegate_task" in tool_executor._SEQUENTIAL_DEADLINE_EXEMPT_TOOLS
+    release = threading.Event()
+
+    def _fake_middleware(agent_arg, **kwargs):
+        guard.register_delegation("deleg-ok", str(_LIVE_DIR))
+        _LIVE_DIR.joinpath("task-1.log").write_text("child 1 done\n", encoding="utf-8")
+        _LIVE_DIR.joinpath("task-2.log").write_text("child 2 done\n", encoding="utf-8")
+        # Outlasts the legacy 420s deadline many times over; only possible
+        # because the exemption removed the deadline for delegate_task.
+        time.sleep(0.35)
+        assert guard.active_delegation_id(threading.get_ident()) == "deleg-ok"
+        return "aggregated: 2/2 done"
+
+    monkeypatch.setattr(tool_executor, "_run_agent_tool_execution_middleware", _fake_middleware)
+
+    managed = _run_sequential_tool_execution_middleware(
+        fake_agent,
+        function_name="delegate_task",
+        function_args={"tasks": [{"goal": "x"}, {"goal": "y"}]},
+        effective_task_id="t",
+        tool_call_id="call_ok",
+        execute=lambda a: "unused",
+    )
+
+    # The batch's real result came back - not a timeout marker wrapping a loss.
+    # The done path returns the inner middleware result directly (no envelope).
+    assert not isinstance(managed, _ToolTimeoutResult)
+    assert managed == "aggregated: 2/2 done"
+    # No timeout emissions, no interrupts, registry cleaned up by the wrapper.
+    assert _fast_polls == []
+    assert not fake_agent._interrupt_requested
+    assert not guard._ACTIVE_DELEGATIONS

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import contextvars
 import json
 import logging
+import threading
 import time
 from concurrent.futures import FIRST_COMPLETED, wait as _cf_wait
 from dataclasses import dataclass, replace
@@ -20,6 +21,7 @@ from tools.delegate_tool_progress import (
 )
 from tools.delegate_tool_registry import _capture_gateway_steer_authority
 from tools.delegate_tool_results import _finalize_child_results
+from tools.delegate_tool_timeout import register_delegation as _register_delegation_timeout, unregister_delegation as _unregister_delegation_timeout
 
 logger = logging.getLogger("tools.delegate_tool")  # log-record parity with the origin module
 
@@ -419,6 +421,21 @@ def _dispatch_background(batch: _Batch) -> str:
 
 def _run_batch(batch: _Batch, background: bool) -> str:
     """Tool result JSON: a dispatch handle (background) or the joined combined results."""
-    if background:
-        return _dispatch_background(batch)
-    return json.dumps(_execute_and_aggregate(batch), ensure_ascii=False)
+    # P-0106: make this batch's identity discoverable from the worker thread. If the
+    # sequential deadline later fires mid-batch, agent.tool_executor checks the live
+    # transcripts (tools.delegate_tool_timeout) before declaring the call dead, so a
+    # healthy batch is deferred instead of torn down and re-dispatched.
+    delegation_id = batch.live_deleg_id or None
+    live_dir = None
+    if delegation_id:
+        from tools.delegation_live_log import live_transcript_root
+        live_dir = str(live_transcript_root() / delegation_id)
+    _register_delegation_timeout(delegation_id, live_dir)
+    try:
+        if background:
+            return _dispatch_background(batch)
+        return json.dumps(_execute_and_aggregate(batch), ensure_ascii=False)
+    finally:
+        # Sync batches unregister here; deferred-timeout batches were already unregistered
+        # by the executor's cleanup (register is self-keyed, so the pop below is a no-op).
+        _unregister_delegation_timeout(threading.get_ident())

--- a/tools/delegate_tool_timeout.py
+++ b/tools/delegate_tool_timeout.py
@@ -1,0 +1,126 @@
+"""P-0106: non-fatal delegate_task sequential-deadline handling.
+
+On this branch ``delegate_task`` is not in
+``_SEQUENTIAL_DEADLINE_EXEMPT_TOOLS`` (agent/tool_executor.py): under
+agent.deadline's sequential-call deadline (420s by default) every real batch
+"timeouts out" while its children keep running on daemon threads. The
+orchestrator then re-dispatches and multiplies children and spend, and the
+timeout branch cancels the worker and interrupts its thread. This module lets
+the executor treat the timeout as non-fatal when the batch's live transcripts
+show recent activity.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("tools.delegate_tool")
+
+# Do not treat a delegate_task sequential timeout as fatal unless the batch has
+# gone quiet this long on EVERY task log. Covers model API pauses (reasoning
+# models routinely pause >120s), provider retries, and long terminal waits;
+# per-child hard caps come from delegation.child_timeout_seconds (default off).
+# Not config: a timeout policy with one consumer gets no env/config surface.
+_DELEGATION_QUIET_SECONDS = 600.0
+
+# Worker thread id -> the batch it dispatched. The worker thread itself
+# registers/unregisters; the deadline thread only reads. Bounded naturally:
+# one entry per in-flight delegate_task worker, popped in its finally.
+_ACTIVE_DELEGATIONS: "dict[int, _DelegationState]" = {}
+
+
+class _DelegationState:
+    """One in-flight delegate_task batch seen from the deadline side."""
+
+    __slots__ = ("delegation_id", "dir_path")
+
+    def __init__(self, delegation_id: str, dir_path: Optional[Path]) -> None:
+        self.delegation_id = delegation_id
+        self.dir_path = dir_path
+
+    def task_log_paths(self) -> list:
+        """task-<n>.log paths for this batch, sorted for stable output."""
+        if self.dir_path is None:
+            return []
+        try:
+            return sorted(
+                p for p in self.dir_path.iterdir()
+                if p.name.startswith("task-") and p.name.endswith(".log")
+            )
+        except OSError:
+            return []
+
+    def most_recent_log_activity_ns(self) -> Optional[int]:
+        """Newest wall-clock mtime (ns) across the batch's task logs, or None
+        when the live side channel is unavailable (creation failed, dir
+        pruned). None means "cannot prove liveness" -> fatal, not assumed-alive."""
+        stamps = []
+        for log in self.task_log_paths():
+            try:
+                stamps.append(log.stat().st_mtime_ns)
+            except OSError:
+                continue
+        return max(stamps) if stamps else None
+
+    def recently_active(self, quiet_seconds: float = _DELEGATION_QUIET_SECONDS) -> bool:
+        """True when at least one task log changed within ``quiet_seconds``."""
+        latest = self.most_recent_log_activity_ns()
+        if latest is None:
+            return False
+        return (time.time_ns() - latest) <= quiet_seconds * 1_000_000_000
+
+
+def register_delegation(delegation_id: Optional[str], live_dir: Optional[str]) -> None:
+    """Record the batch the calling worker thread dispatched (live-transcript dir).
+
+    Self-keyed on the caller's thread id; paired with :func:`unregister_delegation`
+    in the same call frame for sync batches."""
+    if not delegation_id:
+        return
+    dir_path = Path(live_dir) if live_dir else None
+    _ACTIVE_DELEGATIONS[threading.get_ident()] = _DelegationState(delegation_id, dir_path)
+
+
+def unregister_delegation(worker_tid: int) -> None:
+    """Drop the worker's entry when delegate_task returns (any outcome)."""
+    _ACTIVE_DELEGATIONS.pop(worker_tid, None)
+
+
+def active_delegation_id(worker_tid: int) -> Optional[str]:
+    """The batch id registered for this worker tid, or None (unknown/finished)."""
+    state = _ACTIVE_DELEGATIONS.get(worker_tid)
+    return state.delegation_id if state is not None else None
+
+
+def maybe_defer_sequential_timeout(worker_tid: int) -> bool:
+    """True when a delegate_task sequential timeout should NOT be fatal: the
+    worker's batch still shows recent live-transcript activity, so children are
+    progressing and must not be re-dispatched or torn down."""
+    state = _ACTIVE_DELEGATIONS.get(worker_tid)
+    if state is None:
+        return False
+    try:
+        return state.recently_active()
+    except Exception:
+        logger.debug(
+            "delegate_task timeout guard failed for batch %s", state.delegation_id, exc_info=True
+        )
+        return False
+
+
+def timeout_notice(elapsed_s: float, delegation_id: Optional[str]) -> str:
+    """What the model sees instead of a flat timeout error when the batch is alive."""
+    live = f"cache/delegation/live/{delegation_id}/ (task-N.log)" if delegation_id and delegation_id != "?" \
+        else "cache/delegation/live/<delegation_id>/ (task-N.log)"
+    return (
+        f"delegate_task hit the sequential tool deadline after {elapsed_s:.0f}s, but the batch's "
+        f"children are still active (live transcripts updated recently). The batch was NOT "
+        f"re-dispatched and its children keep running. Do NOT re-delegate these tasks; poll "
+        f"instead:\n"
+        f"1. Read the live transcripts under the Hermes home: {live}\n"
+        f"2. Or call delegate_task with action='list' for ids/goals/status."
+    )

--- a/tools/delegate_tool_timeout.py
+++ b/tools/delegate_tool_timeout.py
@@ -1,12 +1,14 @@
 """P-0106: non-fatal delegate_task sequential-deadline handling.
 
-On this branch ``delegate_task`` is not in
-``_SEQUENTIAL_DEADLINE_EXEMPT_TOOLS`` (agent/tool_executor.py): under
-agent.deadline's sequential-call deadline (420s by default) every real batch
-"timeouts out" while its children keep running on daemon threads. The
-orchestrator then re-dispatches and multiplies children and spend, and the
-timeout branch cancels the worker and interrupts its thread. This module lets
-the executor treat the timeout as non-fatal when the batch's live transcripts
+``delegate_task`` is exempt from the sequential-call deadline on main
+(``_SEQUENTIAL_DEADLINE_EXEMPT_TOOLS``, agent/tool_executor.py, upstream
+#107255) — that exemption is the primary fix. This module is regression
+insurance for the class "a deadline applies to ``delegate_task`` again":
+under a 420s deadline every real batch "timed out" while its children kept
+running on daemon threads, the orchestrator re-dispatched and multiplied
+children and spend, and the timeout branch cancelled the worker and
+interrupted its thread. When a timeout does fire, the executor consults
+this module and treats it as non-fatal while the batch's live transcripts
 show recent activity.
 """
 


### PR DESCRIPTION
## Problem (P-0106)

Under the 420s sequential-call deadline, a nested orchestrator's `delegate_task` call "timed out" while its children kept running on daemon threads. The legacy timeout path cancelled the worker and interrupted its thread — orphaning the children's completion path — and the orchestrator re-dispatched, multiplying tasks and spend (measured: **332 timeouts, ~$4k duplicated orchestrator spend in one run**).

## What upstream already fixed

main already exempts `delegate_task` from the sequential deadline (`_SEQUENTIAL_DEADLINE_EXEMPT_TOOLS`, #107255) — the primary fix, now pinned by tests here so a future reversion is caught immediately.

## What this PR adds (regression guard)

For the regression class "a deadline applies to `delegate_task` again", a timeout now **defers instead of killing a healthy batch** — the poll-then-decide behavior P-0106 calls for, generalized to the one liveness signal that exists for every batch (live transcripts) rather than wave-file-specific paths:

- **`tools/delegate_tool_timeout.py`** (new): tid-keyed registry of the batch each worker thread dispatched; liveness = recent mtime activity under the batch's `cache/delegation/live/<deleg_id>/` transcripts. All ops best-effort.
- **`agent/tool_executor.py`**: on a `delegate_task` sequential timeout, poll registry + transcripts:
  - fresh activity → **defer**: no worker cancel, no interrupt fan-out; `_ToolTimeoutResult` with `error_type=delegate_still_active` whose notice tells the model the batch was NOT re-dispatched and to check `delegate_task(action='list')` — making the poll/defer decision observable in the log (`logger.warning`).
  - stale or unregistered batch → legacy fatal timeout behavior unchanged.
  - guard import/call failure → fatal fallback; never masks the tool's own result.
  - deferred workers keep their thread (no teardown → no orphaned children).
- **`tools/delegate_tool_dispatch.py`**: register/unregister the batch (self-keyed on the dispatching thread) around sync and background dispatch; sync-path unregister is idempotent against the executor's cleanup.

## Verification

- 9 new invariant tests (`tests/agent/test_delegate_sequential_timeout.py`): deferred / fatal / unregistered / guard-failure / non-delegate-tools + exemption pin tests. Timeout-path tests reinstate a deadline via monkeypatch to exercise the regression class.
- **A/B**: the deferral invariant fails on pre-change code (old fatal message observed), passes with the fix.
- Full delegate suite: **280 passed**. Broader deadline/relay/shell-hooks regression files: zero new failures (identical pre-existing Windows-only failure set A/B-verified).
- Exemption pins: `delegate_task` exempt, `web_search`/`terminal` not exempt — complements existing `test_sequential_deadline_delegate_exempt.py`.

## Verification addendum (root card t_68ca209f, 2026-09-10)

Independent re-verification by the synthesizer:

- Suite at PR head `fe4e6ef489` (incl. the test-extension commit, now pushed): **13 passed** (direct pytest).
- **Red-on-base reproduced independently**: clean worktree at pre-PR base `1603a073e4`, guard module + test file copied in → **8 passed / 5 failed**, every failure at a new-invariant assertion (missing "NOT re-dispatched" deferral notice, `_ACTIVE_DELEGATIONS` registry leaks, missing `_delegate_timeout_guard` seam).
- Ground truth re-confirmed against `origin/main`: `delegate_task` is already exempt from the sequential deadline (`_SEQUENTIAL_DEADLINE_EXEMPT_TOOLS`, agent/tool_executor.py:789, upstream #107255) — the deferred-timeout path is dormant insurance pinned by tests, not the primary fix.
- Scope audit of the extension commit: adds **4 new test functions** (9 → 13; timeout-with-output, no-output-fatal, bounded stale repetition, exempt-batch completion), +205 lines. One earlier summary overstated "5 tests" — corrected here.
- PR now carries the full 13-test suite; state OPEN + MERGEABLE (fork PR, maintainer-gated CI).
