### PR TITLE
feat(cli,gateway): /agents shows running kanban dispatcher workers

### DIFF
--- a/gateway/slash_commands_status.py
+++ b/gateway/slash_commands_status.py
@@ -79,6 +79,29 @@ def _quiet_sync(call, default=None):
         return default
 
 
+def _running_kanban_tasks() -> list[dict]:
+    """Running kanban tasks from the shared board (dispatcher-spawned workers).
+
+    Kept as a tiny wrapper so tests can monkeypatch it directly without
+    stubbing the kanban_db modules (tests patch the binding this call reads).
+    """
+    from hermes_cli.kanban_status import list_running_tasks
+
+    return list_running_tasks()
+
+
+def _kanban_task_lines(task: dict) -> list[str]:
+    from tools.process_registry import format_uptime_short
+
+    task_id = str(task.get("task_id") or "?")
+    title = _clip(" ".join(str(task.get("title") or "").split()), 70)
+    assignee = str(task.get("assignee") or "unassigned")
+    board = str(task.get("board") or "default")
+    elapsed = task.get("elapsed_seconds")
+    up = f" · {format_uptime_short(int(elapsed))}" if elapsed is not None else ""
+    return [f"- `{task_id}` · {assignee} · board {board}{up} · {title}"]
+
+
 def _status_model_route(status_agent, persisted_route: dict, session_row: dict, session_entry):
     """``(model, provider, context_used, context_total)`` for /status.
 
@@ -425,7 +448,16 @@ class GatewayStatusCommandsMixin:
         if delegations:
             lines += ["", t("gateway.agents.background_delegations", count=len(delegations))]
             lines += _capped_rows(delegations, _agents_delegation_lines)
-        if not (agent_rows or running_processes or background_tasks or delegations):
+
+        # Kanban workers spawned by the dispatcher are separate processes, not
+        # children of this gateway's sessions — only the shared board knows.
+        kanban_tasks = _quiet_sync(_running_kanban_tasks, [])
+        if kanban_tasks:
+            lines += ["", t("gateway.agents.kanban_tasks", count=len(kanban_tasks))]
+            lines += _capped_rows(kanban_tasks, _kanban_task_lines)
+
+        if not (agent_rows or running_processes or background_tasks or delegations
+                or kanban_tasks):
             lines += ["", t("gateway.agents.none")]
         return "\n".join(lines)
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -947,6 +947,18 @@ class CLICommandsMixin:
                     if idle is not None:
                         part += f" · last activity {idle:.0f}s ago"
                     _cp(part)
+        # Kanban workers spawned by the dispatcher are separate processes, not
+        # this session's children — only the shared board knows about them.
+        kanban = _probe("hermes_cli.kanban_status", "list_running_tasks", [])
+        if kanban:
+            _cp(f"  Kanban tasks running: {len(kanban)}")
+            for task in kanban[:15]:
+                board = task.get("board") or "default"
+                assignee = task.get("assignee") or "unassigned"
+                elapsed = task.get("elapsed_seconds")
+                up = f" · {format_uptime_short(int(elapsed))}" if elapsed is not None else ""
+                _cp(f"    {task.get('task_id', '?')} · {assignee} · board {board}{up} · "
+                    f"{(task.get('title') or '')[:60]}")
         agent_running = getattr(self, "_agent_running", False)
         _cp(f"  Agent: {'running' if agent_running else 'idle'}")
 

--- a/hermes_cli/kanban_status.py
+++ b/hermes_cli/kanban_status.py
@@ -1,0 +1,92 @@
+"""Kanban running-task snapshot for /agents.
+
+The kanban dispatcher spawns worker processes OUTSIDE any agent session
+(``hermes -p <profile> chat -q work kanban task <id>``), so neither the CLI
+nor the gateway ``/agents`` handler can see them via the process registry or
+async-delegation list — the workers are not that session's children. The
+board, however, is shared SQLite across profiles BY DESIGN
+(``kanban_db.kanban_home``), so the authoritative "what is running" answer is
+one read-only query per board.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_cli import kanban_db as _kb
+
+
+def _read_only_rows(db_path: Path) -> list[sqlite3.Row]:
+    """Query running tasks from one board DB without initializing it.
+
+    Existence is checked BEFORE connect (sqlite3 would create an empty file
+    otherwise) and no schema SQL is ever executed, so a status read never
+    initializes or migrates a board. Plain connect (not ``mode=ro``) because a
+    read-only URI cannot read a WAL board with a live writer (needs a
+    writable ``-shm``); only SELECTs are issued, and ``no such table`` (fresh,
+    schema-less file) is answered with an empty list.
+    """
+    if not db_path.is_file():
+        return []
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row  # name-based access; default is a bare tuple
+    try:
+        return conn.execute(
+            "SELECT id, title, assignee, started_at FROM tasks "
+            "WHERE status = 'running' "
+            "ORDER BY (started_at IS NULL), started_at ASC, created_at ASC",
+        ).fetchall()
+    except sqlite3.OperationalError as exc:
+        # Fresh install: the DB file exists but has no schema yet.
+        if "no such table" in str(exc).lower():
+            return []
+        raise
+    finally:
+        conn.close()
+
+
+def list_running_tasks() -> list[dict[str, Any]]:
+    """Running kanban tasks across every board (oldest-started first).
+
+    Returns dicts with ``task_id``, ``title``, ``assignee``, ``board``,
+    ``started_at``. Fail-open: unreadable boards are skipped, never raised —
+    /agents is a status command and must not crash on a locked or partial
+    board. An import failure (kanban module absent in stripped installs)
+    surfaces as ``[]`` via the callers' ``_probe``/``_quiet_sync`` wrappers.
+    """
+    import time
+
+    rows: list[dict[str, Any]] = []
+    try:
+        boards = [meta.get("slug", _kb.DEFAULT_BOARD)
+                  for meta in _kb.list_boards(include_archived=False)]
+    except Exception:
+        return []
+    for board in boards:
+        try:
+            db_path = _kb.kanban_db_path(board=board)
+            for row in _read_only_rows(db_path):
+                rows.append({
+                    "task_id": row["id"],
+                    "title": row["title"] or "",
+                    "assignee": row["assignee"],
+                    "board": board,
+                    "started_at": row["started_at"],
+                })
+        except Exception:
+            continue
+    now = int(time.time())
+    for row in rows:
+        started = row.get("started_at")
+        row["elapsed_seconds"] = max(0, now - int(started)) if started else None
+    return rows
+
+
+def running_count() -> Optional[int]:
+    """Total running kanban tasks, or ``None`` when the board is unreadable."""
+    try:
+        return len(list_running_tasks())
+    except Exception:
+        return None

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -69,6 +69,7 @@ gateway:
     running_processes:     "**Running background processes:** {count}"
     async_jobs:            "**Gateway async jobs:** {count}"
     background_delegations: "**Background delegations:** {count}"
+    kanban_tasks:          "**Kanban tasks running:** {count}"
     none:                  "No active agents or running tasks."
     state_starting:        "starting"
     state_running:         "running"

--- a/tests/hermes_cli/test_agents_kanban_visibility.py
+++ b/tests/hermes_cli/test_agents_kanban_visibility.py
@@ -1,0 +1,123 @@
+"""Kanban running tasks in /agents output (CLI + gateway).
+
+/agents previously reported only the session's own children (process
+registry, async delegations). Dispatcher-spawned kanban workers are separate
+processes on separate profiles, invisible to both — the shared board is the
+only authoritative source. These tests drive the REAL snapshot function
+against a REAL sqlite board via the public kanban_db API (no mocked DB), plus
+the gateway projection and the CLI section rendering.
+"""
+
+import asyncio
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+
+
+@pytest.fixture()
+def kanban_home(tmp_path, monkeypatch):
+    """Point the shared board at a temp root and open a default-board DB."""
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    conn = kbc.connect()  # initializes + schema + WAL on the temp board
+    yield conn
+    conn.close()
+
+
+def _seed(conn, title, assignee):
+    """Create + claim a task the way the dispatcher does (ready -> running)."""
+    task_id = kb.create_task(conn, title=title, assignee=assignee, created_by="test")
+    claimed = kb.claim_task(conn, task_id, claimer="test-worker")
+    assert claimed is not None
+    return task_id
+
+
+def _runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._background_tasks = set()
+    runner._session_key_for_source = lambda source: "agent:main:test:dm:1"
+    return runner
+
+
+class _Event:
+    source = None
+
+
+def test_list_running_tasks_reports_dispatcher_workers(kanban_home):
+    from hermes_cli.kanban_status import list_running_tasks
+
+    t1 = _seed(kanban_home, "web: brand kit", "frontend-dev")
+    t2 = _seed(kanban_home, "scraper: reconcile", "backend-dev")
+    rows = list_running_tasks()
+    ids = {r["task_id"] for r in rows}
+    assert {t1, t2} <= ids
+    by_id = {r["task_id"]: r for r in rows}
+    assert by_id[t1]["assignee"] == "frontend-dev"
+    assert by_id[t1]["board"] == "default"
+    assert by_id[t1]["elapsed_seconds"] is not None and by_id[t1]["elapsed_seconds"] >= 0
+    # Done tasks must not leak into the running view.
+    kb.complete_task(kanban_home, t2, result="done")
+    ids = {r["task_id"] for r in list_running_tasks()}
+    assert t1 in ids and t2 not in ids
+
+
+def test_list_running_tasks_empty_board_returns_empty(kanban_home):
+    from hermes_cli.kanban_status import list_running_tasks
+
+    assert list_running_tasks() == []
+
+
+def test_list_running_tasks_never_creates_or_initializes(tmp_path, monkeypatch):
+    """A bare HERMES_KANBAN_HOME must not gain a kanban.db from a status read."""
+    from hermes_cli.kanban_status import list_running_tasks
+
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    assert list_running_tasks() == []
+    assert not (tmp_path / "kanban.db").exists()
+
+
+def test_list_running_tasks_skips_unreadable_board(kanban_home):
+    """One corrupt board must not hide the others (fail-open per board)."""
+    from hermes_cli import kanban_status
+
+    _seed(kanban_home, "web: brand kit", "frontend-dev")
+    (kb.boards_root() / "junkboard").mkdir(parents=True)
+    junk = kb.boards_root() / "junkboard" / "kanban.db"
+    junk.write_bytes(b"this is not sqlite")
+    rows = kanban_status.list_running_tasks()
+    assert any(r["task_id"] for r in rows)
+
+
+def test_gateway_agents_includes_kanban_section(kanban_home):
+    _seed(kanban_home, "web: brand kit", "frontend-dev")
+    runner = _runner()
+    out = asyncio.run(runner._handle_agents_command(_Event()))
+    assert "Kanban tasks running" in out
+    assert "web: brand kit" in out
+    assert "frontend-dev" in out
+
+
+def test_gateway_agents_empty_board_shows_none_line(kanban_home):
+    runner = _runner()
+    out = asyncio.run(runner._handle_agents_command(_Event()))
+    # Empty board → canonical "nothing" line, no kanban section.
+    assert "Kanban tasks running" not in out
+    assert "No active agents or running tasks." in out
+
+
+def test_cli_agents_prints_kanban_section(kanban_home, capsys):
+    _seed(kanban_home, "scraper: reconcile", "backend-dev")
+    from cli import HermesCLI  # the real class owning the handler
+
+    instance = object.__new__(HermesCLI)
+    instance._agent_running = False
+    instance._handle_agents_command()
+    captured = capsys.readouterr().out
+    assert "Kanban tasks running: 1" in captured
+    assert "scraper: reconcile" in captured
+    assert "backend-dev" in captured


### PR DESCRIPTION
## Summary

`/agents` (CLI + gateway) never showed running **kanban dispatcher workers**. The dispatcher spawns them as independent processes (`hermes -p <profile> chat -q "work kanban task <id>"`), outside any agent session — so neither the process registry nor the async-delegation list can see them. With workers active, `/agents` reported nothing, while the shared board said `running: 2`.

The kanban board is shared SQLite across profiles by design (`kanban_db.kanban_home` resolves to the default Hermes root regardless of profile), so it is the authoritative "what is running" source — one read-only query per board.

## What this does

- New `hermes_cli/kanban_status.py`: snapshot of running tasks across **every board** (default + named). Existence-checked connect (never creates a DB), no schema SQL (never initializes/migrates), WAL-safe reads, per-board fail-open.
- CLI `/agents` (`hermes_cli/cli_commands_mixin.py`): new "Kanban tasks running" section via the existing `_probe` fail-open pattern — no new core surface.
- Gateway `/agents` (`gateway/slash_commands_status.py`): same section, plus the canonical "no active agents or running tasks" line now suppresses only when the board is also empty (previously it printed "nothing running" while dispatcher workers ran).
- Locale: `gateway.agents.kanban_tasks` (en; `t()` falls back to English for other langs — translations can follow separately).

## Test plan

- 7 new tests in `tests/hermes_cli/test_agents_kanban_visibility.py`, driving the **real** `kanban_db` claim path (`create_task` → `claim_task`) against a temp `HERMES_KANBAN_HOME`: workers appear with assignee/board/uptime, done tasks don't leak, a bare home gains no `kanban.db` from a status read, a corrupt board hides nothing, gateway + CLI sections render.
- Verified live on a machine with two real dispatcher workers running: `/agents` output matched `ps` exactly (task ids, assignees, elapsed time).
- `scripts/run_tests.sh` on this file + neighboring suites (`test_kanban_worker_lifecycle_hooks`, `test_kanban_write_guard`, `test_agents_command_delegations`, `test_status_command`): **27/27 passed**.
- `scripts/check_compat_pointers.py`: clean (no compat-path imports).

Example gateway output with two workers running:

```
🤖 **Active Agents & Tasks**

**Active agents:** 0

**Running background processes:** 0

**Gateway async jobs:** 0

**Kanban tasks running:** 2
- `t_5daf06e9` · frontend-dev · board lab-price-aggregator · 43m 36s · web: Phase 2.5a — brand identity kit (flask emblem B), ...
- `t_bbc14a37` · backend-dev · board lab-price-aggregator · 42m 36s · scraper: reconcile prod vs local offer/alias state ...
```
