### PR TITLE
fix(plugins): close HTTP response when fetching image URL in OpenAI provider

### DIFF
--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -50,10 +50,10 @@ def _load_image_bytes(ref: str) -> Tuple[bytes, str]:
     if lower.startswith(("http://", "https://")):
         import requests
 
-        resp = requests.get(ref, timeout=60)
-        resp.raise_for_status()
-        name = ref.split("?", 1)[0].rsplit("/", 1)[-1] or "image.png"
-        return resp.content, name
+        with requests.get(ref, timeout=60) as resp:
+            resp.raise_for_status()
+            name = ref.split("?", 1)[0].rsplit("/", 1)[-1] or "image.png"
+            return resp.content, name
     if lower.startswith("data:"):
         import base64
 


### PR DESCRIPTION
## Problem
The `_load_image_bytes()` helper opens an HTTP connection to fetch an image from a URL but never closes the response, leaking sockets when processing remote image references.

## Solution
Use a context manager to ensure the response is closed after reading content.

## Changes
- Wrap `requests.get()` in a `with` statement in `plugins/image_gen/openai/__init__.py`
