### PR TITLE
fix(cli): keep the working directory off the dashboard backend's import path

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -701,6 +701,7 @@ from hermes_cli.main_platform_setup import (
     cmd_whatsapp_cloud,
 )
 from hermes_cli.main_dashboard import (
+    _drop_cwd_from_sys_path,
     _finalize_update_output,
     _find_stale_dashboard_pids,
     _install_hangup_protection,
@@ -710,6 +711,7 @@ from hermes_cli.main_dashboard import (
     _report_dashboard_status,
     _resolve_dashboard_web_dist,
     _route_named_profile_dashboard,
+    _web_stack_import_error_report,
 )
 from hermes_cli.main_dashboard import (  # frozen updater surface: update_cmd*.py resolve these via _m()
     _respawn_dashboard_processes,
@@ -2452,14 +2454,13 @@ def _dashboard_prepare_runtime(args, headless_backend) -> bool:
         import fastapi  # noqa: F401
         import uvicorn  # noqa: F401
     except ImportError as e:
-        print("Web UI dependencies not installed (need fastapi + uvicorn).")
         print(
-            f"Re-install the package into this interpreter so metadata updates apply:\n"
-            f"  cd {PROJECT_ROOT}\n"
-            f"  {sys.executable} -m pip install -e .\n"
-            "If `pip` is missing in this venv, use:  uv pip install -e ."
+            _web_stack_import_error_report(
+                e,
+                project_root=str(PROJECT_ROOT),
+                python_executable=sys.executable,
+            )
         )
-        print(f"Import error: {e}")
         sys.exit(1)
 
     # Seed bundled skills on first dashboard launch so the desktop GUI's
@@ -2533,6 +2534,12 @@ def cmd_dashboard(args):
     _headless_backend = getattr(args, "headless_backend", False)
     _ssh_owner_nonce = _dashboard_validate_serve_args(args, _headless_backend, _token_file)
     _dashboard_sanitize_desktop_env(_headless_backend)
+
+    # The working directory must never be importable here. `python -m` puts it
+    # first on sys.path, and Desktop spawns this backend with cwd set to the
+    # user's home directory, where a stray module shadows an installed package
+    # (a leftover ~/email_validator.py killed the backend before it bound).
+    _drop_cwd_from_sys_path()
 
     _route_named_profile_dashboard(args, _headless_backend, _ssh_owner_nonce, _token_file)
 

--- a/hermes_cli/main_dashboard.py
+++ b/hermes_cli/main_dashboard.py
@@ -5,11 +5,13 @@ are imported lazily inside the functions that use them (avoids an import cycle).
 """
 
 import contextlib
+import importlib.util
 import os
 import re
 import shlex
 import subprocess
 import sys
+import sysconfig
 
 from pathlib import Path
 from typing import NoReturn
@@ -772,3 +774,90 @@ def _resolve_dashboard_web_dist(args, _headless_backend: bool) -> None:
         # validated "~/dist" would otherwise pass here and still 404 there.
         os.environ["HERMES_WEB_DIST"] = str(_dist_root)
         print(f"→ Using web dist from HERMES_WEB_DIST: {_dist_root}")
+
+
+# ---------------------------------------------------------------------------
+# Import-path safety for the dashboard/serve backend
+# ---------------------------------------------------------------------------
+
+def _drop_cwd_from_sys_path() -> None:
+    """Remove the working-directory placeholder from ``sys.path``.
+
+    ``python -m`` puts ``""`` first, which makes the *working directory*
+    importable. Hermes Desktop spawns this backend with ``cwd`` set to the
+    user's home directory, so a stray module there wins over the installed
+    package of the same name: a leftover ``~/email_validator.py`` shadowed
+    pydantic's optional email dependency and the backend died on its first
+    ``import fastapi``, before the gateway could bind. Absolute entries
+    (``PYTHONPATH``, the repo root inserted at startup) are deliberate — only
+    the CWD placeholder goes.
+    """
+    while "" in sys.path:
+        sys.path.remove("")
+
+
+def _import_outside_environment(name: str) -> str | None:
+    """Path of ``name`` when it resolves outside the installed environment.
+
+    A module importable from a location no installer manages (the working
+    directory, a stray ``PYTHONPATH`` entry) is a shadowing file: it wins over
+    the real distribution instead of failing the import outright.
+    """
+    candidates = dict.fromkeys((name, name.replace("-", "_"), name.replace("_", "-")))
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            spec = importlib.util.find_spec(candidate)
+        except (AttributeError, ImportError, ValueError):
+            continue
+        origin = getattr(spec, "origin", None)
+        if not origin or origin in {"built-in", "frozen"}:
+            continue
+        origin = os.path.abspath(origin)
+        for root in set(sysconfig.get_paths().values()):
+            try:
+                if os.path.commonpath([origin, os.path.abspath(root)]) == os.path.abspath(root):
+                    break
+            except ValueError:
+                continue
+        else:
+            return origin
+    return None
+
+
+def _web_stack_import_error_report(
+    exc: ImportError, *, project_root: str, python_executable: str
+) -> str:
+    """Report for an ``ImportError`` raised while importing fastapi/uvicorn.
+
+    The guard in ``_dashboard_prepare_runtime`` wraps those two imports, so it
+    catches every ``ImportError`` the chain raises — including a
+    ``PackageNotFoundError``, which subclasses ``ModuleNotFoundError``. Blaming
+    fastapi/uvicorn for a transitive failure sends the user to reinstall what
+    they already have, so name the real failure and point at the shadowing file
+    when there is one. Reinstall instructions are only honest when a web-stack
+    distribution really is the missing one.
+    """
+    missing = str(getattr(exc, "name", "") or "")
+    lines: list[str] = []
+
+    if missing in {"fastapi", "uvicorn"}:
+        lines.append("Web UI dependencies not installed (need fastapi + uvicorn).")
+        lines.append(
+            "Re-install the package into this interpreter so metadata updates apply:\n"
+            f"  cd {project_root}\n"
+            f"  {python_executable} -m pip install -e .\n"
+            "If `pip` is missing in this venv, use:  uv pip install -e ."
+        )
+    else:
+        lines.append("The web UI stack failed to import; fastapi and uvicorn are installed.")
+        shadow = _import_outside_environment(missing) if missing else None
+        if shadow:
+            lines.append(
+                f"`{missing}` resolves to {shadow} — outside the installed environment. "
+                "Move that file away (it shadows the installed package) and retry."
+            )
+
+    lines.append(f"Import error: {type(exc).__name__}: {exc}")
+    return "\n".join(lines)

--- a/hermes_cli/main_dashboard.py
+++ b/hermes_cli/main_dashboard.py
@@ -781,19 +781,25 @@ def _resolve_dashboard_web_dist(args, _headless_backend: bool) -> None:
 # ---------------------------------------------------------------------------
 
 def _drop_cwd_from_sys_path() -> None:
-    """Remove the working-directory placeholder from ``sys.path``.
+    """Remove the working directory from ``sys.path``.
 
-    ``python -m`` puts ``""`` first, which makes the *working directory*
-    importable. Hermes Desktop spawns this backend with ``cwd`` set to the
-    user's home directory, so a stray module there wins over the installed
-    package of the same name: a leftover ``~/email_validator.py`` shadowed
-    pydantic's optional email dependency and the backend died on its first
-    ``import fastapi``, before the gateway could bind. Absolute entries
-    (``PYTHONPATH``, the repo root inserted at startup) are deliberate — only
-    the CWD placeholder goes.
+    ``python -m`` puts the *absolute* working directory at ``sys.path[0]``; the
+    bare ``""`` placeholder only appears for ``-c``/interactive runs. Hermes
+    Desktop spawns this backend with ``cwd`` set to the user's home directory,
+    so either form makes the working directory importable and a stray module
+    there wins over the installed package of the same name: a leftover
+    ``~/email_validator.py`` shadowed pydantic's optional email dependency and
+    the backend died on its first ``import fastapi``, before the gateway could
+    bind. Entries that resolve inside the working directory are dropped; other
+    absolute entries (``PYTHONPATH``, the repo root inserted at startup) are
+    deliberate and stay.
     """
-    while "" in sys.path:
-        sys.path.remove("")
+    cwd = os.path.normcase(os.path.abspath(os.getcwd()))
+    sys.path[:] = [
+        entry
+        for entry in sys.path
+        if os.path.normcase(os.path.abspath(entry or os.curdir)) != cwd
+    ]
 
 
 def _import_outside_environment(name: str) -> str | None:

--- a/tests/hermes_cli/test_dashboard_import_guard.py
+++ b/tests/hermes_cli/test_dashboard_import_guard.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import importlib
 import importlib.metadata
+import os
 import sys
 from pathlib import Path
 
@@ -32,11 +33,30 @@ from hermes_cli.main_dashboard import (
 REPORT_KWARGS = {"project_root": "/repo", "python_executable": "/repo/venv/bin/python"}
 
 
-def test_drop_cwd_from_sys_path_removes_only_the_cwd_placeholder(monkeypatch):
-    """The CWD placeholder goes; explicit absolute entries are deliberate."""
-    monkeypatch.setattr(sys, "path", ["", "/keep/me", "", "/keep/me/too"])
+def test_drop_cwd_from_sys_path_removes_cwd_entries_only(monkeypatch, tmp_path):
+    """Every entry resolving to the cwd goes; other absolute entries stay."""
+    monkeypatch.chdir(tmp_path)
+    cwd = os.path.normcase(os.path.abspath(str(tmp_path)))
+    monkeypatch.setattr(
+        sys, "path", ["", "/keep/me", cwd, str(tmp_path / "sub"), ""]
+    )
     _drop_cwd_from_sys_path()
-    assert sys.path == ["/keep/me", "/keep/me/too"]
+    assert sys.path == ["/keep/me", str(tmp_path / "sub")]
+
+
+def test_drop_cwd_from_sys_path_removes_the_absolute_cwd(monkeypatch, tmp_path):
+    """``python -m`` puts the absolute cwd on ``sys.path[0]``, not ``""``.
+
+    The desktop spawns the backend as ``python -m hermes_cli.main serve`` with
+    cwd set to the home directory, so this is the entry that actually shadows
+    an installed package in the reported repro. Stripping only ``""`` leaves it
+    in place and the backend still dies on the ``import fastapi`` chain.
+    """
+    monkeypatch.chdir(tmp_path)
+    cwd = os.path.normcase(os.path.abspath(str(tmp_path)))
+    monkeypatch.setattr(sys, "path", [cwd, "/keep/me"])
+    _drop_cwd_from_sys_path()
+    assert sys.path == ["/keep/me"]
 
 
 def test_import_outside_environment_flags_a_stray_file(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_dashboard_import_guard.py
+++ b/tests/hermes_cli/test_dashboard_import_guard.py
@@ -1,0 +1,105 @@
+"""Invariants for the dashboard/serve web-stack import guard.
+
+Two behaviours are pinned here:
+
+1. ``_drop_cwd_from_sys_path`` keeps the working directory off ``sys.path`` for
+   the dashboard/serve backend. Desktop spawns that backend with ``cwd`` set to
+   the user's home directory and ``python -m`` puts it first on ``sys.path``, so
+   a stray module there shadowed an installed package and the backend died
+   before it could bind (a leftover ``~/email_validator.py`` shadowed pydantic's
+   optional email dependency).
+2. ``_web_stack_import_error_report`` names what actually failed. The guard
+   around ``import fastapi`` / ``import uvicorn`` catches every ``ImportError``
+   the chain raises, so a transitive failure used to be reported as "fastapi and
+   uvicorn are missing" — sending the user to reinstall what they already had.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.main_dashboard import (
+    _drop_cwd_from_sys_path,
+    _import_outside_environment,
+    _web_stack_import_error_report,
+)
+
+REPORT_KWARGS = {"project_root": "/repo", "python_executable": "/repo/venv/bin/python"}
+
+
+def test_drop_cwd_from_sys_path_removes_only_the_cwd_placeholder(monkeypatch):
+    """The CWD placeholder goes; explicit absolute entries are deliberate."""
+    monkeypatch.setattr(sys, "path", ["", "/keep/me", "", "/keep/me/too"])
+    _drop_cwd_from_sys_path()
+    assert sys.path == ["/keep/me", "/keep/me/too"]
+
+
+def test_import_outside_environment_flags_a_stray_file(tmp_path, monkeypatch):
+    """A module resolving outside every installed root is a shadowing file."""
+    stray = tmp_path / "email_validator.py"
+    stray.write_text("SHADOW = True\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+    sys.modules.pop("email_validator", None)
+
+    assert _import_outside_environment("email-validator") == str(stray)
+
+    sys.modules.pop("email_validator", None)
+
+
+def test_report_names_the_shadowing_file_instead_of_blaming_fastapi(tmp_path, monkeypatch):
+    """A transitive failure must not be reported as a missing web stack."""
+    stray = tmp_path / "email_validator.py"
+    stray.write_text("SHADOW = True\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+    sys.modules.pop("email_validator", None)
+
+    # What pydantic's import_email_validator() raises when the stray file wins
+    # the import but owns no distribution metadata.
+    exc = importlib.metadata.PackageNotFoundError("email-validator")
+
+    report = _web_stack_import_error_report(exc, **REPORT_KWARGS)
+
+    assert "Web UI dependencies not installed" not in report
+    assert "fastapi and uvicorn are installed" in report
+    assert str(stray) in report
+    assert "PackageNotFoundError: No package metadata was found for email-validator" in report
+
+    sys.modules.pop("email_validator", None)
+
+
+def test_report_keeps_reinstall_guidance_when_a_web_distribution_is_missing():
+    """The genuine missing-fastapi case still gets the reinstall instructions."""
+    exc = ModuleNotFoundError("No module named 'fastapi'", name="fastapi")
+
+    report = _web_stack_import_error_report(exc, **REPORT_KWARGS)
+
+    assert "Web UI dependencies not installed (need fastapi + uvicorn)." in report
+    assert "cd /repo" in report
+    assert "/repo/venv/bin/python -m pip install -e ." in report
+    assert "Import error: ModuleNotFoundError: No module named 'fastapi'" in report
+
+
+def test_report_is_honest_about_an_unshadowed_transitive_failure():
+    """No fastapi/uvicorn claim and no bogus reinstall hint without evidence."""
+    exc = ModuleNotFoundError("No module named 'totally_absent_thing'", name="totally_absent_thing")
+
+    report = _web_stack_import_error_report(exc, **REPORT_KWARGS)
+
+    assert "Web UI dependencies not installed" not in report
+    assert "pip install -e ." not in report
+    assert "Import error: ModuleNotFoundError: No module named 'totally_absent_thing'" in report
+
+
+@pytest.mark.parametrize("name", ["fastapi", "uvicorn"])
+def test_report_treats_each_web_distribution_as_the_install_case(name):
+    exc = ModuleNotFoundError(f"No module named '{name}'", name=name)
+    assert "Web UI dependencies not installed" in _web_stack_import_error_report(
+        exc, **REPORT_KWARGS
+    )


### PR DESCRIPTION
## Symptom

Hermes Desktop never starts. The backend exits before it binds, and the renderer retries forever:

```
[hermes] Web UI dependencies not installed (need fastapi + uvicorn).
[hermes] Re-install the package into this interpreter so metadata updates apply:
[hermes]   cd /home/you/.hermes/hermes-agent
[hermes]   /home/you/.hermes/hermes-agent/venv/bin/python -m pip install -e .
[hermes] Import error: No package metadata was found for email-validator
[hermes] [boot] Hermes backend exited before it became ready (1).
```

`fastapi` and `uvicorn` were installed the whole time (0.133.1 / 0.41.0), `pip check` was clean, and `hermes serve` launched by hand from any other directory worked. The message sends you to reinstall two packages that are already there.

## Root cause

`python -m` puts the **absolute** working directory at `sys.path[0]` (the `""` placeholder only appears for `-c`/interactive runs), and Desktop spawns its `serve` backend with `cwd` set to the user's home directory (`resolveHermesCwd()` → `app.getPath('home')`). Any stray module in `$HOME` therefore wins over the installed package of the same name.

A leftover `~/email_validator.py` (a 15-line throwaway script, nothing to do with the real distribution) is enough:

1. `import fastapi` → `fastapi/openapi/models.py` declares `email: EmailStr`
2. pydantic `networks.py::import_email_validator()` → `import email_validator` → **picks up `~/email_validator.py`** (succeeds)
3. the next line, `importlib.metadata.version('email-validator')`, raises `PackageNotFoundError`
4. `PackageNotFoundError` subclasses `ModuleNotFoundError`, so the guard around `import fastapi` / `import uvicorn` catches it and reports it as a missing web stack

Reproduced on `main` (0.21.1), minimal form:

```
$ mkdir -p /tmp/shadowproof && echo 'SHADOW = True' > /tmp/shadowproof/email_validator.py
$ cd /tmp/shadowproof && python -c "import fastapi"
  File ".../pydantic/networks.py", line 969, in import_email_validator
    if not version('email-validator').partition('.')[0] == '2':
  ...
importlib.metadata.PackageNotFoundError: No package metadata was found for email-validator
```

The cwd entry the guard has to remove is not the same one in both launches, and that is what this revision fixes:

```
$ cd /tmp/shadowproof && python -m <pkg>          # desktop's launch shape
sys.path[0] = '/tmp/shadowproof'                  # absolute cwd; "" is NOT in sys.path
$ cd /tmp/shadowproof && python -c "import sys; print('' in sys.path)"
True                                              # "" is the -c/interactive form only
```

Same interpreter, same venv, no stray file — works. So it is the working directory, not the environment.

## Changes

**1. The dashboard/serve backend no longer imports from its working directory.**

`_drop_cwd_from_sys_path()` (in `hermes_cli/main_dashboard.py`) drops every `sys.path` entry that resolves to the working directory, in `cmd_dashboard`, before the web stack is imported: the `""` placeholder **and** the absolute cwd that `python -m` actually installs. Comparison goes through `os.path.normcase(os.path.abspath(...))`, so Windows case and separators are handled. Other absolute entries — `PYTHONPATH`, the repo root `main.py` inserts at startup — are deliberate and stay.

Scoped to this backend on purpose: it is a server, not a user script runner, and the desktop's choice of `cwd=$HOME` stays valid. This is the same failure anyone hits running `python -m hermes_cli.main serve` from a directory that happens to contain a shadowing file.

**2. The guard reports what actually failed.**

`_web_stack_import_error_report()` replaces the hardcoded message:

- missing module is `fastapi` or `uvicorn` → unchanged message plus reinstall instructions (the genuine case)
- anything else → state that the web stack imports and name the real exception, plus the shadowing file's path when it resolves outside the installed environment. No reinstall hint, because reinstalling would not have fixed this.

Before / after, with the stray file in the working directory:

```
$ cd /tmp/shadowproof && python -c "import fastapi"
importlib.metadata.PackageNotFoundError: No package metadata was found for email-validator

$ python -c "import sys; sys.path.remove(''); import fastapi"
fastapi OK 0.133.1 | uvicorn 0.41.0
```

Under `python -m` the entry to remove is the absolute cwd instead: after `_drop_cwd_from_sys_path()`, the cwd is gone from `sys.path` and `import email_validator` no longer resolves to the stray file.

## Tests

`tests/hermes_cli/test_dashboard_import_guard.py` — 8 passing:

- every `sys.path` entry resolving to the cwd is dropped — the `""` placeholder and the absolute cwd (`python -m`), the latter with its own test; unrelated absolute entries survive
- a module resolving outside every `sysconfig` root is reported as the shadow
- a `PackageNotFoundError` report names the shadowing file and does **not** claim fastapi/uvicorn are missing
- a real missing `fastapi` / `uvicorn` still gets the message and the reinstall instructions
- an unshadowed transitive failure gets neither the fastapi claim nor a bogus reinstall hint

## Not changed

Electron still spawns the backend with `cwd=$HOME`, and `PYTHONSAFEPATH=1` was deliberately not added to the desktop's env: the backend's environment is inherited by the agent's own subprocesses, so a blanket safe-path flag would change how user scripts launched through the terminal tool resolve imports. The fix belongs on the server side.
