### PR TITLE
fix(opencode-go): send reasoning controls for the canonical deepseek-flash id

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -25,9 +25,15 @@ def _flat_model_name(model: str | None) -> str:
     return (model or "").strip().rsplit("/", 1)[-1].lower()
 
 
+# Version-less DeepSeek ids that still carry the thinking/effort knobs on this wire: the retired
+# ``deepseek-reasoner`` alias and the canonical ``deepseek-flash`` (2026-09 Flash refresh), for
+# which the Go relay honours the same top-level ``reasoning_effort``/``thinking`` contract.
+_THINKING_CAPABLE_IDS: frozenset[str] = frozenset({"deepseek-reasoner", "deepseek-flash"})
+
+
 def _is_deepseek_thinking_model(model: str | None) -> bool:
     m = _flat_model_name(model)
-    return (m.startswith("deepseek-v") and not m.startswith("deepseek-v3")) or m == "deepseek-reasoner"
+    return (m.startswith("deepseek-v") and not m.startswith("deepseek-v3")) or m in _THINKING_CAPABLE_IDS
 
 
 def _is_glm_5_2_model(model: str | None) -> bool:

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -182,6 +182,36 @@ class TestOpenCodeGoDeepSeekThinking:
             assert extra_body == {}
             assert top_level == {"reasoning_effort": "max"}
 
+    @pytest.mark.parametrize("model", ["deepseek-flash", "deepseek/deepseek-flash"])
+    def test_version_less_canonical_id_gets_the_controls(self, opencode_go_profile, model):
+        """The canonical version-less Flash id must reach the wire like the versioned ids:
+        the asked effort, and an explicit thinking-off when reasoning is disabled."""
+        _, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model=model,
+        )
+        assert top_level == {"reasoning_effort": "high"}
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model=model,
+        )
+        assert extra_body == {"thinking": {"type": "disabled"}}
+        assert top_level == {}
+
+    def test_version_less_flash_effort_reaches_the_wire(self, opencode_go_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="deepseek-flash",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=opencode_go_profile,
+            reasoning_config={"enabled": True, "effort": "max"},
+            base_url="https://opencode.ai/zen/go/v1",
+        )
+        assert "extra_body" not in kwargs
+        assert kwargs["reasoning_effort"] == "max"
+
 
 class TestOpenCodeGoGLM52Reasoning:
     """GLM-5.2 uses its native high/max reasoning_effort knob on OpenCode Go."""


### PR DESCRIPTION
## Problem

`OpenCodeGoProfile._is_deepseek_thinking_model()` recognises `deepseek-v*` (except v3) and
`deepseek-reasoner` only. The vendor's canonical, version-less Flash id `deepseek-flash`
(2026-09 Flash refresh; listed in the Go `/models` catalog) is therefore not recognised at all, so
neither `thinking` nor `reasoning_effort` is ever emitted: `agent.reasoning_effort` and every
`auxiliary.<task>.reasoning_effort` are silently dropped on the OpenCode Go relay. The direct
DeepSeek provider got the matching recognition today (`_THINKING_CAPABLE_IDS`, commits 8435a3ae00 /
aeecb110f8); the relay route needs the same treatment.

## Evidence from the exact route (OpenCode Go relay, `deepseek-flash`)

Multi-step arithmetic prompt, `usage.completion_tokens_details.reasoning_tokens`:

- `reasoning_effort: "low"` → ≈906
- `reasoning_effort: "high"` → ≈1371
- `reasoning_effort: "max"` → ≥2500 (capped by `max_tokens`)
- no reasoning field at all → ≈20 on a trivial prompt (thinking ON by relay default)

The knob is real and graded on this route. Integer efforts (25/50/75/100) are rejected by the relay
(`server_error` for ints, `invalid_request_error` for digit strings) — named levels are the correct
contract. `thinking: {"type": "disabled"}` is accepted and matters: with thinking on, a 64-token
title prompt returns empty content (`finish_reason: length`); with it disabled the same prompt
returns a clean JSON title in 9 tokens.

## Change

Mirror the direct-provider shape — a version-less `_THINKING_CAPABLE_IDS` set on the OpenCode Go
profile — so `deepseek-flash` receives the same clamped effort / explicit thinking-off as
`deepseek-v4-flash`. No other model id changes behaviour; the existing gating tests
(`test_non_target_models_emit_nothing`, etc.) are unchanged.

## Tests

- `tests/plugins/model_providers/test_opencode_go_profile.py`: 2 new tests (profile extras for the
  version-less id, including `deepseek/deepseek-flash`; and the transport-level kwargs carrying
  `reasoning_effort: "max"`).
- `scripts/run_tests.sh tests/plugins/model_providers` → all green (30 tests in the profile file).