### PR TITLE
fix(state): compare fd identity against the watched path, not st_nlink

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -983,8 +983,9 @@ class SessionDB(
             watched = _watched_sqlite_sidecar_paths(self.db_path)
             try:
                 for target, fd_path in _proc_fd_targets(os.getpid()):
-                    if (" (deleted)" in target and _canonical_sqlite_path(target) in watched
-                            and _fd_is_truly_unlinked(fd_path)):
+                    canonical = _canonical_sqlite_path(target)
+                    if (" (deleted)" in target and canonical in watched
+                            and _fd_is_truly_unlinked(fd_path, watched[canonical])):
                         return True
             except OSError:
                 return False

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -46,8 +46,9 @@ from hermes_state_telegram import SessionTelegramTopicsMixin
 from hermes_state_schema import SessionSchemaMixin
 import hermes_state_holders as _state_holders
 from hermes_state_dbfile import (
-    _canonical_sqlite_path, _connect_tracked_db, _read_sqlite_application_id, _stat_sqlite_sidecar_identity,
-    _watched_sqlite_sidecar_paths, has_invalid_sqlite_header_preopen, is_zeroed_state_db, quarantine_cross_process_lock,
+    _canonical_sqlite_path, _connect_tracked_db, _fd_is_truly_unlinked, _read_sqlite_application_id,
+    _stat_sqlite_sidecar_identity, _watched_sqlite_sidecar_paths, has_invalid_sqlite_header_preopen,
+    is_zeroed_state_db, quarantine_cross_process_lock,
     quarantine_invalid_state_db,
     refuse_deleted_wal_generation,
 )
@@ -981,8 +982,9 @@ class SessionDB(
         if sys.platform.startswith("linux"):
             watched = _watched_sqlite_sidecar_paths(self.db_path)
             try:
-                for target in _proc_fd_targets(os.getpid()):
-                    if " (deleted)" in target and _canonical_sqlite_path(target) in watched:
+                for target, fd_path in _proc_fd_targets(os.getpid()):
+                    if (" (deleted)" in target and _canonical_sqlite_path(target) in watched
+                            and _fd_is_truly_unlinked(fd_path)):
                         return True
             except OSError:
                 return False

--- a/hermes_state_dbfile.py
+++ b/hermes_state_dbfile.py
@@ -105,8 +105,22 @@ def _watched_sqlite_sidecar_paths(db_path) -> Set[str]:
     return {_canonical_sqlite_path(base + "-wal"), _canonical_sqlite_path(base + "-shm")}
 
 
+def _fd_is_truly_unlinked(fd_path: str) -> bool:
+    """Confirm a `` (deleted)`` /proc fd target really lost its last name.
+
+    The suffix alone is not proof: on OpenZFS a live, still-linked file whose
+    dentry was unhashed is reported as deleted while ``st_nlink`` is still 1 and
+    the path resolves to the very same inode. Only ``st_nlink == 0`` means the
+    inode is an orphan generation. An unstattable descriptor counts as deleted
+    so the guard keeps failing closed."""
+    try:
+        return os.stat(fd_path).st_nlink == 0
+    except OSError:
+        return True
+
+
 def _iter_proc_fd_targets():
-    """Yield ``(pid, readlink target)`` for every readable ``/proc/<pid>/fd`` entry."""
+    """Yield ``(pid, readlink target, fd path)`` for every readable ``/proc/<pid>/fd`` entry."""
     for pid_str in os.listdir("/proc"):
         if not pid_str.isdigit():
             continue
@@ -117,7 +131,8 @@ def _iter_proc_fd_targets():
             continue  # process gone or not ours
         for fd in fds:
             with contextlib.suppress(OSError):
-                yield int(pid_str), os.readlink(f"{fd_dir}/{fd}")
+                fd_path = f"{fd_dir}/{fd}"
+                yield int(pid_str), os.readlink(fd_path), fd_path
 
 
 def iter_deleted_sqlite_sidecar_holders(db_path) -> List[Tuple[int, str]]:
@@ -130,8 +145,9 @@ def iter_deleted_sqlite_sidecar_holders(db_path) -> List[Tuple[int, str]]:
     holders: List[Tuple[int, str]] = []
     watched = _watched_sqlite_sidecar_paths(db_path)
     try:
-        for pid, target in _iter_proc_fd_targets():
-            if " (deleted)" in target and _canonical_sqlite_path(target) in watched:
+        for pid, target, fd_path in _iter_proc_fd_targets():
+            if (" (deleted)" in target and _canonical_sqlite_path(target) in watched
+                    and _fd_is_truly_unlinked(fd_path)):
                 holders.append((pid, target))
     except Exception as exc:
         logger.debug("deleted-WAL holder scan failed for %s: %s", db_path, exc)
@@ -371,7 +387,7 @@ def count_db_holders(db_path: Path) -> Optional[int]:
         if not sys.platform.startswith("linux"):
             return None
         target = os.path.realpath(str(db_path))
-        return len({pid for pid, link in _iter_proc_fd_targets() if link == target})
+        return len({pid for pid, link, _fd_path in _iter_proc_fd_targets() if link == target})
     except Exception:
         return None
 

--- a/hermes_state_dbfile.py
+++ b/hermes_state_dbfile.py
@@ -19,7 +19,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_state_common import (
     FTS_REBUILD_DEFERRAL_KEY, stat_db_file_identity as _stat_db_file_identity
@@ -100,23 +100,36 @@ def _canonical_sqlite_path(path: str) -> str:
     return os.path.normcase(os.path.abspath(path.removesuffix(" (deleted)")))
 
 
-def _watched_sqlite_sidecar_paths(db_path) -> Set[str]:
+def _watched_sqlite_sidecar_paths(db_path) -> Dict[str, str]:
+    """Map each sidecar's canonical (/proc-comparable) form to its literal, still-named path,
+    so a canonical match can be re-``stat``'d for identity rather than trusted as text."""
     base = os.path.abspath(os.fspath(db_path))
-    return {_canonical_sqlite_path(base + "-wal"), _canonical_sqlite_path(base + "-shm")}
+    literal = (base + "-wal", base + "-shm")
+    return {_canonical_sqlite_path(path): path for path in literal}
 
 
-def _fd_is_truly_unlinked(fd_path: str) -> bool:
-    """Confirm a `` (deleted)`` /proc fd target really lost its last name.
+def _fd_is_truly_unlinked(fd_path: str, watched_path: str) -> bool:
+    """Confirm a `` (deleted)`` /proc fd target really names an orphaned generation, not the
+    CURRENT watched sidecar.
 
-    The suffix alone is not proof: on OpenZFS a live, still-linked file whose
-    dentry was unhashed is reported as deleted while ``st_nlink`` is still 1 and
-    the path resolves to the very same inode. Only ``st_nlink == 0`` means the
-    inode is an orphan generation. An unstattable descriptor counts as deleted
-    so the guard keeps failing closed."""
+    The suffix alone is not proof: on OpenZFS a live, still-linked file whose dentry was
+    unhashed is reported as deleted while it is still the very same inode the watched path
+    names. Conversely ``st_nlink == 0`` is not proof of the opposite — a stale generation can
+    keep a surviving hard link (a backup, an operator copy) after the watched path itself is
+    removed or replaced, leaving ``st_nlink >= 1`` on a truly orphaned inode. So compare
+    identity, not link count: only an exact ``(st_dev, st_ino)`` match between the fd and the
+    CURRENT watched path proves they are the same live file. A mismatch, or a watched path
+    that cannot be stat'd at all, means the fd holds a generation the watched path no longer
+    names — the guard keeps failing closed."""
     try:
-        return os.stat(fd_path).st_nlink == 0
+        fd_stat = os.stat(fd_path)
     except OSError:
         return True
+    try:
+        watched_stat = os.stat(watched_path)
+    except OSError:
+        return True
+    return (fd_stat.st_dev, fd_stat.st_ino) != (watched_stat.st_dev, watched_stat.st_ino)
 
 
 def _iter_proc_fd_targets():
@@ -146,8 +159,9 @@ def iter_deleted_sqlite_sidecar_holders(db_path) -> List[Tuple[int, str]]:
     watched = _watched_sqlite_sidecar_paths(db_path)
     try:
         for pid, target, fd_path in _iter_proc_fd_targets():
-            if (" (deleted)" in target and _canonical_sqlite_path(target) in watched
-                    and _fd_is_truly_unlinked(fd_path)):
+            canonical = _canonical_sqlite_path(target)
+            if (" (deleted)" in target and canonical in watched
+                    and _fd_is_truly_unlinked(fd_path, watched[canonical])):
                 holders.append((pid, target))
     except Exception as exc:
         logger.debug("deleted-WAL holder scan failed for %s: %s", db_path, exc)

--- a/hermes_state_readpool.py
+++ b/hermes_state_readpool.py
@@ -69,13 +69,14 @@ _fd_usage_lock = threading.Lock()
 _fd_usage_cache: "tuple[float, Optional[int]]" = (0.0, None)
 
 
-def _proc_fd_targets(pid: int) -> Iterator[str]:
-    """readlink() of every entry in /proc/<pid>/fd (unreadable links skipped).
-    Raises OSError when the fd directory itself cannot be listed."""
+def _proc_fd_targets(pid: int) -> "Iterator[tuple[str, str]]":
+    """Yield ``(readlink target, fd path)`` for every entry in /proc/<pid>/fd (unreadable
+    links skipped). Raises OSError when the fd directory itself cannot be listed."""
     fd_dir = f"/proc/{pid}/fd"
     for fd in os.listdir(fd_dir):
+        fd_path = f"{fd_dir}/{fd}"
         try:
-            yield os.readlink(f"{fd_dir}/{fd}")
+            yield os.readlink(fd_path), fd_path
         except OSError:
             continue
 

--- a/tests/hermes_state/test_deleted_wal_generation_guard.py
+++ b/tests/hermes_state/test_deleted_wal_generation_guard.py
@@ -209,6 +209,33 @@ def test_write_path_ignores_live_unhashed_dentry(tmp_path, force_wal, monkeypatc
 
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"),
+    reason="deleted-WAL /proc scan is Linux-only",
+)
+def test_iter_holders_flags_orphan_kept_alive_by_hardlink(tmp_path, force_wal):
+    """`st_nlink == 0` is not proof of an orphan either: a stale generation can keep a
+    surviving hard link (a backup, an operator copy) after the watched path itself is
+    unlinked or replaced, so `st_nlink` stays >= 1 on a truly orphaned inode. The guard
+    must still flag it by comparing the fd's identity against the CURRENT watched path,
+    not by trusting the link count."""
+    path = tmp_path / "state.db"
+    db = _make_db(path, "s", "held")
+    wal = _require_wal(db)
+    backup = tmp_path / "backup-wal"
+    os.link(wal, backup)  # keeps the old inode's nlink >= 1 after the unlink below
+    try:
+        _unlink_sidecars(path)
+        wal.write_bytes(b"new-generation")  # watched path recreated on a different inode
+        assert backup.stat().st_nlink >= 1
+        holders = iter_deleted_sqlite_sidecar_holders(path)
+        assert any(
+            target.removesuffix(" (deleted)").endswith("-wal") for _pid, target in holders
+        )
+    finally:
+        db.close()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
     reason="deleted-WAL write halt uses Linux unlink semantics",
 )
 def test_writer_halts_after_own_wal_unlinked(tmp_path, force_wal):

--- a/tests/hermes_state/test_deleted_wal_generation_guard.py
+++ b/tests/hermes_state/test_deleted_wal_generation_guard.py
@@ -15,6 +15,8 @@ from pathlib import Path
 import pytest
 
 import hermes_state
+import hermes_state_dbfile
+import hermes_state_readpool
 import hermes_state_wal
 from hermes_state import DeletedWalGenerationError, SessionDB, classify_persistence_error, refuse_deleted_wal_generation
 from hermes_state_dbfile import iter_deleted_sqlite_sidecar_holders
@@ -146,6 +148,63 @@ def test_second_sessiondb_open_refuses_and_does_not_mint_wal(tmp_path, force_wal
     if wal.exists():
         assert wal.stat().st_ino == inode_before
     writer.close()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="deleted-WAL /proc scan is Linux-only",
+)
+def test_iter_holders_ignores_live_unhashed_dentry(tmp_path, force_wal, monkeypatch):
+    """OpenZFS can report a live, still-linked file's /proc fd target with the
+    `` (deleted)`` suffix (dentry unhashed, nlink still 1) even though nothing
+    was actually unlinked. The scan must not treat that as an orphaned WAL."""
+    path = tmp_path / "state.db"
+    db = _make_db(path, "s", "held")
+    wal = _require_wal(db)
+    real_readlink = os.readlink
+
+    def fake_readlink(fd_path, *args, **kwargs):
+        target = real_readlink(fd_path, *args, **kwargs)
+        if target.endswith(("-wal", "-shm")):
+            return target + " (deleted)"
+        return target
+
+    monkeypatch.setattr(hermes_state_dbfile.os, "readlink", fake_readlink)
+    try:
+        assert iter_deleted_sqlite_sidecar_holders(path) == []
+        assert wal.exists()
+    finally:
+        db.close()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="deleted-WAL write halt uses Linux unlink semantics",
+)
+def test_write_path_ignores_live_unhashed_dentry(tmp_path, force_wal, monkeypatch):
+    """Same OpenZFS artifact as above, but on the sticky in-process write-path
+    probe (_wal_generation_was_lost), which the open-path fix alone does not cover."""
+    path = tmp_path / "state.db"
+    db = _make_db(path, "s", "held")
+    _require_wal(db)
+    # Mimic the post-close-race state that forces the /proc probe path.
+    db._db_sidecar_identity = {}
+    real_readlink = os.readlink
+
+    def fake_readlink(fd_path, *args, **kwargs):
+        target = real_readlink(fd_path, *args, **kwargs)
+        if target.endswith(("-wal", "-shm")):
+            return target + " (deleted)"
+        return target
+
+    monkeypatch.setattr(hermes_state_readpool.os, "readlink", fake_readlink)
+    try:
+        assert db._wal_generation_was_lost() is False
+        db.append_message("s", role="user", content="after-artifact")
+        rows = db.get_messages("s")
+        assert any(m["content"] == "after-artifact" for m in rows)
+    finally:
+        db.close()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## What does this PR do?

Fixes #107401 — on OpenZFS, `iter_deleted_sqlite_sidecar_holders()` (open-path
guard) and `SessionDB._wal_generation_was_lost()` (the sticky in-process
write-path probe) both misread a live, still-linked `state.db-wal` /
`state.db-shm` file as an orphaned WAL generation, permanently refusing every
open/write and falling back to JSONL forever.

## Root cause

Both call sites treat a `` (deleted)`` suffix on a `/proc/<pid>/fd/*`
`readlink()` target as proof the sidecar was unlinked. That suffix only means
the kernel's `d_path()` found the dentry unhashed (`d_unlinked()`). On ext4 or
tmpfs that always correlates with `st_nlink == 0`, but on OpenZFS a live file
can have its dentry unhashed (e.g. after certain rename/lookup paths) while
`st_nlink` is still 1 and the fd still resolves to the exact same, fully
intact inode. `psutil` already documents and guards against this exact
caveat in `_pslinux.py`. Once the guard trips, `_db_wal_generation_lost`
is sticky — no restart clears it, because nothing was ever actually deleted.

`st_nlink == 0` is not a safe substitute either: a genuinely orphaned
generation can keep a surviving hard link (a backup, an operator copy) after
the watched sidecar path itself is removed or replaced, leaving
`st_nlink >= 1` on a truly orphaned inode and letting a new opener through
while a live writer still owns the old generation.

## Fix

Add `_fd_is_truly_unlinked(fd_path, watched_path)` in `hermes_state_dbfile.py`,
which compares `(st_dev, st_ino)` between the fd and the *current* watched
sidecar path. Only an exact identity match means the fd and the watched path
name the same live file; any mismatch, or a watched path that can't be
stat'd at all, keeps the guard failing closed. This correctly handles both
directions: the OpenZFS unhashed-dentry false positive (fd and watched path
are the same live inode) and the hard-link false negative (fd's inode no
longer matches the watched path, even though `st_nlink >= 1`).

Two call sites needed the descriptor path plumbed through:
- `_iter_proc_fd_targets()` (`hermes_state_dbfile.py`) now yields
  `(pid, target, fd_path)` instead of `(pid, target)`; its other consumer,
  `count_db_holders()`, just ignores the extra element.
- `_proc_fd_targets()` (`hermes_state_readpool.py`) now yields
  `(target, fd_path)` instead of a bare `target`; its only consumer,
  `SessionDB._wal_generation_was_lost()`, is updated to match — this is the
  site that makes the failure sticky, so patching only the open path is not
  enough.

## How to test

```
scripts/run_tests.sh tests/hermes_state/test_deleted_wal_generation_guard.py -v
scripts/run_tests.sh tests/hermes_state/ -q
scripts/run_tests.sh tests/test_state_db_stats.py -v
scripts/run_tests.sh tests/test_session_db_read_conn_pool.py -q
```

Result: `315 passed, 1 skipped` for `tests/hermes_state/`; `14 passed` for
`test_state_db_stats.py`; `3 passed, 17 skipped` (Linux-gated) for
`test_session_db_read_conn_pool.py`.

Regression tests, all Linux-only:

- `test_iter_holders_ignores_live_unhashed_dentry` /
  `test_write_path_ignores_live_unhashed_dentry` — simulate the OpenZFS
  artifact by monkeypatching `os.readlink` to append `" (deleted)"` to a
  real, still-open WAL/SHM fd target whose underlying file was never
  actually unlinked; the guard must not treat it as a holder.
- `test_iter_holders_flags_orphan_kept_alive_by_hardlink` — hard-links the
  WAL before unlinking the watched path and recreating it on a new inode,
  then asserts the guard still reports the old generation as a holder even
  though `st_nlink >= 1` on it.

Confirmed all three fail on the pre-fix code and pass once the fix is
restored.

`scripts/check-windows-footguns.py` — clean on all changed files.

## What platforms you tested on

Linux (the guard and the new tests are Linux-only; behavior on macOS/Windows
is unchanged — both already short-circuit before reaching this code).

## Related Issue

Fixes #107401.

---

*AI-assisted: implemented and tested by an autonomous coding agent (Claude Code) against the reporter's own proposed fix and reproduction evidence in the issue; verified independently against current `main` before writing the patch.*
