### PR TITLE
fix(stt): honor an explicit CPU compute_type on Apple Silicon

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -419,6 +419,22 @@ class TestTranscribeLocalExtended:
         mock_whisper_cls.assert_called_once_with("base", device="cpu", compute_type="float32")
 
 
+    @pytest.mark.parametrize(
+        "configured, expected",
+        [("auto", "int8"), (None, "int8"), ("float32", "float32"), (" int8_float16 ", "int8_float16")],
+    )
+    def test_forced_cpu_path_honors_explicit_compute_type(self, configured, expected):
+        """On Apple Silicon/Rosetta the loader forces device=cpu, but must still honour the
+        documented ``stt.local.compute_type`` knob; ``auto``/unset keeps the historical int8."""
+        from tools import transcription_local
+
+        mock_whisper_cls = MagicMock(return_value=MagicMock())
+        with patch("faster_whisper.WhisperModel", mock_whisper_cls), \
+             patch.object(transcription_local, "_should_force_faster_whisper_cpu", return_value=True):
+            transcription_local._load_local_whisper_model("base", device="auto", compute_type=configured)
+
+        mock_whisper_cls.assert_called_once_with("base", device="cpu", compute_type=expected)
+
     def test_cuda_out_of_memory_does_not_trigger_cpu_fallback(self, tmp_path):
         """'CUDA out of memory' is a real error, not a missing lib — surface it."""
         audio = tmp_path / "test.ogg"

--- a/tools/transcription_local.py
+++ b/tools/transcription_local.py
@@ -136,9 +136,13 @@ def _load_local_whisper_model(model_name: str, device: str = "auto", compute_typ
         os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
     from faster_whisper import WhisperModel
     if force_cpu:
+        # Keep the safety override on the device, but honour an explicit CPU
+        # compute_type from stt.local; ``auto`` keeps the historical int8.
+        requested = str(compute_type or "auto").strip()
+        effective_compute_type = "int8" if requested.lower() == "auto" else requested
         logger.info("Apple Silicon/Rosetta detected — loading faster-whisper on CPU "
-                    "(int8) to avoid native device autodetection crashes")
-        return WhisperModel(model_name, device="cpu", compute_type="int8")
+                    "(%s) to avoid native device autodetection crashes", effective_compute_type)
+        return WhisperModel(model_name, device="cpu", compute_type=effective_compute_type)
     try:
         return WhisperModel(model_name, device=device, compute_type=compute_type)
     except Exception as exc:


### PR DESCRIPTION
## Summary

`_load_local_whisper_model`'s forced-CPU branch (Apple Silicon / Rosetta, where device autodetection can crash) hardcodes `compute_type="int8"`, so the documented `stt.local.compute_type` knob is silently ignored on exactly the hosts that most often want a different CPU quantization (`int8_float16`, or `float32` for accuracy checks). The function's own docstring advertises the knob as the way to pin a configuration (#9088).

## Change

Keep the device override, but pass the configured `compute_type` through. `auto` / unset still resolves to `int8`, so existing installs are unchanged.

## Tests

`test_forced_cpu_path_honors_explicit_compute_type`, parametrized over `auto`, `None`, `float32` and a padded `int8_float16`.

`tests/tools/test_transcription_tools.py`: 58 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
