### PR TITLE
fix(gateway): compare the commit, not the ref name, when detecting code skew

### DIFF
--- a/gateway/code_skew.py
+++ b/gateway/code_skew.py
@@ -10,10 +10,15 @@ IO error) the boot snapshot stays ``None`` and detection no-ops — never a fals
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _boot_fingerprint: str | None = None
+
+# A resolved commit id inside a ``git:<ref>:<sha>`` fingerprint. Short and full
+# object names both match; ``unresolved`` (no ref file, no packed-ref) does not.
+_COMMIT_RE = re.compile(r"[0-9a-f]{7,64}")
 
 
 def _fingerprint() -> str | None:
@@ -40,9 +45,29 @@ def _short(fingerprint: str) -> str:
     return sha[:10] if sha and sha != "unresolved" and len(sha) > 10 else (sha or fingerprint)
 
 
+def _commit_id(fingerprint: str) -> str | None:
+    """The commit id inside a ``git:<ref>:<sha>`` fingerprint, or None if unresolved."""
+    sha = fingerprint.rsplit(":", 1)[-1].strip().lower()
+    return sha if _COMMIT_RE.fullmatch(sha) else None
+
+
 def detect_code_skew() -> tuple[str, str] | None:
-    """``(boot_rev, disk_rev)`` short labels if the checkout drifted since boot, else ``None``."""
+    """``(boot_rev, disk_rev)`` short labels if the checkout drifted since boot, else ``None``.
+
+    Identity is the COMMIT, not the ref name: switching branches at the same
+    commit (a checkout between refs, a worktree of the same commit) leaves every
+    file on disk byte-identical, so no lazily-imported module can be stale.
+    Comparing raw fingerprints reported those as skew and blocked the model
+    picker with a "restart required" banner until the next process restart.
+    What is stored is unchanged, so the callers that key on the whole string —
+    the ``__pycache__`` sweep stamp (``hermes_cli.main_web_build``) and the
+    Termux bundled-skill sync key (``_termux_bundled_skills_fingerprint``) —
+    behave exactly as before; only the safety decision narrows here.
+    """
     current = _fingerprint() if _boot_fingerprint is not None else None
     if current is None or current == _boot_fingerprint:
+        return None
+    boot_commit = _commit_id(_boot_fingerprint)
+    if boot_commit is not None and boot_commit == _commit_id(current):
         return None
     return _short(_boot_fingerprint), _short(current)

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -40,6 +40,28 @@ class TestDetectCodeSkew:
         skew = code_skew.detect_code_skew()
         assert skew == ("abc1234567", "def4567890")
 
+    def test_ref_switch_at_the_same_commit_is_not_skew(self, monkeypatch):
+        """Boot on one branch, disk now on another branch of the SAME commit.
+
+        Every file is byte-identical, so nothing can be stale: a raw-fingerprint
+        compare reported this as skew and 503'd ``/api/model/options`` (the
+        Desktop Models page showed a bogus "running old code" banner).
+        """
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:abc1234567890abcdef")
+        code_skew.record_boot_fingerprint()
+
+        monkeypatch.setattr(
+            code_skew, "_fingerprint", lambda: "git:refs/heads/local/topic:abc1234567890abcdef"
+        )
+        assert code_skew.detect_code_skew() is None
+
+    def test_ref_switch_to_a_different_commit_is_skew(self, monkeypatch):
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:aaa1111111111111111")
+        code_skew.record_boot_fingerprint()
+
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/topic:bbb2222222222222222")
+        assert code_skew.detect_code_skew() == ("aaa1111111", "bbb2222222")
+
 
 
 


### PR DESCRIPTION
## Symptom

Switching the checkout to another branch **at the same commit** makes the dashboard refuse the model picker with a restart banner that no restart can clear:

```
2026-09-10 18:28:03 WARNING hermes_cli.web_server: GET /api/model/options refused:
  This process is running code from 6e07eb4838 but the checkout on disk is now 6e07eb4838
```

Both revisions are the same commit — nothing on disk is stale — yet the Model Settings page stays blocked until the process is restarted, and the same guard refuses `/model` in the gateway.

Real drift (`693641aa8b` → `a32ba8cd0c` after a pull) and this false positive are indistinguishable in the message, which is what makes it hard to read.

## Cause

`record_boot_fingerprint()` stores the full `git:<ref>:<sha>` fingerprint and `detect_code_skew()` compared those strings verbatim. A branch switch at one commit (`main` → `local/topic`) changes only the ref name, and the detector treats any string difference as code drift:

```python
if current is None or current == _boot_fingerprint:
    return None
```

## Fix

`detect_code_skew()` decides on the **commit id** when both fingerprints resolve to one — a difference that is not a commit difference is not skew. When either side is `unresolved`, the raw string compare is kept, so an unresolvable revision still invalidates as before instead of being silently muted.

The stored fingerprint is unchanged, so the callers that key on the whole string — the `__pycache__` sweep stamp (`hermes_cli.main_web_build`) and the Termux bundled-skill sync key (`_termux_bundled_skills_fingerprint`) — behave exactly as before. Only the safety decision narrows here.

## Tests

`tests/test_code_skew.py`, two invariant tests:

- a ref switch at the same commit is not skew — **red on base**: reverting only the detector change while keeping the test gives `13 passed, 1 failed` (`test_ref_switch_at_the_same_commit_is_not_skew`)
- a ref switch to a different commit is still reported (guards against over-muting)

`scripts/run_tests.sh tests/test_code_skew.py` → 14 passed, 0 failed, on base `67764dc08`.
