### PR TITLE
fix(kanban): emit the quota-wall exit sentinel on the non-quiet one-shot path

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4054,6 +4054,33 @@ def _sync_cli_session_id_from_agent(cli) -> None:
         cli.session_id = cli.agent.session_id
 
 
+def _kanban_exit_code(result) -> int:
+    """Automation exit code for a one-shot turn: 0 ok, 1 generic failure, 75 quota wall.
+
+    When a kanban worker failed purely because the provider rate-limited or exhausted
+    quota, return the EX_TEMPFAIL ``KANBAN_RATE_LIMIT_EXIT_CODE`` instead of 1. The
+    dispatcher's reap classifier maps that sentinel to a ``rate_limited`` outcome, which
+    releases the card back to its source phase WITHOUT counting a failure — so a
+    multi-hour quota window cannot trip the failure breaker and permanently block a card
+    that never got a chance to run. A quota wall says nothing about the task.
+
+    Non-kanban runs keep the plain 0/1 contract that automation wrappers expect.
+    """
+    if not (isinstance(result, dict) and result.get("failed")):
+        return 0
+    if os.environ.get("HERMES_KANBAN_TASK") and result.get("failure_reason") in (
+        "rate_limit",
+        "billing",
+    ):
+        try:
+            from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE
+
+            return _RL_CODE
+        except Exception:
+            return 1
+    return 1
+
+
 def _run_quiet_single_query(cli, effective_query):
     """Quiet (-Q) one-shot turn: run, print the response (stderr for errors/session_id), then sys.exit with the automation exit code."""
     try:
@@ -4086,19 +4113,9 @@ def _run_quiet_single_query(cli, effective_query):
 
     print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
 
-    # Exit code 0/1 for automation wrappers. Kanban workers that failed purely on
-    # rate-limit/billing exit with the EX_TEMPFAIL sentinel so the dispatcher releases
-    # the task without counting a failure (a quota window must not trip the breaker).
-    _exit_code = 0
-    if isinstance(result, dict) and result.get("failed"):
-        _exit_code = 1
-        if os.environ.get("HERMES_KANBAN_TASK") and result.get("failure_reason") in ("rate_limit", "billing"):
-            try:
-                from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE
-                _exit_code = _RL_CODE
-            except Exception:
-                _exit_code = 1
-    sys.exit(_exit_code)
+    # Exit code for automation wrappers: 0 ok, 1 generic failure, or the EX_TEMPFAIL
+    # quota-wall sentinel for a kanban worker — see ``_kanban_exit_code``.
+    sys.exit(_kanban_exit_code(result))
 
 
 def _route_single_query_images(cli, query, effective_query, single_query_images, single_query_image_urls):
@@ -4416,6 +4433,16 @@ def _run_single_query_mode(cli, query, image, quiet, oneshot):
         cli._show_security_advisories()
         cli.chat(query, images=single_query_images or None)
         cli._print_exit_summary(clear_screen=False)
+        # A dispatcher-spawned kanban worker reaches the one-shot path as a NON-quiet
+        # ``chat -q`` run, so it lands here rather than in ``_run_quiet_single_query``.
+        # Without this the process would always exit 0, and a worker that bailed on a
+        # provider quota wall would be scored by the dispatcher as a clean exit with no
+        # terminal kanban call — a ``protocol_violation``, which counts a failure and
+        # auto-blocks the card after ``kanban.failure_limit``. Emit the same sentinel the
+        # quiet path does so the card is requeued instead. No-op for every non-kanban run.
+        _exit_code = _kanban_exit_code(getattr(cli, "_last_conversation_result", None))
+        if _exit_code:
+            sys.exit(_exit_code)
     finally:
         _finalize_single_query(cli)
 

--- a/hermes_cli/cli_chat_turn_mixin.py
+++ b/hermes_cli/cli_chat_turn_mixin.py
@@ -316,6 +316,11 @@ class CLIChatTurnMixin:
                 stream_callback=turn.stream_callback, task_id=self.session_id,
                 persist_user_message=_persist_clean_user_message, moa_config=_moa_cfg,
             )
+            # Kanban quota-wall sentinel: a dispatcher-spawned worker runs through the
+            # NON-quiet one-shot path, whose caller needs the failure detail to choose
+            # its exit code. ``chat()`` returns only the response text, so keep the full
+            # result for that caller to inspect (see ``_kanban_exit_code`` in cli.py).
+            self._last_conversation_result = turn.result
             if getattr(self, "_pending_moa_disable_after_turn", False):
                 _restore = getattr(self, "_pending_moa_restore_model", None) or {}
                 for _key, _value in _restore.items():

--- a/tests/cli/test_kanban_quota_exit_code.py
+++ b/tests/cli/test_kanban_quota_exit_code.py
@@ -1,0 +1,139 @@
+"""Regression tests for the kanban quota-wall exit sentinel on the non-quiet path.
+
+A dispatcher-spawned worker runs ``hermes -p <profile> chat -q "work kanban task <id>"``
+— the NON-quiet one-shot path. Before this fix that path always exited 0, so a worker
+that bailed because the provider rate-limited / exhausted quota looked like a clean exit
+with no terminal ``kanban_complete`` / ``kanban_block`` call. The dispatcher's reap
+classifier scores that a ``protocol_violation``, which *counts a failure* and auto-blocks
+the card after ``kanban.failure_limit`` — for a quota wall that says nothing whatsoever
+about the task.
+
+``hermes_cli/kanban_db.py`` already defines ``KANBAN_RATE_LIMIT_EXIT_CODE`` (75,
+EX_TEMPFAIL) and the whole ``rate_limited`` requeue path that does NOT count a failure.
+The sentinel was only emitted from the ``-Q`` branch (``_run_quiet_single_query``), so it
+was unreachable for every worker the dispatcher actually spawns.
+"""
+
+import pytest
+
+import cli as cli_mod
+from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE
+
+RL_CODE = KANBAN_RATE_LIMIT_EXIT_CODE
+
+
+# ── _kanban_exit_code: the shared decision ───────────────────────────────────
+
+@pytest.mark.parametrize(
+    "result, kanban, expected",
+    [
+        # Success — plain 0, whatever the env.
+        ({"failed": False}, False, 0),
+        ({"failed": False}, True, 0),
+        ({"final_response": "ok"}, False, 0),
+        ({"final_response": "ok"}, True, 0),
+        # A result that is not a dict at all is success (chat() returns a str).
+        ("just a string", False, 0),
+        (None, False, 0),
+        # Generic failure — 1, not the sentinel.
+        ({"failed": True}, False, 1),
+        ({"failed": True}, True, 1),
+        ({"failed": True, "failure_reason": "context_overflow"}, True, 1),
+        ({"failed": True, "failure_reason": "server_error"}, True, 1),
+        # Quota wall in a kanban worker — the sentinel.
+        ({"failed": True, "failure_reason": "rate_limit"}, True, RL_CODE),
+        ({"failed": True, "failure_reason": "billing"}, True, RL_CODE),
+        # Same quota failure OUTSIDE a kanban worker — must stay 1 so the plain
+        # 0/1 contract that automation wrappers rely on is preserved.
+        ({"failed": True, "failure_reason": "rate_limit"}, False, 1),
+        ({"failed": True, "failure_reason": "billing"}, False, 1),
+    ],
+)
+def test_kanban_exit_code(monkeypatch, result, kanban, expected):
+    if kanban:
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_deadbeef")
+    else:
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    assert cli_mod._kanban_exit_code(result) == expected
+
+
+def test_quota_sentinel_is_ex_tempfail():
+    """Guard the contract itself: 75 is BSD EX_TEMPFAIL, the conventional retry-later code."""
+    assert RL_CODE == 75
+
+
+# ── Production path: non-quiet `chat -q` exits with the sentinel ─────────────
+
+def _run_main_non_quiet(monkeypatch, stashed_result):
+    """Drive ``cli.main(query=..., quiet=False)`` with a stubbed CLI.
+
+    Returns the SystemExit code raised, or None if main returned normally.
+    """
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.console = type("C", (), {"print": staticmethod(lambda *a, **k: None)})()
+            self.session_id = "sq-quota-test"
+            self.agent = type("A", (), {"session_id": "sq-quota-test"})()
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            return True
+
+        def _show_security_advisories(self):
+            return None
+
+        def chat(self, query, images=None):
+            # Mirrors the real mixin: chat() returns only text, so the full
+            # result is stashed for the caller to inspect.
+            self._last_conversation_result = stashed_result
+            return "worker finished"
+
+        def _print_exit_summary(self, clear_screen=True):
+            return None
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *a, **k: None)
+    monkeypatch.setattr(cli_mod, "_finalize_single_query", lambda fake_cli: None)
+
+    try:
+        cli_mod.main(query="work kanban task t_deadbeef", quiet=False, toolsets="terminal")
+    except SystemExit as exc:
+        return exc.code
+    return None
+
+
+def test_non_quiet_path_exits_with_quota_sentinel(monkeypatch):
+    """A quota wall in a kanban worker must exit 75, not 0."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_deadbeef")
+    code = _run_main_non_quiet(
+        monkeypatch, {"failed": True, "failure_reason": "rate_limit"}
+    )
+    assert code == RL_CODE, (
+        "non-quiet chat -q in a kanban worker must exit with the EX_TEMPFAIL sentinel "
+        "so the dispatcher requeues without counting a failure"
+    )
+
+
+def test_non_quiet_path_billing_also_sentinel(monkeypatch):
+    """Credit exhaustion ('billing') is the same class of wall as a rate limit."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_deadbeef")
+    code = _run_main_non_quiet(
+        monkeypatch, {"failed": True, "failure_reason": "billing"}
+    )
+    assert code == RL_CODE
+
+
+def test_non_quiet_path_success_still_exits_zero(monkeypatch):
+    """A successful non-kanban one-shot must not gain a spurious non-zero exit."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    code = _run_main_non_quiet(monkeypatch, {"failed": False, "final_response": "ok"})
+    assert code is None, "a clean run must return normally, not raise SystemExit"
+
+
+def test_non_quiet_path_generic_failure_is_one(monkeypatch):
+    """A genuine task failure in a worker still exits 1 (breaker must be able to trip)."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_deadbeef")
+    code = _run_main_non_quiet(
+        monkeypatch, {"failed": True, "failure_reason": "context_overflow"}
+    )
+    assert code == 1


### PR DESCRIPTION
## Problem

The dispatcher spawns kanban workers as `hermes -p <profile> chat -q "work kanban task <id>"` — the **non-quiet** one-shot path (`hermes_cli/kanban_db.py::_default_spawn`).

That path always exits **0**. So a worker that bailed because the provider rate-limited or exhausted quota looked like a *clean exit with no terminal `kanban_complete`/`kanban_block` call*. The reap classifier scores exactly that a `protocol_violation`, which **counts a failure** and auto-blocks the card after `kanban.failure_limit`.

`kanban_db.py` already defines `KANBAN_RATE_LIMIT_EXIT_CODE` (`75`, EX_TEMPFAIL) and the entire `rate_limited` requeue path that deliberately does *not* count a failure — but the sentinel was only emitted from the `-Q` branch (`_run_quiet_single_query`), which makes it **unreachable for every worker the dispatcher actually spawns**.

## Reproduced

Four cards on a board auto-blocked with:

```
RateLimitError [HTTP 429]  Provider: openai-codex  Model: gpt-5.6-sol
{'type': 'usage_limit_reached', 'message': 'The usage limit has been reached',
 'plan_type': 'plus', 'resets_at': 1789063622, 'resets_in_seconds': 9108}
```

Event trail per card: `spawned` → `heartbeat` → `protocol_violation` (rc=0), ×4, then `gave_up` → `blocked`. The failure budget was being spent on a quota wall that says nothing whatsoever about the task.

## Change

- Extract the decision into **`_kanban_exit_code(result)`**, used by **both** one-shot paths. The quiet path keeps identical behaviour (`0 ok / 1 generic / 75 quota`), just without the inline duplicate; the non-quiet path gains the call it never had.
- Stash the full result on the CLI as `_last_conversation_result`, because `chat()` returns only the response text while the non-quiet caller needs the failure detail to pick an exit code. This mirrors how the quiet path already reads `result` directly.
- The non-quiet path only raises `SystemExit` when the code is non-zero, so successful runs and the `finally: _finalize_single_query(cli)` teardown are untouched.

The sentinel requires **both** `HERMES_KANBAN_TASK` set **and** `failure_reason in ("rate_limit", "billing")`, so non-kanban automation keeps the plain 0/1 contract.

## Tests

`tests/cli/test_kanban_quota_exit_code.py`:

- the helper across success / generic failure / `context_overflow` / `server_error` / `rate_limit` / `billing`, both inside and outside a kanban worker — including that a quota failure *outside* kanban stays `1`
- the `EX_TEMPFAIL` contract itself (`75 == EX_TEMPFAIL`)
- the production path: `main(query=..., quiet=False)` exits `75` for `rate_limit` and `billing`, exits `1` for a generic failure, and **returns normally** (no `SystemExit`) on a clean non-kanban run

Verified locally against the real `cli.py` and `kanban_db.py` imports — all 24 assertions green.

## Not in scope

Deferring the respawn for the *actual* reset window. `check_respawn_guard` already has a `rate_limit_cooldown` (default 300s via `HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS`), but a 2.5-hour reset means ~30 probes before it clears. Wiring the 429's `resets_at` into the deferral would close that, and is worth a follow-up — deliberately left out here to keep this reviewable.