### PR TITLE
fix(aux): deliver task reasoning_effort to provider profiles that translate reasoning

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5986,6 +5986,31 @@ def _project_provider_profile(
     return _ProfileProjection(body, reasoning_extra, top_level, handles_reasoning)
 
 
+def _resolve_aux_reasoning_config(
+    task: Optional[str], reasoning_config: Optional[dict], extra_body: Optional[dict],
+) -> Optional[dict]:
+    """Hand the task-level effort to provider profiles that translate reasoning.
+
+    ``auxiliary.<task>.reasoning_effort`` is folded into the generic OpenRouter-shaped
+    ``extra_body["reasoning"]`` (``_get_task_extra_body``), but a provider profile only ever sees the
+    ``reasoning_config`` argument — so wires that translate reasoning (DeepSeek ``thinking`` /
+    ``reasoning_effort``, zai, kimi) never received the task's effort, and a model matched by such a
+    profile defaulted from ``None`` to thinking *enabled*. The folded value is added, never removed:
+    the generic field stays for wires that consume it, so nothing else changes. A task whose own
+    ``extra_body`` block carries a provider-shaped ``reasoning`` payload is passed through verbatim.
+    """
+    if reasoning_config is not None or not isinstance(extra_body, dict):
+        return reasoning_config
+    folded = extra_body.get("reasoning")
+    if not isinstance(folded, dict):
+        return reasoning_config
+    task_config = _get_auxiliary_task_config(task) if task else {}
+    raw_extra_body = task_config.get("extra_body") if isinstance(task_config, dict) else None
+    if isinstance(raw_extra_body, dict) and "reasoning" in raw_extra_body:
+        return reasoning_config
+    return folded
+
+
 def _merge_aux_extra_body(
     extra_body: Optional[dict], projection: _ProfileProjection, reasoning_config: Optional[dict], provider_norm: str,
 ) -> Dict[str, Any]:
@@ -6649,7 +6674,7 @@ _PreparedAuxRequest = NamedTuple("_PreparedAuxRequest", [
     ("resolved_provider", str), ("request_provider", str), ("resolved_model", Optional[str]),
     ("resolved_base_url", Optional[str]), ("resolved_api_key", Optional[str]),
     ("resolved_api_mode", Optional[str]), ("effective_timeout", float),
-    ("effective_extra_body", Dict[str, Any]), ("base_info", str)])
+    ("effective_extra_body", Dict[str, Any]), ("base_info", str), ("reasoning_config", Optional[dict])])
 
 
 def _prepare_aux_request(
@@ -6697,6 +6722,8 @@ def _prepare_aux_request(
                          f" at {base_info}" if base_info and "openrouter" not in base_info else "")
     # Client's actual base_url so endpoint-specific temperature overrides work on
     # auto-detected routes (api.moonshot.ai vs api.kimi.com/coding).
+    # The task's folded reasoning must reach profiles that translate it (see the helper).
+    reasoning_config = _resolve_aux_reasoning_config(task, reasoning_config, effective_extra_body)
     kwargs = _build_call_kwargs(
         request_provider, final_model, messages, temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
@@ -6710,7 +6737,7 @@ def _prepare_aux_request(
     return _PreparedAuxRequest(
         client, final_model, kwargs, resolved_provider, request_provider, resolved_model,
         resolved_base_url, resolved_api_key, resolved_api_mode, effective_timeout,
-        effective_extra_body, base_info)
+        effective_extra_body, base_info, reasoning_config)
 
 
 class _LadderStep(NamedTuple):
@@ -7162,7 +7189,7 @@ def _plan_aux_call(
     candidate_kwargs = dict(
         task=task, messages=messages, temperature=temperature, max_tokens=max_tokens,
         tools=tools, effective_timeout=req.effective_timeout,
-        effective_extra_body=req.effective_extra_body, reasoning_config=reasoning_config,
+        effective_extra_body=req.effective_extra_body, reasoning_config=req.reasoning_config,
     )
     retry_kwargs = dict(
         candidate_kwargs, resolved_base_url=req.resolved_base_url,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -106,6 +106,62 @@ class TestAuxiliaryMaxTokensParam:
 
 
 
+class TestAuxiliaryTaskEffortWiring:
+    """Task-level ``reasoning_effort`` must reach wires that translate reasoning.
+
+    ``auxiliary.<task>.reasoning_effort`` is folded into the generic ``extra_body.reasoning`` while
+    provider profiles only see ``reasoning_config`` (DeepSeek ``thinking``/``reasoning_effort``, zai,
+    kimi) — the folded value must be promoted for those, and left untouched for passthrough wires.
+    """
+
+    def test_promoted_for_a_translating_wire(self):
+        from agent.auxiliary_client import _build_call_kwargs, _resolve_aux_reasoning_config
+
+        folded = {"reasoning": {"enabled": False}, "response_format": {"type": "json_object"}}
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"reasoning_effort": "none"},
+        ):
+            reasoning_config = _resolve_aux_reasoning_config("title_generation", None, folded)
+        assert reasoning_config == {"enabled": False}
+
+        kwargs = _build_call_kwargs(
+            "opencode-go", "deepseek-flash", [{"role": "user", "content": "x"}],
+            max_tokens=64, extra_body=folded, reasoning_config=reasoning_config,
+            task="title_generation",
+        )
+        assert kwargs["extra_body"]["thinking"] == {"type": "disabled"}
+        # the folded value is added to, never removed from, the caller's extra_body
+        assert kwargs["extra_body"]["reasoning"] == {"enabled": False}
+        assert kwargs["extra_body"]["response_format"] == {"type": "json_object"}
+
+    def test_wire_without_a_reasoning_profile_keeps_the_generic_field(self):
+        """A provider without a reasoning-aware profile keeps the generic passthrough verbatim."""
+        from agent.auxiliary_client import _build_call_kwargs, _resolve_aux_reasoning_config
+
+        folded = {"reasoning": {"enabled": True, "effort": "low"}}
+        reasoning_config = _resolve_aux_reasoning_config("compression", None, folded)
+        assert reasoning_config == {"enabled": True, "effort": "low"}
+
+        kwargs = _build_call_kwargs(
+            "acme-openai-compat", "some-model", [{"role": "user", "content": "x"}],
+            extra_body=folded, reasoning_config=reasoning_config, task="compression",
+        )
+        assert kwargs["extra_body"]["reasoning"] == {"enabled": True, "effort": "low"}
+
+    def test_provider_shaped_task_extra_body_is_not_reshaped(self):
+        """A ``reasoning`` payload set by the task's own extra_body block is passed through verbatim."""
+        from agent.auxiliary_client import _resolve_aux_reasoning_config
+
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"extra_body": {"enable_thinking": False, "reasoning": {"effort": "none"}}},
+        ):
+            assert _resolve_aux_reasoning_config(
+                "session_search", None, {"enable_thinking": False, "reasoning": {"effort": "none"}}
+            ) is None
+
+
 class TestResolveTaskProviderModel:
     @pytest.mark.parametrize(
         "provider",


### PR DESCRIPTION
## Problem

`auxiliary.<task>.reasoning_effort` never reaches a provider profile, so wires that translate
reasoning never receive the task's effort:

- `_get_task_extra_body()` folds the task's effort into the generic OpenRouter-shaped
  `extra_body["reasoning"]`.
- Profiles consume reasoning through the `reasoning_config` argument of
  `build_api_kwargs_extras` (via `_project_provider_profile`), and that argument is `None` on every
  auxiliary call: `call_llm(...)` defaults `reasoning_config=None` and no aux consumer passes one.
- Consequence: DeepSeek (`thinking`/`reasoning_effort`), zai and Kimi aux calls ignore the
  configured effort. Worse, when the model *is* matched by such a profile, the profile defaults from
  `None` to `thinking: {"type": "enabled"}` — a task configured `none` gets thinking ON.

Reproduced on v0.21.1 (OpenCode Go relay + DeepSeek Flash; `auxiliary.title_generation` pinned with
`reasoning_effort: none`):

- wire today: `extra_body: {"reasoning": {"enabled": false}}` — the relay ignores that field, thinking
  stays on, and the 64-token title cap returns empty content (`finish_reason: length`).
- same configuration against a matched id (`deepseek-v4-flash`): the wire carries
  `thinking: {"type": "enabled"}` while the task asked for `none`.

## Change

`_resolve_aux_reasoning_config()` hands the folded value to the profile projection as
`reasoning_config`, so translating wires emit their native control (`thinking`,
`reasoning_effort`, …). It **adds, never removes**: the generic `extra_body.reasoning` field stays
exactly as it is today, so wires that consume it (OpenRouter-shaped endpoints, no-profile
providers) are byte-for-byte unchanged. A task whose own `extra_body` block already carries a
provider-shaped `reasoning` payload is passed through verbatim, untouched.

The resolved config also rides `_PreparedAuxRequest`, so same-provider retries and fallback
candidates rebuild the request consistently instead of silently dropping it.

Verified through the real `_plan_aux_call` path (no network):
`title_generation` (effort `none`, opencode-go/deepseek-flash) →
`extra_body: {"reasoning": {"enabled": false}, "response_format": …, "thinking": {"type":
"disabled"}}`; `compression` (effort `high`) → top-level `reasoning_effort: "high"` while keeping the
generic field.

## Tests

- `tests/agent/test_auxiliary_client.py::TestAuxiliaryTaskEffortWiring` — 3 invariants: the native
  control is emitted for a translating wire, the generic field survives without a reasoning profile,
  and a task-set provider-shaped `reasoning` payload is not re-shaped.
- Two existing contracts were exercised and kept intact while validating the design:
  `tests/agent/test_fast_compression_lane.py::test_certified_fast_lane_ignores_legacy_cap_and_preserves_reasoning`
  (certified non-reasoning marker must stay on the wire) and
  `TestAuxiliaryTaskExtraBody::test_sync_call_merges_task_extra_body_from_config` (verbatim
  task `extra_body` passthrough).
- `scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/agent/test_fast_compression_lane.py`
  → 221 passed, 0 failed.

## Notes

Provider-agnostic bug fix; pairs with the OpenCode Go `deepseek-flash` id recognition (separate PR),
which is what makes this observable on that route today.