### PR TITLE
fix(update): adopt the user bus before spawning the fresh restart recovery child

### DIFF
--- a/hermes_cli/update_abort_recovery.py
+++ b/hermes_cli/update_abort_recovery.py
@@ -105,8 +105,12 @@ def _normalize_user_bus_env() -> None:
         from hermes_cli.gateway import _ensure_user_systemd_env
 
         _ensure_user_systemd_env()
-    except Exception:
-        logger.debug("User-bus env normalization unavailable; recovery child inherits environment as-is")
+    except Exception as exc:
+        # Only the adoption is lost (never the spawn), but losing it silently restores the bug on
+        # a bus-less dispatcher, so the fallback must be visible at the operator level.
+        logger.warning(
+            "User-bus env normalization unavailable (%s); recovery child inherits the "
+            "environment as-is and may report relaunch_attempted on a healthy fleet", exc)
 
 
 def _run_fresh_recovery_process(

--- a/hermes_cli/update_abort_recovery.py
+++ b/hermes_cli/update_abort_recovery.py
@@ -90,12 +90,32 @@ def _qualified_serve_skips(skip_units) -> list[dict]:
     return rows
 
 
+def _normalize_user_bus_env() -> None:
+    """Adopt ``XDG_RUNTIME_DIR``/``DBUS_SESSION_BUS_ADDRESS`` before spawning the recovery child (#107614).
+
+    Under a bus-less dispatcher (``sudo -u``, cron, an SSH automation wrapper) the inherited
+    environment has neither variable, so the child's every ``systemctl --user`` probe fails and a
+    healthy gateway reads ``relaunch_attempted`` — the false exit 1 of the same bug class #107477
+    fixed at the in-process listing helper. Normalization must run in this (pre-update) interpreter:
+    the child deliberately imports no gateway code, because importing the freshly pulled tree is
+    what aborted the phase in the first place. The helper fabricates nothing, so a genuinely
+    bus-less host stays fail-closed; a broken gateway module only costs the adoption, never the spawn.
+    """
+    try:
+        from hermes_cli.gateway import _ensure_user_systemd_env
+
+        _ensure_user_systemd_env()
+    except Exception:
+        logger.debug("User-bus env normalization unavailable; recovery child inherits environment as-is")
+
+
 def _run_fresh_recovery_process(
     profiles, candidates, *, gateway_mode: bool, recover_serve: bool, skip_units
 ) -> "subprocess.CompletedProcess | None":
     """Spawn ``hermes_cli.update_restart_recovery --stdin`` detached from this process; None when it
     could not run (no systemd-run in gateway mode, OSError, timeout) — the caller fails closed."""
     command = [sys.executable, "-m", "hermes_cli.update_restart_recovery", "--stdin"]
+    _normalize_user_bus_env()
     env = os.environ.copy()
     env["HERMES_UPDATE_RESTART_RECOVERY"] = "1"
     for marker in ("_HERMES_GATEWAY", "HERMES_GATEWAY", "HERMES_GATEWAY_MODE"):

--- a/tests/hermes_cli/test_update_gateway_restart_aborted.py
+++ b/tests/hermes_cli/test_update_gateway_restart_aborted.py
@@ -12,9 +12,15 @@ gateway kept serving pre-update modules and died on the next turn with
 
 from __future__ import annotations
 
+import importlib
+import json
+import logging
 import os
 import sys
 import types
+from types import SimpleNamespace
+
+import pytest
 
 from hermes_cli import update_abort_recovery
 from hermes_cli.update_cmd import _restart_phase_failure_is_incomplete, _surviving_gateway_pids_after_failed_restart, _warn_gateway_restart_phase_aborted
@@ -168,3 +174,154 @@ class TestFreshRecoveryUserBusEnv:
         # Nothing was fabricated for a bus the host never advertised — fail closed stays intact.
         assert "XDG_RUNTIME_DIR" not in captured["env"]
         assert "DBUS_SESSION_BUS_ADDRESS" not in captured["env"]
+
+
+class _Completed:
+    """CompletedProcess stand-in for the faked systemctl / fresh-child calls."""
+
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _env_sensitive_systemctl(calls: list, restarted: list):
+    """A ``systemctl`` faithful to the real one (test design credit: the #107623 review): every
+    ``--user`` probe fails without a session bus — the observable separating a reachable user
+    manager from an absent one (``Failed to connect to user scope bus``, rc=1)."""
+
+    def fake_run(argv, **kwargs):
+        argv = list(argv)
+        if "hermes_cli.main" in argv:  # the per-profile relaunch
+            calls.append(argv)
+            return _Completed(0)
+        if argv and str(argv[0]).endswith("systemctl"):
+            calls.append(argv)
+            user_scope = "--user" in argv
+            if user_scope and not (
+                os.environ.get("XDG_RUNTIME_DIR") and os.environ.get("DBUS_SESSION_BUS_ADDRESS")
+            ):
+                return _Completed(1, stderr="Failed to connect to user scope bus via local transport")
+            if "is-active" in argv:
+                return _Completed(0, stdout="active\n")
+            if "list-units" in argv:
+                # The serve unit exists in the user manager only (system scope: nothing to recover).
+                return _Completed(0, stdout="hermes-serve.service loaded active running\n" if user_scope else "")
+            if "show" in argv:
+                return _Completed(0, stdout="5151\n" if restarted else "4242\n")
+            if "restart" in argv:
+                restarted.append({"user" if user_scope else "system": argv[-1]})
+                return _Completed(0)
+            return _Completed(0)
+        return _Completed(0)
+
+    return fake_run
+
+
+class TestFreshRecoveryOutcome:
+    """#107614 at the outcome level (test design credit: the #107623 review): what the child
+    observes — not the env blob — decides the update's exit code. The fresh child is faked to run
+    the REAL recovery passes in the environment the parent handed down, so the parent-side
+    adoption is exercised end-to-end through the real ``_recover_gateway_restart_after_abort``
+    entry and the real ``_abort_recovery_is_complete`` verdict."""
+
+    def _busless_parent_with_fake_child(self, monkeypatch, gateway_fake):
+        """Wire a bus-less parent (with the given fake adoption helper) to a faked fresh child that
+        runs the real recovery passes in the environment it inherited; returns ``(invoke, calls,
+        restarted)``."""
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway", gateway_fake)
+        recovery = importlib.import_module("hermes_cli.update_restart_recovery")
+        monkeypatch.setattr(recovery.shutil, "which", lambda name: f"/usr/bin/{name}")
+        calls: list = []
+        restarted: list = []
+        child_run = _env_sensitive_systemctl(calls, restarted)
+
+        def fake_child(_command, **kwargs):
+            """The fresh child's output: the production passes, in the environment it inherited."""
+            payload = json.loads(kwargs["input"])
+            result = recovery.restart_profiles(
+                payload["profiles"], supervisors=payload["supervisors"], run=child_run
+            )
+            if payload["serve_units"]["recover"]:
+                result["serve_units"] = recovery.restart_serve_units(run=child_run)
+            return _Completed(0, stdout=json.dumps(result))
+
+        monkeypatch.setattr(update_abort_recovery.subprocess, "run", fake_child)
+        plan = SimpleNamespace(
+            runtimes=[SimpleNamespace(profile="default", supervisor="systemd", kind="gateway", pid=1234)]
+        )
+
+        def invoke():
+            return update_abort_recovery._recover_gateway_restart_after_abort(plan, gateway_mode=False)
+
+        return invoke, calls, restarted
+
+    def test_adopted_env_verifies_and_completes_the_abort_path(self, monkeypatch):
+        fake = types.ModuleType("hermes_cli.gateway")
+
+        def _adopt():
+            os.environ["XDG_RUNTIME_DIR"] = f"/run/user/{os.getuid()}"
+            os.environ["DBUS_SESSION_BUS_ADDRESS"] = f"unix:path=/run/user/{os.getuid()}/bus"
+
+        fake._ensure_user_systemd_env = _adopt
+
+        invoke, _calls, _restarted = self._busless_parent_with_fake_child(monkeypatch, fake)
+        result = invoke()
+
+        assert result["verified"] == ["default"]
+        assert result["relaunch_attempted"] == []
+        # The consequence the issue reports: the abort path may clear ``incomplete`` (exit 0)
+        # instead of failing the whole update for a fleet already on the new code.
+        assert update_abort_recovery._abort_recovery_is_complete(
+            planned_gateway_profiles={"default"},
+            covered_gateway_profiles={"default"},
+            recovery_result=result,
+            stale_runtime_rows=[],
+        )
+
+    def test_unavailable_adoption_fails_closed_and_warns(self, monkeypatch, caplog):
+        """The #107623 review's regression point: an adoption that cannot run (an import failure in
+        the pre-pull interpreter) must not silently restore the bug — the loss is visible at
+        warning level and the honest outcome (``relaunch_attempted``) keeps the update incomplete."""
+
+        def _boom():
+            raise ImportError("cannot import name '_ensure_user_systemd_env'")
+
+        fake = types.ModuleType("hermes_cli.gateway")
+        fake._ensure_user_systemd_env = _boom
+
+        invoke, _calls, _restarted = self._busless_parent_with_fake_child(monkeypatch, fake)
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.update_abort_recovery"):
+            result = invoke()
+
+        assert result["verified"] == []
+        assert result["relaunch_attempted"] == ["default"]
+        assert "User-bus env normalization unavailable" in caplog.text
+        assert "cannot import name '_ensure_user_systemd_env'" in caplog.text
+        # Nothing was fabricated — completeness stays unprovable, the update keeps exit 1.
+        assert not update_abort_recovery._abort_recovery_is_complete(
+            planned_gateway_profiles={"default"},
+            covered_gateway_profiles={"default"},
+            recovery_result=result,
+            stale_runtime_rows=[],
+        )
+
+    @pytest.mark.linux_only
+    def test_adopted_env_recovers_the_user_scope_serve_unit(self, monkeypatch):
+        """Serve half of the same outcome: the user manager lists and restarts ``hermes-serve``
+        only once the parent-side adoption reaches the child's ``systemctl --user`` probes."""
+
+        def _adopt():
+            os.environ["XDG_RUNTIME_DIR"] = f"/run/user/{os.getuid()}"
+            os.environ["DBUS_SESSION_BUS_ADDRESS"] = f"unix:path=/run/user/{os.getuid()}/bus"
+
+        fake = types.ModuleType("hermes_cli.gateway")
+        fake._ensure_user_systemd_env = _adopt
+
+        invoke, _calls, restarted = self._busless_parent_with_fake_child(monkeypatch, fake)
+        result = invoke()
+
+        assert result["serve_units"] == {"verified": ["user/hermes-serve"], "failed": []}
+        assert restarted == [{"user": "hermes-serve.service"}]

--- a/tests/hermes_cli/test_update_gateway_restart_aborted.py
+++ b/tests/hermes_cli/test_update_gateway_restart_aborted.py
@@ -12,9 +12,11 @@ gateway kept serving pre-update modules and died on the next turn with
 
 from __future__ import annotations
 
+import os
 import sys
 import types
 
+from hermes_cli import update_abort_recovery
 from hermes_cli.update_cmd import _restart_phase_failure_is_incomplete, _surviving_gateway_pids_after_failed_restart, _warn_gateway_restart_phase_aborted
 
 
@@ -99,3 +101,70 @@ class TestAbortedRestartWarning:
         assert "Update incomplete" in out
         assert "systemctl exploded" in out
         assert "hermes gateway restart" in out
+
+
+class TestFreshRecoveryUserBusEnv:
+    """#107614 — the fresh recovery child must inherit a user-bus env it cannot build itself.
+
+    ``update_restart_recovery`` deliberately imports no gateway code (a broken freshly pulled
+    import graph is what aborts the phase), so it can never call ``_ensure_user_systemd_env``
+    itself. Under a bus-less dispatcher (``sudo -u``, cron) every ``systemctl --user`` probe of the
+    child then fails: a healthy gateway reads ``relaunch_attempted`` and the update exits 1 — the
+    same false negative #107477 fixed at the in-process listing helper.
+    """
+
+    def _spawn_capturing(self, monkeypatch):
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+        captured = {}
+
+        class _Completed:
+            returncode = 0
+            stdout = "{}"
+            stderr = ""
+
+        def fake_run(_command, **kwargs):
+            captured["env"] = kwargs["env"]
+            return _Completed()
+
+        monkeypatch.setattr(update_abort_recovery.subprocess, "run", fake_run)
+        result = update_abort_recovery._run_fresh_recovery_process(
+            ["default"], {"default": "systemd"},
+            gateway_mode=False, recover_serve=False, skip_units=())
+        return result, captured
+
+    def test_child_env_adopts_user_bus_before_spawn(self, monkeypatch):
+        fake = types.ModuleType("hermes_cli.gateway")
+
+        def _adopt():
+            os.environ["XDG_RUNTIME_DIR"] = "/run/user/501"
+            os.environ["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=/run/user/501/bus"
+
+        fake._ensure_user_systemd_env = _adopt
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway", fake)
+
+        result, captured = self._spawn_capturing(monkeypatch)
+
+        assert result is not None
+        assert captured["env"]["XDG_RUNTIME_DIR"] == "/run/user/501"
+        assert captured["env"]["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/run/user/501/bus"
+        # The recovery self-identification markers stay independent of the adoption.
+        assert captured["env"]["HERMES_UPDATE_RESTART_RECOVERY"] == "1"
+        assert "_HERMES_GATEWAY" not in captured["env"]
+
+    def test_spawn_survives_a_broken_gateway_module(self, monkeypatch):
+        """A gateway module that cannot even import must not cancel the recovery spawn (#78574 shape)."""
+
+        def _boom():
+            raise ImportError("cannot import name '_ensure_user_systemd_env'")
+
+        fake = types.ModuleType("hermes_cli.gateway")
+        fake._ensure_user_systemd_env = _boom
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway", fake)
+
+        result, captured = self._spawn_capturing(monkeypatch)
+
+        assert result is not None
+        # Nothing was fabricated for a bus the host never advertised — fail closed stays intact.
+        assert "XDG_RUNTIME_DIR" not in captured["env"]
+        assert "DBUS_SESSION_BUS_ADDRESS" not in captured["env"]


### PR DESCRIPTION
## What does this PR do?

Fixes the last unnormalized site of the #107477 user-bus bug class: the fresh recovery process that `hermes update` spawns when the in-process restart phase aborts.

`hermes_cli/update_abort_recovery.py` started that child with `env = os.environ.copy()`, and `hermes_cli/update_restart_recovery.py` runs every `systemctl --user` probe (`_systemd_verified_active`, `_listed_serve_units`) with that inherited environment — the module contains no bus normalization by design, because it deliberately imports no gateway code (importing the freshly pulled tree is what aborts the phase). Under any bus-less dispatcher (`sudo -u`, cron, an SSH automation wrapper) this produced two silent failures:

1. **False exit 1.** A probe that could not run is indistinguishable from "unit not active", so a healthy profile lands in `relaunch_attempted` instead of `verified`; `_abort_recovery_is_complete()` can then never be proven and the fail-closed `sys.exit(1)` fires even though the gateway did restart onto the pulled code.
2. **User-scope `hermes-serve*` units silently skipped.** `_listed_serve_units()` returns `[]` on any listing failure, so a user-scope unit still serving the pre-update generation is neither restarted nor reported.

The fix adopts the user-bus environment in the **parent**, right before the spawn: `_normalize_user_bus_env()` lazily imports and calls the existing `hermes_cli.gateway._ensure_user_systemd_env()` helper — the same helper the strict restart path already uses (`update_cmd_fleet.py`). Running it in the pre-update interpreter respects the child's no-gateway-import contract. The adoption also covers the `systemd-run --user --scope` prefix used in gateway mode, which needs the same bus. The helper fabricates nothing (it only adopts sockets that actually exist), so a genuinely bus-less host stays fail-closed, and a broken gateway module only costs the adoption, never the spawn — matching the #78574 lesson that this phase must survive a broken gateway import.

## Related Issue

Fixes #107614

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_abort_recovery.py`: added `_normalize_user_bus_env()` and called it at the top of `_run_fresh_recovery_process()`, before `env = os.environ.copy()`, so the recovery child (and the `systemd-run --user` prefix in gateway mode) inherits `XDG_RUNTIME_DIR`/`DBUS_SESSION_BUS_ADDRESS` when the host actually has a user bus. Import failure of the gateway module degrades to a debug log — the spawn itself never fails here.
- `tests/hermes_cli/test_update_gateway_restart_aborted.py`: added `TestFreshRecoveryUserBusEnv` — one test asserting the spawned child's env carries the adopted bus variables plus the existing recovery markers, and one fail-closed test asserting a broken gateway module neither cancels the spawn nor fabricates env vars.

No changes to `hermes_cli/update_restart_recovery.py`: the child keeps importing no gateway code; the environment is normalized before it exists.

## How to Test

1. `pytest tests/hermes_cli/test_update_gateway_restart_aborted.py tests/hermes_cli/test_update_restart_recovery.py tests/hermes_cli/test_update_serve_generation_recovery.py -q` — should pass (12 + 17 + 59, including the two new tests).
2. Red/green against the issue's scenario, run with the venv python from the repo root:
   ```python
   import os, sys, types, subprocess
   sys.path.insert(0, ".")
   from hermes_cli import update_abort_recovery as uar
   fake = types.ModuleType("hermes_cli.gateway")
   fake._ensure_user_systemd_env = lambda: os.environ.update(
       XDG_RUNTIME_DIR=f"/run/user/{os.getuid()}",
       DBUS_SESSION_BUS_ADDRESS=f"unix:path=/run/user/{os.getuid()}/bus")
   sys.modules["hermes_cli.gateway"] = fake
   captured = {}
   def fake_run(cmd, **kw):
       captured["env"] = kw["env"]; return types.SimpleNamespace(returncode=0, stdout="{}", stderr="")
   uar.subprocess.run = fake_run
   assert uar._run_fresh_recovery_process(["default"], {"default": "systemd"},
       gateway_mode=False, recover_serve=False, skip_units=()) is not None
   print("bus adopted:", captured["env"].get("DBUS_SESSION_BUS_ADDRESS"))
   ```
   Observed result: `bus adopted: unix:path=/run/user/<uid>/bus` with the fix; without it the child env has neither variable and every `systemctl --user` probe of the recovery fails exactly as reported in #107614.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A