### PR TITLE
feat(plugin-catalog): admit standalone Desktop plugins

### DIFF
--- a/.github/workflows/plugin-catalog-ci.yml
+++ b/.github/workflows/plugin-catalog-ci.yml
@@ -100,6 +100,7 @@ jobs:
           print(f"REPO={shlex.quote(str(data.get('repo', '')))}")
           print(f"SHA={shlex.quote(str(data.get('sha', '')))}")
           print(f"SUBDIR={shlex.quote(str(data.get('subdir', '') or ''))}")
+          print(f"NAME={shlex.quote(str(data.get('name', '') or ''))}")
           PYEOF
           )"
             echo "repo=$REPO sha=$SHA subdir=$SUBDIR"
@@ -118,15 +119,9 @@ jobs:
             fi
 
             PLUGIN_DIR="$CLONE_DIR${SUBDIR:+/$SUBDIR}"
-            # Native plugin.yaml OR portable Agent Plugins v1 plugin.json
-            # (#81196; native manifest wins when both exist).
-            if [ ! -f "$PLUGIN_DIR/plugin.yaml" ] && [ ! -f "$PLUGIN_DIR/plugin.yml" ] && [ ! -f "$PLUGIN_DIR/plugin.json" ]; then
-              echo "::error file=$entry::no plugin.yaml or plugin.json at subdir '$SUBDIR' of $REPO@$SHA"
-              FAILED=1; echo "::endgroup::"; continue
-            fi
-
-            # Manifest schema + declared-vs-registered capability check.
-            if hermes plugins validate "$PLUGIN_DIR"; then
+            # Agent manifests retain their capability-validation path. With no
+            # Agent manifest, validate the documented root Desktop plugin.js.
+            if hermes plugins validate "$PLUGIN_DIR" --expected-id "$NAME"; then
               echo "✅ PASS: $entry"
             else
               echo "::error file=$entry::hermes plugins validate failed"

--- a/hermes_cli/plugin_validate.py
+++ b/hermes_cli/plugin_validate.py
@@ -30,6 +30,18 @@ _CONFIG_TYPES = {
 }
 _PROBE_TIMEOUT = 30
 _PROBE_SENTINEL = "HERMES_VALIDATE_JSON:"
+_DESKTOP_IMPORT_RE = re.compile(
+    r"(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s+)(?:['\"])([^'\"]+)(?:['\"])",
+)
+_DESKTOP_ALLOWED_IMPORTS = {
+    "@hermes/plugin-sdk", "react", "react/jsx-runtime", "react/jsx-dev-runtime",
+}
+_DESKTOP_EXPORT_RE = re.compile(r"\bexport\s+default\s*\{(?P<body>.*?)\}\s*;?\s*$", re.S)
+_DESKTOP_ID_RE = re.compile(r"(?:^|,)\s*id\s*:\s*(['\"])([^'\"]+)\1\s*(?:,|$)", re.S)
+_DESKTOP_REGISTER_RE = re.compile(
+    r"(?:^|,)\s*(?:register\s*\([^)]*\)\s*\{|register\s*:\s*(?:function\s*)?\([^)]*\)\s*=>|register\s*:\s*function\s*\([^)]*\))",
+    re.S,
+)
 
 
 @dataclass
@@ -404,7 +416,9 @@ def _check_builtin_collisions(
 # ─── Entry point ─────────────────────────────────────────────────────────────
 
 
-def validate_plugin_dir(plugin_dir: Path) -> ValidationReport:
+def validate_plugin_dir(
+    plugin_dir: Path, expected_id: Optional[str] = None
+) -> ValidationReport:
     """Run every admission check against *plugin_dir* and return the report."""
     report = ValidationReport()
     plugin_dir = Path(plugin_dir)
@@ -426,9 +440,12 @@ def validate_plugin_dir(plugin_dir: Path) -> ValidationReport:
         portable_file = plugin_dir / "plugin.json"
         if portable_file.is_file():
             return _validate_portable_plugin(report, plugin_dir)
+        desktop_file = plugin_dir / "plugin.js"
+        if desktop_file.is_file():
+            return _validate_desktop_plugin(report, desktop_file, expected_id)
         report.add(
             "manifest", False,
-            "no plugin.yaml (or portable plugin.json) in the plugin directory",
+            "no plugin.yaml, portable plugin.json, or standalone plugin.js in the plugin directory",
         )
         return report
 
@@ -452,6 +469,54 @@ def validate_plugin_dir(plugin_dir: Path) -> ValidationReport:
     _check_requires_env(report, manifest)
     recorded = _check_capabilities(report, manifest, plugin_dir)
     _check_builtin_collisions(report, manifest, recorded)
+    return report
+
+
+def _validate_desktop_plugin(
+    report: ValidationReport, plugin_file: Path, expected_id: Optional[str]
+) -> ValidationReport:
+    """Fail-closed static validation of the Desktop runtime-loader contract."""
+    try:
+        source = plugin_file.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        report.add("desktop plugin", False, f"plugin.js is not readable UTF-8: {exc}")
+        return report
+
+    if len(source.encode("utf-8")) > 512 * 1024:
+        report.add("desktop plugin", False, "plugin.js exceeds the Desktop loader's 512 KiB limit")
+        return report
+
+    imports = _DESKTOP_IMPORT_RE.findall(source)
+    unsupported = sorted({
+        spec for spec in imports
+        if not (spec in _DESKTOP_ALLOWED_IMPORTS or spec.startswith(("./", "../", "/"))
+                or re.match(r"^[a-z][a-z0-9+.-]*:", spec, re.I))
+    })
+    report.add(
+        "desktop imports", not unsupported,
+        "imports match the Desktop runtime loader" if not unsupported
+        else f"unsupported import(s): {', '.join(unsupported)}",
+    )
+
+    export = _DESKTOP_EXPORT_RE.search(source)
+    if export is None:
+        report.add("desktop export", False, "plugin.js must default-export a HermesPlugin object")
+        return report
+    body = export.group("body")
+    id_match = _DESKTOP_ID_RE.search(body)
+    plugin_id = id_match.group(2) if id_match else ""
+    valid_id = bool(plugin_id) and (expected_id is None or plugin_id == expected_id)
+    detail = "default export has a literal id"
+    if expected_id is not None and plugin_id != expected_id:
+        detail = f"plugin id {plugin_id!r} does not match catalog name {expected_id!r}"
+    elif not plugin_id:
+        detail = "default export must contain a non-empty literal id"
+    report.add("desktop id", valid_id, detail)
+    report.add(
+        "desktop register", bool(_DESKTOP_REGISTER_RE.search(body)),
+        "default export has a register function" if _DESKTOP_REGISTER_RE.search(body)
+        else "default export must contain a register function",
+    )
     return report
 
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -2068,7 +2068,9 @@ _PLUGIN_ACTIONS = {
     "search": lambda args: _catalog().cmd_search(
         getattr(args, "term", "") or "", json_output=getattr(args, "json", False)),
     "browse": lambda args: _catalog().cmd_search(""),
-    "validate": lambda args: _catalog().cmd_validate(args.path, as_json=getattr(args, "json", False)),
+    "validate": lambda args: _catalog().cmd_validate(
+        args.path, as_json=getattr(args, "json", False),
+        expected_id=getattr(args, "expected_id", None)),
     "update": lambda args: cmd_update(args.name),
     "remove": lambda args: cmd_remove(args.name),
     "rm": lambda args: cmd_remove(args.name),

--- a/hermes_cli/plugins_cmd_catalog.py
+++ b/hermes_cli/plugins_cmd_catalog.py
@@ -223,11 +223,11 @@ def cmd_info(name: str) -> None:
     console.print()
 
 
-def cmd_validate(path: str, as_json: bool = False) -> None:
+def cmd_validate(path: str, as_json: bool = False, expected_id: Optional[str] = None) -> None:
     """Catalog-admission validation of a plugin directory (the CI gate); exits 0/1."""
     from hermes_cli.plugin_validate import validate_plugin_dir
     from hermes_cli.plugins_cmd import _console
-    report = validate_plugin_dir(Path(path))
+    report = validate_plugin_dir(Path(path), expected_id=expected_id)
     if as_json:
         print(json.dumps(report.to_dict(), indent=2))
         sys.exit(report.exit_code)

--- a/hermes_cli/subcommands/plugins.py
+++ b/hermes_cli/subcommands/plugins.py
@@ -50,6 +50,10 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
     plugins_validate = plugins_subparsers.add_parser(
         "validate", help="Validate a plugin directory for catalog admission (CI gate)")
     plugins_validate.add_argument("path", help="Path to the plugin directory")
+    plugins_validate.add_argument(
+        "--expected-id", default=None,
+        help="Expected id for a standalone Desktop plugin",
+    )
     add_json_flag(plugins_validate, "Print machine-readable JSON (for CI)")
 
     plugins_update = plugins_subparsers.add_parser(

--- a/tests/hermes_cli/test_plugin_validate.py
+++ b/tests/hermes_cli/test_plugin_validate.py
@@ -112,3 +112,40 @@ class TestCapabilityProbe:
         )
         report = validate_plugin_dir(d)
         assert report.ok, report.failures
+
+
+class TestStandaloneDesktopPlugin:
+    SOURCE = (
+        "import { host } from '@hermes/plugin-sdk'\n"
+        "export default { id: 'desktop-only', register(ctx) { void host; void ctx } }\n"
+    )
+
+    def _write(self, tmp_path: Path, source: str | None = None) -> Path:
+        d = tmp_path / "desktop-only"
+        d.mkdir()
+        (d / "plugin.js").write_text(source or self.SOURCE, encoding="utf-8")
+        return d
+
+    def test_valid_standalone_desktop_plugin_is_accepted(self, tmp_path):
+        report = validate_plugin_dir(self._write(tmp_path), expected_id="desktop-only")
+        assert report.ok, report.failures
+
+    def test_missing_agent_manifest_and_plugin_js_is_rejected(self, tmp_path):
+        assert not validate_plugin_dir(tmp_path).ok
+
+    def test_malformed_desktop_plugin_is_rejected(self, tmp_path):
+        report = validate_plugin_dir(self._write(tmp_path, "export default { id: 'desktop-only' }"))
+        assert not report.ok
+        assert any("register" in failure for failure in report.failures)
+
+    def test_unsupported_desktop_import_is_rejected(self, tmp_path):
+        source = "import fs from 'fs'\nexport default { id: 'desktop-only', register() {} }\n"
+        report = validate_plugin_dir(self._write(tmp_path, source))
+        assert not report.ok
+        assert any("fs" in failure for failure in report.failures)
+
+    def test_agent_manifest_still_wins_for_hybrid_plugin(self, tmp_path):
+        d = _make_plugin(tmp_path, manifest=dict(BASE_MANIFEST))
+        (d / "plugin.js").write_text("not valid desktop js", encoding="utf-8")
+        report = validate_plugin_dir(d)
+        assert report.ok, report.failures


### PR DESCRIPTION
## Summary

- Admit documented standalone Hermes Desktop packages when the selected catalog source has a root `plugin.js` and no Agent manifest.
- Validate the actual Desktop runtime-loader contract: supported SDK/React imports, a non-empty literal `id`, and a callable `register`.
- Preserve the existing native/portable Agent validation path; Agent manifests continue to win for hybrid packages.
- Keep SHA reachability and every existing catalog admission/security gate unchanged.

Fixes #107262

## Tests

- `uv run --with pytest --with pytest-asyncio pytest tests/hermes_cli/test_plugin_validate.py tests/hermes_cli/test_plugin_catalog.py tests/scripts/test_validate_plugin_catalog.py tests/hermes_cli/test_plugins_cmd_catalog.py -q` — **44 passed**
- `uvx ruff check hermes_cli/plugin_validate.py hermes_cli/plugins_cmd.py hermes_cli/plugins_cmd_catalog.py hermes_cli/subcommands/plugins.py tests/hermes_cli/test_plugin_validate.py` — passed
- `git diff --check` — passed

## Regression coverage

- valid standalone root `plugin.js` accepted
- neither Agent manifest nor `plugin.js` rejected
- malformed Desktop export rejected
- unsupported Desktop import rejected
- existing Agent/hybrid manifest path unchanged