### PR TITLE
fix(gateway): long-session 400 envelope gets the /compact reply, other failures keep their text (salvage #107364)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2106,7 +2106,7 @@ from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.run_voice import GatewayVoiceMixin
 from gateway.run_adapters import GatewayAdapterLifecycleMixin
 from gateway.run_topics import GatewayTopicThreadsMixin
-from gateway.run_turn import GatewayTurnMixin
+from gateway.run_turn import GatewayTurnMixin, is_context_overflow_failure_result
 from gateway.run_shutdown import GatewayShutdownMixin, _exit_with_failure_verdict, _resolve_gateway_exit_verdict
 from gateway.run_busy import GatewayBusySessionMixin
 from gateway.run_config_loaders import GatewayConfigLoadersMixin
@@ -3027,10 +3027,13 @@ def _normalize_empty_agent_response(
     hits a stale generation token and returns an empty result, leaving the platform with nothing to send.
     (#31884)
 
-    Failed context-overflow turns rewrite even when ``final_response`` already holds the raw HTTP
-    400 envelope. Returning that envelope unchanged lets chat sanitizers replace it with a generic
-    provider-failed reply, so the user never sees /compact (#1630 message layer).
+    A failed context-overflow turn whose ``final_response`` is only the raw provider envelope
+    (``HTTP 400: {...}``) is rewritten too: returned unchanged, chat sanitizers turn it into a
+    generic provider-failed reply and the user never sees /compact. Curated agent text survives.
     """
+    is_overflow = is_context_overflow_failure_result(agent_result, history_len)
+    if response and not (is_overflow and _looks_like_gateway_provider_error(response)):
+        return response
     if agent_result.get("failed"):
         # ``error`` can be an EXPLICIT None (bypasses dict.get default) -> would render "failed: None".
         error_detail = agent_result.get("error") or "unknown error"
@@ -3047,19 +3050,13 @@ def _normalize_empty_agent_response(
                 "⚠️ Session storage was temporarily unavailable, so this "
                 "turn was stopped to protect your conversation history. "
                 "Your message should already be saved — please send it again in a moment.")
-        if any(p in error_str for p in (
-                "context", "token", "too large", "too long", "exceed", "payload")) or (
-                "400" in error_str and history_len > 50):
+        if is_overflow:
             return (
                 "⚠️ Session too large for the model's context window.\n"
                 "Use /compact to compress the conversation, or /reset to start fresh.")
-        if response:
-            return response
         return (
             f"The request failed: {str(error_detail)[:300]}\n"
             "Try again or use /reset to start a fresh session.")
-    if response:
-        return response
 
     api_calls = int(agent_result.get("api_calls", 0) or 0)
     if agent_result.get("interrupted"):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3026,9 +3026,11 @@ def _normalize_empty_agent_response(
     non-failed turn -- this is the silent-drop pattern observed after ``/stop`` where the next user message
     hits a stale generation token and returns an empty result, leaving the platform with nothing to send.
     (#31884)
+
+    Failed context-overflow turns rewrite even when ``final_response`` already holds the raw HTTP
+    400 envelope. Returning that envelope unchanged lets chat sanitizers replace it with a generic
+    provider-failed reply, so the user never sees /compact (#1630 message layer).
     """
-    if response:
-        return response
     if agent_result.get("failed"):
         # ``error`` can be an EXPLICIT None (bypasses dict.get default) -> would render "failed: None".
         error_detail = agent_result.get("error") or "unknown error"
@@ -3051,9 +3053,13 @@ def _normalize_empty_agent_response(
             return (
                 "⚠️ Session too large for the model's context window.\n"
                 "Use /compact to compress the conversation, or /reset to start fresh.")
+        if response:
+            return response
         return (
             f"The request failed: {str(error_detail)[:300]}\n"
             "Try again or use /reset to start a fresh session.")
+    if response:
+        return response
 
     api_calls = int(agent_result.get("api_calls", 0) or 0)
     if agent_result.get("interrupted"):

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -43,6 +43,29 @@ if TYPE_CHECKING:  # string annotations only; never imported at runtime (cycle)
 logger = logging.getLogger("gateway.run")
 
 
+_CONTEXT_OVERFLOW_ERROR_PHRASES = (
+    "context length", "context size", "context window",
+    "maximum context", "token limit", "too many tokens",
+    "reduce the length", "exceeds the limit",
+    "request entity too large", "prompt is too long",
+    "payload too large", "input is too long",
+)
+
+
+def is_context_overflow_failure_result(agent_result: dict, history_len: int) -> bool:
+    """One verdict for "this failed turn is a context overflow", shared by transcript persistence
+    (#1630 skip) and the user-facing reply so the two can never disagree.
+
+    Multi-word phrases (not bare "exceed"/"token") avoid matching "rate limit exceeded" or
+    "invalid authentication token"; a bare 400 only counts on a long session."""
+    if not agent_result.get("failed"):
+        return False
+    if agent_result.get("compression_exhausted"):
+        return True
+    err = str(agent_result.get("error") or "").lower()
+    return any(p in err for p in _CONTEXT_OVERFLOW_ERROR_PHRASES) or ("400" in err and history_len > 50)
+
+
 class GatewayTurnMixin:
     """Agent-turn execution for GatewayRunner (see module docstring)."""
 
@@ -1498,14 +1521,6 @@ class GatewayTurnMixin:
         except Exception as e:
             logger.debug("Watch queue drain error: %s", e)
 
-    _CONTEXT_OVERFLOW_ERROR_PHRASES = (
-        "context length", "context size", "context window",
-        "maximum context", "token limit", "too many tokens",
-        "reduce the length", "exceeds the limit",
-        "request entity too large", "prompt is too long",
-        "payload too large", "input is too long",
-    )
-
     def _hmwa_classify_turn_failure(self, agent_result, history, session_entry):
         """Classify a finished turn for transcript persistence. Returns
         ``(agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure)``.
@@ -1524,13 +1539,7 @@ class GatewayTurnMixin:
         # user turn so the conversation is preserved. (#7100)
         agent_failed_early = bool(agent_result.get("failed"))
         hidden_reasoning_incomplete = _is_gateway_hidden_reasoning_incomplete_turn(agent_result)
-        _err = str(agent_result.get("error", "")).lower()
-        # Multi-word phrases (not bare "exceed"/"token") avoid matching "rate limit exceeded".
-        is_context_overflow_failure = agent_failed_early and (
-            bool(agent_result.get("compression_exhausted"))
-            or any(p in _err for p in self._CONTEXT_OVERFLOW_ERROR_PHRASES)
-            or ("400" in _err and len(history) > 50)
-        )
+        is_context_overflow_failure = is_context_overflow_failure_result(agent_result, len(history))
         if is_context_overflow_failure:
             logger.info(
                 "Skipping transcript persistence for context-overflow "

--- a/tests/gateway/test_7100_transient_failure_transcript.py
+++ b/tests/gateway/test_7100_transient_failure_transcript.py
@@ -16,25 +16,12 @@ The gateway classifier must distinguish:
 """
 
 
-def _classify(agent_result: dict, history_len: int) -> tuple[bool, bool]:
-    """Replicate the gateway classifier from GatewayRunner._run_agent.
+from gateway.run_turn import is_context_overflow_failure_result
 
-    Returns ``(agent_failed_early, is_context_overflow_failure)``.
-    """
-    agent_failed_early = bool(agent_result.get("failed"))
-    err = str(agent_result.get("error", "")).lower()
-    is_context_overflow_failure = agent_failed_early and (
-        bool(agent_result.get("compression_exhausted"))
-        or any(p in err for p in (
-            "context length", "context size", "context window",
-            "maximum context", "token limit", "too many tokens",
-            "reduce the length", "exceeds the limit",
-            "request entity too large", "prompt is too long",
-            "payload too large", "input is too long",
-        ))
-        or ("400" in err and history_len > 50)
-    )
-    return agent_failed_early, is_context_overflow_failure
+
+def _classify(agent_result: dict, history_len: int) -> tuple[bool, bool]:
+    """``(agent_failed_early, is_context_overflow_failure)`` as the gateway computes them."""
+    return bool(agent_result.get("failed")), is_context_overflow_failure_result(agent_result, history_len)
 
 
 class TestContextOverflowStillSkipsTranscript:

--- a/tests/gateway/test_normalize_empty_agent_response.py
+++ b/tests/gateway/test_normalize_empty_agent_response.py
@@ -126,3 +126,42 @@ class TestGenericFailureRegression:
 
         assert "context window" in response
         assert "/compact" in response
+
+
+class TestNonempty400EnvelopeOverflowReply:
+    """Failed turns that already carry the HTTP 400 envelope as
+    ``final_response`` must still get the session-too-large rewrite.
+
+    Production order is normalize then Telegram sanitizer. The empty-response
+    rewriter used to return the 56-char envelope unchanged, and the sanitizer
+    then replaced it with a generic 'provider failed' — so users never saw
+    /compact even though the gateway already classified the turn as overflow.
+    """
+
+    _ENVELOPE = 'HTTP 400: {"object":"error","model":"deepseek-v4-flash"}'
+
+    def _failed_400(self):
+        return {
+            "final_response": self._ENVELOPE,
+            "failed": True,
+            "error": self._ENVELOPE,
+            "api_calls": 1,
+        }
+
+    def test_long_history_rewrites_envelope_to_session_too_large(self):
+        response = _normalize_empty_agent_response(
+            self._failed_400(), self._ENVELOPE, history_len=138,
+        )
+        assert "context window" in response.lower()
+        assert "/compact" in response
+        assert self._ENVELOPE not in response
+
+    def test_telegram_sanitizer_keeps_overflow_rewrite(self):
+        from gateway.run import _sanitize_gateway_final_response
+
+        rewritten = _normalize_empty_agent_response(
+            self._failed_400(), self._ENVELOPE, history_len=138,
+        )
+        delivered = _sanitize_gateway_final_response("telegram", rewritten)
+        assert "/compact" in delivered
+        assert "provider failed after retries" not in delivered.lower()

--- a/tests/gateway/test_normalize_empty_agent_response.py
+++ b/tests/gateway/test_normalize_empty_agent_response.py
@@ -135,8 +135,8 @@ class TestNonempty400EnvelopeOverflowReply:
 
     _ENVELOPE = 'HTTP 400: {"object":"error","model":"deepseek-v4-flash"}'
 
-    def _failed(self, text, error=None):
-        return {"final_response": text, "failed": True, "error": error or text, "api_calls": 1}
+    def _failed(self, text):
+        return {"final_response": text, "failed": True, "error": text, "api_calls": 1}
 
     def test_long_history_rewrites_envelope_to_session_too_large(self):
         response = _normalize_empty_agent_response(

--- a/tests/gateway/test_normalize_empty_agent_response.py
+++ b/tests/gateway/test_normalize_empty_agent_response.py
@@ -129,39 +129,32 @@ class TestGenericFailureRegression:
 
 
 class TestNonempty400EnvelopeOverflowReply:
-    """Failed turns that already carry the HTTP 400 envelope as
-    ``final_response`` must still get the session-too-large rewrite.
-
-    Production order is normalize then Telegram sanitizer. The empty-response
-    rewriter used to return the 56-char envelope unchanged, and the sanitizer
-    then replaced it with a generic 'provider failed' — so users never saw
-    /compact even though the gateway already classified the turn as overflow.
-    """
+    """Failed turns that already carry the HTTP 400 envelope as ``final_response`` must still get
+    the session-too-large rewrite (chat sanitizers would otherwise turn the envelope into a generic
+    'provider failed' reply); every other failure with text keeps that text."""
 
     _ENVELOPE = 'HTTP 400: {"object":"error","model":"deepseek-v4-flash"}'
 
-    def _failed_400(self):
-        return {
-            "final_response": self._ENVELOPE,
-            "failed": True,
-            "error": self._ENVELOPE,
-            "api_calls": 1,
-        }
+    def _failed(self, text, error=None):
+        return {"final_response": text, "failed": True, "error": error or text, "api_calls": 1}
 
     def test_long_history_rewrites_envelope_to_session_too_large(self):
         response = _normalize_empty_agent_response(
-            self._failed_400(), self._ENVELOPE, history_len=138,
+            self._failed(self._ENVELOPE), self._ENVELOPE, history_len=138,
         )
         assert "context window" in response.lower()
         assert "/compact" in response
         assert self._ENVELOPE not in response
 
-    def test_telegram_sanitizer_keeps_overflow_rewrite(self):
-        from gateway.run import _sanitize_gateway_final_response
+    @pytest.mark.parametrize("text", [
+        "Billing or credits exhausted: HTTP 429: You exceeded your current quota",
+        "API call failed after 3 retries: HTTP 429 rate limit exceeded",
+        "HTTP 401: invalid authentication token",
+    ])
+    def test_non_overflow_failure_keeps_its_own_text(self, text):
+        assert _normalize_empty_agent_response(self._failed(text), text, history_len=138) == text
 
-        rewritten = _normalize_empty_agent_response(
-            self._failed_400(), self._ENVELOPE, history_len=138,
-        )
-        delivered = _sanitize_gateway_final_response("telegram", rewritten)
-        assert "/compact" in delivered
-        assert "provider failed after retries" not in delivered.lower()
+    def test_curated_overflow_text_from_the_agent_survives(self):
+        text = "Context compression timed out without reducing this conversation. No messages were dropped."
+        result = {**self._failed(text), "compression_exhausted": True}
+        assert _normalize_empty_agent_response(result, text, history_len=138) == text


### PR DESCRIPTION
Long chat sessions that hit a bare provider `HTTP 400: {...}` envelope now get the existing "Session too large — use /compact or /reset" reply instead of the sanitizer's generic "provider failed, check gateway logs".

Salvage of #107364 by @xxxigm (both commits cherry-picked, authorship preserved) plus a follow-up that fixes a regression the original ordering change introduced.

## What changed

- `gateway/run_turn.py`: the transcript-skip classifier (`_CONTEXT_OVERFLOW_ERROR_PHRASES` + `compression_exhausted` + 400-on-long-session) is hoisted from a class attribute/inline expression into a module-level `is_context_overflow_failure_result(agent_result, history_len)`. Same phrases, same shape — no #1630/#7100 behaviour change.
- `gateway/run.py::_normalize_empty_agent_response`: uses that one predicate for the user-facing rewrite, so the reply and the persistence decision can never disagree. Populated text is rewritten only when it is the bare provider envelope on an overflow turn (`_looks_like_gateway_provider_error`, the same check the sanitizer uses). Curated agent text (billing, rate-limit, auth, content-policy, compression-timeout, `/compress` guidance) passes through unchanged. The old loose inline word list (`"token"`, `"exceed"`, `"context"`, `"payload"`) is deleted.
- Tests: envelope → `/compact` invariant (red on main); passthrough invariants for billing / rate-limit / auth text and for curated `compression_exhausted` text (red on the original PR head); `test_7100_transient_failure_transcript.py` now exercises the shared helper instead of its own copy of the phrase list.

## Why the follow-up

The original PR moved `if response: return response` below the failed branch. That exposed the normalizer's loose predicate to failed turns that carry real text: on the PR head, `Billing or credits exhausted: ... exceeded your current quota`, `API call failed after 3 retries: ... rate limit exceeded` and `HTTP 401: invalid authentication token` were all rewritten to "Session too large … /compact" (verified, even at `history_len=5`). The gateway also already owned a stricter classifier in `run_turn.py` whose comment explicitly rejects bare `exceed`/`token`; this stack converges on it.

Behaviour deltas vs main beyond the reported symptom: (a) an empty-response failure whose error merely contains `token`/`exceed` (e.g. auth, rate limit) now falls to the generic "The request failed" reply rather than "Session too large" — correct; (b) any bare-400 envelope on a >50-message session is rewritten, matching the heuristic the exception path at `run_turn.py` already applies.

## Validation

| Check | Result |
|---|---|
| Live repro, real `run_turn._hmwa_shape_agent_response` + Telegram sanitizer | main: envelope → "provider failed after retries…"; branch: → "Session too large… /compact". Billing, auth, success, short-session, persistence outputs byte-identical to main |
| `scripts/run_tests.sh` on the 6 test files touching the changed symbols | 170 passed, 0 failed |
| Mutation | envelope test red with main's `run.py`; passthrough tests red with the original PR's `run.py`; all green on this stack |
| ruff, `check-windows-footguns --all`, `check_compat_pointers` | clean |

Closes #107364.
