### PR TITLE
fix(kanban): blocker_auth respawn guard transitions ready->blocked instead of stalling forever

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1487,6 +1487,34 @@ def _call_spawn_fn(spawn_fn, task: Task, workspace: str, board: Optional[str]) -
         return spawn_fn(task, workspace)
 
 
+def _block_blocker_auth_task(conn: sqlite3.Connection, task_id: str) -> None:
+    """Transition a ``blocker_auth``-guarded ready task to ``blocked`` /
+    ``needs_input`` (t_dd8a811d), with a comment naming the matched
+    substring. Called at most once per ready-cycle: after this the task is
+    no longer in the ready lane, so ``check_respawn_guard`` never sees it
+    again until a human ``kanban_unblock``. Best-effort: a race where the
+    row already left ``ready``/``running`` (a concurrent dispatcher, or the
+    reclaim phase already blocked it) is silently ignored — ``block_task``
+    itself is a no-op then (rowcount check).
+    """
+    row = conn.execute(
+        "SELECT last_failure_error FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    err = (row["last_failure_error"] if row else None) or ""
+    match = _RESPAWN_BLOCKER_RE.search(err)
+    matched_text = match.group(0) if match else "auth/quota error"
+    reason = f"respawn guard: blocker_auth ({matched_text!r} in last_failure_error)"
+    if not _kb.block_task(conn, task_id, reason=reason, kind="needs_input"):
+        return
+    _kb.add_comment(
+        conn, task_id, "dispatcher",
+        f"Auto-blocked: dispatcher respawn guard detected a quota/auth "
+        f"pattern ({matched_text!r}) in the last failure and will never "
+        f"retry it automatically. Resolve the credential/quota issue, then "
+        f"kanban_unblock to resume.\n\nlast_failure_error: {err[:500]}",
+    )
+
+
 def _dispatch_lane_task(
     conn: sqlite3.Connection,
     row: sqlite3.Row,
@@ -1535,6 +1563,14 @@ def _dispatch_lane_task(
         if not dry_run:
             with _kb.write_txn(conn):
                 _kb._append_event(conn, task_id, "respawn_guarded", {"reason": guard_reason})
+            # blocker_auth has no TTL and no "auth restored" signal to expire
+            # on (unlike rate_limit_cooldown, which self-clears): left in
+            # 'ready' it silently re-triggers this guard every tick forever
+            # (t_dd8a811d / t_2b487430 repro). Surface it once, on the FIRST
+            # hit, as a normal needs_input block so a human sees it in the
+            # blocked lane instead of a task that looks alive but never spawns.
+            if guard_reason == "blocker_auth":
+                _block_blocker_auth_task(conn, task_id)
         return False
 
     def _count_spawn(name: str) -> None:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -372,6 +372,78 @@ def test_respawn_guard_defers_rate_limited_within_cooldown(
         assert kbd.check_respawn_guard(conn, tid) is None
 
 
+def test_respawn_guard_blocker_auth_transitions_ready_task_to_blocked(
+    kanban_home, all_assignees_spawnable,
+):
+    """t_dd8a811d: the blocker_auth branch has no TTL and (before the fix)
+    never transitions the task out of ``ready`` — it strands the task
+    forever, silently re-emitting ``respawn_guarded`` every tick with no
+    state change (only the diagnostics-actuator side channel notices).
+
+    The sibling ``rate_limit_cooldown`` branch self-clears after
+    ``DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS``; blocker_auth has no such
+    signal to expire on (there's no "auth restored" event), so the correct
+    symmetric behavior is: on the FIRST blocker_auth guard hit, transition
+    ready -> blocked(kind=needs_input) with a comment naming the matched
+    substring, so the stall surfaces in the normal blocked-lane review flow
+    instead of parking invisibly in ready forever.
+    """
+    def fake_spawn(task, workspace, board=None):
+        raise AssertionError("a blocker_auth-guarded task must never spawn")
+
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="auth-stuck", assignee="alice")
+        # Mirrors the live t_2b487430 repro string exactly.
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("workspace: [Errno 13] Permission denied: '/Users'", tid),
+        )
+        conn.commit()
+
+        res = kbd.dispatch_once(conn, spawn_fn=fake_spawn)
+        task = kb.get_task(conn, tid)
+        comments = kb.list_comments(conn, tid)
+
+    assert res.respawn_guarded == [(tid, "blocker_auth")]
+    assert not res.spawned
+    # This is the fix: no longer stuck in 'ready' — visibly blocked within
+    # one dispatcher tick, no manual kanban_unblock required to observe it.
+    assert task.status == "blocked"
+    assert task.block_kind == "needs_input"
+    # A comment names the matched substring so a human reviewing the
+    # blocked lane immediately sees WHY, without digging into dispatcher logs.
+    assert any("permission" in c.body.lower() for c in comments)
+
+
+def test_respawn_guard_blocker_auth_second_tick_does_not_reblock(
+    kanban_home, all_assignees_spawnable,
+):
+    """Once blocked, the task is no longer in the ready lane, so a second
+    dispatcher tick must not re-fire the guard/block path against it (no
+    duplicate blocked events, no crash from double-blocking an already
+    blocked task)."""
+    def fake_spawn(task, workspace, board=None):
+        raise AssertionError("must not spawn")
+
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="auth-stuck-2", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("Billing or credits exhausted: HTTP 404", tid),
+        )
+        conn.commit()
+
+        first = kbd.dispatch_once(conn, spawn_fn=fake_spawn)
+        second = kbd.dispatch_once(conn, spawn_fn=fake_spawn)
+        task = kb.get_task(conn, tid)
+
+    assert first.respawn_guarded == [(tid, "blocker_auth")]
+    assert task.status == "blocked"
+    # Second tick sees no ready-lane row at all for this task (it's blocked
+    # now), so the guard never fires again.
+    assert second.respawn_guarded == []
+
+
 
 
 


### PR DESCRIPTION
## Problem

`check_respawn_guard()` in `hermes_cli/kanban_db_dispatch.py` has an asymmetric
design defect: the `rate_limit_cooldown` branch explicitly checks elapsed time
and self-clears after `DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS` (300s), but the
`blocker_auth` branch (quota/auth pattern match against `last_failure_error`)
has NO time check and NO auto-clear — once a task's `last_failure_error`
matches `_RESPAWN_BLOCKER_RE` (quota/rate-limit/429/403/auth/unauthorized/
forbidden/billing/subscription/permission-denied/invalid-api-key), the
dispatcher refuses to ever respawn it again, silently, with no promotion to
`blocked`/`needs_input`. The task sits in `status=ready` forever, invisible to
normal review — only surfaced by an out-of-band diagnostics side-channel
(comment-only, no state mutation).

Live-confirmed on a production board: two tasks stuck in `ready` with
`respawn_guarded{reason:blocker_auth}` events firing every dispatcher tick for
hours — one from a stale 11-day-old error string that could never be
superseded (the guard prevents any new run from overwriting
`last_failure_error`), one from a red-herring path-permission error
misclassified as an auth failure by the bare `\bpermission[\s_]denied\b` regex
term.

## Fix

On the first `blocker_auth` guard hit for a ready-lane row, transition it to
`blocked`/`needs_input` via the existing `block_task()` path and leave a
comment naming the matched substring from `last_failure_error`. This surfaces
the stall in the normal blocked-lane triage flow instead of a task that looks
alive (`status=ready`, assignee set) but silently never spawns again.

`rate_limit_cooldown` behavior is unchanged — this only touches the
`blocker_auth` branch, and only after the reclaim/respawn-guard shared
plumbing already decided to skip the spawn.

## Tests

- `test_respawn_guard_blocker_auth_transitions_ready_task_to_blocked` — proven
  RED on unmodified `main` (asserted `status == "blocked"`, failed with
  `'ready' == 'blocked'` on old code), GREEN after the fix.
- `test_respawn_guard_blocker_auth_second_tick_does_not_reblock` — guards
  against a re-block loop / duplicate blocked events on the next dispatcher
  tick once the task has left the ready lane.

Full kanban dispatch test surface verified green locally: 142 tests across 19
files (`test_kanban_boards`, `test_kanban_core_functionality`,
`test_kanban_review_lifecycle*`, `test_kanban_dispatch_*`, etc.) plus 52 in
`test_kanban_db.py` + `test_kanban_review_lifecycle.py` — 0 failures, 0
regressions. `ruff check` clean.

## Scope

Dispatcher/application code only. No credential, provider/model, live-trading,
or schedule mutation.