### PR TITLE
fix(desktop): resolve runtime plugin SDK namespaces lazily

### DIFF
--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -13,21 +13,59 @@ import * as jsxRuntime from 'react/jsx-runtime'
 
 import * as sdk from './index'
 
-const GLOBALS = {
-  __HERMES_PLUGIN_SDK__: sdk,
-  __HERMES_REACT__: React,
-  __HERMES_REACT_JSX__: jsxRuntime,
-  __HERMES_REACT_JSX_DEV__: jsxDevRuntime
-} as const
+type GlobalKey =
+  | '__HERMES_PLUGIN_SDK__'
+  | '__HERMES_REACT__'
+  | '__HERMES_REACT_JSX__'
+  | '__HERMES_REACT_JSX_DEV__'
+
+// NOTE: resolve namespaces at call time, never at module scope. The bundler
+// may evaluate this module before the sdk barrel's namespace binding is
+// initialized (a hoisted `var` still reads as undefined), which silently
+// empties ({...undefined} === {}) or crashes (Object.keys(undefined)) every
+// runtime plugin load. Both consumers run long after boot, so laziness is
+// free and always safe.
+function resolveNamespace(key: GlobalKey): Record<string, unknown> | null | undefined {
+  switch (key) {
+    case '__HERMES_PLUGIN_SDK__':
+      // Spread into a plain object: the loader re-exports these members
+      // dynamically (Object.keys), invisible to tree-shaking, so a static
+      // use of every member keeps plugin-facing exports in the bundle.
+      return { ...sdk }
+    case '__HERMES_REACT__':
+      return React as unknown as Record<string, unknown>
+    case '__HERMES_REACT_JSX__':
+      return jsxRuntime as unknown as Record<string, unknown>
+    case '__HERMES_REACT_JSX_DEV__':
+      return jsxDevRuntime as unknown as Record<string, unknown> | null | undefined
+  }
+}
 
 export function installPluginSdk(): void {
-  Object.assign(globalThis, GLOBALS)
+  Object.assign(globalThis, {
+    __HERMES_PLUGIN_SDK__: resolveNamespace('__HERMES_PLUGIN_SDK__'),
+    __HERMES_REACT__: resolveNamespace('__HERMES_REACT__'),
+    __HERMES_REACT_JSX__: resolveNamespace('__HERMES_REACT_JSX__'),
+    __HERMES_REACT_JSX_DEV__: resolveNamespace('__HERMES_REACT_JSX_DEV__')
+  })
 }
 
 /** Build a shim ESM blob that re-exports a global namespace's live members.
  *  Export names come from the namespace itself, so the list can't drift. */
-function shimUrl(globalKey: keyof typeof GLOBALS): string {
-  const names = Object.keys(GLOBALS[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
+function shimUrl(globalKey: GlobalKey): string {
+  const ns = resolveNamespace(globalKey)
+
+  // A nullish namespace (e.g. a bundler-mangled react/jsx-dev-runtime) must
+  // not break every plugin load: emit a module that throws only if imported.
+  if (ns == null) {
+    return URL.createObjectURL(
+      new Blob([`throw new Error('unavailable runtime namespace: ${globalKey}')`], {
+        type: 'text/javascript'
+      })
+    )
+  }
+
+  const names = Object.keys(ns).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
 
   const source =
     `const m = globalThis.${globalKey};\n` +


### PR DESCRIPTION
Resolves runtime-loaded plugins (disk/fetched) failing every load on the macOS arm64 Electron build.

## What does this PR do?

sdk/runtime.ts snapshotted the SDK namespace at module scope and read it eagerly in shimUrl()/installPluginSdk(). When the bundler evaluates this module before the ./index barrel's namespace binding is assigned (a hoisted var still reads undefined), the snapshot is either empty OR crashes (Object.keys(undefined) -> TypeError: Cannot convert undefined or null to object). Every runtime-loaded plugin importing @hermes/plugin-sdk (e.g. atom, Input) dies with 'runtime load failed'.

Fix: resolve namespaces at call time via resolveNamespace(key), used by both installPluginSdk() and shimUrl(); nullish namespaces get a throw-on-import shim instead of failing all plugins.

## Related Issue

Refs #107288 (duplicates #107303, #107304).

## Type of Change

- [x] Bug fix (non-breaking change)

## Changes Made

- apps/desktop/src/sdk/runtime.ts - module-scope GLOBALS snapshot replaced with call-time resolveNamespace keyed on GLOBALS key.

## How to Test

1. Reproduce: fresh macOS arm64 app (ee35a4624f), install a disk plugin importing SDK members (quota widget), relaunch - widget missing, 'runtime load failed' TypeError in desktop.log.
2. Apply fix, hermes desktop --build-only, relaunch.
3. Widget loads and renders; no new failures in desktop.log.

Verified on Electron macOS arm64 production build (ee35a4624f): a zero-import probe plugin fails identically (host-side fault), Node-side eval+register of the real plugin passes with stubs, and the packed build relaunch shows the fix working.

## Checklist

### Code
- [x] Read Contributing Guide
- [x] Conventional Commits
- [x] Searched for existing PRs (#107288/#107303/#107304 cover the regression)
- [x] Only changes related to this fix
- [ ] pytest tests/ -q (self-contained desktop source checkout; test harness unavailable here)
- [ ] Added tests (loader-internal; verified via packed-build reproduction above - happy to add a harness unit test on request)
- [x] Tested on macOS 26.6 arm64 (Electron 40.10.2)

### Documentation & Housekeeping
- [x] Docs: N/A (internal bug fix)
- [x] cli-config.yaml.example: N/A
- [x] CONTRIBUTING.md: N/A
- [x] Cross-platform: fix is loader-internal, safe everywhere
- [x] Tool descriptions/schemas: N/A

