### PR TITLE
fix(tools): give kanban_show/kanban_list model payloads a local timestamp

### DIFF
--- a/hermes_time.py
+++ b/hermes_time.py
@@ -91,3 +91,24 @@ def now() -> datetime:
     """Current time as a tz-aware datetime: configured zone, else server-local."""
     tz = get_timezone()
     return datetime.now(tz) if tz is not None else datetime.now().astimezone()
+
+
+def format_epoch(ts: Optional[float]) -> Optional[str]:
+    """Render a Unix epoch as wall-clock text in the configured timezone.
+
+    Returns ISO-8601 with an explicit UTC offset, e.g. ``2026-09-09 20:18:49+07:00``.
+    Returns ``None`` for ``None`` and for anything unusable — callers hand this straight
+    into a JSON payload, so it must never raise.
+    """
+    if ts is None:
+        return None
+    try:
+        ts = float(ts)
+    except (TypeError, ValueError):
+        return None
+    tz = get_timezone()
+    try:
+        dt = datetime.fromtimestamp(ts, tz) if tz is not None else datetime.fromtimestamp(ts).astimezone()
+    except (OverflowError, OSError, ValueError):
+        return None
+    return dt.isoformat(sep=" ", timespec="seconds")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -81,6 +81,30 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert "runs" in d
 
 
+def test_show_renders_timestamps_in_configured_timezone(monkeypatch, worker_env):
+    """#107400: kanban_show must not hand the model a bare epoch to convert
+    itself — created_at_local should be the wall-clock string in the
+    configured timezone, not the host's local time nor the epoch again."""
+    monkeypatch.setenv("HERMES_TIMEZONE", "Asia/Tokyo")
+    import hermes_time
+    hermes_time.reset_cache()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_show({})
+    d = json.loads(out)
+    task = d["task"]
+    created_at = task["created_at"]
+
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+    expected = datetime.fromtimestamp(created_at, ZoneInfo("Asia/Tokyo")).isoformat(
+        sep=" ", timespec="seconds")
+
+    assert task["created_at_local"] == expected
+    assert task["created_at_local"] != str(created_at)
+    hermes_time.reset_cache()
+
+
 def test_list_filters_tasks(monkeypatch, worker_env):
     """kanban_list gives orchestrators filtered board discovery."""
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -15,6 +15,7 @@ import time
 from contextlib import contextmanager
 from typing import Any, Callable, Optional
 
+import hermes_time
 from agent.redact import redact_sensitive_text
 from hermes_cli.goals import judge_goal
 from tools.registry import registry, tool_error
@@ -320,10 +321,25 @@ _ATTACHMENT_FIELDS = tuple(
     "id filename content_type size uploaded_by stored_path created_at".split())
 _CREATED_FIELDS = ("status", "workspace_kind", "workspace_path", "project_id")
 
+# Epoch fields that also get a "<name>_local" companion (#107400): the model was
+# converting bare epochs to wall-clock time in its head and getting it wrong.
+_TIMESTAMP_FIELDS = frozenset({"created_at", "started_at", "completed_at", "ended_at"})
+
 
 def _fields(obj: Any, names: tuple[str, ...]) -> dict[str, Any]:
-    """``{name: getattr(obj, name)}``; every value None when ``obj`` is None."""
-    return {n: getattr(obj, n) if obj is not None else None for n in names}
+    """``{name: getattr(obj, name)}``; every value None when ``obj`` is None.
+
+    Timestamp fields (see ``_TIMESTAMP_FIELDS``) also get a ``<name>_local`` string
+    rendered in the configured timezone, so the model can quote it instead of
+    converting the epoch itself.
+    """
+    out: dict[str, Any] = {}
+    for n in names:
+        value = getattr(obj, n) if obj is not None else None
+        out[n] = value
+        if n in _TIMESTAMP_FIELDS:
+            out[f"{n}_local"] = hermes_time.format_epoch(value)
+    return out
 
 
 def _task_summary_dict(kb, conn, task) -> dict[str, Any]:

--- a/tools/kanban_tools_schemas.py
+++ b/tools/kanban_tools_schemas.py
@@ -8,6 +8,15 @@ _DESC_TASK_ID_DEFAULT = (
     "(the task the dispatcher spawned you to work on)."
 )
 
+_DESC_TIMESTAMPS = (
+    "Every timestamp appears twice. The bare field (e.g. created_at) is a Unix "
+    "epoch integer for machine use. The '_local' field (e.g. created_at_local) "
+    "is the same instant already rendered in the user's configured timezone "
+    "with its UTC offset, e.g. '2026-09-09 20:18:49+07:00'. When reporting a "
+    "time to the user, quote the '_local' value verbatim — never convert an "
+    "epoch yourself."
+)
+
 _DESC_BOARD = (
     "Kanban board slug to target. When omitted, the call resolves the "
     "active board the usual way: HERMES_KANBAN_DB env → "
@@ -48,7 +57,7 @@ KANBAN_SHOW_SCHEMA = _schema(
         "and recent events. Use this to (re)orient yourself before "
         "starting work, especially on retries. The response includes a "
         "pre-formatted ``worker_context`` string suitable for inclusion "
-        "verbatim in your reasoning."
+        "verbatim in your reasoning. " + _DESC_TIMESTAMPS
     ),
     {
         "task_id": _prop("string", _DESC_TASK_ID_DEFAULT),
@@ -66,7 +75,7 @@ KANBAN_LIST_SCHEMA = _schema(
         "counts. Bounded to 50 rows by default, 200 max, with truncation "
         "metadata. Also recomputes ready tasks before listing, matching the "
         "CLI. Orchestrator-only — dispatcher-spawned task workers never see "
-        "this tool."
+        "this tool. " + _DESC_TIMESTAMPS
     ),
     {
         "assignee": _prop("string", "Optional assignee/profile filter."),


### PR DESCRIPTION
Fixes #107400.

## Problem

`kanban_list` and `kanban_show` hand the model every timestamp as a bare Unix
epoch integer. The model has to convert it to wall-clock time in its head,
and gets it wrong often enough that a user can receive a confidently stated
date that's off by a day, with nothing in the reply signalling that a
conversion happened. The correct timezone is already known server-side via
`hermes_time.get_timezone()` — the model was being asked to re-derive
something the process could just render.

## Fix

- `hermes_time.py`: add `format_epoch(ts)`, which renders an epoch through
  the already-configured `get_timezone()` as ISO-8601 with an explicit UTC
  offset (e.g. `2026-09-09 20:18:49+07:00`). Never raises — returns `None`
  for `None`/unusable input, since callers hand the result straight into a
  JSON payload.
- `tools/kanban_tools.py`: `_fields()` (the shared helper behind task,
  task-summary, run, comment, event, and attachment payloads) now emits a
  `"<field>_local"` string next to every timestamp field
  (`created_at`, `started_at`, `completed_at`, `ended_at`). The bare epoch is
  unchanged, so machine consumers are unaffected.
- `tools/kanban_tools_schemas.py`: the `kanban_show` and `kanban_list` tool
  descriptions now tell the model that every timestamp appears twice — the
  bare field for machine use, `_local` to quote verbatim — and to never
  convert an epoch itself. The payload change alone wasn't enough without
  this: the model needs to be told which field to read.

## Testing

Added `test_show_renders_timestamps_in_configured_timezone` to
`tests/tools/test_kanban_tools.py`, which sets `HERMES_TIMEZONE=Asia/Tokyo`,
calls `kanban_show`, and asserts `created_at_local` matches the epoch
rendered in that specific zone (not the epoch itself, not host-local time).

Confirmed it fails without the fix:

```
$ git checkout HEAD~1 -- hermes_time.py tools/kanban_tools.py tools/kanban_tools_schemas.py
$ scripts/run_tests.sh tests/tools/test_kanban_tools.py -k "timezone or show_defaults"
...
E       KeyError: 'created_at_local'
1 failed, 1 passed
$ git checkout HEAD -- hermes_time.py tools/kanban_tools.py tools/kanban_tools_schemas.py
```

And passes with the fix:

```
$ scripts/run_tests.sh tests/tools/test_kanban_tools.py tests/test_timezone.py
=== Summary: 2 files, 52 tests passed, 0 failed (100% complete) in 8.2s (8 workers) ===
```

`ruff check` passes on all changed files. `ty check` on `tools/kanban_tools.py`
reports the same 4 pre-existing `heartbeat_worker` diagnostics present on
unmodified `main` (unrelated to this change, verified by stashing the diff
and re-running); `hermes_time.py` and `tools/kanban_tools_schemas.py` are
clean.

## Disclosure

This PR was prepared with AI assistance (Claude Code), including the
implementation, test, and this description. All changes were verified by
running the repo's real test suite, `ruff`, and `ty` locally before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
