### PR TITLE
fix(agent): fall back to the configured model when auxiliary provider is auto and no external provider exists

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4158,9 +4158,19 @@ def _main_route_target(runtime: Dict[str, Any], task: Optional[str]) -> Tuple[st
 
 def _try_main_provider_route(
     main_provider: str, main_model: str, runtime_base_url: str, runtime_api_key: Any, runtime_api_mode: str,
+    *, allow_endpoint_default_model: bool = False,
 ) -> Optional[Tuple[Any, str, str]]:
-    """Step 1: route aux onto the main provider + main model; None if unusable."""
-    if not (main_provider and main_model and main_provider not in {"auto", ""}):
+    """Step 1: route aux onto the main provider + main model; None if unusable.
+
+    ``allow_endpoint_default_model`` lets a custom/self-hosted route stand in for a missing model
+    id: the endpoint (or its ``custom_providers`` entry) is the only thing that can supply a model
+    in an install with no external provider, so ``_resolve_auto_route()`` retries it there instead
+    of dead-ending every auxiliary subsystem (#107509). Off for Step 1, so a named provider with no
+    model id keeps deferring to the configured fallback policy exactly as before.
+    """
+    _custom_route = main_provider == "custom" or main_provider.startswith("custom:")
+    _has_model = bool(main_model) or (allow_endpoint_default_model and _custom_route)
+    if not (main_provider and _has_model and main_provider not in {"auto", ""}):
         return None
     resolved_provider = main_provider
     explicit_base_url = runtime_base_url or None
@@ -4268,6 +4278,22 @@ def _resolve_auto_route(
         task, main_provider or "auto", reason="main provider unavailable")
     if fb_client is not None:
         return fb_client, fb_model, fb_label
+    # Self-hosted-only install (#107509): model.provider is a custom endpoint with no model id
+    # configured, and no external provider exists to fall back to. Step 1 vetoed the route on the
+    # missing model above and _discovery_chain_allowed() below refuses the built-in chain once a
+    # main provider is named, so every auxiliary subsystem used to hard-fail even though the
+    # endpoint IS main. Retry it and let the endpoint (or its custom_providers entry) supply the
+    # model. Gated on a reachable endpoint so a bare "custom" can never fall through to an
+    # API-key provider the user did not select.
+    _custom_route = main_provider == "custom" or main_provider.startswith("custom:")
+    if not main_model and _custom_route and (
+            main_provider.startswith("custom:") or base_url or _read_main_base_url()):
+        routed = _try_main_provider_route(
+            main_provider, main_model, base_url, api_key, api_mode, allow_endpoint_default_model=True)
+        if routed is not None:
+            logger.info("Auxiliary %s: no model configured for %s — using the endpoint's own model (%s)",
+                        task or "call", main_provider, routed[1] or "default")
+            return routed
     if not _discovery_chain_allowed(main_provider, task):
         return None, None, ""
     return _try_discovery_chain()

--- a/tests/agent/test_auxiliary_custom_route_without_model_id.py
+++ b/tests/agent/test_auxiliary_custom_route_without_model_id.py
@@ -1,0 +1,136 @@
+"""``auxiliary.*.provider: auto`` must fall back to a configured custom endpoint (#107509).
+
+A self-hosted-only install (``model.provider: custom`` + a local ``model.base_url``, no external
+provider configured anywhere) has exactly one reachable route: the endpoint the user configured.
+When no model id is configured, ``_try_main_provider_route()`` vetoed that route outright and
+``_discovery_chain_allowed()`` then refused the built-in chain ("refusing to guess another
+logged-in provider"), so every ``auxiliary.*`` subsystem (kanban_decomposer, curator, vision,
+title_generation, compression, ...) hard-failed with
+``RuntimeError: No LLM provider configured for task=... provider=auto`` instead of using the only
+provider that actually exists.
+
+These tests pin: (1) the custom route is retried with the endpoint/entry-supplied model,
+(2) an explicit fallback policy still wins, (3) main-first routing is untouched when an external
+provider IS configured, and (4) installs with a selected non-custom main provider still refuse to
+guess other logged-in accounts.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from agent import auxiliary_client as aux
+
+_EXTERNAL_ENV = (
+    "OPENROUTER_API_KEY", "NOUS_API_KEY", "OPENAI_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_BASE",
+    "ANTHROPIC_API_KEY", "XAI_API_KEY", "DEEPINFRA_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+)
+
+
+def _selfhosted_home(tmp_path, monkeypatch, model_block: str, extra: str = "") -> None:
+    """Hermetic HERMES_HOME with only the given model block + no external provider creds."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("model:\n" + model_block + extra, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for var in _EXTERNAL_ENV:
+        monkeypatch.delenv(var, raising=False)
+    aux.clear_runtime_main()
+    aux._aux_unhealthy_until.clear()
+
+
+def _client_base_url(client) -> str:
+    for attr in ("base_url",):
+        value = getattr(client, attr, None)
+        if value:
+            return str(value)
+    inner = getattr(client, "_client", None)
+    return str(getattr(inner, "base_url", "") or "")
+
+
+def test_auto_uses_configured_custom_endpoint_when_no_model_id_is_set(tmp_path, monkeypatch):
+    """model.provider: custom + base_url, no model id, zero external providers → route to it."""
+    _selfhosted_home(
+        tmp_path, monkeypatch,
+        "  provider: custom\n  base_url: 'https://local.example/v1'\n  api_key: local-key\n",
+    )
+
+    client, model, provider = aux._resolve_auto_route(main_runtime=None, task="kanban_decomposer")
+
+    assert client is not None, "auto dead-ended on the configured custom endpoint"
+    assert provider == "custom"
+    assert _client_base_url(client).rstrip("/") == "https://local.example/v1"
+    assert model, "auto must carry a model for the resolved endpoint"
+
+
+def test_auto_uses_named_custom_entry_model_when_model_id_is_unset(tmp_path, monkeypatch):
+    """A ``custom:<name>`` entry supplies its own model; a missing model.default must not veto it."""
+    _selfhosted_home(
+        tmp_path, monkeypatch,
+        "  provider: 'custom:selfhosted'\n  base_url: ''\n",
+        "custom_providers:\n"
+        "  - name: selfhosted\n"
+        "    base_url: 'https://entry.example/v1'\n"
+        "    model: local-qwen\n"
+        "    api_key: entry-key\n",
+    )
+
+    client, model, provider = aux._resolve_auto_route(main_runtime=None, task="title_generation")
+
+    assert client is not None, "named custom entry was vetoed by the missing model id"
+    assert model == "local-qwen"
+    assert _client_base_url(client).rstrip("/") == "https://entry.example/v1"
+    assert provider == "custom:selfhosted"
+
+
+def test_configured_fallback_policy_still_wins_over_the_custom_retry(tmp_path, monkeypatch):
+    """Precedence is unchanged: an explicit fallback chain is honoured before the custom retry."""
+    _selfhosted_home(
+        tmp_path, monkeypatch,
+        "  provider: custom\n  base_url: 'https://local.example/v1'\n  api_key: local-key\n",
+    )
+    fallback_client = MagicMock(name="fallback-client")
+
+    with patch.object(aux, "_try_main_fallback_chain",
+                      return_value=(fallback_client, "fb-model", "fallback_providers[0](openrouter)")):
+        client, model, provider = aux._resolve_auto_route(main_runtime=None, task="compression")
+
+    assert client is fallback_client
+    assert model == "fb-model"
+    assert provider == "fallback_providers[0](openrouter)"
+
+
+def test_external_provider_configured_keeps_main_first_routing(tmp_path, monkeypatch):
+    """With an external provider available, ``auto`` still runs on the main model (unchanged)."""
+    _selfhosted_home(
+        tmp_path, monkeypatch,
+        "  provider: custom\n  model: local-qwen\n  base_url: 'https://local.example/v1'\n  api_key: local-key\n",
+    )
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")  # external provider IS configured
+
+    with patch.object(aux, "_try_discovery_chain") as discovery:
+        client, model, provider = aux._resolve_auto_route(main_runtime=None, task="title_generation")
+
+    assert client is not None and model == "local-qwen" and provider == "custom"
+    discovery.assert_not_called()
+
+
+def test_selected_non_custom_main_provider_still_refuses_to_guess(tmp_path, monkeypatch):
+    """The anti-"bill another account" guard is preserved for non-custom main providers."""
+    _selfhosted_home(tmp_path, monkeypatch, "  model: local-qwen\n")
+    runtime = {"provider": "xai-oauth", "model": "grok-4.6",
+               "base_url": "https://api.x.ai/v1", "api_key": "dead"}
+
+    with patch.object(aux, "_try_main_provider_route", return_value=None), \
+         patch.object(aux, "_try_discovery_chain", return_value=(MagicMock(), "guessed", "nous")) as discovery:
+        assert aux._resolve_auto_route(main_runtime=runtime, task="compression") == (None, None, "")
+    discovery.assert_not_called()
+
+
+def test_custom_route_without_any_endpoint_still_fails_cleanly(tmp_path, monkeypatch):
+    """No endpoint configured anywhere → no route (never a silent API-key-provider guess)."""
+    _selfhosted_home(tmp_path, monkeypatch, "  provider: custom\n")
+
+    with patch.object(aux, "_try_discovery_chain") as discovery:
+        assert aux._resolve_auto_route(main_runtime=None, task="compression") == (None, None, "")
+    discovery.assert_not_called()


### PR DESCRIPTION
## What Problem This Solves

`auxiliary.*` subsystems (`kanban_decomposer`, `curator`, `vision`, `title_generation`, `compression`, ...) all default to `provider: auto`. In a fully self-hosted install — `model.provider: custom` + a local `model.base_url`, with **no external provider configured anywhere** — `auto` had no fallback left and every auxiliary call hard-failed instead of running on the only provider that actually exists.

**Root cause** (`agent/auxiliary_client.py`, verified on `96fbc47f14`): `_resolve_auto_route()` is the resolver every `auxiliary.*` subsystem goes through.

1. Step 1, `_try_main_provider_route()` (line ~4159), vetoed the configured custom route whenever no model id was configured:

   ```python
   if not (main_provider and main_model and main_provider not in {"auto", ""}):
       return None
   ```

   A missing `model.default` is exactly the self-hosted shape — a bare `custom` endpoint whose server picks the model, or a `custom_providers` entry that declares `model:` itself.

2. `_discovery_chain_allowed()` (line ~4207) then **refused** the built-in chain because a main provider was named ("refusing to guess another logged-in provider"), so `_resolve_auto_route()` returned `(None, None, "")` and `call_llm()` raised:

   ```
   RuntimeError: No LLM provider configured for task=kanban_decomposer provider=auto. Run: hermes setup
   ```

Naming your custom provider was strictly *worse* than leaving it unnamed: with `model.provider` unset, the discovery chain's own `local/custom` arm resolves the same endpoint fine.

Scope note, in the interest of an honest report: the issue also states that `auto` "tries external providers first". On current `main` that is no longer true — Step 1 is main-first (covered by `tests/agent/test_auxiliary_main_first.py`), and the report's literal repro (`provider: custom` + `base_url` **with** a model id) already resolves. The remaining hole is the one reproduced and fixed here; that is what `Closes` below refers to.

## Fix

Retry the custom route after the configured fallback chains and before the built-in chain, letting the endpoint (or its `custom_providers` entry) supply the model:

* `_try_main_provider_route(..., allow_endpoint_default_model=True)` — a custom route no longer requires a configured model id. **Off by default**, so Step 1 keeps its existing precedence for every other provider: a named provider with no model id still defers to the configured fallback policy, and nothing reorders main-first routing.
* `_resolve_auto_route()` invokes it only when all of: `main_model` is empty, the main provider is a custom route (`custom` / `custom:<name>`), and an endpoint is actually reachable (`custom:<name>` entry, runtime `base_url`, or config `model.base_url`). The reachability gate keeps a bare `custom` from falling through to an API-key provider the user never selected.

Unchanged: main-first routing when a model id is configured, explicit `auxiliary.<task>.provider` overrides, `fallback_providers` / `auxiliary.<task>.fallback_chain` precedence, and the "never bill another logged-in account" guard for non-custom main providers.

## Evidence

Minimal repro: isolated `HERMES_HOME` with only `model.provider: custom` + a local `base_url`, every external provider env var deleted, a local OpenAI-compatible mock endpoint, and `call_llm(task=...)` (no network to any external provider).

Before:

```
=== B: provider=custom + base_url, NO model ===
   call_llm(kanban_decomposer) RAISED RuntimeError: No LLM provider configured for task=kanban_decomposer provider=auto
   call_llm(title_generation)  RAISED RuntimeError: No LLM provider configured for task=title_generation provider=auto
   call_llm(compression)       RAISED RuntimeError: No LLM provider configured for task=compression provider=auto
   server hits: []
```

Resolver level: `_resolve_auto_route(main_runtime=None, task="kanban_decomposer")` → `(None, None, "")` plus the log line `Auxiliary kanban_decomposer: main provider custom is unavailable and no fallback_chain / fallback_providers is configured — refusing to guess another logged-in provider.`

After the same repro:

```
=== B: provider=custom + base_url, NO model ===
   call_llm(kanban_decomposer) -> ChatCompletion(...)   OK
   call_llm(title_generation)  -> ChatCompletion(...)   OK
   call_llm(compression)       -> ChatCompletion(...)   OK
   server hits: [('POST', '/v1/chat/completions', ...), ...]
```

Resolvers: bare `custom` + `base_url` → `(openai.OpenAI, 'gpt-4o-mini' endpoint default, 'custom')`; `custom:<name>` entry declaring `model: local-qwen` with no `model.default` → `(openai.OpenAI, 'local-qwen', 'custom:selfhosted')`. Nearby shapes (`model.provider` unset, `model.default` set, no `api_key`, default empty `auxiliary.*` blocks) already resolved and still do.

## Tests

New: `tests/agent/test_auxiliary_custom_route_without_model_id.py` (red before the fix, green after; sabotage-verified by short-circuiting the new branch — the two behaviour tests fail again, the rest stay green):

* bare `custom` + `base_url`, no model id, zero external providers → routes to that endpoint
* `custom:<name>` entry, no `model.default` → uses the entry's own model + base_url
* a configured fallback policy still wins over the custom retry
* an external provider IS configured (OPENROUTER_API_KEY) → main-first routing unchanged, built-in chain untouched
* a non-custom main provider (xai-oauth) → still refuses to guess another logged-in account
* no endpoint configured anywhere → still `(None, None, "")`

```
HERMES_PYTHON=<venv>/python.exe bash scripts/run_tests.sh \
  tests/agent/test_auxiliary_custom_route_without_model_id.py \
  tests/agent/test_auxiliary_main_first.py \
  tests/agent/test_auxiliary_auto_never_guesses_provider.py \
  tests/agent/test_set_runtime_main_custom_provider.py
=== Summary: 4 files, 31 tests passed, 1 failed ===
```

Pre-existing failures, declared as such (each reproduced identically on the pristine tree with this change stashed — control run before touching anything):

* `tests/agent/test_set_runtime_main_custom_provider.py::TestResolveAutoCustomEndToEnd::test_named_custom_anthropic_messages_keeps_full_name_and_url` — environment: the test venv has no `anthropic` SDK, so the run logs `Named custom provider 'palantir' declares api_mode=anthropic_messages but the anthropic SDK is not installed — falling back to OpenAI-wire` and expects `AnthropicAuxiliaryClient`. Same result with and without this change (pristine: `1 failed, 4 passed`).
* `tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout::test_enforces_total_timeout_while_stream_keeps_emitting_events` — wall-clock assertion (`time.monotonic() - started < 0.14` against a 0.05 s budget) that is sensitive to Windows scheduling. Pristine tree: `1 failed, 203 passed`; same single failure. Not touched by this change.

Both are out of scope here and left alone rather than narrowed around.

Closes #107509
