### PR TITLE
fix(gateway): rehydrate model status overrides

### DIFF
--- a/gateway/slash_commands_model.py
+++ b/gateway/slash_commands_model.py
@@ -482,6 +482,11 @@ class GatewayModelCommandsMixin:
         # Check for session override. See #30479.
         source = await asyncio.to_thread(self._normalize_source_for_session_key, event.source)
         session_key = self._session_key_for_source(source)
+        # Runtime routing rehydrates persisted per-session overrides before every turn.
+        # Do the same before rendering /model or snapshotting --once, otherwise a
+        # post-restart status reply can show the global default while turns use the
+        # persisted override.
+        self._rehydrate_session_model_override(session_key)
         ctx = _ModelSwitchContext(
             # Gateway routing columns — forward ALL of them at CREATE time, same fix as the
             # compression-rotation bug in agent/conversation_compression.py. Without these, the branched

--- a/tests/gateway/test_model_command_profile_config.py
+++ b/tests/gateway/test_model_command_profile_config.py
@@ -1,6 +1,7 @@
 """Regression coverage for profile-scoped gateway ``/model`` reads."""
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -79,3 +80,54 @@ async def test_model_picker_reads_routed_profile_config(tmp_path, monkeypatch):
     assert adapter.kwargs is not None
     assert adapter.kwargs["current_model"] == "secondary-model"
     assert adapter.kwargs["current_provider"] == "secondary-provider"
+
+
+@pytest.mark.asyncio
+async def test_model_picker_rehydrates_persisted_session_override_after_restart(tmp_path, monkeypatch):
+    """Bare /model must report the persisted session choice after process-local state is lost."""
+    import gateway.run as gateway_run
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n  default: global-model\n  provider: global-provider\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs_for_provider",
+        lambda provider: {
+            "provider": provider,
+            "api_key": "test-key",
+            "base_url": "https://api.venice.test/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch_providers.list_picker_providers",
+        lambda **_kwargs: [],
+    )
+
+    runner = object.__new__(GatewayRunner)
+    adapter = _CapturingPickerAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.config = SimpleNamespace(multiplex_profiles=False)
+    runner._voice_mode = {}
+    runner._session_model_overrides = {}  # fresh process: no in-memory override
+    runner._running_agents = {}
+    runner.session_store = MagicMock()
+    runner.session_store.get_model_override.return_value = {
+        "model": "persisted-session-model",
+        "provider": "venice",
+        "base_url": "https://api.venice.test/v1",
+    }
+    runner._thread_metadata_for_source = lambda *_args, **_kwargs: None
+    runner._reply_anchor_for_event = lambda *_args, **_kwargs: None
+
+    result = await runner._handle_model_command(_make_event())
+
+    assert result is not None
+    assert "Current: `persisted-session-model` on venice" in result
+    runner.session_store.get_model_override.assert_called_once()


### PR DESCRIPTION
## Summary
- Rehydrate persisted session `/model` overrides before rendering or switching models.
- Make bare `/model` report the same thread-local model/provider that post-restart turns actually use.
- Make `/model <target> --once` snapshot and restore the persisted override rather than an empty in-memory state.

## Reproduction
1. Switch a gateway thread to a session-scoped model/provider with `/model`.
2. Restart the gateway.
3. Send a normal message: routing rehydrates and uses the persisted override.
4. Run bare `/model`: before this fix, it reports the global/profile default instead.

## Test plan
- `scripts/run_tests.sh tests/gateway/test_model_command_profile_config.py tests/gateway/test_model_switch_persistence.py tests/gateway/test_session_override_thread_recovery.py` (8 passed)
- `python -m compileall -q gateway/slash_commands_model.py tests/gateway/test_model_command_profile_config.py`
- `git diff --check` and current-main merge-tree

## Scope
This is complementary to #101312: that PR corrects OpenCode API-mode/base-URL reconstruction during rehydration; this PR makes the `/model` command’s status and `--once` snapshot consume the already-persisted session override.
