### PR TITLE
fix(gateway): make failed-turn persistence exactly-once

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -9,6 +9,7 @@ import logging
 from typing import TYPE_CHECKING
 import asyncio
 import dataclasses
+import hashlib
 import inspect
 import json
 import os
@@ -1644,13 +1645,44 @@ class GatewayTurnMixin:
         return _user_entry
 
     @staticmethod
+    def _hmwa_persistence_owner(source, event):
+        """Derive one stable owner from the transport event instance and its retry-stable fields."""
+        import uuid
+
+        timestamp = getattr(event, "timestamp", None)
+        timestamp = timestamp.isoformat() if hasattr(timestamp, "isoformat") else str(timestamp or "")
+        metadata = getattr(event, "metadata", None) or {}
+        event_token = next(
+            (metadata[key] for key in ("event_id", "update_id", "receipt_key", "delivery_id")
+             if isinstance(metadata, dict) and metadata.get(key) is not None),
+            "",
+        )
+        raw_message = getattr(event, "raw_message", None)
+        raw_fingerprint = ""
+        if isinstance(raw_message, (dict, list)):
+            try:
+                raw_fingerprint = hashlib.sha256(
+                    json.dumps(raw_message, sort_keys=True, default=str, ensure_ascii=False).encode("utf-8")
+                ).hexdigest()
+            except (TypeError, ValueError, RecursionError):
+                raw_fingerprint = ""
+        namespace = [
+            getattr(getattr(source, "platform", None), "value", str(getattr(source, "platform", ""))),
+            getattr(source, "profile", None), getattr(source, "scope_id", None),
+            getattr(source, "chat_id", None), getattr(source, "thread_id", None),
+            str(getattr(event, "message_id", None) or ""),
+            str(getattr(event, "platform_update_id", None) or ""), timestamp,
+            str(event_token), raw_fingerprint,
+        ]
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, json.dumps(namespace, ensure_ascii=False)))
+
+    @staticmethod
     def _hmwa_failed_turn_boundary_entry(*, session_id, event, prepared, content, ts):
         """Build a stable, machine-owned boundary for one failed inbound event."""
-        import uuid
-        identity = prepared.persistence_owner or (
-            str(event.message_id) if getattr(event, "message_id", None) else None
+        identity = getattr(prepared, "persistence_owner", None) or GatewayTurnMixin._hmwa_persistence_owner(
+            getattr(event, "source", None), event
         )
-        boundary_key = f"gateway:{identity}" if identity else f"gateway:{session_id}:{uuid.uuid4()}"
+        boundary_key = f"gateway:{identity}"
         return {
             "role": "assistant",
             "content": content,
@@ -1962,11 +1994,7 @@ class GatewayTurnMixin:
         self._bind_adapter_run_generation(self._adapter_for_source(source), session_key, run_generation)
         # Delivery IDs are only unique in their transport namespace. Keyless turns
         # need their own identity, even when another process writes to this session.
-        import uuid
-        namespace = [source.platform.value, source.profile, source.scope_id,
-                     source.chat_id, source.thread_id, str(event.message_id)]
-        owner = (str(uuid.uuid5(uuid.NAMESPACE_URL, json.dumps(namespace)))
-                 if event.message_id else str(uuid.uuid4()))
+        owner = self._hmwa_persistence_owner(source, event)
         return self._PreparedTurn(
             history, context_prompt, message_text, persist_user_message, persist_user_timestamp,
             persist_user_display_kind, session_entry.session_id, owner,

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1643,6 +1643,25 @@ class GatewayTurnMixin:
             _user_entry["message_id"] = str(event.message_id)
         return _user_entry
 
+    @staticmethod
+    def _hmwa_failed_turn_boundary_entry(*, session_id, event, prepared, content, ts):
+        """Build a stable, machine-owned boundary for one failed inbound event."""
+        import uuid
+        identity = prepared.persistence_owner or (
+            str(event.message_id) if getattr(event, "message_id", None) else None
+        )
+        boundary_key = f"gateway:{identity}" if identity else f"gateway:{session_id}:{uuid.uuid4()}"
+        return {
+            "role": "assistant",
+            "content": content,
+            "timestamp": ts,
+            "display_kind": "gateway_failed_turn_boundary",
+            "display_metadata": {"gateway_failed_turn_boundary": boundary_key},
+            "_gateway_boundary_platform_message_id": (
+                str(event.message_id) if getattr(event, "message_id", None) else None
+            ),
+        }
+
     async def _hmwa_persist_turn_transcript(
         self, *, event, source, session_entry, session_key, agent_result, agent_messages,
         prepared, response, agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure,
@@ -1698,7 +1717,10 @@ class GatewayTurnMixin:
                 # provider details; this row is gateway-owned and was not written by the agent.
                 await store.append_to_transcript(
                     sid,
-                    {"role": "assistant", "content": failed_turn_notice, "timestamp": ts},
+                    self._hmwa_failed_turn_boundary_entry(
+                        session_id=sid, event=event, prepared=prepared,
+                        content=failed_turn_notice, ts=ts,
+                    ),
                 )
             else:
                 # Only the NEW messages: history_offset (what the agent saw), not len(history), which
@@ -1806,11 +1828,10 @@ class GatewayTurnMixin:
                     )
                 await self.async_session_store.append_to_transcript(
                     session_entry.session_id,
-                    {
-                        "role": "assistant",
-                        "content": self._PARTIAL_FAILED_TURN_NOTICE,
-                        "timestamp": time.time(),
-                    },
+                    self._hmwa_failed_turn_boundary_entry(
+                        session_id=session_entry.session_id, event=event, prepared=prepared,
+                        content=self._PARTIAL_FAILED_TURN_NOTICE, ts=time.time(),
+                    ),
                 )
         except Exception:
             logger.debug("Failed to persist inbound user message after agent exception", exc_info=True)

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1505,6 +1505,16 @@ class GatewayTurnMixin:
         "request entity too large", "prompt is too long",
         "payload too large", "input is too long",
     )
+    _FAILED_TURN_NOTICE = (
+        "Your request was not processed. Send it again if you still want me to carry it out."
+    )
+
+    def _hmwa_add_failed_turn_notice(self, response):
+        """Make failed-turn delivery explicit without replacing the provider-specific guidance."""
+        response = str(response or "").strip()
+        if self._FAILED_TURN_NOTICE in response:
+            return response
+        return f"{response}\n\n{self._FAILED_TURN_NOTICE}" if response else self._FAILED_TURN_NOTICE
 
     def _hmwa_classify_turn_failure(self, agent_result, history, session_entry):
         """Classify a finished turn for transcript persistence. Returns
@@ -1595,11 +1605,10 @@ class GatewayTurnMixin:
     @staticmethod
     def _hmwa_user_transcript_entry(event, prepared, ts):
         """Transcript row for the inbound user turn (clean text + event time when captured)."""
-        # Transient failure (429/timeout/5xx): persist only the user message so the next message can load a
-        # transcript that reflects what was said. Skip the assistant error text since it's a
-        # gateway-generated hint, not model output. Hidden- reasoning-only incomplete turns follow the same
-        # persistence rule so peer-agent channels don't ingest them as completed assistant turns. (#7100,
-        # #51628)
+        # Transient failure (429/timeout/5xx): persist the user message so the next message can load a
+        # transcript that reflects what was said. The caller pairs it with a stable assistant safety
+        # boundary rather than the provider error text. Hidden-reasoning-only incomplete turns follow the
+        # same persistence rule so peer-agent channels don't ingest provider details. (#7100, #51628)
         _user_entry = {
             "role": "user",
             "content": (
@@ -1620,8 +1629,8 @@ class GatewayTurnMixin:
         self, *, event, source, session_entry, session_key, agent_result, agent_messages,
         prepared, response, agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure,
     ):
-        """Persist this turn to the transcript (session_meta on first turn, user-only on transient
-        failure, nothing on context overflow), update last_prompt_tokens, and re-baseline the
+        """Persist this turn to the transcript (session_meta on first turn, closed failed turn on
+        transient failure, nothing on context overflow), update last_prompt_tokens, and re-baseline the
         cached agent's message count."""
         from gateway.run import _resolve_gateway_model
         ts = time.time()  # Unix epoch float — consistent with DB storage
@@ -1654,8 +1663,8 @@ class GatewayTurnMixin:
                     "timestamp": ts,
                 })
             if agent_failed_early or hidden_reasoning_incomplete:
-                # Transient failure / hidden-reasoning incomplete: persist only the user message (the
-                # assistant error text is a gateway hint, not model output). Dedupe on platform
+                # Transient failure / hidden-reasoning incomplete: persist the user message without
+                # the provider error text (a gateway hint, not model output). Dedupe on platform
                 # message_id (Telegram retries after transient failures).
                 if event.message_id and await store.has_platform_message_id(sid, str(event.message_id)):
                     logger.info(
@@ -1664,6 +1673,14 @@ class GatewayTurnMixin:
                     )
                 else:
                     await store.append_to_transcript(sid, _user_row, skip_db=agent_persisted)
+                # Close the failed turn with a durable assistant boundary. Leaving a user-only tail
+                # lets alternation repair merge this request into an unrelated future message and
+                # can replay stale side effects. Persist only the stable safety statement, not raw
+                # provider details; this row is gateway-owned and was not written by the agent.
+                await store.append_to_transcript(
+                    sid,
+                    {"role": "assistant", "content": self._FAILED_TURN_NOTICE, "timestamp": ts},
+                )
             else:
                 # Only the NEW messages: history_offset (what the agent saw), not len(history), which
                 # counts session_meta entries stripped before the agent saw them.
@@ -1768,6 +1785,14 @@ class GatewayTurnMixin:
                     await self.async_session_store.append_to_transcript(
                         session_entry.session_id, self._hmwa_user_transcript_entry(event, prepared, time.time()),
                     )
+                await self.async_session_store.append_to_transcript(
+                    session_entry.session_id,
+                    {
+                        "role": "assistant",
+                        "content": self._FAILED_TURN_NOTICE,
+                        "timestamp": time.time(),
+                    },
+                )
         except Exception:
             logger.debug("Failed to persist inbound user message after agent exception", exc_info=True)
         # Never expose raw exception types/messages to end users (info-leakage risk).
@@ -1791,13 +1816,13 @@ class GatewayTurnMixin:
         elif status_code in {400, 500}:
             # 400/500 on a large session: context overflow / payload too large.
             if len(prepared.history) > 50:
-                return (
+                return self._hmwa_add_failed_turn_notice(
                     "⚠️ Session too large for the model's context window.\nUse /compact to "
                     "compress the conversation, or /reset to start fresh."
                 )
             elif status_code == 400:
                 status_hint = " The request was rejected by the API."
-        return (
+        return self._hmwa_add_failed_turn_notice(
             f"Sorry, I encountered an unexpected error.{status_hint}\n"
             "Try again or use /reset to start a fresh session."
         )
@@ -2003,6 +2028,8 @@ class GatewayTurnMixin:
             agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure = (
                 self._hmwa_classify_turn_failure(agent_result, history, session_entry)
             )
+            if agent_failed_early and not is_context_overflow_failure:
+                response = self._hmwa_add_failed_turn_notice(response)
             response, session_entry = await self._hmwa_compression_exhaustion_reset(
                 agent_result, response, session_entry, session_key, source,
             )

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1704,13 +1704,7 @@ class GatewayTurnMixin:
                 # Transient failure / hidden-reasoning incomplete: persist the user message without
                 # the provider error text (a gateway hint, not model output). Dedupe on platform
                 # message_id (Telegram retries after transient failures).
-                if event.message_id and await store.has_platform_message_id(sid, str(event.message_id)):
-                    logger.info(
-                        "Skipping duplicate user turn (message_id=%s) in session %s",
-                        event.message_id, sid,
-                    )
-                else:
-                    await store.append_to_transcript(sid, _user_row, skip_db=agent_persisted)
+                await store.append_to_transcript(sid, _user_row, skip_db=agent_persisted)
                 # Close the failed turn with a durable assistant boundary. Leaving a user-only tail
                 # lets alternation repair merge this request into an unrelated future message and
                 # can replay stale side effects. Persist only the stable safety statement, not raw
@@ -1819,13 +1813,9 @@ class GatewayTurnMixin:
         # Replay can coalesce inputs; only this input's durable marker establishes ownership.
         try:
             if prepared.message_text is not None and session_entry is not None:
-                _owned = await self.async_session_store.has_input_owner(
-                    prepared.persistence_session_id, prepared.persistence_owner,
+                await self.async_session_store.append_to_transcript(
+                    session_entry.session_id, self._hmwa_user_transcript_entry(event, prepared, time.time()),
                 )
-                if not _owned:
-                    await self.async_session_store.append_to_transcript(
-                        session_entry.session_id, self._hmwa_user_transcript_entry(event, prepared, time.time()),
-                    )
                 await self.async_session_store.append_to_transcript(
                     session_entry.session_id,
                     self._hmwa_failed_turn_boundary_entry(

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1508,13 +1508,31 @@ class GatewayTurnMixin:
     _FAILED_TURN_NOTICE = (
         "Your request was not processed. Send it again if you still want me to carry it out."
     )
+    _PARTIAL_FAILED_TURN_NOTICE = (
+        "This turn did not complete. Some actions may already have run; verify their effects "
+        "before resending."
+    )
 
-    def _hmwa_add_failed_turn_notice(self, response):
+    def _hmwa_add_failed_turn_notice(self, response, notice=None):
         """Make failed-turn delivery explicit without replacing the provider-specific guidance."""
+        notice = notice or self._FAILED_TURN_NOTICE
         response = str(response or "").strip()
-        if self._FAILED_TURN_NOTICE in response:
+        if notice in response:
             return response
-        return f"{response}\n\n{self._FAILED_TURN_NOTICE}" if response else self._FAILED_TURN_NOTICE
+        return f"{response}\n\n{notice}" if response else notice
+
+    def _hmwa_failed_turn_notice(self, agent_result):
+        """Choose retry guidance without assuming completed tool effects can be repeated safely."""
+        messages = agent_result.get("messages", []) or []
+        history_offset = agent_result.get("history_offset", 0)
+        turn_messages = messages[history_offset:]
+        if any(
+            message.get("role") == "tool"
+            or (message.get("role") == "assistant" and message.get("tool_calls"))
+            for message in turn_messages
+        ):
+            return self._PARTIAL_FAILED_TURN_NOTICE
+        return self._FAILED_TURN_NOTICE
 
     def _hmwa_classify_turn_failure(self, agent_result, history, session_entry):
         """Classify a finished turn for transcript persistence. Returns
@@ -1628,6 +1646,7 @@ class GatewayTurnMixin:
     async def _hmwa_persist_turn_transcript(
         self, *, event, source, session_entry, session_key, agent_result, agent_messages,
         prepared, response, agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure,
+        failed_turn_notice,
     ):
         """Persist this turn to the transcript (session_meta on first turn, closed failed turn on
         transient failure, nothing on context overflow), update last_prompt_tokens, and re-baseline the
@@ -1679,7 +1698,7 @@ class GatewayTurnMixin:
                 # provider details; this row is gateway-owned and was not written by the agent.
                 await store.append_to_transcript(
                     sid,
-                    {"role": "assistant", "content": self._FAILED_TURN_NOTICE, "timestamp": ts},
+                    {"role": "assistant", "content": failed_turn_notice, "timestamp": ts},
                 )
             else:
                 # Only the NEW messages: history_offset (what the agent saw), not len(history), which
@@ -1789,7 +1808,7 @@ class GatewayTurnMixin:
                     session_entry.session_id,
                     {
                         "role": "assistant",
-                        "content": self._FAILED_TURN_NOTICE,
+                        "content": self._PARTIAL_FAILED_TURN_NOTICE,
                         "timestamp": time.time(),
                     },
                 )
@@ -1818,13 +1837,15 @@ class GatewayTurnMixin:
             if len(prepared.history) > 50:
                 return self._hmwa_add_failed_turn_notice(
                     "⚠️ Session too large for the model's context window.\nUse /compact to "
-                    "compress the conversation, or /reset to start fresh."
+                    "compress the conversation, or /reset to start fresh.",
+                    self._PARTIAL_FAILED_TURN_NOTICE,
                 )
             elif status_code == 400:
                 status_hint = " The request was rejected by the API."
         return self._hmwa_add_failed_turn_notice(
             f"Sorry, I encountered an unexpected error.{status_hint}\n"
-            "Try again or use /reset to start a fresh session."
+            "Use /reset to start a fresh session if needed.",
+            self._PARTIAL_FAILED_TURN_NOTICE,
         )
 
     def _hmwa_discard_stale_result(self, source, _quick_key, run_generation):
@@ -2028,8 +2049,9 @@ class GatewayTurnMixin:
             agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure = (
                 self._hmwa_classify_turn_failure(agent_result, history, session_entry)
             )
+            failed_turn_notice = self._hmwa_failed_turn_notice(agent_result)
             if agent_failed_early and not is_context_overflow_failure:
-                response = self._hmwa_add_failed_turn_notice(response)
+                response = self._hmwa_add_failed_turn_notice(response, failed_turn_notice)
             response, session_entry = await self._hmwa_compression_exhaustion_reset(
                 agent_result, response, session_entry, session_key, source,
             )
@@ -2039,6 +2061,7 @@ class GatewayTurnMixin:
                 response=response, agent_failed_early=agent_failed_early,
                 hidden_reasoning_incomplete=hidden_reasoning_incomplete,
                 is_context_overflow_failure=is_context_overflow_failure,
+                failed_turn_notice=failed_turn_notice,
             )
             return await self._hmwa_deliver_turn_response(
                 event, source, session_entry, session_key, run_generation,

--- a/gateway/session_transcript.py
+++ b/gateway/session_transcript.py
@@ -5,6 +5,7 @@ bound onto ``SessionStore`` via the MRO."""
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 import threading
 from agent.turn_context import extract_api_content_sidecar
@@ -31,6 +32,17 @@ def _plain_text(content) -> str:
         parts = [p.get("text", "") for p in content if isinstance(p, dict) and p.get("type") == "text"]
         return "\n".join(t for t in parts if t)
     return content if isinstance(content, str) else ""
+
+
+def _gateway_input_owner(message: Dict[str, Any]) -> Optional[str]:
+    """Read the gateway ownership marker from dict or serialized legacy metadata."""
+    metadata = message.get("display_metadata")
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    return metadata.get("gateway_input_owner") if isinstance(metadata, dict) else None
 
 
 def _spool_dropped(session_id: str, message: Dict[str, Any]):
@@ -333,7 +345,11 @@ class SessionTranscriptMixin:
             # into the ambient store.
             raise RuntimeError(
                 f"no owning session store for {session_id}; deferring transcript write")
-        if message.get("role") == "user" and (message.get("platform_message_id") or message.get("message_id")):
+        if message.get("role") == "user" and (
+            message.get("platform_message_id")
+            or message.get("message_id")
+            or _gateway_input_owner(message)
+        ):
             _db.append_user_message_if_absent(session_id, message)
             return
         if message.get("display_kind") == "gateway_failed_turn_boundary":

--- a/gateway/session_transcript.py
+++ b/gateway/session_transcript.py
@@ -333,6 +333,18 @@ class SessionTranscriptMixin:
             # into the ambient store.
             raise RuntimeError(
                 f"no owning session store for {session_id}; deferring transcript write")
+        if message.get("role") == "user" and (message.get("platform_message_id") or message.get("message_id")):
+            _db.append_user_message_if_absent(session_id, message)
+            return
+        if message.get("display_kind") == "gateway_failed_turn_boundary":
+            metadata = message.get("display_metadata") or {}
+            _db.append_gateway_failed_turn_boundary(
+                session_id,
+                message,
+                str(metadata.get("gateway_failed_turn_boundary") or ""),
+                legacy_platform_message_id=message.get("_gateway_boundary_platform_message_id"),
+            )
+            return
         is_assistant = message.get("role") == "assistant"
         _db.append_message(
             session_id=session_id,

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -307,6 +307,96 @@ class SessionMessagesMixin:
         # holding the lock for seconds (VACUUM, checkpoint) can't kill it.
         return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
 
+    def append_user_message_if_absent(self, session_id: str, message: Dict[str, Any]) -> bool:
+        """Append a platform user message once, atomically keyed by its platform id."""
+        platform_message_id = message.get("platform_message_id") or message.get("message_id")
+        if not session_id or not platform_message_id:
+            raise ValueError("Atomic user deduplication requires a platform message id")
+        msg = {**message, "platform_message_id": str(platform_message_id)}
+        owner = (msg.get("display_metadata") or {}).get("gateway_input_owner")
+        tool_calls = _parse_tool_calls(msg.get("tool_calls"))
+        message_timestamp = _coerce_timestamp(msg.get("timestamp"), time.time())
+        params = self._message_row_params(
+            session_id, "user", msg, tool_calls, message_timestamp, keep_reasoning=False)
+
+        def _do(conn):
+            existing = conn.execute(
+                """WITH RECURSIVE lineage(id) AS (
+                    SELECT ? UNION
+                    SELECT s.parent_session_id FROM sessions s JOIN lineage l ON s.id = l.id
+                    JOIN sessions p ON p.id = s.parent_session_id WHERE p.end_reason = 'compression'
+                ) SELECT 1 FROM messages m JOIN lineage l ON m.session_id = l.id
+                WHERE m.role = 'user' AND (m.active = 1 OR m.compacted = 1) AND m.observed = 0
+                  AND m.platform_message_id = ?
+                  AND CASE WHEN json_valid(m.display_metadata)
+                       THEN json_extract(m.display_metadata, '$.gateway_input_owner') END = ? LIMIT 1""",
+                (session_id, str(platform_message_id), owner),
+            ).fetchone()
+            if existing is not None:
+                return False
+            self._check_transcript_write_guards(conn, session_id, None)
+            conn.execute(_INSERT_MESSAGE_SQL, params)
+            self._bump_session_counters(conn, session_id, 1, _tool_calls_count(tool_calls), unit=True)
+            return True
+
+        return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
+    def append_gateway_failed_turn_boundary(
+        self, session_id: str, message: Dict[str, Any], boundary_key: str,
+        *, legacy_platform_message_id: Optional[str] = None,
+    ) -> bool:
+        """Append one failed-turn boundary, atomically deduplicated by its stable gateway key.
+
+        The legacy content probe prevents a rollout from adding a second boundary after a row written
+        by the pre-marker implementation.
+        """
+        if not session_id or not boundary_key:
+            raise ValueError("Failed-turn boundary requires a session and stable key")
+        msg = dict(message)
+        metadata = dict(msg.get("display_metadata") or {})
+        metadata["gateway_failed_turn_boundary"] = boundary_key
+        msg["display_kind"] = "gateway_failed_turn_boundary"
+        msg["display_metadata"] = metadata
+        tool_calls = _parse_tool_calls(msg.get("tool_calls"))
+        message_timestamp = _coerce_timestamp(msg.get("timestamp"), time.time())
+        params = self._message_row_params(
+            session_id, "assistant", msg, tool_calls, message_timestamp, keep_reasoning=True)
+        encoded_content = self._encode_content(msg.get("content"))
+        legacy_id = str(legacy_platform_message_id) if legacy_platform_message_id else None
+
+        def _do(conn):
+            existing = conn.execute(
+                """WITH RECURSIVE lineage(id) AS (
+                    SELECT ? UNION
+                    SELECT s.parent_session_id FROM sessions s JOIN lineage l ON s.id = l.id
+                    JOIN sessions p ON p.id = s.parent_session_id WHERE p.end_reason = 'compression'
+                ) SELECT 1 FROM messages m JOIN lineage l ON m.session_id = l.id
+                   WHERE m.role = 'assistant'
+                     AND (m.active = 1 OR m.compacted = 1)
+                     AND (
+                         (m.display_kind = 'gateway_failed_turn_boundary'
+                          AND CASE WHEN json_valid(m.display_metadata)
+                               THEN json_extract(m.display_metadata, '$.gateway_failed_turn_boundary') END = ?)
+                         OR (
+                             ? IS NOT NULL AND m.content = ?
+                             AND m.id > COALESCE((
+                                 SELECT MAX(mu.id) FROM messages mu JOIN lineage lu ON mu.session_id = lu.id
+                                 WHERE mu.role = 'user'
+                                   AND (mu.active = 1 OR mu.compacted = 1) AND mu.platform_message_id = ?
+                             ), 0)
+                         )
+                     ) LIMIT 1""",
+                (session_id, boundary_key, legacy_id, encoded_content, legacy_id),
+            ).fetchone()
+            if existing is not None:
+                return False
+            self._check_transcript_write_guards(conn, session_id, None)
+            conn.execute(_INSERT_MESSAGE_SQL, params)
+            self._bump_session_counters(conn, session_id, 1, _tool_calls_count(tool_calls), unit=True)
+            return True
+
+        return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
     def append_delegation_delivery(self, session_id: str, content: str, metadata: Dict[str, Any]) -> int:
         """Record a detached API result once, between client turns, including replay after rotation.
 

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -308,29 +308,48 @@ class SessionMessagesMixin:
         return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
 
     def append_user_message_if_absent(self, session_id: str, message: Dict[str, Any]) -> bool:
-        """Append a platform user message once, atomically keyed by its platform id."""
+        """Append one gateway user message, atomically keyed by its event owner."""
         platform_message_id = message.get("platform_message_id") or message.get("message_id")
-        if not session_id or not platform_message_id:
-            raise ValueError("Atomic user deduplication requires a platform message id")
-        msg = {**message, "platform_message_id": str(platform_message_id)}
-        owner = (msg.get("display_metadata") or {}).get("gateway_input_owner")
+        msg = dict(message)
+        if platform_message_id:
+            platform_message_id = str(platform_message_id)
+            msg["platform_message_id"] = platform_message_id
+        metadata = msg.get("display_metadata")
+        if isinstance(metadata, str):
+            try:
+                metadata = json.loads(metadata)
+            except (json.JSONDecodeError, TypeError):
+                metadata = None
+        owner = metadata.get("gateway_input_owner") if isinstance(metadata, dict) else None
+        if not session_id or not platform_message_id and not owner:
+            raise ValueError("Atomic user deduplication requires a platform message id or owner")
         tool_calls = _parse_tool_calls(msg.get("tool_calls"))
         message_timestamp = _coerce_timestamp(msg.get("timestamp"), time.time())
         params = self._message_row_params(
             session_id, "user", msg, tool_calls, message_timestamp, keep_reasoning=False)
+        if platform_message_id:
+            identity_clause = (
+                "m.platform_message_id = ? AND CASE WHEN json_valid(m.display_metadata) "
+                "THEN json_extract(m.display_metadata, '$.gateway_input_owner') END = ?"
+            )
+            identity_params = (platform_message_id, owner)
+        else:
+            identity_clause = (
+                "m.platform_message_id IS NULL AND CASE WHEN json_valid(m.display_metadata) "
+                "THEN json_extract(m.display_metadata, '$.gateway_input_owner') END = ?"
+            )
+            identity_params = (owner,)
 
         def _do(conn):
             existing = conn.execute(
-                """WITH RECURSIVE lineage(id) AS (
+                f"""WITH RECURSIVE lineage(id) AS (
                     SELECT ? UNION
                     SELECT s.parent_session_id FROM sessions s JOIN lineage l ON s.id = l.id
                     JOIN sessions p ON p.id = s.parent_session_id WHERE p.end_reason = 'compression'
                 ) SELECT 1 FROM messages m JOIN lineage l ON m.session_id = l.id
                 WHERE m.role = 'user' AND (m.active = 1 OR m.compacted = 1) AND m.observed = 0
-                  AND m.platform_message_id = ?
-                  AND CASE WHEN json_valid(m.display_metadata)
-                       THEN json_extract(m.display_metadata, '$.gateway_input_owner') END = ? LIMIT 1""",
-                (session_id, str(platform_message_id), owner),
+                  AND {identity_clause} LIMIT 1""",
+                (session_id, *identity_params),
             ).fetchone()
             if existing is not None:
                 return False

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -137,7 +137,7 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
     runner._run_agent = AsyncMock(
         return_value={
             "failed": True,
-            "final_response": None,
+            "final_response": "API call failed after 3 retries: 429 Too Many Requests",
             "error": "429 Too Many Requests — rate limit exceeded",
             "messages": [],
             "history_offset": 0,
@@ -145,13 +145,30 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
         }
     )
 
-    await runner._handle_message_with_agent(
+    response = await runner._handle_message_with_agent(
         _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
     )
 
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
     )
+    assert "not processed" in response
+
+    transcript_rows = [
+        call.args[1]
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2 and call.args[1].get("role") in {"user", "assistant"}
+    ]
+    assert [row["role"] for row in transcript_rows] == ["user", "assistant"]
+    assert "not processed" in transcript_rows[-1]["content"]
+
+    # The next unrelated input remains its own turn instead of alternation repair
+    # merging the failed mutating request into it.
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    replay = [*transcript_rows, {"role": "user", "content": "unrelated question"}]
+    assert repair_message_sequence(None, replay) == 0
+    assert replay[-1]["content"] == "unrelated question"
 
 
 # ── Test 2: agent_failed_early with no _session_db → skip_db not True ─

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -171,6 +171,51 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
     assert replay[-1]["content"] == "unrelated question"
 
 
+@pytest.mark.asyncio
+async def test_failed_turn_with_tool_activity_does_not_recommend_blind_retry(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "failed": True,
+            "final_response": "API call failed after 3 retries: 500 Internal Server Error",
+            "error": "500 Internal Server Error",
+            "messages": [
+                {"role": "user", "content": "reset the password"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "function": {"name": "reset_password", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "Password reset"},
+            ],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    response = await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assistant_rows = [
+        call.args[1]
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2 and call.args[1].get("role") == "assistant"
+    ]
+    assert len(assistant_rows) == 1
+    assert assistant_rows[0]["content"] == runner._PARTIAL_FAILED_TURN_NOTICE
+    assert runner._PARTIAL_FAILED_TURN_NOTICE in response
+    assert "not processed" not in response
+    assert "Send it again" not in response
+
+
 # ── Test 2: agent_failed_early with no _session_db → skip_db not True ─
 
 

--- a/tests/gateway/test_dedupe_user_turns.py
+++ b/tests/gateway/test_dedupe_user_turns.py
@@ -3,7 +3,7 @@
 When the gateway persists a user message after a transient provider
 failure (429/timeout/auth error), subsequent retries of the same
 Telegram message must not stack duplicate user turns in the transcript.
-The dedupe guard checks has_platform_message_id before persisting.
+The failure path uses an owner-scoped atomic insert instead of a check-then-act guard.
 """
 
 import concurrent.futures
@@ -70,8 +70,8 @@ class TestDedupeOnTransientFailure:
 
         # Simulate a second attempt to persist the same message
         assert store.has_platform_message_id("s1", "msg-789")
-        # The gateway code checks this before calling append_to_transcript,
-        # so the second append should never fire.
+        # The gateway uses the atomic writer for the actual persistence path;
+        # this lower-level probe remains a compatibility check for the index.
 
     def test_failed_turn_boundary_is_atomic_and_reload_safe(self, tmp_path):
         """Concurrent duplicate delivery creates one boundary and reloads role-safe."""
@@ -123,5 +123,51 @@ class TestDedupeOnTransientFailure:
 
         assert sum(results) == 1
         assert db.message_count("s1") == 1
+        foreign = {**message, "display_metadata": {"gateway_input_owner": "owner-2"}}
+        assert db.append_user_message_if_absent("s1", foreign)
+        assert db.message_count("s1") == 2
         db.close()
+
+    def test_exception_fallback_is_atomic_for_duplicate_events(self, tmp_path):
+        """Concurrent exception handlers persist one user/boundary pair."""
+        import asyncio
+
+        from gateway.config import GatewayConfig, Platform
+        from gateway.platforms.event import MessageEvent
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource, SessionStore
+
+        async def exercise():
+            store = SessionStore(tmp_path / "sessions", GatewayConfig())
+            runner = object.__new__(GatewayRunner)
+            runner.session_store = store
+
+            async def stop_typing(event, source):
+                return None
+
+            runner._hmwa_stop_typing_for_turn = stop_typing
+            source = SessionSource(
+                platform=Platform.TELEGRAM, chat_id="atomic-exception", user_id="fixture"
+            )
+            session = store.get_or_create_session(source)
+            prepared = runner._PreparedTurn(
+                [], "", "mutate record", [{"type": "text", "text": "mutate record"}],
+                1700000000, None, session.session_id, "exception-owner",
+            )
+            event = MessageEvent(text="mutate record", source=source, message_id="msg-exception")
+            await asyncio.gather(*(
+                runner._hmwa_agent_error_reply(
+                    RuntimeError("controlled"), event, source, session,
+                    session.session_key, prepared,
+                )
+                for _ in range(8)
+            ))
+
+            db = store._db_for_session_id(session.session_id)
+            rows = db.get_messages(session.session_id, include_inactive=True)
+            assert [row["role"] for row in rows] == ["user", "assistant"]
+            assert rows[-1]["display_kind"] == "gateway_failed_turn_boundary"
+            db.close()
+
+        asyncio.run(exercise())
 

--- a/tests/gateway/test_dedupe_user_turns.py
+++ b/tests/gateway/test_dedupe_user_turns.py
@@ -131,6 +131,7 @@ class TestDedupeOnTransientFailure:
     def test_exception_fallback_is_atomic_for_duplicate_events(self, tmp_path):
         """Concurrent exception handlers persist one user/boundary pair."""
         import asyncio
+        from datetime import datetime, timezone
 
         from gateway.config import GatewayConfig, Platform
         from gateway.platforms.event import MessageEvent
@@ -152,9 +153,20 @@ class TestDedupeOnTransientFailure:
             session = store.get_or_create_session(source)
             prepared = runner._PreparedTurn(
                 [], "", "mutate record", [{"type": "text", "text": "mutate record"}],
-                1700000000, None, session.session_id, "exception-owner",
+                1700000000, None, session.session_id,
+                runner._hmwa_persistence_owner(
+                    source,
+                    MessageEvent(
+                        text="mutate record", source=source, timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                        raw_message={"event_id": "keyless-1"},
+                    ),
+                ),
             )
-            event = MessageEvent(text="mutate record", source=source, message_id="msg-exception")
+            event = MessageEvent(
+                text="mutate record", source=source,
+                timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                raw_message={"event_id": "keyless-1"},
+            )
             await asyncio.gather(*(
                 runner._hmwa_agent_error_reply(
                     RuntimeError("controlled"), event, source, session,
@@ -170,4 +182,42 @@ class TestDedupeOnTransientFailure:
             db.close()
 
         asyncio.run(exercise())
+
+    def test_event_owner_distinguishes_reused_platform_ids(self):
+        """A retry is stable while a later event reusing an id is distinct."""
+        from datetime import datetime, timezone
+
+        from gateway.config import Platform
+        from gateway.platforms.event import MessageEvent
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="identity", user_id="fixture")
+        first = MessageEvent(
+            text="first", source=source, message_id="42", platform_update_id=100,
+            timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            raw_message={"id": 42, "date": "2026-01-01T00:00:00Z"},
+        )
+        retry = MessageEvent(
+            text="first", source=source, message_id="42", platform_update_id=100,
+            timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            raw_message={"id": 42, "date": "2026-01-01T00:00:00Z"},
+        )
+        reused = MessageEvent(
+            text="second", source=source, message_id="42", platform_update_id=101,
+            timestamp=datetime(2026, 1, 2, tzinfo=timezone.utc),
+            raw_message={"id": 42, "date": "2026-01-02T00:00:00Z"},
+        )
+
+        owner = GatewayRunner._hmwa_persistence_owner
+        assert owner(source, first) == owner(source, retry)
+        assert owner(source, first) != owner(source, reused)
+
+        prepared = GatewayRunner._PreparedTurn(
+            [], "", "first", [{"type": "text", "text": "first"}], 1.0, None, "identity", None,
+        )
+        boundary = GatewayRunner._hmwa_failed_turn_boundary_entry(
+            session_id="identity", event=first, prepared=prepared, content="failed", ts=1.0,
+        )
+        assert boundary["display_metadata"]["gateway_failed_turn_boundary"].startswith("gateway:")
 

--- a/tests/gateway/test_dedupe_user_turns.py
+++ b/tests/gateway/test_dedupe_user_turns.py
@@ -6,6 +6,8 @@ Telegram message must not stack duplicate user turns in the transcript.
 The dedupe guard checks has_platform_message_id before persisting.
 """
 
+import concurrent.futures
+
 from gateway.session import SessionStore
 from hermes_state import SessionDB
 
@@ -70,4 +72,56 @@ class TestDedupeOnTransientFailure:
         assert store.has_platform_message_id("s1", "msg-789")
         # The gateway code checks this before calling append_to_transcript,
         # so the second append should never fire.
+
+    def test_failed_turn_boundary_is_atomic_and_reload_safe(self, tmp_path):
+        """Concurrent duplicate delivery creates one boundary and reloads role-safe."""
+        db = self._make_db(tmp_path)
+        db.append_message(
+            session_id="s1",
+            role="user",
+            content="mutate record",
+            platform_message_id="msg-boundary",
+        )
+        boundary = {
+            "role": "assistant",
+            "content": "Your request was not processed. Send it again if you still want me to carry it out.",
+            "timestamp": 1.0,
+            "display_kind": "gateway_failed_turn_boundary",
+            "display_metadata": {"gateway_failed_turn_boundary": "s1:msg-boundary"},
+        }
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(
+                lambda _:
+                    db.append_gateway_failed_turn_boundary(
+                        "s1", boundary, "s1:msg-boundary", legacy_platform_message_id="msg-boundary",
+                    ),
+                range(8),
+            ))
+
+        assert sum(results) == 1
+        restored = db.get_messages_as_conversation("s1", repair_alternation=True)
+        assert [message["role"] for message in restored] == ["user", "assistant"]
+        assert restored[-1]["content"] == boundary["content"]
+        db.close()
+
+    def test_failed_turn_user_owner_is_atomic(self, tmp_path):
+        """Concurrent retries of one owned platform input create one user row."""
+        db = self._make_db(tmp_path)
+        message = {
+            "role": "user",
+            "content": "mutate record",
+            "platform_message_id": "msg-user",
+            "display_metadata": {"gateway_input_owner": "owner-1"},
+        }
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(
+                lambda _: db.append_user_message_if_absent("s1", message),
+                range(8),
+            ))
+
+        assert sum(results) == 1
+        assert db.message_count("s1") == 1
+        db.close()
 

--- a/tests/gateway/test_failure_writer_ownership.py
+++ b/tests/gateway/test_failure_writer_ownership.py
@@ -93,7 +93,7 @@ def test_failure_owner_follows_only_live_lineage_markers(tmp_path):
             store._transcript_reroutes.clear()
             assert store.has_input_owner(sid, owner) is owned, location
             before = db.message_count()
-            await runner._hmwa_agent_error_reply(
+            reply = await runner._hmwa_agent_error_reply(
                 RuntimeError("controlled post-compaction failure"),
                 MessageEvent(text="same", source=source, message_id=pid),
                 source, entry, entry.session_key, prepared,
@@ -104,7 +104,10 @@ def test_failure_owner_follows_only_live_lineage_markers(tmp_path):
             assert store.has_input_owner(sid, owner), location
             live_messages = db.get_messages(child)
             assert live_messages[-1]["role"] == "assistant"
-            assert "not processed" in live_messages[-1]["content"]
+            assert "Some actions may already have run" in live_messages[-1]["content"]
+            assert "not processed" not in live_messages[-1]["content"]
+            assert "Some actions may already have run" in reply
+            assert "not processed" not in reply
             if not owned:
                 persisted_user = live_messages[-2]
                 assert persisted_user["content"] == prepared.persist_user_message

--- a/tests/gateway/test_failure_writer_ownership.py
+++ b/tests/gateway/test_failure_writer_ownership.py
@@ -98,12 +98,17 @@ def test_failure_owner_follows_only_live_lineage_markers(tmp_path):
                 MessageEvent(text="same", source=source, message_id=pid),
                 source, entry, entry.session_key, prepared,
             )
-            assert db.message_count() == before + (not owned), location
+            # Exception fallback adds the missing user only when unowned, then always
+            # closes the failed turn with a durable assistant safety boundary.
+            assert db.message_count() == before + (not owned) + 1, location
             assert store.has_input_owner(sid, owner), location
+            live_messages = db.get_messages(child)
+            assert live_messages[-1]["role"] == "assistant"
+            assert "not processed" in live_messages[-1]["content"]
             if not owned:
-                latest = db.get_messages(child)[-1]
-                assert latest["content"] == prepared.persist_user_message
-                assert latest["display_metadata"]["gateway_input_owner"] == owner
+                persisted_user = live_messages[-2]
+                assert persisted_user["content"] == prepared.persist_user_message
+                assert persisted_user["display_metadata"]["gateway_input_owner"] == owner
         db.close()
 
     asyncio.run(check())

--- a/tests/gateway/test_incomplete_gateway_turns.py
+++ b/tests/gateway/test_incomplete_gateway_turns.py
@@ -123,7 +123,7 @@ def _make_event() -> MessageEvent:
 
 
 @pytest.mark.asyncio
-async def test_incomplete_codex_turn_stays_out_of_slack_transcript(monkeypatch, tmp_path):
+async def test_incomplete_codex_turn_closes_transcript_without_slack_delivery(monkeypatch, tmp_path):
     adapter = CaptureSlackAdapter()
     runner = _make_runner(adapter)
 
@@ -148,8 +148,11 @@ async def test_incomplete_codex_turn_stays_out_of_slack_transcript(monkeypatch, 
         call.args[1]["role"]
         for call in runner.session_store.append_to_transcript.call_args_list
     ]
-    assert transcript_roles == ["session_meta", "user"]
+    assert transcript_roles == ["session_meta", "user", "assistant"]
     assert runner.session_store.append_to_transcript.call_args_list[1].args[1]["content"] == "hello"
+    boundary = runner.session_store.append_to_transcript.call_args_list[2].args[1]["content"]
+    assert "not processed" in boundary
+    assert "remained incomplete" not in boundary
     assert adapter.processing_hooks == [
         ("start", "m-1"),
         ("complete", "m-1", ProcessingOutcome.SUCCESS),


### PR DESCRIPTION
## Summary

This PR carries the verified #107070 fix from #107088 and adds the missing exactly-once hardening for concurrent failed-turn persistence.

The direct carrier #107088 is still open. This branch is owned by the authenticated fork because the original carrier fork is not writable. PR #107438, which carried the same base fix, was closed as a duplicate. This PR should be reviewed as the carry-forward plus the incremental atomic persistence fixes in commits `c53af791af2f29a27e158d6881fe9acef1e2cbfe`, `fbaa95c6d233bd3aec064ef73377e574aadd81a5`, and `a77283343ceb055c3edaae85a4204ff47e0b94a4`.

## Problem and reproduction

A transient or incomplete gateway turn intentionally retains the inbound user content for retry context. Before the base fix, it could leave a durable `user` row without a terminal `assistant` row. On reload, `repair_message_sequence` correctly repaired the resulting `user/user` sequence by merging the unanswered historical request into the next user message. A later model request could therefore contain stale mutating instructions.

The base fix closes every persisted failed/incomplete turn with a durable gateway-owned assistant boundary, preserving retry context without allowing alternation repair to merge the stale request into the next turn.

During review of the base fix, a second P1 race was reproduced: two gateway writers can both observe that the accepted input has no owner and then append the same user row and the same assistant boundary. The existing in-memory queue serialization is not a cross-process identity guarantee, and the previous boundary row had no durable idempotency key.

## Root cause

The failure path had two independent read-then-write windows:

1. `GatewayTurnMixin._hmwa_agent_error_reply` checked `has_input_owner()` and then appended the user row separately.
2. Both the normal failed-turn persistence path and exception fallback appended an ordinary assistant message without a stable event key.

Concurrent workers could therefore pass both checks before either write committed. A session reroute or restart could also change the session id while the same platform event was being retried, making a session-scoped boundary key insufficient.

`repair_message_sequence` was not the defect. It was repairing a transcript that lacked the invariant that an unanswered failed turn must be role-closed.

## Solution

- Route failed-turn assistant writes through `SessionDB.append_gateway_failed_turn_boundary()`.
- Generate the boundary key from the stable gateway input owner (the deterministic event identity), not from the current session id. Keyless events retain a per-turn fallback because they have no durable transport identity.
- Perform boundary existence check and insert in one `BEGIN IMMEDIATE` transaction via the existing `_execute_write()` retry/commit path.
- Search the current compression lineage, so a boundary written before a reroute or restart prevents a second boundary in the live child.
- Keep a content/platform-id compatibility probe for boundaries written before the marker rollout.
- Add `append_user_message_if_absent()` with the same transactional check-and-insert semantics for owner-scoped platform retries. It only deduplicates non-observed rows carrying the same owner; foreign markers and legacy unmarked rows are not treated as ownership.
- Route both the normal transient-failure path and exception fallback through that atomic user writer; neither caller performs a non-atomic ownership pre-check.
- Support owner-only identity for keyless events within one prepared turn, and normalize serialized legacy `display_metadata` before extracting the owner.
- Derive the owner from retry-stable event fields (`message_id`, `platform_update_id`, timestamp, and a bounded raw-envelope fingerprint) so legitimate later events that reuse a platform id do not inherit the earlier owner.
- Keep both the normal failed/incomplete path and exception fallback on the same boundary writer, avoiding duplicated persistence logic.

The normal successful-turn path is unchanged. The additional lineage queries run only on user persistence with a platform id or on failed-turn boundary persistence.

## Safety and compatibility

- The durable boundary contains only the fixed safety notice and machine metadata; raw provider exception text is not persisted.
- If tool activity may have occurred, the user-facing and durable notices require effect verification before resending. The code does not claim that a failed request had no side effects.
- Existing successful transcripts and provider payloads are unchanged.
- Existing pre-marker boundaries remain recognized by the bounded legacy content probe.
- No schema migration, configuration, dependency, or API changes are required.

## Tests and verification

Passed locally on Windows with the repository's canonical runner unless noted:

- `python -m py_compile gateway/run_turn.py gateway/session_transcript.py hermes_state_messages.py tests/gateway/test_dedupe_user_turns.py` — passed.
- `HERMES_TEST_WORKERS=1 HERMES_PYTHON=C:/Users/Nitro/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe scripts/run_tests.sh tests/gateway/test_dedupe_user_turns.py tests/gateway/test_42039_duplicate_user_message.py tests/gateway/test_incomplete_gateway_turns.py` — 9 passed.
- `HERMES_TEST_WORKERS=1 HERMES_PYTHON=C:/Users/Nitro/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe scripts/run_tests.sh tests/gateway/test_dedupe_user_turns.py tests/gateway/test_failure_writer_ownership.py -k 'not test_gateway_failure_writer_preserves_accepted_turn_identity'` — passed, including the concurrent user dedupe, concurrent boundary dedupe, and lineage ownership cases.
- The real `_hmwa_agent_error_reply()` exception path was exercised concurrently with eight identical events — exactly one user row and one failed-turn boundary were persisted after the caller-level pre-checks were removed.
- The owner identity contract was tested directly: identical event instances produce the same owner, while a later event reusing the platform id with a different update/timestamp produces a different owner. The real exception path was also exercised with a keyless event carrying a stable timestamp/envelope.
- `HERMES_TEST_WORKERS=1 HERMES_PYTHON=C:/Users/Nitro/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe scripts/run_tests.sh tests/gateway/test_42039_duplicate_user_message.py tests/gateway/test_failure_writer_ownership.py tests/gateway/test_incomplete_gateway_turns.py` — the selected ownership regression passed; the nested probe is described below.
- Five consecutive SQLite stress rounds using 8 concurrent writers — every round produced exactly one user insert, exactly one boundary insert, and the role sequence `user/assistant`.
- The pre-existing replay-repair stress harness was also exercised in the earlier carry-forward validation: 8 workers x 1,000 iterations per round, with no role-boundary loss or current-input mutation.
- `git diff --check` and commit-level diff hygiene — passed.

The full `tests/gateway/test_failure_writer_ownership.py` file has one environment-only blocker on this Windows host: its nested `evals/gateway_failure_ownership/probe.py` deliberately clears all home-directory variables, while importing `gateway.run` evaluates an existing `Path.home()` fallback at `gateway/run.py:2083`. The probe exits before writing its receipt with `RuntimeError: Could not determine home directory.` The ownership test itself passes; this nested-probe failure is not caused by the changed persistence code and is reproducible independently of this commit.

Graphify investigation used the existing primary-checkout graph to trace `repair_message_sequence` -> `_rows_to_conversation` and the gateway persistence callers. A post-edit `graphify update . --no-cluster` reached 10,851/10,851 AST files but stalled without writing `graphify-out/graph.json`; it was terminated rather than reported as successful. No generated graph artifact is included in this PR.

## Related work

- #107070 — reported stale failed-turn replay.
- #107088 — direct existing carrier for the base role-closing fix.
- #107108 — timestamp age-gate alternative; not copied because it does not establish failure provenance or a durable boundary.
- #107438 — prior carry PR, closed as duplicate.
- #7100 — historical reason failed user context is retained; dropping failed user rows would regress that behavior.

## Delivery

- Branch: `fix/107070-stale-failed-turn-replay`
- Base: `main`
- New hardening commit: `c53af791af2f29a27e158d6881fe9acef1e2cbfe`
- Fork ref: `JoaoMarcos44:fix/107070-stale-failed-turn-replay`

## Post-publication verification

- Three consecutive rounds after PR creation, each running the canonical focused suite plus the concurrent SQLite stress harness.
- Each round: 11 focused tests passed, 0 failed; the nested Windows home-variable probe was excluded for the documented environment-only reason.
- Each round: 8 concurrent writers produced exactly 1 user insert, exactly 1 assistant boundary insert, and `user/assistant` after transcript reload.
- Round durations for the focused suite: 40.3 s, 17.3 s, and 19.5 s. No correctness failure, lock failure, race, or anomalous repeated growth occurred.
- Hosted GitHub checks: `gh pr checks 107561` currently reports `no checks reported`; the PR remains open and requires maintainer/CI provisioning.

## Post-push verification after reviewer follow-up

- Follow-up commit `fbaa95c6d233bd3aec064ef73377e574aadd81a5` was pushed to the same PR after an independent review found that the original callers still bypassed the atomic user writer.
- Three consecutive post-push rounds were rerun after that correction. Each round passed 12 focused tests with 0 failures and the 8-writer SQLite stress harness with exactly 1 user insert, 1 boundary insert, and `user/assistant` after reload.
- Focused-suite wall times: 38.2 s, 41.1 s, and 64.7 s. The longest run was caused by one test file taking 42.0 s; it completed successfully without a timeout or correctness failure.
- The PR remains open at head `fbaa95c6d233bd3aec064ef73377e574aadd81a5`; hosted checks still report `no checks reported`.

## Post-push verification after event-identity follow-up

- Follow-up commit `a77283343ceb055c3edaae85a4204ff47e0b94a4` was pushed after an independent review found platform-id reuse and keyless-event identity gaps.
- Three consecutive post-push rounds were rerun after that correction. Each round passed 13 focused tests with 0 failures and the 8-writer SQLite stress harness with exactly 1 user insert, 1 boundary insert, and `user/assistant` after reload.
- Focused-suite wall times: 29.3 s, 21.8 s, and 21.9 s.
- The PR remains open at head `a77283343ceb055c3edaae85a4204ff47e0b94a4`; hosted checks still report `no checks reported`.
