### PR TITLE
fix(agent): retire the shared client in close() instead of hard-closing it (#107475)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -923,7 +923,12 @@ class AIAgent(
         _quietly(self.shutdown_memory_provider, session_messages if isinstance(session_messages, list) else None)
         self._close_task_resources(getattr(self, "session_id", None) or "")
         self._close_active_children(soft=False)
-        _quietly(self._drop_shared_client, lambda c: self._close_openai_client(c, reason="agent_close", shared=True))
+        # Retire (don't hard-close) the shared client, same as release_clients(): teardown can run on
+        # a cron-cleanup / stranger thread while an auxiliary stream (compression) is still in flight
+        # on it — an inline close() released the FDs under the live stream, which then went silent for
+        # its whole inactivity budget (#107475). Retirement shuts pooled sockets down (FD-safe) and
+        # lets GC release the FDs once no thread holds them (#70773).
+        _quietly(self._drop_shared_client, lambda c: self._retire_shared_openai_client(c, reason="agent_close"))
         self._close_request_clients("agent_close")
         _quietly(self._close_codex_session)
         # Free conversation history proactively: callers may still hold the closed agent. The DB-flush

--- a/tests/run_agent/test_agent_close_shared_client_race.py
+++ b/tests/run_agent/test_agent_close_shared_client_race.py
@@ -1,0 +1,172 @@
+"""Regressions for issue #107475 — ``close()`` hard-closed the shared OpenAI
+client from the teardown thread while another thread could still be unwinding a
+request on it (the reporter's case: an auxiliary context-compression stream that
+produced no further event and no error until its inactivity budget expired).
+
+The codebase already holds the invariant "never hard-close the shared client from
+a thread that may not own its FDs" and enforces it at the two sibling sites —
+``release_clients()`` (cache_evict) and ``_replace_primary_openai_client``
+(replace) both route the shared client through ``_retire_shared_openai_client``
+(shutdown(SHUT_RDWR) only; FD release deferred to GC). ``close()`` was the third
+shared-client teardown site and the only one still calling ``_close_openai_client``
+(FDs released inline). These tests pin the fixed contract:
+
+1. ``close()`` retires the shared client — ``client.close()`` must NEVER run on
+   it from the teardown thread.
+2. An in-flight (checked-out-of-pool) stream socket is untouched by teardown —
+   the stream can still settle on its own.
+3. Teardown still drops the reference (idempotence for a second ``close()``) and
+   the per-request slot keeps its own in-flight-aware close.
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from run_agent import AIAgent
+
+
+def _make_close_agent(client):
+    """Real AIAgent instance (no __init__/network) wired for close().
+
+    close() runs many guarded phases; only the seams it actually reads need to
+    exist. The shared client is the object under observation.
+    """
+    agent = AIAgent.__new__(AIAgent)
+    agent.client = client
+    agent._session_messages = None
+    return agent
+
+
+class _RetireSpy:
+    """Records retire/close routing for the shared client without touching FDs."""
+
+    def __init__(self, client):
+        self.client = client
+        self.retired = []
+        self.closed = []
+        self.force_closed = []
+        agent = _make_close_agent(client)
+        self.agent = agent
+
+        # Spy on the two seams production routes through; retire does the real
+        # (safe) sweep via the patched _force_close_tcp_sockets below.
+        def _retire(client, *, reason):
+            self.retired.append((client, reason))
+
+        def _close(client, *, reason, shared):
+            self.closed.append((client, reason, shared))
+
+        agent._retire_shared_openai_client = _retire
+        agent._close_openai_client = _close
+        agent._force_close_tcp_sockets = lambda client: (
+            self.force_closed.append(client),
+            len(self.force_closed),
+        )[1]
+
+    def run_close(self):
+        self.agent.close()
+
+
+def test_close_retires_shared_client_instead_of_hard_close():
+    """The core fix: close() must route the shared client through retire."""
+    client = _StubSharedClient()
+    spy = _RetireSpy(client)
+    spy.run_close()
+
+    assert spy.retired == [(client, "agent_close")]
+    assert spy.closed == [], (
+        "close() must not hard-close the shared client (#107475): another thread "
+        "may still be unwinding a request on it"
+    )
+    assert client.close_calls == 0
+
+
+def test_close_shared_client_survives_in_flight_stream():
+    """Object-granularity replay of the reporter's timeline.
+
+    The stream's socket is checked OUT of the idle connection pool while the
+    request is in flight, so the pool walk in the shutdown sweep finds nothing
+    (tcp_force_closed=0) — the reporter saw exactly that — and the danger is the
+    inline ``client.close()`` that follows. After the fix, teardown neither shuts
+    down nor closes that socket: the stream keeps its connection.
+    """
+    stream_sock = _FakeSocket()
+    client = _build_shared_client_with_checked_out_stream(stream_sock)
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.client = client
+    agent._session_messages = None
+    agent._retire_shared_openai_client = _real_retire_spy()
+    agent._close_openai_client = MagicMock(
+        side_effect=AssertionError("must not be called for the shared client")
+    )
+
+    agent.close()
+
+    assert stream_sock.shutdown_calls == 0, (
+        "a checked-out stream socket must not be shut down by teardown — the aux "
+        "stream must be able to complete on its own (#107475)"
+    )
+    assert stream_sock.close_calls == 0
+    assert agent.client is None, "teardown must still drop the shared-client reference"
+
+
+def test_close_idempotent_second_call_is_noop():
+    """close() is documented idempotent: a second call must not re-retire."""
+    client = _StubSharedClient()
+    spy = _RetireSpy(client)
+    spy.run_close()
+    spy.run_close()
+
+    assert spy.retired == [(client, "agent_close")]
+    assert agent_client_of(spy.agent) is None
+
+
+def agent_client_of(agent):
+    return getattr(agent, "client", "missing")
+
+
+class _StubSharedClient:
+    def __init__(self):
+        self.close_calls = 0
+
+    def close(self):
+        # Real OpenAI SDK close() would raise once the underlying httpx client
+        # is gone; counting the call is enough for the routing assertion.
+        self.close_calls += 1
+
+
+class _FakeSocket:
+    def __init__(self):
+        self.shutdown_calls = 0
+        self.close_calls = 0
+
+    def shutdown(self, _how):
+        self.shutdown_calls += 1
+
+    def close(self):
+        self.close_calls += 1  # tripwire: teardown must never release the FD (#29507)
+
+
+def _build_shared_client_with_checked_out_stream(stream_sock):
+    """Mimic an OpenAI client whose pool has NO idle connections (the stream
+    holds the only one, checked out) — the layout the reporter's
+    ``tcp_force_closed=0`` log line proves."""
+    pool = SimpleNamespace(_connections=[])
+    transport = SimpleNamespace(_pool=pool)
+    http_client = SimpleNamespace(_transport=transport)
+    return SimpleNamespace(_client=http_client, close=lambda: None)
+
+
+def _real_retire_spy():
+    """A retire that performs the real (safe) sweep: force_close_tcp_sockets
+    walks only idle pool sockets, so a checked-out stream socket is untouched."""
+    from agent.agent_runtime_helpers import force_close_tcp_sockets
+
+    def _retire(client, *, reason):
+        force_close_tcp_sockets(client)
+
+    return _retire


### PR DESCRIPTION
Fixes #107475.

## What

`AIAgent.close()` (the `agent_close` path) handed the shared OpenAI/httpx client straight to `_close_openai_client(..., shared=True)` — an inline `client.close()` that releases the pool's FDs from the calling thread. When teardown runs on a stranger thread (cron cleanup, gateway eviction) while another thread still has a request in flight on that client — the reporter's case: an auxiliary context-compression stream — the in-flight stream receives no further event and no error, and burns its whole inactivity budget before failing (`tcp_force_closed=0` because the stream's socket was checked out of the idle pool, so the socket sweep found nothing — the inline `close()` that followed is what killed it).

The codebase already holds the invariant "never hard-close the shared client from a thread that may not own its FDs" and enforces it at both sibling sites: `release_clients()` (`cache_evict`) and `_replace_primary_openai_client` (`replace:*`) both route through `_retire_shared_openai_client` — socket `shutdown(SHUT_RDWR)` only, FD release deferred to GC — with docstrings citing #29507/#70773 for exactly this hazard class. This PR applies the same routing at the third and last shared-client teardown site:

```python
_drop_shared_client, lambda c: self._retire_shared_openai_client(c, reason="agent_close")
```

This is the issue's Suggested Fix alternative ("hand the client to the same deferred-close mechanism #29507 introduced"). Retirement still shuts pooled sockets down (the memory/socket win close() wanted), so an idle agent's teardown is not weakened — only the FD release moves to GC once no thread holds them. Idempotence and the `self.client = None` drop are unchanged; the per-request slot keeps its own in-flight-aware close.

## Why retire rather than an in-use check

The shared client has no single owning thread and no checkout tracking: codex-direct/MoA stream on it directly, and stale-killed worker threads unwind on it — so there is no reliable `in_use` bit to consult at teardown time. A bracket-based in-use test (e.g. the turn path's `_model_request_active` or the inline path's `_active_request_abort`) covers only the main/inline turn paths — the auxiliary compression path sets neither, which is exactly the reported scenario. `_retire_shared_openai_client` is the mechanism built for this (#70773), already used at both sibling sites.

## Tests

New `tests/run_agent/test_agent_close_shared_client_race.py` (3 tests, production-path):

- `close()` routes the shared client through retire — `client.close()` must never run on it from the teardown thread;
- an in-flight (checked-out-of-pool) stream socket is untouched by teardown — neither socket `shutdown()` nor `close()` — replaying the reporter's `tcp_force_closed=0` layout at object granularity;
- a second `close()` is a no-op and the reference is still dropped.

RED: 3/3 fail on pristine upstream/main (retire never called; `_close_openai_client` reached instead). GREEN post-fix.

Focused verification (post-rebase onto current main, post-format):
- new suite + `tests/agent/test_request_client_reuse.py` + `tests/run_agent/test_tls_fd_recycle_corruption.py` + `tests/gateway/test_agent_cache.py` → **50 passed** (sibling teardown suites unregressed)
- Full `tests/run_agent/` + `tests/agent/` at build time: 8806 passed / 28 failed / 5 skipped — all 28 verified pre-existing on pristine main (order-dependent aux-provider flakes + relay traceparent set); zero regressions attributable to this change.

## Scope

The `state.db ... closed while a write was still in flight` warning in the reporter's log is a separate resource (SQLite handle in `hermes_state`) that already has its own reopen guard; the issue's Suggested Fix addresses only the client close, so it is out of scope here.

Note: #107604 (opened while this was in review) takes the bracket-based in-use approach for the same issue; as above, the aux path that produced the report sets neither bracket, and this branch instead matches the existing sibling-site mechanism.
