### PR TITLE
fix(bedrock): key streamed content blocks by contentBlockIndex, not arrival count

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -701,7 +701,13 @@ def stream_converse_with_callbacks(
     """boto3 ``converse_stream()`` response + callbacks → the ``normalize_converse_response()`` shape.
     ``on_text_delta`` only fires while no toolUse block has been seen (as on the Anthropic/chat_completions
     paths); ``on_interrupt_check`` True stops streaming; ``on_event`` fires for EVERY event before branching
-    and its exceptions are swallowed so a watchdog hook can never abort the stream."""
+    and its exceptions are swallowed so a watchdog hook can never abort the stream.
+
+    Blocks are keyed by the ``contentBlockIndex`` Bedrock stamps on every contentBlockStart/Delta/Stop.
+    Text blocks get NO contentBlockStart on the wire (only toolUse does), so the index has to be read off
+    the deltas themselves: keying text by a running counter shreds one text block into one block per delta,
+    lets the later toolUse start overwrite one fragment and sort into the middle of the text, and that
+    ``[text, toolUse, text...]`` replay is rejected by Claude as assistant prefill on the next turn."""
     parts = _ResponseParts()
     stream_blocks: Dict[int, Dict[str, Any]] = {}
     current_block_index: Optional[int] = None
@@ -711,9 +717,15 @@ def stream_converse_with_callbacks(
     stop_reason = "end_turn"
     usage_data: Dict[str, int] = {}
 
-    def current_block(default: Dict[str, Any]) -> Dict[str, Any]:
-        idx = current_block_index if current_block_index is not None else len(stream_blocks)
-        return stream_blocks.setdefault(idx, default)
+    def block_index(payload: Dict[str, Any], *, new_block: bool = False) -> int:
+        """Index of the block a contentBlock* event addresses. Without ``contentBlockIndex`` (test doubles,
+        proxies) a start opens a fresh slot and a delta/stop continues the current one."""
+        nonlocal current_block_index
+        idx = payload.get("contentBlockIndex")
+        if not isinstance(idx, int) or isinstance(idx, bool):
+            idx = len(stream_blocks) if new_block or current_block_index is None else current_block_index
+        current_block_index = idx
+        return idx
 
     def flush_text() -> None:
         if current_text_buffer:
@@ -728,20 +740,22 @@ def stream_converse_with_callbacks(
             break
         if "contentBlockStart" in event:
             start_event = event["contentBlockStart"]
-            current_block_index = start_event.get("contentBlockIndex", len(stream_blocks))
+            idx = block_index(start_event, new_block=True)
             start = start_event.get("start", {})
             if "toolUse" in start:
                 has_tool_use = True
                 flush_text()
                 current_tool = {"toolUseId": start["toolUse"].get("toolUseId", ""), "name": start["toolUse"].get("name", ""), "input_json": ""}
-                stream_blocks[current_block_index] = _tool_use_block(current_tool["toolUseId"], current_tool["name"], {})
+                stream_blocks[idx] = _tool_use_block(current_tool["toolUseId"], current_tool["name"], {})
                 if on_tool_start:
                     on_tool_start(current_tool["name"])
         elif "contentBlockDelta" in event:
-            delta = event["contentBlockDelta"].get("delta", {})
+            delta_event = event["contentBlockDelta"]
+            idx = block_index(delta_event)
+            delta = delta_event.get("delta", {})
             if "text" in delta:
                 text = delta["text"]
-                block = current_block({"text": ""})
+                block = stream_blocks.setdefault(idx, {"text": ""})
                 block["text"] = block.get("text", "") + text
                 current_text_buffer.append(text)
                 if on_text_delta and not has_tool_use:
@@ -751,14 +765,15 @@ def stream_converse_with_callbacks(
             elif "reasoningContent" in delta:
                 reasoning = delta["reasoningContent"]
                 if isinstance(reasoning, dict) and (reasoning.get("text", "") or _encode_redacted(reasoning.get("redactedContent"))):
-                    block = current_block({"reasoningContent": {}}).setdefault("reasoningContent", {})
+                    block = stream_blocks.setdefault(idx, {"reasoningContent": {}}).setdefault("reasoningContent", {})
                     parts.absorb_reasoning(reasoning, block, on_reasoning_delta)
         elif "contentBlockStop" in event:
+            idx = block_index(event["contentBlockStop"])
             if current_tool is not None:
                 input_dict = _parse_tool_args(current_tool["input_json"])  # "" → {} via the JSON-error path
                 parts.tool_calls.append(_tool_call_ns(current_tool["toolUseId"], current_tool["name"], input_dict))
-                if current_block_index is not None and current_block_index in stream_blocks:
-                    stream_blocks[current_block_index]["toolUse"]["input"] = input_dict
+                if "toolUse" in stream_blocks.get(idx, {}):
+                    stream_blocks[idx]["toolUse"]["input"] = input_dict
                 current_tool = None
             else:
                 flush_text()
@@ -769,7 +784,6 @@ def stream_converse_with_callbacks(
             usage_data = {key: meta_usage.get(key, 0) for key in ("inputTokens", "outputTokens", "cacheReadInputTokens", "cacheWriteInputTokens")}
     flush_text()
     return parts.build([stream_blocks[i] for i in sorted(stream_blocks)], usage_data, stop_reason, "")
-
 
 # --- High-level API: call Bedrock Converse ---
 

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -486,6 +486,58 @@ class TestNormalizeConverseStreamEvents:
         assert tc[0].function.name == "read_file"
         assert json.loads(tc[0].function.arguments) == {"path": "/tmp/f"}
 
+    # Real ConverseStream wire shape (captured from global.anthropic.claude-opus-5): a text block gets NO
+    # contentBlockStart, only deltas stamped contentBlockIndex=0; the toolUse block then starts at index 1.
+    _LIVE_TEXT_THEN_TOOL_EVENTS = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "I"}}},
+        {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "'ll echo "}}},
+        {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "banana"}}},
+        {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": " now."}}},
+        {"contentBlockStop": {"contentBlockIndex": 0}},
+        {"contentBlockStart": {"contentBlockIndex": 1, "start": {"toolUse": {"toolUseId": "tooluse_1", "name": "echo"}}}},
+        {"contentBlockDelta": {"contentBlockIndex": 1, "delta": {"toolUse": {"input": ""}}}},
+        {"contentBlockDelta": {"contentBlockIndex": 1, "delta": {"toolUse": {"input": '{"s": "banana"}'}}}},
+        {"contentBlockStop": {"contentBlockIndex": 1}},
+        {"messageStop": {"stopReason": "tool_use"}},
+        {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 8}}},
+    ]
+
+    def test_text_deltas_without_content_block_start_stay_one_block_ahead_of_tool_use(self):
+        """Regression: keying text deltas by a running counter instead of their contentBlockIndex shredded
+        the text into one block per delta and let the toolUse start (index 1) overwrite the second fragment
+        and sort into the middle — a ``[text, toolUse, text...]`` sidecar Claude 5 on Bedrock rejects on
+        replay as "does not support assistant message prefill"."""
+        from agent.bedrock_adapter import convert_messages_to_converse, normalize_converse_stream_events
+        result = normalize_converse_stream_events({"stream": list(self._LIVE_TEXT_THEN_TOOL_EVENTS)})
+        msg = result.choices[0].message
+        assert msg.content == "I'll echo banana now."
+        assert msg.bedrock_content_blocks == [
+            {"text": "I'll echo banana now."},
+            {"toolUse": {"toolUseId": "tooluse_1", "name": "echo", "input": {"s": "banana"}}},
+        ]
+        assert [tc.function.name for tc in msg.tool_calls] == ["echo"]
+        # The sidecar is authoritative on replay: the next turn must go out as text THEN toolUse, nothing after.
+        _, converse = convert_messages_to_converse([
+            {"role": "user", "content": "echo banana"},
+            {"role": "assistant", "content": msg.content, "bedrock_content_blocks": msg.bedrock_content_blocks,
+             "tool_calls": [{"id": "tooluse_1", "type": "function", "function": {"name": "echo", "arguments": '{"s": "banana"}'}}]},
+            {"role": "tool", "tool_call_id": "tooluse_1", "content": "banana"},
+        ])
+        assert [list(b)[0] for b in converse[1]["content"]] == ["text", "toolUse"]
+        assert converse[1]["content"][0]["text"] == "I'll echo banana now."
+
+    def test_events_without_content_block_index_fall_back_to_arrival_order(self):
+        """Proxies/test doubles may omit contentBlockIndex: deltas continue the current block, a start opens a
+        new one, so text still lands before the toolUse instead of being overwritten by it."""
+        from agent.bedrock_adapter import normalize_converse_stream_events
+        events = [{k: {kk: vv for kk, vv in v.items() if kk != "contentBlockIndex"} for k, v in e.items()}
+                  for e in self._LIVE_TEXT_THEN_TOOL_EVENTS]
+        msg = normalize_converse_stream_events({"stream": events}).choices[0].message
+        assert msg.content == "I'll echo banana now."
+        assert [list(b)[0] for b in msg.bedrock_content_blocks] == ["text", "toolUse"]
+        assert msg.bedrock_content_blocks[1]["toolUse"]["input"] == {"s": "banana"}
+
 
 # ---------------------------------------------------------------------------
 # build_converse_kwargs


### PR DESCRIPTION
## What does this PR do?

Fixes a deterministic 400 from Claude 5 on Bedrock (`global.anthropic.claude-opus-5` observed) on every tool-continuation turn that follows an assistant reply containing **both text and a tool call**:

```
ValidationException: The model returned the following errors: This model does not support
assistant message prefill. The conversation must end with a user message.
```

The payload *does* end with a user turn. The rejected shape is the assistant turn before it, replayed from the `bedrock_content_blocks` sidecar as

```
assistant[text, text, toolUse, text x16, cachePoint]
```

i.e. the model's text shredded into one block per streamed delta, the `toolUse` spliced into the middle, and one text fragment missing. Claude 5 rejects text trailing a `tool_use` in the last assistant turn as prefill. Text-only and toolUse-only replies were unaffected, which made the failure look intermittent; the joined `content` string was correct, so transcripts looked fine while the wire payload was not.

**Root cause** — `stream_converse_with_callbacks()` in `agent/bedrock_adapter.py` only read `contentBlockIndex` on `contentBlockStart`. Bedrock emits **no `contentBlockStart` for text blocks** (only for `toolUse`), so `current_block_index` stayed `None` and every text delta was keyed by `len(stream_blocks)`, a fresh slot per delta. When the `toolUse` block then started at its real index it overwrote one text fragment and sorted into the middle of the text on replay. Every existing streaming test fabricates a `contentBlockStart` for text, which is why none caught it.

Live event sequence captured from Opus 5 (this is what the new test replays):

```
messageStart
contentBlockDelta  idx=0 {"text": "I"}
contentBlockDelta  idx=0 {"text": "'ll echo the word \""}
...
contentBlockStop   idx=0
contentBlockStart  idx=1 {"toolUse": {...}}
contentBlockDelta  idx=1 {"toolUse": {"input": ...}}
contentBlockStop   idx=1
messageStop        tool_use
```

**Fix** — read `contentBlockIndex` off every `contentBlockStart`/`Delta`/`Stop` and key `stream_blocks` by it, so all deltas of a block merge into one entry and blocks keep Bedrock's order. Events without an index (test doubles, proxies) fall back to arrival order: a start opens a new slot, a delta/stop continues the current one.

Verified against Bedrock directly: replaying the dumped failing request reproduces the 400; the same request with the assistant text ahead of the `toolUse` (merged or still fragmented) is accepted; dropping only the `cachePoint` still fails, so prompt caching is not involved.

Related but distinct (same error text, different causes): #105780 / #105798 (reasoning-only assistant turns), #101401 (transcript genuinely ending on an assistant turn).

## Related Issue

No issue filed; this PR carries the full diagnosis. Related: #105780, #101401.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/bedrock_adapter.py` — `stream_converse_with_callbacks()`: new `block_index()` helper reads `contentBlockIndex` from each content-block event (with arrival-order fallback); text/reasoning deltas and toolUse start/stop all address `stream_blocks` by that index. Docstring documents the wire behaviour.
- `tests/agent/test_bedrock_adapter.py` — two regression tests in `TestNormalizeConverseStreamEvents` using the captured live event sequence: (1) text deltas without a `contentBlockStart` stay one block ahead of the `toolUse`, and the replay through `convert_messages_to_converse()` is `[text, toolUse]`; (2) events with no `contentBlockIndex` at all still land text before the `toolUse`. Both fail on `main`.

## How to Test

1. `pytest tests/agent/test_bedrock_adapter.py tests/agent/test_bedrock_transport_replay.py -q` → 82 passed (80 on main + 2 new; the 2 new fail on main).
2. `pytest tests/agent -q -k "bedrock or converse or stream"` → 368 passed.
3. Live: with `provider: bedrock` and a Claude 5 model, ask for something that makes the model narrate before calling a tool (e.g. "say what you're about to do, then run `ls`"), then send a follow-up. On `main` the follow-up fails 3/3 with the prefill 400; with this patch it succeeds and `HERMES_DUMP_REQUESTS=1` shows the assistant turn as `[text, toolUse, cachePoint]`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the Bedrock/Converse/streaming test selection above (full `pytest tests/ -q` not run locally)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux (kernel 7.1), Python 3.11, boto3 against us-east-1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure event parsing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
