### PR TITLE
fix(agent): isolate detached forks from API-request-level lifecycle hooks

### DIFF
--- a/agent/api_request_hooks.py
+++ b/agent/api_request_hooks.py
@@ -165,6 +165,9 @@ class ApiRequestHooksMixin:
         max_retries: Optional[int] = None, retryable: Optional[bool] = None,
         reason: Optional[str] = None,
     ) -> None:
+        # Persistence-disabled forks share their parent's session ID and are not real sessions.
+        if getattr(self, "_persist_disabled", False):
+            return
         # Lazy module import (not from-import) so tests can replace lifecycle dispatch at this call site.
         with suppress(Exception):
             from hermes_cli import lifecycle as _lifecycle

--- a/agent/turn_api_request.py
+++ b/agent/turn_api_request.py
@@ -47,6 +47,9 @@ def _fire_pre_api_request_hook(
     api_call_count: Any, api_request_id: Any, api_start_time: Any, effective_task_id: Any,
     turn_id: Any,
 ) -> None:
+    # Persistence-disabled forks share their parent's session ID and are not real sessions.
+    if getattr(agent, "_persist_disabled", False):
+        return
     from agent.conversation_loop import _system_prompt_for_hooks
 
     try:

--- a/agent/turn_response_intake.py
+++ b/agent/turn_response_intake.py
@@ -56,6 +56,9 @@ def _fire_post_api_request_hook(
     api_call_count: Any, api_duration: Any, api_start_time: Any, api_request_id: Any,
     effective_task_id: Any, turn_id: Any,
 ) -> None:
+    # Persistence-disabled forks share their parent's session ID and are not real sessions.
+    if getattr(agent, "_persist_disabled", False):
+        return
     from agent.conversation_loop import _moa_reference_metrics_for_hook
 
     try:

--- a/tests/agent/test_detached_fork_api_request_hooks.py
+++ b/tests/agent/test_detached_fork_api_request_hooks.py
@@ -1,0 +1,89 @@
+"""Lifecycle-hook isolation for persistence-disabled forks, at the API-request granularity.
+
+Mirrors test_detached_fork_lifecycle_hooks.py's session/turn-level guard (#107069), extended to
+the three API-request hooks (pre_api_request, post_api_request, api_request_error) that PR left
+unguarded — a detached fork (background_review) shares its parent's real session_id, so without
+this guard a plugin like plugins/observability/langfuse attributes per-request trace events to
+the live session even though nothing was persisted.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from agent.api_request_hooks import ApiRequestHooksMixin
+from agent.turn_api_request import _fire_pre_api_request_hook
+from agent.turn_response_intake import _fire_post_api_request_hook
+
+
+def _agent(*, persist_disabled: bool):
+    return SimpleNamespace(
+        _persist_disabled=persist_disabled,
+        session_id="shared-session",
+        platform="cli",
+        model="test/model",
+        provider="test-provider",
+        base_url="https://api.test",
+        api_mode="chat",
+        max_tokens=1024,
+        tools=[],
+        _last_api_first_chunk_at=None,
+        _api_request_payload_for_hook=Mock(return_value={"messages": []}),
+        _api_response_payload_for_hook=Mock(return_value={"content": "hi"}),
+        _usage_summary_for_api_request_hook=Mock(return_value={"total_tokens": 10}),
+    )
+
+
+def _assistant_message():
+    return SimpleNamespace(role="assistant", content="hi", tool_calls=None)
+
+
+def _fire_pre(agent):
+    _fire_pre_api_request_hook(
+        agent, {"messages": []}, [], [], messages=[], original_user_message="hi",
+        approx_tokens=10, total_chars=10, retry_count=0, api_call_count=1,
+        api_request_id="req-1", api_start_time=0.0, effective_task_id="task-1", turn_id="turn-1",
+    )
+
+
+def _fire_post(agent):
+    _fire_post_api_request_hook(
+        agent, response=SimpleNamespace(model="test/model"), assistant_message=_assistant_message(),
+        finish_reason="stop", api_messages=[], api_call_count=1, api_duration=0.5,
+        api_start_time=0.0, api_request_id="req-1", effective_task_id="task-1", turn_id="turn-1",
+    )
+
+
+def _fire_error(agent):
+    ApiRequestHooksMixin._invoke_api_request_error_hook(
+        agent, task_id="task-1", turn_id="turn-1", api_request_id="req-1", api_call_count=1,
+        api_start_time=0.0, api_kwargs={}, error_type="RateLimitError", error_message="boom",
+    )
+
+
+def test_persist_disabled_fork_skips_all_three_api_request_hooks():
+    agent = _agent(persist_disabled=True)
+    with (
+        patch("hermes_cli.lifecycle.invoke_hook") as lifecycle_hook,
+        patch("hermes_cli.lifecycle.has_hook", return_value=True),
+    ):
+        _fire_pre(agent)
+        _fire_post(agent)
+        _fire_error(agent)
+
+    lifecycle_hook.assert_not_called()
+
+
+def test_persisted_agent_still_fires_all_three_api_request_hooks():
+    agent = _agent(persist_disabled=False)
+    with (
+        patch("hermes_cli.lifecycle.invoke_hook") as lifecycle_hook,
+        patch("hermes_cli.lifecycle.has_hook", return_value=True),
+        patch("agent.conversation_loop._system_prompt_for_hooks", return_value="sys"),
+        patch("agent.conversation_loop._moa_reference_metrics_for_hook", return_value=None),
+    ):
+        _fire_pre(agent)
+        _fire_post(agent)
+        _fire_error(agent)
+
+    fired = [call.args[0] for call in lifecycle_hook.call_args_list]
+    assert fired == ["pre_api_request", "post_api_request", "api_request_error"]


### PR DESCRIPTION
## Summary

Same-day PR #107069 (fixing #107062) gated four session-lifecycle hooks (`on_session_start`, `pre_llm_call`, `post_llm_call`, `on_session_end`) behind `not agent._persist_disabled`, so a `background_review` fork — which shares its parent's real `session_id` but never persists — stops firing phantom session activity to plugin hooks.

Three sibling hooks at the API-request granularity were left unguarded:
- `_fire_pre_api_request_hook` (`agent/turn_api_request.py`)
- `_fire_post_api_request_hook` (`agent/turn_response_intake.py`)
- `_invoke_api_request_error_hook` (`agent/api_request_hooks.py`)

A detached fork still makes real LLM calls through `run_conversation()`, so these three hooks fire on every fork API call carrying the parent's real `session_id` — reopening the exact "phantom activity under the parent's identity" bug one layer down, for a narrower but real audience: any plugin hooked into `pre_api_request`/`post_api_request`/`api_request_error`. `plugins/observability/langfuse/__init__.py` registers for exactly these three hooks, so this isn't theoretical — any user with the built-in Langfuse observability plugin enabled (and `background_review`, on by default) gets per-request trace events attributed to the live session for every fork API call.

## Fix

Mirrors the merged fix's guard pattern (`if getattr(agent, "_persist_disabled", False): return`), placed at the top of each function/method rather than wrapping each call site:
- `turn_api_request.py`/`turn_response_intake.py` each have a single caller, so guarding the function body is equivalent to guarding the call site.
- `api_request_hooks.py`'s `_invoke_api_request_error_hook` has three callers (`turn_truncation.py`, `turn_api_error.py`, `turn_response_check.py`) — one guard inside the method covers all three, rather than risking a missed call site.

## Test plan

- [x] New `tests/agent/test_detached_fork_api_request_hooks.py`, mirroring the merged `test_detached_fork_lifecycle_hooks.py`'s `SimpleNamespace`/`unittest.mock.patch` style: one test proves all three hooks are skipped when `_persist_disabled=True`, another proves they still fire (in order) for a normal persisted agent.
- [x] Mutation-verified: reverted the three production guards, confirmed the new test fails with `invoke_hook` called 3 times (exact predicted symptom), then restored the fix and confirmed it passes again.
- [x] `tests/agent/test_detached_fork_lifecycle_hooks.py` (the sibling test for the merged session-level fix) + the new test file together: 4 passed.
- [x] Broader regression sweep: every existing test referencing the touched modules (`tests/agent/test_surrogate_chokepoints.py`, `tests/run_agent/test_run_agent.py`) — 290 passed, 1 pre-existing failure (`anthropic` package missing from this sandbox's `--frozen --extra dev` install, unrelated to this change — fails on an `ImportError` in the Anthropic client builder, nowhere near the touched hook code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
