### PR TITLE
fix(desktop): settle the login-shell PATH probe and kill the probe child on timeout

### DIFF
--- a/apps/desktop/electron/shell-path.test.ts
+++ b/apps/desktop/electron/shell-path.test.ts
@@ -138,11 +138,16 @@ test('ensureLoginShellPath is single-flight — concurrent callers share one she
   assert.equal(env.PATH, '/opt/homebrew/bin:/usr/bin')
 })
 
-test('applyLoginShellPath force-settles when a hung grandchild keeps the execFile callback from firing', async () => {
+test('applyLoginShellPath kills the probe child and force-settles when its callback does not fire', async () => {
   const env: any = { SHELL: '/bin/zsh', PATH: '/usr/bin' }
-  // Simulates a probe whose shell spawns a daemon (e.g. gitstatusd) that
-  // keeps stdout open: execFile's callback never fires.
-  const execFileFn = () => ({ pid: 424242, stdin: { end() {} } })
+  const kills: string[] = []
+  const execFileFn = () => ({
+    stdin: { end() {} },
+    kill(signal) {
+      kills.push(signal)
+      return true
+    }
+  })
 
   const start = Date.now()
   const result = await applyLoginShellPath({ env, platform: 'linux', execFileFn, timeoutMs: 20 })
@@ -150,6 +155,7 @@ test('applyLoginShellPath force-settles when a hung grandchild keeps the execFil
 
   assert.equal(result.applied, false)
   assert.equal(result.reason, 'unresolved')
+  assert.deepEqual(kills, ['SIGKILL', 'SIGKILL'])
   assert.ok(elapsed < 4000, `expected the probe to force-settle well under the test timeout, took ${elapsed}ms`)
 })
 

--- a/apps/desktop/electron/shell-path.test.ts
+++ b/apps/desktop/electron/shell-path.test.ts
@@ -137,6 +137,21 @@ test('ensureLoginShellPath is single-flight — concurrent callers share one she
   assert.equal(env.PATH, '/opt/homebrew/bin:/usr/bin')
 })
 
+test('applyLoginShellPath force-settles when a hung grandchild keeps the execFile callback from firing', async () => {
+  const env: any = { SHELL: '/bin/zsh', PATH: '/usr/bin' }
+  // Simulates a probe whose shell spawns a daemon (e.g. gitstatusd) that
+  // keeps stdout open: execFile's callback never fires.
+  const execFileFn = () => ({ pid: 424242, stdin: { end() {} } })
+
+  const start = Date.now()
+  const result = await applyLoginShellPath({ env, platform: 'linux', execFileFn, timeoutMs: 20 })
+  const elapsed = Date.now() - start
+
+  assert.equal(result.applied, false)
+  assert.equal(result.reason, 'unresolved')
+  assert.ok(elapsed < 4000, `expected the probe to force-settle well under the test timeout, took ${elapsed}ms`)
+})
+
 test('ensureLoginShellPath never rejects', async () => {
   const execFileFn = () => {
     throw new Error('spawn EACCES')

--- a/apps/desktop/electron/shell-path.test.ts
+++ b/apps/desktop/electron/shell-path.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
 
 import { beforeEach, test } from 'vitest'
 
@@ -150,6 +151,23 @@ test('applyLoginShellPath force-settles when a hung grandchild keeps the execFil
   assert.equal(result.applied, false)
   assert.equal(result.reason, 'unresolved')
   assert.ok(elapsed < 4000, `expected the probe to force-settle well under the test timeout, took ${elapsed}ms`)
+})
+
+test('applyLoginShellPath keeps a sentinel already printed when the hard timer force-settles', async () => {
+  const env: any = { SHELL: '/bin/zsh', PATH: '/usr/bin' }
+  // Simulates a probe whose shell already wrote the sentinel before a
+  // daemon-holding descendant wedges the pipe: execFile's callback never
+  // fires, but the stdout stream itself did emit the data.
+  const stdout = new EventEmitter()
+  const execFileFn = () => ({ pid: 424243, stdin: { end() {} }, stdout })
+
+  const resultPromise = applyLoginShellPath({ env, platform: 'linux', execFileFn, timeoutMs: 20 })
+  stdout.emit('data', `${START}/opt/homebrew/bin:/usr/bin${END}`)
+
+  const result = await resultPromise
+
+  assert.equal(result.applied, true)
+  assert.equal(env.PATH, '/opt/homebrew/bin:/usr/bin')
 })
 
 test('ensureLoginShellPath never rejects', async () => {

--- a/apps/desktop/electron/shell-path.ts
+++ b/apps/desktop/electron/shell-path.ts
@@ -89,7 +89,7 @@ function runProbe(shell, flags, execFileFn, timeoutMs): Promise<string | null> {
       const child = execFileFn(
         shell,
         [...flags, PROBE_COMMAND],
-        { encoding: 'utf8', timeout: timeoutMs, windowsHide: true, detached: process.platform !== 'win32' },
+        { encoding: 'utf8', timeout: timeoutMs, windowsHide: true },
         (_error, stdout) => {
           // A profile script may exit nonzero after the sentinel already
           // printed — trust the sentinel, not the exit code.
@@ -106,25 +106,12 @@ function runProbe(shell, flags, execFileFn, timeoutMs): Promise<string | null> {
         capturedStdout += chunk
       })
 
-      // execFile's own `timeout` only SIGTERMs the direct child; a profile
-      // that spawns a daemon (e.g. Powerlevel10k's gitstatusd) can leave a
-      // grandchild holding the stdout pipe open, so the callback above never
-      // fires and this promise would hang forever. Force-settle past the
-      // requested timeout and reap the whole process group so a hung
-      // profile can never park boot.
+      // Kill the probe child directly before settling so a hung profile cannot park boot.
       hardTimer = setTimeout(() => {
-        if (child?.pid && process.platform !== 'win32') {
-          try {
-            process.kill(-child.pid, 'SIGKILL')
-          } catch {
-            // Group may already be gone.
-          }
-        } else {
-          try {
-            child?.kill?.('SIGKILL')
-          } catch {
-            // Already gone.
-          }
+        try {
+          child?.kill?.('SIGKILL')
+        } catch {
+          // Hard settlement must not depend on kill succeeding.
         }
 
         finish(extractSentinelPath(capturedStdout))

--- a/apps/desktop/electron/shell-path.ts
+++ b/apps/desktop/electron/shell-path.ts
@@ -70,10 +70,16 @@ function mergeLoginShellPath(loginPath, currentPath, { delimiter = ':' }: any = 
 function runProbe(shell, flags, execFileFn, timeoutMs): Promise<string | null> {
   return new Promise(resolve => {
     let settled = false
+    let hardTimer: ReturnType<typeof setTimeout> | null = null
 
     const finish = value => {
       if (!settled) {
         settled = true
+
+        if (hardTimer) {
+          clearTimeout(hardTimer)
+        }
+
         resolve(value)
       }
     }
@@ -82,7 +88,7 @@ function runProbe(shell, flags, execFileFn, timeoutMs): Promise<string | null> {
       const child = execFileFn(
         shell,
         [...flags, PROBE_COMMAND],
-        { encoding: 'utf8', timeout: timeoutMs, windowsHide: true },
+        { encoding: 'utf8', timeout: timeoutMs, windowsHide: true, detached: process.platform !== 'win32' },
         (_error, stdout) => {
           // A profile script may exit nonzero after the sentinel already
           // printed — trust the sentinel, not the exit code.
@@ -92,6 +98,30 @@ function runProbe(shell, flags, execFileFn, timeoutMs): Promise<string | null> {
 
       // Interactive shells with a broken rc can block reading stdin.
       child?.stdin?.end?.()
+
+      // execFile's own `timeout` only SIGTERMs the direct child; a profile
+      // that spawns a daemon (e.g. Powerlevel10k's gitstatusd) can leave a
+      // grandchild holding the stdout pipe open, so the callback above never
+      // fires and this promise would hang forever. Force-settle past the
+      // requested timeout and reap the whole process group so a hung
+      // profile can never park boot.
+      hardTimer = setTimeout(() => {
+        if (child?.pid && process.platform !== 'win32') {
+          try {
+            process.kill(-child.pid, 'SIGKILL')
+          } catch {
+            // Group may already be gone.
+          }
+        } else {
+          try {
+            child?.kill?.('SIGKILL')
+          } catch {
+            // Already gone.
+          }
+        }
+
+        finish(null)
+      }, timeoutMs + 1000)
     } catch {
       finish(null)
     }

--- a/apps/desktop/electron/shell-path.ts
+++ b/apps/desktop/electron/shell-path.ts
@@ -71,6 +71,7 @@ function runProbe(shell, flags, execFileFn, timeoutMs): Promise<string | null> {
   return new Promise(resolve => {
     let settled = false
     let hardTimer: ReturnType<typeof setTimeout> | null = null
+    let capturedStdout = ''
 
     const finish = value => {
       if (!settled) {
@@ -99,6 +100,12 @@ function runProbe(shell, flags, execFileFn, timeoutMs): Promise<string | null> {
       // Interactive shells with a broken rc can block reading stdin.
       child?.stdin?.end?.()
 
+      // Mirror what the callback would have seen, so a sentinel that already
+      // printed before a descendant wedged the pipe isn't thrown away below.
+      child?.stdout?.on?.('data', chunk => {
+        capturedStdout += chunk
+      })
+
       // execFile's own `timeout` only SIGTERMs the direct child; a profile
       // that spawns a daemon (e.g. Powerlevel10k's gitstatusd) can leave a
       // grandchild holding the stdout pipe open, so the callback above never
@@ -120,7 +127,7 @@ function runProbe(shell, flags, execFileFn, timeoutMs): Promise<string | null> {
           }
         }
 
-        finish(null)
+        finish(extractSentinelPath(capturedStdout))
       }, timeoutMs + 1000)
     } catch {
       finish(null)


### PR DESCRIPTION
## Summary

Linux desktop boot can no longer hang on the login-shell PATH probe, and the probe child is killed when the probe times out.

Root cause: `runProbe` waits for `execFile`'s callback, but that callback never fires when a shell descendant keeps captured stdout open.

This consolidates the two existing fixes. The wall-clock settlement boundary and incremental sentinel capture are plain cherry-picks from #107114, so chelsealong remains the author of those commits. Its process-group cleanup was removed because `execFile` silently drops the `detached` option, which leaves the negative-PID kill targeting a nonexistent group; an executable topology probe confirmed that the group kill never engaged. The direct-child `SIGKILL` fallback comes from #107118 and is the surviving cleanup path, so KoNit-K is the author of that commit. The adapted regression test is a separate yoniebans-authored commit.

| Path | Before | After |
| --- | --- | --- |
| Probe success | Applies a complete PATH sentinel from the `execFile` callback. | Preserves the same callback path and applies the complete sentinel. |
| Timed-out `-ilc` attempt | Node times out the shell, but `runProbe` can remain pending while a descendant holds stdout open. | Sends `SIGKILL` to the probe child and settles from incrementally captured stdout at the wall-clock boundary. |
| Timed-out `-lc` attempt | The fallback can hang for the same reason as the first attempt. | Uses the same direct-child kill and independent wall-clock boundary, then returns unresolved if no complete sentinel was captured. |
| Descendant holds stdout open | The callback may never run, so backend resolution and desktop startup can wait indefinitely. | Startup proceeds when the hard timer settles the probe, even though the descendant may survive. |

Grandchildren of the probe are not killed. The wall-clock boundary keeps them from ever blocking startup.

## Changes

- `apps/desktop/electron/shell-path.ts`: capture stdout incrementally, clear the hard timer on ordinary settlement, kill the direct probe child with `SIGKILL` on timeout, and settle without waiting for callback or pipe closure.
- `apps/desktop/electron/shell-path.test.ts`: cover forced settlement, both probe-child kills, and recovery of a complete sentinel emitted before callback delivery wedges.

## Test plan

- [x] `npx vitest run electron/shell-path.test.ts --project electron` (14/14 passed)
- [x] `npx vitest run electron/backend-env.test.ts --project electron` (10/10 passed)
- [x] `npm run typecheck` (exit 0)
- [x] Executable production-entry proof using `applyLoginShellPath` with Node's built-in timeout disabled: both sequential probe children exited with `SIGKILL` and the call returned `{"result":"unresolved","exitSignals":["SIGKILL","SIGKILL"]}`.
- [ ] Verify a live Linux desktop boot with a Powerlevel10k-style shell configuration whose descendant holds stdout open. This VM cannot host that process topology, so this remains the operator/reporter verification.

Supersedes #107114 (settlement and sentinel carried, group kill replaced because it never engaged) and #107118 (its direct-child kill is the surviving cleanup path). Fixes #107109.