### PR TITLE
fix(desktop): pin settings layout and HUD back to the right titlebar

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -1144,12 +1144,14 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   }
 
   const titlebarToolsRight = titlebarToolsRightCss(nativeOverlayWidth, titlebarChrome)
-  // App controls live on the left; flip and the right toggle share the right.
-  const titlebarToolsWidth = titlebarToolsWidthCss(2)
+  // Right cluster: settings, layout, HUD, flip, right-sidebar toggle.
+  const SYSTEM_TOOL_COUNT = 5
+  const paneToolCount = rightTitlebarTools.filter(tool => !tool.hidden).length
+  const systemToolsWidth = titlebarToolsWidthCss(SYSTEM_TOOL_COUNT)
+  const titlebarToolsWidth =
+    paneToolCount > 0 ? `calc(${systemToolsWidth} + ${titlebarToolsWidthCss(paneToolCount)})` : systemToolsWidth
 
-  const leftToolsWidth = titlebarToolsWidthCss(
-    4 + [...leftTitlebarTools, ...rightTitlebarTools].filter(tool => !tool.hidden).length
-  )
+  const leftToolsWidth = titlebarToolsWidthCss(1 + leftTitlebarTools.filter(tool => !tool.hidden).length)
 
   return (
     <ContribWiringContext.Provider value={api}>
@@ -1162,7 +1164,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
             '--titlebar-controls-width': leftToolsWidth,
             '--titlebar-controls-y-nudge': titlebarControlsYNudge(titlebarChrome),
             '--titlebar-tools-right': titlebarToolsRight,
-            '--titlebar-tools-width': titlebarToolsWidth
+            '--titlebar-tools-width': titlebarToolsWidth,
+            '--shell-preview-toolbar-gap': systemToolsWidth
           } as CSSProperties
         }
       >

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -48,6 +48,7 @@ import { $cronReviewRequest, setCronFocusJobId } from '@/store/cron'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { $previewTarget } from '@/store/preview'
+import { $titlebarAppActionsSide, titlebarAppActionsClusterCounts } from '@/store/titlebar-app-actions'
 import {
   $activeGatewayProfile,
   $freshSessionRequest,
@@ -1144,14 +1145,15 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   }
 
   const titlebarToolsRight = titlebarToolsRightCss(nativeOverlayWidth, titlebarChrome)
-  // Right cluster: settings, layout, HUD, flip, right-sidebar toggle.
-  const SYSTEM_TOOL_COUNT = 5
+  const appActionsSide = useStore($titlebarAppActionsSide)
   const paneToolCount = rightTitlebarTools.filter(tool => !tool.hidden).length
-  const systemToolsWidth = titlebarToolsWidthCss(SYSTEM_TOOL_COUNT)
+  const leftExtraCount = leftTitlebarTools.filter(tool => !tool.hidden).length
+  const clusters = titlebarAppActionsClusterCounts(appActionsSide, leftExtraCount, 0)
+  const systemToolsWidth = titlebarToolsWidthCss(clusters.right)
   const titlebarToolsWidth =
     paneToolCount > 0 ? `calc(${systemToolsWidth} + ${titlebarToolsWidthCss(paneToolCount)})` : systemToolsWidth
 
-  const leftToolsWidth = titlebarToolsWidthCss(1 + leftTitlebarTools.filter(tool => !tool.hidden).length)
+  const leftToolsWidth = titlebarToolsWidthCss(clusters.left)
 
   return (
     <ContribWiringContext.Provider value={api}>

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -24,6 +24,11 @@ import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enable
 import { $reasoningCollapsedByDefault, setReasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
 import { $sessionListDensity, type SessionListDensity, setSessionListDensity } from '@/store/session-list-density'
 import { $tabStripDefault, setTabStripDefault, type TabStripDefault } from '@/store/tabstrip-prefs'
+import {
+  $titlebarAppActionsSide,
+  setTitlebarAppActionsSide,
+  type TitlebarAppActionsSide
+} from '@/store/titlebar-app-actions'
 import { $retiredTips, $tipsEnabled, resetTips, setTipsEnabled } from '@/store/tips'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $toursEnabled, setToursEnabled } from '@/store/tours'
@@ -397,6 +402,7 @@ export function AppearanceSettings() {
   const reasoningCollapsedByDefault = useStore($reasoningCollapsedByDefault)
   const sessionListDensity = useStore($sessionListDensity)
   const tabStripDefault = useStore($tabStripDefault)
+  const titlebarAppActionsSide = useStore($titlebarAppActionsSide)
   const zoomPercent = useStore($zoomPercent)
   const embedMode = useStore($embedMode)
   const embedAllowed = useStore($embedAllowed)
@@ -485,6 +491,11 @@ export function AppearanceSettings() {
     { id: 'always', label: a.tabStripAlways },
     { id: 'never', label: a.tabStripNever }
   ] as const satisfies readonly { id: TabStripDefault; label: string }[]
+
+  const appActionsOptions = [
+    { id: 'right', label: a.appActionsRight },
+    { id: 'left', label: a.appActionsLeft }
+  ] as const satisfies readonly { id: TitlebarAppActionsSide; label: string }[]
 
   const embedOptions = [
     { id: 'ask', label: a.embedsAsk },
@@ -659,6 +670,22 @@ export function AppearanceSettings() {
             }
             description={a.tabStripDesc}
             title={a.tabStripTitle}
+          />
+
+          <ListRow
+            action={
+              <SegmentedControl
+                onChange={id => {
+                  triggerHaptic('selection')
+                  setTitlebarAppActionsSide(id)
+                }}
+                options={appActionsOptions}
+                value={titlebarAppActionsSide}
+              />
+            }
+            description={a.appActionsDesc}
+            id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.appActions)}
+            title={a.appActionsTitle}
           />
 
           {/* Linux has neither half of this setting (see TRANSLUCENCY_SUPPORTED),

--- a/apps/desktop/src/app/settings/settings-search.ts
+++ b/apps/desktop/src/app/settings/settings-search.ts
@@ -11,6 +11,7 @@ import type { DesktopConfigSection, SettingsView } from './types'
 export type CredentialSettingsView = 'settings' | 'tools'
 
 export const APPEARANCE_SETTING_IDS = {
+  appActions: 'appearance.app-actions',
   backdrop: 'appearance.backdrop',
   embeds: 'appearance.embeds',
   introSplash: 'appearance.intro-splash',

--- a/apps/desktop/src/app/settings/use-settings-search.ts
+++ b/apps/desktop/src/app/settings/use-settings-search.ts
@@ -200,6 +200,15 @@ export function useSettingsSearchCatalog(enabled: boolean) {
     },
     {
       context: appearanceContext,
+      description: appearance.appActionsDesc,
+      icon: Palette,
+      id: `setting:${APPEARANCE_SETTING_IDS.appActions}`,
+      keywords: ['titlebar', 'settings gear', 'layout', 'HUD', 'left', 'right', 'tabs'],
+      label: appearance.appActionsTitle,
+      target: { setting: APPEARANCE_SETTING_IDS.appActions, view: 'config:appearance' }
+    },
+    {
+      context: appearanceContext,
       description: appearance.embedsDesc,
       icon: Palette,
       id: `setting:${APPEARANCE_SETTING_IDS.embeds}`,

--- a/apps/desktop/src/app/shell/titlebar-controls.test.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
+import { setTitlebarAppActionsSide } from '@/store/titlebar-app-actions'
 
 import { TitlebarControls } from './titlebar-controls'
 
@@ -16,10 +17,13 @@ function mount() {
   )
 }
 
-afterEach(cleanup)
+afterEach(() => {
+  setTitlebarAppActionsSide('right')
+  cleanup()
+})
 
 describe('titlebar app-action cluster', () => {
-  it('keeps settings, layout, and HUD on the right so the left titlebar stays free for tabs', () => {
+  it('defaults settings, layout, and HUD to the right so the left titlebar stays free for tabs', () => {
     mount()
 
     const left = screen.getByLabelText('Window controls')
@@ -33,5 +37,18 @@ describe('titlebar app-action cluster', () => {
     expect(within(left).queryByLabelText('Layout editor')).toBeNull()
     expect(within(left).queryByLabelText('HUD mode')).toBeNull()
     expect(within(left).getByLabelText(/Hide sidebar|Show sidebar/)).toBeTruthy()
+  })
+
+  it('moves settings, layout, and HUD to the left when the appearance setting says left', () => {
+    setTitlebarAppActionsSide('left')
+    mount()
+
+    const left = screen.getByLabelText('Window controls')
+    const right = screen.getByLabelText('App controls')
+
+    expect(within(left).getByLabelText('Open settings')).toBeTruthy()
+    expect(within(left).getByLabelText('Layout editor')).toBeTruthy()
+    expect(within(left).getByLabelText('HUD mode')).toBeTruthy()
+    expect(within(right).queryByLabelText('Open settings')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/shell/titlebar-controls.test.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+
+import { TitlebarControls } from './titlebar-controls'
+
+function mount() {
+  return render(
+    <MemoryRouter>
+      <I18nProvider configClient={null} initialLocale="en">
+        <TitlebarControls onOpenSettings={() => undefined} />
+      </I18nProvider>
+    </MemoryRouter>
+  )
+}
+
+afterEach(cleanup)
+
+describe('titlebar app-action cluster', () => {
+  it('keeps settings, layout, and HUD on the right so the left titlebar stays free for tabs', () => {
+    mount()
+
+    const left = screen.getByLabelText('Window controls')
+    const right = screen.getByLabelText('App controls')
+
+    expect(within(right).getByLabelText('Open settings')).toBeTruthy()
+    expect(within(right).getByLabelText('Layout editor')).toBeTruthy()
+    expect(within(right).getByLabelText('HUD mode')).toBeTruthy()
+
+    expect(within(left).queryByLabelText('Open settings')).toBeNull()
+    expect(within(left).queryByLabelText('Layout editor')).toBeNull()
+    expect(within(left).queryByLabelText('HUD mode')).toBeNull()
+    expect(within(left).getByLabelText(/Hide sidebar|Show sidebar/)).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -24,6 +24,7 @@ import {
   toggleSidebarOpen
 } from '@/store/layout'
 import { $unreadSessionCount } from '@/store/session-dot-state'
+import { $titlebarAppActionsSide } from '@/store/titlebar-app-actions'
 
 import { appViewForPath, isOverlayView } from '../routes'
 
@@ -138,6 +139,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const panesFlipped = useStore($panesFlipped)
   const sidebarOpen = useStore($sidebarOpen)
   const unreadCount = useStore($unreadSessionCount)
+  const appActionsSide = useStore($titlebarAppActionsSide)
   const unreadBadge = unreadCount > 0 ? unreadCount : undefined
   const unreadHint = unreadBadge ? ` · ${t.titlebar.unreadSessions(unreadBadge)}` : ''
 
@@ -244,8 +246,10 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     return null
   }
 
-  const visibleLeftTools = [sidebarTool, ...leftTools].filter(tool => !tool.hidden)
-  const visibleSystemTools = systemTools.filter(tool => !tool.hidden)
+  const visibleLeftTools = (
+    appActionsSide === 'left' ? [sidebarTool, ...systemTools, ...leftTools] : [sidebarTool, ...leftTools]
+  ).filter(tool => !tool.hidden)
+  const visibleSystemTools = appActionsSide === 'right' ? systemTools.filter(tool => !tool.hidden) : []
   const visiblePaneTools = tools.filter(tool => !tool.hidden)
 
   return (

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -187,7 +187,8 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     tour: 'right-pane-toggle'
   }
 
-  // App actions stay visible beside the left sidebar toggle.
+  // Static system tools — always pinned to the screen's right edge so the
+  // left titlebar stays free for tabs (#107351).
   const systemTools: TitlebarTool[] = [
     {
       actionId: 'nav.settings',
@@ -243,7 +244,9 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     return null
   }
 
-  const visibleLeftTools = [sidebarTool, ...systemTools, ...leftTools, ...tools].filter(tool => !tool.hidden)
+  const visibleLeftTools = [sidebarTool, ...leftTools].filter(tool => !tool.hidden)
+  const visibleSystemTools = systemTools.filter(tool => !tool.hidden)
+  const visiblePaneTools = tools.filter(tool => !tool.hidden)
 
   return (
     <>
@@ -259,15 +262,32 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
         ))}
         <Slot area="titleBar.left" />
         <Slot area="titleBar.center" />
-        <Slot area="titleBar.right" />
       </div>
+
+      {visiblePaneTools.length > 0 && (
+        <div
+          aria-label={t.shell.appControls}
+          className={cn(
+            titlebarToolClusterClass,
+            'top-[calc(var(--titlebar-controls-top)+var(--right-rail-top-inset,0px))] right-[calc(var(--titlebar-tools-right)+var(--shell-preview-toolbar-gap,0))]'
+          )}
+        >
+          {visiblePaneTools.map(tool => (
+            <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
+          ))}
+        </div>
+      )}
 
       <div
         aria-label={t.shell.appControls}
         className={cn(titlebarToolClusterClass, 'right-(--titlebar-tools-right) top-(--titlebar-controls-top)')}
       >
+        {visibleSystemTools.map(tool => (
+          <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
+        ))}
         <TitlebarToolButton navigate={navigate} tool={flipTool} />
         <TitlebarToolButton navigate={navigate} tool={rightSidebarTool} />
+        <Slot area="titleBar.right" />
       </div>
     </>
   )

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -598,6 +598,10 @@ export const en: Translations = {
       tabStripAuto: 'Auto',
       tabStripAlways: 'Always',
       tabStripNever: 'Never',
+      appActionsTitle: 'App Actions',
+      appActionsDesc: 'Where Settings, Layout, and HUD sit in the titlebar. Right leaves room for tabs on the left.',
+      appActionsLeft: 'Left',
+      appActionsRight: 'Right',
       terminalFontTitle: 'Terminal Font',
       terminalFontDesc:
         'Choose an installed font for Desktop terminals. Nerd Fonts render Powerlevel10k and shell icons; leave blank to use bundled JetBrains Mono.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -422,6 +422,10 @@ export const ja = defineLocale({
       tabStripAuto: '自動',
       tabStripAlways: '常に表示',
       tabStripNever: '表示しない',
+      appActionsTitle: 'アプリ操作',
+      appActionsDesc: '設定・レイアウト・HUD をタイトルバーの左右どちらに置くか。右にするとタブ用のスペースが左に残ります。',
+      appActionsLeft: '左',
+      appActionsRight: '右',
       terminalFontTitle: 'ターミナルフォント',
       terminalFontDesc:
         'Desktop のターミナルで使用するインストール済みフォントを選びます。Nerd Font は Powerlevel10k とシェルアイコンを表示できます。空欄では内蔵の JetBrains Mono を使用します。',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -568,6 +568,10 @@ export const ru = defineLocale({
       tabStripAuto: 'Авто',
       tabStripAlways: 'Всегда',
       tabStripNever: 'Никогда',
+      appActionsTitle: 'Действия приложения',
+      appActionsDesc: 'Где в заголовке окна сидят Настройки, Макет и HUD. Справа оставляют место для вкладок слева.',
+      appActionsLeft: 'Слева',
+      appActionsRight: 'Справа',
       terminalFontTitle: 'Шрифт терминала',
       terminalFontDesc:
         'Выберите установленный шрифт для терминалов приложения. Nerd Fonts отображают Powerlevel10k и иконки оболочки; оставьте пустым, чтобы использовать встроенный JetBrains Mono.',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -487,6 +487,10 @@ export interface Translations {
       tabStripAuto: string
       tabStripAlways: string
       tabStripNever: string
+      appActionsTitle: string
+      appActionsDesc: string
+      appActionsLeft: string
+      appActionsRight: string
       terminalFontTitle: string
       terminalFontDesc: string
       terminalFontPlaceholder: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -411,6 +411,10 @@ export const zhHant = defineLocale({
       tabStripAuto: '自動',
       tabStripAlways: '一律',
       tabStripNever: '永不',
+      appActionsTitle: '應用操作',
+      appActionsDesc: '設定、版面與 HUD 放在標題列左側或右側。選右側可把左側留給分頁。',
+      appActionsLeft: '左側',
+      appActionsRight: '右側',
       terminalFontTitle: '終端機字型',
       terminalFontDesc:
         '選擇已安裝的字型用於桌面端終端機。Nerd Font 可正確顯示 Powerlevel10k 與 Shell 圖示；留空則使用內建的 JetBrains Mono。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -582,6 +582,10 @@ export const zh: Translations = {
       tabStripAuto: '自动',
       tabStripAlways: '始终',
       tabStripNever: '从不',
+      appActionsTitle: '应用操作',
+      appActionsDesc: '设置、布局和 HUD 放在标题栏左侧还是右侧。选右侧可给标签留出左边空间。',
+      appActionsLeft: '左侧',
+      appActionsRight: '右侧',
       terminalFontTitle: '终端字体',
       terminalFontDesc:
         '选择已安装的字体用于桌面端终端。Nerd Font 可正确显示 Powerlevel10k 和 Shell 图标；留空则使用内置的 JetBrains Mono。',

--- a/apps/desktop/src/store/titlebar-app-actions.test.ts
+++ b/apps/desktop/src/store/titlebar-app-actions.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $titlebarAppActionsSide,
+  setTitlebarAppActionsSide,
+  TITLEBAR_APP_ACTIONS_DEFAULT,
+  titlebarAppActionsClusterCounts
+} from './titlebar-app-actions'
+
+describe('titlebarAppActionsClusterCounts', () => {
+  it('puts the three app actions on the right by default', () => {
+    expect(titlebarAppActionsClusterCounts('right')).toEqual({ left: 1, right: 5 })
+    expect(titlebarAppActionsClusterCounts('left')).toEqual({ left: 4, right: 2 })
+  })
+
+  it('adds extras to the cluster they belong to', () => {
+    expect(titlebarAppActionsClusterCounts('right', 1, 2)).toEqual({ left: 2, right: 7 })
+    expect(titlebarAppActionsClusterCounts('left', 1, 2)).toEqual({ left: 5, right: 4 })
+  })
+})
+
+describe('$titlebarAppActionsSide', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    setTitlebarAppActionsSide(TITLEBAR_APP_ACTIONS_DEFAULT)
+  })
+
+  it('defaults to right', () => {
+    expect($titlebarAppActionsSide.get()).toBe('right')
+  })
+
+  it('persists left', () => {
+    setTitlebarAppActionsSide('left')
+    expect($titlebarAppActionsSide.get()).toBe('left')
+    expect(window.localStorage.getItem('hermes.desktop.titlebarAppActions')).toBe('left')
+  })
+})

--- a/apps/desktop/src/store/titlebar-app-actions.ts
+++ b/apps/desktop/src/store/titlebar-app-actions.ts
@@ -1,0 +1,41 @@
+import { type Codec, persistentAtom } from '@/lib/persisted'
+
+export type TitlebarAppActionsSide = 'left' | 'right'
+
+const STORAGE_KEY = 'hermes.desktop.titlebarAppActions'
+
+/** Right is the original titlebar: Settings / Layout / HUD stay off the tab strip. */
+export const TITLEBAR_APP_ACTIONS_DEFAULT: TitlebarAppActionsSide = 'right'
+
+const codec: Codec<TitlebarAppActionsSide> = {
+  decode: raw => (raw === 'left' || raw === 'right' ? raw : TITLEBAR_APP_ACTIONS_DEFAULT),
+  encode: value => value
+}
+
+export const $titlebarAppActionsSide = persistentAtom<TitlebarAppActionsSide>(
+  STORAGE_KEY,
+  TITLEBAR_APP_ACTIONS_DEFAULT,
+  codec
+)
+
+export function setTitlebarAppActionsSide(side: TitlebarAppActionsSide) {
+  $titlebarAppActionsSide.set(side)
+}
+
+/** Button counts for the two titlebar clusters. Sidebar is always left; flip and
+ *  the right-sidebar toggle are always right; the three app actions follow `side`. */
+export function titlebarAppActionsClusterCounts(
+  side: TitlebarAppActionsSide,
+  leftExtras = 0,
+  rightExtras = 0
+): { left: number; right: number } {
+  const sidebar = 1
+  const appActions = 3
+  const rightFixed = 2
+
+  if (side === 'left') {
+    return { left: sidebar + appActions + leftExtras, right: rightFixed + rightExtras }
+  }
+
+  return { left: sidebar + leftExtras, right: appActions + rightFixed + rightExtras }
+}


### PR DESCRIPTION
## What does this PR do?

Keep panel tabs in the titlebar moved Settings, Layout, and HUD next to the left sidebar toggle, which leaves no room for session tabs.

This restores the default to the right edge, and adds an Appearance setting so anyone can put those three actions on the left or the right.

- Default: Right (tabs keep the left titlebar)
- Setting: Settings → Appearance → App Actions → Left / Right
- Sidebar toggle stays on the left either way

## Related Issue

Fixes #107351

Related PRs: #107358 (haptics mute titlebar entry, not this change), #107223 (left tab clipping).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/titlebar-app-actions.ts` — persisted Left/Right preference, default Right
- `apps/desktop/src/app/shell/titlebar-controls.tsx` — cluster placement follows the setting
- `apps/desktop/src/app/contrib/wiring.tsx` — titlebar width CSS vars follow the setting
- `apps/desktop/src/app/settings/appearance-settings.tsx` — Appearance row with a Left/Right control
- Tests for the store, both cluster placements, and titlebar sizing

## How to Test

1. Open Desktop. Settings, Layout, and HUD should sit on the right of the titlebar.
2. Settings → Appearance → App Actions → Left. Those three move left. Right puts them back.
3. Sidebar toggle stays on the left. Swap-sidebar and the right-sidebar toggle still work.

```bash
cd apps/desktop
npx vitest run src/store/titlebar-app-actions.test.ts src/app/shell/titlebar-controls.test.tsx src/app/shell/titlebar.test.ts
```

Expected: 3 files, 18 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md or AGENTS.md — N/A
- [x] Cross-platform impact considered — N/A (same clusters on every OS)
- [x] Tool descriptions/schemas — N/A
