### PR TITLE
feat(models): DeepSeek V4.1 Flash on the Nous Portal and OpenRouter pickers

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -343,7 +343,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # (version-less canonical id, 2026-09 Flash refresh) needs a discrete entry or the
     # longest-key-first scan falls through to the 128K ``deepseek`` catch-all below.
     # https://api-docs.deepseek.com/zh-cn/quick_start/pricing
-    "deepseek-v4-pro": 1_000_000, "deepseek-v4-flash": 1_000_000, "deepseek-chat": 1_000_000,
+    "deepseek-v4-pro": 1_000_000, "deepseek-v4.1-flash": 1_000_000, "deepseek-v4-flash": 1_000_000, "deepseek-chat": 1_000_000,
     "deepseek-reasoner": 1_000_000, "deepseek-flash": 1_000_000, "deepseek": 128000,
     # Meta; Muse Spark family (1.1/1.2/1.3, -contributor(-free), meta/ prefixed) is 1M per OpenRouter,
     # models.dev and api.commandcode.ai /models — keep the "muse-spark" prefix (bare "muse" would match

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -22,7 +22,7 @@ _REASONING_STALE_TIMEOUT_FLOORS: dict[int, tuple[str, ...]] = {
         # DeepSeek R1 / V4 (reasoning_content streamed before final content).
         # ``deepseek-flash`` is the version-less canonical Flash id (2026-09 Flash refresh);
         # ``deepseek-v4-flash`` still aliases onto it server-side.
-        "deepseek-r1", "deepseek-reasoner", "deepseek-flash", "deepseek-v4-flash", "deepseek-v4-pro",
+        "deepseek-r1", "deepseek-reasoner", "deepseek-flash", "deepseek-v4-flash", "deepseek-v4.1-flash", "deepseek-v4-pro",
         # OpenAI o-series: each variant enumerated so bare ``o1`` cannot over-match ``olmo-1``.
         "o1", "o1-mini", "o1-pro", "o1-preview", "o3", "o3-pro",
         # Mythos-class named models (claude-fable-5): 1M ctx + 128K output, a heavier thinking

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -35,7 +35,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
         "openai/gpt-5.6-terra", "openai/gpt-5.6-terra-pro", "openai/gpt-5.6-luna", "openai/gpt-5.6-luna-pro",
         "openai/gpt-5.5", "openai/gpt-5.5-pro", "openai/gpt-5.4-mini", "google/gemini-3.1-pro-preview",
         "google/gemini-3.8-flash", "google/gemini-3.7-flash", "x-ai/grok-4.6", "deepseek/deepseek-v4-pro",
-        "deepseek/deepseek-v4-pro-0813", "deepseek/deepseek-v4-flash-0731",
+        "deepseek/deepseek-v4-pro-0813", "deepseek/deepseek-v4.1-flash", "deepseek/deepseek-v4-flash-0731",
         "qwen/qwen3.8-max-0902", "qwen/qwen3.8-flash", "moonshotai/kimi-k3", "minimax/minimax-m3", "z-ai/glm-5.3",
         "z-ai/glm-5.3-flash", "z-ai/glm-5.2", "xiaomi/mimo-v2.5-pro", "tencent/hy4-preview", "tencent/hy3",
         "stepfun/step-3.7-flash", "nvidia/nemotron-3-super-120b-a12b", "meta/muse-spark-1.2",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-09-05T09:33:43Z",
+  "updated_at": "2026-09-10T16:09:08Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -127,6 +127,10 @@
         {
           "id": "deepseek/deepseek-v4-pro-0813",
           "description": "dated snapshot of v4-pro"
+        },
+        {
+          "id": "deepseek/deepseek-v4.1-flash",
+          "description": ""
         },
         {
           "id": "deepseek/deepseek-v4-flash-0731",
@@ -329,6 +333,9 @@
         },
         {
           "id": "deepseek/deepseek-v4-pro-0813"
+        },
+        {
+          "id": "deepseek/deepseek-v4.1-flash"
         },
         {
           "id": "deepseek/deepseek-v4-flash-0731"


### PR DESCRIPTION
`deepseek/deepseek-v4.1-flash` now appears in the Nous Portal and OpenRouter model pickers with the right context window and reasoning timeout.

- `hermes_cli/models_catalog_static.py::OPENROUTER_MODELS`: slug added under `deepseek-v4-pro-0813`, above the older `v4-flash-0731` snapshot (Nous list derives from this tuple)
- `website/static/api/model-catalog.json`: regenerated (`scripts/build_model_catalog.py`) in the same commit
- `agent/model_metadata.py::DEFAULT_CONTEXT_LENGTHS`: discrete `deepseek-v4.1-flash` = 1M — without it the longest-key scan fell through to the 128K `deepseek` catch-all
- `agent/reasoning_timeouts.py`: slug added to the 600s stale floor alongside its V4 siblings (floor was `None` before)

Root cause of the extra two lines: the substring tables match `deepseek-v4-flash`, not `deepseek-v4.1-flash`.

## Validation

| Check | Before | After |
|---|---|---|
| `get_model_context_length(slug, provider=nous/openrouter)` fresh HERMES_HOME | 128000 (catch-all) | 1048576 |
| `get_reasoning_stale_timeout_floor(slug)` | None | 600.0 |
| Slug in `_PROVIDER_MODELS["nous"]` / `OPENROUTER_MODELS` | absent | present |
| Live `max_tokens=16` completion via Nous Portal | — | echoed `model=deepseek/deepseek-v4.1-flash`, `usage.cost=2.88e-05` |
| Live `max_tokens=16` completion via OpenRouter | — | same echo + cost; `supported_parameters ∋ tools`, ctx 1048576 |
| `scripts/check_model_list_dupes.py` | — | clean |
| `run_tests.sh` test_models / test_model_catalog / test_model_metadata / test_reasoning_timeouts / nous + openrouter profiles | — | 232 passed |

Deliberate skips: no pricing entry (Nous and OpenRouter both bill via `official_models_api` / live usage.cost); no search alias (slug is self-descriptive); no `-cn`/plan-list siblings carry the OpenRouter-format slug.

## Infographic
![nous portal support added](https://v3b.fal.media/files/b/0aa9e248/RC_HQg9LUiF-CNb3x-YQ6_EMQ5DAwc.png)
