### PR TITLE
fix(evals): close HTTP response in Browserbase session cleanup

### DIFF
--- a/evals/browser_use/orchestrate_cloud.py
+++ b/evals/browser_use/orchestrate_cloud.py
@@ -107,7 +107,8 @@ class Browserbase:
             },
             method="POST",
         )
-        urllib.request.urlopen(req, timeout=30)
+        with urllib.request.urlopen(req, timeout=30):
+            pass
 
 
 provider = NousCloud() if args.backend == "nous-cloud" else Browserbase()


### PR DESCRIPTION
## Problem
The `Browserbase.close()` method opens an HTTP connection to release a session but never closes the response, leaving a socket leak.

## Solution
Use a context manager to ensure the response is closed immediately after the request completes.

## Changes
- Wrap `urllib.request.urlopen()` in a `with` statement in `evals/browser_use/orchestrate_cloud.py`
