### PR TITLE
fix(delegate): forward output_schema through the model dispatch path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1298,6 +1298,7 @@ class AIAgent(
             goal=function_args.get("goal"), context=function_args.get("context"),
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"), role=function_args.get("role"),
+            output_schema=function_args.get("output_schema"),
             background=not (getattr(self, "_delegate_depth", 0) > 0), action=function_args.get("action"),
             subagent_id=function_args.get("subagent_id"), message=function_args.get("message"), parent_agent=self,
         )

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1660,6 +1660,23 @@ class TestDispatchDelegateTask(unittest.TestCase):
         self.assertNotIn("acp_command", captured["tasks"][0])
         self.assertNotIn("acp_args", captured["tasks"][0])
 
+    def test_model_output_schema_is_forwarded(self):
+        """The live model dispatch path forwards the top-level output schema."""
+        import run_agent
+
+        captured = {}
+        schema = {"type": "object", "properties": {"ok": {"type": "boolean"}}}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(parent, {"goal": "test", "output_schema": schema})
+
+        self.assertEqual(captured.get("output_schema"), schema)
+
 class TestDelegateEventEnum(unittest.TestCase):
     """Tests for DelegateEvent enum and back-compat aliases."""
 


### PR DESCRIPTION
## Summary

`AIAgent._dispatch_delegate_task` is the single call site that turns the model's `delegate_task` tool call into `tools.delegate_tool.delegate_task(...)`. It forwarded every field except the top-level `output_schema`, so a structured-output delegation issued by the live model silently degraded to free text. The registry fallback handler already forwards `output_schema`, so only the model path was affected.

## Change

Add `output_schema=function_args.get("output_schema")` to the dispatch kwargs in `run_agent.py`. One line; no behaviour change for calls without a schema.

## Tests

`TestDispatchDelegateTask::test_model_output_schema_is_forwarded` patches `delegate_task`, dispatches a call carrying a schema, and asserts it arrives unchanged. `tests/tools/test_delegate.py`: 81 passed; the one failure (`test_child_dedicated_db_follows_parents_db_path`, a macOS `/private/var` vs `/var` path comparison) fails identically on pristine `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
