### PR TITLE
fix(cron): handle passthrough secrets in multiplexed dispatch

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3065,7 +3065,13 @@ def _launch_external_cron_worker(job: dict) -> bool:
         str(ack_path),
     ]
 
-    from agent.secret_scope import is_multiplex_active
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        is_multiplex_active,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+    from hermes_cli.env_loader import hydrate_profile_secret_sources
     from tools.environments.local import build_subprocess_env
     from tools.process_registry import (
         restart_safe_gateway_child_argv,
@@ -3107,11 +3113,17 @@ def _launch_external_cron_worker(job: dict) -> bool:
         payload_path.unlink(missing_ok=True)
         raise
 
-    worker_env = build_subprocess_env(
-        scrub_secrets=multiplex_active,
-        inherit_profile_home=True,
-        extra={"HERMES_HOME": str(_get_hermes_home().resolve())},
-    )
+    profile_home = _get_hermes_home().resolve()
+    hydrate_profile_secret_sources(profile_home)
+    secret_token = set_secret_scope(build_profile_secret_scope(profile_home))
+    try:
+        worker_env = build_subprocess_env(
+            scrub_secrets=multiplex_active,
+            inherit_profile_home=True,
+            extra={"HERMES_HOME": str(profile_home)},
+        )
+    finally:
+        reset_secret_scope(secret_token)
     worker_env = systemd_user_bus_env(worker_env)
     try:
         process = subprocess.Popen(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3042,6 +3042,30 @@ def _wait_for_external_cron_worker(
                 pass
 
 
+def _restart_safe_worker_secret_scope(
+    profile_home: Path, *, trust_process_passthrough: bool
+) -> tuple[dict[str, str], frozenset[str]]:
+    """Build one worker's scope and exact passthrough projection.
+
+    The gateway process env belongs only to its launch profile. A spawned
+    worker's env is already scrubbed to its target profile, so that child may
+    retain the projected values when rebuilding its runtime scope.
+    """
+    from agent.secret_scope import build_profile_secret_scope
+    from hermes_cli.env_loader import hydrate_profile_secret_sources
+    from tools.env_passthrough import get_all_passthrough
+
+    hydrate_profile_secret_sources(profile_home)
+    secrets = build_profile_secret_scope(profile_home)
+    passthrough_names = get_all_passthrough()
+    if trust_process_passthrough:
+        for name in passthrough_names:
+            value = os.environ.get(name)
+            if value is not None:
+                secrets.setdefault(name, value)
+    return secrets, passthrough_names
+
+
 def _launch_external_cron_worker(job: dict) -> bool:
     """Launch *job* outside a managed gateway cgroup when required.
 
@@ -3065,14 +3089,9 @@ def _launch_external_cron_worker(job: dict) -> bool:
         str(ack_path),
     ]
 
-    from agent.secret_scope import (
-        build_profile_secret_scope,
-        is_multiplex_active,
-        reset_secret_scope,
-        set_secret_scope,
-    )
-    from hermes_cli.env_loader import hydrate_profile_secret_sources
+    from agent.secret_scope import is_multiplex_active, reset_secret_scope, set_secret_scope
     from tools.environments.local import build_subprocess_env
+    from tools.env_passthrough import resolve_passthrough_value
     from tools.process_registry import (
         restart_safe_gateway_child_argv,
         systemd_user_bus_env,
@@ -3114,16 +3133,14 @@ def _launch_external_cron_worker(job: dict) -> bool:
         raise
 
     profile_home = _get_hermes_home().resolve()
-    hydrate_profile_secret_sources(profile_home)
-    profile_secrets = build_profile_secret_scope(profile_home)
     from hermes_constants import get_process_hermes_home
-    from tools.env_passthrough import get_all_passthrough
 
-    if profile_home == get_process_hermes_home().resolve():
-        for name in get_all_passthrough():
-            value = os.environ.get(name)
-            if value is not None:
-                profile_secrets.setdefault(name, value)
+    profile_secrets, passthrough_names = _restart_safe_worker_secret_scope(
+        profile_home,
+        trust_process_passthrough=(
+            profile_home == get_process_hermes_home().resolve()
+        ),
+    )
     secret_token = set_secret_scope(profile_secrets)
     try:
         worker_env = build_subprocess_env(
@@ -3131,6 +3148,10 @@ def _launch_external_cron_worker(job: dict) -> bool:
             inherit_profile_home=True,
             extra={"HERMES_HOME": str(profile_home)},
         )
+        for name in passthrough_names:
+            value = resolve_passthrough_value(name)
+            if value is not None:
+                worker_env[name] = value
     finally:
         reset_secret_scope(secret_token)
     worker_env = systemd_user_bus_env(worker_env)
@@ -3248,14 +3269,12 @@ def _run_external_worker_payload(payload_path: Path, ack_path: Path) -> bool:
             pass
 
     from agent.secret_scope import (
-        build_profile_secret_scope,
         is_multiplex_active,
         reset_secret_scope,
         set_multiplex_active,
         set_secret_scope,
     )
     from cron.executions import adopt_claimed_execution
-    from hermes_cli.env_loader import hydrate_profile_secret_sources
     from hermes_constants import (
         reset_hermes_home_override,
         set_hermes_home_override,
@@ -3265,8 +3284,10 @@ def _run_external_worker_payload(payload_path: Path, ack_path: Path) -> bool:
     previous_multiplex = is_multiplex_active()
     multiplex_active = bool(payload.get("multiplex_active", False))
     set_multiplex_active(multiplex_active)
-    hydrate_profile_secret_sources(profile_home)
-    secret_token = set_secret_scope(build_profile_secret_scope(profile_home))
+    worker_secrets, _ = _restart_safe_worker_secret_scope(
+        profile_home, trust_process_passthrough=True
+    )
+    secret_token = set_secret_scope(worker_secrets)
     try:
         with use_cron_store(profile_home):
             if adopt_claimed_execution(execution_id) is None:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3115,7 +3115,16 @@ def _launch_external_cron_worker(job: dict) -> bool:
 
     profile_home = _get_hermes_home().resolve()
     hydrate_profile_secret_sources(profile_home)
-    secret_token = set_secret_scope(build_profile_secret_scope(profile_home))
+    profile_secrets = build_profile_secret_scope(profile_home)
+    from hermes_constants import get_process_hermes_home
+    from tools.env_passthrough import get_all_passthrough
+
+    if profile_home == get_process_hermes_home().resolve():
+        for name in get_all_passthrough():
+            value = os.environ.get(name)
+            if value is not None:
+                profile_secrets.setdefault(name, value)
+    secret_token = set_secret_scope(profile_secrets)
     try:
         worker_env = build_subprocess_env(
             scrub_secrets=multiplex_active,

--- a/tests/cron/test_restart_safe_worker.py
+++ b/tests/cron/test_restart_safe_worker.py
@@ -188,9 +188,14 @@ def test_launch_external_worker_uses_restart_safe_scope_and_acknowledges(
     tmp_path, monkeypatch
 ):
     import cron.scheduler as scheduler
+    from tools.env_passthrough import clear_env_passthrough, register_env_passthrough
 
     job = {"id": "job-1", "execution_id": "exec-1", "prompt": "work"}
     monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: tmp_path)
+    (tmp_path / ".env").write_text(
+        "SERVICE_TOKEN=target-profile-token\n", encoding="utf-8"
+    )
+    register_env_passthrough(["SERVICE_TOKEN"])
     wrapped_commands = []
 
     def wrap(command, *, unit_suffix):
@@ -239,17 +244,20 @@ def test_launch_external_worker_uses_restart_safe_scope_and_acknowledges(
     get = Mock(side_effect=lambda _execution_id: next(observed_statuses))
     monkeypatch.setattr(scheduler, "get_execution", get)
     monkeypatch.setenv("ANTHROPIC_API_KEY", "should-not-cross-profile")
+    monkeypatch.setenv("SERVICE_TOKEN", "default-profile-token")
     from agent.secret_scope import set_multiplex_active
 
     set_multiplex_active(True)
     try:
         assert scheduler._launch_external_cron_worker(job) is True
     finally:
+        clear_env_passthrough()
         set_multiplex_active(False)
     assert wrapped_commands[0][1] == "cron-job-1-exec-exec-1"
     assert spawned[0][0][0:2] == ["scope", "--"]
     assert spawned[0][1]["start_new_session"] is True
     assert "ANTHROPIC_API_KEY" not in spawned[0][1]["env"]
+    assert spawned[0][1]["env"]["SERVICE_TOKEN"] == "target-profile-token"
     handoff.assert_called_once_with("exec-1")
     assert get.call_count == 2
     assert payloads[0]["multiplex_active"] is True

--- a/tests/cron/test_restart_safe_worker.py
+++ b/tests/cron/test_restart_safe_worker.py
@@ -122,6 +122,8 @@ def test_external_worker_adopts_execution_and_runs_payload_once(
     tmp_path, monkeypatch
 ):
     import cron.scheduler as scheduler
+    from agent.secret_scope import get_secret
+    from tools.env_passthrough import clear_env_passthrough, register_env_passthrough
 
     payload = tmp_path / "payload.json"
     ack = tmp_path / "ready.json"
@@ -141,21 +143,30 @@ def test_external_worker_adopts_execution_and_runs_payload_once(
             or {"id": execution_id, "status": "running"}
         )
     )
-    run = Mock(
-        side_effect=lambda *_args, **_kwargs: (
-            observed_homes.append(get_hermes_home().resolve()) or True
-        )
-    )
+    observed_tokens = []
+
+    def run(*_args, **_kwargs):
+        observed_homes.append(get_hermes_home().resolve())
+        observed_tokens.append(get_secret("SERVICE_TOKEN"))
+        return True
+
+    run = Mock(side_effect=run)
     monkeypatch.setattr("cron.executions.adopt_claimed_execution", adopted)
     monkeypatch.setattr(scheduler, "run_one_job", run)
+    monkeypatch.setenv("SERVICE_TOKEN", "projected-profile-token")
+    register_env_passthrough(["SERVICE_TOKEN"])
 
-    assert scheduler._run_external_worker_payload(payload, ack) is True
+    try:
+        assert scheduler._run_external_worker_payload(payload, ack) is True
+    finally:
+        clear_env_passthrough()
 
     adopted.assert_called_once_with("exec-1")
     run.assert_called_once()
     assert run.call_args.args[0]["id"] == "job-1"
     expected_home = (tmp_path / "profile").resolve()
     assert observed_homes == [expected_home, expected_home]
+    assert observed_tokens == ["projected-profile-token"]
     assert ack.exists()
     assert not payload.exists()
 
@@ -185,15 +196,15 @@ def test_external_worker_refuses_to_run_without_durable_ownership(
 
 
 @pytest.mark.parametrize(
-    ("profile_value", "is_process_profile", "expected_token"),
+    ("profile_value", "process_value", "is_process_profile", "expected_token"),
     [
-        ("target-profile-token", False, "target-profile-token"),
-        (None, False, None),
-        (None, True, "default-profile-token"),
+        ("target-profile-token", None, False, "target-profile-token"),
+        (None, "default-profile-token", False, None),
+        (None, "default-profile-token", True, "default-profile-token"),
     ],
 )
 def test_launch_external_worker_uses_restart_safe_scope_and_acknowledges(
-    tmp_path, monkeypatch, profile_value, is_process_profile, expected_token
+    tmp_path, monkeypatch, profile_value, process_value, is_process_profile, expected_token
 ):
     import cron.scheduler as scheduler
     from tools.env_passthrough import clear_env_passthrough, register_env_passthrough
@@ -257,7 +268,10 @@ def test_launch_external_worker_uses_restart_safe_scope_and_acknowledges(
     get = Mock(side_effect=lambda _execution_id: next(observed_statuses))
     monkeypatch.setattr(scheduler, "get_execution", get)
     monkeypatch.setenv("ANTHROPIC_API_KEY", "should-not-cross-profile")
-    monkeypatch.setenv("SERVICE_TOKEN", "default-profile-token")
+    if process_value is None:
+        monkeypatch.delenv("SERVICE_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("SERVICE_TOKEN", process_value)
     from agent.secret_scope import set_multiplex_active
 
     set_multiplex_active(True)

--- a/tests/cron/test_restart_safe_worker.py
+++ b/tests/cron/test_restart_safe_worker.py
@@ -184,16 +184,29 @@ def test_external_worker_refuses_to_run_without_durable_ownership(
     assert not ack.exists()
 
 
+@pytest.mark.parametrize(
+    ("profile_value", "is_process_profile", "expected_token"),
+    [
+        ("target-profile-token", False, "target-profile-token"),
+        (None, False, None),
+        (None, True, "default-profile-token"),
+    ],
+)
 def test_launch_external_worker_uses_restart_safe_scope_and_acknowledges(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, profile_value, is_process_profile, expected_token
 ):
     import cron.scheduler as scheduler
     from tools.env_passthrough import clear_env_passthrough, register_env_passthrough
 
     job = {"id": "job-1", "execution_id": "exec-1", "prompt": "work"}
     monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: tmp_path)
-    (tmp_path / ".env").write_text(
-        "SERVICE_TOKEN=target-profile-token\n", encoding="utf-8"
+    if profile_value is not None:
+        (tmp_path / ".env").write_text(
+            f"SERVICE_TOKEN={profile_value}\n", encoding="utf-8"
+        )
+    process_home = tmp_path if is_process_profile else tmp_path / "launch-profile"
+    monkeypatch.setattr(
+        "hermes_constants.get_process_hermes_home", lambda: process_home
     )
     register_env_passthrough(["SERVICE_TOKEN"])
     wrapped_commands = []
@@ -257,7 +270,10 @@ def test_launch_external_worker_uses_restart_safe_scope_and_acknowledges(
     assert spawned[0][0][0:2] == ["scope", "--"]
     assert spawned[0][1]["start_new_session"] is True
     assert "ANTHROPIC_API_KEY" not in spawned[0][1]["env"]
-    assert spawned[0][1]["env"]["SERVICE_TOKEN"] == "target-profile-token"
+    if expected_token is None:
+        assert "SERVICE_TOKEN" not in spawned[0][1]["env"]
+    else:
+        assert spawned[0][1]["env"]["SERVICE_TOKEN"] == expected_token
     handoff.assert_called_once_with("exec-1")
     assert get.call_count == 2
     assert payloads[0]["multiplex_active"] is True

--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -217,6 +217,18 @@ class TestExecuteCodeIntegration:
 class TestTerminalIntegration:
     """Verify that the passthrough is checked in terminal's env sanitizers."""
 
+    def test_multiplex_unscoped_child_keeps_registered_process_value(self, monkeypatch):
+        """Restart-safe workers may forward explicitly allowlisted process env."""
+        from tools.environments.local import build_subprocess_env
+
+        register_env_passthrough(["SERVICE_TOKEN"])
+        monkeypatch.setenv("SERVICE_TOKEN", "process-session-token")
+        ss.set_multiplex_active(True)
+
+        child_env = build_subprocess_env(scrub_secrets=True, inherit_profile_home=True)
+
+        assert child_env["SERVICE_TOKEN"] == "process-session-token"
+
     def test_background_terminal_uses_active_profile_for_passthrough(self, monkeypatch):
         """Background/PTY terminal children must use the routed profile value."""
         from tools.environments.local import _sanitize_subprocess_env

--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -217,18 +217,6 @@ class TestExecuteCodeIntegration:
 class TestTerminalIntegration:
     """Verify that the passthrough is checked in terminal's env sanitizers."""
 
-    def test_multiplex_unscoped_child_keeps_registered_process_value(self, monkeypatch):
-        """Restart-safe workers may forward explicitly allowlisted process env."""
-        from tools.environments.local import build_subprocess_env
-
-        register_env_passthrough(["SERVICE_TOKEN"])
-        monkeypatch.setenv("SERVICE_TOKEN", "process-session-token")
-        ss.set_multiplex_active(True)
-
-        child_env = build_subprocess_env(scrub_secrets=True, inherit_profile_home=True)
-
-        assert child_env["SERVICE_TOKEN"] == "process-session-token"
-
     def test_background_terminal_uses_active_profile_for_passthrough(self, monkeypatch):
         """Background/PTY terminal children must use the routed profile value."""
         from tools.environments.local import _sanitize_subprocess_env

--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -65,6 +65,27 @@ class TestConfigPassthrough:
         assert "CONFIG_KEY" in all_pt
         assert "SKILL_KEY" in all_pt
 
+    def test_config_cache_is_profile_scoped(self, tmp_path):
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        homes = [tmp_path / "profiles" / name for name in ("a", "b")]
+        for home, key in zip(homes, ("PROFILE_A_KEY", "PROFILE_B_KEY")):
+            home.mkdir(parents=True)
+            (home / "config.yaml").write_text(
+                yaml.dump({"terminal": {"env_passthrough": [key]}}), encoding="utf-8"
+            )
+
+        for home, own_key, other_key in (
+            (homes[0], "PROFILE_A_KEY", "PROFILE_B_KEY"),
+            (homes[1], "PROFILE_B_KEY", "PROFILE_A_KEY"),
+        ):
+            token = set_hermes_home_override(home)
+            try:
+                assert is_env_passthrough(own_key)
+                assert not is_env_passthrough(other_key)
+            finally:
+                reset_hermes_home_override(token)
+
 
 class TestProfileScopedResolution:
     def test_active_scope_overrides_process_fallback(self):

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -117,9 +117,10 @@ def resolve_passthrough_value(name: str, fallback: str | None = None) -> str | N
     """Resolve an allowlisted variable without crossing profile boundaries. ``fallback``
     is what the caller would have forwarded before secret scopes existed (a snapshot of
     ``os.environ`` / the profile ``.env``). An active multiplex scope is authoritative:
-    a missing key returns ``None``, never the process-global env, and an unscoped read
-    raises the fail-closed ``UnscopedSecretError``. Outside multiplexing an installed
-    scope keeps overlay semantics and an unscoped caller keeps its fallback."""
+    a missing key returns ``None``, never the process-global env. An unscoped multiplex
+    caller may forward a present fallback only when the key is explicitly allowlisted;
+    otherwise resolution fails closed. Outside multiplexing an installed scope keeps
+    overlay semantics and an unscoped caller keeps its fallback."""
     from agent.secret_scope import (
         _is_global_env, current_secret_scope, get_secret, is_multiplex_active)
     # Global terminal/runtime settings are not profile secrets; ``fallback`` is
@@ -128,6 +129,8 @@ def resolve_passthrough_value(name: str, fallback: str | None = None) -> str | N
         return fallback
     multiplex_active = is_multiplex_active()
     if current_secret_scope() is None:
+        if multiplex_active and fallback is not None and is_env_passthrough(name):
+            return fallback
         return get_secret(name) if multiplex_active else fallback
     return get_secret(name, None if multiplex_active else fallback)
 

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -117,10 +117,9 @@ def resolve_passthrough_value(name: str, fallback: str | None = None) -> str | N
     """Resolve an allowlisted variable without crossing profile boundaries. ``fallback``
     is what the caller would have forwarded before secret scopes existed (a snapshot of
     ``os.environ`` / the profile ``.env``). An active multiplex scope is authoritative:
-    a missing key returns ``None``, never the process-global env. An unscoped multiplex
-    caller may forward a present fallback only when the key is explicitly allowlisted;
-    otherwise resolution fails closed. Outside multiplexing an installed scope keeps
-    overlay semantics and an unscoped caller keeps its fallback."""
+    a missing key returns ``None``, never the process-global env, and an unscoped read
+    raises the fail-closed ``UnscopedSecretError``. Outside multiplexing an installed
+    scope keeps overlay semantics and an unscoped caller keeps its fallback."""
     from agent.secret_scope import (
         _is_global_env, current_secret_scope, get_secret, is_multiplex_active)
     # Global terminal/runtime settings are not profile secrets; ``fallback`` is
@@ -129,8 +128,6 @@ def resolve_passthrough_value(name: str, fallback: str | None = None) -> str | N
         return fallback
     multiplex_active = is_multiplex_active()
     if current_secret_scope() is None:
-        if multiplex_active and fallback is not None and is_env_passthrough(name):
-            return fallback
         return get_secret(name) if multiplex_active else fallback
     return get_secret(name, None if multiplex_active else fallback)
 

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -28,8 +28,10 @@ def _get_allowed() -> set[str]:
         return val
 
 
-# Cache for the config-based allowlist (loaded once per process).
-_config_passthrough: frozenset[str] | None = None
+# Config-based allowlists keyed by profile home. One gateway process may route
+# several profiles, so a process-wide singleton would let the launch profile's
+# names authorize a secondary profile.
+_config_passthrough: dict[str, frozenset[str]] | None = None
 
 
 def _is_hermes_provider_credential(name: str) -> bool:
@@ -79,12 +81,18 @@ def _accepted(names, refusal_msg: str):
 
 
 def _load_config_passthrough() -> frozenset[str]:
-    """Load ``tools.env_passthrough`` from config.yaml (cached). Same credential
+    """Load this profile's ``tools.env_passthrough`` from config.yaml (cached). Same credential
     filter as register_env_passthrough: operator config must not tunnel provider
     credentials into sandbox children either (GHSA-rhgp-j443-p4rf)."""
     global _config_passthrough
-    if _config_passthrough is not None:
-        return _config_passthrough
+    from hermes_constants import hermes_home_key
+
+    home_key = hermes_home_key()
+    if _config_passthrough is None:
+        _config_passthrough = {}
+    cached = _config_passthrough.get(home_key)
+    if cached is not None:
+        return cached
     result: set[str] = set()
     try:
         passthrough = cfg_get(read_raw_config(), "terminal", "env_passthrough")
@@ -99,8 +107,9 @@ def _load_config_passthrough() -> frozenset[str]:
         )))
     except Exception as e:
         logger.debug("Could not read tools.env_passthrough from config: %s", e)
-    _config_passthrough = frozenset(result)
-    return _config_passthrough
+    loaded = frozenset(result)
+    _config_passthrough[home_key] = loaded
+    return loaded
 
 
 def is_env_passthrough(var_name: str) -> bool:


### PR DESCRIPTION
## Summary

- install the firing profile's hydrated secret scope while constructing a restart-safe cron worker environment
- preserve fail-closed unscoped multiplex resolution and ensure the child receives the target profile's passthrough value
- cover the restart-safe path with a two-profile isolation regression test

## Testing

- `scripts/run_tests.sh tests/cron/test_restart_safe_worker.py -k test_launch_external_worker_uses_restart_safe_scope_and_acknowledges`
- `scripts/run_tests.sh tests/tools/test_env_passthrough.py tests/cron/test_restart_safe_worker.py`
- `scripts/run_tests.sh tests/tools/test_local_env_blocklist.py -k TestProfileScopedPassthrough`

## Related Issue

Closes #107399
