### PR TITLE
fix(tools): keep ssh-backend file paths out of local host resolution

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -362,6 +362,70 @@ class TestWindowsMsysPathResolution:
 
 
 # ---------------------------------------------------------------------------
+# SSH backend path resolution (#79663)
+# ---------------------------------------------------------------------------
+
+class TestSSHRemotePathResolution:
+    """The ssh backend is a separate path namespace: file-tool paths must not
+    be dereferenced against the LOCAL host filesystem (on macOS the ``/home``
+    firmlink rewrites ``/home/...`` into ``/System/Volumes/Data/home/...``,
+    which is meaningless on the remote peer)."""
+
+    def test_ssh_backend_uses_separate_namespace_paths(self, monkeypatch):
+        import tools.file_tools_paths as file_tools
+
+        monkeypatch.setattr(file_tools, "_terminal_env_type_for_task", lambda task_id="default": "ssh")
+
+        assert file_tools._uses_container_paths() is True
+        # The import-failure fallback set must agree with the primary branch.
+        assert "ssh" in file_tools._CONTAINER_PATH_BACKENDS_FALLBACK
+
+    def test_ssh_backend_absolute_path_not_dereferenced_locally(self, monkeypatch, tmp_path):
+        """A remote-absolute path must survive resolution untouched even when
+        the same-looking path dereferences elsewhere on the local host (here:
+        a symlink that host resolve() would follow)."""
+        import tools.file_tools_paths as file_tools
+
+        monkeypatch.setattr(file_tools, "_terminal_env_type_for_task", lambda task_id="default": "ssh")
+        monkeypatch.setattr(
+            file_tools,
+            "_authoritative_workspace_root",
+            lambda task_id="default": str(tmp_path),
+        )
+
+        real = tmp_path / "real" / "draft.txt"
+        real.parent.mkdir()
+        real.write_text("remote-target")
+        link = tmp_path / "home-link"
+        link.symlink_to(real.parent)
+
+        resolved = file_tools._resolve_path_for_task(str(link / "draft.txt"))
+        assert str(resolved) == str(link / "draft.txt")
+
+    def test_local_backend_still_dereferences_locally(self, monkeypatch, tmp_path):
+        """Control: the local backend keeps host resolve() semantics and DOES
+        follow the symlink the ssh case must leave alone."""
+        import tools.file_tools_paths as file_tools
+
+        monkeypatch.setattr(file_tools, "_terminal_env_type_for_task", lambda task_id="default": "local")
+        monkeypatch.setattr(
+            file_tools,
+            "_authoritative_workspace_root",
+            lambda task_id="default": str(tmp_path),
+        )
+
+        real = tmp_path / "real" / "draft.txt"
+        real.parent.mkdir()
+        real.write_text("local")
+        link = tmp_path / "home-link"
+        link.symlink_to(real.parent)
+
+        assert file_tools._uses_container_paths() is False
+        resolved = file_tools._resolve_path_for_task(str(link / "draft.txt"))
+        assert str(resolved) == str(real.resolve())
+
+
+# ---------------------------------------------------------------------------
 # Tool result hint tests (#722)
 # ---------------------------------------------------------------------------
 

--- a/tools/file_tools_paths.py
+++ b/tools/file_tools_paths.py
@@ -14,7 +14,7 @@ from pathlib import Path, PurePosixPath
 # ``TERMINAL_CWD`` values that mean "not configured" ("." from a stale config;
 # "auto"/"cwd" are wizard placeholders). gateway/run.py sanitizes the same set.
 _TERMINAL_CWD_SENTINELS = frozenset({"", ".", "./", "auto", "cwd"})
-_CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
+_CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox", "ssh"})
 # Backend name inferred from the live environment's class name (first match wins).
 _ENV_CLASS_NAME_HINTS = ("local", "ssh", "docker", "singularity", "modal", "daytona")
 
@@ -64,6 +64,12 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
 
 def _uses_container_paths(task_id: str = "default") -> bool:
     env_type = _terminal_env_type_for_task(task_id)
+    if env_type == "ssh":
+        # The remote SSH peer is a separate path namespace, exactly like a
+        # container sandbox: a remote-absolute path must never be rewritten by
+        # host-side resolve() (e.g. the macOS /home firmlink deref) before the
+        # backend builds its remote command (#79663).
+        return True
     try:
         from tools.terminal_tool import _is_container_backend
 


### PR DESCRIPTION
## What does this PR do?

When `terminal.backend: ssh` is configured, the file toolset (`write_file`, `read_file`, `patch`, `search_files`) resolved absolute paths against the **local** filesystem instead of treating them as remote-peer paths: the backend set that drives the path-resolution strategy only lists container sandboxes, so `ssh` fell through to the host branch where `Path.resolve()` runs on the machine hosting Hermes.

On macOS this is actively destructive: the synthetic `/home` firmlink rewrites `/home/<user>/file.txt` into `/System/Volumes/Data/home/<user>/file.txt` before the remote command is built, so every write to a remote absolute path fails with e.g. `mkdir: cannot create directory '/System': Permission denied`.

This PR teaches `_uses_container_paths()` that the ssh backend is a separate path namespace (the same semantics as a container sandbox: paths are meaningful elsewhere, so host-side deref must not touch them). `_CONTAINER_BACKENDS` itself is deliberately untouched so container-specific behavior elsewhere (cwd sanitize, image config, `docker_volumes`) is unchanged, and the import-failure fallback set gains `ssh` to stay consistent with the primary branch.

## Related Issue

Fixes #79663

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_tools_paths.py`: `_uses_container_paths()` returns `True` for the `ssh` backend (separate-namespace semantics, with a comment referencing the issue); `_CONTAINER_PATH_BACKENDS_FALLBACK` gains `"ssh"` so the import-failure fallback agrees with the primary branch.
- `tests/tools/test_file_tools.py`: new `TestSSHRemotePathResolution` — (1) ssh flips the resolution strategy, (2) an ssh-backend absolute path survives resolution untouched (symlink proof: host `resolve()` would follow it, ssh must not), (3) a local-backend control proves host deref still applies where it belongs.

## How to Test

1. Run `python -m pytest tests/tools/test_file_tools.py::TestSSHRemotePathResolution -v` (new tests) — observed result: 3 passed.
2. Regression over every test file that references `file_tools_paths` / `_uses_container_paths`: `pytest tests/tools/test_file_tools.py tests/tools/test_container_cwd_sanitize.py tests/tools/test_session_cwd_store.py tests/tools/test_file_tools_tilde_profile.py tests/tools/test_resolve_path.py tests/tools/test_file_tools_cwd_resolution.py tests/tools/test_terminal_scope_multiplex.py tests/hermes_cli/test_mcp_config.py` — observed result: 145 passed, 2 skipped, plus 2 failures in `test_file_tools.py` (`TestWriteFileHandler::test_writes_content`, `TestPatchHandler::test_replace_mode_calls_patch_replace`) that also fail on pristine `upstream/main` at the same base commit (verified via a `git stash` baseline run), i.e. pre-existing and unrelated to this change.
3. End-to-end shape (from the issue): with `terminal.backend: ssh` pointing at a Linux peer, `write_file` to `/home/<remote_user>/file.txt` should pass the remote-absolute path to the backend command unchanged instead of rewriting it to `/System/Volumes/Data/home/...` on a macOS host.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tools):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (affected surface; see How to Test step 2 for the exact commands, results, and the pre-existing main-baseline failures)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment carries the namespace semantics)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (the fix removes a macOS-specific rewrite; the local backend keeps host deref, covered by the control test)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

New regression tests: `3 passed in 4.55s`; full referencing-file regression: `145 passed, 2 skipped` (2 pre-existing main failures documented above).
