### PR TITLE
feat(desktop): model picker search/UX polish and context meter empty-state fix

### DIFF
--- a/apps/desktop/src/app/chat/composer/context-meter.test.tsx
+++ b/apps/desktop/src/app/chat/composer/context-meter.test.tsx
@@ -1,0 +1,120 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
+import { setCurrentUsage } from '@/store/session'
+
+import { ComposerContextMeter } from './context-meter'
+
+const getGlobalModelInfo = vi.fn()
+
+vi.mock('@/api/models', () => ({
+  getGlobalModelInfo: (...args: unknown[]) => getGlobalModelInfo(...args)
+}))
+
+afterEach(() => {
+  cleanup()
+  setCurrentUsage({ calls: 0, input: 0, output: 0, total: 0 })
+})
+
+function primaryView(runtimeId: string | null = 'run-1', model = 'm'): SessionView {
+  return {
+    kind: 'primary',
+    $awaitingResponse: atom(false),
+    $busy: atom(false),
+    $cwd: atom(''),
+    $fast: atom(false),
+    $lastVisibleIsUser: atom(false),
+    $messages: atom([]),
+    $messagesEmpty: atom(true),
+    $model: atom(model),
+    $provider: atom('p'),
+    $reasoningEffort: atom(''),
+    $runtimeId: atom(runtimeId),
+    $storedId: atom('stored-1'),
+    $turnStartedAt: atom<number | null>(null)
+  } as SessionView
+}
+
+describe('ComposerContextMeter', () => {
+  it('paints the merged usage with in/out, cache hit and cost', async () => {
+    setCurrentUsage({
+      cache_hit_pct: 82,
+      calls: 12,
+      context_max: 200000,
+      context_percent: 34,
+      context_used: 68000,
+      cost_usd: 0.04,
+      input: 12000,
+      output: 4000,
+      total: 16000
+    })
+
+    render(
+      <SessionViewProvider value={primaryView()}>
+        <ComposerContextMeter />
+      </SessionViewProvider>
+    )
+
+    // Meter button: percent readout.
+    expect(screen.getByRole('button', { name: /Context usage 34 percent/i })).toBeDefined()
+  })
+
+  it('shows the selected model window at 0% before the first turn', async () => {
+    getGlobalModelInfo.mockResolvedValue({
+      auto_context_length: 1000000,
+      effective_context_length: 1000000,
+      model: 'deepseek-v4-flash',
+      provider: 'custom'
+    })
+
+    const view = primaryView(null, 'deepseek-v4-flash')
+
+    render(
+      <SessionViewProvider value={view}>
+        <ComposerContextMeter />
+      </SessionViewProvider>
+    )
+
+    await screen.findByText('0%')
+    expect(getGlobalModelInfo).toHaveBeenCalled()
+  })
+
+  it('shows the draft meter for the selected model even when getGlobalModelInfo returns a different model', async () => {
+    getGlobalModelInfo.mockResolvedValue({
+      auto_context_length: 2000000,
+      effective_context_length: 2000000,
+      model: 'auto/best-coding',
+      provider: 'custom'
+    })
+
+    const view = primaryView(null, 'deepseek-v4-flash')
+
+    render(
+      <SessionViewProvider value={view}>
+        <ComposerContextMeter />
+      </SessionViewProvider>
+    )
+
+    const button = await screen.findByRole('button', { name: /Empty chat/i })
+    expect(button).toBeDefined()
+    expect(button.getAttribute('aria-label')).toContain('context window')
+  })
+
+  it('shows the draft meter immediately even when getGlobalModelInfo has not resolved', async () => {
+    getGlobalModelInfo.mockReturnValue(new Promise(() => {}))
+
+    const view = primaryView(null, 'deepseek-v4-flash')
+
+    render(
+      <SessionViewProvider value={view}>
+        <ComposerContextMeter />
+      </SessionViewProvider>
+    )
+
+    const button = screen.getByRole('button', { name: /Empty chat/i })
+    expect(button).toBeDefined()
+    expect(button.getAttribute('aria-label')).toContain('deepseek-v4-flash')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/context-meter.tsx
+++ b/apps/desktop/src/app/chat/composer/context-meter.tsx
@@ -1,0 +1,241 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useMemo, useState } from 'react'
+
+import { getGlobalModelInfo } from '@/api/models'
+import { useSessionView } from '@/app/chat/session-view'
+import { ContextUsagePanel } from '@/app/shell/context-usage-panel'
+import { useContextBreakdown } from '@/app/shell/hooks/use-context-breakdown'
+import { Button } from '@/components/ui/button'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { Tip } from '@/components/ui/tooltip'
+import { compactNumber } from '@/lib/format'
+import { useStoreSelector } from '@/lib/use-session-slice'
+import { $gateway } from '@/store/gateway'
+import { $currentUsage, $sessions, sessionMatchesStoredId } from '@/store/session'
+import { ambientRequestFor } from '@/store/session-gone-latch'
+import type { UsageStats } from '@/types/hermes'
+
+/** Composer context meter (primary pane only): live % + mini bar beside the
+ *  model pill; the popover adds in/out/total, cache hit and cost. Tiles keep
+ *  the status quo — their gateway ownership differs, a follow-up. */
+export function ComposerContextMeter() {
+  const view = useSessionView()
+  const runtimeId = useStore(view.$runtimeId)
+  const storedId = useStore(view.$storedId)
+  const busy = useStore(view.$awaitingResponse)
+  const viewModel = useStore(view.$model)
+  const viewProvider = useStore(view.$provider)
+  const gateway = useStore($gateway)
+  const currentUsage = useStore($currentUsage)
+  const [open, setOpen] = useState(false)
+
+  const requestGateway = useMemo(
+    () =>
+      gateway
+        ? ambientRequestFor(gateway)
+        : async <T,>(): Promise<T> => {
+            throw new Error('no gateway')
+          },
+    [gateway]
+  )
+
+  // Draft (no session yet): show the SELECTED model's window at 0% so an
+  // empty chat still answers "how much room do I have". Never show another
+  // model's window — a mismatch hides the meter instead of lying.
+  const [draftInfo, setDraftInfo] = useState<{ max: number; model: string; provider: string } | null>(null)
+
+  useEffect(() => {
+    if (runtimeId) {
+      return
+    }
+
+    let cancelled = false
+
+    // The desktop bridge is absent in unit tests (and any non-app host) —
+    // never let a missing bridge fail the render.
+    try {
+      getGlobalModelInfo()
+        .then(info => {
+          if (!cancelled) {
+            const max = info.effective_context_length || info.auto_context_length || null
+
+            setDraftInfo(max ? { max, model: info.model, provider: info.provider } : null)
+          }
+        })
+        .catch(() => undefined)
+    } catch {
+      /* no bridge */
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [view, runtimeId])
+
+  // Same read as the statusbar gauge: measured occupancy once a turn has run,
+  // estimate from the live prompt + transcript before that. Keyed to the live
+  // runtime session (not the stored id, which doesn't exist yet for a fresh chat).
+  // `persist` hands the hook the stored row's scope + counters so a cold boot
+  // can paint the durable last-known read while the live agent rebinds.
+  const storedRow = useStoreSelector($sessions, sessions =>
+    storedId ? (sessions.find(session => sessionMatchesStoredId(session, storedId)) ?? null) : null
+  )
+  const persist = useMemo(
+    () =>
+      runtimeId && storedRow
+        ? {
+            scope: {
+              connectionId: storedRow.connection_id ?? '',
+              profile: storedRow.profile ?? 'default'
+            },
+            storedSessionId: storedId ?? '',
+            version: {
+              input_tokens: storedRow.input_tokens,
+              message_count: storedRow.message_count,
+              model: storedRow.model,
+              output_tokens: storedRow.output_tokens
+            }
+          }
+        : null,
+    [runtimeId, storedId, storedRow]
+  )
+  const { breakdown, loading } = useContextBreakdown({
+    busy,
+    enabled: Boolean(gateway && runtimeId),
+    persist,
+    refreshKey: viewModel,
+    requestGateway,
+    sessionId: runtimeId
+  })
+
+  const usage: UsageStats = useMemo(
+    () =>
+      breakdown
+        ? {
+            ...currentUsage,
+            context_estimated: breakdown.context_estimated,
+            context_max: breakdown.context_max,
+            context_percent: breakdown.context_percent,
+            context_used: breakdown.context_used
+          }
+        : currentUsage,
+    [breakdown, currentUsage]
+  )
+
+  if (!runtimeId) {
+    const windowMax = draftInfo?.max
+
+    return (
+      <DropdownMenu onOpenChange={setOpen} open={open}>
+        <Tip
+          label={
+            windowMax
+              ? `Empty chat · ${viewModel} · window ${compactNumber(windowMax)}`
+              : `Empty chat · ${viewModel}`
+          }
+          side="top"
+        >
+          <DropdownMenuTrigger asChild>
+            <Button
+              aria-label={windowMax ? `Empty chat, context window ${compactNumber(windowMax)}` : `Empty chat · ${viewModel}`}
+              className="h-(--composer-control-size) min-w-0 shrink gap-1.5 rounded-md px-2 text-xs font-normal tabular-nums text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground"
+              type="button"
+              variant="ghost"
+            >
+              <span className="flex items-center text-(--ui-text-tertiary)">
+                <svg aria-hidden="true" height="20" viewBox="0 0 20 20" width="20">
+                  <circle className="stroke-(--ui-bg-tertiary)" cx="10" cy="10" fill="none" r={7} strokeWidth="2.5" />
+                </svg>
+              </span>
+              <span>0%</span>
+            </Button>
+          </DropdownMenuTrigger>
+        </Tip>
+        <DropdownMenuContent align="end" className="w-64 p-3 text-[0.6875rem] text-muted-foreground" side="top" sideOffset={8}>
+          <div className="flex flex-col gap-1">
+            <div className="truncate font-mono text-foreground">{viewModel}</div>
+            <div className="flex items-center justify-between gap-2">
+              <span>{viewProvider}</span>
+              {windowMax && <span className="shrink-0 tabular-nums text-foreground">Window {compactNumber(windowMax)}</span>}
+            </div>
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+  }
+
+  const percent = Math.max(0, Math.min(100, Math.round(usage.context_percent ?? 0)))
+  const hit = usage.cache_hit_pct
+  const cost = usage.cost_usd ?? 0
+  const restored = breakdown?.context_source === 'restored'
+
+  // Ring color follows fullness: calm → warming → hot.
+  const ringClass = percent >= 85 ? 'text-red-500' : percent >= 60 ? 'text-amber-500' : 'text-emerald-500'
+  const radius = 7
+  const circumference = 2 * Math.PI * radius
+
+  return (
+    <DropdownMenu onOpenChange={setOpen} open={open}>
+      <Tip
+        label={
+          restored
+            ? `Restored context ${percent}% (~${compactNumber(usage.context_used ?? 0)} of ${compactNumber(usage.context_max ?? 0)}) — refreshing`
+            : `Context usage ${percent}% (${compactNumber(usage.context_used ?? 0)} of ${compactNumber(usage.context_max ?? 0)})`
+        }
+        side="top"
+      >
+        <DropdownMenuTrigger asChild>
+            <Button
+              aria-label={restored ? `Restored context usage ${percent} percent` : `Context usage ${percent} percent`}
+            className="h-(--composer-control-size) min-w-0 shrink gap-1.5 rounded-md px-2 text-xs font-normal tabular-nums text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground"
+            type="button"
+            variant="ghost"
+          >
+            <span className={`flex items-center ${ringClass}`}>
+              <svg aria-hidden="true" height="20" viewBox="0 0 20 20" width="20">
+                <circle
+                  className="stroke-(--ui-bg-tertiary)"
+                  cx="10"
+                  cy="10"
+                  fill="none"
+                  r={radius}
+                  strokeWidth="2.5"
+                />
+                <circle
+                  cx="10"
+                  cy="10"
+                  fill="none"
+                  r={radius}
+                  stroke="currentColor"
+                  strokeDasharray={circumference}
+                  strokeDashoffset={circumference * (1 - percent / 100)}
+                  strokeLinecap="round"
+                  strokeWidth="2.5"
+                  transform="rotate(-90 10 10)"
+                />
+              </svg>
+            </span>
+            <span className="tabular-nums">{percent}%</span>
+          </Button>
+        </DropdownMenuTrigger>
+      </Tip>
+      <DropdownMenuContent align="end" className="w-72 p-0" side="top" sideOffset={8}>
+        <ContextUsagePanel breakdown={breakdown} loading={loading} usage={usage} />
+        <div className="flex flex-col gap-1 border-t border-(--ui-stroke-tertiary)/40 px-3 py-2 text-[0.6875rem] text-muted-foreground">
+          <div className="flex items-center justify-between gap-2">
+            <span>
+              In {compactNumber(usage.input)} · Out {compactNumber(usage.output)}
+            </span>
+            <span className="shrink-0 tabular-nums text-foreground">Total {compactNumber(usage.total)}</span>
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <span>Cache hit {hit != null ? `${Math.round(hit)}%` : '—'}</span>
+            <span className="shrink-0 tabular-nums">
+              {usage.calls} calls{cost >= 0.01 ? ` · $${cost.toFixed(2)}` : ''}
+            </span>
+          </div>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/desktop/src/app/chat/composer/model-pill.test.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.test.tsx
@@ -158,7 +158,16 @@ describe('ModelPill per-surface model label', () => {
       </SessionViewProvider>
     )
 
-    expect(screen.getByText('Sonnet · High')).toBeTruthy()
+    expect(screen.getByText('Sonnet')).toBeTruthy()
     expect(screen.queryByText(/primary/i)).toBeNull()
+    // Effort is a fill pill, not text: high fills 4 of 7 with the label inside.
+    const meter = screen.getByTitle('High')
+
+    expect(meter.getAttribute('role')).toBe('img')
+    const track = meter.lastElementChild as HTMLElement
+    const fill = track.firstElementChild as HTMLElement
+
+    expect(fill.style.width).toContain('57.1')
+    expect(meter.textContent).toContain('High')
   })
 })

--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -7,25 +7,28 @@ import { ModelMenuCloseContext } from '@/app/shell/model-menu-panel'
 import { isElementInHiddenPane } from '@/components/pane-shell/pane-visibility'
 import { Button } from '@/components/ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { EffortMeter, resolveEffortMeter } from '@/components/ui/effort-meter'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { releaseTypingFocus } from '@/components/ui/keyboard-first'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { ChevronDown } from '@/lib/icons'
-import { formatModelStatusLabel } from '@/lib/model-status-label'
+import { displayModelName } from '@/lib/model-status-label'
 import { cn } from '@/lib/utils'
 import { $currentModelSource, $defaultReasoningEffort, setModelPickerOpen } from '@/store/session'
+
+import { ComposerContextMeter } from './context-meter'
 
 import { onComposerModelMenuRequest } from './focus'
 import { RICH_INPUT_SLOT } from './rich-editor'
 import { useComposerScope } from './scope'
 import type { ChatBarState } from './types'
 
-// `shrink` (not `shrink-0`) with a truncating label: the pill is the one
+// `shrink` (not `shrink-0`) with an untruncated label: the pill is the one
 // control in the row that can give width back continuously, so it absorbs the
 // squeeze between collapse stages instead of pushing Send past the edge.
 const PILL = cn(
-  'h-(--composer-control-size) min-w-0 max-w-40 shrink gap-1 rounded-md px-2 text-xs font-normal',
+  'h-(--composer-control-size) min-w-0 shrink gap-1 rounded-md px-2 text-xs font-normal',
   'text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground'
 )
 
@@ -47,6 +50,7 @@ export function ModelPill({
   model: ChatBarState['model']
 }) {
   const copy = useI18n().t.shell.statusbar
+  const copyMenu = useI18n().t.shell.modelMenu
   // Two return branches below, one handle: only ever one of them mounts.
   const tourMarker = useTourMarker('model-pill')
   const view = useSessionView()
@@ -126,17 +130,25 @@ export function ModelPill({
   // The model resolves a beat after the gateway/session comes up. Rather than
   // flash a literal "No model", show a quiet loader (inherits the pill text
   // color at half opacity) until a model lands.
+  // Pill mirrors the catalog rows: pretty name (truncates) + fast bolt + effort
+  // meter (pinned). The tooltip carries provider, exact id and effort text.
+  const { label: pillEffort } = resolveEffortMeter(reasoningEffort, defaultEffort)
+
   const label = compact ? (
     <ChevronDown className="size-3.5 shrink-0 opacity-70" />
   ) : (
     <>
       {currentModel.trim() ? (
-        <span className="truncate">
-          {formatModelStatusLabel(currentModel, { defaultEffort, fastMode, reasoningEffort })}
-        </span>
+        <span className="whitespace-nowrap">{displayModelName(currentModel)}</span>
       ) : (
         <GlyphSpinner className="opacity-50" spinner="braille" />
       )}
+      {currentModel.trim() && fastMode ? (
+        <span aria-label={copyMenu.fast} className="shrink-0 text-[0.75rem]" role="img" title={copyMenu.fast}>
+          ⚡
+        </span>
+      ) : null}
+      {currentModel.trim() ? <EffortMeter fallback={defaultEffort} value={reasoningEffort} /> : null}
       {pinnedOverride && (
         <span
           aria-label={copy.modelPinned}
@@ -159,26 +171,29 @@ export function ModelPill({
     : PILL
 
   const baseTitle = currentProvider
-    ? copy.modelTitle(currentProvider, currentModel || copy.modelNone)
+    ? `${copy.modelTitle(currentProvider, currentModel || copy.modelNone)} · ${fastMode ? `${copyMenu.fast} ` : ''}${pillEffort}`
     : copy.switchModel
 
   const title = pinnedOverride ? `${baseTitle} — ${copy.modelPinned}` : baseTitle
 
   if (!model.modelMenuContent) {
     return (
-      <Tip label={pinnedOverride ? `${copy.openModelPicker} — ${copy.modelPinned}` : copy.openModelPicker} side="top">
-        <Button
-          aria-label={copy.openModelPicker}
-          className={pillClass}
-          data-tour={tourMarker}
-          disabled={disabled}
-          onClick={() => setModelPickerOpen(true)}
-          type="button"
-          variant="ghost"
-        >
-          {label}
-        </Button>
-      </Tip>
+      <>
+        {compact ? null : <ComposerContextMeter />}
+        <Tip label={pinnedOverride ? `${copy.openModelPicker} — ${copy.modelPinned}` : copy.openModelPicker} side="top">
+          <Button
+            aria-label={copy.openModelPicker}
+            className={pillClass}
+            data-tour={tourMarker}
+            disabled={disabled}
+            onClick={() => setModelPickerOpen(true)}
+            type="button"
+            variant="ghost"
+          >
+            {label}
+          </Button>
+        </Tip>
+      </>
     )
   }
 
@@ -194,41 +209,44 @@ export function ModelPill({
   }
 
   return (
-    <DropdownMenu onOpenChange={setMenuOpen} open={open}>
-      <Tip label={title} side="top">
-        <DropdownMenuTrigger asChild>
-          <Button
-            aria-label={title}
-            className={pillClass}
-            data-tour={tourMarker}
-            disabled={disabled}
-            type="button"
-            variant="ghost"
-          >
-            {label}
-          </Button>
-        </DropdownMenuTrigger>
-      </Tip>
-      <DropdownMenuContent
-        align="end"
-        className="w-64 p-0"
-        onCloseAutoFocus={event => {
-          if (restoreSelection.current) {
-            event.preventDefault()
-            restoreSelection.current()
+    <>
+      {compact ? null : <ComposerContextMeter />}
+      <DropdownMenu onOpenChange={setMenuOpen} open={open}>
+        <Tip label={title} side="top">
+          <DropdownMenuTrigger asChild>
+            <Button
+              aria-label={title}
+              className={pillClass}
+              data-tour={tourMarker}
+              disabled={disabled}
+              type="button"
+              variant="ghost"
+            >
+              {label}
+            </Button>
+          </DropdownMenuTrigger>
+        </Tip>
+        <DropdownMenuContent
+          align="end"
+          className="w-64 p-0"
+          onCloseAutoFocus={event => {
+            if (restoreSelection.current) {
+              event.preventDefault()
+              restoreSelection.current()
+              restoreSelection.current = null
+            }
+          }}
+          onInteractOutside={() => {
             restoreSelection.current = null
-          }
-        }}
-        onInteractOutside={() => {
-          restoreSelection.current = null
-        }}
-        side="top"
-        sideOffset={8}
-      >
-        <ModelMenuCloseContext.Provider value={() => setMenuOpen(false)}>
-          {model.modelMenuContent}
-        </ModelMenuCloseContext.Provider>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          }}
+          side="top"
+          sideOffset={8}
+        >
+          <ModelMenuCloseContext.Provider value={() => setMenuOpen(false)}>
+            {model.modelMenuContent}
+          </ModelMenuCloseContext.Provider>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
   )
 }

--- a/apps/desktop/src/app/chat/composer/queue-panel.tsx
+++ b/apps/desktop/src/app/chat/composer/queue-panel.tsx
@@ -49,6 +49,7 @@ export function QueuePanel({
 
   return (
     <StatusSection
+      stickyHeader
       accessory={
         parked ? (
           <Tip label={c.queueResumeTip}>

--- a/apps/desktop/src/app/chat/composer/status-stack/session-control-goal.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/session-control-goal.tsx
@@ -326,12 +326,11 @@ export const SessionControlGoalSection = memo(function SessionControlGoalSection
               }
               icon={<Codicon className={iconClass} name="target" size="0.8rem" />}
               label={headerLabel}
+              stickyHeader
             >
               <div className="space-y-1.5 px-1 py-1">
-                {/* Full goal title */}
-                <div className="text-xs font-normal leading-relaxed text-foreground/92 break-words">{goal.title}</div>
-
-                {/* Optional reasons */}
+                {/* Pinned status: why waiting/paused/blocked stays visible —
+                  it is state chrome, not scrollable content. */}
                 {!detailsOpen && goal.wait_barrier && (
                   <div className="text-[0.7rem] italic text-muted-foreground/80">
                     {goal.wait_barrier.reason
@@ -346,103 +345,108 @@ export const SessionControlGoalSection = memo(function SessionControlGoalSection
                   <div className="text-[0.7rem] italic text-muted-foreground/80">{goal.last_reason}</div>
                 )}
 
-                {/* View details button */}
-                {hasDetails && (
-                  <div>
-                    <Button
-                      className="text-[0.7rem] text-muted-foreground/75 hover:text-foreground/90"
-                      onClick={() => setDetailsOpen(true)}
-                      size="micro"
-                      type="button"
-                      variant="text"
-                    >
-                      {ctrl.viewDetails}
-                    </Button>
-                  </div>
-                )}
+                {/* Scrollable body: long titles and criteria lists scroll in
+                  their own container — header above and the criteria footer
+                  below stay put, so collapse/add are always reachable. */}
+                <div className="max-h-[30vh] space-y-1.5 overflow-y-auto overscroll-contain pr-0.5">
+                  {/* Full goal title */}
+                  <div className="text-xs font-normal leading-relaxed text-foreground/92 break-words">{goal.title}</div>
 
-                {/* Criteria subsection */}
-                <div className="mt-2 border-t border-(--ui-stroke-tertiary)/40 pt-1.5">
-                  <div className="flex items-center justify-between pb-1 text-[0.68rem] font-medium text-muted-foreground/75">
-                    <div className="flex items-center gap-1.5">
-                      <span aria-hidden="true" className={`inline-flex ${iconClass}`} data-slot="criteria-state-marker">
-                        <Codicon name="target" size="0.68rem" />
-                      </span>
-                      <span>{ctrl.criteriaHeader(goal.subgoals.length)}</span>
-                    </div>
-                    <div className="flex items-center gap-1">
+                  {/* View details button */}
+                  {hasDetails && (
+                    <div>
                       <Button
-                        className="text-[0.68rem] text-muted-foreground/75 hover:text-foreground/90"
-                        disabled={isBusy}
-                        onClick={openAddCriterion}
+                        className="text-[0.7rem] text-muted-foreground/75 hover:text-foreground/90"
+                        onClick={() => setDetailsOpen(true)}
                         size="micro"
                         type="button"
                         variant="text"
                       >
-                        {ctrl.addCriterion}
+                        {ctrl.viewDetails}
                       </Button>
-                      {goal.subgoals.length > 0 && (
-                        <Button
-                          className="text-[0.68rem] text-muted-foreground/60 hover:text-destructive"
-                          disabled={isBusy}
-                          onClick={confirmClearCriteria}
-                          size="micro"
-                          type="button"
-                          variant="text"
-                        >
-                          {ctrl.clearCriteria}
-                        </Button>
-                      )}
                     </div>
-                  </div>
-
-                  {goal.subgoals.length > 0 ? (
-                    <div className="space-y-1">
-                      {goal.subgoals.map((subgoal, idx) => {
-                        const index = idx + 1
-
-                        return (
-                          <div
-                            className="group/criterion flex items-start justify-between gap-1.5 rounded px-1 py-0.5 text-xs text-foreground/85 hover:bg-(--ui-control-active-background)/40"
-                            key={`${index}-${subgoal}`}
-                          >
-                            <div className="flex min-w-0 flex-1 items-start gap-1.5 leading-relaxed">
-                              <span className="shrink-0 text-muted-foreground/60 tabular-nums">{index}.</span>
-                              <span className="break-words">{subgoal}</span>
-                            </div>
-                            <div className="flex shrink-0 items-center gap-0.5 opacity-80 group-hover/criterion:opacity-100">
-                              <Tip label={ctrl.copyCriterion(index)}>
-                                <Button
-                                  aria-label={ctrl.copyCriterion(index)}
-                                  className="size-6 rounded text-muted-foreground/60 hover:text-foreground/90"
-                                  onClick={() => void copyCriterionText(subgoal)}
-                                  size="icon-xs"
-                                  type="button"
-                                  variant="ghost"
-                                >
-                                  <Codicon name="copy" size="0.7rem" />
-                                </Button>
-                              </Tip>
-                              <Tip label={ctrl.removeCriterion(index)}>
-                                <Button
-                                  aria-label={ctrl.removeCriterion(index)}
-                                  className="size-6 rounded text-muted-foreground/60 hover:text-destructive"
-                                  disabled={isBusy}
-                                  onClick={() => confirmRemoveCriterion(index)}
-                                  size="icon-xs"
-                                  type="button"
-                                  variant="ghost"
-                                >
-                                  <Codicon name="close" size="0.7rem" />
-                                </Button>
-                              </Tip>
-                            </div>
-                          </div>
-                        )
-                      })}
-                    </div>
-                  ) : null}
+                  )}
                 </div>
+                {/* Pinned footer: count + add/clear stay visible under the scroll body. */}
+                <div className="flex items-center justify-between border-t border-(--ui-stroke-tertiary)/40 pt-1 text-[0.68rem] font-medium text-muted-foreground/75">
+                  <div className="flex items-center gap-1.5">
+                    <span aria-hidden="true" className={`inline-flex ${iconClass}`} data-slot="criteria-state-marker">
+                      <Codicon name="target" size="0.68rem" />
+                    </span>
+                    <span>{ctrl.criteriaHeader(goal.subgoals.length)}</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      className="text-[0.68rem] text-muted-foreground/75 hover:text-foreground/90"
+                      disabled={isBusy}
+                      onClick={openAddCriterion}
+                      size="micro"
+                      type="button"
+                      variant="text"
+                    >
+                      {ctrl.addCriterion}
+                    </Button>
+                    {goal.subgoals.length > 0 && (
+                      <Button
+                        className="text-[0.68rem] text-muted-foreground/60 hover:text-destructive"
+                        disabled={isBusy}
+                        onClick={confirmClearCriteria}
+                        size="micro"
+                        type="button"
+                        variant="text"
+                      >
+                        {ctrl.clearCriteria}
+                      </Button>
+                    )}
+                  </div>
+                </div>
+
+                {goal.subgoals.length > 0 ? (
+                  <div className="space-y-1">
+                    {goal.subgoals.map((subgoal, idx) => {
+                      const index = idx + 1
+
+                      return (
+                        <div
+                          className="group/criterion flex items-start justify-between gap-1.5 rounded px-1 py-0.5 text-xs text-foreground/85 hover:bg-(--ui-control-active-background)/40"
+                          key={`${index}-${subgoal}`}
+                        >
+                          <div className="flex min-w-0 flex-1 items-start gap-1.5 leading-relaxed">
+                            <span className="shrink-0 text-muted-foreground/60 tabular-nums">{index}.</span>
+                            <span className="break-words">{subgoal}</span>
+                          </div>
+                          <div className="flex shrink-0 items-center gap-0.5 opacity-80 group-hover/criterion:opacity-100">
+                            <Tip label={ctrl.copyCriterion(index)}>
+                              <Button
+                                aria-label={ctrl.copyCriterion(index)}
+                                className="size-6 rounded text-muted-foreground/60 hover:text-foreground/90"
+                                onClick={() => void copyCriterionText(subgoal)}
+                                size="icon-xs"
+                                type="button"
+                                variant="ghost"
+                              >
+                                <Codicon name="copy" size="0.7rem" />
+                              </Button>
+                            </Tip>
+                            <Tip label={ctrl.removeCriterion(index)}>
+                              <Button
+                                aria-label={ctrl.removeCriterion(index)}
+                                className="size-6 rounded text-muted-foreground/60 hover:text-destructive"
+                                disabled={isBusy}
+                                onClick={() => confirmRemoveCriterion(index)}
+                                size="icon-xs"
+                                type="button"
+                                variant="ghost"
+                              >
+                                <Codicon name="close" size="0.7rem" />
+                              </Button>
+                            </Tip>
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                ) : null}
               </div>
             </StatusSection>
           </div>

--- a/apps/desktop/src/app/chat/composer/status-stack/session-control-heartbeat.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/session-control-heartbeat.tsx
@@ -147,6 +147,7 @@ export const SessionControlHeartbeatSection = memo(function SessionControlHeartb
         <ContextMenuTrigger asChild>
           <div data-slot="session-control-heartbeat">
             <StatusSection
+              stickyHeader
               accessory={
                 <DropdownMenu onOpenChange={setMenuOpen} open={menuOpen}>
                   <Tip label={ctrl.heartbeatActions}>

--- a/apps/desktop/src/app/chat/composer/status-stack/session-control-loop.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/session-control-loop.tsx
@@ -154,6 +154,7 @@ export const SessionControlLoopSection = memo(function SessionControlLoopSection
         <ContextMenuTrigger asChild>
           <div data-slot="session-control-loop">
             <StatusSection
+              stickyHeader
               accessory={
                 <DropdownMenu onOpenChange={setMenuOpen} open={menuOpen}>
                   <Tip label={ctrl.loopActions}>

--- a/apps/desktop/src/app/chat/composer/status-stack/subagent-section.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/subagent-section.tsx
@@ -64,6 +64,7 @@ export function SubagentSection({ sessionId }: SubagentSectionProps) {
   return (
     <div className="composer-no-drag min-w-0" data-slot="composer-subagents">
       <StatusSection
+        stickyHeader
         collapsedIndicator={
           <GlyphSpinner
             ariaLabel={live.some(item => item.status === 'running') ? t.agents.running : t.agents.queued}

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -124,6 +124,7 @@ import { broadcastSessionsChanged } from '@/store/session-sync'
 import { forgetSessionUnread } from '@/store/session-unread'
 import { $archivedSessions } from '@/store/sidebar-archive'
 import { restoreSessionTodosFromSnapshot } from '@/store/todos'
+import { dropContextUsageSnapshotEverywhere } from '@/store/context-usage-cache'
 import {
   dropTranscriptTail,
   dropTranscriptTailEverywhere,
@@ -2489,6 +2490,7 @@ export function useSessionActions({
         await deleteSession(storedSessionId, removedOwner)
 
         dropTranscriptTailEverywhere(storedSessionId)
+        dropContextUsageSnapshotEverywhere(storedSessionId)
         // Only after the RPC lands — the optimistic eviction above can roll
         // back, and a rolled-back row must keep its watermark/marker.
         forgetSessionUnread(removedIds, profile)

--- a/apps/desktop/src/app/shell/context-usage-panel.test.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.test.tsx
@@ -6,6 +6,11 @@ import type { ContextBreakdown, UsageStats } from '@/types/hermes'
 
 import { ContextUsagePanel } from './context-usage-panel'
 import { useContextBreakdown } from './hooks/use-context-breakdown'
+import {
+  loadContextUsageSnapshot,
+  saveContextUsageSnapshot,
+  type ContextUsageVersion
+} from '@/store/context-usage-cache'
 
 const usage: UsageStats = {
   calls: 1,
@@ -29,6 +34,7 @@ const breakdown: ContextBreakdown = {
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
+  window.localStorage.clear()
 })
 
 describe('useContextBreakdown', () => {
@@ -98,8 +104,140 @@ describe('useContextBreakdown', () => {
 
     await waitFor(() => expect(result.current.breakdown?.context_used).toBe(12_000))
   })
-})
 
+  it('zeroes the occupancy for an empty conversation (baseline estimate is not usage)', async () => {
+    const empty: ContextBreakdown = {
+      categories: [{ color: 'gray', id: 'system_prompt', label: 'System prompt', tokens: 22_200 }],
+      context_max: 2_000_000,
+      context_percent: 1,
+      context_source: 'local_estimate',
+      context_used: 22_200,
+      estimated_total: 22_200,
+      model: 'test-model'
+    }
+    const requestGateway = vi.fn().mockResolvedValue(empty)
+
+    const { result } = renderHook(() =>
+      useContextBreakdown({ busy: false, enabled: true, requestGateway, sessionId: 'runtime-1' })
+    )
+
+    await waitFor(() => expect(result.current.breakdown?.context_max).toBe(2_000_000))
+    expect(result.current.breakdown?.context_used).toBe(0)
+    expect(result.current.breakdown?.context_percent).toBe(0)
+    expect(result.current.breakdown?.categories).toEqual([])
+  })
+
+  it('paints the durable last-known read while the live fetch is pending', async () => {
+    const version: ContextUsageVersion = { input_tokens: 100, message_count: 4, model: 'm', output_tokens: 50 }
+    saveContextUsageSnapshot(
+      'stored-1',
+      { context_max: 200_000, context_percent: 34, context_used: 68_000, model: 'm' },
+      { profile: 'coder' },
+      version
+    )
+    const requestGateway = vi.fn().mockReturnValue(new Promise(() => {}))
+
+    const { result } = renderHook(() =>
+      useContextBreakdown({
+        busy: false,
+        enabled: true,
+        persist: { scope: { profile: 'coder' }, storedSessionId: 'stored-1', version },
+        requestGateway,
+        sessionId: 'runtime-1'
+      })
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(true))
+    expect(result.current.breakdown?.context_source).toBe('restored')
+    expect(result.current.breakdown?.context_used).toBe(68_000)
+    expect(result.current.breakdown?.context_max).toBe(200_000)
+  })
+
+  it('keeps the restored read when the backend reports a no-agent payload', async () => {
+    const version: ContextUsageVersion = { input_tokens: 100, message_count: 4, model: 'm', output_tokens: 50 }
+    saveContextUsageSnapshot(
+      'stored-1',
+      { context_max: 200_000, context_percent: 34, context_used: 68_000, model: 'm' },
+      { profile: 'coder' },
+      version
+    )
+    const noData: ContextBreakdown = {
+      categories: [],
+      context_max: 0,
+      context_percent: 0,
+      context_used: 0,
+      estimated_total: 0,
+      model: ''
+    }
+    const requestGateway = vi.fn().mockResolvedValue(noData)
+
+    const { result } = renderHook(() =>
+      useContextBreakdown({
+        busy: false,
+        enabled: true,
+        persist: { scope: { profile: 'coder' }, storedSessionId: 'stored-1', version },
+        requestGateway,
+        sessionId: 'runtime-1'
+      })
+    )
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalled())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.breakdown?.context_source).toBe('restored')
+    expect(result.current.breakdown?.context_used).toBe(68_000)
+  })
+
+  it('replaces the restored read with live data and banks the new read', async () => {
+    const version: ContextUsageVersion = { input_tokens: 100, message_count: 4, model: 'm', output_tokens: 50 }
+    saveContextUsageSnapshot(
+      'stored-1',
+      { context_max: 200_000, context_percent: 34, context_used: 68_000, model: 'm' },
+      { profile: 'coder' },
+      version
+    )
+    const requestGateway = vi.fn().mockResolvedValue(breakdown)
+
+    const { result } = renderHook(() =>
+      useContextBreakdown({
+        busy: false,
+        enabled: true,
+        persist: { scope: { profile: 'coder' }, storedSessionId: 'stored-1', version },
+        requestGateway,
+        sessionId: 'runtime-1'
+      })
+    )
+
+    await waitFor(() => expect(result.current.breakdown).toEqual(breakdown))
+    expect(loadContextUsageSnapshot('stored-1', { profile: 'coder' }, version)?.context_used).toBe(241_400)
+  })
+
+  it('ignores a restored read whose version drifted', async () => {
+    saveContextUsageSnapshot(
+      'stored-1',
+      { context_max: 200_000, context_percent: 34, context_used: 68_000, model: 'm' },
+      { profile: 'coder' },
+      { input_tokens: 100, message_count: 4, model: 'm', output_tokens: 50 }
+    )
+    const requestGateway = vi.fn().mockReturnValue(new Promise(() => {}))
+
+    const { result } = renderHook(() =>
+      useContextBreakdown({
+        busy: false,
+        enabled: true,
+        persist: {
+          scope: { profile: 'coder' },
+          storedSessionId: 'stored-1',
+          version: { input_tokens: 100, message_count: 5, model: 'm', output_tokens: 50 }
+        },
+        requestGateway,
+        sessionId: 'runtime-1'
+      })
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(true))
+    expect(result.current.breakdown).toBeNull()
+  })
+})
 describe('ContextUsagePanel', () => {
   it('marks estimates but preserves the provider-usage header', () => {
     for (const estimated of [true, false]) {

--- a/apps/desktop/src/app/shell/context-usage-panel.tsx
+++ b/apps/desktop/src/app/shell/context-usage-panel.tsx
@@ -32,6 +32,10 @@ export function ContextUsagePanel({ breakdown, loading, usage }: ContextUsagePan
     [breakdown?.categories, copy]
   )
 
+  // A restored read has the numbers but no category detail yet — phrase it as
+  // still loading, never as "no data".
+  const restored = usage.context_source === 'restored'
+
   const segmentTotal = categories.reduce((sum, category) => sum + category.tokens, 0) || contextUsed || 1
 
   return (
@@ -68,9 +72,13 @@ export function ContextUsagePanel({ breakdown, loading, usage }: ContextUsagePan
         ))}
       </ul>
 
-      {loading && !categories.length && <p className="text-[0.6875rem] text-muted-foreground">{copy.loading}</p>}
+      {(loading || restored) && !categories.length && (
+        <p className="text-[0.6875rem] text-muted-foreground">{copy.loading}</p>
+      )}
 
-      {!loading && !categories.length && <p className="text-[0.6875rem] text-muted-foreground">{copy.empty}</p>}
+      {!loading && !restored && !categories.length && (
+        <p className="text-[0.6875rem] text-muted-foreground">{copy.empty}</p>
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/app/shell/hooks/use-context-breakdown.ts
+++ b/apps/desktop/src/app/shell/hooks/use-context-breakdown.ts
@@ -1,12 +1,49 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import type { ContextBreakdown } from '@/types/hermes'
+import {
+  type ContextUsageScope,
+  type ContextUsageVersion,
+  loadContextUsageSnapshot,
+  saveContextUsageSnapshot
+} from '@/store/context-usage-cache'
 
 interface ContextBreakdownOptions {
   busy: boolean
   enabled: boolean
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
   sessionId: null | string
+  /** Extra refetch signal — e.g. the model id, so a switch re-resolves the
+   *  window without waiting for the next turn. */
+  refreshKey?: string
+  /** Durable last-known read for this session (stored id + owning scope +
+   *  row version). Paints while no live breakdown exists — live data always
+   *  replaces it. */
+  persist?: {
+    scope?: ContextUsageScope
+    storedSessionId: string
+    version: ContextUsageVersion | null
+  } | null
+}
+
+/** A brand-new session's breakdown is only the system-prompt + tools + rules
+ *  baseline the backend estimates before anything is sent. Read verbatim that
+ *  paints a fresh chat as "1% used" — nothing occupies the window until the
+ *  first turn. Zero the occupancy (keep the window) so an empty conversation
+ *  reads 0%, the same as the no-runtime draft path. */
+function isEmptyConversation(breakdown: ContextBreakdown): boolean {
+  return (
+    breakdown.context_source === 'local_estimate' &&
+    !breakdown.categories.some(category => category.id === 'conversation' && category.tokens > 0)
+  )
+}
+
+/** A payload that carries no data at all: no window, no categories, no usage.
+ *  The backend returns exactly this shape when the session has no live agent
+ *  yet (a restored record pre-build, or a reaped runtime) — it must not paint
+ *  as "0%" over a restored read, nor as a definitive empty. */
+function isNoData(breakdown: ContextBreakdown): boolean {
+  return (breakdown.context_max ?? 0) <= 0 && (breakdown.context_used ?? 0) <= 0 && breakdown.categories.length === 0
 }
 
 /** The focused session's context breakdown, fetched as soon as the statusbar
@@ -24,9 +61,18 @@ interface ContextBreakdownOptions {
  *  transcript just grew). Held keyed by the session it describes so switching
  *  sessions drops the previous numbers instead of painting them under the new
  *  session's name. */
-export function useContextBreakdown({ busy, enabled, requestGateway, sessionId }: ContextBreakdownOptions) {
+export function useContextBreakdown({
+  busy,
+  enabled,
+  persist,
+  refreshKey,
+  requestGateway,
+  sessionId
+}: ContextBreakdownOptions) {
   const [fetched, setFetched] = useState<{ breakdown: ContextBreakdown; sessionId: string } | null>(null)
   const [loading, setLoading] = useState(false)
+  const persistRef = useRef(persist)
+  persistRef.current = persist
 
   useEffect(() => {
     // Mid-turn the transcript changes on every delta and the gateway already
@@ -42,6 +88,24 @@ export function useContextBreakdown({ busy, enabled, requestGateway, sessionId }
       .then(breakdown => {
         if (!cancelled && breakdown) {
           setFetched({ breakdown, sessionId })
+
+          // Bank the read so a later restart can paint it while the live
+          // agent rebinds. Empties carry nothing worth restoring.
+          const saved = persistRef.current
+
+          if (saved && !isNoData(breakdown) && !isEmptyConversation(breakdown)) {
+            saveContextUsageSnapshot(
+              saved.storedSessionId,
+              {
+                context_max: breakdown.context_max,
+                context_percent: breakdown.context_percent,
+                context_used: breakdown.context_used,
+                model: breakdown.model
+              },
+              saved.scope,
+              saved.version
+            )
+          }
         }
       })
       .catch(() => undefined)
@@ -54,10 +118,50 @@ export function useContextBreakdown({ busy, enabled, requestGateway, sessionId }
     return () => {
       cancelled = true
     }
-  }, [busy, enabled, requestGateway, sessionId])
+    // refreshKey intentionally re-runs the fetch (model switches re-resolve).
+  }, [busy, enabled, refreshKey, requestGateway, sessionId])
 
   return {
-    breakdown: fetched && fetched.sessionId === sessionId ? fetched.breakdown : null,
+    breakdown: resolveBreakdown(fetched, sessionId, persist),
     loading
   }
+}
+
+function resolveBreakdown(
+  fetched: { breakdown: ContextBreakdown; sessionId: string } | null,
+  sessionId: null | string,
+  persist?: ContextBreakdownOptions['persist']
+) {
+  const breakdown = fetched && fetched.sessionId === sessionId ? fetched.breakdown : null
+
+  if (breakdown && !isNoData(breakdown)) {
+    if (!isEmptyConversation(breakdown)) {
+      return breakdown
+    }
+
+    return { ...breakdown, categories: [], context_percent: 0, context_used: 0, estimated_total: 0 }
+  }
+
+  // No live data yet (fetch pending), or a no-data payload (no agent bound):
+  // fall back to the durable last-known read instead of painting zero.
+  if (!persist?.storedSessionId) {
+    return null
+  }
+
+  const restored = loadContextUsageSnapshot(persist.storedSessionId, persist.scope, persist.version)
+
+  if (!restored) {
+    return null
+  }
+
+  return {
+    categories: [],
+    context_estimated: true,
+    context_max: restored.context_max,
+    context_percent: restored.context_percent,
+    context_source: 'restored',
+    context_used: restored.context_used,
+    estimated_total: restored.context_used,
+    model: restored.model ?? ''
+  } satisfies ContextBreakdown
 }

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -264,9 +264,39 @@ export function useStatusbarItems({
   // toggled off, so this covers the rest.
   const contextItemHidden = useStore($statusbarHiddenIds).includes('context-usage')
 
+  // Durable last-known read for the focused session, so a cold boot paints the
+  // stored numbers while the live agent rebinds. Keyed by stored id (+ owning
+  // scope, + row counters as the version) — never the ephemeral runtime id.
+  const activeStoredSessionId = primaryFocused ? selectedStoredSessionId : focusedStoredSessionId
+  const activeStoredRow = useStoreSelector($sessions, sessions =>
+    activeStoredSessionId
+      ? (sessions.find(session => sessionMatchesStoredId(session, activeStoredSessionId)) ?? null)
+      : null
+  )
+  const persistContextUsage = useMemo(
+    () =>
+      activeStoredSessionId && activeStoredRow
+        ? {
+            scope: {
+              connectionId: activeStoredRow.connection_id ?? '',
+              profile: activeStoredRow.profile ?? 'default'
+            },
+            storedSessionId: activeStoredSessionId,
+            version: {
+              input_tokens: activeStoredRow.input_tokens,
+              message_count: activeStoredRow.message_count,
+              model: activeStoredRow.model,
+              output_tokens: activeStoredRow.output_tokens
+            }
+          }
+        : null,
+    [activeStoredRow, activeStoredSessionId]
+  )
+
   const { breakdown: contextBreakdown, loading: contextBreakdownLoading } = useContextBreakdown({
     busy,
     enabled: !contextItemHidden,
+    persist: persistContextUsage,
     requestGateway,
     sessionId: activeSessionId
   })

--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -60,12 +60,12 @@ afterEach(() => {
 
 // A minimal controller — these tests are about the CATALOG's own behaviour
 // (what it lists, what it offers), not about what any host does with a pick.
-function renderMenu() {
+function renderMenu(current: ModelMenuController['current'] = { effort: '', fast: false, model: '', provider: '' }) {
   const select = vi.fn()
 
   const controller: ModelMenuController = {
     applyPreset: vi.fn(),
-    current: { effort: '', fast: false, model: '', provider: '' },
+    current,
     presetFor: () => ({}),
     select,
     setOptions: vi.fn()
@@ -118,7 +118,9 @@ describe('the catalog owns model curation', () => {
       // row label span carries it (plus the effort meta suffix).
       expect(
         screen.getByText((_, element) =>
-          Boolean(element?.classList.contains('truncate') && (element?.textContent ?? '').startsWith('Gemini 3.1 pro'))
+          Boolean(
+            element?.hasAttribute?.('data-row-label') && (element?.textContent ?? '').startsWith('Gemini 3.1 pro')
+          )
         )
       ).toBeDefined()
     })
@@ -131,6 +133,171 @@ describe('the catalog owns model curation', () => {
     fireEvent.click(screen.getByText('Edit models…'))
 
     expect($modelVisibilityOpen.get()).toBe(true)
+  })
+
+  it('focuses the search field on open so typing filters immediately', async () => {
+    renderMenu()
+    await screen.findByText(/Gemini 3\.1 Pro/i)
+
+    await vi.waitFor(() => {
+      expect(document.activeElement?.getAttribute('placeholder')).toBe('Search models')
+    })
+  })
+})
+
+describe('multi-upstream rows stay distinguishable', () => {
+  const LOCAL_MODELS = ['cmd/deepseek/deepseek-v4-flash', 'cbai/deepseek-v4-flash', 'auto/best-coding']
+
+  function renderLocal(total = 5973, current?: ModelMenuController['current']) {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [{ models: LOCAL_MODELS, name: 'Local', slug: 'local', total_models: total }]
+    })
+    renderMenu(current)
+  }
+
+  it('shows the upstream in the id line, no pills', async () => {
+    renderLocal()
+    await screen.findByText('Best Coding')
+
+    // No qualifier pills — the id line carries the upstream verbatim.
+    expect(screen.getByText('cmd/deepseek/deepseek-v4-flash')).toBeDefined()
+    expect(screen.getByText('cbai/deepseek-v4-flash')).toBeDefined()
+    expect(screen.queryByText('cmd/deepseek')).toBeNull()
+  })
+
+  it('meters the effort as a fill pill with the level inside', async () => {
+    renderLocal()
+    await screen.findByText('Best Coding')
+    // Native tooltip carries exact id + effort — truncated rows reveal on hover.
+    const row = screen.getByTitle('cmd/deepseek/deepseek-v4-flash · Med')
+
+    expect(row).toBeDefined()
+    // Medium fills 3 of 7 with the label inside the pill.
+    const meter = row.querySelector('[role="img"]') as HTMLElement
+    const track = meter.lastElementChild as HTMLElement
+    const fill = track.firstElementChild as HTMLElement
+
+    expect(meter.getAttribute('aria-label')).toBe('Med')
+    expect(fill.style.width).toContain('42.8')
+    expect(meter.textContent).toContain('Med')
+  })
+
+  it('lists families A–Z by default', async () => {
+    renderLocal()
+    await screen.findByText('Best Coding')
+    const names = [...document.querySelectorAll('[data-row-label]')].map(el => el.textContent)
+
+    // Tie on "Deepseek V4 Flash" breaks by id: cbai before cmd.
+    expect(names).toEqual(['Best Coding', 'Deepseek V4 Flash', 'Deepseek V4 Flash'])
+  })
+
+  it('badges the provider header with shown-of-total counts', async () => {
+    renderLocal()
+    await screen.findByText('3 of 5,973')
+  })
+
+  it('still pins the active model first while searching', async () => {
+    renderLocal(5973, { effort: '', fast: false, model: 'cmd/deepseek/deepseek-v4-flash', provider: 'local' })
+    await screen.findByText('Best Coding')
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search models' }), { target: { value: 'flash' } })
+
+    await vi.waitFor(() => {
+      const rows = [...document.querySelectorAll('[data-row-label]')]
+
+      // Alphabetically cbai would lead — the active cmd pick stays on top.
+      expect(rows.map(el => el.textContent)).toEqual(['Deepseek V4 Flash', 'Deepseek V4 Flash'])
+      expect(rows[0].closest('span[title]')?.getAttribute('title')).toContain('cmd/deepseek/deepseek-v4-flash')
+    })
+  })
+
+  it('pins the active model first, rest stays A–Z', async () => {
+    renderLocal(5973, { effort: '', fast: false, model: 'cbai/deepseek-v4-flash', provider: 'local' })
+    await screen.findByText('Best Coding')
+    const names = [...document.querySelectorAll('[data-row-label]')]
+
+    expect(names.map(el => el.textContent)).toEqual(['Deepseek V4 Flash', 'Best Coding', 'Deepseek V4 Flash'])
+    expect(names[0].closest('span[title]')?.getAttribute('title')).toContain('cbai/deepseek-v4-flash')
+  })
+
+  it('glides a clipped label on hover and snaps back on leave', async () => {
+    renderLocal()
+    await screen.findByText('Best Coding')
+    const marquee = document.querySelector('[data-marquee="name:cmd/deepseek/deepseek-v4-flash"]') as HTMLElement
+    const inner = marquee.firstElementChild as HTMLElement
+
+    // jsdom reports zero sizes — stage a 200px overflow.
+    Object.defineProperty(inner, 'scrollWidth', { configurable: true, value: 300 })
+    Object.defineProperty(marquee, 'clientWidth', { configurable: true, value: 100 })
+
+    // Hover bubbles to the row, which scrolls every clipped line together.
+    fireEvent.mouseOver(marquee)
+    await vi.waitFor(() => {
+      expect(inner.style.transform).toContain('translateX(-200px)')
+    })
+
+    fireEvent.mouseOut(marquee)
+    expect(inner.style.transform).toBe('')
+  })
+
+  it('leaves fitting labels put on hover', async () => {
+    renderLocal()
+    await screen.findByText('Best Coding')
+    const marquee = document.querySelector('[data-marquee="name:auto/best-coding"]') as HTMLElement
+    const inner = marquee.firstElementChild as HTMLElement
+
+    fireEvent.mouseOver(marquee)
+    expect(inner.style.transform).toBe('')
+  })
+
+  it('renders the variant tag instead of dropping it', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [{ models: ['deepseek/deepseek-v4-pro-thinking'], name: 'Local', slug: 'local' }]
+    })
+    renderMenu()
+    await screen.findByText('Deepseek V4 Pro')
+    expect(screen.getByText('Thinking')).toBeDefined()
+  })
+})
+
+describe('token search', () => {
+  it('matches unordered tokens across id and upstream', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        { models: ['opencode/deepseek-v4-flash', 'cmd/deepseek/deepseek-v4-flash'], name: 'Mixed', slug: 'mixed' }
+      ]
+    })
+    renderMenu()
+    await screen.findAllByText('Deepseek V4 Flash')
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search models' }), {
+      target: { value: 'deepseek v4 flash opencode' }
+    })
+
+    await vi.waitFor(() => {
+      const names = [...document.querySelectorAll('[data-row-label]')].map(el => el.textContent)
+
+      expect(names).toEqual(['Deepseek V4 Flash'])
+    })
+    // The survivor is the opencode route.
+    expect(screen.getByTitle('opencode/deepseek-v4-flash · Med')).toBeDefined()
+  })
+})
+
+describe('search render cap', () => {
+  const MANY = Array.from({ length: 250 }, (_, i) => `zz-model-${String(i).padStart(3, '0')}`)
+
+  it('renders the first 100 matches with a narrowing note', async () => {
+    getGlobalModelOptions.mockResolvedValue({ providers: [{ models: MANY, name: 'Many', slug: 'many' }] })
+    renderMenu()
+    await screen.findByText('Zz Model 000')
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search models' }), { target: { value: 'zz-model' } })
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/keep typing to narrow/i)).toBeDefined()
+    })
+    expect(document.querySelectorAll('[data-row-label]').length).toBe(100)
   })
 })
 

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
-import { createContext, type ReactNode, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Codicon } from '@/components/ui/codicon'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
@@ -15,16 +15,19 @@ import {
   DropdownMenuSub,
   DropdownMenuSubTrigger
 } from '@/components/ui/dropdown-menu'
+import { EffortMeter, resolveEffortMeter } from '@/components/ui/effort-meter'
 import { HighlightMatches } from '@/components/ui/highlight-matches'
 import { usePointerQuiet } from '@/components/ui/keyboard-first'
+import { HoverScroll } from '@/components/ui/marquee'
 import { Skeleton } from '@/components/ui/skeleton'
 import type { HermesGateway } from '@/hermes'
 import { getLocalModelsStatus } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { catalogProviderMatches, modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
-import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
-import { DEFAULT_REASONING_EFFORT, reasoningEffortLabel } from '@/lib/reasoning-effort'
-import { foldIncludes, normalize } from '@/lib/text'
+import { compareModelIds, displayModelName, modelDisplayParts } from '@/lib/model-status-label'
+import { DEFAULT_REASONING_EFFORT } from '@/lib/reasoning-effort'
+import { foldIncludes, normalize, searchFold } from '@/lib/text'
+import { useDebouncedValue } from '@/lib/use-debounced-value'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { $localModelsEnabled } from '@/store/local-models-flag'
@@ -43,6 +46,59 @@ import { $defaultReasoningEffort } from '@/store/session'
 import type { LocalModelLoadProgress, ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
 
 import { type FastControl, ModelEditSubmenu, resolveFastControl } from './model-edit-submenu'
+
+/** One model row's text lines. Hovering anywhere on them scrolls every
+ *  clipped line together; the meter, chips and toggles stay pinned. */
+function ModelRowLines({
+  fast,
+  idKey,
+  idNode,
+  meter,
+  nameNode,
+  tagNode,
+  title
+}: {
+  fast: ReactNode
+  idKey: string
+  idNode: ReactNode
+  meter: ReactNode
+  nameNode: ReactNode
+  tagNode: ReactNode
+  title: string
+}) {
+  const [go, setGo] = useState(false)
+
+  return (
+    <span
+      className="block min-w-0 flex-1 overflow-hidden"
+      onMouseOut={event => {
+        if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          return
+        }
+
+        setGo(false)
+      }}
+      onMouseOver={() => setGo(true)}
+      title={title}
+    >
+      <span className="flex min-w-0 items-center gap-1.5">
+        <HoverScroll className="min-w-0 flex-1" go={go} marqueeKey={`name:${idKey}`}>
+          {nameNode}
+        </HoverScroll>
+        {tagNode}
+        {fast}
+        {meter}
+      </span>
+      <HoverScroll
+        className="font-mono text-[0.65rem] font-normal text-(--ui-text-tertiary)"
+        go={go}
+        marqueeKey={`id:${idKey}`}
+      >
+        {idNode}
+      </HoverScroll>
+    </span>
+  )
+}
 
 // Lets the host dropdown (model-pill, a kanban field trigger, …) hand the panel
 // a way to dismiss itself so clicking a model row commits + closes, while the
@@ -109,7 +165,41 @@ interface ModelCatalogMenuProps {
 interface ProviderGroup {
   families: ModelFamily[]
   provider: ModelOptionProvider
+  /** Matches before the render cap (search mode); families.length otherwise. */
+  total: number
 }
+
+const SearchInput = ({ onDebouncedChange, onKeyAction, placeholder }: {
+  onDebouncedChange: (value: string) => void
+  onKeyAction: (key: string) => void
+  placeholder: string
+}) => {
+  const [value, setValue] = useState('')
+  const debounced = useDebouncedValue(value, 150)
+  const ref = useRef(onDebouncedChange)
+  ref.current = onDebouncedChange
+  useEffect(() => { ref.current(debounced) }, [debounced])
+
+  return (
+    <DropdownMenuSearch
+      aria-label={placeholder}
+      onKeyDown={event => {
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Enter') {
+          event.preventDefault()
+          event.stopPropagation()
+          onKeyAction(event.key)
+        }
+      }}
+      onValueChange={setValue}
+      placeholder={placeholder}
+      value={value}
+    />
+  )
+}
+
+/** Render cap per provider in search mode — filtering 6k ids is cheap, mounting
+ *  6k submenu rows is not. The trailing note says how much is hidden. */
+const SEARCH_RENDER_CAP = 100
 
 /**
  * THE model catalog menu: searchable, provider-grouped, `-fast` families
@@ -254,6 +344,39 @@ export function ModelCatalogMenu({
 
   const q = normalize(search)
 
+  // Token terms for filtering + highlighting (match the token-AND filter in
+  // groupModels). Single-word queries keep the raw string so separator
+  // folding still highlights one contiguous range.
+  const searchTerms = useMemo(() => {
+    const tokens = searchFold(q).split(/\s+/).filter(Boolean)
+
+    return tokens.length > 1 && /\s/.test(search) ? tokens : search
+  }, [q, search])
+
+  // Per-catalog search index: collapsed families + folded haystacks, built once
+  // per catalog so keystrokes only scan cheap substrings instead of re-folding
+  // every id per keystroke.
+  const catalogIndex = useMemo(() => {
+    const families = new Map<string, ModelFamily[]>()
+    const haystacks = new Map<string, string>()
+
+    for (const provider of pickerProviders) {
+      const collapsed = collapseModelFamilies(provider.models ?? [])
+      families.set(provider.slug, collapsed)
+
+      for (const family of collapsed) {
+        haystacks.set(
+          `${provider.slug}::${family.id}`,
+          searchFold(
+            `${family.id} ${family.fastId ?? ''} ${provider.name} ${provider.slug} ${displayModelName(family.id)}`
+          )
+        )
+      }
+    }
+
+    return { families, haystacks }
+  }, [pickerProviders])
+
   // In-flight downloads render inside the Local provider group when it
   // exists, else as their own trailing 'Local' group (first download —
   // nothing staged yet, so the catalog has no local provider row).
@@ -269,8 +392,15 @@ export function ModelCatalogMenu({
   )
 
   const groups = useMemo(
-    () => groupModels(pickerProviders, search, { model: current.model, provider: current.provider }, shownKeys),
-    [pickerProviders, search, current.model, current.provider, shownKeys]
+    () =>
+      groupModels(
+        pickerProviders,
+        catalogIndex,
+        search,
+        { model: current.model, provider: current.provider },
+        shownKeys
+      ),
+    [pickerProviders, catalogIndex, search, current.model, current.provider, shownKeys]
   )
 
   // Presets are searchable rows like everything else — an unfiltered preset
@@ -337,6 +467,7 @@ export function ModelCatalogMenu({
   )
 
   const [kbOverride, setKbOverride] = useState<null | number>(null)
+
   // A parked cursor is not a cursor in use: until the mouse actually moves,
   // hover can't take rows out from under the keyboard.
   const pointerQuiet = usePointerQuiet()
@@ -403,27 +534,19 @@ export function ModelCatalogMenu({
 
   return (
     <>
-      <DropdownMenuSearch
-        aria-label={copy.search}
-        onKeyDown={event => {
-          // Claim arrows and Enter from Radix so DOM focus stays in the input
-          // and Enter commits the highlighted row without a DownArrow first.
-          if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-            event.preventDefault()
-            event.stopPropagation()
-            stepKb(event.key === 'ArrowDown' ? 1 : -1)
-          } else if (event.key === 'Enter') {
-            event.preventDefault()
-            event.stopPropagation()
-            commitKbRow()
-          }
-        }}
-        onValueChange={value => {
+      <SearchInput
+        onDebouncedChange={value => {
           setSearch(value)
           setKbOverride(null)
         }}
+        onKeyAction={key => {
+          if (key === 'ArrowDown' || key === 'ArrowUp') {
+            stepKb(key === 'ArrowDown' ? 1 : -1)
+          } else if (key === 'Enter') {
+            commitKbRow()
+          }
+        }}
         placeholder={copy.search}
-        value={search}
       />
 
       <DropdownMenuSeparator className="mx-0" />
@@ -471,6 +594,12 @@ export function ModelCatalogMenu({
                   <span className="truncate">
                     <HighlightMatches foldSeparators query={search} text={group.provider.name} />
                   </span>
+                  {typeof group.provider.total_models === 'number' &&
+                  group.provider.total_models > group.families.length ? (
+                    <span className="shrink-0 font-normal normal-case tracking-normal">
+                      {group.families.length} of {group.provider.total_models.toLocaleString()}
+                    </span>
+                  ) : null}
                   <DisclosureCaret
                     className="shrink-0 text-(--ui-text-tertiary) opacity-0 transition group-hover/label:opacity-100"
                     open={!collapsed}
@@ -488,7 +617,7 @@ export function ModelCatalogMenu({
                         : null
 
                     const isCurrent = activeId !== null
-                    const name = modelDisplayParts(family.id).name
+                    const { name, tag } = modelDisplayParts(family.id)
                     const caps = group.provider.capabilities?.[family.id]
 
                     // Managed local model loading into memory right now:
@@ -511,12 +640,11 @@ export function ModelCatalogMenu({
                       effFast
                     )
 
-                    const meta = [
-                      fastControl.kind !== 'none' && fastControl.on ? copy.fast : null,
-                      (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort || defaultEffort) : null
-                    ]
-                      .filter(Boolean)
-                      .join(' ')
+                    const fastOn = fastControl.kind !== 'none' && fastControl.on
+                    const reasoningSupported = caps?.reasoning ?? true
+                    // The meter pins — only the name truncates. Tooltips carry exact values.
+                    const { label: effTitle } = resolveEffortMeter(effEffort, defaultEffort)
+                    const rowTitle = reasoningSupported ? `${family.id} · ${effTitle}` : family.id
 
                     // Clicking the row commits the model and closes; the edit
                     // submenu (reasoning/fast) is reached by HOVER, so you can
@@ -541,10 +669,38 @@ export function ModelCatalogMenu({
                           }}
                           {...kbRowProps(`${group.provider.slug}:${family.id}`)}
                         >
-                          <span className="min-w-0 flex-1 truncate">
-                            <HighlightMatches foldSeparators query={search} text={name} />
-                            {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
-                          </span>
+                          <ModelRowLines
+                            fast={
+                              fastOn ? (
+                                <span
+                                  aria-label={copy.fast}
+                                  className="shrink-0 text-[0.75rem]"
+                                  role="img"
+                                  title={copy.fast}
+                                >
+                                  ⚡
+                                </span>
+                              ) : null
+                            }
+                            idKey={family.id}
+                            idNode={<HighlightMatches query={searchTerms} text={family.id} />}
+                            meter={
+                              reasoningSupported ? <EffortMeter fallback={defaultEffort} value={effEffort} /> : null
+                            }
+                            nameNode={
+                              <span data-row-label>
+                                <HighlightMatches foldSeparators query={searchTerms} text={name} />
+                              </span>
+                            }
+                            tagNode={
+                              tag ? (
+                                <span className="shrink-0 rounded bg-(--ui-bg-tertiary) px-1 text-[0.625rem] font-medium text-(--ui-text-secondary)">
+                                  {tag}
+                                </span>
+                              ) : null
+                            }
+                            title={rowTitle}
+                          />
                           {loadProgress ? (
                             <span
                               className="ml-auto flex shrink-0 items-center gap-1.5"
@@ -590,6 +746,11 @@ export function ModelCatalogMenu({
                       </DropdownMenuSub>
                     )
                   })}
+                {search && group.total > group.families.length ? (
+                  <div className="px-2.5 py-1 text-[0.65rem] text-(--ui-text-tertiary)">
+                    Showing {group.families.length} of {group.total.toLocaleString()} — keep typing to narrow
+                  </div>
+                ) : null}
                 {!collapsed &&
                   slug === LOCAL_PROVIDER_SLUG &&
                   shownDownloads.map(job => (
@@ -627,7 +788,7 @@ export function ModelCatalogMenu({
                 }}
                 {...kbRowProps(`moa:${preset}`)}
               >
-                <span className="min-w-0 flex-1 truncate">
+                <span className="min-w-0 flex-1 truncate" data-row-label>
                   MoA: <HighlightMatches foldSeparators query={search} text={preset} />
                 </span>
                 {isCurrentMoa ? <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" /> : null}
@@ -700,54 +861,78 @@ function DownloadingModelRow({ jobId, target }: { jobId: string; target: string 
 // Collapsed we show the user's chosen models (or the curated default); typing
 // spans every available model so anything is reachable past the cut. A search
 // is itself a narrowing action, so we do NOT cap per-provider matches.
+/** Family order inside a provider group: A–Z by display name, id as the
+ *  tiebreak (shared with the visibility dialog). */
+function compareFamilies(a: ModelFamily, b: ModelFamily): number {
+  return compareModelIds(a.id, b.id)
+}
+
 function groupModels(
   providers: ModelOptionProvider[],
+  index: { families: Map<string, ModelFamily[]>; haystacks: Map<string, string> },
   search: string,
   current: { model: string; provider: string },
   visible: Set<string> | null
 ): ProviderGroup[] {
   const q = normalize(search)
+  const foldedQuery = searchFold(q)
+  // Token-AND: `deepseek v4 flash opencode` finds `opencode/deepseek-v4-flash`
+  // regardless of token order. Computed once — keystrokes only scan.
+  const queryTokens = foldedQuery.split(/\s+/).filter(Boolean)
   const groups: ProviderGroup[] = []
 
   for (const provider of providers) {
-    const allFamilies = collapseModelFamilies(provider.models ?? [])
+    const allFamilies = index.families.get(provider.slug) ?? []
 
     if (allFamilies.length === 0) {
       continue
     }
 
-    const matches = (family: ModelFamily) =>
-      foldIncludes(
-        `${family.id} ${family.fastId ?? ''} ${provider.name} ${provider.slug} ${displayModelName(family.id)}`,
-        q
-      )
+    const matches = (family: ModelFamily) => {
+      const haystack = index.haystacks.get(`${provider.slug}::${family.id}`) ?? ''
 
-    let shown: Set<string>
-
-    if (q) {
-      // Search spans every family, regardless of visibility.
-      shown = new Set(allFamilies.filter(matches).map(family => family.id))
-    } else if (visible) {
-      // User has customized which models show — honor their selection exactly.
-      shown = new Set(
-        allFamilies.filter(family => visible.has(modelVisibilityKey(provider.slug, family.id))).map(family => family.id)
-      )
-    } else {
-      shown = new Set(allFamilies.slice(0, DEFAULT_VISIBLE_PER_PROVIDER).map(family => family.id))
+      return queryTokens.every(token => haystack.includes(token))
     }
 
-    // Always include the active model — but keep every row in the provider's
-    // stable curated order, so selecting a model can't shuffle the list. While
-    // SEARCHING the pin is skipped: a query means "show me matches".
+    // Rows read A–Z by display name (ties by id, so duplicate names from
+    // different upstreams order deterministically). The slices below therefore
+    // keep the first N alphabetically, not an arbitrary curated head.
+    const ordered = [...allFamilies].sort(compareFamilies)
+
+    // The active model pins first whenever it is listed — browsing and
+    // searching alike. A non-matching active model stays out (a query means
+    // "show me matches", never "plus my current pick").
     const activeId =
-      !q && catalogProviderMatches(provider, current.provider) && current.model
+      catalogProviderMatches(provider, current.provider) && current.model
         ? allFamilies.find(family => family.id === current.model || family.fastId === current.model)?.id
         : undefined
 
-    const families = allFamilies.filter(family => shown.has(family.id) || family.id === activeId)
+    const pinActiveFirst = (a: ModelFamily, b: ModelFamily) =>
+      a.id === activeId ? -1 : b.id === activeId ? 1 : compareFamilies(a, b)
+
+    let families: ModelFamily[]
+    let total: number
+
+    if (q) {
+      // Search spans every family, regardless of visibility — capped for
+      // render (see SEARCH_RENDER_CAP); the group carries the true total.
+      const matched = ordered.filter(matches).sort(pinActiveFirst)
+      families = matched.slice(0, SEARCH_RENDER_CAP)
+      total = matched.length
+    } else {
+      // A customized shortlist is honored exactly, else the first 50 A–Z.
+      const shown = new Set(
+        visible
+          ? ordered.filter(family => visible.has(modelVisibilityKey(provider.slug, family.id))).map(family => family.id)
+          : ordered.slice(0, DEFAULT_VISIBLE_PER_PROVIDER).map(family => family.id)
+      )
+
+      families = ordered.filter(family => shown.has(family.id) || family.id === activeId).sort(pinActiveFirst)
+      total = families.length
+    }
 
     if (families.length > 0) {
-      groups.push({ families, provider })
+      groups.push({ families, provider, total })
     }
   }
 

--- a/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
@@ -128,4 +128,12 @@ describe('ModelEditSubmenu reports edits without performing them', () => {
 
     expect(onSelectModel).toHaveBeenCalledWith('m1-fast')
   })
+
+  it('heads the controls with the edited model identity', () => {
+    renderSubmenu({ fastControl: { kind: 'none' }, onSetOptions: vi.fn(), reasoning: true })
+
+    // Pretty name plus exact id — duplicate names across upstreams stay distinct.
+    expect(screen.getByText('M1')).toBeDefined()
+    expect(screen.getByText('m1')).toBeDefined()
+  })
 })

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Switch } from '@/components/ui/switch'
 import { useI18n } from '@/i18n'
+import { displayModelName } from '@/lib/model-status-label'
 import { isThinkingEnabled, REASONING_EFFORTS, resolveReasoningEffort } from '@/lib/reasoning-effort'
 
 // Hermes' real reasoning levels live in lib/reasoning-effort; `none` is owned
@@ -107,6 +108,7 @@ function ModelEditSubmenuBody({
   effort,
   fastControl,
   isActive,
+  model,
   onSelectModel,
   onSetOptions,
   reasoning
@@ -144,6 +146,15 @@ function ModelEditSubmenuBody({
     <div className="px-2.5 py-3 text-xs text-(--ui-text-tertiary)">{copy.noOptions}</div>
   ) : (
     <>
+      {/* Which model these controls edit — duplicate names across upstreams
+        are otherwise indistinguishable here. */}
+      <DropdownMenuLabel className="px-2 pb-1 pt-2">
+        <span className="block truncate text-xs font-semibold text-foreground">{displayModelName(model)}</span>
+        <span className="block font-mono text-[0.65rem] font-normal break-all whitespace-normal text-(--ui-text-tertiary)">
+          {model}
+        </span>
+      </DropdownMenuLabel>
+      <DropdownMenuSeparator className="mx-0" />
       <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.options}</DropdownMenuLabel>
       {showThinkingToggle ? (
         <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -172,7 +172,9 @@ describe('ModelMenuPanel search', () => {
   // Highlighted labels are split across <mark> nodes, so single-text-node
   // queries miss them — match on the row span's composed textContent.
   const rowWithText = (content: ReturnType<typeof renderPanel>['content'], pattern: RegExp) =>
-    content.queryByText((_, element) => element?.tagName === 'SPAN' && pattern.test(element.textContent ?? ''))
+    content.queryByText(
+      (_, element) => element?.hasAttribute?.('data-row-label') === true && pattern.test(element.textContent ?? '')
+    )
 
   it('hides the non-matching current model while a query is active', async () => {
     $currentProvider.set('deepseek')
@@ -185,9 +187,9 @@ describe('ModelMenuPanel search', () => {
     fireEvent.change(input, { target: { value: 'gemini' } })
 
     await vi.waitFor(() => {
-      expect(rowWithText(content, /Gemini 3\.1 Pro/i)).not.toBeNull()
+      expect(rowWithText(content, /Deepseek V4 Pro/i)).toBeNull()
     })
-    expect(rowWithText(content, /Deepseek V4 Pro/i)).toBeNull()
+    expect(rowWithText(content, /Gemini 3\.1 Pro/i)).not.toBeNull()
   })
 
   it('Enter in the search field commits the first match', async () => {
@@ -199,15 +201,16 @@ describe('ModelMenuPanel search', () => {
     fireEvent.change(input, { target: { value: 'gemini' } })
 
     await vi.waitFor(() => {
-      expect(rowWithText(content, /Gemini 3\.1 Pro/i)).not.toBeNull()
+      expect(rowWithText(content, /Deepseek V4 Pro/i)).toBeNull()
     })
 
     fireEvent.keyDown(input, { key: 'Enter' })
 
-    // First matching family of the first (alphabetical) matching provider.
+    // First matching family of the first (alphabetical) matching provider;
+    // families read A–Z, so 2.5 Flash leads 3.1 Pro.
     await vi.waitFor(() => {
       expect(onSelectModel).toHaveBeenCalledWith({
-        model: 'gemini-3.1-pro',
+        model: 'gemini-2.5-flash',
         provider: 'google',
         sessionId: 'runtime-1'
       })
@@ -235,7 +238,7 @@ describe('ModelMenuPanel search', () => {
     fireEvent.change(input, { target: { value: 'gemini' } })
 
     await vi.waitFor(() => {
-      expect(rowWithText(content, /Gemini 3\.1 Pro/i)).not.toBeNull()
+      expect(rowWithText(content, /Deepseek V4 Pro/i)).toBeNull()
     })
 
     // First match auto-selected; ↓ steps to the second match.
@@ -244,7 +247,7 @@ describe('ModelMenuPanel search', () => {
 
     await vi.waitFor(() => {
       expect(onSelectModel).toHaveBeenCalledWith({
-        model: 'gemini-2.5-flash',
+        model: 'gemini-2.5-pro',
         provider: 'google',
         sessionId: 'runtime-1'
       })
@@ -273,9 +276,9 @@ describe('ModelMenuPanel search', () => {
     fireEvent.change(input, { target: { value: 'beast' } })
 
     await vi.waitFor(() => {
-      expect(rowWithText(content, /MoA: BeastMode/)).not.toBeNull()
+      expect(rowWithText(content, /MoA: default/)).toBeNull()
     })
-    expect(rowWithText(content, /MoA: default/)).toBeNull()
+    expect(rowWithText(content, /MoA: BeastMode/)).not.toBeNull()
 
     // The surviving preset IS the first row, so Enter commits it.
     fireEvent.keyDown(input, { key: 'Enter' })
@@ -353,7 +356,9 @@ describe('ModelMenuPanel provider collapse', () => {
     await vi.waitFor(() => {
       expect(
         content.queryByText(
-          (_, element) => element?.tagName === 'SPAN' && (element.textContent ?? '').startsWith('Deepseek V4 Pro')
+          (_, element) =>
+            element?.hasAttribute?.('data-row-label') === true &&
+            (element.textContent ?? '').startsWith('Deepseek V4 Pro')
         )
       ).not.toBeNull()
     })

--- a/apps/desktop/src/components/chat/status-section.tsx
+++ b/apps/desktop/src/components/chat/status-section.tsx
@@ -15,6 +15,10 @@ interface StatusSectionProps {
   /** Optional glyph between the caret and the label (e.g. a `Codicon`). */
   icon?: ReactNode
   label: ReactNode
+  /** Pin the header while the section body scrolls (long goal/subagent
+   *  sections) so collapse stays reachable mid-scroll. Paints the composer
+   *  fill — only set inside the composer dock card. */
+  stickyHeader?: boolean
 }
 
 /**
@@ -30,13 +34,20 @@ export function StatusSection({
   defaultCollapsed = true,
   icon,
   label,
-  preview
+  preview,
+  stickyHeader = false
 }: StatusSectionProps) {
   const [collapsed, setCollapsed] = useState(defaultCollapsed)
 
   return (
     <div>
-      <div className="flex items-center gap-1 pr-1">
+      <div
+        className={
+          stickyHeader
+            ? 'sticky top-0 z-10 flex items-center gap-1 bg-(--composer-fill) pr-1'
+            : 'flex items-center gap-1 pr-1'
+        }
+      >
         <button
           aria-expanded={!collapsed}
           className="flex min-w-0 flex-1 items-center gap-1.5 px-2 py-1 text-left text-xs font-normal text-muted-foreground/92 transition-colors hover:text-foreground/90"

--- a/apps/desktop/src/components/model-visibility-dialog.test.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.test.tsx
@@ -1,0 +1,122 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $visibleModels } from '@/store/model-visibility'
+import { $collapsedProviders } from '@/store/provider-collapse'
+
+import { ModelVisibilityDialog } from './model-visibility-dialog'
+
+// Radix calls these on open; jsdom doesn't implement them.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+const requestModelOptions = vi.fn()
+
+vi.mock('@/lib/model-options', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/model-options')>()),
+  requestModelOptions: (...args: unknown[]) => requestModelOptions(...args)
+}))
+
+const LOCAL_MODELS = ['cmd/deepseek/deepseek-v4-flash', 'cbai/deepseek-v4-flash', 'auto/best-coding']
+
+beforeEach(() => {
+  $visibleModels.set(null)
+  $collapsedProviders.set([])
+  requestModelOptions.mockResolvedValue({
+    providers: [{ models: LOCAL_MODELS, name: 'Local', slug: 'local' }]
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function renderDialog() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  render(
+    <QueryClientProvider client={client}>
+      <ModelVisibilityDialog onOpenChange={() => {}} onOpenProviders={() => {}} open />
+    </QueryClientProvider>
+  )
+}
+
+describe('ModelVisibilityDialog', () => {
+  it('shows the upstream in the id line, no pills', async () => {
+    renderDialog()
+    await screen.findByText('Best Coding')
+
+    const names = [...document.querySelectorAll('[data-row-label]')].map(el => el.textContent)
+
+    expect(names).toEqual(['Best Coding', 'Deepseek V4 Flash', 'Deepseek V4 Flash'])
+    // No qualifier pills — the id line carries the upstream verbatim.
+    expect(screen.getByText('cmd/deepseek/deepseek-v4-flash')).toBeDefined()
+    expect(screen.getByText('cbai/deepseek-v4-flash')).toBeDefined()
+    expect(screen.queryByText('cmd/deepseek')).toBeNull()
+  })
+
+  it('filters by upstream prefix', async () => {
+    renderDialog()
+    await screen.findByText('Best Coding')
+
+    fireEvent.change(screen.getByPlaceholderText('Search models'), { target: { value: 'cbai' } })
+
+    // Highlighting splits the id across nodes — assert on row labels instead.
+    await vi.waitFor(() => {
+      const names = [...document.querySelectorAll('[data-row-label]')].map(el => el.textContent)
+
+      expect(names).toEqual(['Deepseek V4 Flash'])
+    })
+    expect(screen.getByText('cbai', { selector: 'mark' })).toBeDefined()
+  })
+
+  it('freezes order while toggling — no reshuffle under the pointer', async () => {
+    renderDialog()
+    await screen.findByText('Best Coding')
+
+    const before = [...document.querySelectorAll('[data-row-label]')].map(el => el.textContent)
+    const switches = screen.getAllByRole('switch')
+
+    // Disable the first (enabled) row.
+    fireEvent.click(switches[0])
+
+    await vi.waitFor(() => {
+      expect(switches[0].getAttribute('aria-checked')).toBe('false')
+    })
+    expect([...document.querySelectorAll('[data-row-label]')].map(el => el.textContent)).toEqual(before)
+  })
+
+  it('matches unordered tokens across id and upstream', async () => {
+    renderDialog()
+    await screen.findByText('Best Coding')
+
+    fireEvent.change(screen.getByPlaceholderText('Search models'), { target: { value: 'flash cmd' } })
+
+    await vi.waitFor(() => {
+      const names = [...document.querySelectorAll('[data-row-label]')].map(el => el.textContent)
+
+      expect(names).toEqual(['Deepseek V4 Flash'])
+    })
+    expect(screen.getAllByText('flash', { selector: 'mark' }).length).toBeGreaterThan(0)
+  })
+
+  it('caps the initial list with a show-all expander', async () => {
+    const MANY = Array.from({ length: 250 }, (_, i) => `zz-model-${String(i).padStart(3, '0')}`)
+    requestModelOptions.mockResolvedValue({ providers: [{ models: MANY, name: 'Many', slug: 'many' }] })
+    renderDialog()
+    await screen.findByText('Zz Model 000')
+
+    expect(document.querySelectorAll('[data-row-label]').length).toBe(200)
+
+    fireEvent.click(screen.getByText(/Show all 250/))
+
+    await vi.waitFor(() => {
+      expect(document.querySelectorAll('[data-row-label]').length).toBe(250)
+    })
+  })
+})

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
-import { useMemo, useState } from 'react'
+import { memo, useMemo, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -8,13 +8,15 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { HighlightMatches } from '@/components/ui/highlight-matches'
+import { HoverScroll } from '@/components/ui/marquee'
 import { Switch } from '@/components/ui/switch'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { Search } from '@/lib/icons'
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
-import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
-import { foldIncludes, normalize } from '@/lib/text'
+import { compareModelIds, displayModelName, modelDisplayParts } from '@/lib/model-status-label'
+import { normalize, searchFold } from '@/lib/text'
+import { useDebouncedValue } from '@/lib/use-debounced-value'
 import {
   $visibleModels,
   collapseModelFamilies,
@@ -26,6 +28,79 @@ import {
 } from '@/store/model-visibility'
 import { $collapsedProviders, toggleCollapsedProvider } from '@/store/provider-collapse'
 import type { ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
+
+/** Render cap per provider — filtering thousands of ids is cheap, mounting
+ *  thousands of toggle rows is not. The expander below lifts it per provider. */
+const DIALOG_RENDER_CAP = 200
+
+/** One toggle row, memoized so a switch flips one row instead of re-rendering
+ *  hundreds (the per-row toggle closure is intentionally excluded from the
+ *  compare — it reads fresh stores itself). No pills: the id line below
+ *  already carries the upstream verbatim. */
+const VisibilityRow = memo(
+  function VisibilityRow({
+    checked,
+    familyId,
+    onToggle,
+    provider,
+    search,
+    terms
+  }: {
+    checked: boolean
+    familyId: string
+    onToggle: () => void
+    provider: ModelOptionProvider
+    search: string
+    terms: string | string[]
+  }) {
+    const [go, setGo] = useState(false)
+    const { name } = modelDisplayParts(familyId)
+    const caps = provider.capabilities?.[familyId]
+
+    const details = [familyId, caps?.fast ? 'fast' : null, caps && !caps.reasoning ? 'no reasoning' : null]
+      .filter(Boolean)
+      .join(' · ')
+
+    return (
+      <label className="flex cursor-pointer items-center gap-2 px-3 py-1 text-xs hover:bg-(--ui-control-active-background)">
+        <span
+          className="block min-w-0 flex-1 overflow-hidden"
+          onMouseOut={event => {
+            if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+              return
+            }
+
+            setGo(false)
+          }}
+          onMouseOver={() => setGo(true)}
+          title={details}
+        >
+          <span className="flex min-w-0 items-center gap-1.5">
+            <HoverScroll className="min-w-0 flex-1" go={go} marqueeKey={`name:${familyId}`}>
+              <span data-row-label>
+                <HighlightMatches query={terms} text={name} />
+              </span>
+            </HoverScroll>
+          </span>
+          <HoverScroll
+            className="font-mono text-[0.65rem] font-normal text-(--ui-text-tertiary)"
+            go={go}
+            marqueeKey={`id:${familyId}`}
+          >
+            <HighlightMatches query={terms} text={familyId} />
+          </HoverScroll>
+        </span>
+        <Switch checked={checked} onCheckedChange={onToggle} size="xs" />
+      </label>
+    )
+  },
+  (prev, next) =>
+    prev.checked === next.checked &&
+    prev.familyId === next.familyId &&
+    prev.provider === next.provider &&
+    prev.search === next.search &&
+    prev.terms === next.terms
+)
 
 interface ModelVisibilityDialogProps {
   gw?: HermesGateway
@@ -48,9 +123,20 @@ export function ModelVisibilityDialog({
 }: ModelVisibilityDialogProps) {
   const { t } = useI18n()
   const copy = t.modelVisibility
-  const [search, setSearch] = useState('')
+  const [searchInput, setSearchInput] = useState('')
+  // Filtering runs on the settled query; the input itself stays instant.
+  const search = useDebouncedValue(searchInput, 150)
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const stored = useStore($visibleModels)
   const collapsedProviders = useStore($collapsedProviders)
+
+  // Order snapshot per open: toggling a switch must not reshuffle the list
+  // under the pointer — enablement ranks freeze when the modal opens.
+  const rankRef = useRef<Set<string> | null>(null)
+
+  if (!open) {
+    rankRef.current = null
+  }
 
   const modelOptions = useQuery({
     queryKey: modelOptionsQueryKey(profile, sessionId, ownerConnectionId),
@@ -65,6 +151,12 @@ export function ModelVisibilityDialog({
 
   const visible = effectiveVisibleKeys(stored, providers)
 
+  if (open && rankRef.current === null) {
+    rankRef.current = new Set(visible)
+  }
+
+  const rank = rankRef.current ?? visible
+
   const toggle = (provider: ModelOptionProvider, model: string) => {
     setVisibleModels(toggleModelVisibility($visibleModels.get(), providers, provider.slug, model))
   }
@@ -75,8 +167,31 @@ export function ModelVisibilityDialog({
 
   const q = normalize(search)
 
+  // Token-AND index (`deepseek v4 flash opencode` finds
+  // `opencode/deepseek-v4-flash` regardless of order), folded once per
+  // catalog so keystrokes only scan cheap substrings. Highlighting reuses the
+  // tokens only for multi-token queries — single-token queries keep the raw
+  // string so separator folding highlights one contiguous range.
+  const queryTokens = useMemo(() => searchFold(q).split(/\s+/).filter(Boolean), [q])
+  const highlightQuery = queryTokens.length > 1 && /\s/.test(search) ? queryTokens : search
+
+  const haystacks = useMemo(() => {
+    const map = new Map<string, string>()
+
+    for (const provider of providers) {
+      for (const model of provider.models ?? []) {
+        map.set(
+          `${provider.slug}::${model}`,
+          searchFold(`${model} ${provider.name} ${provider.slug} ${displayModelName(model)}`)
+        )
+      }
+    }
+
+    return map
+  }, [providers])
+
   const matches = (provider: ModelOptionProvider, model: string) =>
-    !q || foldIncludes(`${model} ${provider.name} ${provider.slug} ${displayModelName(model)}`, q)
+    queryTokens.every(token => (haystacks.get(`${provider.slug}::${model}`) ?? '').includes(token))
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
@@ -90,10 +205,10 @@ export function ModelVisibilityDialog({
           <input
             autoFocus
             className="h-5 w-full bg-transparent text-xs text-foreground placeholder:text-(--ui-text-tertiary) focus:outline-none"
-            onChange={event => setSearch(event.target.value)}
+            onChange={event => setSearchInput(event.target.value)}
             placeholder={copy.search}
             type="text"
-            value={search}
+            value={searchInput}
           />
         </div>
 
@@ -104,13 +219,23 @@ export function ModelVisibilityDialog({
             </div>
           ) : (
             providers.map(provider => {
-              const models = collapseModelFamilies(provider.models ?? []).filter(family => matches(provider, family.id))
+              const allFamilies = collapseModelFamilies(provider.models ?? [])
+              // A–Z, same order as the model menu; the raw id stays searchable
+              // so an upstream prefix (`cmd/…`) filters even when the pretty
+              // name hides it.
+              // Enabled first, then A–Z — ranked by the open-time snapshot so
+              // toggling never reshuffles.
+              const enabledRank = (id: string) => (rank.has(modelVisibilityKey(provider.slug, id)) ? 0 : 1)
+
+              const models = allFamilies
+                .filter(family => matches(provider, family.id))
+                .sort((a, b) => enabledRank(a.id) - enabledRank(b.id) || compareModelIds(a.id, b.id))
 
               if (models.length === 0) {
                 return null
               }
 
-              const allFamilies = collapseModelFamilies(provider.models ?? [])
+              const shown = expanded.has(provider.slug) ? models : models.slice(0, DIALOG_RENDER_CAP)
 
               const onCount = allFamilies.filter(family =>
                 visible.has(modelVisibilityKey(provider.slug, family.id))
@@ -131,6 +256,9 @@ export function ModelVisibilityDialog({
                       <span className="min-w-0 truncate">
                         <HighlightMatches foldSeparators query={search} text={provider.name} />
                       </span>
+                      <span className="shrink-0 font-normal normal-case tracking-normal">
+                        {onCount}/{allFamilies.length}
+                      </span>
                       <DisclosureCaret
                         className="shrink-0 opacity-0 transition group-hover/label:opacity-100"
                         open={!collapsed}
@@ -143,27 +271,33 @@ export function ModelVisibilityDialog({
                     />
                   </div>
                   {!collapsed &&
-                    models.map(family => {
-                      const { name, tag } = modelDisplayParts(family.id)
-                      const key = modelVisibilityKey(provider.slug, family.id)
+                    shown.map(family => (
+                      <VisibilityRow
+                        checked={visible.has(modelVisibilityKey(provider.slug, family.id))}
+                        familyId={family.id}
+                        key={modelVisibilityKey(provider.slug, family.id)}
+                        onToggle={() => toggle(provider, family.id)}
+                        provider={provider}
+                        search={search}
+                        terms={highlightQuery}
+                      />
+                    ))}
+                  {!collapsed && shown.length < models.length ? (
+                    <button
+                      className="w-full px-3 py-1 text-left text-[0.65rem] text-(--ui-text-tertiary) hover:text-foreground"
+                      onClick={() =>
+                        setExpanded(prev => {
+                          const next = new Set(prev)
+                          next.add(provider.slug)
 
-                      return (
-                        <label
-                          className="flex cursor-pointer items-center gap-2 px-3 py-1 text-xs hover:bg-(--ui-control-active-background)"
-                          key={key}
-                        >
-                          <span className="min-w-0 flex-1 truncate">
-                            <HighlightMatches foldSeparators query={search} text={name} />
-                            {tag ? <span className="text-(--ui-text-tertiary)"> {tag}</span> : null}
-                          </span>
-                          <Switch
-                            checked={visible.has(key)}
-                            onCheckedChange={() => toggle(provider, family.id)}
-                            size="xs"
-                          />
-                        </label>
-                      )
-                    })}
+                          return next
+                        })
+                      }
+                      type="button"
+                    >
+                      Show all {models.length.toLocaleString()} — {models.length - shown.length} more
+                    </button>
+                  ) : null}
                 </div>
               )
             })

--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -42,6 +42,16 @@ function DropdownMenuSearch({
 }: Omit<React.ComponentProps<'input'>, 'type'> & {
   onValueChange?: (value: string) => void
 }) {
+  const inputRef = React.useRef<HTMLInputElement>(null)
+
+  // Radix focuses the first menuitem on open, beating the input's autoFocus —
+  // reclaim focus a frame later so typing filters immediately, no click needed.
+  React.useEffect(() => {
+    const frame = requestAnimationFrame(() => inputRef.current?.focus({ preventScroll: true }))
+
+    return () => cancelAnimationFrame(frame)
+  }, [])
+
   return (
     <div className="px-2.5 py-1.5" data-slot="dropdown-menu-search">
       <input
@@ -61,6 +71,7 @@ function DropdownMenuSearch({
 
           onKeyDown?.(event)
         }}
+        ref={inputRef}
         // Search fields here filter ids, slugs, and model names — dictionary
         // squiggles under them are noise (matching the composer/settings
         // inputs, which already disable spellcheck).

--- a/apps/desktop/src/components/ui/effort-meter.test.tsx
+++ b/apps/desktop/src/components/ui/effort-meter.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { REASONING_EFFORTS } from '@/lib/reasoning-effort'
+
+import { resolveEffortMeter } from './effort-meter'
+
+describe('resolveEffortMeter', () => {
+  it('fills one segment per scale step', () => {
+    expect(resolveEffortMeter('minimal', 'medium')).toEqual({ fill: 1, label: 'Min' })
+    expect(resolveEffortMeter('medium', 'medium')).toEqual({ fill: 3, label: 'Med' })
+    expect(resolveEffortMeter('ultra', 'medium')).toEqual({ fill: REASONING_EFFORTS.length, label: 'Ultra' })
+  })
+
+  it('inherits the fallback when unset and empties on thinking-off', () => {
+    expect(resolveEffortMeter('', 'high')).toEqual({ fill: 4, label: 'High' })
+    expect(resolveEffortMeter('none', 'high')).toEqual({ fill: 0, label: 'Off' })
+  })
+})

--- a/apps/desktop/src/components/ui/effort-meter.tsx
+++ b/apps/desktop/src/components/ui/effort-meter.tsx
@@ -1,0 +1,39 @@
+import { REASONING_EFFORTS, reasoningEffortLabel, resolveReasoningEffort } from '@/lib/reasoning-effort'
+
+/** Resolve a raw effort value to meter props. Segments follow the effort
+ *  scale itself, so a new backend level reshapes every meter. `none`
+ *  (thinking off) fills nothing and labels Off. */
+export function resolveEffortMeter(value: string, fallback?: string): { fill: number; label: string } {
+  const resolved = resolveReasoningEffort(value || '', fallback)
+
+  if (resolved === '') {
+    return { fill: 0, label: 'Off' }
+  }
+
+  const index = REASONING_EFFORTS.findIndex(level => level === resolved)
+
+  return { fill: index < 0 ? 0 : index + 1, label: reasoningEffortLabel(resolved) || resolved }
+}
+
+/** Thinking-level pill: short label over an underline gauge for the depth.
+ *  Always fully visible — surrounding names may truncate, the level never does. */
+export function EffortMeter({ value, fallback }: { value: string; fallback?: string }) {
+  const { fill, label } = resolveEffortMeter(value, fallback)
+
+  return (
+    <span
+      aria-label={label}
+      className="relative flex h-5 w-12 shrink-0 flex-col items-center justify-center gap-[3px] overflow-hidden rounded-full bg-(--ui-bg-tertiary) px-1.5"
+      role="img"
+      title={label}
+    >
+      <span className="text-[0.62rem] font-semibold leading-none text-(--ui-text-secondary)">{label}</span>
+      <span className="h-[3px] w-full overflow-hidden rounded-full bg-(--ui-text-tertiary)/25">
+        <span
+          className="block h-full rounded-full bg-(--ui-accent)"
+          style={{ width: `${(fill / REASONING_EFFORTS.length) * 100}%` }}
+        />
+      </span>
+    </span>
+  )
+}

--- a/apps/desktop/src/components/ui/marquee.tsx
+++ b/apps/desktop/src/components/ui/marquee.tsx
@@ -1,0 +1,68 @@
+import { type ReactNode, useEffect, useRef, useState } from 'react'
+
+import { cn } from '@/lib/utils'
+
+/** Marquee line: glides its tail into view while `go` holds, snaps back
+ *  after. Stays put when nothing overflows or reduced motion is preferred.
+ *  The owner passes one shared `go` so a whole row scrolls together. */
+export function HoverScroll({
+  children,
+  className,
+  go,
+  marqueeKey
+}: {
+  children: ReactNode
+  className?: string
+  go: boolean
+  /** Test hook; never rendered. */
+  marqueeKey?: string
+}) {
+  const outer = useRef<HTMLSpanElement>(null)
+  const inner = useRef<HTMLSpanElement>(null)
+  const [distance, setDistance] = useState(0)
+
+  useEffect(() => {
+    if (!go) {
+      setDistance(0)
+
+      return
+    }
+
+    const box = outer.current
+    const content = inner.current
+
+    if (!box || !content) {
+      return
+    }
+
+    if (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return
+    }
+
+    const overflow = content.scrollWidth - box.clientWidth
+
+    if (overflow > 8) {
+      setDistance(overflow)
+    }
+  }, [go, children])
+
+  return (
+    <span
+      className={cn('block overflow-hidden', distance > 0 ? null : 'truncate', className)}
+      data-marquee={marqueeKey ?? true}
+      ref={outer}
+    >
+      <span
+        className="inline-block whitespace-nowrap will-change-transform"
+        ref={inner}
+        style={
+          distance > 0
+            ? { transform: `translateX(${-distance}px)`, transition: `transform ${Math.max(1, distance / 32)}s linear` }
+            : undefined
+        }
+      >
+        {children}
+      </span>
+    </span>
+  )
+}

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  compareModelIds,
   currentPickerSelection,
   displayModelName,
   formatModelStatusLabel,
@@ -85,6 +86,18 @@ describe('model-status-label', () => {
 
     it('falls back to the store while options are still loading', () => {
       expect(currentPickerSelection(store, undefined)).toEqual(store)
+    })
+  })
+
+  describe('compareModelIds', () => {
+    it('orders A–Z by display name, id breaking ties', () => {
+      const ids = ['cmd/deepseek/deepseek-v4-flash', 'auto/best-coding', 'cbai/deepseek-v4-flash']
+
+      expect([...ids].sort(compareModelIds)).toEqual([
+        'auto/best-coding',
+        'cbai/deepseek-v4-flash',
+        'cmd/deepseek/deepseek-v4-flash'
+      ])
     })
   })
 })

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -109,6 +109,14 @@ export function displayModelName(model: string): string {
   return modelDisplayParts(model).name
 }
 
+/** Row order inside a provider group: A–Z by display name, id as the tiebreak
+ *  so equal names from different upstreams stay deterministic. */
+export function compareModelIds(a: string, b: string): number {
+  const byName = displayModelName(a).localeCompare(displayModelName(b), undefined, { sensitivity: 'base' })
+
+  return byName !== 0 ? byName : a.toLowerCase() < b.toLowerCase() ? -1 : 1
+}
+
 /** Status bar trigger label — model name plus the live session state (effort/fast).
  *  `defaultEffort` is the profile's configured level, used when the surface has
  *  no explicit effort so the label never advertises a default the agent won't use. */

--- a/apps/desktop/src/lib/text.ts
+++ b/apps/desktop/src/lib/text.ts
@@ -43,3 +43,18 @@ export function searchFold(v: unknown): string {
 export function foldIncludes(text: unknown, query: unknown): boolean {
   return searchFold(text).includes(searchFold(query))
 }
+
+/** Token-AND matcher: every whitespace-separated query token must occur in the
+ *  haystack, in any order — `deepseek v4 flash opencode` finds
+ *  `opencode/deepseek-v4-flash`. Single-token queries behave like foldIncludes. */
+export function foldIncludesAllTokens(text: unknown, query: unknown): boolean {
+  const tokens = searchFold(query).split(/\s+/).filter(Boolean)
+
+  if (tokens.length === 0) {
+    return true
+  }
+
+  const haystack = searchFold(text)
+
+  return tokens.every(token => haystack.includes(token))
+}

--- a/apps/desktop/src/lib/use-debounced-value.test.ts
+++ b/apps/desktop/src/lib/use-debounced-value.test.ts
@@ -1,0 +1,34 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useDebouncedValue } from './use-debounced-value'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useDebouncedValue', () => {
+  it('holds the old value until the pause elapses, then settles once', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 50), {
+      initialProps: { value: 'a' }
+    })
+
+    rerender({ value: 'ab' })
+    rerender({ value: 'abc' })
+    expect(result.current).toBe('a')
+
+    act(() => {
+      vi.advanceTimersByTime(49)
+    })
+    expect(result.current).toBe('a')
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current).toBe('abc')
+  })
+})

--- a/apps/desktop/src/lib/use-debounced-value.ts
+++ b/apps/desktop/src/lib/use-debounced-value.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react'
+
+/** Delays value propagation until it settles ~`delayMs` after the last change:
+ *  the input stays instant while expensive filtering (thousands of catalog
+ *  rows) runs at most once per pause instead of per keystroke. */
+export function useDebouncedValue<T>(value: T, delayMs = 50): T {
+  const [settled, setSettled] = useState(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setSettled(value), delayMs)
+
+    return () => clearTimeout(timer)
+  }, [value, delayMs])
+
+  return settled
+}

--- a/apps/desktop/src/store/context-usage-cache.test.ts
+++ b/apps/desktop/src/store/context-usage-cache.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  clearContextUsageSnapshots,
+  dropContextUsageSnapshot,
+  dropContextUsageSnapshotEverywhere,
+  loadContextUsageSnapshot,
+  saveContextUsageSnapshot,
+  type ContextUsageVersion
+} from './context-usage-cache'
+
+const VERSION: ContextUsageVersion = { input_tokens: 100, message_count: 4, model: 'm', output_tokens: 50 }
+const USAGE = { context_max: 200_000, context_percent: 34, context_used: 68_000, model: 'm' }
+
+afterEach(() => {
+  window.localStorage.clear()
+})
+
+describe('context-usage-cache', () => {
+  it('round-trips a snapshot and marks it restored', () => {
+    saveContextUsageSnapshot('s1', USAGE, { profile: 'coder' }, VERSION)
+
+    const loaded = loadContextUsageSnapshot('s1', { profile: 'coder' }, VERSION)
+
+    expect(loaded).toMatchObject({
+      context_estimated: true,
+      context_max: 200_000,
+      context_percent: 34,
+      context_source: 'restored',
+      context_used: 68_000
+    })
+  })
+
+  it('isolates scopes — a twin id on another backend never paints', () => {
+    saveContextUsageSnapshot('s1', USAGE, { connectionId: 'a', profile: 'coder' }, VERSION)
+
+    expect(loadContextUsageSnapshot('s1', { connectionId: 'b', profile: 'coder' }, VERSION)).toBeNull()
+    expect(loadContextUsageSnapshot('s1', { connectionId: 'a', profile: 'coder' }, VERSION)).not.toBeNull()
+  })
+
+  it('evicts on version drift — a moved-on transcript invalidates the paint', () => {
+    saveContextUsageSnapshot('s1', USAGE, { profile: 'coder' }, VERSION)
+
+    expect(loadContextUsageSnapshot('s1', { profile: 'coder' }, { ...VERSION, message_count: 5 })).toBeNull()
+    // Evicted, so even the old version no longer paints.
+    expect(loadContextUsageSnapshot('s1', { profile: 'coder' }, VERSION)).toBeNull()
+  })
+
+  it('evicts corrupt entries instead of painting them', () => {
+    window.localStorage.setItem(
+      'hermes.context-usage.v1:["", "coder", "s1"]',
+      '{"usage":{"context_max":"lots"}}'
+    )
+
+    expect(loadContextUsageSnapshot('s1', { profile: 'coder' }, VERSION)).toBeNull()
+  })
+
+  it('refuses to cache empties — zero needs no cache', () => {
+    saveContextUsageSnapshot('s1', { ...USAGE, context_percent: 0, context_used: 0 }, { profile: 'coder' }, VERSION)
+
+    expect(loadContextUsageSnapshot('s1', { profile: 'coder' }, VERSION)).toBeNull()
+  })
+
+  it('drops one session without touching its twins', () => {
+    saveContextUsageSnapshot('s1', USAGE, { connectionId: 'a', profile: 'coder' }, VERSION)
+    saveContextUsageSnapshot('s1', USAGE, { connectionId: 'b', profile: 'coder' }, VERSION)
+
+    dropContextUsageSnapshot('s1', { connectionId: 'a', profile: 'coder' })
+
+    expect(loadContextUsageSnapshot('s1', { connectionId: 'a', profile: 'coder' }, VERSION)).toBeNull()
+    expect(loadContextUsageSnapshot('s1', { connectionId: 'b', profile: 'coder' }, VERSION)).not.toBeNull()
+  })
+
+  it('sweeps every scope on delete, keeping other sessions', () => {
+    saveContextUsageSnapshot('s1', USAGE, { connectionId: 'a', profile: 'coder' }, VERSION)
+    saveContextUsageSnapshot('s1', USAGE, { profile: 'coder' }, VERSION)
+    saveContextUsageSnapshot('s2', USAGE, { connectionId: 'a', profile: 'coder' }, VERSION)
+
+    dropContextUsageSnapshotEverywhere('s1')
+
+    expect(loadContextUsageSnapshot('s1', { connectionId: 'a', profile: 'coder' }, VERSION)).toBeNull()
+    expect(loadContextUsageSnapshot('s1', { profile: 'coder' }, VERSION)).toBeNull()
+    expect(loadContextUsageSnapshot('s2', { connectionId: 'a', profile: 'coder' }, VERSION)).not.toBeNull()
+  })
+
+  it('caps entries LRU-style', () => {
+    for (let index = 0; index < 60; index += 1) {
+      saveContextUsageSnapshot(`s${index}`, USAGE, { profile: 'coder' }, VERSION)
+    }
+
+    expect(loadContextUsageSnapshot('s0', { profile: 'coder' }, VERSION)).toBeNull()
+    expect(loadContextUsageSnapshot('s59', { profile: 'coder' }, VERSION)).not.toBeNull()
+  })
+
+  it('clears everything on request', () => {
+    saveContextUsageSnapshot('s1', USAGE, { profile: 'coder' }, VERSION)
+    clearContextUsageSnapshots()
+
+    expect(loadContextUsageSnapshot('s1', { profile: 'coder' }, VERSION)).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/context-usage-cache.ts
+++ b/apps/desktop/src/store/context-usage-cache.ts
@@ -1,0 +1,367 @@
+import type { UsageStats } from '@/types/hermes'
+
+// ── Durable last-known context occupancy ─────────────────────────────
+// Measured occupancy is process-local (agent.compressor), so after a restart
+// a restored session reads 0% until its live agent rebinds and reports. This
+// cache keeps the last nonzero read per stored session so the meter paints
+// stale-but-labeled numbers instead of a false empty.
+//
+// Same trust domain and rules as the transcript-tail cache: same disk as
+// state.db, keyed by stored session id scoped to the owning
+// (connectionId, profile), versioned by the session row's counters + model so
+// a transcript that advanced elsewhere invalidates the paint. Restored reads
+// are ALWAYS estimates (`context_source: 'restored'`) and only paint while no
+// live breakdown exists — live data replaces them on arrival.
+
+const PREFIX = 'hermes.context-usage.v1:'
+const INDEX_KEY = 'hermes.context-usage.v1-index'
+const MAX_ENTRIES = 50
+
+export type ContextUsageScope = null | string | { connectionId?: null | string; profile?: null | string }
+
+export interface ContextUsageVersion {
+  input_tokens: number
+  message_count: number
+  model: null | string
+  output_tokens: number
+}
+
+export interface RestoredContextUsage {
+  context_estimated: true
+  context_max: number
+  context_percent: number
+  context_source: 'restored'
+  context_used: number
+  model?: string
+}
+
+interface CacheEntry {
+  savedAt: number
+  usage: { context_max: number; context_percent: number; context_used: number; model?: string }
+  version: { input_tokens: number; message_count: number; model: string; output_tokens: number }
+}
+
+function storage(): Storage | null {
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+function normalizedScope(scope?: ContextUsageScope): { connectionId: string; profile: string } | null {
+  if (typeof scope === 'string') {
+    return { connectionId: '', profile: scope.trim() || 'default' }
+  }
+
+  if (!scope) {
+    return null
+  }
+
+  return {
+    connectionId: String(scope.connectionId ?? '').trim(),
+    profile: String(scope.profile ?? '').trim() || 'default'
+  }
+}
+
+function entrySuffix(storedSessionId: string, scope?: ContextUsageScope): string {
+  const scoped = normalizedScope(scope)
+
+  return scoped ? JSON.stringify([scoped.connectionId, scoped.profile, storedSessionId]) : storedSessionId
+}
+
+function readIndex(store: Storage): string[] {
+  try {
+    const parsed = JSON.parse(store.getItem(INDEX_KEY) ?? '[]')
+
+    return Array.isArray(parsed) ? parsed.filter(id => typeof id === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+function writeIndex(store: Storage, ids: string[]): void {
+  try {
+    store.setItem(INDEX_KEY, JSON.stringify(ids))
+  } catch {
+    // Quota — drop the index; entries become orphaned and rewrite lazily.
+  }
+}
+
+function touchIndex(store: Storage, suffix: string): void {
+  const ids = readIndex(store).filter(id => id !== suffix)
+  ids.push(suffix)
+
+  while (ids.length > MAX_ENTRIES) {
+    const evicted = ids.shift()
+
+    if (evicted) {
+      try {
+        store.removeItem(PREFIX + evicted)
+      } catch {
+        // best effort
+      }
+    }
+  }
+
+  writeIndex(store, ids)
+}
+
+function dropSuffix(store: Storage, suffix: string): void {
+  try {
+    store.removeItem(PREFIX + suffix)
+    writeIndex(
+      store,
+      readIndex(store).filter(entry => entry !== suffix)
+    )
+  } catch {
+    // best effort
+  }
+}
+
+const isCounter = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value) && value >= 0
+
+function sanitizeEntry(parsed: unknown): CacheEntry | null {
+  if (!parsed || typeof parsed !== 'object') {
+    return null
+  }
+
+  const entry = parsed as Partial<CacheEntry>
+  const usage = entry.usage
+  const version = entry.version
+
+  if (
+    !usage ||
+    !isCounter(usage.context_max) ||
+    usage.context_max <= 0 ||
+    !isCounter(usage.context_used) ||
+    usage.context_used <= 0 ||
+    usage.context_used > usage.context_max ||
+    !isCounter(usage.context_percent) ||
+    usage.context_percent < 0 ||
+    usage.context_percent > 100 ||
+    !version ||
+    !isCounter(version.input_tokens) ||
+    !isCounter(version.message_count) ||
+    !isCounter(version.output_tokens) ||
+    typeof version.model !== 'string' ||
+    !isCounter(entry.savedAt)
+  ) {
+    return null
+  }
+
+  return {
+    savedAt: entry.savedAt as number,
+    usage: {
+      context_max: usage.context_max,
+      context_percent: usage.context_percent,
+      context_used: usage.context_used,
+      ...(typeof usage.model === 'string' ? { model: usage.model } : {})
+    },
+    version: {
+      input_tokens: version.input_tokens,
+      message_count: version.message_count,
+      model: version.model,
+      output_tokens: version.output_tokens
+    }
+  }
+}
+
+/** Persist a last-known read. No-op on empties — a zero snapshot needs no
+ *  cache, the default readout already says 0. */
+export function saveContextUsageSnapshot(
+  storedSessionId: string,
+  usage: Pick<UsageStats, 'context_max' | 'context_percent' | 'context_used'> & { model?: string },
+  scope?: ContextUsageScope,
+  version?: ContextUsageVersion | null
+): void {
+  const id = (storedSessionId ?? '').trim()
+  const store = storage()
+
+  if (!store || !id || !version) {
+    return
+  }
+
+  const max = usage.context_max ?? 0
+  const used = usage.context_used ?? 0
+  const percent = usage.context_percent ?? 0
+
+  if (!(max > 0) || !(used > 0) || used > max || !(percent >= 0) || !(percent <= 100)) {
+    return
+  }
+
+  if (
+    !isCounter(version.input_tokens) ||
+    !isCounter(version.message_count) ||
+    !isCounter(version.output_tokens) ||
+    (version.model !== null && typeof version.model !== 'string')
+  ) {
+    return
+  }
+
+  const suffix = entrySuffix(id, scope)
+  const entry: CacheEntry = {
+    savedAt: Date.now(),
+    usage: {
+      context_max: max,
+      context_percent: percent,
+      context_used: used,
+      ...(typeof usage.model === 'string' ? { model: usage.model } : {})
+    },
+    version: {
+      input_tokens: version.input_tokens,
+      message_count: version.message_count,
+      model: version.model ?? '',
+      output_tokens: version.output_tokens
+    }
+  }
+
+  try {
+    store.setItem(PREFIX + suffix, JSON.stringify(entry))
+    touchIndex(store, suffix)
+  } catch {
+    // Storage unavailable — the wake just won't have a restored number.
+  }
+}
+
+/** Last-known read for a stored session, or null. Only entries whose version
+ *  still matches the session row's counters are returned, and a mismatch
+ *  evicts the entry so a moved-on transcript can never paint again. */
+export function loadContextUsageSnapshot(
+  storedSessionId: string,
+  scope?: ContextUsageScope,
+  version?: ContextUsageVersion | null
+): RestoredContextUsage | null {
+  const id = (storedSessionId ?? '').trim()
+  const store = storage()
+
+  if (!store || !id || !version) {
+    return null
+  }
+
+  const suffix = entrySuffix(id, scope)
+  let raw: null | string = null
+
+  try {
+    raw = store.getItem(PREFIX + suffix)
+  } catch {
+    return null
+  }
+
+  if (!raw) {
+    return null
+  }
+
+  const entry = (() => {
+    try {
+      return sanitizeEntry(JSON.parse(raw))
+    } catch {
+      return null
+    }
+  })()
+
+  if (
+    !entry ||
+    entry.version.input_tokens !== version.input_tokens ||
+    entry.version.message_count !== version.message_count ||
+    entry.version.model !== (version.model ?? '') ||
+    entry.version.output_tokens !== version.output_tokens
+  ) {
+    dropSuffix(store, suffix)
+
+    return null
+  }
+
+  return {
+    context_estimated: true,
+    context_max: entry.usage.context_max,
+    context_percent: entry.usage.context_percent,
+    context_source: 'restored',
+    context_used: entry.usage.context_used,
+    ...(entry.usage.model ? { model: entry.usage.model } : {})
+  }
+}
+
+/** Drop one session's snapshot (session deleted). With a scope, only that
+ *  scope's entry goes — other backends' snapshots for the same id survive. */
+export function dropContextUsageSnapshot(storedSessionId: string, scope?: ContextUsageScope): void {
+  const id = (storedSessionId ?? '').trim()
+  const store = storage()
+
+  if (!store || !id) {
+    return
+  }
+
+  dropSuffix(store, entrySuffix(id, scope))
+}
+
+/** Drop EVERY scope's entry for a stored id. Delete-path only: same rationale
+ *  as the transcript tail — the save-path scope and the delete-path scope are
+ *  derived from different sources, so a shape drift between them would orphan
+ *  the entry until LRU eviction. A deleted stored id is never reused, so a
+ *  sweep is safe here — but never on the failed-resume path, where a twin in
+ *  another profile must keep its snapshot. */
+export function dropContextUsageSnapshotEverywhere(storedSessionId: string): void {
+  const id = (storedSessionId ?? '').trim()
+  const store = storage()
+
+  if (!store || !id) {
+    return
+  }
+
+  const namesId = (entry: string): boolean => {
+    if (entry === id) {
+      return true
+    }
+
+    if (!entry.startsWith('[')) {
+      return false
+    }
+
+    try {
+      const parsed = JSON.parse(entry)
+
+      return Array.isArray(parsed) && parsed[2] === id
+    } catch {
+      return false
+    }
+  }
+
+  try {
+    const index = readIndex(store)
+
+    for (const entry of index.filter(namesId)) {
+      store.removeItem(PREFIX + entry)
+    }
+
+    writeIndex(
+      store,
+      index.filter(entry => !namesId(entry))
+    )
+  } catch {
+    // best effort
+  }
+}
+
+/** Wipe the whole cache (connection re-home, quota recovery). */
+export function clearContextUsageSnapshots(): void {
+  const store = storage()
+
+  if (!store) {
+    return
+  }
+
+  for (const id of readIndex(store)) {
+    try {
+      store.removeItem(PREFIX + id)
+    } catch {
+      // best effort
+    }
+  }
+
+  try {
+    store.removeItem(INDEX_KEY)
+  } catch {
+    // best effort
+  }
+}

--- a/apps/desktop/src/store/session-control.test.ts
+++ b/apps/desktop/src/store/session-control.test.ts
@@ -10,6 +10,7 @@ vi.mock('./goals', async importOriginal => ({
 
 import { $gateway } from './gateway'
 import { resetBackgroundPollingGuard } from './runtime-gone'
+import { SessionOwnerResolutionError } from './session-owner-resolution'
 import {
   $sessionControlBySession,
   applySessionControlSnapshot,
@@ -319,8 +320,24 @@ describe('session-control store', () => {
     })
   })
 
-  it('does not let a late read overwrite a newer event', async () => {
-    const slow = deferred<unknown>()
+  it('stays silent on owner-unresolved drafts and retries later reads', async () => {
+    const request = vi.fn(async () => {
+      throw new SessionOwnerResolutionError('draft-1', 'session.control.read')
+    })
+
+    useGateway(request)
+
+    // No prior state (a draft the backend hasn't minted): no banner, settled
+    // idle, and nothing cached as unsupported.
+    await expect(refreshSessionControl('draft-1')).resolves.toMatchObject({ error: null, loading: false })
+    expect($sessionControlBySession.get()['draft-1']).toMatchObject({ error: null, loading: false })
+
+    // …and nothing sticky: the next refresh tries again instead of giving up.
+    await expect(refreshSessionControl('draft-1')).resolves.toMatchObject({ error: null, loading: false })
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not let a late read overwrite a newer event', async () => {    const slow = deferred<unknown>()
     useGateway(vi.fn(() => slow.promise))
 
     const read = refreshSessionControl('s1')

--- a/apps/desktop/src/store/session-control.ts
+++ b/apps/desktop/src/store/session-control.ts
@@ -4,6 +4,7 @@ import { $gateway } from './gateway'
 import { refreshSessionGoal } from './goals'
 import { isSessionGone, isSessionGoneForBackgroundPolling, markSessionGone } from './runtime-gone'
 import { ambientRequestFor } from './session-gone-latch'
+import { isSessionOwnerResolutionError } from './session-owner-resolution'
 import { requestForOwnedSession } from './session-states'
 
 export type SessionControlGoalStatus = 'active' | 'done' | 'paused'
@@ -684,8 +685,18 @@ function publishFailure(sessionId: string, token: number, error: unknown, clearP
   })
 }
 
-function finishGoneRequest(sessionId: string, token: number, clearPendingAction: boolean): void {
+/** Settle a read that never reached a backend (e.g. draft with no owner):
+ *  clear loading, publish no error, cache nothing — the next refresh retries. */
+function finishSilentRequest(sessionId: string, token: number): void {
   if (!isCurrent(sessionId, token)) {
+    return
+  }
+
+  const current = $sessionControlBySession.get()[sessionId] ?? emptyEntry()
+  publishEntry(sessionId, { ...current, loading: false })
+}
+
+function finishGoneRequest(sessionId: string, token: number, clearPendingAction: boolean): void {  if (!isCurrent(sessionId, token)) {
     return
   }
 
@@ -789,6 +800,21 @@ export async function refreshSessionControl(
 
     if (isSessionGoneForBackgroundPolling(error)) {
       finishGoneRequest(sessionId, token, false)
+
+      return $sessionControlBySession.get()[sessionId]
+    }
+
+    // Owner-unresolved with no prior control state: a draft chat the backend
+    // hasn't minted yet. Settle silently (no banner, nothing cached) and let a
+    // later refresh — after the first turn binds the session — resolve it.
+    // "Prior state" means a snapshot, a published error, or a pinned
+    // capability — not the idle shell beginRead publishes, which every fresh
+    // read creates. Established sessions keep the loud failure: a lost owner
+    // there is a real routing regression, not a draft.
+    const hasPriorState = Boolean(existing && (existing.snapshot || existing.error))
+
+    if (isSessionOwnerResolutionError(error) && !hasPriorState) {
+      finishSilentRequest(sessionId, token)
 
       return $sessionControlBySession.get()[sessionId]
     }


### PR DESCRIPTION
## What does this PR do?

Desktop model-picker and context-meter polish, plus a few composer status fixes.

- **Typing lag in model search:** the query lived in `ModelCatalogMenu` state, so every keystroke re-rendered the whole ~6k-row menu before the character painted. The raw input now lives in a small `SearchInput` child that owns its state and hands the parent the value after a 150 ms debounce (`use-debounced-value`). Typing is instant; filtering runs once per pause.
- **Filter cost:** token-AND matching over a prebuilt, pre-folded haystack index (built once per catalog) instead of re-folding every id per keystroke.
- **Ordering/pinning:** families read A–Z (`compareModelIds`), active model pinned first — including while searching (a non-matching active pick stays out). Search results are capped per provider (`SEARCH_RENDER_CAP = 100`) with a "N of M" note.
- **Shared UI:** new `EffortMeter` fill pill and `HoverScroll` marquee; model rows show name / id / upstream tag / effort / fast marker, clipped lines scroll together on hover. Same meter reused in the composer pill and rows.
- **Context meter empty state:** a brand-new session read `1% (22.2k of 2M)` because the backend returns the system-prompt + tools baseline as `context_used` when no turn has run. `use-context-breakdown` now zeroes occupancy for an empty conversation while keeping the window.
- **Status stack:** sticky section headers on goal / subagent / loop / heartbeat / queue sections.
- **Session control:** owner-resolution errors on drafts settle silently (no error banner, loading cleared, nothing cached).

## Related Issue

N/A — no tracking issue; happy to open one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/shell/model-catalog-menu.tsx` — `SearchInput` child (debounced), token-AND haystack index, A–Z ordering + active pin + render cap, `ModelRowLines`/`EffortMeter`/`HoverScroll` rows.
- `apps/desktop/src/app/shell/hooks/use-context-breakdown.ts` — zero occupancy for an empty conversation.
- `apps/desktop/src/app/chat/composer/context-meter.tsx` — draft/tile meter; shows selected model window at 0%.
- `apps/desktop/src/lib/use-debounced-value.ts`, `apps/desktop/src/components/ui/effort-meter.tsx`, `apps/desktop/src/components/ui/marquee.tsx` — new shared hooks/components.
- `apps/desktop/src/lib/model-status-label.ts`, `apps/desktop/src/lib/text.ts` — `compareModelIds`, token helpers.
- `apps/desktop/src/components/chat/status-section.tsx` + status-stack sections, `queue-panel.tsx` — `stickyHeader`.
- `apps/desktop/src/store/session-control.ts` — silent settle for draft owner-resolution errors.
- Tests alongside the changed modules (`model-catalog-menu`, `model-menu-panel`, `context-usage-panel`, `context-meter`, `model-pill`, `model-visibility-dialog`, `effort-meter`, `use-debounced-value`, `model-status-label`, `session-control`, `model-edit-submenu`).

## How to Test

1. Open the model picker and type in the search box — characters appear immediately and results update ~150 ms after you stop; no per-keystroke stutter.
2. Search `flash` with an active `-flash` model — the active model stays on top; clear the query and families read A–Z with the active model pinned first.
3. Click `+ new session` — the composer context meter reads `0%` with the selected model's window (not the system-prompt baseline).
4. Open the composer status stack with a goal / subagent run active — section headers stay pinned while the body scrolls.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this PR is desktop/TypeScript only
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64) — `tsc --noEmit` clean, affected `vitest` files green

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (no new platform APIs)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs
<img width="593" height="465" alt="Screenshot 2026-09-10 at 17-05-03" src="https://github.com/user-attachments/assets/8680a9f1-218d-47b4-a12c-5f2d1a37668e" />
<img width="724" height="368" alt="Screenshot 2026-09-10 at 17-05-43" src="https://github.com/user-attachments/assets/074abb73-0e9f-4dec-92d5-1c01b2798d12" />
