### PR TITLE
fix(desktop): resolve the plugin-SDK namespaces lazily so bundler order can't break runtime plugins

### DIFF
--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -13,21 +13,37 @@ import * as jsxRuntime from 'react/jsx-runtime'
 
 import * as sdk from './index'
 
-const GLOBALS = {
-  __HERMES_PLUGIN_SDK__: sdk,
-  __HERMES_REACT__: React,
-  __HERMES_REACT_JSX__: jsxRuntime,
-  __HERMES_REACT_JSX_DEV__: jsxDevRuntime
-} as const
+type SdkGlobals = {
+  __HERMES_PLUGIN_SDK__: typeof sdk
+  __HERMES_REACT__: typeof React
+  __HERMES_REACT_JSX__: typeof jsxRuntime
+  __HERMES_REACT_JSX_DEV__: typeof jsxDevRuntime
+}
+
+/** The live namespaces — resolved on EVERY call, never captured at module init.
+ *
+ *  LOCAL PATCH (2026-09-10): a module-level map can be built BEFORE `./index`
+ *  assigns its namespace binding (bundler ordering is not a contract), and
+ *  `Object.keys(undefined)` in shimUrl then fails EVERY runtime plugin with
+ *  "Cannot convert undefined or null to object". Reading the bindings here is
+ *  order-independent. */
+function sdkGlobals(): SdkGlobals {
+  return {
+    __HERMES_PLUGIN_SDK__: sdk,
+    __HERMES_REACT__: React,
+    __HERMES_REACT_JSX__: jsxRuntime,
+    __HERMES_REACT_JSX_DEV__: jsxDevRuntime
+  }
+}
 
 export function installPluginSdk(): void {
-  Object.assign(globalThis, GLOBALS)
+  Object.assign(globalThis, sdkGlobals())
 }
 
 /** Build a shim ESM blob that re-exports a global namespace's live members.
  *  Export names come from the namespace itself, so the list can't drift. */
-function shimUrl(globalKey: keyof typeof GLOBALS): string {
-  const names = Object.keys(GLOBALS[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
+function shimUrl(globalKey: keyof SdkGlobals): string {
+  const names = Object.keys(sdkGlobals()[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
 
   const source =
     `const m = globalThis.${globalKey};\n` +


### PR DESCRIPTION
### What breaks

On the **2026-09-10** packaged Windows build (`main` @ `073c57872a4`) **every runtime (disk) desktop plugin fails to load** — reproducibly, for two unrelated plugins:

```
[plugins] runtime load failed (provider-usage) TypeError: Cannot convert undefined or null to object
  (…/resources/app.asar.unpacked/dist/assets/sdk-RKHbz2ri.js:5)
[plugins] runtime load failed (stt-switch) TypeError: Cannot convert undefined or null to object
  (…/resources/app.asar.unpacked/dist/assets/sdk-RKHbz2ri.js:5)
```

`Capabilities → Plugins` lists both desktop plugins as `failed` with that message, and none of their contributions register (status-bar chips, palette commands). It hits unrelated plugins, so this is not plugin-specific: no disk plugin can load at all.

### Why

`apps/desktop/src/sdk/runtime.ts` materialises its namespace map at **module init**:

```ts
const GLOBALS = { __HERMES_PLUGIN_SDK__: sdk, … } as const
```

In that build the bundler emitted this module's body **before** `./index` assigns its namespace binding:

| built chunk (`dist/assets/sdk-*.js`) | offset |
| --- | --- |
| `var bg={__HERMES_PLUGIN_SDK__:Lb, …}` (this file) | 157012 |
| `var Lb=t({…})` (the `./index` namespace) | 231521 |

so `bg.__HERMES_PLUGIN_SDK__` was captured as `undefined`. The loader then runs `installPluginSdk()` / `shimUrl()`, whose `Object.keys(GLOBALS[key])` throws exactly this TypeError; because `sdkImportMap()` builds all four shims eagerly and only caches them on success, one unassigned namespace kills the map for every plugin.

The previous packaged build (2026-08-31) emitted the same two statements in the opposite order (`var kp=…` @101714, `var tm=…` @116891) and worked. Same source, different bundler order — which is why this appeared only with the rebuild, and why the capture is the bug.

### Fix

Resolve the namespaces inside a function, so they are read at call time (plugin load, when they are guaranteed assigned) instead of at module-init time. Nothing else changes.

### Verification

* Node reproduction of the failing shape: eager capture + later assignment → `TypeError: Cannot convert undefined or null to object`; the lazy form → the namespace's live keys, globals installed.
* Bundle offsets above, read from the failing build's chunk.
* The same change applied to that build's chunk in place clears the failure path on the affected machine; the renderer reload is the last step (I will confirm in a comment).
* No test added: the failure depends on the bundler's emission order and cannot be reproduced under vitest — the invariant is now structural (no module-scope capture).
