### PR TITLE
docs: session hygiene — why /new still matters for memory and cost

### DIFF
--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -800,6 +800,32 @@ variables are ignored. Cached agents may be released to reclaim resources withou
 replacing the durable conversation. Restart-recovery freshness limits automatic
 continuation, not the history loaded when you send a message.
 
+### Session hygiene: why you should still run `/new`
+
+Because gateway conversations never expire on their own, it is easy to run one
+session for weeks. That works, but it quietly defeats the learning loop and
+inflates costs:
+
+- **Memory only pays off at boundaries.** `MEMORY.md` / `USER.md` are injected
+  at session start, and `session_search` exists to recall what fell out of
+  context. In a never-ending session everything is still *in* context, so the
+  agent has no reason to consult memory — the "self-learning" machinery barely
+  runs. Memory distillation (the save before reset) also only happens when a
+  session actually ends.
+- **Cost grows with history.** Compression keeps a long session functional,
+  but every turn still carries a large (compacted) prefix. A fresh session
+  with distilled memory is almost always cheaper than a month-old thread.
+
+Practical rule: end a session when you finish a task or topic. Run `/new`
+(optionally named, e.g. `/new payments-refactor`) at natural stopping points —
+daily or per-project both work. Before the reset, ask the agent to "remember
+anything worth keeping" if the work surfaced durable preferences or
+procedures; it saves memories and skills from the expiring session
+automatically, but an explicit nudge helps. Restarting the machine or the
+gateway is **not** a boundary — the same session resumes.
+
+See [Memory](features/memory.md) for what gets carried across boundaries.
+
 
 ### Continuity After Crashes and Restarts
 


### PR DESCRIPTION
Sessions doc now explains why users should still run `/new` even though gateway conversations never expire — the community was discovering the hard way that a never-ending session quietly disables the learning loop.

## Why
A community deep-dive ("I think I used the Hermes Agent wrong", heyjonny.dev, on HN 2026-09-09) ran Hermes for 18 days in 5 sessions: `session_search` fired 9 times across 1,990 messages, memory files only ever got compacted instead of curated, and costs ballooned — because nothing in the docs says session boundaries are what make memory pay off. `sessions.md` states conversations never reset on their own but never tells the user why or when to create a boundary themselves.

## Changes
- New "Session hygiene: why you should still run `/new`" subsection in `website/docs/user-guide/sessions.md` (Session continuity area):
  - memory injection / `session_search` / pre-reset distillation only do work at boundaries
  - compaction keeps long sessions functional but cost grows with the prefix
  - practical rule: `/new` at task/topic boundaries; machine or gateway restart is NOT a boundary
- Cross-link to the Memory feature page.

## Validation
Docs-only, +26 lines, one file. Claims cross-checked against `sessions.md` (continuity semantics), `features/memory.md` (injection at session start, distillation before reset), and `guides/tips.md` (compression/cost).

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9e4f8/r2GYT6iBLgmY60nRmp1xH_ogqL2bdn.png)
