### PR TITLE
fix(agent): retire the shared client instead of closing it mid-request

### DIFF
--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -214,6 +214,37 @@ class ClientLifecycleMixin:
         except Exception as exc:
             logger.debug("Shared OpenAI client retire failed (%s) %s error=%s", reason, self._client_log_context(), exc)
 
+    def _shared_openai_client_in_use(self) -> bool:
+        """True while a provider request that may still hold the shared client is running on this agent.
+
+        The shared client's ``in_use`` cannot be a plain flag (many threads share one client), so it is
+        derived from the two request brackets: the turn path sets ``_model_request_active`` around its
+        provider call, and the inline (cron/delegated) path registers ``_active_request_abort`` until the
+        call settles. Either marker means a worker thread still owns the pool's FDs. #107475
+        """
+        try:
+            active = getattr(self, "_model_request_active", None)
+            if active is not None and active.is_set():
+                return True
+        except Exception:
+            pass
+        return callable(getattr(self, "_active_request_abort", None))
+
+    def _close_shared_openai_client(self, client: Any, *, reason: str) -> None:
+        """``close_fn`` for the shared client: hard-close when idle, retire while a request is in flight.
+
+        Same split the per-request teardown applies via ``in_use``: only the thread that owns the FDs may
+        release them. ``close()`` runs on a stranger thread (gateway memory manager, a cron turn overlapping
+        an auxiliary context-compression request), so hard-closing here releases the pool's FDs under the
+        borrowing worker's live SSL BIO (FD recycle → #29507/#70773) and leaves the in-flight request mute
+        on a closed pool (#107475). Retirement ``shutdown()``s the sockets (the win ``close()`` wanted) and
+        defers FD release to GC/the owning worker.
+        """
+        if self._shared_openai_client_in_use():
+            self._retire_shared_openai_client(client, reason=f"{reason}_in_flight")
+        else:
+            self._close_openai_client(client, reason=reason, shared=True)
+
     def _drain_transports_after_abandonment(self, *, reason: str) -> int:
         """FD-safe transport drain for an abandoned (timed-out) worker; returns sockets shut down.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -923,7 +923,9 @@ class AIAgent(
         _quietly(self.shutdown_memory_provider, session_messages if isinstance(session_messages, list) else None)
         self._close_task_resources(getattr(self, "session_id", None) or "")
         self._close_active_children(soft=False)
-        _quietly(self._drop_shared_client, lambda c: self._close_openai_client(c, reason="agent_close", shared=True))
+        # #107475: close() can run on a stranger thread while a request still streams on the shared client;
+        # the in_use-aware close retires it there instead of releasing the pool's FDs under the owning worker.
+        _quietly(self._drop_shared_client, lambda c: self._close_shared_openai_client(c, reason="agent_close"))
         self._close_request_clients("agent_close")
         _quietly(self._close_codex_session)
         # Free conversation history proactively: callers may still hold the closed agent. The DB-flush

--- a/tests/run_agent/test_107475_agent_close_shared_client_in_flight.py
+++ b/tests/run_agent/test_107475_agent_close_shared_client_in_flight.py
@@ -1,0 +1,90 @@
+"""#107475: ``AIAgent.close()`` must not hard-close the shared OpenAI client while a request is in flight.
+
+``_drop_shared_client`` handed the shared client straight to ``_close_openai_client(shared=True)`` — the
+FD-releasing close — even though the per-request teardown already refuses to do that while a worker still
+owns the pool (its ``in_use`` flag). A scheduled cron turn and an auxiliary context-compression request
+overlapping left the in-flight request mute on a closed pool.
+
+Fix: ``close()`` goes through ``_close_shared_openai_client``, which retires (socket ``shutdown()``, FDs
+left to GC/the owning worker) while a request is in flight and hard-closes only when the agent is idle.
+"""
+import threading
+
+import pytest
+
+import run_agent
+
+
+class _FakeSharedClient:
+    """Stand-in for the shared OpenAI/httpx client; only ``close()`` is observable in this path."""
+
+    def __init__(self):
+        self.is_closed = False
+        self.close_calls = 0
+
+    def close(self):
+        self.close_calls += 1
+        self.is_closed = True
+
+
+def _build_agent(client):
+    """Agent skeleton whose only live resource is the shared client (no sessions/processes/memory)."""
+    agent = run_agent.AIAgent.__new__(run_agent.AIAgent)
+    agent.provider = "openai"
+    agent.model = "gpt-5"
+    agent.base_url = "https://api.openai.com/v1"
+    agent.quiet_mode = True
+    agent.client = client
+    agent._model_request_active = threading.Event()
+    return agent
+
+
+@pytest.fixture
+def retired(monkeypatch):
+    """Record retirement calls instead of touching real sockets."""
+    calls = []
+    monkeypatch.setattr(
+        run_agent.AIAgent,
+        "_retire_shared_openai_client",
+        lambda self, client, *, reason: calls.append((client, reason)),
+    )
+    return calls
+
+
+def test_close_retires_shared_client_while_turn_request_in_flight(retired):
+    """The turn path brackets its provider call with ``_model_request_active``."""
+    client = _FakeSharedClient()
+    agent = _build_agent(client)
+    agent._model_request_active.set()
+
+    agent.close()
+
+    assert client.close_calls == 0, "in-flight request still owns the pool's FDs"
+    assert [c for c, _ in retired] == [client]
+    assert retired[0][1] == "agent_close_in_flight"
+    assert agent.client is None
+
+
+def test_close_retires_shared_client_while_inline_request_registered(retired):
+    """The inline cron/delegated path keeps ``_active_request_abort`` registered for the whole call."""
+    client = _FakeSharedClient()
+    agent = _build_agent(client)
+    agent._active_request_abort = lambda reason: None
+
+    agent.close()
+
+    assert client.close_calls == 0, "in-flight request still owns the pool's FDs"
+    assert retired[0][1] == "agent_close_in_flight"
+    assert agent.client is None
+
+
+def test_close_hard_closes_shared_client_when_idle(retired):
+    """Idle agent: close() keeps its hard-close semantics (it is the resource-owning boundary)."""
+    client = _FakeSharedClient()
+    agent = _build_agent(client)
+
+    agent.close()
+
+    assert client.close_calls == 1
+    assert retired == []
+    assert agent.client is None


### PR DESCRIPTION
Fixes #107475

`AIAgent.close()` (the `agent_close` path) drops the shared OpenAI client with a bare `close()`. When that close runs on a stranger thread — the gateway memory manager, a cron turn overlapping an auxiliary compression request — while a provider request is still streaming on the shared client, it releases the pool's file descriptors under the borrowing worker's live SSL BIO (FD recycle, cf. #29507 / #70773) and leaves the in-flight request mute on a closed pool.

The per-request teardown already guards this with the `in_use` split (`_close_request_clients`, `_close_openai_client(..., shared=False)`); the shared client did not. This applies the same split to the shared-client close:

- `ClientLifecycleMixin._shared_openai_client_in_use()` — derives "in use" from the two request brackets the agent already keeps: `_model_request_active` (turn path) and `_active_request_abort` (inline/cron path).
- `ClientLifecycleMixin._close_shared_openai_client(client, *, reason)` — hard-closes when the client is idle, retires it (`shutdown()` + deferred FD release, reason suffixed `_in_flight`) while a request is in flight.
- `run_agent.py` — the shared-client drop now goes through the new wrapper.

## Evidence

New behavioral test `tests/run_agent/test_107475_agent_close_shared_client_in_flight.py` (3 passed, 0 failed):
- an idle client is still hard-closed on `agent_close`;
- an in-flight turn request (`_model_request_active` set) retires instead;
- an in-flight inline/cron request (`_active_request_abort` registered) retires instead.

Existing neighbours under `tests/run_agent/` stay green (run with `scripts/run_tests.sh`).

## Not verified

- No end-to-end repro with a real streamed socket; the test asserts behavior against fakes.
- While in flight, FD release moves from `close()` to GC / the owning worker. The retire path still `shutdown()`s the sockets, which is the effect the original `close()` wanted.
