### PR TITLE
fix(retry): handle every GLM-5.x Z.AI Coding Plan overload and never wait on pool rotation for it

### DIFF
--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -16,7 +16,7 @@ from typing import Any, Optional
 _jitter_counter = 0
 _jitter_lock = threading.Lock()
 
-# Z.AI Coding Plan's GLM-5.2 endpoint often returns 429 code 1305 ("service may be
+# Z.AI Coding Plan's GLM-5.x endpoint often returns 429 code 1305 ("service may be
 # temporarily overloaded"). Short retries hammer the same window, so after
 # ``_ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS`` normal retries the wait widens progressively;
 # the cap stays interactive-friendly (a TUI message should fail visibly in minutes).
@@ -92,7 +92,7 @@ def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, err
     return (
         getattr(error, "status_code", None) == 429
         and "api.z.ai/api/coding/paas/v4" in (base_url or "").lower()
-        and "glm-5.2" in (model or "").lower()
+        and "glm-5" in (model or "").lower()
         and ("1305" in text or "temporarily overloaded" in text)
     )
 
@@ -101,7 +101,7 @@ def adaptive_rate_limit_backoff(
     attempt: int, *, base_url: str | None, model: str | None, error: Any, default_wait: float,
     short_attempts: int = _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS,
 ) -> tuple[float, str | None]:
-    """``(wait_seconds, reason_label)``: ``default_wait`` for most providers; Z.AI Coding GLM-5.2 overloads keep
+    """``(wait_seconds, reason_label)``: ``default_wait`` for most providers; Z.AI Coding GLM-5.x overloads keep
     ``short_attempts`` short retries, then 30→60→90→120s with light jitter. ``attempt`` is 1-based."""
     if not is_zai_coding_overload_error(base_url=base_url, model=model, error=error):
         return default_wait, None

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -1274,6 +1274,21 @@ def _is_genuine_nous_rate_limit(agent: Any, api_error: Exception, error_context:
     return _genuine
 
 
+def _pool_rotation_may_recover(agent: Any, classified: Any, *, is_zai_coding_overload: bool) -> bool:
+    """Whether waiting on credential-pool rotation could still clear this error.
+
+    False for the two service-side conditions a different key cannot fix: an upstream-aggregator
+    429 (the aggregator's own upstream is throttled, #11314) and a Z.AI Coding Plan overload
+    (HTTP 429 code 1305 from the endpoint itself). Rotating a multi-key pool through the same
+    overloaded endpoint only delays the configured fallback chain; the short retry window in
+    ``adaptive_rate_limit_backoff`` already covers the transient case.
+    """
+    if classified.reason == FailoverReason.upstream_rate_limit or is_zai_coding_overload:
+        return False
+    from agent.conversation_loop import _ra
+    return bool(_ra()._pool_may_recover_from_rate_limit(agent._credential_pool))
+
+
 def route_classified_error(
     agent: Any, api_error: Exception, classified: Any, _retry: TurnRetryState, *, error_msg: str,
     error_context: Any, recovered_with_pool: bool, base_url: Any, model: Any,
@@ -1407,12 +1422,12 @@ def route_classified_error(
         or (_is_transport_failure and retry_count >= 2)
     )
     if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
-        # No eager fallback while credential pool rotation may recover. Exception: an
-        # upstream-aggregator 429 — the pool can't help, always fall back.
+        # No eager fallback while credential pool rotation may recover. Exceptions: an
+        # upstream-aggregator 429 or a Z.AI Coding Plan overload — the pool can't help there.
         # Fixes #11314.
         _is_upstream = classified.reason == FailoverReason.upstream_rate_limit
-        pool_may_recover = (
-            False if _is_upstream else _ra()._pool_may_recover_from_rate_limit(agent._credential_pool)
+        pool_may_recover = _pool_rotation_may_recover(
+            agent, classified, is_zai_coding_overload=_is_zai_coding_overload,
         )
         if not pool_may_recover:
             agent._buffer_status(_eager_fallback_status(classified, _is_upstream, _is_transport_failure))

--- a/tests/agent/test_turn_recovery_pool_rotation_gate.py
+++ b/tests/agent/test_turn_recovery_pool_rotation_gate.py
@@ -1,0 +1,52 @@
+"""Eager-fallback gate: when credential-pool rotation cannot help, fall back immediately.
+
+``route_classified_error`` defers the fallback chain while a multi-key pool may still recover
+from a 429. That is wrong for service-side conditions a different key cannot fix: an
+upstream-aggregator 429 (#11314) and a Z.AI Coding Plan overload (429 / code 1305), which
+classifies ``overloaded`` and reaches the gate as a transport failure after its short retries.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.error_classifier import FailoverReason
+from agent.turn_recovery import _pool_rotation_may_recover
+
+
+def _agent():
+    return SimpleNamespace(_credential_pool=object())
+
+
+def _classified(reason):
+    return SimpleNamespace(reason=reason)
+
+
+def test_zai_coding_overload_never_waits_on_pool_rotation():
+    with patch("run_agent._pool_may_recover_from_rate_limit", return_value=True) as pool_check:
+        assert _pool_rotation_may_recover(
+            _agent(), _classified(FailoverReason.overloaded), is_zai_coding_overload=True,
+        ) is False
+    pool_check.assert_not_called()
+
+
+def test_upstream_aggregator_rate_limit_never_waits_on_pool_rotation():
+    with patch("run_agent._pool_may_recover_from_rate_limit", return_value=True) as pool_check:
+        assert _pool_rotation_may_recover(
+            _agent(), _classified(FailoverReason.upstream_rate_limit), is_zai_coding_overload=False,
+        ) is False
+    pool_check.assert_not_called()
+
+
+def test_ordinary_rate_limit_defers_to_pool_rotation_room():
+    agent = _agent()
+    with patch("run_agent._pool_may_recover_from_rate_limit", return_value=True) as pool_check:
+        assert _pool_rotation_may_recover(
+            agent, _classified(FailoverReason.rate_limit), is_zai_coding_overload=False,
+        ) is True
+    pool_check.assert_called_once_with(agent._credential_pool)
+    with patch("run_agent._pool_may_recover_from_rate_limit", return_value=False):
+        assert _pool_rotation_may_recover(
+            agent, _classified(FailoverReason.rate_limit), is_zai_coding_overload=False,
+        ) is False

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -2,6 +2,8 @@
 
 import threading
 
+import pytest
+
 import agent.retry_utils as retry_utils
 from types import SimpleNamespace
 
@@ -119,6 +121,25 @@ def _zai_overload_error():
 
 
 
+
+
+@pytest.mark.parametrize("model", ["glm-5.2", "glm-5.3", "GLM-5.4-Air", "zai/glm-5.3"])
+def test_zai_overload_detection_covers_every_glm5_model(model):
+    """The overload shape (429 + code 1305) is a property of the Coding Plan endpoint, not of
+    one model: GLM-5.3 (and later 5.x) must not bypass the long-backoff policy."""
+    assert is_zai_coding_overload_error(
+        base_url="https://api.z.ai/api/coding/paas/v4", model=model, error=_zai_overload_error(),
+    )
+
+
+def test_zai_overload_detection_ignores_other_models_and_endpoints():
+    err = _zai_overload_error()
+    assert not is_zai_coding_overload_error(
+        base_url="https://api.z.ai/api/coding/paas/v4", model="glm-4.7", error=err,
+    )
+    assert not is_zai_coding_overload_error(
+        base_url="https://api.z.ai/api/paas/v4", model="glm-5.3", error=err,
+    )
 
 
 def test_zai_overload_retry_ceiling_exceeds_short_attempts():


### PR DESCRIPTION
## Summary

Two gaps in the Z.AI Coding Plan overload handling (HTTP 429, code 1305, "The service may be temporarily overloaded"):

1. `is_zai_coding_overload_error` matched only `glm-5.2`. The overload shape is a property of the coding endpoint, not of one model, so GLM-5.3 (the current Coding Plan default) bypassed the whole adaptive backoff path and burned the plain retry budget against the same overloaded window.
2. `route_classified_error` deferred the fallback chain while a multi-key credential pool "may recover" from the 429. A Z.AI overload is a service-side condition, not a bad key: rotating the pool only walks every key through the same overloaded endpoint and delays the configured fallback.

## Change

- Match any GLM-5.x model on the coding endpoint.
- Treat a Z.AI overload like an upstream-aggregator 429 (#11314) and fall back as soon as the short retry window is exhausted. The decision is pulled into `_pool_rotation_may_recover` so it can be unit-tested without driving the whole recovery routine; behaviour for every other reason is unchanged.

## Tests

- `tests/test_retry_utils.py`: parametrized detection over GLM-5.2 / 5.3 / 5.4-Air / `zai/glm-5.3`, plus a negative case for other models and the non-coding endpoint.
- `tests/agent/test_turn_recovery_pool_rotation_gate.py`: Z.AI overload and upstream-aggregator 429 never consult the pool; ordinary rate limits still defer to `_pool_may_recover_from_rate_limit`.

`tests/test_retry_utils.py` + the new file + `tests/run_agent/test_32646_fallback_429_after_timeout.py`: 24 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
