### PR TITLE
feat(gateway): record interactive turn timing

### DIFF
--- a/gateway/interactive_timing.py
+++ b/gateway/interactive_timing.py
@@ -1,0 +1,165 @@
+"""Content-free timing contract for interactive gateway turns.
+
+The record uses one process-local monotonic clock for durations and a UTC wall
+clock only for the server-receipt anchor. It intentionally excludes message,
+user, chat, and session identifiers so the default INFO log is safe to retain.
+Channel clients rarely expose render acknowledgements, therefore visible
+milestones are explicitly labelled as server-side proxies.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA_VERSION = "hermes.interactive_turn.v1"
+_RUNTIME_FIELDS = ("platform", "model", "provider", "reasoning", "harness_revision", "lane")
+
+
+def _safe_runtime_value(value: Any, *, limit: int = 256) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, dict):
+        value = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    text = str(value).strip().replace("\n", " ").replace("\r", " ")
+    return text[:limit]
+
+
+def _default_harness_revision() -> str:
+    configured = _safe_runtime_value(os.getenv("HERMES_HARNESS_REVISION"), limit=128)
+    if configured:
+        return configured
+    try:
+        from hermes_cli import __version__
+
+        return _safe_runtime_value(__version__, limit=128) or "unknown"
+    except Exception:
+        return "unknown"
+
+
+@dataclass
+class InteractiveTurnTiming:
+    """Idempotent process-local milestone recorder for one admitted message."""
+
+    platform: str = "unknown"
+    turn_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    _wall_ns: Callable[[], int] = field(default=time.time_ns, repr=False, compare=False)
+    _monotonic_ns: Callable[[], int] = field(default=time.monotonic_ns, repr=False, compare=False)
+    _received_wall_ns: int = field(init=False, repr=False)
+    _received_monotonic_ns: int = field(init=False, repr=False)
+    _milestones_ns: dict[str, int] = field(default_factory=dict, init=False, repr=False)
+    _milestone_basis: dict[str, str] = field(default_factory=dict, init=False, repr=False)
+    _runtime: dict[str, str] = field(default_factory=dict, init=False, repr=False)
+    _outcome: str = field(default="unknown", init=False, repr=False)
+    _emitted: bool = field(default=False, init=False, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        self._received_wall_ns = self._wall_ns()
+        self._received_monotonic_ns = self._monotonic_ns()
+        self.update_runtime(platform=self.platform, harness_revision=_default_harness_revision())
+
+    def update_runtime(self, **values: Any) -> None:
+        """Merge allowlisted, bounded runtime metadata; empty values do not erase known values."""
+        with self._lock:
+            for key in _RUNTIME_FIELDS:
+                if key not in values:
+                    continue
+                value = _safe_runtime_value(values[key], limit=128 if key != "model" else 256)
+                if value:
+                    self._runtime[key] = value
+
+    def mark(self, milestone: str, *, basis: str = "server_proxy") -> bool:
+        """Record the first occurrence of an allowlisted milestone."""
+        if milestone not in {"accepted", "working_state", "first_meaningful_response", "completed"}:
+            raise ValueError(f"Unsupported interactive milestone: {milestone}")
+        with self._lock:
+            if milestone in self._milestones_ns:
+                return False
+            self._milestones_ns[milestone] = max(self._received_monotonic_ns, self._monotonic_ns())
+            self._milestone_basis[milestone] = _safe_runtime_value(basis, limit=64) or "server_proxy"
+            return True
+
+    def fork_deferred_turn(self) -> "InteractiveTurnTiming":
+        """Create an independent queued turn retaining this event's receipt anchor."""
+        with self._lock:
+            received_wall_ns = self._received_wall_ns
+            received_monotonic_ns = self._received_monotonic_ns
+            inherited_runtime = {
+                key: self._runtime[key]
+                for key in ("harness_revision", "lane")
+                if key in self._runtime
+            }
+        # Seed construction with fixed anchor clocks, then restore the live monotonic clock for
+        # future milestones. This avoids consuming or advancing injected clocks in tests.
+        child = type(self)(
+            platform=self.platform,
+            _wall_ns=lambda: received_wall_ns,
+            _monotonic_ns=lambda: received_monotonic_ns,
+        )
+        child._wall_ns = self._wall_ns
+        child._monotonic_ns = self._monotonic_ns
+        child.update_runtime(**inherited_runtime)
+        return child
+
+    def complete(self, outcome: str) -> None:
+        with self._lock:
+            self._outcome = _safe_runtime_value(outcome, limit=32) or "unknown"
+        self.mark("completed", basis="server_processing_complete")
+
+    def to_record(self) -> dict[str, Any]:
+        """Return the stable JSON-compatible telemetry record."""
+        with self._lock:
+            milestones = dict(self._milestones_ns)
+            basis = dict(self._milestone_basis)
+            runtime = {key: self._runtime.get(key, "unknown") for key in _RUNTIME_FIELDS}
+            outcome = self._outcome
+        offsets = {
+            "server_receipt": 0,
+            **{
+                name: max(0, (stamp - self._received_monotonic_ns) // 1_000_000)
+                for name, stamp in milestones.items()
+            },
+        }
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "turn_id": self.turn_id,
+            "received_at": datetime.fromtimestamp(
+                self._received_wall_ns / 1_000_000_000, tz=timezone.utc
+            ).isoformat().replace("+00:00", "Z"),
+            "milestones_ms": offsets,
+            "milestone_basis": basis,
+            "runtime": runtime,
+            "outcome": outcome,
+        }
+
+    def emit_once(self) -> dict[str, Any] | None:
+        """Log one compact machine-readable record, returning it for local consumers/tests."""
+        with self._lock:
+            if self._emitted:
+                return None
+            self._emitted = True
+        record = self.to_record()
+        logger.info("interactive_turn_timing %s", json.dumps(record, sort_keys=True, separators=(",", ":")))
+        return record
+
+
+def ensure_interactive_timing(event: Any, *, platform: Any = None) -> InteractiveTurnTiming:
+    """Return the event's recorder, creating it at the generic adapter receipt boundary."""
+    timing = getattr(event, "_interactive_timing", None)
+    if not isinstance(timing, InteractiveTurnTiming):
+        platform_name = getattr(platform, "value", platform) or "unknown"
+        timing = InteractiveTurnTiming(platform=str(platform_name))
+        event._interactive_timing = timing
+    elif platform is not None:
+        timing.update_runtime(platform=getattr(platform, "value", platform))
+    return timing

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2916,7 +2916,8 @@ class BasePlatformAdapter(ABC):
         return list(unique), re.sub(r'\n{3,}', '\n\n', cleaned).strip()
 
     async def _keep_typing(self, chat_id: str, interval: float = 2.0, metadata=None,
-                           stop_event: asyncio.Event | None = None) -> None:
+                           stop_event: asyncio.Event | None = None,
+                           on_visible: Optional[Callable[[], None]] = None) -> None:
         """Refresh the typing indicator every ``interval`` seconds until cancelled (platform typing
         state expires after ~5s). Chats in ``_typing_paused`` are skipped (approval waits — Slack's
         setStatus disables the compose box). Each ``send_typing`` is bounded by a sub-interval
@@ -2930,6 +2931,8 @@ class BasePlatformAdapter(ABC):
                     try:
                         await asyncio.wait_for(self.send_typing(chat_id, metadata=metadata),
                                                timeout=_send_typing_timeout)
+                        if on_visible is not None:
+                            on_visible()
                     except asyncio.TimeoutError:
                         pass  # Slow network — abandon this tick, stay on schedule.
                     except Exception as typing_err:
@@ -3489,6 +3492,8 @@ class BasePlatformAdapter(ABC):
     async def handle_message(self, event: MessageEvent) -> None:
         """Process an incoming message; returns quickly by spawning a background
         task so new messages (and interrupts) can arrive while an agent runs."""
+        from gateway.interactive_timing import ensure_interactive_timing
+        timing = ensure_interactive_timing(event, platform=self.platform)
         event._gateway_accepted = False
         if not self._message_handler:
             return
@@ -3510,9 +3515,13 @@ class BasePlatformAdapter(ABC):
             self._heal_stale_session_lock(session_key)
         if session_key in self._active_sessions:
             await self._handle_message_while_active(event, session_key)
+            if event._gateway_accepted:
+                timing.mark("accepted", basis="adapter_busy_queue")
             return
         # Guard installed synchronously BEFORE the task spawns so a second message can't race in.
         event._gateway_accepted = self._start_session_processing(event, session_key)
+        if event._gateway_accepted:
+            timing.mark("accepted", basis="adapter_session_claim")
 
     async def _handle_message_while_active(self, event: MessageEvent, session_key: str) -> None:
         """Route a message that arrived while ``session_key`` is busy: bypass
@@ -3797,6 +3806,10 @@ class BasePlatformAdapter(ABC):
             event, session_key, text_content, delivery_adapter, is_ephemeral_response)
         result = await delivery_adapter._send_with_retry(
             chat_id=event.source.chat_id, content=text_content, reply_to=reply_to, metadata=metadata)
+        if getattr(result, "success", False):
+            from gateway.interactive_timing import ensure_interactive_timing
+            ensure_interactive_timing(event, platform=self.platform).mark(
+                "first_meaningful_response", basis="server_send_completed_proxy")
         if obligation_id is not None:
             await self._finalize_delivery_obligation(obligation_id, result, event, delivery_adapter)
         return result, delivery_adapter
@@ -3819,10 +3832,14 @@ class BasePlatformAdapter(ABC):
         try:
             error_detail = str(e)[:300] if str(e) else "no details available"
             _thread_metadata = _thread_metadata_for_event(event)
-            await self.send(
+            result = await self.send(
                 chat_id=event.source.chat_id,
                 content=(f"Sorry, I encountered an error ({type(e).__name__}).\n{error_detail}\n"
                 "Try again or use /reset to start a fresh session."), metadata=_thread_metadata)
+            if getattr(result, "success", False):
+                from gateway.interactive_timing import ensure_interactive_timing
+                ensure_interactive_timing(event, platform=self.platform).mark(
+                    "first_meaningful_response", basis="error_send_completed_proxy")
         except Exception as notify_err:
             logger.error(
                 "[%s] Failed to send error notification to user: %s", self.name, notify_err, exc_info=True)
@@ -3858,6 +3875,16 @@ class BasePlatformAdapter(ABC):
         kwargs: Dict[str, Any] = {"metadata": metadata}
         if self._accepts_kwarg(self._keep_typing, "stop_event", var_kw=False, unknown=True):
             kwargs["stop_event"] = interrupt_event
+        supports_typing_signal = (
+            getattr(self.send_typing, "__func__", self.send_typing)
+            is not BasePlatformAdapter.send_typing
+        )
+        if supports_typing_signal and self._accepts_kwarg(
+                self._keep_typing, "on_visible", var_kw=False, unknown=True):
+            from gateway.interactive_timing import ensure_interactive_timing
+            timing = ensure_interactive_timing(event, platform=self.platform)
+            kwargs["on_visible"] = lambda: timing.mark(
+                "working_state", basis="typing_handler_completed_proxy")
         return asyncio.create_task(self._keep_typing(event.source.chat_id, **kwargs))
 
     async def _extract_response_content(self, response: str, event: MessageEvent, session_key: str,
@@ -3946,13 +3973,19 @@ class BasePlatformAdapter(ABC):
 
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:
         """Background task that actually processes the message."""
+        from gateway.interactive_timing import ensure_interactive_timing
+        timing = ensure_interactive_timing(event, platform=self.platform)
+        processing_outcome = ProcessingOutcome.FAILURE
         delivery_attempted = delivery_succeeded = False  # feeds the processing-complete hook
 
         def _record_delivery(result):
             nonlocal delivery_attempted, delivery_succeeded
             if result is not None:
                 delivery_attempted = True
-                delivery_succeeded = delivery_succeeded or bool(getattr(result, "success", False))
+                succeeded = bool(getattr(result, "success", False))
+                delivery_succeeded = delivery_succeeded or succeeded
+                if succeeded:
+                    timing.mark("first_meaningful_response", basis="server_send_completed_proxy")
         # Reuse the interrupt event handle_message() installed; new Event only if removed externally.
         interrupt_event = self._active_sessions.get(session_key) or asyncio.Event()
         self._active_sessions[session_key] = interrupt_event
@@ -4003,13 +4036,14 @@ class BasePlatformAdapter(ABC):
                     anything_sent=delivery_attempted or _tts_caption_delivered,
                     record_delivery=_record_delivery)
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
+            processing_outcome = ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE
             # Clean up the per-turn streaming-TTS flag.
             self._streaming_tts_completed_turns.discard(self._streaming_tts_turn_key(
                 session_key, getattr(interrupt_event, "_hermes_run_generation", None),
                 event=event) or "")
             await self._run_processing_hook(
                 "on_processing_complete", event,
-                ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE)
+                processing_outcome)
             # Force-flush an unfired debounce timer so this task hands off to a fresh drain task.
             # Clear the Event BEFORE the stop-typing await so concurrent inbound sees a live guard.
             await self._flush_text_debounce_now(session_key)
@@ -4022,11 +4056,13 @@ class BasePlatformAdapter(ABC):
                 return  # Drain task owns the session now.
         except asyncio.CancelledError:
             expected = asyncio.current_task() in self._expected_cancelled_tasks
+            processing_outcome = ProcessingOutcome.CANCELLED if expected else ProcessingOutcome.FAILURE
             await self._run_processing_hook(
                 "on_processing_complete", event,
-                ProcessingOutcome.CANCELLED if expected else ProcessingOutcome.FAILURE)
+                processing_outcome)
             raise
         except BaseException as e:
+            processing_outcome = ProcessingOutcome.FAILURE
             await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
             _thread_metadata = (await self._notify_turn_error(event, e)) or _thread_metadata
@@ -4034,6 +4070,8 @@ class BasePlatformAdapter(ABC):
             if isinstance(e, (SystemExit, KeyboardInterrupt)):
                 raise
         finally:
+            timing.complete(processing_outcome.value)
+            timing.emit_once()
             # Stop typing BEFORE the post-delivery callback: a stuck callback must not keep it
             # alive.
             await self._stop_typing_refresh(event.source.chat_id, typing_task, metadata=_thread_metadata)

--- a/gateway/platforms/event.py
+++ b/gateway/platforms/event.py
@@ -86,6 +86,9 @@ class MessageEvent:
 
     # Process-local admission receipt, never routing metadata or execution acknowledgement.
     _gateway_accepted: bool = field(default=False, init=False, repr=False, compare=False)
+    # Content-free process-local timing recorder, created at the generic adapter receipt boundary.
+    # Typed as Any to keep this shared event module a leaf with no gateway-runtime imports.
+    _interactive_timing: Any = field(default=None, init=False, repr=False, compare=False)
 
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -53,6 +53,9 @@ class GatewayBusySessionMixin:
         else:
             pending_slot[session_key] = queued_event
         queued_event._gateway_accepted = True
+        timing = getattr(queued_event, "_interactive_timing", None)
+        if timing is not None:
+            timing.mark("accepted", basis="busy_fifo_enqueue")
 
     def _promote_queued_event(
         self, session_key: str, adapter: Any, pending_event: Optional["MessageEvent"]
@@ -896,7 +899,7 @@ class GatewayBusySessionMixin:
             return "Usage: /queue <prompt>"
         adapter = self._adapter_for_source(source)
         if adapter:
-            self._enqueue_fifo(quick_key, MessageEvent(
+            queued_event = MessageEvent(
                 text=queued_text, message_type=event.message_type if has_media else MessageType.TEXT,
                 source=event.source, raw_message=event.raw_message, message_id=event.message_id,
                 media_urls=list(getattr(event, "media_urls", []) or []),
@@ -908,7 +911,11 @@ class GatewayBusySessionMixin:
                 reply_to_is_own_message=event.reply_to_is_own_message, auto_skill=event.auto_skill,
                 channel_prompt=event.channel_prompt, channel_context=event.channel_context,
                 internal=event.internal, timestamp=event.timestamp,
-            ), adapter)
+            )
+            timing = getattr(event, "_interactive_timing", None)
+            if timing is not None:
+                queued_event._interactive_timing = timing.fork_deferred_turn()
+            self._enqueue_fifo(quick_key, queued_event, adapter)
         depth = self._queue_depth(quick_key, adapter=adapter)
         return "Queued for the next turn." + (f" ({depth} queued)" if depth > 1 else "")
 
@@ -926,11 +933,15 @@ class GatewayBusySessionMixin:
             # Turn-boundary fallback: queue the steer text as its own follow-up turn.
             adapter = self._adapter_for_source(source)
             if adapter:
-                self._enqueue_fifo(quick_key, MessageEvent(
+                queued_event = MessageEvent(
                     text=steer_text, message_type=MessageType.TEXT, source=event.source,
                     message_id=event.message_id, channel_prompt=event.channel_prompt,
                     channel_context=event.channel_context,
-                ), adapter)
+                )
+                timing = getattr(event, "_interactive_timing", None)
+                if timing is not None:
+                    queued_event._interactive_timing = timing.fork_deferred_turn()
+                self._enqueue_fifo(quick_key, queued_event, adapter)
             return reply
 
         if running_agent is _AGENT_PENDING_SENTINEL:

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1969,11 +1969,13 @@ class GatewayTurnMixin:
             # Admission/typing is not execution. All routing, authorization and
             # turn preparation gates have passed when the agent runner is entered.
             event._heartbeat_execution_started = True
+            _interactive_timing = getattr(event, "_interactive_timing", None)
             agent_result = await self._run_agent(
                 message=message_text, context_prompt=prepared.context_prompt, history=history, source=source,
                 session_id=_run_start_session_id, session_key=session_key,
                 run_generation=run_generation, event_message_id=self._reply_anchor_for_event(event),
                 inbound_message_id=str(event.message_id) if event.message_id else None,
+                interactive_timing=_interactive_timing,
                 channel_prompt=event.channel_prompt, moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=prepared.persist_user_message,
                 persist_user_timestamp=prepared.persist_user_timestamp,
@@ -1982,6 +1984,12 @@ class GatewayTurnMixin:
                 message_type=event.message_type,
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
+            # Streaming transports do not expose a central first-send acknowledgement,
+            # so their completed stream is recorded as an honest upper bound.
+            if _interactive_timing is not None:
+                if agent_result.get("already_sent") and agent_result.get("final_response"):
+                    _interactive_timing.mark(
+                        "first_meaningful_response", basis="stream_completion_upper_bound")
 
             # A queued (/queue) chain answered the LAST message of the chain, so the outer final
             # send (bracketed by the adapter against this event) must be ledgered under that
@@ -3820,11 +3828,15 @@ class GatewayTurnMixin:
         persist_user_message: Optional[Any] = None, persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None, message_type: Optional[str] = None,
         persist_user_display_metadata: Optional[dict] = None,
+        interactive_timing: Any = None,
     ) -> Dict[str, Any]:
         """Run the agent; returns the full run_conversation result dict.
 
         Keys: "final_response", "messages", "api_calls", "completed"."""
         if self._get_proxy_url():
+            if interactive_timing is not None:
+                interactive_timing.update_runtime(
+                    model="remote_unknown", provider="gateway_proxy", reasoning="remote_unknown")
             return await self._run_agent_via_proxy(
                 message=message, context_prompt=context_prompt, history=history, source=source,
                 session_id=session_id, session_key=session_key, run_generation=run_generation,
@@ -3844,6 +3856,7 @@ class GatewayTurnMixin:
             persist_user_timestamp=persist_user_timestamp,
             persist_user_display_kind=persist_user_display_kind,
             persist_user_display_metadata=persist_user_display_metadata,
+            interactive_timing=interactive_timing,
         )
         _status_thread_metadata = self._run_agent_bind_turn_wiring(
             turn_ctx, turn_runner, source, event_message_id, disp._native_slack_task_cards,

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1740,10 +1740,28 @@ class TurnRunner:
         agent, reused_cached_agent = self._resolve_turn_agent(
             turn_route, platform_key, combined_ephemeral, max_iterations, reasoning_config, pr,
         )
+        if ctx.interactive_timing is not None:
+            ctx.interactive_timing.update_runtime(
+                model=getattr(agent, "model", None), provider=getattr(agent, "provider", None),
+                reasoning=reasoning_config,
+            )
         self._wire_turn_agent_callbacks(agent, turn_route, reasoning_config, stream_delta_cb, interim_cb, want_interim)
         agent_history, observed_group_context, history_media_paths = self._load_turn_history(agent, reused_cached_agent)
         persist_msg, persist_ts = self._prepare_turn_message(agent_history)
-        result = self._run_conversation_with_approval(agent, agent_history, observed_group_context, persist_msg, persist_ts)
+        try:
+            result = self._run_conversation_with_approval(
+                agent, agent_history, observed_group_context, persist_msg, persist_ts)
+        finally:
+            # Fallbacks can mutate the active agent's model/provider during the call. Refresh from
+            # the final runtime even when the turn raises or is cancelled so comparisons are not
+            # attributed only to the failed initial route.
+            final_agent = ctx.agent_holder[0] or agent
+            if ctx.interactive_timing is not None:
+                ctx.interactive_timing.update_runtime(
+                    model=getattr(final_agent, "model", None),
+                    provider=getattr(final_agent, "provider", None),
+                    reasoning=reasoning_config,
+                )
         self._finish_stream_consumer(result, agent_history, stream_consumer)
         # The streaming-TTS consumer's finish() runs on the outer loop thread after the executor
         # returns, so early run_sync returns are also finalised.

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -48,6 +48,7 @@ class TurnContext:
     process_baseline: frozenset[str] = field(default_factory=frozenset)
     _interrupt_depth: int = 0
     event_message_id: Optional[str] = None
+    interactive_timing: Any = None
     # Raw inbound platform id (not the event_message_id reply anchor); stamped on the user turn.
     inbound_message_id: Optional[str] = None
     moa_config: Optional[dict] = None

--- a/tests/gateway/test_interactive_timing.py
+++ b/tests/gateway/test_interactive_timing.py
@@ -1,0 +1,175 @@
+"""Invariant tests for content-free interactive gateway timing."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.interactive_timing import InteractiveTurnTiming, ensure_interactive_timing
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.platforms.event import MessageEvent
+from gateway.run_busy import GatewayBusySessionMixin
+from gateway.session import SessionSource, build_session_key
+
+
+class _Clock:
+    def __init__(self, *values: int):
+        self._values = iter(values)
+
+    def __call__(self) -> int:
+        return next(self._values)
+
+
+class _StubAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="sent")
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+class _BusyQueueHarness(GatewayBusySessionMixin):
+    def __init__(self):
+        self.adapter = SimpleNamespace(_pending_messages={})
+
+    def _adapter_for_source(self, _source):
+        return self.adapter
+
+    def _peek_session_state(self, _session_key):
+        return None
+
+
+def test_interactive_timing_is_monotonic_machine_readable_and_content_free():
+    timing = InteractiveTurnTiming(
+        platform="slack",
+        turn_id="turn-1",
+        _wall_ns=_Clock(1_700_000_000_000_000_000),
+        _monotonic_ns=_Clock(
+            1_000_000_000, 1_120_000_000, 1_250_000_000, 1_900_000_000, 2_000_000_000),
+    )
+    timing.update_runtime(
+        model="openai/gpt-test", provider="openai", reasoning={"effort": "low"},
+        harness_revision="rev-1",
+    )
+    assert timing.mark("working_state", basis="typing_send_completed_proxy") is True
+    assert timing.mark("working_state", basis="duplicate") is False
+    timing.mark("first_meaningful_response", basis="server_send_completed_proxy")
+    timing.complete("success")
+
+    record = timing.to_record()
+    encoded = json.dumps(record)
+
+    assert record["milestones_ms"] == {
+        "server_receipt": 0,
+        "working_state": 120,
+        "first_meaningful_response": 250,
+        "completed": 900,
+    }
+    assert record["milestone_basis"]["first_meaningful_response"] == "server_send_completed_proxy"
+    assert record["runtime"] == {
+        "platform": "slack",
+        "model": "openai/gpt-test",
+        "provider": "openai",
+        "reasoning": '{"effort":"low"}',
+        "harness_revision": "rev-1",
+        "lane": "unknown",
+    }
+    assert record["outcome"] == "success"
+    assert "secret message" not in encoded
+    assert "user_id" not in encoded and "chat_id" not in encoded and "session_id" not in encoded
+
+    deferred = timing.fork_deferred_turn()
+    deferred.mark("accepted", basis="queued")
+    deferred_record = deferred.to_record()
+    assert deferred_record["turn_id"] != record["turn_id"]
+    assert deferred_record["received_at"] == record["received_at"]
+    assert deferred_record["milestones_ms"] == {"server_receipt": 0, "accepted": 1000}
+    assert deferred_record["outcome"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_adapter_records_receipt_working_response_and_completion(caplog):
+    adapter = _StubAdapter(
+        PlatformConfig(enabled=True, token="t", typing_indicator=True), Platform.SLACK,
+    )
+    adapter.send_typing = AsyncMock(return_value=None)
+    adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True, message_id="sent"))
+
+    async def _handler(_event):
+        await asyncio.sleep(0.02)
+        return "a useful response"
+
+    adapter._message_handler = _handler
+    source = SessionSource(platform=Platform.SLACK, chat_id="C123", chat_type="dm")
+    event = MessageEvent(text="private request body", source=source, message_id="m1")
+    session_key = build_session_key(source)
+
+    with caplog.at_level("INFO", logger="gateway.interactive_timing"):
+        await adapter.handle_message(event)
+        task = adapter._session_tasks[session_key]
+        await task
+
+    record = event._interactive_timing.to_record()
+    offsets = record["milestones_ms"]
+    assert event._gateway_accepted is True
+    assert offsets["server_receipt"] == 0
+    assert offsets["accepted"] <= offsets["working_state"] <= offsets["first_meaningful_response"]
+    assert offsets["first_meaningful_response"] <= offsets["completed"]
+    assert record["outcome"] == "success"
+    assert record["runtime"]["platform"] == "slack"
+    emitted = next(message for message in caplog.messages if message.startswith("interactive_turn_timing "))
+    payload = json.loads(emitted.removeprefix("interactive_turn_timing "))
+    assert payload == record
+    assert "private request body" not in emitted
+
+    # A platform inheriting the no-op typing method must not claim a visible working state.
+    unsupported = _StubAdapter(
+        PlatformConfig(enabled=True, token="t", typing_indicator=True), Platform.WEBHOOK,
+    )
+    unsupported_event = MessageEvent(text="hidden", source=SessionSource(
+        platform=Platform.WEBHOOK, chat_id="hook", chat_type="dm"))
+    unsupported_timing = ensure_interactive_timing(unsupported_event, platform=Platform.WEBHOOK)
+    stop_event = asyncio.Event()
+    typing_task = unsupported._start_typing_refresh(unsupported_event, stop_event, None)
+    await asyncio.sleep(0)
+    stop_event.set()
+    await typing_task
+    assert "working_state" not in unsupported_timing.to_record()["milestones_ms"]
+
+    # A successfully delivered failure notice is still the first meaningful response.
+    error_event = MessageEvent(text="hidden", source=source, message_id="m2")
+    ensure_interactive_timing(error_event, platform=Platform.SLACK)
+    await adapter._notify_turn_error(error_event, RuntimeError("boom"))
+    error_record = error_event._interactive_timing.to_record()
+    assert error_record["milestone_basis"]["first_meaningful_response"] == (
+        "error_send_completed_proxy"
+    )
+
+    # Synthetic /queue and failed-/steer turns preserve receipt time and mark admission in FIFO.
+    for command, handler_name in (
+        ("/queue finish this", "_busy_queue_command"),
+        ("/steer finish this", "_busy_steer_command"),
+    ):
+        harness = _BusyQueueHarness()
+        queued_source = SessionSource(platform=Platform.SLACK, chat_id="C456", chat_type="dm")
+        command_event = MessageEvent(text=command, source=queued_source, message_id="queued")
+        command_event._interactive_timing = InteractiveTurnTiming(
+            platform="slack",
+            _wall_ns=_Clock(1_700_000_000_000_000_000),
+            _monotonic_ns=_Clock(1_000_000_000, 1_250_000_000),
+        )
+        await getattr(harness, handler_name)(command_event, "session-key", queued_source)
+        queued_event = harness.adapter._pending_messages["session-key"]
+        queued_record = queued_event._interactive_timing.to_record()
+        assert queued_record["received_at"] == command_event._interactive_timing.to_record()["received_at"]
+        assert queued_record["milestones_ms"]["accepted"] == 250
+        assert queued_record["milestone_basis"]["accepted"] == "busy_fifo_enqueue"


### PR DESCRIPTION
## Summary

Implements the first independently reviewable slice of [buster-walsh/hermes-agent#2](https://github.com/buster-walsh/hermes-agent/issues/2):

- add a content-free, machine-readable interactive-turn timing contract;
- capture generic adapter receipt, admission, honest working-state proxy, first successful meaningful delivery, and processing completion;
- use a process-local monotonic clock for all durations and wall time only for the receipt anchor;
- preserve platform, harness revision, and effective local model/provider/reasoning metadata, including post-fallback runtime;
- label proxy and streaming measurements honestly;
- retain original receipt time across deferred `/queue` and `/steer` fallback turns without sharing completion state;
- do not change routing or user-visible response behavior.

This is intentionally a partial implementation of buster-walsh/hermes-agent#2. The deterministic simple/long/concurrent/cancellation evaluation fixtures, load snapshots, and aggregate JSONL reports remain follow-up work under that issue.

## Safety and privacy

Telemetry excludes message content and user/chat/session identifiers. Failed outbound sends do not count as successful first responses. Unsupported no-op typing adapters do not claim a visible working state.

## Verification

- `scripts/run_tests.sh tests/gateway/test_interactive_timing.py tests/gateway/test_busy_session_ack.py tests/gateway/test_subagent_protection_30170.py tests/gateway/test_gateway_silence_tokens.py tests/gateway/test_platform_base.py tests/gateway/test_typing_indicator_toggle.py tests/gateway/test_keep_typing_timeout.py`
  - 137 passed, 1 skipped
- Full `tests/gateway` run exercised 802 files. The initial 96-worker run had 32 resource/timing failures and five file timeouts; all 28 affected files passed on a 16-worker retry after installing required messaging extras, except two WeCom tests blocked by its optional XML dependency. After installing the `wecom` extra, those six WeCom tests passed.
- Ruff: passed for all touched Python files
- `ty`: passed for the new timing contract and `TurnContext`
- `compileall`: passed
- `git diff --check`: passed
- Independent spec-compliance review: PASS
- Independent code-quality review: APPROVED

Part of https://github.com/buster-walsh/hermes-agent/issues/2
Parent specification: https://github.com/buster-walsh/hermes-agent/issues/1
