### PR TITLE
fix(desktop): surface the catalog kill-list recall notice on plugin rows

### DIFF
--- a/apps/desktop/src/app/skills/plugins-tab.test.tsx
+++ b/apps/desktop/src/app/skills/plugins-tab.test.tsx
@@ -217,6 +217,26 @@ describe('PluginsTab catalog UX', () => {
     expect(screen.getByRole('button', { name: `Update to ${'b'.repeat(8)}` })).toBeTruthy()
   })
 
+  it('shows a removed badge for a still-installed, catalog-recalled plugin', () => {
+    // CLI (`hermes plugins list`) and the web dashboard already surface this kill-list
+    // recall notice for a still-installed plugin; the desktop row had no equivalent.
+    $agentPlugins.set([
+      {
+        description: '',
+        key: 'killed-plugin',
+        name: 'killed-plugin',
+        removed_reason: 'malware found in a dependency',
+        source: 'git',
+        status: 'enabled',
+        version: '1.0.0'
+      }
+    ])
+
+    render(<PluginsTab profile={null} />)
+
+    expect(screen.getByText('removed')).toBeTruthy()
+  })
+
   it('re-pins through plugins.manage update when the chip is clicked', async () => {
     $agentPlugins.set([
       {

--- a/apps/desktop/src/app/skills/plugins-tab.tsx
+++ b/apps/desktop/src/app/skills/plugins-tab.tsx
@@ -121,6 +121,13 @@ function AgentPluginListRow({
               </span>
             </Tip>
           )}
+          {row.removed_reason && (
+            <Tip label={t.skills.plugins.removedProvenance(row.removed_reason)}>
+              <span className="rounded border border-destructive/40 px-1 text-[0.65rem] text-destructive">
+                {t.skills.plugins.removedBadge}
+              </span>
+            </Tip>
+          )}
           {row.update_available && onUpdate && (
             <Button
               className="h-5 px-1.5 text-[0.65rem]"

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1530,6 +1530,8 @@ export const en: Translations = {
       pinnedBadge: (sha: string) => `pinned @ ${sha}`,
       tierOfficial: 'official',
       tierCommunity: 'community',
+      removedBadge: 'removed',
+      removedProvenance: (reason: string) => `Pulled from the Hermes catalog: ${reason}`,
       updateToPin: (sha: string) => `Update to ${sha}`,
       updateFailed: (name: string) => `Could not update ${name}`,
       updated: (name: string) => `${name} updated to the current catalog pin. Restart the gateway to apply.`

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1339,6 +1339,8 @@ export interface Translations {
       pinnedBadge: (sha: string) => string
       tierOfficial: string
       tierCommunity: string
+      removedBadge: string
+      removedProvenance: (reason: string) => string
       updateToPin: (sha: string) => string
       updateFailed: (name: string) => string
       updated: (name: string) => string

--- a/apps/desktop/src/store/agent-plugins.ts
+++ b/apps/desktop/src/store/agent-plugins.ts
@@ -36,6 +36,9 @@ export interface AgentPluginRow {
   update_available?: boolean
   /** Full commit SHA a `--ref` install is pinned to (custom sources; refuses `update`). */
   pinned_sha?: string
+  /** Set when this still-installed plugin was pulled from the catalog (security/policy);
+   *  the CLI and web dashboard already surface this recall notice. */
+  removed_reason?: string
 }
 
 /** A `--ref` pin is a full 40-hex commit SHA; branches and tags are refused server-side. */

--- a/tests/tui_gateway/test_plugins_manage_install_ref.py
+++ b/tests/tui_gateway/test_plugins_manage_install_ref.py
@@ -1,6 +1,7 @@
 """Desktop/TUI ``plugins.manage`` honours a ``ref`` pin exactly like ``hermes plugins install --ref``."""
 from unittest.mock import patch
 
+from hermes_cli.plugin_catalog import RemovedEntry
 from tui_gateway import methods_tools, server
 
 
@@ -22,3 +23,37 @@ def test_plugins_manage_list_reports_ref_pin(monkeypatch, tmp_path):
     monkeypatch.setattr(methods_tools._tools_mod("hermes_cli.plugins_cmd_catalog"), "catalog_pins", dict)
     (row,) = methods_tools._plugin_rows()
     assert row["pinned_sha"] == sha
+
+
+def test_plugins_manage_list_reports_kill_list_recall(monkeypatch, tmp_path):
+    # The CLI (`plugins_cmd.cmd_list`) and web dashboard (`web_server_dashboard.py`) both surface
+    # `removed_annotation()` for a still-installed, catalog-recalled plugin; the desktop/TUI
+    # `plugins.manage list` row builder (`_plugin_rows`) had no equivalent field at all.
+    pc = methods_tools._tools_mod("hermes_cli.plugins_cmd")
+    monkeypatch.setattr(
+        pc, "_discover_all_plugins", lambda: [("killed-plugin", "1.0", "", "git", tmp_path, "killed-plugin")])
+    monkeypatch.setattr(pc, "_read_install_metadata", dict)
+    monkeypatch.setattr(pc, "_get_enabled_set", set)
+    monkeypatch.setattr(pc, "_get_disabled_set", set)
+    monkeypatch.setattr(methods_tools._tools_mod("hermes_cli.plugins_cmd_catalog"), "catalog_pins", dict)
+    monkeypatch.setattr(
+        "hermes_cli.plugin_catalog.load_removed_list",
+        lambda catalog_dir=None: [RemovedEntry(name="killed-plugin", reason="malware found in a dependency")],
+    )
+    monkeypatch.setattr("hermes_cli.plugin_catalog.fetch_live_catalog", lambda **_: None)
+    (row,) = methods_tools._plugin_rows()
+    assert row["removed_reason"] == "malware found in a dependency"
+
+
+def test_plugins_manage_list_omits_removed_reason_for_a_healthy_plugin(monkeypatch, tmp_path):
+    pc = methods_tools._tools_mod("hermes_cli.plugins_cmd")
+    monkeypatch.setattr(
+        pc, "_discover_all_plugins", lambda: [("healthy-plugin", "1.0", "", "git", tmp_path, "healthy-plugin")])
+    monkeypatch.setattr(pc, "_read_install_metadata", dict)
+    monkeypatch.setattr(pc, "_get_enabled_set", set)
+    monkeypatch.setattr(pc, "_get_disabled_set", set)
+    monkeypatch.setattr(methods_tools._tools_mod("hermes_cli.plugins_cmd_catalog"), "catalog_pins", dict)
+    monkeypatch.setattr("hermes_cli.plugin_catalog.load_removed_list", lambda catalog_dir=None: [])
+    monkeypatch.setattr("hermes_cli.plugin_catalog.fetch_live_catalog", lambda **_: None)
+    (row,) = methods_tools._plugin_rows()
+    assert "removed_reason" not in row

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1344,7 +1344,11 @@ def _plugin_rows() -> list[dict]:
             "name": name, "key": key, "version": str(version or ""), "description": desc or "",
             "source": source, "status": status, "portable": pc._is_portable_plugin_dir(_dir),
             **cat.catalog_row_fields(_dir, pins),
-            **({"pinned_sha": sha} if (sha := pc.pinned_revision(name, ref_pins)) else {})})
+            **({"pinned_sha": sha} if (sha := pc.pinned_revision(name, ref_pins)) else {}),
+            # Kill-list recall notice — same field/lookup the CLI (`plugins_cmd.cmd_list`) and
+            # web dashboard (`web_server_dashboard.py`) already surface for a still-installed
+            # plugin pulled from the catalog; the desktop had no equivalent (#removed-warning).
+            **({"removed_reason": reason} if (reason := cat.removed_annotation(name, _dir)) else {})})
     return out
 
 


### PR DESCRIPTION
## Summary

Plugins pulled from the catalog for security/policy reasons (`plugin-catalog/removed.yaml`) surface a recall warning next to a still-installed match on **two of the three** surfaces that render an installed plugin's row:

- CLI (`hermes_cli/plugins_cmd.py::cmd_list`) prints a bold red `"✗ REMOVED from catalog: <reason>"` line via `removed_annotation()`.
- Web dashboard (`hermes_cli/web_server_dashboard.py`) sends a `"removed_reason"` field that `PluginsPage.tsx` renders as a destructive badge + inline reason.
- **Desktop/TUI's `plugins.manage list` row builder (`_plugin_rows()` in `tui_gateway/methods_tools.py`) never called `removed_annotation()` at all** — a desktop-only user with a catalog-recalled plugin still installed sees nothing; the row renders identically to any healthy plugin.

`plugin-catalog/removed.yaml` is currently empty (`removed: []`) — no plugin has ever actually been recalled — so this closes a **latent** gap rather than an active incident. Framed honestly: cheap insurance for the day the kill list is first used, not a live security bug today.

## Fix

Threaded the missing field through, mirroring each surface's existing pattern exactly (no new mechanism):

- `tui_gateway/methods_tools.py`: `_plugin_rows()` now includes `"removed_reason"` — the same `cat.removed_annotation(name, _dir)` call the CLI/web already make — spread in conditionally, same style as the existing `pinned_sha` field.
- `apps/desktop/src/store/agent-plugins.ts`: `AgentPluginRow` gets the optional `removed_reason` field.
- `apps/desktop/src/app/skills/plugins-tab.tsx`: a destructive-styled badge + tooltip with the reason, mirroring the existing catalog-tier/pinned-sha badge pattern already in the same row.
- New `removedBadge`/`removedProvenance` i18n keys added to `en.ts` (canonical) + `types.ts` (interface) only — this codebase's established partial-locale-with-English-fallback pattern covers the rest.

**Scope note:** open PR #107314 ("Plugins is one row per plugin...") touches the exact same dict-literal block in `_plugin_rows()` (adding `install_dir`/`has_desktop_half`) — textually adjacent, not a semantic conflict (different fields, both additive); flagging for the reviewer's awareness.

## Test plan

- [x] New Python tests in `tests/tui_gateway/test_plugins_manage_install_ref.py`: one proves `_plugin_rows()` reports `removed_reason` for a kill-listed plugin, another proves the field is omitted for a healthy one.
- [x] New desktop test in `apps/desktop/src/app/skills/plugins-tab.test.tsx`: renders a row with `removed_reason` set, asserts the badge appears.
- [x] Mutation-verified on both sides: reverted the backend field (Python test failed with `KeyError: 'removed_reason'`), then the frontend field (React test failed, element not found) — both restored and re-passing.
- [x] `tsc --noEmit` (electron tsconfig) clean, `eslint` clean on every changed file.
- [x] Broader regression: full `tests/tui_gateway/` + `tests/hermes_cli/` plugin-related suites (613 tests) and the full `apps/desktop/src/app/skills` vitest suite (28 tests) — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
