### PR TITLE
fix(gateway): long-session rate-limit reply no longer rewritten to /compact when its text contains 400 (follow-up #107567)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3028,8 +3028,8 @@ def _normalize_empty_agent_response(
     (#31884)
 
     A failed context-overflow turn whose ``final_response`` is only the raw provider envelope
-    (``HTTP 400: {...}``) is rewritten too: returned unchanged, chat sanitizers turn it into a
-    generic provider-failed reply and the user never sees /compact. Curated agent text survives.
+    (``HTTP 400: {...}``) is rewritten too -- left as-is, the chat sanitizer would collapse it into a
+    generic "provider failed" reply and the user would never see /compact. Curated agent text survives.
     """
     is_overflow = is_context_overflow_failure_result(agent_result, history_len)
     if response and not (is_overflow and _looks_like_gateway_provider_error(response)):

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -51,7 +51,7 @@ _CONTEXT_OVERFLOW_ERROR_PHRASES = (
     "request entity too large", "prompt is too long",
     "payload too large", "input is too long",
 )
-# Whole-token 400 only: "Limit 40000" in a rate-limit envelope or a request id must not read as a status.
+# Whole-token 400 only: "Limit 40000" in a rate-limit envelope must not read as a status.
 _HTTP_400_RE = re.compile(r"\b400\b")
 
 
@@ -67,7 +67,7 @@ def is_context_overflow_failure_result(agent_result: dict, history_len: int) -> 
         return True
     err = str(agent_result.get("error") or "").lower()
     return any(p in err for p in _CONTEXT_OVERFLOW_ERROR_PHRASES) or (
-        history_len > 50 and _HTTP_400_RE.search(err) is not None)
+        history_len > 50 and bool(_HTTP_400_RE.search(err)))
 
 
 class GatewayTurnMixin:

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -13,6 +13,7 @@ import inspect
 import json
 import os
 import queue
+import re
 import threading
 import time
 from agent.i18n import t
@@ -50,6 +51,8 @@ _CONTEXT_OVERFLOW_ERROR_PHRASES = (
     "request entity too large", "prompt is too long",
     "payload too large", "input is too long",
 )
+# Whole-token 400 only: "Limit 40000" in a rate-limit envelope or a request id must not read as a status.
+_HTTP_400_RE = re.compile(r"\b400\b")
 
 
 def is_context_overflow_failure_result(agent_result: dict, history_len: int) -> bool:
@@ -57,13 +60,14 @@ def is_context_overflow_failure_result(agent_result: dict, history_len: int) -> 
     (#1630 skip) and the user-facing reply so the two can never disagree.
 
     Multi-word phrases (not bare "exceed"/"token") avoid matching "rate limit exceeded" or
-    "invalid authentication token"; a bare 400 only counts on a long session."""
+    "invalid authentication token"; a bare 400 status only counts on a long session."""
     if not agent_result.get("failed"):
         return False
     if agent_result.get("compression_exhausted"):
         return True
     err = str(agent_result.get("error") or "").lower()
-    return any(p in err for p in _CONTEXT_OVERFLOW_ERROR_PHRASES) or ("400" in err and history_len > 50)
+    return any(p in err for p in _CONTEXT_OVERFLOW_ERROR_PHRASES) or (
+        history_len > 50 and _HTTP_400_RE.search(err) is not None)
 
 
 class GatewayTurnMixin:

--- a/tests/gateway/test_7100_transient_failure_transcript.py
+++ b/tests/gateway/test_7100_transient_failure_transcript.py
@@ -16,7 +16,7 @@ The gateway classifier must distinguish:
 """
 
 
-from gateway.run_turn import is_context_overflow_failure_result as _classify
+from gateway.run_turn import is_context_overflow_failure_result
 
 
 class TestContextOverflowStillSkipsTranscript:
@@ -28,18 +28,18 @@ class TestContextOverflowStillSkipsTranscript:
             "compression_exhausted": True,
             "error": "Request payload too large: max compression attempts reached.",
         }
-        assert _classify(agent_result, history_len=100)
+        assert is_context_overflow_failure_result(agent_result, history_len=100)
 
     def test_bare_400_status_on_long_session_is_context_overflow(self):
         agent_result = {"failed": True, "error": 'HTTP 400: {"object":"error","model":"deepseek-v4-flash"}'}
-        assert _classify(agent_result, history_len=138)
+        assert is_context_overflow_failure_result(agent_result, history_len=138)
 
     def test_digits_400_inside_a_larger_number_are_not_a_status(self):
         agent_result = {
             "failed": True,
             "error": "API call failed after 3 retries: HTTP 429 rate limit exceeded. Limit 40000, Used 39990",
         }
-        assert not _classify(agent_result, history_len=138)
+        assert not is_context_overflow_failure_result(agent_result, history_len=138)
 
 
 class TestTransientFailureKeepsUserMessage:
@@ -54,14 +54,14 @@ class TestTransientFailureKeepsUserMessage:
                 "— rate limit exceeded"
             ),
         }
-        assert not _classify(agent_result, history_len=10)
+        assert not is_context_overflow_failure_result(agent_result, history_len=10)
 
     def test_read_timeout_is_not_context_overflow(self):
         agent_result = {
             "failed": True,
             "error": "ReadTimeout: HTTPSConnectionPool(host='api.z.ai'): Read timed out.",
         }
-        assert not _classify(agent_result, history_len=10)
+        assert not is_context_overflow_failure_result(agent_result, history_len=10)
 
 
 class TestSuccessfulResultUnaffected:
@@ -70,4 +70,4 @@ class TestSuccessfulResultUnaffected:
             "final_response": "Hello!",
             "messages": [{"role": "assistant", "content": "Hello!"}],
         }
-        assert not _classify(agent_result, history_len=10)
+        assert not is_context_overflow_failure_result(agent_result, history_len=10)

--- a/tests/gateway/test_7100_transient_failure_transcript.py
+++ b/tests/gateway/test_7100_transient_failure_transcript.py
@@ -16,12 +16,7 @@ The gateway classifier must distinguish:
 """
 
 
-from gateway.run_turn import is_context_overflow_failure_result
-
-
-def _classify(agent_result: dict, history_len: int) -> tuple[bool, bool]:
-    """``(agent_failed_early, is_context_overflow_failure)`` as the gateway computes them."""
-    return bool(agent_result.get("failed")), is_context_overflow_failure_result(agent_result, history_len)
+from gateway.run_turn import is_context_overflow_failure_result as _classify
 
 
 class TestContextOverflowStillSkipsTranscript:
@@ -33,9 +28,18 @@ class TestContextOverflowStillSkipsTranscript:
             "compression_exhausted": True,
             "error": "Request payload too large: max compression attempts reached.",
         }
-        failed, ctx_overflow = _classify(agent_result, history_len=100)
-        assert failed
-        assert ctx_overflow
+        assert _classify(agent_result, history_len=100)
+
+    def test_bare_400_status_on_long_session_is_context_overflow(self):
+        agent_result = {"failed": True, "error": 'HTTP 400: {"object":"error","model":"deepseek-v4-flash"}'}
+        assert _classify(agent_result, history_len=138)
+
+    def test_digits_400_inside_a_larger_number_are_not_a_status(self):
+        agent_result = {
+            "failed": True,
+            "error": "API call failed after 3 retries: HTTP 429 rate limit exceeded. Limit 40000, Used 39990",
+        }
+        assert not _classify(agent_result, history_len=138)
 
 
 class TestTransientFailureKeepsUserMessage:
@@ -50,18 +54,14 @@ class TestTransientFailureKeepsUserMessage:
                 "— rate limit exceeded"
             ),
         }
-        failed, ctx_overflow = _classify(agent_result, history_len=10)
-        assert failed
-        assert not ctx_overflow
+        assert not _classify(agent_result, history_len=10)
 
     def test_read_timeout_is_not_context_overflow(self):
         agent_result = {
             "failed": True,
             "error": "ReadTimeout: HTTPSConnectionPool(host='api.z.ai'): Read timed out.",
         }
-        failed, ctx_overflow = _classify(agent_result, history_len=10)
-        assert failed
-        assert not ctx_overflow
+        assert not _classify(agent_result, history_len=10)
 
 
 class TestSuccessfulResultUnaffected:
@@ -70,6 +70,4 @@ class TestSuccessfulResultUnaffected:
             "final_response": "Hello!",
             "messages": [{"role": "assistant", "content": "Hello!"}],
         }
-        failed, ctx_overflow = _classify(agent_result, history_len=10)
-        assert not failed
-        assert not ctx_overflow
+        assert not _classify(agent_result, history_len=10)

--- a/tests/gateway/test_normalize_empty_agent_response.py
+++ b/tests/gateway/test_normalize_empty_agent_response.py
@@ -150,6 +150,8 @@ class TestNonempty400EnvelopeOverflowReply:
         "Billing or credits exhausted: HTTP 429: You exceeded your current quota",
         "API call failed after 3 retries: HTTP 429 rate limit exceeded",
         "HTTP 401: invalid authentication token",
+        # digits "400" inside a larger number are not an HTTP 400 status
+        "API call failed after 3 retries: HTTP 429 rate limit exceeded. Limit 40000, Used 39990",
     ])
     def test_non_overflow_failure_keeps_its_own_text(self, text):
         assert _normalize_empty_agent_response(self._failed(text), text, history_len=138) == text


### PR DESCRIPTION
A long-session rate-limit reply whose text contains the digits `400` inside a larger number (e.g. `Limit 40000, Used 39990`) no longer gets rewritten to "Session too large — use /compact".

**Who/when/why:** Follow-up to #107567 (salvage of #107364 by @xxxigm), merged earlier today. That PR made the shared overflow classifier run on failed turns that still carry text; its bare `"400" in err` substring check then started matching rate-limit envelopes on long sessions. Found in the post-merge review pass.

**Changes**
- `gateway/run_turn.py`: the long-session 400 arm matches `\b400\b` (a whole-token status) instead of any `400` substring. The #1630 transcript-skip uses the same verdict and tightens the same way.
- `tests/gateway/test_7100_transient_failure_transcript.py`: drop the `_classify` wrapper that echoed the fixture's own `failed` key (tautological asserts); call the production predicate by name; pin the bare-400-on-long-session and digits-inside-a-number shapes.
- `tests/gateway/test_normalize_empty_agent_response.py`: one more passthrough case for the reply path.
- `gateway/run.py`: docstring wording only (the counterfactual read as if the rewritten text were returned unchanged).

**Validation**

| Check | Result |
|---|---|
| `test_7100_transient_failure_transcript.py`, `test_normalize_empty_agent_response.py`, `test_lazy_session_regressions.py`, `test_tool_response_drop_recovery.py` | 33 passed |
| Same suite with `gateway/run_turn.py` reverted to `origin/main` | exactly the 2 new guard tests fail, rest green |
| Live probe, 138-msg history, `... HTTP 429 rate limit exceeded. Limit 40000, Used 39990` | before: "Session too large / /compact"; after: rate-limit reply |
| Live probe, `HTTP 400: {"object":"error",...}` envelope, 138-msg history | unchanged: "/compact" reply |
| Every 400 shape the agent emits today (`HTTP 400: `, `(HTTP 400)`, `[HTTP 400]`, `Gemini HTTP 400 (...)`) | still matches `\b400\b` |
| ruff, `check-windows-footguns.py --all`, `git diff --check` | clean |
