### PR TITLE
fix(profiles): toggle MCP servers via the enabled key the runtime reads

### DIFF
--- a/tests/tui_gateway/test_profiles_configure.py
+++ b/tests/tui_gateway/test_profiles_configure.py
@@ -1,0 +1,87 @@
+"""profiles.describe / profiles.configure use the MCP ``enabled`` key the runtime reads.
+
+Every runtime resolver (``enabled_mcp_server_names``, coding_context, oneshot, the gateway's
+tool-name resolver) keys an MCP server's on/off state off ``mcp_servers.<name>.enabled``. The
+profile editor used to read and write a separate ``disabled`` key, so a server toggled off in
+the editor stayed live at runtime and a server with ``enabled: false`` showed as on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+import tui_gateway.server as server
+
+
+@pytest.fixture
+def profile_dir(tmp_path, monkeypatch) -> Path:
+    """A temp HERMES_HOME root with one named profile, ``bot``, at ``<root>/profiles/bot``."""
+    root = tmp_path / "hermes_home"
+    path = root / "profiles" / "bot"
+    path.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    from hermes_constants import get_hermes_home_override
+
+    assert get_hermes_home_override() is None
+    return path
+
+
+def _write_mcp(profile_dir: Path, servers: dict) -> None:
+    (profile_dir / "config.yaml").write_text(
+        yaml.safe_dump({"mcp_servers": servers}), encoding="utf-8"
+    )
+
+
+def _read_mcp(profile_dir: Path) -> dict:
+    return yaml.safe_load((profile_dir / "config.yaml").read_text(encoding="utf-8"))["mcp_servers"]
+
+
+def _call(method: str, params: dict) -> dict:
+    resp = server._methods[method](1, {"name": "bot", **params})
+    assert "error" not in resp, resp.get("error")
+    return resp["result"]
+
+
+def test_describe_reports_mcp_enabled_key_and_legacy_disabled(profile_dir):
+    _write_mcp(profile_dir, {
+        "on": {"command": "on", "enabled": True},
+        "off": {"command": "off", "enabled": False},
+        "legacy-off": {"command": "legacy", "disabled": True},
+        "implicit-on": {"command": "implicit"},
+    })
+
+    status = {s["name"]: s["enabled"] for s in _call("profiles.describe", {})["mcp_servers"]}
+
+    assert status == {"on": True, "off": False, "legacy-off": False, "implicit-on": True}
+
+
+def test_configure_writes_mcp_enabled_key_and_drops_legacy_disabled(profile_dir):
+    _write_mcp(profile_dir, {
+        "wanted": {"command": "wanted", "enabled": False},
+        "unwanted": {"command": "unwanted", "enabled": True, "disabled": True},
+    })
+
+    result = _call("profiles.configure", {"enabled_mcp_servers": ["wanted"]})
+
+    assert result["ok"] is True
+    assert result["applied"]["mcp_servers"] is True
+    assert _read_mcp(profile_dir) == {
+        "wanted": {"command": "wanted", "enabled": True},
+        "unwanted": {"command": "unwanted", "enabled": False},
+    }
+
+
+def test_configure_toggle_is_seen_by_runtime_resolver(profile_dir):
+    """The bug: disabling in the editor wrote ``disabled: true``, which the runtime ignored."""
+    from hermes_cli.tools_config import enabled_mcp_server_names
+
+    _write_mcp(profile_dir, {"keep": {"command": "keep"}, "drop": {"command": "drop"}})
+
+    _call("profiles.configure", {"enabled_mcp_servers": ["keep"]})
+
+    assert enabled_mcp_server_names({"mcp_servers": _read_mcp(profile_dir)}) == {"keep"}
+    status = {s["name"]: s["enabled"] for s in _call("profiles.describe", {})["mcp_servers"]}
+    assert status == {"keep": True, "drop": False}

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -418,7 +418,7 @@ def _(rid, params: dict) -> dict:
         soul = _try(lambda: soul_path.read_text(encoding="utf-8", errors="replace") if soul_path.is_file() else "", "")
         mcp_cfg = cfg.get("mcp_servers")
         mcp_out = _try(lambda: [
-            {"name": str(srv_name), "enabled": not is_truthy_value(entry.get("disabled", False)),
+            {"name": str(srv_name), "enabled": _mcp_entry_enabled(entry),
              "transport": str(entry.get("transport") or "http") if entry.get("url") else "stdio"}
             for srv_name in sorted(mcp_cfg.keys()) for entry in (mcp_cfg[srv_name],)
             if isinstance(entry, dict)
@@ -516,17 +516,26 @@ def _save_toolset_pin(cfg, enabled, save_config) -> None:
     save_config(cfg)
 
 
+def _mcp_entry_enabled(entry: dict) -> bool:
+    """Editor-side twin of ``enabled_mcp_server_names``: the runtime keys off ``enabled`` (default
+    True); a legacy ``disabled: true`` (what older editors wrote) is still honoured."""
+    from hermes_cli.tools_config import _parse_enabled_flag
+    return (_parse_enabled_flag(entry.get("enabled", True), default=True)
+            and not _parse_enabled_flag(entry.get("disabled", False), default=False))
+
+
 def _save_mcp_toggles(cfg, enabled, launch_mcp, save_config) -> None:
+    """Write the ``enabled`` flag every runtime resolver reads (``enabled_mcp_server_names``,
+    coding_context, oneshot); the legacy ``disabled`` key is dropped so old configs migrate."""
     wanted = _clean_names(enabled)
     mcp_cfg = cfg.get("mcp_servers") if isinstance(cfg.get("mcp_servers"), dict) else {}
     for srv in wanted:
         if not isinstance(mcp_cfg.get(srv), dict) and isinstance(launch_mcp.get(srv), dict):
             mcp_cfg[srv] = dict(launch_mcp[srv])
-        if isinstance(mcp_cfg.get(srv), dict):
-            mcp_cfg[srv].pop("disabled", None)
     for srv, entry in mcp_cfg.items():
-        if srv not in wanted and isinstance(entry, dict):
-            entry["disabled"] = True
+        if isinstance(entry, dict):
+            entry["enabled"] = srv in wanted
+            entry.pop("disabled", None)
     if mcp_cfg:
         cfg["mcp_servers"] = mcp_cfg
     save_config(cfg)


### PR DESCRIPTION
## Summary

The profile editor (`profiles.describe` / `profiles.configure` in `tui_gateway/methods_profiles.py`) tracks an MCP server's on/off state through a `disabled` key on `mcp_servers.<name>`, but every runtime resolver (`enabled_mcp_server_names`, `coding_context`, `oneshot`, the gateway tool-name resolver) keys off `enabled`. Disabling a server in the editor writes `disabled: true` and the server stays live; a server with `enabled: false` shows as enabled in the editor.

## Change

- `profiles.describe` reports the `enabled` flag (default true) via the same `_parse_enabled_flag` the runtime uses, still honouring a legacy `disabled: true`.
- `_save_mcp_toggles` writes `enabled: true/false` for every server and drops the legacy `disabled` key, so old configs migrate on the next save. Launch-catalog copying is unchanged.

The `platform_toolsets` write support that accompanied this in the fork is deliberately left out; it is a separate feature.

## Tests

New `tests/tui_gateway/test_profiles_configure.py` pins describe's reading of `enabled` / `enabled: false` / legacy `disabled` / unset, configure's written flags and removal of `disabled`, and a round-trip: a server disabled through the editor is excluded by `enabled_mcp_server_names`. All three fail on current main. The existing `tests/tui_gateway/test_profiles_*` and `test_mcp_profile_rpcs.py` files still pass (50 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
