### PR TITLE
feat(skills): archify appears in the optional-skills catalog, content pulled live from upstream

### DIFF
--- a/optional-skills/creative/archify/SKILL.md
+++ b/optional-skills/creative/archify/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: archify
+description: Validated interactive HTML diagrams, upstream-maintained.
+version: 2.17.0
+author: tt-a1i
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [diagram, architecture, workflow, sequence, dataflow, state-machine, mermaid, html, svg]
+    category: creative
+    related_skills: [architecture-diagram, excalidraw, concept-diagrams]
+    upstream:
+      repo: tt-a1i/archify
+      path: archify
+---
+
+# Archify (upstream-maintained)
+
+> **Catalog stub.** This entry is maintained upstream at
+> [tt-a1i/archify](https://github.com/tt-a1i/archify): the project ships a
+> self-contained skill directory (`archify/`) with the Node CLI, schemas,
+> renderers, examples and references. `hermes skills install
+> official/creative/archify` pulls the current tree live from that repo
+> (quarantined and scanned like any hub install) — this directory holds only
+> the catalog metadata, so the vendored copy can never go stale.
+
+Archify turns a small typed JSON spec into a self-contained, explorable HTML
+diagram: `architecture`, `workflow`, `sequence`, `dataflow` and `lifecycle`
+(state machine) types, dark/light themes, pan/zoom, search, relationship
+tracing, optional trace motion, and PNG/JPEG/WebP/SVG/WebM export. It accepts
+plain-language requirements or pasted Mermaid (`flowchart`, `sequenceDiagram`,
+`stateDiagram`) and can read repository evidence when the diagram must reflect
+real code. Every candidate goes through a 9-check `validate` / `deliver`
+receipt, so the output is verifiable rather than eyeballed.
+
+## Prerequisites
+
+- Node.js 18+ on `PATH` (`node bin/archify.mjs doctor` confirms the install;
+  no `npm install` is needed inside the skill package).
+- Installs pull ~200 files (~8 MB, mostly upstream tests and examples) from
+  GitHub; the fetch is pinned to one tree SHA, recorded in the bundle metadata.
+- Upstream's "Update awareness" step runs `scripts/check-update.mjs`, which
+  reads a release manifest from GitHub and only prints a notice — it never
+  downloads or installs anything. Skip it if outbound calls are unwanted.
+
+After install, the bundled `architecture-diagram` skill remains the
+zero-dependency fallback (it ports the same Cocoon AI lineage archify grew out
+of); prefer archify when the user wants validated receipts, Mermaid conversion,
+sequence/lifecycle types, or export beyond a single HTML file.
+
+Full documentation: https://github.com/tt-a1i/archify#readme

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -55,6 +55,7 @@ hermes skills uninstall <skill-name>
 
 | Skill | Description |
 |-------|-------------|
+| [**archify**](/docs/user-guide/skills/optional/creative/creative-archify) | Validated interactive HTML diagrams, upstream-maintained. |
 | [**ascii-art**](/docs/user-guide/skills/optional/creative/creative-ascii-art) | ASCII art: pyfiglet, cowsay, boxes, image-to-ascii. |
 | [**audiocraft-audio-generation**](/docs/user-guide/skills/optional/creative/creative-audiocraft-audio-generation) | AudioCraft: MusicGen text-to-music, AudioGen text-to-sound. |
 | [**baoyu-article-illustrator**](/docs/user-guide/skills/optional/creative/creative-baoyu-article-illustrator) | Article illustrations: type × style × palette consistency. |

--- a/website/docs/user-guide/skills/optional/creative/creative-archify.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-archify.md
@@ -1,0 +1,66 @@
+---
+title: "Archify — Validated interactive HTML diagrams, upstream-maintained"
+sidebar_label: "Archify"
+description: "Validated interactive HTML diagrams, upstream-maintained"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Archify
+
+Validated interactive HTML diagrams, upstream-maintained.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/creative/archify` |
+| Path | `optional-skills/creative/archify` |
+| Version | `2.17.0` |
+| Author | tt-a1i |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `diagram`, `architecture`, `workflow`, `sequence`, `dataflow`, `state-machine`, `mermaid`, `html`, `svg` |
+| Related skills | [`architecture-diagram`](/docs/user-guide/skills/bundled/creative/creative-architecture-diagram), [`excalidraw`](/docs/user-guide/skills/optional/creative/creative-excalidraw), [`concept-diagrams`](/docs/user-guide/skills/optional/creative/creative-concept-diagrams) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Archify (upstream-maintained)
+
+> **Catalog stub.** This entry is maintained upstream at
+> [tt-a1i/archify](https://github.com/tt-a1i/archify): the project ships a
+> self-contained skill directory (`archify/`) with the Node CLI, schemas,
+> renderers, examples and references. `hermes skills install
+> official/creative/archify` pulls the current tree live from that repo
+> (quarantined and scanned like any hub install) — this directory holds only
+> the catalog metadata, so the vendored copy can never go stale.
+
+Archify turns a small typed JSON spec into a self-contained, explorable HTML
+diagram: `architecture`, `workflow`, `sequence`, `dataflow` and `lifecycle`
+(state machine) types, dark/light themes, pan/zoom, search, relationship
+tracing, optional trace motion, and PNG/JPEG/WebP/SVG/WebM export. It accepts
+plain-language requirements or pasted Mermaid (`flowchart`, `sequenceDiagram`,
+`stateDiagram`) and can read repository evidence when the diagram must reflect
+real code. Every candidate goes through a 9-check `validate` / `deliver`
+receipt, so the output is verifiable rather than eyeballed.
+
+## Prerequisites
+
+- Node.js 18+ on `PATH` (`node bin/archify.mjs doctor` confirms the install;
+  no `npm install` is needed inside the skill package).
+- Installs pull ~200 files (~8 MB, mostly upstream tests and examples) from
+  GitHub; the fetch is pinned to one tree SHA, recorded in the bundle metadata.
+- Upstream's "Update awareness" step runs `scripts/check-update.mjs`, which
+  reads a release manifest from GitHub and only prints a notice — it never
+  downloads or installs anything. Skip it if outbound calls are unwanted.
+
+After install, the bundled `architecture-diagram` skill remains the
+zero-dependency fallback (it ports the same Cocoon AI lineage archify grew out
+of); prefer archify when the user wants validated receipts, Mermaid conversion,
+sequence/lifecycle types, or export beyond a single HTML file.
+
+Full documentation: https://github.com/tt-a1i/archify#readme

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -352,6 +352,7 @@ const sidebars: SidebarsConfig = {
                   collapsed: true,
                   items: [
                     'user-guide/skills/optional/creative/creative-ascii-art',
+                    'user-guide/skills/optional/creative/creative-archify',
                     'user-guide/skills/optional/creative/creative-audiocraft-audio-generation',
                     'user-guide/skills/optional/creative/creative-baoyu-article-illustrator',
                     'user-guide/skills/optional/creative/creative-baoyu-comic',


### PR DESCRIPTION
`hermes skills install official/creative/archify` now works: archify (tt-a1i/archify, MIT, 57k★) appears in the optional-skills catalog and docs as an upstream-maintained stub whose content is fetched live from the upstream repo at install time.

## Changes
- `optional-skills/creative/archify/SKILL.md` — catalog stub with `metadata.hermes.upstream: {repo: tt-a1i/archify, path: archify}`; `OptionalSkillSource._fetch_from_upstream` pulls the pinned upstream tree (CLI, schemas, renderers, examples, references). Same pattern as `impeccable` (45d9c33d85b). Nothing executable vendored; can't go stale.
- Docs: generated skill page, one catalog row, one sidebar line. Scoped to archify only (the generator wanted to rewrite 195 unrelated pages; left alone).

## Why a stub, not a port
Upstream ships a complete, self-contained skill dir (`archify/`, ~200 files / 8 MB, Node 18+, no `npm install`) and cuts versions daily. Vendoring it (or just its references, as #106442 does) forks a fast-moving tool; the upstream pointer keeps us at zero maintenance. The bundled `architecture-diagram` skill stays as the zero-dependency fallback; the stub body says when to prefer which.

## Validation
| Check | Result |
|---|---|
| `OptionalSkillSource().inspect/fetch("official/creative/archify")` against temp `HERMES_HOME` | bundle of 199 files, `upstream_repo`/`upstream_path` metadata set, `bin/archify.mjs` + 7 schemas present |
| Fetched bundle written to disk → `node bin/archify.mjs doctor` | "Archify is ready" |
| `deliver sequence examples/cache-miss-request.sequence.json … --quality showcase --json` on the fetched bundle | `ok: true`, 9/9 checks, composition `pass` |
| `scripts/run_tests.sh tests/skills/test_authoring_standards.py tests/tools/test_skill_bundle_provenance.py tests/tools/test_skills_hub_official.py` | 1216 passed, 0 failed |
| windows-footguns / `git diff --check` / vendor-name grep | clean |

Not exercised: the skill's `visual-check` headless-browser path (needs a browser at use time; unrelated to the catalog wiring).

Note for reviewers: upstream's SKILL.md has an "Update awareness" step that runs `scripts/check-update.mjs` (reads a GitHub release manifest, prints a notice, never downloads). The stub's Prerequisites call this out so users can skip it.

Credit: [@tt-a1i](https://github.com/tt-a1i) (upstream author). Supersedes #106442 (vendored-references port of the same skill).

## Infographic
![archify joins optional skills](https://v3b.fal.media/files/b/0aa9e135/V5VemoC6mvxihnpJl10oR_OzOnWQPP.png)
