### PR TITLE
fix(desktop): keep Close and + on a lone workspace tab strip

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts
@@ -11,8 +11,8 @@ const toolPanel = (): StripPane => ({ collapsePane: true, placement: 'bottom' })
 const sideChrome = (): StripPane => ({ collapsePane: false, placement: 'right' })
 
 describe('auto (no stored choice)', () => {
-  it('gives a lone workspace no strip and a stack of two a strip', () => {
-    expect(resolveTabStripVisible({ shown: [workspace()] })).toBe(false)
+  it('gives a lone workspace a strip so Close and + stay reachable', () => {
+    expect(resolveTabStripVisible({ shown: [workspace()] })).toBe(true)
     expect(resolveTabStripVisible({ shown: [workspace(), sideChrome()] })).toBe(true)
   })
 
@@ -44,11 +44,16 @@ describe('no dead zone', () => {
     expect(resolveTabStripVisible({ mode: 'never', shown: [toolPanel()] })).toBe(true)
   })
 
+  it('keeps the strip for a lone workspace even when the zone says never', () => {
+    // Workspace cannot leave the tree, but Close still empties it to a draft
+    // and + still opens a tab. Chromeless is a dead zone for those handles.
+    expect(resolveTabStripVisible({ mode: 'never', shown: [workspace()] })).toBe(true)
+  })
+
   it('still hides a zone that cannot strand anything', () => {
-    // The workspace is uncloseable, a stack is reachable by tab cycling, and
-    // hide-only chrome (sessions / Bots) keeps its panes + ⌘⌥T — the invariant
-    // protects handles, it does not veto hiding as such.
-    expect(resolveTabStripVisible({ mode: 'never', shown: [workspace()] })).toBe(false)
+    // A stack is reachable by tab cycling, and hide-only chrome (sessions /
+    // Bots) keeps its panes + ⌘⌥T — the invariant protects handles, it does
+    // not veto hiding as such.
     expect(resolveTabStripVisible({ mode: 'never', shown: [toolPanel(), toolPanel()] })).toBe(false)
     expect(resolveTabStripVisible({ mode: 'never', shown: [sideChrome()] })).toBe(false)
     expect(resolveTabStripVisible({ mode: 'never', shown: [sideChrome(), sideChrome()] })).toBe(false)
@@ -113,7 +118,7 @@ describe('tabStripVisibleForZone', () => {
   afterEach(() => setTabStripDefault('auto'))
 
   it('reads placement, uncloseable and collapse off the contributions', () => {
-    expect(visible(['workspace'])).toBe(false)
+    expect(visible(['workspace'])).toBe(true)
     expect(visible(['tile:a'], 'never')).toBe(true)
     expect(visible(['terminal'], 'never')).toBe(true)
   })
@@ -131,6 +136,6 @@ describe('tabStripVisibleForZone', () => {
     expect(visible(['workspace'], 'always')).toBe(true)
 
     setTabStripDefault('always')
-    expect(visible(['workspace'], 'never')).toBe(false)
+    expect(visible(['workspace'], 'never')).toBe(true)
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
@@ -38,12 +38,13 @@ export interface StripZone {
 
 /**
  * A pane is STRANDED without a strip when the strip is the only thing carrying
- * its handle: a lone closeable tile needs its ✕, a lone tool panel needs a chip
- * to grab. The uncloseable workspace is not strandable — it cannot be closed
- * or lost, so a lone chat is free to be chromeless. Hide-only chrome (sessions
- * / Bots) is the same: the panes stay, Show/Hide is a separate verb, and a
- * hidden strip comes back via ⌘⌥T. Treating it as stranded at any count made
- * Hide tabs a silent no-op on the sessions sidebar.
+ * its handle: a lone main tile needs its ✕ and +, a lone tool panel needs a
+ * chip to grab. The workspace cannot leave the tree, but Close still empties
+ * it to a draft and + still opens a tab — chromeless is a dead zone for those
+ * handles. Hide-only chrome (sessions / Bots) is different: the panes stay,
+ * Show/Hide is a separate verb, and a hidden strip comes back via ⌘⌥T.
+ * Treating side chrome as stranded at any count made Hide tabs a silent no-op
+ * on the sessions sidebar.
  *
  * This outranks an explicit `never` on purpose. "Hide the strip" is a request
  * about chrome, never a request to make a surface unreachable, and a zone that
@@ -64,7 +65,7 @@ function stranded(shown: readonly StripPane[]): boolean {
 
   const [only] = shown
 
-  return only.collapsePane || (!only.uncloseable && only.placement === 'main')
+  return only.collapsePane || only.placement === 'main'
 }
 
 export function resolveTabStripVisible(zone: StripZone): boolean {


### PR DESCRIPTION
## What does this PR do?

A lone workspace pane was chromeless: no tab strip, no Close, no +. Close still empties the workspace to a draft and + still opens a tab, so hiding the strip left a chat with no way to close or add tabs. Ctrl+Alt+T recovered it; that is a recovery shortcut, not the default.

Lone main panes (workspace included) now keep the strip even when the zone says hide. Hide tabs still works on stacks that have another tab to cycle to. Sessions/Bots side chrome is unchanged.

## Related Issue

N/A. Distinct from #86278 / #91714 (double-click hiding the strip). Those landed. This is the remaining chromeless-workspace trap.

Related PRs checked: #96852 (plugin/closeable tiles), #86191 (lone tile vs headerHidden), #106009 (sidebar width). None of those keep the workspace strip.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- `stranded()` treats any lone `placement: 'main'` pane as needing a strip, including the uncloseable workspace.
- Tests: lone workspace keeps Close/+ on auto and against `never`; hide-on-stack cases stay green.

## How to Test

1. Split the window so one quadrant holds only the main workspace chat (no extra session tiles in that zone).
2. That quadrant should show a tab, a hover Close, and +.
3. Close empties to a draft; + opens a new session tab in that zone.
4. Hide tabs on a zone with two session tabs still hides; Ctrl+Alt+T still toggles stacks.

```bash
cd apps/desktop
npx vitest run src/components/pane-shell/tree
```

Expected: 30 files, 161 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform impact considered — N/A (resolver is platform-agnostic)
- [x] Tool descriptions — N/A
