### PR TITLE
fix(gateway): keep session-too-large reply when a failed 400 still has text

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3026,9 +3026,11 @@ def _normalize_empty_agent_response(
     non-failed turn -- this is the silent-drop pattern observed after ``/stop`` where the next user message
     hits a stale generation token and returns an empty result, leaving the platform with nothing to send.
     (#31884)
+
+    Failed context-overflow turns rewrite even when ``final_response`` already holds the raw HTTP
+    400 envelope. Returning that envelope unchanged lets chat sanitizers replace it with a generic
+    provider-failed reply, so the user never sees /compact (#1630 message layer).
     """
-    if response:
-        return response
     if agent_result.get("failed"):
         # ``error`` can be an EXPLICIT None (bypasses dict.get default) -> would render "failed: None".
         error_detail = agent_result.get("error") or "unknown error"
@@ -3051,9 +3053,13 @@ def _normalize_empty_agent_response(
             return (
                 "⚠️ Session too large for the model's context window.\n"
                 "Use /compact to compress the conversation, or /reset to start fresh.")
+        if response:
+            return response
         return (
             f"The request failed: {str(error_detail)[:300]}\n"
             "Try again or use /reset to start a fresh session.")
+    if response:
+        return response
 
     api_calls = int(agent_result.get("api_calls", 0) or 0)
     if agent_result.get("interrupted"):

--- a/tests/gateway/test_normalize_empty_agent_response.py
+++ b/tests/gateway/test_normalize_empty_agent_response.py
@@ -126,3 +126,42 @@ class TestGenericFailureRegression:
 
         assert "context window" in response
         assert "/compact" in response
+
+
+class TestNonempty400EnvelopeOverflowReply:
+    """Failed turns that already carry the HTTP 400 envelope as
+    ``final_response`` must still get the session-too-large rewrite.
+
+    Production order is normalize then Telegram sanitizer. The empty-response
+    rewriter used to return the 56-char envelope unchanged, and the sanitizer
+    then replaced it with a generic 'provider failed' — so users never saw
+    /compact even though the gateway already classified the turn as overflow.
+    """
+
+    _ENVELOPE = 'HTTP 400: {"object":"error","model":"deepseek-v4-flash"}'
+
+    def _failed_400(self):
+        return {
+            "final_response": self._ENVELOPE,
+            "failed": True,
+            "error": self._ENVELOPE,
+            "api_calls": 1,
+        }
+
+    def test_long_history_rewrites_envelope_to_session_too_large(self):
+        response = _normalize_empty_agent_response(
+            self._failed_400(), self._ENVELOPE, history_len=138,
+        )
+        assert "context window" in response.lower()
+        assert "/compact" in response
+        assert self._ENVELOPE not in response
+
+    def test_telegram_sanitizer_keeps_overflow_rewrite(self):
+        from gateway.run import _sanitize_gateway_final_response
+
+        rewritten = _normalize_empty_agent_response(
+            self._failed_400(), self._ENVELOPE, history_len=138,
+        )
+        delivered = _sanitize_gateway_final_response("telegram", rewritten)
+        assert "/compact" in delivered
+        assert "provider failed after retries" not in delivered.lower()


### PR DESCRIPTION
## Summary
- On a long Telegram session, OpenCode can return a bare HTTP 400 envelope (`HTTP 400: {"object":"error","model":"..."}`). The agent puts that envelope in `final_response`, so the empty-response rewriter never ran.
- Chat sanitizers then replaced it with a generic "provider failed, check gateway logs" reply — even though the gateway already classified the turn as context overflow and skipped transcript persistence (#1630).
- Failed overflow turns now rewrite to the existing "session too large / /compact or /reset" message before sanitizing, matching the empty-response and exception paths.

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_normalize_empty_agent_response.py` (includes the two new invariants: long-history 400 envelope rewrites, Telegram sanitizer keeps `/compact`)
- [x] `scripts/run_tests.sh tests/test_lazy_session_regressions.py tests/gateway/test_tool_response_drop_recovery.py`
- [ ] Reproduce: long Telegram session → provider 400 → reply should say the session is too large and suggest `/compact` or `/reset` (`/new`), not "check gateway logs"