### PR TITLE
fix(cli): the orphan-serve reaper still identifies processes by argv substring (#90778 sibling)

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -492,9 +492,11 @@ def _is_desktop_local_serve_cmdline(command: str) -> bool:
     Long-lived headless serves (``--host <tailscale-ip> --port 9119``) must never match —
     those are operator-managed remote backends that legitimately run with ppid 1.
     """
-    cmd = command.lower()
-    if "serve" not in cmd or ("hermes" not in cmd and "hermes_cli" not in cmd):
+    from hermes_cli.update_cmd_windows import _hermes_holder_subcommand
+
+    if _hermes_holder_subcommand(command) != "serve":
         return False
+    cmd = command.lower()
     has_loopback = any(tok in cmd for tok in (
         "--host 127.0.0.1", "--host=127.0.0.1", "--host localhost", "--host=localhost"))
     return has_loopback and ("--port 0" in cmd or "--port=0" in cmd)

--- a/tests/hermes_cli/test_orphan_desktop_serve_reap.py
+++ b/tests/hermes_cli/test_orphan_desktop_serve_reap.py
@@ -27,6 +27,13 @@ def test_desktop_local_serve_shape_matches_ephemeral_loopback():
     assert _is_desktop_local_serve_cmdline(
         "/venv/bin/hermes serve --host=127.0.0.1 --port=0"
     )
+    assert not _is_desktop_local_serve_cmdline(
+        "hermes_cli.main kanban --preserve-cache --host 127.0.0.1 --port 0"
+    )
+    assert not _is_desktop_local_serve_cmdline(
+        "/home/u/hermes-server/venv/bin/python -m hermes_cli.main dashboard "
+        "--host 127.0.0.1 --port 0"
+    )
 
 
 def test_desktop_local_serve_shape_spares_fixed_port_and_non_serve():


### PR DESCRIPTION
## Summary

`#90778` reported that Windows venv-holder code identified Hermes subcommands by raw argv **substring**. The merged fix (#91869) corrected the venv-holder labeling path and introduced the parser-derived matcher `_hermes_holder_subcommand`. A sibling consumer in `hermes_cli/dashboard_procs.py` still does the substring test — and that one feeds a process **reaper**.

## Root cause

`hermes_cli/dashboard_procs.py::_is_desktop_local_serve_cmdline` (line ~496):

```python
cmd = command.lower()
if "serve" not in cmd or ("hermes" not in cmd and "hermes_cli" not in cmd):
    return False
```

`"serve"` is a substring of `preserve`, `server`, `observer`, `reserved`. The repository's own sibling module documents this exact hazard at `hermes_cli/update_cmd_windows.py:231`:

> Token-based, never substring (``kanban --preserve-cache`` contains "serve")

and the root `AGENTS.md` names it as a bug class:

> Never infer process identity from argv substrings (`"serve" in cmdline`) — the bug class behind ~10 fleet-update issues (#90778, #87594, #78089, #76129, #91964). Use the canonical matchers ... match FULL cmdlines and truncate only for display.

## Why this matters (severity)

The sole consumer is the orphan reap at `hermes_cli/dashboard_procs.py:641`:

```python
matched = [pid for pid, cmd in scanned
           if _is_desktop_local_serve_cmdline(cmd) and pid not in owned_now
           and _process_ppid(pid) in (0, 1) and _is_stale_orphan(pid)]
```

Matched PIDs receive `SIGTERM`, then `SIGKILL` after a grace period. A false positive therefore **kills a live user process**.

Reachability: `_scan_dashboard_processes` reads full command lines from `ps -A -o pid=,command=` (lines 65-70) and also accepts full argv from the process ledger (lines 92-105), so absolute paths are present in the matched string. A checkout or venv path containing `preserve`/`server` — e.g. `/home/u/hermes-server/venv/bin/python -m hermes_cli.main dashboard --host 127.0.0.1 --port 0` — satisfies the substring gate. `dashboard` accepts `--host`/`--port` (`hermes_cli/subcommands/dashboard.py:18-19`). The reap is POSIX-only: `_process_ppid()` returns `None` on win32 (lines 505-509).

Honest scoping: the full trigger requires loopback host + `--port 0` + ppid 0/1 + stale age + not lock-owned, so the argv shape is uncommon. This is a documented invariant violation with a lethal consequence, not a widespread incident.

## The change

Uses the existing canonical parser-derived matcher instead of adding a second classifier:

```python
from hermes_cli.update_cmd_windows import _hermes_holder_subcommand

if _hermes_holder_subcommand(command) != "serve":
    return False
```

Two deliberate details:

- **Imported from the defining module.** `_hermes_holder_subcommand` is defined in `hermes_cli/update_cmd_windows.py:228`; `hermes_cli/update_cmd.py` only re-exports it. Root `AGENTS.md`: *"Import from the defining module."*
- **Imported lazily, inside the function.** `hermes_cli/update_cmd_maint.py:288-300` and `update_cmd_config.py:18-24` reload the process-scan modules dependency-first in the order (`hermes_cli._subprocess_compat`, `hermes_cli.dashboard_procs`). A module-level import of the heavier `update_cmd*` surface into `dashboard_procs` would invert that documented direction and risk binding a stale module object during an update reload. Verified no cycle: `update_cmd_windows.py` does not import `dashboard_procs` at module level.

Loopback/`--port 0` semantics are unchanged: fixed-port operator serves (`--host 100.x --port 9119`) still do not match.

```
hermes_cli/dashboard_procs.py | 6 ++++--
tests/hermes_cli/test_orphan_desktop_serve_reap.py | 7 +++++++
2 files changed, 11 insertions(+), 2 deletions(-)
```

## Tests

Added behavior-contract negatives (no source-text reading):

- `... hermes_cli.main kanban --preserve-cache --host 127.0.0.1 --port 0` → must be `False`
- `/home/u/hermes-server/venv/bin/python -m hermes_cli.main dashboard --host 127.0.0.1 --port 0` → must be `False`

Existing positives and negatives are retained: `hermes serve --host 127.0.0.1 --port 0`, `--isolated`, `--host=127.0.0.1 --port=0` stay `True`; fixed-port and non-serve cases stay `False`.

Note: the pre-existing negative `"vim notes about hermes serve --port 0"` passed only because it lacks a loopback host — incidental, not protection against this class.

**Proven red before green.** With only `hermes_cli/dashboard_procs.py` restored to `origin/main` and the new tests kept, the wrapper reported 1 of 11 failing: the `kanban --preserve-cache` case returned `True`.

Green after the fix, via the canonical wrapper (`scripts/run_tests.sh`):

| Scope | Result |
|---|---|
| `tests/hermes_cli/test_orphan_desktop_serve_reap.py` | 11 passed |
| `tests/hermes_cli/test_venv_holder_classifier.py` | 20 passed |
| `tests/hermes_cli/test_scan_venv_blockers.py` | 38 passed |
| `tests/hermes_cli/test_update_serve_generation_recovery.py` | 59 passed |
| `tests/hermes_cli/test_update_concurrent_quarantine.py` | 32 passed |
| `tests/hermes_cli/test_update_stale_dashboard.py` | 31 passed, 14 skipped (non-Windows) |
| `tests/hermes_cli/test_stale_pid_guard.py` | 17 passed |
| `tests/hermes_cli/test_serve_runtime_inventory.py` | 12 passed |
| `tests/hermes_cli/test_dashboard_lifecycle_flags.py` | 8 passed |
| `tests/hermes_cli/test_update_desktop_stale_warning.py` | 8 passed |
| `tests/hermes_cli/test_lazy_command_exports.py` | 4 passed |
| `tests/hermes_cli/test_update_sqlite_remediation.py` | 4 passed |
| `tests/hermes_cli/test_curator_recent_run_notice.py` | 2 passed |
| `tests/hermes_cli/test_update_modified_notice.py` | 1 passed |

The updater-reload suites were run specifically because this change alters an import inside a module the updater reloads.

**Pre-existing failure, disclosed:** `tests/test_resource_limits.py` reported 21 passed / 1 failed (a spawned subprocess could not determine its home directory). Re-running that file with `hermes_cli/dashboard_procs.py` reverted to `origin/main` reproduced the identical failure, so it is pre-existing and unrelated to this change.

## Related work

- #90778 — closed report of the substring-identity mechanism
- #91869 — merged fix; covered the venv-holder labeling path only
- #87594, #78089, #76129, #91964 — the wider bug class cited in `AGENTS.md`

## Scope

One predicate plus two test cases. No refactor, no new classifier, no change to reap policy or host/port semantics.
