### PR TITLE
feat(cli/tui): opt-in `account` status-bar field showing the active pooled credential

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -650,6 +650,34 @@ def sync_credential_pool_entry_id(agent) -> None:
         agent._credential_pool_entry_id = None
 
 
+def active_credential_label(agent) -> str:
+    """Safe display label of the pooled credential the agent is dispatching with, or ``""``.
+
+    Shared by the classic CLI status bar and the TUI gateway usage payload (the opt-in
+    ``account`` field) so the two surfaces can never disagree about which account a session
+    is burning. Resolution mirrors ``_failed_credential_identity``: the entry id bound at
+    dispatch time wins, then the pool cursor. Only ``PooledCredential.label`` is ever
+    returned — the same email/label ``hermes auth list`` prints — never token material.
+    Empty when no pool is bound (single env-var key, keyless custom provider).
+    """
+    pool = getattr(agent, "_credential_pool", None)
+    if pool is None:
+        return ""
+    try:
+        entry_id = getattr(agent, "_credential_pool_entry_id", None)
+        if not (isinstance(entry_id, str) and entry_id):
+            entry_id = pool.entry_id_for_api_key(getattr(agent, "api_key", None))
+        entry = None
+        if entry_id:
+            entry = next((e for e in pool.entries() if getattr(e, "id", None) == entry_id), None)
+        if entry is None:
+            entry = pool.current()
+        label = getattr(entry, "label", "") if entry is not None else ""
+        return label.strip() if isinstance(label, str) else ""
+    except Exception:
+        return ""
+
+
 _STATUS_TO_FAILOVER_REASON = {
     402: FailoverReason.billing, 429: FailoverReason.rate_limit, 401: FailoverReason.auth,
     403: FailoverReason.auth,

--- a/hermes_cli/cli_status_bar_mixin.py
+++ b/hermes_cli/cli_status_bar_mixin.py
@@ -208,6 +208,7 @@ class CLIStatusBarMixin:
             "battery_label": "",
             "battery_category": "dim",
             "focus_label": "",  # /focus badge: the reduced-output mode is never invisible.
+            "account_label": "",  # opt-in ``account`` field: active pooled-credential label
             "goal_active": False,
             "goal_turns_used": 0,
             "goal_max_turns": 0}
@@ -264,6 +265,17 @@ class CLIStatusBarMixin:
 
         if not agent:
             return snapshot
+
+        # Opt-in ``account`` field: which pooled credential this session dispatches with.
+        # Only rendered when the user lists it in display.status_bar.fields, so the label
+        # lookup is skipped entirely for everyone else.
+        field_set = self._get_status_bar_field_set()
+        if field_set is not None and "account" in field_set:
+            try:
+                from agent.agent_runtime_helpers import active_credential_label
+                snapshot["account_label"] = active_credential_label(agent)
+            except Exception:
+                pass
 
         for key in _AGENT_COUNTERS:
             snapshot[key] = getattr(agent, key, 0) or 0
@@ -954,10 +966,10 @@ class CLIStatusBarMixin:
         """Visible status-bar fields from ``display.status_bar.fields`` (module-level
         ``CLI_CONFIG``; no per-render YAML parse). ``None`` = not customized, show everything.
 
-        Fields: model, context_detail, context_pct, cache_hit, latency, tps, compressions,
-        bg_tasks, bg_processes, bg_subagents, goal, duration, prompt_elapsed, idle_since,
-        focus, yolo, stash, battery, title, total_tokens (opt-in only). Order is fixed; the
-        config controls visibility only.
+        Fields: model, account (opt-in only), context_detail, context_pct, cache_hit, latency,
+        tps, compressions, bg_tasks, bg_processes, bg_subagents, goal, duration, prompt_elapsed,
+        idle_since, focus, yolo, stash, battery, title, total_tokens (opt-in only). Order is
+        fixed; the config controls visibility only.
         """
         from cli import CLI_CONFIG
         if hasattr(self, "_status_bar_field_set_cache"):
@@ -1004,6 +1016,14 @@ class CLIStatusBarMixin:
                 segs.append([(_SB, " ⚕ "), (_STRONG, model_short)])
             else:
                 segs.append([("", f"⚕ {model_short}")])
+        # Opt-in only (explicit fields list): the pooled-credential label the session is
+        # dispatching with. Sits right after the model — the two together answer
+        # "what is running and on whose account". Empty label = no segment.
+        account_label = snapshot.get("account_label") or ""
+        if account_label and field_set is not None and "account" in field_set:
+            if len(account_label) > 32:
+                account_label = f"{account_label[:29]}..."
+            segs.append([(_DIM, f"@ {account_label}")])
         narrow, wide = width < 52, width >= 76
         if narrow:
             # Narrow bars put duration ahead of the goal segment; the other tiers reverse it.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -894,9 +894,10 @@ DEFAULT_CONFIG = {
         },
         # CLI/TUI status bar fields. Non-empty = only listed fields show (built-in order kept,
         # config controls visibility not ordering); empty = default set. Available: model,
-        # context_detail, context_pct, cache_hit, latency, tps, compressions, bg_tasks,
-        # bg_processes, bg_subagents, goal, duration, prompt_elapsed, idle_since, focus, yolo,
-        # stash, battery, title, total_tokens (session Σ, opt-in only). Narrow terminals still drop
+        # account (opt-in only: active pooled-credential label), context_detail, context_pct,
+        # cache_hit, latency, tps, compressions, bg_tasks, bg_processes, bg_subagents, goal,
+        # duration, prompt_elapsed, idle_since, focus, yolo, stash, battery, title,
+        # total_tokens (session Σ, opt-in only). Narrow terminals still drop
         # context_detail/prompt_elapsed/idle_since.
         "status_bar": {
             "fields": [],

--- a/tests/agent/test_active_credential_label.py
+++ b/tests/agent/test_active_credential_label.py
@@ -1,0 +1,99 @@
+"""Opt-in ``account`` status-bar field: the shared label resolver and the TUI usage payload.
+
+The classic CLI bar (``tests/cli/test_cli_status_bar.py``) and the TUI status rule both read
+``active_credential_label``; these tests pin the resolver's contract so the two surfaces can
+never disagree about which pooled credential a session is dispatching with.
+"""
+
+from types import SimpleNamespace
+
+from agent.agent_runtime_helpers import active_credential_label
+
+
+def _pool(entries, *, current=None, resolved_id=None):
+    return SimpleNamespace(
+        entries=lambda: list(entries),
+        current=lambda: current,
+        entry_id_for_api_key=lambda hint=None: resolved_id,
+    )
+
+
+def _entry(entry_id, label, key="sk"):
+    return SimpleNamespace(id=entry_id, label=label, runtime_api_key=key)
+
+
+class TestActiveCredentialLabel:
+    def test_no_pool_bound_is_empty(self):
+        assert active_credential_label(SimpleNamespace(api_key="sk-env")) == ""
+        assert active_credential_label(SimpleNamespace(_credential_pool=None)) == ""
+
+    def test_dispatch_entry_id_wins_over_pool_cursor(self):
+        """After a failover the pool cursor may already point elsewhere; the label must
+        describe the credential this agent actually dispatches with."""
+        mine, other = _entry("a1", "alice@example.com", "sk-a"), _entry("b2", "bob@example.com", "sk-b")
+        agent = SimpleNamespace(
+            api_key="sk-a", _credential_pool_entry_id="a1",
+            _credential_pool=_pool([mine, other], current=other, resolved_id="b2"))
+        assert active_credential_label(agent) == "alice@example.com"
+
+    def test_falls_back_to_key_match_when_entry_id_unbound(self):
+        mine, other = _entry("a1", "alice@example.com", "sk-a"), _entry("b2", "bob@example.com", "sk-b")
+        agent = SimpleNamespace(
+            api_key="sk-b", _credential_pool_entry_id=None,
+            _credential_pool=_pool([mine, other], current=mine, resolved_id="b2"))
+        assert active_credential_label(agent) == "bob@example.com"
+
+    def test_falls_back_to_pool_cursor_when_nothing_resolves(self):
+        cur = _entry("c3", "carol@example.com")
+        agent = SimpleNamespace(
+            api_key=None, _credential_pool_entry_id="gone",
+            _credential_pool=_pool([cur], current=cur, resolved_id=None))
+        assert active_credential_label(agent) == "carol@example.com"
+
+    def test_label_is_stripped_and_never_token_material(self):
+        entry = SimpleNamespace(id="a1", label="  alice@example.com  ", runtime_api_key="sk-secret-token")
+        agent = SimpleNamespace(
+            api_key="sk-secret-token", _credential_pool_entry_id="a1",
+            _credential_pool=_pool([entry], current=entry, resolved_id="a1"))
+        label = active_credential_label(agent)
+        assert label == "alice@example.com"
+        assert "sk-secret" not in label
+
+    def test_pool_errors_never_propagate(self):
+        class _Boom:
+            def entries(self):
+                raise RuntimeError("pool exploded")
+
+            def current(self):
+                raise RuntimeError("pool exploded")
+
+            def entry_id_for_api_key(self, hint=None):
+                raise RuntimeError("pool exploded")
+
+        agent = SimpleNamespace(api_key="sk", _credential_pool_entry_id="a1", _credential_pool=_Boom())
+        assert active_credential_label(agent) == ""
+
+
+class TestGatewayUsagePayload:
+    """``tui_gateway.server._get_usage`` carries the label to the TUI status rule."""
+
+    def _agent(self, pool=None):
+        return SimpleNamespace(
+            model="m", session_input_tokens=1, session_output_tokens=1, session_prompt_tokens=1,
+            session_completion_tokens=1, session_total_tokens=2, session_api_calls=1,
+            context_compressor=None, api_key="sk-a", _credential_pool_entry_id="a1",
+            _credential_pool=pool)
+
+    def test_account_label_present_when_pool_bound(self):
+        from tui_gateway import server
+
+        entry = _entry("a1", "alice@example.com", "sk-a")
+        usage = server._get_usage(self._agent(_pool([entry], current=entry, resolved_id="a1")))
+        assert usage["account_label"] == "alice@example.com"
+
+    def test_account_label_omitted_not_blanked_without_pool(self):
+        """The TUI segment self-hides on a missing key; an empty string would be a lie."""
+        from tui_gateway import server
+
+        usage = server._get_usage(self._agent(pool=None))
+        assert "account_label" not in usage

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -453,6 +453,71 @@ class TestStatusBarFieldConfig:
             text = cli_obj._build_status_bar_text(width=120)
         assert "Σ" not in text
 
+    def _cli_with_pool(self, label="alice@example.com"):
+        """Agent bound to a credential pool whose dispatch entry carries ``label``."""
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        entry = SimpleNamespace(id="abc123", label=label, runtime_api_key="sk-live")
+        cli_obj.agent.api_key = "sk-live"
+        cli_obj.agent._credential_pool_entry_id = "abc123"
+        cli_obj.agent._credential_pool = SimpleNamespace(
+            entries=lambda: [entry],
+            current=lambda: entry,
+            entry_id_for_api_key=lambda hint=None: "abc123",
+        )
+        return cli_obj
+
+    def test_account_when_explicitly_requested(self):
+        cli_obj = self._cli_with_pool()
+        with patch.object(cli_mod, "CLI_CONFIG", {"display": {"status_bar": {"fields": ["model", "account"]}}}):
+            text = cli_obj._build_status_bar_text(width=120)
+        assert "@ alice@example.com" in text
+        # Sits right after the model so the pair reads "what, on whose account".
+        assert text.index("claude-sonnet-4-20250514") < text.index("@ alice@example.com")
+
+    def test_account_hidden_by_default(self):
+        """Like total_tokens: a bound pool alone never widens the default bar."""
+        cli_obj = self._cli_with_pool()
+        with patch.object(cli_mod, "CLI_CONFIG", {}):
+            text = cli_obj._build_status_bar_text(width=120)
+        assert "alice@example.com" not in text
+        assert "@ " not in text
+
+    def test_account_hidden_when_no_pool_bound(self):
+        """Single env-var key: the field is requested but there is no label to show."""
+        text = self._cli_with_fields(["model", "account"])
+        assert "@ " not in text
+        assert "claude-sonnet-4-20250514" in text
+
+    def test_account_label_truncates_long_labels(self):
+        cli_obj = self._cli_with_pool(label="a-very-long-service-account-name@corp.example.com")
+        with patch.object(cli_mod, "CLI_CONFIG", {"display": {"status_bar": {"fields": ["model", "account"]}}}):
+            text = cli_obj._build_status_bar_text(width=120)
+        assert "@ a-very-long-service-account-n..." in text
+        assert "corp.example.com" not in text
+
+    def test_account_follows_dispatch_entry_not_pool_cursor(self):
+        """Mid-session failover: the entry bound at dispatch wins over pool.current()."""
+        cli_obj = self._cli_with_pool()
+        other = SimpleNamespace(id="zzz999", label="bob@example.com", runtime_api_key="sk-other")
+        mine = cli_obj.agent._credential_pool.entries()[0]
+        cli_obj.agent._credential_pool = SimpleNamespace(
+            entries=lambda: [mine, other],
+            current=lambda: other,
+            entry_id_for_api_key=lambda hint=None: "zzz999",
+        )
+        with patch.object(cli_mod, "CLI_CONFIG", {"display": {"status_bar": {"fields": ["model", "account"]}}}):
+            text = cli_obj._build_status_bar_text(width=120)
+        assert "@ alice@example.com" in text
+        assert "bob@example.com" not in text
+
     def test_narrow_terminal_drops_context_detail(self):
         """Narrow terminal (<76) ignores context_detail even if configured."""
         text = self._cli_with_fields(["model", "context_detail", "duration"], width=60)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1948,6 +1948,13 @@ def _get_usage(agent) -> dict:
     with contextlib.suppress(Exception):
         from tools.async_delegation import active_count as _async_active_count
         usage["active_subagents"] = _async_active_count()
+    # Active pooled-credential label (CLI status bar ``account`` field parity). Omitted, not
+    # blanked, when no pool is bound so the TUI segment self-hides; the label is the same safe
+    # email/label ``hermes auth list`` prints — never token material.
+    with contextlib.suppress(Exception):
+        from agent.agent_runtime_helpers import active_credential_label
+        if _label := active_credential_label(agent):
+            usage["account_label"] = _label
     # Dev-only live credits-spent readout, gated on HERMES_DEV_CREDITS so the payload stays clean otherwise.
     if is_truthy_value(os.environ.get("HERMES_DEV_CREDITS")):
         with contextlib.suppress(Exception):

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -567,3 +567,47 @@ describe('StatusRule perf read-outs (cache hit / latency / tps)', () => {
     expect(textContent(element)).not.toContain('weekly-digest')
   })
 })
+
+describe('StatusRule account segment', () => {
+  const pooledUsage = { ...baseProps.usage, account_label: 'alice@example.com' }
+  const withAccount = new Set(['model', 'context_pct', 'account'])
+
+  it('renders the active credential label when opted in', () => {
+    const rendered = textContent(
+      StatusRule({ ...baseProps, cols: 160, statusBarFields: withAccount, usage: pooledUsage })
+    )
+
+    expect(rendered).toContain('@ alice@example.com')
+    // Reads "what, on whose account": model first, then the label.
+    expect(rendered.indexOf('opus 4.8')).toBeLessThan(rendered.indexOf('@ alice@example.com'))
+  })
+
+  it('is opt-in only — a bound pool never widens the default bar', () => {
+    const rendered = textContent(StatusRule({ ...baseProps, cols: 160, usage: pooledUsage }))
+
+    expect(rendered).not.toContain('alice@example.com')
+  })
+
+  it('self-hides when the server omits the key (no pool bound)', () => {
+    const rendered = textContent(StatusRule({ ...baseProps, cols: 160, statusBarFields: withAccount }))
+
+    expect(rendered).not.toContain('@ ')
+  })
+
+  it('truncates long labels instead of crushing the pinned essentials', () => {
+    const usage = { ...baseProps.usage, account_label: 'a-very-long-service-account-name@corp.example.com' }
+    const rendered = textContent(StatusRule({ ...baseProps, cols: 160, statusBarFields: withAccount, usage }))
+
+    expect(rendered).toContain('@ a-very-long-service-account-n...')
+    expect(rendered).not.toContain('corp.example.com')
+  })
+
+  it('drops whole on a narrow terminal rather than clipping model │ ctx', () => {
+    const rendered = textContent(
+      StatusRule({ ...baseProps, cols: 40, statusBarFields: withAccount, usage: pooledUsage })
+    )
+
+    expect(rendered).toContain('opus 4.8')
+    expect(rendered).not.toContain('alice@example.com')
+  })
+})

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -604,6 +604,17 @@ export function StatusRule({
       ? `Δ ${(usage.dev_credits_spent_micros / 10000).toFixed(1)}¢`
       : ''
 
+  // Opt-in only (explicit display.status_bar.fields list, like total_tokens): the pooled
+  // credential label the session dispatches with. The server omits the key when no pool
+  // is bound, so it self-hides for single-key users. Evaluated first so it takes tail
+  // budget ahead of the bar — it's the whole point of enabling it — but still budgeted so
+  // model │ ctx never clip.
+  const rawAccount = typeof usage.account_label === 'string' ? usage.account_label.trim() : ''
+  const accountText = rawAccount ? `@ ${rawAccount.length > 32 ? `${rawAccount.slice(0, 29)}...` : rawAccount}` : ''
+
+  const showAccount =
+    statusBarFields !== null && statusBarFields.has('account') && !!accountText && fits(SEP + stringWidth(accountText))
+
   const showBar = !!bar && fits(SEP + stringWidth(`[${bar}] ${pct != null ? `${contextMark}${pct}%` : ''}`))
   const showDuration = segs.duration && ok('duration') && !!sessionStartedAt && fits(SEP + MAX_DURATION_WIDTH)
 
@@ -722,6 +733,12 @@ export function StatusRule({
             </Text>
           ) : null}
         </Box>
+        {showAccount ? (
+          <Text color={t.color.muted} wrap="truncate-end">
+            {' │ '}
+            {accountText}
+          </Text>
+        ) : null}
         {showFocus ? (
           <Box flexDirection="row" flexShrink={0}>
             <Text color={t.color.muted}>{' │ '}</Text>

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -274,6 +274,7 @@ export interface SessionUndoResponse {
 }
 
 export interface SessionUsageResponse {
+  account_label?: string
   active_subagents?: number
   avg_latency_s?: number
   avg_tps?: number

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -210,6 +210,8 @@ export interface SessionInfo {
 }
 
 export interface Usage {
+  /** Safe label (email / pool label) of the active pooled credential; omitted when no pool is bound. */
+  account_label?: string
   active_subagents?: number
   /** Rolling mean API latency over the last 10 calls (seconds). */
   avg_latency_s?: number

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2104,11 +2104,12 @@ display:
     fields: ["model", "duration", "total_tokens"]   # visibility only; built-in order is preserved
 ```
 
-Supported fields: `model`, `context_detail` (used/total tokens), `context_pct` (percent + meter), `cache_hit` (prompt cache hit ratio — resets on model switch and compression), `latency` (rolling mean API latency, last 10 calls), `tps` (rolling output tokens/sec, last 10 calls), `compressions`, `bg_tasks`, `bg_processes`, `bg_subagents`, `goal`, `duration`, `prompt_elapsed`, `idle_since`, `focus`, `yolo`, `stash`, `battery`, `title` (right-aligned session badge), and `total_tokens` (session Σ — opt-in only, never shown by default).
+Supported fields: `model`, `account` (label of the active pooled credential — opt-in only, see below), `context_detail` (used/total tokens), `context_pct` (percent + meter), `cache_hit` (prompt cache hit ratio — resets on model switch and compression), `latency` (rolling mean API latency, last 10 calls), `tps` (rolling output tokens/sec, last 10 calls), `compressions`, `bg_tasks`, `bg_processes`, `bg_subagents`, `goal`, `duration`, `prompt_elapsed`, `idle_since`, `focus`, `yolo`, `stash`, `battery`, `title` (right-aligned session badge), and `total_tokens` (session Σ — opt-in only, never shown by default).
 
 Notes:
 
-- An empty list (the default) keeps the standard set — everything except `total_tokens`.
+- An empty list (the default) keeps the standard set — everything except `account` and `total_tokens`.
+- `account` shows `@ <label>` right after the model — the same email / label `hermes auth list` marks with `←`, so with a [credential pool](/user-guide/features/credential-pools) you can see which account a session is burning and notice a mid-session failover. Never token material. Hidden when the provider has no pool (single env-var key, keyless custom provider).
 - The config controls **visibility, not order**; fields render in their built-in positions.
 - Narrow terminals still drop wide-mode-only fields (`context_detail`, `cache_hit`, `latency`, `tps`, `prompt_elapsed`, `idle_since`) regardless of config (`cache_hit` also shows in the medium ≥52-col tier).
 - `latency`/`tps` stay hidden until API calls have been recorded (e.g. the Codex app-server backend reports no latency).


### PR DESCRIPTION
## What does this PR do?

Adds an **opt-in `account` field** to `display.status_bar.fields` that shows the label of the pooled credential a session is currently dispatching with — `@ alice@example.com` — right after the model, in both the classic CLI bar and the TUI status rule.

```
⚕ claude-opus-5 │ @ alice@example.com │ 68.2K/200K │ [███░░░░░░░] 34% │ 15m
```

With a [credential pool](https://hermes-agent.nousresearch.com/docs/user-guide/features/credential-pools) Hermes can fail over to a different account mid-session, but nothing in the status bar says which one is being consumed; today the only way to find out is to leave the composer and run `hermes auth list` and look for the `←`. This is the identity half of the "account limits in the status bar" asks (#16643 / #53306 track the *quota %* half): it needs no network calls — the data already lives in the pool state — so it lands independently and is small.

Design choices, mapped to `AGENTS.md`:

- **Opt-in only**, same rule as `total_tokens`: it renders only when the user lists `account` in an explicit `fields:` list. The default bar is byte-identical, and the label lookup is skipped entirely for everyone else.
- **One resolver, two surfaces.** `agent.agent_runtime_helpers.active_credential_label(agent)` is read by both the CLI snapshot and `tui_gateway.server._get_usage`, so the two bars can never disagree. Resolution mirrors the existing `_failed_credential_identity`: the dispatch-bound `_credential_pool_entry_id` wins, then key match, then pool cursor — so after a failover the bar shows the account this agent is *actually* using, not wherever the shared cursor moved.
- **Never token material.** Only `PooledCredential.label` is returned — the same email/label `hermes auth list` already prints. The gateway *omits* the key (rather than sending `""`) when no pool is bound so the TUI segment self-hides for single-key users.
- **Width-budgeted.** TUI segment participates in the existing `fits()` tail budget and drops whole on narrow terminals; labels over 32 chars truncate on both surfaces. `model │ ctx` never clip.
- Zero impact on prompt caching — display-only, no request payload is touched.

## Related Issue

Fixes #107354

Related (quota %, not identity): #16643, #53306, #59425

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/agent_runtime_helpers.py` — new `active_credential_label(agent)` next to `sync_credential_pool_entry_id`.
- `hermes_cli/cli_status_bar_mixin.py` — `account_label` in the snapshot (gated on the field being requested) and an `@ <label>` segment after the model in `_status_bar_segments`; docstring field list updated.
- `tui_gateway/server.py` — `_get_usage` adds `account_label` when a pool is bound.
- `ui-tui/src/types.ts`, `ui-tui/src/gatewayTypes.ts` — `account_label?: string` on `Usage` / `SessionUsageResponse`.
- `ui-tui/src/components/appChrome.tsx` — `showAccount` segment in `StatusRule`, gated on `statusBarFields.has('account')`.
- `hermes_cli/config_defaults.py` — field list comment.
- `website/docs/user-guide/configuration.md` — documents the field and its opt-in/no-pool behaviour.
- Tests: `tests/cli/test_cli_status_bar.py` (+5), `tests/agent/test_active_credential_label.py` (new, 8), `ui-tui/src/__tests__/appChromeStatusRule.test.tsx` (+5).

## How to Test

1. Have ≥1 pooled credential for your provider (`hermes auth list` shows a `←`).
2. In `~/.hermes/config.yaml`:
   ```yaml
   display:
     status_bar:
       fields: [model, account, context_pct, duration]
   ```
3. `hermes` (classic) and `hermes --tui` — the bar shows `@ <label>` after the model.
4. Remove `account` from the list (or use the default empty list) — the segment disappears and the bar is unchanged from `main`.
5. Automated:
   ```
   pytest tests/cli/test_cli_status_bar.py tests/agent/test_active_credential_label.py -q   # 61 passed
   cd ui-tui && npx vitest run src/__tests__/appChromeStatusRule.test.tsx                    # 48 passed (3 files)
   ```

Verification done on this branch (Windows 10):

- `pytest tests/cli/test_cli_status_bar.py tests/cli/test_cli_status_command.py tests/cli/test_cli_new_session.py tests/agent/test_active_credential_label.py tests/agent/test_credential_pool.py` — **136 passed**
- `pytest tests/test_tui_gateway_server.py -k usage` — **17 passed**
- `ui-tui`: `tsc --noEmit` clean, `eslint` clean, `prettier --check` clean, vitest **48 passed**
- `ruff check` on all touched Python — clean
- **Sabotage run:** stubbing `active_credential_label` to return `""` makes 8 of the new tests fail; restored → green.
- **E2E (real path, not mocks):** `load_pool("anthropic")` against a copied `auth.json` in a temp `HERMES_HOME` with a 2-entry pool → the CLI bar, the resolver, and `_get_usage()` all report the same label; default config shows no label.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #16652, #53375, #83014 etc. add *quota* segments; none surface the active credential identity
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the relevant test suites and all tests pass (see above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10 (Server 2022)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/configuration.md`, docstrings)
- [x] `cli-config.yaml.example` — N/A (it does not list `status_bar` fields)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change)
- [x] Cross-platform: display-only string handling, no OS-specific paths
- [x] Tool descriptions/schemas — N/A
