### PR TITLE
fix(vault): propagate unlock session ownership onto the tool's worker thread

### DIFF
--- a/agent/vault_backends/unlock.py
+++ b/agent/vault_backends/unlock.py
@@ -71,6 +71,15 @@ def set_current_session_id(session_id: Optional[str]) -> None:
     _current_session_tls.sid = session_id
 
 
+def get_current_session_id() -> Optional[str]:
+    """The session id bound to the calling thread, if any. Paired with ``set_current_session_id``
+    so ``tools.thread_context.propagate_context_to_thread`` can carry it onto a tool's worker
+    thread the same way it carries the unlock/save-login prompt callbacks — otherwise an unlock
+    performed from a worker thread always records ``None`` as its owner and outlives the session
+    that made it (see ``store_session_token``/``release_session``)."""
+    return getattr(_current_session_tls, "sid", None)
+
+
 def _live(backend: str, *, touch: bool) -> Optional[str]:
     key = _key(backend)
     with _lock:

--- a/tests/agent/test_vault_backends.py
+++ b/tests/agent/test_vault_backends.py
@@ -167,3 +167,37 @@ def test_lock_during_unlock_wins_and_only_the_owning_session_release_drops_a_tok
         unlock_mod.release_session("sess-A")
         assert not backend.is_unlocked()
         unlock_mod.set_current_session_id(None)
+
+
+def test_unlock_from_a_tool_worker_thread_still_records_the_calling_sessions_ownership(fake_bw):
+    """browser_vault_unlock (the model-facing tool) runs on a ThreadPoolExecutor worker via
+    tools.thread_context.propagate_context_to_thread, never on the thread that bound the session id
+    in tui_gateway/agent_callbacks.py's _wire_callbacks. The worker must still see that session id so
+    release_session() actually finds and drops the token it created — otherwise every real unlock is
+    recorded under a None owner and only ever clears via the idle TTL or an explicit Lock, no matter
+    how long ago the owning session ended."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    from tools.browser_vault_tool import browser_vault_unlock
+    from tools.thread_context import propagate_context_to_thread
+
+    exe, _log = fake_bw
+    patcher, backend = _enabled(exe)
+    unlock_mod.set_unlock_prompt_callback(lambda name, display: "correct horse")
+    unlock_mod.set_current_session_id("sess-A")
+    try:
+        with patcher, patch("agent.vault_backends.enabled_backends", return_value=[backend]):
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                out = executor.submit(propagate_context_to_thread(browser_vault_unlock), "bitwarden").result(timeout=5)
+
+            assert json.loads(out)["success"] is True
+            assert backend.is_unlocked()
+
+            unlock_mod.release_session("sess-A")
+            assert not backend.is_unlocked(), (
+                "the worker thread did not see the calling session's id, so the token was recorded "
+                "under no owner and release_session('sess-A') could not find it"
+            )
+    finally:
+        unlock_mod.set_current_session_id(None)
+        unlock_mod.set_unlock_prompt_callback(None)

--- a/tools/thread_context.py
+++ b/tools/thread_context.py
@@ -29,7 +29,11 @@ def _callback_api():
     return ((tt._get_approval_callback, tt.set_approval_callback),
             (tt._get_sudo_password_callback, tt.set_sudo_password_callback),
             (vault_unlock.get_unlock_prompt_callback, vault_unlock.set_unlock_prompt_callback),
-            (vault_unlock.get_save_login_prompt_callback, vault_unlock.set_save_login_prompt_callback))
+            (vault_unlock.get_save_login_prompt_callback, vault_unlock.set_save_login_prompt_callback),
+            # Not a prompt callback, but the same per-thread gap applies: an unlock committed from
+            # this worker must still see the session id the parent thread bound, or it records a
+            # None owner that release_session() can never match (see vault_backends/unlock.py).
+            (vault_unlock.get_current_session_id, vault_unlock.set_current_session_id))
 
 
 def propagate_context_to_thread(target: Callable) -> Callable:


### PR DESCRIPTION
## What does this PR do?

`agent/vault_backends/unlock.py`'s `store_session_token()` records which gateway session performed an unlock (`_owner_session[key] = getattr(_current_session_tls, "sid", None)`), specifically so `release_session(sid)` can drop only the tokens *that* session unlocked when it ends — not a sibling session's tokens in the same profile. `tui_gateway/agent_callbacks.py`'s `_wire_callbacks()` calls `set_current_session_id(sid)` to bind this for exactly that purpose.

The problem: the actual unlock happens inside `browser_vault_unlock` (the model-facing tool in `tools/browser_vault_tool.py`), which `agent/tool_executor.py` dispatches via `executor.submit(propagate_context_to_thread(self.run_worker), ...)` — a `ThreadPoolExecutor` worker thread, not the thread that ran `_wire_callbacks()`. `_current_session_tls` is a bare `threading.local()`, so the worker thread never sees the session id the parent thread bound. `store_session_token()` on the worker therefore always records `None` as the owner.

### Impact

`release_session(real_session_id)` can never match a `None`-owned entry, so **every real unlock outlives the session that made it** — it only ever clears via the 30-minute idle TTL or an explicit `Lock`. A user who unlocks Bitwarden/1Password mid-conversation and then ends that session leaves the manager unlocked (and usable by another session in the same profile, no re-prompt) for up to 30 more idle minutes, contrary to the documented behavior ("the token is released when THAT session ends").

Note: this only concerns `browser_vault_unlock` (the chat-session-scoped tool path). Desktop Settings' `vault.unlock` RPC (`tui_gateway/methods_vault.py`) is a separate, profile-level control surface with no session id in its handler signature at all — leaving its tokens unowned (governed only by TTL/explicit Lock) looks like a deliberate choice for that surface, not something this PR touches.

## Fix

`tools/thread_context.py` already has an established `_callback_api()` table of `(getter, setter)` pairs that `propagate_context_to_thread()` uses to carry every other per-thread prompt callback (approval, sudo, vault unlock/save-login prompts) onto a tool's worker thread. Added a `get_current_session_id()` getter next to the existing `set_current_session_id()` setter in `unlock.py`, and wired the pair into that same table — the session id now travels onto the worker thread exactly the way the sibling callbacks already do.

## Competitor check

Searched by mechanism name, thread-local name, and behavior description — no open or closed PR touches this propagation gap. Only hit is the original feature PR (#106480, merged) that this bug sits on top of.

## Testing

Added `test_unlock_from_a_tool_worker_thread_still_records_the_calling_sessions_ownership` to `tests/agent/test_vault_backends.py`: unlocks via the real `browser_vault_unlock` tool dispatched through `propagate_context_to_thread` on an actual `ThreadPoolExecutor` worker (not a same-thread call, which the existing `test_lock_during_unlock_wins_and_only_the_owning_session_release_drops_a_token` test uses and which is exactly why it couldn't catch this), then asserts `release_session()` actually drops the token. Mutation-verified: reverting the fix while keeping the test reproduces the bug exactly (`release_session("sess-A")` leaves the backend unlocked). Full `tests/agent/test_vault_backends.py` (4/4) passes; confirmed the shared `_callback_api()` table's two consumers (`tools/code_kernel.py`, `tests/tools/test_code_kernel.py`) destructure it generically and are unaffected by the new fifth entry.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)