### PR TITLE
fix(mcp): secondary-profile stdio MCP servers no longer receive the default profile's vault secrets (salvage #86685)

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -88,6 +88,12 @@ def get_secret_source(env_var: str) -> str | None:
     return _SECRET_SOURCES.get(env_var)
 
 
+def secret_source_names() -> tuple[str, ...]:
+    """Every env-var name some profile's external secret source supplied (names only — the map is
+    process-wide, so a value must be resolved through the active profile's secret scope)."""
+    return tuple(_SECRET_SOURCES)
+
+
 def get_secret_source_values(hermes_home: str | os.PathLike) -> dict[str, str]:
     """Return the external-secret value snapshot for ``hermes_home``."""
     return dict(_SECRET_SOURCE_VALUES_BY_HOME.get(str(Path(hermes_home).resolve()), {}))

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import threading
 from contextlib import nullcontext
+from contextvars import copy_context
 from typing import Optional
-
-from hermes_constants import get_hermes_home_override, reset_hermes_home_override, set_hermes_home_override
 
 _mcp_discovery_lock = threading.Lock()
 _mcp_discovery_started = False
@@ -95,15 +94,13 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
         if not _has_configured_mcp_servers():
             return
 
-        # Re-install the caller's context-local HERMES_HOME override (multi-profile dashboard/desktop
-        # backends) inside the thread: ContextVars don't propagate into bare threads, so a session
-        # switched to profile X would otherwise discover the LAUNCH profile's mcp_servers.
-        # The config gate above already runs on the caller's thread, so it sees the same override. See
-        # #67605.
-        home_override = get_hermes_home_override()
-
+        # Bare threads start from an empty context: run discovery under a copy of the caller's, so
+        # the context-local HERMES_HOME override (multi-profile dashboard/desktop backends, #67605)
+        # AND the profile's secret scope reach it. Without the scope a session switched to profile
+        # X would discover the LAUNCH profile's mcp_servers, and ``${TOKEN}`` interpolation / the
+        # stdio child env would fail closed (multiplex) or resolve the launch profile's value.
+        # The config gate above already runs on the caller's thread, so it sees the same context.
         def _discover() -> None:
-            token = set_hermes_home_override(home_override)
             try:
                 _discover_mcp_tools_without_interactive_oauth()
                 try:
@@ -114,12 +111,11 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
             except Exception:
                 logger.debug("Background MCP tool discovery failed", exc_info=True)
             finally:
-                reset_hermes_home_override(token)
                 with _mcp_discovery_lock:
                     global _mcp_discovery_thread
                     _mcp_discovery_thread = None
 
-        thread = threading.Thread(target=_discover, name=thread_name, daemon=True)
+        thread = threading.Thread(target=copy_context().run, args=(_discover,), name=thread_name, daemon=True)
         _mcp_discovery_thread = thread
         thread.start()
 

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -236,6 +236,46 @@ def test_background_mcp_discovery_suppresses_interactive_oauth(monkeypatch):
     assert state["active"] is False
 
 
+def test_background_mcp_discovery_propagates_profile_secret_scope(monkeypatch):
+    """A dashboard-profile discovery thread must retain that profile's secrets."""
+    from agent.secret_scope import current_secret_scope, reset_secret_scope, set_secret_scope
+
+    seen = []
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            read_raw_config=lambda: {"mcp_servers": {"demo": {"url": "https://mcp.example.test/mcp"}}},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_oauth",
+        types.SimpleNamespace(suppress_interactive_oauth=lambda: nullcontext()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool_discovery",
+        types.SimpleNamespace(
+            discover_mcp_tools=lambda: seen.append(dict(current_secret_scope() or {})),
+        ),
+    )
+
+    expected_scope = {"MCP_DEMO_TOKEN": "profile-only-secret"}
+    token = set_secret_scope(expected_scope)
+    try:
+        mcp_startup.start_background_mcp_discovery(
+            logger=types.SimpleNamespace(debug=lambda *_a, **_k: None),
+            thread_name="test-mcp-discovery",
+        )
+        assert mcp_startup._mcp_discovery_thread is not None
+        mcp_startup._mcp_discovery_thread.join(timeout=1.0)
+    finally:
+        reset_secret_scope(token)
+
+    assert seen == [expected_scope]
+
+
 def test_portable_only_mcp_configuration_opens_startup_gate(monkeypatch):
     monkeypatch.setitem(
         sys.modules,

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1392,6 +1392,29 @@ class TestBuildSafeEnv:
         assert result["NOTION_TOKEN"] == "from-op"
         assert "UNTRACKED_SECRET_KEY" not in result
 
+    def test_secret_source_vars_resolve_through_active_profile_scope(self, monkeypatch):
+        """Under multiplex the stdio child gets the ROUTED profile's value for a source-tagged name,
+        never the launch profile's os.environ copy; a name the profile lacks is omitted."""
+        from agent.secret_scope import set_multiplex_active, set_secret_scope, reset_secret_scope
+        from hermes_cli import env_loader
+        from tools.mcp_tool_config import _build_safe_env
+
+        monkeypatch.setitem(env_loader._SECRET_SOURCES, "GITHUB_TOKEN", "bitwarden")
+        monkeypatch.setitem(env_loader._SECRET_SOURCES, "NOTION_TOKEN", "onepassword")
+        fake_env = {"PATH": "/usr/bin", "GITHUB_TOKEN": "default-profile", "NOTION_TOKEN": "default-notion"}
+        set_multiplex_active(True)
+        token = set_secret_scope({"GITHUB_TOKEN": "profile-b"})
+        try:
+            with patch.dict("os.environ", fake_env, clear=True):
+                result = _build_safe_env(None)
+        finally:
+            reset_secret_scope(token)
+            set_multiplex_active(False)
+
+        assert result["PATH"] == "/usr/bin"
+        assert result["GITHUB_TOKEN"] == "profile-b"
+        assert "NOTION_TOKEN" not in result
+
     def test_windows_location_vars_passed_without_secrets(self):
         """Windows launcher tools need location vars, but secrets stay filtered."""
         from tools.mcp_tool_config import _build_safe_env

--- a/tools/mcp_tool_config.py
+++ b/tools/mcp_tool_config.py
@@ -95,14 +95,18 @@ def _build_safe_env(user_env: Optional[dict]) -> dict:
     """Filtered env for stdio subprocesses so API keys/tokens don't leak: the safe baseline
     keys, ``XDG_*``, vars injected by an external secret source (users configured that backend
     precisely so subprocesses can consume them), plus the server config's own ``env``."""
-    try:
-        from hermes_cli.env_loader import get_secret_source
-    except Exception:  # pragma: no cover — early bootstrap/import fallback
-        get_secret_source = None
+    from agent.secret_scope import get_secret
+    from hermes_cli.env_loader import secret_source_names
     env = {
         key: value for key, value in os.environ.items()
-        if key in _SAFE_ENV_KEYS or key.upper() in _SAFE_ENV_KEYS_CASE_INSENSITIVE
-        or key.startswith("XDG_") or (get_secret_source is not None and get_secret_source(key))}
+        if key in _SAFE_ENV_KEYS or key.upper() in _SAFE_ENV_KEYS_CASE_INSENSITIVE or key.startswith("XDG_")}
+    # Source-tagged names are process-wide (any profile's hydration tags them) while os.environ
+    # holds only the LAUNCH profile's values, so the value must come from the active profile's
+    # secret scope; a profile that lacks the name gets nothing, never another profile's token.
+    for key in secret_source_names():
+        value = get_secret(key)
+        if value is not None:
+            env[key] = value
     for key in ("HERMES_KANBAN_DB", "HERMES_KANBAN_BOARD"):
         if key in os.environ:
             env[key] = os.environ[key]

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -212,8 +212,11 @@ keep working.
 
 Per-profile `.env` credential isolation is preserved and, if anything,
 stricter: a profile's keys are resolved from its own scope and are never unioned
-into a shared environment (this also means subprocesses like MCP servers and
-Kanban workers only ever see their own profile's secrets). Terminal settings
+into a shared environment. Subprocesses like MCP servers and Kanban workers only
+ever see their own profile's secrets — including credentials injected by an
+external secret source (1Password, Bitwarden, …): a stdio MCP server started for
+profile B receives B's value for such a name, or nothing if B has none, never the
+default profile's. Terminal settings
 (`terminal.backend`, `terminal.cwd`, `terminal.docker_volumes`,
 `terminal.docker_shared_container_key`, SSH targets, …) are likewise resolved
 per profile on every routed turn: a profile that omits a terminal key gets the


### PR DESCRIPTION
Under a multiplexed gateway, a secondary profile's stdio MCP servers now receive that profile's own vault-injected credentials (or none), never the default profile's `os.environ` copy.

## Changes
- `tools/mcp_tool_config.py::_build_safe_env` — names tagged in the process-global secret-source map are resolved through the active profile's secret scope (`agent/secret_scope.py::get_secret`) instead of `os.environ`. Under multiplex a miss omits the name (no environ fallthrough); single-profile runs keep today's behaviour (vault vars still reach MCP children via the `.env` overlay + environ path).
- `hermes_cli/env_loader.py::secret_source_names` — exposes the tagged *names* only; values are never read from the shared map.
- `hermes_cli/mcp_startup.py::start_background_mcp_discovery` — the discovery thread runs under `copy_context()`, so the caller's HERMES_HOME override **and** secret scope both reach it (previously only the home override was re-installed by hand; `${TOKEN}` interpolation and the stdio child env ran unscoped). Salvage of #86685 by @nickseelert (cherry-picked with authorship; the manual scope re-install collapsed into `copy_context`, test retargeted to `tools.mcp_tool_discovery`).
- `website/docs/user-guide/multi-profile-gateways.md` — the "MCP subprocesses only see their own profile's secrets" claim is now true for source-injected names too, and says so explicitly.

## Root cause
`_SECRET_SOURCES` is filled by **every** served profile's hydration, but `os.environ` only holds the **launch** profile's values, so one profile's 1Password/Bitwarden source tagging `GITHUB_TOKEN` made every profile's stdio server inherit the default's token.

## Validation
**Live repro** (real stdio MCP child spawned through `discover_mcp_tools` under profile B's scope, multiplex on, `GITHUB_TOKEN`/`NOTION_TOKEN` tagged as vault-sourced, B's scope holds only `GITHUB_TOKEN=B-PROFILE-TOKEN`; child reports its own `os.environ`):

| | child saw |
|---|---|
| before (origin/main) | `GITHUB_TOKEN=DEFAULT-PROFILE-TOKEN, NOTION_TOKEN=DEFAULT-NOTION` → **LEAK** |
| after | `GITHUB_TOKEN=B-PROFILE-TOKEN, NOTION_TOKEN=null` → **CLEAN** |

Discovery thread scope before: `None`; after: profile B's mapping.

| Test | base | fix |
|---|---|---|
| `tests/tools/test_mcp_tool.py::TestBuildSafeEnv::test_secret_source_vars_resolve_through_active_profile_scope` | red | green |
| `tests/hermes_cli/test_mcp_startup.py::test_background_mcp_discovery_propagates_profile_secret_scope` (salvaged) | red | green |

Existing `test_secret_source_injected_vars_are_passed` (single-profile vault-var passthrough) still passes.

## Credits
- @nickseelert — earliest fix for the discovery-thread half (#86685, salvaged with authorship)
- Multiplex startup audit lane (F1) — report

Addresses #106005 (secret-leak half only; the server-NAME-keyed registry half is separate work in #99594/#104534).

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9e65e/ifpWareR8DtcFkTU74fq-_Ln4YDkV3.png)
