### PR TITLE
fix(routing): /model and auxiliary auto never bill a provider the user did not select (Astra→OpenRouter, Grok→Nous)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3827,6 +3827,8 @@ def _try_payment_fallback(
     provider (and the main-provider path when it maps to the same backend). Returns (client, model, label) or (None, None, "")."""
     skip = failed_provider.lower().strip()
     main_provider = _read_main_provider()
+    if not _discovery_chain_allowed(main_provider, task):
+        return None, None, ""
     skip_labels = {skip}
     if main_provider and main_provider.lower() in skip:
         skip_labels.add(main_provider.lower())
@@ -4200,6 +4202,21 @@ def _try_main_provider_route(
     return client, resolved or main_model, resolved_provider
 
 
+def _discovery_chain_allowed(main_provider: str, task: Optional[str] = None) -> bool:
+    """The built-in discovery chain is a convenience for installs with NO selected main provider.
+    Once the user picked one, every auxiliary route must be a provider they configured (main,
+    ``auxiliary.<task>``, ``fallback_providers``); guessing "whatever else is logged in" bills an
+    account they never pointed this session at (xAI OAuth session with a dead token → every
+    compression silently charged to a Nous Portal balance)."""
+    if (main_provider or "").strip().lower() in {"", "auto"}:
+        return True
+    logger.warning(
+        "Auxiliary %s: main provider %s is unavailable and no fallback_chain / fallback_providers is "
+        "configured — refusing to guess another logged-in provider. Re-authenticate (`hermes model`) "
+        "or declare a fallback.", task or "call", main_provider)
+    return False
+
+
 def _try_discovery_chain() -> Tuple[Optional[OpenAI], Optional[str], str]:
     """Step 3: hardcoded aggregator/fallback chain, skipping unhealthy providers."""
     tried = []
@@ -4249,6 +4266,8 @@ def _resolve_auto_route(
         task, main_provider or "auto", reason="main provider unavailable")
     if fb_client is not None:
         return fb_client, fb_model, fb_label
+    if not _discovery_chain_allowed(main_provider, task):
+        return None, None, ""
     return _try_discovery_chain()
 
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3821,12 +3821,14 @@ async def _call_fallback_candidate_async(
 
 def _try_payment_fallback(
     failed_provider: str, task: str = None, reason: str = "payment error", *,
-    failed_base_url: str = "", failure_scope: Any = None,
+    failed_base_url: str = "", failure_scope: Any = None, main_runtime: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Try the auto-detection chain after a payment/credit or connection error, skipping the failed
     provider (and the main-provider path when it maps to the same backend). Returns (client, model, label) or (None, None, "")."""
     skip = failed_provider.lower().strip()
-    main_provider = _read_main_provider()
+    # The SESSION's provider decides whether discovery is allowed: a live `/model xai-oauth` session
+    # over a persisted ``provider: auto`` is a selection, so the disk value alone is not the answer.
+    main_provider = _normalize_main_runtime(main_runtime).get("provider") or _read_main_provider()
     if not _discovery_chain_allowed(main_provider, task):
         return None, None, ""
     skip_labels = {skip}
@@ -6934,6 +6936,27 @@ def _ladder_credential_rungs(
     return None, first_err
 
 
+def _next_fallback_after_quarantine(
+    task: Optional[str], resolved_provider: str, is_auto: bool, route: _LadderRoute,
+    failed_model: Optional[str], failure_scope: Any,
+) -> Tuple[Optional[Any], Optional[str], str]:
+    """Next candidate after a fallback entry was quarantined mid-request: remaining configured
+    entries (task chain, then main chain on auto) before the discovery chain."""
+    reason = "stale fallback credential"
+    fb = _try_configured_fallback_chain(
+        task, resolved_provider or "auto", reason=reason, failed_model=failed_model,
+        failed_base_url=route.base_info, failure_scope=failure_scope)
+    if fb[0] is None and is_auto:
+        fb = _try_main_fallback_chain(
+            task, resolved_provider or "auto", reason=reason, failed_model=failed_model,
+            failed_base_url=route.base_info, failure_scope=failure_scope)
+    if fb[0] is None:
+        fb = _try_payment_fallback(
+            resolved_provider, task, reason=reason, failed_base_url=route.base_info,
+            failure_scope=failure_scope, main_runtime=route.main_runtime)
+    return fb
+
+
 def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
     """Last rung: other providers (per-task chain; then auto: main fallback chain + discovery
     chain, explicit: main-agent-model net). Returns the response or None.
@@ -6981,23 +7004,23 @@ def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
         if fb_client is None:
             fb_client, fb_model, fb_label = _try_payment_fallback(
                 resolved_provider, task, reason=reason, failed_base_url=route.base_info,
-                failure_scope=_chain_failure_scope)
+                failure_scope=_chain_failure_scope, main_runtime=route.main_runtime)
     elif fb_client is None:
         fb_client, fb_model, fb_label = _try_main_agent_model_fallback(
             resolved_provider, task, reason=reason, failed_model=_chain_failed_model,
             failed_base_url=route.base_info, failure_scope=_chain_failure_scope)
     if fb_client is not None:
-        # Second pass: the candidate credential was stale and quarantined — walk the discovery
-        # chain once more (unhealthy entries are skipped).
+        # Second pass: the candidate credential was stale and quarantined — re-walk the CONFIGURED
+        # chains first (the quarantined entry is now unhealthy and skipped, so later entries get
+        # their turn), then discovery where the selection policy allows it.
         for _pass in range(2):
             _record_route_info(route.route_info, _fallback_provider_from_label(fb_label), fb_model)
             fb_resp = yield _LadderStep("fallback", (fb_client, fb_model, fb_label))
             if fb_resp is not None:
                 return fb_resp
             if _pass == 0:
-                fb_client, fb_model, fb_label = _try_payment_fallback(
-                    resolved_provider, task, reason="stale fallback credential",
-                    failed_base_url=route.base_info, failure_scope=_chain_failure_scope)
+                fb_client, fb_model, fb_label = _next_fallback_after_quarantine(
+                    task, resolved_provider, is_auto, route, _chain_failed_model, _chain_failure_scope)
                 if fb_client is None:
                     break
     # All fallback layers exhausted — one user-visible warning, then re-raise.

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -938,7 +938,8 @@ def detect_provider_for_model(
     skipped and the ladder continues (``None`` = stay on the current provider). Exceptions: the user
     NAMED the provider (``/model nous``), or there is no current provider yet (``auto``) — then the
     first guess is returned so the credential step fails loudly instead of silently ignoring input."""
-    from hermes_cli.models_detect import current_provider_catalog_match, provider_has_credentials
+    from hermes_cli.models_detect import (
+        current_provider_catalog_match, current_provider_owns_vendor, provider_has_credentials)
 
     name = (model_name or "").strip()
     if not name:
@@ -950,6 +951,10 @@ def detect_provider_for_model(
     served = current_provider_catalog_match(name, current_provider)
     if served is not None:
         return (current_provider, served) if served != name else None
+    # Live catalog unavailable or lagging: the vendor's own id on the vendor's first-party provider
+    # is still a selection — an aggregator relisting it is not grounds to switch.
+    if current_provider_owns_vendor(name, current_provider):
+        return None
 
     no_selection = (current_provider or "").strip().lower() in {"", "auto"}
     for candidate in _detection_candidates(name, current_provider):

--- a/hermes_cli/models_detect.py
+++ b/hermes_cli/models_detect.py
@@ -65,7 +65,9 @@ def current_provider_owns_vendor(model_name: str, current_provider: str) -> bool
     vendor = detect_vendor(model_name or "")
     if not vendor:
         return False
-    native = {detect_vendor(mid) for mid in _PROVIDER_MODELS.get(normalized, ())} - {None}
+    # An id the classifier cannot place (Bedrock ``us.anthropic.claude-…``) is evidence the
+    # provider is NOT single-vendor; only a fully classified, single-vendor catalog owns the name.
+    native = {detect_vendor(mid) for mid in _PROVIDER_MODELS.get(normalized, ())}
     return native == {vendor}
 
 

--- a/hermes_cli/models_detect.py
+++ b/hermes_cli/models_detect.py
@@ -44,6 +44,31 @@ def current_provider_catalog_match(model_name: str, current_provider: str) -> Op
         (mid for mid in catalog if "/" in mid and mid.split("/", 1)[1].lower() == wanted), None)
 
 
+def current_provider_owns_vendor(model_name: str, current_provider: str) -> bool:
+    """True when *model_name* belongs to the vendor a single-vendor first-party provider natively
+    serves (``gpt-6-astra`` on ``openai-codex``, ``grok-4.6`` on ``xai-oauth``).
+
+    A first-party session plus that vendor's own id is a selection, not a guess: when the live
+    catalog could not confirm the id (fetch failed, static fallback lags an early-access rollout)
+    the answer is "stay and let the vendor accept or reject it", never "a reseller lists it, so
+    switch there". Aggregators, custom endpoints and multi-vendor resellers (nvidia, alibaba, ...)
+    have no single native vendor and are skipped."""
+    from hermes_cli.model_normalize import detect_vendor
+    from hermes_cli.models import _AGGREGATOR_PROVIDERS, _PROVIDER_MODELS, normalize_provider
+
+    provider = (current_provider or "").strip().lower()
+    if provider in _SKIP or provider.startswith("custom:"):
+        return False
+    normalized = normalize_provider(provider)
+    if normalized in _SKIP or normalized in _AGGREGATOR_PROVIDERS:
+        return False
+    vendor = detect_vendor(model_name or "")
+    if not vendor:
+        return False
+    native = {detect_vendor(mid) for mid in _PROVIDER_MODELS.get(normalized, ())} - {None}
+    return native == {vendor}
+
+
 def provider_has_credentials(provider: str) -> bool:
     """Whether *provider* can be switched to without the user typing a key: env/.env key, auth
     store login, or a usable credential-pool entry. ``custom``/``custom:*`` targets only come out

--- a/tests/agent/test_auxiliary_auto_never_guesses_provider.py
+++ b/tests/agent/test_auxiliary_auto_never_guesses_provider.py
@@ -28,11 +28,29 @@ def nous_is_the_only_working_provider():
         yield
 
 
-def test_selected_main_provider_down_refuses_to_guess_another_account(nous_is_the_only_working_provider):
+@pytest.mark.parametrize("persisted_provider", ["xai-oauth", "auto"])
+def test_selected_main_provider_down_refuses_to_guess_another_account(
+        nous_is_the_only_working_provider, persisted_provider):
+    """The SESSION runtime is the selection: a live `/model xai-oauth` over a persisted
+    ``provider: auto`` must not re-open discovery through the disk value."""
     runtime = {"provider": "xai-oauth", "model": "grok-4.6", "base_url": "https://api.x.ai/v1", "api_key": "dead"}
-    with patch.object(aux, "_read_main_provider", return_value="xai-oauth"):
+    with patch.object(aux, "_read_main_provider", return_value=persisted_provider):
         assert aux._resolve_auto_route(main_runtime=runtime, task="compression") == (None, None, "")
-        assert aux._try_payment_fallback("xai-oauth", task="compression") == (None, None, "")
+        assert aux._try_payment_fallback("xai-oauth", task="compression", main_runtime=runtime) == (None, None, "")
+
+
+def test_quarantined_fallback_hands_over_to_the_next_configured_entry():
+    """A stale first fallback (401, refresh failed) is quarantined mid-request; the second
+    configured entry must still get its turn instead of the request dying on the original error."""
+    healthy = MagicMock(name="second-fallback")
+    route = aux._LadderRoute(None, "compression", "", False, "", "xai-oauth", None, None, None, None, None,
+                             {"provider": "xai-oauth"}, None)
+    with patch.object(aux, "_try_configured_fallback_chain", return_value=(healthy, "m2", "fallback_chain[1](nous)")), \
+         patch.object(aux, "_try_payment_fallback") as discovery:
+        client, model, label = aux._next_fallback_after_quarantine(
+            "compression", "auto", True, route, None, None)
+    assert client is healthy and label == "fallback_chain[1](nous)"
+    discovery.assert_not_called()
 
 
 def test_no_selected_main_provider_still_discovers(nous_is_the_only_working_provider):

--- a/tests/agent/test_auxiliary_auto_never_guesses_provider.py
+++ b/tests/agent/test_auxiliary_auto_never_guesses_provider.py
@@ -1,0 +1,41 @@
+"""``auxiliary.*.provider: auto`` never bills a provider the user did not select.
+
+Regression for the Grok/Nous incident: main provider ``xai-oauth`` with an expired token, Nous
+Portal still logged in from an earlier setup, no ``fallback_providers``. Every compression, title
+and memory-flush call for the Grok conversation fell through to the built-in discovery chain and
+was charged to the Portal balance while the chat visibly stayed on Grok. The discovery chain is
+only for installs that have no selected main provider at all.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import auxiliary_client as aux
+
+
+@pytest.fixture
+def nous_is_the_only_working_provider():
+    """Main provider unusable; Nous would win the discovery chain; no configured fallback policy."""
+    aux._aux_unhealthy_until.clear()
+    with patch.object(aux, "_try_main_provider_route", return_value=None), \
+         patch.object(aux, "_try_configured_fallback_chain", return_value=(None, None, "")), \
+         patch.object(aux, "_try_main_fallback_chain", return_value=(None, None, "")), \
+         patch.object(aux, "_try_openrouter", return_value=(None, None)), \
+         patch.object(aux, "_try_nous", return_value=(MagicMock(name="nous"), "nous-model")):
+        yield
+
+
+def test_selected_main_provider_down_refuses_to_guess_another_account(nous_is_the_only_working_provider):
+    runtime = {"provider": "xai-oauth", "model": "grok-4.6", "base_url": "https://api.x.ai/v1", "api_key": "dead"}
+    with patch.object(aux, "_read_main_provider", return_value="xai-oauth"):
+        assert aux._resolve_auto_route(main_runtime=runtime, task="compression") == (None, None, "")
+        assert aux._try_payment_fallback("xai-oauth", task="compression") == (None, None, "")
+
+
+def test_no_selected_main_provider_still_discovers(nous_is_the_only_working_provider):
+    with patch.object(aux, "_read_main_provider", return_value="auto"):
+        client, model, label = aux._resolve_auto_route(main_runtime={"provider": "auto"}, task="compression")
+    assert client is not None and (model, label) == ("nous-model", "nous")

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1596,10 +1596,12 @@ class TestTryPaymentFallback:
         _aux_unhealthy_logged_at.clear()
 
     def test_skips_failed_provider(self):
+        """Discovery only walks with no selected main provider (``auto``); a selected provider that
+        fails never hops to another logged-in account (test_auxiliary_auto_never_guesses_provider)."""
         mock_client = MagicMock()
         with patch("agent.auxiliary_client._try_openrouter", return_value=(None, None)), \
              patch("agent.auxiliary_client._try_nous", return_value=(mock_client, "nous-model")), \
-             patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"):
+             patch("agent.auxiliary_client._read_main_provider", return_value="auto"):
             client, model, label = _try_payment_fallback("openrouter", task="compression")
         assert client is mock_client
         assert model == "nous-model"
@@ -1617,7 +1619,7 @@ class TestTryPaymentFallback:
              patch("agent.auxiliary_client._try_nous", return_value=(None, None)), \
              patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
              patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)), \
-             patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"):
+             patch("agent.auxiliary_client._read_main_provider", return_value="auto"):
             client, model, label = _try_payment_fallback("openrouter")
         assert client is None
         assert model is None
@@ -4168,7 +4170,7 @@ class TestAuxUnhealthyCache:
         # Mark BOTH the failed provider (openrouter) and a sibling (custom)
         # unhealthy. The chain should still find nous.
         _mark_provider_unhealthy("local/custom")
-        with patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"), \
+        with patch("agent.auxiliary_client._read_main_provider", return_value="auto"), \
              patch("agent.auxiliary_client._try_openrouter") as or_try, \
              patch("agent.auxiliary_client._try_nous", return_value=(nous_client, "n-model")), \
              patch("agent.auxiliary_client._try_custom_endpoint") as custom_try, \

--- a/tests/hermes_cli/test_models_detect_vendor_ownership.py
+++ b/tests/hermes_cli/test_models_detect_vendor_ownership.py
@@ -1,0 +1,35 @@
+"""A first-party session never re-routes its own vendor's model when the live catalog cannot vouch.
+
+Second half of the Astra incident (#97487): the live-catalog guard only helps when the fetch
+succeeds. A transient Codex outage, or a static fallback that lags an early-access rollout, left
+``/model gpt-6-astra`` on ``openai-codex`` walking the ladder to OpenRouter (which relists every
+vendor) and silently rebuilding the session on a metered aggregator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import models, models_detect
+
+
+@pytest.fixture
+def ladder_would_hijack(monkeypatch):
+    """Live catalog unavailable; OpenRouter lists everything; the user holds an OpenRouter key."""
+    monkeypatch.setattr(models, "cached_provider_model_ids", lambda provider, **_: [])
+    monkeypatch.setattr(models, "_find_openrouter_slug", lambda name: f"vendor/{name}")
+    monkeypatch.setattr(models_detect, "provider_has_credentials", lambda p: p == "openrouter")
+
+
+@pytest.mark.parametrize("provider,model", [
+    ("openai-codex", "gpt-6-astra"),
+    ("xai-oauth", "grok-5-preview"),
+    ("anthropic", "claude-opus-5-early"),
+])
+def test_own_vendor_id_stays_when_live_catalog_is_empty(ladder_would_hijack, provider, model):
+    assert models.detect_provider_for_model(model, provider) is None
+
+
+def test_other_vendor_id_still_remaps_to_keyed_aggregator(ladder_would_hijack):
+    assert models.detect_provider_for_model("claude-opus-4.7", "openai-codex") == (
+        "openrouter", "vendor/claude-opus-4.7")

--- a/tests/hermes_cli/test_models_detect_vendor_ownership.py
+++ b/tests/hermes_cli/test_models_detect_vendor_ownership.py
@@ -30,6 +30,10 @@ def test_own_vendor_id_stays_when_live_catalog_is_empty(ladder_would_hijack, pro
     assert models.detect_provider_for_model(model, provider) is None
 
 
-def test_other_vendor_id_still_remaps_to_keyed_aggregator(ladder_would_hijack):
-    assert models.detect_provider_for_model("claude-opus-4.7", "openai-codex") == (
-        "openrouter", "vendor/claude-opus-4.7")
+@pytest.mark.parametrize("provider,model", [
+    ("openai-codex", "claude-opus-4.7"),   # other vendor's id on a single-vendor provider
+    ("bedrock", "deepseek-v4-pro"),        # multi-vendor catalog whose non-deepseek ids the
+                                           # classifier cannot place: never "exclusively deepseek"
+])
+def test_non_owned_id_still_remaps_to_keyed_aggregator(ladder_would_hijack, provider, model):
+    assert models.detect_provider_for_model(model, provider) == ("openrouter", f"vendor/{model}")

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -73,7 +73,7 @@ Click **Show auxiliary** to reveal the 11 task slots:
 
 ![Auxiliary panel expanded](/img/docs/dashboard-models/auxiliary-expanded.png)
 
-Every auxiliary task defaults to `auto` — meaning Hermes tries your main model for that job too. If that route is unavailable or hits a capacity-style failure, `auto` follows any task-specific `auxiliary.<task>.fallback_chain`, then the main `fallback_providers` / `fallback_model` chain, then Hermes' built-in auxiliary discovery chain. Override a specific task when you want a cheaper or faster model for a side-job.
+Every auxiliary task defaults to `auto` — meaning Hermes tries your main model for that job too. If that route is unavailable or hits a capacity-style failure, `auto` follows any task-specific `auxiliary.<task>.fallback_chain`, then the main `fallback_providers` / `fallback_model` chain. It never guesses a provider you did not configure: with a main provider selected and no fallback declared, the side task is skipped with a warning rather than billed to another account you happen to be logged into. (Hermes' built-in discovery chain only runs when no main provider is selected at all.) Override a specific task when you want a cheaper or faster model for a side-job.
 
 ### Common override patterns
 
@@ -163,7 +163,7 @@ auxiliary:
         model: inclusionai/ring-2.6-1t:free
 ```
 
-When `fallback_chain` is absent, `auto` uses the top-level `fallback_providers` chain before the built-in auxiliary discovery chain.
+When `fallback_chain` is absent, `auto` uses the top-level `fallback_providers` chain. If that is also absent and the main provider cannot serve the call, the task is skipped with a warning — Hermes does not fall through to other logged-in providers.
 
 ## Per-provider request options
 

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -214,11 +214,11 @@ Hermes uses separate lightweight models for side tasks. Each task has its own pr
 
 ### Auto-Detection Chain
 
-When a task's provider is set to `"auto"` (the default), Hermes first tries the main provider + main model for that auxiliary task. If that route is unavailable or later fails with a capacity-style error, Hermes now honors user-configured fallback policy before using the built-in discovery chain:
+When a task's provider is set to `"auto"` (the default), Hermes first tries the main provider + main model for that auxiliary task. If that route is unavailable or later fails with a capacity-style error, Hermes follows your configured fallback policy and then stops:
 
 ```text
 Main provider + main model → auxiliary.<task>.fallback_chain →
-fallback_providers / fallback_model → built-in auxiliary discovery chain
+fallback_providers / fallback_model → skip the task (warn)
 ```
 
 A billing or quota failure quarantines only the failed custom endpoint for the auxiliary health cooldown, not every route registered as `custom`. A healthy local endpoint with a different base URL remains eligible for fallback and subsequent auto routing. Aliases for the same custom endpoint share its health state. Built-in providers retain their shared-account health checks.
@@ -239,7 +239,7 @@ Main provider (if vision-capable) → OpenRouter → Nous Portal →
 Codex OAuth → Anthropic → Custom endpoint → give up
 ```
 
-Those built-in chains are a convenience fallback for users who have not declared a task-specific or main fallback policy.
+Those built-in chains run **only when no main provider is selected** (`model.provider: auto` or unset). Once you have picked a main provider, an unavailable main route with no `fallback_chain` / `fallback_providers` skips the auxiliary task with a warning instead of guessing another provider you happen to be logged into — an expired xAI or Codex session must never bill your Nous Portal or OpenRouter balance behind your back. Declare a fallback if you want one.
 
 ### Configuring Auxiliary Providers
 
@@ -269,7 +269,7 @@ auxiliary:
     model: ""
 ```
 
-Every task above follows the same **provider / model / base_url** pattern. Each task can also declare its own `fallback_chain`; if omitted, `provider: auto` uses the top-level `fallback_providers` chain before Hermes' built-in auxiliary discovery chain.
+Every task above follows the same **provider / model / base_url** pattern. Each task can also declare its own `fallback_chain`; if omitted, `provider: auto` uses the top-level `fallback_providers` chain (the built-in discovery chain applies only when no main provider is selected).
 
 Context compression is configured under `auxiliary.compression`:
 


### PR DESCRIPTION
Auto-routing no longer lands a session, or its side tasks, on a provider the user did not select — closing both halves of this week's "Hermes billed the wrong account" reports.

## Two incidents, one class

| Report | Path | Root cause on `origin/main` (49ef015) | After |
|---|---|---|---|
| Wolfram: `/model gpt-6-astra` on a Codex sub switched to metered OpenRouter ($100) | `/model` switch | Live-catalog guard (#215fd0ecb9a) only helps when the fetch succeeds; a Codex outage / cold cache looks identical to "not served", so the ladder walked to OpenRouter (relists every vendor) whenever an OpenRouter key existed | Own-vendor id on that vendor's first-party provider = a selection; stay, let the vendor accept/reject |
| Ayush: using Grok on his X Premium+ sub, Nous Portal balance kept draining; restart / re-login to X did nothing | auxiliary `auto` | Main `xai-oauth` token dead → no `fallback_providers` → built-in discovery chain (OpenRouter → **Nous** → custom → api-key) ran every compression/title/memory-flush on whichever *other* account was still logged in, while the chat visibly stayed on Grok | Discovery chain only runs when **no main provider is selected**; otherwise main → `fallback_chain` → `fallback_providers` → refuse with a warning naming the dead provider |

Same rule both places (matches the standing ruling): an auto-picked provider is a guess, and a guess is only actionable when the user configured it. Possessing a credential is not selecting a provider.

## Changes

- `agent/auxiliary_client.py` — `_discovery_chain_allowed(main_provider, task)` gates both discovery entry points: the resolve-time route (`_resolve_auto_route`) and the mid-request 401/402/429 hop (`_try_payment_fallback`). `provider: auto` / unset keeps discovery. Warning text names the provider and the fix (`hermes model` or declare a fallback).
- `hermes_cli/models_detect.py::current_provider_owns_vendor` + one early return in `detect_provider_for_model` — single-vendor first-party providers (openai-codex, xai-oauth, anthropic, deepseek, …) keep their own vendor's ids. Aggregators, `custom*`, and multi-vendor resellers (nvidia, alibaba, opencode-*) are excluded, so `/model claude-opus-4.7` on Codex with an OpenRouter key still remaps as before. All 6 `detect_provider_for_model` callers (CLI/gateway `/model`, ACP, oneshot, dashboard Model field) go through this choke point.
- Docs: `configuring-models.md`, `features/fallback-providers.md` — the `auto` ladder now ends in "skip + warn", discovery is documented as no-selection-only.
- Tests: 2 invariants per fix (`tests/agent/test_auxiliary_auto_never_guesses_provider.py`, `tests/hermes_cli/test_models_detect_vendor_ownership.py`), proven red on base (4/6 fail on `origin/main` source; the 2 controls asserting legit paths pass on both). Three existing chain tests that pinned the hop now pin `provider=auto`, the one case where discovery remains the contract.

## Validation

**Live repro (in-process, temp `HERMES_HOME`, all `*_API_KEY` popped, catalogs pinned):**

```
/model gpt-6-astra on openai-codex, codex catalog EMPTY, OR key     before: openrouter  after: openai-codex
/model grok-5-new  on xai-oauth,   xai catalog EMPTY,   OR key      before: openrouter  after: xai-oauth
/model claude-opus-4.7 on openai-codex, OR key (cross-vendor)       before: openrouter  after: openrouter   (unchanged, wanted)
aux compression, main=xai-oauth dead, nous logged in, no fallback   before: nous        after: refuse + warn
aux compression, same + fallback_providers=[nous]                   before: nous        after: nous        (declared → allowed)
aux compression, provider=auto (no selection), nous logged in       before: nous        after: nous        (discovery kept)
```

E2E through public entry points (`get_text_auxiliary_client`, `switch_model`) with purged `sys.modules`: 5/5 assertions pass. Suites: `tests/agent/test_auxiliary_client.py` 204/204; 14 routing/aux/switch files 589 passed, 0 failed. ruff, windows-footguns, compat-pointers, `git diff --check` clean.

## Related

- Fixes #54684 (Codex timeout → aux hops to Gemini it has no valid key for — same class, same gate). Credit @westkite1201 (#59514) for the earlier opt-in-gate attempt at this; this PR makes the safe behavior the default rather than a flag.
- Follows #215fd0ecb9a / #2466684db54 (live-catalog + credential gates), which this completes for the empty-catalog case.
- Public reports: @WolframRvnwlf (X, `/model gpt-6-astra` → OpenRouter, v2026.9.7), @AyushSin164510 (X, Grok sub → Nous balance).

## Infographic

![Auto-routing never bills an account you did not pick](https://v3b.fal.media/files/b/0aa9dde5/MCnKBtDa_tKj_oMAsJvH3_xMFvkCmg.png)
