### PR TITLE
fix(discord): tolerate unset integration_types/contexts in app-command sync equality

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2603,6 +2603,45 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
             ],
         }
 
+    def _app_commands_equivalent(
+        self, existing: Dict[str, Any], desired: Dict[str, Any]
+    ) -> bool:
+        """Equality that tolerates unset installation/context fields.
+
+        discord.py's ``to_dict()`` emits ``integration_types=None`` when the
+        tree sets no installation preference, but Discord materializes its
+        default (``[0, 1]`` — guild + user install) on every stored command.
+        A plain payload compare therefore flags EVERY command as changed on
+        EVERY sync, and the reconciler delete+recreates all of them — which
+        burns Discord's small command-management rate bucket, blows the
+        600s sync timeout (130 mutations × 4.5s spacing), and exhausts the
+        200-creates/day cap (error 30034), leaving the app's commands in a
+        half-synced state forever.
+
+        ``None`` on the desired side means "no preference", so accept
+        whatever the server materialized for ``contexts`` and
+        ``integration_types``. Explicit desired values still compare
+        exactly, so a tree that pins installations keeps working.
+        """
+        if existing == desired:
+            return True
+        unset_ok_fields = ("contexts", "integration_types")
+        exact_fields = (
+            "type",
+            "name",
+            "description",
+            "default_member_permissions",
+            "dm_permission",
+            "nsfw",
+            "options",
+        )
+        return all(
+            existing.get(field) == desired.get(field) or desired.get(field) is None
+            for field in unset_ok_fields
+        ) and all(
+            existing.get(field) == desired.get(field) for field in exact_fields
+        )
+
     @staticmethod
     def _normalize_permissions(value: Any) -> Optional[str]:
         """Normalize default_member_permissions to str-or-None (Discord returns str, discord.py sets int)."""
@@ -2709,7 +2748,7 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
             current_existing_payload = self._existing_command_to_payload(current)
             current_payload = self._canonicalize_app_command_payload(current_existing_payload)
             desired_payload = self._canonicalize_app_command_payload(desired)
-            if current_payload == desired_payload:
+            if self._app_commands_equivalent(current_payload, desired_payload):
                 summary["unchanged"] += 1
                 continue
             if self._patchable_app_command_payload(current_existing_payload) == self._patchable_app_command_payload(desired):

--- a/tests/gateway/test_discord_sync_limit.py
+++ b/tests/gateway/test_discord_sync_limit.py
@@ -57,6 +57,109 @@ def adapter():
     return adapter
 
 
+# The sync-limit tests above use the fixture's identity-canonicalize mock; the
+# churn-regression tests below deliberately exercise the REAL canonicalizer
+# (del of the instance attribute falls back to the bound method) so field
+# normalization matches production.
+
+class _UnsetPrefTreeCommand:
+    """Desired command whose tree sets no installation/context preference.
+
+    Mirrors discord.py's ``to_dict()``: emits ``None`` for unset
+    ``integration_types``/``contexts``, while Discord materializes defaults
+    server-side.
+    """
+
+    def __init__(self, name: str, description: str = "Show or change the model"):
+        self.name = name
+        self.type = 1
+        self._description = description
+
+    def to_dict(self, _tree):
+        return {
+            "name": self.name, "type": 1,
+            "description": self._description,
+            "dm_permission": True, "nsfw": False,
+            "contexts": None, "integration_types": None, "options": [],
+        }
+
+
+class _PinnedTreeCommand(_UnsetPrefTreeCommand):
+    """Desired command that EXPLICITLY pins installation/context values."""
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self._description = "d"
+
+    def to_dict(self, _tree):
+        return {
+            "name": self.name, "type": 1, "description": self._description,
+            "dm_permission": True, "nsfw": False,
+            "contexts": [0], "integration_types": [0], "options": [],
+        }
+
+
+@pytest.mark.asyncio
+async def test_sync_treats_unset_installation_context_as_matching(adapter):
+    """Desired integration_types/contexts=None must match server-materialized values.
+
+    Regression guard for the churn bug: discord.py's to_dict() emits None when
+    the tree sets no preference, but Discord stores [0, 1]; naive payload
+    equality flagged every command changed on every sync, the reconciler
+    delete+recreated all of them, the 600s sync timeout meant last_success_at
+    was never stamped, and the rate bucket burned — the 'slash commands break
+    on every update' signature. Unset on the DESIRED side means no preference.
+    """
+    adapter._existing_command_to_payload = MagicMock(side_effect=lambda cmd: {
+        "name": cmd.name, "type": 1, "description": "Show or change the model",
+        "default_member_permissions": None, "dm_permission": True, "nsfw": False,
+        "contexts": [0, 1, 2], "integration_types": [0, 1], "options": [],
+    })
+    del adapter._canonicalize_app_command_payload
+
+    adapter._client.tree.fetch_commands = AsyncMock(
+        return_value=[SimpleNamespace(id="id_model", name="model", type=1)])
+    adapter._client.tree.get_commands = MagicMock(
+        return_value=[_UnsetPrefTreeCommand(name="model")])
+
+    summary = await adapter._safe_sync_slash_commands()
+
+    assert summary["unchanged"] == 1
+    assert summary["created"] == 0 and summary["recreated"] == 0
+    assert summary["updated"] == 0 and summary["deleted"] == 0
+    assert adapter._client.http.delete_global_command.await_count == 0
+    assert adapter._client.http.upsert_global_command.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_sync_still_mutates_when_desired_pins_installation_explicitly(adapter):
+    """An EXPLICIT desired integration_types/contexts value still compares exactly.
+
+    Unset-tolerance must mean 'no preference', never 'anything matches': a tree
+    that pins [0] against a server-materialized [0, 1] is a real change and must
+    still be reconciled (patchable fields equal → the recreate path).
+    """
+    adapter._existing_command_to_payload = MagicMock(side_effect=lambda cmd: {
+        "name": cmd.name, "type": 1, "description": "d",
+        "default_member_permissions": None, "dm_permission": True, "nsfw": False,
+        "contexts": [0], "integration_types": [0, 1], "options": [],
+    })
+    del adapter._canonicalize_app_command_payload
+    # Exercise the REAL patchable shape (name/description/options only) so the
+    # pinned-but-patchable-equal case takes the production recreate path.
+    del adapter._patchable_app_command_payload
+
+    adapter._client.tree.fetch_commands = AsyncMock(
+        return_value=[SimpleNamespace(id="id_x", name="model", type=1)])
+    adapter._client.tree.get_commands = MagicMock(
+        return_value=[_PinnedTreeCommand(name="model")])
+
+    summary = await adapter._safe_sync_slash_commands()
+
+    assert summary["recreated"] == 1
+    assert summary["unchanged"] == 0
+
+
 @pytest.mark.asyncio
 async def test_safe_sync_deletes_before_creating():
     """Sync must delete obsolete commands BEFORE creating new ones.


### PR DESCRIPTION
## Problem

`_safe_sync_slash_commands` compares the desired payload against the server's stored payload with plain equality. discord.py's `to_dict()` emits `integration_types=None` / `contexts=None` when the command tree sets no installation/context preference, but Discord materializes its defaults (`integration_types: [0, 1]`, `contexts: [0, 1, 2]`) on every stored command.

Naive payload equality therefore flags **every command as changed on every sync**, and the reconciler delete+recreates all of them. Consequences observed in production:

- Discord's small command-management rate bucket burns on every sync
- the 600s sync timeout (130 mutations x 4.5s spacing) expires before `last_success_at` is stamped, so sync is retried forever
- the 200-creates/day cap (error 30034) exhausts, leaving the app's commands half-synced

## Fix

Add `DiscordAdapter._app_commands_equivalent()`: `None` on the desired side for `contexts`/`integration_types` means *no preference* — accept what the server materialized. All other fields (type, name, description, permissions, options) still compare exactly, so a tree that explicitly pins installations keeps reconciling.

## Tests

`tests/gateway/test_discord_sync_limit.py` gains two behavior-contract tests exercising the real canonicalizer:

- unset desired `integration_types`/`contexts` vs server-materialized values → `unchanged`, zero mutations
- explicit desired values still compare exactly → recreate path taken

3/3 tests in the file pass.