### PR TITLE
fix(tools): keep find matches when an unreadable sibling exits 1

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -499,6 +499,79 @@ class TestSearchFilesFallbackHiddenPaths:
         assert set(result.files) == {str(visible_file), str(visible_nested_file)}
 
 
+class TestSearchFilesPartialTraversal:
+    """GNU find exits 1 when it cannot descend into SOME directory (EACCES)
+    even after printing every readable match. Those results must survive as
+    a partial success with a warning, not be discarded as a hard failure."""
+
+    def _make_env(self):
+        return LocalEnvironment("/")
+
+    def test_unreadable_sibling_keeps_printed_matches(self, tmp_path, monkeypatch):
+        root = tmp_path / "repro"
+        readable = root / "readable"
+        blocked = root / "blocked"
+        readable.mkdir(parents=True)
+        blocked.mkdir(parents=True)
+        probe = readable / "probe-target.txt"
+        probe.write_text("x")
+        os.chmod(blocked, 0)
+
+        try:
+            ops = ShellFileOperations(self._make_env())
+            monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+            result = ops._search_files("probe-target*", str(root), limit=50, offset=0)
+        finally:
+            os.chmod(blocked, 0o755)
+
+        assert result.error is None
+        assert result.files == [str(probe)]
+        assert result.total_count == 1
+        assert result.warning is not None
+        assert "could not be traversed" in result.warning
+
+    def test_exit_one_with_no_matches_still_fails_closed(self, tmp_path, monkeypatch):
+        """Exit 1 with an empty payload stays a hard error: without printed
+        matches there is no evidence the traversal produced anything usable."""
+        root = tmp_path / "repo"
+        root.mkdir()
+
+        env = MagicMock()
+        env.cwd = str(root)
+        env.execute.return_value = {"output": "", "returncode": 1}
+        ops = ShellFileOperations(env)
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+
+        result = ops._search_files("*.log", str(root), limit=50, offset=0)
+
+        assert result.error is not None
+        assert result.files == []
+
+    def test_modified_order_exit_one_stays_capability_error(
+        self, tmp_path, monkeypatch
+    ):
+        """order='modified' keeps its distinct capability error: the -printf
+        pipeline's exit 1 means something else than a partial traversal."""
+        root = tmp_path / "repo"
+        root.mkdir()
+
+        env = MagicMock()
+        env.cwd = str(root)
+        env.execute.return_value = {
+            "output": "1690000000.0000000000 /repo/a.log\n",
+            "returncode": 1,
+        }
+        ops = ShellFileOperations(env)
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+
+        result = ops._search_files(
+            "*.log", str(root), limit=50, offset=0, order="modified"
+        )
+
+        assert result.error is not None
+        assert "exact modification-time order" in result.error.lower()
+
+
 class TestShellFileOpsWriteDenied:
     def test_write_file_denied_path(self, file_ops):
         result = file_ops.write_file("~/.ssh/authorized_keys", "evil key")

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -719,19 +719,40 @@ class SearchMixin:
             elif line:
                 raw_files.append(line)
         bounded_sigpipe = result.exit_code == 141 and len(raw_files) >= fetch_limit
-        if result.exit_code not in {0, 124} and not bounded_sigpipe:
+        # GNU find exits 1 when it cannot descend into SOME directory (EACCES on a
+        # root-owned /tmp sibling) even after printing every readable match. With a
+        # usable payload that is a partial success, not a failure — mirrors the
+        # rg path ({0, 1, 124}) and _parse_search_output's payload-first rule.
+        partial_traversal = (
+            result.exit_code == 1 and bool(raw_files) and order != "modified"
+        )
+        if (
+            result.exit_code not in {0, 124}
+            and not bounded_sigpipe
+            and not partial_traversal
+        ):
             if order == "modified":
                 return SearchResult(error=(
                     "Exact modification-time order requires GNU find with "
                     "-printf support; install ripgrep 14+ or use order='discovery'."))
             return SearchResult(error="File search failed while running bounded find traversal.")
+        warning = (
+            (
+                "Some directories could not be traversed (permission denied); "
+                "results may be incomplete."
+            )
+            if partial_traversal
+            else None
+        )
 
         from tools.environments.local import LocalEnvironment, _IS_WINDOWS, _msys_to_windows_path
         if _IS_WINDOWS and isinstance(self.env, LocalEnvironment):
             raw_files = [_msys_to_windows_path(file_path) for file_path in raw_files]
         return SearchResult(
             files=raw_files[offset:offset + limit], total_count=len(raw_files),
-            truncated=len(raw_files) > offset + limit or bool(limit_reason), limit_reason=limit_reason)
+            truncated=len(raw_files) > offset + limit or bool(limit_reason), limit_reason=limit_reason,
+            warning=warning,
+        )
 
     def _search_files_rg(self, pattern: str, path: str | List[str], limit: int, offset: int,
                          order: str = "discovery", rg_executable: Optional[str] = None) -> SearchResult:


### PR DESCRIPTION
## Summary

Fixes #107403

`search_files(target="files")` without ripgrep builds a bounded `find | head` pipeline and treats any exit code outside `{0, 124}` as a total failure. GNU `find` exits **1** when it cannot descend into *some* directory (EACCES on a root-owned `/tmp` sibling such as `/tmp/systemd-private-*`), even though it already printed every readable match to stdout. Those captured matches were discarded and the caller got `{"total_count": 0, "error": "File search failed while running bounded find traversal."}` — a search of `/tmp` or `$HOME` fails on most real systems.

## Fix

In `_search_files` (find fallback), exit 1 with a non-empty parsed payload is now a **partial success**: the matches are returned and a `warning` notes the traversal was incomplete, so the agent can tell "no matches" apart from "matches + skipped subtree".

- exit 1 + empty payload still fails closed (no evidence the traversal produced anything usable)
- `order="modified"` keeps its distinct capability error (`-printf` + `sort` pipeline)
- 124 (timeout) and 141-bounded-SIGPIPE semantics untouched
- mirrors the rg path, which already tolerates `{0, 1, 124}`, and the payload-first rule in `_parse_search_output`

## Tests

`TestSearchFilesPartialTraversal` in `tests/tools/test_file_operations.py`:

1. reporter's exact repro (readable dir with `probe-target*` next to a `chmod 000` sibling, real `find` run) — matches survive, warning present, permissions restored in `finally`
2. exit 1 with empty payload → still a hard error
3. `order="modified"` exit 1 → capability error preserved

Mutation check: disabling the `partial_traversal` branch turns test 1 red. Full local run: `tests/tools/test_file_operations.py`, `test_search_files_engine_selection.py`, `test_search_hidden_dirs.py`, `test_search_budget_truncation.py`, `test_search_zero_match_and_multipath.py` — 158 passed, 5 skipped (same skips on pristine main).