### PR TITLE
fix(desktop): scope Messaging's manual gateway restart to its own profile selector

### DIFF
--- a/apps/desktop/src/api/system.ts
+++ b/apps/desktop/src/api/system.ts
@@ -135,9 +135,9 @@ export function runCurator(): Promise<ActionResponse> {
   })
 }
 
-export function restartGateway(): Promise<ActionResponse> {
+export function restartGateway(profile?: null | string): Promise<ActionResponse> {
   return hermesApi<ActionResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: '/api/gateway/restart',
     method: 'POST'
   })

--- a/apps/desktop/src/app/messaging/index.test.tsx
+++ b/apps/desktop/src/app/messaging/index.test.tsx
@@ -63,7 +63,7 @@ vi.mock('@/store/system-actions', async () => {
 
   return {
     $gatewayRestarting: atom(false),
-    runGatewayRestart: () => runGatewayRestart(),
+    runGatewayRestart: (profile?: null | string) => runGatewayRestart(profile),
     watchGatewayRestartOutcome: () => watchGatewayRestartOutcome()
   }
 })
@@ -295,6 +295,38 @@ describe('MessagingView restart banner', () => {
     })
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Restart now' })).toBeNull())
     expect(runGatewayRestart).toHaveBeenCalledTimes(2)
+  })
+
+  it('restarts the gateway for the page\'s own scoped profile, not whichever one is active elsewhere', async () => {
+    // Every other write action on this page (updateMessagingPlatform, approvePairing, ...)
+    // already targets $settingsScopeOverride's profile; the manual restart button used to
+    // call runGatewayRestart() with no argument, silently falling back to the ambient
+    // active profile instead of the one the credential was actually saved to.
+    const { $settingsScopeOverride } = await import('@/store/settings-scope')
+
+    $settingsScopeOverride.set('worker')
+
+    try {
+      getMessagingPlatforms.mockResolvedValue({ platforms: [platform({ env_vars: [tokenField] })] })
+
+      await renderMessaging()
+
+      fireEvent.change(await screen.findByLabelText('Token'), { target: { value: 'secret-1' } })
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /Save changes/ }))
+      })
+
+      await waitFor(() => expect(updateMessagingPlatform).toHaveBeenCalled())
+      const restartNow = await screen.findByRole('button', { name: 'Restart now' })
+
+      await act(async () => {
+        fireEvent.click(restartNow)
+      })
+
+      expect(runGatewayRestart).toHaveBeenCalledWith('worker')
+    } finally {
+      $settingsScopeOverride.set(null)
+    }
   })
 })
 

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -158,13 +158,17 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   const restartGatewayNow = useCallback(async () => {
     // runGatewayRestart never rejects: it toasts the failure and settles the
     // statusbar indicator; the banner stays if the restart did not complete.
-    const ok = await runGatewayRestart()
+    // Scoped to this page's own profile selector — the same target every other
+    // write action here (updateMessagingPlatform, approvePairing, ...) uses —
+    // so a credential saved to a non-active profile restarts THAT profile's
+    // gateway instead of whichever one happens to be active elsewhere.
+    const ok = await runGatewayRestart(scopeProfile)
 
     if (ok) {
       setRestartNeeded(false)
       window.setTimeout(() => void refreshPlatformsRef.current(true), 4000)
     }
-  }, [])
+  }, [scopeProfile])
 
   const refreshPlatforms = useCallback(
     async (silent = false) => {

--- a/apps/desktop/src/store/system-actions.ts
+++ b/apps/desktop/src/store/system-actions.ts
@@ -40,11 +40,14 @@ async function awaitAction(name: string): Promise<void> {
 // `void runGatewayRestart()`, and a failure is the only thing that toasts.
 // Resolves `true` when the restart child completed cleanly (callers that keep
 // a "restart needed" banner clear it on that signal only).
-export async function runGatewayRestart(): Promise<boolean> {
+// `profile` targets a non-active profile (e.g. Messaging's own "Applies to"
+// scope selector) — undefined keeps every other caller's existing ambient
+// (active-profile) behavior, since profileScoped(undefined) falls back to it.
+export async function runGatewayRestart(profile?: null | string): Promise<boolean> {
   $gatewayRestarting.set(true)
 
   try {
-    const started: ActionResponse = await restartGateway()
+    const started: ActionResponse = await restartGateway(profile)
     await awaitAction(started.name)
 
     return true


### PR DESCRIPTION
## Summary

Every other write action on the Messaging page (`updateMessagingPlatform`, `approvePairing`, `revokePairing`, the Telegram QR onboarding calls) threads the page's own "Applies to" scope selector (`$settingsRequestProfile`) through to the backend. The manual **"Restart now"** banner button was the one outlier: `runGatewayRestart()` → `restartGateway()` took **no parameters at all** and always resolved through `profileScoped()`'s ambient fallback — whichever profile happens to be active elsewhere in the app, not the page's selected scope.

The backend's `POST /api/gateway/restart` already accepts a `profile` query param and uses it to decide which gateway subprocess to restart (`_gateway_mod._gateway_subcommand(profile, "restart")`). Its action tracking is also **single-flight per dashboard process** — a restart request for a different profile's subcommand raises `"gateway restart already in progress for another profile"` rather than running concurrently (`hermes_cli/web_server.py::_spawn_gateway_restart`). So a multi-profile user who selects a non-active profile via the scope selector, saves a credential there, and clicks "Restart now" gets the **wrong** profile's gateway restarted — the credential never takes effect, and the "restart needed" banner persists no matter how many times they retry.

## Fix

Threaded an optional `profile` parameter through `restartGateway()` (`api/system.ts`) and `runGatewayRestart()` (`store/system-actions.ts`), mirroring the existing `profile?: null | string` pattern every sibling API helper in this file already uses (e.g. `updateMessagingPlatform`). `messaging/index.tsx`'s `restartGatewayNow` now passes `scopeProfile`, the same value every other write action on the page already uses.

Every other caller of `runGatewayRestart()`/`restartGateway()` (command-center, gateway-menu-panel, command-palette, webhooks, plugin-install-modal, the SDK) is untouched — they call it with no argument, which still resolves through the exact same ambient fallback as before, since `profileScoped(undefined)` behaves identically to `profileScoped()`.

**Scope note:** left `awaitAction()`/`getActionStatus()` unscoped. The backend's action-status registry (`_ACTION_PROCS`/`_ACTION_RESULTS` in `hermes_cli/web_routers/actions.py`) is a shared, unscoped dict keyed only by action name, and `get_action_status()` doesn't declare a `profile` parameter at all — threading one through the client would be inert.

## Test plan

- [x] New regression test in `apps/desktop/src/app/messaging/index.test.tsx`: sets `$settingsScopeOverride.set('worker')`, saves a credential, clicks "Restart now", asserts `runGatewayRestart` was called with `'worker'` (not `undefined`).
- [x] Mutation-verified: reverted the three production files, confirmed the new test fails with the exact predicted symptom (`runGatewayRestart` called with `undefined` instead of `'worker'`), then restored and confirmed it passes.
- [x] Full `apps/desktop/src/app/messaging/index.test.tsx` (11/11), plus the broader profile-scoping contract test (`src/hermes-profile-scope.test.ts`, 4/4) and the gateway restart button's other entry point (`src/app/shell/gateway-menu-panel.test.tsx`, passing) — 17/17 across the 3 files together.
- [x] `tsc --noEmit` (both `tsconfig.json` and `tsconfig.electron.json`) clean.
- [x] `eslint` clean on every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
