### PR TITLE
fix(tools): close HTTP response in browser real-profile CDP check

### DIFF
--- a/tools/browser_tool_real_profile.py
+++ b/tools/browser_tool_real_profile.py
@@ -94,7 +94,8 @@ def _surviving_chrome_cdp(data_dir: str) -> Optional[str]:
     http_cdp = f"http://127.0.0.1:{port}"
     try:
         import requests
-        ws_url = str(requests.get(f"{http_cdp}/json/version", timeout=2).json().get("webSocketDebuggerUrl") or "")
+        with requests.get(f"{http_cdp}/json/version", timeout=2) as resp:
+            ws_url = str(resp.json().get("webSocketDebuggerUrl") or "")
     except Exception:
         return None
     return http_cdp if ws_url.endswith(browser_path) else None


### PR DESCRIPTION
## Problem
The `_discover_cdp_ws_url()` helper opens an HTTP connection to fetch the Chrome DevTools Protocol version endpoint but never closes the response, leaking sockets during browser initialization.

## Solution
Use a context manager to ensure the response is closed after reading JSON.

## Changes
- Wrap `requests.get()` in a `with` statement in `tools/browser_tool_real_profile.py`
