### PR TITLE
fix(models): keep new Copilot models visible after catalog outages

### DIFF
--- a/apps/desktop/src/store/model-visibility.test.ts
+++ b/apps/desktop/src/store/model-visibility.test.ts
@@ -7,6 +7,7 @@ import {
   defaultVisibleKeys,
   effectiveVisibleKeys,
   emptyProviderSentinelKey,
+  hiddenModelVisibilityKey,
   isProviderSentinel,
   modelVisibilityKey,
   resolveVisibleKeys,
@@ -34,13 +35,19 @@ describe('model visibility', () => {
     expect(visible.has(modelVisibilityKey('local-ollama', 'llama3.2:latest'))).toBe(true)
   })
 
-  it('does not re-add models from a provider that already has stored choices', () => {
-    const stored = new Set([modelVisibilityKey('local-ollama', 'qwen3:latest')])
+  it('shows newly discovered models without restoring explicitly hidden models', () => {
+    const stored = new Set([
+      modelVisibilityKey('local-ollama', 'qwen3:latest'),
+      hiddenModelVisibilityKey('local-ollama', 'llama3.2:latest')
+    ])
 
-    const visible = effectiveVisibleKeys(stored, [provider('local-ollama', ['qwen3:latest', 'llama3.2:latest'])])
+    const visible = effectiveVisibleKeys(stored, [
+      provider('local-ollama', ['qwen3:latest', 'llama3.2:latest', 'deepseek-r1:latest'])
+    ])
 
     expect(visible.has(modelVisibilityKey('local-ollama', 'qwen3:latest'))).toBe(true)
     expect(visible.has(modelVisibilityKey('local-ollama', 'llama3.2:latest'))).toBe(false)
+    expect(visible.has(modelVisibilityKey('local-ollama', 'deepseek-r1:latest'))).toBe(true)
   })
 
   it('preserves hidden-provider sentinel without re-adding defaults', () => {
@@ -64,15 +71,13 @@ describe('model visibility', () => {
     // Simulates: user hid all "nous" models, then toggles one back on.
     const stored = new Set([emptyProviderSentinelKey('nous'), modelVisibilityKey('ollama', 'qwen3:latest')])
 
-    // After toggle: sentinel removed, one model added.
-    const afterToggle = new Set(stored)
-    afterToggle.delete(emptyProviderSentinelKey('nous'))
-    afterToggle.add(modelVisibilityKey('nous', 'hermes-3-llama-3.1-70b'))
-
-    const visible = effectiveVisibleKeys(afterToggle, [
+    const providers = [
       provider('nous', ['hermes-3-llama-3.1-70b', 'hermes-3-llama-3.1-8b']),
       provider('ollama', ['qwen3:latest'])
-    ])
+    ]
+
+    const afterToggle = toggleModelVisibility(stored, providers, 'nous', 'hermes-3-llama-3.1-70b')
+    const visible = effectiveVisibleKeys(afterToggle, providers)
 
     expect(visible.has(modelVisibilityKey('nous', 'hermes-3-llama-3.1-70b'))).toBe(true)
     expect(visible.has(modelVisibilityKey('nous', 'hermes-3-llama-3.1-8b'))).toBe(false)

--- a/apps/desktop/src/store/model-visibility.ts
+++ b/apps/desktop/src/store/model-visibility.ts
@@ -13,6 +13,16 @@ export const DEFAULT_VISIBLE_PER_PROVIDER = 50
  *  that contain a single colon, e.g. `model:tag`). */
 export const modelVisibilityKey = (provider: string, model: string): string => `${provider}::${model}`
 
+const HIDDEN_MODEL_MARKER = '__hidden__::'
+
+/** Persisted deny-list marker for an explicitly hidden model. This lets a
+ *  customized provider admit future catalog additions without restoring models
+ *  the user deliberately hid. */
+export const hiddenModelVisibilityKey = (provider: string, model: string): string =>
+  modelVisibilityKey(provider, `${HIDDEN_MODEL_MARKER}${model}`)
+
+const isHiddenModelKey = (key: string): boolean => key.includes(`::${HIDDEN_MODEL_MARKER}`)
+
 /** Sentinel key suffix stored when the user explicitly hides ALL models for a
  *  provider.  Distinguishes "user hid everything" from "never customized" so
  *  `effectiveVisibleKeys` does not re-add defaults for that provider. */
@@ -154,7 +164,17 @@ export function resolveVisibleKeys(stored: Set<string> | null, providers: readon
 
     const hasSentinel = stored.has(emptyProviderSentinelKey(provider.slug))
 
-    if (hasStoredProvider || hasSentinel) {
+    if (hasSentinel) {
+      continue
+    }
+
+    if (hasStoredProvider) {
+      for (const family of collapseModelFamilies(provider.models ?? [])) {
+        if (!stored.has(hiddenModelVisibilityKey(provider.slug, family.id))) {
+          next.add(modelVisibilityKey(provider.slug, family.id))
+        }
+      }
+
       continue
     }
 
@@ -174,7 +194,7 @@ export function effectiveVisibleKeys(
 
   // Strip sentinel keys — they are bookkeeping, not real visibility entries.
   for (const key of [...next]) {
-    if (isProviderSentinel(key)) {
+    if (isProviderSentinel(key) || isHiddenModelKey(key)) {
       next.delete(key)
     }
   }
@@ -196,13 +216,17 @@ export function toggleModelVisibility(
   // `resolveVisibleKeys` always returns a fresh Set, so we can mutate it directly.
   const next = resolveVisibleKeys(stored, providers)
   const key = modelVisibilityKey(providerSlug, model)
+  const hiddenKey = hiddenModelVisibilityKey(providerSlug, model)
   const sentinel = emptyProviderSentinelKey(providerSlug)
 
   if (next.has(key)) {
     next.delete(key)
+    next.add(hiddenKey)
 
     // Check if this was the last real model for this provider.
-    const remainingForProvider = [...next].some(k => k.startsWith(`${providerSlug}::`) && !isProviderSentinel(k))
+    const remainingForProvider = [...next].some(
+      k => k.startsWith(`${providerSlug}::`) && !isProviderSentinel(k) && !isHiddenModelKey(k)
+    )
 
     if (!remainingForProvider) {
       next.add(sentinel)
@@ -212,7 +236,18 @@ export function toggleModelVisibility(
     // set of exactly the one re-enabled model — the curated defaults are NOT
     // restored. Intentional: "you hid everything, you get back only what you
     // re-enable." (Locked in by the sentinel-clear-on-re-enable test.)
+    if (next.has(sentinel)) {
+      const provider = providers.find(candidate => candidate.slug === providerSlug)
+
+      for (const family of collapseModelFamilies(provider?.models ?? [])) {
+        if (family.id !== model) {
+          next.add(hiddenModelVisibilityKey(providerSlug, family.id))
+        }
+      }
+    }
+
     next.delete(sentinel)
+    next.delete(hiddenKey)
     next.add(key)
   }
 

--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -193,8 +193,8 @@ def _prefetch_provider_models_parallel(provider_slugs: list[str]) -> None:
     """Fetch stale/missing provider catalogs in parallel before the serial picker loop.
 
     On a cold cache the serial loop would block 1-8s per provider; after the prefetch the wait is
-    the slowest single provider. Each worker re-persists through the thread-safe
-    ``update_provider_cache_entry`` so concurrent writes cannot clobber each other."""
+    the slowest single provider. Each worker uses the thread-safe cache writer inside
+    ``cached_provider_model_ids`` so concurrent writes cannot clobber each other."""
     from hermes_cli.models import (
         _PROVIDER_MODELS_CACHE_TTL, _credential_fingerprint, _load_provider_models_cache,
         cached_provider_model_ids, normalize_provider)
@@ -222,12 +222,7 @@ def _prefetch_provider_models_parallel(provider_slugs: list[str]) -> None:
     import concurrent.futures
     def _fetch_one(slug: str) -> None:
         try:
-            models = cached_provider_model_ids(slug, force_refresh=True)
-            # cached_provider_model_ids persists via a non-locked read-modify-write; re-persist
-            # through the locked path so no write is lost under concurrency.
-            if models:
-                from hermes_cli.models import update_provider_cache_entry
-                update_provider_cache_entry(slug, models)
+            cached_provider_model_ids(slug, force_refresh=True)
         except Exception:
             pass  # best-effort; picker falls back to curated list
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1208,7 +1208,7 @@ def _copilot_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]
             return live
     except Exception:
         pass
-    return list(_PROVIDER_MODELS.get("copilot", [])) if normalized == "copilot-acp" else None
+    return _FallbackModelIds(_PROVIDER_MODELS.get("copilot", [])) if normalized == "copilot-acp" else None
 
 
 def _nous_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]:
@@ -1353,6 +1353,14 @@ _PROVIDER_CATALOG_FETCHERS: dict[str, Any] = {
     "opencode-free": _opencode_free_catalog}
 
 
+class _FallbackModelIds(list[str]):
+    """A displayable catalog floor that must not become an authoritative disk-cache entry."""
+
+
+def _models_are_cacheable(models: list[str]) -> bool:
+    return bool(models) and not isinstance(models, _FallbackModelIds)
+
+
 def _profile_live_catalog(normalized: str) -> Optional[list[str]]:
     """Generic live fetch for any provider registered in providers/ with ``auth_type="api_key"``.
 
@@ -1408,7 +1416,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
     # model, flux-*, ahead of its chat models).
     curated_static = list(_PROVIDER_MODELS.get(normalized, []))
     if normalized not in _MODELS_DEV_PREFERRED:
-        return curated_static
+        return _FallbackModelIds(curated_static)
     merged = _merge_with_models_dev(normalized, curated_static)
     return _xai_finalize_catalog(merged) if normalized in {"xai", "xai-oauth"} else merged
 
@@ -1458,7 +1466,7 @@ def _spawn_swr_refresh(cache_key: str, refresh_fn=None) -> None:
 
     def _default_refresh():
         live = provider_model_ids(cache_key, force_refresh=True)
-        if live or (cache_key == "ollama" and _ollama_native_probe_reachable()):
+        if _models_are_cacheable(live) or (cache_key == "ollama" and _ollama_native_probe_reachable()):
             return _cache_entry(_credential_fingerprint(cache_key), live or [])
         return None
 
@@ -1638,8 +1646,8 @@ def cached_provider_model_ids(
             return list(entry["models"])
 
     live = provider_model_ids(normalized, force_refresh=force_refresh)
-    if live:
-        _store_cache_entry(normalized, _cache_entry(fp, live, now), cache)
+    if _models_are_cacheable(live):
+        update_provider_cache_entry(normalized, live)
         return list(live)
 
     if is_ollama:
@@ -1658,7 +1666,7 @@ def cached_provider_model_ids(
     # next successful fetch restores them).
     if _cache_entry_valid(entry, fp):
         return [model for model in entry["models"] if not _model_requires_account_discovery(normalized, model)]
-    return []
+    return list(live)
 
 
 def clear_provider_models_cache(provider: Optional[str] = None) -> None:

--- a/tests/hermes_cli/test_model_cache_parallel_prefetch.py
+++ b/tests/hermes_cli/test_model_cache_parallel_prefetch.py
@@ -100,6 +100,19 @@ class TestUpdateProviderCacheEntry:
 class TestPrefetchProviderModelsParallel:
     """Verify ``_prefetch_provider_models_parallel`` fetches concurrently."""
 
+    def test_failed_copilot_fetch_does_not_persist_static_fallback(self, tmp_path, monkeypatch):
+        import hermes_cli.models as models_mod
+
+        cache_path = tmp_path / "provider_models_cache.json"
+        monkeypatch.setattr(models_mod, "_provider_models_cache_path", lambda: cache_path)
+        monkeypatch.setattr(models_mod, "_fetch_github_models", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(models_mod, "_credential_fingerprint", lambda _provider: "fp")
+
+        assert models_mod.cached_provider_model_ids("copilot-acp", force_refresh=True)
+        model_switch_providers._prefetch_provider_models_parallel(["copilot-acp"])
+
+        assert "copilot-acp" not in models_mod._load_provider_models_cache()
+
     def test_skips_all_fresh_entries(self, monkeypatch):
         """When all cache entries are fresh, no fetch is made."""
         from hermes_cli.model_switch_providers import _prefetch_provider_models_parallel


### PR DESCRIPTION
## What does this PR do?

Keeps GitHub Copilot model pickers current after a transient catalog outage. A failed live fetch can still serve the curated fallback immediately, but that fallback no longer becomes a fresh one-hour disk-cache entry. Desktop visibility preferences now use explicit per-model hidden markers, so later catalog additions appear automatically without restoring models the user deliberately hid.

### Symptom

After the Copilot `/models` request failed, the picker kept serving the static fallback across restarts until the disk-cache TTL expired. Even after the live catalog recovered, a Desktop provider with stored visibility choices could show only the stale catalog intersection and hide every newly enabled model.

### Impact

CLI and Desktop users could not select models already enabled on their Copilot account. Restarting, re-authenticating, and refreshing did not reliably recover the picker.

### Bug Cause

**Trigger:** `hermes_cli/models.py:1204` in `_copilot_catalog` and `apps/desktop/src/store/model-visibility.ts:139` in `resolveVisibleKeys`.

**Causal chain:**
1. The live Copilot catalog request fails and `_copilot_catalog` returns the curated static list.
2. `cached_provider_model_ids` and the parallel prefetch path treat that truthy fallback as authoritative and persist it with a fresh TTL.
3. Desktop treats any stored provider visibility set as a complete allow-list, so recovered or newly enabled catalog models remain absent.

**Why it is wrong:** Display fallbacks do not prove account availability and must not refresh an authoritative cache. A persisted visibility preference must distinguish explicit hides from models that did not exist when the preference was saved.

**Working sibling / contrast:** A successful live catalog remains cacheable, and an explicit provider hide-all sentinel remains authoritative. Both represent verified data or direct user intent.

**Ruled out:** The live Copilot API filtering was not the cause. Independent live fetches returned the enabled models, while the shared disk cache and Desktop visibility resolver continued serving stale subsets.

### Fix

- Mark static catalog floors as non-authoritative while preserving their list behavior for immediate display.
- Route successful provider cache writes through the existing lock and remove the parallel prefetch's unconditional second write, which could refresh stale or fallback data.
- Persist explicit per-model hidden markers in Desktop and auto-admit catalog entries without a matching hide marker.
- Preserve the existing hide-all and single-model re-enable contracts.

## Related Issue

Closes #107391

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py` - distinguish display fallbacks from authoritative catalogs and lock successful cache updates.
- `hermes_cli/model_switch_providers.py` - stop re-persisting fallback or stale prefetch results.
- `apps/desktop/src/store/model-visibility.ts` - track explicit model hides and surface later catalog additions.
- Regression tests cover failed Copilot prefetch persistence and Desktop catalog growth.

## How to Test

1. Block the Copilot models endpoint and refresh the picker; the curated fallback remains available but `provider_models_cache.json` does not gain a fresh Copilot entry.
2. Restore the endpoint and refresh; the live catalog is cached.
3. Hide one Desktop model, add another model to the provider catalog, and refresh; the hidden model stays hidden and the new model appears.
4. Automated tests run locally:

```bash
scripts/run_tests.sh tests/hermes_cli/test_model_cache_parallel_prefetch.py tests/hermes_cli/test_model_cache_swr.py
cd apps/desktop && npx vitest run src/store/model-visibility.test.ts
cd apps/desktop && npx eslint src/store/model-visibility.ts src/store/model-visibility.test.ts
cd apps/desktop && npm run typecheck
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo test entry on the relevant Python tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is unchanged; code comments document the persistence contract
- [x] No config keys changed
- [x] No architecture or workflow documentation changed
- [x] Cross-platform impact was considered; the cache and visibility logic is platform-independent
- [x] No tool descriptions or schemas changed
