### PR TITLE
feat(web): openai-native backend for Codex server-side web_search

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -154,11 +154,40 @@ def _xai_prefers_native_web_search() -> bool:
         return True
 
 
-def _alias_wire_tools(response_tools: Any, params: dict[str, Any], is_xai_responses: bool) -> tuple[Any, dict[str, str]]:
+def _openai_prefers_native_web_search() -> bool:
+    """True when the active web-search backend selects OpenAI's server-side ``web_search``.
+
+    Same contract as :func:`_xai_prefers_native_web_search` with one deliberate
+    difference: it fails CLOSED (False). A resolution failure must leave the client-side
+    Hermes tool in place rather than swap in a built-in the endpoint might reject.
+
+    Only consulted for the Codex backend (``chatgpt.com/backend-api/codex``); a custom
+    OpenAI-compatible endpoint does not implement the server-side tool.
+    """
+    try:
+        from agent.web_search_registry import get_active_search_provider
+
+        provider = get_active_search_provider()
+        if provider is not None:
+            return getattr(provider, "name", None) == "openai-native"
+
+        from tools.web_tools import _get_search_backend
+
+        return (_get_search_backend() or "").strip().lower() == "openai-native"
+    except Exception:  # noqa: BLE001 — a probe failure must not change the request shape
+        return False
+
+
+def _alias_wire_tools(
+    response_tools: Any, params: dict[str, Any], is_xai_responses: bool, is_codex_backend: bool = False,
+) -> tuple[Any, dict[str, str]]:
     """Apply provider-reserved tool-name aliasing; returns ``(tools, {alias: original})`` for THIS request.
 
     xAI: a client ``web_search`` collides with Grok's native search — native mode
     swaps it 1:1 for the built-in, client mode keeps Hermes dispatch under an alias.
+
+    OpenAI Codex: the Responses endpoint carries the same collision, so the backend
+    selection drives the same 1:1 swap (``web.search_backend: openai-native``).
     """
     wire_aliases: dict[str, str] = {}
 
@@ -173,6 +202,13 @@ def _alias_wire_tools(response_tools: Any, params: dict[str, Any], is_xai_respon
                 {**t, "name": _XAI_CLIENT_WEB_SEARCH_ALIAS} if is_client_web_search(t) else t for t in response_tools
             ]
             wire_aliases[_XAI_CLIENT_WEB_SEARCH_ALIAS] = "web_search"
+    # OpenAI Codex: the Responses endpoint exposes the same server-executed ``web_search``,
+    # and a client-side function of that name collides with it the same way. Unlike xAI there
+    # is no alias fallback: when the user has not selected ``openai-native`` we leave the
+    # client tool untouched, so an endpoint that cannot host the built-in never breaks.
+    if is_codex_backend and response_tools and any(is_client_web_search(t) for t in response_tools):
+        if _openai_prefers_native_web_search():
+            response_tools = [t for t in response_tools if not is_client_web_search(t)] + [{"type": "web_search"}]
     # OpenCode Responses backends reserve web_search / search_files as function names (HTTP 400 "custom
     # function name 'X' is reserved", #85589). Alias them on the wire; normalize_response maps them back.
     if response_tools and _is_opencode_responses_backend(params):
@@ -578,7 +614,9 @@ class ResponsesApiTransport(ProviderTransport):
         native_compaction_active = _native_compaction_active(context_management)
 
         reasoning_effort, reasoning_enabled = _resolve_reasoning(model, params)
-        response_tools, self._last_wire_aliases = _alias_wire_tools(self.convert_tools(tools), params, is_xai_responses)
+        response_tools, self._last_wire_aliases = _alias_wire_tools(
+            self.convert_tools(tools), params, is_xai_responses, is_codex_backend,
+        )
 
         # Lazy: provider plugins import this transport during model_metadata init.
         from agent.model_metadata import strip_codex_context_variant_suffix as _strip_ctx_variant

--- a/plugins/web/openai_native/__init__.py
+++ b/plugins/web/openai_native/__init__.py
@@ -1,0 +1,9 @@
+"""OpenAI native web search plugin — bundled, auto-loaded."""
+
+from __future__ import annotations
+
+from plugins.web.openai_native.provider import OpenAINativeWebSearchProvider
+
+
+def register(ctx) -> None:
+    ctx.register_web_search_provider(OpenAINativeWebSearchProvider())

--- a/plugins/web/openai_native/plugin.yaml
+++ b/plugins/web/openai_native/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-openai-native
+version: 1.0.0
+description: "OpenAI native web search — declares the Responses API server-side ``web_search`` built-in instead of running a client-side search. Requires the Codex Responses transport plus openai-codex OAuth (``hermes auth --provider openai-codex``)."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - openai-native

--- a/plugins/web/openai_native/provider.py
+++ b/plugins/web/openai_native/provider.py
@@ -1,0 +1,88 @@
+"""OpenAI native web search — declares the Responses API server-side ``web_search`` built-in.
+
+Config: ``web.search_backend: openai-native`` (or ``web.backend``).
+Auth: openai-codex OAuth (``hermes auth --provider openai-codex``); no API key of its own.
+
+Unlike every other provider here, this one never executes a search itself. Selecting it
+tells the Codex Responses transport to declare the provider-executed ``web_search`` tool
+(``{"type": "web_search"}``) in place of the client-side ``web_search`` function, so the
+model drives search server-side. The transport performs that swap; this class exists so
+``web.search_backend`` has a real provider name to point at.
+
+Auth gating lives here rather than in the transport because the transport must stay
+reachable for a user who configured this backend but has not signed in yet — they get the
+clear "sign in" error from :meth:`search` rather than a silently different backend.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from plugins.web._common import BaseWebSearchProvider, search_fail
+
+_UNSUPPORTED_MSG = (
+    "openai-native declares OpenAI's server-side web_search tool; it cannot run as a "
+    "client-side search and requires the Codex Responses transport (provider "
+    "openai-codex). For client-side search use firecrawl (default) or another backend."
+)
+
+
+def _dget(obj: Any, key: str) -> Any:
+    return obj.get(key) if isinstance(obj, dict) else None
+
+
+def has_codex_credentials() -> bool:
+    """Cheap probe: True when openai-codex OAuth tokens are *likely* usable.
+
+    Mirrors ``tools/xai_http.has_xai_credentials`` — deliberately avoids
+    ``resolve_codex_runtime_credentials`` (disk locks, OAuth network refresh), because
+    this runs on every ``hermes tools`` repaint. Checks, fast-to-slow:
+    ``providers.openai-codex.tokens.access_token`` in ``auth.json``, then any
+    ``credential_pool.openai-codex`` entry carrying an ``access_token`` (pool-only
+    multi-account grants never write the providers singleton). Returns False on any
+    exception so a corrupted auth store cannot block other availability scans.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+
+        auth_path = get_hermes_home() / "auth.json"
+        if not auth_path.exists():
+            return False
+        store = json.loads(auth_path.read_text(encoding="utf-8-sig"))
+        tokens = _dget(_dget(_dget(store, "providers"), "openai-codex"), "tokens")
+        if str(_dget(tokens, "access_token") or "").strip():
+            return True
+        entries = _dget(_dget(store, "credential_pool"), "openai-codex")
+        return isinstance(entries, list) and any(
+            isinstance(e, dict) and str(e.get("access_token", "") or "").strip() for e in entries
+        )
+    except Exception:  # noqa: BLE001 — availability must never raise
+        return False
+
+
+class OpenAINativeWebSearchProvider(BaseWebSearchProvider):
+    """Marker provider: the Codex Responses transport swaps the client ``web_search``
+    function for the server-executed built-in when this backend is active."""
+
+    NAME = "openai-native"
+    DISPLAY_NAME = "OpenAI Native Web Search (Codex Responses)"
+
+    def is_available(self) -> bool:
+        return has_codex_credentials()
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Never called on a successful native turn — the transport replaces the tool
+        before the request goes out. Reached only when the active transport cannot host
+        the built-in, so fail loudly instead of returning an empty result set."""
+        return search_fail(_UNSUPPORTED_MSG)
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        from plugins.web._common import setup_schema
+
+        return setup_schema(
+            self.DISPLAY_NAME,
+            "native",
+            "由模型服务端执行搜索（需 Codex Responses transport + openai-codex 登录）；仅搜索，提取仍用其他后端",
+            "",
+        )

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -942,6 +942,89 @@ class TestCodexBuildKwargs:
             for t in tools
         )
 
+    # --- OpenAI Codex native web-search swap ---
+    # The Codex Responses endpoint exposes the same server-executed
+    # ``web_search`` built-in as xAI, so selecting the ``openai-native``
+    # backend performs the same 1:1 swap. Unlike xAI there is no alias path:
+    # an unselected or non-Codex request keeps the client-side function, so a
+    # custom OpenAI-compatible endpoint never receives a tool it cannot host.
+
+    def test_openai_native_swaps_client_web_search_for_builtin(self, transport, monkeypatch):
+        """Selecting ``openai-native`` replaces the client ``web_search``
+        function with the provider-executed built-in. ``web_extract`` is a
+        separate capability and must survive — native search covers search only.
+        """
+        import agent.transports.codex as codex_mod
+
+        monkeypatch.setattr(codex_mod, "_openai_prefers_native_web_search", lambda: True)
+        kw = transport.build_kwargs(
+            model="gpt-5.6-sol",
+            messages=[{"role": "user", "content": "Find current prices."}],
+            tools=[
+                {"type": "function", "function": {
+                    "name": "read_file", "description": "Read a file.",
+                    "parameters": {"type": "object",
+                                   "properties": {"path": {"type": "string"}}}}},
+                {"type": "function", "function": {
+                    "name": "web_search", "description": "Search the web.",
+                    "parameters": {"type": "object",
+                                   "properties": {"query": {"type": "string"}}}}},
+                {"type": "function", "function": {
+                    "name": "web_extract", "description": "Extract a page.",
+                    "parameters": {"type": "object",
+                                   "properties": {"url": {"type": "string"}}}}},
+            ],
+            is_codex_backend=True,
+        )
+        tools = kw.get("tools", [])
+        assert any(t.get("type") == "web_search" for t in tools), tools
+        names = [t.get("name") for t in tools if t.get("type") == "function"]
+        assert "web_search" not in names
+        assert "read_file" in names
+        assert "web_extract" in names
+
+    def test_openai_native_not_selected_keeps_client_web_search(self, transport, monkeypatch):
+        """A Codex turn that has not selected ``openai-native`` keeps Hermes
+        dispatch — the built-in must never be granted additively."""
+        import agent.transports.codex as codex_mod
+
+        monkeypatch.setattr(codex_mod, "_openai_prefers_native_web_search", lambda: False)
+        kw = transport.build_kwargs(
+            model="gpt-5.6-sol",
+            messages=[{"role": "user", "content": "Find current prices."}],
+            tools=[{"type": "function", "function": {
+                "name": "web_search", "description": "Search the web.",
+                "parameters": {"type": "object",
+                               "properties": {"query": {"type": "string"}}}}}],
+            is_codex_backend=True,
+        )
+        tools = kw.get("tools", [])
+        assert not any(t.get("type") == "web_search" for t in tools), tools
+        names = [t.get("name") for t in tools if t.get("type") == "function"]
+        assert "web_search" in names
+
+    def test_openai_native_ignored_on_non_codex_transport(self, transport, monkeypatch):
+        """The provider-executed built-in only exists on
+        ``chatgpt.com/backend-api/codex``. A custom OpenAI-compatible endpoint
+        must keep the client tool even when the search backend says native.
+        """
+        import agent.transports.codex as codex_mod
+
+        monkeypatch.setattr(codex_mod, "_openai_prefers_native_web_search", lambda: True)
+        kw = transport.build_kwargs(
+            model="gpt-5.6-sol",
+            messages=[{"role": "user", "content": "Find current prices."}],
+            tools=[{"type": "function", "function": {
+                "name": "web_search", "description": "Search the web.",
+                "parameters": {"type": "object",
+                               "properties": {"query": {"type": "string"}}}}}],
+            is_codex_backend=False,
+        )
+        tools = kw.get("tools", [])
+        assert not any(t.get("type") == "web_search" for t in tools), tools
+        names = [t.get("name") for t in tools if t.get("type") == "function"]
+        assert "web_search" in names
+
     # --- Grok reasoning-effort capability allowlist ---
     # api.x.ai 400s with "Model X does not support parameter reasoningEffort"
     # on grok-4 / grok-4-fast / grok-3 / grok-code-fast / grok-4.20-0309-*.

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -28,8 +28,9 @@ Both are configured through a single backend selection. Providers are chosen via
 | **Perplexity** | `PERPLEXITY_API_KEY` | ✔ | ✔ (query-relevant snippets) | Paid (per-request Search API pricing) |
 | **Keenable** | `KEENABLE_API_KEY` (optional) | ✔ | ✔ | ✔ Keyless ring member · paid with key |
 | **xAI (Grok)** | `XAI_API_KEY` or `hermes auth add xai-oauth` | ✔ | — | Paid (SuperGrok or per-token) |
+| **OpenAI Native (Codex)** | `hermes auth --provider openai-codex` | ✔ | — | Requires a ChatGPT/Codex subscription |
 
-Brave Search, DDGS, and xAI are **search-only** — pair any of them with Firecrawl/Tavily/Perplexity/Keenable/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
+Brave Search, DDGS, xAI, and OpenAI Native are **search-only** — pair any of them with Firecrawl/Tavily/Perplexity/Keenable/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below). OpenAI Native declares the same kind of provider-executed tool on the Codex Responses endpoint (see [below](#openai-native)).
 
 **Per-capability split:** you can use different providers for search and extract independently — for example SearXNG (free) for search and Firecrawl for extract. See [Per-capability configuration](#per-capability-configuration) below.
 
@@ -372,6 +373,24 @@ web:
 :::caution Trust model
 Unlike index-backed providers (Brave, Tavily, Exa) which return verbatim search-engine results, xAI is an LLM choosing which URLs to surface and writing the titles and descriptions itself. The *content* of the query influences the output, so a maliciously crafted query (e.g. injected via untrusted upstream input the agent picked up) can in principle steer Grok into emitting attacker-chosen URLs. Treat returned URLs the same way you'd treat any model-generated link — validate before fetching, especially if the query came from untrusted input.
 :::
+
+### OpenAI Native (Codex Responses) {#openai-native}
+
+Declares OpenAI's provider-executed `web_search` tool on the Codex Responses endpoint (ChatGPT/Codex subscriptions). The model drives search server-side and folds the results into its own answer — Hermes never runs a client-side search in this mode.
+
+```yaml
+# ~/.hermes/config.yaml
+web:
+  search_backend: "openai-native"
+```
+
+Requirements and scope:
+
+- **Credentials**: an openai-codex OAuth login (`hermes auth --provider openai-codex`). This backend has no API key of its own; without a login it is simply unavailable.
+- **Transport**: only the Codex Responses endpoint exposes the built-in. On any other transport — a custom OpenAI-compatible `base_url`, or a non-OpenAI model — the client-side `web_search` function is left untouched, because the endpoint cannot be relied on to host the tool. Point `web.search_backend` at an ordinary provider for those.
+- **Search only**: the built-in covers search, not extraction. Pair it with Firecrawl (or another extract-capable backend) through `web.extract_backend` when you also need `web_extract`.
+
+**One tool either way.** Selecting this backend swaps the client-side `web_search` function for the built-in 1:1 — it is not an additive grant. A session whose toolset has no `web_search` never gets server-side search injected.
 
 ---
 


### PR DESCRIPTION
## Problem

`web_search` always routes through a client-side provider, even on the Codex Responses
endpoint — which exposes a provider-executed `web_search` built-in that lets the model drive
search server-side. There was no way to select it.

The Responses adapter already knows the built-in tool shape (`_RESPONSES_BUILTIN_TOOL_TYPES`)
and `_preflight_tool` passes those through, so the only missing pieces were the swap itself and
a backend name for `web.search_backend` to point at.

This is the config-driven counterpart to the two closed env-var attempts (#16634, #20918) and
re-scopes the direction maintainer review asked for on #19320.

## Approach

Mirrors the existing xAI native-search path in `agent/transports/codex.py`:

- **New backend** `plugins/web/openai_native/` — a marker provider named `openai-native`.
  It never executes a search; it exists so `web.search_backend` has a real provider name to
  select. `search()` fails loudly if it is ever reached (i.e. the active transport cannot host
  the built-in), rather than returning an empty result set.
- **Transport swap** — `_openai_prefers_native_web_search()` + a 1:1 replacement of the client
  `web_search` function with `{"type": "web_search"}` in `_alias_wire_tools()`.

```yaml
web:
  search_backend: "openai-native"
  extract_backend: firecrawl   # the built-in covers search only
```

Deliberate differences from the xAI path:

- **Two-sided gating.** Requires the Codex backend *and* a selected `openai-native` backend. A
  custom OpenAI-compatible `base_url` never receives the built-in, because that endpoint cannot
  be relied on to host it.
- **Fails closed.** Unlike `_xai_prefers_native_web_search()` (which fails *closed to native* to
  preserve the #48108 incomplete-hang fix), a resolution failure here returns False — the safe
  default is to leave the client tool untouched.
- **No alias fallback.** xAI renames its client tool to `hermes_web_search` when native mode is
  off; OpenAI simply keeps the client tool as-is, so no `normalize_response` mapping is needed.
- **Not additive.** The swap only fires when a client `web_search` is already present, matching
  the existing 1:1 contract.

Credentials reuse the existing openai-codex OAuth login; `is_available()` probes `auth.json`
for a provider singleton *or* a `credential_pool.openai-codex` entry (pool-only multi-account
grants never write the singleton), with no disk locks or token refresh — mirroring
`tools/xai_http.has_xai_credentials()`.

## Tests

`tests/agent/transports/test_codex_transport.py` — three invariants:

1. Codex + `openai-native` selected → built-in declared, client `web_search` dropped,
   `web_extract` and other tools preserved.
2. Codex but not selected → client tool untouched, no built-in.
3. Non-Codex transport → client tool untouched even when the backend says native.

Verified with a sabotage run: with the swap disabled, test 1 fails
(`assert any(t.get("type") == "web_search" ...)`) and tests 2–3 still pass, confirming the
suite pins the behaviour rather than the implementation.

```
tests/agent/transports/test_codex_transport.py + tests/agent/test_codex_responses_adapter.py
```

## Risk

- Additive: selection is opt-in via `web.search_backend`. Existing installs are unaffected —
  the xAI path, the default client-side path, and preflight are unchanged.
- `web_extract` is unaffected by design (the built-in is search-only).
- No new env vars; configuration lives in `config.yaml` per the project's config policy.

## Exclusions

- No `web_extract` equivalent — the Responses built-in does not cover extraction.
- No auto-detection: an unpinned install never silently switches to server-side search.
