### PR TITLE
fix(tools): humanize DCR redirect_uri rejection (e.g. Gamma) instead of raw 400 dump

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -1162,3 +1162,38 @@ def test_humanize_non_registration_403_passthrough():
         )
         is None
     )
+
+
+def test_humanize_redirect_uri_rejected_400():
+    """DCR providers (e.g. Gamma) that require a public HTTPS redirect_uri reject Hermes' default
+    loopback callback with a 400 before any browser step -- the paste-back fallback in
+    ``_announce_authorization_url`` never gets a chance to run. Regression test for the raw
+    "Registration failed: 400 {...}" dump a headless user saw instead of actionable next steps."""
+    from tools.mcp_oauth import humanize_oauth_registration_error
+
+    msg = humanize_oauth_registration_error(
+        "gamma",
+        RuntimeError(
+            'Registration failed: 400 {"message":"redirect_uri not allowed: '
+            'http://127.0.0.1:27890/callback","error":"Bad Request","statusCode":400}'
+        ),
+        server_url="https://mcp.gamma.app/mcp",
+    )
+    assert msg is not None
+    assert "oauth.redirect_uri" in msg
+    assert "--auth header" in msg
+
+
+def test_humanize_redirect_uri_rejection_does_not_shadow_403_path():
+    """A 403 on a redirect_uri-mentioning message should still take the registration-allowlist
+    branch, not the 400 redirect-rejection branch -- the two conditions are mutually exclusive on
+    the status code, but guard against a future edit collapsing them."""
+    from tools.mcp_oauth import humanize_oauth_registration_error
+
+    msg = humanize_oauth_registration_error(
+        "some-server",
+        RuntimeError("HTTP 403: Forbidden — registration denied for this redirect_uri"),
+        server_url="https://mcp.example.com/mcp",
+    )
+    assert msg is not None
+    assert "pre-approved OAuth clients" in msg

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -949,11 +949,30 @@ def _maybe_preregister_client(storage: "HermesTokenStorage", cfg: dict, client_m
 
 def humanize_oauth_registration_error(
     server_name: str, exc: BaseException | str, *, server_url: str | None = None) -> str | None:
-    """Turn a DCR 403/Forbidden into a useful next step; None for anything else so the caller keeps the
-    original text. Figma gates DCR on exact ``client_name`` (auto-set to ``Claude Code``), so this fires
-    when the user overrode it or an older Hermes is running."""
+    """Turn a DCR 403/Forbidden, or a redirect_uri-rejected 400, into a useful next step; None for
+    anything else so the caller keeps the original text. Figma gates DCR on exact ``client_name``
+    (auto-set to ``Claude Code``), so the 403 branch fires when the user overrode it or an older
+    Hermes is running. The 400 branch fires for providers (e.g. Gamma) whose DCR endpoint requires a
+    publicly reachable HTTPS redirect_uri and rejects Hermes' default loopback callback outright --
+    unlike a loopback the browser merely can't reach (already handled by the paste-back prompt in
+    ``_announce_authorization_url``), registration itself fails before any browser step exists to
+    fall back on, so the raw "redirect_uri not allowed" 400 was the only thing a headless user saw."""
     msg = str(exc)
     lowered = msg.lower()
+
+    looks_like_redirect_rejection = (
+        "redirect_uri" in lowered
+        and ("not allowed" in lowered or "invalid" in lowered)
+        and ("400" in msg or "bad request" in lowered))
+    if looks_like_redirect_rejection:
+        return (
+            f"'{server_name}' rejected Hermes' OAuth redirect_uri during client registration (DCR) — it "
+            "requires a publicly reachable HTTPS callback, which a bare loopback (http://127.0.0.1:<port>) "
+            "can never satisfy, headless or not. Options: configure oauth.redirect_uri to an HTTPS URL you "
+            "control that proxies back to this host (mcp_servers.<name>.oauth.redirect_uri in config.yaml), "
+            "or use the provider's stdio / API-key / header-auth server instead if one exists "
+            f"(hermes mcp add {server_name} --auth header).")
+
     looks_like_registration = ("403" in msg or "forbidden" in lowered) and (
         any(k in lowered for k in ("regist", "dcr", "dynamic client"))
         or lowered.strip() in {"forbidden", "403 forbidden", "http 403: forbidden"}


### PR DESCRIPTION
What & why: hermes mcp login <name> / hermes mcp add --auth oauth dumps a raw Registration failed: 400 {...} when a provider's DCR endpoint requires a publicly reachable HTTPS redirect_uri (e.g. Gamma) — unlike a loopback the browser merely can't reach (already handled by the paste-back prompt), registration itself fails before any browser step exists to recover in. This extends humanize_oauth_registration_error() (same pattern as the existing Figma 403 case) to explain the real constraint and point at oauth.redirect_uri / --auth header as next steps.

How to test: pytest tests/tools/test_mcp_oauth.py -v -k humanize. Repro: hermes mcp add gamma --url https://mcp.gamma.app/mcp --auth oauth on a headless host.

---
> uv run pytest tests/tools/test_mcp_oauth.py -v -k humanize
Uninstalled 19 packages in 97ms
Installed 19 packages in 76ms
========================================================================= test session starts ==========================================================================
platform darwin -- Python 3.11.16, pytest-9.1.1, pluggy-1.6.0 -- /Users/thegaragecorp./www/hermes-agent/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/thegaragecorp./www/hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 61 items / 58 deselected / 3 selected                                                                                                                        

tests/tools/test_mcp_oauth.py::test_humanize_non_registration_403_passthrough PASSED                                                                             [ 33%]
tests/tools/test_mcp_oauth.py::test_humanize_redirect_uri_rejected_400 PASSED                                                                                    [ 66%]
tests/tools/test_mcp_oauth.py::test_humanize_redirect_uri_rejection_does_not_shadow_403_path PASSED     
---

Platforms tested: Linux (Debian 12).