### PR TITLE
fix(website): configure DocSearch key at build time

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -177,7 +177,11 @@ jobs:
           working-directory: website
 
       - name: Build Docusaurus
-        run: npm run build
+        env:
+          ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}
+        run: |
+          node -e "if (!process.env.ALGOLIA_SEARCH_API_KEY?.trim()) { throw new Error('Set the ALGOLIA_SEARCH_API_KEY deployment secret before publishing docs'); }"
+          npm run build
         working-directory: website
 
       - name: Stage deployment

--- a/.github/workflows/docs-site-checks.yml
+++ b/.github/workflows/docs-site-checks.yml
@@ -48,6 +48,10 @@ jobs:
         run: npm run lint:diagrams
         working-directory: website
 
+      - name: Test documentation search configuration
+        run: node --test docusaurus.config.test.mjs
+        working-directory: website
+
       - name: Build Docusaurus
         # Build only the default (en) locale in CI — the full bilingual
         # build runs in deploy-site.yml on push-to-main / release.

--- a/website/README.md
+++ b/website/README.md
@@ -24,6 +24,25 @@ yarn build
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
 
+## Documentation search
+
+DocSearch is enabled only when `ALGOLIA_SEARCH_API_KEY` is supplied at build time.
+Local builds and source archives contain no default key; the site builds without search when the variable is absent or blank.
+
+For the hosted site, create an Algolia key with only the `search` permission, restricted to the documentation index.
+Store it in the `ALGOLIA_SEARCH_API_KEY` secret for the repository or its `github-pages` environment before merging this configuration change.
+The deployment workflow requires this secret before building, so missing configuration leaves the previous deployment in place.
+
+The generated browser bundle contains the configured key, as required by DocSearch.
+Never supply an admin key or a key with unnecessary `browse`, write, or delete permissions.
+Moving a key out of source does not revoke an older key; the Algolia application owner must replace or revoke it separately.
+
+Run the configuration checks after installing website dependencies:
+
+```bash
+node --test docusaurus.config.test.mjs
+```
+
 ## Deployment
 
 Using SSH:

--- a/website/docusaurus.config.test.mjs
+++ b/website/docusaurus.config.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import {spawnSync} from 'node:child_process';
+import {test} from 'node:test';
+
+function loadSearchConfig(apiKey) {
+  const env = {...process.env};
+  delete env.ALGOLIA_SEARCH_API_KEY;
+  if (apiKey !== undefined) {
+    env.ALGOLIA_SEARCH_API_KEY = apiKey;
+  }
+  const result = spawnSync(process.execPath, ['--input-type=module', '-e', `
+    const {default: config} = await import('./docusaurus.config.ts');
+    console.log(JSON.stringify(config.themeConfig.algolia ?? null));
+  `], {cwd: new URL('.', import.meta.url), env, encoding: 'utf8'});
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+test('source builds omit DocSearch when no key is supplied', () => {
+  for (const key of [undefined, '', '   ']) {
+    assert.equal(loadSearchConfig(key) === null, true, 'DocSearch must be absent without a key');
+  }
+});
+
+test('hosted builds use the supplied key and preserve contextual search', () => {
+  const key = 'synthetic-docsearch-test-key';
+  const config = loadSearchConfig(` ${key} `);
+  assert.equal(config.apiKey === key, true, 'DocSearch must use only the supplied key');
+  assert.equal(config.contextualSearch, true);
+  assert.ok(config.appId);
+  assert.ok(config.indexName);
+});

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -2,6 +2,8 @@ import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
+const algoliaSearchApiKey = process.env.ALGOLIA_SEARCH_API_KEY?.trim();
+
 const config: Config = {
   title: 'Hermes Agent',
   tagline: 'The self-improving AI agent',
@@ -92,20 +94,16 @@ const config: Config = {
 
   themeConfig: {
     image: 'img/hermes-agent-banner.png',
-    // Algolia DocSearch (replaces @easyops-cn/docusaurus-search-local).
-    // The local plugin shipped a ~16 MB client-side lunr index that every
-    // visitor downloaded and hydrated before their first result; DocSearch
-    // answers from Algolia's servers with no client index at all. These are
-    // public search-only credentials — safe to commit (the admin key is not
-    // in the repo). Index is populated by the Algolia Crawler configured at
-    // crawler.algolia.com; contextualSearch scopes results to the active
-    // locale via the docusaurus_tag/lang facets the crawler records carry.
-    algolia: {
-      appId: '2JLBVEYZN5',
-      apiKey: '8fda2a49223ce185ac30c2dbf6898a07',
-      indexName: 'hermes docs',
-      contextualSearch: true,
-    },
+    // Supply a search-only key when building the hosted documentation site.
+    // Source archives and downstream runtime images do not need this credential.
+    ...(algoliaSearchApiKey ? {
+      algolia: {
+        appId: '2JLBVEYZN5',
+        apiKey: algoliaSearchApiKey,
+        indexName: 'hermes docs',
+        contextualSearch: true,
+      },
+    } : {}),
     colorMode: {
       defaultMode: 'dark',
       respectPrefersColorScheme: true,


### PR DESCRIPTION
## What does this PR do?

Load the hosted documentation site's DocSearch key from build configuration instead of committing a live key into every Hermes source archive. Local builds omit DocSearch when no key is supplied; the official Pages deployment requires its configured key before building.

The current committed key is live and has `search`, `listIndexes`, `settings`, and `browse` permissions. These are read permissions, not unrestricted administrative access. However, the public AlgoliaAdminKey secret detector treats `browse` as sensitive, so enterprise consumers that package Hermes source can receive verified-secret findings for a credential their runtime never needs. This PR removes that distribution dependency without obfuscating the key or disabling scanners.

**Before merge:** an upstream maintainer must configure `ALGOLIA_SEARCH_API_KEY` as a repository or `github-pages` environment secret. Use a replacement key restricted to `search` on the documentation index. The application owner should revoke or restrict the older key separately; removing it from current source does not remove it from history or revoke it.

## Related Issue

No existing issue found. This was reproduced during downstream image packaging. The separate spoofed-URL fixture change in #105917 is unrelated to this credential change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Read `ALGOLIA_SEARCH_API_KEY` at Docusaurus build time, preserving the existing application, index, and contextual-search configuration.
- Omit DocSearch from unconfigured local/consumer builds.
- Require the deployment secret before the official docs build so absent configuration cannot silently publish a site without search.
- Add two real configuration-import tests to Docs Site Checks. Failure diagnostics do not print key values.
- Document the frontend key's public exposure, required scope, rollout, and independent revocation step.

## How to Test

1. `node --test docusaurus.config.test.mjs` from `website/`: both tests fail against the original configuration and pass against the patch.
2. `npm run build:fast -- --out-dir build-docsearch-unset`: passed.
3. `ALGOLIA_SEARCH_API_KEY=synthetic-docsearch-test-key npm run build:fast -- --out-dir build-docsearch-configured`: passed.
4. Inspect both generated sites: the removed live key is absent from both, and only the configured build contains the synthetic key.
5. Search tracked working-tree contents for the removed value: no occurrences remain. No live value was copied into tests, documentation, or this PR description.

Validation runs in an isolated Node 26 Debian container with website dependencies from the existing lockfile. `npm run typecheck` is independently blocked by the unchanged Docusaurus/TypeScript 6 configuration (`TS5101`, deprecated `baseUrl`). This PR does not change that configuration.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs and found no equivalent key-removal change.
- [x] This PR contains only changes related to this fix.
- [ ] Full Python suite — not run; this change affects only website configuration and its deployment.
- [x] Added behavior tests and demonstrated failure on the original code.
- [x] Tested in an isolated Linux/ARM64 Node 26 container on macOS.

### Documentation & Housekeeping

- [x] Updated website setup and deployment documentation.
- [x] Agent runtime configuration and tool schemas — not affected.
- [x] Cross-platform behavior uses Node's environment and configuration loader; no platform-specific paths or shell quoting were added to runtime code.

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
