### PR TITLE
fix(feishu): drop root_id fallback and skip thread_id for regular replies

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -104,7 +104,17 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     ``direct_messages_topic_id`` when supported."""
     thread_id = getattr(source, "thread_id", None)
     platform = _platform_name(getattr(source, "platform", None))
-    metadata = {"thread_id": thread_id} if thread_id is not None else {}
+    # Feishu SDK populates message.thread_id with the reply chain root_id for both
+    # group and DM chats. Appending it to reply metadata causes every bot response to
+    # be nested into a subtopic. Skip thread_id for feishu group/dm — feishu has no
+    # real subtopic concept for these chat types, regular replies should stay in the
+    # main chat.
+    if thread_id is not None and not (
+        platform == "feishu" and getattr(source, "chat_type", None) in {"group", "dm"}
+    ):
+        metadata = {"thread_id": thread_id}
+    else:
+        metadata = {}
     # Slack workspace identity is routing state: carry it so a multi-workspace Socket Mode
     # gateway never falls back to its primary WebClient.
     scope_id = getattr(source, "scope_id", None) if platform == "slack" else None
@@ -156,8 +166,13 @@ def _reply_anchor_for_event(event) -> str | None:
         if getattr(source, "chat_type", None) != "dm":
             return None
         return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
-    if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
-        return getattr(event, "reply_to_message_id", None)
+    if platform == "feishu":
+        # Feishu reply API nests the response under the replied-to message even
+        # without an explicit thread_id (it auto-uses root_id). That collapses the
+        # bot's response into a subtopic in the UI. Return None to skip reply
+        # semantics for feishu group/dm — let the bot post to chat_id directly.
+        if getattr(source, "chat_type", None) in {"group", "dm"}:
+            return None
     return getattr(event, "message_id", None)
 
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -677,7 +677,11 @@ def build_session_key(
         parts.append(chat_id)
     # DMs put the participant before the thread; groups/threads put it after.
     user_part = [str(participant_id)] if isolate_user and participant_id else []
-    thread_part = [thread_id] if thread_id else []
+    # Feishu SDK populates thread_id with reply-chain root_id for both group and DM
+    # chats. Including it in the session key causes session fork on every reply,
+    # dropping prior conversation context. Skip feishu thread_id for group/dm.
+    is_feishu_chat = source.platform == Platform.FEISHU and source.chat_type in {"group", "dm"}
+    thread_part = [thread_id] if thread_id and not is_feishu_chat else []
     parts += user_part + thread_part if is_dm else thread_part + user_part
     return ":".join(str(part) for part in parts)
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2504,7 +2504,7 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        thread_id = getattr(message, "thread_id", None) or None
         reply_to_message_id = (
             getattr(message, "parent_id", None) or getattr(message, "upper_message_id", None)
             or getattr(message, "root_id", None) or None


### PR DESCRIPTION
## Problem

Feishu SDK populates `message.thread_id` with the reply chain root_id for both group and DM chats. Three downstream effects all cause bugs in v0.21.0:

1. **`plugins/platforms/feishu/adapter.py`** uses `thread_id` (with `root_id` fallback) for outbound sends. The `root_id` fallback causes every regular reply to be treated as a thread reply, so bot responses get nested into subtopics instead of flowing in the main chat.

2. **`gateway/platforms/base.py:_reply_anchor_for_event()`** returns `reply_to_message_id` for feishu whenever both `thread_id` and `reply_to_message_id` are present. Combined with feishu's reply API behavior (which auto-uses `root_id` even without explicit `thread_id`), this nests the bot response under the original message in the UI.

3. **`gateway/session.py:build_session_key()`** appends `thread_id` to the session key, causing session fork on every reply — agent loses prior conversation context.

## Fix

Four changes across three files (+24/-5):

### `plugins/platforms/feishu/adapter.py`
Drop `root_id` fallback on outbound thread_id (line ~2506):
```python
# before
thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
# after
thread_id = getattr(message, "thread_id", None) or None
```
`root_id` is still valid for `reply_to_message_id` — only the `thread_id` fallback is wrong.

### `gateway/platforms/base.py:_thread_metadata_for_source()`
Skip `thread_id` in metadata for feishu group/dm so the adapter doesn't pass it to feishu's API.

### `gateway/platforms/base.py:_reply_anchor_for_event()`
Return `None` for feishu group/dm (don't call feishu reply API; let the bot post directly to `chat_id`).

### `gateway/session.py:build_session_key()`
Skip feishu `thread_id` when building the session key for group/dm.

## Validation

Tested locally on v0.21.0 (2026-09-09) with a 7-profile multiplex gateway:

- Regular feishu group replies stay in main chat (no subtopic nesting)
- Session continuity preserved across multi-round conversations
- Telegram forum topics / Slack thread_ts unaffected (regression check)
- Topic-mode behavior preserved when feishu explicitly provides `thread_id` in the event payload (only the `root_id` fallback is removed)

## Fixes

- #20548 — root_id fallback causes all replies to be threaded

## Related

- #17875 — feishu topic progress messages can still create new topics (also still reproduces on v0.21.0)
- #36233 — similar territory; this PR proposes a layered fix at the adapter + base + session layer
