### PR TITLE
fix(plugins): serialize first-time plugin module loads (startup race can drop a memory provider)

### DIFF
--- a/plugins/plugin_loader.py
+++ b/plugins/plugin_loader.py
@@ -10,10 +10,18 @@ import importlib.machinery
 import importlib.util
 import logging
 import sys
+import threading
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple
 
 _PLUGINS_ROOT = Path(__file__).parent
+
+# First-time plugin loads are serialized: this loader hand-executes modules on the calling
+# thread, outside the import system's own per-module locks. The name is reserved in
+# sys.modules before exec (its __file__ is set pre-exec), so two threads racing to load the
+# same plugin (e.g. two agent builds at startup) could otherwise hand one of them a
+# still-executing module and extract no provider instance from it.
+_load_lock = threading.RLock()
 
 
 def register_synthetic_package(name: str, search_locations: List[str]) -> None:
@@ -84,42 +92,46 @@ def load_plugin_module(module_name: str, plugin_dir: Path, *, parents: Tuple[str
     """Import ``plugin_dir/__init__.py`` as *module_name* (reusing sys.modules when loaded).
     Order matters: parents first (relative imports need them), then siblings as ``module_name.<stem>``
     (so ``from ._x import Y`` resolves), then the module. Finally child is bound onto parent and
-    siblings onto module — the shape normal imports produce, which monkeypatch relies on."""
-    init_file = plugin_dir / "__init__.py"
-    if not init_file.exists():
-        return None
-    # A synthetic package shell has no __file__; only reuse modules loaded from disk.
-    cached = sys.modules.get(module_name)
-    if cached is not None and getattr(cached, "__file__", None):
-        return cached
-    for parent in parents:
-        parent_path = _PLUGINS_ROOT.joinpath(*parent.split(".")[1:])
-        if parent not in sys.modules and (parent_path / "__init__.py").exists():
-            _exec(_new_module(parent, parent_path / "__init__.py", [str(parent_path)]))
-    if synthetic_namespace:
-        register_synthetic_package(synthetic_namespace, [])
-    # Reserve the name before siblings exec so their relative imports resolve.
-    mod = _new_module(module_name, init_file, [str(plugin_dir)])
-    if mod is None:
-        return None
-    loaded_submodules = []
-    for sub_file in plugin_dir.glob("*.py"):
-        full_sub_name = f"{module_name}.{sub_file.stem}"
-        if sub_file.name == "__init__.py" or full_sub_name in sys.modules:
-            continue
-        sub_mod = _new_module(full_sub_name, sub_file)
-        if _exec(sub_mod, logger):
-            loaded_submodules.append((sub_file.stem, sub_mod))
-    if not _exec(mod, logger):
-        sys.modules.pop(module_name, None)
-        return None
-    parent_name, child_name = module_name.rsplit(".", 1)
-    parent_mod = sys.modules.get(parent_name)
-    if parent_mod is not None:
-        setattr(parent_mod, child_name, mod)
-    for sub_name, sub_mod in loaded_submodules:
-        setattr(mod, sub_name, sub_mod)
-    return mod
+    siblings onto module — the shape normal imports produce, which monkeypatch relies on.
+
+    Serialized by ``_load_lock`` so no caller can ever observe a reserved-but-still-executing
+    module (see the lock's comment)."""
+    with _load_lock:
+        init_file = plugin_dir / "__init__.py"
+        if not init_file.exists():
+            return None
+        # A synthetic package shell has no __file__; only reuse modules loaded from disk.
+        cached = sys.modules.get(module_name)
+        if cached is not None and getattr(cached, "__file__", None):
+            return cached
+        for parent in parents:
+            parent_path = _PLUGINS_ROOT.joinpath(*parent.split(".")[1:])
+            if parent not in sys.modules and (parent_path / "__init__.py").exists():
+                _exec(_new_module(parent, parent_path / "__init__.py", [str(parent_path)]))
+        if synthetic_namespace:
+            register_synthetic_package(synthetic_namespace, [])
+        # Reserve the name before siblings exec so their relative imports resolve.
+        mod = _new_module(module_name, init_file, [str(plugin_dir)])
+        if mod is None:
+            return None
+        loaded_submodules = []
+        for sub_file in plugin_dir.glob("*.py"):
+            full_sub_name = f"{module_name}.{sub_file.stem}"
+            if sub_file.name == "__init__.py" or full_sub_name in sys.modules:
+                continue
+            sub_mod = _new_module(full_sub_name, sub_file)
+            if _exec(sub_mod, logger):
+                loaded_submodules.append((sub_file.stem, sub_mod))
+        if not _exec(mod, logger):
+            sys.modules.pop(module_name, None)
+            return None
+        parent_name, child_name = module_name.rsplit(".", 1)
+        parent_mod = sys.modules.get(parent_name)
+        if parent_mod is not None:
+            setattr(parent_mod, child_name, mod)
+        for sub_name, sub_mod in loaded_submodules:
+            setattr(mod, sub_name, sub_mod)
+        return mod
 
 
 class NoopPluginContext:

--- a/tests/plugins/test_plugin_loader_concurrency.py
+++ b/tests/plugins/test_plugin_loader_concurrency.py
@@ -1,0 +1,129 @@
+"""Regression: two concurrent first-time loads of one plugin must both yield a provider.
+
+The directory-plugin loader (``plugins/plugin_loader.py::load_plugin_module``)
+hand-executes plugin modules on the calling thread, outside the import system's
+own per-module locks. The module name is reserved in ``sys.modules`` *before*
+exec and the cache check returns that reservation (``__file__`` is set
+pre-exec), so a second thread racing the first load used to observe a
+partially-executed module, extract no provider instance, and get ``None``.
+
+Real impact (2026-09-10): two desktop chats restored concurrently after a
+restart raced ``load_memory_provider("openviking")``; the losing build ran
+without the provider's six tools for the whole conversation ("Tool
+'viking_search' does not exist") because a session's toolset is frozen for the
+life of the conversation.
+
+This test holds one module exec open (the fixture blocks until the test
+releases it) and runs a second load inside that window. Both loads must return
+a provider instance; on unfixed code the second returns ``None``.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+_FIXTURE_NAME = "racefixture"
+_USER_NAMESPACE_PREFIX = "_hermes_user_memory"
+
+# Everything (class + register) is defined only AFTER the block, so a load
+# that observes this module mid-exec can extract nothing from it.
+_FIXTURE_INIT = '''\
+"""Concurrency fixture memory provider (register_memory_provider / MemoryProvider markers).
+
+Exec is held open until the test releases it, so a concurrent load can only
+ever observe a fully-executed module once first-time loads are serialized.
+"""
+import time
+from pathlib import Path
+
+from agent.memory_provider import MemoryProvider
+
+_DIR = Path(__file__).parent
+_MARKER = _DIR / "exec_started"
+_RELEASE = _DIR / "exec_release"
+
+_MARKER.write_text("started", encoding="utf-8")
+_deadline = time.monotonic() + 15.0
+while not _RELEASE.exists() and time.monotonic() < _deadline:
+    time.sleep(0.01)
+
+
+class RaceFixtureProvider(MemoryProvider):
+    @property
+    def name(self) -> str:
+        return "racefixture"
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        pass
+
+    def get_tool_schemas(self):
+        return []
+
+
+def register(ctx):
+    ctx.register_memory_provider(RaceFixtureProvider())
+'''
+
+
+@pytest.fixture
+def race_plugin_dir():
+    """A user-installed memory provider whose module exec the test controls."""
+    home = Path(os.environ["HERMES_HOME"])
+    plugin_dir = home / "plugins" / _FIXTURE_NAME
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text(_FIXTURE_INIT, encoding="utf-8")
+    try:
+        yield plugin_dir
+    finally:
+        for name in [n for n in list(sys.modules) if n.startswith(_USER_NAMESPACE_PREFIX)]:
+            sys.modules.pop(name, None)
+
+
+def test_concurrent_first_loads_both_yield_a_provider(race_plugin_dir):
+    from plugins.memory import load_memory_provider
+
+    marker = race_plugin_dir / "exec_started"
+    release = race_plugin_dir / "exec_release"
+    results = {}
+    errors = {}
+
+    def _load(key):
+        try:
+            results[key] = load_memory_provider(_FIXTURE_NAME)
+        except Exception as exc:  # surfaced via the assertions below
+            errors[key] = exc
+
+    first = threading.Thread(target=_load, args=("first",), daemon=True)
+    first.start()
+    deadline = time.monotonic() + 10.0
+    while not marker.exists() and time.monotonic() < deadline:
+        time.sleep(0.005)
+    assert marker.exists(), "fixture module exec never started"
+
+    second = threading.Thread(target=_load, args=("second",), daemon=True)
+    second.start()
+    # Give the second load the chance to land inside the first load's exec
+    # window; once loads are serialized it blocks here and is released below.
+    time.sleep(0.3)
+    release.write_text("go", encoding="utf-8")
+
+    first.join(timeout=10.0)
+    second.join(timeout=10.0)
+    assert not first.is_alive() and not second.is_alive(), "loads did not finish"
+    assert not errors, f"load raised: {errors!r}"
+
+    assert results.get("first") is not None, "first load returned no provider"
+    assert results.get("second") is not None, (
+        "the concurrent second load returned no provider instance: it observed the "
+        "partially-executed plugin module (regressed plugins/plugin_loader.py first-load lock)"
+    )
+    assert results["first"].name == _FIXTURE_NAME
+    assert results["second"].name == _FIXTURE_NAME


### PR DESCRIPTION
# Serialize first-time plugin module loads (fixes a startup race that can drop a memory provider)

## Problem

`plugins/plugin_loader.py::load_plugin_module()` hand-executes plugin modules on the calling
thread, outside the import system's own per-module locks. The module name is reserved in
`sys.modules` *before* exec, and the reserved module already has `__file__` set — so the cache
check hands that reservation to any other thread.

When two agent builds race the *first* load of the same plugin (real incident: two desktop chats
restored concurrently after an app restart — observed as two builds 8 ms apart), the second
`load_memory_provider("<name>")` can extract no provider instance from the still-executing
module. `load_named` logs:

```
WARNING plugins.memory: Memory provider 'openviking' loaded but no provider instance found
```

…while the other build logs `registered (6 tools)` ~6 ms later. `agent/agent_init.py` treats the
`None` provider as "not configured", so that session is built **without the provider's tools for
its entire life** (the toolset is frozen per conversation), silently degrading the session.

The same loader serves `plugins/cron_providers/` and `plugins/context_engine/`, so the same loss
is possible for those kinds.

## Reproduction

New test `tests/plugins/test_plugin_loader_concurrency.py`: a fixture user-dir memory provider
whose module exec is held open; a second concurrent `load_memory_provider()` must also return an
instance. Without the fix the second load returns `None` and the exact warning above is logged.

## Fix

`plugins/plugin_loader.py`: module-level `threading.RLock()`; the `load_plugin_module()` body is
wrapped in `with _load_lock:`. First-time loads of one plugin can no longer overlap, so a cached
module observed by another thread is always fully executed. Sequential loads are unchanged;
`RLock` covers same-thread re-entrancy.

## Verification

- `scripts/run_tests.sh tests/plugins/test_plugin_loader_concurrency.py` — red on unfixed code
  (second load `None` + the exact warning), green with the fix.
- Focused consumer suites on this branch's base (`67764dc08`): `tests/run_agent/test_memory_provider_init.py`,
  `tests/agent/test_memory_provider.py`, `tests/plugins/memory/`, `tests/plugins/test_memory_hook_registration.py`,
  `tests/plugins/test_plugin_loader_concurrency.py` — **30 files, 484 passed, 9 skipped**.
  The 10 remaining failures in `tests/plugins/memory/` are environment-only on the reporter's
  Windows machine (missing optional `hindsight-client` with lazy installs disabled ×8, Windows
  symlink privilege ×1, CRLF expectation ×1) and reproduce identically on an unfixed checkout.

## Scope notes

- Fixes the whole bug class (memory / cron_providers / context_engine share `load_plugin_module`).
- Deliberately minimal: lock + regression test only.
