### PR TITLE
fix(desktop): idle HUD/popout windows no longer refuse drive_preview for the active session (#101016, salvage #101051)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $gateway } from '@/store/gateway'
+
+import { handleDesktopBridgeEvent } from './desktop-bridge'
+import type { GatewayEventContext } from './types'
+
+function previewActContext({
+  explicitSid,
+  isActiveEvent
+}: {
+  explicitSid: string
+  isActiveEvent: boolean
+}): GatewayEventContext {
+  return {
+    event: { session_id: explicitSid || undefined, type: 'preview.act.request' },
+    explicitSid,
+    isActiveEvent,
+    payload: { action: 'elements', request_id: 'request-1' }
+  } as GatewayEventContext
+}
+
+describe('preview action bridge routing', () => {
+  afterEach(() => {
+    $gateway.set(null)
+  })
+
+  it('leaves a scoped action request unanswered in a window showing another session', () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+
+    expect(handleDesktopBridgeEvent(previewActContext({ explicitSid: 'session-a', isActiveEvent: false }))).toBe(true)
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('keeps the legacy fail-fast response for an unscoped inactive request', () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+
+    expect(handleDesktopBridgeEvent(previewActContext({ explicitSid: '', isActiveEvent: false }))).toBe(true)
+    expect(request).toHaveBeenCalledWith('preview.act.respond', {
+      request_id: 'request-1',
+      text: JSON.stringify({
+        error: 'The in-app browser only takes actions in the session the user is looking at.',
+        success: false
+      })
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $gateway } from '@/store/gateway'
+import { $toursEnabled } from '@/store/tours'
 
 import { handleDesktopBridgeEvent } from './desktop-bridge'
 import type { GatewayEventContext } from './types'
@@ -42,6 +43,51 @@ describe('preview action bridge routing', () => {
       request_id: 'request-1',
       text: JSON.stringify({
         error: 'The in-app browser only takes actions in the session the user is looking at.',
+        success: false
+      })
+    })
+  })
+})
+
+function tourContext({
+  explicitSid,
+  isActiveEvent
+}: {
+  explicitSid: string
+  isActiveEvent: boolean
+}): GatewayEventContext {
+  return {
+    event: { session_id: explicitSid || undefined, type: 'tour.request' },
+    explicitSid,
+    isActiveEvent,
+    payload: { action: 'discover', request_id: 'tour-request-1' }
+  } as GatewayEventContext
+}
+
+describe('tour bridge routing', () => {
+  afterEach(() => {
+    $gateway.set(null)
+    $toursEnabled.set(true)
+  })
+
+  it('leaves a scoped request unanswered in another session even when tours are disabled', () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+    $toursEnabled.set(false)
+
+    expect(handleDesktopBridgeEvent(tourContext({ explicitSid: 'session-a', isActiveEvent: false }))).toBe(true)
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('keeps the legacy fail-fast response for an unscoped inactive request', () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+
+    expect(handleDesktopBridgeEvent(tourContext({ explicitSid: '', isActiveEvent: false }))).toBe(true)
+    expect(request).toHaveBeenCalledWith('tour.respond', {
+      request_id: 'tour-request-1',
+      text: JSON.stringify({
+        error: 'Tours only run in the session the user is looking at.',
         success: false
       })
     })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -45,7 +45,7 @@ const loadPreviewEngine = () => {
  *  (terminal/preview/window), agent terminal streaming, pane reveal, and
  *  message reactions. */
 export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
-  const { event, payload, isActiveEvent } = ctx
+  const { event, payload, explicitSid, isActiveEvent } = ctx
 
   if (event.type === 'terminal.read.request') {
     // read_terminal tool: serialize the renderer's xterm buffer and answer
@@ -95,6 +95,13 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
     if (requestId) {
+      // Every mounted desktop window can observe the same gateway event. A
+      // scoped mismatch belongs to another window, so answering here would race
+      // the owning window and could make this refusal win before its real result.
+      if (explicitSid && !isActiveEvent) {
+        return true
+      }
+
       const answer = (result: unknown) =>
         $gateway.get()?.request('preview.act.respond', {
           request_id: requestId,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -186,6 +186,13 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
     if (requestId) {
+      // As with preview actions, only the renderer that owns an explicitly
+      // scoped request may answer. Inactive windows must stay silent even when
+      // tours are disabled locally, or their refusal can beat the owner.
+      if (explicitSid && !isActiveEvent) {
+        return true
+      }
+
       const answer = (result: unknown) =>
         $gateway.get()?.request('tour.respond', {
           request_id: requestId,


### PR DESCRIPTION
`drive_preview` and `annotate_preview` now work when a second Hermes window is open — previously an idle HUD, popout, or browser window could answer the request first with "The in-app browser only takes actions in the session the user is looking at" and the owning window's real result was discarded (#101016).

Salvage of #101051 (@fangliquanflq), cherry-picked with authorship; both commits apply clean on current main.

## Changes

- `gateway-event/desktop-bridge.ts` — for `preview.act.request` and `tour.request`, a renderer that receives a **session-scoped** request for a session it is not showing consumes the event without responding. Unscoped requests keep the legacy fail-fast refusal (single-window behavior unchanged).
- `desktop-bridge.test.ts` — one positive + one negative per bridge (4).

## Root cause

Every mounted chat root registers the bridge handler; the gateway's `_block` accepts the first `*.respond` for a request id. A window whose active session differed evaluated the gate against its own session and refused — a valid answer only for the owning window.

## Validation

| Check | Result |
|---|---|
| `vitest --project ui …/desktop-bridge.test.ts` | 4/4 |
| Sabotage (`git checkout origin/main -- desktop-bridge.ts`) | both "stay silent" tests fail, both legacy tests pass |
| `tsc -p .`, `eslint` | clean |
| Independent verification | @akierstein-insider on the PR thread, against head `67d5d8f` |

**Live repro:** not performed here; the reporter's source-level trace in #101016 plus the independent verification on the PR stand as evidence.

Closes #101016. Closes #101051.

## Infographic

![Preview actions answer from the right window](https://v3b.fal.media/files/b/0aa9e2af/m-uPkmW9FRX_K5ZRXVZyi_QVug7w6C.png)
