### PR TITLE
fix(telegram): add opt-in classic TLS key exchange for handshake resets

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1306,6 +1306,7 @@ platform_toolsets:
 #     guest_mode: false
 #     # allowed_chats: ["-1001234567890"]
 #     extra:
+#       tls_classic_key_exchange: false  # Opt in to X25519 for TLS handshake EOFs on PQ-incompatible paths; keeps TLS 1.3 and certificate verification
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
 #       rich_messages: false          # Bot API 10.1 rich messages (tables/task lists/details/math); default false for copyable legacy MarkdownV2, set true to opt in
 #       rich_drafts: false            # Experimental rich draft previews during Telegram DM streaming; default false because Telegram Desktop/macOS can visually overlay draft frames

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -149,7 +149,8 @@ from gateway.platforms.base import (
 from gateway.platforms.event import MessageEvent, MessageType, ProcessingOutcome
 from plugins.platforms.telegram.telegram_ids import normalize_telegram_chat_id
 from plugins.platforms.telegram.telegram_network import (
-    SEED_FALLBACK_IPS, TelegramFallbackTransport, discover_fallback_ips, parse_fallback_ip_env, tcp_keepalive_socket_options)
+    SEED_FALLBACK_IPS, TelegramFallbackTransport, discover_fallback_ips, parse_fallback_ip_env,
+    tcp_keepalive_socket_options, telegram_tls_kwargs)
 from utils import env_float, env_int
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
@@ -2756,15 +2757,16 @@ class TelegramAdapter(BasePlatformAdapter):
             else:
                 logger.info("[%s] Auto-discovered Telegram fallback IPs: %s", self.name, ", ".join(fallback_ips))
         proxy_url = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org", *fallback_ips])
+        tls_kwargs = telegram_tls_kwargs(self.config.extra.get("tls_classic_key_exchange", False))
 
         def _pair(general_httpx: dict, updates_httpx: dict, **extra) -> tuple:
-            return (HTTPXRequest(**request_kwargs, **extra, httpx_kwargs=general_httpx),
-                    HTTPXRequest(**request_kwargs, **extra, httpx_kwargs=updates_httpx))
+            return (HTTPXRequest(**request_kwargs, **extra, httpx_kwargs={**tls_kwargs, **general_httpx}),
+                    HTTPXRequest(**request_kwargs, **extra, httpx_kwargs={**tls_kwargs, **updates_httpx}))
 
         if fallback_ips and not proxy_url and not disable_fallback:
             logger.info("[%s] Telegram fallback IPs active: %s", self.name, ", ".join(fallback_ips))
             # Separate request/update pools reduce contention during polling reconnect + bootstrap calls.
-            _transport_kwargs: dict = {"socket_options": tcp_keepalive_socket_options()}
+            _transport_kwargs: dict = {"socket_options": tcp_keepalive_socket_options(), **tls_kwargs}
             # Keep request/update pools separate to reduce contention during polling reconnect + bot API
             # bootstrap/delete_webhook calls. httpx ignores the client-level `limits` kwarg when a custom
             # `transport` is supplied (#58790). Unlike the proxy/direct branches (which inject limits at the

--- a/plugins/platforms/telegram/telegram_network.py
+++ b/plugins/platforms/telegram/telegram_network.py
@@ -50,6 +50,18 @@ SEED_FALLBACK_IPS: list[str] = ["149.154.166.110", "149.154.167.220"]
 _UNSET = object()
 
 
+def telegram_tls_kwargs(classic_key_exchange=False) -> dict:
+    """Opt out of PQ key shares only for Telegram on incompatible network paths."""
+    if str(classic_key_exchange).lower() not in {"true", "1", "yes", "on"}:
+        return {}
+    # Keep httpx's CA selection (including SSL_CERT_FILE/SSL_CERT_DIR), hostname
+    # verification and TLS versions. OpenSSL 3.5's larger hybrid ClientHello can
+    # be reset mid-handshake on paths where a classic X25519 hello succeeds.
+    context = httpx.create_ssl_context()
+    context.set_ecdh_curve("X25519")
+    return {"verify": context}
+
+
 def _resolve_proxy_url(target_hosts=None) -> str | None:
     from gateway.platforms.base import resolve_proxy_url  # env vars + macOS system proxy
     return resolve_proxy_url("TELEGRAM_PROXY", target_hosts=target_hosts)

--- a/tests/plugins/test_telegram_tls_key_exchange.py
+++ b/tests/plugins/test_telegram_tls_key_exchange.py
@@ -1,0 +1,108 @@
+"""The Telegram TLS workaround reaches every pool without weakening verification."""
+
+import ssl
+
+import httpx
+import pytest
+import yaml
+
+from gateway.config import GatewayConfig, Platform
+from gateway.config_loader import load_yaml_layer
+from plugins.platforms.telegram import adapter as tg
+
+
+def _supported_groups(context):
+    incoming, outgoing = ssl.MemoryBIO(), ssl.MemoryBIO()
+    connection = context.wrap_bio(incoming, outgoing, server_side=False, server_hostname="api.telegram.org")
+    with pytest.raises(ssl.SSLWantReadError):
+        connection.do_handshake()
+    hello = outgoing.read()[9:]  # TLS record header + handshake header
+    pos = 34
+    pos += 1 + hello[pos]  # session ID
+    pos += 2 + int.from_bytes(hello[pos:pos + 2], "big")  # cipher suites
+    pos += 1 + hello[pos]  # compression methods
+    pos += 2  # extensions length
+    while pos < len(hello):
+        kind = int.from_bytes(hello[pos:pos + 2], "big")
+        size = int.from_bytes(hello[pos + 2:pos + 4], "big")
+        data = hello[pos + 4:pos + 4 + size]
+        if kind == 10:  # supported_groups
+            return [int.from_bytes(data[i:i + 2], "big") for i in range(2, len(data), 2)]
+        pos += 4 + size
+    raise AssertionError("ClientHello did not advertise supported_groups")
+
+
+async def _build_requests(tmp_path, monkeypatch, route, enabled):
+    # Exercise the real YAML -> PlatformConfig -> adapter -> PTB/httpx chain.
+    extra = {} if enabled is None else {"tls_classic_key_exchange": enabled}
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"platforms": {"telegram": {"extra": extra}}}), encoding="utf-8"
+    )
+    data = {}
+    load_yaml_layer(tmp_path, data)
+    config = GatewayConfig.from_dict(data).platforms[Platform.TELEGRAM]
+    adapter = tg.TelegramAdapter(config)
+    monkeypatch.setenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "false" if route == "fallback" else "true")
+    monkeypatch.setattr(adapter, "_fallback_ips", lambda: ["149.154.166.110"])
+    monkeypatch.setattr(tg, "resolve_proxy_url", lambda *a, **k: "http://127.0.0.1:7890" if route == "proxy" else None)
+    from plugins.platforms.telegram import telegram_network
+    monkeypatch.setattr(telegram_network, "_resolve_proxy_url", lambda **k: None)
+    return await adapter._build_ptb_requests()
+
+
+async def _contexts(request, route):
+    transport = request._client._transport
+    if route == "fallback":
+        yield transport._primary._pool._ssl_context
+        yield (await transport._get_fallback("149.154.166.110"))._pool._ssl_context
+        await transport._reset_primary(transport._primary)
+        await transport._reset_fallback("149.154.166.110")
+        yield transport._primary._pool._ssl_context
+        yield (await transport._get_fallback("149.154.166.110"))._pool._ssl_context
+    elif route == "proxy":
+        for mounted in request._client._mounts.values():
+            if mounted is not None:
+                yield mounted._pool._ssl_context
+    else:
+        yield transport._pool._ssl_context
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", ["direct", "proxy", "fallback"])
+async def test_classic_key_exchange_reaches_all_pools(tmp_path, monkeypatch, route):
+    # A distinct one-root bundle catches accidental loss of the operator's CA override.
+    root = httpx.create_ssl_context().get_ca_certs(binary_form=True)[0]
+    bundle = tmp_path / "custom-ca.pem"
+    bundle.write_text(ssl.DER_cert_to_PEM_cert(root), encoding="ascii")
+    monkeypatch.setenv("SSL_CERT_FILE", str(bundle))
+    baseline = httpx.create_ssl_context()
+    requests = await _build_requests(tmp_path, monkeypatch, route, True)
+    try:
+        for request in requests:
+            contexts = [ctx async for ctx in _contexts(request, route)]
+            assert contexts
+            for context in contexts:
+                assert _supported_groups(context) == [29]  # IANA X25519
+                assert context.check_hostname and context.verify_mode == ssl.CERT_REQUIRED
+                assert context.get_ca_certs(binary_form=True) == baseline.get_ca_certs(binary_form=True)
+                assert context.minimum_version == baseline.minimum_version
+                assert context.maximum_version == baseline.maximum_version
+        assert _supported_groups(httpx.create_ssl_context()) == _supported_groups(baseline)
+    finally:
+        for request in requests:
+            await request.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enabled", [False, None])
+@pytest.mark.parametrize("route", ["direct", "proxy", "fallback"])
+async def test_default_key_exchange_is_unchanged(tmp_path, monkeypatch, route, enabled):
+    baseline = httpx.create_ssl_context()
+    requests = await _build_requests(tmp_path, monkeypatch, route, enabled)
+    try:
+        for request in requests:
+            async for context in _contexts(request, route):
+                assert _supported_groups(context) == _supported_groups(baseline)
+    finally:
+        for request in requests:
+            await request.shutdown()

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1225,6 +1225,32 @@ The proxy applies to both the primary transport and all fallback IP transports. 
 This covers the custom fallback transport layer that Hermes uses for Telegram connections. The standard `httpx` client used elsewhere already respects proxy env vars natively.
 :::
 
+### TLS handshake failures with OpenSSL 3.5
+
+If Telegram repeatedly reconnects with an empty `httpx.ConnectError` or an
+`SSL: UNEXPECTED_EOF_WHILE_READING`, while curl works through the same proxy,
+the network path may reject OpenSSL 3.5's larger post-quantum TLS ClientHello.
+This symptom alone is not proof: compare the default handshake with X25519
+before enabling the workaround.
+
+To use classic X25519 key exchange only for Telegram, add to `config.yaml`
+and restart the gateway:
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      tls_classic_key_exchange: true
+```
+
+This covers both Bot API requests and long polling, including proxy and
+fallback-IP connections. TLS 1.3, hostname checks, and certificate verification
+remain enabled; `SSL_CERT_FILE` and `SSL_CERT_DIR` are still respected. The
+tradeoff is opting out of post-quantum key exchange for Telegram. Other
+platforms and model-provider clients keep their existing TLS settings.
+The default is `false`; remove the setting or set it to `false` to restore
+OpenSSL's default groups. See also [the related OpenSSL 3.5 report](https://github.com/NousResearch/hermes-agent/issues/106384).
+
 ## Message Reactions
 
 The bot can add emoji reactions to messages as visual processing feedback:


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in Telegram TLS compatibility setting for network paths that reset OpenSSL 3.5's default handshake. On current main (`8defaaad48`), the real Telegram HTTPXRequest clients reproduced empty `httpx.ConnectError` failures at `proxy.start_tls`; selecting classic X25519 eliminated failures in the paired live sample while still negotiating TLS 1.3.

```yaml
platforms:
  telegram:
    extra:
      tls_classic_key_exchange: true
```

The default remains OpenSSL's normal policy. This is an operator-selected workaround, not an automatic downgrade or a claim that every empty ConnectError has this cause. It does not identify which hop closes the connection.

## Related Issue

Related to #106384 (OpenSSL 3.5/PQ handshake interoperability) and #1526 (Telegram TLS resets). #106517 adds Codex login diagnostics/documentation; this change covers Telegram's HTTP clients. #44392 targets provider TLS version caps and does not cover these Telegram pools.

## Type of Change

- [x] Bug fix

## Changes Made

- Build a Telegram-scoped SSL context using httpx's existing CA selection, then select X25519 only when explicitly enabled.
- Pass that context to both general Bot API and getUpdates clients, including explicit-proxy mounts and every primary/fallback transport generation. Client-level `verify` alone does not configure a supplied custom transport.
- Preserve certificate and hostname checks, CA environment overrides, TLS version bounds, and other clients' TLS defaults. Opting in deliberately forgoes post-quantum key exchange for Telegram.
- Document the setting in the Telegram guide and sample configuration. No new dependency or environment variable.

## How to Test

1. On an affected network, reproduce with the adapter's real `_build_ptb_requests()` clients requesting `https://api.telegram.org/`. Use a temporary HERMES_HOME/config.yaml and HTTP `Connection: close` to exercise a fresh handshake each time. No bot token is needed for this probe.
2. Enable the YAML setting, rebuild both clients, and repeat through the same proxy. Check the httpx trace's `proxy.start_tls.failed` events and the negotiated TLS version.
3. Restart the gateway with the setting enabled and verify `getUpdates progressing` and connected status.

Live results on Ubuntu 24.04, Python 3.11.16 / OpenSSL 3.5.7 / httpx 0.28.1, same local HTTP proxy and Telegram endpoint, 40 fresh connections per client:

| Code | General client | getUpdates client | Negotiated TLS on success |
| --- | --- | --- | --- |
| Main before patch | 30 success / 10 ConnectError | 36 success / 4 ConnectError | TLS 1.3 |
| Patched, setting enabled | 40 success / 0 errors | 40 success / 0 errors | TLS 1.3 |

This is a bounded live sample, not a long-term reliability claim. The same patch is applied to the reporter's installation; its gateway started successfully and confirmed real polling progress.

Two invariant tests (9 parameterized cases) exercise real YAML loading, PTB/httpx objects, and generated TLS ClientHello supported_groups across direct, proxy, and fallback paths. They cover reset/recreated pools, a distinct custom CA bundle, unchanged TLS bounds, and default/unset behavior. On unmodified main the three opt-in cases fail; the six default cases pass.

Validation:

- `scripts/run_tests.sh tests/plugins/test_telegram_tls_key_exchange.py tests/gateway/test_telegram_closewait_limits_31599.py tests/gateway/test_telegram_network.py tests/gateway/test_telegram_connect.py -j 4 -q` — 37 passed.
- Re-ran the 9 invariant cases after strengthening the custom-CA and omitted-setting assertions — all passed.
- `scripts/check-windows-footguns.py` on the changed Python files — passed.
- `git diff --check` — passed.

## Checklist

- [x] Read CONTRIBUTING.md and applicable AGENTS.md instructions.
- [x] Conventional commit; searched existing issues/PRs; only this fix is included.
- [x] Added behavior tests and proved the regression on main.
- [x] Tested on Linux; no OS-specific code added. Windows/macOS were not run live.
- [x] Updated relevant documentation and cli-config.yaml.example.
- [ ] Full repository test suite (targeted results above; full suite not run).

Implementation and validation assisted by Codex.
