### PR TITLE
fix(compression): guard non-scalar content-part `type` in the two compressor siblings #104840 missed

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1289,7 +1289,10 @@ _IMAGE_PART_TYPES = frozenset({"image_url", "input_image", "image"})
 
 def _is_image_part(part: Any) -> bool:
     """True if ``part`` is an image block (``image_url``, ``input_image``, or ``image``)."""
-    return isinstance(part, dict) and part.get("type") in _IMAGE_PART_TYPES
+    if not isinstance(part, dict):
+        return False
+    part_type = part.get("type")
+    return isinstance(part_type, str) and part_type in _IMAGE_PART_TYPES
 
 
 def _content_has_images(content: Any) -> bool:
@@ -1363,7 +1366,7 @@ def _summary_part_text(part: Any) -> str:
     ptype = part.get("type")
     if ptype == "text":
         return part.get("text", "")
-    return _image_part_label(part) if ptype in _IMAGE_PART_TYPES else f"[{ptype or 'attachment'}]"
+    return _image_part_label(part) if isinstance(ptype, str) and ptype in _IMAGE_PART_TYPES else f"[{ptype or 'attachment'}]"
 
 
 def _image_part_label(part: Dict[str, Any]) -> str:

--- a/tests/agent/test_compressor_unhashable_image_types.py
+++ b/tests/agent/test_compressor_unhashable_image_types.py
@@ -1,0 +1,24 @@
+"""Regression tests for non-scalar content-part types."""
+
+from agent.context_compressor import (
+    ContextCompressor,
+    _content_has_images,
+)
+
+
+def test_non_scalar_types_are_safe_and_not_images():
+    for value in ({"type": {"type": "string"}}, {"type": ["string", "null"]}):
+        content = [value]
+        assert _content_has_images(content) is False
+
+        compressor = ContextCompressor.__new__(ContextCompressor)
+        serialized = compressor._serialize_for_summary([{"role": "user", "content": content}])
+        assert serialized.startswith("[USER]: ")
+
+
+def test_scalar_content_types_keep_existing_behavior():
+    compressor = ContextCompressor.__new__(ContextCompressor)
+    assert _content_has_images([{"type": "image_url", "image_url": {"url": "https://example.test/x"}}]) is True
+    assert _content_has_images([{"type": "text", "text": "hello"}]) is False
+    serialized = compressor._serialize_for_summary([{"role": "user", "content": [{"type": "text", "text": "hello"}]}])
+    assert "hello" in serialized


### PR DESCRIPTION
## Summary

`#104793` and `#104795` reported the same mechanism — `TypeError: unhashable type: 'dict'` raised by a `part.get("type") in <frozenset>` membership test when a JSON-Schema node carries a sub-schema (or a multi-type list) under the `"type"` key. A dict and a list are both unhashable, so the membership test raises instead of returning `False`.

The merged fix (#104840) guarded **one of three** sites. This PR guards the two remaining siblings, which live on the context-compression path.

## Root cause

`_IMAGE_PART_TYPES` is a `frozenset`. Testing `x in frozenset` hashes `x`, so a non-scalar `type` value raises `TypeError` rather than simply not matching.

`agent/chat_completion_helpers.py::_payload_chars` was fixed in #104840 and now reads:

```python
part_type = value.get("type")
# JSON-Schema nodes may hold a sub-schema (``properties.type``) or a multi-type list
# under the "type" key; only scalar content-part types can ever match (#104793).
if isinstance(part_type, str) and part_type in _IMAGE_PART_TYPES and ...
```

Two siblings in `agent/context_compressor.py` were left unguarded:

- `_is_image_part` (line 1292): `return isinstance(part, dict) and part.get("type") in _IMAGE_PART_TYPES`
- `_summary_part_text` (line 1366): `return _image_part_label(part) if ptype in _IMAGE_PART_TYPES else ...`

## Why this matters (severity)

The raise is **not** contained by compression's own error handling. `_serialize_for_summary` is called at `agent/context_compressor.py:3309`, *before* the `try` block that begins at line 3314, so the `TypeError` escapes `_generate_summary` instead of being routed through `_on_summary_failure`. The same crash is independently reachable via `_content_has_images` during media pruning (lines 1202-1204, 1319-1351).

Consequence: a session holding such a content part cannot compress. Once it is over the limit, it stays over the limit — the "permanently uncompressible session" symptom of the closed pain cluster #106459 / #105663.

## Reachability

Tool-result messages are built without scalar coercion of the content parts (`agent/tool_dispatch_helpers.py:400-425`), and MCP results are explicitly treated as untrusted tool output (lines 425-429). Provider-shaped or schema-shaped blocks can therefore remain in a message `content` list and reach compression with a non-scalar `type`.

## The change

Applies the same guard shape the merged sibling fix used, at both sites. Behavior for every legitimate scalar type is unchanged; a dict- or list-valued `type` now falls into the existing non-image branch instead of raising.

```
agent/context_compressor.py | 7 +++++--
tests/agent/test_compressor_unhashable_image_types.py | 24 ++++++++++
2 files changed, 29 insertions(+), 2 deletions(-)
```

## Tests

New behavior-contract regression test (no source-text reading, no snapshots):

- a content part whose `type` is a dict, and one whose `type` is a list, must not raise and must not be classified as an image
- controls: `{"type": "image_url", ...}` is still detected as an image; `{"type": "text", "text": "hello"}` still yields its text

**Proven red before green.** With only `agent/context_compressor.py` restored to `origin/main` and the new test kept:

```
$ scripts/run_tests.sh tests/agent/test_compressor_unhashable_image_types.py
part = {'type': {'type': 'string'}}
>       return isinstance(part, dict) and part.get("type") in _IMAGE_PART_TYPES
E       TypeError: unhashable type: 'dict'
agent\context_compressor.py:1292: TypeError
========================= 1 failed, 1 passed in 0.57s =========================
```

Green after the fix, via the canonical wrapper (`scripts/run_tests.sh`):

| Scope | Result |
|---|---|
| `tests/agent/test_compressor_unhashable_image_types.py` | 2 passed |
| `tests/agent/test_context_compressor.py` | 149 passed |
| `tests/agent/test_compressor_historical_media.py` | 23 passed |
| `tests/agent/test_compressor_stale_tool_images.py` | 6 passed |
| `tests/agent/test_compressor_image_tokens.py` | 4 passed |
| `tests/agent/test_compressor_media_stripping.py` | 3 passed |

No pre-existing failures were encountered in these files.

## Related work

- #104793, #104795 — closed reports of this exact mechanism
- #104840 — merged fix; covered `chat_completion_helpers.py::_payload_chars` only
- #106459, #105663 — closed "permanently uncompressible session" cluster, the symptom this crash can produce

## Scope

Two guard expressions plus one new test file. No refactor, no new helper, no behavior change for scalar types.
