### PR TITLE
fix(evals): close HTTP response in history-live status check

### DIFF
--- a/evals/desktop_bug_campaign/history_live.py
+++ b/evals/desktop_bug_campaign/history_live.py
@@ -43,7 +43,8 @@ try:
     for _ in range(120):
         try:
             req=urllib.request.Request(f'http://127.0.0.1:{args.port}/api/status',headers={'X-Hermes-Token':'history-fixture-token'})
-            status=json.load(urllib.request.urlopen(req,timeout=2));break
+            with urllib.request.urlopen(req,timeout=2) as resp:
+                status=json.load(resp);break
         except Exception:
             if p.poll() is not None: raise RuntimeError('serve exited')
             time.sleep(.5)


### PR DESCRIPTION
## Problem
The history-live evaluation probe opens an HTTP connection to check serve health but never closes the response, leaking sockets during the retry loop.

## Solution
Use a context manager to ensure the response is closed after reading JSON.

## Changes
- Wrap `urllib.request.urlopen()` in a `with` statement in `evals/desktop_bug_campaign/history_live.py`
