### PR TITLE
fix(plugins): validate requires_hermes from manifest module

### DIFF
--- a/hermes_cli/plugin_validate.py
+++ b/hermes_cli/plugin_validate.py
@@ -74,11 +74,11 @@ class ValidationReport:
 def _requires_hermes_spec_valid(spec: str) -> bool:
     """Strictly validate a ``requires_hermes`` spec.
 
-    Unlike :func:`hermes_cli.plugins._version_satisfies` (permissive at load
+    Unlike :func:`hermes_cli.plugins_manifest.version_satisfies` (permissive at load
     time), validation REJECTS clauses whose version segment doesn't parse —
     a typo'd spec should fail admission, not silently gate nothing.
     """
-    from hermes_cli.plugins import _VERSION_COMPARATOR_RE, _version_tuple
+    from hermes_cli.plugins_manifest import _VERSION_COMPARATOR_RE, _version_tuple
 
     for clause in spec.split(","):
         clause = clause.strip()

--- a/tests/hermes_cli/test_plugin_validate.py
+++ b/tests/hermes_cli/test_plugin_validate.py
@@ -33,6 +33,16 @@ BASE_MANIFEST = {
 }
 
 
+def test_requires_hermes_spec_is_validated(tmp_path):
+    manifest = dict(BASE_MANIFEST, requires_hermes=">=0.21")
+    d = _make_plugin(tmp_path, manifest=manifest)
+
+    report = validate_plugin_dir(d)
+
+    assert report.ok, report.failures
+    assert ("requires_hermes", True, "spec '>=0.21' parses") in report.checks
+
+
 class TestCapabilityProbe:
     def test_undeclared_tool_registration_fails_with_diff(self, tmp_path):
         init = (


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes plugins validate` for manifests that declare `requires_hermes`.

The version parsing helpers moved from `hermes_cli.plugins` to `hermes_cli.plugins_manifest`, but the validator still imported them from the old facade. Because that import is lazy, manifests without `requires_hermes` continued to validate while manifests such as `requires_hermes: ">=0.21"` raised `ImportError`.

The validator now imports the helpers from their defining module. A regression test exercises the complete `validate_plugin_dir()` path with `requires_hermes` declared.

## Related Issue

No issue filed; this is a small, isolated regression fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `hermes_cli/plugin_validate.py` to import `_VERSION_COMPARATOR_RE` and `_version_tuple` from `hermes_cli.plugins_manifest`.
- Add a validator regression test using `requires_hermes: ">=0.21"`.

## How to Test

1. Run `pytest tests/hermes_cli/test_plugin_validate.py -q`.
2. Confirm all 9 tests pass, including `test_requires_hermes_spec_is_validated`.
3. Before this fix, that regression test fails with `ImportError` from `hermes_cli.plugins`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2, Python 3.12.13

Full-suite note: `pytest tests/ -q -x` reached 730 passed and 12 skipped, then failed in `TestGetTextAuxiliaryClient.test_returns_none_when_nothing_available` because the local environment auto-detected the configured OpenRouter provider `test/model`. This failure is unrelated to the changed validator code. The focused validator suite passes: 9 passed.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A except the corrected function reference in the validator docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — import-only fix with no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
