### PR TITLE
fix(desktop): persist active-profile.json on explicit-local rail switches

### DIFF
--- a/apps/desktop/src/store/profile-select-source.test.ts
+++ b/apps/desktop/src/store/profile-select-source.test.ts
@@ -201,6 +201,24 @@ describe('selectProfile startup preference (#79886)', () => {
     await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('tilly'))
   })
 
+  it('remembers a local rail switch when the explicit local source is live (#107528)', async () => {
+    activeGatewayConnectionId.mockReturnValue('local')
+
+    selectProfile('searxng')
+
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('searxng'))
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('searxng'))
+  })
+
+  it('remembers Default on the explicit local source after successful activation (#107528)', async () => {
+    activeGatewayConnectionId.mockReturnValue('local')
+
+    selectProfile('default')
+
+    await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('local', 'default'))
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('default'))
+  })
+
   it('does not replace the local startup preference for a profile SSH override', async () => {
     activeGatewayConnectionId.mockReturnValue(null)
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -817,9 +817,10 @@ export function selectProfile(name: string): void {
   // profile.set() and reload the window. Once activation succeeds, remember
   // the selection for the next Desktop launch through the persistence-only
   // IPC instead (#79886). Registry-source picks name ANOTHER source's
-  // profiles, so only a primary-backend activation updates the startup
-  // preference.
-  const onPrimary = activeGatewayConnectionId() == null
+  // profiles, so only a primary-backend or explicit-local activation updates
+  // the startup preference (#107528).
+  const connectionId = activeGatewayConnectionId()
+  const onPrimary = connectionId == null || connectionId === LOCAL_CONNECTION_ID
 
   const shouldRememberStartupProfile = onPrimary ? isLocalDesktopProfile(target) : Promise.resolve(false)
 


### PR DESCRIPTION
## What does this PR do?

Desktop rail switches persist the next-launch pointer through `hermes:profile:remember` → `active-profile.json`. That path only ran when `activeGatewayConnectionId()` was `null`. After the explicit `local` source started reporting `LOCAL_CONNECTION_ID` (`'local'`), `selectProfile` treated every local rail click as a non-primary pick and skipped `remember`. The file stayed frozen; the next launch re-rooted the primary backend on the stale profile (`hermes --profile <old>`).

This keeps the existing remember IPC and `isLocalDesktopProfile` gate. The only change is treating `null` **or** `'local'` as a local startup source, still waiting for `activateOnCurrentSource` to succeed before writing.

## Related Issue

Fixes #107528

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `apps/desktop/src/store/profile.ts`: `onPrimary` is true when the live connection id is `null` or `LOCAL_CONNECTION_ID`.
- `apps/desktop/src/store/profile-select-source.test.ts`: named local pick (`searxng`) and Default-on-local both must call `profile.remember` after activation.

## How to Test

```
cd apps/desktop
npx vitest run --project ui src/store/profile-select-source.test.ts
```

Proof Receipt (pre-fix base `8defaaad48`):

- BEFORE: 2 failed / 13 passed. `remember` call count was 0 for `selectProfile('searxng')` and `selectProfile('default')` while `activeGatewayConnectionId() === 'local'`.
- AFTER: 15 passed (1 file)
- CONTROL: registry-source picks still do not remember; SSH/remote/cloud overrides still do not replace the local startup pointer; activation still precedes persist

## Related work (not duplicates)

- No open competing PR for #107528 at push time.
- Complements #79886 (persistence-only `remember` IPC) rather than replacing it. Does not call `profile.set()` (window reload / primary teardown).
- Does not change gateway pool, message routing, `state.db`, or first-boot `migrateActiveProfileIfMissing`. Mid-session "typed into the displayed profile but wrote another DB" remains a residual risk if a later send path ignores the live gateway.

## Review follow-up

- Independent P0 review skipped (1 module, 25 lines, not auth/crypto/state.db/gateway, self-review P0=0).
- Self-review P0: 0.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run relevant tests locally (desktop vitest ui project; this change is TS, not `pytest tests/`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (vitest/jsdom)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — persist path is Electron IPC, not OS-specific
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Made with [Cursor](https://cursor.com)