### PR TITLE
fix(skill_ledger): stop snapshot_paths from sweeping transient dirs into the blob store

### DIFF
--- a/tests/tools/test_skill_ledger.py
+++ b/tests/tools/test_skill_ledger.py
@@ -8,7 +8,9 @@ The first four tests are adapted from PR #50261 by @yu-xin-c (autonomous
 skill history), reshaped for the all-actor JSONL ledger design.
 """
 
+import hashlib
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -249,6 +251,46 @@ def test_blob_dedupe_same_content_one_blob(ledger_env):
     assert len(hashes) == 1  # same content → same hash
     blobs = list(skill_ledger.blobs_dir().iterdir())
     assert len(blobs) == 1  # → one blob on disk
+
+
+def test_snapshot_paths_skips_transient_dirs(ledger_env):
+    """Transient local artifacts (venv, node_modules, caches, .git) never reach
+    the manifest or the blob store — sweeping them in grows the blob dir
+    unboundedly on real installs (#107539)."""
+    from tools import skill_ledger
+
+    d = ledger_env["skills"] / "has-venv"
+    d.mkdir()
+    for rel, body in (("SKILL.md", "# skill"), ("scripts/run.py", "print('hi')"),
+                      ("node_modules/pkg/index.js", "junk"), ("venv/bin/python", "junk"),
+                      ("__pycache__/run.cpython-311.pyc", "junk"), (".git/config", "junk")):
+        p = d / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8")
+
+    manifest = skill_ledger.snapshot_paths(d)
+    rel = {str(Path(i["path"]).relative_to(d)) for i in manifest}
+    assert rel == {"SKILL.md", os.path.join("scripts", "run.py")}
+
+    # None of the transient content was stored as a blob either.
+    junk_sha = hashlib.sha256(b"junk").hexdigest()
+    assert junk_sha not in {p.name for p in skill_ledger.blobs_dir().iterdir()}
+
+
+def test_snapshot_paths_keeps_file_named_like_transient_dir(ledger_env):
+    """The filter drops files *inside* transient dirs; a plain file whose own
+    name collides with one (e.g. a ``venv`` bootstrap script) is skill content."""
+    from tools import skill_ledger
+
+    d = ledger_env["skills"] / "edge"
+    d.mkdir()
+    (d / "SKILL.md").write_text("# skill", encoding="utf-8")
+    (d / "venv").write_text("#!/bin/sh\n", encoding="utf-8")  # a FILE, not a dir
+
+    manifest = skill_ledger.snapshot_paths(d)
+    rel = {str(Path(i["path"]).relative_to(d)) for i in manifest}
+    assert "venv" in rel
+    assert "SKILL.md" in rel
 
 
 def test_rollback_fails_closed_when_safety_capture_fails(ledger_env, monkeypatch):

--- a/tools/skill_ledger.py
+++ b/tools/skill_ledger.py
@@ -36,6 +36,16 @@ _ARCHIVE_TS_SUFFIX_RE = re.compile(r"^(.+)-\d{14}$")
 _PACKAGE_RESTORE_ACTIONS = frozenset({"delete", "archive", "purge"})
 _VALID_ACTORS = {"curator", "agent", "user"}
 _NON_PACKAGE_TOPS = {".curator_backups", ".hub", ".archive"}
+# Transient/regeneratable local artifacts that must never be swept into a
+# snapshot, no matter how deep they sit under the skill dir — a stray venv or
+# node_modules turns a multi-KB ledger capture into gigabytes of blobs (#107539).
+# Mirrors the tarball-side set proposed for agent.curator_backup (#100545).
+_SNAPSHOT_EXCLUDE_DIRS = {
+    ".venv", "venv", "env", ".env",
+    "node_modules", "__pycache__",
+    ".pytest_cache", ".mypy_cache", ".ruff_cache",
+    ".git",
+}
 
 # Explicit actor override: the CLI sets "user", the curator walk sets "curator".
 _actor_override: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
@@ -121,14 +131,18 @@ def read_blob(sha256: str) -> Optional[bytes]:
 
 def snapshot_paths(root: Optional[Path], *, complete_package: bool = False) -> List[Dict[str, str]]:
     """{path, sha256} for every file under *root*, each stored as a blob; [] when root is
-    None/missing. Raises on I/O failure — callers decide whether that is fatal (rollback safety
-    capture) or swallowed (telemetry). ``complete_package`` unions in the newest curator
-    tarball's files (disk hashes win)."""
+    None/missing. Transient local artifacts (venvs, node_modules, caches, .git) are
+    excluded wherever they appear under *root*. Raises on I/O failure — callers decide
+    whether that is fatal (rollback safety capture) or swallowed (telemetry).
+    ``complete_package`` unions in the newest curator tarball's files (disk hashes win)."""
     if root is None:
         return []
     root = Path(root)  # gone from disk -> []; the complete_package fill may still recover it
     files = ([root] if root.is_file()
-             else sorted(p for p in root.rglob("*") if p.is_file()) if root.is_dir() else [])
+             else sorted(p for p in root.rglob("*") if p.is_file()
+                         and not any(part in _SNAPSHOT_EXCLUDE_DIRS
+                                     for part in p.relative_to(root).parts[:-1]))
+             if root.is_dir() else [])
     out = [{"path": str(f), "sha256": _store_blob(f.read_bytes())} for f in files]
     return fill_snapshot_from_curator_backup(root, out) if complete_package else out
 


### PR DESCRIPTION
## What does this PR do?

`tools/skill_ledger.py::snapshot_paths()` hashed **every** file under a skill dir with no exclusion filter, so a stray `venv` / `node_modules` / `__pycache__` / `.git` inside a skill directory was copied content-addressed into `~/.hermes/.curator_backups/blobs/` on every mutation — and nothing ever prunes that store, so it grew without bound (the issue documents a real install where one burst created 47k blobs / 1.3 GB in a single day, 98.9% of them unreferenced by any ledger entry).

This adds capture-side filtering: a file is skipped when any component of its parent chain (relative to the snapshot root) matches `_SNAPSHOT_EXCLUDE_DIRS` — the same transient-dir set proposed for the curator tarball filter in #100545, so blobs and tarballs stay consistent once both land. A plain *file* whose own name collides with a transient dir (e.g. a `venv` bootstrap script) is still captured; only files inside those directories are dropped.

The blob-GC half suggested in the issue is intentionally left out: capture-side filtering stops the growth, and pruning already-written garbage is a separate (and riskier) change that deserves its own PR.

## Related Issue

Fixes #107539

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_ledger.py`: added module-level `_SNAPSHOT_EXCLUDE_DIRS` (mirrors the #100545 tarball-side set) and applied it inside `snapshot_paths()`'s directory walk; updated the docstring.
- `tests/tools/test_skill_ledger.py`: added `test_snapshot_paths_skips_transient_dirs` (transient trees never reach the manifest nor the blob store) and `test_snapshot_paths_keeps_file_named_like_transient_dir` (the filter drops files *inside* transient dirs, not files *named* like one).

## How to Test

1. Run the ledger suite: `pytest tests/tools/test_skill_ledger.py -q` — Observed result: **21 passed** (19 pre-existing + 2 new).
2. Wider dependency chain (ledger callers + curator backup): `pytest tests/tools/test_skill_ledger.py tests/tools/test_skill_manager_tool.py tests/tools/test_skill_usage.py tests/tools/test_skill_manage_batch.py tests/agent/test_curator_backup.py tests/agent/test_curator.py -q` — Observed result: **164 passed**.
3. `ruff check tools/skill_ledger.py tests/tools/test_skill_ledger.py` — All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#106679 touches `skill_ledger.py` but fixes duplicate before-paths in the backup fill; #97420 adds read-tolerance/logging; neither filters the walk)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python path filtering via `pathlib.parts`, platform-neutral)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
