### PR TITLE
fix(gateway): preserve structured voice transcription provenance

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1680,6 +1680,10 @@ def merge_pending_message_event(pending_messages: Dict[str, MessageEvent], sessi
         # side. Captions merge in every absorbing case.
         if both_photo or existing.media_urls or incoming_has_media:
             if both_photo or incoming_has_media:
+                from gateway.transcription_metadata import media_source_message_ids
+                existing.media_source_message_ids = (
+                    media_source_message_ids(existing) + media_source_message_ids(event)
+                )
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
                 existing.media_text_inlined.extend(incoming_inline_flags)
@@ -1691,6 +1695,7 @@ def merge_pending_message_event(pending_messages: Dict[str, MessageEvent], sessi
                 existing.message_type = event.message_type
             # Drop the *derived* STT cache (event changed); the echo ledger must survive or
             # notes echo twice.
+            existing.metadata.pop("audio_transcriptions", None)
             for attr in ("_gateway_pending_stt_text", "_gateway_pending_stt_transcripts"):
                 if hasattr(existing, attr):
                     delattr(existing, attr)

--- a/gateway/platforms/event.py
+++ b/gateway/platforms/event.py
@@ -87,6 +87,10 @@ class MessageEvent:
     # Process-local admission receipt, never routing metadata or execution acknowledgement.
     _gateway_accepted: bool = field(default=False, init=False, repr=False, compare=False)
 
+    # Original platform message IDs aligned with media_urls after a pending merge.
+    # Empty on a fresh event; missing IDs stay None rather than being synthesized.
+    media_source_message_ids: List[Optional[str]] = field(default_factory=list)
+
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""
         return self.allow_gateway_control and (self.text or "").lstrip().startswith("/")

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -898,6 +898,7 @@ class GatewayBusySessionMixin:
                 media_urls=list(getattr(event, "media_urls", []) or []),
                 media_types=list(getattr(event, "media_types", []) or []),
                 media_text_inlined=list(getattr(event, "media_text_inlined", []) or []),
+                media_source_message_ids=list(event.media_source_message_ids),
                 reply_to_message_id=event.reply_to_message_id, reply_to_text=event.reply_to_text,
                 reply_to_author_id=event.reply_to_author_id,
                 reply_to_author_name=event.reply_to_author_name,

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1413,7 +1413,7 @@ class GatewayInboundMixin:
         self, event: MessageEvent, source: SessionSource, message_text: str, audio_paths: list[str]
     ) -> str:
         message_text, _successful_transcripts = await self._enrich_message_with_transcription(
-            message_text, audio_paths,
+            message_text, audio_paths, event=event,
         )
         # Echo each successful transcript back immediately when configured so users can verify STT
         # quality in real time. On transcription failure do NOT send a hardcoded notice: that
@@ -1925,7 +1925,7 @@ class GatewayInboundMixin:
         agent_path = to_agent_visible_cache_path(os.path.abspath(path))
         return f"[voice message could not be transcribed automatically; the audio is available at: {agent_path}]"
 
-    async def _transcribe_one_clip(self, path: str, transcribe_audio, transcribe_audio_local_fallback) -> Tuple[Optional[str], str]:
+    async def _transcribe_one_clip(self, path: str, transcribe_audio, transcribe_audio_local_fallback, *, evidence=None) -> Tuple[Optional[str], str]:
         """``(transcript_or_None, note)`` for one clip via configured STT with local fallback."""
         result = await asyncio.to_thread(transcribe_audio, path, None, "gateway")
         if not result.get("success"):
@@ -1933,6 +1933,8 @@ class GatewayInboundMixin:
             if fallback.get("success"):
                 logger.info("Configured STT failed for %s; recovered with local STT", path)
                 result = fallback
+                if evidence is not None:
+                    evidence["method"] = "local_fallback"
         if not result["success"]:
             logger.info("Voice transcription failed for %s: %s", path, result.get("error", "unknown error"))
             return None, self._untranscribed_audio_note(path)
@@ -1941,6 +1943,8 @@ class GatewayInboundMixin:
         # empty quotes make the agent reply to nothing and can loop, so emit a sentinel note.
         # See #41603.
         if not (transcript or "").strip():
+            if evidence is not None:
+                evidence["status"] = "empty"
             return None, (
                 "[The user sent a voice message but it came through "
                 "empty or inaudible — speech-to-text returned no "
@@ -1949,19 +1953,25 @@ class GatewayInboundMixin:
             )
         # Plain quoted line: a "The user sent a voice message..." wrapper read as a meta-instruction
         # and made the LLM comment on voice mode instead.
+        if evidence is not None:
+            evidence.update(status="transcribed", transcript=transcript)
         return transcript, f'"{transcript}"'
 
     async def _enrich_message_with_transcription(
-        self, user_text: str, audio_paths: List[str]
+        self, user_text: str, audio_paths: List[str], *, event: Optional[MessageEvent] = None,
     ) -> tuple[str, List[str]]:
         """Transcribe voice clips with the configured STT provider and prepend the transcripts →
         ``(enriched_text, successful_transcripts)``; the transcripts (input order; empty if every clip
         failed or STT is disabled) let callers echo them back before the agent loop."""
         from gateway.run import _probe_audio_duration
+        from gateway.transcription_metadata import transcription_evidence
         audio_paths = list(dict.fromkeys(audio_paths))
+        evidence = transcription_evidence(event, audio_paths) if event is not None else [None] * len(audio_paths)
         if not getattr(self.config, "stt_enabled", True):
             notes = []
-            for path in audio_paths:
+            for path, record in zip(audio_paths, evidence):
+                if record is not None:
+                    record.update(status="disabled", method=None)
                 abs_path = os.path.abspath(path)
                 duration_str = await _probe_audio_duration(abs_path)
                 suffix = f" (duration: {duration_str})" if duration_str else ""
@@ -1978,11 +1988,11 @@ class GatewayInboundMixin:
 
         enriched_parts = []
         successful_transcripts: List[str] = []
-        for path in audio_paths:
+        for path, record in zip(audio_paths, evidence):
             try:
                 logger.debug("Transcribing user voice: %s", path)
                 transcript, note = await self._transcribe_one_clip(
-                    path, transcribe_audio, transcribe_audio_local_fallback,
+                    path, transcribe_audio, transcribe_audio_local_fallback, evidence=record,
                 )
                 if transcript is not None:
                     successful_transcripts.append(transcript)
@@ -2014,7 +2024,7 @@ class GatewayInboundMixin:
         if not audio_paths:
             return user_text if user_text is not None else (getattr(event, "text", None) or None), []
         text = user_text if user_text is not None else (getattr(event, "text", "") or "")
-        enriched_text, successful_transcripts = await self._enrich_message_with_transcription(text, audio_paths)
+        enriched_text, successful_transcripts = await self._enrich_message_with_transcription(text, audio_paths, event=event)
         event._gateway_pending_stt_text = enriched_text
         event._gateway_pending_stt_transcripts = list(successful_transcripts)
         return enriched_text, successful_transcripts

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -29,6 +29,7 @@ from gateway.session import (
 )
 from gateway.session_transcript import TranscriptReadError
 from gateway.turn_context import TurnContext
+from gateway.transcription_metadata import user_display_metadata
 from gateway.turn_lease import DEFAULT_LEASE_WAIT, TurnLeaseTimeoutError
 from hermes_constants import get_hermes_home_override
 from pathlib import Path
@@ -1610,8 +1611,8 @@ class GatewayTurnMixin:
         }
         if prepared.persist_user_display_kind:
             _user_entry["display_kind"] = prepared.persist_user_display_kind
-        if prepared.persistence_owner:
-            _user_entry["display_metadata"] = {"gateway_input_owner": prepared.persistence_owner}
+        if metadata := user_display_metadata(event, persistence_owner=prepared.persistence_owner):
+            _user_entry["display_metadata"] = metadata
         if getattr(event, "message_id", None):
             _user_entry["message_id"] = str(event.message_id)
         return _user_entry
@@ -1969,7 +1970,7 @@ class GatewayTurnMixin:
                 persist_user_message=prepared.persist_user_message,
                 persist_user_timestamp=prepared.persist_user_timestamp,
                 persist_user_display_kind=prepared.persist_user_display_kind,
-                persist_user_display_metadata={"gateway_input_owner": prepared.persistence_owner},
+                persist_user_display_metadata=user_display_metadata(event, persistence_owner=prepared.persistence_owner),
                 message_type=event.message_type,
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
@@ -3514,6 +3515,7 @@ class GatewayTurnMixin:
             run_generation=run_generation, _interrupt_depth=_interrupt_depth + 1,
             event_message_id=next_message_id, inbound_message_id=next_inbound_id,
             channel_prompt=next_channel_prompt, message_type=next_message_type,
+            persist_user_display_metadata=user_display_metadata(pending_event),
         )
         merged = _preserve_queued_followup_history_offset(result, followup_result)
         # The TERMINAL turn of the chain owns the ledger identity for the outer final send, which

--- a/gateway/transcription_metadata.py
+++ b/gateway/transcription_metadata.py
@@ -1,0 +1,38 @@
+"""Gateway-owned STT evidence, separate from the text sent to the model."""
+
+from copy import deepcopy
+
+
+def media_source_message_ids(event):
+    """Keep original message identities when pending attachment events merge."""
+    paths = event.media_urls
+    origins = list(event.media_source_message_ids)
+    return origins + [event.message_id] * (len(paths) - len(origins))
+
+
+def transcription_evidence(event, paths):
+    origins = media_source_message_ids(event)
+    records = []
+    for path in paths:
+        index = event.media_urls.index(path)
+        records.append({
+            "media_index": index,
+            "source_path": path,
+            "source_message_id": origins[index],
+            "kind": "audio_transcript",
+            "status": "failed",
+            "method": "configured",
+            # Completion is not a calibrated measure of recognition accuracy.
+            "confidence": None,
+        })
+    event.metadata["audio_transcriptions"] = records
+    return records
+
+
+def user_display_metadata(event, *, persistence_owner=None):
+    metadata = {}
+    if persistence_owner:
+        metadata["gateway_input_owner"] = persistence_owner
+    if event is not None and event.metadata.get("audio_transcriptions"):
+        metadata["audio_transcriptions"] = deepcopy(event.metadata["audio_transcriptions"])
+    return metadata

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -256,7 +256,7 @@ class TestBusySessionAck:
         await runner._handle_active_session_busy_message(event, sk)
 
         runner._enrich_message_with_transcription.assert_awaited_once_with(
-            "", ["/tmp/follow-up.ogg"]
+            "", ["/tmp/follow-up.ogg"], event=event,
         )
         agent.steer.assert_called_once()
         injected = agent.steer.call_args.args[0]
@@ -517,5 +517,4 @@ class TestLongRunningNotificationOwnership:
         assert runner._should_emit_long_running_notification(
             "sess", original_agent, executor_task=None
         ) is False
-
 

--- a/tests/gateway/test_voice_transcription_provenance.py
+++ b/tests/gateway/test_voice_transcription_provenance.py
@@ -1,0 +1,101 @@
+"""STT origin survives gateway preparation without changing model-facing text."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.turn_context import _stage_turn_user_message
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import merge_pending_message_event
+from gateway.platforms.event import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _runner():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True, stt_echo_transcripts=False)
+    runner.adapters = {}
+    runner._model = "synthetic-model"
+    runner._base_url = ""
+    return runner
+
+
+def _event(path, message_id):
+    return MessageEvent(
+        text="", message_type=MessageType.VOICE,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="synthetic-room", chat_type="dm"),
+        message_id=message_id, media_urls=[str(path)], media_types=["audio/ogg"],
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pending", [False, True])
+@pytest.mark.parametrize("outcome", ["configured", "fallback", "empty", "failed"])
+async def test_prepared_voice_keeps_origin_and_text_contract(tmp_path, pending, outcome):
+    runner = _runner()
+    event = _event(tmp_path / "clip.ogg", "voice-17")
+    transcript = "The observatory booking is Friday at seven."
+    success = {"success": True, "transcript": transcript}
+    configured = success if outcome == "configured" else (
+        {"success": True, "transcript": " "} if outcome == "empty" else {"success": False}
+    )
+    fallback = success if outcome == "fallback" else {"success": False}
+    with patch("tools.transcription_tools.transcribe_audio", return_value=configured) as stt, patch(
+        "tools.transcription_tools.transcribe_audio_local_fallback", return_value=fallback,
+    ):
+        if pending:
+            await runner._transcribe_pending_audio_event_once(event)
+        text = await runner._prepare_inbound_message_text(event=event, source=event.source, history=[])
+        stt.assert_called_once()
+    record, = event.metadata["audio_transcriptions"]
+    assert record["source_path"] == event.media_urls[0]
+    assert record["source_message_id"] == event.message_id
+    assert record["confidence"] is None
+    assert record["kind"] == "audio_transcript"
+    if outcome in {"configured", "fallback"}:
+        assert text == f'"{transcript}"'
+        assert record["transcript"] == transcript
+        assert record["status"] == "transcribed"
+        assert record["method"] == ("local_fallback" if outcome == "fallback" else "configured")
+    else:
+        assert "transcript" not in record
+        assert record["status"] == ("empty" if outcome == "empty" else "failed")
+        assert transcript not in text
+
+    from gateway.transcription_metadata import user_display_metadata
+
+    metadata = user_display_metadata(event, persistence_owner="test-owner")
+    row, _ = _stage_turn_user_message(SimpleNamespace(), text, text, 123.0, event.message_id, None, metadata)
+    prepared = SimpleNamespace(persist_user_message=text, message_text=text, persist_user_timestamp=123.0,
+                               persist_user_display_kind=None, persistence_owner="test-owner")
+    failure_row = runner._hmwa_user_transcript_entry(event, prepared, 124.0)
+    assert row["content"] == failure_row["content"] == text
+    assert row["display_metadata"] == failure_row["display_metadata"] == metadata
+    event.metadata["audio_transcriptions"].clear()
+    assert row["display_metadata"]["audio_transcriptions"] == [record]
+
+
+@pytest.mark.asyncio
+async def test_merged_pending_clips_keep_their_own_origins(tmp_path):
+    runner = _runner()
+    first = _event(tmp_path / "first.ogg", "voice-1")
+    second = _event(tmp_path / "second.ogg", "voice-2")
+    queue = {"session-a": first}
+    with patch("tools.transcription_tools.transcribe_audio", side_effect=lambda path, *_: {
+        "success": True, "transcript": "Morning" if path == first.media_urls[0] else "Evening",
+    }) as stt:
+        await runner._transcribe_pending_audio_event_once(first)
+        merge_pending_message_event(queue, "session-a", second)
+        assert "audio_transcriptions" not in first.metadata
+        text, _ = await runner._transcribe_pending_audio_event_once(first)
+        replay, _ = await runner._transcribe_pending_audio_event_once(first)
+        assert stt.call_count == 3  # existing pending-merge behavior reprocesses the changed event
+    records = first.metadata["audio_transcriptions"]
+    assert [(r["source_message_id"], r["source_path"], r["transcript"]) for r in records] == [
+        ("voice-1", str(tmp_path / "first.ogg"), "Morning"),
+        ("voice-2", str(tmp_path / "second.ogg"), "Evening"),
+    ]
+    assert text == replay == '"Morning"\n\n"Evening"'
+    assert "audio_transcriptions" not in second.metadata

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -72,6 +72,31 @@ entry point at a package rather than a single module if you ship either.
 
 ## The MemoryProvider ABC
 
+### Gateway audio evidence
+
+Gateway voice preprocessing preserves optional clip evidence in the accepted
+user row's `display_metadata.audio_transcriptions` list. The normal turn,
+queued follow-up and transient-failure persistence paths retain this metadata.
+It is not appended to the model prompt, transcript text or transcript echo.
+
+Each entry contains `media_index`, `source_path`, `source_message_id`,
+`kind: "audio_transcript"`, `status`, `method` and `confidence`. Successful,
+nonempty results also contain `transcript`. Status is `transcribed`, `empty`,
+`failed` or `disabled`. Method is `configured`, `local_fallback` when recovery
+succeeded, or null when STT is disabled. Confidence is null: successful STT
+does not establish recognition accuracy. Failed entries do not carry error
+strings or invented speech. Source paths are cached attachment references,
+not a guarantee that the original file remains available.
+
+Pending-event merges preserve each clip's original platform message ID, if
+available, instead of assigning the first message's ID to every clip. The
+changed event invalidates its prior STT evidence together with its text cache.
+The owning event/session still supplies scope; clip IDs do not grant access
+to another conversation. Providers should retain the derived nature of STT
+text, tolerate missing fields on older rows, and avoid exporting local paths
+or interpreting metadata as instructions. This does not reconstruct origins
+for transcripts stored before this metadata existed.
+
 Your plugin implements the `MemoryProvider` abstract base class from `agent/memory_provider.py`:
 
 ```python


### PR DESCRIPTION
## What does this PR do?

A successfully transcribed gateway voice clip becomes an ordinary quoted user message. Memory providers and transcript consumers then cannot distinguish that derivative from typed text or associate merged clips with their original messages.

Preserve gateway-owned audio evidence in optional `display_metadata.audio_transcriptions`, without changing user/model prompt text, transcript echoes, acknowledgment timing or STT selection. Each record identifies its clip and original message, derivative kind, completion state and configured/local-fallback route. Confidence remains unknown rather than inferred from successful completion.

## Related Issue

Related to #17762 by @river-morgan, whose review identified the prompt-free structured-metadata direction. This is a separate, narrower follow-up: no acknowledgment or prompt rewrite. #100991 proposes a text-transforming `post_transcription` hook; this change does not add that hook and also covers pending clips, failed/empty results and local fallback.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Preserve original per-clip message IDs when pending attachments merge; invalidate derived evidence with the existing STT cache.
- Carry evidence through normal, queued and transient-failure transcript persistence paths.
- Document the optional provider surface and its limits. Existing rows are not backfilled and completion is not recognition accuracy.

## How to Test

Run the canonical `scripts/run_tests.sh` with these files:

- `tests/gateway/test_voice_transcription_provenance.py`
- `tests/gateway/test_stt_config.py`
- `tests/gateway/test_busy_session_ack.py`
- `tests/gateway/test_telegram_audio_vs_voice.py`
- `tests/gateway/test_queued_native_image_session_key.py`
- `tests/gateway/test_pending_drain_no_recursion.py`

31 focused tests passed with file retries disabled. The new nine parameterized cases fail on unchanged base `67764dc0863349a384c16425e73ee8571f3a94b7` because `audio_transcriptions` is absent. They exercise actual gateway preparation/merge and native row building, with only the STT backend replaced by synthetic results. They do not validate real audio decoding, model responses or external channel delivery. Changed-file Ruff and diff whitespace checks passed.

The isolated dependency resolution honored the repository's existing uv age policy and package-specific pins; no manifest or exception changed. A hash-locked dependency audit is **not clean**: existing dev pins `httpcore2==2.7.0` and `httpx2==2.7.0` report PYSEC-2026-3844 through PYSEC-2026-3849 (six findings). These unchanged dependencies remain outside this patch; no finding was ignored. Full repository secret scanning could not complete under the credential file protection profile; a tracked, changed-file, filename-only heuristic scan completed with no matches.

## Checklist

- [x] Read the contributing guide and searched existing work.
- [x] Conventional commit; only changes related to this behavior.
- [x] Added behavioral regression coverage and updated provider documentation.
- [x] Tested on macOS with Python 3.13 in an isolated environment.
- [ ] Full repository test suite (only focused suites run).
- [ ] Real audio decoding and external channel end-to-end test.

No production profile, memory, service or credential was changed.
