### PR TITLE
fix(desktop): break runtime plugin SDK cycle

### DIFF
--- a/apps/desktop/src/app/skills/desktop-plugins-section.test.tsx
+++ b/apps/desktop/src/app/skills/desktop-plugins-section.test.tsx
@@ -7,6 +7,17 @@ import { $pluginInstallRequest, closePluginInstallRequest } from '@/store/plugin
 
 import { DesktopPluginsSection } from './desktop-plugins-section'
 
+const runtimeLoaderProbe = vi.hoisted(() => ({
+  discoverRuntimePlugins: vi.fn(),
+  imported: false
+}))
+
+vi.mock('@/contrib/runtime-loader', () => {
+  runtimeLoaderProbe.imported = true
+
+  return { discoverRuntimePlugins: runtimeLoaderProbe.discoverRuntimePlugins }
+})
+
 beforeEach(() => {
   $pluginRecords.set({})
   $agentPlugins.set([])
@@ -20,6 +31,20 @@ afterEach(() => {
 })
 
 describe('DesktopPluginsSection', () => {
+  it('loads the runtime loader only when the user requests a rescan', async () => {
+    expect(runtimeLoaderProbe.imported).toBe(false)
+
+    render(<DesktopPluginsSection profile={null} />)
+    expect(runtimeLoaderProbe.imported).toBe(false)
+
+    screen.getAllByRole('button')[1].click()
+
+    await vi.waitFor(() => {
+      expect(runtimeLoaderProbe.discoverRuntimePlugins).toHaveBeenCalledTimes(1)
+    })
+    expect(runtimeLoaderProbe.imported).toBe(true)
+  })
+
   it('flags a unified-root desktop half whose agent half is missing in the scoped profile', () => {
     $pluginRecords.set({
       'pixel-overlay': {

--- a/apps/desktop/src/app/skills/desktop-plugins-section.tsx
+++ b/apps/desktop/src/app/skills/desktop-plugins-section.tsx
@@ -6,7 +6,6 @@ import { Codicon } from '@/components/ui/codicon'
 import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
 import { $pluginRecords, type PluginRecord, setPluginEnabled } from '@/contrib/plugins-store'
-import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { FolderOpen, Monitor, RefreshCw } from '@/lib/icons'
@@ -239,7 +238,7 @@ export function DesktopPluginsSection({ profile }: { profile: null | string }) {
             <Button
               onClick={() => {
                 triggerHaptic('selection')
-                void discoverRuntimePlugins()
+                void import('@/contrib/runtime-loader').then(module => module.discoverRuntimePlugins())
               }}
               size="icon"
               type="button"


### PR DESCRIPTION
## Summary

Break the production import cycle that makes every disk/runtime desktop plugin fail after #107212. The runtime loader is now imported only when the user presses Rescan; initial discovery remains on the existing `watchRuntimePlugins()` path.

This is a carry-forward of the verified production fix in #107301 with a behavior-level regression test that complies with the repository rule against reading source text in tests. #107301's head fork is not writable by the authenticated contributor account (GitHub reports no permissions), so this PR preserves the root fix and credits KoNit-K in the commit.

## Problem observed

- Incorrect behavior: after merged PR #107212 (`61afcde8f9`), every on-disk desktop plugin failed on production desktop startup with `TypeError: Cannot convert undefined or null to object` from the bundled SDK chunk. The failure occurred for standalone and unified-package disk plugins, including zero-import plugins, before plugin code ran.
- Expected behavior: disk/runtime plugins load and register as before #107212; a manual rescan keeps working.
- Confirmation: the issue report and independent comments reproduce the failure on macOS and Windows. On the clean base `67764dc086`, the new regression test is RED (`1 failed, 3 passed`). A production build of that base emitted `dist/assets/sdk-B6X_oHhs.js` with the SDK namespace map at byte position 158620 and the referenced SDK declaration at 228722, so the declaration was evaluated after the map read.

## Root cause

#107212 moved `app/settings/plugins-settings.tsx` to `app/skills/desktop-plugins-section.tsx` without removing its static `@/contrib/runtime-loader` import. That completed this cycle:

```text
sdk/index.ts -> app/skills -> plugins-tab -> desktop-plugins-section
  -> contrib/runtime-loader -> sdk/runtime -> sdk/index.ts
```

`apps/desktop/src/sdk/runtime.ts` captured `import * as sdk from './index'` in a module-scope `GLOBALS` object. Rolldown's production output hoisted the namespace as a variable and emitted the globals map before that variable's declaration. `sdkImportMap()` then called `Object.keys()` on the undefined SDK namespace while preparing shims. `loadRuntimePlugin()` performs this preparation before evaluating the plugin source, so all disk plugins failed uniformly; bundled plugins did not use this path.

The updated Graphify desktop graph records `runtime-loader.ts`, `runtime.ts`, `installPluginSdk()`, `sdkImportMap()`, `loadRuntimePlugin()`, `DesktopPluginsSection()`, and `index.ts` as the relevant nodes. A full repository `graphify update . --no-cluster` reached 100% AST extraction but timed out before writing a receipt; the scoped authoritative update `graphify update apps/desktop --no-cluster` completed with 17,596 nodes and 60,750 edges.

## Impact and scope

- Affected: all disk/runtime desktop plugins loaded from the Electron-local plugin roots; both standalone `desktop-plugins/<name>/plugin.js` and unified `plugins/<name>/desktop/plugin.js` entries use this loader.
- Not affected: bundled plugins, backend/agent plugins, the existing disk scan/reconciliation algorithm, plugin capabilities, or the initial watcher setup.
- Consequence: users saw all disk plugins as failed/inert after upgrading to the affected desktop build.
- Security: no new capability or trust boundary is introduced. Disk plugins retain the existing local-plugin authority model; no credentials or secret-bearing files were touched.
- Performance/resources: initial startup no longer includes the section's static edge. Manual Rescan adds one cached dynamic module import before invoking the same loader function; there is no new polling, retry loop, persistent state, or per-plugin memory allocation. The change is O(1) per rescan and leaves the scan loop unchanged.

## Solution

- Remove the static `discoverRuntimePlugins` import from `desktop-plugins-section.tsx`.
- Dynamically import `@/contrib/runtime-loader` inside the existing Rescan button handler and invoke the same `discoverRuntimePlugins()` function.
- Add a behavior test that observes module loading through a mocked module factory: the loader must not initialize while the section is imported/rendered, and must initialize exactly once when Rescan is clicked.

This removes the static edge that closes the cycle while preserving the manual control and the production watcher. A null guard in `sdk/runtime.ts` was not selected: it would only relocate or hide the failure and could leave the SDK shim without named exports. PRs #107303, #107309, and #107338 were reviewed as related alternatives; they harden the symptom path rather than removing the newly introduced static cycle.

## Compatibility and residual risks

- No migration, configuration, or API change.
- Dynamic `import()` is already supported by the Vite/Electron build and is emitted as `runtime-loader-DNE3smZ6.js` in the fixed production build.
- The fixed build contains no `sdk-*.js` chunk. Its runtime-loader chunk places the SDK namespace declaration at byte position 108494 before the globals map at 124072.
- Full `electron-builder` packaging and a live installed-app disk-plugin boot were not run in this Windows session; the production Vite bundle, chunk-order probe, focused runtime tests, and type/lint checks were run. The issue's packed-app reproduction remains the external end-to-end evidence.
- Local verification used Node v22.16.0/npm 11.4.1 while the repository requires Node >=22.22.0; npm emitted engine warnings. `npm ci --engine-strict=false` was used only to install the locked dependencies for verification.

## Tests and verification

| Command/test | Objective | Result |
|---|---|---|
| `npm run test:ui -- src/app/skills/desktop-plugins-section.test.tsx` on base `67764dc086` with the source restored | Prove the regression test catches the old static edge | RED: 1 failed, 3 passed |
| `npm run test:ui -- src/app/skills/desktop-plugins-section.test.tsx` on head `6d8dbba033` | Verify deferred loader import and existing section behavior | PASS: 1 file, 4 tests |
| `npm run test:ui -- src/contrib/runtime-loader.test.ts src/sdk/index.test.ts src/app/skills/desktop-plugins-section.test.tsx` | Exercise loader, SDK consumer, and section paths together | PASS: 3 files, 26 tests |
| `npm run check:lint` | Typecheck all desktop configs and lint `src/` + `electron/` | PASS, exit 0; 0 errors and 142 repository warnings in unrelated existing files |
| `npm run build` on clean base `67764dc086` | Reproduce the production chunk-order mechanism | PASS build; `sdk-B6X_oHhs.js`, SDK map before declaration |
| `npm run build` on head `6d8dbba033` | Verify production graph after the fix | PASS build; no SDK chunk, `runtime-loader-DNE3smZ6.js`, declaration before map |
| `git diff --check` | Check whitespace/patch integrity | PASS |
| `graphify update apps/desktop --no-cluster` | Refresh the scoped code graph after edits | PASS: 17,596 nodes / 60,750 edges |

## Related work and duplication decision

- #107301 is the same verified production root fix and remains the canonical upstream candidate unless maintainers choose this carry-forward. Its original source-text test was rejected by the repository's `AGENTS.md` policy; this PR replaces that test with runtime behavior coverage and leaves #107301 untouched.
- #107303, #107309, and #107338 address lazy/null namespace handling. They do not provide the same direct cycle removal as the selected change and were not copied as unrelated hardening.
- The production fix credits KoNit-K and Cursor via verified commit trailers. No issue/PR was closed or force-updated by this PR.

## Files and documentation

- `apps/desktop/src/app/skills/desktop-plugins-section.tsx`: remove the eager loader edge; lazy-load only for Rescan.
- `apps/desktop/src/app/skills/desktop-plugins-section.test.tsx`: add behavior coverage for deferred module loading and preserve the existing plugin-section contract tests.
- No product documentation or configuration changes are required; this is a scoped production import-graph fix.

Fixes #107288

## Publication receipt

- PR: https://github.com/NousResearch/hermes-agent/pull/107447
- Base: `main` at `67764dc0863349a384c16425e73ee8571f3a94b7`
- Head: `JoaoMarcos44:fix/107288-runtime-plugin-cycle` at `6d8dbba0337b4b47b2b2e4a15638280eefbeeb3a`
- Published files: exactly the two files listed above; no generated build artifacts are in the PR.
- Initial GitHub check read immediately after publication: `no checks reported`; this is not treated as a green CI result.

## Post-publication stress verification

- The first generic subprocess harness attempt was inconclusive: the test output reached `3 files passed / 26 tests passed`, but the harness timeout/pipe cleanup exceeded its budget. A later unrestricted worker run exposed a Vitest fork-worker startup timeout with `no tests` and an unhandled worker error; this was a runner resource failure, not a code assertion or production-path failure.
- Auto-correction was limited to the stress harness: use direct Vitest invocation with `--maxWorkers=1` to remove the worker-start race. No source or test code changed and no failure was suppressed.
- Corrected battery: 3 rounds x 5 consecutive executions of `src/app/skills/desktop-plugins-section.test.tsx`, 15/15 invocations passed, 60/60 test assertions passed, and every process exited 0. Duration range was 4.61s-21.78s (mean 8.83s); sampled peak RSS ranged from 374.3 MB to 411.2 MB. This is a deterministic in-process/module-load stress harness, not a provider-network capacity benchmark.
- The repository's `scripts/run_tests.sh` was not applicable to this TypeScript-only desktop change; the authoritative project checks used here are the desktop `npm` typecheck/lint/build/Vitest commands documented above.
- A post-publication default-pool rerun of the three-file focused suite hit the same Vitest fork-worker startup timeout (`3 errors, no tests`) under host resource pressure. The corrected `--maxWorkers=1` rerun passed all 3 files and 26 tests in 79.82s; no source code changed.
