### PR TITLE
fix(desktop): make agent gateway activation cancellation-safe

### DIFF
--- a/apps/desktop/src/store/gateway-profile-request.test.ts
+++ b/apps/desktop/src/store/gateway-profile-request.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { deferred } from '../test/deferred'
+
 const secondaryGateways: Array<{
   close: ReturnType<typeof vi.fn>
   connect: ReturnType<typeof vi.fn>
@@ -47,6 +49,7 @@ vi.mock('@/store/notify-baseline', () => ({ markNativeNotifyBaseline: vi.fn() })
 
 const {
   $gateway,
+  activeGatewayConnectionId,
   closeSecondaryGateways,
   configureGatewayRegistry,
   ensureGatewayForAgent,
@@ -566,21 +569,75 @@ describe('retainGatewayForAgent (#93602)', () => {
 })
 
 describe('attached shared-remote group turns (#96493)', () => {
-  function installAttachedSharedRemote() {
+  type AgentDescriptor = {
+    connectionId: string
+    port: number
+    profile: string
+    sharedRemote: boolean
+  }
+
+  function installAgentResolver(getConnectionFor: ReturnType<typeof vi.fn>): void {
     ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
       getConnection: vi.fn(async (profile: null | string) => ({ port: 4242, profile, token: 't' })),
-      getConnectionFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
-        connectionId,
-        port: 9119,
-        profile,
-        sharedRemote: true
-      })),
+      getConnectionFor,
       getGatewayWsUrlFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
         ok: true as const,
         wsUrl: `ws://${connectionId}/${profile}`
       })),
       touchBackend: vi.fn(async () => undefined)
     }
+  }
+
+  function installAttachedSharedRemote() {
+    const getConnectionFor = vi.fn(
+      async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+        connectionId,
+        port: 9119,
+        profile,
+        sharedRemote: true
+      })
+    )
+
+    installAgentResolver(getConnectionFor)
+
+    return getConnectionFor
+  }
+
+  function installDelayedSharedProbe(probe: Promise<AgentDescriptor>) {
+    const getConnectionFor = vi.fn(
+      async ({ connectionId, profile }: { connectionId: string; profile: string }) => {
+        if (connectionId === 'homelab' && profile === 'voter') {
+          return probe
+        }
+
+        return { connectionId, port: 9119, profile, sharedRemote: false }
+      }
+    )
+
+    installAgentResolver(getConnectionFor)
+
+    return getConnectionFor
+  }
+
+  async function activateLocalSecondary() {
+    const primary = makePrimary()
+
+    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'homelab' })
+    const getConnectionFor = installAttachedSharedRemote()
+    await ensureGatewayForAgent('local', 'default')
+
+    return { getConnectionFor, local: secondaryGateways[0], primary }
+  }
+
+  async function waitForSharedProbe(getConnectionFor: ReturnType<typeof vi.fn>): Promise<void> {
+    await vi.waitFor(() =>
+      expect(getConnectionFor).toHaveBeenCalledWith(
+        expect.objectContaining({ connectionId: 'homelab', profile: 'voter' })
+      )
+    )
+    await Promise.resolve()
+    await Promise.resolve()
   }
 
   it('reuses the primary socket for a named profile on the attached shared remote', async () => {
@@ -654,6 +711,233 @@ describe('attached shared-remote group turns (#96493)', () => {
 
     expect(secondaryGateways).toHaveLength(0)
     expect(primary.request).toHaveBeenCalledOnce()
+  })
+
+  it('activates the attached primary when leaving a local secondary for its named profile', async () => {
+    const { primary } = await activateLocalSecondary()
+    const localActivationEpoch = gatewayActivationEpoch()
+
+    expect($gateway.get()).toBe(secondaryGateways[0])
+
+    await ensureGatewayForAgent('homelab', 'voter')
+
+    expect(activeGatewayConnectionId()).toBe('homelab')
+    expect($gateway.get()).toBe(primary)
+    expect(gatewayActivationEpoch()).toBeGreaterThan(localActivationEpoch)
+    expect(secondaryGateways).toHaveLength(1)
+  })
+
+  it('waits for the commit barrier before activating an attached shared remote primary', async () => {
+    const barrier = deferred<void>()
+    const { getConnectionFor } = await activateLocalSecondary()
+    let settled = false
+
+    const activation = ensureGatewayForAgent('homelab', 'voter', { activationBarrier: barrier.promise }).finally(() => {
+      settled = true
+    })
+
+    await waitForSharedProbe(getConnectionFor)
+    expect(settled).toBe(false)
+    expect(activeGatewayConnectionId()).toBe('local')
+
+    barrier.resolve()
+    await expect(activation).resolves.toBe(true)
+    expect(activeGatewayConnectionId()).toBe('homelab')
+  })
+
+  it('does not activate an attached shared remote primary when aborted behind the commit barrier', async () => {
+    const barrier = deferred<void>()
+    const controller = new AbortController()
+    const { getConnectionFor, local } = await activateLocalSecondary()
+    let settled = false
+
+    const activation = ensureGatewayForAgent('homelab', 'voter', {
+      activationBarrier: barrier.promise,
+      signal: controller.signal
+    }).finally(() => {
+      settled = true
+    })
+
+    await waitForSharedProbe(getConnectionFor)
+    expect(settled).toBe(false)
+
+    controller.abort()
+    barrier.resolve()
+
+    await expect(activation).resolves.toBe(false)
+    expect(activeGatewayConnectionId()).toBe('local')
+    expect($gateway.get()).toBe(local)
+  })
+
+  it('does not activate the exact primary route when aborted behind the commit barrier', async () => {
+    const barrier = deferred<void>()
+    const controller = new AbortController()
+    const { local } = await activateLocalSecondary()
+    let settled = false
+
+    const activation = ensureGatewayForAgent('homelab', 'default', {
+      activationBarrier: barrier.promise,
+      signal: controller.signal
+    }).finally(() => {
+      settled = true
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(settled).toBe(false)
+    expect(activeGatewayConnectionId()).toBe('local')
+
+    controller.abort()
+    barrier.resolve()
+
+    await expect(activation).resolves.toBe(false)
+    expect(activeGatewayConnectionId()).toBe('local')
+    expect($gateway.get()).toBe(local)
+  })
+
+  it('rejects a primary activation after same-id connection metadata is republished', async () => {
+    const barrier = deferred<void>()
+    const primary = makePrimary()
+
+    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'homelab' })
+    await ensureGatewayForProfile('default')
+
+    let settled = false
+
+    const activation = ensureGatewayForAgent('homelab', 'default', {
+      activationBarrier: barrier.promise
+    }).finally(() => {
+      settled = true
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    setPrimaryGatewayConnection({ connectionId: 'homelab' })
+    barrier.resolve()
+
+    await expect(activation).resolves.toBe(false)
+    expect($gateway.get()).toBe(primary)
+  })
+
+  it('does not activate when primary ownership changes behind the commit barrier', async () => {
+    const barrier = deferred<void>()
+    const { getConnectionFor, local } = await activateLocalSecondary()
+    let settled = false
+
+    const activation = ensureGatewayForAgent('homelab', 'voter', {
+      activationBarrier: barrier.promise
+    }).finally(() => {
+      settled = true
+    })
+
+    await waitForSharedProbe(getConnectionFor)
+    expect(settled).toBe(false)
+
+    setPrimaryGateway(makePrimary() as never, 'default')
+    barrier.resolve()
+
+    await expect(activation).resolves.toBe(false)
+    expect(activeGatewayConnectionId()).toBe('local')
+    expect($gateway.get()).toBe(local)
+  })
+
+  it('does not let a slower shared-remote probe override a newer activation', async () => {
+    const probe = deferred<AgentDescriptor>()
+    const getConnectionFor = installDelayedSharedProbe(probe.promise)
+    const primary = makePrimary()
+
+    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'homelab' })
+    const staleActivation = ensureGatewayForAgent('homelab', 'voter')
+
+    await vi.waitFor(() =>
+      expect(getConnectionFor).toHaveBeenCalledWith(
+        expect.objectContaining({ connectionId: 'homelab', profile: 'voter' })
+      )
+    )
+    await expect(ensureGatewayForAgent('local', 'default')).resolves.toBe(true)
+    const local = $gateway.get()
+    const winnerEpoch = gatewayActivationEpoch()
+
+    probe.resolve({ connectionId: 'homelab', port: 9119, profile: 'voter', sharedRemote: true })
+
+    await expect(staleActivation).resolves.toBe(false)
+    expect(activeGatewayConnectionId()).toBe('local')
+    expect($gateway.get()).toBe(local)
+    expect(gatewayActivationEpoch()).toBe(winnerEpoch)
+  })
+
+  it('does not advance the epoch after an aborted isolated probe loses to a newer activation', async () => {
+    const probe = deferred<AgentDescriptor>()
+    const controller = new AbortController()
+    const getConnectionFor = installDelayedSharedProbe(probe.promise)
+    const primary = makePrimary()
+
+    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'homelab' })
+    const staleActivation = ensureGatewayForAgent('homelab', 'voter', { signal: controller.signal })
+
+    await vi.waitFor(() =>
+      expect(getConnectionFor).toHaveBeenCalledWith(
+        expect.objectContaining({ connectionId: 'homelab', profile: 'voter' })
+      )
+    )
+    controller.abort()
+    await expect(ensureGatewayForAgent('local', 'default')).resolves.toBe(true)
+    const local = $gateway.get()
+    const winnerEpoch = gatewayActivationEpoch()
+
+    probe.resolve({ connectionId: 'homelab', port: 9119, profile: 'voter', sharedRemote: false })
+
+    await expect(staleActivation).resolves.toBe(false)
+    expect(activeGatewayConnectionId()).toBe('local')
+    expect($gateway.get()).toBe(local)
+    expect(gatewayActivationEpoch()).toBe(winnerEpoch)
+  })
+
+  it('does not activate an isolated secondary when aborted behind the commit barrier', async () => {
+    const barrier = deferred<void>()
+    const controller = new AbortController()
+
+    const getConnectionFor = vi.fn(
+      async ({ connectionId, profile }: { connectionId: string; profile: string }) => ({
+        connectionId,
+        port: 9119,
+        profile,
+        sharedRemote: false
+      })
+    )
+
+    const primary = makePrimary()
+
+    installAgentResolver(getConnectionFor)
+    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGatewayConnection({ connectionId: 'homelab' })
+    await ensureGatewayForProfile('default')
+
+    let settled = false
+
+    const activation = ensureGatewayForAgent('archive', 'voter', {
+      activationBarrier: barrier.promise,
+      signal: controller.signal
+    }).finally(() => {
+      settled = true
+    })
+
+    await vi.waitFor(() => expect(secondaryGateways).toHaveLength(1))
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    expect(activeGatewayConnectionId()).toBe('homelab')
+
+    controller.abort()
+    barrier.resolve()
+
+    await expect(activation).resolves.toBe(false)
+    expect(activeGatewayConnectionId()).toBe('homelab')
+    expect($gateway.get()).toBe(primary)
   })
 
   it('openGatewayForAgent and ensureGatewayForAgent do not dial a secondary', async () => {

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -161,6 +161,7 @@ interface GatewayRegistryState {
   primaryProfile: string
   activeKey: string
   activationEpoch: number
+  primaryConnectionGeneration: number
   secondaries: Map<string, Secondary>
   /** Scopes that opened in this renderer generation, even if later pruned. */
   openedSecondaryScopes?: Set<string>
@@ -182,6 +183,7 @@ function createRegistryState(): GatewayRegistryState {
     primaryProfile: 'default',
     activeKey: 'default',
     activationEpoch: 0,
+    primaryConnectionGeneration: 0,
     secondaries: new Map<string, Secondary>(),
     openedSecondaryScopes: new Set<string>(),
     turnLeases: new Map<string, () => void>(),
@@ -212,7 +214,8 @@ function gatewayState(): GatewayRegistryState {
     const store = globalThis as unknown as { [STATE_KEY]?: GatewayRegistryState }
     store[STATE_KEY] ??= createRegistryState()
 
-    // Existing dev-HMR containers predate whole-turn leases.
+    // Existing dev-HMR containers predate whole-turn leases and connection generations.
+    store[STATE_KEY].primaryConnectionGeneration ??= 0
     store[STATE_KEY].turnLeases ??= new Map()
     store[STATE_KEY].turnLeaseReleaseTimers ??= new Map()
 
@@ -298,6 +301,7 @@ export function setPrimaryGatewayConnectionId(connectionId: null | string | unde
     return
   }
 
+  g.primaryConnectionGeneration += 1
   g.primaryConnectionId = (connectionId ?? '').trim() || null
 
   if (g.activeKey === g.primaryProfile) {
@@ -1427,14 +1431,65 @@ export async function openGatewayForAgent(
   }
 }
 
+interface AgentActivationRequest {
+  activationEpoch: number
+  primaryConnectionGeneration: number
+  primaryGateway: HermesGateway | null
+  primaryProfile: string
+}
+
+function beginAgentActivationRequest(): AgentActivationRequest {
+  return {
+    activationEpoch: beginGatewayActivation(),
+    primaryConnectionGeneration: g.primaryConnectionGeneration,
+    primaryGateway: g.primaryGateway,
+    primaryProfile: g.primaryProfile
+  }
+}
+
+function isCurrentAgentActivation(request: AgentActivationRequest): boolean {
+  return request.activationEpoch === gatewayActivationEpoch()
+}
+
+async function activatePrimaryForAgent(
+  connectionId: null | string,
+  request: AgentActivationRequest,
+  {
+    activationBarrier,
+    requireOpen = false,
+    signal
+  }: { activationBarrier?: Promise<unknown>; requireOpen?: boolean; signal?: AbortSignal }
+): Promise<boolean> {
+  if (activationBarrier) {
+    await activationBarrier
+  }
+
+  if (
+    signal?.aborted ||
+    !isCurrentAgentActivation(request) ||
+    g.primaryConnectionGeneration !== request.primaryConnectionGeneration ||
+    normKey(connectionId) !== g.primaryConnectionId ||
+    request.primaryGateway !== g.primaryGateway ||
+    request.primaryProfile !== g.primaryProfile ||
+    (requireOpen && !isOpen(request.primaryGateway))
+  ) {
+    return false
+  }
+
+  return applyActive(request.primaryProfile, request.activationEpoch)
+}
+
 export async function ensureGatewayForAgent(
   connectionId: null | string,
   profile: string,
-  { signal }: { signal?: AbortSignal } = {}
+  {
+    activationBarrier,
+    signal
+  }: { activationBarrier?: Promise<unknown>; signal?: AbortSignal } = {}
 ): Promise<boolean> {
   const scope = registryBackendScopeKey(connectionId, profile)
 
-  if (scope === normKey(profile) || isPrimaryRegistryRoute(connectionId, profile)) {
+  if (scope === normKey(profile)) {
     if (signal?.aborted) {
       return false
     }
@@ -1444,15 +1499,36 @@ export async function ensureGatewayForAgent(
     return !signal?.aborted
   }
 
-  if (await isAttachedSharedRemote(connectionId, profile, 'foreground')) {
-    return Boolean(isOpen(g.primaryGateway) && !signal?.aborted)
+  if (signal?.aborted) {
+    return false
   }
 
-  if (!window.hermesDesktop?.getConnectionFor) {
+  const primaryRoute = isPrimaryRegistryRoute(connectionId, profile)
+
+  if (!primaryRoute && !window.hermesDesktop?.getConnectionFor) {
     throw new Error('This Desktop build cannot dial registry connections. Update Hermes Desktop.')
   }
 
-  const activationEpoch = beginGatewayActivation()
+  const request = beginAgentActivationRequest()
+
+  if (primaryRoute) {
+    return activatePrimaryForAgent(connectionId, request, { activationBarrier, signal })
+  }
+
+  const attachedSharedRemote = await isAttachedSharedRemote(connectionId, profile, 'foreground')
+
+  if (signal?.aborted || !isCurrentAgentActivation(request)) {
+    return false
+  }
+
+  if (attachedSharedRemote) {
+    // A named profile on the registered remote primary shares that primary
+    // socket. This is an activation path, not a background request: move the
+    // foreground gateway back to primary when the current route is a local or
+    // other-source secondary. Merely reporting "open" leaves $gateway on the
+    // old source while the wrapper publishes the shared-remote metadata.
+    return activatePrimaryForAgent(connectionId, request, { activationBarrier, requireOpen: true, signal })
+  }
 
   let entry = g.secondaries.get(scope)
 
@@ -1482,9 +1558,13 @@ export async function ensureGatewayForAgent(
   // The activation is settling either way — release the prune lease.
   entry.activationLeaseUntil = 0
 
+  if (activationBarrier) {
+    await activationBarrier
+  }
+
   // A timed-out owner may leave the dial running, but it no longer has the
   // right to move the foreground route when that work eventually settles.
-  if (signal?.aborted) {
+  if (signal?.aborted || !isCurrentAgentActivation(request)) {
     return false
   }
 
@@ -1500,7 +1580,7 @@ export async function ensureGatewayForAgent(
     g.secondaries.get(scope) === entry &&
     Boolean(entry.connection) &&
     isOpen(entry.gateway) &&
-    applyActive(scope, activationEpoch)
+    applyActive(scope, request.activationEpoch)
 
   if (activated && entry.connection) {
     publishActiveConnection(entry.connection)

--- a/apps/desktop/src/store/profile-agent-activation.test.ts
+++ b/apps/desktop/src/store/profile-agent-activation.test.ts
@@ -417,6 +417,12 @@ describe('ensureGatewayAgent commit hook (beforeActivate) — the Sessions switc
 
     const abandoned = ensureGatewayAgent('homelab', 'research', { signal: controller.signal })
     await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledTimes(1))
+    expect(ensureGatewayForAgent).toHaveBeenNthCalledWith(
+      1,
+      'homelab',
+      'research',
+      expect.objectContaining({ activationBarrier: expect.any(Promise), signal: controller.signal })
+    )
 
     controller.abort()
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -703,12 +703,16 @@ export async function ensureGatewayAgent(
     }
 
     // Descriptor resolves concurrently with the dial, same as the profile
-    // path, so no await sits between the activation and the publication.
+    // path. A cancellable attached-primary activation waits on the same
+    // promise before changing active state, so cancellation cannot strand a
+    // gateway-only publication ahead of this frame.
+    const descriptorPromise = resolveConnectionForAgent(connection, target)
+
     const activation = signal
-      ? ensureGatewayForAgent(connection, target, { signal })
+      ? ensureGatewayForAgent(connection, target, { activationBarrier: descriptorPromise, signal })
       : ensureGatewayForAgent(connection, target)
 
-    const [descriptor, activated] = await Promise.all([resolveConnectionForAgent(connection, target), activation])
+    const [descriptor, activated] = await Promise.all([descriptorPromise, activation])
 
     if (signal?.aborted) {
       return


### PR DESCRIPTION
## What does this PR do?

Fixes foreground route ownership when an agent turn targets a profile on the attached shared-remote primary while another source's secondary gateway is active.

The existing fast path recognized the shared primary socket and returned success when it was open, but did not make that socket active. The wrapper could therefore publish the remote `(connectionId, profile)` while `$gateway` still pointed at the previous local secondary.

This change makes foreground agent activation an ordered operation before its first asynchronous boundary:

- exact-primary and named shared-primary routes activate the existing primary instead of only reporting it as available;
- cancellable switches use the existing bounded, fail-open descriptor promise as a commit barrier, then recheck cancellation, request epoch, source ownership, and the primary gateway/profile generation before publication;
- the same commit barrier also covers isolated-secondary activation after its socket is ready;
- a slower probe cannot reclaim the foreground from a newer activation;
- an aborted `sharedRemote: false` probe cannot invalidate the newer winner or publish a stale isolated route;
- same-ID primary connection metadata republishes advance a generation guard, so an older descriptor cannot commit across an ABA update.

The normal path without an `AbortSignal` does not wait on the descriptor barrier. `openGateway`/request/retain behavior and background prewarming are unchanged. Isolated routes still use their own secondary socket; only stale or cancelled activations are prevented from taking foreground ownership.

## Related Issue

Related to #90477.

This overlaps the primary-reactivation hunk in #105139, but not that PR's REST readiness, profile-cache, or sidebar work. The narrower patch here also covers cancellation, exact-primary activation, primary-generation replacement, and out-of-order probe completion on current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/gateway.ts`: activate exact/shared primary routes through one epoch- and generation-guarded commit path; reuse the same request epoch across shared probing and isolated fallback; track accepted primary connection republishes with an HMR-safe generation.
- `apps/desktop/src/store/profile.ts`: pass the existing bounded descriptor promise as an activation barrier only for cancellable foreground switches.
- `apps/desktop/src/store/gateway-profile-request.test.ts`: add regression coverage for local-secondary → shared-primary activation, barrier cancellation, exact-primary cancellation, primary replacement, stale probe ordering, and aborted isolated fallback.
- `apps/desktop/src/store/profile-agent-activation.test.ts`: verify the wrapper passes the descriptor barrier and signal together.

## How to Test

1. Register a shared remote primary with a named profile and keep a local secondary active.
2. Select the remote named profile.
3. Verify the active connection and `$gateway` both move to the remote primary without creating a ghost secondary or closing the existing local secondary.
4. Repeat with a delayed descriptor and cancel the activation; the local route must remain unchanged.
5. Start a slower remote probe, then complete a newer local activation; the stale probe must return `false` without changing the winner or its epoch.

Executed from `apps/desktop` on current `main`:

```sh
npm run test:ui -- src/store/gateway-profile-request.test.ts src/store/profile-agent-activation.test.ts
# 43 passed

npm run test:ui
# 771 files, 7,452 tests passed

npm run check:lint
# typecheck passed; ESLint: 0 errors (existing warnings in untouched files)

git diff --check
# passed
```

`npm run check` is not claimed as fully green on this macOS host: one unrelated Electron fixture hard-codes `/bin/true`, which is absent here (`/usr/bin/true` exists), and two bounded DMG attempts later stopped at the same external TLS download failure. No production code was changed for either environment-specific blocker.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing open PRs and documented the overlap with #105139.
- [x] The PR contains only this routing/activation fix and its regression tests.
- [ ] Full Python test suite — not run; this is a Desktop TypeScript-only change.
- [x] Regression tests were observed failing before their fixes and passing afterwards.
- [x] Tested on macOS; no OS-specific production behavior was added.

### Documentation & Housekeeping

- [x] README/docs update — N/A; no user-facing setup or configuration changed.
- [x] `cli-config.yaml.example` update — N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no contributor workflow changed.
- [x] Tool descriptions/schemas update — N/A; no tool surface changed.

## Screenshots / Logs

No UI layout changes. Regression output and state assertions are included in the tests; no private connection details, credentials, or user data are included.
