### PR TITLE
fix(desktop): flag a rebuild when the installed app's commit is behind HEAD (#107542)

### DIFF
--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -6,6 +6,7 @@ are imported lazily inside the functions that use them (avoids an import cycle).
 
 import logging
 import contextlib
+import json
 import argparse
 import os
 import re
@@ -109,9 +110,59 @@ def _desktop_build_needed(desktop_dir: Path, project_root: Path, *, source_mode:
         print(f"  ⚠ A previous update left the desktop bundle incomplete ({dist_dir}); rebuilding it")
         return True
 
+    # A failed stage-and-swap leaves the source-content stamp current while the
+    # INSTALLED app in release/ is behind: the swap failed, so the packaged tree
+    # still holds the OLD commit, and the content hash (which describes the
+    # source tree, not the output) can't see it. Treat installed-stamp commit !=
+    # HEAD as a rebuild trigger too, so `hermes desktop` stops reporting an app
+    # weeks behind as up to date (#107542). Packaged mode only — a source-mode
+    # run has no installed stamp.
+    if not source_mode and _installed_desktop_stamp_behind_head(desktop_dir, project_root):
+        print("  ⚠ The installed desktop app was built from an older commit than the "
+              "checkout; rebuilding it")
+        return True
+
     return not _stamp_is_current(
         _desktop_stamp_path(), lambda: _compute_desktop_content_hash(project_root), sourceMode=source_mode
     )
+
+
+def _installed_desktop_commit(desktop_dir: Path) -> Optional[str]:
+    """Commit the currently-installed packaged desktop app was built from.
+
+    Read from ``install-stamp.json`` shipped in the unpacked app's resources (beside the exe on
+    Windows/Linux, under ``Contents/Resources`` on macOS). Returns ``None`` when the stamp is
+    absent, unreadable, malformed, or an unpinned all-zero fallback (a local/ZIP build with no
+    real commit — not a divergence signal).
+    """
+    exe = _desktop_packaged_executable(desktop_dir)
+    if exe is None:
+        return None
+    resources = exe.parent.parent / "Resources" if sys.platform == "darwin" else exe.parent / "resources"
+    try:
+        data = json.loads((resources / "install-stamp.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    commit = data.get("commit") if isinstance(data, dict) else None
+    if not isinstance(commit, str) or len(commit) != 40 or commit == "0" * 40:
+        return None
+    return commit
+
+
+def _installed_desktop_stamp_behind_head(desktop_dir: Path, project_root: Path) -> bool:
+    """True only when the installed app's commit and HEAD are both resolvable and differ.
+
+    Conservative by design: any unknown (no/fallback stamp, no resolvable git HEAD) returns
+    ``False`` so a signal we cannot trust never forces a rebuild (#107542).
+    """
+    installed = _installed_desktop_commit(desktop_dir)
+    if installed is None:
+        return False
+    from hermes_cli.build_info import _resolve_git_head_sha
+    head = _resolve_git_head_sha(project_root)
+    if head is None:
+        return False
+    return installed != head
 
 
 def _write_desktop_build_stamp(project_root: Path, *, source_mode: bool) -> None:

--- a/tests/hermes_cli/test_desktop_installed_stamp_staleness.py
+++ b/tests/hermes_cli/test_desktop_installed_stamp_staleness.py
@@ -1,0 +1,121 @@
+"""`hermes desktop` must not report up to date when the INSTALLED app is behind.
+
+A failed stage-and-swap leaves the source-content build stamp current while the
+packaged app in ``release/`` still holds an older commit. The content hash
+describes the source tree, not the output, so it can't see the gap — the app
+silently runs weeks behind. `_desktop_build_needed()` now also treats an
+installed-stamp commit that diverges from HEAD as a rebuild trigger (#107542).
+"""
+
+import json
+
+import hermes_cli.build_info as build_info
+import hermes_cli.main_desktop as md
+
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+FALLBACK = "0" * 40
+
+
+def _install_app(tmp_path, platform, *, stamp=None):
+    """Build a fake unpacked app for *platform* and return (exe_path, resources_dir)."""
+    if platform == "darwin":
+        exe = tmp_path / "release" / "mac" / "Hermes.app" / "Contents" / "MacOS" / "Hermes"
+        resources = exe.parent.parent / "Resources"
+    elif platform == "win32":
+        exe = tmp_path / "release" / "win-unpacked" / "Hermes.exe"
+        resources = exe.parent / "resources"
+    else:
+        exe = tmp_path / "release" / "linux-unpacked" / "hermes"
+        resources = exe.parent / "resources"
+    exe.parent.mkdir(parents=True, exist_ok=True)
+    exe.write_text("", encoding="utf-8")
+    resources.mkdir(parents=True, exist_ok=True)
+    if stamp is not None:
+        (resources / "install-stamp.json").write_text(json.dumps(stamp), encoding="utf-8")
+    return exe, resources
+
+
+class TestInstalledDesktopCommit:
+    def test_reads_commit_for_each_platform(self, tmp_path, monkeypatch):
+        for platform in ("darwin", "win32", "linux"):
+            base = tmp_path / platform
+            exe, _ = _install_app(base, platform, stamp={"schemaVersion": 1, "commit": SHA_A})
+            monkeypatch.setattr(md.sys, "platform", platform)
+            monkeypatch.setattr(md, "_desktop_packaged_executable", lambda _d, exe=exe: exe)
+            assert md._installed_desktop_commit(base) == SHA_A
+
+    def test_missing_stamp_returns_none(self, tmp_path, monkeypatch):
+        exe, _ = _install_app(tmp_path, "linux", stamp=None)
+        monkeypatch.setattr(md.sys, "platform", "linux")
+        monkeypatch.setattr(md, "_desktop_packaged_executable", lambda _d: exe)
+        assert md._installed_desktop_commit(tmp_path) is None
+
+    def test_fallback_commit_is_not_a_signal(self, tmp_path, monkeypatch):
+        exe, _ = _install_app(tmp_path, "linux", stamp={"commit": FALLBACK})
+        monkeypatch.setattr(md.sys, "platform", "linux")
+        monkeypatch.setattr(md, "_desktop_packaged_executable", lambda _d: exe)
+        assert md._installed_desktop_commit(tmp_path) is None
+
+    def test_malformed_stamp_returns_none(self, tmp_path, monkeypatch):
+        exe, resources = _install_app(tmp_path, "linux", stamp=None)
+        (resources / "install-stamp.json").write_text("{not json", encoding="utf-8")
+        monkeypatch.setattr(md.sys, "platform", "linux")
+        monkeypatch.setattr(md, "_desktop_packaged_executable", lambda _d: exe)
+        assert md._installed_desktop_commit(tmp_path) is None
+
+    def test_no_packaged_exe_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(md, "_desktop_packaged_executable", lambda _d: None)
+        assert md._installed_desktop_commit(tmp_path) is None
+
+
+class TestInstalledStampBehindHead:
+    def test_true_when_installed_differs_from_head(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(md, "_installed_desktop_commit", lambda _d: SHA_A)
+        monkeypatch.setattr(build_info, "_resolve_git_head_sha", lambda _p: SHA_B)
+        assert md._installed_desktop_stamp_behind_head(tmp_path, tmp_path) is True
+
+    def test_false_when_installed_matches_head(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(md, "_installed_desktop_commit", lambda _d: SHA_A)
+        monkeypatch.setattr(build_info, "_resolve_git_head_sha", lambda _p: SHA_A)
+        assert md._installed_desktop_stamp_behind_head(tmp_path, tmp_path) is False
+
+    def test_false_when_no_installed_commit(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(md, "_installed_desktop_commit", lambda _d: None)
+        monkeypatch.setattr(build_info, "_resolve_git_head_sha", lambda _p: SHA_B)
+        assert md._installed_desktop_stamp_behind_head(tmp_path, tmp_path) is False
+
+    def test_false_when_head_unresolvable(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(md, "_installed_desktop_commit", lambda _d: SHA_A)
+        monkeypatch.setattr(build_info, "_resolve_git_head_sha", lambda _p: None)
+        assert md._installed_desktop_stamp_behind_head(tmp_path, tmp_path) is False
+
+
+class TestBuildNeededHonorsInstalledStamp:
+    def _isolate(self, monkeypatch):
+        # Packaged mode present, no torn bundle, content stamp CURRENT — so only
+        # the installed-stamp path can flip the verdict.
+        monkeypatch.setattr(md, "_desktop_packaged_executable", lambda _d: object())
+        monkeypatch.setattr(md, "_renderer_bundle_dir", lambda _d, source_mode: None)
+        monkeypatch.setattr(md, "_stamp_is_current", lambda *a, **k: True)
+
+    def test_rebuild_when_installed_behind_even_if_content_stamp_current(self, tmp_path, monkeypatch):
+        self._isolate(monkeypatch)
+        monkeypatch.setattr(md, "_installed_desktop_stamp_behind_head", lambda _d, _p: True)
+        assert md._desktop_build_needed(tmp_path, tmp_path, source_mode=False) is True
+
+    def test_up_to_date_when_installed_current_and_content_current(self, tmp_path, monkeypatch):
+        self._isolate(monkeypatch)
+        monkeypatch.setattr(md, "_installed_desktop_stamp_behind_head", lambda _d, _p: False)
+        assert md._desktop_build_needed(tmp_path, tmp_path, source_mode=False) is False
+
+    def test_source_mode_ignores_installed_stamp(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(md, "_desktop_dist_exists", lambda _d: True)
+        monkeypatch.setattr(md, "_renderer_bundle_dir", lambda _d, source_mode: None)
+        monkeypatch.setattr(md, "_stamp_is_current", lambda *a, **k: True)
+        # would flip the verdict if consulted — it must not be in source mode.
+        called = []
+        monkeypatch.setattr(md, "_installed_desktop_stamp_behind_head",
+                            lambda _d, _p: called.append(1) or True)
+        assert md._desktop_build_needed(tmp_path, tmp_path, source_mode=True) is False
+        assert called == []


### PR DESCRIPTION
## What does this PR do?

`_desktop_build_needed()` (`hermes_cli/main_desktop.py`) decided staleness purely from a source-content hash stamp (`$HERMES_HOME/desktop-build-stamp.json`) vs. the current tree. After a **failed stage-and-swap** the build succeeds (hash stamp current) but the swap into `release/` doesn't, so the packaged app keeps running an older commit while `hermes desktop` reports "up to date" — the issue documents an install a month behind (installed `eca85e81` vs HEAD `67764dc086`) that survived two update runs unnoticed (#107542).

This reads the commit from the `install-stamp.json` shipped in the unpacked app's resources — the ground truth for "what the user is actually running" — and treats **installed-commit != HEAD** as a rebuild trigger alongside the content hash.

Resources location matches electron-builder's layout: beside the exe on Windows/Linux (`release/<...>-unpacked/resources/`), under `Contents/Resources` on macOS. HEAD comes from `build_info._resolve_git_head_sha` (reads `.git` directly — no subprocess, test-friendly).

**Conservative by design:** a missing / malformed / all-zero-fallback stamp, or an unresolvable git HEAD, returns `False` — an untrustworthy signal never forces a rebuild. Source-mode runs (no installed stamp) are untouched.

**Scope:** this closes the `hermes desktop` rebuild-needed surface (Blind path #1 in the issue's table). The Electron update-button / visible UI indicator (Blind path #2, `electron/main.ts`) is a separate TS follow-up; the issue's "verified NOT in scope" bootstrap-pin behavior is left as-is.

## Related Issue

Fixes #107542 (partial — CLI rebuild-needed surface; the Electron UI indicator remains a follow-up)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

1. `pytest tests/hermes_cli/test_desktop_installed_stamp_staleness.py -q` — **12 passed**.
2. Regression: `pytest tests/hermes_cli/test_update_desktop_stale_warning.py tests/hermes_cli/test_update_handoff_desktop_rebuild.py tests/hermes_cli/test_desktop_update_verify.py tests/hermes_cli/test_desktop_exe_integrity.py tests/hermes_cli/test_gui_command.py -q` — **75 passed, 12 skipped**.
3. `ruff check hermes_cli/main_desktop.py tests/hermes_cli/test_desktop_installed_stamp_staleness.py` — clean.

## Checklist

- [x] Conventional commit (`fix(desktop):`)
- [x] Searched existing PRs/issues — none cover the installed-stamp staleness check
- [x] Only changes related to this fix
- [x] Added tests
- [x] Cross-platform: resources path resolved per `sys.platform`; pure `pathlib`/`json`, no subprocess
