### PR TITLE
fix(desktop): don't require npm to launch an up-to-date packaged app

### DIFF
--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -1525,13 +1525,22 @@ def cmd_gui(args: argparse.Namespace):
 
     packaged_executable = _desktop_packaged_executable(desktop_dir)
 
-    npm = None
-    if source_mode or not skip_build:
-        npm = _resolve_node_runtime_npm()
-        if not npm:
-            print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
-            print("Install Node.js, then run:  hermes gui")
-            sys.exit(1)
+    # Resolve npm lazily: a launch whose packaged app is already up to date
+    # (the common case, including desktop-launcher starts outside a login
+    # shell, where nvm/fnm/mise/Linuxbrew PATH setup never applies) must not
+    # require Node.js at all — only builds and source-mode launches do.
+    npm: str | None = None
+
+    def _ensure_npm() -> str:
+        nonlocal npm
+        if npm is None:
+            resolved = _resolve_node_runtime_npm()
+            if not resolved:
+                print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
+                print("Install Node.js, then run:  hermes gui")
+                sys.exit(1)
+            npm = resolved
+        return npm
 
     if skip_build:
         _check_desktop_skip_build(
@@ -1539,12 +1548,19 @@ def cmd_gui(args: argparse.Namespace):
         )
     elif force_build or _desktop_build_needed(desktop_dir, PROJECT_ROOT, source_mode=source_mode):
         # --force-build overrides the content-hash stamp and always rebuilds.
-        built = _build_desktop_app(desktop_dir, source_mode=source_mode, npm=npm, env=env)
+        built = _build_desktop_app(desktop_dir, source_mode=source_mode, npm=_ensure_npm(), env=env)
         if not source_mode:
             packaged_executable = built
     else:
         build_label = "source build" if source_mode else "packaged app"
         print(f"✓ Desktop {build_label} is up to date (content stamp matches)")
+
+    # A source-mode launch needs npm below; resolve it before the desktop-entry
+    # side effect so a missing-npm run exits without first (re)writing the
+    # launcher entry, matching the old eager check's exit-before-side-effects
+    # ordering.
+    if source_mode and not getattr(args, "build_only", False):
+        _ensure_npm()
 
     # Best-effort and idempotent; a failure must never stop the app from launching.
     _register_linux_desktop_entry()
@@ -1570,7 +1586,7 @@ def cmd_gui(args: argparse.Namespace):
 
     if source_mode:
         print("→ Launching Hermes Desktop from source build...")
-        launch_command = [npm, "exec", "--", "electron", "."]
+        launch_command = [_ensure_npm(), "exec", "--", "electron", "."]
     else:
         if packaged_executable is None:
             print(f"✗ Desktop package build completed but no launchable app was found at: {desktop_dir / 'release'}")

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -182,6 +182,68 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
 
 
+def test_up_to_date_packaged_gui_launch_skips_npm_resolution(tmp_path, monkeypatch):
+    """An up-to-date packaged launch must not require Node/npm at all.
+
+    Regression (#88004): npm was resolved before the content-stamp check, so a
+    current packaged app refused to launch whenever npm was absent — e.g. an
+    XDG desktop-entry start, which runs outside a login shell and therefore
+    without the nvm/fnm/mise/Linuxbrew PATH setup that puts npm on PATH.
+    Resolution returning None here doubles as a trap: if the launch path
+    resolved npm, cmd_gui would exit 1.
+    """
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch)
+
+    launch_ok = subprocess.CompletedProcess([str(packaged_exe)], 0)
+
+    with patch("hermes_cli.main_install_repair._resolve_node_runtime_npm", return_value=None) as mock_resolve, \
+         patch("hermes_cli.main_desktop._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main_web_build._run_npm_install_deterministic") as mock_install, \
+         patch("hermes_cli.main_desktop._desktop_linux_sandbox_fixup", return_value=True), \
+         patch("hermes_cli.main_desktop._register_linux_desktop_entry"), \
+         patch("hermes_cli.main.subprocess.run", return_value=launch_ok) as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns())
+
+    assert exc.value.code == 0
+    mock_resolve.assert_not_called()
+    mock_install.assert_not_called()
+    assert mock_run.call_count == 1
+    launched = mock_run.call_args.args[0]
+    if sys.platform.startswith("linux"):
+        assert launched == [str(packaged_exe), "--disable-setuid-sandbox"]
+    else:
+        assert launched == [str(packaged_exe)]
+    assert mock_run.call_args.kwargs["cwd"] == desktop_dir
+
+
+def test_source_launch_without_npm_fails_before_desktop_entry_write(tmp_path, monkeypatch):
+    """A doomed source-mode launch must exit before any side effects.
+
+    Lazy npm resolution moves the missing-npm exit later in cmd_gui; the
+    resolve is hoisted above _register_linux_desktop_entry() so a failed run
+    cannot leave a freshly (re)written launcher entry behind, matching the old
+    eager check's exit-before-side-effects ordering.
+    """
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    _make_packaged_executable(root, monkeypatch)
+
+    with patch("hermes_cli.main_install_repair._resolve_node_runtime_npm", return_value=None), \
+         patch("hermes_cli.main_desktop._desktop_build_needed", return_value=False), \
+         patch("hermes_cli.main_desktop._register_linux_desktop_entry") as mock_register, \
+         patch("hermes_cli.main.subprocess.run") as mock_run, \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(source=True))
+
+    assert exc.value.code == 1
+    mock_register.assert_not_called()
+    mock_run.assert_not_called()
+
+
 def test_gui_install_env_prepends_managed_node_on_bare_path(tmp_path, monkeypatch):
     """Regression: npm's child scripts (electron-winstaller's select-7z-arch.js)
     shell out to bare ``node``. When Desktop is launched from the updater chain


### PR DESCRIPTION
Fixes the Linux desktop-launcher failure in #88004.

This is a rebase of @z80dev's #84036 onto current `main`. That PR still targets `hermes_cli/main.py`, but the desktop code was split into `hermes_cli/main_desktop.py`; `main.py` now only re-exports `_resolve_node_runtime_npm`. #84036 has had no CI runs since 2026-08-11, and the review request in #88004 ("nobody has run it on the actual Universal Blue / Linuxbrew case") was still open, so this carries the same approach forward with that case verified. Happy to close this if #84036 gets rebased instead — the approach is z80dev's.

## Problem

`cmd_gui` resolved npm *before* asking whether a build was needed (`hermes_cli/main_desktop.py`):

```python
npm = None
if source_mode or not skip_build:
    npm = _resolve_node_runtime_npm()
    if not npm:
        print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
        sys.exit(1)
```

`--skip-build` is off by default, so this ran even when the content stamp matched and both `npm ci` and `npm run pack` were about to be skipped. The packaged launch is `subprocess.run([packaged_executable])` and never touches npm.

The XDG desktop entry is the loudest way to hit it: it runs outside a login shell, so nvm/fnm/mise/Linuxbrew PATH setup never applies, and `Terminal=false` makes the exit invisible — no window, no error.

## Change

Resolve npm lazily, at the points that need it: the build, and the source-mode launch. The source-mode resolve is hoisted above `_register_linux_desktop_entry()` so a doomed run exits before side effects, matching the old eager check's ordering — otherwise a failing source-mode launch could leave a freshly rewritten launcher entry behind.

## Tests

Two regression tests in `tests/hermes_cli/test_gui_command.py`:

- `test_up_to_date_packaged_gui_launch_skips_npm_resolution` — `_resolve_node_runtime_npm` returning `None` doubles as a trap; the up-to-date packaged launch must never call it. **Fails without the code change** (exit 1, `npm was not found on PATH`), passes with it.
- `test_source_launch_without_npm_fails_before_desktop_entry_write` — guards the ordering the lazy resolve could otherwise regress: exit 1, `_register_linux_desktop_entry` not called.

```
$ pytest tests/hermes_cli/test_gui_command.py -q
1 failed, 48 passed, 9 skipped
```

The one failure is `test_gui_bridges_ozone_hint_to_launch_env`, pre-existing on unmodified `main` on this host: it asserts `ELECTRON_OZONE_PLATFORM_HINT == "x11"` but reads the host session and gets `auto` on Wayland. Unrelated to this change; happy to file it separately.

## Manual verification (Linuxbrew case from #88004)

Fedora 44, KDE/Wayland, Node/npm from Linuxbrew only (`/home/linuxbrew/.linuxbrew/bin/npm`, no `/usr/bin/npm`), git install, packaged app present, content stamp current. Same command against the same tree, with the desktop session's `PATH` (no brew):

```
env -i HOME=$HOME USER=$USER PATH=/usr/local/bin:/usr/bin:/bin \
  XDG_DATA_HOME=/tmp/throwaway XDG_RUNTIME_DIR=/run/user/$(id -u) \
  DISPLAY=:0 WAYLAND_DISPLAY=wayland-0 XAUTHORITY=$XAUTHORITY \
  DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus \
  hermes desktop
```

Before: exit 1, `Desktop GUI requires Node.js/npm, but npm was not found on PATH.`, no window.

After: Electron starts and the app runs (killed by the harness `timeout`, not by the launcher); `gui.log` shows the gateway accepting websocket peers.

`XDG_DATA_HOME` is redirected only to keep the run from rewriting the real `~/.local/share/applications/hermes.desktop`.
