### PR TITLE
feat(footer): opt-in account/billing/effort runtime-footer fields

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -558,6 +558,9 @@ _TURN_STATE: Dict[str, Any] = {
     # a stale rebuild instead of clobbering a newer one.
     "_tool_snapshot_generation": 0,
     "_rate_limit_state": None,  # from x-ratelimit-* headers; read by /usage
+    # Per-call anthropic-ratelimit-unified-overage-in-use header (None = absent); read by the
+    # runtime footer's ``billing`` field (gateway/runtime_footer.py).
+    "_last_anthropic_overage_in_use": None,
     # Credits tracking (dev-only, HERMES_DEV_CREDITS) from x-nous-credits-* headers; session
     # start is latched on the first header so cumulative spend can be reported.
     "_credits_state": None,

--- a/agent/rate_limit_credits.py
+++ b/agent/rate_limit_credits.py
@@ -54,6 +54,16 @@ class RateLimitCreditsMixin:
         aggregated ``Message`` drops them). Fail-open."""
         self._capture_rate_limits(http_response)
         self._capture_credits(http_response)
+        # Per-call overage flag straight from the provider's own header, for the runtime footer's
+        # ``billing`` field (gateway/runtime_footer.py). None = header absent (non-subscription
+        # account or a proxy stripped it); True/False = the provider's per-message answer to
+        # "was this turn served on paid overage rather than the included allowance?".
+        try:
+            headers = _response_headers(http_response)
+            raw = headers.get("anthropic-ratelimit-unified-overage-in-use") if headers else None
+            self._last_anthropic_overage_in_use = None if raw is None else str(raw).strip().lower() == "true"
+        except Exception:
+            self._last_anthropic_overage_in_use = None
 
     def _capture_credits(self, http_response: Any) -> None:
         """Parse x-nous-credits-* headers, cache CreditsState, fire threshold notices.

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1459,12 +1459,15 @@ class GatewayTurnMixin:
         from gateway.run import _load_gateway_config, _platform_config_key, _terminal_scope_cwd
         try:
             from gateway.runtime_footer import build_footer_line as _bfl
+            _frf = agent_result.get("footer_runtime_fields") or {}
             return _bfl(
                 user_config=_load_gateway_config(),
                 platform_key=_platform_config_key(source.platform), model=agent_result.get("model"),
                 context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                 context_length=agent_result.get("context_length") or None,
                 cwd=_terminal_scope_cwd(""), turn_seconds=_turn_seconds,
+                account_label=_frf.get("account"), billing=_frf.get("billing"),
+                effort=_frf.get("effort"),
             )
         except Exception as _footer_err:
             logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1749,12 +1749,22 @@ class TurnRunner:
         agent = ctx.agent_holder[0]
         has_comp = bool(agent) and hasattr(agent, "context_compressor")
         comp = agent.context_compressor if has_comp else None
+        # Serving-credential identity for the runtime footer, captured from the live agent
+        # BEFORE it is released (the footer renders after the turn, when the agent may be gone).
+        footer_runtime_fields: dict = {}
+        if agent is not None:
+            try:
+                from gateway.runtime_footer import resolve_agent_runtime_fields
+                footer_runtime_fields = resolve_agent_runtime_fields(agent)
+            except Exception:
+                footer_runtime_fields = {}
         usage = {
             "last_prompt_tokens": getattr(comp, "last_prompt_tokens", 0) if has_comp else 0,
             "input_tokens": getattr(agent, "session_prompt_tokens", 0) if has_comp else 0,
             "output_tokens": getattr(agent, "session_completion_tokens", 0) if has_comp else 0,
             "model": getattr(agent, "model", None) if agent else None,
             "context_length": (getattr(comp, "context_length", 0) or 0) if has_comp else 0,
+            "footer_runtime_fields": footer_runtime_fields,
         }
         compacted_in_place, effective_session_id, history_offset = self._sync_session_after_run(agent_history)
         # failure_reason must survive the empty-response path too (TUI billing, transient-failure

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -3,9 +3,15 @@ minimal. Config: ``display.runtime_footer: {enabled: bool, fields: [model, conte
 (order shown; drop any to hide), per-platform override ``display.platforms.<p>.runtime_footer``,
 toggled by ``/footer on|off``. Fields: ``model`` (vendor prefix dropped), ``context_pct`` (last-call
 occupancy), ``latency`` (turn wall-clock, opt-in — NOT in the default set so an unset ``fields``
-renders exactly as before), ``cwd`` (home-relative). ``gateway/run.py`` appends the footer to the
-final response only (never to tool-progress or streaming partials); when streaming already
-delivered the text, it goes out as a trailing message via ``send_trailing_footer()``."""
+renders exactly as before), ``cwd`` (home-relative), and three more opt-in fields resolved from the
+live agent by ``resolve_agent_runtime_fields()``: ``account`` (credential-pool entry label of the
+serving credential, falling back to the provider name), ``billing`` (``sub`` for OAuth subscription
+seats, ``extra`` when the provider stamped the turn as paid overage via its
+``anthropic-ratelimit-unified-overage-in-use`` response header, ``API`` for per-token keys) and
+``effort`` (the agent's reasoning effort). Like ``latency``, none of the three is in the default
+field set, so an unset ``fields`` renders byte-identically to before. ``gateway/run.py`` appends the
+footer to the final response only (never to tool-progress or streaming partials); when streaming
+already delivered the text, it goes out as a trailing message via ``send_trailing_footer()``."""
 
 from __future__ import annotations
 
@@ -74,6 +80,8 @@ def _format_latency(seconds: float) -> str:
 def format_runtime_footer(*, model: Optional[str], context_tokens: int,
                           context_length: Optional[int], cwd: Optional[str] = None,
                           turn_seconds: Optional[float] = None,
+                          account_label: Optional[str] = None, billing: Optional[str] = None,
+                          effort: Optional[str] = None,
                           fields: Iterable[str] = _DEFAULT_FIELDS) -> str:
     """Render the footer line, or "" if no fields have data. Fields whose data is missing (and
     unknown field names) are skipped silently — a partial footer beats ``?%`` or empty slots."""
@@ -88,20 +96,92 @@ def format_runtime_footer(*, model: Optional[str], context_tokens: int,
         # Skipped when the caller did not measure (None) or the value is negative.
         "latency": lambda: _format_latency(turn_seconds) if turn_seconds is not None and turn_seconds >= 0 else "",
         "cwd": lambda: _home_relative_cwd(cwd or _env_cwd()),
+        # Opt-in agent-identity fields (resolve_agent_runtime_fields); skipped when unresolved.
+        "account": lambda: account_label or "",
+        "billing": lambda: billing or "",
+        "effort": lambda: f"effort {effort}" if effort else "",
     }
     return _SEP.join(v for field in fields if (render := renderers.get(field)) and (v := render()))
 
 
+def resolve_agent_runtime_fields(agent: Any) -> dict[str, Optional[str]]:
+    """Derive the ``account`` / ``billing`` / ``effort`` footer fields from a live agent.
+
+    Reads the same attributes the dispatch path uses, so the footer can never disagree with the
+    wire. Never raises; unresolvable fields come back ``None`` and render as skipped.
+
+    - ``account``: credential-pool entry label via ``agent._credential_pool_entry_id`` looked up
+      in the persisted pool (``hermes_cli.auth.read_credential_pool``); falls back to the raw
+      entry id, then to the provider name for non-pool credentials.
+    - ``billing``: ``sub`` when the serving credential is an OAuth subscription seat, ``extra``
+      when the provider's own per-response header
+      (``anthropic-ratelimit-unified-overage-in-use: true``) marked the turn as served on paid
+      overage rather than the included allowance (captured per call in
+      ``_capture_anthropic_response_headers`` as ``agent._last_anthropic_overage_in_use``), and
+      ``API`` for per-token keys. ``openai-codex`` is a subscription-only backend → ``sub``.
+    - ``effort``: the agent's ``reasoning_config`` effort value, if any.
+    """
+    out: dict[str, Optional[str]] = {"account": None, "billing": None, "effort": None}
+    try:
+        provider = (getattr(agent, "provider", "") or "").strip().lower()
+        pool_id = getattr(agent, "_credential_pool_entry_id", None)
+        label = None
+        if pool_id:
+            try:
+                from hermes_cli.auth import read_credential_pool
+                for prov_entries in (read_credential_pool() or {}).values():
+                    for entry in prov_entries or []:
+                        if isinstance(entry, dict) and entry.get("id") == pool_id:
+                            label = entry.get("label") or str(pool_id)
+                            break
+                    if label:
+                        break
+            except Exception:
+                label = None
+            if not label:
+                label = str(pool_id)
+        if label:
+            out["account"] = label
+        elif provider:
+            out["account"] = provider
+        if provider == "anthropic":
+            if getattr(agent, "_is_anthropic_oauth", False):
+                # The provider's own per-response stamp: True = this turn was paid from the
+                # overage top-up, not the subscription's included allowance.
+                overage = getattr(agent, "_last_anthropic_overage_in_use", None)
+                out["billing"] = "extra" if overage is True else "sub"
+            else:
+                out["billing"] = "API"
+        elif provider == "openai-codex":
+            out["billing"] = "sub"
+        elif provider:
+            out["billing"] = "API"
+        rc = getattr(agent, "reasoning_config", None)
+        if isinstance(rc, dict):
+            eff = rc.get("effort") or rc.get("reasoning_effort")
+            if eff:
+                out["effort"] = str(eff)
+        elif isinstance(rc, str) and rc:
+            out["effort"] = rc
+    except Exception:
+        pass
+    return out
+
+
 def build_footer_line(*, user_config: dict[str, Any] | None, platform_key: str | None,
                       model: Optional[str], context_tokens: int, context_length: Optional[int],
-                      cwd: Optional[str] = None, turn_seconds: Optional[float] = None) -> str:
+                      cwd: Optional[str] = None, turn_seconds: Optional[float] = None,
+                      account_label: Optional[str] = None, billing: Optional[str] = None,
+                      effort: Optional[str] = None) -> str:
     """Entry point for gateway/run.py: footer text, or "" when disabled / no data. Callers append it
     to the final response themselves, preserving a single blank line of separation.
     ``turn_seconds`` is the caller-measured (``time.monotonic()``) run duration; ``None`` skips the
-    ``latency`` field."""
+    ``latency`` field. ``account_label`` / ``billing`` / ``effort`` come from
+    ``resolve_agent_runtime_fields()`` on the live agent; ``None`` skips each."""
     cfg = resolve_footer_config(user_config, platform_key)
     if not cfg.get("enabled"):
         return ""
     return format_runtime_footer(model=model, context_tokens=context_tokens,
                                  context_length=context_length, cwd=cwd, turn_seconds=turn_seconds,
+                                 account_label=account_label, billing=billing, effort=effort,
                                  fields=cfg.get("fields") or _DEFAULT_FIELDS)

--- a/tests/gateway/test_runtime_footer_account_billing.py
+++ b/tests/gateway/test_runtime_footer_account_billing.py
@@ -1,0 +1,182 @@
+"""Unit tests for the opt-in ``account`` / ``billing`` / ``effort`` runtime-footer fields.
+
+Companion to tests/gateway/test_runtime_footer.py, which covers the base footer. These cover
+``resolve_agent_runtime_fields()`` (live-agent → field values) and the render path for the three
+fields, including the invariant that the DEFAULT field set is unchanged — a footer whose
+``fields`` are unset must render byte-identically to before this feature existed.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from gateway.runtime_footer import (
+    _DEFAULT_FIELDS,
+    build_footer_line,
+    format_runtime_footer,
+    resolve_agent_runtime_fields,
+)
+
+
+def _cfg(fields):
+    return {"display": {"runtime_footer": {"enabled": True, "fields": fields}}}
+
+
+def _fake_agent(**kw):
+    agent = types.SimpleNamespace()
+    agent.provider = kw.get("provider", "anthropic")
+    agent._credential_pool_entry_id = kw.get("pool_id")
+    agent._is_anthropic_oauth = kw.get("oauth", True)
+    agent.reasoning_config = kw.get("reasoning_config", {"enabled": True, "effort": "high"})
+    if "overage" in kw:
+        agent._last_anthropic_overage_in_use = kw["overage"]
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# billing: sub / extra / API from the provider's own per-response header
+# ---------------------------------------------------------------------------
+
+def test_billing_extra_when_provider_stamps_overage():
+    """anthropic-ratelimit-unified-overage-in-use: true → the turn was paid overage."""
+    out = resolve_agent_runtime_fields(_fake_agent(overage=True))
+    assert out["billing"] == "extra"
+
+
+def test_billing_sub_when_overage_header_false():
+    out = resolve_agent_runtime_fields(_fake_agent(overage=False))
+    assert out["billing"] == "sub"
+
+
+def test_billing_sub_when_overage_header_absent():
+    # Attribute missing entirely (header never seen) → included allowance assumed.
+    out = resolve_agent_runtime_fields(_fake_agent())
+    assert out["billing"] == "sub"
+
+
+def test_billing_api_for_key_auth_ignores_overage_flag():
+    # Per-token API keys are "API" regardless of any stale overage attribute.
+    out = resolve_agent_runtime_fields(_fake_agent(oauth=False, overage=True))
+    assert out["billing"] == "API"
+
+
+def test_billing_api_for_generic_provider_and_sub_for_codex():
+    assert resolve_agent_runtime_fields(_fake_agent(provider="openrouter", oauth=False))["billing"] == "API"
+    assert resolve_agent_runtime_fields(_fake_agent(provider="openai-codex"))["billing"] == "sub"
+
+
+# ---------------------------------------------------------------------------
+# account: pool label lookup with provider-name fallback
+# ---------------------------------------------------------------------------
+
+def test_account_resolves_pool_entry_label(monkeypatch):
+    import hermes_cli.auth as auth_mod
+
+    monkeypatch.setattr(
+        auth_mod, "read_credential_pool",
+        lambda provider_id=None: {"anthropic": [{"id": "abc123", "label": "work seat"}]},
+    )
+    out = resolve_agent_runtime_fields(_fake_agent(pool_id="abc123"))
+    assert out["account"] == "work seat"
+
+
+def test_account_falls_back_to_pool_id_then_provider(monkeypatch):
+    import hermes_cli.auth as auth_mod
+
+    monkeypatch.setattr(auth_mod, "read_credential_pool", lambda provider_id=None: {})
+    assert resolve_agent_runtime_fields(_fake_agent(pool_id="abc123"))["account"] == "abc123"
+    assert resolve_agent_runtime_fields(_fake_agent(pool_id=None))["account"] == "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# effort
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "reasoning_config,expected",
+    [
+        ({"enabled": True, "effort": "high"}, "high"),
+        ({"reasoning_effort": "medium"}, "medium"),
+        ("low", "low"),
+        ({}, None),
+        (None, None),
+    ],
+)
+def test_effort_resolved_from_reasoning_config(reasoning_config, expected):
+    out = resolve_agent_runtime_fields(_fake_agent(reasoning_config=reasoning_config))
+    assert out["effort"] == expected
+
+
+# ---------------------------------------------------------------------------
+# render path
+# ---------------------------------------------------------------------------
+
+def test_footer_renders_account_billing_effort():
+    line = build_footer_line(
+        user_config=_cfg(["model", "context_pct", "account", "billing", "effort"]),
+        platform_key="telegram",
+        model="anthropic/claude-sonnet-4.6",
+        context_tokens=50_000,
+        context_length=1_000_000,
+        account_label="work seat",
+        billing="sub",
+        effort="high",
+    )
+    assert line == "claude-sonnet-4.6 · 5% · work seat · sub · effort high"
+
+
+def test_unresolved_new_fields_are_skipped_not_blanked():
+    line = build_footer_line(
+        user_config=_cfg(["model", "context_pct", "account", "billing", "effort"]),
+        platform_key="telegram",
+        model="gpt-5.4",
+        context_tokens=40_000,
+        context_length=400_000,
+        account_label=None,
+        billing=None,
+        effort=None,
+    )
+    assert line == "gpt-5.4 · 10%"
+
+
+def test_default_field_set_unchanged():
+    """Invariant: the new fields are opt-in only. The default field set stays exactly
+    (model, context_pct, cwd), and a default-fields render never shows the new values."""
+    assert _DEFAULT_FIELDS == ("model", "context_pct", "cwd")
+    line = format_runtime_footer(
+        model="m",
+        context_tokens=1,
+        context_length=100,
+        cwd="/",
+        account_label="work seat",
+        billing="API",
+        effort="high",
+    )
+    assert "work seat" not in line and "API" not in line and "effort" not in line
+
+
+# ---------------------------------------------------------------------------
+# fail-open
+# ---------------------------------------------------------------------------
+
+def test_resolver_never_raises_on_broken_agent():
+    class Broken:
+        def __getattr__(self, name):
+            raise RuntimeError("boom")
+
+    out = resolve_agent_runtime_fields(Broken())
+    assert out == {"account": None, "billing": None, "effort": None}
+
+
+def test_resolver_survives_broken_auth_store(monkeypatch):
+    import hermes_cli.auth as auth_mod
+
+    def _boom(provider_id=None):
+        raise RuntimeError("auth store unreadable")
+
+    monkeypatch.setattr(auth_mod, "read_credential_pool", _boom)
+    out = resolve_agent_runtime_fields(_fake_agent(pool_id="abc123"))
+    assert out["account"] == "abc123"  # falls back to the raw pool id
+    assert out["billing"] == "sub"


### PR DESCRIPTION
## Motivation

Users running **multi-account credential pools** (`hermes auth add` … several Anthropic seats, or mixed OAuth + API-key providers) currently can't tell, per turn:

- **which seat actually served the turn** — the pool rotates on exhaustion/cooldown, and the reply looks identical either way;
- **how the turn was billed** — subscription included allowance vs. **paid overage** ("extra usage") vs. a per-token API key. On Anthropic subscription seats with extra usage enabled, a turn silently switches from the included allowance to paid overage when the window is exhausted — nothing in the product surfaces this today;
- **what reasoning effort** the serving agent ran at (per-session `/effort` overrides make this vary).

The runtime footer already exists exactly for this kind of per-turn metadata (`model · context % · cwd`, opt-in via `display.runtime_footer`). This PR extends it with three more **opt-in** fields rather than adding any new surface.

## What each field shows

| field | value | source |
|---|---|---|
| `account` | credential-pool entry label (e.g. `work seat`), falling back to the raw entry id, then the provider name | `agent._credential_pool_entry_id` looked up via `hermes_cli.auth.read_credential_pool()` |
| `billing` | `sub` (OAuth subscription seat, included allowance) / `extra` (this turn was served on paid overage) / `API` (per-token key) | `agent._is_anthropic_oauth` + the provider's own per-response header (below); `openai-codex` is subscription-only → `sub` |
| `effort` | `effort high` etc. | `agent.reasoning_config` effort value |

Example with `fields: [model, context_pct, account, billing, effort]`:

```
claude-sonnet-4.6 · 5% · work seat · extra · effort high
```

## Provider-header evidence for the overage flag

Anthropic stamps every Messages API response served to a subscription (OAuth) credential that has extra usage enabled with:

```
anthropic-ratelimit-unified-overage-in-use: true|false
```

`true` means *this* response was billed against the paid overage balance rather than the subscription's included allowance. The header is absent for accounts without the extra-usage feature and for plain API keys. Verified live against two subscription accounts: an account without extra usage never sends the header (→ `sub`), and a topped-up account with its included allowance exhausted (`unified_7d` utilization 1.0) sends `true` (→ `extra`).

The capture rides the existing response-header hook (`_capture_anthropic_response_headers` in `agent/rate_limit_credits.py`, where rate-limit and credits headers are already parsed) and stores per-call `agent._last_anthropic_overage_in_use` — `None` when absent, fail-open `try/except` like its siblings. No extra request, no new I/O.

## Default behavior is byte-identical

- The **default field set stays exactly `(model, context_pct, cwd)`** — like the existing `latency` field, the three new fields render only when the user opts in via `display.runtime_footer.fields`. A config with `fields` unset renders byte-identically to before (asserted by `test_default_field_set_unchanged`).
- Config-gated display pref only — **no new env vars**, no new tools, no new config keys (reuses the existing `display.runtime_footer.fields` list).
- **Fail-open everywhere**: `resolve_agent_runtime_fields()` never raises (broken agent → all-`None`; unreadable auth store → falls back to the pool id); unresolved fields are skipped, not blanked; the footer call site keeps its existing `try/except`.
- The resolver runs once per turn in `gateway/run_turn_runner.py` right where the usage dict is already built from the live agent (the footer renders later, when the agent may be released), and the values ride the existing result dict to the `build_footer_line` call site in `gateway/run_turn.py`.

## Tests

New file `tests/gateway/test_runtime_footer_account_billing.py` (17 tests): billing `extra`/`sub`/`API` from header true/false/absent, key-auth ignoring a stale overage flag, pool-label lookup with id/provider fallbacks, effort variants, the render path, the default-field-set invariant, and resolver fail-open on a broken agent and a broken auth store.

```
$ scripts/run_tests.sh tests/gateway/test_runtime_footer.py tests/gateway/test_runtime_footer_account_billing.py tests/gateway/test_footer_command_mid_run.py
=== Summary: 3 files, 55 tests passed, 0 failed ===

$ scripts/run_tests.sh tests/agent/test_credits_cold_start.py tests/agent/test_credits_fixture_snapshot.py \
    tests/agent/test_credits_policy.py tests/agent/test_credits_tracker.py tests/agent/test_credits_view.py \
    tests/agent/test_rate_limit_tracker.py tests/agent/test_credential_pool_routing.py
=== Summary: 7 files, 121 tests passed, 0 failed ===

$ scripts/run_tests.sh tests/gateway/test_usage_command.py
=== Summary: 1 files, 6 tests passed, 0 failed ===
```

`ruff check` and `ty check` clean on all touched files.
