### PR TITLE
fix(google-chat): close HTTP response during OAuth token revocation

### DIFF
--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -399,12 +399,12 @@ def revoke(email: Optional[str] = None) -> None:
         if creds.expired and creds.refresh_token:
             creds.refresh(Request())
         import urllib.request
-        urllib.request.urlopen(
-            urllib.request.Request(
-                f"https://oauth2.googleapis.com/revoke?token={creds.token}",
-                method="POST",
-                headers={"Content-Type": "application/x-www-form-urlencoded"}),
-            timeout=15)
+        req = urllib.request.Request(
+            f"https://oauth2.googleapis.com/revoke?token={creds.token}",
+            method="POST",
+            headers={"Content-Type": "application/x-www-form-urlencoded"})
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            resp.read()
         print("Token revoked with Google.")
     except Exception as exc:
         print(f"Remote revocation failed (token may already be invalid): {exc}")


### PR DESCRIPTION
## Problem
The `revoke_flow()` method opened an HTTP connection to revoke a Google OAuth token but never closed the response, leaving a socket leak.

## Solution
Use a context manager to ensure the response is closed immediately after the request completes.

## Changes
- Wrap `urllib.request.urlopen()` in a `with` statement in `plugins/platforms/google_chat/oauth.py`
