### PR TITLE
fix(gateway): keep the macOS orphan reaper fail-closed on launchd lookup timeouts

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -117,8 +117,12 @@ class WindowsGatewayService:
     gateway_create_time: float = 0.0
 
 
-def _get_service_pids(all_profiles: bool = False) -> set:
+def _get_service_pids(all_profiles: bool = False, *, fail_closed: bool = False) -> set:
     """PIDs managed by systemd/launchd gateway services (excluded from stale-process sweeps).
+
+    ``fail_closed``: a service-manager query that times out re-raises ``subprocess.TimeoutExpired``
+    instead of being skipped. Destructive callers (the orphan reaper) need this: a supervised PID
+    missing from the result because ``launchctl`` stalled must abort the sweep, not become a kill.
 
     Relies on the service manager committing the new PID before the restart command returns.
     ``all_profiles`` widens the current profile's unit/label to the whole ``hermes-gateway*`` /
@@ -164,9 +168,15 @@ def _get_service_pids(all_profiles: bool = False) -> set:
                         pid = int(show.stdout.strip())
                         if pid > 0:
                             pids.add(pid)
-                    except (ValueError, subprocess.TimeoutExpired):
+                    except subprocess.TimeoutExpired:
+                        if fail_closed:
+                            raise
+                    except ValueError:
                         pass
-            except (FileNotFoundError, subprocess.TimeoutExpired):
+            except subprocess.TimeoutExpired:
+                if fail_closed:
+                    raise
+            except FileNotFoundError:
                 pass
 
     # --- launchd (macOS) ---
@@ -183,6 +193,8 @@ def _get_service_pids(all_profiles: bool = False) -> set:
             try:
                 _domain, pid = _locate_launchd_gateway_service(label)
             except subprocess.TimeoutExpired:
+                if fail_closed:
+                    raise
                 continue
             if pid is not None and pid > 0:
                 pids.add(pid)
@@ -201,7 +213,10 @@ def _get_service_pids(all_profiles: bool = False) -> set:
                                     pids.add(pid)
                             except ValueError:
                                 pass
-            except (FileNotFoundError, subprocess.TimeoutExpired):
+            except subprocess.TimeoutExpired:
+                if fail_closed:
+                    raise
+            except FileNotFoundError:
                 pass
 
     return pids
@@ -1615,6 +1630,8 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
 
     from gateway.status import _pid_exists, get_process_start_time, write_planned_stop_marker
     own = _reaper_exclusion_pids(extra_exclude)
+    if own is None:
+        return False
     try:
         # On Windows also drop Task Scheduler-owned candidates (the pidfile-less gap).
         orphans = [
@@ -1659,12 +1676,17 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     return reaped
 
 
-def _reaper_exclusion_pids(extra_exclude: set | None) -> set[int]:
-    """PIDs the orphan reaper must never kill: self, caller extras, service-managed, recorded."""
+def _reaper_exclusion_pids(extra_exclude: set | None) -> set[int] | None:
+    """PIDs the orphan reaper must never kill: self, caller extras, service-managed, recorded.
+
+    Returns ``None`` when the exclusion set could not be built completely on macOS: launchd PID
+    discovery is the ONLY thing standing between a supervised gateway and the SIGTERM below, so an
+    incomplete answer must abort the sweep rather than shrink the exclusion set.
+    """
     own = {os.getpid()} | (extra_exclude or set())
     # Service-managed gateways are never orphans (on macOS supports_systemd_services() is False, so a
     # launchd gateway would otherwise be SIGTERM'd); all_profiles because the scan sees siblings too.
-    with contextlib.suppress(Exception):
+    try:
         # This covers macOS launchd (supports_systemd_services() is False there, so without this the launchd
         # gateway looks like an unsupervised orphan and gets SIGTERM'd, causing launchd to restart it — or
         # leaving it down under KeepAlive.SuccessfulExit=false) and any systemd unit reachable from a host
@@ -1674,7 +1696,16 @@ def _reaper_exclusion_pids(extra_exclude: set | None) -> set[int]:
         # cover the whole ai.hermes.gateway* fleet — not just the current profile's label — or a sibling
         # profile's launchd gateway is misclassified as an unsupervised orphan and reaped. Same class as the
         # update-sweep fix in #74075.
-        own |= _get_service_pids(all_profiles=True)
+        # fail_closed on macOS: a transient launchctl stall must abort this destructive sweep instead
+        # of exposing the root/sibling launchd gateway PID as an apparent orphan. Elsewhere the
+        # exclusion set is best-effort, as before.
+        own |= _get_service_pids(all_profiles=True, fail_closed=is_macos())
+    except subprocess.TimeoutExpired:
+        # Only reachable with fail_closed=True, i.e. on macOS.
+        logger.debug("Skipping orphan reap: launchd PID discovery was incomplete", exc_info=True)
+        return None
+    except Exception:
+        pass
     # Exempt the recorded gateway PID and its parent chain (on Windows the Scheduled-Task bootstrap's
     # ``gateway run`` argv matches the scan; killing it takes the gateway down). Use the RAW pidfile +
     # lock records, not only the validated probe: get_running_pid returns None on any validation

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -5,6 +5,8 @@ import os
 import subprocess
 import sys
 import textwrap
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from types import ModuleType, SimpleNamespace
 
 import pytest
@@ -610,7 +612,7 @@ class TestReapUnsupervisedGatewayOrphansMacOS:
         # _get_service_pids returns the launchd-managed gateway PID.
         # (accepts all_profiles: the reaper asks for the whole fleet, #74075)
         monkeypatch.setattr(
-            gateway, "_get_service_pids", lambda all_profiles=False: {launchd_pid}
+            gateway, "_get_service_pids", lambda all_profiles=False, **_kw: {launchd_pid}
         )
         # No pidfile-recorded gateway in this scenario.
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
@@ -645,7 +647,7 @@ class TestReapUnsupervisedGatewayOrphansMacOS:
         monkeypatch.setattr(gateway, "is_macos", lambda: True)
         monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
         monkeypatch.setattr(
-            gateway, "_get_service_pids", lambda all_profiles=False: {launchd_pid}
+            gateway, "_get_service_pids", lambda all_profiles=False, **_kw: {launchd_pid}
         )
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
 
@@ -663,6 +665,114 @@ class TestReapUnsupervisedGatewayOrphansMacOS:
 
         assert result is False  # no orphans reaped
         assert killed_pids == []  # nothing was killed
+
+    def test_macos_reap_aborts_when_launchd_lookup_times_out(self, monkeypatch):
+        """A launchctl stall must abort the sweep, not expose the supervised PID.
+
+        ``_get_service_pids(all_profiles=True)`` used to swallow ``TimeoutExpired``
+        per label, so a transient launchd stall silently dropped the root gateway
+        from the exclusion set and the reaper SIGTERM'd it as an "orphan".
+        """
+        root_pid = 52615
+
+        monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "get_launchd_label", lambda: "ai.hermes.gateway-analyst")
+        monkeypatch.setattr(
+            gateway,
+            "launchd_gateway_labels_for_install",
+            lambda: ["ai.hermes.gateway", "ai.hermes.gateway-analyst"],
+        )
+
+        def fake_locate(label):
+            if label == "ai.hermes.gateway":
+                raise subprocess.TimeoutExpired(["launchctl", "print", label], 5)
+            return (None, None)
+
+        monkeypatch.setattr(gateway, "_locate_launchd_gateway_service", fake_locate)
+        monkeypatch.setattr(
+            gateway.subprocess, "run", lambda argv, **_kwargs: SimpleNamespace(returncode=1, stdout="")
+        )
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda **_kw: None)
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None, **_kwargs: [
+                pid for pid in [root_pid] if pid not in (exclude_pids or set())
+            ],
+        )
+
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append(pid))
+        monkeypatch.setattr("gateway.status._pid_exists", lambda _pid: False)
+        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda _pid: None)
+
+        # Non-destructive callers keep the old best-effort contract ...
+        assert gateway._get_service_pids(all_profiles=True) == set()
+        # ... the reaper asks for fail-closed discovery and propagates the stall.
+        with pytest.raises(subprocess.TimeoutExpired):
+            gateway._get_service_pids(all_profiles=True, fail_closed=True)
+
+        assert gateway._reap_unsupervised_gateway_orphans() is False
+        assert killed_pids == []
+
+    def test_concurrent_profile_reapers_fail_closed_when_root_lookup_times_out(
+        self, monkeypatch
+    ):
+        """Several profile backends reaping at once must all abort on a stalled root lookup."""
+        root_pid = 52615
+        concurrent_lookups = 3
+        root_lookup_barrier = threading.Barrier(concurrent_lookups)
+
+        monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway, "get_launchd_label", lambda: "ai.hermes.gateway-analyst")
+        monkeypatch.setattr(
+            gateway,
+            "launchd_gateway_labels_for_install",
+            lambda: ["ai.hermes.gateway", "ai.hermes.gateway-analyst"],
+        )
+
+        def fake_locate(label):
+            if label == "ai.hermes.gateway":
+                root_lookup_barrier.wait(timeout=5)
+                raise subprocess.TimeoutExpired(["launchctl", "print", label], 5)
+            return (None, None)
+
+        monkeypatch.setattr(gateway, "_locate_launchd_gateway_service", fake_locate)
+        monkeypatch.setattr(
+            gateway.subprocess, "run", lambda argv, **_kwargs: SimpleNamespace(returncode=1, stdout="")
+        )
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda **_kw: None)
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None, **_kwargs: [
+                pid for pid in [root_pid] if pid not in (exclude_pids or set())
+            ],
+        )
+
+        killed_pids = []
+        killed_pids_lock = threading.Lock()
+
+        def record_kill(pid, _signal):
+            with killed_pids_lock:
+                killed_pids.append(pid)
+
+        monkeypatch.setattr(gateway.os, "kill", record_kill)
+        monkeypatch.setattr("gateway.status._pid_exists", lambda _pid: False)
+        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda _pid: None)
+
+        with ThreadPoolExecutor(max_workers=concurrent_lookups) as executor:
+            results = list(
+                executor.map(
+                    lambda _index: gateway._reap_unsupervised_gateway_orphans(),
+                    range(concurrent_lookups),
+                )
+            )
+
+        assert results == [False] * concurrent_lookups
+        assert killed_pids == []
 
 
 class TestReapUnsupervisedGatewayOrphansWindows:


### PR DESCRIPTION
## Summary

`_get_service_pids(all_profiles=True)` swallows `subprocess.TimeoutExpired` per launchd label. A transient `launchctl` stall therefore silently drops a supervised gateway (root or a sibling profile) from the orphan reaper's exclusion set. On macOS `supports_systemd_services()` is False, so `_reap_unsupervised_gateway_orphans` then classifies that PID as an unsupervised orphan and SIGTERMs it; launchd restarts it, or leaves it down under `KeepAlive.SuccessfulExit=false`.

`_reaper_exclusion_pids` wraps the call in `contextlib.suppress(Exception)`, so today there is no path at all on which an incomplete discovery aborts the sweep.

## Change

- `_get_service_pids(all_profiles=False, *, fail_closed=False)`: with `fail_closed=True` a service-manager query that times out re-raises instead of being skipped. Non-destructive callers (`gateway status`, cron checks, the update sweep) keep the best-effort contract.
- `_reaper_exclusion_pids` passes `fail_closed=is_macos()` and returns `None` on `TimeoutExpired`; `_reap_unsupervised_gateway_orphans` returns False in that case instead of killing with an incomplete exclusion set. Other exceptions stay swallowed as before.

## Tests

- The two existing macOS reaper stubs accept the new keyword.
- `test_macos_reap_aborts_when_launchd_lookup_times_out`: the fail-closed lookup raises, the default lookup does not, and the reaper aborts without killing.
- `test_concurrent_profile_reapers_fail_closed_when_root_lookup_times_out`: three profile backends reaping at once all abort when the root label lookup stalls.

`tests/hermes_cli/test_gateway.py`: 39 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
