### PR TITLE
fix(gateway): agent-error-reply exception path shares the overflow classifier

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1798,8 +1798,11 @@ class GatewayTurnMixin:
             else:
                 status_hint = " Your plan's usage limit has been reached. Please wait until it resets."
         elif status_code in {400, 500}:
-            # 400/500 on a large session: context overflow / payload too large.
-            if len(prepared.history) > 50:
+            # Same verdict is_context_overflow_failure_result reaches for a failed agent_result (the
+            # #1630 transcript skip / user-facing rewrite): an exception-raised failure must reach the
+            # same conclusion, or a billing/auth/content-policy/500 error on a long session gets the
+            # misleading "Session too large" reply instead of its own explanation.
+            if is_context_overflow_failure_result({"failed": True, "error": str(e)}, len(prepared.history)):
                 return (
                     "⚠️ Session too large for the model's context window.\nUse /compact to "
                     "compress the conversation, or /reset to start fresh."

--- a/tests/gateway/test_agent_error_reply_overflow_classifier.py
+++ b/tests/gateway/test_agent_error_reply_overflow_classifier.py
@@ -1,0 +1,83 @@
+"""_hmwa_agent_error_reply (the ``except Exception`` fallback reply) must reach the same
+context-overflow verdict as ``is_context_overflow_failure_result`` — the classifier
+``949724b321`` hoisted so the #1630 transcript skip and the failed-``agent_result`` user-facing
+rewrite can never disagree. This except-handler path is a third, independent site: it fires when
+``run_conversation`` raises instead of returning a failed result dict (auth/billing/content-policy/
+internal-server exceptions all take this path), and it used to decide "Session too large" from
+nothing but ``status_code in {400, 500}`` and a long history — no text classification at all,
+reproducing the exact misclassification bug the shared classifier exists to prevent.
+"""
+
+import asyncio
+
+from gateway.run import GatewayRunner
+
+
+class _FakeAPIError(Exception):
+    """A provider exception carrying the ``status_code`` attribute the except-handler reads."""
+
+    def __init__(self, status_code: int, message: str):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+
+    async def _noop_stop_typing(event, source):
+        return None
+
+    runner._hmwa_stop_typing_for_turn = _noop_stop_typing
+    return runner
+
+
+def _prepared(runner: GatewayRunner, history_len: int):
+    # message_text=None skips the input-ownership/transcript-persistence block, which needs a
+    # real SessionStore this test has no reason to build.
+    return runner._PreparedTurn(
+        [{"role": "user", "content": "x"}] * history_len, "", None, None, None, None,
+    )
+
+
+def _reply(e: Exception, history_len: int) -> str:
+    runner = _runner()
+    prepared = _prepared(runner, history_len)
+    return asyncio.run(
+        runner._hmwa_agent_error_reply(e, None, None, None, "fixture-session", prepared)
+    )
+
+
+def test_content_policy_400_on_long_session_keeps_its_own_reply():
+    """A validation/content-policy 400 names no overflow phrase and no bare "400" digits — a long
+    session must not steer it into the misleading "Session too large" rewrite."""
+    reply = _reply(_FakeAPIError(400, "content flagged by moderation policy, please rephrase"), 138)
+    assert "Session too large" not in reply
+    assert "unexpected error" in reply
+
+
+def test_generic_500_on_long_session_keeps_its_own_reply():
+    """A bare 500 (no overflow phrase, no "400" substring) on a long session is the exact
+    regression shape ``949724b321`` fixed for the other two call sites."""
+    reply = _reply(_FakeAPIError(500, "internal server error, please retry"), 138)
+    assert "Session too large" not in reply
+    assert "unexpected error" in reply
+
+
+def test_genuine_overflow_phrase_still_gets_the_compact_reply():
+    reply = _reply(_FakeAPIError(400, "This model's maximum context length is 128000 tokens"), 138)
+    assert "Session too large" in reply
+    assert "/compact" in reply
+
+
+def test_bare_400_envelope_on_long_session_still_gets_the_compact_reply():
+    """Preserves the historical "any bare 400 on a long session" fallback for provider envelopes
+    that carry no recognizable overflow phrase at all."""
+    reply = _reply(_FakeAPIError(400, 'HTTP 400: {"object":"error","model":"deepseek-v4-flash"}'), 138)
+    assert "Session too large" in reply
+
+
+def test_short_session_400_never_gets_the_compact_reply():
+    """The history_len > 50 gate is unchanged by this fix."""
+    reply = _reply(_FakeAPIError(400, 'HTTP 400: {"object":"error"}'), 10)
+    assert "Session too large" not in reply
+    assert "request was rejected" in reply


### PR DESCRIPTION
## Summary

`949724b321` (merged earlier today) hoisted `is_context_overflow_failure_result` into a module-level classifier specifically so the #1630 transcript skip and the failed-`agent_result` user-facing reply could never disagree on what counts as "context overflow" — a billing, rate-limit, auth, or content-policy failure on a long session was being misclassified and rewritten to "Session too large / /compact".

That fix covered two call sites. A third, independent site has the identical shape and was left on the old loose heuristic: `GatewayTurnMixin._hmwa_agent_error_reply` — the `except Exception` handler that builds the user-facing reply when `run_conversation` *raises* instead of returning a `{"failed": True, ...}` result dict (real provider exceptions: auth failures, content-policy rejections, generic 500s, etc.). It decided the reply purely from `status_code in {400, 500}` plus `len(prepared.history) > 50` — no text classification at all — so any such exception on a session with more than 50 messages got the misleading "/compact" guidance instead of its own explanation, telling the user to compress/reset their conversation for an unrelated failure.

## Fix

Route this third site through the same `is_context_overflow_failure_result` classifier (already module-level in `gateway/run_turn.py`) by building the minimal synthetic result it expects (`{"failed": True, "error": str(e)}`). No new heuristic, no new import — reuses the exact verdict the other two sites already share.

## Scope note (textual, not semantic overlap)

Open PR #107561 ("make failed-turn persistence exactly-once") also touches this same `elif status_code in {400, 500}:` block, but for an unrelated concern — it wraps both return values in `self._hmwa_add_failed_turn_notice(...)` for exactly-once persistence marking, and leaves the classification condition itself (`len(prepared.history) > 50`) untouched. The two changes are complementary, not conflicting; if both land, reconciling the adjacent lines is a trivial rebase.

## Test plan

- New `tests/gateway/test_agent_error_reply_overflow_classifier.py` (5 cases): a content-policy 400 and a generic 500 on a long session now keep their own reply (previously misclassified); a genuine overflow-phrase 400, a bare-400 provider envelope, and a short session all keep their pre-existing behavior.
- Mutation-verify: reverting the fix reproduces exactly the 2 new guard-test failures with the predicted symptom ("Session too large" wrongly present); the other 3 cases pass unchanged either way.
- `tests/gateway/test_normalize_empty_agent_response.py` + `tests/gateway/test_failure_writer_ownership.py` (the two existing call sites' tests) unaffected — 19/19 passed together.
- `ruff check` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)