### PR TITLE
fix(desktop): stage group-chat PDFs as workspace files

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-attachments.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-attachments.ts
@@ -27,8 +27,8 @@ function groupAttachmentKind(file: File): AttachmentKind {
 
 /** File objects → [{ name, data, kind }] (data URLs), oversized files skipped
  *  with a toast. Images are downscaled; PDFs and other files ride as raw data
- *  URLs for the gateway's pdf.attach / file.attach staging. Shared by the
- *  picker button, the composer paste handler, and room drag & drop. */
+ *  URLs for the gateway's file.attach staging. Shared by the picker button,
+ *  the composer paste handler, and room drag & drop. */
 export async function filesToGroupAttachments(files: File[] | FileList | null | undefined): Promise<Attachment[]> {
   const picked: Attachment[] = []
 

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
@@ -536,6 +536,36 @@ describe('attachments', () => {
     expect(staged?.data).toBe(pdf.data)
   })
 
+  it('stages group PDFs via file.attach and puts the workspace ref in the member prompt', async () => {
+    const room = await loadRoom()
+    const pdf: Attachment = { data: 'data:application/pdf;base64,JVBERi0=', kind: 'pdf', name: 'spec.pdf' }
+
+    room.rounds.sendToGroupChat('PdfFile', [{ name: 'research', title: '' }], 'read this', null, [pdf])
+    await settle(room, 'PdfFile')
+
+    expect(room.gateway.attaches.some(attach => attach.method === 'file.attach' && attach.filename === 'spec.pdf')).toBe(
+      true
+    )
+    expect(room.gateway.calls).toHaveLength(1)
+    expect(room.gateway.calls[0].prompt).toContain('Attached files staged in your session workspace:')
+    expect(room.gateway.calls[0].prompt).toContain('spec.pdf → @file:attachments/spec.pdf')
+  })
+
+  it('names a failed group PDF attach in the member prompt instead of pretending the file is there', async () => {
+    const room = await loadRoom({
+      failAttach: { 'file.attach': Object.assign(new Error('pdftoppm not installed'), { code: 5028 }) }
+    })
+    const pdf: Attachment = { data: 'data:application/pdf;base64,JVBERi0=', kind: 'pdf', name: 'notes.pdf' }
+
+    room.rounds.sendToGroupChat('PdfFail', [{ name: 'research', title: '' }], 'summarize this', null, [pdf])
+    await settle(room, 'PdfFail')
+
+    expect(room.gateway.calls).toHaveLength(1)
+    expect(room.gateway.calls[0].prompt).toContain('could not be staged into your session')
+    expect(room.gateway.calls[0].prompt).toContain('notes.pdf')
+    expect(room.gateway.calls[0].prompt).not.toContain('Attached files staged in your session workspace:')
+  })
+
   it('appends the file.attach ref_text to the member turn prompt', async () => {
     const room = await loadRoom()
     const doc: Attachment = { data: 'data:text/plain;base64,aGVsbG8=', kind: 'file', name: 'notes.txt' }

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
@@ -503,7 +503,7 @@ describe('attachments', () => {
     expect(room.gateway.calls).toHaveLength(2)
   })
 
-  it('routes PDFs through pdf.attach and files through file.attach, per member', async () => {
+  it('routes PDFs and files through file.attach, and images through image.attach_bytes, per member', async () => {
     const room = await loadRoom()
     const pdf: Attachment = { data: 'data:application/pdf;base64,JVBERi0=', kind: 'pdf', name: 'spec.pdf' }
     const doc: Attachment = { data: 'data:text/plain;base64,aGVsbG8=', kind: 'file', name: 'notes.txt' }
@@ -526,11 +526,14 @@ describe('attachments', () => {
       byMethod[attach.method] = (byMethod[attach.method] || 0) + 1
     }
 
-    // 3 attachments × 2 members, each via its own RPC.
+    // 3 attachments × 2 members. PDFs share file.attach with other files so
+    // the member workspace gets a readable copy (1:1 chat does the same).
     expect(room.gateway.attaches).toHaveLength(6)
-    expect(byMethod).toEqual({ 'file.attach': 2, 'image.attach_bytes': 2, 'pdf.attach': 2 })
+    expect(byMethod).toEqual({ 'file.attach': 4, 'image.attach_bytes': 2 })
 
-    const staged = room.gateway.attaches.find(attach => attach.method === 'pdf.attach')
+    const staged = room.gateway.attaches.find(
+      attach => attach.method === 'file.attach' && attach.filename === 'spec.pdf'
+    )
 
     expect(staged?.filename).toBe('spec.pdf')
     expect(staged?.data).toBe(pdf.data)
@@ -543,9 +546,9 @@ describe('attachments', () => {
     room.rounds.sendToGroupChat('PdfFile', [{ name: 'research', title: '' }], 'read this', null, [pdf])
     await settle(room, 'PdfFile')
 
-    expect(room.gateway.attaches.some(attach => attach.method === 'file.attach' && attach.filename === 'spec.pdf')).toBe(
-      true
-    )
+    expect(
+      room.gateway.attaches.some(attach => attach.method === 'file.attach' && attach.filename === 'spec.pdf')
+    ).toBe(true)
     expect(room.gateway.calls).toHaveLength(1)
     expect(room.gateway.calls[0].prompt).toContain('Attached files staged in your session workspace:')
     expect(room.gateway.calls[0].prompt).toContain('spec.pdf → @file:attachments/spec.pdf')

--- a/apps/desktop/src/plugins/hermes-bots/group-test-utils.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-test-utils.ts
@@ -90,6 +90,9 @@ export interface GatewayOptions {
    *  `profiles.configure`, then reject it as a CAS conflict — the race the
    *  sync worker's pull-merge-retry exists for. */
   conflictOnce?: { key: string; value: unknown }
+  /** Reject attach RPCs whose method is in this map — after recording the call
+   *  so tests can see the staging attempt even when it throws. */
+  failAttach?: Record<string, unknown>
   /** Reject every prompt.submit with this — a fatal, non-recoverable failure. */
   failEverySubmitWith?: unknown
   /** Reject only the FIRST prompt.submit — the 4001 reap the retry recovers. */
@@ -292,6 +295,10 @@ export function createGroupGateway(options: GatewayOptions = {}): ScriptedGatewa
         profile: session.profile,
         runtime: String(params.session_id ?? '')
       })
+
+      if (Object.hasOwn(options.failAttach ?? {}, method)) {
+        throw options.failAttach![method]
+      }
 
       return method === 'file.attach'
         ? { attached: true, ref_text: `@file:attachments/${String(params.name ?? 'attachment')}` }

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.ts
@@ -685,53 +685,68 @@ export async function runGroupChatMemberTurn(
   }
 }
 
+function groupTurnAttachmentSuffix(fileRefs: string[], failed: string[]) {
+  const extras: string[] = []
+
+  if (fileRefs.length) {
+    extras.push(`Attached files staged in your session workspace:\n${fileRefs.join('\n')}`)
+  }
+
+  if (failed.length) {
+    extras.push(
+      `These attachments could not be staged into your session (filename only; the file is not available to your tools):\n${failed.join('\n')}`
+    )
+  }
+
+  return extras.join('\n\n')
+}
+
 async function stageGroupTurnAttachments(member: GroupMember, runtime: string, images?: Attachment[]) {
   // Stage this delta's attachments into the member's session so the model
   // receives the actual payload with the prompt — the same attach RPCs the
   // 1:1 chat uses (they also work cross-connection, where the member's
-  // gateway can't see this machine's files). Images queue as vision tiles,
-  // PDFs render per-page via pdf.attach, and other files materialize in the
-  // session workspace (their @file: refs are appended to the prompt so the
-  // member's file tools can read them). A failed attach degrades that
-  // member to text-only; the transcript line still names the attachment so
-  // the member knows something was shared.
+  // gateway can't see this machine's files). Images queue as vision tiles.
+  // PDFs and other files materialize in the session workspace via file.attach
+  // so file tools can read them; pdf.attach only rasterizes pages and needs
+  // pdftoppm, so a swallowed miss left the member with a filename and no file.
   const fileRefs: string[] = []
+  const failed: string[] = []
 
   for (const img of Array.isArray(images) ? images : []) {
     if (!img || typeof img.data !== 'string' || !img.data) {
       continue
     }
 
+    const label =
+      img.name || (img.kind === 'pdf' ? 'attachment.pdf' : img.kind === 'file' ? 'attachment' : 'attachment.png')
+
     try {
-      if (img.kind === 'pdf') {
-        await requestForBot(member, 'pdf.attach', {
-          session_id: runtime,
-          content_base64: img.data,
-          filename: img.name || 'attachment.pdf'
-        })
-      } else if (img.kind === 'file') {
+      if (img.kind === 'pdf' || img.kind === 'file') {
         const res = (await requestForBot(member, 'file.attach', {
           session_id: runtime,
           data_url: img.data,
-          name: img.name || 'attachment'
+          name: label
         })) as { ref_text?: string }
 
         if (res?.ref_text) {
-          fileRefs.push(`${img.name || 'attachment'} → ${res.ref_text}`)
+          fileRefs.push(`${label} → ${res.ref_text}`)
+        } else {
+          failed.push(label)
         }
       } else {
         await requestForBot(member, 'image.attach_bytes', {
           session_id: runtime,
           content_base64: img.data,
-          filename: img.name || 'attachment.png'
+          filename: label
         })
       }
-    } catch {
-      /* text-only fallback for this member */
+    } catch (error) {
+      failed.push(label)
+      host.notifyError?.(error, `Could not attach ${label} for ${member.title || member.name}`)
     }
   }
 
-  return fileRefs
+  return { failed, fileRefs }
 }
 
 interface GroupTurnPollContext {
@@ -923,15 +938,14 @@ async function runGroupChatMemberTurnLeased(
 
     const { before, runtimeIds } = await prepareGroupTurnBaseline(member, runtime, stored)
 
-    const fileRefs = await stageGroupTurnAttachments(member, runtime, images)
+    const { failed, fileRefs } = await stageGroupTurnAttachments(member, runtime, images)
 
     if (!binding.isLive()) {
       return null
     }
 
-    const turnText = fileRefs.length
-      ? `${prompt}\n\nAttached files staged in your session workspace:\n${fileRefs.join('\n')}`
-      : prompt
+    const staged = groupTurnAttachmentSuffix(fileRefs, failed)
+    const turnText = staged ? `${prompt}\n\n${staged}` : prompt
 
     // #93602: one-shot recovery when the runtime session was reaped between
     // minting and submitting. Tracks the runtime id the submit landed on so


### PR DESCRIPTION
## Summary
- Direct chat already uploads a PDF into the bot's session workspace. Group chat instead called `pdf.attach`, which needs `pdftoppm` and swallowed errors, so members only saw `[attached PDF: name.pdf]` and then searched an empty workspace.
- Group turns now stage PDFs through `file.attach` like 1:1, append the `@file:` ref to that member's prompt, and name a failed attach instead of hiding it.

## Test plan
- [ ] From `apps/desktop`: `npx vitest run src/plugins/hermes-bots/group-rounds.test.ts src/plugins/hermes-bots/group-turns.test.ts`
- [ ] In a multi-bot group chat, attach a PDF and ask about it — bots should be able to read the file
- [ ] Same PDF in a 1:1 bot chat still works
- [ ] If attach fails, the bot's prompt says the file was not staged (no silent filename-only fallback)