### PR TITLE
fix: opaque fallback for mobile header/sidebar background

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -532,7 +532,8 @@ export default function App() {
           "bg-background-base",
         )}
         style={{
-          background: "var(--component-header-background)",
+          background:
+            "var(--component-header-background, var(--background-base))",
           borderImage: "var(--component-header-border-image)",
           clipPath: "var(--component-header-clip-path)",
         }}
@@ -591,7 +592,8 @@ export default function App() {
               collapsed && "lg:w-14",
             )}
             style={{
-              background: "var(--component-sidebar-background)",
+              background:
+                "var(--component-sidebar-background, var(--background-base))",
               clipPath: "var(--component-sidebar-clip-path)",
               borderImage: "var(--component-sidebar-border-image)",
             }}


### PR DESCRIPTION
## Summary
On mobile viewports (`lg:hidden`), the hamburger menu's sidebar and top header read their background color from `--component-header-background` / `--component-sidebar-background`. In themes where these theme tokens resolve to an empty string, the `background: var(--empty-var)` declaration is invalid CSS and the browser falls back to `transparent`.

Result: opening the mobile nav shows an overlay where the darkening backdrop (`bg-black/70`, working correctly) sits behind a **see-through** sidebar panel -- page content/text behind it bleeds through and visually collides with the nav item labels.

## Fix
Add `var(--background-base)` as an explicit CSS fallback in both `var()` expressions, so the sidebar/header always paint an opaque background even when the component-specific token is unset. Themes that do set the token keep overriding it as before.

```diff
- background: "var(--component-header-background)",
+ background: "var(--component-header-background, var(--background-base))",

- background: "var(--component-sidebar-background)",
+ background: "var(--component-sidebar-background, var(--background-base))",
```

## Test plan
- Reproduced with Playwright at a 390x844 mobile viewport against a local `hermes dashboard` instance: before the fix, sidebar `background-color` computed to `rgba(0, 0, 0, 0)` with the CSS var resolving empty; after the fix it resolves to the opaque `--background-base` value and the nav renders solid.
- Screenshot comparison confirms nav items (CHAT/SESSIONS/FILES/...) are fully legible with no page-content bleed-through.

Files changed: `web/src/App.tsx` (mobile header + sidebar inline `style` background).