### PR TITLE
fix(update): reuse the parent's pre-update backup in the Windows exe hand-off child (#107543)

### DIFF
--- a/hermes_cli/update_cmd_maint.py
+++ b/hermes_cli/update_cmd_maint.py
@@ -773,6 +773,59 @@ def _run_quick_snapshots() -> Optional[str]:
     return snapshot_id
 
 
+# Path of the pre-update full backup the parent update process wrote, published
+# into the environment so a Windows exe hand-off child (which re-execs the venv
+# Python and re-runs ``hermes update``) can reuse it instead of writing a second,
+# near-identical zip (#107543). The hand-off copies ``{**os.environ}``, so the
+# child inherits this automatically.
+_PRE_UPDATE_BACKUP_ENV = "HERMES_PRE_UPDATE_BACKUP_PATH"
+
+
+def _reuse_handoff_pre_update_backup() -> Optional[Path]:
+    """Return the parent's pre-update full backup to reuse, or ``None`` to write a fresh one.
+
+    On Windows the ``hermes.exe`` shim cannot replace itself, so mid-update it hands off to the
+    venv interpreter, which re-enters the update flow and calls ``_run_pre_update_backup`` a second
+    time. Both legs are one user-visible update, so the child should not take a second full backup
+    (~172 MB / ~20 s each on a real install, #107543). The parent's zip is taken BEFORE the code
+    swap — the more valuable rollback point — so the child reuses it: only when we are the hand-off
+    child AND the parent left a backup whose path (inherited via the environment) still exists.
+    ``backup.py`` writes via an atomic rename, so existence implies a complete zip. Any miss (parent
+    backup failed, path gone) falls through to a fresh full backup — never fewer backups than today.
+    """
+    try:
+        from hermes_cli.main_install_repair import _UPDATE_REEXEC_ENV
+    except Exception:
+        _UPDATE_REEXEC_ENV = "HERMES_UPDATE_REEXEC"
+    if os.environ.get(_UPDATE_REEXEC_ENV) != "1":
+        return None
+    path_str = os.environ.get(_PRE_UPDATE_BACKUP_ENV)
+    if not path_str:
+        return None
+    try:
+        path = Path(path_str)
+        if not path.is_file():
+            return None
+    except Exception:
+        return None
+
+    from hermes_cli.sizefmt import format_bytes
+    try:
+        size = format_bytes(path.stat().st_size)
+    except OSError:
+        size = "unknown size"
+    try:
+        from hermes_constants import display_hermes_home, get_hermes_home
+        display_path = f"{display_hermes_home()}/{path.relative_to(get_hermes_home())}"
+    except Exception:
+        display_path = str(path)
+    print("◆ Pre-update backup: reusing the one taken before the Windows hand-off")
+    print(f"  Kept:     {display_path} ({size})")
+    print(f"  Restore:  hermes import {path}")
+    print()
+    return path
+
+
 def _run_full_backup() -> None:
     """Zip HERMES_HOME under ``backups/`` (restorable via ``hermes import``). Never raises."""
     try:
@@ -821,6 +874,12 @@ def _run_full_backup() -> None:
     print("  Disable:  set updates.pre_update_backup: quick (or off) in config.yaml")
     print()
 
+    # Publish for a Windows exe hand-off child so it reuses this zip instead of
+    # writing a second, near-identical one (#107543); harmless when no hand-off
+    # follows (nothing else re-runs the pre-update backup in this process tree).
+    with suppress(Exception):
+        os.environ[_PRE_UPDATE_BACKUP_ENV] = str(out_path)
+
 
 def _run_pre_update_backup(args) -> Optional[str]:
     """Run the pre-update backup; return the quick-snapshot id (None when off/failed). Never raises.
@@ -849,7 +908,10 @@ def _run_pre_update_backup(args) -> Optional[str]:
             print()
         return snapshot_id
 
-    _run_full_backup()
+    # A Windows exe hand-off child reuses the parent's pre-update zip rather than
+    # writing a second, near-identical one for the same update (#107543).
+    if _reuse_handoff_pre_update_backup() is None:
+        _run_full_backup()
     return snapshot_id
 
 

--- a/tests/hermes_cli/test_update_handoff_backup_dedup.py
+++ b/tests/hermes_cli/test_update_handoff_backup_dedup.py
@@ -1,0 +1,108 @@
+"""The Windows exe hand-off child must not re-run the full pre-update backup.
+
+On Windows the ``hermes.exe`` shim cannot replace itself, so mid-update it hands
+off to the venv interpreter, which re-runs ``hermes update`` and re-enters the
+pre-update backup path. Without a session-level guard both legs write a full
+~172 MB pre-update zip for one user-visible update (#107543). The child reuses
+the parent's zip (taken before the code swap — the better rollback point), which
+the parent publishes into the environment the hand-off inherits.
+"""
+
+import types
+
+import hermes_cli.update_cmd_maint as m
+from hermes_cli.main_install_repair import _UPDATE_REEXEC_ENV
+
+
+class TestReuseHandoffPreUpdateBackup:
+    def test_child_reuses_existing_parent_backup(self, tmp_path, monkeypatch):
+        zip_path = tmp_path / "backups" / "pre-update-2026-09-10-214152.zip"
+        zip_path.parent.mkdir(parents=True)
+        zip_path.write_bytes(b"PK\x03\x04")  # existence => complete (atomic rename)
+
+        monkeypatch.setenv(_UPDATE_REEXEC_ENV, "1")
+        monkeypatch.setenv(m._PRE_UPDATE_BACKUP_ENV, str(zip_path))
+
+        assert m._reuse_handoff_pre_update_backup() == zip_path
+
+    def test_non_handoff_process_never_reuses(self, tmp_path, monkeypatch):
+        """The parent (not a re-exec child) always takes its own backup even if the
+        path env var is somehow present — no accidental skip of the real backup."""
+        zip_path = tmp_path / "pre-update.zip"
+        zip_path.write_bytes(b"PK\x03\x04")
+        monkeypatch.delenv(_UPDATE_REEXEC_ENV, raising=False)
+        monkeypatch.setenv(m._PRE_UPDATE_BACKUP_ENV, str(zip_path))
+
+        assert m._reuse_handoff_pre_update_backup() is None
+
+    def test_child_without_published_path_takes_fresh_backup(self, monkeypatch):
+        monkeypatch.setenv(_UPDATE_REEXEC_ENV, "1")
+        monkeypatch.delenv(m._PRE_UPDATE_BACKUP_ENV, raising=False)
+
+        assert m._reuse_handoff_pre_update_backup() is None
+
+    def test_child_with_missing_parent_backup_takes_fresh_backup(self, tmp_path, monkeypatch):
+        """Parent backup failed / was pruned: the child must fall through to a fresh
+        full backup rather than silently leaving no rollback point."""
+        monkeypatch.setenv(_UPDATE_REEXEC_ENV, "1")
+        monkeypatch.setenv(m._PRE_UPDATE_BACKUP_ENV, str(tmp_path / "gone.zip"))
+
+        assert m._reuse_handoff_pre_update_backup() is None
+
+
+class TestRunPreUpdateBackupFullLeg:
+    def _full_mode_args(self, monkeypatch):
+        monkeypatch.setattr(m, "_resolve_pre_update_backup_mode", lambda _a: "full")
+        monkeypatch.setattr(m, "_run_quick_snapshots", lambda: "snap-1")
+
+    def test_handoff_child_skips_full_backup(self, tmp_path, monkeypatch):
+        self._full_mode_args(monkeypatch)
+        zip_path = tmp_path / "pre-update.zip"
+        zip_path.write_bytes(b"PK\x03\x04")
+        monkeypatch.setenv(_UPDATE_REEXEC_ENV, "1")
+        monkeypatch.setenv(m._PRE_UPDATE_BACKUP_ENV, str(zip_path))
+
+        calls = []
+        monkeypatch.setattr(m, "_run_full_backup", lambda: calls.append(1))
+
+        snap = m._run_pre_update_backup(types.SimpleNamespace())
+        assert snap == "snap-1"          # quick snapshot still runs (self-prunes)
+        assert calls == []               # but the full zip is NOT re-taken
+
+    def test_parent_still_takes_full_backup(self, monkeypatch):
+        self._full_mode_args(monkeypatch)
+        monkeypatch.delenv(_UPDATE_REEXEC_ENV, raising=False)
+
+        calls = []
+        monkeypatch.setattr(m, "_run_full_backup", lambda: calls.append(1))
+
+        m._run_pre_update_backup(types.SimpleNamespace())
+        assert calls == [1]
+
+
+class TestFullBackupPublishesPath:
+    def test_successful_backup_publishes_path_env(self, tmp_path, monkeypatch):
+        zip_path = tmp_path / "backups" / "pre-update.zip"
+        zip_path.parent.mkdir(parents=True)
+        zip_path.write_bytes(b"PK\x03\x04")
+
+        import hermes_cli.backup as backup
+        monkeypatch.setattr(backup, "create_pre_update_backup", lambda **_k: zip_path)
+        monkeypatch.setattr(m, "_load_updates_cfg", lambda: {"backup_keep": 5})
+        monkeypatch.delenv(m._PRE_UPDATE_BACKUP_ENV, raising=False)
+
+        m._run_full_backup()
+
+        import os
+        assert os.environ.get(m._PRE_UPDATE_BACKUP_ENV) == str(zip_path)
+
+    def test_failed_backup_does_not_publish_path(self, monkeypatch):
+        import hermes_cli.backup as backup
+        monkeypatch.setattr(backup, "create_pre_update_backup", lambda **_k: None)
+        monkeypatch.setattr(m, "_load_updates_cfg", lambda: {"backup_keep": 5})
+        monkeypatch.delenv(m._PRE_UPDATE_BACKUP_ENV, raising=False)
+
+        m._run_full_backup()
+
+        import os
+        assert m._PRE_UPDATE_BACKUP_ENV not in os.environ


### PR DESCRIPTION
## What does this PR do?

On Windows the `hermes.exe` shim cannot replace itself, so mid-update it hands off to the venv interpreter, which re-runs `hermes update` and re-enters the pre-update backup path. Both legs called `_run_full_backup()`, so a single `hermes update --yes --backup` wrote **two** near-identical ~172 MB `pre-update-*.zip` files (~343 MB / ~45 s per update, #107543). Quick snapshots self-prune, but the full zips accumulate — and the redundant *child* zip is the one most users keep, while the *parent's* zip (taken before the code swap) is the more valuable rollback point.

This implements the issue's **Option A** (preferred): the parent publishes its completed backup path into the environment (`HERMES_PRE_UPDATE_BACKUP_PATH`); the hand-off copies `{**os.environ}` (`main_install_repair.py`), so the child inherits it. When the child — identified by `HERMES_UPDATE_REEXEC=1` — finds that path still on disk, it reuses the parent's backup and skips the full leg, printing a receipt line for the skip. `backup.py` writes via an atomic rename, so existence implies a complete zip (the issue's freshness/integrity signal). Any miss (parent backup failed or was pruned) falls through to a fresh full backup, so the child is **never** left without a rollback point.

The quick state-snapshot still runs in both legs (it self-prunes to keep=1), so the `pre_update_snapshot_id` that feeds the post-update safety net is unchanged.

## Related Issue

Fixes #107543

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd_maint.py`: added `_PRE_UPDATE_BACKUP_ENV` and `_reuse_handoff_pre_update_backup()`; `_run_full_backup()` publishes the completed backup path on success; `_run_pre_update_backup()` skips the full leg when the hand-off child can reuse the parent's zip.
- `tests/hermes_cli/test_update_handoff_backup_dedup.py`: reuse predicate (child-with-live-parent-zip reuses; parent / missing-path / gone-file each take a fresh backup), full-leg skip wiring, and parent publishing/not-publishing the path on success/failure.

## How to Test

1. `pytest tests/hermes_cli/test_update_handoff_backup_dedup.py -q` — **8 passed**.
2. Regression: `pytest tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_backup.py -q` — **126 passed**.
3. `ruff check hermes_cli/update_cmd_maint.py tests/hermes_cli/test_update_handoff_backup_dedup.py` — clean.

## Checklist

- [x] Conventional commit (`fix(update):`)
- [x] Searched existing PRs/issues — no open PR covers this hand-off backup dedup
- [x] Only changes related to this fix
- [x] Added tests
- [x] Cross-platform: the guard is pure `os.environ`/`pathlib`; on non-Windows nothing re-runs the pre-update backup in one process tree, so behavior is unchanged
