### PR TITLE
fix(desktop): restore a titlebar entry point for the haptics mute toggle

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -1148,7 +1148,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const titlebarToolsWidth = titlebarToolsWidthCss(2)
 
   const leftToolsWidth = titlebarToolsWidthCss(
-    4 + [...leftTitlebarTools, ...rightTitlebarTools].filter(tool => !tool.hidden).length
+    5 + [...leftTitlebarTools, ...rightTitlebarTools].filter(tool => !tool.hidden).length
   )
 
   return (

--- a/apps/desktop/src/app/shell/titlebar-controls.test.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type * as PaneShellTreeStore from '@/components/pane-shell/tree/store'
+import { $hapticsMuted } from '@/store/haptics'
+import type * as HudStore from '@/store/hud'
+
+import { TitlebarControls } from './titlebar-controls'
+
+afterEach(() => {
+  cleanup()
+  $hapticsMuted.set(false)
+})
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      shell: {
+        appControls: 'App controls',
+        windowControls: 'Window controls'
+      },
+      titlebar: {
+        enterHud: 'Enter HUD',
+        hideRightSidebar: 'Hide right sidebar',
+        hideSidebar: 'Hide sidebar',
+        layoutEditor: 'Layout editor',
+        layoutEditorTitle: (modifier: string) => `Layout editor (${modifier})`,
+        muteHaptics: 'Mute haptics',
+        openSettings: 'Open settings',
+        showRightSidebar: 'Show right sidebar',
+        showSidebar: 'Show sidebar',
+        swapSidebarSides: 'Swap sidebar sides',
+        unmuteHaptics: 'Unmute haptics',
+        unreadSessions: (count: number) => `${count} unread`
+      }
+    }
+  })
+}))
+
+vi.mock('@/app/hud/handoff', () => ({ hudTargetSessionId: () => null }))
+vi.mock('@/components/pane-shell/edit-mode', () => ({ toggleLayoutEditMode: vi.fn() }))
+vi.mock('@/components/pane-shell/tree/store', async importOriginal => ({
+  ...(await importOriginal<typeof PaneShellTreeStore>()),
+  resetLayoutTree: vi.fn()
+}))
+vi.mock('@/store/hud', async importOriginal => ({
+  ...(await importOriginal<typeof HudStore>()),
+  toggleHud: vi.fn()
+}))
+
+function renderTitlebar() {
+  return render(
+    <MemoryRouter>
+      <TitlebarControls onOpenSettings={vi.fn()} />
+    </MemoryRouter>
+  )
+}
+
+describe('TitlebarControls haptics toggle', () => {
+  it('renders a mute-haptics button and flips $hapticsMuted when clicked', () => {
+    renderTitlebar()
+
+    const button = screen.getByRole('button', { name: 'Mute haptics' })
+    expect($hapticsMuted.get()).toBe(false)
+
+    fireEvent.click(button)
+
+    expect($hapticsMuted.get()).toBe(true)
+  })
+
+  it('relabels to unmute once haptics are muted', () => {
+    $hapticsMuted.set(true)
+    renderTitlebar()
+
+    expect(screen.getByRole('button', { name: 'Unmute haptics' })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -14,6 +14,7 @@ import { compactNumber } from '@/lib/format'
 import { triggerHaptic } from '@/lib/haptics'
 import { formatModifierToken } from '@/lib/keybinds/combo'
 import { cn } from '@/lib/utils'
+import { $hapticsMuted, toggleHapticsMuted } from '@/store/haptics'
 import { toggleHud } from '@/store/hud'
 import {
   $fileBrowserOpen,
@@ -134,12 +135,25 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const navigate = useNavigate()
   const location = useLocation()
   const modHeld = useModifierHeld()
+  const hapticsMuted = useStore($hapticsMuted)
   const fileBrowserOpen = useStore($fileBrowserOpen)
   const panesFlipped = useStore($panesFlipped)
   const sidebarOpen = useStore($sidebarOpen)
   const unreadCount = useStore($unreadSessionCount)
   const unreadBadge = unreadCount > 0 ? unreadCount : undefined
   const unreadHint = unreadBadge ? ` · ${t.titlebar.unreadSessions(unreadBadge)}` : ''
+
+  const toggleHaptics = () => {
+    if (!hapticsMuted) {
+      triggerHaptic('tap')
+    }
+
+    toggleHapticsMuted()
+
+    if (hapticsMuted) {
+      window.requestAnimationFrame(() => triggerHaptic('success'))
+    }
+  }
 
   // POSITIONAL toggles: each button shows/hides everything on its physical
   // side of the main zone (the layout tree collapses the whole side), so they
@@ -232,6 +246,13 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
         triggerHaptic('open')
         toggleHud(hudTargetSessionId())
       }
+    },
+    {
+      active: hapticsMuted,
+      icon: <TitlebarIcon name={hapticsMuted ? 'mute' : 'unmute'} />,
+      id: 'haptics',
+      label: hapticsMuted ? t.titlebar.unmuteHaptics : t.titlebar.muteHaptics,
+      onSelect: toggleHaptics
     }
   ]
 


### PR DESCRIPTION
## What does this PR do?

`feat(desktop): keep panel tabs in the titlebar` (bbe212de, merged Sep 10) reorganized
the Desktop titlebar's button clusters. As part of that reorg it dropped the haptics
mute button from `TitlebarControls` entirely, without adding it anywhere else.
`toggleHapticsMuted()` (`apps/desktop/src/store/haptics.ts`) was left with **zero**
callers in the app — verified with:

```
grep -rn "toggleHapticsMuted\|setHapticsMuted" apps/desktop/src --include="*.tsx" --include="*.ts"
```

which only turns up the store's own definitions, and a search of every Settings panel
under `apps/desktop/src/app/settings/` confirms no replacement UI was added there either.
So users who want to mute/unmute the haptic feedback can no longer do so at all — this is
a dropped feature, not the intentional part of the titlebar re-layout.

This PR only restores that one button, back into the left "system tools" cluster
(alongside settings / layout / HUD) where the other app-action buttons now live post-reorg.
It does **not** touch the left/right positioning question raised in the issue (settings,
layout editor, and HUD moving from the right side to the left) — that's a genuine design
call for the maintainers, not a mechanical bug, and is left alone here.

## Related Issue

Fixes #107351 (the "haptics toggle has no home" part of it — see note above on scope)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/shell/titlebar-controls.tsx`: re-add the haptics mute/unmute tool
  (icon, label, `toggleHaptics` handler) to `systemTools`, wired to the existing
  `$hapticsMuted` store exactly as it was before bbe212de removed it.
- `apps/desktop/src/app/contrib/wiring.tsx`: bump the fixed left-cluster tool count used
  in the titlebar width CSS var calc from 4 to 5 to account for the restored button.
- `apps/desktop/src/app/shell/titlebar-controls.test.tsx` (new): renders `TitlebarControls`
  and asserts a "Mute haptics" button exists and flips `$hapticsMuted` on click, and that
  it relabels to "Unmute haptics" once muted.

## How to Test

1. `cd apps/desktop && npx vitest run src/app/shell/titlebar-controls.test.tsx`
2. Confirmed the new test fails without the fix (reverted the two source files to
   `HEAD` while keeping the test) — both assertions fail because no "Mute haptics"
   button is found:

   ```
   Test Files  1 failed (1)
        Tests  2 failed (2)
   ```

3. With the fix restored:

   ```
   Test Files  1 passed (1)
        Tests  2 passed (2)
   ```

4. `npx tsc -p . --noEmit` — clean.
5. `npx eslint src/app/shell/titlebar-controls.tsx src/app/shell/titlebar-controls.test.tsx src/app/contrib/wiring.tsx` — clean.
6. `npx vitest run src/app/shell src/app/contrib` (full directories, checks for regressions):

   ```
   Test Files  23 passed (23)
        Tests  199 passed (199)
   ```

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (CI-style headless run, vitest/jsdom)

## AI assistance disclosure

This change was authored with Claude Code (Anthropic), acting on an autonomous
triage/fix pass over open issues. All findings (the missing UI entry point,
call-site search) were independently verified by grepping the current
`upstream/main` tree and running the real test/lint/typecheck commands above.
