### PR TITLE
fix(models): use credential pool for Codex catalog in named profiles

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1197,7 +1197,13 @@ def _codex_catalog(normalized: str, force_refresh: bool) -> list[str]:
 
         access_token = resolve_codex_runtime_credentials(refresh_if_expiring=True).get("api_key")
     except Exception:
-        access_token = None
+        try:
+            from agent.credential_pool import load_pool
+
+            entry = load_pool("openai-codex").peek()
+            access_token = str(getattr(entry, "runtime_api_key", "") or "").strip() or None
+        except Exception:
+            access_token = None
     return get_codex_model_ids(access_token=access_token)
 
 

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from unittest.mock import patch
 
 from hermes_cli.codex_models import (
@@ -141,6 +142,46 @@ def test_astra_requires_live_codex_account_discovery(monkeypatch, tmp_path):
     )
     entitled = get_codex_model_ids(access_token="entitled-token")
     assert entitled[entitled.index("gpt-6-astra") + 1] == "gpt-6-astra-900k"
+
+
+def test_named_profile_codex_catalog_borrows_root_pool_credential(monkeypatch, tmp_path):
+    from hermes_cli import models
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "coder"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    (root / "auth.json").write_text(json.dumps({"credential_pool": {"openai-codex": [{
+        "id": "root-codex", "source": "manual", "auth_type": "oauth",
+        "access_token": "borrowed-token", "priority": 0, "last_status": "ok",
+    }]}}))
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("No Codex credentials stored")),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: ["gpt-6-astra"] if access_token == "borrowed-token" else [],
+    )
+
+    assert models.provider_model_ids("openai-codex") == ["gpt-6-astra"]
+
+
+def test_codex_catalog_without_credentials_keeps_offline_astra_gate(monkeypatch, tmp_path):
+    from hermes_cli import models
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    profile = tmp_path / ".hermes" / "profiles" / "coder"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "empty-codex"))
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("No Codex credentials stored")),
+    )
+
+    assert "gpt-6-astra" not in models.provider_model_ids("openai-codex")
 
 
 


### PR DESCRIPTION
## Summary

Fix Codex model discovery in named profiles that use the existing borrowed root credential pool but have no profile-local Codex singleton credentials.

`_codex_catalog()` previously called only `resolve_codex_runtime_credentials()`. When that raises for a named profile, discovery runs without a token and falls back to the offline list. Account-gated models such as Astra disappear from the picker even though inference can use the root credential pool.

## Change

- Preserve the existing singleton resolver as the first choice.
- On resolver failure, use the existing `load_pool("openai-codex").peek()` credential for live discovery.
- Preserve account-scoped live discovery and the offline Astra gate; do not force-add model IDs, copy OAuth grants, or alter profile configuration.
- Add two regression tests for root-pool borrowing and the no-credential fallback.

## Verification

- Based on upstream main `67764dc0863349a384c16425e73ee8571f3a94b7`.
- Regression test fails on unmodified production code (`1 failed, 11 deselected`).
- `scripts/run_tests.sh tests/hermes_cli/test_codex_models.py`: **12 passed** with the patch.
- `git diff --check`: passed.
- Earlier live verification of this same patch returned Astra and its 900K picker alias for all six local profiles; no tokens or account identifiers are included in this PR.
- Full repository suite not run.

Related precedent: #16901 fixed the analogous catalog-vs-runtime credential-pool mismatch for Copilot. This PR is narrowly scoped to the Codex catalog resolver, not a change to model entitlement or cache authority.
