### PR TITLE
fix(cli): close HTTP response in DingTalk auth API calls

### DIFF
--- a/hermes_cli/dingtalk_auth.py
+++ b/hermes_cli/dingtalk_auth.py
@@ -24,9 +24,9 @@ def _api_post(path: str, payload: dict) -> dict:
     """POST to the registration API and return the parsed JSON body."""
     url = f"{REGISTRATION_BASE_URL}{path}"
     try:
-        resp = requests.post(url, json=payload, timeout=15)
-        resp.raise_for_status()
-        data = resp.json()
+        with requests.post(url, json=payload, timeout=15) as resp:
+            resp.raise_for_status()
+            data = resp.json()
     except requests.RequestException as exc:
         raise RegistrationError(f"Network error calling {url}: {exc}") from exc
     errcode = data.get("errcode", -1)


### PR DESCRIPTION
## Problem
The `_api_post()` helper opens an HTTP connection to the DingTalk registration API but never closes the response, leaking sockets during auth flows.

## Solution
Use a context manager to ensure the response is closed after reading JSON.

## Changes
- Wrap `requests.post()` in a `with` statement in `hermes_cli/dingtalk_auth.py`
