### PR TITLE
fix(fast): opt-in trusted endpoints so /fast is consistent on self-hosted proxies

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -120,6 +120,13 @@ DEFAULT_CONFIG = {
         # turn), "cold" (first turn of a session only).
         "service_tier": "",
         "fast_auto_seconds": 60,
+        # Self-hosted endpoints trusted to forward fast-mode params (service_tier / speed)
+        # to the first-party API unchanged. Fast mode is otherwise refused on any custom
+        # base_url, because a proxy that drops or rejects the field bills for a tier that
+        # was never delivered. Entries are exact "provider:hostname" pairs; subdomains do
+        # not inherit trust. Only list an endpoint you have verified passes the param
+        # through, e.g. ["llm-proxy:proxy.example.com"].
+        "fast_mode_trusted_endpoints": [],
         # System-prompt guidance telling the model to call tools instead of describing actions.
         # "auto" = gpt/codex models; true/false = force for all models; or a list of model-name
         # substrings (e.g. ["gpt", "codex", "gemini", "qwen"]).

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1019,6 +1019,30 @@ def provider_label(provider: Optional[str]) -> str:
     return _PROVIDER_LABELS.get(normalized, original or "OpenRouter")
 
 
+def _trusted_fast_mode_endpoints() -> set[tuple[str, str]]:
+    """``agent.fast_mode_trusted_endpoints`` as normalized ``(provider, host)`` pairs.
+
+    Opt-in for self-hosted deployments that forward the fast-mode params verbatim. Malformed
+    entries are ignored rather than raising: a typo must not make fast mode unavailable, and it
+    must not widen the gate either.
+    """
+    from hermes_cli.config import load_config
+
+    try:
+        configured = (load_config() or {}).get("agent", {}).get("fast_mode_trusted_endpoints")
+    except Exception:
+        return set()
+    pairs = set()
+    for entry in configured or []:
+        provider, sep, host = str(entry or "").partition(":")
+        if not sep:
+            continue
+        provider, host = provider.strip().lower(), host.strip().lower()
+        if provider and host:
+            pairs.add((normalize_provider(provider), host))
+    return pairs
+
+
 def _is_openai_fast_model(model_id: Optional[str]) -> bool:
     """OpenAI flagship eligible for Priority Processing. Codex-series excluded — the Codex Responses
     API doesn't accept ``service_tier``."""
@@ -1066,9 +1090,27 @@ def _fast_mode_route_supported(
     else:
         allowed = {"openai": "api.openai.com", "openai-codex": "chatgpt.com"}
     if provider and normalize_provider(provider) not in allowed:
-        return False
+        return _is_trusted_fast_mode_endpoint(provider, base_url)
     host = (urlparse(str(base_url or "")).hostname or "").lower()
-    return not host or host in allowed.values()
+    if not host or host in allowed.values():
+        return True
+    return _is_trusted_fast_mode_endpoint(provider, base_url)
+
+
+def _is_trusted_fast_mode_endpoint(provider: Optional[str], base_url: Optional[str]) -> bool:
+    """Whether this exact provider+host pair is opted in via config.
+
+    Both halves must be present and match exactly: an operator vouches for a specific
+    deployment, not for a provider name or a domain suffix.
+    """
+    from urllib.parse import urlparse
+
+    if not provider or not base_url:
+        return False
+    host = (urlparse(str(base_url)).hostname or "").lower()
+    if not host:
+        return False
+    return (normalize_provider(provider), host) in _trusted_fast_mode_endpoints()
 
 
 def resolve_fast_mode_overrides(

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -339,6 +339,70 @@ class TestAnthropicFastModeAdapter(unittest.TestCase):
         assert "extra_headers" not in kwargs
 
 
+class TestTrustedProxyRoute(unittest.TestCase):
+    """Self-hosted endpoints can be opted in; everything else stays fail-closed.
+
+    Fast mode is refused on custom base URLs because a proxy that drops the param
+    bills for a tier that was never delivered. An operator who has verified their
+    deployment forwards it can vouch for that exact provider+host pair.
+    """
+
+    PROXY_BASE_URL = "https://proxy.example.com/v1"
+    TRUSTED = ["llm-proxy:proxy.example.com"]
+
+    def _resolve(self, model, trusted, **kwargs):
+        from unittest.mock import patch
+
+        from hermes_cli.models import resolve_fast_mode_overrides
+
+        with patch("hermes_cli.config.load_config",
+                   return_value={"agent": {"fast_mode_trusted_endpoints": trusted}}):
+            return resolve_fast_mode_overrides(model, **kwargs)
+
+    def test_opted_in_endpoint_matches_unrouted_answer(self):
+        from hermes_cli.models import resolve_fast_mode_overrides
+
+        for model in ("gpt-5.4", "claude-opus-4-8"):
+            with self.subTest(model=model):
+                routed = self._resolve(
+                    model, self.TRUSTED,
+                    provider="llm-proxy", base_url=self.PROXY_BASE_URL)
+                self.assertIsNotNone(routed)
+                self.assertEqual(routed, resolve_fast_mode_overrides(model))
+
+    def test_endpoint_is_refused_until_opted_in(self):
+        self.assertIsNone(self._resolve(
+            "gpt-5.4", [], provider="llm-proxy", base_url=self.PROXY_BASE_URL))
+
+    def test_trust_does_not_extend_beyond_the_exact_pair(self):
+        for provider, base_url in (
+                ("llm-proxy", "https://staging.proxy.example.com/v1"),   # subdomain
+                ("llm-proxy", "https://proxy.example.com.evil.test/v1"), # suffix spoof
+                ("llm-proxy", "https://other-proxy.example/v1"),         # other host
+                ("openrouter", self.PROXY_BASE_URL)):                    # other provider
+            with self.subTest(provider=provider, base_url=base_url):
+                self.assertIsNone(self._resolve(
+                    "gpt-5.4", self.TRUSTED, provider=provider, base_url=base_url))
+
+    def test_malformed_entries_neither_crash_nor_widen(self):
+        for entry in ("", "llm-proxy", ":proxy.example.com", "llm-proxy:", None):
+            with self.subTest(entry=entry):
+                self.assertIsNone(self._resolve(
+                    "gpt-5.4", [entry],
+                    provider="llm-proxy", base_url=self.PROXY_BASE_URL))
+
+    def test_opt_in_does_not_override_model_support(self):
+        self.assertIsNone(self._resolve(
+            "claude-opus-4-6", self.TRUSTED,
+            provider="llm-proxy", base_url=self.PROXY_BASE_URL))
+
+    def test_first_party_routes_need_no_opt_in(self):
+        self.assertEqual(
+            self._resolve("gpt-5.4", [],
+                          provider="openai", base_url="https://api.openai.com/v1"),
+            {"service_tier": "priority"})
+
+
 
 class TestConfigDefault(unittest.TestCase):
     def test_default_config_has_service_tier(self):

--- a/tests/tui_gateway/test_fast_session_scope.py
+++ b/tests/tui_gateway/test_fast_session_scope.py
@@ -124,3 +124,54 @@ class TestConfigGetFastSessionScope:
         with patch.object(server, "_load_service_tier", return_value="priority"):
             resp = _get({"key": "fast"})
         assert resp["result"]["value"] == "fast"
+
+
+class TestFastAcceptedOnTrustedProxyRoute:
+    """A live session must not be harder to toggle than a fresh one.
+
+    The other tests here stub ``resolve_fast_mode_overrides``, so the real route
+    gate never runs. It is exactly that gate which rejected an EXISTING chat
+    (live agent supplies provider + base_url) while a NEW chat -- no agent, so
+    nothing to check -- was accepted. Same model, same config, two answers.
+    """
+
+    PROXY_BASE_URL = "https://proxy.example.com/v1"
+
+    def _proxy_agent(self):
+        return SimpleNamespace(
+            reasoning_config=None,
+            service_tier=None,
+            request_overrides={},
+            model="gpt-5.4",
+            provider="llm-proxy",
+            base_url=self.PROXY_BASE_URL,
+            session_id="sess-key",
+        )
+
+    def _set_fast_with_trust(self, session_id, session, trusted):
+        with patch.dict(server._sessions, {session_id: session}, clear=False), \
+                patch.object(server, "_write_config_key"), \
+                patch.object(server, "_persist_live_session_runtime"), \
+                patch.object(server, "_emit"), \
+                patch("hermes_cli.config.load_config",
+                      return_value={"agent": {"fast_mode_trusted_endpoints": trusted}}):
+            return _set({"key": "fast", "session_id": session_id, "value": "fast"})
+
+    def test_live_session_on_opted_in_endpoint_is_accepted(self) -> None:
+        agent = self._proxy_agent()
+        resp = self._set_fast_with_trust(
+            "s-proxy", {"session_key": "k-proxy", "agent": agent},
+            ["llm-proxy:proxy.example.com"])
+
+        assert "error" not in resp, resp.get("error")
+        assert resp["result"]["value"] == "fast"
+        assert agent.service_tier == "priority"
+        assert agent.request_overrides.get("service_tier") == "priority"
+
+    def test_live_session_without_opt_in_is_still_refused(self) -> None:
+        agent = self._proxy_agent()
+        resp = self._set_fast_with_trust(
+            "s-other", {"session_key": "k-other", "agent": agent}, [])
+
+        assert "error" in resp
+        assert agent.service_tier is None

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1774,6 +1774,7 @@ Fast mode asks the provider for faster output at a premium price: OpenAI [Priori
 agent:
   service_tier: ""          # "" / normal | fast | auto | cold
   fast_auto_seconds: 60     # window for auto / cold
+  fast_mode_trusted_endpoints: []   # opt-in for self-hosted proxies, see below
 ```
 
 | Mode | When fast params are sent | Use it for |
@@ -1786,6 +1787,21 @@ agent:
 `/fast normal|fast|auto|cold` switches the mode for the session; add `--global` to persist to `config.yaml`. `/fast` alone shows the current mode.
 
 **Cost note:** both providers bill fast requests at a multiplier on standard rates (Anthropic: $10 / $50 per MTok in/out on Opus 4.8 and Opus 5), stacking with prompt-cache pricing. `auto`/`cold` bound that premium to the window only. Fast params are only sent to the first-party endpoint that supports them (`api.openai.com` / Codex subscription, `api.anthropic.com`, `api.x.ai`); OpenRouter, Nous Portal, Copilot, Azure, Bedrock, and custom `base_url` routes never receive them in any mode. Only the per-request parameter changes between requests — the system prompt, tools, and messages stay byte-identical, so the prompt cache survives the window boundary.
+
+### Self-hosted proxies
+
+Fast mode is refused on custom `base_url` routes because a proxy that silently drops `service_tier` / `speed` leaves you paying a premium for a tier that was never delivered. If you run a proxy that forwards the parameter unchanged, opt that exact endpoint in:
+
+```yaml
+agent:
+  service_tier: fast
+  fast_mode_trusted_endpoints:
+    - "llm-proxy:proxy.example.com"    # "<provider>:<hostname>"
+```
+
+Each entry names one provider and one hostname, and both must match — subdomains do not inherit trust, and the entry does not make an unsupported model eligible. Verify your deployment actually passes the parameter through before adding it; if it does not, you gain cost without speed.
+
+Without an entry the toggle behaves inconsistently rather than obviously: a **new** chat has no agent yet, so there is no route to check and `/fast` appears to work, while the same toggle in an **existing** chat is refused with "fast mode is not available for this model".
 
 ## Tool-Use Enforcement
 


### PR DESCRIPTION
## What does this PR do?

`/fast` is refused on custom `base_url` routes, and that default is right: a proxy that silently drops `service_tier` / `speed` bills the premium without delivering the tier. But an operator running a proxy that *does* forward the param has no way to say so — and the refusal surfaces inconsistently enough that it reads as a model or provider bug.

`resolve_fast_mode_overrides()` only sees a route when the caller passes one. `tui_gateway/methods_config_set.py::_set_fast` passes `provider` / `base_url` from the **live agent**, and a fresh session has no agent yet, so the same model with the same config resolves two different ways:

```python
>>> resolve_fast_mode_overrides("gpt-5.4")
{'service_tier': 'priority'}        # new chat: no route to check

>>> resolve_fast_mode_overrides("gpt-5.4", provider="llm-proxy",
...                             base_url="https://proxy.example.com/v1")
None                                # existing chat: refused
```

From the user's side: `/fast` works in a new chat, then fails in an existing one with *"fast mode is not available for this model"* — pointing at the model, when the cause is route policy.

This adds `agent.fast_mode_trusted_endpoints`: exact `"provider:hostname"` pairs an operator has verified forward the parameter.

```yaml
agent:
  service_tier: fast
  fast_mode_trusted_endpoints:
    - "llm-proxy:proxy.example.com"
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config_defaults.py` — new `agent.fast_mode_trusted_endpoints`, default `[]`
- `hermes_cli/models.py` — `_trusted_fast_mode_endpoints()` parses/normalizes the config; `_is_trusted_fast_mode_endpoint()` is consulted only where `_fast_mode_route_supported()` would otherwise refuse
- `tests/cli/test_fast_command.py` — resolver-level gate, both arms
- `tests/tui_gateway/test_fast_session_scope.py` — the same through the real `config.set` RPC
- `website/docs/user-guide/configuration.md` — "Self-hosted proxies" section

## Why this shape

Deliberately narrow, because the fail-closed default is load-bearing (#101285) and a previous attempt to soften it was closed (#89960):

- **Default `[]`** — nothing changes unless an operator opts in.
- **Exact pair** — provider *and* host must match. Vouching for a deployment, not a provider name or a domain.
- **No subdomain inheritance** — `staging.proxy.example.com` is not covered by `proxy.example.com`, and a suffix spoof (`proxy.example.com.evil.test`) is denied.
- **Malformed entries are ignored, never widening** — a typo must not open the gate, and must not break fast mode either.
- **Model support is still required** — opting an endpoint in does not make an ineligible model eligible.
- **First-party routes untouched** — they never consult the opt-in.

## How Has This Been Tested?

`scripts/run_tests.sh tests/cli/test_fast_command.py tests/tui_gateway/test_fast_session_scope.py` → **34 passed**.

Proven red on base: with the change to `models.py` / `config_defaults.py` reverted, the opted-in cases fail (`AssertionError: unexpectedly None`) while every denial test still passes — so the tests pin the fix, not the implementation's shape.

Wider run (`tests/cli/`, `tests/tui_gateway/`, `tests/agent/test_fast_mode_auto.py`): 2484 passed, 26 failed — **the same 26 fail on `origin/main` without this branch** (`test_cli_save_config_value`, `test_personality_none`, `test_exit_watchdog_signal_arm`, `test_oneshot_resumed_session_persist`, and several `tui_gateway` files). Pre-existing, unrelated.

Verified against a real deployment before writing this: the proxy in question returns HTTP 200 for both `service_tier: priority` and `speed: fast`, i.e. it genuinely forwards them rather than dropping them.

Note on the existing tests: `tests/tui_gateway/test_fast_session_scope.py` stubs `resolve_fast_mode_overrides` out, so the route gate never runs there and a regression in it cannot be caught. The new RPC tests deliberately do not stub it.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Open question for maintainers

If a config opt-in is the wrong shape for this, I'd rather adjust than have it sit: an alternative is leaving the gate closed and instead making the **refusal consistent** — so `/fast` fails in a new chat too, rather than appearing to work and then failing later. That fixes the confusing asymmetry without loosening anything, at the cost of leaving self-hosted proxy users with no path to fast mode. Happy to switch to that if you prefer.
