### PR TITLE
fix(acp): preserve ACP-provided MCP tools across model switches and requests

### DIFF
--- a/acp_adapter/commands.py
+++ b/acp_adapter/commands.py
@@ -136,8 +136,15 @@ class SlashCommandsMixin:
             from types import SimpleNamespace
             from agent.memory_manager import inject_memory_provider_tools
 
-            toolsets = _expand_acp_enabled_toolsets(getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"])
-            tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
+            mcp_names = [
+                getattr(s, "name", None) or (s.get("name") if isinstance(s, dict) else str(s))
+                for s in (getattr(state, "mcp_servers", None) or [])
+            ]
+            toolsets = _expand_acp_enabled_toolsets(
+                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
+                mcp_server_names=[n for n in mcp_names if n],
+            )
+            tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True, skip_tool_search_assembly=True)
             tool_view = SimpleNamespace(
                 tools=list(tools or []),
                 valid_tool_names={t.get("function", {}).get("name") for t in tools or [] if isinstance(t, dict)},

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -337,10 +337,15 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
             endpoint = {
                 "base_url": getattr(state.agent, "base_url", None), "api_mode": getattr(state.agent, "api_mode", None)
             }
+        mcp_names = [
+            getattr(s, "name", None) or (s.get("name") if isinstance(s, dict) else str(s))
+            for s in (getattr(state, "mcp_servers", None) or [])
+        ]
         state.agent = self.session_manager._make_agent(
             session_id=state.session_id, cwd=state.cwd, model=new_model,
-            requested_provider=target_provider, **endpoint,
+            requested_provider=target_provider, mcp_server_names=[n for n in mcp_names if n], **endpoint,
         )
+        self._sync_agent_mcp_tools(state)
         self.session_manager.save_session(state.session_id)
         return current_provider, target_provider, new_model
 
@@ -405,18 +410,16 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
             session_id, update, fail_msg="Could not send ACP session info update for %s", level=logging.DEBUG
         )
 
-    async def _register_session_mcp_servers(
-        self, state: SessionState, mcp_servers: list[McpServerStdio | McpServerHttp | McpServerSse] | None
-    ) -> None:
-        """Register ACP-provided MCP servers and refresh the agent tool surface."""
-        if not mcp_servers:
+    def _sync_agent_mcp_tools(self, state: SessionState) -> None:
+        """Synchronize ACP-provided MCP tools onto the session agent's tool surface."""
+        if not getattr(state, "mcp_servers", None):
             return
-        try:
-            from tools.mcp_tool_discovery import register_mcp_servers
-
-            await asyncio.to_thread(register_mcp_servers, {s.name: _mcp_server_config(s) for s in mcp_servers})
-        except Exception:
-            logger.warning("Session %s: failed to register ACP MCP servers", state.session_id, exc_info=True)
+        mcp_names = [
+            getattr(s, "name", None) or (s.get("name") if isinstance(s, dict) else str(s))
+            for s in state.mcp_servers
+        ]
+        mcp_names = [n for n in mcp_names if n]
+        if not mcp_names:
             return
         try:
             from model_tools import get_tool_definitions
@@ -425,24 +428,40 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
             agent = state.agent
             agent.enabled_toolsets = _expand_acp_enabled_toolsets(
                 getattr(agent, "enabled_toolsets", None) or ["hermes-acp"],
-                mcp_server_names=[s.name for s in mcp_servers],
+                mcp_server_names=mcp_names,
             )
             agent.tools = get_tool_definitions(
                 enabled_toolsets=agent.enabled_toolsets,
-                disabled_toolsets=getattr(agent, "disabled_toolsets", None), quiet_mode=True,
+                disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                quiet_mode=True,
+                skip_tool_search_assembly=True,
             )
             agent.valid_tool_names = {tool["function"]["name"] for tool in agent.tools or []}
             inject_memory_provider_tools(agent)
             if callable(invalidate := getattr(agent, "_invalidate_system_prompt", None)):
                 invalidate()
-            logger.info(
-                "Session %s: refreshed tool surface after ACP MCP registration (%d tools)",
-                state.session_id, len(agent.tools or []),
-            )
         except Exception:
-            logger.warning(
-                "Session %s: failed to refresh tool surface after ACP MCP registration", state.session_id, exc_info=True,
-            )
+            logger.warning("Session %s: failed to sync agent MCP tools", state.session_id, exc_info=True)
+
+    async def _register_session_mcp_servers(
+        self, state: SessionState, mcp_servers: list[McpServerStdio | McpServerHttp | McpServerSse] | None
+    ) -> None:
+        """Register ACP-provided MCP servers and refresh the agent tool surface."""
+        if not mcp_servers:
+            return
+        state.mcp_servers = list(mcp_servers)
+        try:
+            from tools.mcp_tool_discovery import register_mcp_servers
+
+            await asyncio.to_thread(register_mcp_servers, {s.name: _mcp_server_config(s) for s in mcp_servers})
+        except Exception:
+            logger.warning("Session %s: failed to register ACP MCP servers", state.session_id, exc_info=True)
+            return
+        self._sync_agent_mcp_tools(state)
+        logger.info(
+            "Session %s: refreshed tool surface after ACP MCP registration (%d tools)",
+            state.session_id, len(getattr(state.agent, "tools", []) or []),
+        )
 
     def _schedule_mcp_late_refresh(self, state: SessionState) -> None:
         """Refresh the tool snapshot when background MCP discovery lands after agent build
@@ -632,7 +651,8 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         if state is None:
             logger.info("Forked session %s -> %s", session_id, "")
             return ForkSessionResponse(session_id="")
-        await self._register_session_mcp_servers(state, mcp_servers)
+        servers_to_register = mcp_servers if mcp_servers is not None else getattr(state, "mcp_servers", None)
+        await self._register_session_mcp_servers(state, servers_to_register)
         logger.info("Forked session %s -> %s", session_id, state.session_id)
         self._schedule_available_commands_update(state.session_id)
         return ForkSessionResponse(
@@ -723,6 +743,8 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         Interactive routing is a ``tools.approval`` contextvar, not ``HERMES_INTERACTIVE`` in
         os.environ, so concurrent workers can't race a global flag onto the non-interactive
         auto-approve path (GHSA-96vc-wcxf-jjff)."""
+        if getattr(state, "mcp_servers", None):
+            self._sync_agent_mcp_tools(state)
         agent = state.agent
         with contextlib.ExitStack() as stack:
             # HERMES_SESSION_KEY scopes per-session caches (interactive sudo password) to this

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -143,6 +143,7 @@ class SessionState:
     runtime_lock: Any = field(default_factory=threading.Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
+    mcp_servers: List[Any] = field(default_factory=list)
 
 
 class SessionManager:
@@ -184,9 +185,18 @@ class SessionManager:
         if original is None:
             return None
         new_id = str(uuid.uuid4())
-        agent = self._make_agent(session_id=new_id, cwd=cwd, model=original.model or None)
+        orig_mcp = getattr(original, "mcp_servers", None) or []
+        mcp_names = [
+            getattr(s, "name", None) or (s.get("name") if isinstance(s, dict) else str(s))
+            for s in orig_mcp
+        ]
+        agent = self._make_agent(
+            session_id=new_id, cwd=cwd, model=original.model or None,
+            mcp_server_names=[n for n in mcp_names if n],
+        )
         model = getattr(agent, "model", original.model) or original.model
         state = self._install_state(new_id, agent, cwd, model, copy.deepcopy(original.history))
+        state.mcp_servers = copy.deepcopy(orig_mcp)
         logger.info("Forked ACP session %s -> %s", session_id, new_id)
         return state
 
@@ -290,6 +300,11 @@ class SessionManager:
             value = getattr(state.agent, key, None)
             if isinstance(value, str) and value.strip():
                 session_meta[key] = value.strip()
+        if getattr(state, "mcp_servers", None):
+            session_meta["mcp_servers"] = [
+                s.model_dump() if hasattr(s, "model_dump") else (s.__dict__ if hasattr(s, "__dict__") else dict(s))
+                for s in state.mcp_servers
+            ]
 
         try:
             if db.get_session(state.session_id) is None:
@@ -297,7 +312,7 @@ class SessionManager:
                     # Empty editor probes stay ephemeral; copied fork history persists.
                     return
                 db.create_session(session_id=state.session_id, source="acp", model=model_str,
-                                  model_config={"cwd": state.cwd})
+                                  model_config=session_meta)
             else:
                 try:
                     db.update_session_meta(state.session_id, json.dumps(session_meta), model_str)
@@ -343,6 +358,12 @@ class SessionManager:
 
         meta = _parse_model_config(row.get("model_config"))
         cwd, model = meta.get("cwd", "."), row.get("model") or None
+        mcp_servers_raw = meta.get("mcp_servers") or []
+        mcp_names = [
+            s.get("name") if isinstance(s, dict) else getattr(s, "name", str(s))
+            for s in mcp_servers_raw
+        ]
+        mcp_names = [n for n in mcp_names if n]
 
         # repair_alternation: this list becomes the resumed agent's LIVE conversation; a durable
         # ``user;user`` violation in state.db would otherwise re-fire the pre-request repair every request.
@@ -356,21 +377,30 @@ class SessionManager:
             agent = self._make_agent(
                 session_id=session_id, cwd=cwd, model=model, api_mode=meta.get("api_mode") or None,
                 requested_provider=meta.get("provider") or row.get("billing_provider"),
-                base_url=meta.get("base_url") or row.get("billing_base_url"))
+                base_url=meta.get("base_url") or row.get("billing_base_url"),
+                mcp_server_names=mcp_names or None)
         except Exception:
             logger.warning("Failed to recreate agent for ACP session %s", session_id, exc_info=True)
             return None
         state = self._install_state(session_id, agent, cwd, model or getattr(agent, "model", "") or "",
                                     history, persist=False)
+        state.mcp_servers = list(mcp_servers_raw)
         logger.info("Restored ACP session %s from DB (%d messages)", session_id, len(history))
         return state
 
     # ---- internal -----------------------------------------------------------
 
     def _make_agent(self, *, session_id: str, cwd: str, model: str | None = None,
-                    requested_provider: str | None = None, base_url: str | None = None, api_mode: str | None = None):
+                    requested_provider: str | None = None, base_url: str | None = None, api_mode: str | None = None,
+                    mcp_server_names: list[str] | None = None):
         if self._agent_factory is not None:
-            return self._agent_factory()
+            agent = self._agent_factory()
+            if mcp_server_names:
+                agent.enabled_toolsets = _expand_acp_enabled_toolsets(
+                    getattr(agent, "enabled_toolsets", None) or ["hermes-acp"],
+                    mcp_server_names=mcp_server_names,
+                )
+            return agent
 
         from run_agent import AIAgent
         from hermes_cli.config import load_config
@@ -388,9 +418,13 @@ class SessionManager:
             name for name, cfg in (config.get("mcp_servers") or {}).items()
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
+        all_mcp_servers = list(configured_mcp_servers)
+        for name in (mcp_server_names or []):
+            if name and name not in all_mcp_servers:
+                all_mcp_servers.append(name)
         kwargs = {
             "platform": "acp", "quiet_mode": True, "session_id": session_id, "session_db": self._get_db(),
-            "enabled_toolsets": _expand_acp_enabled_toolsets(["hermes-acp"], mcp_server_names=configured_mcp_servers),
+            "enabled_toolsets": _expand_acp_enabled_toolsets(["hermes-acp"], mcp_server_names=all_mcp_servers),
             "model": model or default_model,
         }
         try:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1065,6 +1065,7 @@ def _load_tools(agent, enabled_toolsets, disabled_toolsets):
     agent.tools = model_tools.get_tool_definitions(
         enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,
+        skip_tool_search_assembly=getattr(agent, "platform", None) == "acp",
     )
 
     agent.valid_tool_names = {tool["function"]["name"] for tool in agent.tools} if agent.tools else set()

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -311,3 +311,108 @@ class TestSessionLifecycleMcpE2E:
 
         assert fork_resp.session_id != ""
         assert "api" in registered
+
+    @pytest.mark.asyncio
+    async def test_mcp_tools_skip_tool_search_assembly(self, acp_agent, mock_manager):
+        """new_session passes skip_tool_search_assembly=True so MCP tools are not deferred."""
+        servers = [McpServerStdio(name="direct-tool", command="/bin/echo", args=[], env=[])]
+        captured_kwargs = {}
+
+        def mock_get_tool_defs(**kwargs):
+            captured_kwargs.update(kwargs)
+            return [{"function": {"name": "mcp_direct_tool_run"}}]
+
+        with patch("tools.mcp_tool_discovery.register_mcp_servers", return_value=["mcp_direct_tool_run"]), \
+             patch("model_tools.get_tool_definitions", side_effect=mock_get_tool_defs):
+            resp = await acp_agent.new_session(cwd="/tmp", mcp_servers=servers)
+
+        assert captured_kwargs.get("skip_tool_search_assembly") is True
+        state = mock_manager.get_session(resp.session_id)
+        assert state.agent.tools == [{"function": {"name": "mcp_direct_tool_run"}}]
+
+    @pytest.mark.asyncio
+    async def test_set_session_model_preserves_mcp_tools(self, acp_agent, mock_manager):
+        """set_session_model preserves mcp_servers on the session and refreshes agent tools."""
+        servers = [McpServerStdio(name="persist-srv", command="/bin/srv", args=[], env=[])]
+        fake_mcp_tool = {"function": {"name": "mcp_persist_srv_action"}}
+
+        with patch("tools.mcp_tool_discovery.register_mcp_servers", return_value=["mcp_persist_srv_action"]), \
+             patch("model_tools.get_tool_definitions", return_value=[fake_mcp_tool]):
+            resp = await acp_agent.new_session(cwd="/tmp", mcp_servers=servers)
+
+        state = mock_manager.get_session(resp.session_id)
+        assert getattr(state, "mcp_servers", None) == servers
+
+        # Switch model
+        with patch("model_tools.get_tool_definitions", return_value=[fake_mcp_tool]) as mock_defs:
+            await acp_agent.set_session_model("gpt-4o", session_id=resp.session_id)
+
+        assert state.agent.tools == [fake_mcp_tool]
+        assert "mcp_persist_srv_action" in state.agent.valid_tool_names
+        assert "mcp-persist-srv" in state.agent.enabled_toolsets
+
+    @pytest.mark.asyncio
+    async def test_fork_session_inherits_parent_mcp_servers_when_omitted(self, acp_agent, mock_manager):
+        """fork_session preserves parent session's mcp_servers when mcp_servers is None."""
+        servers = [McpServerStdio(name="parent-mcp", command="/bin/p", args=[], env=[])]
+        fake_tool = {"function": {"name": "mcp_parent_mcp_tool"}}
+
+        with patch("tools.mcp_tool_discovery.register_mcp_servers", return_value=["mcp_parent_mcp_tool"]), \
+             patch("model_tools.get_tool_definitions", return_value=[fake_tool]):
+            create_resp = await acp_agent.new_session(cwd="/tmp", mcp_servers=servers)
+
+        sid = create_resp.session_id
+        registered = {}
+
+        def mock_register(config_map):
+            registered.update(config_map)
+            return ["mcp_parent_mcp_tool"]
+
+        with patch("tools.mcp_tool_discovery.register_mcp_servers", side_effect=mock_register), \
+             patch("model_tools.get_tool_definitions", return_value=[fake_tool]):
+            fork_resp = await acp_agent.fork_session(cwd="/tmp", session_id=sid, mcp_servers=None)
+
+        assert fork_resp.session_id != ""
+        assert "parent-mcp" in registered
+        forked_state = mock_manager.get_session(fork_resp.session_id)
+        assert forked_state.mcp_servers == servers
+
+    @pytest.mark.asyncio
+    async def test_slash_cmd_tools_includes_mcp_servers(self, acp_agent, mock_manager):
+        """The /tools slash command includes MCP tools directly without progressive disclosure deferral."""
+        servers = [McpServerStdio(name="search-srv", command="/bin/s", args=[], env=[])]
+        fake_tool = {"function": {"name": "mcp_search_srv_query", "description": "Execute a search"}}
+
+        with patch("tools.mcp_tool_discovery.register_mcp_servers", return_value=["mcp_search_srv_query"]), \
+             patch("model_tools.get_tool_definitions", return_value=[fake_tool]):
+            resp = await acp_agent.new_session(cwd="/tmp", mcp_servers=servers)
+
+        state = mock_manager.get_session(resp.session_id)
+        with patch("model_tools.get_tool_definitions", return_value=[fake_tool]) as mock_defs:
+            out = acp_agent._cmd_tools("", state)
+
+        assert "mcp_search_srv_query" in out
+        assert mock_defs.call_args.kwargs.get("skip_tool_search_assembly") is True
+
+    def test_refresh_agent_mcp_tools_defaults_skip_search_for_acp(self):
+        """refresh_agent_mcp_tools defaults skip_tool_search_assembly=True when agent.platform == 'acp'."""
+        from tools.mcp_tool_agent import refresh_agent_mcp_tools
+
+        fake_agent = MagicMock()
+        fake_agent.platform = "acp"
+        fake_agent.enabled_toolsets = ["hermes-acp", "mcp-demo"]
+        fake_agent.disabled_toolsets = []
+        fake_agent._tool_snapshot_generation = 0
+
+        captured = {}
+
+        def fake_get_tool_definitions(**kwargs):
+            captured.update(kwargs)
+            return [{"function": {"name": "mcp_demo_tool"}}]
+
+        with patch("model_tools.get_tool_definitions", side_effect=fake_get_tool_definitions), \
+             patch("tools.registry.registry._generation", 1):
+            refresh_agent_mcp_tools(fake_agent)
+
+        assert captured.get("skip_tool_search_assembly") is True
+

--- a/tools/mcp_tool_agent.py
+++ b/tools/mcp_tool_agent.py
@@ -86,7 +86,8 @@ def _publish_tool_snapshot(
 
 def refresh_agent_mcp_tools(
     agent, *, enabled_override=None, disabled_override=None, quiet_mode: bool = True,
-    content_aware: bool = False, preserve_prefix: bool = False) -> set:
+    content_aware: bool = False, preserve_prefix: bool = False,
+    skip_tool_search_assembly: Optional[bool] = None) -> set:
     """Re-derive an already-built agent's tool snapshot from the live registry; returns the
     newly-added tool names (empty when unchanged). The agent snapshots ``agent.tools`` at build
     time, so servers that connect later (slow OAuth, ``/reload-mcp``) are invisible until
@@ -107,7 +108,12 @@ def refresh_agent_mcp_tools(
     # Generation captured BEFORE the slow get_tool_definitions call (a slower caller holding an
     # OLDER set must not clobber a newer one); definitions computed OUTSIDE the lock.
     snapshot_generation = registry._generation
-    new_defs = list(get_tool_definitions(enabled_toolsets=enabled, disabled_toolsets=disabled, quiet_mode=quiet_mode) or [])
+    if skip_tool_search_assembly is None:
+        skip_tool_search_assembly = getattr(agent, "platform", None) == "acp"
+    new_defs = list(get_tool_definitions(
+        enabled_toolsets=enabled, disabled_toolsets=disabled, quiet_mode=quiet_mode,
+        skip_tool_search_assembly=skip_tool_search_assembly,
+    ) or [])
     new_names = {_def_name(t) for t in new_defs}
     # Post-build families re-appended on LOCALS only; live attributes untouched until publish.
     staged_engine_names = _reinject_post_build_tools(agent, new_defs, new_names)


### PR DESCRIPTION
## Summary
Fixes #42719.

ACP session-provided MCP servers were registered, but their tools were completely missing from the model's chat completions request:
1. **Tool search deferral / progressive disclosure**: Progressive tool disclosure (`tools.tool_search`) treats all tools starting with `mcp-` as deferrable. In Hermes ACP mode, the `hermes-acp` toolset does not expose the `tool_search` bridge tools, causing ACP-provided MCP tools to be silently deferred and dropped from `agent.tools`.
2. **Session model switches**: When an ACP client switches model via `session/set_model` (`set_session_model`) or `/model`, `_switch_model` rebuilds the agent via `_make_agent`. `SessionState` did not persist `mcp_servers`, resetting `enabled_toolsets` to `["hermes-acp"]` and wiping all session MCP tools.
3. **Session forks & late/between-turns refresh**: Forking a session or between-turns MCP refresh did not inherit session MCP servers or pass `skip_tool_search_assembly=True`.

## Changes
- **Direct Tool Assembly in ACP**: Updated `agent_init._load_tools`, `acp_adapter.server._sync_agent_mcp_tools`, and `tools.mcp_tool_agent.refresh_agent_mcp_tools` to skip progressive tool search deferral (`skip_tool_search_assembly=True`) when `agent.platform == "acp"`, ensuring ACP session MCP tools are exposed directly to the model request.
- **Persist MCP Servers on Session State**: Added `mcp_servers` to `SessionState` and persisted/restored MCP server metadata in `SessionManager._persist`, `_restore`, and `fork_session`.
- **Model Switch & Turn Synchronization**: Updated `_switch_model` to preserve `mcp_servers` and resynchronize the agent's tool surface with the session MCP tools. Updated `_run_agent_turn` to verify and resync ACP MCP tools prior to running turns.
- **Slash Commands**: Updated `_cmd_tools` to include ACP MCP tools without progressive disclosure deferral.
- **Tests**: Added tests in `tests/acp/test_mcp_e2e.py` verifying direct tool exposure, persistence across `set_session_model`, inheritance in `fork_session`, inclusion in `/tools`, and platform-aware defaults in `refresh_agent_mcp_tools`.
