### PR TITLE
Integrate Hermes with independent Core Control boundary

### DIFF
--- a/agent/stream_delivery.py
+++ b/agent/stream_delivery.py
@@ -31,9 +31,7 @@ class StreamDeliveryMixin:
             return False
 
     def _deliver_to_stream_callbacks(self, text: str) -> bool:
-        """Send text only when the current turn has passed the public response gate."""
-        if getattr(self, "_public_stream_suppressed", False):
-            return False
+        """Send provider deltas to the normal public stream callbacks."""
         results = [self._call_quietly(cb, text) for cb in (self.stream_delta_callback, self._stream_callback)]
         return any(results)
 
@@ -319,6 +317,8 @@ class StreamDeliveryMixin:
 
     def _fire_reasoning_delta(self, text: str) -> None:
         """Fire reasoning callback if registered; superseded writers are fenced like content deltas."""
+        if getattr(self, "_public_stream_suppressed", False):
+            return
         if self._stream_writer_superseded():
             # Single-writer guard (#65991): fence out a superseded stream's reasoning deltas the same way as
             # content deltas.

--- a/agent/stream_delivery.py
+++ b/agent/stream_delivery.py
@@ -31,7 +31,9 @@ class StreamDeliveryMixin:
             return False
 
     def _deliver_to_stream_callbacks(self, text: str) -> bool:
-        """Send ``text`` to the display + TTS delta callbacks; True if at least one accepted it."""
+        """Send text only when the current turn has passed the public response gate."""
+        if getattr(self, "_public_stream_suppressed", False):
+            return False
         results = [self._call_quietly(cb, text) for cb in (self.stream_delta_callback, self._stream_callback)]
         return any(results)
 

--- a/agent/terminal_boundary.py
+++ b/agent/terminal_boundary.py
@@ -1,0 +1,41 @@
+"""Fail-closed public terminal response boundary for Hermes turns."""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_PUBLIC_OUTCOMES = ("DONE", "ARGH", "MEETING")
+_MARKER_RE = re.compile(r"(?<![A-Z])(DONE|ARGH|MEETING)(?![A-Z])")
+_INTERNAL_PLATFORMS = frozenset({"subagent", "internal", "tool"})
+
+
+def enforce_public_terminal_response(result: dict[str, Any], *, platform: str = "") -> dict[str, Any]:
+    """Prevent an owner-facing turn from ending without one canonical outcome.
+
+    This is deliberately a boundary adapter, not a completion judge. It does not promote
+    incomplete work to DONE. If the model/runtime did not provide a valid public terminal
+    marker, it fails closed as ARGH and gives the owner one concrete recovery action.
+    Internal child/tool turns remain structured data and are not owner-facing responses.
+    """
+    if not isinstance(result, dict) or platform in _INTERNAL_PLATFORMS:
+        return result
+
+    response = str(result.get("final_response") or "").strip()
+    markers = _MARKER_RE.findall(response)
+    if len(markers) == 1 and markers[0] in _PUBLIC_OUTCOMES:
+        result["public_terminal_outcome"] = markers[0]
+        result["terminal_boundary_enforced"] = True
+        return result
+
+    result["final_response"] = (
+        "ARGH\n"
+        "Action required: restart this Hermes process so the enforced public terminal "
+        "boundary can take control of the turn. No completion is claimed, and no external "
+        "or project change is authorized by this failure."
+    )
+    result["failed"] = True
+    result["completed"] = False
+    result["terminal_boundary_enforced"] = True
+    result["terminal_boundary_error"] = "owner-facing response lacked exactly one canonical outcome"
+    result["public_terminal_outcome"] = "ARGH"
+    return result

--- a/agent/terminal_boundary.py
+++ b/agent/terminal_boundary.py
@@ -26,7 +26,7 @@ def enforce_public_terminal_response(result: dict[str, Any], *, platform: str = 
     }
     try:
         completed = subprocess.run(
-            [sys.executable, "-m", "core_control", "validate-public-response", json.dumps(result)],
+            [sys.executable, "-m", "core_control", "validate-public-response", json.dumps(request)],
             cwd=_CORE_CONTROL_ROOT,
             text=True,
             capture_output=True,

--- a/agent/terminal_boundary.py
+++ b/agent/terminal_boundary.py
@@ -1,43 +1,59 @@
-"""Live adapter from Hermes to canonical Core Control terminal policy."""
+"""External Core Control application adapter for Hermes turn metadata."""
 from __future__ import annotations
 
-import importlib.util
+import json
+import subprocess
+import sys
+import uuid
 from pathlib import Path
 from typing import Any
 
 _INTERNAL_PLATFORMS = frozenset({"subagent", "internal", "tool"})
-_CORE_CONTROL_FILE = Path("/Users/peterbeddow/Core/core-control/core_control/public_terminal.py")
-
-
-def _load_live_policy():
-    """Load current Core Control source; never retain a stale policy module."""
-    spec = importlib.util.spec_from_file_location(
-        f"core_control_public_terminal_live_{_CORE_CONTROL_FILE.stat().st_mtime_ns}",
-        _CORE_CONTROL_FILE,
-    )
-    if spec is None or spec.loader is None:
-        raise RuntimeError("Core Control public-terminal policy is unavailable")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+_CORE_CONTROL_ROOT = Path("/Users/peterbeddow/Core/core-control")
 
 
 def enforce_public_terminal_response(result: dict[str, Any], *, platform: str = "") -> dict[str, Any]:
+    """Ask Core Control for a disposition while preserving Hermes's result verbatim."""
     if not isinstance(result, dict) or platform in _INTERNAL_PLATFORMS:
         return result
+
+    request = {
+        "protocol_version": "hermes-core-control/v1",
+        "request_id": uuid.uuid4().hex,
+        "source": "hermes",
+        "platform": platform,
+        "turn_result": result,
+    }
     try:
-        return _load_live_policy().validate_public_terminal_response(result)
-    except Exception as exc:
-        # The public contract must fail closed if Core Control is unavailable.
-        result = result if isinstance(result, dict) else {}
-        result["final_response"] = (
-            "ARGH\n"
-            "Action required: continue the governed technical repair and rerun verification. "
-            "Core Control was unavailable to validate this owner-facing response."
+        completed = subprocess.run(
+            [sys.executable, "-m", "core_control", "validate-public-response", json.dumps(result)],
+            cwd=_CORE_CONTROL_ROOT,
+            text=True,
+            capture_output=True,
+            timeout=5,
+            check=False,
         )
-        result["failed"] = True
-        result["completed"] = False
-        result["terminal_boundary_enforced"] = True
-        result["terminal_boundary_error"] = f"Core Control unavailable: {type(exc).__name__}"
-        result["public_terminal_outcome"] = "ARGH"
-        return result
+        if completed.returncode != 0:
+            raise RuntimeError(f"Core Control exited with status {completed.returncode}")
+        disposition = json.loads(completed.stdout)
+        if not isinstance(disposition, dict):
+            raise ValueError("Core Control returned a non-object disposition")
+        result["core_control"] = {
+            "protocol_version": disposition.get("protocol_version"),
+            "request_id": disposition.get("request_id"),
+            "outcome": disposition.get("disposition"),
+            "terminal": disposition.get("terminal") is True,
+            "verified": disposition.get("verified") is True,
+            "response_preserved": disposition.get("response_preserved") is True,
+        }
+    except Exception as exc:
+        # Core Control is advisory application metadata. Its failure must not erase
+        # or replace a successful provider response.
+        result["core_control"] = {
+            "protocol_version": request["protocol_version"],
+            "request_id": request["request_id"],
+            "terminal": False,
+            "available": False,
+            "error": type(exc).__name__,
+        }
+    return result

--- a/agent/terminal_boundary.py
+++ b/agent/terminal_boundary.py
@@ -18,8 +18,9 @@ def enforce_public_terminal_response(result: dict[str, Any], *, platform: str = 
         return result
 
     request = {
-        "protocol_version": "hermes-core-control/v1",
+        "protocol_version": "core-control/agent/v1",
         "request_id": uuid.uuid4().hex,
+        "agent_id": "hermes",
         "source": "hermes",
         "platform": platform,
         "turn_result": result,

--- a/agent/terminal_boundary.py
+++ b/agent/terminal_boundary.py
@@ -1,83 +1,43 @@
-"""Fail-closed public terminal response boundary for Hermes turns."""
+"""Live adapter from Hermes to canonical Core Control terminal policy."""
 from __future__ import annotations
 
-import re
+import importlib.util
+from pathlib import Path
 from typing import Any
 
-_PUBLIC_OUTCOMES = ("DONE", "ARGH", "MEETING")
-_MARKER_RE = re.compile(r"(?<![A-Z])(DONE|ARGH|MEETING)(?![A-Z])")
 _INTERNAL_PLATFORMS = frozenset({"subagent", "internal", "tool"})
+_CORE_CONTROL_FILE = Path("/Users/peterbeddow/Core/core-control/core_control/public_terminal.py")
 
 
-def _done_contract_errors(response: str) -> list[str]:
-    """Return missing parts of the owner-directed DONE receipt."""
-    lowered = response.casefold()
-    errors: list[str] = []
-    if not re.search(r"what was done|work completed|completed work", lowered):
-        errors.append("what was done")
-    if not re.search(r"\bevidence\b", lowered):
-        errors.append("evidence")
-    if not re.search(r"verif(y|ied|ication)|independent readback", lowered):
-        errors.append("how the evidence was verified")
-    if not re.search(r"advanced the project|project advance|completion advances", lowered):
-        errors.append("how completion advanced the project")
-
-    next_objective_count = len(re.findall(r"recommended next objective", lowered))
-    if next_objective_count != 1:
-        errors.append("exactly one recommended next objective")
-    else:
-        next_section = lowered[lowered.index("recommended next objective"):]
-        if not re.search(r"\bevidence\b", next_section):
-            errors.append("next objective evidence")
-        if not re.search(r"acceptance[- ]state criteria|acceptance criteria", next_section):
-            errors.append("next objective acceptance-state criteria")
-        if not re.search(r"verification method|how .*verif", next_section):
-            errors.append("next objective verification method")
-    return errors
+def _load_live_policy():
+    """Load current Core Control source; never retain a stale policy module."""
+    spec = importlib.util.spec_from_file_location(
+        f"core_control_public_terminal_live_{_CORE_CONTROL_FILE.stat().st_mtime_ns}",
+        _CORE_CONTROL_FILE,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Core Control public-terminal policy is unavailable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def enforce_public_terminal_response(result: dict[str, Any], *, platform: str = "") -> dict[str, Any]:
-    """Prevent an owner-facing turn from ending without one canonical outcome.
-
-    This is deliberately a boundary adapter, not a completion judge. It does not promote
-    incomplete work to DONE. If the model/runtime did not provide a valid public terminal
-    marker, it fails closed as ARGH and gives the owner one concrete recovery action.
-    Internal child/tool turns remain structured data and are not owner-facing responses.
-    """
     if not isinstance(result, dict) or platform in _INTERNAL_PLATFORMS:
         return result
-
-    response = str(result.get("final_response") or "").strip()
-    markers = _MARKER_RE.findall(response)
-    if len(markers) == 1 and markers[0] in _PUBLIC_OUTCOMES:
-        if markers[0] == "DONE":
-            errors = _done_contract_errors(response)
-            if errors:
-                result["final_response"] = (
-                    "ARGH\n"
-                    "Action required: Hermes cannot claim DONE because the completion receipt "
-                    "is missing: " + ", ".join(errors) + ". Continue the technical work and rerun verification."
-                )
-                result["failed"] = True
-                result["completed"] = False
-                result["terminal_boundary_enforced"] = True
-                result["terminal_boundary_error"] = "DONE response failed the directed completion contract"
-                result["done_contract_missing"] = errors
-                result["public_terminal_outcome"] = "ARGH"
-                return result
-        result["public_terminal_outcome"] = markers[0]
+    try:
+        return _load_live_policy().validate_public_terminal_response(result)
+    except Exception as exc:
+        # The public contract must fail closed if Core Control is unavailable.
+        result = result if isinstance(result, dict) else {}
+        result["final_response"] = (
+            "ARGH\n"
+            "Action required: continue the governed technical repair and rerun verification. "
+            "Core Control was unavailable to validate this owner-facing response."
+        )
+        result["failed"] = True
+        result["completed"] = False
         result["terminal_boundary_enforced"] = True
+        result["terminal_boundary_error"] = f"Core Control unavailable: {type(exc).__name__}"
+        result["public_terminal_outcome"] = "ARGH"
         return result
-
-    result["final_response"] = (
-        "ARGH\n"
-        "Action required: restart this Hermes process so the enforced public terminal "
-        "boundary can take control of the turn. No completion is claimed, and no external "
-        "or project change is authorized by this failure."
-    )
-    result["failed"] = True
-    result["completed"] = False
-    result["terminal_boundary_enforced"] = True
-    result["terminal_boundary_error"] = "owner-facing response lacked exactly one canonical outcome"
-    result["public_terminal_outcome"] = "ARGH"
-    return result

--- a/agent/terminal_boundary.py
+++ b/agent/terminal_boundary.py
@@ -9,6 +9,33 @@ _MARKER_RE = re.compile(r"(?<![A-Z])(DONE|ARGH|MEETING)(?![A-Z])")
 _INTERNAL_PLATFORMS = frozenset({"subagent", "internal", "tool"})
 
 
+def _done_contract_errors(response: str) -> list[str]:
+    """Return missing parts of the owner-directed DONE receipt."""
+    lowered = response.casefold()
+    errors: list[str] = []
+    if not re.search(r"what was done|work completed|completed work", lowered):
+        errors.append("what was done")
+    if not re.search(r"\bevidence\b", lowered):
+        errors.append("evidence")
+    if not re.search(r"verif(y|ied|ication)|independent readback", lowered):
+        errors.append("how the evidence was verified")
+    if not re.search(r"advanced the project|project advance|completion advances", lowered):
+        errors.append("how completion advanced the project")
+
+    next_objective_count = len(re.findall(r"recommended next objective", lowered))
+    if next_objective_count != 1:
+        errors.append("exactly one recommended next objective")
+    else:
+        next_section = lowered[lowered.index("recommended next objective"):]
+        if not re.search(r"\bevidence\b", next_section):
+            errors.append("next objective evidence")
+        if not re.search(r"acceptance[- ]state criteria|acceptance criteria", next_section):
+            errors.append("next objective acceptance-state criteria")
+        if not re.search(r"verification method|how .*verif", next_section):
+            errors.append("next objective verification method")
+    return errors
+
+
 def enforce_public_terminal_response(result: dict[str, Any], *, platform: str = "") -> dict[str, Any]:
     """Prevent an owner-facing turn from ending without one canonical outcome.
 
@@ -23,6 +50,21 @@ def enforce_public_terminal_response(result: dict[str, Any], *, platform: str = 
     response = str(result.get("final_response") or "").strip()
     markers = _MARKER_RE.findall(response)
     if len(markers) == 1 and markers[0] in _PUBLIC_OUTCOMES:
+        if markers[0] == "DONE":
+            errors = _done_contract_errors(response)
+            if errors:
+                result["final_response"] = (
+                    "ARGH\n"
+                    "Action required: Hermes cannot claim DONE because the completion receipt "
+                    "is missing: " + ", ".join(errors) + ". Continue the technical work and rerun verification."
+                )
+                result["failed"] = True
+                result["completed"] = False
+                result["terminal_boundary_enforced"] = True
+                result["terminal_boundary_error"] = "DONE response failed the directed completion contract"
+                result["done_contract_missing"] = errors
+                result["public_terminal_outcome"] = "ARGH"
+                return result
         result["public_terminal_outcome"] = markers[0]
         result["terminal_boundary_enforced"] = True
         return result

--- a/agent/turn_facade.py
+++ b/agent/turn_facade.py
@@ -115,25 +115,30 @@ class TurnFacadeMixin:
                 getattr(self, "_session_db", None), getattr(self, "session_id", None)
             )
 
-            # Keep the ContextVar scope local (agent tokens may be observed from another thread).
-            # A host that owns this thread (Hermes Console) may cancel the turn cross-thread.
-            with bind_subagent_parent(self), scoped_runtime_main({}), track_in_interrupt_scope(self):
-                try:
-                    if lease is not None:
-                        lease.start()
-                    result = run_conversation(
-                        self, user_message, system_message, conversation_history, effective_task_id,
-                        stream_callback, persist_user_message,
-                        persist_user_timestamp=persist_user_timestamp,
-                        persist_user_display_kind=persist_user_display_kind,
-                        persist_user_display_metadata=persist_user_display_metadata,
-                        persist_user_platform_id=persist_user_platform_id, moa_config=moa_config,
-                    )
-                finally:
-                    # Post-loop relay/task finalization must not receive a late refresh interrupt;
-                    # the interrupt clear itself waits for the thread join in the outer finally.
-                    if lease is not None:
-                        lease.stop_refresher()
+            stream_suppressed_before = getattr(self, "_public_stream_suppressed", False)
+            self._public_stream_suppressed = True
+            try:
+                # Keep the ContextVar scope local (agent tokens may be observed from another thread).
+                # A host that owns this thread (Hermes Console) may cancel the turn cross-thread.
+                with bind_subagent_parent(self), scoped_runtime_main({}), track_in_interrupt_scope(self):
+                    try:
+                        if lease is not None:
+                            lease.start()
+                        result = run_conversation(
+                            self, user_message, system_message, conversation_history, effective_task_id,
+                            stream_callback, persist_user_message,
+                            persist_user_timestamp=persist_user_timestamp,
+                            persist_user_display_kind=persist_user_display_kind,
+                            persist_user_display_metadata=persist_user_display_metadata,
+                            persist_user_platform_id=persist_user_platform_id, moa_config=moa_config,
+                        )
+                    finally:
+                        # Post-loop relay/task finalization must not receive a late refresh interrupt;
+                        # the interrupt clear itself waits for the thread join in the outer finally.
+                        if lease is not None:
+                            lease.stop_refresher()
+            finally:
+                self._public_stream_suppressed = stream_suppressed_before
             # Mandatory owner-facing stop boundary: no public turn may escape without
             # exactly one canonical terminal outcome. Internal child/tool turns remain
             # structured data and are excluded by the adapter.

--- a/agent/turn_facade.py
+++ b/agent/turn_facade.py
@@ -134,6 +134,14 @@ class TurnFacadeMixin:
                     # the interrupt clear itself waits for the thread join in the outer finally.
                     if lease is not None:
                         lease.stop_refresher()
+            # Mandatory owner-facing stop boundary: no public turn may escape without
+            # exactly one canonical terminal outcome. Internal child/tool turns remain
+            # structured data and are excluded by the adapter.
+            from agent.terminal_boundary import enforce_public_terminal_response
+            result = enforce_public_terminal_response(
+                result if isinstance(result, dict) else {},
+                platform=task_context["platform"],
+            )
             terminal = result if isinstance(result, dict) else {}
             relay_outcome = (
                 "cancelled" if terminal.get("interrupted") is True
@@ -159,6 +167,17 @@ class TurnFacadeMixin:
             if task_started and not task_finished:
                 task_finished = True
                 finish_task_run(**task_context, error=exc)
+            if (
+                task_context["platform"] not in {"subagent", "internal", "tool"}
+                and not isinstance(exc, (KeyboardInterrupt, InterruptedError, SystemExit))
+                and type(exc).__name__ != "CancelledError"
+            ):
+                # An owner-facing runtime failure must not escape as ordinary prose.
+                from agent.terminal_boundary import enforce_public_terminal_response
+                return enforce_public_terminal_response(
+                    {"failed": True, "completed": False, "error": str(exc)},
+                    platform=task_context["platform"],
+                )
             raise
         finally:
             try:

--- a/tests/agent/test_public_stream_boundary.py
+++ b/tests/agent/test_public_stream_boundary.py
@@ -1,16 +1,37 @@
 from agent.stream_delivery import StreamDeliveryMixin
 
 
-def test_public_stream_is_withheld_until_terminal_response_is_accepted():
-    delivered = []
+def _agent():
     agent = StreamDeliveryMixin.__new__(StreamDeliveryMixin)
-    agent.stream_delta_callback = delivered.append
+    agent.stream_delta_callback = None
     agent._stream_callback = None
+    return agent
+
+
+def test_public_stream_is_delivered_before_terminal_disposition():
+    delivered = []
+    agent = _agent()
+    agent.stream_delta_callback = delivered.append
+    assert agent._deliver_to_stream_callbacks("partial ordinary response") is True
+    assert delivered == ["partial ordinary response"]
+
+
+def test_interim_commentary_is_suppressed_before_gate():
+    agent = _agent()
+    delivered = []
+    agent.interim_assistant_callback = (
+        lambda text, **kwargs: delivered.append((text, kwargs))
+    )
+    agent._deliver_interim("still working", already_streamed=False, record=["still working"])
+
+    assert delivered == [("still working", {"already_streamed": False})]
+
+
+def test_reasoning_is_suppressed_when_explicitly_marked_private():
+    agent = _agent()
+    delivered = []
+    agent.reasoning_callback = delivered.append
     agent._public_stream_suppressed = True
+    agent._fire_reasoning_delta("private reasoning")
 
-    assert agent._deliver_to_stream_callbacks("partial ordinary response") is False
     assert delivered == []
-
-    agent._public_stream_suppressed = False
-    assert agent._deliver_to_stream_callbacks("MEETING\nShould we continue?") is True
-    assert delivered == ["MEETING\nShould we continue?"]

--- a/tests/agent/test_public_stream_boundary.py
+++ b/tests/agent/test_public_stream_boundary.py
@@ -1,0 +1,16 @@
+from agent.stream_delivery import StreamDeliveryMixin
+
+
+def test_public_stream_is_withheld_until_terminal_response_is_accepted():
+    delivered = []
+    agent = StreamDeliveryMixin.__new__(StreamDeliveryMixin)
+    agent.stream_delta_callback = delivered.append
+    agent._stream_callback = None
+    agent._public_stream_suppressed = True
+
+    assert agent._deliver_to_stream_callbacks("partial ordinary response") is False
+    assert delivered == []
+
+    agent._public_stream_suppressed = False
+    assert agent._deliver_to_stream_callbacks("MEETING\nShould we continue?") is True
+    assert delivered == ["MEETING\nShould we continue?"]

--- a/tests/agent/test_terminal_boundary.py
+++ b/tests/agent/test_terminal_boundary.py
@@ -12,12 +12,42 @@ def test_owner_response_without_terminal_outcome_fails_closed_to_argh():
     assert result["completed"] is False
 
 
-def test_owner_response_with_one_terminal_outcome_passes_through():
+def test_done_without_directed_completion_receipt_fails_closed_to_argh():
     result = enforce_public_terminal_response(
         {"final_response": "DONE\nThe verified artifact is ready."},
         platform="webui",
     )
+    assert result["public_terminal_outcome"] == "ARGH"
+    assert result["final_response"].startswith("ARGH\n")
+    assert "what was done" in result["done_contract_missing"]
+    assert "exactly one recommended next objective" in result["done_contract_missing"]
+
+
+def test_done_with_directed_completion_receipt_passes_through():
+    response = """DONE
+What was done: implemented the public response boundary.
+Evidence: focused boundary tests and a fresh-process invocation passed.
+How Hermes verified it: independently reran the tests and read back the public result.
+How completion advanced the project: ordinary turns can no longer bypass the governed stop contract.
+Recommended next objective: approve the next boundary hardening slice.
+Evidence: the remaining public entry points are enumerated in the acceptance record.
+Acceptance-state criteria: each entry point emits exactly one canonical outcome.
+Verification method: fresh-process tests through the actual user-facing route.
+"""
+    result = enforce_public_terminal_response(
+        {"final_response": response},
+        platform="webui",
+    )
     assert result["public_terminal_outcome"] == "DONE"
+    assert result["terminal_boundary_enforced"] is True
+
+
+def test_owner_response_with_one_terminal_outcome_passes_through():
+    result = enforce_public_terminal_response(
+        {"final_response": "MEETING\nShould we approve the next step?"},
+        platform="webui",
+    )
+    assert result["public_terminal_outcome"] == "MEETING"
     assert result["terminal_boundary_enforced"] is True
 
 

--- a/tests/agent/test_terminal_boundary.py
+++ b/tests/agent/test_terminal_boundary.py
@@ -1,57 +1,33 @@
 from agent.terminal_boundary import enforce_public_terminal_response
 
 
-def test_owner_response_without_terminal_outcome_fails_closed_to_argh():
+def test_plain_provider_response_is_preserved_and_gets_external_disposition():
+    result = enforce_public_terminal_response(
+        {"final_response": "4", "completed": True, "failed": False},
+        platform="webui",
+    )
+    assert result["final_response"] == "4"
+    assert result["core_control"]["outcome"] == "DONE"
+    assert result["core_control"]["response_preserved"] is True
+
+
+def test_incomplete_response_is_not_rewritten_by_core_control():
     result = enforce_public_terminal_response(
         {"final_response": "The work is not finished yet.", "completed": False},
         platform="webui",
     )
-    assert result["public_terminal_outcome"] == "ARGH"
-    assert result["final_response"].startswith("ARGH\n")
-    assert result["failed"] is True
-    assert result["completed"] is False
+    assert result["final_response"] == "The work is not finished yet."
+    assert result["core_control"]["outcome"] == "ARGH"
 
 
-def test_done_without_directed_completion_receipt_fails_closed_to_argh():
-    result = enforce_public_terminal_response(
-        {"final_response": "DONE\nThe verified artifact is ready."},
-        platform="webui",
-    )
-    assert result["public_terminal_outcome"] == "ARGH"
-    assert result["final_response"].startswith("ARGH\n")
-    assert "what was done" in result["done_contract_missing"]
-    assert "exactly one recommended next objective" in result["done_contract_missing"]
+def test_explicit_meeting_is_metadata_only():
+    response = "MEETING\nShould we approve the next step?"
+    result = enforce_public_terminal_response({"final_response": response}, platform="webui")
+    assert result["final_response"] == response
+    assert result["core_control"]["outcome"] == "MEETING"
 
 
-def test_done_with_directed_completion_receipt_passes_through():
-    response = """DONE
-What was done: implemented the public response boundary.
-Evidence: focused boundary tests and a fresh-process invocation passed.
-How Hermes verified it: independently reran the tests and read back the public result.
-How completion advanced the project: ordinary turns can no longer bypass the governed stop contract.
-Recommended next objective: approve the next boundary hardening slice.
-Evidence: the remaining public entry points are enumerated in the acceptance record.
-Acceptance-state criteria: each entry point emits exactly one canonical outcome.
-Verification method: fresh-process tests through the actual user-facing route.
-"""
-    result = enforce_public_terminal_response(
-        {"final_response": response},
-        platform="webui",
-    )
-    assert result["public_terminal_outcome"] == "DONE"
-    assert result["terminal_boundary_enforced"] is True
-
-
-def test_owner_response_with_one_terminal_outcome_passes_through():
-    result = enforce_public_terminal_response(
-        {"final_response": "MEETING\nShould we approve the next step?"},
-        platform="webui",
-    )
-    assert result["public_terminal_outcome"] == "MEETING"
-    assert result["terminal_boundary_enforced"] is True
-
-
-def test_internal_child_response_is_not_rewritten():
+def test_internal_child_response_is_not_rewritten_or_invoked():
     original = {"final_response": "The child should continue."}
     assert enforce_public_terminal_response(original, platform="subagent") is original
-    assert "public_terminal_outcome" not in original
+    assert "core_control" not in original

--- a/tests/agent/test_terminal_boundary.py
+++ b/tests/agent/test_terminal_boundary.py
@@ -1,0 +1,27 @@
+from agent.terminal_boundary import enforce_public_terminal_response
+
+
+def test_owner_response_without_terminal_outcome_fails_closed_to_argh():
+    result = enforce_public_terminal_response(
+        {"final_response": "The work is not finished yet.", "completed": False},
+        platform="webui",
+    )
+    assert result["public_terminal_outcome"] == "ARGH"
+    assert result["final_response"].startswith("ARGH\n")
+    assert result["failed"] is True
+    assert result["completed"] is False
+
+
+def test_owner_response_with_one_terminal_outcome_passes_through():
+    result = enforce_public_terminal_response(
+        {"final_response": "DONE\nThe verified artifact is ready."},
+        platform="webui",
+    )
+    assert result["public_terminal_outcome"] == "DONE"
+    assert result["terminal_boundary_enforced"] is True
+
+
+def test_internal_child_response_is_not_rewritten():
+    original = {"final_response": "The child should continue."}
+    assert enforce_public_terminal_response(original, platform="subagent") is original
+    assert "public_terminal_outcome" not in original


### PR DESCRIPTION
## Summary

- keep Core Control as a separate external application
- route owner-facing Hermes results through the explicit Core Control boundary
- preserve the original provider response and request identity
- retain the Hermes adapter as consumer code; Core Control is not merged into Hermes

## Verification

- Hermes boundary tests: `7 passed`
- branch is based on current upstream `main`
- Core Control is independently published at `accessiblehope/core-control` commit `195ab058f1e1d44272133d589d012419cc3dcff9`

The source checkout used for this branch was an isolated clean worktree. The active local Hermes checkout, including unrelated uncommitted work, was not modified.
