### PR TITLE
test(desktop): cover SDK namespace cycles and production plugin loading

### DIFF
--- a/apps/desktop/scripts/check-plugin-sdk-production.mjs
+++ b/apps/desktop/scripts/check-plugin-sdk-production.mjs
@@ -1,0 +1,232 @@
+// Run from any directory: node apps/desktop/scripts/check-plugin-sdk-production.mjs
+// Requires the installed desktop Vite and Playwright dependencies and Chromium.
+// --baseline substitutes only the old eager namespace capture, in memory.
+// --channel=chrome (or msedge) uses an installed browser without downloading one.
+// --screenshot emits a PNG data URL to stdout before deleting all temp artifacts.
+import assert from 'node:assert/strict'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+export const app = fileURLToPath(new URL('../', import.meta.url))
+export const runtime = fileURLToPath(new URL('../src/sdk/runtime.ts', import.meta.url))
+
+// Portable pre-fix control. Never used for the positive test: that loads runtime.ts.
+// This preserves the old module-scope read and shim construction without Git history.
+export const eagerBaseline = `
+import * as sdk from './index'
+import * as React from 'react'
+import * as jsxRuntime from 'react/jsx-runtime'
+import * as jsxDevRuntime from 'react/jsx-dev-runtime'
+const GLOBALS = {
+  __HERMES_PLUGIN_SDK__: sdk, __HERMES_REACT__: React,
+  __HERMES_REACT_JSX__: jsxRuntime, __HERMES_REACT_JSX_DEV__: jsxDevRuntime
+}
+export function installPluginSdk() { Object.assign(globalThis, GLOBALS) }
+function shimUrl(key) {
+  const names = Object.keys(GLOBALS[key]).filter(name =>
+    name !== 'default' && /^[A-Za-z_$][\\w$]*$/.test(name))
+  const source = 'const m = globalThis.' + key + ';\\n' +
+    'export default m.default ?? m;\\n' +
+    (names.length ? 'export const { ' + names.join(', ') + ' } = m;\\n' : '')
+  return URL.createObjectURL(new Blob([source], { type: 'text/javascript' }))
+}
+let cached
+export function sdkImportMap() {
+  return cached ??= {
+    '@hermes/plugin-sdk': shimUrl('__HERMES_PLUGIN_SDK__'),
+    'react/jsx-dev-runtime': shimUrl('__HERMES_REACT_JSX_DEV__'),
+    'react/jsx-runtime': shimUrl('__HERMES_REACT_JSX__'), react: shimUrl('__HERMES_REACT__')
+  }
+}
+`
+
+// A second entry shares the real app graph/chunks, but does not mount the app,
+// discover disk plugins, or connect to a backend. No SDK/React/loader mocks.
+const probe = `
+import * as sdk from '@/sdk/index'
+import * as React from 'react'
+import * as jsx from 'react/jsx-runtime'
+import * as jsxDev from 'react/jsx-dev-runtime'
+import { createRoot } from 'react-dom/client'
+import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
+import { loadRuntimePlugin, unloadRuntimePlugin } from '@/contrib/runtime-loader'
+import { $pluginRecords, dropPlugin } from '@/contrib/plugins-store'
+import { registry } from '@/contrib/registry'
+globalThis.sdkSmoke = async () => {
+  const check = (ok, message) => { if (!ok) throw new Error(message) }
+  const receipt = []
+  const area = 'sdk-smoke-' + crypto.randomUUID()
+  const ids = []
+  const sources = [
+    ['', 'null'],
+    ["import { host } from '@hermes/plugin-sdk'", 'host'],
+    ["import React from 'react'; import { jsx } from 'react/jsx-runtime'; import { jsxDEV } from 'react/jsx-dev-runtime'",
+      '{ React, jsx, jsxDEV, node: jsx("strong", { children: "SDK React JSX registered" }) }']
+  ]
+  try {
+    for (const [imports, value] of sources) {
+      const id = crypto.randomUUID()
+      ids.push(id)
+      const source = imports + '\\nexport default { id: ' + JSON.stringify(id) +
+        ', register(ctx) { const data = { value: ' + value + ', disposed: false }; ' +
+        'ctx.onDispose(() => { data.disposed = true }); ctx.register({ id: "entry", area: ' + JSON.stringify(area) +
+        ', data }) } }'
+      check(await loadRuntimePlugin(source, id) === id,
+        'plugin load failed: ' + ($pluginRecords.get()[id]?.error ?? id))
+      check($pluginRecords.get()[id]?.status === 'loaded', 'plugin did not register')
+      const count = registry.getArea(area).length
+      const previous = registry.getArea(area).find(item => item.id === id + ':entry').data
+      const map = sdkImportMap()
+      check(await loadRuntimePlugin(source, id) === id, 'plugin reload failed')
+      check(registry.getArea(area).length === count, 'reload duplicated contributions')
+      check(previous.disposed, 'reload did not dispose previous plugin')
+      check(sdkImportMap() === map, 'shim cache changed on reload')
+    }
+    const values = registry.getArea(area).map(item => item.data.value)
+    check(values.length === sources.length, 'missing registrations')
+    check(values[1] === sdk.host, 'SDK named import lost host identity')
+    const reactValue = values[2]
+    check(reactValue.React === (React.default ?? React), 'React default is not the app singleton')
+    check(reactValue.jsx === jsx.jsx && reactValue.jsxDEV === jsxDev.jsxDEV, 'JSX runtime identity mismatch')
+    check(React.isValidElement(reactValue.node), 'JSX did not create a React element')
+    check(globalThis.__HERMES_PLUGIN_SDK__ === sdk, 'SDK namespace identity mismatch')
+    const map = sdkImportMap()
+    for (const [specifier, key, namespace] of [
+      ['@hermes/plugin-sdk', '__HERMES_PLUGIN_SDK__', sdk],
+      ['react', '__HERMES_REACT__', React],
+      ['react/jsx-runtime', '__HERMES_REACT_JSX__', jsx],
+      ['react/jsx-dev-runtime', '__HERMES_REACT_JSX_DEV__', jsxDev]
+    ]) {
+      const installed = globalThis[key]
+      installPluginSdk()
+      check(globalThis[key] === installed, specifier + ' namespace changed on reinstall')
+      const shim = await import(/* @vite-ignore */ map[specifier])
+      check(shim.default === (installed.default ?? installed), specifier + ' default identity mismatch')
+      // CJS interop may create separate namespace wrappers across chunks.
+      // The underlying React singleton and every exported value must be shared.
+      for (const name of Object.keys(namespace).filter(name => name !== 'default' && /^[A-Za-z_$][\\w$]*$/.test(name))) {
+        check(installed[name] === namespace[name], specifier + ' installed identity mismatch: ' + name)
+        check(shim[name] === namespace[name], specifier + ' named identity mismatch: ' + name)
+      }
+    }
+    check(sdkImportMap() === map, 'reinstall invalidated shim cache')
+    receipt.push('no-import, SDK named import and React JSX plugins registered',
+      'reload disposes previous contributions; shim map is stable',
+      'SDK, React and both JSX namespaces retain all export identities')
+    for (const [imports, expected] of [
+      ["import 'sdk-smoke-unsupported-package'", /unsupported import/],
+      ["import { __sdkSmokeMissingExport } from '@hermes/plugin-sdk'", /does not provide an export/]
+    ]) {
+      const id = crypto.randomUUID()
+      ids.push(id)
+      const source = imports + '\\nexport default { id: ' + JSON.stringify(id) +
+        ', register() { throw new Error("invalid plugin evaluated") } }'
+      check(await loadRuntimePlugin(source, id) === null, 'invalid import was accepted')
+      const record = $pluginRecords.get()[id]
+      check(record?.status === 'error' && expected.test(record.error),
+        'wrong import error: ' + record?.error)
+    }
+    receipt.push('unsupported package and missing named export remain errors')
+    const root = createRoot(document.getElementById('rendered'))
+    root.render(reactValue.node)
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+    check(document.getElementById('rendered').textContent === 'SDK React JSX registered', 'React render failed')
+    receipt.push('React JSX rendered in Chromium')
+    document.getElementById('receipt').textContent = receipt.join('\\n')
+    return receipt
+  } finally {
+    for (const id of ids) { unloadRuntimePlugin(id); dropPlugin(id) }
+    check(registry.getArea(area).length === 0, 'unload leaked contributions')
+  }
+}
+`
+
+async function main() {
+  const args = process.argv.slice(2)
+  assert(args.every(arg => ['--baseline', '--screenshot', '--channel=chrome', '--channel=msedge'].includes(arg)), 'Unknown argument')
+  const baseline = args.includes('--baseline')
+  const channel = args.find(arg => arg.startsWith('--channel='))?.split('=')[1]
+  const { build, preview } = await import('vite')
+  const { chromium } = await import('@playwright/test')
+  const scratch = await mkdtemp(path.join(tmpdir(), 'hermes-sdk-production-'))
+  let server
+  let browser
+  const oldDirname = globalThis.__dirname
+  try {
+    // The runner loads the existing TS config without writing a config bundle
+    // into node_modules (which may be shared by several worktrees).
+    globalThis.__dirname = app
+    const result = await build({
+      root: app,
+      configFile: path.join(app, 'vite.config.ts'),
+      configLoader: 'runner',
+      envDir: false,
+      logLevel: 'warn',
+      cacheDir: path.join(scratch, 'cache'),
+      plugins: [{
+        name: 'sdk-production-probe',
+        resolveId(id) { if (id === 'virtual:sdk-smoke') return '\0sdk-smoke' },
+        load(id) {
+          if (id === '\0sdk-smoke') return probe
+          if (baseline && id.endsWith('/sdk/runtime.ts') && path.normalize(id) === runtime) return eagerBaseline
+        }
+      }],
+      build: {
+        outDir: path.join(scratch, 'dist'),
+        emptyOutDir: true,
+        rolldownOptions: { input: { app: path.join(app, 'index.html'), smoke: 'virtual:sdk-smoke' } }
+      }
+    })
+    const outputs = (Array.isArray(result) ? result : [result]).flatMap(result => result.output)
+    const modules = new Set(outputs.filter(output => output.type === 'chunk').flatMap(output => Object.keys(output.modules)))
+    assert([...modules].some(id => path.normalize(id) === runtime), 'Actual runtime module missing from app graph')
+    console.log(`Production build: ${modules.size} modules; ${baseline ? 'old eager control' : 'actual runtime.ts'}`)
+    const entry = outputs.find(output => output.type === 'chunk' && output.isEntry && output.name === 'smoke')
+    assert(entry, 'Smoke entry was not emitted')
+    await writeFile(path.join(scratch, 'dist', 'sdk-smoke.html'), `<!doctype html>
+      <html><head><meta charset="utf-8"><title>SDK production smoke</title></head>
+      <body><h1>SDK production smoke</h1><div id="rendered"></div><pre id="receipt"></pre>
+      <script type="module" src="./${entry.fileName}"></script></body></html>`)
+    server = await preview({
+      root: app, configFile: false, envDir: false,
+      build: { outDir: path.join(scratch, 'dist') },
+      preview: { host: '127.0.0.1', port: 0, open: false }
+    })
+    const address = server.httpServer.address()
+    const origin = `http://127.0.0.1:${address.port}`
+    browser = await chromium.launch({ headless: true, channel })
+    const page = await browser.newPage({ viewport: { width: 1100, height: 600 }, serviceWorkers: 'block' })
+    // Only this generated preview is reachable; no backend, CDN or user data.
+    await page.route('**/*', route => {
+      const url = new URL(route.request().url())
+      return url.origin === origin || ['blob:', 'data:'].includes(url.protocol)
+        ? route.continue() : route.abort()
+    })
+    await page.routeWebSocket('**/*', socket => socket.close())
+    const errors = []
+    page.on('pageerror', error => errors.push(error.message))
+    await page.goto(`${origin}/sdk-smoke.html`, { waitUntil: 'load', timeout: 120_000 })
+    await page.waitForFunction(() => typeof globalThis.sdkSmoke === 'function')
+    const receipt = await page.evaluate(() => globalThis.sdkSmoke())
+    assert.deepEqual(errors, [], 'Uncaught browser errors')
+    // Screenshots are temporary like the build. The textual receipt survives
+    // in stdout; no files are retained in the checkout or personal directories.
+    const screenshot = await page.screenshot({ path: path.join(scratch, 'sdk-smoke.png'), fullPage: true })
+    console.log(JSON.stringify({ control: baseline ? 'old-eager' : 'current-runtime',
+      browser: browser.version(), receipt, pageErrors: errors, screenshot: 'captured (temporary)' }, null, 2))
+    if (args.includes('--screenshot')) console.log('SDK_SMOKE_SCREENSHOT=data:image/png;base64,' + screenshot.toString('base64'))
+  } finally {
+    await browser?.close()
+    await server?.close()
+    if (oldDirname === undefined) delete globalThis.__dirname
+    else globalThis.__dirname = oldDirname
+    // scratch is exactly the newly allocated temp directory owned by this run.
+    await rm(scratch, { recursive: true, force: true })
+  }
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  main().catch(error => { console.error(error); process.exitCode = 1 })
+}

--- a/apps/desktop/scripts/tests/plugin-sdk-runtime.test.mjs
+++ b/apps/desktop/scripts/tests/plugin-sdk-runtime.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { test } from 'node:test'
+import { pathToFileURL } from 'node:url'
+import vm from 'node:vm'
+import { eagerBaseline, runtime } from '../check-plugin-sdk-production.mjs'
+
+// Use Vite's bundler even when the package manager does not hoist it.
+const requireFromVite = createRequire(import.meta.resolve('vite'))
+const { rolldown } = await import(pathToFileURL(requireFromVite.resolve('rolldown')).href)
+
+// Deliberate RED: node apps/desktop/scripts/tests/plugin-sdk-runtime.test.mjs --baseline
+// Normal acceptance: node --test apps/desktop/scripts/tests/plugin-sdk-runtime.test.mjs
+
+async function bundledRuntime(baseline) {
+  const bundle = await rolldown({
+    input: 'fixture:entry',
+    plugins: [{
+      name: 'sdk-cycle-fixture',
+      resolveId(id, importer) {
+        if (id.startsWith('fixture:')) return '\0' + id
+        if (id === './index' && importer === runtime) return '\0fixture:sdk'
+        if (id === 'runtime') return runtime
+        if (id.startsWith('react')) return '\0fixture:' + id
+      },
+      load(id) {
+        if (id === runtime && baseline) return eagerBaseline
+        if (id === '\0fixture:entry') return `
+          import * as sdk from 'fixture:sdk';
+          import { installPluginSdk, sdkImportMap } from 'runtime';
+          export { sdk, installPluginSdk, sdkImportMap };
+        `
+        // The barrel enters runtime before its namespace is initialized, as the
+        // app's sdk -> contrib -> runtime-loader -> runtime cycle does.
+        if (id === '\0fixture:sdk') return `
+          export { installPluginSdk, sdkImportMap } from 'runtime';
+          export const marker = {};
+        `
+        if (id.startsWith('\0fixture:react')) return 'export const marker = {}'
+      }
+    }]
+  })
+  try {
+    const { output } = await bundle.generate({ format: 'iife', name: 'fixture', minify: true })
+    const urls = new Map()
+    const context = vm.createContext({ Blob, URL: {
+      createObjectURL(blob) {
+        const url = `blob:fixture/${urls.size}`
+        urls.set(url, blob)
+        return url
+      }
+    } })
+    vm.runInContext(output[0].code, context)
+    return { context, urls, ...context.fixture }
+  } finally {
+    await bundle.close()
+  }
+}
+
+async function evaluateShim(blob, context) {
+  const source = await blob.text()
+  const bundle = await rolldown({
+    input: 'shim',
+    plugins: [{
+      name: 'generated-shim',
+      resolveId(id) { if (id === 'shim') return '\0shim' },
+      load(id) { if (id === '\0shim') return source }
+    }]
+  })
+  try {
+    const { output } = await bundle.generate({ format: 'iife', name: 'shim', exports: 'named' })
+    vm.runInContext(output[0].code, context)
+    return context.shim
+  } finally {
+    await bundle.close()
+  }
+}
+
+test('bundled SDK resolves initialized namespaces and reuses its shim map', async () => {
+  const fixture = await bundledRuntime(process.argv.includes('--baseline'))
+  fixture.installPluginSdk()
+  const map = fixture.sdkImportMap()
+  assert.equal(fixture.context.__HERMES_PLUGIN_SDK__, fixture.sdk)
+  assert.equal(fixture.context.__HERMES_PLUGIN_SDK__.marker, fixture.sdk.marker)
+  fixture.installPluginSdk()
+  assert.equal(fixture.sdkImportMap(), map)
+  assert.equal(fixture.urls.size, Object.keys(map).length)
+  for (const [specifier, key] of [
+    ['@hermes/plugin-sdk', '__HERMES_PLUGIN_SDK__'],
+    ['react', '__HERMES_REACT__'],
+    ['react/jsx-runtime', '__HERMES_REACT_JSX__'],
+    ['react/jsx-dev-runtime', '__HERMES_REACT_JSX_DEV__']
+  ]) {
+    const namespace = fixture.context[key]
+    const shim = await evaluateShim(fixture.urls.get(map[specifier]), fixture.context)
+    assert.equal(shim.default, namespace)
+    for (const name of Object.keys(namespace)) assert.equal(shim[name], namespace[name])
+  }
+})
+
+test('old eager capture fails in the same bundled cycle before plugin evaluation', async () => {
+  const fixture = await bundledRuntime(true)
+  fixture.installPluginSdk()
+  assert.equal(fixture.context.__HERMES_PLUGIN_SDK__, undefined)
+  assert.throws(() => fixture.sdkImportMap(), {
+    name: 'TypeError', message: 'Cannot convert undefined or null to object'
+  })
+  assert.equal(fixture.urls.size, 0)
+})

--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -13,21 +13,37 @@ import * as jsxRuntime from 'react/jsx-runtime'
 
 import * as sdk from './index'
 
-const GLOBALS = {
-  __HERMES_PLUGIN_SDK__: sdk,
-  __HERMES_REACT__: React,
-  __HERMES_REACT_JSX__: jsxRuntime,
-  __HERMES_REACT_JSX_DEV__: jsxDevRuntime
-} as const
+// Resolved LAZILY, never as a module-scope literal. This module sits in an
+// import cycle — `sdk/index` → `contrib/*` → `contrib/runtime-loader` →
+// `sdk/runtime` — so a module-scope `{ __HERMES_PLUGIN_SDK__: sdk, … }` is
+// evaluated BEFORE `sdk/index`'s own body runs. In the bundled app that read
+// yields `undefined` (the bundler emits the namespace as a hoisted `var`), so
+// `Object.keys(GLOBALS.__HERMES_PLUGIN_SDK__)` threw
+// "Cannot convert undefined or null to object" and EVERY runtime (disk)
+// plugin failed to load. Reading them at call time — installPluginSdk() and
+// the shim builder only ever run once the app is up — gets the live
+// namespaces.
+function pluginNamespaces() {
+  return {
+    __HERMES_PLUGIN_SDK__: sdk,
+    __HERMES_REACT__: React,
+    __HERMES_REACT_JSX__: jsxRuntime,
+    __HERMES_REACT_JSX_DEV__: jsxDevRuntime
+  }
+}
+
+type PluginGlobalKey = keyof ReturnType<typeof pluginNamespaces>
 
 export function installPluginSdk(): void {
-  Object.assign(globalThis, GLOBALS)
+  Object.assign(globalThis, pluginNamespaces())
 }
 
 /** Build a shim ESM blob that re-exports a global namespace's live members.
  *  Export names come from the namespace itself, so the list can't drift. */
-function shimUrl(globalKey: keyof typeof GLOBALS): string {
-  const names = Object.keys(GLOBALS[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
+function shimUrl(globalKey: PluginGlobalKey): string {
+  const names = Object.keys(pluginNamespaces()[globalKey]).filter(
+    name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name)
+  )
 
   const source =
     `const m = globalThis.${globalKey};\n` +


### PR DESCRIPTION
## What does this PR do?

Adds executable regression coverage for the production-only runtime/disk plugin failure (`Cannot convert undefined or null to object`) reported in #107288 and #107304.

**This is a test companion stacked on #107303, not a competing implementation.** The first commit preserves @g3org3yo's lazy-namespace fix from `6d719a11b6f9860cef6315a4fcda74cab29a5844` unchanged and with its original authorship. Our incremental commit is `5b90ac4e56` (tests/probe only). Maintainers can cherry-pick that test commit into #107303 instead of merging this PR. If #107303 merges first, this can be rebased to leave only the regression coverage.

## Related Issue

Refs #107288, #107304, #107303.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)
- [x] 🐛 Bug fix (included unchanged from #107303)

## Why this coverage?

We independently reproduced the failure on Windows after updating to `67764dc0863349a384c16425e73ee8571f3a94b7` (Desktop package version 0.17.2). Two unchanged disk plugins failed in the common SDK shim setup, before their code could run. The eager module-level map captured a not-yet-initialized SDK namespace in the generated bundle. Null-guarding `Object.keys` would not restore the missing named exports.

The existing loader/UI/legacy compatibility tests passed with the fix, but exercising the production module cycle and generated blob shims is important for this regression.

## Changes Made

- `apps/desktop/scripts/tests/plugin-sdk-runtime.test.mjs`: uses Vite's actual Rolldown dependency to bundle a cyclic module fixture; the positive path loads the real `src/sdk/runtime.ts`. Executes generated shim modules and checks default/named export identities and cache reuse. An isolated, portable eager-control implementation reproduces the old failure without needing Git history.
- `apps/desktop/scripts/check-plugin-sdk-production.mjs`: builds the real desktop application graph with the existing production Vite config and a second smoke entry sharing its chunks, then loads that entry in a headless browser. No SDK/React/loader mocks in this production smoke. It tests no-import, SDK-named-import and React/JSX plugins, reload/disposal, stable shim caching, namespace export identities, actual React rendering, and rejection of unsupported/missing imports.
- The probe uses a fresh temporary build/preview, blocks nonlocal browser requests and WebSockets, and cleans only its own temporary directory. It does not open personal plugin folders or connect to a Hermes backend. No new dependencies.

These are standalone commands, **not silently added to the default Vitest suite or CI**. The small cycle regression and the opt-in production/browser probe are separate so the normal targeted check does not require a browser/full build. Maintainer guidance on the preferred CI placement is welcome.

## How to Test

From repository root with the existing workspace dependencies installed:

```sh
# GREEN: 2 passed, no skipped tests
node --test apps/desktop/scripts/tests/plugin-sdk-runtime.test.mjs

# Deliberate RED: exits 1 with Object.keys(undefined)
node apps/desktop/scripts/tests/plugin-sdk-runtime.test.mjs --baseline

# Production/browser GREEN
node apps/desktop/scripts/check-plugin-sdk-production.mjs

# Deliberate production RED: exits 1 before the no-import plugin registers
node apps/desktop/scripts/check-plugin-sdk-production.mjs --baseline
```

The browser commands use Playwright's Chromium by default. On this Windows machine its headless-shell was absent, so both controls were actually run with the explicit `--channel=chrome` option (installed Chrome); the probe does not download browsers. `--channel=msedge` is also supported. Optional `--screenshot` emits the synthetic smoke page as a data URL; all temporary files are still cleaned up.

### Actual local results

- Fast bundled-cycle suite: **2 passed**, exit 0.
- Old eager cycle control: exit 1 at `Object.keys(undefined)` (expected RED).
- Old eager production control: exit 1, `plugin load failed: Cannot convert undefined or null to object` (expected RED).
- Current production graph: **4,087 modules**, Chrome **152.0.7977.83**, exit 0, `pageErrors: []`:
  - no-import, SDK named import and React JSX plugins registered;
  - reload disposes previous contributions; shim map is stable;
  - SDK, React and both JSX namespaces retain all export identities;
  - unsupported package and missing named export remain errors;
  - React JSX rendered in Chromium.
- Existing targeted Vitest suites: **16 passed** across `runtime-loader.test.ts`, `desktop-plugins-section.test.tsx`, and `legacy-sdk-compat.test.ts`.
- `npm run typecheck --workspace apps/desktop`: exit 0 (renderer, Electron, E2E types).
- `npm run build --workspace apps/desktop`: exit 0.
- `npm run builder --workspace apps/desktop -- --dir --publish never`: exit 0 (Windows unpacked artifact; no release publishing).
- After backing up and installing the complete rebuilt renderer asset generation in the local packaged Desktop, a renderer reload restored both previously failing plugins without modifying either plugin. Desktop main/backend were not restarted. This is a local recovery observation, not a claim about all supported operating systems.

Existing Vite config/deprecated chunk-option and ineffective-dynamic-import warnings remain. The full Python suite and macOS/Linux runtime checks were not run for this frontend-only contribution.

## Checklist

- [x] Read the contributing guide.
- [x] Conventional commit messages; scope limited to this regression.
- [x] Searched existing issues/PRs and explicitly reused #107303 with attribution.
- [x] Added executable regression coverage and independently reran the production positive check.
- [x] Tested on Windows; no machine paths, private logs, credentials, account data or theme assets included.
- [ ] Full `pytest tests/ -q` (not run; frontend-only scope).
- [ ] macOS/Linux runtime verification (not run).
- [x] No config keys, tool schemas, permissions or authentication changes.

Implementation was AI-assisted; the local test/build outputs and installed renderer recovery were independently checked before submission.
