### PR TITLE
fix(desktop): preserve interim messages across history and tool boundaries

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-history.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-history.test.tsx
@@ -1,0 +1,99 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { chatMessageText, toChatMessages } from '@/lib/chat-messages'
+import type { RpcEvent, SessionMessage } from '@/types/hermes'
+
+import { renderMessageStream } from './test-harness'
+
+const SID = 'interim-preservation'
+
+afterEach(cleanup)
+
+describe('intermediate assistant text survives Desktop lifecycle boundaries', () => {
+  it.each(['message.complete', 'message.interim'] as const)(
+    'keeps pre-tool text when %s settles the next response',
+    async terminal => {
+      const stream = renderMessageStream(SID)
+
+      const emit = async (type: RpcEvent['type'], payload: RpcEvent['payload']) => {
+        await act(() => stream.handleEvent({ type, payload, session_id: SID }))
+      }
+
+      await emit('message.start', {})
+      await emit('message.delta', { text: 'Checking the files.', timestamp: 1 })
+      // Missing/disabled interim delivery must not make this older model response
+      // disposable when the later model response is finalized.
+      await emit('tool.start', { tool_id: 'call-1', name: 'terminal', args: { command: 'pwd' }, timestamp: 2 })
+      await emit('tool.complete', { tool_id: 'call-1', name: 'terminal', result: 'ok', timestamp: 3 })
+      await emit('message.delta', { text: 'Partial answer', timestamp: 4 })
+      await emit(terminal, { text: 'The result is ready.', timestamp: 5 })
+      const messages = stream.state().messages
+      const visible = messages.map(chatMessageText).join('\n')
+      expect(visible).toContain('Checking the files.')
+      expect(visible).toContain('The result is ready.')
+      expect(visible).not.toContain('Partial answer')
+      expect(messages.flatMap(message => message.parts).filter(part => part.type === 'tool-call')).toHaveLength(1)
+      expect(stream.state().busy).toBe(terminal === 'message.interim')
+    }
+  )
+
+  it.each(['rpc', 'rest'] as const)(
+    'preserves the same public commentary on live → %s history projection',
+    async transport => {
+      const stream = renderMessageStream(SID)
+
+      const emit = async (type: RpcEvent['type'], payload: RpcEvent['payload']) => {
+        await act(() => stream.handleEvent({ type, payload, session_id: SID }))
+      }
+
+      await emit('message.start', {})
+      await emit('reasoning.delta', { text: 'Real reasoning.', timestamp: 1 })
+      await emit('message.interim', { text: 'I will inspect the files.', already_streamed: false, timestamp: 2 })
+      await emit('tool.start', { tool_id: 'call-1', name: 'terminal', args: { command: 'pwd' }, timestamp: 3 })
+      await emit('tool.complete', { tool_id: 'call-1', name: 'terminal', result: 'ok', timestamp: 4 })
+      await emit('message.delta', { text: 'All checks passed.', timestamp: 5 })
+      await emit('message.complete', { text: 'All checks passed.', timestamp: 6 })
+
+      const items = [
+        {
+          type: 'message',
+          role: 'assistant',
+          phase: 'commentary',
+          content: [{ type: 'output_text', text: 'I will inspect the files.' }]
+        }
+      ]
+
+      const rows: SessionMessage[] = [
+        {
+          role: 'assistant',
+          content: '',
+          timestamp: 1,
+          reasoning: 'Real reasoning.',
+          codex_message_items: transport === 'rest' ? JSON.stringify(items) : items,
+          tool_calls: [
+            { id: 'call-1', type: 'function', function: { name: 'terminal', arguments: '{"command":"pwd"}' } }
+          ]
+        },
+        { role: 'tool', content: 'ok', tool_call_id: 'call-1', name: 'terminal', timestamp: 4 },
+        { role: 'assistant', content: 'All checks passed.', timestamp: 5 }
+      ]
+
+      const texts = (messages: ReturnType<typeof toChatMessages>) =>
+        messages
+          .flatMap(message => message.parts.flatMap(part => (part.type === 'text' ? [part.text.trim()] : [])))
+          .filter(Boolean)
+
+      const live = texts(stream.state().messages)
+      const restored = texts(toChatMessages(rows))
+      expect(live).toEqual(['I will inspect the files.', 'All checks passed.'])
+      expect(restored).toEqual(live)
+      expect(restored.join('')).not.toContain('Real reasoning.')
+      expect(
+        toChatMessages(rows)
+          .flatMap(message => message.parts)
+          .filter(part => part.type === 'tool-call')
+      ).toHaveLength(1)
+    }
+  )
+})

--- a/apps/desktop/src/lib/chat-messages.codex-json-sidecar.test.ts
+++ b/apps/desktop/src/lib/chat-messages.codex-json-sidecar.test.ts
@@ -30,9 +30,14 @@ it('hydrates the SQLite JSON-text sidecar returned by REST like the decoded RPC 
   expect(toChatMessages([{ ...empty, codex_message_items: '{invalid' }])).toEqual([])
   expect(toChatMessages([{ ...empty, display_kind: 'hidden', codex_message_items: JSON.stringify(items) }])).toEqual([])
 
-  for (const phase of ['analysis', 'commentary']) {
-    expect(toChatMessages([{ ...empty, codex_message_items: JSON.stringify([{ ...items[0], phase }]) }])).toEqual([])
-  }
+  expect(
+    toChatMessages([{ ...empty, codex_message_items: JSON.stringify([{ ...items[0], phase: 'analysis' }]) }])
+  ).toEqual([])
+  expect(
+    chatMessageText(
+      toChatMessages([{ ...empty, codex_message_items: JSON.stringify([{ ...items[0], phase: 'commentary' }]) }])[0]
+    )
+  ).toBe('Durable reply')
 
   expect(
     chatMessageText(

--- a/apps/desktop/src/lib/chat-messages.codex-sidecar-hydration.test.ts
+++ b/apps/desktop/src/lib/chat-messages.codex-sidecar-hydration.test.ts
@@ -66,8 +66,8 @@ describe('#68321 assistant rows whose reply persisted only in codex_message_item
     expect(messages.map(m => m.role)).toEqual(['user', 'assistant', 'user'])
     // The final-answer text is painted as the bubble's reply text...
     expect(chatMessageText(messages[1])).toContain('Here is the full response you saw live.')
-    // ...and commentary / analysis narration (reasoning channel on the backend) is not.
-    expect(chatMessageText(messages[1])).not.toContain('Working through the approach...')
+    // ...and public commentary survives too, without promoting analysis.
+    expect(chatMessageText(messages[1])).toContain('Working through the approach...')
     expect(chatMessageText(messages[1])).not.toContain('Scratchpad thoughts.')
   })
 

--- a/apps/desktop/src/lib/chat-messages.interim-preservation.test.ts
+++ b/apps/desktop/src/lib/chat-messages.interim-preservation.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionMessage } from '@/types/hermes'
+
+import {
+  assistantTextPart,
+  type ChatMessagePart,
+  chatMessageText,
+  mergeFinalAssistantText,
+  reasoningPart,
+  toChatMessages,
+  upsertToolPart
+} from './chat-messages'
+
+const item = (phase: string, text: string) => ({
+  type: 'message',
+  role: 'assistant',
+  phase,
+  content: [{ type: 'output_text', text }]
+})
+
+const textParts = (parts: ChatMessagePart[]) => parts.flatMap(part => (part.type === 'text' ? [part.text] : []))
+
+const assistantText = (rows: SessionMessage[]) =>
+  toChatMessages(rows)
+    .filter(message => message.role === 'assistant')
+    .map(chatMessageText)
+    .join('\n')
+
+const withTool = (parts: ChatMessagePart[], id = 'call-1', timestamp = 2) =>
+  upsertToolPart(
+    parts,
+    { tool_id: id, name: 'terminal', args: { command: 'pwd' }, result: 'ok' },
+    'complete',
+    timestamp
+  )
+
+describe('stored assistant commentary preservation', () => {
+  it.each(['rpc', 'rest'] as const)('restores commentary before the canonical reply through %s history', transport => {
+    const items = [
+      item('commentary', 'I will inspect the files.'),
+      item('analysis', 'Private analysis.'),
+      item('final_answer', 'Stale sidecar final.')
+    ]
+
+    const row: SessionMessage = {
+      role: 'assistant',
+      content: 'Canonical final.',
+      timestamp: 2,
+      reasoning: 'Real reasoning.',
+      codex_message_items: transport === 'rest' ? JSON.stringify(items) : items
+    }
+
+    const [message] = toChatMessages([row])
+    expect(textParts(message.parts)).toEqual(['I will inspect the files.', 'Canonical final.'])
+    expect(chatMessageText(message)).not.toContain('Private analysis.')
+    expect(chatMessageText(message)).not.toContain('Stale sidecar final.')
+    expect(message.parts.filter(part => part.type === 'reasoning')).toEqual([reasoningPart('Real reasoning.', 2)])
+  })
+
+  it.each(['rpc', 'rest'] as const)('keeps a commentary-only assistant row through %s history', transport => {
+    const items = [item('commentary', 'Still checking.')]
+
+    const rows: SessionMessage[] = [
+      { role: 'user', content: 'Check it.', timestamp: 1 },
+      {
+        role: 'assistant',
+        content: '',
+        timestamp: 2,
+        codex_message_items: transport === 'rest' ? JSON.stringify(items) : items
+      },
+      { role: 'user', content: 'Continue.', timestamp: 3 }
+    ]
+
+    expect(toChatMessages(rows).map(message => message.role)).toEqual(['user', 'assistant', 'user'])
+    expect(assistantText(rows)).toBe('Still checking.')
+  })
+
+  it('keeps separate commentary items in order and joins only chunks of the same item', () => {
+    const first = item('commentary', 'First ')
+    first.content.push({ type: 'output_text', text: 'update.' })
+
+    const [message] = toChatMessages([
+      {
+        role: 'assistant',
+        content: '',
+        timestamp: 2,
+        codex_message_items: [first, item('commentary', 'Second update.'), item('final_answer', 'Final answer.')]
+      }
+    ])
+
+    expect(textParts(message.parts)).toEqual(['First update.', 'Second update.', 'Final answer.'])
+  })
+
+  it('normalizes phase spelling without exposing analysis', () => {
+    expect(
+      assistantText([
+        {
+          role: 'assistant',
+          content: '',
+          timestamp: 2,
+          codex_message_items: [
+            item(' Commentary ', 'Visible update.'),
+            item(' ANALYSIS ', 'Hidden analysis.'),
+            item('final_answer', 'Answer.')
+          ]
+        }
+      ])
+    ).toBe('Visible update.Answer.')
+  })
+
+  it('does not duplicate commentary also present in canonical content', () => {
+    const items = [item('commentary', 'First update.'), item('commentary', 'Second update.')]
+    expect(
+      assistantText([
+        {
+          role: 'assistant',
+          content: 'First update.\n\nSecond update.',
+          timestamp: 2,
+          codex_message_items: items
+        }
+      ])
+    ).toBe('First update.\n\nSecond update.')
+  })
+
+  it('keeps canonical text authoritative when it equals one commentary item', () => {
+    expect(
+      assistantText([
+        {
+          role: 'assistant',
+          content: 'Same text.',
+          timestamp: 2,
+          codex_message_items: [item('commentary', 'Same text.'), item('final_answer', 'Stale text.')]
+        }
+      ])
+    ).toBe('Same text.')
+  })
+
+  it('respects explicitly hidden and non-assistant rows', () => {
+    const codex_message_items = [item('commentary', 'Do not surface this.')]
+    expect(
+      toChatMessages([{ role: 'assistant', content: '', timestamp: 2, display_kind: 'hidden', codex_message_items }])
+    ).toEqual([])
+    expect(assistantText([{ role: 'user', content: 'User text.', timestamp: 2, codex_message_items }])).toBe('')
+  })
+
+  it.each(['{broken', 'null', '{}', '42'])(
+    'ignores malformed sidecar %s without losing canonical content',
+    codex_message_items => {
+      expect(assistantText([{ role: 'assistant', content: 'Keep me.', timestamp: 2, codex_message_items }])).toBe(
+        'Keep me.'
+      )
+    }
+  )
+
+  it('does not promote a reasoning-only row into an answer', () => {
+    const [message] = toChatMessages([{ role: 'assistant', content: '', timestamp: 2, reasoning: 'Only reasoning.' }])
+    expect(chatMessageText(message)).toBe('')
+    expect(message.parts).toEqual([reasoningPart('Only reasoning.', 2)])
+  })
+
+  it('rejects malformed and foreign-role items while keeping valid commentary', () => {
+    expect(
+      assistantText([
+        {
+          role: 'assistant',
+          content: '',
+          timestamp: 2,
+          codex_message_items: JSON.stringify([
+            null,
+            1,
+            [],
+            { ...item('commentary', 'Foreign text.'), role: 'user' },
+            { ...item('commentary', 'Wrong type.'), type: 'reasoning' },
+            { ...item('commentary', 'Bad content.'), content: 'not an array' },
+            { ...item('commentary', ''), content: [null, 1, [], { type: 'output_text', text: 42 }] },
+            item('commentary', 'Valid update.')
+          ])
+        }
+      ])
+    ).toBe('Valid update.')
+  })
+})
+
+describe('authoritative final text is scoped to the latest tool-delimited response', () => {
+  it('does not erase commentary from before a tool when the interim frame is absent', () => {
+    const earlier = withTool([assistantTextPart('Checking the repository.', 1)])
+    const parts = [...earlier, assistantTextPart('Partial final', 3)]
+    const before = structuredClone(parts)
+    const result = mergeFinalAssistantText(parts, 'Final answer.', 4)
+    expect(textParts(result)).toEqual(['Checking the repository.', 'Final answer.'])
+    expect(result.slice(0, earlier.length)).toEqual(earlier)
+    expect(parts).toEqual(before)
+  })
+
+  it('keeps all earlier tool-delimited updates, not just the latest one', () => {
+    const first = withTool([assistantTextPart('First update.', 1)])
+    const second = withTool([...first, assistantTextPart('Second update.', 3)], 'call-2', 4)
+    const result = mergeFinalAssistantText([...second, assistantTextPart('Draft', 5)], 'Done.', 6)
+    expect(textParts(result)).toEqual(['First update.', 'Second update.', 'Done.'])
+    expect(result.filter(part => part.type === 'tool-call')).toHaveLength(2)
+  })
+
+  it('does not duplicate an exact cumulative final prefix while preserving the tool boundary', () => {
+    const parts = [...withTool([assistantTextPart('Earlier update.', 1)]), assistantTextPart('Partial', 3)]
+    const result = mergeFinalAssistantText(parts, 'Earlier update.Final answer.', 4)
+    expect(textParts(result)).toEqual(['Earlier update.', 'Final answer.'])
+    expect(result.findIndex(part => part.type === 'tool-call')).toBe(1)
+  })
+
+  it('keeps a longer earlier update when the final is only its short prefix', () => {
+    const parts = withTool([assistantTextPart('Done. The investigation details follow.', 1)])
+    expect(textParts(mergeFinalAssistantText(parts, 'Done.', 3))).toEqual([
+      'Done. The investigation details follow.',
+      'Done.'
+    ])
+  })
+
+  it('still replaces provisional text within one response, even across reasoning parts', () => {
+    const parts = [
+      assistantTextPart('Wrong draft.', 1),
+      reasoningPart('Reconsidering.', 2),
+      assistantTextPart('Another draft.', 3)
+    ]
+
+    expect(textParts(mergeFinalAssistantText(parts, 'Correct final.', 4))).toEqual(['Correct final.'])
+  })
+
+  it('keeps a confirmed full stream and an empty terminal frame unchanged', () => {
+    const parts = [...withTool([assistantTextPart('Earlier.', 1)]), assistantTextPart('Final.', 3)]
+    expect(mergeFinalAssistantText(parts, 'Earlier.Final.', 4)).toBe(parts)
+    expect(mergeFinalAssistantText(parts, '  ', 4)).toBe(parts)
+  })
+})

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -1197,7 +1197,9 @@ describe('mergeFinalAssistantText', () => {
     expect(result[0]).toMatchObject({ text: 'final answer', timestamp: 12.5, type: 'text' })
   })
 
-  it('removes all text parts and appends the final text', () => {
+  it('preserves pre-tool text and appends the later final response', () => {
+    // These deltas precede the tool call: they belong to an earlier model
+    // response, not to the provisional draft of the final being settled.
     const parts = [
       { type: 'text' as const, text: 'streamed delta 1' },
       { type: 'text' as const, text: 'streamed delta 2' },
@@ -1206,8 +1208,11 @@ describe('mergeFinalAssistantText', () => {
 
     const result = mergeFinalAssistantText(parts, 'final answer')
 
-    expect(result.filter(p => p.type === 'text')).toHaveLength(1)
-    expect(result.filter(p => p.type === 'text')[0]).toMatchObject({ text: 'final answer' })
+    expect(result.filter(p => p.type === 'text').map(p => p.text)).toEqual([
+      'streamed delta 1',
+      'streamed delta 2',
+      'final answer'
+    ])
     expect(result.some(p => p.type === 'tool-call')).toBe(true)
   })
 

--- a/apps/desktop/src/lib/chat-messages/hydration.ts
+++ b/apps/desktop/src/lib/chat-messages/hydration.ts
@@ -4,7 +4,14 @@ import { extractImageRefs } from '@/lib/embedded-images'
 import { dedupeGeneratedImageEchoesInParts } from '@/lib/generated-images'
 import type { MessageReaction, SessionMessage } from '@/types/hermes'
 
-import { assistantTextPart, chatMessageText, dedupeRepeatedTextInParts, reasoningPart, textPart } from './parts'
+import {
+  assistantTextPart,
+  chatMessageText,
+  dedupeRepeatedTextInParts,
+  reasoningPart,
+  renderMediaTags,
+  textPart
+} from './parts'
 import {
   applyStoredToolResult,
   applyStoredToolResultToParts,
@@ -20,28 +27,27 @@ const CONTEXT_WARNINGS_MARKER_RE = /(?:^|\n)--- Context Warnings ---[\s\S]*$/
 const CONTEXT_REF_RE = /@(file|folder|url|image|tool|terminal):(?:"[^"\n]+"|'[^'\n]+'|`[^`\n]+`|\S+)/g
 
 /**
- * Reply text from a Responses-API `codex_message_items` sidecar (#68321), for rows
- * whose `content` persisted empty. `commentary` / `analysis` items are mid-turn
- * narration the backend routes to the reasoning channel
- * (codex_responses_adapter `_OutputScan._message`); the remaining phases are the reply.
+ * Responses message items retain their channel in stored history. Commentary
+ * is public assistant text, not analysis; restore it even when the same row
+ * has a canonical final answer. Final items remain a content fallback only.
  */
-function codexMessageItemText(message: SessionMessage): string {
+function codexMessageItemText(message: SessionMessage): { commentary: string[]; reply: string } {
   let items = message.codex_message_items
+  const commentary: string[] = []
+  const replies: string[] = []
 
   // REST carries SQLite JSON text; RPC history carries the decoded list.
   if (typeof items === 'string') {
     try {
       items = JSON.parse(items)
     } catch {
-      return ''
+      return { commentary, reply: '' }
     }
   }
 
   if (!Array.isArray(items)) {
-    return ''
+    return { commentary, reply: '' }
   }
-
-  const texts: string[] = []
 
   for (const item of items) {
     if (!item || typeof item !== 'object' || Array.isArray(item)) {
@@ -54,37 +60,38 @@ function codexMessageItemText(message: SessionMessage): string {
       continue
     }
 
-    if (record.phase === 'commentary' || record.phase === 'analysis') {
+    const phase = typeof record.phase === 'string' ? record.phase.trim().toLowerCase() : ''
+
+    if (phase === 'analysis' || !Array.isArray(record.content)) {
       continue
     }
 
-    const content = record.content
+    const chunks: string[] = []
 
-    if (!Array.isArray(content)) {
-      continue
-    }
-
-    for (const part of content) {
+    for (const part of record.content) {
       if (!part || typeof part !== 'object' || Array.isArray(part)) {
         continue
       }
 
       const partRecord = part as Record<string, unknown>
-      const partType = partRecord.type
 
-      if (partType !== 'output_text' && partType !== 'text') {
-        continue
+      if ((partRecord.type === 'output_text' || partRecord.type === 'text') && typeof partRecord.text === 'string') {
+        chunks.push(partRecord.text)
       }
+    }
 
-      const text = partRecord.text
+    const text = chunks.join('')
 
-      if (typeof text === 'string' && text.length > 0) {
-        texts.push(text)
+    if (phase === 'commentary') {
+      if (text.trim()) {
+        commentary.push(text.trim())
       }
+    } else {
+      replies.push(text)
     }
   }
 
-  return texts.join('')
+  return { commentary, reply: replies.join('') }
 }
 
 function displayContentForMessage(role: SessionMessage['role'], content: unknown): string {
@@ -325,22 +332,27 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
       parts.push(reasoningPart(reasoning, message.timestamp))
     }
 
-    if (displayContent) {
-      parts.push(
-        displayRole === 'assistant'
-          ? assistantTextPart(displayContent, message.timestamp)
-          : textPart(displayContent, message.timestamp)
-      )
+    const codexText =
+      displayRole === 'assistant' && message.display_kind !== 'hidden' ? codexMessageItemText(message) : null
+
+    const reply = displayContent || codexText?.reply
+    // Some providers also persist the joined commentary as canonical content.
+    // Keep that authoritative copy once, without treating unrelated final text
+    // as a reason to discard the earlier public messages.
+    const normalized = (value: string) => renderMediaTags(value).replace(/\s+/g, ' ').trim()
+
+    const commentaryIsReply = Boolean(
+      reply && codexText?.commentary.length && normalized(codexText.commentary.join('\n\n')) === normalized(reply)
+    )
+
+    if (codexText && !commentaryIsReply) {
+      parts.push(...codexText.commentary.map(text => assistantTextPart(text, message.timestamp)))
     }
 
-    // Reply text can live only in the sidecar alongside reasoning or tool parts.
-    // Those parts are not a substitute for the answer; canonical content still wins.
-    if (message.role === 'assistant' && message.display_kind !== 'hidden' && !displayContent) {
-      const codexText = codexMessageItemText(message)
-
-      if (codexText) {
-        parts.push(assistantTextPart(codexText, message.timestamp))
-      }
+    if (reply) {
+      parts.push(
+        displayRole === 'assistant' ? assistantTextPart(reply, message.timestamp) : textPart(reply, message.timestamp)
+      )
     }
 
     if (message.role === 'assistant' && Array.isArray(message.tool_calls)) {

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -156,8 +156,10 @@ export function dedupeRepeatedTextInParts(parts: ChatMessagePart[]): ChatMessage
 /**
  * Merge the final assistant text into a message's parts.
  *
- * - Removes all existing `text` parts (they were streamed deltas, now superseded
- *   by the authoritative final response).
+ * - Preserves earlier tool-delimited responses: a missed interim frame must
+ *   not make their public text disposable.
+ * - Replaces provisional text only in the latest response with its authoritative
+ *   final text, retaining confirmed text/reasoning boundaries.
  * - Keeps `reasoning` parts, but drops one that the final text fully covers
  *   (reasoning ⊆ final) — the final restates it. A short final ("Done.") must
  *   NOT swallow a longer reasoning block that merely starts with it (#61447).
@@ -190,14 +192,33 @@ export function mergeFinalAssistantText(
     return parts
   }
 
+  // A tool call is an explicit model-response boundary even when no
+  // message.interim frame sealed the earlier text into a separate bubble.
+  // Only the suffix after the last call belongs to this authoritative final.
+  const lastToolIndex = parts.findLastIndex(part => part.type === 'tool-call')
+
+  if (lastToolIndex >= 0) {
+    const earlier = parts.slice(0, lastToolIndex + 1)
+
+    const earlierText = earlier
+      .filter((part): part is Extract<ChatMessagePart, { type: 'text' }> => part.type === 'text')
+      .map(part => part.text)
+      .join('')
+
+    // Some terminal frames carry cumulative text. Strip only an exact prefix;
+    // fuzzy similarity is not proof that two assistant messages are the same.
+    const responseText =
+      earlierText && finalText.startsWith(earlierText) ? finalText.slice(earlierText.length) : finalText
+
+    return [...earlier, ...mergeFinalAssistantText(parts.slice(lastToolIndex + 1), responseText, fallbackTimestamp)]
+  }
+
   const previousText = parts.findLast(part => part.type === 'text')
 
   const kept = parts.filter(part => {
     if (part.type === 'text') {
-      // Sealed text parts were already finalized into their own bubbles —
-      // this filter only runs on the LAST streaming bubble, so there are no
-      // sealed parts here. All text parts are streamed deltas that get
-      // replaced by the authoritative final text.
+      // The tool-delimited prefix was retained above. This suffix is
+      // provisional text from the response being finalized.
       return false
     }
 


### PR DESCRIPTION
## Summary

Fix two reproducible Desktop paths where already-visible intermediate assistant text disappears:

- Restore public Responses `phase=commentary` messages from stored history, including rows that also have a canonical final answer.
- Preserve earlier tool-delimited assistant text when a later interim/final event replaces the current response's provisional text.
- Add 25 regression cases, including the actual `useMessageStream` hook, and update three legacy expectations that explicitly encoded commentary suppression or pre-tool text deletion.

This is a standalone Desktop companion to #107350, based directly on main at `67764dc0863349a384c16425e73ee8571f3a94b7`. It does not include or modify that PR's concurrently changing CLI/backend work.

## Root causes

### 1. History projection discards commentary

`codexMessageItemText()` in `apps/desktop/src/lib/chat-messages/hydration.ts` excluded both `commentary` and `analysis`, and its caller consulted the sidecar only when canonical content was empty. As a result, live commentary could disappear on rehydration; commentary-only assistant rows could vanish entirely.

Separate commentary from reply fallback. Preserve commentary as ordinary assistant text even beside canonical final content, while canonical content still takes precedence over a sidecar final answer. Support both decoded RPC sidecars and REST/SQLite JSON strings. Keep analysis out of public text, respect hidden/non-assistant rows, reject malformed items, and avoid repeating joined commentary already present as canonical content.

### 2. Finalization deletes text from earlier tool iterations

`mergeFinalAssistantText()` in `apps/desktop/src/lib/chat-messages/parts.ts` treated every text part in the current bubble as a disposable draft. That assumption fails when the earlier `message.interim` frame was absent or disabled: text before a tool call is still in the bubble when the next response is finalized.

Use the last tool-call boundary to retain the earlier prefix and finalize only the current response's suffix. Preserve existing exact-match/empty-final behavior and tool/reasoning metadata. Handle an exact cumulative-text prefix without duplicating it; do not introduce fuzzy similarity heuristics. Provisional text within one response is still replaced normally.

This finalization fix is provider-neutral within the shared Desktop message path. The history fix applies to providers that persist Responses message items in the existing sidecar; it is not a claim of live end-to-end verification for every provider.

## Reproduction

The new hook tests exercise:

```text
message.start
message.delta("Checking the files.")
# no earlier message.interim
 tool.start → tool.complete
message.delta("Partial answer")
message.complete OR message.interim("The result is ready.")
```

Before: only the later text survives. After: the earlier update, tool, and authoritative later text remain; the later provisional draft does not.

A second hook/history test compares a live commentary → tool → final sequence against both RPC and REST history projection. Before: the stored projection omits the commentary. After: both public messages survive, without promoting the reasoning text.

## Validation — executed

Validation run: https://github.com/Xipong/hermes-agent/actions/runs/34483105707

The runner checks out the pinned upstream base, copies the new tests, proves RED against unchanged production code, then applies/formats the patch and runs the full selected suites and static checks. Only the validated seven Desktop files are committed to this PR branch; the fork-only staging scripts/workflow are not part of the PR.

- **RED:** 15 failed / 10 passed among the 25 new cases on unchanged production code.
- **GREEN:** 308 passed / 0 failed across 34 test files, including all 25 new cases.
- Renderer TypeScript: `tsc -p apps/desktop --noEmit` — passed.
- ESLint on all seven changed files, `--max-warnings 0` — passed.
- Prettier check on all seven changed files — passed.
- `git diff --check` — passed.

Test command, from `apps/desktop`:

```sh
node ../../node_modules/vitest/vitest.mjs run --project ui --maxWorkers=2 \
  src/app/session/hooks/use-message-stream \
  src/lib/chat-messages \
  src/lib/tool-run-continuity.test.ts \
  src/lib/chat-runtime.test.ts \
  src/app/chat/runtime-repository.test.ts
```

The `desktop-interim-validation` artifact contains RED/GREEN JSON and logs, the exact patch, static-check receipts, and base/head SHAs. Validated product commit: `d198c89eaa0b1f19a3c301c0cc9e1481c368100d`.

## Scope and limitations

No prompts, OAuth/authentication, provider protocol, database schema, or Python backend changes. Actual reasoning is not reclassified as an answer. #107350 addresses the separate backend commentary/reasoning classification and CLI delivery issue.

Stored commentary can be restored without a migration when it is present in the session data; text never persisted by the backend cannot be reconstructed here. Tests use synthetic events with the real Desktop hook/projection code. A packaged Electron app, live OAuth/model session, and the complete repository-wide suite were not run.