### PR TITLE
fix(skills): close HTTP response when fetching meme template URL

### DIFF
--- a/optional-skills/creative/meme-generation/scripts/generate_meme.py
+++ b/optional-skills/creative/meme-generation/scripts/generate_meme.py
@@ -39,9 +39,9 @@ IMGFLIP_CACHE_MAX_AGE = 86400  # 24 hours
 def _fetch_url(url: str, timeout: int = 15) -> bytes:
     """Fetch URL content, using requests if available, else urllib."""
     if _requests is not None:
-        resp = _requests.get(url, timeout=timeout)
-        resp.raise_for_status()
-        return resp.content
+        with _requests.get(url, timeout=timeout) as resp:
+            resp.raise_for_status()
+            return resp.content
     import urllib.request
     return urllib.request.urlopen(url, timeout=timeout).read()
 


### PR DESCRIPTION
## Problem
The `_fetch_url()` helper opens an HTTP connection to fetch meme template content but never closes the response when using the requests backend, leaking sockets.

## Solution
Use a context manager to ensure the response is closed after reading content.

## Changes
- Wrap `_requests.get()` in a `with` statement in `optional-skills/creative/meme-generation/scripts/generate_meme.py`
