### PR TITLE
feat(skills): add opt-in lean prompt mode

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1288,6 +1288,7 @@ def _label_visible_entries(visible_entries: list[dict], skills_by_category: dict
 def _render_skills_index(
     skills_by_category: dict[str, list[tuple[str, str]]], category_descriptions: dict[str, str],
     compact_categories: "frozenset[str] | None", available_tools: "set[str] | None",
+    *, lean: bool = False,
 ) -> str:
     """Render the ## Skills block; "" when there is nothing to list."""
     if not skills_by_category:
@@ -1295,6 +1296,10 @@ def _render_skills_index(
     # Demoted categories collapse to one names-only line. NEVER drop entries — agent-created skills are the
     # model's project memory and it won't rediscover them via skills_list. Nested categories follow their parent.
     demoted = frozenset(cat for cat in skills_by_category if cat.split("/", 1)[0] in (compact_categories or frozenset()))
+    if lean:
+        # Keep collision warnings visible: a bare ambiguous name cannot be loaded safely.
+        demoted = frozenset(cat for cat, entries in skills_by_category.items()
+                            if not any("[name collision" in desc for _, desc in entries))
     hidden_note = (
         "\n(Categories marked [names only] are outside the current coding "
         "context, so their descriptions are omitted — the skills work "
@@ -1315,6 +1320,20 @@ def _render_skills_index(
             if name not in seen:
                 seen.add(name)
                 index_lines.append(f"    - {name}: {desc}" if desc else f"    - {name}")
+    if lean:
+        discovery = "Use skills_list to inspect descriptions when names are ambiguous. " if (
+            available_tools is None or "skills_list" in available_tools) else ""
+        return (
+            "## Skills\n"
+            "Load the governing skill with skill_view before an operational workflow, or when its "
+            "procedures, user preferences or safety constraints are needed. Honor explicitly requested "
+            "skills and mandatory task-specific gates. A weak thematic match alone does not require "
+            "loading a skill; answer conceptual questions directly when the available context suffices. "
+            + discovery +
+            "Names-only entries remain available; load references only when needed. Follow loaded skills, "
+            "and correct material errors or record reusable lessons after difficult work.\n\n"
+            "<available_skills>\n" + "\n".join(index_lines) + "\n</available_skills>"
+        )
     return (
         "## Skills\n"
         "Before replying, scan the skills below. If a skill matches or is even partially relevant to your "
@@ -1346,12 +1365,15 @@ def _build_skills_system_prompt_inner(
     # The resolved platform is part of the key: per-platform disabled-skill lists need distinct cache entries.
     _platform_hint = _current_session_platform_hint()
     disabled = get_disabled_skill_names(_platform_hint or None)
+    skills_cfg = _config_readonly("skills.prompt_mode").get("skills")
+    lean = isinstance(skills_cfg, dict) and skills_cfg.get("prompt_mode") == "lean"
     project_dirs = project_dirs or []
     cache_key = (
         str(skills_dir), tuple(str(d) for d in external_dirs), tuple(str(d) for d in project_dirs),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint, tuple(sorted(disabled)), tuple(sorted(compact_categories or ())),
+        lean,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1409,7 +1431,8 @@ def _build_skills_system_prompt_inner(
         for cat, cat_desc in _read_category_descriptions(ext_dir, "Could not read external skill description %s: %s").items():
             category_descriptions.setdefault(cat, cat_desc)
 
-    result = _render_skills_index(skills_by_category, category_descriptions, compact_categories, available_tools)
+    result = _render_skills_index(skills_by_category, category_descriptions, compact_categories, available_tools,
+                                 lean=lean)
     with _SKILLS_PROMPT_CACHE_LOCK:
         _SKILLS_PROMPT_CACHE[cache_key] = result
         _SKILLS_PROMPT_CACHE.move_to_end(cache_key)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1323,6 +1323,9 @@ DEFAULT_CONFIG = {
     # and resolved; read-only — creation goes to ~/.hermes/skills/ unless create_dir redirects it.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # Opt-in names-only catalog + targeted loading guidance; never hides a skill.
+        # Existing sessions keep their frozen prompt. Invalid values use full behavior.
+        "prompt_mode": "full",  # full | lean
         # Where skill_manage-created skills go (empty = profile-local dir). When set, new skills
         # land here AND agent-facing instructions name this path; expanded (~, ${VAR}), relative to
         # HERMES_HOME, scanned alongside the local dir.

--- a/tests/agent/test_skills_lean_prompt.py
+++ b/tests/agent/test_skills_lean_prompt.py
@@ -1,0 +1,92 @@
+"""Opt-in lean skill index: retain discovery, isolate profiles and caches."""
+import pytest
+
+from agent.prompt_builder import build_skills_system_prompt, clear_skills_system_prompt_cache
+
+
+def seed(home, mode=None):
+    home.mkdir(parents=True, exist_ok=True)
+    if mode is not None:
+        (home / "config.yaml").write_text(f"skills:\n  prompt_mode: {mode}\n")
+    for name in ("alpha", "beta"):
+        skill = home / "skills" / "demo" / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: Detailed instructions for {name}\n---\nBody.\n"
+        )
+
+
+def test_lean_config_keeps_names_without_full_descriptions(tmp_path, monkeypatch):
+    seed(tmp_path, "lean")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    prompt = build_skills_system_prompt()
+    assert "alpha" in prompt and "beta" in prompt
+    assert "Detailed instructions" not in prompt
+    assert "even partially relevant" not in prompt
+    assert "skill_view" in prompt
+    assert "skills_list" in prompt
+
+
+@pytest.mark.parametrize("mode", [None, "full", "unknown", "true", "[]", "{}"])
+def test_default_and_invalid_modes_preserve_full_policy(tmp_path, monkeypatch, mode):
+    seed(tmp_path, mode)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    prompt = build_skills_system_prompt()
+    assert "Detailed instructions for alpha" in prompt
+    assert "even partially relevant" in prompt
+
+
+def test_profile_override_does_not_inherit_lean_policy(tmp_path, monkeypatch):
+    root, other = tmp_path / "default", tmp_path / "other"
+    seed(root, "lean")
+    seed(other)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.chdir(tmp_path)
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    lean = build_skills_system_prompt()
+    full = build_skills_system_prompt(skills_dir_override=other / "skills")
+    assert "Detailed instructions" not in lean
+    assert "Detailed instructions" in full
+    assert build_skills_system_prompt() == lean
+
+
+def test_modes_have_separate_index_cache_entries(tmp_path, monkeypatch):
+    seed(tmp_path, "lean")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    lean = build_skills_system_prompt()
+    (tmp_path / "config.yaml").write_text("skills:\n  prompt_mode: full\n")
+    full = build_skills_system_prompt()
+    assert "Detailed instructions" not in lean
+    assert "Detailed instructions" in full
+
+
+def test_lean_preserves_collisions_and_no_dangling_discovery_tool():
+    from agent.prompt_builder import _render_skills_index
+
+    categories = {
+        "demo": [("alpha", "Ordinary description")],
+        "org:test": [("beta", "[name collision — also exists personally; load via category path]")],
+    }
+    prompt = _render_skills_index(categories, {}, None, {"skill_view"}, lean=True)
+    assert "alpha" in prompt and "beta" in prompt
+    assert "name collision" in prompt
+    assert "load via category path" in prompt
+    assert "Ordinary description" not in prompt
+    assert "skills_list" not in prompt
+
+
+def test_disabled_skills_stay_disabled_in_lean_mode(tmp_path, monkeypatch):
+    seed(tmp_path, "lean")
+    (tmp_path / "config.yaml").write_text("skills:\n  prompt_mode: lean\n  disabled: [beta]\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    prompt = build_skills_system_prompt()
+    assert "alpha" in prompt
+    assert "beta" not in prompt

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -158,6 +158,26 @@ Level 2: skill_view(name, path)  → Specific reference file       (varies)
 
 The agent only loads the full skill content when it actually needs it.
 
+### Opt-in lean prompt
+
+`hermes config set skills.prompt_mode lean` uses a names-only skills catalog and
+targeted loading guidance for **new sessions in the active profile**. All otherwise
+visible skills remain listed and loadable; name-collision warnings remain visible.
+The agent still loads governing workflows, explicit skill requests, and required
+safety gates, but a weak thematic match alone no longer requires loading a skill.
+When names are ambiguous, it can inspect descriptions with `skills_list`.
+
+The default is `full`, which preserves the existing catalog and loading policy.
+Unset or invalid values also use `full`. Restore it with
+`hermes config set skills.prompt_mode full`. Other profiles are unchanged unless
+configured explicitly. This does not change tool access, permissions or execution
+verification. Existing conversations keep their frozen prompt until an existing
+rebuild boundary, such as context compression; a running process must also have
+loaded the version that implements this option.
+
+Fewer prompt characters do not establish subscription-quota savings: compare
+provider usage, tool rounds and task outcomes in equivalent fresh sessions.
+
 ## SKILL.md Format
 
 ```markdown


### PR DESCRIPTION
## Summary

Add an opt-in, profile-scoped `skills.prompt_mode: lean` for users who want a smaller always-loaded skill index and more targeted loading guidance.

- Keep `full` as the default, including when the setting is absent or invalid.
- Render ordinary categories as names-only entries without removing otherwise visible skills.
- Preserve name-collision warnings and the existing visibility/disabled-skill filters.
- Require governing workflows, explicitly requested skills, and mandatory task-specific gates while allowing conceptual answers without weak-match skill loading.
- Include the mode in the skills-index cache key without adding conversation-level prompt invalidation.
- Document activation, rollback, profile isolation, and existing prompt-rebuild boundaries.

This does not enable lean mode by default or change tool access, execution verification, or permissions.

## Motivation and trade-offs

Large catalogs and mandatory loading for weak thematic matches can add avoidable context. This option changes the existing renderer rather than introducing a new tool or discovery system. Names-only discovery can be less informative, so `skills_list` remains available when exposed and collision warnings are not compacted away.

Prompt-size reductions alone do not establish subscription-quota savings. Discovery quality, provider usage and tool rounds should be evaluated on equivalent tasks. Existing conversations retain their frozen prompt until an already-supported rebuild boundary, such as compression.

## Verification

- [x] Independent bounded review: no blocking logic or security findings.
- [x] Canonical, isolated test runner: **157 passed, 1 skipped, 0 failed**:
  ```sh
  scripts/run_tests.sh tests/agent/test_skills_lean_prompt.py tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py tests/hermes_cli/test_prompt_size.py
  ```
- [x] Ruff passed for changed Python files.
- [x] `git diff --check` passed.
- [x] Local non-mutating merge-tree check against fetched upstream `main` completed without conflicts.

New tests cover opt-in rendering, invalid-setting fallback, profile isolation, mode-separated index caching, collision warnings, optional discovery-tool guidance, and disabled skills.

The complete repository suite and hosted CI have not been claimed as passing. Broader names-only discovery evaluation and persisted-conversation restoration coverage remain follow-up opportunities.
