### PR TITLE
fix(kanban): keep worker lifecycle tools when profile disables kanban

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -313,12 +313,13 @@ def _apply_toolset_selection(tools: set, names: List[str], quiet_mode: bool, *, 
 def _select_tool_names(enabled_toolsets: Optional[List[str]], disabled_toolsets: Optional[List[str]], quiet_mode: bool) -> set:
     """Tool names requested by the toolset selection (before check_fn filtering)."""
     tools: set = set()
+    # Dispatcher-spawned kanban workers always get the lifecycle handoff
+    # tools, even when the assignee profile restricts its chat toolsets.
+    kanban_worker = (os.environ.get("HERMES_KANBAN_TASK") and not _is_delegated_child_context()
+                     and _is_dispatcher_owned_worker())
     if enabled_toolsets is not None:
         enabled = list(enabled_toolsets)
-        # Dispatcher-spawned kanban workers always get the lifecycle handoff
-        # tools, even when the assignee profile restricts its chat toolsets.
-        if (os.environ.get("HERMES_KANBAN_TASK") and not _is_delegated_child_context()
-                and _is_dispatcher_owned_worker() and "kanban" not in enabled):
+        if kanban_worker and "kanban" not in enabled:
             enabled.append("kanban")
         _apply_toolset_selection(tools, enabled, quiet_mode, disable=False)
     else:
@@ -330,6 +331,13 @@ def _select_tool_names(enabled_toolsets: Optional[List[str]], disabled_toolsets:
     # This ensures that even if a composite toolset (like hermes-cli) is enabled, any tools belonging to a
     # disabled toolset are strictly stripped out. See issue #17309.
     if disabled_toolsets:
+        # The same worker invariant applies here: a profile may disable
+        # `kanban` to hide board tools from its chat sessions, but stripping
+        # kanban_complete/kanban_block from a dispatcher-owned worker leaves it
+        # unable to ever close its task (the stop-guard nudges it until the
+        # iteration budget runs out). Chat sessions still honor the disable.
+        if kanban_worker and "kanban" in disabled_toolsets:
+            disabled_toolsets = [t for t in disabled_toolsets if t != "kanban"]
         _apply_toolset_selection(tools, disabled_toolsets, quiet_mode, disable=True)
     return tools
 

--- a/tests/test_model_tools_kanban_worker_disabled.py
+++ b/tests/test_model_tools_kanban_worker_disabled.py
@@ -1,0 +1,68 @@
+"""Dispatcher-spawned kanban workers keep their lifecycle tools even when the
+assignee profile's ``agent.disabled_toolsets`` lists ``kanban``.
+
+A profile may disable the kanban toolset to hide board tools from its chat
+sessions. Without the worker carve-out, the disabled-subtraction step ran
+after the worker's kanban append and stripped ``kanban_complete`` /
+``kanban_block`` from every worker, which could then never close its task.
+
+Chat sessions are unaffected: without ``HERMES_KANBAN_TASK`` the disable
+still strips the kanban tools.
+"""
+
+import pytest
+
+import tools.kanban_tools  # noqa: F401 - ensure registered
+from model_tools import _clear_tool_defs_cache, get_tool_definitions
+from tools.registry import invalidate_check_fn_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """Both caches key on process-global state (env flags, registry generation);
+    a stale entry from a test that ran without ``HERMES_KANBAN_TASK`` would
+    otherwise mask the worker-append behavior under test."""
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+    yield
+    invalidate_check_fn_cache()
+    _clear_tool_defs_cache()
+
+
+def _names(tools):
+    return {t["function"]["name"] for t in tools}
+
+
+PINNED = ["clarify", "file", "memory", "todo", "web"]
+
+
+def test_worker_keeps_lifecycle_tools_despite_profile_disable(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test123")
+    names = _names(get_tool_definitions(
+        enabled_toolsets=list(PINNED), disabled_toolsets=["kanban", "x_search"], quiet_mode=True,
+    ))
+    # The full worker lifecycle surface (complete, block, show, heartbeat)
+    # must survive a profile-level kanban disable.
+    assert "kanban_complete" in names
+    assert "kanban_block" in names
+    assert "kanban_show" in names
+    assert "kanban_heartbeat" in names
+
+
+def test_non_worker_still_loses_kanban_tools_when_disabled(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    names = _names(get_tool_definitions(
+        enabled_toolsets=list(PINNED) + ["kanban"], disabled_toolsets=["kanban"], quiet_mode=True,
+    ))
+    assert "kanban_complete" not in names
+    assert "kanban_block" not in names
+    assert "kanban_show" not in names
+
+
+def test_worker_disable_of_other_toolsets_still_applies(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test123")
+    names = _names(get_tool_definitions(
+        enabled_toolsets=list(PINNED), disabled_toolsets=["kanban", "web"], quiet_mode=True,
+    ))
+    assert "kanban_complete" in names
+    assert "web_search" not in names


### PR DESCRIPTION
## Summary

A profile with `agent.disabled_toolsets: [kanban]` (to hide board tools from its chat sessions) also strips `kanban_complete` / `kanban_block` / `kanban_show` from dispatcher-spawned workers running under that profile. Such a worker can never close its task; the stop-guard nudges it until the iteration budget is exhausted, and the dispatcher scores the run as a failure.

## Change

`_select_tool_names` already carves `kanban` back in on the enabled side for dispatcher-owned workers. Apply the same predicate on the disabled side: drop `kanban` from `disabled_toolsets` for a dispatcher-owned worker before `_apply_toolset_selection(..., disable=True)`. Chat sessions and delegate children still honour the disable; the tool-defs cache key already includes the worker predicate.

## Tests

New `tests/test_model_tools_kanban_worker_disabled.py` pins that a worker keeps complete/block/show/heartbeat despite the disable, that a non-worker session still loses them, and that other disabled toolsets are still stripped from a worker. The worker cases fail on current main and pass with the fix. `tests/test_model_tools.py`, `test_model_tools_async_bridge.py` and `tests/tools/test_delegate_kanban_isolation.py` still pass (49 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
