### PR TITLE
fix(desktop): make right-sidebar toggle close reliably

### DIFF
--- a/apps/desktop/src/app/skills/desktop-plugins-section.tsx
+++ b/apps/desktop/src/app/skills/desktop-plugins-section.tsx
@@ -6,7 +6,6 @@ import { Codicon } from '@/components/ui/codicon'
 import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
 import { $pluginRecords, type PluginRecord, setPluginEnabled } from '@/contrib/plugins-store'
-import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { FolderOpen, Monitor, RefreshCw } from '@/lib/icons'
@@ -239,7 +238,7 @@ export function DesktopPluginsSection({ profile }: { profile: null | string }) {
             <Button
               onClick={() => {
                 triggerHaptic('selection')
-                void discoverRuntimePlugins()
+                void import('@/contrib/runtime-loader').then(module => module.discoverRuntimePlugins())
               }}
               size="icon"
               type="button"

--- a/apps/desktop/src/sdk/runtime.test.ts
+++ b/apps/desktop/src/sdk/runtime.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { namespaceExportNames } from './runtime'
+
+describe('runtime SDK namespace preparation', () => {
+  it('tolerates an uninitialized namespace from a production import cycle', () => {
+    expect(namespaceExportNames(undefined)).toEqual([])
+    expect(namespaceExportNames(null)).toEqual([])
+  })
+
+  it('preserves valid named exports while excluding default', () => {
+    expect(namespaceExportNames({ default: {}, host: {}, cn: () => undefined })).toEqual(['host', 'cn'])
+  })
+})

--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -13,33 +13,53 @@ import * as jsxRuntime from 'react/jsx-runtime'
 
 import * as sdk from './index'
 
-const GLOBALS = {
-  __HERMES_PLUGIN_SDK__: sdk,
-  __HERMES_REACT__: React,
-  __HERMES_REACT_JSX__: jsxRuntime,
-  __HERMES_REACT_JSX_DEV__: jsxDevRuntime
-} as const
+// This module is reachable through sdk/index's import graph. Do not capture
+// that graph in a module-scope object: production bundling can evaluate the
+// object before the namespace binding has been initialized.
+function pluginNamespaces() {
+  return {
+    __HERMES_PLUGIN_SDK__: sdk,
+    __HERMES_REACT__: React,
+    __HERMES_REACT_JSX__: jsxRuntime,
+    __HERMES_REACT_JSX_DEV__: jsxDevRuntime
+  }
+}
+
+type PluginGlobalKey = keyof ReturnType<typeof pluginNamespaces>
 
 export function installPluginSdk(): void {
-  Object.assign(globalThis, GLOBALS)
+  Object.assign(globalThis, pluginNamespaces())
+}
+
+export function namespaceExportNames(ns: unknown): string[] {
+  if (ns == null || (typeof ns !== 'object' && typeof ns !== 'function')) {
+    return []
+  }
+
+  return Object.keys(ns).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
 }
 
 /** Build a shim ESM blob that re-exports a global namespace's live members.
  *  Export names come from the namespace itself, so the list can't drift. */
-function shimUrl(globalKey: keyof typeof GLOBALS): string {
-  const names = Object.keys(GLOBALS[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
+function shimUrl(globalKey: PluginGlobalKey): string {
+  const names = namespaceExportNames(pluginNamespaces()[globalKey])
 
   const source =
     `const m = globalThis.${globalKey};\n` +
-    `export default m.default ?? m;\n` +
+    `const ns = m != null && typeof m === 'object' ? m : {};\n` +
+    `export default ns.default ?? ns;\n` +
     // Guard the destructuring: `export const {  } = m` is a syntax error, so
     // only emit it when the namespace actually has named exports.
-    (names.length ? `export const { ${names.join(', ')} } = m;\n` : '')
+    (names.length ? `export const { ${names.join(', ')} } = ns;\n` : '')
 
   return URL.createObjectURL(new Blob([source], { type: 'text/javascript' }))
 }
 
 let cached: Record<string, string> | null = null
+
+export function resetSdkImportMapCache(): void {
+  cached = null
+}
 
 /** Specifier -> shim URL map for the runtime loader (longest keys first). */
 export function sdkImportMap(): Record<string, string> {

--- a/apps/desktop/src/store/layout-toggle.test.ts
+++ b/apps/desktop/src/store/layout-toggle.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const togglePane = vi.fn()
+const revealTreePane = vi.fn()
+
+vi.mock('./panes', async () => ({
+  ...(await vi.importActual('./panes')),
+  togglePane
+}))
+
+vi.mock('@/components/pane-shell/tree/store', async () => ({
+  ...(await vi.importActual('@/components/pane-shell/tree/store')),
+  revealTreePane: vi.fn(revealTreePane)
+}))
+
+describe('toggleFileBrowserOpen', () => {
+  beforeEach(() => {
+    togglePane.mockClear()
+    revealTreePane.mockClear()
+  })
+
+  it('closes the pane even when the tree tab is not the visible active tab', async () => {
+    const { toggleFileBrowserOpen } = await import('./layout')
+
+    toggleFileBrowserOpen()
+
+    expect(togglePane).toHaveBeenCalledWith('file-browser')
+    expect(revealTreePane).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -2,7 +2,6 @@ import { atom, computed, type ReadableAtom, type WritableAtom } from 'nanostores
 
 import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '@/app/layout-constants'
 import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
-import { isPaneVisible, revealTreePane } from '@/components/pane-shell/tree/store'
 import { matchesQuery } from '@/hooks/use-media-query'
 import { connectionScopedAtom } from '@/lib/connection-scoped'
 import { type Codec, Codecs, persistentAtom } from '@/lib/persisted'
@@ -543,18 +542,9 @@ export function toggleFileBrowserOpen() {
     return
   }
 
-  // Ask the TREE, not the pane's boolean. `$fileBrowserOpen` stays true while
-  // the tree pane sits behind a sibling tab in the shared right column (the
-  // preview rail, the diff) or inside a minimized zone, so ⌘J spent its press
-  // re-asserting a value it already held and read as a dead key. Only fold the
-  // side when the tree is genuinely the thing on screen; otherwise bring it
-  // forward through the reveal path, which fronts and un-minimizes.
-  if (!isPaneVisible(FILES_PANE_ID) && $fileBrowserOpen.get()) {
-    revealTreePane(FILES_PANE_ID)
-
-    return
-  }
-
+  // The tree may report the files tab as hidden behind a sibling or minimized
+  // while the pane state is still open. Revealing it here consumes the close
+  // intent and leaves the right sidebar open; toggle the side state directly.
   togglePane(FILE_BROWSER_PANE_ID)
 }
 


### PR DESCRIPTION
## Summary

fixes #107312

1. Runtime-loaded desktop plugins failed during SDK initialization with `Object.keys(undefined)`.
2. The right-sidebar toggle could open but not close.
3. `hermes update` could leave a permanent gateway-restart warning after a deferred restart.

## Root cause 1: runtime plugin SDK

`apps/desktop/src/sdk/runtime.ts` captured the SDK and React namespaces in a module-scope `GLOBALS` object. That module is reachable through the `sdk/index -> app/contrib -> runtime-loader -> sdk/runtime -> sdk/index` cycle introduced by the Plugins surface refactor. In the production bundle, the namespace binding could still be uninitialized when the object literal was evaluated. `sdkImportMap()` then called `Object.keys()` on the undefined SDK namespace before any runtime plugin code ran, breaking every disk-loaded plugin.

The fix resolves namespaces at call time instead of module initialization and makes namespace export enumeration null-safe. Generated shim modules also coerce a missing global namespace to `{}`, preserving the existing import map and preventing the same failure during shim evaluation. The Plugins settings section no longer statically imports `runtime-loader`; its manual rescan uses a dynamic import, removing the cycle edge while preserving rescan behavior.

## Root cause 2: right-sidebar toggle

`toggleFileBrowserOpen()` treated a files pane that was open in pane state but not the active visible tree tab as a reveal request. It called `revealTreePane()` and returned, consuming the user's close intent. The fix toggles the authoritative `file-browser` pane state directly after the narrow-viewport path, so the side closes even when a sibling tab or minimized zone hides the files tab.

## Root cause 3: permanent deferred gateway restart warning (#107402)

When a gateway has active work units, a graceful restart is deferred (#77184). The updater may therefore record a temporary stale fleet snapshot before the gateway finishes restarting. The later reconciliation function, `_live_fleet_covers_receipt()`, incorrectly treated every runtime in the update plan as part of the gateway restart obligation. Since the plan can also contain `dashboard` and `serve` runtimes, it returned `False` for a receipt that had a current gateway, permanently retaining `fleet_restart_pending` and the startup warning.

The fix limits this reconciliation to `kind == "gateway"`. Dashboard and serve runtimes retain their independent restart and verification paths and no longer make gateway reconciliation impossible. The algorithm remains linear in the number of planned and live runtimes, with no additional polling, process launches, I/O, or persistent memory.

## Tests and verification

- `scripts/run_tests.sh tests/hermes_cli/test_update_fleet_restart_pending.py` — passed, including the #107402 regression test.
- SDK namespace regression test: `src/sdk/runtime.test.ts` — 2 tests passed.
- Right-sidebar toggle test: `src/store/layout-toggle.test.ts` — passed in 3 consecutive rounds before the dependency state changed.
- Existing tree toggle suite: `src/components/pane-shell/tree/tool-pane-toggle.test.ts` — 13 tests passed.
- Targeted ESLint passed for the original toggle change; after the SDK changes, ESLint was rerun and passed once the import ordering/parsing issue was corrected.
- `git diff --check` passed.

The final local test rerun for the existing desktop changes was blocked by the incomplete dependency installation: Vite could not resolve `@rolldown/plugin-babel`, and typecheck could not resolve `blobatar/blob` and `blobatar/react`. No source error from those changes was reported.

`graphify explain` was used for the runtime-loader and right-sidebar paths. `graphify update .` was attempted after edits but exceeded the local 420-second limit.

## Scope

The PR contains the integrated fixes for the existing branch: runtime plugin SDK initialization, runtime loader cycle removal, right-sidebar close behavior, and the narrowly scoped updater reconciliation fix for #107402. Related updater behavior was reviewed against #77184, #91277, #95294, and #100479.

The updater change is committed as:

`223c63d fix(update): reconcile pending restart with dashboard plans`
