### PR TITLE
fix(skills): close HTTP response during Google Workspace token revocation

### DIFF
--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -465,14 +465,15 @@ def revoke():
             creds.refresh(Request())
 
         import urllib.request
-        urllib.request.urlopen(
+        with urllib.request.urlopen(
             urllib.request.Request(
                 f"https://oauth2.googleapis.com/revoke?token={creds.token}",
                 method="POST",
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             ),
             timeout=15,
-        )
+        ):
+            pass
         print("Token revoked with Google.")
     except Exception as e:
         print(f"Remote revocation failed (token may already be invalid): {e}")


### PR DESCRIPTION
## Problem
The `revoke()` function opens an HTTP connection to revoke a Google OAuth token but never closes the response, leaving a socket leak.

## Solution
Use a context manager to ensure the response is closed immediately after the request completes.

## Changes
- Wrap `urllib.request.urlopen()` in a `with` statement in `skills/productivity/google-workspace/scripts/setup.py`
