### PR TITLE
fix(anthropic): keep pool-selected account through pre-dispatch refresh; add secret-safe wire receipt

### DIFF
--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -861,6 +861,18 @@ class ClientLifecycleMixin:
             or base_url_host_matches(getattr(self, "_anthropic_base_url", "") or "", "azure.com")
         ):
             return False
+        # Pool-owned credentials must refresh/rotate through the pool. The singleton
+        # resolver may belong to a different Claude account; adopting it here changes
+        # the native client while leaving api_key and the pool entry id on the selected
+        # account, misattributing later 429s/401s. This also covers the 401 retry path
+        # (_refresh_credentials_after_401): pool recovery (_recover_auth_failure →
+        # try_refresh_matching/rotate) already ran before that fallback, and the pool
+        # adopts pairs rotated out-of-band via its singleton stores itself.
+        if (
+            getattr(self, "_credential_pool", None) is not None
+            and getattr(self, "_credential_pool_entry_id", None)
+        ):
+            return False
         try:
             from agent.anthropic_credentials import resolve_anthropic_token
             new_token = resolve_anthropic_token()

--- a/agent/rate_limit_credits.py
+++ b/agent/rate_limit_credits.py
@@ -67,6 +67,30 @@ class RateLimitCreditsMixin:
         aggregated ``Message`` drops them). Fail-open."""
         self._capture_rate_limits(http_response)
         self._capture_credits(http_response)
+        # Attribute the response to credentials on the actual HTTP request,
+        # not merely pool bookkeeping. Never log the credential values.
+        pool_entry_id = getattr(self, "_credential_pool_entry_id", None)
+        if getattr(self, "provider", None) == "anthropic" and pool_entry_id:
+            try:
+                request_headers = http_response.request.headers
+                bearer = request_headers.get("authorization", "")
+                sent_keys = [key for key in (
+                    request_headers.get("x-api-key", ""),
+                    bearer[7:] if bearer.startswith("Bearer ") else "",
+                ) if key]
+                matches_selected = bool(sent_keys) and all(
+                    key == getattr(self, "api_key", None) == getattr(self, "_anthropic_api_key", None)
+                    for key in sent_keys
+                )
+                logger.info(
+                    "%sAnthropic wire receipt: pool_entry=%s matches_selected=%s "
+                    "status=%s request_id=%s requested_model=%s",
+                    getattr(self, "log_prefix", ""), pool_entry_id,
+                    matches_selected, http_response.status_code,
+                    http_response.headers.get("request-id", ""), getattr(self, "model", None),
+                )
+            except Exception:
+                logger.debug("Anthropic wire receipt unavailable")
 
     def _capture_credits(self, http_response: Any) -> None:
         """Parse x-nous-credits-* headers, cache CreditsState, fire threshold notices.

--- a/tests/run_agent/test_anthropic_pool_identity.py
+++ b/tests/run_agent/test_anthropic_pool_identity.py
@@ -1,0 +1,111 @@
+"""A pool-selected Anthropic account must survive pre-dispatch refresh.
+
+``_try_refresh_anthropic_client_credentials`` runs the singleton
+``resolve_anthropic_token()`` before every native dispatch
+(``_create_request_anthropic_client``, ``_anthropic_messages_create``) and on
+the 401 retry path (``_refresh_credentials_after_401``). When the agent is
+bound to a credential-pool entry, that singleton may hold a *different* Claude
+account: adopting it swaps the native client while ``api_key`` and
+``_credential_pool_entry_id`` keep claiming the pool-selected entry, so later
+429s/401s are attributed to the wrong account. Pool-owned credentials must
+refresh/rotate through the pool (which already adopts pairs rotated
+out-of-band via its singleton stores).
+"""
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _pool_bound_agent() -> Any:
+    """Only the real runtime seam; no agent startup or live credentials."""
+    agent: Any = object.__new__(AIAgent)
+    agent.api_mode = "anthropic_messages"
+    agent.provider = "anthropic"
+    agent.model = "claude-fable-5"
+    agent.api_key = "test-account-two"
+    agent._anthropic_api_key = "test-account-two"
+    agent._anthropic_base_url = "https://api.anthropic.com"
+    agent._credential_pool = SimpleNamespace()
+    agent._credential_pool_entry_id = "account-two"
+    agent._anthropic_client = MagicMock()
+    return agent
+
+
+def test_pool_selected_account_is_not_replaced_by_singleton_before_dispatch():
+    agent = _pool_bound_agent()
+    original_client = agent._anthropic_client
+
+    with (
+        patch("agent.anthropic_credentials.resolve_anthropic_token", return_value="test-account-one") as singleton,
+        patch("agent.anthropic_adapter.build_anthropic_client") as rebuild,
+    ):
+        refreshed = agent._try_refresh_anthropic_client_credentials()
+
+    assert agent._anthropic_api_key == "test-account-two", "pre-dispatch refresh silently selected another account"
+    assert agent.api_key == agent._anthropic_api_key, "bookkeeping key and dispatched key disagree"
+    assert agent._anthropic_client is original_client
+    assert refreshed is False
+    original_client.close.assert_not_called()
+    singleton.assert_not_called()
+    rebuild.assert_not_called()
+
+
+def test_pool_bound_401_retry_defers_to_pool_not_singleton(capsys):
+    """401s on a pool binding are recovered by the POOL (``try_refresh_matching``
+    → rotate in ``_recover_auth_failure``), which runs *before* the per-provider
+    singleton fallback in ``recover_after_classification``. By the time
+    ``_refresh_credentials_after_401`` runs, the pool has already refreshed or
+    rotated (and it adopts out-of-band-rotated pairs itself), so the singleton
+    fallback must not swap in a possibly-different account; it reports the
+    surviving 401 instead."""
+    from agent.turn_recovery import _refresh_credentials_after_401
+    from agent.turn_retry_state import TurnRetryState
+
+    agent = _pool_bound_agent()
+    agent.log_prefix = ""
+    original_client = agent._anthropic_client
+    retry = TurnRetryState()
+
+    with (
+        patch("agent.anthropic_credentials.resolve_anthropic_token", return_value="test-account-one") as singleton,
+        patch("agent.anthropic_adapter.build_anthropic_client") as rebuild,
+    ):
+        retried = _refresh_credentials_after_401(agent, Exception("401 unauthorized"), retry, 401)
+
+    assert retried is False
+    assert retry.anthropic_auth_retry_attempted is True
+    assert agent._anthropic_api_key == "test-account-two"
+    assert agent._anthropic_client is original_client
+    singleton.assert_not_called()
+    rebuild.assert_not_called()
+    # The surviving 401 is still surfaced to the user, not silently swallowed.
+    assert "Anthropic 401" in capsys.readouterr().out
+
+
+def test_wire_receipt_uses_actual_request_header_without_logging_secret(caplog):
+    import logging
+    import httpx
+
+    agent: Any = object.__new__(AIAgent)
+    agent.provider = "anthropic"
+    agent.model = "claude-fable-5"
+    agent.api_key = "private-selected-token"
+    agent._anthropic_api_key = "private-selected-token"
+    agent._credential_pool_entry_id = "selected-entry"
+    agent.log_prefix = "[test-session] "
+    agent._capture_rate_limits = MagicMock()
+    agent._capture_credits = MagicMock()
+    for sent, expected in (("private-selected-token", "True"), ("private-other-token", "False")):
+        caplog.clear()
+        request = httpx.Request("POST", "https://api.anthropic.com/v1/messages", headers={"authorization": "Bearer " + sent})
+        response = httpx.Response(200, request=request, headers={"request-id": "test-request"})
+        with caplog.at_level(logging.INFO, logger="run_agent"):
+            agent._capture_anthropic_response_headers(response)
+        assert "Anthropic wire receipt" in caplog.text
+        assert "pool_entry=selected-entry" in caplog.text
+        assert "matches_selected=" + expected in caplog.text
+        assert "request_id=test-request" in caplog.text
+        assert "private-selected-token" not in caplog.text
+        assert "private-other-token" not in caplog.text


### PR DESCRIPTION
## Symptom

On a gateway bound to an Anthropic **credential-pool** entry, the agent silently switched to a *different* Claude account mid-session, while all pool bookkeeping (`api_key`, `_credential_pool_entry_id`) still claimed the pool-selected entry. Rate limits earned by the singleton account were attributed to the pool-selected account — the pool then quarantined/rotated the wrong entry. Found in production (silent account swap misattributing 429s on a pool-bound session, 2026-09-09).

## Root cause

`agent/client_lifecycle.py::_try_refresh_anthropic_client_credentials` (line ~850) unconditionally runs the **singleton** `resolve_anthropic_token()` and, when it differs from `_anthropic_api_key`, closes and rebuilds the native client with that token — even when the agent is pool-bound. It updates only `_anthropic_api_key`, never `api_key` / `_credential_pool_entry_id`, so the wire credential and the bookkeeping identity diverge.

Call paths that hit it (whole bug class, not just one site):

- `agent/client_lifecycle.py:497` — `_create_request_anthropic_client` (per-request client, pre-dispatch)
- `agent/client_lifecycle.py:958` — `_anthropic_messages_create` (shared client, pre-dispatch)
- `agent/turn_recovery.py:358` — `_refresh_credentials_after_401` (401 retry fallback)

## Fix

Guard in `_try_refresh_anthropic_client_credentials` itself (covers all three call sites): return `False` when `_credential_pool` + `_credential_pool_entry_id` are set. Pool-owned credentials refresh/rotate **through the pool**:

- pre-dispatch: pool renewal owns the token lifecycle, and the pool already adopts pairs rotated out-of-band via its singleton stores (`credential_pool.py` `_maybe_adopt_rotated_tokens` / `_refresh_anthropic` commit-to-singleton);
- on 401: pool recovery (`_recover_auth_failure` → `try_refresh_matching` → rotate) runs **before** the per-provider singleton fallback in `recover_after_classification`, so by the time `_refresh_credentials_after_401` reaches the anthropic branch on a pool binding, the pool has already refreshed or rotated. Falling back to the singleton there would reintroduce the same wrong-account swap; the surviving 401 is surfaced instead (diagnostics unchanged).

Additionally, `_capture_anthropic_response_headers` (`agent/rate_limit_credits.py`) now logs a **secret-safe wire receipt** for pool-bound native Anthropic responses: pool entry id + boolean `matches_selected` comparing the credential actually sent on the HTTP request (`x-api-key` / `authorization` bearer) against the selected one — never the token values. This makes future attribution drift observable from logs.

Non-pool sessions are unchanged: singleton refresh still picks up `claude /login` token rotation.

## Test evidence

New RED-first test file `tests/run_agent/test_anthropic_pool_identity.py` (3 tests):

- `test_pool_selected_account_is_not_replaced_by_singleton_before_dispatch` — pool-bound agent + singleton holding another account: client must not be swapped, singleton must not be consulted.
- `test_pool_bound_401_retry_defers_to_pool_not_singleton` — the 401 fallback path with a pool binding must not swap accounts and must surface the 401 diagnostics.
- `test_wire_receipt_uses_actual_request_header_without_logging_secret` — receipt reports `matches_selected=True/False` from the real request header and never logs token values.

RED (guard reverted, on current main):

```
scripts/run_tests.sh tests/run_agent/test_anthropic_pool_identity.py
→ 2 failed, 1 passed   # both guard tests fail: singleton silently swaps the account
```

GREEN (with fix):

```
scripts/run_tests.sh tests/run_agent/test_anthropic_pool_identity.py
→ 3 tests passed, 0 failed
```

Regression sweep — every anthropic/credential/pool/fallback/auth/rate-limit/credits test file under `tests/agent/` + `tests/run_agent/` (96 files) via the canonical runner:

```
ls -d tests/run_agent/* tests/agent/* | grep -iE "anthropic|credential|pool|fallback|auth|rate_limit|credits" \
  | sort -u | xargs scripts/run_tests.sh   # plus test_run_agent.py, test_streaming.py
=== Summary: 96 files, 1238 tests passed, 7 failed, 5 skipped ===
```

The 7 failures are **pre-existing on unmodified main** — verified by checking out the parent commit (`67764dc086`) and re-running the 4 affected files: identical 7 failures by name (`test_fallback_dynamic_credential` 1, `test_nous_portal_anthropic_wire` 2, `test_streaming` TestAnthropicStreamCallbacks 3, `test_run_agent` TestAnthropicInterruptHandler 1). None touch the changed code paths.

## Scope

No new tools, no config surface, no env vars, no cache impact (runtime credential path only). Non-pool sessions — the common case — take byte-for-byte the same path as before; the guard only fires when a pool binding exists.
