### PR TITLE
fix(desktop): auto-TTS reads a reply once while the HUD is open (#99717)

### DIFF
--- a/apps/desktop/electron/event-dedupe.test.ts
+++ b/apps/desktop/electron/event-dedupe.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { createEventDeduper } from './event-dedupe'
+import { createAmbientClaimArbiter, createEventDeduper } from './event-dedupe'
 
 test('collapses the same key inside the window (two windows, one event)', () => {
   const isDup = createEventDeduper(1000)
@@ -34,4 +34,21 @@ test('prunes stale keys so the map cannot grow unbounded', () => {
     // Each far-apart key is pruned before the next, so none linger as duplicates.
     assert.equal(isDup(`turnDone:s${i}`, i * 2000), false)
   }
+})
+
+// #99717: the hidden app window under an open HUD claims the same reply late.
+test('a spoken reply stays claimed long after the tick window, a beep does not', () => {
+  const owns = createAmbientClaimArbiter(1000)
+
+  assert.equal(owns('speak:m1', 0), true, 'HUD renderer claims the reply')
+  assert.equal(owns('speak:m1', 5_000), false, 'app window claiming 5 s later stays quiet')
+  assert.equal(owns('sound:turnDone:s1', 0), true)
+  assert.equal(owns('sound:turnDone:s1', 5_000), true, 'beep keys still re-fire after the tick window')
+})
+
+test('a spoken reply can be claimed again once the speech TTL elapses', () => {
+  const owns = createAmbientClaimArbiter(1000, 60_000)
+
+  assert.equal(owns('speak:m1', 0), true)
+  assert.equal(owns('speak:m1', 60_000), true)
 })

--- a/apps/desktop/electron/event-dedupe.ts
+++ b/apps/desktop/electron/event-dedupe.ts
@@ -30,3 +30,21 @@ export function createEventDeduper(intervalMs = DEDUPE_INTERVAL_MS) {
     return false
   }
 }
+
+// A `speak:<messageId>` cue is seconds of audio keyed by a durable backend
+// message id, not an instant beep: the peer's claim can arrive well past the
+// 1 s window (the app window hidden under an open HUD is throttled by Chromium
+// and its transcript subscription fires late), and the reply was read twice
+// (#99717). One reply is one claim for as long as a reply can plausibly play.
+export const SPEECH_CLAIM_TTL_MS = 10 * 60_000
+
+// Cross-window arbiter for every ambient cue: `speak:*` keys hold for the
+// speech TTL, everything else keeps the tick-sized window.
+export function createAmbientClaimArbiter(intervalMs = DEDUPE_INTERVAL_MS, speechTtlMs = SPEECH_CLAIM_TTL_MS) {
+  const cues = createEventDeduper(intervalMs)
+  const speech = createEventDeduper(speechTtlMs)
+
+  return function owns(key: string, now = Date.now()): boolean {
+    return !(key.startsWith('speak:') ? speech(key, now) : cues(key, now))
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -169,7 +169,7 @@ import {
 } from './desktop-uninstall'
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
 import { installEmbedReferer } from './embed-referer'
-import { createEventDeduper } from './event-dedupe'
+import { createAmbientClaimArbiter } from './event-dedupe'
 import {
   buildTerminalScript,
   resolveTerminalLaunch,
@@ -16799,9 +16799,10 @@ ipcMain.handle('hermes:api', async (_event, request) => {
   return handleHermesApiRequest(request).finally(releaseProfileDeletion)
 })
 
-// Main serializes cross-window ambient claims.
-const claimedAmbientCue = createEventDeduper()
-ipcMain.handle('hermes:ambient:claim', (_event, key) => !claimedAmbientCue(String(key ?? '')))
+// Main serializes cross-window ambient claims (see event-dedupe.ts for why a
+// spoken reply holds its claim far longer than a beep).
+const ownsAmbientCue = createAmbientClaimArbiter()
+ipcMain.handle('hermes:ambient:claim', (_event, key) => ownsAmbientCue(String(key ?? '')))
 
 registerNativeNotifications({ getMainWindow: () => mainWindow, focusWindow })
 


### PR DESCRIPTION
With **Read replies aloud** on, a reply that lands while HUD mode is active is spoken once, not twice (#99717).

## Changes

- `apps/desktop/electron/event-dedupe.ts` — `createAmbientClaimArbiter()`: `speak:<messageId>` claims hold for a 10-minute TTL; every other cue (`sound:*`) keeps the existing 1 s tick window.
- `apps/desktop/electron/main.ts` — `hermes:ambient:claim` routes through the arbiter (one line).
- `event-dedupe.test.ts` — two invariants: a late (5 s) second `speak:` claim is denied while a `sound:` key still re-fires; a `speak:` key is claimable again once the TTL elapses.

## Root cause

The HUD renderer and the app window it hid both claim the same reply; main collapsed them with the 1 s deduper tuned for the turn-end beep. The hidden window is throttled by Chromium, so its `$messages` subscription fires past 1 s, finds the key pruned, and is told it owns the cue. The unit was wrong, not the window: speech is minutes of audio keyed by a durable message id.

## Why not the two open PRs

#99810 (@liuhao1024) and #100289 (@shivamjg101) both diagnose this correctly and both special-case "a HUD is open" (by sender id / by displaced-window flag). The same race exists between any two windows showing the same chat (a pop-out session window, a second instance window), so the arbiter fixes the class without knowing about the HUD; #100289's TTL framing is the one taken. Closing both with credit.

## Validation

| Check | Result |
|---|---|
| `vitest --project electron electron/event-dedupe.test.ts` | 6/6 |
| `tsc -p tsconfig.electron.json`, `eslint` | clean |

**Live repro:** not performed — no audio/TTS surface on this host; the arbitration is deterministic and the failing sequence (claim at t=0, peer claim at t>1 s) is the first new test.

Closes #99717. Closes #99810. Closes #100289.

## Infographic

![One reply, spoken once](https://v3b.fal.media/files/b/0aa9e298/s4hTDzTF4PyZn7GwhZ7Ya_iuNtGCYW.png)
