### PR TITLE
fix(kanban): record why a worker crashed, not just its exit code

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -750,6 +750,38 @@ class _DeadWorker:
         return "rate_limited" if self.rate_limited else "crashed"
 
 
+def _worker_crash_reason(task_id: str, board: Optional[str] = None) -> Optional[str]:
+    """Best-effort one-line cause from the tail of a crashed worker's log.
+
+    ``pid 74514 exited with code 1`` tells an operator nothing, while the reason
+    is usually sitting in the worker's own log ("Error: Unknown skill(s):
+    humanizer"). Prefer the last explicit error line; fall back to the last
+    non-empty line. Never raises — a missing/unreadable log just means no
+    extra detail.
+    """
+    try:
+        path = _kb.worker_log_path(task_id, board=board)
+        with open(path, "rb") as fh:
+            try:
+                fh.seek(-8192, os.SEEK_END)
+            except OSError:
+                fh.seek(0)
+            tail = fh.read().decode("utf-8", errors="replace")
+    except (OSError, ValueError):
+        return None
+
+    lines = [ln.strip() for ln in tail.splitlines() if ln.strip()]
+    if not lines:
+        return None
+    for line in reversed(lines):
+        low = line.lower()
+        if low.startswith(("error:", "error ", "fatal:", "traceback")) or (
+            "error:" in low and len(line) < 300
+        ):
+            return line[:300]
+    return lines[-1][:300]
+
+
 def _classify_dead_worker(pid: int, claimer: Optional[str]) -> _DeadWorker:
     """Map a dead worker's reaped exit status to its reclaim bookkeeping."""
     kind, code = _classify_worker_exit(pid)
@@ -802,7 +834,7 @@ class _CrashSweep:
     exited_hook_payloads: list[dict] = field(default_factory=list)
 
 
-def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
+def _reclaim_dead_workers(conn: sqlite3.Connection, *, board: Optional[str] = None) -> _CrashSweep:
     """Release every host-local ``running`` task whose worker PID is dead."""
     sweep = _CrashSweep()
     with _kb.write_txn(conn):
@@ -826,6 +858,14 @@ def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
 
             pid = int(row["worker_pid"])
             dead = _classify_dead_worker(pid, row["claim_lock"])
+            if dead.event_kind == "crashed":
+                # The exit code alone is undiagnosable; the worker's own log
+                # usually names the cause (bad skill, missing profile, auth).
+                # Carry it into last_failure_error so the board can say why.
+                crash_reason = _worker_crash_reason(row["id"], board)
+                if crash_reason:
+                    dead.error_text = f"{dead.error_text}: {crash_reason}"
+                    dead.event_payload["reason"] = crash_reason
             retry_status = _kb._retry_status_for_run(conn, row["id"])
             dead.event_payload["retry_status"] = retry_status
             cur = conn.execute(
@@ -934,7 +974,7 @@ def _account_crashes(conn: sqlite3.Connection, crash_details: list) -> list[str]
     return auto_blocked
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+def detect_crashed_workers(conn: sqlite3.Connection, *, board: Optional[str] = None) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
     Restores the source phase immediately (no waiting for the claim TTL), for
@@ -942,9 +982,10 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     Clean exit while ``running`` is a protocol violation with a bounded
     violation-only retry budget; ``KANBAN_RATE_LIMIT_EXIT_CODE`` is a quota
     wall, released WITHOUT counting a failure and surfaced via the
-    ``_last_rate_limited`` attribute (the return stays crashed-only).
+    ``_last_rate_limited`` attribute (the return stays crashed-only). ``board``
+    locates the worker log so a crash can be annotated with its cause.
     """
-    sweep = _reclaim_dead_workers(conn)
+    sweep = _reclaim_dead_workers(conn, board=board)
     # Outside the main txn: account each crash and maybe trip the breaker.
     auto_blocked = _account_crashes(conn, sweep.crash_details) if sweep.crash_details else []
     # Side-channel attributes keep the public ``list[str]`` return stable;
@@ -1631,6 +1672,7 @@ def _run_reclaim_phase(
     stale_timeout_seconds: int,
     failure_limit: int,
     reconcile_orphans: bool,
+    board: Optional[str] = None,
 ) -> None:
     """Reclaim stale/orphaned/crashed/timed-out running tasks, then promote."""
     reap_worker_zombies()
@@ -1638,7 +1680,7 @@ def _run_reclaim_phase(
     if reconcile_orphans:
         result.reconciled_orphans = reconcile_orphaned_running(conn)
     result.stale = detect_stale_running(conn, stale_timeout_seconds=stale_timeout_seconds)
-    result.crashed = detect_crashed_workers(conn)
+    result.crashed = detect_crashed_workers(conn, board=board)
     # Side-channel attributes (see detect_crashed_workers); rate-limited tasks
     # went back to ``ready`` and the respawn guard defers them until quota clears.
     result.auto_blocked.extend(getattr(detect_crashed_workers, "_last_auto_blocked", []))
@@ -1770,7 +1812,7 @@ def _dispatch_once_locked(
     result = DispatchResult()
     _run_reclaim_phase(
         conn, result, stale_timeout_seconds=stale_timeout_seconds,
-        failure_limit=failure_limit, reconcile_orphans=reconcile_orphans,
+        failure_limit=failure_limit, reconcile_orphans=reconcile_orphans, board=board,
     )
     may_spawn, spawn_budget = _tick_spawn_budget(
         conn, result, max_spawn=max_spawn, max_in_progress=max_in_progress, board=board,

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1656,3 +1656,75 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Crash diagnosis: the worker's own log names the cause, so a nonzero exit
+# must not be recorded as a bare "exited with code 1" (undiagnosable on the
+# board). Regression coverage for the unknown-skill crash loop.
+# ---------------------------------------------------------------------------
+
+
+def test_crash_records_the_reason_from_the_worker_log(kanban_home, monkeypatch):
+    """A nonzero worker exit carries its log's error line into
+    ``last_failure_error`` and the ``crashed`` event payload."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kbc.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="bad skill", assignee="a")
+        kb.claim_task(conn, tid, claimer=f"{host}:w0")
+        conn.execute("UPDATE tasks SET worker_pid=? WHERE id=?", (70123, tid))
+        conn.commit()
+
+        log = _kb.worker_log_path(tid)
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text(
+            "Query: work kanban task t_x\n"
+            "Initializing agent...\n"
+            "Error: Unknown skill(s): humanizer\n"
+        )
+
+        kbd._record_worker_exit(70123, _exited_status(1))
+        assert tid in kbd.detect_crashed_workers(conn)
+
+        task = kb.get_task(conn, tid)
+        assert "Unknown skill(s): humanizer" in (task.last_failure_error or ""), (
+            f"crash reason lost; got {task.last_failure_error!r}"
+        )
+
+        event = next(e for e in kb.list_events(conn, tid) if e.kind == "crashed")
+        assert event.payload["reason"] == "Error: Unknown skill(s): humanizer"
+
+
+def test_crash_without_a_readable_log_still_records_the_exit(kanban_home, monkeypatch):
+    """No log file (GC'd, never spawned) must not break crash accounting."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kbc.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="no log", assignee="a")
+        kb.claim_task(conn, tid, claimer=f"{host}:w0")
+        conn.execute("UPDATE tasks SET worker_pid=? WHERE id=?", (70124, tid))
+        conn.commit()
+
+        kbd._record_worker_exit(70124, _exited_status(1))
+        assert tid in kbd.detect_crashed_workers(conn)
+
+        # The exact exit_kind depends on the process-global exit registry,
+        # so assert the stable property: the crash is still accounted with a
+        # pid-identified reason, and no log excerpt is appended.
+        failure = kb.get_task(conn, tid).last_failure_error or ""
+        assert "70124" in failure, failure
+        assert ":" not in failure.split("pid ", 1)[-1], (
+            f"no log exists, so no excerpt should be appended; got {failure!r}"
+        )
+        event = next(e for e in kb.list_events(conn, tid) if e.kind == "crashed")
+        assert "reason" not in event.payload
+


### PR DESCRIPTION
## Summary

A crashed worker is recorded as `pid 74514 exited with code 1`, which is undiagnosable from the board, while the actual cause sits in the worker's own log. Live example: a task carrying `skills: ["humanizer"]` (no such skill) exits 1 instantly, burns its whole failure budget on retries, and ends up blocked with no stated reason.

## Change

`detect_crashed_workers` now pulls the last error line from the worker log (last 8 KiB; prefers an explicit `Error:` / `fatal:` / `Traceback` line, else the last non-empty line, capped at 300 chars) into `last_failure_error` and into the `crashed` event payload as `reason`, so the desktop failure callout and `hermes kanban show` name the cause.

- Best-effort: a missing or unreadable log leaves the old exit-code text untouched, and no `reason` key is added.
- Rate-limited and clean-exit (protocol violation) reclaims are unchanged.
- The dispatcher threads the board slug into `detect_crashed_workers(conn, board=...)` so the log is located on the task's board. The kwarg defaults to `None`; existing callers are unaffected.

## Tests

- `test_crash_records_the_reason_from_the_worker_log`
- `test_crash_without_a_readable_log_still_records_the_exit`

`tests/hermes_cli/test_kanban_db.py`: 33 passed, 1 skipped. `tests/hermes_cli/test_kanban_core_functionality.py`: 23 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
