### PR TITLE
fix(desktop): stop non-owning windows answering terminal/preview/window read bridges

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { readActivePreview } from '@/app/chat/right-rail/preview-reader'
+import { readActiveTerminal } from '@/app/right-sidebar/terminal/buffer'
 import { $gateway } from '@/store/gateway'
 import { $toursEnabled } from '@/store/tours'
 
 import { handleDesktopBridgeEvent } from './desktop-bridge'
 import type { GatewayEventContext } from './types'
+
+vi.mock('@/app/right-sidebar/terminal/buffer', () => ({ readActiveTerminal: vi.fn() }))
+vi.mock('@/app/chat/right-rail/preview-reader', () => ({ readActivePreview: vi.fn() }))
 
 function previewActContext({
   explicitSid,
@@ -45,6 +50,157 @@ describe('preview action bridge routing', () => {
         error: 'The in-app browser only takes actions in the session the user is looking at.',
         success: false
       })
+    })
+  })
+})
+
+function terminalReadContext({
+  explicitSid,
+  isActiveEvent
+}: {
+  explicitSid: string
+  isActiveEvent: boolean
+}): GatewayEventContext {
+  return {
+    event: { session_id: explicitSid || undefined, type: 'terminal.read.request' },
+    explicitSid,
+    isActiveEvent,
+    payload: { request_id: 'terminal-request-1' }
+  } as GatewayEventContext
+}
+
+describe('terminal read bridge routing', () => {
+  afterEach(() => {
+    $gateway.set(null)
+    vi.mocked(readActiveTerminal).mockReset()
+  })
+
+  it('leaves a scoped read request unanswered in a window showing another session', () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+    vi.mocked(readActiveTerminal).mockReturnValue({ lines: ['this window is on a different session'] } as never)
+
+    expect(handleDesktopBridgeEvent(terminalReadContext({ explicitSid: 'session-a', isActiveEvent: false }))).toBe(true)
+
+    // The window must not read (let alone report) ITS OWN terminal buffer for
+    // a request scoped to a session it isn't showing — that content would be
+    // wrong for the caller and could race the owning window's real answer.
+    expect(readActiveTerminal).not.toHaveBeenCalled()
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('still answers from the owning window', () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+    vi.mocked(readActiveTerminal).mockReturnValue({ lines: ['hello'] } as never)
+
+    expect(handleDesktopBridgeEvent(terminalReadContext({ explicitSid: 'session-a', isActiveEvent: true }))).toBe(true)
+
+    expect(request).toHaveBeenCalledWith('terminal.read.respond', {
+      request_id: 'terminal-request-1',
+      text: JSON.stringify({ lines: ['hello'] })
+    })
+  })
+})
+
+function previewReadContext({
+  explicitSid,
+  isActiveEvent
+}: {
+  explicitSid: string
+  isActiveEvent: boolean
+}): GatewayEventContext {
+  return {
+    event: { session_id: explicitSid || undefined, type: 'preview.read.request' },
+    explicitSid,
+    isActiveEvent,
+    payload: { request_id: 'preview-request-1' }
+  } as GatewayEventContext
+}
+
+describe('preview read bridge routing', () => {
+  afterEach(() => {
+    $gateway.set(null)
+    vi.mocked(readActivePreview).mockReset()
+  })
+
+  it('leaves a scoped read request unanswered in a window showing another session', async () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+    vi.mocked(readActivePreview).mockResolvedValue({ text: 'this window is on a different session' } as never)
+
+    expect(handleDesktopBridgeEvent(previewReadContext({ explicitSid: 'session-a', isActiveEvent: false }))).toBe(true)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(readActivePreview).not.toHaveBeenCalled()
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('still answers from the owning window', async () => {
+    const request = vi.fn()
+    $gateway.set({ request } as never)
+    vi.mocked(readActivePreview).mockResolvedValue({ text: 'hello' } as never)
+
+    expect(handleDesktopBridgeEvent(previewReadContext({ explicitSid: 'session-a', isActiveEvent: true }))).toBe(true)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(request).toHaveBeenCalledWith('preview.read.respond', {
+      request_id: 'preview-request-1',
+      text: JSON.stringify({ text: 'hello' })
+    })
+  })
+})
+
+function windowReadContext({
+  explicitSid,
+  isActiveEvent
+}: {
+  explicitSid: string
+  isActiveEvent: boolean
+}): GatewayEventContext {
+  return {
+    event: { session_id: explicitSid || undefined, type: 'window.read.request' },
+    explicitSid,
+    isActiveEvent,
+    payload: { request_id: 'window-request-1' }
+  } as GatewayEventContext
+}
+
+describe('window read bridge routing', () => {
+  afterEach(() => {
+    $gateway.set(null)
+  })
+
+  it('leaves a scoped read request unanswered in a window showing another session', async () => {
+    const request = vi.fn()
+    const readWindowBelow = vi.fn(async () => 'this window is on a different session')
+    $gateway.set({ request } as never)
+    Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: { readWindowBelow } })
+
+    expect(handleDesktopBridgeEvent(windowReadContext({ explicitSid: 'session-a', isActiveEvent: false }))).toBe(true)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Must not even ask main what sits behind THIS (non-owning) window.
+    expect(readWindowBelow).not.toHaveBeenCalled()
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('still answers from the owning window', async () => {
+    const request = vi.fn()
+    const readWindowBelow = vi.fn(async () => 'hello')
+    $gateway.set({ request } as never)
+    Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: { readWindowBelow } })
+
+    expect(handleDesktopBridgeEvent(windowReadContext({ explicitSid: 'session-a', isActiveEvent: true }))).toBe(true)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(request).toHaveBeenCalledWith('window.read.respond', {
+      request_id: 'window-request-1',
+      text: JSON.stringify('hello')
     })
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -53,6 +53,14 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
     if (requestId) {
+      // Every mounted desktop window can observe the same gateway event. A
+      // scoped mismatch belongs to another window, so answering here would
+      // race the owning window with THIS window's unrelated terminal buffer
+      // and could make it win before the real result does.
+      if (explicitSid && !isActiveEvent) {
+        return true
+      }
+
       const start = typeof payload?.start === 'number' ? payload.start : undefined
       const count = typeof payload?.count === 'number' ? payload.count : undefined
       const result = readActiveTerminal({ start, count })
@@ -72,6 +80,14 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
     if (requestId) {
+      // Every mounted desktop window can observe the same gateway event. A
+      // scoped mismatch belongs to another window, so answering here would
+      // race the owning window with THIS window's unrelated preview pane
+      // and could make it win before the real result does.
+      if (explicitSid && !isActiveEvent) {
+        return true
+      }
+
       const start = typeof payload?.start === 'number' ? payload.start : undefined
       const count = typeof payload?.count === 'number' ? payload.count : undefined
 
@@ -144,6 +160,15 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
     if (requestId) {
+      // Every mounted desktop window can observe the same gateway event. A
+      // scoped mismatch belongs to another window, so answering here would
+      // race the owning window with whatever THIS window (not the one the
+      // user is looking at) happens to sit behind, and could make it win
+      // before the real result does.
+      if (explicitSid && !isActiveEvent) {
+        return true
+      }
+
       const read = window.hermesDesktop?.readWindowBelow
 
       const answer = (result: unknown) =>


### PR DESCRIPTION
## What does this PR do?

`desktop-bridge.ts`'s `handleDesktopBridgeEvent` dispatches every gateway-pushed request in every mounted desktop window (main app window, HUD, popouts). Same-day sibling commits already taught `preview.act.request` and `tour.request` to stay silent when a scoped event belongs to another window's session, because an inactive window's response can otherwise win the backend's first-response race for that `request_id`.

The three read-only bridges in the same dispatch function never got that guard:

- `terminal.read.request` (`read_terminal` tool)
- `preview.read.request` (`read_preview` tool)
- `window.read.request` (`read_window_below` tool)

Each of them unconditionally computes and answers with **this window's own local state** — its own xterm buffer, its own preview pane, whatever OS window sits behind it — regardless of which session the event was actually scoped to. Unlike the `preview.act.request`/`tour.request` case (where an inactive window sends an explicit *refusal* that can only race a real answer), here the non-owning window sends **real-looking, wrong content** that can win the race and be delivered to the agent as if it were correct — silently, with no error surfaced anywhere.

### Failure scenario

Window 1 shows session A (active), Window 2 shows session B. Session A's agent calls `read_terminal`. The gateway event reaches both windows. Window 1 answers correctly with session A's terminal. Window 2 (`isActiveEvent=false` for A) also computes and sends back **session B's** terminal buffer for the same `request_id` — if it wins the race, the agent gets an unrelated window's content presented as its own terminal output. Same shape for `read_preview` and `read_window_below`.

### Fix

Mirror the exact guard already used by `preview.act.request`/`tour.request` (`if (explicitSid && !isActiveEvent) return true`) into the three read handlers, before any work is done — a non-owning window now consumes the event without answering, letting the true owner respond.

## Competitor / precedent check

- Zero PR targets this scoping gap for these three request types (searched by request-type name and by the `isActiveEvent`/`explicitSid` guard shape).
- Open PR #95475 ("bind preview actions to the owning session's active tab") touches the same file, but only the *admission* logic of `preview.act.request` (widening it to also allow a background session that owns the on-screen preview tab) — verified via `gh pr diff` that it does not touch `terminal.read.request`, `preview.read.request`, or `window.read.request` at all. No overlap.

## Testing

Added `desktop-bridge.test.ts` coverage for all three handlers: a scoped mismatch leaves the window silent (and confirms the underlying read function — `readActiveTerminal`/`readActivePreview`/`readWindowBelow` — is never even invoked, not just that no response is sent), and the owning window still answers exactly as before. Mutation-verified: reverting the source guard while keeping the tests reproduces the bug (all 3 new "unanswered" assertions fail with the wrong content actually being sent). `tsc --noEmit` and `eslint` clean; full `gateway-event/` test directory (19 tests) passes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)