### PR TITLE
fix(kanban): isolate same-card reviewer launches

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1553,7 +1553,9 @@ def _dispatch_lane_task(
         return False
     try:
         resolved_branch_name = None
-        if claimed.workspace_kind == "worktree":
+        if lane == "review":
+            workspace = _kbw.resolve_review_workspace(claimed, board=board)
+        elif claimed.workspace_kind == "worktree":
             workspace, resolved_branch_name = _kbw._resolve_worktree_workspace(claimed, board=board)
         else:
             workspace = _kbw.resolve_workspace(claimed, board=board)
@@ -1564,11 +1566,31 @@ def _dispatch_lane_task(
         ):
             result.auto_blocked.append(claimed.id)
         return False
-    _kbw.set_workspace_path(conn, claimed.id, str(workspace))
-    if claimed.workspace_kind == "worktree":
-        _kbw.set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+    # A review checkout is run-scoped and must not replace the implementer's
+    # durable workspace: request_changes needs to route the next build round
+    # back to the original checkout. Record its exact path for board-independent
+    # cleanup when the same-card task reaches a terminal state.
+    if lane == "review":
+        with _kb.write_txn(conn):
+            _kb._append_event(
+                conn, claimed.id, "review_workspace",
+                {"path": str(workspace), "reviewer": claimed.assignee},
+                run_id=claimed.current_run_id,
+            )
+    else:
+        _kbw.set_workspace_path(conn, claimed.id, str(workspace))
+        if claimed.workspace_kind == "worktree":
+            _kbw.set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
     _kbw._maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
     if lane == "review":
+        # Task model/provider overrides belong to the implementer run. A review
+        # handoff changes the assignee profile, so carrying those overrides
+        # across silently boots the reviewer on the builder's model instead of
+        # the reviewer's configured model. Clear only the claimed in-memory
+        # copy: the durable task keeps its builder overrides for a subsequent
+        # request-changes round.
+        claimed.model_override = None
+        claimed.provider_override = None
         # Force-load sdlc-review; the kanban lifecycle is already in every
         # worker's system prompt via KANBAN_GUIDANCE.
         claimed.skills = list(dict.fromkeys([*(claimed.skills or []), "sdlc-review"]))

--- a/hermes_cli/kanban_db_workspace.py
+++ b/hermes_cli/kanban_db_workspace.py
@@ -7,14 +7,16 @@ late-bound via ``_kb`` (import-cycle breaking) so monkeypatching
 
 from __future__ import annotations
 
+import contextlib
+import json
 import os
+import re
 import shutil
 import sqlite3
 import subprocess
 from pathlib import Path
 from typing import Optional
 from typing import TYPE_CHECKING
-import contextlib
 
 if TYPE_CHECKING:
     from hermes_cli.kanban_db import Task
@@ -110,6 +112,44 @@ def _is_managed_scratch_path(p: Path) -> bool:
     return _managed_scratch_path_info(p)[0]
 
 
+def _cleanup_review_workspaces(conn: sqlite3.Connection, task_id: str) -> None:
+    """Remove detached reviewer checkouts recorded for a completed task."""
+    rows = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'review_workspace'",
+        (task_id,),
+    ).fetchall()
+    targets: set[Path] = set()
+    for row in rows:
+        try:
+            payload = json.loads(row["payload"] or "{}")
+            target = Path(payload.get("path") or "").expanduser().resolve(strict=False)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            continue
+        managed, _board = _managed_scratch_path_info(target)
+        if (
+            not managed
+            or target.parent.name != "reviews"
+            or not target.name.startswith(f"{task_id}-")
+        ):
+            continue
+        targets.add(target)
+
+    for target in targets:
+        if not target.is_dir() or not _is_linked_worktree_checkout(target):
+            continue
+        common = _git(target, "rev-parse", "--path-format=absolute", "--git-common-dir", timeout=10)
+        if common.returncode != 0 or not common.stdout.strip():
+            continue
+        common_dir = Path(common.stdout.strip()).resolve(strict=False)
+        repo_root = common_dir.parent if common_dir.name == ".git" else common_dir
+        removed = _git(repo_root, "worktree", "remove", "--force", str(target), timeout=30)
+        if removed.returncode != 0:
+            _kb._log.warning(
+                "Could not remove review worktree for task %s at %s: %s",
+                task_id, target, removed.stderr.strip(),
+            )
+
+
 def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
     """Remove a task's scratch workspace dir and kill its stale tmux session.
     Called from :func:`complete_task` after the transaction commits; best-effort
@@ -120,6 +160,7 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
         row = conn.execute(_WORKSPACE_ROW_SQL, (task_id,)).fetchone()
         if not row:
             return
+        _cleanup_review_workspaces(conn, task_id)
         kind: Optional[str] = row["workspace_kind"]
         path: Optional[str] = row["workspace_path"]
         if kind not in _REMOVABLE_KINDS or not path:
@@ -488,6 +529,63 @@ def _resolve_worktree_workspace(task: Task, *, board: Optional[str] = None) -> t
         )
     _ensure_git_worktree(repo_root, requested, branch_name)
     return requested, branch_name
+
+
+def resolve_review_workspace(task: Task, *, board: Optional[str] = None) -> Path:
+    """Return an isolated detached checkout for a Git-backed review run.
+
+    Same-card review retains the implementation workspace on the durable task so
+    a request-changes round returns to the builder's checkout. The reviewer gets
+    a profile-labelled sibling under Kanban-managed storage, reset to the exact
+    committed candidate HEAD. Non-Git artifacts keep their original workspace.
+    """
+    source = resolve_workspace(task, board=board)
+    repo_root = _git_toplevel(source)
+    if repo_root is None:
+        return source
+
+    head = _git(repo_root, "rev-parse", "--verify", "HEAD", timeout=10)
+    if head.returncode != 0 or not head.stdout.strip():
+        raise ValueError(
+            f"task {task.id} review workspace has no resolvable Git HEAD: "
+            f"{head.stderr.strip() or source}"
+        )
+    revision = head.stdout.strip()
+    reviewer = re.sub(r"[^A-Za-z0-9._-]+", "-", task.assignee or "reviewer").strip("-")
+    reviewer = reviewer or "reviewer"
+    target = _kb.workspaces_root(board=board) / "reviews" / f"{task.id}-{reviewer}"
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if target.exists():
+        if not _is_linked_worktree_checkout(target):
+            raise ValueError(
+                f"refusing to replace non-worktree review workspace for task {task.id}: {target}"
+            )
+        common = _git(
+            target, "rev-parse", "--path-format=absolute", "--git-common-dir", timeout=10
+        )
+        if common.returncode != 0 or not common.stdout.strip():
+            raise ValueError(
+                f"could not resolve existing review worktree for task {task.id}: {target}"
+            )
+        common_dir = Path(common.stdout.strip()).resolve(strict=False)
+        existing_repo = common_dir.parent if common_dir.name == ".git" else common_dir
+        removed = _git(
+            existing_repo, "worktree", "remove", "--force", str(target), timeout=30
+        )
+        if removed.returncode != 0:
+            raise ValueError(
+                f"could not replace review worktree for task {task.id}: "
+                f"{removed.stderr.strip() or target}"
+            )
+
+    added = _git(repo_root, "worktree", "add", "--detach", str(target), revision, timeout=60)
+    if added.returncode != 0:
+        raise ValueError(
+            f"could not create review worktree for task {task.id}: "
+            f"{added.stderr.strip() or target}"
+        )
+    return target.resolve(strict=False)
 
 
 def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:

--- a/tests/hermes_cli/test_kanban_review_dispatch_contract.py
+++ b/tests/hermes_cli/test_kanban_review_dispatch_contract.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+from hermes_cli import kanban_db_workspace as kbw
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda *a, **k: {"kanban": {"review_dispatch": True}},
+    )
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: True)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def test_review_dispatch_uses_reviewer_profile_model_not_implementer_override(
+    kanban_home, tmp_path,
+):
+    workspace = tmp_path / "implementation"
+    workspace.mkdir()
+    captured = {}
+
+    def fake_spawn(task, review_workspace, board=None):
+        captured["task"] = task
+        return 42
+
+    with kbc.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="review candidate",
+            assignee="reviewer",
+            workspace_kind="dir",
+            workspace_path=str(workspace),
+            model_override="grok-implementer",
+            provider_override="builder-provider",
+        )
+        conn.execute(
+            "UPDATE tasks SET status = 'review', claim_lock = NULL, claim_expires = NULL "
+            "WHERE id = ?",
+            (task_id,),
+        )
+        conn.commit()
+        result = kbd.dispatch_once(conn, spawn_fn=fake_spawn)
+        durable = kb.get_task(conn, task_id)
+
+    assert result.spawned
+    assert durable is not None
+    assert captured["task"].model_override is None
+    assert captured["task"].provider_override is None
+    assert durable.model_override == "grok-implementer"
+    assert durable.provider_override == "builder-provider"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def test_review_dispatch_uses_reviewer_owned_detached_worktree(
+    kanban_home, tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    repo.joinpath("candidate.txt").write_text("candidate\n", encoding="utf-8")
+    repo.joinpath(".gitignore").write_text("*.review-cache\n", encoding="utf-8")
+    _git(repo, "add", "candidate.txt", ".gitignore")
+    _git(repo, "commit", "-m", "candidate")
+    candidate_sha = _git(repo, "rev-parse", "HEAD")
+    implementation = tmp_path / "implementer-worktree"
+    _git(repo, "worktree", "add", "--detach", str(implementation), candidate_sha)
+
+    captured = {}
+    board = "review-contract"
+    kb.create_board(board)
+
+    def fake_spawn(task, review_workspace, board=None):
+        captured["workspace"] = Path(review_workspace)
+        return 42
+
+    with kbc.connect(board=board) as conn:
+        task_id = kb.create_task(
+            conn,
+            title="review candidate",
+            assignee="reviewer",
+            workspace_kind="dir",
+            workspace_path=str(implementation),
+        )
+        conn.execute(
+            "UPDATE tasks SET status = 'review', claim_lock = NULL, claim_expires = NULL "
+            "WHERE id = ?",
+            (task_id,),
+        )
+        conn.commit()
+        result = kbd.dispatch_once(conn, spawn_fn=fake_spawn, board=board)
+        persisted = kb.get_task(conn, task_id)
+
+    review_workspace = captured["workspace"]
+    assert persisted is not None
+    assert result.spawned
+    assert review_workspace != implementation
+    assert "reviewer" in review_workspace.name
+    assert _git(review_workspace, "rev-parse", "HEAD") == candidate_sha
+    assert _git(review_workspace, "rev-parse", "--is-inside-work-tree") == "true"
+    assert persisted.workspace_path == str(implementation)
+
+    _git(review_workspace, "switch", "-c", "accidental-review-branch")
+    ignored_artifact = review_workspace / "stale.review-cache"
+    ignored_artifact.write_text("stale\n", encoding="utf-8")
+    reused = kbw.resolve_review_workspace(persisted, board=board)
+    attached = subprocess.run(
+        ["git", "-C", str(reused), "symbolic-ref", "-q", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    assert reused == review_workspace
+    assert attached.returncode != 0
+    assert not ignored_artifact.exists()
+
+    with kbc.connect(board=board) as conn:
+        running_review = kb.get_task(conn, task_id)
+        assert running_review is not None
+        assert kb.complete_task(
+            conn,
+            task_id,
+            summary="review approved",
+            metadata={"review_outcome": "approved"},
+            expected_run_id=running_review.current_run_id,
+        )
+
+    assert not review_workspace.exists()
+    assert str(review_workspace) not in _git(repo, "worktree", "list", "--porcelain")


### PR DESCRIPTION
## Summary
- launch review-lane workers on the reviewer profile model instead of carrying the implementer task override
- create a clean detached reviewer-owned worktree at the candidate HEAD while preserving the implementer workspace for request-changes
- record and safely clean reviewer worktrees on terminal completion, including named boards

## Regression evidence
- `uv run pytest -q tests/hermes_cli/test_kanban_review_dispatch_contract.py tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py tests/hermes_cli/test_kanban_host_cap.py tests/tools/test_kanban_tools.py` → 92 passed
- `uv run ruff check hermes_cli/kanban_db_dispatch.py hermes_cli/kanban_db_workspace.py tests/hermes_cli/test_kanban_review_dispatch_contract.py` → all checks passed
- independent pre-commit review: PASS, no security or logic findings

## Context
Observed in a real same-card handoff: the reviewer profile was assigned correctly, but the task retained the builder model/provider override and source worktree cwd. This made independent verification run as the builder model in the builder checkout.