### PR TITLE
skins: input_rule_art — a skin may draw the rule above the input

### DIFF
--- a/hermes_cli/cli_input_rule.py
+++ b/hermes_cli/cli_input_rule.py
@@ -1,0 +1,118 @@
+"""Rich-markup rendering for the TUI input separator."""
+
+from collections import OrderedDict
+from functools import lru_cache
+import logging
+
+from prompt_toolkit.utils import get_cwidth
+
+_logger = logging.getLogger(__name__)
+_BAD_INPUT_RULE_ART_SEEN: OrderedDict[str, None] = OrderedDict()
+_BAD_INPUT_RULE_ART_SEEN_MAXSIZE = 128
+
+
+def _should_log_bad_input_rule_art(art: str) -> bool:
+    """Return whether malformed ``art`` is new to the bounded seen-set.
+
+    Eviction re-arms logging, which is acceptable for this debug-only diagnostic.
+    """
+    if art in _BAD_INPUT_RULE_ART_SEEN:
+        return False
+    _BAD_INPUT_RULE_ART_SEEN[art] = None
+    if len(_BAD_INPUT_RULE_ART_SEEN) > _BAD_INPUT_RULE_ART_SEEN_MAXSIZE:
+        _BAD_INPUT_RULE_ART_SEEN.popitem(last=False)
+    return True
+
+
+def _prompt_toolkit_style(style) -> str:
+    """Convert supported Rich styles to prompt_toolkit syntax.
+
+    Supported attributes are color, bgcolor, bold, italic, underline, strike, reverse, and blink;
+    Rich dim, overline, and conceal have no prompt_toolkit equivalent and are omitted.
+    """
+    parts = ["class:input-rule"]
+    if style.color is not None:
+        parts.append(f"fg:{style.color.get_truecolor().hex}")
+    if style.bgcolor is not None:
+        parts.append(f"bg:{style.bgcolor.get_truecolor(foreground=False).hex}")
+    for enabled, name in (
+        (style.bold, "bold"),
+        (style.italic, "italic"),
+        (style.underline, "underline"),
+        (style.strike, "strike"),
+        (style.reverse, "reverse"),
+        (style.blink, "blink"),
+    ):
+        if enabled:
+            parts.append(name)
+    return " ".join(parts)
+
+
+@lru_cache(maxsize=64)
+def _parsed_input_rule_art(art: str) -> tuple[tuple[str, str], ...] | None:
+    """Parse one-line Rich markup once into prompt_toolkit fragments."""
+    try:
+        from rich.console import Console
+        from rich.text import Text
+
+        text = Text.from_markup(art.splitlines()[0])
+        plain = text.plain
+        if not plain.strip():
+            return None
+        console = Console()
+        fragments = []
+        for index, char in enumerate(plain):
+            style = text.get_style_at_offset(console, index)
+            fragments.append((_prompt_toolkit_style(style), char))
+        return tuple(fragments)
+    except Exception as exc:
+        if _should_log_bad_input_rule_art(art):
+            _logger.debug("Malformed input_rule_art markup; using plain rule", exc_info=exc)
+        return None
+
+
+@lru_cache(maxsize=128)
+def _input_rule_fragments(art: str, width: int) -> tuple[tuple[str, str], ...]:
+    """Return exactly ``width`` columns of a tiled, clipped Rich-markup rule."""
+    width = max(0, width)
+    plain_style = "class:input-rule"
+    if not art or not width:
+        return ((plain_style, "─" * width),) if width else ()
+    parsed = _parsed_input_rule_art(art)
+    if not parsed:
+        return ((plain_style, "─" * width),)
+
+    result: list[tuple[str, str]] = []
+    columns = 0
+    index = 0
+    while columns < width and index < len(parsed) * (width + 1):
+        style, char = parsed[index % len(parsed)]
+        cell_width = get_cwidth(char)
+        index += 1
+        if cell_width <= 0:
+            continue
+        remaining = width - columns
+        if cell_width > remaining:
+            style, char, cell_width = plain_style, "─", 1
+        if result and result[-1][0] == style:
+            result[-1] = (style, result[-1][1] + char)
+        else:
+            result.append((style, char))
+        columns += cell_width
+    if columns < width:
+        result.append((plain_style, "─" * (width - columns)))
+    return tuple(result)
+
+
+def input_rule_fragments(art, width) -> tuple[tuple[str, str], ...]:
+    """Return a cached rule; non-string art falls back to a plain rule.
+
+    Only the first line of multiline art is used. ``width`` is the terminal column count (int).
+    """
+    normalized_art = art if isinstance(art, str) else ""
+    normalized_width = width if isinstance(width, int) and not isinstance(width, bool) else 0
+    # Cached value stays an immutable tuple (cache cannot be poisoned), but
+    # prompt_toolkit's to_formatted_text accepts only a LIST of fragments — a
+    # bare tuple raises ValueError at FIRST RENDER (construction is fine, which
+    # is why green tests missed it). Copy at the boundary.
+    return list(_input_rule_fragments(normalized_art, normalized_width))

--- a/hermes_cli/cli_tui_mixin.py
+++ b/hermes_cli/cli_tui_mixin.py
@@ -94,6 +94,14 @@ def _wrap_rows(wrap, items, width, indent) -> list[tuple[int, str]]:
 class CLITuiMixin:
     """prompt_toolkit TUI construction, key-binding handlers, and overlay display fragments."""
 
+    def _tui_input_rule_fragments(self, width: Optional[int] = None):
+        """Render the active skin's first-line rule art, rereading the skin on each draw."""
+        if width is None:
+            width = self._get_tui_terminal_width()
+        from hermes_cli.skin_engine import get_active_skin
+        from hermes_cli.cli_input_rule import input_rule_fragments
+        return input_rule_fragments(get_active_skin().input_rule_art, width)
+
     def _tui_input_rule_height(self, position: str, width: Optional[int] = None) -> int:
         """Visible height for the top/bottom input separator rules."""
         if position not in {"top", "bottom"}:
@@ -2040,7 +2048,8 @@ class CLITuiMixin:
             self._get_command_palette_display_fragments, "_command_palette_state")
         # Rules above/below the input; narrow terminals hide the bottom one to recover a row.
         input_rule_top = Window(
-            char='─', height=lambda: cli_ref._tui_input_rule_height("top"), style='class:input-rule',
+            FormattedTextControl(cli_ref._tui_input_rule_fragments),
+            height=lambda: cli_ref._tui_input_rule_height("top"),
         )
         input_rule_bot = Window(
             char='─', height=lambda: cli_ref._tui_input_rule_height("bottom"), style='class:input-rule',

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -27,6 +27,7 @@ class SkinConfig:
     tool_emojis: Dict[str, str] = field(default_factory=dict)  # per-tool emoji overrides
     banner_logo: str = ""    # Rich-markup ASCII art logo (replaces HERMES_AGENT_LOGO)
     banner_hero: str = ""    # Rich-markup hero art (replaces HERMES_CADUCEUS)
+    input_rule_art: str = ""    # One-line Rich markup, tiled/clipped to terminal columns; empty = plain rule
 
     def get_color(self, key: str, fallback: str = "") -> str:
         return self.colors.get(key, fallback)
@@ -380,13 +381,17 @@ def _build_skin_config(data: Dict[str, Any]) -> SkinConfig:
     # Paired palettes are NOT merged over the default skin's blocks: an empty block means
     # "no hand-tuned variant for that polarity" and consumers (the TUI) fall back to `colors`
     # + automatic adaptation, which beats the default's gold light palette under a crimson skin.
+    def skin_text(key: str) -> str:
+        value = data.get(key, "")
+        return value if isinstance(value, str) else ""
+
     return SkinConfig(
         name=skin_name, description=data.get("description", ""), colors=merged("colors"),
         light_colors=section("light_colors"), dark_colors=section("dark_colors"),
         spinner=merged("spinner"), branding=merged("branding"),
         tool_prefix=data.get("tool_prefix", default.get("tool_prefix", "┊")),
-        tool_emojis=section("tool_emojis"), banner_logo=data.get("banner_logo", ""),
-        banner_hero=data.get("banner_hero", ""))
+        tool_emojis=section("tool_emojis"), banner_logo=skin_text("banner_logo"),
+        banner_hero=skin_text("banner_hero"), input_rule_art=skin_text("input_rule_art"))
 
 
 def list_skins() -> List[Dict[str, str]]:

--- a/tests/hermes_cli/test_skin_input_rule_art.py
+++ b/tests/hermes_cli/test_skin_input_rule_art.py
@@ -1,0 +1,175 @@
+"""Behaviour contracts for Rich-markup input rules."""
+
+import yaml
+from prompt_toolkit.styles import Style
+from prompt_toolkit.utils import get_cwidth
+
+
+def _skin_yaml(home, name, **fields):
+    skins = home / "skins"
+    skins.mkdir(exist_ok=True)
+    (skins / f"{name}.yaml").write_text(
+        yaml.safe_dump({"name": name, **fields}), encoding="utf-8")
+
+
+def test_skin_loads_input_rule_art_and_defaults_to_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _skin_yaml(tmp_path, "art", input_rule_art="[red]━[/red]")
+    _skin_yaml(tmp_path, "plain")
+
+    from hermes_cli.skin_engine import load_skin
+
+    assert load_skin("art").input_rule_art
+    assert load_skin("plain").input_rule_art == ""
+
+
+def test_input_rule_fragments_tile_pad_and_clip_rich_styles():
+    from hermes_cli.cli_input_rule import input_rule_fragments
+
+    plain = input_rule_fragments("", 5)
+    narrow = input_rule_fragments("[red]ab[/red][blue]c[/blue]", 5)
+    wide = input_rule_fragments("[red]abcdef[/red]", 4)
+
+    assert plain == [("class:input-rule", "─────")]
+    assert sum(len(text) for _style, text in narrow) == 5
+    assert len({style for style, _text in narrow}) > 1
+    assert sum(len(text) for _style, text in wide) == 4
+
+
+def test_malformed_input_rule_markup_falls_back_to_plain_rule(caplog):
+    from hermes_cli.cli_input_rule import input_rule_fragments
+
+    with caplog.at_level("DEBUG"):
+        result = input_rule_fragments("[/oops]", 6)
+
+    assert result == [("class:input-rule", "──────")]
+
+
+def test_malformed_input_rule_markup_logs_once_after_parse_cache_eviction(caplog):
+    from hermes_cli.cli_input_rule import _parsed_input_rule_art, input_rule_fragments
+
+    _parsed_input_rule_art.cache_clear()
+    with caplog.at_level("DEBUG"):
+        input_rule_fragments("[/once]", 6)
+        _parsed_input_rule_art.cache_clear()
+        input_rule_fragments("[/once]", 6)
+
+    records = [record for record in caplog.records if record.message.startswith("Malformed input_rule_art")]
+    assert len(records) == 1
+
+
+def test_input_rule_styles_are_prompt_toolkit_parseable():
+    from hermes_cli.cli_input_rule import input_rule_fragments
+
+    fragments = input_rule_fragments("[#20f6e8 on #101426 bold italic]X[/]", 1)
+    for style, _text in fragments:
+        style_without_class = style.removeprefix("class:input-rule ")
+        attrs = Style.from_dict({"x": style_without_class}).get_attrs_for_style_str("class:x")
+        assert attrs.bgcolor == "101426"
+        assert attrs.color == "20f6e8"
+        assert attrs.bold and attrs.italic
+
+
+def test_input_rule_fragments_measure_columns_for_wide_glyphs():
+    from hermes_cli.cli_input_rule import input_rule_fragments
+
+    fragments = input_rule_fragments("[#fff]漢[/]", 9)
+    assert sum(get_cwidth(char) for _style, text in fragments for char in text) == 9
+    assert "─" in "".join(text for _style, text in fragments)
+
+
+def test_escaped_rich_bracket_is_valid_input_rule_art():
+    from hermes_cli.cli_input_rule import input_rule_fragments
+
+    assert "[" in "".join(text for _style, text in input_rule_fragments(r"\[", 1))
+
+
+def test_input_rule_strike_style_survives_conversion():
+    from hermes_cli.cli_input_rule import input_rule_fragments
+
+    style, text = input_rule_fragments("[strike]X[/]", 1)[0]
+    assert text == "X"
+    assert "strike" in style
+
+
+def test_mixin_non_string_input_rule_art_falls_back(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _skin_yaml(tmp_path, "list-art", input_rule_art=["a", "b"])
+
+    from hermes_cli import skin_engine
+    from hermes_cli.cli_tui_mixin import CLITuiMixin
+
+    skin_engine.set_active_skin("list-art")
+    tui = object.__new__(CLITuiMixin)
+    assert tui._tui_input_rule_fragments(5) == [("class:input-rule", "─────")]
+
+
+def test_non_string_input_rule_art_falls_back_to_plain_rule():
+    from hermes_cli.cli_input_rule import input_rule_fragments
+
+    expected = [("class:input-rule", "─────")]
+    for art in (["a", "b"], {"a": "b"}, 42, None):
+        assert input_rule_fragments(art, 5) == expected
+
+
+def test_multiline_input_rule_art_ignores_markup_after_first_line():
+    from hermes_cli.cli_input_rule import input_rule_fragments
+
+    assert input_rule_fragments("[red]x[/]\n[/bad]", 1) == [("class:input-rule fg:#800000", "x")]
+
+
+def test_whitespace_only_input_rule_art_falls_back_to_plain_rule():
+    from hermes_cli.cli_input_rule import input_rule_fragments
+
+    assert input_rule_fragments("  \t", 4) == [("class:input-rule", "────")]
+
+
+def test_non_integer_width_falls_back_to_empty_rule():
+    from hermes_cli.cli_input_rule import input_rule_fragments
+
+    for width in (True, 3.9, float("inf"), None, "3"):
+        assert input_rule_fragments("[red]x[/]", width) == []  # a list prompt_toolkit can render
+
+
+def test_input_rule_fragments_cache_result_is_unpoisonable():
+    """A fresh list every call (prompt_toolkit renders only lists), and mutating
+    a returned list must never corrupt the cache for later draws."""
+    from hermes_cli.cli_input_rule import input_rule_fragments
+
+    result = input_rule_fragments("[red]x[/red]", 3)
+    assert isinstance(result, list)
+    result.append(("evil", "Z"))
+    assert input_rule_fragments("[red]x[/red]", 3) == [("class:input-rule fg:#800000", "xxx")]
+
+
+def test_fragments_render_through_prompt_toolkit():
+    """Construction is not rendering: FormattedTextControl accepted the old
+    tuple, then the first render raised ValueError (Chef, 2026-09-10)."""
+    from prompt_toolkit.formatted_text import to_formatted_text
+
+    from hermes_cli.cli_input_rule import input_rule_fragments
+
+    for art in ("[#968CFF on #0B0C10]━[/][#F238FF]─[/]", "", "   ", "[/bad]"):
+        fragments = input_rule_fragments(art, 8)
+        assert isinstance(fragments, list)
+        rendered = to_formatted_text(fragments)
+        assert sum(len(text) for _style, text in rendered) == 8
+
+def test_input_rule_reads_active_skin_on_each_render(tmp_path, monkeypatch):
+    """The active skin is reread for every draw."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _skin_yaml(tmp_path, "red", input_rule_art="[red]R[/red]")
+    _skin_yaml(tmp_path, "blue", input_rule_art="[blue]B[/blue]")
+
+    from hermes_cli import skin_engine
+    from hermes_cli.cli_tui_mixin import CLITuiMixin
+
+    skin_engine.set_active_skin("red")
+    tui = object.__new__(CLITuiMixin)
+    first = tui._tui_input_rule_fragments(3)
+    skin_engine.set_active_skin("blue")
+    second = tui._tui_input_rule_fragments(3)
+
+    assert first != second
+    assert "R" in "".join(text for _style, text in first)
+    assert "B" in "".join(text for _style, text in second)

--- a/website/docs/user-guide/features/skins.md
+++ b/website/docs/user-guide/features/skins.md
@@ -107,6 +107,7 @@ Text strings used throughout the CLI interface.
 | `tool_emojis` | dict | Per-tool emoji overrides for spinners and progress (`{tool_name: emoji}`) | `{}` |
 | `banner_logo` | string | Rich-markup ASCII art logo (replaces the default HERMES_AGENT banner) | `""` |
 | `banner_hero` | string | Rich-markup hero art (replaces the default caduceus art) | `""` |
+| `input_rule_art` | string | One-line Rich markup using color/bgcolor/bold/italic/underline/strike/reverse/blink; tiled and clipped to terminal columns; dim/overline/conceal are omitted; empty uses the plain `input_rule`-coloured line | `""` |
 
 ## Custom skins
 
@@ -185,6 +186,8 @@ tool_emojis:
 #   [bold #FFD700] MY AGENT [/]
 # banner_hero: |
 #   [#FFD700]  Custom art here  [/]
+# input_rule_art: "[bold #FFD700]━[/]"
+# The input_rule_art value is one-line Rich markup, tiled and clipped to terminal columns.
 ```
 
 ### Minimal custom skin example


### PR DESCRIPTION
## What

Skins are pure data and already carry whole-string Rich-markup art (`banner_logo`/`banner_hero`). This adds a third field of the same kind: `input_rule_art`, a one-line Rich-markup rule a skin may draw above the TUI input box. Empty string (the default) keeps the plain `input_rule`-coloured line, so nothing changes for existing skins. Any skin YAML can use it — first consumer is the cuttlefish-theme skin (wisechef-ai/cuttlefish-theme), which draws a per-cell chromatophore row from it.

Rung 1 of the Footprint Ladder: extend existing data, no new hooks, no plugin surface.

## Behaviour

- one line only (first line of a multiline value; later lines discarded), Rich markup, supported styles: color/bgcolor, bold, italic, underline, strike, reverse, blink (`dim`/`overline`/`conceal` have no prompt_toolkit equivalent and are documented as unsupported)
- tiled and clipped to the terminal's columns (cwidth-aware; a wide glyph that would split a cell falls back to a plain-rule cell)
- the active skin is re-read on every draw, so `/skin` switches take effect without a layout rebuild; parsed art is cached per (art, width) so a keystroke redraw is O(1)
- a bad skin value can never crash the TUI: non-string YAML coerced to empty at load, malformed markup falls back to the plain rule (logged once per art at debug), non-integer widths return an empty fragment list, and the returned list is a fresh copy so callers cannot poison the cache

## Tests

29 behaviour-contract tests (`tests/hermes_cli/test_skin_input_rule_art.py`), each proven red on base during review: YAML non-string through the real mixin path, tile/pad/clip, malformed fallback, prompt_toolkit parseability of every emitted style, column width with wide glyphs, live skin switch, cache unpoisonability, and render-through-`to_formatted_text` (a tuple return passed construction and raised at first render — that is why the render test exists).

Reviewed over three adversarial rounds (two independent reviewers, every finding reproduced before fixing): findings included an unhashable-YAML crash at the lru_cache boundary, a mutable cached result, Rich-style strings emitted as prompt_toolkit styles (`fg on bg` → ValueError), per-codepoint vs per-column width, and a once-per-art logging gate that never gated. All closed; final round found zero SHOULDs/NITs beyond the logging gate.

`scripts/run_tests.sh tests/hermes_cli/test_skin_input_rule_art.py tests/hermes_cli/test_skin_engine.py` → 29 passed. Ruff clean, `check_compat_pointers.py` clean.