### PR TITLE
fix(plugins): retry failed sibling imports after dependency setup

### DIFF
--- a/plugins/plugin_loader.py
+++ b/plugins/plugin_loader.py
@@ -110,6 +110,9 @@ def load_plugin_module(module_name: str, plugin_dir: Path, *, parents: Tuple[str
         sub_mod = _new_module(full_sub_name, sub_file)
         if _exec(sub_mod, logger):
             loaded_submodules.append((sub_file.stem, sub_mod))
+        else:
+            # A later setup may supply the missing dependency; do not cache a partial module.
+            sys.modules.pop(full_sub_name, None)
     if not _exec(mod, logger):
         sys.modules.pop(module_name, None)
         return None

--- a/tests/plugins/memory/test_failed_import_recovery.py
+++ b/tests/plugins/memory/test_failed_import_recovery.py
@@ -1,0 +1,58 @@
+"""A setup dependency becoming available must unblock the next discovery in-process."""
+
+import importlib
+import sys
+
+import pytest
+
+import plugins.memory as memory_plugins
+
+
+@pytest.mark.parametrize("failure_site", ["sibling", "package"])
+def test_discovery_recovers_after_dependency_install(tmp_path, monkeypatch, failure_site):
+    home = tmp_path / "home"
+    plugin = home / "plugins" / "retry_memory"
+    plugin.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(memory_plugins, "_MEMORY_PLUGINS_DIR", tmp_path / "bundled")
+    monkeypatch.setattr(memory_plugins, "_iter_entry_points", lambda: [])
+    monkeypatch.chdir(tmp_path)
+    dependency_dir = tmp_path / "dependencies"
+    dependency_dir.mkdir()
+    monkeypatch.syspath_prepend(str(dependency_dir))
+    dependency_name = f"hermes_retry_sdk_{failure_site}"
+    (plugin / "stable.py").write_text("TOKEN = object()\n", encoding="utf-8")
+    dependency_import = f"from {dependency_name} import READY\n"
+    if failure_site == "sibling":
+        (plugin / "backend.py").write_text(dependency_import, encoding="utf-8")
+        dependency_import = "from .backend import READY\n"
+    (plugin / "__init__.py").write_text(
+        "from .stable import TOKEN\n"
+        + dependency_import
+        + "from agent.memory_provider import MemoryProvider\n"
+        "class Provider(MemoryProvider):\n"
+        "    name = 'retry_memory'\n"
+        "    token = TOKEN\n"
+        "    def is_available(self): return READY\n"
+        "    def initialize(self, session_id, **kwargs): pass\n"
+        "    def get_tool_schemas(self): return []\n"
+        "def register(ctx): ctx.register_memory_provider(Provider())\n",
+        encoding="utf-8",
+    )
+    module_name = memory_plugins._module_name(plugin, "retry_memory")
+    try:
+        assert memory_plugins.discover_memory_providers() == [("retry_memory", "", False)]
+        stable = sys.modules[f"{module_name}.stable"]
+        (dependency_dir / f"{dependency_name}.py").write_text("READY = True\n", encoding="utf-8")
+        importlib.invalidate_caches()
+
+        assert memory_plugins.discover_memory_providers() == [("retry_memory", "", True)]
+        provider = memory_plugins.load_memory_provider("retry_memory", register_skills=False)
+        assert provider is not None
+        assert provider.is_available()
+        assert provider.token is stable.TOKEN
+        assert sys.modules[f"{module_name}.stable"] is stable
+    finally:
+        for name in list(sys.modules):
+            if name == module_name or name.startswith(f"{module_name}.") or name == dependency_name:
+                sys.modules.pop(name, None)


### PR DESCRIPTION
a memory provider can stay broken after its missing dependency is installed.. the loader retries the package, but reuses a half-loaded sibling from `sys.modules`

this drops the failed sibling entry so the next discovery can try again. successful modules stay cached. the dashboard setup flow already loads a provider before installing dependencies, then rechecks discovery in the same process

related to #104174, which fixed mem0 locally and left loader recovery as a separate question. #105224 changes concurrency in this function but keeps the failed-import behavior

checked on macos, python 3.11.13

- before: sibling recovery fails, package retry control passes
- after: 176 passed across nine files, including memory discovery, mem0 setup, context-engine and cron provider coverage
- ruff, windows-footgun check and diff check pass

```sh
scripts/run_tests.sh -j 2 tests/plugins/memory/test_failed_import_recovery.py tests/plugins/memory/test_discovery_sources.py tests/plugins/memory/test_mem0_setup.py tests/agent/test_memory_provider.py tests/agent/test_context_engine.py tests/cron/test_cron_provider_pin.py
scripts/run_tests.sh -j 2 tests/cron/test_scheduler_provider.py
scripts/run_tests.sh -j 2 tests/agent/test_context_engine_host_contract.py tests/run_agent/test_plugin_context_engine_init.py
```

the regression uses real discovery and loading with a temporary provider and an offline dependency becoming importable. no actual package install or dashboard http test

ai assistance: i led this contribution and used openai codex to help develop the code and tests, with a separate ai agent reviewing the patch.
