### PR TITLE
fix(update): preserve exact dashboard argv on macOS

### DIFF
--- a/hermes_cli/main_dashboard.py
+++ b/hermes_cli/main_dashboard.py
@@ -211,8 +211,11 @@ def _try_restart_systemd_service(svc_name: str, cgroup_path: str | None = None) 
 
 
 def _dashboard_cmdline_for_pid(pid: int) -> list[str] | None:
-    """Exact argv of a running process: ``/proc/<pid>/cmdline`` (Linux), ``ps -o command=`` + shlex
-    (macOS), None on Windows (no graceful taskkill window; Desktop manages its backend)."""
+    """Return exact process argv from ``/proc`` or psutil, when available.
+
+    Display-oriented ``ps -o command=`` output has no recoverable argv boundaries, so capture
+    failures return None and let the update path print its manual-restart hint instead.
+    """
     if sys.platform == "win32":
         return None
     try:
@@ -221,19 +224,17 @@ def _dashboard_cmdline_for_pid(pid: int) -> list[str] | None:
             with open(cmdline_path, "rb") as f:
                 raw = f.read()
             argv = [part.decode("utf-8", errors="replace") for part in raw.split(b"\x00") if part]
-            return argv or None
-        result = _run_probe(["ps", "-p", str(pid), "-o", "command="], timeout=10)
-        if result.returncode != 0:
-            return None
-        command = (result.stdout or "").strip()
-        if not command:
-            return None
-        try:
-            argv = shlex.split(command)
-        except ValueError:
-            argv = command.split()
-        return argv or None
-    except (OSError, ValueError, subprocess.TimeoutExpired):
+            if argv:
+                return argv
+    except OSError:
+        pass
+    try:
+        import psutil
+    except ImportError:
+        return None
+    try:
+        return psutil.Process(pid).cmdline() or None
+    except (psutil.Error, OSError, ValueError):
         return None
 
 

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -21,6 +21,7 @@ import sys
 from unittest.mock import patch, MagicMock
 
 import pytest
+import psutil
 
 from hermes_cli.main_dashboard import _find_stale_dashboard_pids
 from hermes_cli.dashboard_procs import _kill_stale_dashboard_processes
@@ -792,7 +793,7 @@ class TestFilterDashboardRespawnCandidates:
 
 
 class TestCmdlineCapture:
-    """_dashboard_cmdline_for_pid reads /proc on Linux, ps on macOS."""
+    """_dashboard_cmdline_for_pid reads exact, structured process argv."""
 
     def _live(self):
         return main_dashboard
@@ -823,19 +824,37 @@ class TestCmdlineCapture:
 
         assert argv == ["/usr/bin/python3", "-m", "hermes_cli.main", "serve"]
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX ps cmdline fallback")
-    def test_falls_back_to_ps_without_proc(self, monkeypatch):
+    @pytest.mark.macos_only
+    def test_preserves_arguments_and_executable_with_spaces(self, tmp_path):
+        install_dir = tmp_path / "Python Runtime"
+        install_dir.mkdir()
+        executable = install_dir / "python with spaces"
+        executable.symlink_to(sys.executable)
+        expected = [
+            str(executable),
+            "-c",
+            "import time; time.sleep(30)",
+            "argument with spaces",
+            "quote'\" and \\ slash",
+            "--looks-like-option=value with spaces",
+        ]
+        process = subprocess.Popen(expected)
+        try:
+            assert self._live()._dashboard_cmdline_for_pid(process.pid) == expected
+        finally:
+            process.terminate()
+            process.wait(timeout=5)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX structured cmdline capture")
+    def test_does_not_reconstruct_argv_from_ps_output(self):
         live = self._live()
-
-        def fake_run(args, *a, **kw):
-            assert args == ["ps", "-p", "888", "-o", "command="]
-            return MagicMock(returncode=0, stdout="hermes serve --port 8300\n", stderr="")
-
         with patch.object(live.os.path, "exists", return_value=False), \
-             patch("subprocess.run", side_effect=fake_run):
+             patch.object(psutil, "Process", side_effect=psutil.AccessDenied(888)), \
+             patch.object(live, "_run_probe") as probe:
             argv = main_dashboard._dashboard_cmdline_for_pid(888)
 
-        assert argv == ["hermes", "serve", "--port", "8300"]
+        assert argv is None
+        probe.assert_not_called()
 
     @pytest.mark.windows_only
     def test_returns_none_on_windows(self):


### PR DESCRIPTION
## Summary
- capture dashboard and serve argv only from lossless `/proc/<pid>/cmdline` records or structured `psutil.Process(pid).cmdline()` data
- fail safely to the existing manual-restart hint when exact argv is unavailable instead of reconstructing ambiguous `ps` display text
- add macOS regression coverage for executable-path spaces, argument spaces, quotes, backslashes, option-like values, and unavailable structured argv

## Root cause and reproduction
macOS `ps -o command=` flattens a process command and does not preserve argv element boundaries. The previous `shlex.split()` fallback changed `/Users/RBIAP115/My Apps/...` into executable `/Users/RBIAP115/My` plus extra elements, so the real respawn path raised `[Errno 2] No such file or directory: '/Users/RBIAP115/My'`.

On clean revision `67764dc0863349a384c16425e73ee8571f3a94b7` with only the regression tests applied, the focused test command failed as expected: 2 failed, 44 deselected. The live six-element argv became 18 elements, and the fail-safe test showed the ambiguous `ps` probe was called.

## Design
The existing Linux `/proc/<pid>/cmdline` path remains first. The fallback uses psutil structured argv. If structured capture fails, the existing cleanup path reports the process as unrecovered and provides the manual-restart hint. Restart passes a list directly to `subprocess.Popen` without a shell. Windows behavior is unchanged.

## Validation
- `HERMES_PYTHON='/Users/RBIAP115/My Apps/hermes-agent/.venv/bin/python' scripts/run_tests.sh tests/hermes_cli/test_update_stale_dashboard.py` — 43 passed, 3 skipped
- `'/Users/RBIAP115/My Apps/hermes-agent/.venv/bin/python' -m ruff check hermes_cli/main_dashboard.py tests/hermes_cli/test_update_stale_dashboard.py` — passed
- `'/Users/RBIAP115/My Apps/hermes-agent/.venv/bin/python' scripts/check-windows-footguns.py --all` — passed across 1512 files
- `git diff origin/main...HEAD --check` — passed

Linux-only and Windows-only runtime arms were skipped on macOS and remain for their CI lanes; the Linux lossless path and Windows early return are unchanged.
