### PR TITLE
fix(skills): exclude trashed files from drive search by default

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -218,9 +218,10 @@ $GAPI calendar delete EVENT_ID
 ### Drive
 
 ```bash
-# Search existing files
+# Search existing files (trashed files are excluded, like Drive's own search)
 $GAPI drive search "quarterly report" --max 10
 $GAPI drive search "mimeType='application/pdf'" --raw-query --max 5
+$GAPI drive search "quarterly report" --include-trashed
 
 # Get metadata for a single file
 $GAPI drive get FILE_ID

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -570,7 +570,12 @@ def calendar_delete(args):
 
 
 def drive_search(args):
+    # Drive's files.list returns trashed files by default; hide them so search
+    # matches what the user sees in Drive's UI. Raw queries are caller-authored
+    # and passed through untouched.
     query = args.query if args.raw_query else f"fullText contains '{args.query}'"
+    if not args.raw_query and not args.include_trashed:
+        query = f"({query}) and trashed = false"
     if _gws_binary():
         results = _run_gws(
             ["drive", "files", "list"],
@@ -1127,6 +1132,11 @@ def main():
     p.add_argument("query")
     p.add_argument("--max", type=int, default=10)
     p.add_argument("--raw-query", action="store_true", help="Use query as raw Drive API query")
+    p.add_argument(
+        "--include-trashed",
+        action="store_true",
+        help="Include files in the Drive trash (excluded by default; ignored with --raw-query)",
+    )
     p.set_defaults(func=drive_search)
 
     p = drv_sub.add_parser("get")

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -136,6 +136,59 @@ def test_api_calendar_list_uses_events_list(api_module):
     assert params["calendarId"] == "primary"
 
 
+def _drive_search_args(api_module, **overrides):
+    defaults = dict(
+        query="quarterly report",
+        max=10,
+        raw_query=False,
+        include_trashed=False,
+        func=api_module.drive_search,
+    )
+    defaults.update(overrides)
+    return api_module.argparse.Namespace(**defaults)
+
+
+def _captured_gws_params(api_module, args):
+    captured = {}
+
+    def capture_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return MagicMock(returncode=0, stdout="{}", stderr="")
+
+    with patch.object(api_module.subprocess, "run", side_effect=capture_run):
+        api_module.drive_search(args)
+
+    cmd = captured["cmd"]
+    assert cmd[0] == "/usr/bin/gws"
+    return json.loads(cmd[cmd.index("--params") + 1])
+
+
+def test_drive_search_excludes_trashed_by_default(api_module):
+    """Plain search appends `trashed = false` so deleted files don't resurface."""
+    params = _captured_gws_params(api_module, _drive_search_args(api_module))
+    assert params["q"] == "(fullText contains 'quarterly report') and trashed = false"
+
+
+def test_drive_search_include_trashed_flag_keeps_legacy_behavior(api_module):
+    """--include-trashed sends the bare query, the pre-fix behavior."""
+    params = _captured_gws_params(
+        api_module, _drive_search_args(api_module, include_trashed=True)
+    )
+    assert params["q"] == "fullText contains 'quarterly report'"
+
+
+def test_drive_search_raw_query_is_passed_through(api_module):
+    """--raw-query is caller-authored: never rewritten with a trashed clause,
+    even when --include-trashed is also set (it is raw-query that wins)."""
+    params = _captured_gws_params(
+        api_module,
+        _drive_search_args(
+            api_module, query="mimeType='application/pdf'", raw_query=True, include_trashed=True
+        ),
+    )
+    assert params["q"] == "mimeType='application/pdf'"
+
+
 
 
 


### PR DESCRIPTION
## Summary

Drive's `files.list` includes trashed files by default, so `drive search` kept surfacing files the user had deleted (moved to trash by `drive delete` / `drive_search`-adjacent trash flows) until the trash was emptied — recurring ingestion jobs would re-process removed content. Fixes #107428.

- `drive_search()` now wraps the default query as `(fullText contains '…') and trashed = false`, matching how Drive's own UI search behaves.
- New `--include-trashed` flag keeps the legacy (unfiltered) behavior reachable for callers that genuinely want trashed results.
- `--raw-query` is untouched: the caller owns the full query syntax, so nothing is appended there (documented in the flag help).
- Both integration paths (`gws` CLI bridge and direct `googleapiclient` fallback) share the same `query` string, so one change covers both.
- `SKILL.md` documents the new default and the flag.

## Testing

- `uv run python -m pytest tests/skills/test_google_workspace_api.py -q` → **7 passed** (3 new tests: default excludes trash, `--include-trashed` keeps legacy query, `--raw-query` passthrough even when combined with `--include-trashed`).
- `uvx ruff check` on both touched files → clean.
- `google_api.py drive search --help` shows the new flag with expected help text.