### PR TITLE
fix(dashboard): keep SSH-isolated backends alive during in-process cron

### DIFF
--- a/hermes_cli/web_server_idle_exit.py
+++ b/hermes_cli/web_server_idle_exit.py
@@ -95,20 +95,38 @@ _probe_failure_logged = False
 
 
 def turn_in_flight() -> Optional[bool]:
-    """True/False from the gateway's running-session table; None when it cannot be read. The table
-    lives on ``tui_gateway.server`` (the voice mixin's helper is bound into that namespace). None
-    keeps the backend alive forever, so the cause is logged once — a silent never-exits would be
-    the original bug with a new face."""
+    """True when a GUI session is running or in-process cron is in-flight via
+    ``cron.scheduler.get_running_job_ids``; False when both probes succeed and report idle;
+    None when a half cannot be read. The session table lives on ``tui_gateway.server``
+    (the voice mixin's helper is bound into that namespace). None keeps the backend alive
+    forever, so the cause is logged once — a silent never-exits would be the original bug
+    with a new face."""
     global _probe_failure_logged
+
     try:
         import tui_gateway.server as gateway
         with gateway._sessions_lock:
-            return any(s.get("running") for s in gateway._sessions.values())
+            session_running: Optional[bool] = any(s.get("running") for s in gateway._sessions.values())
     except Exception:
         if not _probe_failure_logged:
             _probe_failure_logged = True
             _log.warning("idle-exit turn probe unavailable; this backend will not self-retire", exc_info=True)
+        session_running = None
+
+    try:
+        import cron.scheduler as cron
+        cron_running: Optional[bool] = bool(cron.get_running_job_ids())
+    except Exception:
+        if not _probe_failure_logged:
+            _probe_failure_logged = True
+            _log.warning("idle-exit turn probe unavailable; this backend will not self-retire", exc_info=True)
+        cron_running = None
+
+    if session_running or cron_running:
+        return True
+    if session_running is None or cron_running is None:
         return None
+    return False
 
 
 def should_exit_idle(tracker: IdleClientTracker, grace_s: float,

--- a/tests/hermes_cli/test_web_server_idle_exit.py
+++ b/tests/hermes_cli/test_web_server_idle_exit.py
@@ -7,7 +7,21 @@ from starlette.testclient import TestClient
 
 import hermes_cli.web_server as ws_mod
 from hermes_cli.web_server_idle_exit import (
-    IdleClientTracker, should_exit_idle, start_idle_watchdog, wrap_asgi_with_ws_tracking)
+    IdleClientTracker, should_exit_idle, start_idle_watchdog, turn_in_flight,
+    wrap_asgi_with_ws_tracking)
+
+
+def _stub_gateway_sessions(monkeypatch, sessions=None):
+    """Empty / no-running gateway table — the pre-fix probe's only liveness signal."""
+    import tui_gateway.server as gateway
+    monkeypatch.setattr(gateway, "_sessions", {} if sessions is None else sessions)
+
+
+def _past_grace_tracker(grace=900.0):
+    clock = {"t": 0.0}
+    tracker = IdleClientTracker(now=lambda: clock["t"])
+    clock["t"] = grace + 1.0
+    return tracker, grace
 
 
 def test_ws_sessions_are_counted_at_the_asgi_boundary_for_any_route():
@@ -78,3 +92,43 @@ def test_watchdog_sets_should_exit_and_only_arms_for_ssh_isolated_backends(monke
         assert isinstance(ws_mod.app.state.ssh_isolated_clients, IdleClientTracker)
     finally:
         ws_mod.app.state._state.pop("ssh_isolated_clients", None)  # process-global app: never leak the tracker
+
+
+def test_turn_in_flight_is_true_when_cron_has_running_job_ids(monkeypatch):
+    """In-process cron dispatch is active work even when no GUI session is running (#107485)."""
+    import cron.scheduler as cron_sched
+
+    _stub_gateway_sessions(monkeypatch)
+    monkeypatch.setattr(cron_sched, "get_running_job_ids", lambda: frozenset({"job-1"}))
+
+    assert turn_in_flight() is True
+    tracker, grace = _past_grace_tracker()
+    assert should_exit_idle(tracker, grace, probe=turn_in_flight) is False
+
+
+def test_turn_in_flight_is_false_when_cron_and_sessions_are_idle(monkeypatch):
+    """Empty get_running_job_ids is a conclusive no — idle-exit still fires (#107485)."""
+    import cron.scheduler as cron_sched
+
+    _stub_gateway_sessions(monkeypatch)
+    monkeypatch.setattr(cron_sched, "get_running_job_ids", lambda: frozenset())
+
+    assert turn_in_flight() is False
+    tracker, grace = _past_grace_tracker()
+    assert should_exit_idle(tracker, grace, probe=turn_in_flight) is True
+
+
+def test_turn_in_flight_is_none_when_cron_probe_raises(monkeypatch):
+    """get_running_job_ids import/call failure is indeterminate — fail closed (#107485)."""
+    import cron.scheduler as cron_sched
+
+    _stub_gateway_sessions(monkeypatch)
+
+    def _boom():
+        raise RuntimeError("cron scheduler unavailable")
+
+    monkeypatch.setattr(cron_sched, "get_running_job_ids", _boom)
+
+    assert turn_in_flight() is None
+    tracker, grace = _past_grace_tracker()
+    assert should_exit_idle(tracker, grace, probe=turn_in_flight) is False


### PR DESCRIPTION
## What does this PR do?

SSH-isolated dashboard backends host the in-process cron ticker (`_start_desktop_cron_ticker`) and are also subject to the idle-exit watchdog. `turn_in_flight()` only read `tui_gateway.server._sessions` (GUI/dashboard chat). A cron agent execution never registers there, so the probe returned **False** while a job was mid-flight. The watchdog then exited the interpreter (`cannot schedule new futures after interpreter shutdown`), left the execution without a durable terminal state, and the scheduler restart consumed the scheduled slot.

This PR composes the existing gateway session probe with `cron.scheduler.get_running_job_ids()` — the same in-flight set the gateway shutdown drain already uses (#60432). Either half True keeps the backend up; either half unreadable returns None (fail closed); both False still allows idle-exit.

### Symptom

SSH-isolated dashboard backends host the in-process cron ticker (`_start_desktop_cron_ticker`) and are also subject to the idle-exit watchdog. `turn_in_flight()` only read `tui_gateway.server._sessions` (GUI/dashboard chat). A cron agent execution never registers there, so the probe returned **False** while a job was mid-flight. The watchdog then exited the interpreter (`cannot schedule new futures after interpreter shutdown`), left the execution without a durable terminal state, and the scheduler restart consumed the scheduled slot.

This PR composes the existing gateway session probe with `cron.scheduler.get_running_job_ids()` — the same in-flight set the gateway shutdown drain already uses (#60432). Either half True keeps the backend up; either half unreadable returns None (fail closed); both False still allows idle-exit.


Fixes #107485


- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


- `hermes_cli/web_server_idle_exit.py`: `turn_in_flight()` is True when a GUI session is `running` **or** `get_running_job_ids()` is non-empty. Lazy-import cron inside the probe. Fail-closed composition if either half cannot be read.
- `tests/hermes_cli/test_web_server_idle_exit.py`: detection (cron IDs, no GUI session), CONTROL (empty IDs sti

### Impact

SSH-isolated dashboard backends host the in-process cron ticker (`_start_desktop_cron_ticker`) and are also subject to the idle-exit watchdog. `turn_in_flight()` only read `tui_gateway.server._sessions` (GUI/dashboard chat).

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

SSH-isolated dashboard backends host the in-process cron ticker (`_start_desktop_cron_ticker`) and are also subject to the idle-exit watchdog. `turn_in_flight()` only read `tui_gateway.server._sessions` (GUI/dashboard chat). A cron agent execution never registers there, so the probe returned **False** while a job was mid-flight.

## Related Issue

Fixes #107485

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server_idle_exit.py`: `turn_in_flight()` is True when a GUI session is `running` **or** `get_running_job_ids()` is non-empty. Lazy-import cron inside the probe. Fail-closed composition if either half cannot be read.
- `tests/hermes_cli/test_web_server_idle_exit.py`: detection (cron IDs, no GUI session), CONTROL (empty IDs still allow exit), fail-closed (cron probe raises → None).

## How to Test

- ✅ `scripts/run_tests.sh` on the files in Changes Made — focused verification
- ✅ Focused verification completed on this branch
- ✅ `scripts/run_tests.sh tests/hermes_cli/test_web_server_idle_exit.py`
- ✅ BEFORE (RED): 2 failed, 4 passed — `turn_in_flight()` returned False with `get_running_job_ids() == frozenset({"job-1"})` and empty sessions; cron probe raise also returned False instead of None
- ✅ AFTER (GREEN): 6 passed, 0 failed

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

