### PR TITLE
fix(desktop): stop unsigned OAuth boot retry loop

### DIFF
--- a/apps/desktop/electron/backend-health.test.ts
+++ b/apps/desktop/electron/backend-health.test.ts
@@ -234,6 +234,20 @@ test('unsigned OAuth is a terminal reauth failure; needsOauthLogin alone is not'
   assert.equal(isReauthRequiredError(new Error('Could not reach the remote Hermes gateway')), false)
 })
 
+test('unsigned OAuth still classifies as reauth when only the message survives', () => {
+  // startHermes latches on isReauthRequiredError. If a wrapper (IPC, pool
+  // catch) copies the message onto a plain Error, the flag is gone — without
+  // a message fallback the boot is treated as transient and retries forever.
+  const wrapped = new Error(
+    'Remote Hermes gateway uses OAuth, but you are not signed in. ' +
+      'Open Settings → Gateway and click "Sign in", or switch back to Local.'
+  )
+
+  assert.equal((wrapped as any).isReauthRequired, undefined)
+  assert.equal(isReauthRequiredError(wrapped), true)
+  assert.equal(isReauthRequiredError(new Error('Your remote gateway session has expired. Open Settings → Gateway and click "Sign in" again.')), true)
+})
+
 test('a credentialed 403 is also a terminal reauth failure', async () => {
   await assert.rejects(
     waitForHermesReady('https://gateway.example', {

--- a/apps/desktop/electron/backend-health.ts
+++ b/apps/desktop/electron/backend-health.ts
@@ -218,7 +218,16 @@ export function makeUnsignedOauthError(): Error {
 }
 
 export function isReauthRequiredError(error: unknown): boolean {
-  return Boolean((error as any)?.isReauthRequired)
+  if (Boolean((error as any)?.isReauthRequired)) {
+    return true
+  }
+
+  // Wrappers (IPC, pool catch) often copy only `message`. Without this
+  // fallback startHermes treats unsigned OAuth as a transient remote fault
+  // and retries "Resolving Hermes backend" forever.
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  return message.includes(REMOTE_UNSIGNED_OAUTH_MESSAGE) || message.includes(REMOTE_SESSION_EXPIRED_MESSAGE)
 }
 
 function supersededError() {

--- a/apps/desktop/electron/backend-start-failure.test.ts
+++ b/apps/desktop/electron/backend-start-failure.test.ts
@@ -83,6 +83,19 @@ test('unsigned OAuth latches and is never auto-retried; needsOauthLogin alone st
   assert.equal(isRetryableRemoteBootFailure({ attemptedRemote: true, isReauth: ticketHint }), true)
 })
 
+test('a message-only unsigned OAuth Error still latches and is not auto-retried', () => {
+  // Same composition startHermes uses, but the Error lost isReauthRequired.
+  const wrapped = new Error(
+    'Remote Hermes gateway uses OAuth, but you are not signed in. ' +
+      'Open Settings → Gateway and click "Sign in", or switch back to Local.'
+  )
+  const isReauth = isReauthRequiredError(wrapped)
+
+  assert.equal(isReauth, true)
+  assert.equal(shouldLatchRemoteReauthFailure({ attemptedRemote: true, isReauth }), true)
+  assert.equal(isRetryableRemoteBootFailure({ attemptedRemote: true, isReauth }), false)
+})
+
 test('local failures are never auto-retried by the remote self-heal loop', () => {
   assert.equal(isRetryableRemoteBootFailure({ attemptedRemote: false, isReauth: false }), false)
   assert.equal(isRetryableRemoteBootFailure({ attemptedRemote: false, isReauth: true }), false)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -13267,20 +13267,9 @@ async function startHermes() {
       ...getWindowState()
     }
   })().catch(async error => {
-    if (!backendConnectionState.clearPromiseForAttempt(connectionAttempt)) {
-      throw error
-    }
-
-    const failedProcess = backendConnectionState.invalidate()
-    stopBackendChild(failedProcess)
-    await waitForBackendExit(failedProcess)
-
-    if (error instanceof FirstRunSetupResetError) {
-      throw error
-    }
-
     const message = error instanceof Error ? error.message : String(error)
     const hostKeyChanged = isHostKeyChangedBootFailure(error)
+    const isReauth = isReauthRequiredError(error)
 
     // Carry structured Cloud-down metadata through the boot-progress / IPC
     // boundary when present, so the renderer overlay can key on it rather than
@@ -13294,29 +13283,47 @@ async function startHermes() {
         : NaN
     )
 
-    // Only latch LOCAL boot failures. A remote failure (lapsed session / mint
-    // timeout / host briefly unreachable across sleep) is transient and has no
-    // child 'exit' handler to clear the cache — latching it would wedge the app
-    // on "session expired" until a full restart, defeating reconnect, the
-    // "Sign out & sign in" reload, and the wake-recovery revalidate path.
-    if (shouldLatchBackendStartFailure({ attemptedRemote })) {
-      backendStartFailure = error instanceof Error ? error : new Error(message)
+    // Latches MUST be assigned before any await (and before the superseded
+    // early-return). waitForBackendExit yields the event loop; hermes:api from
+    // refreshProfiles then calls startHermes, passes the still-empty latch,
+    // and re-logs "Resolving Hermes backend" forever on unsigned OAuth.
+    if (!(error instanceof FirstRunSetupResetError)) {
+      // Only latch LOCAL boot failures. A remote failure (lapsed session / mint
+      // timeout / host briefly unreachable across sleep) is transient and has no
+      // child 'exit' handler to clear the cache — latching it would wedge the app
+      // on "session expired" until a full restart, defeating reconnect, the
+      // "Sign out & sign in" reload, and the wake-recovery revalidate path.
+      if (shouldLatchBackendStartFailure({ attemptedRemote })) {
+        backendStartFailure = error instanceof Error ? error : new Error(message)
+      }
+
+      // A host-key CHANGE is the terminal exception among remote failures: SSH
+      // fails closed until the user verifies the change and clears the stale
+      // known_hosts entry, so retrying re-drives the identical doomed boot (one
+      // bundle showed 157 consecutive failures over 2.5h). Latch it like a local
+      // failure — reset/repair/apply-config clear the latch after the user fixes
+      // known_hosts.
+      if (shouldLatchHostKeyChangedFailure({ attemptedRemote, isReauth: false, isHostKeyChanged: hostKeyChanged })) {
+        backendStartFailure = error instanceof Error ? error : new Error(message)
+      }
+
+      // A confirmed reauth rejection latches separately: it can't self-heal, and
+      // leaving it unlatched hides the overlay's "Sign in" button on every retry.
+      if (shouldLatchRemoteReauthFailure({ attemptedRemote, isReauth })) {
+        remoteReauthFailure = error instanceof Error ? error : new Error(message)
+      }
     }
 
-    // A host-key CHANGE is the terminal exception among remote failures: SSH
-    // fails closed until the user verifies the change and clears the stale
-    // known_hosts entry, so retrying re-drives the identical doomed boot (one
-    // bundle showed 157 consecutive failures over 2.5h). Latch it like a local
-    // failure — reset/repair/apply-config clear the latch after the user fixes
-    // known_hosts.
-    if (shouldLatchHostKeyChangedFailure({ attemptedRemote, isReauth: false, isHostKeyChanged: hostKeyChanged })) {
-      backendStartFailure = error instanceof Error ? error : new Error(message)
+    if (!backendConnectionState.clearPromiseForAttempt(connectionAttempt)) {
+      throw error
     }
 
-    // A confirmed reauth rejection latches separately: it can't self-heal, and
-    // leaving it unlatched hides the overlay's "Sign in" button on every retry.
-    if (shouldLatchRemoteReauthFailure({ attemptedRemote, isReauth: isReauthRequiredError(error) })) {
-      remoteReauthFailure = error instanceof Error ? error : new Error(message)
+    const failedProcess = backendConnectionState.invalidate()
+    stopBackendChild(failedProcess)
+    await waitForBackendExit(failedProcess)
+
+    if (error instanceof FirstRunSetupResetError) {
+      throw error
     }
 
     updateBootProgress(
@@ -13333,7 +13340,7 @@ async function startHermes() {
         // sign-in affordance.
         retryable: isRetryableRemoteBootFailure({
           attemptedRemote,
-          isReauth: isReauthRequiredError(error),
+          isReauth,
           isHostKeyChanged: hostKeyChanged
         }),
         running: false,


### PR DESCRIPTION
## Summary
- Unsigned remote OAuth (`not signed in`) kept retrying `Resolving Hermes backend` forever after NAS/gateway restart, so Settings never stayed open.
- `startHermes` now latches that reauth failure **before** awaiting backend teardown, so a concurrent `hermes:api` cannot sneak past the latch.
- `isReauthRequiredError` also matches the unsigned/expired copy when a wrapper drops the `isReauthRequired` flag.

## Test plan
- [ ] `npx vitest run electron/backend-health.test.ts electron/backend-start-failure.test.ts` (from `apps/desktop`)
- [ ] Point Desktop at a remote OAuth gateway with no session, confirm the recovery overlay stays put (Sign in / Gateway settings) instead of spinning
- [ ] Sign in (or switch to Local) and confirm boot continues normally