### PR TITLE
fix(gateway): prevent stale failed-turn replay

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1505,6 +1505,16 @@ class GatewayTurnMixin:
         "request entity too large", "prompt is too long",
         "payload too large", "input is too long",
     )
+    _FAILED_TURN_NOTICE = (
+        "Your request was not processed. Send it again if you still want me to carry it out."
+    )
+
+    def _hmwa_add_failed_turn_notice(self, response):
+        """Make failed-turn delivery explicit without replacing the provider-specific guidance."""
+        response = str(response or "").strip()
+        if self._FAILED_TURN_NOTICE in response:
+            return response
+        return f"{response}\n\n{self._FAILED_TURN_NOTICE}" if response else self._FAILED_TURN_NOTICE
 
     def _hmwa_classify_turn_failure(self, agent_result, history, session_entry):
         """Classify a finished turn for transcript persistence. Returns
@@ -1595,11 +1605,10 @@ class GatewayTurnMixin:
     @staticmethod
     def _hmwa_user_transcript_entry(event, prepared, ts):
         """Transcript row for the inbound user turn (clean text + event time when captured)."""
-        # Transient failure (429/timeout/5xx): persist only the user message so the next message can load a
-        # transcript that reflects what was said. Skip the assistant error text since it's a
-        # gateway-generated hint, not model output. Hidden- reasoning-only incomplete turns follow the same
-        # persistence rule so peer-agent channels don't ingest them as completed assistant turns. (#7100,
-        # #51628)
+        # Transient failure (429/timeout/5xx): persist the user message so the next message can load a
+        # transcript that reflects what was said. The caller pairs it with a stable assistant safety
+        # boundary rather than the provider error text. Hidden-reasoning-only incomplete turns follow the
+        # same persistence rule so peer-agent channels don't ingest provider details. (#7100, #51628)
         _user_entry = {
             "role": "user",
             "content": (
@@ -1620,8 +1629,8 @@ class GatewayTurnMixin:
         self, *, event, source, session_entry, session_key, agent_result, agent_messages,
         prepared, response, agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure,
     ):
-        """Persist this turn to the transcript (session_meta on first turn, user-only on transient
-        failure, nothing on context overflow), update last_prompt_tokens, and re-baseline the
+        """Persist this turn to the transcript (session_meta on first turn, closed failed turn on
+        transient failure, nothing on context overflow), update last_prompt_tokens, and re-baseline the
         cached agent's message count."""
         from gateway.run import _resolve_gateway_model
         ts = time.time()  # Unix epoch float — consistent with DB storage
@@ -1654,8 +1663,8 @@ class GatewayTurnMixin:
                     "timestamp": ts,
                 })
             if agent_failed_early or hidden_reasoning_incomplete:
-                # Transient failure / hidden-reasoning incomplete: persist only the user message (the
-                # assistant error text is a gateway hint, not model output). Dedupe on platform
+                # Transient failure / hidden-reasoning incomplete: persist the user message without
+                # the provider error text (a gateway hint, not model output). Dedupe on platform
                 # message_id (Telegram retries after transient failures).
                 if event.message_id and await store.has_platform_message_id(sid, str(event.message_id)):
                     logger.info(
@@ -1664,6 +1673,14 @@ class GatewayTurnMixin:
                     )
                 else:
                     await store.append_to_transcript(sid, _user_row, skip_db=agent_persisted)
+                # Close the failed turn with a durable assistant boundary. Leaving a user-only tail
+                # lets alternation repair merge this request into an unrelated future message and
+                # can replay stale side effects. Persist only the stable safety statement, not raw
+                # provider details; this row is gateway-owned and was not written by the agent.
+                await store.append_to_transcript(
+                    sid,
+                    {"role": "assistant", "content": self._FAILED_TURN_NOTICE, "timestamp": ts},
+                )
             else:
                 # Only the NEW messages: history_offset (what the agent saw), not len(history), which
                 # counts session_meta entries stripped before the agent saw them.
@@ -1768,6 +1785,14 @@ class GatewayTurnMixin:
                     await self.async_session_store.append_to_transcript(
                         session_entry.session_id, self._hmwa_user_transcript_entry(event, prepared, time.time()),
                     )
+                await self.async_session_store.append_to_transcript(
+                    session_entry.session_id,
+                    {
+                        "role": "assistant",
+                        "content": self._FAILED_TURN_NOTICE,
+                        "timestamp": time.time(),
+                    },
+                )
         except Exception:
             logger.debug("Failed to persist inbound user message after agent exception", exc_info=True)
         # Never expose raw exception types/messages to end users (info-leakage risk).
@@ -1791,13 +1816,13 @@ class GatewayTurnMixin:
         elif status_code in {400, 500}:
             # 400/500 on a large session: context overflow / payload too large.
             if len(prepared.history) > 50:
-                return (
+                return self._hmwa_add_failed_turn_notice(
                     "⚠️ Session too large for the model's context window.\nUse /compact to "
                     "compress the conversation, or /reset to start fresh."
                 )
             elif status_code == 400:
                 status_hint = " The request was rejected by the API."
-        return (
+        return self._hmwa_add_failed_turn_notice(
             f"Sorry, I encountered an unexpected error.{status_hint}\n"
             "Try again or use /reset to start a fresh session."
         )
@@ -2003,6 +2028,8 @@ class GatewayTurnMixin:
             agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure = (
                 self._hmwa_classify_turn_failure(agent_result, history, session_entry)
             )
+            if agent_failed_early and not is_context_overflow_failure:
+                response = self._hmwa_add_failed_turn_notice(response)
             response, session_entry = await self._hmwa_compression_exhaustion_reset(
                 agent_result, response, session_entry, session_key, source,
             )

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1508,13 +1508,31 @@ class GatewayTurnMixin:
     _FAILED_TURN_NOTICE = (
         "Your request was not processed. Send it again if you still want me to carry it out."
     )
+    _PARTIAL_FAILED_TURN_NOTICE = (
+        "This turn did not complete. Some actions may already have run; verify their effects "
+        "before resending."
+    )
 
-    def _hmwa_add_failed_turn_notice(self, response):
+    def _hmwa_add_failed_turn_notice(self, response, notice=None):
         """Make failed-turn delivery explicit without replacing the provider-specific guidance."""
+        notice = notice or self._FAILED_TURN_NOTICE
         response = str(response or "").strip()
-        if self._FAILED_TURN_NOTICE in response:
+        if notice in response:
             return response
-        return f"{response}\n\n{self._FAILED_TURN_NOTICE}" if response else self._FAILED_TURN_NOTICE
+        return f"{response}\n\n{notice}" if response else notice
+
+    def _hmwa_failed_turn_notice(self, agent_result):
+        """Choose retry guidance without assuming completed tool effects can be repeated safely."""
+        messages = agent_result.get("messages", []) or []
+        history_offset = agent_result.get("history_offset", 0)
+        turn_messages = messages[history_offset:]
+        if any(
+            message.get("role") == "tool"
+            or (message.get("role") == "assistant" and message.get("tool_calls"))
+            for message in turn_messages
+        ):
+            return self._PARTIAL_FAILED_TURN_NOTICE
+        return self._FAILED_TURN_NOTICE
 
     def _hmwa_classify_turn_failure(self, agent_result, history, session_entry):
         """Classify a finished turn for transcript persistence. Returns
@@ -1628,6 +1646,7 @@ class GatewayTurnMixin:
     async def _hmwa_persist_turn_transcript(
         self, *, event, source, session_entry, session_key, agent_result, agent_messages,
         prepared, response, agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure,
+        failed_turn_notice,
     ):
         """Persist this turn to the transcript (session_meta on first turn, closed failed turn on
         transient failure, nothing on context overflow), update last_prompt_tokens, and re-baseline the
@@ -1679,7 +1698,7 @@ class GatewayTurnMixin:
                 # provider details; this row is gateway-owned and was not written by the agent.
                 await store.append_to_transcript(
                     sid,
-                    {"role": "assistant", "content": self._FAILED_TURN_NOTICE, "timestamp": ts},
+                    {"role": "assistant", "content": failed_turn_notice, "timestamp": ts},
                 )
             else:
                 # Only the NEW messages: history_offset (what the agent saw), not len(history), which
@@ -1789,7 +1808,7 @@ class GatewayTurnMixin:
                     session_entry.session_id,
                     {
                         "role": "assistant",
-                        "content": self._FAILED_TURN_NOTICE,
+                        "content": self._PARTIAL_FAILED_TURN_NOTICE,
                         "timestamp": time.time(),
                     },
                 )
@@ -1818,13 +1837,15 @@ class GatewayTurnMixin:
             if len(prepared.history) > 50:
                 return self._hmwa_add_failed_turn_notice(
                     "⚠️ Session too large for the model's context window.\nUse /compact to "
-                    "compress the conversation, or /reset to start fresh."
+                    "compress the conversation, or /reset to start fresh.",
+                    self._PARTIAL_FAILED_TURN_NOTICE,
                 )
             elif status_code == 400:
                 status_hint = " The request was rejected by the API."
         return self._hmwa_add_failed_turn_notice(
             f"Sorry, I encountered an unexpected error.{status_hint}\n"
-            "Try again or use /reset to start a fresh session."
+            "Use /reset to start a fresh session if needed.",
+            self._PARTIAL_FAILED_TURN_NOTICE,
         )
 
     def _hmwa_discard_stale_result(self, source, _quick_key, run_generation):
@@ -2028,8 +2049,9 @@ class GatewayTurnMixin:
             agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure = (
                 self._hmwa_classify_turn_failure(agent_result, history, session_entry)
             )
+            failed_turn_notice = self._hmwa_failed_turn_notice(agent_result)
             if agent_failed_early and not is_context_overflow_failure:
-                response = self._hmwa_add_failed_turn_notice(response)
+                response = self._hmwa_add_failed_turn_notice(response, failed_turn_notice)
             response, session_entry = await self._hmwa_compression_exhaustion_reset(
                 agent_result, response, session_entry, session_key, source,
             )
@@ -2039,6 +2061,7 @@ class GatewayTurnMixin:
                 response=response, agent_failed_early=agent_failed_early,
                 hidden_reasoning_incomplete=hidden_reasoning_incomplete,
                 is_context_overflow_failure=is_context_overflow_failure,
+                failed_turn_notice=failed_turn_notice,
             )
             return await self._hmwa_deliver_turn_response(
                 event, source, session_entry, session_key, run_generation,

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -137,7 +137,7 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
     runner._run_agent = AsyncMock(
         return_value={
             "failed": True,
-            "final_response": None,
+            "final_response": "API call failed after 3 retries: 429 Too Many Requests",
             "error": "429 Too Many Requests — rate limit exceeded",
             "messages": [],
             "history_offset": 0,
@@ -145,13 +145,30 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
         }
     )
 
-    await runner._handle_message_with_agent(
+    response = await runner._handle_message_with_agent(
         _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
     )
 
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
     )
+    assert "not processed" in response
+
+    transcript_rows = [
+        call.args[1]
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2 and call.args[1].get("role") in {"user", "assistant"}
+    ]
+    assert [row["role"] for row in transcript_rows] == ["user", "assistant"]
+    assert "not processed" in transcript_rows[-1]["content"]
+
+    # The next unrelated input remains its own turn instead of alternation repair
+    # merging the failed mutating request into it.
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    replay = [*transcript_rows, {"role": "user", "content": "unrelated question"}]
+    assert repair_message_sequence(None, replay) == 0
+    assert replay[-1]["content"] == "unrelated question"
 
 
 # ── Test 2: agent_failed_early with no _session_db → skip_db not True ─

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -171,6 +171,51 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
     assert replay[-1]["content"] == "unrelated question"
 
 
+@pytest.mark.asyncio
+async def test_failed_turn_with_tool_activity_does_not_recommend_blind_retry(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "failed": True,
+            "final_response": "API call failed after 3 retries: 500 Internal Server Error",
+            "error": "500 Internal Server Error",
+            "messages": [
+                {"role": "user", "content": "reset the password"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "function": {"name": "reset_password", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "Password reset"},
+            ],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    response = await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assistant_rows = [
+        call.args[1]
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2 and call.args[1].get("role") == "assistant"
+    ]
+    assert len(assistant_rows) == 1
+    assert assistant_rows[0]["content"] == runner._PARTIAL_FAILED_TURN_NOTICE
+    assert runner._PARTIAL_FAILED_TURN_NOTICE in response
+    assert "not processed" not in response
+    assert "Send it again" not in response
+
+
 # ── Test 2: agent_failed_early with no _session_db → skip_db not True ─
 
 

--- a/tests/gateway/test_failure_writer_ownership.py
+++ b/tests/gateway/test_failure_writer_ownership.py
@@ -93,7 +93,7 @@ def test_failure_owner_follows_only_live_lineage_markers(tmp_path):
             store._transcript_reroutes.clear()
             assert store.has_input_owner(sid, owner) is owned, location
             before = db.message_count()
-            await runner._hmwa_agent_error_reply(
+            reply = await runner._hmwa_agent_error_reply(
                 RuntimeError("controlled post-compaction failure"),
                 MessageEvent(text="same", source=source, message_id=pid),
                 source, entry, entry.session_key, prepared,
@@ -104,7 +104,10 @@ def test_failure_owner_follows_only_live_lineage_markers(tmp_path):
             assert store.has_input_owner(sid, owner), location
             live_messages = db.get_messages(child)
             assert live_messages[-1]["role"] == "assistant"
-            assert "not processed" in live_messages[-1]["content"]
+            assert "Some actions may already have run" in live_messages[-1]["content"]
+            assert "not processed" not in live_messages[-1]["content"]
+            assert "Some actions may already have run" in reply
+            assert "not processed" not in reply
             if not owned:
                 persisted_user = live_messages[-2]
                 assert persisted_user["content"] == prepared.persist_user_message

--- a/tests/gateway/test_failure_writer_ownership.py
+++ b/tests/gateway/test_failure_writer_ownership.py
@@ -98,12 +98,17 @@ def test_failure_owner_follows_only_live_lineage_markers(tmp_path):
                 MessageEvent(text="same", source=source, message_id=pid),
                 source, entry, entry.session_key, prepared,
             )
-            assert db.message_count() == before + (not owned), location
+            # Exception fallback adds the missing user only when unowned, then always
+            # closes the failed turn with a durable assistant safety boundary.
+            assert db.message_count() == before + (not owned) + 1, location
             assert store.has_input_owner(sid, owner), location
+            live_messages = db.get_messages(child)
+            assert live_messages[-1]["role"] == "assistant"
+            assert "not processed" in live_messages[-1]["content"]
             if not owned:
-                latest = db.get_messages(child)[-1]
-                assert latest["content"] == prepared.persist_user_message
-                assert latest["display_metadata"]["gateway_input_owner"] == owner
+                persisted_user = live_messages[-2]
+                assert persisted_user["content"] == prepared.persist_user_message
+                assert persisted_user["display_metadata"]["gateway_input_owner"] == owner
         db.close()
 
     asyncio.run(check())

--- a/tests/gateway/test_incomplete_gateway_turns.py
+++ b/tests/gateway/test_incomplete_gateway_turns.py
@@ -123,7 +123,7 @@ def _make_event() -> MessageEvent:
 
 
 @pytest.mark.asyncio
-async def test_incomplete_codex_turn_stays_out_of_slack_transcript(monkeypatch, tmp_path):
+async def test_incomplete_codex_turn_closes_transcript_without_slack_delivery(monkeypatch, tmp_path):
     adapter = CaptureSlackAdapter()
     runner = _make_runner(adapter)
 
@@ -148,8 +148,11 @@ async def test_incomplete_codex_turn_stays_out_of_slack_transcript(monkeypatch, 
         call.args[1]["role"]
         for call in runner.session_store.append_to_transcript.call_args_list
     ]
-    assert transcript_roles == ["session_meta", "user"]
+    assert transcript_roles == ["session_meta", "user", "assistant"]
     assert runner.session_store.append_to_transcript.call_args_list[1].args[1]["content"] == "hello"
+    boundary = runner.session_store.append_to_transcript.call_args_list[2].args[1]["content"]
+    assert "not processed" in boundary
+    assert "remained incomplete" not in boundary
     assert adapter.processing_hooks == [
         ("start", "m-1"),
         ("complete", "m-1", ProcessingOutcome.SUCCESS),


### PR DESCRIPTION
## Summary

Carry forward the verified fix for #107070 from existing PR #107088 into a branch owned by the authenticated contributor, because the original carrier fork is not writable by this account. Failed or incomplete gateway turns now receive a durable assistant boundary instead of leaving a user-only transcript tail. This preserves retry context while preventing alternation repair from silently merging stale requests into a later message.

This PR is intentionally a carry-forward, not an independent competing design. The effective patch was compared against PR #107088 with `git patch-id --stable`; both patches produced `64506164deedd75993adcad069ccc9b0905962de`.

## Problem observed

- Incorrect behavior: a non-context-overflow failed gateway turn could persist its user row without an assistant row. A later unrelated user row then became adjacent and `repair_message_sequence` merged both rows into one provider-facing user message.
- Expected behavior: retain useful failed-turn context without allowing an unanswered historical request to become part of a future live instruction. A failed turn must end with an explicit durable boundary, and effect uncertainty must not be presented as permission to blindly retry.
- Confirmation: on the current baseline, a temporary SQLite transcript with `user("mutate record id=42")` followed by `user("show status")` restored with `repair_alternation=True` as one merged user payload. The focused regression tests were also applied to the baseline and failed on the missing boundary assertions.

## Root cause

`gateway/run_turn.py::_hmwa_classify_turn_failure` retained failed user input for retry-context preservation, but the persistence path omitted a terminal assistant row. On reload, `hermes_state_messages.py::_rows_to_conversation` invoked `repair_message_sequence`; its consecutive-user repair pass merged the unanswered historical row into the next inbound user turn. The merged content lost the durable turn boundary and timestamp distinction at the model input boundary.

The failure was not caused by the alternation algorithm itself: it correctly repaired an invalid user/user sequence under its existing contract. The missing invariant was that every persisted failed/incomplete gateway turn must be role-closed before a later turn can be appended.

A second safety issue was verified during review: `failed=True` does not prove that no tool effects occurred. A turn can execute tool calls and then fail on a subsequent model request. The fix therefore distinguishes current-turn tool-call/tool-result evidence from the no-tool positive control.

## Impact and scope

- Affected: gateway sessions using persistent transcripts, across messaging platforms; the reported incident was Telegram.
- Affected failure classes: persisted non-overflow failed turns, hidden-reasoning-incomplete turns, and exception fallback after an accepted inbound turn.
- Not affected: successful turns, context-overflow reset behavior, normal provider retry mechanics, or the original retention intent from #7100.
- Consequence before this change: stale mutating requests could execute as part of an unrelated later request.
- Security consideration: the durable boundary is machine-owned and does not include raw provider exception text. When tool activity may have occurred, both the user-facing response and the durable boundary require effect verification before resending.
- Performance: the change adds one bounded transcript append and constant-time turn-local classification on failed/incomplete paths only. It does not alter the normal successful-turn path or the asymptotic behavior of sequence repair.

## Related work and non-duplication

- #107088 is the direct existing carrier. Its original fork reports `push:false` for the authenticated account, so this branch carries forward only its verified patch and preserves the original PR and authorship.
- #107108 is a competing partial approach. Its timestamp age gate fails open for missing/invalid timestamps and recent rows, and it promotes user-controlled text into a `system` role; it does not establish failure provenance or a durable boundary. It was not copied.
- #7100 is the historical reason failed user context is retained; dropping the user row would regress that behavior.
- #82863 concerns durable reconciliation of alternation repair, but does not close unanswered failed turns.
- #79576 and #90833 describe adjacent persistence/ingress staleness hazards, not this failure-owner boundary.

## Solution

- Add stable no-effect and effect-uncertain assistant boundary notices.
- Persist the user row plus an assistant boundary after failed or hidden-reasoning-incomplete turns, preserving retry context while making the transcript role-valid before the next inbound message.
- Detect current-turn assistant tool calls or tool results and use conservative effect-uncertain guidance: `Some actions may already have run; verify their effects before resending.`
- Use the same conservative boundary in exception fallback, where effect completion cannot be proven.
- Keep context-overflow failures out of the transcript-growth loop.
- Preserve existing message ownership/deduplication and agent-owned SQLite persistence behavior.

Alternatives rejected:

- Dropping all failed user rows would lose the retry-context behavior introduced by #7100.
- Age-only filtering cannot prove failure provenance and fails open when timestamps are absent or malformed.
- A prompt/SOUL rule would depend on model compliance and would not repair the durable transcript boundary.

## Compatibility and residual risks

No configuration, migration, or provider API changes are required. Existing successful transcripts retain their shape. Failed turns now contain one additional assistant boundary row by design.

Residual limitation: a failed turn with tool activity cannot prove whether an external effect committed. The implementation refuses to label it "not processed" and requires verification before resending; it does not attempt to infer provider-side settlement.

The existing `test_gateway_failure_writer_preserves_accepted_turn_identity` subprocess witness remains blocked on this Windows environment because the canonical hermetic runner clears the home-directory variables before the nested probe imports `Path.home()`. The same witness fails on the clean baseline for that environment reason; it is not reported as a pass.

## Tests and verification

| Command/test | Purpose | Result |
|---|---|---|
| `graphify query 'repair_message_sequence' --graph graphify-out/graph.json --budget 3000` | Bound the repair call graph | Passed on the existing graph; identified `agent/agent_runtime_helpers.py` and restoration callers |
| `graphify explain '_rows_to_conversation' --graph graphify-out/graph.json --budget 2000` | Trace durable restore into repair | Passed; identified `hermes_state_messages.py::_rows_to_conversation` |
| `graphify path '_rows_to_conversation' 'repair_message_sequence' --graph graphify-out/graph.json --directed` | Prove the direct call path | Passed; direct one-hop path |
| Temporary SQLite replay harness on baseline | Reproduce two persisted user rows becoming one merged payload | Failed on baseline as expected: `mutate record id=42\n\nshow status` was produced |
| Baseline with carry-forward regression tests applied | Prove the tests bite before the fix | Exit 1: 2 tests passed and 5 failed; missing assistant-boundary assertions failed on the baseline, with the nested Windows home-directory probe separately blocked |
| `HERMES_PYTHON=/c/Users/Nitro/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe scripts/run_tests.sh tests/gateway/test_42039_duplicate_user_message.py tests/gateway/test_7100_transient_failure_transcript.py tests/gateway/test_compression_failure_session_sync.py tests/gateway/test_incomplete_gateway_turns.py tests/gateway/test_failure_writer_ownership.py -k 'not test_gateway_failure_writer_preserves_accepted_turn_identity'` | Final focused changed-path suite on the carry branch | Passed: 12 tests, 0 failed, 29.2 s. A prior run had one timeout in the unchanged compression test; rerunning that file passed 2/2 and the final aggregate passed. |
| `HERMES_PYTHON=/c/Users/Nitro/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe scripts/run_tests.sh tests/gateway/test_failure_writer_ownership.py -k test_failure_owner_follows_only_live_lineage_markers` | New exception-fallback lineage witness | Passed: 1 selected test |
| `HERMES_PYTHON=/c/Users/Nitro/AppData/Local/hermes-agent/venv/Scripts/python.exe scripts/run_tests.sh tests/gateway/test_7100_transient_failure_transcript.py tests/gateway/test_retry_replacement.py tests/gateway/test_retry_response.py tests/gateway/test_session_messages_shutdown_preserve.py` | Sibling transient/retry/session paths | Passed: 20 tests |
| `git diff --check origin/main...HEAD` | Patch hygiene | Passed |
| Stable patch-id comparison with PR #107088 | Verify carry-forward is the same effective patch | Passed: both effective patches `64506164deedd75993adcad069ccc9b0905962de` |
| `graphify update . --no-cluster` in the carry worktree | Refresh graph after code edits | Inconclusive: AST extraction reached 10,851/10,851 files, but no `graph.json` was written after 858 seconds; the process was terminated. A documented `graphify extract . --code-only --no-cluster --max-workers 4` fallback also timed out after 420 seconds without producing an index. The existing `graphify-out/graph.json` in the primary checkout was used for the query/explain/path evidence above. |
| `python C:/Users/Nitro/AppData/Local/Temp/stress_107070.py` (5 consecutive pre-publication rounds) | Concurrent deterministic replay-boundary stress: 8 workers x 1,000 iterations per round; assert no merge, no input mutation, and stable role/content boundaries | Passed 5/5 rounds; 8,000 iterations per round. Elapsed seconds: 0.316, 0.277, 0.401, 0.904, 1.240. Peak allocations: 1,007,649; 1,007,713; 965,141; 965,141; 1,007,713 bytes. |
| Three post-publication rounds, each combining the canonical focused suite and `stress_107070.py` | Stability after the PR was published | Passed 3/3 rounds. Each focused suite passed 12/12 tests. Stress elapsed seconds: 0.449, 0.209, 0.234; peak allocations: 1,007,713; 1,000,226; 993,337 bytes. |
| `python C:/Users/Nitro/AppData/Local/Temp/stress_107070.py` (5 additional post-publication rounds) | Consecutive concurrency/load/memory check after publication | Passed 5/5 rounds; 8,000 iterations per round. Elapsed seconds: 0.235, 0.252, 0.252, 0.200, 0.219. Peak allocations: 993,553; 993,553; 3,959,583; 993,553; 993,553 bytes. The one higher peak did not recur in the following two rounds and had no throughput or correctness failure. |
| `HERMES_PYTHON=/c/Users/Nitro/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe scripts/run_tests.sh tests/gateway/` | Broad gateway regression sweep | Exit 1 after the runner completed 6,921 discovered tests: 85 failures across 29 files, including adapters, shutdown, runtime-footer, status, and other paths outside this patch. The directly changed ownership file retained its known Windows nested-probe failure. No code attribution is claimed from this broad result. |
| Same 29 failing files on the baseline worktree with `HERMES_TEST_WORKERS=4` | Classify broad failures against base | Inconclusive: the 420-second terminal capture timed out and raised a Windows `UnicodeDecodeError` while reading subprocess output; no final baseline test result was produced. |

## Files and documentation

- `gateway/run_turn.py`: close failed/incomplete turns and classify effect uncertainty.
- `tests/gateway/test_42039_duplicate_user_message.py`: failed-turn boundary, replay separation, and tool-effect guidance regressions.
- `tests/gateway/test_failure_writer_ownership.py`: exception fallback ownership and conservative boundary regression.
- `tests/gateway/test_incomplete_gateway_turns.py`: incomplete-turn durable closure regression.

No additional repository documentation or configuration changes are required for this focused bug fix.

## Delivery

- Issue: #107070
- Original verified carrier: #107088
- Carry-forward branch: `fix/107070-stale-failed-turn-replay`
- Base: `origin/main`
- Head SHA: `b507cfe2734f486ad90797f6e79814734119cbf3`.
- Fork ref: `JoaoMarcos44:fix/107070-stale-failed-turn-replay` (verified with `git ls-remote`).
- PR URL: `https://github.com/NousResearch/hermes-agent/pull/107438`.
- Base SHA: `67764dc0863349a384c16425e73ee8571f3a94b7`.
- Initial/final hosted CI read-back: `gh pr checks 107438 --repo NousResearch/hermes-agent` reports no checks; `gh run list` found three completed workflow runs for this exact head (`CI`, `Nix flake check`, and `Docker Build, Test, and Publish`) with `conclusion=failure`, but each has `jobs=[]`, `total_count=0`, and `gh run view --log-failed` returns `log not found`. This is a hosted workflow provisioning/permission blocker, not an observed code or test failure; the PR remains blocked and CI evidence is not green.
