### PR TITLE
fix(dashboard): sum session cost across the whole compression lineage

### DIFF
--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -951,10 +951,36 @@ class SessionSessionsMixin:
         combined = " AND ".join(clauses)
         return (f"{where_sql} AND {combined}" if where_sql else f"WHERE {combined}"), params
 
+    def _chain_spend_by_tip(self, chains: Dict[str, List[str]]) -> Dict[str, float]:
+        """Whole-lineage spend per tip, keyed by tip id: every member's billed-over-estimated
+        figure (``COALESCE(actual_cost_usd, estimated_cost_usd, 0)``) summed, in one chunked
+        query. A root's own cost is a snapshot frozen at rotation while the tip keeps billing,
+        so a row projected from a tip must carry the chain total instead (#105535). Ids absent
+        from the table (pruned/deleted segments) simply contribute nothing."""
+        member_tip: Dict[str, str] = {}
+        for tip, chain in chains.items():
+            for member in chain:
+                member_tip.setdefault(member, tip)
+        totals = dict.fromkeys(chains, 0.0)
+        members = list(member_tip)
+        # SQLITE_MAX_VARIABLE_NUMBER is 999 on old SQLite; same choke-point chunking as
+        # _get_session_rich_rows_batch.
+        for start in range(0, len(members), 900):
+            chunk = members[start:start + 900]
+            rows = self._read_all(
+                "SELECT id, COALESCE(actual_cost_usd, estimated_cost_usd, 0) AS spend FROM sessions"
+                f" WHERE id IN ({','.join('?' for _ in chunk)})",
+                chunk,
+            )
+            for row in rows:
+                totals[member_tip[row["id"]]] += float(row["spend"] or 0.0)
+        return totals
+
     def _project_compression_tips(self, sessions: List[Dict[str, Any]], compact_rows: bool) -> List[Dict[str, Any]]:
         """Replace each compression root's surfaced fields with its live tip's (root ``started_at`` kept
         for stable ordering), one batched query. ``_lineage_ids`` carries every chain id (a tile may
-        hold a MIDDLE segment's id)."""
+        hold a MIDDLE segment's id). Cost is not a per-segment figure on this row: the whole chain's
+        spend is stamped on it, so a rotation cannot freeze the sidebar's number (#105535)."""
         chain_by_root: Dict[str, List[str]] = {}  # only roots whose tip differs from themselves
         for s in sessions:
             if s.get("end_reason") == "compression":
@@ -965,6 +991,12 @@ class SessionSessionsMixin:
             self._get_session_rich_rows_batch(
                 {chain[-1] for chain in chain_by_root.values()}, compact_rows=compact_rows,
             ) if chain_by_root else {}
+        )
+        # Only chains that actually rotated resolve here, so this extra query runs per page,
+        # not per row.
+        chain_spend = (
+            self._chain_spend_by_tip({chain[-1]: chain for chain in chain_by_root.values()})
+            if chain_by_root else {}
         )
         projected = []
         for s in sessions:
@@ -980,6 +1012,14 @@ class SessionSessionsMixin:
             ):
                 if key in tip_row:
                     merged[key] = tip_row[key]
+            # The whole conversation's spend belongs to the one row that represents it. The sum
+            # prefers billed figures per member, so the carried root's own ``actual_cost_usd``
+            # must be cleared: consumers read the pair as ``actual or estimated``
+            # (sidebar-archive.ts sessionCostUsd, tui_gateway/project_tree.py) and a nonzero root
+            # actual would shadow the fresh total behind the frozen snapshot. ``None`` is the
+            # never-billed state the column already holds (#105535).
+            merged["estimated_cost_usd"] = chain_spend.get(chain[-1], 0.0)
+            merged["actual_cost_usd"] = None
             if merged.get("title") is None:
                 # The title is carried root->tip AFTER the publish transaction; a rotation cut off in
                 # between leaves it on the ended root, and exact-title lookups (`hermes peer dm` ->

--- a/hermes_state_usage.py
+++ b/hermes_state_usage.py
@@ -386,8 +386,10 @@ class SessionUsageMixin:
 
     def usage_totals(self, *, min_message_count: int = 1, include_archived: bool = False) -> Dict[str, float]:
         """Tokens and spend across the whole store (one scan), so the sidebar total does not
-        shrink with paging. Spend prefers the billed figure over the estimate."""
-        where = ["parent_session_id IS NULL", "message_count >= ?"]
+        shrink with paging. Spend prefers the billed figure over the estimate. Every row with
+        messages counts — a compression continuation or delegate child bills the same account
+        as its parent, and a roots-only predicate silently dropped all of it (#105535)."""
+        where = ["message_count >= ?"]
         params: List[Any] = [min_message_count]
         if not include_archived:
             where.append("COALESCE(archived, 0) = 0")

--- a/tests/hermes_state/test_105535_compression_lineage_cost.py
+++ b/tests/hermes_state/test_105535_compression_lineage_cost.py
@@ -1,0 +1,112 @@
+"""#105535 — a compressed conversation's spend must follow the whole lineage.
+
+``/compress`` rotates a conversation onto a new ``parent_session_id``-chained row. Two
+cost paths kept reading the pre-rotation state:
+
+- ``_project_compression_tips`` replaces a root's surfaced fields with its live tip's, but
+  the field tuple had no cost column — so the sidebar row for a 3-segment conversation
+  showed the ROOT's at-rotation snapshot while ``message_count`` on the same row was the
+  tip's fresh count.
+- ``usage_totals`` summed ``WHERE parent_session_id IS NULL``, a pre-compression-era
+  predicate that excluded every continuation segment — so the sidebar's profile usage
+  header permanently lagged true spend.
+
+Numbers below are the ones from the issue's live store (root $0.5120 / mid $1.1730 /
+tip $0.9303 = $2.6153).
+"""
+
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+ROOT_COST, MID_COST, TIP_COST = 0.5120097099, 1.1730, 0.9303
+TRUE_TOTAL = ROOT_COST + MID_COST + TIP_COST
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = SessionDB(tmp_path / "state.db")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def _lineage(db: SessionDB, *, billed_root: bool = False) -> None:
+    """root -> mid -> tip, each segment carrying its own spend, as a real rotation leaves it."""
+    base = time.time() - 3600
+    db.create_session("root", source="cli")
+    db.create_session("mid", source="cli", parent_session_id="root")
+    db.create_session("tip", source="cli", parent_session_id="mid")
+    for sid in ("root", "mid", "tip"):
+        db.append_message(sid, "user", f"message in {sid}")
+    db._conn.execute(
+        "UPDATE sessions SET started_at=?, ended_at=?, end_reason='compression', message_count=299,"
+        " estimated_cost_usd=?, actual_cost_usd=? WHERE id='root'",
+        # ``None`` = never billed, the state an estimated-only segment rows in as.
+        (base, base + 10, ROOT_COST, ROOT_COST if billed_root else None),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at=?, ended_at=?, end_reason='compression', message_count=616,"
+        " estimated_cost_usd=? WHERE id='mid'",
+        (base + 20, base + 30, MID_COST),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at=?, message_count=585, estimated_cost_usd=? WHERE id='tip'",
+        (base + 40, TIP_COST),
+    )
+    db._conn.commit()
+
+
+def _sidebar_rows(db: SessionDB):
+    """The sidebar's exact read (recents slice of /api/profiles/sessions/sidebar)."""
+    return db.list_sessions_rich(
+        source="cli", exclude_sources=["tool"], limit=20, offset=0, min_message_count=1,
+        include_archived=False, archived_only=False, order_by_last_active=True,
+        compact_rows=True, include_pinned=True,
+    )
+
+
+@pytest.mark.parametrize("billed_root", [False, True])
+def test_projected_row_carries_whole_lineage_spend(db: SessionDB, billed_root: bool) -> None:
+    """The projected tip row shows root + mid + tip, not the root's rotation-time snapshot.
+
+    ``billed_root`` is the shadowing case: the root's own ``actual_cost_usd`` is carried onto
+    the projected row, and consumers pick the cost with ``actual or estimated``
+    (``sidebar-archive.ts``, ``tui_gateway/project_tree.py``) — a nonzero root actual would
+    hide the fresh lineage sum behind the frozen figure.
+    """
+    _lineage(db, billed_root=billed_root)
+
+    (row,) = _sidebar_rows(db)
+
+    assert row["_lineage_root_id"] == "root"
+    assert row["message_count"] == 585, "projection must have run (tip identity surfaced)"
+    assert row["estimated_cost_usd"] == pytest.approx(TRUE_TOTAL)
+    assert not row["actual_cost_usd"], "stale root actual must not shadow the lineage sum"
+    assert (row["actual_cost_usd"] or row["estimated_cost_usd"] or 0) == pytest.approx(TRUE_TOTAL)
+
+
+def test_usage_totals_counts_post_compression_segments(db: SessionDB) -> None:
+    """Profile usage header: every priced row on the account counts, continuations included."""
+    _lineage(db)
+    assert db.usage_totals() == {"tokens": 0, "cost_usd": pytest.approx(TRUE_TOTAL)}
+
+
+def test_usage_totals_ignores_archived_lineage(db: SessionDB) -> None:
+    """Archiving a conversation still removes it from the total — the lineage-wide archive
+    (``set_session_archived``) covers root, mid and tip together."""
+    _lineage(db)
+    assert db.set_session_archived("tip", True) is True
+    assert db.usage_totals()["cost_usd"] == 0.0
+
+
+def test_usage_totals_keeps_the_empty_child_floor(db: SessionDB) -> None:
+    """A rotation cut off before the child billed anything stays out of the total."""
+    _lineage(db)
+    db.create_session("child", source="cli", parent_session_id="tip")
+    db._conn.execute("UPDATE sessions SET message_count=0, estimated_cost_usd=9.99 WHERE id='child'")
+    db._conn.commit()
+    assert db.usage_totals() == {"tokens": 0, "cost_usd": pytest.approx(TRUE_TOTAL)}


### PR DESCRIPTION
## What Problem This Solves

`/compress` rotates a conversation onto a new `parent_session_id`-chained row (root → … → tip). Two cost paths kept reading the pre-rotation state, so a compressed conversation's spend stopped updating everywhere it is displayed:

1. **Per-row (sidebar).** `_project_compression_tips` replaces a compression root's surfaced fields with its live tip's, but the copied field tuple (`hermes_state_sessions.py:977-980` — `id, ended_at, end_reason, message_count, tool_call_count, title, last_active, preview, model, …`) carries **no cost column**. The projected row therefore kept the ROOT's `estimated_cost_usd`: a snapshot frozen at rotation time, while the very same row already showed the tip's fresh `message_count`. A conversation mid-compressed at $0.5120 kept reading $0.5120 while the tip billed on.

2. **Profile aggregate.** `usage_totals` (`hermes_state_usage.py:390`) summed `WHERE parent_session_id IS NULL`. That predicate pre-dates compression continuations: every post-rotation segment (and every other child row — branch/delegate/tool sessions bill the same account) was invisible to the sidebar's profile usage header, so the shown total permanently lagged true spend.

Data flow: sidebar recents/profile slice (`GET /api/profiles/sessions/sidebar`, `hermes_cli/web_routers/profiles.py:448-463`) → `SessionDB.list_sessions_rich(project_compression_tips=True)` → `_project_compression_tips` (row cost) and `usage_totals()` (profile total) → the Desktop renders the row with `apps/desktop/src/store/sidebar-archive.ts:35` (`actual_cost_usd || estimated_cost_usd || 0`).

The fix makes one row represent one conversation's whole spend, and one total represent the whole store's own spend:

- **`_chain_spend_by_tip`** (new, `hermes_state_sessions.py`): per-member `COALESCE(actual_cost_usd, estimated_cost_usd, 0)` summed per chain in one chunked `IN` query, run only when the page actually holds rotated chains (not per row). A member absent from the table (pruned/deleted) contributes 0, so maintenance can't break the projection.
- **`_project_compression_tips`** stamps that sum onto the projected tip's `estimated_cost_usd` and clears the carried root's `actual_cost_usd` to `None` (the never-billed state the column already holds). Without the clear, a billed root would shadow the fresh sum for every consumer that reads the pair as `actual or estimated`.
- **`usage_totals`** drops the roots-only predicate: all non-archived rows with ≥1 message count. Archive semantics are unchanged — `set_session_archived` already spans the lineage, so an archived conversation still leaves the total as a unit.

Known interaction: the per-member sum is billed-over-estimated, so if only some segments carry `actual_cost_usd` the bases mix. That is the same preference `usage_totals` already applied, and it is a best-effort display figure.

Closes #105535

## Evidence

Reproduced against a real `SessionDB` on current main with the issue's own 3-segment numbers (root $0.5120097099 / mid $1.1730 / tip $0.9303), through the sidebar's exact read flags — no GUI required:

```
chain            : ['root', 'mid', 'tip']
projected row id : tip   root: root
row message_count: 585        (tip's 585 => projection ran)
row estimated    : 0.5120097099      <-- root's rotation-time snapshot
row actual       : None
row cost shown   : 0.5120097099
usage_totals     : {'tokens': 0, 'cost_usd': 0.5120097099}
TRUE lineage     : 2.6153097099
```

After the fix, same store, same call:

```
row estimated    : 2.6153097099
row actual       : None
row cost shown   : 2.6153097099
usage_totals     : {'tokens': 0, 'cost_usd': 2.6153097099}
```

## How to Test

```
# Regression tests (new file), on the fix:
HERMES_PYTHON=<python> bash scripts/run_tests.sh tests/hermes_state/test_105535_compression_lineage_cost.py
# => 5 passed

# Same file with the fix reverted (cost stamping removed + roots-only predicate restored):
# => 4 failed, 1 passed
#    FAILED ::test_projected_row_carries_whole_lineage_spend[False]
#    FAILED ::test_projected_row_carries_whole_lineage_spend[True]
#    FAILED ::test_usage_totals_counts_post_compression_segments
#    FAILED ::test_usage_totals_keeps_the_empty_child_floor
#    (the 1 passing test is the archive guard, which is 0 == 0 in both states by construction)
#    e.g. AssertionError: {'cost_usd': 0.5120097099} != {'cost_usd': 2.6153097099 ± 2.6e-06}

# Directly related suites, on the fix:
HERMES_PYTHON=<python> bash scripts/run_tests.sh tests/hermes_state/test_105535_compression_lineage_cost.py \
  tests/hermes_state/test_session_archiving.py tests/hermes_cli/test_profiles_sidebar_scope.py tests/hermes_cli/test_sessions_pin.py
# => 4 files, 21 tests passed, 0 failed

HERMES_PYTHON=<python> bash scripts/run_tests.sh tests/test_hermes_state.py
# => 1 failed, 263 passed — the failure is TestFTS5Search::test_search_projection_skips_context_enrichment_queries,
#    pre-existing and unrelated (reproduced identically with this PR's source changes stashed).
```

Pre-existing failures on this machine, declared rather than fixed (all reproduce with this PR's changes stashed — `git stash push -- hermes_state_sessions.py hermes_state_usage.py`, rerun, same failures, then `git stash pop`):

- `tests/hermes_state/test_state_db_file_identity.py` (3), `tests/hermes_state/test_shared_session_db_registry.py` (5, `PermissionError` — Windows file-handle/inode semantics), `tests/hermes_state/test_state_db_corrupt_quarantine.py` (1), `tests/test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries` (1) — same 10 failures on the unmodified tree, unrelated to cost aggregation.

Lint/typecheck: `ruff check` clean on all three files. (`ty check` reports the same pre-existing `unresolved-attribute` diagnostics on these files as on the base ref; the new helper adds none. The `ty` CI job is an advisory diff.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_sessions.py` — new `_chain_spend_by_tip`; `_project_compression_tips` stamps the whole-chain sum on the projected row and clears the carried root `actual_cost_usd`.
- `hermes_state_usage.py` — `usage_totals` counts every message-bearing row instead of roots only; docstring updated.
- `tests/hermes_state/test_105535_compression_lineage_cost.py` — new: projected row carries the lineage sum (with and without a billed root), `usage_totals` includes continuations, archived lineage still excluded, empty-child floor kept.

Scope boundary: this does not touch row de-duplication/pinning (that is #105507's area) and does not change which rows are listed.

Relationship to other open work (not linked from the issue): **#105537** implements the same two root causes independently (as does part of #89524 for the row figure) — noting it here so a maintainer can take whichever lands first rather than merge both. #89524's row semantics differ: it projects the tip segment's *own* totals, whereas #105535's expected behavior is the whole conversation's spend, which is what this PR implements.

## Checklist

- [x] Commit follows Conventional Commits (`fix(dashboard): …`)
- [x] Searched for existing PRs — see the note above on #105537
- [x] Only changes related to this fix (root cause, not the path the ticket named: both cost readers fixed)
- [x] Added regression tests, proven to fail without the fix
- [x] Tested on Windows 11 (Python 3.11.15)
