### PR TITLE
fix(evals): close HTTP response in lease probe control helper

### DIFF
--- a/evals/desktop_bug_campaign/leases_live.py
+++ b/evals/desktop_bug_campaign/leases_live.py
@@ -149,7 +149,8 @@ memory:
         print(json.dumps(results['checks'][-1]), flush=True)
     def control(port, action, sid):
         req = urllib.request.Request(f'http://127.0.0.1:{port}/lease-probe/{action}/{sid}', data=b'', method='POST', headers={'X-Hermes-Session-Token': 'lease-probe'})
-        return json.load(urllib.request.urlopen(req, timeout=30))
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.load(resp)
     def wait_idle(port, sid):
         deadline = time.monotonic() + 90
         while time.monotonic() < deadline:


### PR DESCRIPTION
## Problem
The `control()` helper in the desktop bug campaign lease probe opens an HTTP connection to interact with the lease probe endpoint but never closes the response, leaving a socket leak in the evaluation harness.

## Solution
Use a context manager to ensure the response is closed after reading JSON.

## Changes
- Wrap `urllib.request.urlopen()` in a `with` statement in `evals/desktop_bug_campaign/leases_live.py`
