### PR TITLE
feat(image-gen): transparent background support via the `background` param

### DIFF
--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -94,7 +94,9 @@ class OpenAIImageGenProvider(StaticImageGenProvider):
 
     def capabilities(self) -> Dict[str, Any]:
         # images.edit() accepts up to 16 source images.
-        return {"modalities": ["text", "image"], "max_reference_images": 16}
+        return {
+            "modalities": ["text", "image"], "max_reference_images": 16,
+            "supports_background": ["transparent", "opaque", "auto"]}
 
     def generate(
         self, prompt: str, aspect_ratio: str = DEFAULT_ASPECT_RATIO, *,
@@ -127,6 +129,12 @@ class OpenAIImageGenProvider(StaticImageGenProvider):
         # ``response_format`` as an unknown parameter. Don't send it.
         request: Dict[str, Any] = dict(
             model=meta["api_model"], prompt=prompt, size=size, n=1, quality=meta["quality"])
+        # Background control (transparency): the API only honours it for PNG output,
+        # so pin output_format=png whenever an explicit background is requested.
+        background = kwargs.get("background")
+        if isinstance(background, str) and background.strip():
+            request["background"] = background.strip().lower()
+            request["output_format"] = "png"
         if is_edit:
             try:
                 files = [_named_bytes_io(ref) for ref in sources]

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -257,3 +257,39 @@ class TestGenerate:
         assert "example.com" not in result["image"]
         mock_save_url.assert_called_once()
 
+
+# ── Background control (transparency) ──────────────────────────────────────
+
+
+class TestBackground:
+    """``background`` reaches the images API; PNG output is pinned alongside
+    it (the API only honours transparency for PNG). No request without it."""
+
+    def test_background_sent_with_pinned_png_output(self, provider):
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate("raven sticker", background="  TRANSPARENT ")
+
+        assert result["success"] is True
+        call_kwargs = fake_client.images.generate.call_args.kwargs
+        assert call_kwargs["background"] == "transparent"
+        assert call_kwargs["output_format"] == "png"
+
+    def test_no_background_neither_key_sent(self, provider):
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        call_kwargs = fake_client.images.generate.call_args.kwargs
+        assert "background" not in call_kwargs
+        assert "output_format" not in call_kwargs
+
+    def test_capabilities_declare_background_support(self, provider):
+        caps = provider.capabilities()
+        assert caps["supports_background"] == ["transparent", "opaque", "auto"]
+

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -720,3 +720,101 @@ class TestUpscaleDispatchForwarding:
 
         image_tool._dispatch_to_plugin_provider("a cat", "square")
         assert "upscale" not in fake_provider.generate.call_args.kwargs
+
+
+# ---------------------------------------------------------------------------
+# Transparent background control
+# ---------------------------------------------------------------------------
+
+class TestBackgroundTransparency:
+    """``background`` flows from handler args through every route, normalized.
+
+    Invariant: a model/provider that cannot honor the param never receives
+    it (FAL: per-model ``supports`` filter; schema: not advertised), and a
+    supported one gets the exact OpenAI-compatible enum value.
+    """
+
+    _SUPPORTED_MODEL = "fal-ai/gpt-image-1.5"  # catalog supports: background
+    _UNSUPPORTED_MODEL = "fal-ai/flux-2/klein/9b"
+
+    def _fal_tool(self, image_tool, monkeypatch, *, model, captured):
+        monkeypatch.setenv("FAL_IMAGE_MODEL", model)
+        monkeypatch.setattr(image_tool, "fal_key_is_configured", lambda: True)
+        monkeypatch.setattr(image_tool, "_resolve_managed_fal_gateway", lambda: None)
+
+        def _fake_submit(endpoint, arguments=None):
+            captured.update(endpoint=endpoint, arguments=dict(arguments or {}))
+            return _FakeHandle({"images": [{"url": "https://fal/out.png"}]})
+
+        monkeypatch.setattr(image_tool, "_submit_fal_request", _fake_submit)
+
+    def test_handler_sends_normalized_background_to_fal(self, image_tool, monkeypatch):
+        import json as _json
+        captured = {}
+        self._fal_tool(image_tool, monkeypatch, model=self._SUPPORTED_MODEL, captured=captured)
+        out = image_tool._handle_image_generate(
+            {"prompt": "raven sticker", "background": "  TRANSPARENT "})
+        assert _json.loads(out)["success"] is True
+        assert captured["arguments"]["background"] == "transparent"
+
+    def test_handler_drops_background_for_model_without_support(self, image_tool, monkeypatch):
+        import json as _json
+        captured = {}
+        self._fal_tool(image_tool, monkeypatch, model=self._UNSUPPORTED_MODEL, captured=captured)
+        out = image_tool._handle_image_generate(
+            {"prompt": "raven", "background": "transparent"})
+        assert _json.loads(out)["success"] is True
+        assert "background" not in captured["arguments"]
+
+    def test_dispatch_forwards_normalized_background_to_provider(self, image_tool, monkeypatch):
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: "krea")
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: None)
+        fake_provider = MagicMock()
+        fake_provider.generate.return_value = {"success": True, "image": "/tmp/x.png"}
+        monkeypatch.setattr(
+            "agent.image_gen_registry.get_provider", lambda name: fake_provider
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **k: None
+        )
+
+        image_tool._dispatch_to_plugin_provider("a cat", "square", background=" Opaque ")
+        kwargs = fake_provider.generate.call_args.kwargs
+        assert kwargs["background"] == "opaque"
+
+    def test_dispatch_omits_background_when_blank_or_absent(self, image_tool, monkeypatch):
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: "krea")
+        monkeypatch.setattr(image_tool, "_read_configured_image_model", lambda: None)
+        fake_provider = MagicMock()
+        fake_provider.generate.return_value = {"success": True, "image": "/tmp/x.png"}
+        monkeypatch.setattr(
+            "agent.image_gen_registry.get_provider", lambda name: fake_provider
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **k: None
+        )
+
+        image_tool._dispatch_to_plugin_provider("a cat", "square", background="   ")
+        image_tool._dispatch_to_plugin_provider("a cat", "square")
+        for call in fake_provider.generate.call_args_list:
+            assert "background" not in call.kwargs
+
+    def test_schema_advertises_background_only_when_declared(self, image_tool, monkeypatch):
+        monkeypatch.setattr(image_tool, "_read_configured_image_provider", lambda: None)
+
+        monkeypatch.setattr(
+            image_tool, "_resolve_fal_model",
+            lambda: (self._SUPPORTED_MODEL, image_tool.FAL_MODELS[self._SUPPORTED_MODEL]))
+        schema = image_tool._build_dynamic_image_schema()
+        bg = schema["parameters"]["properties"]["background"]
+        assert bg["enum"] == ["transparent", "opaque", "auto"]
+
+        monkeypatch.setattr(
+            image_tool, "_resolve_fal_model",
+            lambda: (self._UNSUPPORTED_MODEL, image_tool.FAL_MODELS[self._UNSUPPORTED_MODEL]))
+        schema = image_tool._build_dynamic_image_schema()
+        assert "background" not in schema["parameters"]["properties"]

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -415,7 +415,8 @@ def image_generate_tool(
     num_inference_steps: Optional[int] = None, guidance_scale: Optional[float] = None,
     num_images: Optional[int] = None, output_format: Optional[str] = None,
     seed: Optional[int] = None, image_url: Optional[str] = None,
-    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None) -> str:
+    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None,
+    background: Optional[str] = None) -> str:
     """Generate (or, with source images + an ``edit_endpoint`` model, edit) an image via FAL.
 
     Extra kwargs are overrides filtered per-model via ``supports`` / ``edit_supports`` (dropped
@@ -429,7 +430,7 @@ def image_generate_tool(
     modality = "image" if use_edit else "text"
     overrides: Dict[str, Any] = {
         "num_inference_steps": num_inference_steps, "guidance_scale": guidance_scale,
-        "num_images": num_images, "output_format": output_format}
+        "num_images": num_images, "output_format": output_format, "background": background}
     debug_call_data = {
         "model": model_id,
         "parameters": {"prompt": prompt, "aspect_ratio": aspect_ratio, **overrides, "seed": seed,
@@ -597,7 +598,8 @@ def _provider_result(result, contract_error: str) -> str:
     return json.dumps(result)
 
 
-def _add_provider_kwargs(kwargs, image_url, reference_image_urls, upscale, model=None) -> Dict[str, Any]:
+def _add_provider_kwargs(kwargs, image_url, reference_image_urls, upscale, model=None,
+                         background=None) -> Dict[str, Any]:
     """Add the optional ``provider.generate(**kwargs)`` args in place (edit args only when supplied)."""
     if model:
         kwargs["model"] = model
@@ -610,12 +612,15 @@ def _add_provider_kwargs(kwargs, image_url, reference_image_urls, upscale, model
             kwargs["reference_image_urls"] = norm_refs
     if upscale is not None:
         kwargs["upscale"] = bool(upscale)
+    if isinstance(background, str) and background.strip():
+        kwargs["background"] = background.strip().lower()
     return kwargs
 
 
 def _dispatch_to_plugin_provider(
     prompt: str, aspect_ratio: str, image_url: Optional[str] = None,
-    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None):
+    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None,
+    background: Optional[str] = None):
     """JSON result from the selected plugin provider, or ``None`` to fall through to in-tree FAL
     (provider unset / ``"fal"`` / ``"nous"``). Providers without ``upscale`` ignore it via ``**kwargs``."""
     configured = _plugin_provider_name()
@@ -641,7 +646,7 @@ def _dispatch_to_plugin_provider(
     kwargs: Dict[str, Any] = {"prompt": prompt, "aspect_ratio": aspect_ratio}
     try:
         _add_provider_kwargs(kwargs, image_url, reference_image_urls, upscale,
-                             model=_read_configured_image_model())
+                             model=_read_configured_image_model(), background=background)
         result = provider.generate(**kwargs)
     except Exception as exc:
         # A TypeError from generate() predating image_url support (third-party plugin not yet
@@ -674,7 +679,8 @@ def _normalize_krea_model(model_id: Optional[str]) -> Optional[str]:
 
 def _maybe_route_managed_krea(
     prompt: str, aspect_ratio: str, image_url: Optional[str] = None,
-    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None) -> Optional[str]:
+    reference_image_urls: Optional[list] = None, upscale: Optional[bool] = None,
+    background: Optional[str] = None) -> Optional[str]:
     """JSON result from the managed Krea gateway, or ``None`` to fall through.
 
     Fires only for a native ``krea-2-*`` model with no ``image_gen.provider`` other than
@@ -698,7 +704,7 @@ def _maybe_route_managed_krea(
         return None
     kwargs: Dict[str, Any] = {"prompt": prompt, "aspect_ratio": aspect_ratio, "model": normalized}
     try:
-        _add_provider_kwargs(kwargs, image_url, reference_image_urls, upscale)
+        _add_provider_kwargs(kwargs, image_url, reference_image_urls, upscale, background=background)
         result = provider.generate(**kwargs)
     except Exception as exc:  # noqa: BLE001
         logger.warning("Managed Krea routing failed: %s", exc)
@@ -737,6 +743,11 @@ def _handle_image_generate(args, **kw):
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
     upscale = args.get("upscale")
+    background = args.get("background")
+    if isinstance(background, str) and background.strip():
+        background = background.strip().lower()
+    else:
+        background = None
     task_id = kw.get("task_id")
     # Confinement chokepoint BEFORE any dispatch: every route receives sandbox-confined bytes.
     image_url, reference_image_urls, confine_error = _confine_source_images(
@@ -746,7 +757,8 @@ def _handle_image_generate(args, **kw):
     # Order matters: explicit plugin provider (incl. "krea"), then model-driven managed Krea
     # interception (only when no provider is set, so BYO/direct FAL stays untouched), then FAL.
     sources = dict(image_url=image_url, reference_image_urls=reference_image_urls,
-                   upscale=upscale if isinstance(upscale, bool) else None)
+                   upscale=upscale if isinstance(upscale, bool) else None,
+                   background=background)
     raw = None
     for route in (_dispatch_to_plugin_provider, _maybe_route_managed_krea, image_generate_tool):
         raw = route(prompt, aspect_ratio, **sources)
@@ -785,6 +797,9 @@ def _active_image_capabilities() -> Dict[str, Any]:
                     info["max_reference_images"] = int(caps["max_reference_images"])
                 # Plugins opt in explicitly; absent = no upscale param.
                 info["supports_upscale"] = bool(caps.get("supports_upscale"))
+                # Plugins declare accepted background values (e.g. transparent); absent = no param.
+                if caps.get("supports_background"):
+                    info["supports_background"] = list(caps["supports_background"])
                 return info
         except Exception:  # noqa: BLE001
             pass
@@ -797,6 +812,11 @@ def _active_image_capabilities() -> Dict[str, Any]:
     info["max_reference_images"] = int(meta.get("max_reference_images") or 1) if can_edit else 0
     # Clarity is available on request for ANY catalog model (``upscale`` is only the default).
     info["supports_upscale"] = True
+    # Catalog models whose FAL schema has a ``background`` param (gpt-image-1.5,
+    # gpt-image-2.5) take the OpenAI-compatible transparency enum; the payload
+    # builder per-model-filters it, so unsupported models just drop it.
+    if "background" in meta.get("supports", set()):
+        info["supports_background"] = list(_BACKGROUND_VALUES)
     return info
 
 
@@ -819,6 +839,16 @@ _UPSCALE_PARAM = {
         "than fidelity."
     ),
 }
+
+# Accepted ``background`` values for backends with transparency control (the
+# OpenAI-compatible enum, also used by FAL's gpt-image endpoints).
+_BACKGROUND_VALUES = ("transparent", "opaque", "auto")
+
+_BACKGROUND_PARAM_DESCRIPTION = (
+    "Background control for the generated image. 'transparent' returns "
+    "an RGBA PNG with an alpha channel (ideal for stickers/logos); "
+    "'opaque' forces a solid background; 'auto' lets the model decide."
+)
 
 
 def _build_dynamic_image_schema() -> Dict[str, Any]:
@@ -854,6 +884,12 @@ def _build_dynamic_image_schema() -> Dict[str, Any]:
         edit_clause = " (text-to-image only — the active model cannot edit existing images)"
     if info.get("supports_upscale"):
         properties["upscale"] = _UPSCALE_PARAM
+    if info.get("supports_background"):
+        properties["background"] = {
+            "type": "string",
+            "enum": list(info["supports_background"]),
+            "description": _BACKGROUND_PARAM_DESCRIPTION,
+        }
     return {"description": base_desc.format(edit_clause=edit_clause),
             "parameters": {"type": "object", "properties": properties, "required": ["prompt"]}}
 

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -308,6 +308,22 @@ When the FAL image pass runs, it uses these settings:
 
 If upscaling fails (network issue, rate limit), the original image is returned automatically. The response reports `upscaled: true/false` so the agent knows which resolution it got.
 
+## Transparent backgrounds
+
+### The `background` parameter (per-call opt-in)
+
+Backends with transparency control accept a `background` parameter:
+
+- `background: transparent` — RGBA PNG with a fully transparent background (ideal for stickers, logos, and overlays). The API only honours transparency for PNG output, so PNG is pinned alongside the parameter.
+- `background: opaque` — forces a solid background.
+- `background: auto` (default) — the model decides.
+
+The parameter is advertised only when the active backend declares support: the
+OpenAI plugin (`gpt-image-2` / `gpt-image-2.5`) always exposes it, and on FAL
+the schema gate follows each catalog model's declared `background` support
+(`gpt-image-1.5`, `gpt-image-2.5`). Models without it silently ignore the
+parameter, like every other per-model override.
+
 ## How It Works Internally
 
 1. **Model resolution** — `_resolve_fal_model()` reads `image_gen.model` from `config.yaml`, falls back to the `FAL_IMAGE_MODEL` env var, then to `fal-ai/flux-2/klein/9b`.


### PR DESCRIPTION
## What

Adds transparency control to image generation: a `background` parameter (`transparent` | `opaque` | `auto`) that reaches both the OpenAI images API and the in-tree FAL path, with the tool schema advertising it only when the active backend supports it.

## The gap

`background` was unreachable end-to-end:

- **OpenAI plugin** — `images.generate`/`images.edit` natively accept `background` (transparency requires PNG output), but `generate()` never sent it and `capabilities()` never declared it, so the dynamic schema never advertised the param.
- **FAL path** — the catalog already declared `background` in the `supports` whitelists of `fal-ai/gpt-image-1.5` and the `openai/gpt-image-2.5/*` variants, and `_build_payload()` already filters overrides against those whitelists — but no caller could supply the key: `_handle_image_generate` never read the arg, and neither route signature accepted it.

## Changes

`tools/image_generation_tool.py`
- `_handle_image_generate` reads + normalizes `background` once (strip/lower, blank → `None`) and threads it through the shared `sources` dict to **every** route: `_dispatch_to_plugin_provider`, `_maybe_route_managed_krea` (must accept the splat or the route loop TypeErrors), and `image_generate_tool`.
- FAL path: `background` joins the overrides, so the existing per-model `supports`/`edit_supports` filter decides — unsupported models silently drop it, exactly like every other override.
- `_active_image_capabilities()` picks up `supports_background` from plugin `capabilities()` **and** from the FAL catalog (`"background" in meta["supports"]`); `_build_dynamic_image_schema()` advertises `background` with the declared enum only then (fail-closed, same gating contract as `supports_upscale`).

`plugins/image_gen/openai/__init__.py`
- `generate()` sends `background` to the API and pins `output_format: "png"` alongside it (the API only honours transparency for PNG).
- `capabilities()` declares `supports_background: ["transparent", "opaque", "auto"]`.

Docs: new "Transparent backgrounds" section in the user-guide image-generation page, mirroring the `upscale` parameter write-up.

## Verification

- Invariant tests in `tests/tools/test_image_generation.py` (`TestBackgroundTransparency`) and `tests/plugins/image_gen/test_openai_provider.py` (`TestBackground`) — **proven red on base** (6 fail: handler swallowed the arg; schema never advertised it; plugin never sent it), green with the fix.
- `scripts/run_tests.sh` over all image-gen-adjacent files: 342 tests, 0 failures (16 files).
- E2E on the real chain: handler → route → FAL payload with `background: "TRANSPARENT "` → normalized `transparent` in the submitted arguments; unsupported model (`fal-ai/flux-2/klein/9b`) → key absent; OpenAI plugin request carries `background=transparent` + `output_format=png`, and neither key without it.
- `scripts/check_compat_pointers.py` clean; ruff clean.