### PR TITLE
fix(model-metadata): resolve deepseek-flash to its 1M context window

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -485,7 +485,19 @@ DEFAULT_CONTEXT_LENGTHS = {
     # and inherit the same 1M window. The ``deepseek`` substring entry
     # below remains as a 128K fallback for older / unknown DeepSeek model
     # ids (e.g. via custom endpoints).
+    #
+    # ``deepseek-flash`` is the production name for DeepSeek-V4.1-Flash,
+    # which superseded the time-boxed beta slug
+    # ``deepseek-v4.1-flash-expires-on-0910`` on 2026-09-10. It is NOT
+    # covered by the ``deepseek-v4-flash`` entry — substring matching never
+    # spans the ``v4-`` infix — so without an explicit entry it drops
+    # through to the 128K ``deepseek`` catch-all while the API actually
+    # serves a 1M window, silently capping token budgeting and compression.
+    # ``deepseek-v4-flash`` and ``deepseek-v4-flash-vision-exp`` remain
+    # accepted aliases that route to V4.1-Flash server-side and bill at the
+    # Flash price.
     # https://api-docs.deepseek.com/zh-cn/quick_start/pricing
+    "deepseek-flash": 1_000_000,
     "deepseek-v4-pro": 1_000_000,
     "deepseek-v4-flash": 1_000_000,
     "deepseek-chat": 1_000_000,

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -339,6 +339,7 @@ class TestDefaultContextLengths:
         from unittest.mock import patch as mock_patch
 
         expected_keys = {
+            "deepseek-flash": 1_000_000,
             "deepseek-v4-pro": 1_000_000,
             "deepseek-v4-flash": 1_000_000,
             "deepseek-chat": 1_000_000,
@@ -358,8 +359,11 @@ class TestDefaultContextLengths:
              mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
              mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
             cases = [
+                ("deepseek-flash", 1_000_000),
+                ("deepseek/deepseek-flash", 1_000_000),
                 ("deepseek-v4-pro", 1_000_000),
                 ("deepseek-v4-flash", 1_000_000),
+                ("deepseek-v4-flash-vision-exp", 1_000_000),
                 ("deepseek/deepseek-v4-pro", 1_000_000),
                 ("deepseek/deepseek-v4-flash", 1_000_000),
                 ("deepseek-chat", 1_000_000),


### PR DESCRIPTION
## What

`deepseek-flash` — DeepSeek's production slug for **DeepSeek-V4.1-Flash**, which superseded the time-boxed beta id `deepseek-v4.1-flash-expires-on-0910` on 2026-09-10 — has no entry in `DEFAULT_CONTEXT_LENGTHS` and mis-resolves to **128,000**.

It is also not reachable through the existing `deepseek-v4-flash` entry: `get_model_context_length()` matches longest-substring-first, and `deepseek-v4-flash` is not a substring of `deepseek-flash` — the `v4-` infix breaks the match. So the id falls all the way through to the 128K `deepseek` catch-all.

## Why it matters

The API serves **1M** tokens for this model, so token budgeting and context compression were computed against 128K for a 1M-window model. Long sessions compress earlier than necessary, and the error is silent — nothing warns that the resolved length disagrees with the provider.

## Evidence

Against the live API on 2026-09-10:

- `GET /models` returns exactly `deepseek-flash` and `deepseek-v4-pro`; the beta slug is gone.
- Every Flash-family id is still accepted and responds with `"model": "deepseek-flash"` — `deepseek-flash`, `deepseek-v4.1-flash-expires-on-0910`, `deepseek-v4-flash`, `deepseek-v4-flash-vision-exp`.
- The published pricing page lists 1M context / 384K max output for `deepseek-flash`.

`get_model_context_length()`, before → after:

| model id | before | after |
| --- | --- | --- |
| `deepseek-flash` | 128,000 | **1,000,000** |
| `deepseek/deepseek-flash` | 128,000 | **1,000,000** |
| `deepseek-v4-flash` | 1,000,000 | 1,000,000 |
| `deepseek-v4-pro` | 1,000,000 | 1,000,000 |

## Tests

- `tests/agent/test_model_metadata.py` — **115 passed**. Extended with the production id and its `deepseek/`-prefixed form, plus `deepseek-v4-flash-vision-exp`, which is a live alias that the resolution cases did not cover before.
- `tests/agent/test_model_metadata_local_ctx.py` + `tests/agent/test_uncompressed_context_guardrail.py` — **44 passed**.

## Scope

Two files, +16/−0. No behavior change for any other model id — `deepseek-flash` is not a substring of any other key in the table, so nothing else can match it first, and the new key cannot shadow `deepseek-v4-flash` (which matches at a longer length).
