### PR TITLE
fix(desktop): Hyprland HUD floats even when j/clients lags the first map (#103091, salvage #103116)

### DIFF
--- a/apps/desktop/electron/hud-hyprland.ts
+++ b/apps/desktop/electron/hud-hyprland.ts
@@ -28,8 +28,8 @@ type HyprlandDispatchSyntax = 'legacy' | 'lua'
 
 export type HyprlandRequestFn = (socketPath: string, command: string) => Promise<null | string>
 
-const DEFAULT_ATTEMPTS = 8
-const DEFAULT_DELAY_MS = 50
+const DEFAULT_ATTEMPTS = 24
+const DEFAULT_DELAY_MS = 100
 
 let cachedSyntax: null | HyprlandDispatchSyntax = null
 


### PR DESCRIPTION
On Hyprland the HUD now reliably lands floated and pinned even when the compositor's `j/clients` lists the new window late; before, a slow first map left it a stretched transparent tile (#103091, also the geometry half of #103528).

Salvage of #103116 (@kokhlo).

## Changes

- `apps/desktop/electron/hud-hyprland.ts` — promotion retry budget 8 × 50 ms → 24 × 100 ms. The loop returns on the first successful float + pin, so a prompt compositor pays nothing; only the laggy case waits longer.

**Dropped from the source PR:** the `focusWindow()` re-promotion branch. It fires only when `!win.isVisible()` and the window is re-shown, but the HUD is destroyed and respawned on every toggle and is not minimizable, so that branch never runs for the HUD; the first-map path (`wireWindowReveal` → `onRevealed` → `promoteHudOverlay`) already covers every map the HUD has.

## Root cause

`promoteHudOnHyprland` gave up after 400 ms; on some Hyprland 0.55+ setups the client is not yet in `j/clients` by then.

## Validation

| Check | Result |
|---|---|
| `vitest --project electron electron/hud-hyprland.test.ts` | 12/12 (the promotion loop is already covered with injected `request`/`sleep`) |
| `eslint electron/hud-hyprland.ts` | clean |

**Live repro:** not performed (no Hyprland here). The reporter's RCA in #103091 and @kokhlo's confirmation are the evidence; this is a budget change on an existing, tested path.

Closes #103091. Closes #103116.
Leaves #103528 open for its invisible-composer-text half, which is a rendering symptom on the same session, not a placement one.

## Infographic

![HUD floats on Hyprland](https://v3b.fal.media/files/b/0aa9e298/3Hs0qJeQ6cNOplUiuw3nf_ruX8HUMU.png)
