### PR TITLE
fix(desktop): late-bind plugin SDK globals so packaged runtime plugins load

### DIFF
--- a/apps/desktop/src/sdk/runtime.test.ts
+++ b/apps/desktop/src/sdk/runtime.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import * as sdk from './index'
+import { installPluginSdk, pluginSdkGlobalsForTest, sdkImportMap } from './runtime'
+
+const GLOBAL_KEYS = [
+  '__HERMES_PLUGIN_SDK__',
+  '__HERMES_REACT__',
+  '__HERMES_REACT_JSX__',
+  '__HERMES_REACT_JSX_DEV__'
+] as const
+
+const SPECIFIERS = [
+  '@hermes/plugin-sdk',
+  'react',
+  'react/jsx-runtime',
+  'react/jsx-dev-runtime'
+] as const
+
+function liveSdkNamedExport(): string {
+  const name = Object.keys(sdk).find((key) => key !== 'default' && /^[A-Za-z_$][\w$]*$/.test(key))
+  expect(name).toEqual(expect.any(String))
+  return name as string
+}
+
+const shimBlobs = new Map<string, Blob>()
+
+beforeAll(() => {
+  const originalCreateObjectURL = URL.createObjectURL.bind(URL)
+  vi.spyOn(URL, 'createObjectURL').mockImplementation((obj) => {
+    const url = originalCreateObjectURL(obj)
+    if (obj instanceof Blob) shimBlobs.set(url, obj)
+    return url
+  })
+})
+
+async function readShimSource(url: string): Promise<string> {
+  const blob = shimBlobs.get(url)
+  expect(blob).toBeInstanceOf(Blob)
+  return blob!.text()
+}
+
+function emitShimSource(globalKey: string, names: string[]): string {
+  return (
+    `const m = globalThis.${globalKey};\n` +
+    `export default m.default ?? m;\n` +
+    (names.length ? `export const { ${names.join(', ')} } = m;\n` : '')
+  )
+}
+
+afterEach(() => {
+  for (const key of GLOBAL_KEYS) {
+    delete (globalThis as Record<string, unknown>)[key]
+  }
+})
+
+describe('plugin SDK runtime globals', () => {
+  it('exposes the four host namespaces as late-bound accessors', () => {
+    for (const key of GLOBAL_KEYS) {
+      const descriptor = Object.getOwnPropertyDescriptor(pluginSdkGlobalsForTest, key)
+      expect(descriptor?.get).toEqual(expect.any(Function))
+    }
+  })
+
+  it('builds a cached import map for the four runtime specifiers', () => {
+    const first = sdkImportMap()
+    expect(() => sdkImportMap()).not.toThrow()
+    const second = sdkImportMap()
+    expect(second).toBe(first)
+    expect(Object.keys(first).sort()).toEqual([...SPECIFIERS].sort())
+  })
+
+  it('installs a live SDK namespace that Object.keys can enumerate', async () => {
+    installPluginSdk()
+    const installed = (globalThis as Record<string, unknown>).__HERMES_PLUGIN_SDK__
+    expect(installed).toEqual(expect.any(Object))
+    expect(() => Object.keys(installed as object)).not.toThrow()
+
+    const named = liveSdkNamedExport()
+    expect(Object.keys(installed as object)).toContain(named)
+
+    const source = await readShimSource(sdkImportMap()['@hermes/plugin-sdk'])
+    expect(source).toContain(`const m = globalThis.__HERMES_PLUGIN_SDK__`)
+    expect(source).toContain('export default m.default ?? m')
+    expect(source).toContain(named)
+  })
+
+  it('late-binds so Object.keys sees the namespace after it is assigned', () => {
+    const ns = pluginSdkGlobalsForTest.__HERMES_PLUGIN_SDK__
+    expect(ns).toEqual(expect.any(Object))
+    expect(() => Object.keys(ns)).not.toThrow()
+    expect(Object.keys(ns)).toContain(liveSdkNamedExport())
+    expect(ns).toBe(sdk)
+  })
+
+  it('does not emit empty named-export destructuring', async () => {
+    expect(emitShimSource('__HERMES_PLUGIN_SDK__', [])).not.toContain('export const { }')
+
+    const source = await readShimSource(sdkImportMap()['@hermes/plugin-sdk'])
+    expect(source).not.toMatch(/export const \{\s*\} = m/)
+  })
+})

--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -14,11 +14,13 @@ import * as jsxRuntime from 'react/jsx-runtime'
 import * as sdk from './index'
 
 const GLOBALS = {
-  __HERMES_PLUGIN_SDK__: sdk,
-  __HERMES_REACT__: React,
-  __HERMES_REACT_JSX__: jsxRuntime,
-  __HERMES_REACT_JSX_DEV__: jsxDevRuntime
+  get __HERMES_PLUGIN_SDK__() { return sdk },
+  get __HERMES_REACT__() { return React },
+  get __HERMES_REACT_JSX__() { return jsxRuntime },
+  get __HERMES_REACT_JSX_DEV__() { return jsxDevRuntime }
 } as const
+
+export const pluginSdkGlobalsForTest = GLOBALS
 
 export function installPluginSdk(): void {
   Object.assign(globalThis, GLOBALS)


### PR DESCRIPTION
## What does this PR do?

Packaged Windows `win-unpacked` builds hoist the plugin SDK namespace (`var Lb=…`) *after* `GLOBALS` captures it (`var bg={__HERMES_PLUGIN_SDK__:Lb,…}`). `var` hoisting leaves `bg.__HERMES_PLUGIN_SDK__` permanently `undefined`. Every runtime disk plugin then dies in `sdkImportMap()` → `shimUrl()` → `Object.keys(undefined)`:

```
[plugins] runtime load failed (<name>) TypeError: Cannot convert undefined or null to object
```

Bundled consumers still work (live import bindings). Dev-server chunking also hides this, which is why CI missed it.

This keeps the existing `installPluginSdk` / `sdkImportMap` / shim-blob seam and only changes how `GLOBALS` reads the four host namespaces: getters, so evaluation happens at first install/import-map call — after module evaluation completes. `Object.assign(globalThis, GLOBALS)` and `Object.keys(GLOBALS[key])` both invoke those getters at call time. No loader, pack, or Windows-only branch.

## Related Issue

Fixes #107484

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `apps/desktop/src/sdk/runtime.ts`: `__HERMES_PLUGIN_SDK__` / `__HERMES_REACT__` / `__HERMES_REACT_JSX__` / `__HERMES_REACT_JSX_DEV__` are accessors; `pluginSdkGlobalsForTest` is a test-only export of that object.
- `apps/desktop/src/sdk/runtime.test.ts` (new): accessor structure probe (RED on pre-fix data properties), cached import-map CONTROL, live `Object.keys` after `installPluginSdk()`, late-bind identity, empty-names fail-open.

## How to Test

```
cd apps/desktop
npx vitest run --project ui src/sdk/runtime.test.ts
```

Proof Receipt (pre-fix base `2feb546828`, rebased onto `0596631bf3`):

- BEFORE: `exposes the four host namespaces as late-bound accessors` failed (`descriptor?.get` was `undefined` on eager data properties). 4 CONTROL tests already passed on unbundled vitest.
- AFTER: 5 passed (1 file)
- CONTROL: `sdkImportMap()` still caches the four specifiers; `installPluginSdk()` still assigns a live SDK object `Object.keys` can enumerate; empty named-export lists still omit `export const { } = m`

## Related work (not duplicates)

- No open competing PR for #107484 at push time.
- Does not rewrite the runtime loader, freeze export-name lists, or swallow `Object.keys` failures with `?? {}` (that would load plugins against an empty SDK).

## Review follow-up

- Independent P0 review skipped (1 module, 108/4 lines, not auth/crypto/state.db/gateway, self-review P0=0).
- Self-review P0: 0.
- Residual risk: `pluginSdkGlobalsForTest` is a production export used only by the unit test (allowed by the implementation contract). Packaged-Windows end-to-end load of a disk plugin was not re-run here; the getter fix is the issue's byte-level proposed patch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run relevant tests locally (desktop vitest ui project; this change is TS, not `pytest tests/`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (vitest/jsdom accessor + shim-source assertions; no packaged Windows Electron run)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the hoist bug is pack-order, not OS-specific; getters apply to all packaged builds
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Made with [Cursor](https://cursor.com)