### PR TITLE
fix(update): adopt the user bus before the recovery child's systemd probes (#107614)

### DIFF
--- a/hermes_cli/update_restart_recovery.py
+++ b/hermes_cli/update_restart_recovery.py
@@ -109,6 +109,61 @@ def _run_profile_restart(profile: str, *, run: Callable[..., Any]) -> bool:
     return _succeeded(_run_quiet(run, argv, timeout=_PROFILE_RESTART_TIMEOUT, **kwargs))
 
 
+def _runtime_dir_is_ours(path: str) -> bool:
+    """True only when ``path`` is a runtime directory this uid owns (never adopt a foreign
+    ``/run/user/0`` leaked by ``su``/``sudo -u``)."""
+    uid = os.getuid()  # windows-footgun: ok — POSIX systemd helper, never invoked on Windows
+    try:
+        return os.path.isdir(path) and os.stat(path).st_uid == uid
+    except OSError:
+        return False
+
+
+def _path_exists(path: str) -> bool:
+    try:
+        return os.path.exists(path)
+    except OSError:
+        return False
+
+
+def _adopt_user_bus_env() -> None:
+    """Point ``systemctl --user`` at OUR user manager when the dispatcher did not.
+
+    ``update_abort_recovery._run_fresh_recovery_process`` spawns this module with
+    ``os.environ.copy()``, so a bus-less dispatcher (``sudo -u <user>``, cron, a systemd service, an
+    SSH wrapper) hands the child no session bus. Every ``systemctl --user`` probe then fails against
+    a perfectly reachable user manager: the profile is reported ``relaunch_attempted`` rather than
+    ``verified`` (which is what ``_abort_recovery_is_complete`` requires), and user-scope
+    ``hermes-serve*`` units are never listed at all, so they are neither restarted nor reported.
+
+    Same contract as ``gateway._ensure_user_systemd_env``, inlined: this module deliberately imports
+    no Hermes code (importing the freshly pulled tree is what aborted the phase that called us).
+    Adopts only our own ``/run/user/<uid>``, and only when the ``bus`` socket exists — a genuinely
+    bus-less host keeps failing its probes instead of being handed an address that points at nothing.
+    """
+    if sys.platform != "linux":  # windows-footgun: ok — POSIX systemd helper, never invoked on Windows
+        return
+    uid = os.getuid()  # windows-footgun: ok — see above
+    ours = f"/run/user/{uid}"
+    xdg = os.environ.get("XDG_RUNTIME_DIR")
+    if (not xdg or not _runtime_dir_is_ours(xdg)) and _runtime_dir_is_ours(ours):
+        os.environ["XDG_RUNTIME_DIR"] = ours
+    if "DBUS_SESSION_BUS_ADDRESS" not in os.environ:
+        bus = f"{os.environ.get('XDG_RUNTIME_DIR', ours)}/bus"
+        if _path_exists(bus):
+            os.environ["DBUS_SESSION_BUS_ADDRESS"] = f"unix:path={bus}"
+
+
+def _user_scope_cmd(systemctl: str) -> list[str]:
+    """``systemctl --user`` argv, with the user bus adopted first.
+
+    Both user-scope probe paths (``_systemd_verified_active`` and ``_systemctl_scopes``) go through
+    here, so a future call site cannot get the argv without the normalization.
+    """
+    _adopt_user_bus_env()
+    return [systemctl, "--user"]
+
+
 def _systemd_unit_candidates(profile: str) -> tuple[str, ...]:
     """Unit names the existing systemd gateway lifecycle produces per profile."""
     if profile == "default":
@@ -122,7 +177,7 @@ def _systemd_verified_active(profile: str, *, run: Callable[..., Any]) -> bool:
     ``active``) means we could NOT verify, never that the restart failed."""
     systemctl = shutil.which("systemctl")
     return bool(systemctl) and any(
-        _unit_is_active([systemctl, "--user"], unit, run=run, require_rc0=True)
+        _unit_is_active(_user_scope_cmd(systemctl), unit, run=run, require_rc0=True)
         for unit in _systemd_unit_candidates(profile)
     )
 
@@ -153,12 +208,14 @@ def _systemctl_scopes() -> list[tuple[str, list[str]]]:
 
     ``systemctl`` comes from ``shutil.which`` so this module never imports a Hermes platform helper —
     importing the freshly pulled tree is exactly what aborted the phase that called us. Scopes carry
-    their label because the same unit name in both managers is two different processes.
+    their label because the same unit name in both managers is two different processes. The user
+    scope's argv is built by ``_user_scope_cmd`` so the session bus is adopted even when the
+    dispatcher handed this process none.
     """
     systemctl = shutil.which("systemctl")
     if not systemctl or sys.platform != "linux":
         return []
-    return [("user", [systemctl, "--user"]), ("system", [systemctl])]
+    return [("user", _user_scope_cmd(systemctl)), ("system", [systemctl])]
 
 
 def _listed_serve_units(scope: list[str], *, run: Callable[..., Any]) -> list[str]:

--- a/tests/hermes_cli/test_update_restart_recovery.py
+++ b/tests/hermes_cli/test_update_restart_recovery.py
@@ -14,10 +14,13 @@ from __future__ import annotations
 import importlib
 import io
 import json
+import os
 import subprocess
 import sys
 import textwrap
 from types import SimpleNamespace
+
+import pytest
 
 from hermes_cli import update_abort_recovery as abort_recovery
 from hermes_cli import update_cmd
@@ -481,3 +484,145 @@ def test_recovery_module_end_to_end_in_a_real_fresh_process(tmp_path):
     assert [argv[argv.index("-p") + 1] for argv in restarts] == ["coder", "default"]
     for argv in restarts:
         assert argv[-2:] == ["gateway", "restart"]
+
+
+def _env_sensitive_systemctl(calls: list, restarted: list):
+    """A ``systemctl`` faithful to the real one: every ``--user`` probe fails without a session bus.
+
+    That is the observable that separates a reachable user manager from an absent one — the real
+    command prints ``Failed to connect to user scope bus via local transport`` and exits 1.
+    """
+
+    def fake_run(argv, **kwargs):
+        argv = list(argv)
+        if "hermes_cli.main" in argv:  # the per-profile relaunch
+            calls.append(argv)
+            return _Completed(0)
+        if argv and str(argv[0]).endswith("systemctl"):
+            calls.append(argv)
+            user_scope = "--user" in argv
+            if user_scope and not (
+                os.environ.get("XDG_RUNTIME_DIR") and os.environ.get("DBUS_SESSION_BUS_ADDRESS")
+            ):
+                return _Completed(1, stderr="Failed to connect to user scope bus via local transport")
+            if "is-active" in argv:
+                return _Completed(0, stdout="active\n")
+            if "list-units" in argv:
+                # The serve unit exists in the user manager only (system scope: nothing to recover).
+                return _Completed(0, stdout="hermes-serve.service loaded active running\n" if user_scope else "")
+            if "show" in argv:
+                return _Completed(0, stdout="5151\n" if restarted else "4242\n")
+            if "restart" in argv:
+                restarted.append({"user" if user_scope else "system": argv[-1]})
+                return _Completed(0)
+            return _Completed(0)
+        return _Completed(0)
+
+    return fake_run
+
+
+@pytest.mark.linux_only
+def test_bus_less_recovery_child_reaches_our_user_manager(monkeypatch):
+    """#107614: the recovery child must observe a user manager that IS on disk.
+
+    ``update_abort_recovery`` spawns this module with ``os.environ.copy()``, so a bus-less
+    dispatcher (``sudo -u <user>``, cron, a systemd service, an SSH wrapper) hands the child no
+    session bus. Every ``systemctl --user`` probe then fails, and two things follow: the profile is
+    reported ``relaunch_attempted`` rather than ``verified`` — which ``_abort_recovery_is_complete``
+    reads as incomplete, so a healthy restart still fails the update — and user-scope
+    ``hermes-serve*`` units are never listed, so they are neither restarted nor reported.
+    """
+    recovery = importlib.import_module("hermes_cli.update_restart_recovery")
+    runtime_dir = f"/run/user/{os.getuid()}"
+    # The on-disk state ``loginctl enable-linger`` leaves behind: ours, and the bus socket exists.
+    monkeypatch.setattr(recovery, "_runtime_dir_is_ours", lambda path: str(path) == runtime_dir)
+    monkeypatch.setattr(recovery, "_path_exists", lambda path: str(path) == f"{runtime_dir}/bus")
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+    monkeypatch.setattr(recovery.shutil, "which", lambda name: f"/usr/bin/{name}")
+    calls: list = []
+    restarted: list = []
+    run = _env_sensitive_systemctl(calls, restarted)
+
+    profiles = recovery.restart_profiles(["default"], supervisors={"default": "systemd"}, run=run)
+    serve = recovery.restart_serve_units(run=run)
+
+    assert profiles == {"verified": ["default"], "relaunch_attempted": [], "failed": []}
+    assert serve == {"verified": ["user/hermes-serve"], "failed": []}
+    assert os.environ["XDG_RUNTIME_DIR"] == runtime_dir
+    assert os.environ["DBUS_SESSION_BUS_ADDRESS"] == f"unix:path={runtime_dir}/bus"
+    assert restarted == [{"user": "hermes-serve.service"}]
+
+
+@pytest.mark.linux_only
+def test_bus_less_recovery_child_never_fabricates_a_bus(monkeypatch):
+    """Fail closed, never invent: with no user manager on disk the bare environment must survive.
+
+    A fabricated bus address would turn an honest "could not verify" into a connect failure that
+    looks like a broken host, and would let a later probe "reach" a manager that does not exist.
+    """
+    recovery = importlib.import_module("hermes_cli.update_restart_recovery")
+    monkeypatch.setattr(recovery, "_runtime_dir_is_ours", lambda path: False)
+    monkeypatch.setattr(recovery, "_path_exists", lambda path: False)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+    monkeypatch.setattr(recovery.shutil, "which", lambda name: f"/usr/bin/{name}")
+    calls: list = []
+    restarted: list = []
+    run = _env_sensitive_systemctl(calls, restarted)
+
+    profiles = recovery.restart_profiles(["default"], supervisors={"default": "systemd"}, run=run)
+    serve = recovery.restart_serve_units(run=run)
+
+    assert profiles == {"verified": [], "relaunch_attempted": ["default"], "failed": []}
+    assert serve == {"verified": [], "failed": []}
+    assert restarted == []
+    assert "XDG_RUNTIME_DIR" not in os.environ
+    assert "DBUS_SESSION_BUS_ADDRESS" not in os.environ
+
+
+@pytest.mark.linux_only
+def test_bus_less_recovery_child_result_completes_the_abort_path(monkeypatch):
+    """#107614, consumer half: what the child prints is what decides the update's exit code.
+
+    ``_abort_recovery_is_complete()`` requires ``not relaunch_attempted``, so a bus-less child's
+    misclassification of a healthy profile makes completeness unprovable: the abort path keeps
+    ``out.incomplete`` set and ``hermes update`` exits 1 for a gateway that WAS restarted onto the
+    new code. Drives the real parent entry with the real child passes for a bus-less dispatch.
+    """
+    recovery = importlib.import_module("hermes_cli.update_restart_recovery")
+    runtime_dir = f"/run/user/{os.getuid()}"
+    monkeypatch.setattr(recovery, "_runtime_dir_is_ours", lambda path: str(path) == runtime_dir)
+    monkeypatch.setattr(recovery, "_path_exists", lambda path: str(path) == f"{runtime_dir}/bus")
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+    monkeypatch.setattr(recovery.shutil, "which", lambda name: f"/usr/bin/{name}")
+    calls: list = []
+    restarted: list = []
+    child_run = _env_sensitive_systemctl(calls, restarted)
+
+    def fake_child(argv, **kwargs):
+        """The fresh child's output: the production passes, in the environment it inherited."""
+        payload = json.loads(kwargs["input"])
+        result = recovery.restart_profiles(
+            payload["profiles"], supervisors=payload["supervisors"], run=child_run
+        )
+        if payload["serve_units"]["recover"]:
+            result["serve_units"] = recovery.restart_serve_units(run=child_run)
+        return _Completed(0, stdout=json.dumps(result))
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_child)
+    plan = SimpleNamespace(runtimes=[_runtime("default", "systemd")])
+
+    result = update_cmd._recover_gateway_restart_after_abort(plan, gateway_mode=False)
+
+    assert result["verified"] == ["default"]
+    assert result["relaunch_attempted"] == []
+    # The consequence the issue reports: the abort path may clear ``incomplete`` (exit 0) instead of
+    # failing the whole update for a fleet that is already running the new code.
+    assert update_cmd._abort_recovery_is_complete(
+        planned_gateway_profiles={"default"},
+        covered_gateway_profiles={"default"},
+        recovery_result=result,
+        stale_runtime_rows=[],
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes a false negative in the **fresh recovery process** the updater spawns when the in-process
gateway restart phase aborts. `update_abort_recovery._run_fresh_recovery_process` starts
`hermes_cli.update_restart_recovery` with `env = os.environ.copy()`, and that module ran every
`systemctl --user` probe in whatever environment it inherited. A bus-less dispatcher
(`sudo -u <user>`, cron, a systemd service, an SSH wrapper) therefore handed it no session bus, so
probes failed against a perfectly reachable user manager:

- `_systemd_verified_active()` classified a healthy profile as `relaunch_attempted` instead of
  `verified`. `_abort_recovery_is_complete()` requires `not relaunch_attempted`, so completeness
  could never be proven; the fail-closed branch then kept `out.incomplete` set → warning +
  `sys.exit(1)` on a fleet that had, in fact, been restarted onto the new code (and
  `.update_exit_code = 1` in gateway mode).
- `restart_serve_units()` enumerated serve units through `_systemctl_scopes()` → `_listed_serve_units()`,
  which returns `[]` on a failed listing: a user-scope `hermes-serve*` unit still serving the
  pre-update generation was neither restarted nor reported, and the child still exited 0.

Both user-scope probe paths now build their argv through a single helper, `_user_scope_cmd()`, which
adopts the user bus first — the same contract as `gateway._ensure_user_systemd_env()` (only our own
`/run/user/<uid>`, only when the `bus` socket exists), inlined because this module deliberately
imports no Hermes code: importing the freshly pulled tree is exactly what aborted the phase that
called it. Same bug class as #107477, at the sibling site that PR left out of scope.

## Related Issue

Fixes #107614

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_restart_recovery.py`
  - `_adopt_user_bus_env()` — sets `XDG_RUNTIME_DIR` to our own `/run/user/<uid>` (replacing a
    foreign one leaked by `su`/`sudo -u`) and `DBUS_SESSION_BUS_ADDRESS` only when that `bus` socket
    exists. Nothing is fabricated when no user manager is on disk, so a genuinely bus-less host still
    fails its probes and still reports the incomplete restart.
  - `_user_scope_cmd(systemctl)` — returns `[systemctl, "--user"]` after adoption. Both user-scope
    probe paths (`_systemd_verified_active()`, `_systemctl_scopes()`) route through it, so neither can
    get the argv without the normalization; no sibling construction sites remain in the module.
  - `_runtime_dir_is_ours()` / `_path_exists()` — the two on-disk guards, mirroring the gateway
    helper (and the seam its tests monkeypatch). The POSIX-only `os.getuid()` carries the repo's
    `# windows-footgun: ok` marker, on the same line, as the repo-wide scan test requires.
- `tests/hermes_cli/test_update_restart_recovery.py` — three `linux_only` tests driving the real
  passes against an env-sensitive fake `systemctl` (it fails every `--user` probe without a session
  bus, exactly like the real command):
  - `test_bus_less_recovery_child_reaches_our_user_manager` — the child observes the reachable
    manager: the profile is `verified` (not `relaunch_attempted`) and the user-scope serve unit is
    listed, restarted and reported.
  - `test_bus_less_recovery_child_result_completes_the_abort_path` — the consumer half: the real
    `_recover_gateway_restart_after_abort()` plus `_abort_recovery_is_complete()` now hold with that
    child's output, so the update can clear `incomplete` instead of exiting 1.
  - `test_bus_less_recovery_child_never_fabricates_a_bus` — fail-closed counterpart: no manager on
    disk → bare environment kept, `relaunch_attempted`, no serve unit claimed.

## How to Test

```bash
HERMES_PYTHON=<python-with-pytest> scripts/run_tests.sh \
  tests/hermes_cli/test_update_restart_recovery.py \
  tests/hermes_cli/test_update_serve_generation_recovery.py \
  tests/hermes_cli/test_gateway_user_bus_adoption.py \
  tests/hermes_cli/test_gateway_foreign_xdg_runtime.py \
  tests/hermes_cli/test_gateway_linger.py \
  tests/scripts/test_windows_footguns_full_repo_scan.py
```

- Touched file: **20 passed**. Six-file run above: **107 passed, 0 failed**.
- `scripts/check-windows-footguns.py --all`: clean (1525 files scanned).
- Red on base, for the behavioural reason — sabotaging only the two call sites (helpers left
  defined, so nothing fails with `AttributeError`):
  `test_bus_less_recovery_child_reaches_our_user_manager` fails with
  `{'verified': []} != {'verified': ['default']}`, and
  `test_bus_less_recovery_child_result_completes_the_abort_path` fails with `[] == ['default']`.
  The fail-closed counterpart passes both ways by design.
- **Full suite** (`scripts/run_tests.sh`, no paths — what CI runs): 3,937 files,
  **46,539 passed, 207 failed, 447 skipped** in 1,505 s, 16 workers. Every failure is outside this
  diff: 207 of the 208 distinct failing node ids reproduce identically on pristine `origin/main`
  `872bafd5` in a second worktree (same files, same tests), and the single extra one
  (`tests/tui_gateway/test_slash_worker_mcp_discovery.py::test_profile_local_mcp_tool_is_visible_in_slash_worker`)
  passes in isolation in **both** trees, i.e. a parallelism flake. Nothing in
  `update_restart_recovery.py` / `update_abort_recovery.py` / the serve-recovery files failed in
  either tree.

### Real bus-less dispatch (the reported scenario)

Debian 13, `hermes-gateway.service` active in the user manager, dispatched as
`sudo -u <user> -H env -u XDG_RUNTIME_DIR -u DBUS_SESSION_BUS_ADDRESS`, using the module's own probes:

- **pre-fix** (`origin/main` `872bafd5`): `_systemd_verified_active("default")` → `False`
  → bucket `relaunch_attempted`; `_listed_serve_units(["systemctl", "--user"])` → `[]`.
- **this PR**: `True` → bucket `verified`; env adopted (`/run/user/1000`,
  `unix:path=/run/user/1000/bus`).

For the serve half, with a throwaway `hermes-serve-probe.service` unit (created, exercised, removed):

- **pre-fix**: `restart_serve_units()` → `{'verified': [], 'failed': []}` and the unit's MainPID
  unchanged — the unit was silently never touched.
- **this PR**: `{'verified': ['user/hermes-serve-probe'], 'failed': []}` with MainPID
  `1704037` → `1704151`, i.e. actually replaced and observed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(update): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no open PR touches `update_restart_recovery.py` / `update_abort_recovery.py`; #107505 scopes this site out explicitly
- [x] My PR contains **only** changes related to this fix/feature (2 files, 1 commit)
- [x] I've run `pytest tests/ -q` — through `scripts/run_tests.sh`, the runner AGENTS.md mandates: 46,539 passed / 207 failed, with every failure shown above to be pre-existing on pristine `main`
- [x] I've added tests for my changes (3, sabotage-verified)
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), kernel 6.12.107+deb13-amd64, Python 3.11.15, Hermes Agent v0.21.1 (2026.9.7)

### Documentation & Housekeeping

- [x] Updated docstrings in the touched module — N/A otherwise
- [x] No config keys added or changed — N/A
- [x] No architecture/workflow change — N/A
- [x] Cross-platform considered: the adoption returns immediately unless `sys.platform == "linux"`, and the POSIX-only guard is marked for the footgun scan; Windows/macOS behavior is unchanged
- [x] No tool descriptions/schemas touched — N/A

## What this PR does not cover

- A live `hermes update` driven into a real phase abort end-to-end: that would restart this host's
  gateway mid-run. The consequence is pinned instead at the real decision functions the abort path
  calls (`_recover_gateway_restart_after_abort()` → `_abort_recovery_is_complete()`), by
  `test_bus_less_recovery_child_result_completes_the_abort_path`.
- CI status on this PR: this repo runs no workflows for fork heads (0 check runs, same as #107505),
  so the runs above are the whole verification story.
