### PR TITLE
fix(auth): secondary profiles no longer get a sibling profile's Nous bearer from per-process memos under multiplex (salvage #77865)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -113,7 +113,7 @@ from agent.model_metadata import (
 )
 from hermes_cli.config import get_hermes_home
 from agent.auxiliary_health import _custom_health_base_url, _unhealthy_cache_key
-from hermes_constants import OPENROUTER_BASE_URL
+from hermes_constants import OPENROUTER_BASE_URL, hermes_home_key
 from utils import base_url_host_matches, base_url_hostname, base_url_origin, env_float, is_truthy_value, model_forces_max_completion_tokens, normalize_proxy_env_vars
 
 logger = logging.getLogger(__name__)
@@ -5255,7 +5255,9 @@ def _client_cache_key(
     # share an entry, and the second builder's _store_cached_client would close the first's client.
     model_key = model or runtime.get("model", "")
     api_key_key = _runtime_cache_discriminator("api_key", api_key or "")
-    return (provider, async_mode, base_url or "", api_key_key, api_mode or "", runtime_key, is_vision, task_key, pool_hint, model_key)
+    # Profile home leads the key: callers that omit api_key (pool / Nous auth.json paths) would
+    # otherwise share one client across multiplex profiles holding different credentials.
+    return (hermes_home_key(), provider, async_mode, base_url or "", api_key_key, api_mode or "", runtime_key, is_vision, task_key, pool_hint, model_key)
 
 
 def _current_event_loop() -> Any:

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -142,7 +142,7 @@ def _resolve_preset_cached(preset_name: str) -> tuple[dict[str, Any], Any]:
 
 
 _runtime_cache_lock = threading.Lock()
-_runtime_cache: dict[tuple[str, str], tuple[float, dict[str, Any]]] = {}
+_runtime_cache: dict[tuple[str, str, str], tuple[float, dict[str, Any]]] = {}
 
 # Short TTL so rotated keys / base_url edits are picked up within 5 minutes.
 _RUNTIME_CACHE_TTL_SECONDS = 300.0
@@ -245,12 +245,15 @@ def _aggregator_reasoning_config(aggregator: dict[str, Any]) -> dict[str, Any] |
 def _slot_runtime(slot: dict[str, Any]) -> dict[str, Any]:
     """Slot → ``call_llm`` kwargs with the provider's real api_mode/base_url/api_key.
 
-    Cached per (provider, model) with a short TTL. Falls back to bare provider/model
+    Cached per (profile home, provider, model) with a short TTL. Falls back to bare provider/model
     on error — never cached, or a transient error would pin bare kwargs for a TTL.
     """
     provider = str(slot.get("provider") or "").strip()
     model = str(slot.get("model") or "").strip()
-    cache_key = (provider, model)
+    # hermes_home_key() in the key: the resolved api_key/base_url are per-profile, and under a
+    # multiplex gateway two profiles can share (provider, model) with different accounts.
+    from hermes_constants import hermes_home_key
+    cache_key = (hermes_home_key(), provider, model)
     now = time.monotonic()
     with _runtime_cache_lock:
         entry = _runtime_cache.get(cache_key)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -32,7 +32,7 @@ from urllib.parse import urlparse
 
 from hermes_cli.config import (
     get_hermes_home, get_config_path, read_raw_config, require_readable_config_before_write)
-from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
+from hermes_constants import OPENROUTER_BASE_URL, hermes_home_key, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
 from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value  # noqa: F401  (env_float: agent.credential_pool reads auth_mod.env_float)
 from hermes_cli.auth_zai_kimi import (  # noqa: F401  re-exported
@@ -1571,8 +1571,11 @@ _NOUS_PORTAL_ALLOWED_HOSTS: FrozenSet[str] = frozenset({
 # Per-process memo for resolve_nous_access_token: startup runs one check_fn per managed tool and
 # each would trigger its own ~15s blocking refresh of an expired token; a short-TTL memo collapses
 # the burst into one round-trip. Callers needing freshness use force_fresh/refresh_nous_oauth_pure.
+# Keyed by hermes_home_key(): the resolution itself is profile-scoped (_auth_file_path reads the
+# per-turn HERMES_HOME override a multiplex gateway sets), so a single slot would hand profile A's
+# Portal bearer to profile B for up to the TTL.
 _RESOLVE_TOKEN_CACHE_LOCK = threading.Lock()
-_RESOLVE_TOKEN_CACHE: "tuple[float, str] | None" = None
+_RESOLVE_TOKEN_CACHE: "dict[str, tuple[float, str]]" = {}
 _RESOLVE_TOKEN_CACHE_TTL_S = 5.0
 
 
@@ -1601,20 +1604,19 @@ def resolve_nous_access_token(
     ca_bundle: Optional[str] = None,
     refresh_skew_seconds: int = ACCESS_TOKEN_REFRESH_SKEW_SECONDS) -> str:
     """Resolve a refresh-aware Nous Portal access token for managed tool gateways."""
-    global _RESOLVE_TOKEN_CACHE
     # Only a default-TLS resolution is memoised; error paths never populate the memo.
     memoable = not insecure and ca_bundle is None
+    cache_key = hermes_home_key()
     if memoable:
         with _RESOLVE_TOKEN_CACHE_LOCK:
-            cached = _RESOLVE_TOKEN_CACHE
+            cached = _RESOLVE_TOKEN_CACHE.get(cache_key)
         if cached is not None and (time.monotonic() - cached[0]) < _RESOLVE_TOKEN_CACHE_TTL_S:
             return cached[1]
 
     def _memo(token: str) -> str:
-        global _RESOLVE_TOKEN_CACHE
         if memoable:
             with _RESOLVE_TOKEN_CACHE_LOCK:
-                _RESOLVE_TOKEN_CACHE = (time.monotonic(), token)
+                _RESOLVE_TOKEN_CACHE[cache_key] = (time.monotonic(), token)
         return token
 
     with _provider_state_transaction("nous") as (auth_store, state, state_source_path):

--- a/hermes_cli/nous_billing.py
+++ b/hermes_cli/nous_billing.py
@@ -121,8 +121,9 @@ def _absolutize_portal_url(portal_url: Optional[str]) -> Optional[str]:
 # cross-process file locks + reads two files per call, wasteful for the 2s charge poll loop
 # (~150 calls per purchase). The resolver only returns tokens with >=120s of life (its refresh
 # skew), so a 30s cache can never hand back an about-to-expire token; a 401 still surfaces.
+# Keyed by hermes_home_key() so a multiplex profile never bills through a sibling's token.
 _TOKEN_CACHE_TTL_SECONDS = 30.0
-_token_cache: tuple[float, str, str] | None = None  # (cached_at, token, base)
+_token_cache: dict[str, tuple[float, str, str]] = {}  # home key -> (cached_at, token, base)
 
 
 def invalidate_cached_token() -> None:
@@ -131,8 +132,7 @@ def invalidate_cached_token() -> None:
     ``_request`` only self-busts on a 401, not on a 403 scope denial — after a step-up grant the
     cache would otherwise still hold the pre-grant unscoped token and the replay would 403 again.
     """
-    global _token_cache
-    _token_cache = None
+    _token_cache.clear()
 
 
 def _billing_not_logged_in(exc: Optional[BaseException] = None) -> "BillingAuthError":
@@ -145,9 +145,12 @@ def _billing_not_logged_in(exc: Optional[BaseException] = None) -> "BillingAuthE
 
 def _resolve_token_and_base(*, use_cache: bool = True) -> tuple[str, str]:
     """``(access_token, portal_base_url)``, cached for ``_TOKEN_CACHE_TTL_SECONDS`` unless ``use_cache=False``."""
-    global _token_cache
-    if use_cache and _token_cache is not None:
-        cached_at, token, base = _token_cache
+    from hermes_constants import hermes_home_key
+
+    cache_key = hermes_home_key()
+    cached = _token_cache.get(cache_key) if use_cache else None
+    if cached is not None:
+        cached_at, token, base = cached
         if (time.time() - cached_at) < _TOKEN_CACHE_TTL_SECONDS:
             return token, base
     try:
@@ -170,7 +173,7 @@ def _resolve_token_and_base(*, use_cache: bool = True) -> tuple[str, str]:
         except AuthError as exc:
             raise _billing_not_logged_in(exc) from exc
     resolved = (token.strip(), base)
-    _token_cache = (time.time(), *resolved)
+    _token_cache[cache_key] = (time.time(), *resolved)
     return resolved
 
 

--- a/tests/agent/test_auxiliary_runtime_cache_key.py
+++ b/tests/agent/test_auxiliary_runtime_cache_key.py
@@ -152,3 +152,20 @@ def test_string_api_keys_are_not_retained_in_cache_key_repr():
     assert second_secret not in rendered
 
 
+
+
+def test_client_cache_key_is_scoped_per_profile_home(tmp_path):
+    """Callers that omit api_key (pool / Nous auth.json paths) must not share a client across
+    multiplex profiles: the per-turn HERMES_HOME override has to participate in the key."""
+    import hermes_constants
+
+    a, b = tmp_path / "a", tmp_path / "b"
+    a.mkdir(); b.mkdir()
+    keys = []
+    for home in (a, b):
+        tok = hermes_constants.set_hermes_home_override(str(home))
+        try:
+            keys.append(aux._client_cache_key("nous", async_mode=False, base_url="https://inf.example", model="m"))
+        finally:
+            hermes_constants.reset_hermes_home_override(tok)
+    assert keys[0] != keys[1]

--- a/tests/agent/test_moa_cold_start_cache_66793.py
+++ b/tests/agent/test_moa_cold_start_cache_66793.py
@@ -14,6 +14,8 @@ import types  # noqa: F401  (used by _fake_response)
 
 import pytest
 
+from hermes_constants import hermes_home_key
+
 
 def _make_preset_config() -> dict:
     return {
@@ -181,7 +183,7 @@ def test_slot_runtime_cache_expires_after_ttl(monkeypatch):
     assert calls["n"] == 1
 
     # Age the entry past the TTL and confirm re-resolution.
-    key = ("openai", "gpt-5")
+    key = (hermes_home_key(), "openai", "gpt-5")
     stamped_at, cached = moa._runtime_cache[key]
     moa._runtime_cache[key] = (
         stamped_at - moa._RUNTIME_CACHE_TTL_SECONDS - 1, cached
@@ -224,3 +226,33 @@ def _fake_response():
     ns = types.SimpleNamespace()
     ns.usage = None
     return ns
+
+
+def test_slot_runtime_cache_is_scoped_per_profile_home(monkeypatch, tmp_path):
+    """Under a multiplex gateway two profiles can share (provider, model) with different
+    accounts; a cached api_key/base_url must never cross the per-turn HERMES_HOME override."""
+    import agent.moa_loop as moa
+    import hermes_constants
+
+    moa._runtime_cache.clear()
+    a, b = tmp_path / "a", tmp_path / "b"
+    a.mkdir(); b.mkdir()
+
+    import hermes_cli.runtime_provider as rt_mod
+    monkeypatch.setattr(
+        rt_mod, "resolve_runtime_provider",
+        lambda **kw: {"provider": "openai", "model": "gpt-5",
+                      "api_key": f"key-{hermes_constants.get_hermes_home().name}",
+                      "base_url": "https://x", "api_mode": None})
+
+    slot = {"provider": "openai", "model": "gpt-5"}
+    tok = hermes_constants.set_hermes_home_override(str(a))
+    try:
+        assert moa._slot_runtime(slot)["api_key"] == "key-a"
+    finally:
+        hermes_constants.reset_hermes_home_override(tok)
+    tok = hermes_constants.set_hermes_home_override(str(b))
+    try:
+        assert moa._slot_runtime(slot)["api_key"] == "key-b"
+    finally:
+        hermes_constants.reset_hermes_home_override(tok)

--- a/tests/hermes_cli/test_nous_billing_request.py
+++ b/tests/hermes_cli/test_nous_billing_request.py
@@ -48,7 +48,7 @@ def _http_error(status: int, body: bytes | dict[str, object] = b"{}", headers=No
 def _sequence(monkeypatch, *outcomes, resolver=None):
     """Stub urlopen with ordered outcomes and record each Request."""
     seen: list[dict[str, object]] = []
-    monkeypatch.setattr(nb, "_token_cache", None, raising=False)
+    monkeypatch.setattr(nb, "_token_cache", {}, raising=False)
     monkeypatch.setattr(
         nb,
         "_resolve_token_and_base",
@@ -77,7 +77,7 @@ def _sequence(monkeypatch, *outcomes, resolver=None):
 def _stub(monkeypatch, body: bytes, status: int = 200):
     # Bypass auth/token resolution entirely — we only exercise response parsing.
     monkeypatch.setattr(nb, "_resolve_token_and_base", lambda **kw: ("tok", "https://portal.example"))
-    monkeypatch.setattr(nb, "_token_cache", None, raising=False)
+    monkeypatch.setattr(nb, "_token_cache", {}, raising=False)
     monkeypatch.setattr(nb.urllib.request, "urlopen", lambda req, timeout=None: _FakeResp(body, status))
     yield
 
@@ -212,3 +212,26 @@ def test_404_get_charge_status_maps_to_generic_billing_error(monkeypatch):
 
 
 
+
+
+def test_billing_token_cache_is_scoped_per_profile_home(monkeypatch, tmp_path):
+    """The 30s (token, base) memo must not hand profile A's Portal bearer to profile B under a
+    multiplex gateway, where the per-turn HERMES_HOME override selects the auth.json."""
+    import hermes_constants
+    import hermes_cli.auth as auth
+
+    monkeypatch.setattr(nb, "_token_cache", {}, raising=False)
+    monkeypatch.setattr(auth, "get_provider_auth_state", lambda provider: {})
+    monkeypatch.setattr(
+        auth, "resolve_nous_access_token",
+        lambda **kw: f"tok-{hermes_constants.get_hermes_home().name}")
+    a, b = tmp_path / "a", tmp_path / "b"
+    a.mkdir(); b.mkdir()
+    seen = []
+    for home in (a, b):
+        tok = hermes_constants.set_hermes_home_override(str(home))
+        try:
+            seen.append(nb._resolve_token_and_base()[0])
+        finally:
+            hermes_constants.reset_hermes_home_override(tok)
+    assert seen == ["tok-a", "tok-b"]

--- a/tests/hermes_cli/test_nous_portal_staging_allowlist.py
+++ b/tests/hermes_cli/test_nous_portal_staging_allowlist.py
@@ -91,7 +91,7 @@ class TestResolveAccessTokenEnvOverrideWins:
         # The resolve memo is module-level state; clear it so each test's
         # resolution actually exercises the refresh path instead of serving
         # a token cached by a previous test.
-        monkeypatch.setattr(auth, "_RESOLVE_TOKEN_CACHE", None)
+        monkeypatch.setattr(auth, "_RESOLVE_TOKEN_CACHE", {})
 
         def _fake_refresh(*, client, portal_base_url, client_id, refresh_token):
             seen_portal_urls.append(portal_base_url)

--- a/tests/hermes_cli/test_resolve_token_memo.py
+++ b/tests/hermes_cli/test_resolve_token_memo.py
@@ -19,7 +19,7 @@ def _fresh_memo(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.delenv("HERMES_PORTAL_BASE_URL", raising=False)
     monkeypatch.delenv("NOUS_PORTAL_BASE_URL", raising=False)
-    monkeypatch.setattr(auth, "_RESOLVE_TOKEN_CACHE", None)
+    monkeypatch.setattr(auth, "_RESOLVE_TOKEN_CACHE", {})
     yield
 
 
@@ -75,11 +75,12 @@ def test_memo_expires_after_ttl(monkeypatch, tmp_path):
     calls = _count_transactions(monkeypatch)
 
     auth.resolve_nous_access_token()
-    cached_at, tok = auth._RESOLVE_TOKEN_CACHE
+    cache_key = auth.hermes_home_key()
+    cached_at, tok = auth._RESOLVE_TOKEN_CACHE[cache_key]
     monkeypatch.setattr(
         auth,
         "_RESOLVE_TOKEN_CACHE",
-        (cached_at - auth._RESOLVE_TOKEN_CACHE_TTL_S - 1.0, tok),
+        {cache_key: (cached_at - auth._RESOLVE_TOKEN_CACHE_TTL_S - 1.0, tok)},
     )
     auth.resolve_nous_access_token()
 
@@ -94,3 +95,40 @@ def test_insecure_callers_bypass_memo(monkeypatch, tmp_path):
     auth.resolve_nous_access_token(insecure=True)
 
     assert calls["n"] == 2, "insecure callers must bypass the memo entirely"
+
+
+def test_memo_does_not_leak_across_multiplex_profile_contexts(tmp_path):
+    """A multiplex gateway scopes each profile's context via
+    hermes_constants.set_hermes_home_override (gateway/run.py,
+    tui_gateway/server.py), not the HERMES_HOME env var — the memo must key
+    on that same resolved home, or one profile's context can read another
+    profile's already-cached Nous access token for up to the TTL window.
+    """
+    import hermes_constants
+
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    profile_a.mkdir()
+    profile_b.mkdir()
+    _write_valid_auth_file(profile_a, token="token-a")
+    _write_valid_auth_file(profile_b, token="token-b")
+
+    token_a = token_b = None
+    reset_token = hermes_constants.set_hermes_home_override(str(profile_a))
+    try:
+        token_a = auth.resolve_nous_access_token()
+    finally:
+        hermes_constants.reset_hermes_home_override(reset_token)
+
+    # Still well within the 5s TTL — this is exactly the race window: profile
+    # B's context calls resolve_nous_access_token() shortly after profile A's.
+    reset_token = hermes_constants.set_hermes_home_override(str(profile_b))
+    try:
+        token_b = auth.resolve_nous_access_token()
+    finally:
+        hermes_constants.reset_hermes_home_override(reset_token)
+
+    assert token_a == "token-a"
+    assert token_b == "token-b", (
+        "profile B's context must not receive profile A's cached access token"
+    )


### PR DESCRIPTION
Under a multiplexed gateway, a secondary profile no longer receives the default (or any sibling) profile's Nous Portal bearer / provider credentials from a per-process memo.

## Changes
- `hermes_cli/auth.py::_RESOLVE_TOKEN_CACHE` — the 5 s startup-burst memo was one unkeyed `(monotonic, token)` slot; now a dict keyed by `hermes_home_key()` (the per-turn HERMES_HOME override the multiplex gateway sets, symlink-stable). Reaches every consumer: `tools/managed_tool_gateway.py::read_nous_access_token` (web search/extract/image-gen managed gateways), `hermes_cli/nous_billing.py`, `hermes_cli/nous_account.py`, `gateway/relay`, chronos cron provider.
- `hermes_cli/nous_billing.py::_token_cache` — same unkeyed shape (30 s); keyed by home; `invalidate_cached_token()` clears the dict.
- `agent/moa_loop.py::_runtime_cache` — `(provider, model)` carried `api_key`/`base_url`/`api_mode` across profiles for 5 min → `(hermes_home_key(), provider, model)`.
- `agent/auxiliary_client.py::_client_cache_key` — no profile component, so callers omitting `api_key` (pool / Nous `auth.json` paths) could be handed a client built with another profile's bearer → `hermes_home_key()` leads the key.

## Validation
**Live repro** (`/tmp/mux_audit/fix-token-memo/repro.py`: temp HERMES_HOME with `profiles/B/`, distinct `auth.json` in each, real imports, `set_hermes_home_override(B)` after A resolves):

before
```
A resolve: TOKEN_PROFILE_A
override -> /tmp/mux_tok_j5qf00lk/profiles/B
B resolve (memo hit): TOKEN_PROFILE_A      <-- leak
B resolve (memo cleared): TOKEN_PROFILE_B
```
after
```
A resolve: TOKEN_PROFILE_A
override -> /tmp/mux_tok_jh8iqvop/profiles/B
B resolve (memo hit): TOKEN_PROFILE_B
B resolve (memo cleared): TOKEN_PROFILE_B
```

| Test (all proven red on `origin/main`) | Result |
|---|---|
| `tests/hermes_cli/test_resolve_token_memo.py::test_memo_does_not_leak_across_multiplex_profile_contexts` | pass |
| `tests/hermes_cli/test_nous_billing_request.py::test_billing_token_cache_is_scoped_per_profile_home` | pass |
| `tests/agent/test_moa_cold_start_cache_66793.py::test_slot_runtime_cache_is_scoped_per_profile_home` | pass |
| `tests/agent/test_auxiliary_runtime_cache_key.py::test_client_cache_key_is_scoped_per_profile_home` | pass |
| `scripts/run_tests.sh tests/hermes_cli/ tests/agent/` | 16013 passed, 1 failed (`test_update_head_moved_gate.py` — fails identically on unmodified `origin/main`, updater subsystem, unrelated) |

## Root cause
The token/credential resolution is already profile-scoped (`_auth_file_path()` → `get_hermes_home()` honours the contextvar override), but the memos in front of it were keyed on wall-clock only, so the first profile to resolve within the TTL won for everyone.

## Credits
- @pierrenode — earliest fix, salvaged via cherry-pick (#77865): profile-keyed `_RESOLVE_TOKEN_CACHE` + the multiplex leak test. Rebased onto the current `_memo` closure shape and switched the key from `str(get_hermes_home())` to `hermes_home_key()`; sibling memos widened on top.

Addresses the multiplex credential-isolation audit (memo F2 critical, F5, F6).

## Infographic
![profile-keyed credential memos](https://v3b.fal.media/files/b/0aa9e5e2/NYdJIY_O9rycckMlTrvGf_awvASOvi.png)
