### PR TITLE
fix(desktop): persist active-profile.json on per-profile new-chat activation (#107528)

### DIFF
--- a/apps/desktop/src/store/profile-select-source.test.ts
+++ b/apps/desktop/src/store/profile-select-source.test.ts
@@ -14,6 +14,7 @@ const ensureGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const ensureGatewayForAgent = vi.fn(async (_connectionId: null | string, _profile: string) => true)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const activeGatewayConnectionId = vi.fn<() => null | string>(() => null)
+const isActivePrimary = vi.fn<() => boolean>(() => true)
 const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
 
@@ -22,6 +23,7 @@ vi.mock('@/store/gateway', () => ({
   activeGatewayConnectionId,
   ensureGatewayForAgent,
   ensureGatewayForProfile,
+  isActivePrimary,
   openGatewayForProfile
 }))
 vi.mock('@/hermes', () => ({
@@ -38,6 +40,8 @@ beforeEach(() => {
   ensureGatewayForAgent.mockClear()
   activeGatewayConnectionId.mockReset()
   activeGatewayConnectionId.mockReturnValue(null)
+  isActivePrimary.mockReset()
+  isActivePrimary.mockReturnValue(true)
   $gateway.set({ id: 'live-socket' })
   $activeGatewayProfile.set('default')
   // resolveConnectionForAgent is best-effort; without a bridge it resolves
@@ -109,6 +113,84 @@ describe('newSessionInProfile', () => {
 
     await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('local', 'default'))
     expect(ensureGatewayForProfile).not.toHaveBeenCalled()
+  })
+})
+
+describe('newSessionInProfile startup preference (#107528 follow-up)', () => {
+  const rememberProfile = vi.fn(async (name: null | string) => ({ profile: name }))
+
+  beforeEach(() => {
+    rememberProfile.mockClear()
+
+    const getConnectionConfig = vi.fn(async () => ({ mode: 'local' }))
+
+    ;(globalThis as { window?: unknown }).window = {
+      hermesDesktop: {
+        getConnectionConfig,
+        profile: { remember: rememberProfile }
+      }
+    }
+  })
+
+  it('remembers the profile for the next launch after successful activation', async () => {
+    isActivePrimary.mockReturnValue(true)
+
+    newSessionInProfile('searxng')
+
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('searxng'))
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('searxng'))
+  })
+
+  it('waits for gateway activation before replacing the startup preference', async () => {
+    let resolveGateway!: () => void
+
+    isActivePrimary.mockReturnValue(true)
+    ensureGatewayForProfile.mockImplementationOnce(
+      () =>
+        new Promise<undefined>(resolve => {
+          resolveGateway = () => resolve(undefined)
+        })
+    )
+
+    newSessionInProfile('searxng')
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('searxng'))
+    expect(rememberProfile).not.toHaveBeenCalled()
+
+    resolveGateway()
+
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('searxng'))
+  })
+
+  it('does not replace the startup preference for a registry-source pick', async () => {
+    activeGatewayConnectionId.mockReturnValue('mini')
+    isActivePrimary.mockReturnValue(false)
+
+    newSessionInProfile('designer')
+
+    await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('mini', 'designer'))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(rememberProfile).not.toHaveBeenCalled()
+  })
+
+  it('does not replace the local startup preference for a profile SSH override', async () => {
+    isActivePrimary.mockReturnValue(true)
+
+    const getConnectionConfig = vi.fn(async () => ({ mode: 'ssh' }))
+
+    ;(globalThis as { window?: unknown }).window = {
+      hermesDesktop: {
+        getConnectionConfig,
+        profile: { remember: rememberProfile }
+      }
+    }
+
+    newSessionInProfile('macmini-hermes')
+
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('macmini-hermes'))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(rememberProfile).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -20,6 +20,7 @@ import {
   activeGatewayConnectionId,
   ensureGatewayForAgent,
   ensureGatewayForProfile,
+  isActivePrimary,
   openGatewayForAgent,
   openGatewayForProfile,
   openSecondaryCount
@@ -894,12 +895,30 @@ export function pinNewChatProfile(name: string): string {
 export function newSessionInProfile(name: string): void {
   const target = pinNewChatProfile(name)
   requestFreshSession()
+
+  // A profile reached only through the per-profile "+" moves the live gateway
+  // onto its backend, so it is the last-used profile: persist it for the next
+  // Desktop launch once activation succeeds (#107528 follow-up). Same gate as
+  // the rail path — window-primary activations of local profiles only, never
+  // registry-source picks or remote overrides.
+  const shouldRememberStartupProfile = isActivePrimary()
+    ? isLocalDesktopProfile(target)
+    : Promise.resolve(false)
+
   // #81094: surface the failed dial instead of failing silently.
-  void activateOnCurrentSource(target).catch((error: unknown) => {
-    if (!notifyRemoteOverrideAuthFailure(target, error)) {
-      notifyError(error, `Failed to open profile "${target}"`)
-    }
-  })
+  void Promise.all([activateOnCurrentSource(target), shouldRememberStartupProfile])
+    .then(([, shouldRemember]) => {
+      if (shouldRemember) {
+        return window.hermesDesktop?.profile?.remember(target)
+      }
+
+      return undefined
+    })
+    .catch((error: unknown) => {
+      if (!notifyRemoteOverrideAuthFailure(target, error)) {
+        notifyError(error, `Failed to open profile "${target}"`)
+      }
+    })
 }
 
 /** Start a draft owned by a specific registry agent. Foreground activation is

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -898,9 +898,10 @@ export function newSessionInProfile(name: string): void {
 
   // A profile reached only through the per-profile "+" moves the live gateway
   // onto its backend, so it is the last-used profile: persist it for the next
-  // Desktop launch once activation succeeds (#107528 follow-up). Same gate as
-  // the rail path — window-primary activations of local profiles only, never
-  // registry-source picks or remote overrides.
+  // Desktop launch once activation succeeds (#107528 follow-up). Gate mirrors
+  // the rail path's #102507 shape (isActivePrimary + local-mode check), so a
+  // registry-backed primary inherits #102507's semantics verbatim — any change
+  // to that edge belongs there, not here.
   const shouldRememberStartupProfile = isActivePrimary()
     ? isLocalDesktopProfile(target)
     : Promise.resolve(false)


### PR DESCRIPTION
## What does this PR do?

`newSessionInProfile` (the per-profile "+" in the All-profiles view) moves the live gateway onto the profile's backend but never persisted the startup pointer, so a profile reached only through "+" left `active-profile.json` frozen and the next launch re-rooted the stale profile (#107528 mechanism). This chains the existing `profile.remember` IPC after successful activation, under the rail path's gate.

## Related Issue

Refs #107528 — follow-up sibling. Rail-click persistence is #102507/#107531 scope, not this PR; this covers the remaining activation-without-persistence entry point named in review discussion on #107531, with the reporter's consent to carry it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `apps/desktop/src/store/profile.ts`: `newSessionInProfile` persists via `profile.remember(target)` after `activateOnCurrentSource` succeeds, gated on `isActivePrimary()` + `isLocalDesktopProfile(target)`; the #81094 failed-dial surfacing is preserved unchanged.
- `apps/desktop/src/store/profile-select-source.test.ts`: 4 tests (persist after activation, activation precedes persist, skip for registry-source picks, skip for SSH overrides).

## How to Test

```bash
cd apps/desktop
npx vitest run --project ui src/store/profile-select-source.test.ts
```

- 17 passed (1 file); neighboring profile suites (`profile`, `profile-switch-failure`, `profile-remote-override`) 47 passed.
- Sabotage: reverting the source hunk fails exactly the 2 positive tests, 15 pass — the tests bite.

## Exclusions

- The gate mirrors #102507 verbatim (`isActivePrimary` + local-mode check), including its registry-backed-primary semantics — any change to that edge belongs in #102507, not here.
- No last-write-wins guard across rapid repeated calls and no dedicated persistence-failure message — same as the rail path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run relevant tests locally (desktop vitest ui project; this change is TS, not `pytest tests/`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64 (vitest/jsdom)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — persist path is the existing Electron IPC, not OS-specific
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
