### PR TITLE
Seeded sessions survive a gateway restart and store their seed once (tui_gateway)

### DIFF
--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -74,11 +74,13 @@ _PREVIEW_MERGED_PRIOR_UNWRAPPED_SQL = (f"CASE WHEN SUBSTR({_PREVIEW_MERGED_PRIOR
 _PREVIEW_FORCE_USER_REMAINDER_SQL = _sql_after_marker(_SUMMARY_END_MARKER)
 
 # Pure compaction rows are ineligible; force-user-leading and merged carriers only when authentic content survives.
-_PREVIEW_ELIGIBLE_SQL = (f"((NOT {_PREVIEW_STANDALONE_SUMMARY_SQL} AND NOT {_PREVIEW_MERGED_SUMMARY_SQL})"
+# A display_kind="hidden" row is model-facing scaffolding the gateway never paints; the preview must not paint it either.
+_PREVIEW_ELIGIBLE_SQL = (f"(COALESCE(m.display_kind, '') <> 'hidden'"
+    f" AND ((NOT {_PREVIEW_STANDALONE_SUMMARY_SQL} AND NOT {_PREVIEW_MERGED_SUMMARY_SQL})"
     f" OR ({_PREVIEW_STANDALONE_SUMMARY_SQL} AND INSTR(m.content, {_sql_literal(_SUMMARY_END_MARKER)}) > 0"
     f" AND LENGTH({_sql_trim_whitespace(_PREVIEW_FORCE_USER_REMAINDER_SQL)}) > 0)"
     f" OR ({_PREVIEW_MERGED_SUMMARY_SQL}"
-    f" AND LENGTH({_sql_trim_whitespace(_PREVIEW_MERGED_PRIOR_UNWRAPPED_SQL)}) > 0))")
+    f" AND LENGTH({_sql_trim_whitespace(_PREVIEW_MERGED_PRIOR_UNWRAPPED_SQL)}) > 0)))")
 
 # ``_preview_raw`` SELECT for every listing query (scaffolded rows: head + tail around SKILL_EXCERPT_JOINT).
 _PREVIEW_RAW_SELECT = (

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -20973,6 +20973,7 @@ def test_persist_branch_seed_keeps_reasoning_fields(monkeypatch, tmp_path):
         session_key="branch-key",
         parent_session_id="parent-key",
         history=_branch_history(),
+        seeded=True,  # stamped by session.create: this history exists only in memory
     )
     try:
         db.create_session("branch-key", source="tui")

--- a/tests/tui_gateway/test_seeded_session_create.py
+++ b/tests/tui_gateway/test_seeded_session_create.py
@@ -1,0 +1,80 @@
+"""session.create with seeded messages: the seed is durable before the first prompt, and durable once."""
+
+from hermes_state import SessionDB
+from tui_gateway import server
+
+
+def _quiet_create(monkeypatch, db):
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda _sid: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+
+
+def _create(params: dict) -> dict:
+    resp = server.handle_request({"id": "create", "method": "session.create", "params": params})
+    assert "result" in resp, resp
+    return resp["result"]
+
+
+def test_parentless_seed_survives_a_restart_and_hides_its_runbook(monkeypatch, tmp_path):
+    """A client that opens a chat with its first turns already written (no parent) gets a durable row and
+    transcript at create: a restart before the first prompt resumes it, the hidden runbook stays out of the
+    transcript on the wire, and the seed is not written a second time by the first-submit path."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _quiet_create(monkeypatch, db)
+    sids = []
+    try:
+        result = _create({
+            "cols": 96, "source": "desktop", "title": "Welcome to Hermes",
+            "messages": [
+                {"role": "user", "content": "Private setup runbook", "display_kind": "hidden"},
+                {"role": "assistant", "content": "Welcome to Hermes"},
+                # Only "hidden" is accepted from the wire; other kinds are stamped by the gateway itself.
+                {"role": "user", "content": "Second question", "display_kind": "steer"},
+            ]})
+        sids.append(result["session_id"])
+        key = result["stored_session_id"]
+        assert [m["role"] for m in result["messages"]] == ["assistant", "user"]
+
+        assert db.get_session(key)["title"] == "Welcome to Hermes"
+        rows = db.get_messages_as_conversation(key)
+        assert [r["content"] for r in rows] == ["Private setup runbook", "Welcome to Hermes", "Second question"]
+        assert rows[0]["display_kind"] == "hidden"
+        assert rows[2].get("display_kind") is None
+
+        server._sessions.pop(sids.pop())  # the gateway restarts; only state.db remains
+        resumed = server.handle_request({"id": "resume", "method": "session.resume", "params": {"session_id": key, "cols": 96}})
+        assert "result" in resumed, resumed
+        sids.append(resumed["result"]["session_id"])
+        assert [m["role"] for m in resumed["result"]["messages"]] == ["assistant", "user"]
+
+        server._persist_branch_seed(server._sessions[sids[-1]])  # what the first prompt.submit calls
+        assert len(db.get_messages_as_conversation(key)) == 3
+    finally:
+        for sid in sids:
+            server._sessions.pop(sid, None)
+        db.close()
+
+
+def test_branch_child_seed_is_written_once(monkeypatch, tmp_path):
+    """A seeded branch child persists its copied transcript at create (#93959); the first prompt's seed
+    persist is the fallback for a failed create-time copy, not a second copy."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _quiet_create(monkeypatch, db)
+    seed = [{"role": "user", "content": "hello from parent"}, {"role": "assistant", "content": "parent reply"}]
+    db.create_session("parent-1", source="desktop")
+    db.append_messages_batch("parent-1", seed)
+    db.set_session_title("parent-1", "Parent chat")
+    sid = None
+    try:
+        result = _create({"cols": 96, "source": "desktop", "parent_session_id": "parent-1", "messages": seed})
+        sid, key = result["session_id"], result["stored_session_id"]
+        assert [r["content"] for r in db.get_messages_as_conversation(key)] == ["hello from parent", "parent reply"]
+
+        server._persist_branch_seed(server._sessions[sid])
+        assert [r["content"] for r in db.get_messages_as_conversation(key)] == ["hello from parent", "parent reply"]
+    finally:
+        if sid:
+            server._sessions.pop(sid, None)
+        db.close()

--- a/tests/tui_gateway/test_seeded_session_create.py
+++ b/tests/tui_gateway/test_seeded_session_create.py
@@ -36,12 +36,15 @@ def test_parentless_seed_survives_a_restart_and_hides_its_runbook(monkeypatch, t
         sids.append(result["session_id"])
         key = result["stored_session_id"]
         assert [m["role"] for m in result["messages"]] == ["assistant", "user"]
+        assert result["message_count"] == 2  # counts what is on the wire, as session.resume does
 
         assert db.get_session(key)["title"] == "Welcome to Hermes"
         rows = db.get_messages_as_conversation(key)
         assert [r["content"] for r in rows] == ["Private setup runbook", "Welcome to Hermes", "Second question"]
         assert rows[0]["display_kind"] == "hidden"
         assert rows[2].get("display_kind") is None
+        listed = server.handle_request({"id": "list", "method": "session.list", "params": {}})["result"]["sessions"]
+        assert next(s for s in listed if s["id"] == key)["preview"].startswith("Second question")  # the hidden row is not the preview
 
         server._sessions.pop(sids.pop())  # the gateway restarts; only state.db remains
         resumed = server.handle_request({"id": "resume", "method": "session.resume", "params": {"session_id": key, "cols": 96}})

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -375,9 +375,9 @@ def _(rid, params: dict) -> dict:
     _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
     cwd = _sessions[sid]["cwd"]
     override = session_model_override or {}
+    messages = _history_to_messages(history)  # hidden seed rows are not on the wire; count what is (as resume does)
     return _ok(rid, {
-        "session_id": sid, "stored_session_id": key, "message_count": len(history),
-        "messages": _history_to_messages(history),
+        "session_id": sid, "stored_session_id": key, "message_count": len(messages), "messages": messages,
         # Reflect the override now so the client doesn't clobber its sticky pick.
         "info": {"model": override.get("model") if override else _resolve_model(),
                  **({"provider": override["provider"]} if override.get("provider") else {}),

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -558,10 +558,10 @@ def _resume_live_unpersisted(ctx: _Resume, live_sid: str, live: dict) -> dict:
                 _rebind_live_transport(live_sid, live, transport)
         else:
             _cancel_ws_orphan_reap(live_sid)
-    history = live.get("history") or []
+    messages = ctx.messages(live.get("history") or [])  # count the wire, as every other resume path does
     return _ok(ctx.rid, _attach_todo_state({
         "session_id": live_sid, "stored_session_id": str(live.get("session_key") or ""),
-        "message_count": len(history), "messages": ctx.messages(history),
+        "message_count": len(messages), "messages": messages,
         "info": {"model": _resolve_model(), "lazy": True, "profile_name": profile_name_for_home(live.get("profile_home")) or _response_profile_name(ctx.profile)}}, live))
 
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -270,9 +270,29 @@ def _seed_branch_row(record: dict, key: str, parent_session_id: str, history: li
                             source=source, cwd=record["cwd"],
                             profile_name=profile_name_for_home(profile_home) or _current_profile_name(), compensate=True)
             record["pending_title"] = None
+            # The first submit's _persist_branch_seed is the fallback for a failed seed, not a second copy.
+            record["_branch_seed_persisted"] = True
     except Exception:
         logger.warning("seeded-branch persistence failed for %s; falling back to lazy row creation", key,
                        exc_info=True)
+
+
+def _seed_row(record: dict) -> None:
+    """Persist a parentless seeded session NOW, for the reason ``_seed_branch_row`` gives: seeded content is
+    intent, not an abandoned draft, and the renderer's post-create hydration reads the DB. The client's title
+    lands with the row so a restart before the first prompt keeps it. Best-effort — the first-prompt path is
+    the fallback."""
+    try:
+        if _ensure_session_db_row(record) is False:
+            return
+        _persist_branch_seed(record)
+        if title := record.get("pending_title"):
+            with _session_db(record) as db:
+                if db is not None and db.set_session_title(record["session_key"], title):
+                    record["pending_title"] = None
+    except Exception:
+        logger.warning("seeded-session persistence failed for %s; falling back to lazy row creation",
+                       record.get("session_key"), exc_info=True)
 
 
 def _create_overrides(params: dict) -> tuple:
@@ -317,6 +337,7 @@ def _(rid, params: dict) -> dict:
             "cols": int(params.get("cols", 80)), "created_at": now, "edit_snapshots": {},
             "explicit_cwd": explicit_cwd,
             "history": history, "history_lock": threading.Lock(), "history_version": 0, "image_counter": 0,
+            "seeded": bool(history),  # gates _persist_branch_seed: only create-time history is unpersisted
             "cwd": _completion_cwd(params), "inflight_turn": None, "last_active": now,
             "model_override": session_model_override,
             "create_reasoning_override": create_reasoning_override,
@@ -329,7 +350,7 @@ def _(rid, params: dict) -> dict:
             "slash_worker": None, "tool_progress_mode": _load_tool_progress_mode(), "tool_started_at": {},
             "transport": current_transport() or _stdio_transport}
         _register_session_cwd(_sessions[sid])
-    # No DB row here (drafts left "Untitled" litter): created on the first prompt — except seeded branch children.
+    # No DB row here (drafts left "Untitled" litter): created on the first prompt — except seeded sessions.
     # NOTE: we intentionally do NOT persist a DB row here. Every TUI/desktop launch (and every "New agent" /
     # draft) opens a session here just to paint the composer, so eagerly creating a row left an "Untitled"
     # empty session behind for every launch the user never typed into. The row is now created lazily on the
@@ -342,8 +363,13 @@ def _(rid, params: dict) -> dict:
     # optimistic row vanishes on restart. Persisting up front also means a restart keeps the branch (both
     # reports lost it) and the title lands in the parent's lineage instead of falling back to a
     # message-preview name. Title mirrors the TUI /branch naming.
+    # The same holds for a seeded session WITHOUT a parent (a client opening a chat with its first turns
+    # already written): the transcript exists only in memory, so a restart before the first prompt lost it
+    # and the post-create resume 404'd. Persist it up front too; only empty drafts stay lazy.
     if parent_session_id and history:
         _seed_branch_row(_sessions[sid], key, parent_session_id, history, source, profile_home)
+    elif history:
+        _seed_row(_sessions[sid])
     # Return immediately so Ink can paint; the AIAgent builds right after the flush.
     _schedule_agent_build(sid)
     _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap

--- a/tui_gateway/session_history.py
+++ b/tui_gateway/session_history.py
@@ -250,7 +250,13 @@ def _coerce_seed_history(value: Any) -> list[dict]:
             continue
         content = item.get("text") if item.get("content") is None else item.get("content")
         if isinstance(content, str) and content.strip():
-            history.append({"role": item["role"], "content": content})
+            row = {"role": item["role"], "content": content}
+            # "hidden" is the one display_kind a seeding client may author: model-facing scaffolding the
+            # renderer must not paint (a guided-chat runbook). Every other kind is stamped by the gateway
+            # at turn time, so it is not accepted from the wire.
+            if item.get("display_kind") == "hidden":
+                row["display_kind"] = "hidden"
+            history.append(row)
     return history
 
 

--- a/tui_gateway/session_workdir.py
+++ b/tui_gateway/session_workdir.py
@@ -305,11 +305,13 @@ _WORKDIR_SEED_FIELDS = (
 
 
 def _persist_branch_seed(session: dict) -> None:
-    """First-turn persist of a branch's copied transcript. A branch is a draft until its first submit: the parent's
-    messages live only in ``session["history"]`` (ridden into the agent as ``conversation_history``, which
-    ``_flush_messages_to_session_db`` skips by identity), so the row would otherwise resume missing its pre-branch
-    context. Runs once, after ``_ensure_session_db_row`` wrote the row + parent link."""
-    if not (key := session.get("session_key")) or not session.get("parent_session_id") or session.get("_branch_seed_persisted"):
+    """Persist a seeded transcript once its row exists. Seeded messages (a branch's copied parent, a client's
+    opening turns) live only in ``session["history"]`` (ridden into the agent as ``conversation_history``, which
+    ``_flush_messages_to_session_db`` skips by identity), so the row would otherwise resume without them. Runs
+    once: at create for a seeded session, else at the first submit after ``_ensure_session_db_row`` wrote the
+    row. ``seeded`` is stamped by session.create; a resumed session carries its stored transcript in
+    ``history`` and must never re-append it."""
+    if not (key := session.get("session_key")) or not session.get("seeded") or session.get("_branch_seed_persisted"):
         return
     with session["history_lock"]:
         seed = [dict(msg) for msg in (session.get("history") or [])]


### PR DESCRIPTION
A chat that a client opens with its first messages already written now survives a gateway restart, keeps a hidden opening message out of the visible transcript, and stores those opening messages exactly once.

**Terms used below.** The *gateway* is `tui_gateway`, the JSON-RPC server behind the terminal UI (the TUI) and the Desktop app; both spawn it as `python -m tui_gateway.entry`. `HERMES_HOME` is the directory that holds a Hermes install's state; `state.db` inside it is the sqlite store with one *session row* per chat and one *message row* per turn; a named profile has its own `state.db` (its *profile store*). A *seeded session* is a `session.create` call that carries `messages`, so the chat starts with content in it; those messages are the *seed*. A *branch child* is a seeded session that also names a `parent_session_id`. Desktop's "branch from here" has two paths: a live chat branches through `session.branch`; a stored chat that is not open live branches through `session.create` with the copied messages and `parent_session_id`. `display_kind` is a per-message tag that tells a renderer how to paint a row; `"hidden"` means "the model sees this message, the person does not". The *wire transcript* is the `messages` array a gateway result carries.

## The problem

Three defects sat in the same code path. All three were reproduced live on upstream `main` against the real gateway process in a throwaway `HERMES_HOME`; the evidence is in the capture and the matrix below.

1. **A seeded session without a parent was never written to `state.db`.** The gateway kept the seed in memory and created the session row on the first prompt, as it does for empty drafts. A restart before that prompt lost the chat: `session.resume` answered `4007 session not found`. Even after a first prompt the seed never landed, because the first-prompt copy only ran for sessions with a parent; the row was then titled with the prompt text and the client's title was lost.
2. **A seeded message tagged `display_kind: "hidden"` rendered as a user bubble.** The seed coercion copied only `role` and `content`. Messages read back from `state.db` keep their tag; the create path was the one place that dropped it.
3. **A branch child's seed was written twice.** PR #93959 made a branch child persist its copied transcript at create, so the renderer's immediate re-fetch would not 404. The first `prompt.submit` then ran the first-prompt seed copy again, because nothing recorded that the copy had already happened. After the first message the branch showed the parent's messages two times.

```mermaid
flowchart LR
  subgraph B[Before]
    a1[session.create with opening messages] --> b1[seed kept in memory only]
    b1 --> c1[gateway restarts]
    c1 --> d1[session.resume: 4007 session not found]
  end
  subgraph A[After]
    a2[session.create with opening messages] --> b2[session row, message rows and title written to state.db]
    b2 --> c2[gateway restarts]
    c2 --> d2[session.resume returns the chat]
  end
```

<!-- before-and-after:start -->
| Before (Live probe on the real gateway: seeded create, restart, first prompt) | After (Live probe on the real gateway: seeded create, restart, first prompt) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/05a5c976-59d1-42ea-adf3-a31b186e5cb7) | ![After](https://github.com/user-attachments/assets/ff0c6a91-d90d-4440-b1e5-e55fc61a0469) |

<!-- before-and-after:end -->

## What changes

One rule replaces the special case: **seeded content is intent, not a draft.** An untyped "New chat" still creates no session row until the first prompt, so the sidebar does not fill with "Untitled" entries.

- `tui_gateway/session_history.py`, `_coerce_seed_history`: a seeded message keeps `display_kind` when it equals `"hidden"`. Only that value. Every other kind (`steer`, `skill_invocation`, timeline markers) is set by the gateway itself when a turn runs, so a client cannot supply it.
- `tui_gateway/methods_session.py`, `session.create`: stamps `seeded` on the in-memory session record when the create carried messages. A seeded create without a parent calls the new `_seed_row`, which writes the session row through the existing `_ensure_session_db_row` (the same profile, visibility and working-directory rules a first prompt applies), the message rows through the existing `_persist_branch_seed`, then the client's `title`. Best effort, like the branch path: a failure logs a warning and the first prompt stays the fallback. The #93959 comment stays; the new case is documented beside it. The result's `message_count` now counts the wire transcript, the rule `session.resume` already applies. On `main` the count was the raw seed length while the array was already filtered, so the two disagreed for any suppressed row (a `[System: …]` marker today, a hidden message with this PR).
- `tui_gateway/methods_session.py`, `_seed_branch_row`: sets the in-memory flag `_branch_seed_persisted` after a successful copy, so the first prompt's copy is a fallback and not a second copy.
- `tui_gateway/methods_session.py`, `_resume_live_unpersisted` (a resume of a live session that has no row yet): reports `message_count` as the wire transcript length, the same rule as the other resume paths and now `session.create`.
- `tui_gateway/session_workdir.py`, `_persist_branch_seed`: gates on the create-time `seeded` stamp instead of `parent_session_id`. A resumed session loads its history from `state.db` and never carries the stamp, so it can never re-append its own transcript.
- `hermes_state_common.py`, the preview predicate shared by every session listing: skips `display_kind = 'hidden'` messages. Found by the live matrix: once a hidden opening message is durable, `session.list` picked it as the session's preview text. The predicate already had the same gap for `[System: …]` marker rows on `main`; this PR closes it for the tag it makes durable and leaves the marker case alone.

```mermaid
flowchart TD
  create[session.create] --> coerce["_coerce_seed_history<br/>keeps display_kind only when it is the value hidden"]
  coerce --> q{opening messages?}
  q -- none --> lazy[no session row yet: created on the first prompt]
  q -- with parent_session_id --> branch["_seed_branch_row (existing path)<br/>session row + copied messages + lineage title<br/>now also marks the seed as persisted"]
  q -- without a parent --> seed["_seed_row (new)<br/>_ensure_session_db_row, then _persist_branch_seed, then the title"]
```

```mermaid
sequenceDiagram
  participant C as client
  participant G as gateway
  participant DB as state.db
  C->>G: session.create(messages, title)
  G->>DB: session row (INSERT OR IGNORE)
  G->>DB: message rows, display_kind kept for "hidden"
  G->>DB: title
  Note over G: seeded = true, _branch_seed_persisted = true
  G-->>C: result (the hidden message is filtered from the wire transcript)
  C->>G: prompt.submit
  G->>DB: session row (no-op, it exists)
  Note over G: _persist_branch_seed: already persisted, skip
  G->>DB: the prompt row
```

No migration: no schema change, no config key, no new RPC. Existing rows and existing clients are unaffected.

## What the user experiences after merge

| Surface | Before | After |
|---|---|---|
| Desktop, "branch from here" on a stored chat that is not open live | After the first message the transcript shows the parent's messages twice | Once |
| Desktop, "branch from here" on a live chat, and TUI `/branch` (both `session.branch`) | Unaffected | Unchanged |
| Any client that opens a fresh chat with its first turns written. No client in this repository does that today; the guided first-run chat in a later PR is the first | Lost on restart before the first prompt; the seed never stored; a `"hidden"` message shown as a user bubble | Stored at create with its title; the hidden message stays out of the wire transcript and out of the list preview; the model still sees it |
| An untyped "New chat" | No session row | No session row (unchanged) |

Behaviour to notice, beyond the fixes:

- A seeded create now writes to `state.db`, so it waits for a held write lock like any other write. In the matrix cell that held the lock for 8 s from another process, the create returned after 8.1 s with the row written; on `main` it returned in 0.06 s because it wrote nothing.
- A client's `title` on a seeded create lands at create instead of at the first prompt (see the decision below).
- `session.create` reports `message_count` = number of messages on the wire; on `main` it was the raw seed length. They only differ when the seed carries a message the wire suppresses.
- The preview predicate is shared by every session listing (`hermes_state_sessions.py`, `hermes_state_telegram.py`), so the preview of an existing session whose first user row is already tagged `hidden` (a handoff or retry scaffold written by the composer) changes from that scaffold text to the next visible user row, or to an empty preview when there is none. The title is unaffected.

## What this PR does not do

- No renderer change. No client in this repository sends a hidden opening message today.
- No `display_kind` other than `"hidden"` is accepted from a client.
- `_persist_branch_seed` keeps its name although it now serves every seeded create. Twelve existing tests patch that name; a rename would change no behaviour.
- The REST route `GET /api/sessions/<id>/messages` returns a hidden message tagged, not filtered, as it does for hidden messages written by the composer today. Unchanged.

## One decision for reviewers

The client's `title` is written at create for a parentless seed (the four `title` lines at the end of `_seed_row`). Before, a title waited for the first prompt (`prompt_turn.py`, "Apply pending_title now that the DB row exists"). Writing it early means a restart before the first prompt keeps the name the client gave instead of a preview-derived title. If you would rather keep the title on the first-prompt path, the revert is those four lines.

## How to test

```bash
scripts/run_tests.sh tests/tui_gateway/test_seeded_session_create.py   # 2 tests, both fail on main
scripts/run_tests.sh tests/test_tui_gateway_server.py -k seed            # 5 tests
```

Live, against the real gateway process. No provider is needed; `session.create` and `session.resume` never call a model.

```bash
export HERMES_HOME=$(mktemp -d)/home; mkdir -p "$HERMES_HOME"
printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"session.create","params":{"cols":96,"source":"desktop","title":"Welcome","messages":[{"role":"user","content":"runbook","display_kind":"hidden"},{"role":"assistant","content":"hello"}]}}' \
  | python -m tui_gateway.entry 2>/dev/null | grep -o '"stored_session_id": *"[^"]*"\|"message_count": *[0-9]*'
# main: "message_count": 2 (the runbook is on the wire as a user turn). This branch: "message_count": 1.
printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"session.resume","params":{"session_id":"<stored_session_id>","cols":96}}' \
  | python -m tui_gateway.entry 2>/dev/null | grep -o '"message_count": *[0-9]*\|"error": *{[^}]*}'
# main: {"code": 4007, "message": "session not found"}. This branch: "message_count": 1.
```

Suites run locally on the final tree: `tests/tui_gateway/` and `tests/test_tui_gateway_server.py` together (1739 passed, 1 failed: `test_model_options_preserves_canonical_custom_row_after_agent_init` also fails on `main` on this machine, where ambient provider credentials exist), the state-layer and preview files (`tests/test_hermes_state.py`, `tests/hermes_state/`, `tests/test_session_skill_previews.py` and four related files: 655 passed, 1 failed: `test_unreadable_schema_without_cli_names_the_sqlite3_requirement`, which also fails on `main` here), and every other file that imports the changed modules (88 passed).

## Live verification

Seventeen cells, each driven by its own script against the real gateway process (`python -m tui_gateway.entry`, or a real uvicorn server for the WebSocket cell), each in a fresh `HERMES_HOME`, run once on `main` (8defaaad48) and once on this branch. "Restart" means the process was stopped and a new one started on the same `HERMES_HOME`. Every cell matched its expectation on both trees; the one cell that raised a concern (the list preview) led to the second commit, and its driver was re-run on the final tree. Observed at d85ca53c7c unless noted; the preview and count rows were re-observed at d7a0d081e4; every driver was then re-run on the final tree 44bfe705e3 (results below the table).

| Cell | `main` | This branch |
|---|---|---|
| Hidden runbook + greeting + title, restart, resume, first prompt | Both messages on the wire; no session row; resume `4007`; after a first prompt only the prompt row exists and the title is the prompt text | Greeting only on the wire; row titled "Welcome to Hermes"; resume ok; after the first prompt the runbook is stored once, tagged hidden |
| Same under `profile: hermes-setup` | Nothing stored in either store | Row and messages in the profile's `state.db` only; resume with the profile ok; without it `4007` (the row lives in the profile store) |
| Same with `hidden: true` | Nothing stored | Row born `hidden=1`; absent from the default list; resume ok; list preview empty (re-observed at d7a0d081e4) |
| Same with no `title` | `4007` | Row with a null title; resume ok; first prompt assigns the title |
| `display_kind` values: `hidden`, `steer`, `skill_invocation`, `async_delegation_complete`, `Hidden`, `hidden ` (trailing space), `123`, untagged | All eight painted as plain rows; nothing stored | Only the exact `hidden` row tagged and filtered; the other seven stored untagged and painted |
| Junk seed: number, string, `role: tool`, blank content, empty content, `text` instead of `content` | Two rows on the wire, nothing stored | The same two rows stored and painted; an all-junk seed leaves no row and resumes `4007` on both trees |
| Empty draft: no `messages`, `messages: []`, `messages: []` with a title | No row, `4007` | Identical |
| 1200-row seed | Create 0.07 s; nothing stored; `4007` | Create 0.18 s; 1200 rows in order, none missing or doubled; resume ok with 1200 |
| Branch child, then first prompt | Seed stored twice (four seed rows, then the prompt) | Once |
| Branch child, restart, then first prompt | Once | Once |
| Branch child whose parent row does not exist | Foreign-key error at create, lazy fallback, `4007` | Byte-identical after normalising ids |
| Read-only `HERMES_HOME` | With `chmod` alone: Hermes repairs the permissions at start (`preflight_db_writability`, `secure_parent_dir`), so the home is writable again; same as the first row. With the directory made immutable (`chflags uchg`): create ok, nothing stored, restart resume `5000 state.db unavailable: not writable` | `chmod` round: row and messages stored, resume ok. Immutable round: create ok (best effort), nothing stored, restart resume `5000` with the same wording as `main`; no crash, no hang |
| Another process holds `BEGIN IMMEDIATE` for 8 s | Create returns in 0.06 s (writes nothing) | Create returns after 8.1 s with the row and seed written; no failure, no hang |
| WebSocket gateway (`/api/ws`), then REST | `GET /api/sessions/<id>` and `/messages` both `404`; the list is empty | Both `200`; the list shows the row; the messages route returns the runbook tagged hidden |
| Two gateways, 20 concurrent seeded creates on one `HERMES_HOME` | 20 ok, nothing stored | 20 rows, 40 message rows, every title intact, no lock errors |
| `session.close` before any prompt, restart | Not listed, `4007` | Listed, resume ok |
| `close_on_disconnect: true`, then EOF | `4007` | Resume ok |

Re-run on the final tree (44bfe705e3): all seventeen drivers completed, no new error frames. Compared leaf by leaf with the first run, the only changes are the ones the second commit made: `session.create` now reports `message_count` as the wire count (2 → 1 where the seed carries a hidden message, 8 → 7 in the whitelist cell), and the list preview of a session whose only user row is hidden is empty instead of the runbook text. Timestamps, ids and paths differ; nothing else does.


Paths a completeness pass named and this PR does not change, listed so a reviewer can weigh them: the compute-host bridge builds its session records through `_init_session`, which sets neither `seeded` nor `parent_session_id`, so the seed copy is a no-op there on both trees; `_resume_deferred` reports the stored row's `message_count`, which counts hidden rows the same way it counts the composer's hidden rows today; a `/rewind` or compaction on a seeded session before its first prompt was not driven.

## Review

- Greptile CLI: five runs (`greptile review -b main --agent`, with and without `--json`, from the worktree and from a plain clone) all ended in "The review failed unexpectedly" (correlation ids 0499ab5b, bb022f9b, 1acc9364, 4f66b3c4, c5e80d20). The Greptile GitHub app is not installed on this repository (no Greptile review on the last six merged PRs).
- Independent review instead: a stock `codex review --base main` and a read-only `codex exec` pass with targeted questions. Findings (a hidden row still matched message search; a partial seed copy could be duplicated by the first-prompt retry; the reuse-live resume counted the raw history) ship as the follow-up PR linked in the comments. Every other check (callers relying on the old parent gate, resumed sessions re-appending, other listings, clients depending on the old count, empty drafts, test quality) found nothing.
- A zero-context readability pass on this description produced eleven edits (terms defined up front, PR #93959 explained, the recipe's comments now match what the commands print); all folded in.




