### PR TITLE
fix(cron): count in-flight cron executions in the SSH-isolated backend idle-exit probe

### DIFF
--- a/hermes_cli/web_server_idle_exit.py
+++ b/hermes_cli/web_server_idle_exit.py
@@ -103,7 +103,13 @@ def turn_in_flight() -> Optional[bool]:
     try:
         import tui_gateway.server as gateway
         with gateway._sessions_lock:
-            return any(s.get("running") for s in gateway._sessions.values())
+            if any(s.get("running") for s in gateway._sessions.values()):
+                return True
+        # Cron runs in the scheduler's pool rather than registering a GUI session.  The
+        # dashboard backend can therefore be otherwise idle while a cron execution is
+        # still using this interpreter; include that shared activity source here.
+        from cron.scheduler import get_running_job_ids
+        return bool(get_running_job_ids())
     except Exception:
         if not _probe_failure_logged:
             _probe_failure_logged = True

--- a/tests/cron/test_cron_idle_exit_liveness.py
+++ b/tests/cron/test_cron_idle_exit_liveness.py
@@ -1,0 +1,21 @@
+"""Cron activity must keep an SSH-isolated dashboard backend alive (#107485)."""
+
+import types
+
+from hermes_cli import web_server_idle_exit as idle_exit
+
+
+def test_turn_probe_counts_in_process_cron_execution(monkeypatch):
+    gateway = types.SimpleNamespace(_sessions_lock=__import__("threading").Lock(), _sessions={})
+    monkeypatch.setitem(__import__("sys").modules, "tui_gateway.server", gateway)
+    monkeypatch.setattr("cron.scheduler.get_running_job_ids", lambda: frozenset({"daily"}))
+
+    assert idle_exit.turn_in_flight() is True
+
+
+def test_turn_probe_allows_exit_only_when_cron_and_chat_are_idle(monkeypatch):
+    gateway = types.SimpleNamespace(_sessions_lock=__import__("threading").Lock(), _sessions={})
+    monkeypatch.setitem(__import__("sys").modules, "tui_gateway.server", gateway)
+    monkeypatch.setattr("cron.scheduler.get_running_job_ids", lambda: frozenset())
+
+    assert idle_exit.turn_in_flight() is False


### PR DESCRIPTION
# fix(cron): count in-flight cron executions in the SSH-isolated backend's idle-exit probe

Fixes #107485.

## Summary

The idle-exit watchdog of an SSH-isolated dashboard backend could terminate the interpreter **while a cron agent execution was still running inside it**, because its liveness probe was structurally blind to cron work. This PR makes `turn_in_flight()` treat an in-flight cron execution as an active turn, so the backend that hosts the in-process cron scheduler cannot self-retire underneath a running job.

## Reproduction / premise verification

The issue's premise was verified against current `main` before any code was written, at the line level.

`hermes_cli/web_server_idle_exit.py` decides whether the backend may exit:

```python
def should_exit_idle(tracker, grace_s, probe=turn_in_flight) -> bool:
    """Exit only when no client has been connected for ``grace_s`` AND no turn is provably running.
    A probe that cannot answer keeps the process (fail closed)."""
    return tracker.idle_for() >= grace_s and probe() is False
```

The probe it defaults to (`turn_in_flight`, `hermes_cli/web_server_idle_exit.py:97`) read **only** the GUI/chat session table:

```python
import tui_gateway.server as gateway
with gateway._sessions_lock:
    return any(s.get("running") for s in gateway._sessions.values())
```

A regression test pinning the correct behavior was added first and proven **RED on the parent commit**:

```
$ git checkout HEAD~1 -- hermes_cli/web_server_idle_exit.py
$ scripts/run_tests.sh tests/cron/test_cron_idle_exit_liveness.py
FAILED tests/cron/test_cron_idle_exit_liveness.py::test_turn_probe_counts_in_process_cron_execution
========================= 1 failed, 1 passed in 1.20s =========================
```

## Root cause

1. `hermes_cli/web_server.py::_start_desktop_cron_ticker()` deliberately hosts the multiplex in-process cron scheduler inside the dashboard backend, because that primary backend outlives the per-profile pool. That same backend is subject to the idle-exit watchdog.
2. Cron executions do **not** run as GUI sessions. They are dispatched through the scheduler's own thread pool and tracked separately, in `cron/scheduler.py`:

```python
def get_running_job_ids() -> "frozenset[str]":
    with _running_lock:
        return frozenset(_running_job_ids | _running_fire_owners.keys())
```

   Nothing about a running cron job ever appears in `tui_gateway.server._sessions`.
3. Therefore the probe returned a hard **`False`** — "no turn running" — while a cron job was mid-flight. This is worse than the probe being unavailable: the watchdog is explicitly designed to fail *closed* on `None`, but a false negative sails straight through the `probe() is False` gate and the process exits.
4. Consequences observed in the issue follow directly: the executing turn's executor dies (`cannot schedule new futures after interpreter shutdown`), the execution is left without a durable terminal state (status `unknown`), and the restarted scheduler recomputes `next_run_at` past any instant that elapsed during the gap — silently consuming that slot.

### Same bug class, already fixed once on the sibling path

This is not a novel oversight; it is the **second** occurrence of one bug class. The gateway's shutdown drain had the identical blindness and was fixed by consuming the very same accessor. The docstring of `get_running_job_ids()` records it (#60432):

> Read by the gateway shutdown drain, otherwise blind to cron work (runs outside `_running_agents`) ... cron jobs run through their own thread pool here, entirely outside that dict, so without this the drain is structurally blind to them.

The idle-exit watchdog is the sibling call path that was missed at that time. Fixing it here closes the class: both places that may end this interpreter now consult both activity sources.

## The change

`hermes_cli/web_server_idle_exit.py`, +7/-1:

```python
    import tui_gateway.server as gateway
    with gateway._sessions_lock:
        if any(s.get("running") for s in gateway._sessions.values()):
            return True
    # Cron runs in the scheduler's pool rather than registering a GUI session.  The
    # dashboard backend can therefore be otherwise idle while a cron execution is
    # still using this interpreter; include that shared activity source here.
    from cron.scheduler import get_running_job_ids
    return bool(get_running_job_ids())
```

Notes on the shape of the fix:

- The chat-session check keeps its short-circuit; the cron check is only consulted when no chat turn is running, so the common path costs one lock acquisition on an already-hot in-process set.
- The `cron.scheduler` import stays **inside** the function. `web_server_idle_exit` is imported during dashboard startup and must not pull the scheduler module into that import graph at module scope.
- Both new statements remain inside the existing `try:` block, so an unavailable scheduler still yields `None` and the watchdog still fails closed — the documented invariant is preserved, not bypassed.
- No new configuration surface, no new `HERMES_*` env var, no new tool, no change to the scheduler itself.

## Scope

The issue offers three candidate remedies. This PR implements the first (make the probe count in-flight cron executions) and deliberately stops there:

- **Moving the scheduler out of the dashboard backend** would relocate a hosting decision that `web_server.py` documents as intentional, and would risk the failure mode its docstring already warns about.
- **Missed-window catch-up on restart** is a broader scheduler-semantics change (`tests/cron/test_misfire_catchup.py` shows that area has its own contracts) and is orthogonal to the race: with this fix, the idle-exit no longer *creates* the restart gap that consumes the slot. Independent crash recovery is left as separate work rather than smuggled in here.

## Files changed

| File | Change |
|---|---|
| `hermes_cli/web_server_idle_exit.py` | `turn_in_flight()` also reports in-flight cron executions (+7/-1) |
| `tests/cron/test_cron_idle_exit_liveness.py` | New: 2 invariant tests (+21) |

## Tests

Added `tests/cron/test_cron_idle_exit_liveness.py` with two behavior-contract tests (no snapshots, no change-detectors):

- `test_turn_probe_counts_in_process_cron_execution` — cron job running + no chat sessions ⇒ probe is `True` (backend must stay alive).
- `test_turn_probe_allows_exit_only_when_cron_and_chat_are_idle` — both idle ⇒ probe is `False` (the fix must not make the backend immortal).

Commands and real results, run via `scripts/run_tests.sh` (never bare pytest):

```
# targeted, on this branch
$ scripts/run_tests.sh tests/cron/test_cron_idle_exit_liveness.py
=== Summary: 1 files, 2 tests passed, 0 failed (100% complete) in 19.4s (24 workers) ===

# RED proof: same tests against the parent commit's production file
$ git checkout HEAD~1 -- hermes_cli/web_server_idle_exit.py
$ scripts/run_tests.sh tests/cron/test_cron_idle_exit_liveness.py
FAILED tests/cron/test_cron_idle_exit_liveness.py::test_turn_probe_counts_in_process_cron_execution
========================= 1 failed, 1 passed in 1.20s =========================

# the watchdog's own suite, on this branch
tests/hermes_cli/test_web_server_idle_exit.py — 3 passed
```

Regression check on the surrounding area, run on **both** this branch and its parent commit in separate worktrees with an identical command:

```
base (HEAD~1): === Summary: 101 files, 883 tests passed, 19 failed, 32 skipped in 1245.0s (24 workers) ===
this branch:   === Summary: 102 files, 877 tests passed, 16 failed, 32 skipped in 1244.6s (24 workers) ===
```

The failure sets overlap heavily and differ in **both** directions (6 base-only, 2 branch-only), i.e. they are nondeterministic rather than caused by the diff; three consecutive runs of the same command produced 19, 17 and 13 failures. Neither branch-only failure (`test_cron_workdir.py::TestTickWorkdirPartition::test_workdir_jobs_overlap_on_parallel_pool`, `test_script_claim_heartbeat.py::test_repeated_heartbeat_errors_cancel_after_bounded_grace`) touches idle-exit or the probe. The largest stable block (`tests/cron/test_file_permissions.py`, 6 tests asserting `0700`/`0600` modes) fails identically on both and is a POSIX-permissions suite on a Windows host.

## Limitations / honest gaps

- **Host:** all runs above are on Windows. The Linux CI lane is authoritative; two `linux_only` files were skipped locally on both branches.
- The pre-existing `tests/cron/` failures listed above are **not** addressed by this PR and are not claimed to pass.
- The fix removes the idle-exit-induced restart gap. It does not add generic missed-slot catch-up for restarts from unrelated causes (crash, OOM, deploy) — the issue's third suggested remedy remains open work.
- Not reproduced on a live SSH-isolated multiplex deployment; verification is the line-level trace plus the RED/GREEN regression test.

## Security / operational impact

- No new attack surface, no credential handling, no network or filesystem access added.
- Liveness only becomes **more** conservative: the set of states in which the backend agrees to exit strictly shrinks. The failure mode of a bug in this change would be a backend that lingers, not one that dies mid-job, and the pre-existing `None` fail-closed path is untouched.
- No telemetry, no config, no user-visible surface change.
