### PR TITLE
fix(desktop): download Kanban attachments through authenticated gateway

### DIFF
--- a/apps/desktop/src/api/file-download.test.ts
+++ b/apps/desktop/src/api/file-download.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { setApiRequestConnection, setApiRequestProfile } from './client'
+import { captureGatewayFileDownload } from './file-download'
+
+afterEach(() => {
+  setApiRequestConnection(null)
+  setApiRequestProfile(null)
+  vi.unstubAllGlobals()
+})
+
+describe('captured gateway file download', () => {
+  it('reports an unavailable desktop bridge', async () => {
+    vi.stubGlobal('hermesDesktop', {})
+    await expect(captureGatewayFileDownload()('/persisted/file.md', 'file.md')).rejects.toThrow(
+      'Desktop file download bridge is unavailable'
+    )
+  })
+
+  it('rejects an absent stored path before invoking the bridge', async () => {
+    const saveGatewayFile = vi.fn()
+    vi.stubGlobal('hermesDesktop', { saveGatewayFile })
+    await expect(captureGatewayFileDownload()('  ', 'file.md')).rejects.toThrow('Missing gateway file path')
+    expect(saveGatewayFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unsuccessful non-canceled save', async () => {
+    vi.stubGlobal('hermesDesktop', { saveGatewayFile: vi.fn().mockResolvedValue({ saved: false }) })
+    await expect(captureGatewayFileDownload()('/persisted/file.md', 'file.md')).rejects.toThrow('File download failed')
+  })
+
+  it('preserves legacy primary routing instead of inventing a default profile', async () => {
+    const saveGatewayFile = vi.fn().mockResolvedValue({ saved: true })
+    vi.stubGlobal('hermesDesktop', { saveGatewayFile })
+    const download = captureGatewayFileDownload()
+    setApiRequestConnection('remote')
+    setApiRequestProfile('work')
+    await download('/persisted/file.md', 'file.md')
+    expect(saveGatewayFile).toHaveBeenCalledWith({ path: '/persisted/file.md', suggestedName: 'file.md' })
+  })
+
+  it('keeps explicit local ownership even after switching to a remote', async () => {
+    const saveGatewayFile = vi.fn().mockResolvedValue({ canceled: true, saved: false })
+    vi.stubGlobal('hermesDesktop', { saveGatewayFile })
+    setApiRequestConnection('local')
+    setApiRequestProfile('personal')
+    const download = captureGatewayFileDownload()
+    setApiRequestConnection('remote')
+    setApiRequestProfile('work')
+    await expect(download('/persisted/file.md', 'file.md')).resolves.toEqual({ canceled: true, saved: false })
+    expect(saveGatewayFile).toHaveBeenCalledWith({
+      connectionId: 'local',
+      profile: 'personal',
+      path: '/persisted/file.md',
+      suggestedName: 'file.md'
+    })
+  })
+})

--- a/apps/desktop/src/api/file-download.ts
+++ b/apps/desktop/src/api/file-download.ts
@@ -1,0 +1,29 @@
+import { capabilityScoped } from './client'
+
+/** Capture alongside a REST read, never at click time: cached resources belong
+ * to the connection/profile that returned them, not the currently focused chat.
+ * Paths stay on the gateway; only Electron's authenticated save bridge sees them.
+ * An absent connection id preserves legacy profile-pool routing; an explicit
+ * `local` id must not be dropped (the registry primary may be remote).
+ */
+export function captureGatewayFileDownload() {
+  const scope = capabilityScoped()
+
+  return async (path: string, suggestedName: string) => {
+    if (!path?.trim()) {
+      throw new Error('Missing gateway file path')
+    }
+
+    if (!window.hermesDesktop?.saveGatewayFile) {
+      throw new Error('Desktop file download bridge is unavailable')
+    }
+
+    const result = await window.hermesDesktop.saveGatewayFile({ ...scope, path, suggestedName })
+
+    if (!result.saved && !result.canceled) {
+      throw new Error('File download failed')
+    }
+
+    return result
+  }
+}

--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -11,6 +11,7 @@
 
 import {
   atom,
+  captureGatewayFileDownload,
   type PluginOs,
   type PluginRestOptions,
   type PluginStorage,
@@ -172,7 +173,12 @@ export const ORCHESTRATION_KEY = ['kanban', 'orchestration'] as const
 export const fetchBoard = (archived: boolean) =>
   call<KanbanBoard>(withBoard('/board', archived ? { include_archived: 'true' } : {}))
 
-export const fetchTask = (id: string) => call<KanbanTaskDetail>(withBoard(`/tasks/${id}`))
+export const fetchTask = async (id: string) => {
+  const downloadAttachment = captureGatewayFileDownload()
+  const detail = await call<KanbanTaskDetail>(withBoard(`/tasks/${id}`))
+
+  return { ...detail, downloadAttachment }
+}
 
 /** Worker stdout/stderr tail (last 16 KiB — plenty for the drawer). */
 export const fetchLog = (id: string) => call<WorkerLog>(withBoard(`/tasks/${id}/log`, { tail: '16384' }))

--- a/apps/desktop/src/plugins/kanban/drawer.test.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.test.tsx
@@ -63,7 +63,12 @@ beforeEach(() => {
   )
 })
 
-afterEach(() => {
+afterEach(async () => {
+  const { setApiRequestConnection, setApiRequestProfile } = await import('@/api/client')
+  setApiRequestConnection(null)
+  setApiRequestProfile(null)
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
   cleanup()
   client.clear()
   disposeApi()
@@ -80,6 +85,83 @@ function openDrawer() {
 }
 
 describe('task attachment compatibility', () => {
+  it('downloads the persisted attachment through its original remote owner', async () => {
+    const { setApiRequestConnection, setApiRequestProfile } = await import('@/api/client')
+    const save = vi.fn().mockResolvedValue({ saved: true })
+    vi.stubGlobal('hermesDesktop', { saveGatewayFile: save })
+    setApiRequestConnection('remote-owner')
+    setApiRequestProfile('research')
+    detail = {
+      ...legacyDetail,
+      attachments: [{ id: 42, filename: 'report.md', stored_path: '/persisted/attachments/report.md' }]
+    }
+    openDrawer()
+    const download = await screen.findByRole('button', { name: 'Download report.md' })
+    setApiRequestConnection('other-host')
+    setApiRequestProfile('other-profile')
+    fireEvent.click(download)
+    await waitFor(() =>
+      expect(save).toHaveBeenCalledWith({
+        connectionId: 'remote-owner',
+        profile: 'research',
+        path: '/persisted/attachments/report.md',
+        suggestedName: 'report.md'
+      })
+    )
+    setApiRequestConnection(null)
+    setApiRequestProfile(null)
+  })
+
+  it('disables downloads with no persisted path instead of guessing a workspace path', async () => {
+    detail = { ...legacyDetail, attachments: [{ id: 1, filename: 'gone.md' }] }
+    openDrawer()
+    const button = await screen.findByRole('button', { name: 'Download gone.md' })
+    expect((button as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('reports a failed download and allows retry', async () => {
+    const { host } = await import('@hermes/plugin-sdk')
+    const notify = vi.spyOn(host, 'notify')
+    const save = vi.fn().mockRejectedValue(new Error('File not found'))
+    vi.stubGlobal('hermesDesktop', { saveGatewayFile: save })
+    detail = { ...legacyDetail, attachments: [{ id: 1, filename: 'gone.md', stored_path: '/persisted/gone.md' }] }
+    openDrawer()
+    const button = await screen.findByRole('button', { name: 'Download gone.md' })
+    fireEvent.click(button)
+    await waitFor(() => expect(notify).toHaveBeenCalledWith({ kind: 'error', message: 'File not found' }))
+    await waitFor(() => expect((button as HTMLButtonElement).disabled).toBe(false))
+    save.mockResolvedValueOnce({ saved: true })
+    fireEvent.click(button)
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(2))
+    notify.mockRestore()
+  })
+
+  it('disables a pending download and treats save-dialog cancellation quietly', async () => {
+    const { host } = await import('@hermes/plugin-sdk')
+    const notify = vi.spyOn(host, 'notify')
+    let finish!: (value: { saved: boolean; canceled: boolean }) => void
+
+    const save = vi.fn(
+      () =>
+        new Promise(resolve => {
+          finish = resolve
+        })
+    )
+
+    vi.stubGlobal('hermesDesktop', { saveGatewayFile: save })
+    detail = { ...legacyDetail, attachments: [{ id: 1, filename: 'report.md', stored_path: '/persisted/report.md' }] }
+    openDrawer()
+    const button = await screen.findByRole('button', { name: 'Download report.md' })
+    fireEvent.click(button)
+    await waitFor(() => expect((button as HTMLButtonElement).disabled).toBe(true))
+    fireEvent.click(button)
+    expect(save).toHaveBeenCalledOnce()
+    await act(async () => finish({ saved: false, canceled: true }))
+    await waitFor(() => expect((button as HTMLButtonElement).disabled).toBe(false))
+    expect(notify).not.toHaveBeenCalled()
+    notify.mockRestore()
+  })
+
   it.each([{}, { attachments: null }])(
     'keeps older task details usable without attachment controls (%j)',
     async extra => {

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -22,6 +22,7 @@ import {
   LogView,
   Textarea,
   Tip,
+  useI18n,
   useMutation,
   useQuery,
   useQueryClient,
@@ -409,11 +410,41 @@ function DescriptionSection({ body, onSave }: { body: null | string | undefined;
 // administrative note into that slot; hide those (Runs still shows them).
 const isAdminSummary = (summary: string) => /^status changed to \w+ \(dashboard\/direct\)$/.test(summary)
 
+function AttachmentDownload({
+  attachment,
+  onDownload
+}: {
+  attachment: KanbanAttachment
+  onDownload: (path: string, suggestedName: string) => Promise<unknown>
+}) {
+  const { t } = useI18n()
+
+  const download = useMutation({
+    mutationFn: () => onDownload(attachment.stored_path!, attachment.filename),
+    onError: err => host.notify({ kind: 'error', message: errText(err) })
+  })
+
+  return (
+    <Button
+      aria-label={`${t.fileMenu.download} ${attachment.filename}`}
+      disabled={!attachment.stored_path?.trim() || download.isPending}
+      onClick={() => download.mutate()}
+      size="xs"
+      variant="ghost"
+    >
+      <Codicon name={download.isPending ? 'sync' : 'cloud-download'} size="0.75rem" spinning={download.isPending} />
+      {attachment.filename}
+    </Button>
+  )
+}
+
 function AttachmentsSection({
   attachments,
   onUpload,
+  onDownload,
   pending
 }: {
+  onDownload: (path: string, suggestedName: string) => Promise<unknown>
   attachments: KanbanAttachment[]
   onUpload: (file: File) => void
   pending: boolean
@@ -456,8 +487,7 @@ function AttachmentsSection({
         <ul className="flex flex-col gap-1">
           {attachments.map(attachment => (
             <li className="flex items-center gap-1.5 text-[0.75rem] text-(--ui-text-tertiary)" key={attachment.id}>
-              <Codicon name="file" size="0.75rem" />
-              {attachment.filename}
+              <AttachmentDownload attachment={attachment} onDownload={onDownload} />
             </li>
           ))}
         </ul>
@@ -948,6 +978,7 @@ export function TaskDrawer({
             {Array.isArray(detail.attachments) && (
               <AttachmentsSection
                 attachments={detail.attachments}
+                onDownload={detail.downloadAttachment}
                 onUpload={file => uploadMut.mutate(file)}
                 pending={uploadMut.isPending}
               />

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -88,6 +88,7 @@ export interface KanbanEvent {
 export interface KanbanAttachment {
   id: number | string
   filename: string
+  stored_path?: null | string
   size?: null | number
 }
 

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -22,6 +22,8 @@ import { atom, computed, type ReadableAtom } from 'nanostores'
 import type { ReactNode } from 'react'
 
 import { capabilityScoped } from '@/api/client'
+
+export { captureGatewayFileDownload } from '@/api/file-download'
 import { PRIMARY_SESSION_VIEW } from '@/app/chat/session-view'
 import { openSession, type OpenSessionIntent } from '@/app/open-session'
 import type { ClientSessionState } from '@/app/types'

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -45,6 +45,15 @@ plugin, and fail to resolve in a disk plugin). Capability comes in tiers:
   restart the gateway, subscribe to the gateway event stream.
 - **`host.request`** — the gateway JSON-RPC door: sessions, config, skills,
   cron — everything the app itself calls.
+- **`captureGatewayFileDownload()`** — capture a gateway file-save action
+  immediately before starting a REST read, and retain it alongside the returned
+  data. The action `(storedPath, suggestedName) => Promise<{ saved, canceled?, path? }>`
+  keeps that read's connection/profile scope even if the user switches hosts
+  before clicking. Invoke only on an explicit user download gesture, using the
+  backend's persisted file path, never a guessed workspace path. Electron handles
+  authenticated streaming, the native save dialog, and older-gateway fallback;
+  plugins never receive credentials or open remote paths with `file://`.
+  Cancellation resolves quietly; missing bridge/path and failed saves reject.
 - **`ctx.rest` / `ctx.socket`** — your plugin's own backend namespace
   (`/api/plugins/<id>`) if you ship a `plugin_api.py`.
 - **`ui.*`** — the design language: the app's real components, theme variables,


### PR DESCRIPTION
## What does this PR do?

Make Kanban task attachments downloadable in Desktop, including when the file exists only on a remote gateway. On the tested main revision, attachment rows render filenames without an action.

Use the backend-provided `stored_path` and the existing authenticated Electron `saveGatewayFile` bridge. Capture the REST read's connection/profile scope with the task result so a later host/profile switch cannot redirect an explicitly scoped attachment download to the currently selected host. Preserve legacy unscoped routing and explicit local ownership.

## Related Issue

Related #87727 (open attachment support). That proposal opens a canonical `file://` URL through `ctx.os.openExternal`, which is useful for local files but does not transfer remote-gateway bytes to the desktop. This change instead offers an authenticated remote-capable **Download** action with a native save dialog. It overlaps the drawer affordance, but addresses the remote ownership/authentication path rather than duplicating the local-open implementation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `apps/desktop/src/api/file-download.ts`: small SDK action built on the existing scoped native save capability, with missing bridge/path and unsuccessful-save errors.
- `apps/desktop/src/sdk/index.ts`: expose the action to plugins without exposing credentials.
- `apps/desktop/src/plugins/kanban/{api,types,drawer}.ts*`: retain the action with fetched task details, consume persisted attachment paths, and render accessible download buttons. Disable missing paths and repeated pending clicks; cancellation is quiet, errors notify and permit retry.
- Regression tests cover captured remote/local ownership, legacy routing, absent paths/bridge, failures, pending state and cancellation.
- `website/docs/developer-guide/desktop-plugin-sdk.md`: document capture timing and intended usage.

Security: no new transport, raw URL fallback, shell execution, credential access, or gateway permission bypass. Existing native authentication, download streaming, safe destination handling and older-gateway fallback remain authoritative. Paths in tests are synthetic.

## How to Test

1. Connect Desktop to a remote gateway and open a Kanban task with a persisted attachment. On unmodified main, the attachment name has no download control.
2. With this change, activate Download, select a local destination, and verify the saved contents. The file must not need to exist on the desktop or in the original workspace.
3. Check cancellation, missing files/retry, repeated clicks while pending, and connection/profile changes after the task has loaded.

Executed with Node v24.20.0 in an isolated Linux checkout based on `67764dc086`:

```sh
npm run test:ui --workspace apps/desktop -- src/plugins/kanban src/api/file-download.test.ts src/lib/media.remote.test.ts
# 6 files, 72 tests passed
npm run test:desktop:platforms --workspace apps/desktop -- electron/gateway-file-download.test.ts electron/gateway-file-download.fs.test.ts electron/gateway-file-download-transport.test.ts electron/native-auth-decisions.test.ts
# 4 files, 52 tests passed
npm run typecheck --workspace apps/desktop
# renderer, Electron and E2E TypeScript checks passed
npm exec --workspace apps/desktop -- eslint --max-warnings 0 src/api/file-download.ts src/api/file-download.test.ts src/plugins/kanban/api.ts src/plugins/kanban/drawer.tsx src/plugins/kanban/drawer.test.tsx src/plugins/kanban/types.ts src/sdk/index.ts
# passed without warnings
```

The persisted-attachment drawer regression was also run against this main revision's unmodified production files: it failed because `Download report.md` was absent, then passed with the fix restored.

The reporter confirmed an actual macOS arm64 remote-gateway download using the original patch. The rebased patch changes only synthetic test fixtures and lint-required whitespace relative to that original patch; the Mac test was not repeated on this revision. Linux renderer tests mock IPC; existing Electron tests include real-filesystem save coverage. Full Python, graphical Electron E2E, packaged-build, and Windows tests were not run.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing PRs; related local-open work is discussed above.
- [x] Only changes related to this fix are included.
- [ ] I've run `pytest tests/ -q` and all tests pass (not run; Desktop-only change).
- [x] I've added regression tests.
- [x] I've tested on Linux; reporter confirmed the original patch on macOS arm64.

### Documentation & Housekeeping

- [x] Relevant SDK documentation updated.
- [x] Config example updates: N/A, no config changes.
- [x] Architecture/workflow guide updates: N/A; SDK capability documented.
- [x] Cross-platform impact considered; native save behavior is reused.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

Automated results and real-device validation scope are listed above. No private attachment contents, machine identifiers, credentials, or personal paths are included.


Authored with AI assistance (Hermes); reviewed and regression-tested before submission.
