### PR TITLE
fix(desktop): HUD mode shows the transcript again (#107050, salvage #107052)

### DIFF
--- a/apps/desktop/src/app/hud/transcript-band.test.tsx
+++ b/apps/desktop/src/app/hud/transcript-band.test.tsx
@@ -6,15 +6,7 @@ import { stubResizeObserver } from '@/test/jsdom'
 
 import { useHudTranscriptBand } from './transcript-band'
 
-function Harness({
-  children,
-  withThreadContent = true,
-  withViewport
-}: {
-  children?: ReactNode
-  withThreadContent?: boolean
-  withViewport: boolean
-}) {
+function Harness({ children, withViewport }: { children?: ReactNode; withViewport: boolean }) {
   const ref = useRef<HTMLDivElement | null>(null)
 
   useHudTranscriptBand(ref)
@@ -24,7 +16,7 @@ function Harness({
       <div data-slot="composer-dock" />
       {withViewport && (
         <div data-slot="aui_thread-viewport">
-          {withThreadContent && <div data-slot="aui_thread-content">{children ?? <div>row</div>}</div>}
+          <div data-slot="aui_thread-content">{children ?? <div>row</div>}</div>
         </div>
       )}
     </div>
@@ -90,6 +82,7 @@ describe('useHudTranscriptBand', () => {
   // short session at --hud-band-height: 0px and clips the transcript.
   it('measures a TurnRow with data-slot="aui_message-group" as transcript height', () => {
     stubMeasuredRects()
+
     const { container } = render(
       <Harness withViewport>
         <div data-slot="aui_message-group">turn</div>
@@ -99,32 +92,15 @@ describe('useHudTranscriptBand', () => {
     expect(bandHeight(container)).toBeGreaterThan(0)
   })
 
-  it('still measures slot-less direct children such as show-earlier', () => {
-    stubMeasuredRects()
-    const { container } = render(
-      <Harness withViewport>
-        <button type="button">Show earlier</button>
-      </Harness>
-    )
-
-    expect(bandHeight(container)).toBeGreaterThan(0)
-  })
-
   it('does not treat clearance or background-resume spacers as message rows', () => {
     stubMeasuredRects()
+
     const { container } = render(
       <Harness withViewport>
         <div data-slot="aui_background-resume">resume</div>
         <div data-slot="aui_composer-clearance" />
       </Harness>
     )
-
-    expect(bandHeight(container)).toBe(0)
-  })
-
-  it('keeps an empty band when aui_thread-content is missing', () => {
-    stubMeasuredRects()
-    const { container } = render(<Harness withThreadContent={false} withViewport />)
 
     expect(bandHeight(container)).toBe(0)
   })

--- a/apps/desktop/src/app/hud/transcript-band.test.tsx
+++ b/apps/desktop/src/app/hud/transcript-band.test.tsx
@@ -1,12 +1,20 @@
 import { act, render } from '@testing-library/react'
-import { useRef } from 'react'
+import { type ReactNode, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { stubResizeObserver } from '@/test/jsdom'
 
 import { useHudTranscriptBand } from './transcript-band'
 
-function Harness({ withViewport }: { withViewport: boolean }) {
+function Harness({
+  children,
+  withThreadContent = true,
+  withViewport
+}: {
+  children?: ReactNode
+  withThreadContent?: boolean
+  withViewport: boolean
+}) {
   const ref = useRef<HTMLDivElement | null>(null)
 
   useHudTranscriptBand(ref)
@@ -16,13 +24,27 @@ function Harness({ withViewport }: { withViewport: boolean }) {
       <div data-slot="composer-dock" />
       {withViewport && (
         <div data-slot="aui_thread-viewport">
-          <div data-slot="aui_thread-content">
-            <div>row</div>
-          </div>
+          {withThreadContent && <div data-slot="aui_thread-content">{children ?? <div>row</div>}</div>}
         </div>
       )}
     </div>
   )
+}
+
+function bandHeight(container: HTMLElement): number {
+  const root = container.firstElementChild as HTMLElement
+
+  return Number.parseFloat(root.style.getPropertyValue('--hud-band-height') || '0')
+}
+
+function stubMeasuredRects() {
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+    if (this.dataset.slot === 'composer-dock') {
+      return { bottom: 768, height: 58, top: 710 } as DOMRect
+    }
+
+    return { bottom: 172, height: 72, top: 100 } as DOMRect
+  })
 }
 
 beforeEach(() => {
@@ -32,6 +54,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.restoreAllMocks()
 })
 
 describe('useHudTranscriptBand', () => {
@@ -60,5 +83,49 @@ describe('useHudTranscriptBand', () => {
     const muchLater = measureSpy.mock.calls.length
 
     expect(muchLater).toBe(justAfterFound)
+  })
+
+  // TurnRow roots now carry data-slot="aui_message-group". The band must still
+  // treat them as transcript rows; matching only *:not([data-slot]) leaves a
+  // short session at --hud-band-height: 0px and clips the transcript.
+  it('measures a TurnRow with data-slot="aui_message-group" as transcript height', () => {
+    stubMeasuredRects()
+    const { container } = render(
+      <Harness withViewport>
+        <div data-slot="aui_message-group">turn</div>
+      </Harness>
+    )
+
+    expect(bandHeight(container)).toBeGreaterThan(0)
+  })
+
+  it('still measures slot-less direct children such as show-earlier', () => {
+    stubMeasuredRects()
+    const { container } = render(
+      <Harness withViewport>
+        <button type="button">Show earlier</button>
+      </Harness>
+    )
+
+    expect(bandHeight(container)).toBeGreaterThan(0)
+  })
+
+  it('does not treat clearance or background-resume spacers as message rows', () => {
+    stubMeasuredRects()
+    const { container } = render(
+      <Harness withViewport>
+        <div data-slot="aui_background-resume">resume</div>
+        <div data-slot="aui_composer-clearance" />
+      </Harness>
+    )
+
+    expect(bandHeight(container)).toBe(0)
+  })
+
+  it('keeps an empty band when aui_thread-content is missing', () => {
+    stubMeasuredRects()
+    const { container } = render(<Harness withThreadContent={false} withViewport />)
+
+    expect(bandHeight(container)).toBe(0)
   })
 })

--- a/apps/desktop/src/app/hud/transcript-band.ts
+++ b/apps/desktop/src/app/hud/transcript-band.ts
@@ -49,7 +49,9 @@ export function useHudTranscriptBand(rootRef: RefObject<HTMLDivElement | null>):
       // rows only. Measuring to the viewport edge counted the full-window scroll
       // container (min-height: 100%) as transcript and painted a empty slab almost
       // the size of the HUD.
-      const rows = el?.querySelectorAll<HTMLElement>('[data-slot="aui_thread-content"] > *:not([data-slot])')
+      const rows = el?.querySelectorAll<HTMLElement>(
+        '[data-slot="aui_thread-content"] > [data-slot="aui_message-group"], [data-slot="aui_thread-content"] > *:not([data-slot])'
+      )
 
       // Zero-height rows are not a transcript. A fresh thread still renders
       // scaffolding inside the content box (clearance, empty state), so


### PR DESCRIPTION
HUD mode shows the assistant's reply again: a fresh session's transcript band was 0 px tall, so the reply rendered but was clipped to nothing (#107050).

Salvage of #107052 by @KoNit-K (earliest of two identical fixes; #107055 by @kokhlo landed seven minutes later with the same selector).

## Changes

- `src/app/hud/transcript-band.ts` — the band measured message rows as `aui_thread-content > *:not([data-slot])`. Since `342f76a7c2` every `TurnRow` root carries `data-slot="aui_message-group"`, so on a short transcript `rows` was empty → `--hud-band-height: 0px` → the glass sheet and band collapsed. The selector now also matches `aui_message-group` rows; the slot-less branch stays for the "show earlier" button.
- `src/app/hud/transcript-band.test.tsx` — fixture mirrors the real DOM shape (rows carry the slot, `getBoundingClientRect` stubbed). Trimmed from the PR's four cases to two invariants: a `aui_message-group` row measures; clearance / background-resume spacers do not.

## Root cause

The band's row selector encoded "rows have no `data-slot`" and the thread rows grew one.

## Validation

| Check | Result |
|---|---|
| `vitest --project ui src/app/hud/transcript-band.test.tsx` | 3/3 |
| Sabotage (`git checkout origin/main -- transcript-band.ts`) | `measures a TurnRow with data-slot="aui_message-group"` fails, others pass |
| `tsc -p .`, `eslint` | clean |

**Live repro:** not performed here (no display); the reporter's UIA dump + jsdom repro in #107050 and @kokhlo's independent confirmation against main establish it.

Closes #107050. Closes #107052. Closes #107055.

## Infographic

![HUD transcript shows again](https://v3b.fal.media/files/b/0aa9e24c/38fic0tXqpnRZLP5j5GBg_9ce22Z1t.png)
