### PR TITLE
fix(tools): honor explicit empty platform toolsets

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -561,6 +561,11 @@ def _get_platform_tools(config: dict, platform: str, *, include_default_mcp_serv
         toolset_names = [_platform_default_toolset(platform)]
     # YAML may parse bare numeric names (``12306:``) as int; normalise so sorted() never mixes types.
     toolset_names = [str(ts) for ts in toolset_names]
+    # An explicitly EMPTY list is a deny-all selection (distinct from an omitted key, which falls back to the
+    # platform composite). Return before native-toolset recovery and default MCP injection, or non-configurable
+    # toolsets such as ``kanban`` leak back onto a surface the user deliberately disabled.
+    if explicitly_configured and not toolset_names:
+        return set()
 
     configurable_keys = _configurable_keys()
     plugin_ts_keys = _get_plugin_toolset_keys()
@@ -581,8 +586,8 @@ def _get_platform_tools(config: dict, platform: str, *, include_default_mcp_serv
         enabled_toolsets |= _enabled_plugin_toolsets(config, platform, toolset_names, plugin_ts_keys)
 
     # Context-engine tools are runtime-provided, not in any static composite: keep them for a non-default
-    # engine even after an explicit save. An explicit EMPTY list means none, unless ``context_engine`` is added by hand.
-    if _context_engine_active(config) and not (explicitly_configured and not toolset_names):
+    # engine even after an explicit save (an explicit EMPTY list already returned above).
+    if _context_engine_active(config):
         enabled_toolsets.add("context_engine")
 
     # Explicit non-configurable entries (custom toolsets, MCP server names) pass through.

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -158,6 +158,18 @@ def test_discord_toolsets_do_not_leak_to_other_platforms():
     assert "discord_admin" not in enabled
 
 
+def test_explicit_empty_platform_toolsets_disable_non_configurable_toolsets():
+    """An explicitly empty list is a deny-all selection. ``kanban`` is
+    non-configurable and normally recovered from the platform composite; it
+    must not leak back into an explicitly empty discord/cron surface while
+    staying available on the CLI surface that lists it."""
+    config = {"platform_toolsets": {"cli": ["kanban"], "discord": [], "cron": []}}
+
+    assert _get_platform_tools(config, "cli", include_default_mcp_servers=False) == {"kanban"}
+    assert _get_platform_tools(config, "discord", include_default_mcp_servers=False) == set()
+    assert _get_platform_tools(config, "cron", include_default_mcp_servers=False) == set()
+
+
 
 
 


### PR DESCRIPTION
## Summary

An explicitly empty `platform_toolsets` entry such as `discord: []` is documented as a deny-all selection, distinct from omitting the key (which falls back to the platform composite). `_get_platform_tools` only honoured that for `context_engine`: it still ran `_recover_platform_native_toolsets` and `_merge_mcp_servers`, so non-configurable toolsets such as `kanban` were re-added to surfaces the user had deliberately disabled. On current main, `{"cli": ["kanban"], "discord": [], "cron": []}` resolves to `['kanban']` for all three platforms.

## Change

Return an empty set right after the saved list is normalised when it is explicitly empty, before native-toolset recovery and default-MCP injection. The `context_engine` guard drops its now-unreachable empty-list special case.

## Tests

`test_explicit_empty_platform_toolsets_disable_non_configurable_toolsets` pins that the config above resolves to `{"kanban"}` for cli and an empty set for discord and cron. `tests/hermes_cli/test_tools_config.py` plus the related toolset / CLI / gateway / cron test files pass (213 passed, 6 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
