### PR TITLE
fix(gateway): MEDIA: delivery can no longer attach another profile's .env / auth.json / state.db under multiplex

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -734,6 +734,8 @@ _CACHE_DIR_IMPORT_DEFAULTS = {
     "VIDEO_CACHE_DIR": VIDEO_CACHE_DIR, "DOCUMENT_CACHE_DIR": DOCUMENT_CACHE_DIR,
     "SCREENSHOT_CACHE_DIR": SCREENSHOT_CACHE_DIR}
 
+# Launch-time homes: fine for the static ALLOW roots below (per-profile cache roots are
+# enumerated at check time), never for the credential DENY side — see _credential_home_roots.
 _HERMES_HOME = get_hermes_home()
 _HERMES_ROOT = get_default_hermes_root()
 MEDIA_DELIVERY_ALLOW_DIRS_ENV = "HERMES_MEDIA_ALLOW_DIRS"
@@ -795,11 +797,24 @@ def _profile_cache_roots() -> List[Path]:
     profile path is allowlisted *before* the ``/root`` system denylist is consulted (which otherwise wins
     when HERMES_HOME is symlinked under a denied prefix and $HOME is not that prefix). See issue #31733.
     """
+    return [p / "cache" / subdir for p in _profile_dirs() for subdir in _MEDIA_DELIVERY_CACHE_SUBDIRS]
+
+
+def _profile_dirs() -> List[Path]:
+    """Every ``<root>/profiles/<name>`` directory, read at check time."""
     try:
-        profile_dirs = [p for p in (_HERMES_ROOT / "profiles").iterdir() if p.is_dir()]
+        return [p for p in (_HERMES_ROOT / "profiles").iterdir() if p.is_dir()]
     except OSError:
         return []
-    return [p / "cache" / subdir for p in profile_dirs for subdir in _MEDIA_DELIVERY_CACHE_SUBDIRS]
+
+
+def _credential_home_roots() -> List[Path]:
+    """Every Hermes home whose credential stores the denylist must cover: the ACTIVE home
+    (the per-turn HERMES_HOME override under ``gateway.multiplex_profiles``), the shared root
+    and every ``<root>/profiles/*``. Enumerated at check time like ``_profile_cache_roots`` on
+    the allow side — a denylist frozen at import covers only the launch profile, so a
+    ``MEDIA:<root>/profiles/<other>/.env`` emitted in any profile's turn would upload it."""
+    return list(dict.fromkeys((get_hermes_home(), _HERMES_ROOT, *_profile_dirs())))
 
 
 def _kanban_root() -> Path:
@@ -858,7 +873,7 @@ def _media_delivery_denied_paths() -> List[Path]:
     home = Path(os.path.expanduser("~"))
     return [*map(Path, _MEDIA_DELIVERY_DENIED_PREFIXES),
             *(home / sub for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS),
-            *(r / rel for r in (_HERMES_HOME, _HERMES_ROOT) for rel in _ROOT_CREDENTIAL_PATHS),
+            *(r / rel for r in _credential_home_roots() for rel in _ROOT_CREDENTIAL_PATHS),
             *_kanban_board_db_paths()]
 
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -706,6 +706,37 @@ class TestMediaDeliveryDefaultMode:
         assert [rel for rel in denied if BasePlatformAdapter.validate_media_delivery_path(str(hermes_dir / rel))] == []
         assert [rel for rel in allowed if not BasePlatformAdapter.validate_media_delivery_path(str(hermes_dir / rel))] == []
 
+    def test_denylist_covers_every_profile_home_not_just_the_launch_home(self, tmp_path, monkeypatch):
+        """Multiplex: one process serves every ``<root>/profiles/*``. The credential denylist must
+        cover each profile's ``.env`` / ``auth.json`` / ``state.db`` / transcripts whether the emitting
+        turn is the launch (default) profile's or the secondary's own (HERMES_HOME override), while
+        the profile's cache artifacts and plain agent-written files stay deliverable."""
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        self._patch_roots(monkeypatch)
+        fake_home = tmp_path / "home"
+        hermes_root = fake_home / ".hermes"
+        profile_b = hermes_root / "profiles" / "beta"
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_root)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_root)
+
+        denied = [".env", "auth.json", "state.db", "state.db-wal", "config.yaml",
+                  "sessions/20260101_abc.json", "mcp-tokens/server.json"]
+        allowed = ["cache/images/gen.png", "report.pdf"]
+        for rel in denied + allowed:
+            path = profile_b / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"SECRET=1\n")
+
+        for scope in (None, profile_b):  # default profile's turn, then beta's own turn
+            token = set_hermes_home_override(scope)
+            try:
+                assert [rel for rel in denied if BasePlatformAdapter.validate_media_delivery_path(str(profile_b / rel))] == []
+                assert [rel for rel in allowed if not BasePlatformAdapter.validate_media_delivery_path(str(profile_b / rel))] == []
+            finally:
+                reset_hermes_home_override(token)
+
     def test_strict_mode_envvar_restores_legacy_behavior(self, tmp_path, monkeypatch):
         """Setting HERMES_MEDIA_DELIVERY_STRICT=1 reactivates the older
         allowlist+recency logic. A stale file outside the allowlist is

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -219,7 +219,11 @@ Kanban workers only ever see their own profile's secrets). Terminal settings
 per profile on every routed turn: a profile that omits a terminal key gets the
 documented default, never the launch profile's value, and a profile whose
 `config.yaml`/`.env` cannot be parsed has terminal execution refused rather than
-run under another profile's sandbox policy. Kanban,
+run under another profile's sandbox policy. The media-delivery credential
+guard (the denylist behind `MEDIA:` attachments — `.env`, `auth.json`,
+`config.yaml`, `state.db`, session transcripts, OAuth token stores) covers every
+profile under `profiles/`, so no profile's turn can attach another profile's
+secrets or chat history to a reply. Kanban,
 profile-scoped skills/memory/SOUL, and model routing all behave per-profile
 exactly as they do with separate gateways.
 


### PR DESCRIPTION
Under a multiplexed gateway, a `MEDIA:` tag pointing at another profile's `.env` / `auth.json` / `state.db` / `config.yaml` / session transcripts is now blocked like the launch profile's own — before this, every secondary profile's secrets and full chat history were natively uploadable from any profile's turn.

## Changes

- `gateway/platforms/base.py::_credential_home_roots` — new check-time enumeration of the homes whose `_ROOT_CREDENTIAL_PATHS` the denylist must cover: the active `get_hermes_home()` (the per-turn HERMES_HOME override), the shared root, and every `<root>/profiles/*`. `_media_delivery_denied_paths` builds from it instead of the import-time `(_HERMES_HOME, _HERMES_ROOT)` pair.
- `_profile_dirs()` extracted from `_profile_cache_roots` so the allow and deny sides enumerate the same directory list.
- Profile cache artifacts (`profiles/<x>/cache/images/…`) and plain agent-written files under a profile stay deliverable (whole-tree deny was rejected in #32090/#34425 and is not reintroduced).
- Test: `tests/gateway/test_platform_base.py::TestMediaDeliveryDefaultMode::test_denylist_covers_every_profile_home_not_just_the_launch_home` (RED on `origin/main`, GREEN here; both the default-profile turn and the secondary's own override turn).
- Docs: `website/docs/user-guide/multi-profile-gateways.md` § "What does not change" — one sentence on the cross-profile media guard.

**Live repro** (`repro.py`: temp root, `profiles/B/{.env,auth.json,state.db,config.yaml,sessions/s1.json}`, real imports):

before
```
  .env                         -> None
  profiles/B/.env              -> /tmp/mux_root_f5eb1nb5/profiles/B/.env
  profiles/B/auth.json         -> /tmp/mux_root_f5eb1nb5/profiles/B/auth.json
  profiles/B/state.db          -> /tmp/mux_root_f5eb1nb5/profiles/B/state.db
  profiles/B/config.yaml       -> /tmp/mux_root_f5eb1nb5/profiles/B/config.yaml
  profiles/B/sessions/s1.json  -> /tmp/mux_root_f5eb1nb5/profiles/B/sessions/s1.json
== B turn (override -> /tmp/mux_root_f5eb1nb5/profiles/B ) ==
  profiles/B/.env              -> /tmp/mux_root_f5eb1nb5/profiles/B/.env
RESULT: LEAK ['profiles/B/.env', 'profiles/B/auth.json', 'profiles/B/state.db', 'profiles/B/config.yaml', 'profiles/B/sessions/s1.json']
```
after
```
  profiles/B/.env              -> None
  profiles/B/auth.json         -> None
  profiles/B/state.db          -> None
  profiles/B/config.yaml       -> None
  profiles/B/sessions/s1.json  -> None
== B turn (override -> .../profiles/B ) ==
  profiles/B/.env              -> None
== must stay deliverable ==
  profiles/B/cache/images/gen.png -> .../profiles/B/cache/images/gen.png
  profiles/B/report.pdf        -> .../profiles/B/report.pdf
RESULT: clean []
```

**Root cause:** the credential denylist was expanded only under the two import-time launch-home constants, while the allow side (`_profile_cache_roots`, #31733) already enumerated `<root>/profiles/*` at check time — the asymmetry left every non-launch profile's credential stores outside the deny set, and the per-turn HERMES_HOME override was never consulted.

**Validation:** `scripts/run_tests.sh tests/gateway/` → 803 files, 8003 passed, 0 failed. ruff / windows-footguns / compat-pointers / `git diff --check` clean.

**Credits:** no prior report (found by an internal multiplex audit). Write-side analogue of this bug class is #107327 / PR #107335 by @PRATHAMESH75 (memoized resolver keying in `tools/file_tools_write_guards.py`) — a different mechanism, intentionally not folded in here.

## Infographic

![media denylist covers every profile](https://v3b.fal.media/files/b/0aa9e5e6/736Vo8vwW4A3Bat-je50u_rgPvtWFx.png)
