### PR TITLE
fix(plugins): never auto-delete test_* files under $HERMES_HOME/scripts

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -99,7 +99,7 @@ _NEVER_TRACK_TOP_LEVEL = frozenset({
     # User-authored project trees — never sweep empty directories inside these (#75403).
     # User-authored and project trees — never auto-delete files inside these just because they happen to be
     # named test_* or tmp_* (#75403, also #32164, #37721).
-    "patches", "projects", "skins", "themes", "contributors",
+    "patches", "projects", "scripts", "skins", "themes", "contributors",
     "profiles", "backups", "optional-skills"})
 
 @functools.lru_cache(maxsize=1)  # built lazily so HERMES_HOME resolves once

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -115,6 +115,18 @@ class TestGuessCategory:
         # Even though it matches test_* pattern, logs/ is excluded.
         assert dg.guess_category(p) is None
 
+    def test_skips_user_scripts_tree(self, _isolate_env):
+        """$HERMES_HOME/scripts is user-authored; test_* files there are not disposable (#107343)."""
+        dg = _load_lib()
+        scripts_dir = _isolate_env / "scripts"
+        scripts_dir.mkdir()
+        p = scripts_dir / "test_granola_parser.py"
+        p.write_text("x")
+        assert dg.guess_category(p) is None
+        tmp = scripts_dir / "tmp_scratch.py"
+        tmp.write_text("x")
+        assert dg.guess_category(tmp) is None
+
     def test_cron_subtree_categorised(self, _isolate_env):
         dg = _load_lib()
         # Only files under ``cron/output/`` are disposable run artifacts.


### PR DESCRIPTION
## Summary

`disk-cleanup` auto-tracks and deletes any `$HERMES_HOME` file whose basename starts with `test_`/`tmp_` unless the top-level directory is in `_NEVER_TRACK_TOP_LEVEL`. User-authored `scripts/` (cron job scripts) was missing from that set, so files like `scripts/test_granola_parser.py` were deleted at session end.

Same rationale as `projects`/`patches` (#75403 / #83378 class).

## Changes

- Add `"scripts"` to `_NEVER_TRACK_TOP_LEVEL`
- Regression test: `test_skips_user_scripts_tree`

## Testing

```
python3 -m pytest tests/plugins/test_disk_cleanup_plugin.py -q
```

28 passed.

Fixes #107343