### PR TITLE
fix(kanban): keep create --initial-status blocked sticky until unblock

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1236,7 +1236,8 @@ def create_task(
     """Create a task (optionally under ``parents``); returns its id.
 
     Status: ``ready`` unless a parent is not ``done`` (``todo``); ``triage=True``
-    forces ``triage``; ``initial_status="blocked"`` parks it for human ops.
+    forces ``triage``; ``initial_status="blocked"`` parks it for human ops
+    (sticky until ``unblock_task``; ``recompute_ready`` will not auto-promote).
     ``idempotency_key``: an existing non-archived task with the key is returned
     instead of a duplicate. ``max_runtime_seconds``: cap before the dispatcher
     SIGTERMs and re-queues. ``model_override``/``provider_override`` pin the
@@ -1366,6 +1367,16 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                if task_status == "blocked":
+                    # Same #28712 seam as ``block_task``: a ``blocked`` event
+                    # makes ``_has_sticky_block`` True so ``recompute_ready``
+                    # cannot auto-promote a parked create.
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"reason": "initial_status", "source_status": "blocked"},
+                    )
                 # ACK-edge: the originating channel hears a child BLOCK, not just the fan-in.
                 inherit_creator_origin(conn, task_id, creator_task_id, created_at=now)
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -157,6 +157,73 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# create_task(initial_status="blocked") must be sticky (#107512)
+# ---------------------------------------------------------------------------
+
+
+def test_create_task_initial_status_blocked_is_sticky(kanban_home: Path) -> None:
+    """Parent-less ``create_task(..., initial_status="blocked")`` parks the
+    task for human ops: status stays ``blocked``, a ``blocked`` event makes
+    ``_has_sticky_block`` True, and ``recompute_ready`` must not emit
+    ``promoted`` across repeated dispatcher ticks."""
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="parked for human ops", initial_status="blocked")
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert kb._has_sticky_block(conn, tid)
+
+        for _ in range(2):
+            promoted = kb.recompute_ready(conn)
+            assert promoted == 0, "create(initial_status=blocked) must not auto-promote"
+            assert kb.get_task(conn, tid).status == "blocked"
+
+        kinds = [e.kind for e in kb.list_events(conn, tid)]
+        assert "blocked" in kinds
+        assert "promoted" not in kinds
+
+
+def test_create_task_default_is_not_stuck_blocked(kanban_home: Path) -> None:
+    """Default ``create_task`` (no ``initial_status``) stays on the normal
+    ready path and is not sticky-blocked."""
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="plain create")
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert not kb._has_sticky_block(conn, tid)
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_create_task_initial_blocked_unblocks_to_ready(kanban_home: Path) -> None:
+    """Explicit ``unblock_task`` clears a create-time sticky block; a
+    parent-less task lands ``ready`` and later ticks do not re-block it."""
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="parked then unblocked", initial_status="blocked")
+        assert kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "ready"
+        assert not kb._has_sticky_block(conn, tid)
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_parent_gated_todo_still_promotes_when_parent_completes(kanban_home: Path) -> None:
+    """A default/todo child under an unfinished parent still promotes to
+    ``ready`` once the parent is completed and ``recompute_ready`` runs."""
+    with kbc.connect() as conn:
+        parent = kb.create_task(conn, title="unfinished parent")
+        child = kb.create_task(conn, title="gated child", parents=[parent])
+        assert kb.get_task(conn, child).status == "todo"
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, child).status == "todo"
+
+        assert kb.complete_task(conn, parent, result="done")
+        assert kb.get_task(conn, parent).status == "done"
+        # complete_task already runs recompute_ready so children see ``done``.
+        assert kb.get_task(conn, child).status == "ready"
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, child).status == "ready"
+
+
+# ---------------------------------------------------------------------------
 # Schema-init recovery on legacy DBs is covered by
 # tests/hermes_cli/test_kanban_db.py::test_connect_migrates_legacy_db_before_optional_column_indexes
 # (landed via #28754 / #28781).  The original PR shipped a duplicate test


### PR DESCRIPTION
## What does this PR do?

`hermes kanban create <title> --initial-status blocked` (no `--parent`) already inserted the task as `blocked`, but the next dispatcher tick ran `recompute_ready` and emitted `promoted` → `ready`. Create wrote only a `created` event, so `_has_sticky_block` (the #28712 seam) stayed false, and an empty parent set is treated as satisfied (`all([])`).

This PR appends a `blocked` event in the same `create_task` write txn when `task_status == "blocked"`:

```python
{"reason": "initial_status", "source_status": "blocked"}
```

That reuses the existing sticky-block guard. The parked task stays `blocked` until an explicit `unblock_task`. Circuit-breaker `gave_up` blocks, default creates, and parent-gated `todo` children are unchanged.

## Related Issue

Fixes #107512

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`: after the `created` event, `create_task` writes a `blocked` event when `initial_status="blocked"` so `_has_sticky_block` is true. Docstring now states the sticky / `unblock_task` contract.
- `tests/hermes_cli/test_kanban_blocked_sticky.py`: detection (parent-less create stays blocked across ticks), CONTROL default create stays ready, CONTROL unblock lands ready, CONTROL parent-gated todo still promotes.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py -q --tb=short
scripts/run_tests.sh tests/hermes_cli/test_kanban_swarm.py -q --tb=short
```

Proof receipt (base `8defaaad48`):

- BEFORE (RED): `test_create_task_initial_status_blocked_is_sticky` failed — `_has_sticky_block` was `False` (1 failed, 5 passed)
- AFTER (GREEN): 6/6 sticky tests passed; swarm 5/5 passed (root still `done`, workers still `ready`)

CONTROL: default `create_task` stays `ready`; `unblock_task` clears the park; a `todo` child still promotes when its parent completes.

## Claim scope

Only `create_task(..., initial_status="blocked")` persistence via the existing `#28712` sticky-block event. Does not change `recompute_ready` parent gating, does not skip all parent-less `blocked` tasks, and does not alter swarm's blocked→done CAS.

## Related work (not duplicates)

- Searched open PRs for `107512` — none claimed this issue.
- `#28712` already made worker `kanban_block` sticky; this is the matching create-time park path.

## Review follow-up

Self-review P0 = 0. Independent review skipped (2 files, +79/−1, not auth/crypto/state.db/gateway).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run relevant tests locally (see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Made with [Cursor](https://cursor.com)