### PR TITLE
fix(agent): keep the shared client open while requests are in flight during agent_close

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2092,10 +2092,14 @@ def _chat_summary_attempt(agent, api_messages: list, api_request_id: str):
     summary_kwargs = _iteration_summary_chat_kwargs(agent, api_messages)
 
     def _attempt(retry_count: int) -> str:
-        summary_client = agent._ensure_primary_openai_client(reason="iteration_limit_summary_retry" if retry_count else "iteration_limit_summary")
-        response = _managed_summary_call(
-            agent, api_request_id, summary_kwargs, lambda request: summary_client.chat.completions.create(**request), retry_count=retry_count)
-        return _summary_text(agent, response)
+        # The summary drives the SHARED primary client in place: hold it checked out (see
+        # ``_shared_client_checkout``) so a concurrent agent_close parks its close for this thread
+        # instead of yanking the transport out from under an in-flight request (#107475).
+        reason = "iteration_limit_summary_retry" if retry_count else "iteration_limit_summary"
+        with agent._shared_client_checkout(reason=reason) as summary_client:
+            response = _managed_summary_call(
+                agent, api_request_id, summary_kwargs, lambda request: summary_client.chat.completions.create(**request), retry_count=retry_count)
+            return _summary_text(agent, response)
     return _attempt
 
 

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -6,7 +6,7 @@
 import logging
 import threading
 import time
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from typing import Any, Optional
 
 from agent.lazy_forward import forward as _forward, forward_static as _forward_static, lazy_attr as _lazy_attr
@@ -533,6 +533,71 @@ class ClientLifecycleMixin:
 
     def _abort_request_anthropic_client(self, client: Any, *, reason: str) -> None:
         self._abort_request_slot_client(_ANTHROPIC_SLOT, client, reason=reason)
+
+    # ------------------------------------------------------------------ shared primary client in-use guard
+    # The per-request slot keeps concurrent calls off ONE pool via its ``in_use`` flag and its teardown
+    # hook (``_close_cached_request_openai_client``) refuses to hard-close a checked-out client. The
+    # shared primary client is driven IN PLACE by requests that have no per-request clone (codex-direct
+    # stream, iteration-limit summaries, MoA facade), so it carries the same flag here: closing it while
+    # a worker is mid-request yanks the transport out from under that request — it stops receiving events
+    # and raises nothing, hanging until a watchdog — so the teardown is parked for the request's own
+    # thread (the FD owner) instead. See #107475.
+    _SHARED_IN_FLIGHT_ATTR = "_shared_client_in_flight"
+
+    def _shared_in_flight(self) -> int:
+        """Number of requests currently checked out on the shared primary client (0 when never used)."""
+        with self._openai_client_lock():
+            return int(getattr(self, self._SHARED_IN_FLIGHT_ATTR, 0) or 0)
+
+    def _acquire_shared_client(self, *, reason: str) -> Any:
+        """Check out the shared primary client for one in-place request (twin of ``_checkout_request_slot``)."""
+        client = self._ensure_primary_openai_client(reason=reason)
+        with self._openai_client_lock():
+            setattr(self, self._SHARED_IN_FLIGHT_ATTR, self._shared_in_flight() + 1)
+        return client
+
+    @contextmanager
+    def _shared_client_checkout(self, *, reason: str):
+        """Run one request that drives the shared primary client in place under the in-use guard."""
+        client = self._acquire_shared_client(reason=reason)
+        try:
+            yield client
+        finally:
+            self._release_shared_client()
+
+    def _release_shared_client(self) -> None:
+        """Owner-thread release; runs the teardown close parked while this request was in flight."""
+        parked = None
+        with self._openai_client_lock():
+            self._shared_client_in_flight = max(0, self._shared_in_flight() - 1)
+            if not self._shared_client_in_flight:
+                parked, self._shared_client_close_parked = getattr(self, "_shared_client_close_parked", None), None
+        if parked is not None:  # the request-driving thread owns the transport FDs (#70773)
+            parked()
+
+    def _teardown_shared_client(self, close_fn, *, reason: str) -> None:
+        """Guarded shared-client teardown: the same in-use check the per-request path performs.
+
+        ``close_fn(client)`` runs only when no request has the shared client checked out; while one does,
+        the teardown is parked and the LAST ``_release_shared_client`` runs it from that request's own
+        thread. That mirrors ``_close_cached_request_openai_client`` (which aborts instead of closing a
+        checked-out client) because the shared client has no owner thread to defer to.
+        """
+        with self._openai_client_lock():
+            client = getattr(self, "client", None)
+            if client is None:
+                return
+            self.client = None
+            if self._shared_in_flight():
+                # One parked teardown at a time: a later teardown supersedes it, and the superseded
+                # client falls to GC (safe — nothing closes under a live reader).
+                self._shared_client_close_parked = lambda: close_fn(client)
+                logger.info(
+                    "Shared OpenAI client teardown deferred (%s, shared=True, in_flight=%d) %s",
+                    reason, self._shared_in_flight(), self._client_log_context(),
+                )
+                return
+        close_fn(client)
 
     # ------------------------------------------------------------------ credential refresh
     def _sync_client_kwargs_credentials(self) -> None:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -866,6 +866,19 @@ def _bypass_sdk_request_transform(stream_kwargs: dict) -> dict:
 
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):
     """One streaming Responses API request over raw ``responses.create(stream=True)`` events."""
+    if client is not None:
+        return _run_codex_stream_body(agent, api_kwargs, client=client, on_first_delta=on_first_delta)
+    # ``client=None`` drives the SHARED primary client in place. Check it out for the whole request
+    # (twin of the per-request slot's ``in_use``) so a concurrent teardown — ``agent.close()`` — parks
+    # its close for this thread instead of shutting the transport down mid-stream, which leaves this
+    # request with no events and no error (silent hang). See #107475.
+    with agent._shared_client_checkout(reason="codex_stream_direct") as shared_client:
+        return _run_codex_stream_body(
+            agent, api_kwargs, client=shared_client, on_first_delta=on_first_delta, shared_primary=True)
+
+
+def _run_codex_stream_body(agent, api_kwargs: dict, client: Any = None, on_first_delta=None, *,
+                          shared_primary: bool = False):
     import httpx as _httpx
     from openai import APIConnectionError as _APIConnectionError
     from agent import relay_llm
@@ -960,9 +973,9 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 close_fn()
         except Exception:
             # A failed close can leave this connection checked out of the httpx pool while the caller
-            # reuse-caches the client; poison the slot so close really closes the pool. ``client is None``
-            # is the shared primary client — never force-shut.
-            if client is not None:
+            # reuse-caches the client; poison the slot so close really closes the pool. The shared primary
+            # client is never force-shut (``shared_primary`` / ``client is None``).
+            if not shared_primary:
                 agent._abort_request_openai_client(active_client, reason="codex_stream_close_failed")
     show_commentary = getattr(agent, "show_commentary", True)
     wants_commentary = getattr(agent, "interim_assistant_callback", None) is not None and show_commentary

--- a/run_agent.py
+++ b/run_agent.py
@@ -910,8 +910,12 @@ class AIAgent(
         memory provider are kept). Idempotent; distinct from ``close()``."""
         self._close_active_children(soft=True)
         # Retire (don't hard-close) the shared client: eviction runs on the gateway memory-manager thread,
-        # and a cross-thread close can release TLS FDs under a still-unwinding worker.
-        _quietly(self._drop_shared_client, lambda c: self._retire_shared_openai_client(c, reason="cache_evict"))
+        # and a cross-thread close can release TLS FDs under a still-unwinding worker. The shared-client
+        # teardown parks that work while a request still has the client checked out (#107475).
+        _quietly(
+            self._teardown_shared_client,
+            lambda c: self._retire_shared_openai_client(c, reason="cache_evict"), reason="cache_evict",
+        )
         self._close_request_clients("cache_evict")
 
     def close(self) -> None:
@@ -923,7 +927,10 @@ class AIAgent(
         _quietly(self.shutdown_memory_provider, session_messages if isinstance(session_messages, list) else None)
         self._close_task_resources(getattr(self, "session_id", None) or "")
         self._close_active_children(soft=False)
-        _quietly(self._drop_shared_client, lambda c: self._close_openai_client(c, reason="agent_close", shared=True))
+        _quietly(
+            self._teardown_shared_client,
+            lambda c: self._close_openai_client(c, reason="agent_close", shared=True), reason="agent_close",
+        )
         self._close_request_clients("agent_close")
         _quietly(self._close_codex_session)
         # Free conversation history proactively: callers may still hold the closed agent. The DB-flush
@@ -953,18 +960,6 @@ class AIAgent(
                 except Exception:
                     pass
             _quietly(lambda: child.close())
-
-    def _drop_shared_client(self, close_fn: Callable[[Any], None]) -> None:
-        """Hand the shared OpenAI/httpx client to ``close_fn`` and clear the attribute."""
-        # Retire the OpenAI/httpx client to release sockets immediately. #70773: eviction runs on the
-        # gateway's memory-manager thread — a cross-thread hard close of the shared client can release TLS
-        # FDs under a still-unwinding worker (FD-recycle → SQLite corruption). Retirement shuts the pooled
-        # sockets down (the memory/socket win we want here) and lets GC release the FDs once no thread holds
-        # them.
-        client = getattr(self, "client", None)
-        if client is not None:
-            close_fn(client)
-            self.client = None
 
     def _close_request_clients(self, reason: str) -> None:
         """Drop the cached per-request wire clients (reused across sequential LLM calls)."""

--- a/tests/run_agent/test_107475_shared_client_close_in_flight.py
+++ b/tests/run_agent/test_107475_shared_client_close_in_flight.py
@@ -1,0 +1,185 @@
+"""#107475: ``agent_close`` must not hard-close the shared OpenAI/httpx client under an in-flight request.
+
+The per-request wire client runs under an in-use guard: ``_close_cached_request_openai_client`` reads the
+slot's ``in_use`` flag and refuses to hard-close a client a worker has checked out (it aborts the sockets
+and lets the owning worker close). The shared primary client — driven IN PLACE by requests that get no
+per-request clone (codex-direct streams, iteration-limit summaries) — had no such check: ``close()``
+unconditionally closed it, so a request that was mid-stream lost its transport without an error and hung
+until a watchdog.
+
+These tests pin the reuse of the same guard:
+
+1. an in-flight request keeps its transport across a concurrent ``agent.close()`` and still completes;
+2. the parked close then runs from the request's own thread (the FD owner), once it releases;
+3. with nothing in flight the shared client is closed immediately, as before.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_agent():
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "codex_responses"
+    return agent
+
+
+def _delta_event(text):
+    return SimpleNamespace(type="response.output_text.delta", delta=text)
+
+
+def _completed_event():
+    return SimpleNamespace(
+        type="response.completed",
+        response=SimpleNamespace(usage=None, id="resp_1", status="completed"),
+    )
+
+
+class _StallingStream:
+    """Codex SSE stand-in: one delta, then a provider pause the test controls."""
+
+    def __init__(self, client):
+        self._client = client
+        self.streaming = threading.Event()  # first event delivered: the request is on the wire
+        self.release = threading.Event()    # let the provider deliver the rest
+
+    def __iter__(self):
+        yield _delta_event("partial ")
+        self.streaming.set()
+        while not self.release.is_set():
+            if self._client.closed_event.is_set():
+                # Transport torn down under the reader: the provider's remaining events never
+                # arrive and nothing raises — the silent hang the report describes. Bounded so a
+                # broken fix fails the assertions below instead of hanging the suite.
+                self.release.wait(timeout=5.0)
+                return
+            time.sleep(0.005)
+        yield _delta_event("more")
+        yield _completed_event()
+
+
+class _SharedClient:
+    """Shared primary client stand-in (not a Mock: ``_is_openai_client_closed`` reads ``is_closed``)."""
+
+    def __init__(self):
+        self.is_closed = False
+        self.close_calls = 0
+        self.close_thread = None
+        self.closed_event = threading.Event()
+        self.created = threading.Event()  # responses.create() reached: the request is on the wire
+        self.last_stream = None
+        self.responses = SimpleNamespace(create=self._create)
+
+    def _create(self, **kwargs):
+        self.last_stream = _StallingStream(self)
+        self.created.set()
+        return self.last_stream
+
+    def close(self):
+        self.close_calls += 1
+        self.close_thread = threading.current_thread().ident
+        self.closed_event.set()
+        self.is_closed = True
+
+
+class _ForceCloseSpy:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, client):
+        self.calls.append(client)
+        return 0
+
+
+def test_agent_close_leaves_the_transport_of_an_in_flight_request_alone():
+    from agent.codex_runtime import run_codex_stream
+
+    agent = _make_agent()
+    client = _SharedClient()
+    agent.client = client
+    force_close = _ForceCloseSpy()
+    agent._force_close_tcp_sockets = force_close
+    result = {}
+
+    def _request():
+        try:
+            result["response"] = run_codex_stream(agent, {"model": "test/model"})
+        except BaseException as exc:  # noqa: BLE001 - asserted below
+            result["error"] = exc
+
+    worker = threading.Thread(target=_request, daemon=True)
+    worker.start()
+    # No fixed sleep: wait until the request is genuinely mid-stream (first delta consumed), so the
+    # close below really interleaves with an in-flight request.
+    assert client.created.wait(timeout=30.0), f"request never reached the wire: {result.get('error')!r}"
+    assert client.last_stream.streaming.wait(timeout=30.0), (
+        f"request never consumed its first delta: {result.get('error')!r}"
+    )
+
+    agent.close()
+
+    assert client.close_calls == 0, "agent_close closed the shared client of an in-flight request"
+    assert force_close.calls == [], "agent_close force-shut the in-flight request's sockets"
+    assert agent.client is None, "the shared client must be dropped from the agent"
+
+    # The provider finishes normally because its transport was never touched.
+    client.last_stream.release.set()
+    worker.join(timeout=5.0)
+    assert not worker.is_alive(), "the in-flight request hung instead of completing"
+    assert "error" not in result, f"in-flight request failed: {result.get('error')!r}"
+    assert result["response"].output_text == "partial more"
+
+    # ...and the deferred close ran once, from the request's own thread (FD owner).
+    assert client.close_calls == 1
+    assert client.close_thread == worker.ident
+
+
+def test_agent_close_closes_the_shared_client_when_nothing_is_in_flight():
+    agent = _make_agent()
+    client = _SharedClient()
+    agent.client = client
+
+    agent.close()
+
+    assert (client.close_calls, client.close_thread) == (1, threading.current_thread().ident)
+    assert agent.client is None
+
+
+def test_release_clients_parks_the_shared_retirement_too():
+    """``release_clients`` (gateway cache evict) shares the guard: same in-flight deferral."""
+    agent = _make_agent()
+    client = _SharedClient()
+    agent.client = client
+    retired = []
+    agent._retire_shared_openai_client = lambda c, *, reason: retired.append((c, reason))
+
+    with agent._shared_client_checkout(reason="test_request"):
+        agent.release_clients()
+        assert (retired, agent.client) == ([], None), "retirement must be parked for the in-flight request"
+
+    assert [reason for _c, reason in retired] == ["cache_evict"]
+    assert retired[0][0] is client
+
+
+def test_shared_checkout_releases_on_failure():
+    agent = _make_agent()
+    agent.client = _SharedClient()
+
+    with pytest.raises(RuntimeError):
+        with agent._shared_client_checkout(reason="test_request"):
+            raise RuntimeError("request blew up")
+
+    assert agent._shared_in_flight() == 0


### PR DESCRIPTION
## What Problem This Solves

`AIAgent.close()` ("agent_close") hard-closed the **shared** OpenAI/httpx client unconditionally:

```python
# run_agent.py (pre-fix)
_quietly(self._drop_shared_client, lambda c: self._close_openai_client(c, reason="agent_close", shared=True))
self._close_request_clients("agent_close")
```

The per-request wire client right next to it runs under an **in-use guard** (`agent/client_lifecycle.py:450-460`): the teardown takes the slot, and when the client is checked out it *aborts the sockets and lets the owning worker do the real close* instead of hard-closing.

The shared primary client, however, is driven **in place** by requests that get no per-request clone, and nothing told `agent_close` they were there:

* `codex_responses` summaries: `agent/chat_completion_helpers.py:2075` → `run_codex_stream(api_kwargs)` with `client=None` → `agent/codex_runtime.py:873` resolves the **shared primary** client;
* chat summaries: `agent/chat_completion_helpers.py:2095` → `_ensure_primary_openai_client(...)` and then `chat.completions.create()` on that same shared client.

That asymmetry is the reported defect: a summary/aux stream that is mid-read on the shared client is silently destroyed by a concurrent `agent_close` — the request stops receiving events and raises nothing, so it hangs until a watchdog ends the turn.

## Evidence

The two paths side by side (line numbers as of the pre-fix tree):

```
agent/client_lifecycle.py:450  def _close_cached_request_openai_client(self, *, reason: str) -> None:
agent/client_lifecycle.py:452      client, in_use = self._take_request_slot(_OPENAI_SLOT)   # the in-use check
agent/client_lifecycle.py:455      if in_use:
agent/client_lifecycle.py:458          self._abort_request_openai_client(client, reason=f"{reason}_in_flight")
agent/client_lifecycle.py:460      else:
                                       self._close_openai_client(client, reason=reason, shared=False)

run_agent.py:926 (pre-fix)     _quietly(self._drop_shared_client,
                                   lambda c: self._close_openai_client(c, reason="agent_close", shared=True))
                               # no in-use question at all, and the shared client has no owning worker
                               # to defer to — so close() + _force_close_tcp_sockets() run immediately
```

Interleaving that produces the silent hang:

1. **worker thread** — the summary stream is mid-read on the shared client (socket checked out of its httpx pool, SSE frames in flight);
2. **control thread** — `agent.close()` → `_drop_shared_client` → `_close_openai_client(..., shared=True)` → `_force_close_tcp_sockets()` + `client.close()` **under the live reader**;
3. the worker receives no further event and no exception is raised, so it blocks until a watchdog kills it.

Why the per-request guard is sufficient for its own clients (and was reusable here): the teardown never closes a checked-out client; it shuts the sockets so the blocked read settles, and the request's own thread performs the close — the FD-ownership rule the file already documents (`#70773`, `_abort_request_slot_client`). `_force_close_tcp_sockets()` itself is already owner-scoped on a process-shared pool (`agent/agent_runtime_helpers.py::_iter_pool_sockets`), so the only thing missing was asking *"is anyone using the shared client right now?"* before touching it.

## Fix

Reuse the same in-use contract for the shared client, and make every shared-client teardown go through it:

* `agent/client_lifecycle.py` — `_shared_client_in_flight` counter (twin of the per-request slot's `in_use` flag), `_shared_client_checkout()` context manager (check out for one in-place request, release in a `finally`), and `_teardown_shared_client(close_fn, *, reason)`:
  * nothing in flight → `close_fn(client)` immediately (previous behaviour);
  * a request in flight → the agent drops its reference (`self.client = None`, so no new request can pick the parked client up) and **parks** the teardown; the last `_release_shared_client()` runs it from the request's own thread.
* `run_agent.py` — `close()` and `release_clients()` route through `_teardown_shared_client` (the `_drop_shared_client` helper it subsumes is deleted).
* `agent/codex_runtime.py` — `run_codex_stream(client=None)` now holds a `_shared_client_checkout` for the whole request; the body moved to `_run_codex_stream_body(..., shared_primary=True)` so the "never force-shut the shared primary" close-failure rule is preserved without relying on `client is None` being passed through.
* `agent/chat_completion_helpers.py` — `_chat_summary_attempt` runs its shared-client `create()` inside the checkout.

Per-request semantics are untouched: the request-client cache, its `in_use` flag, its abort-vs-close teardown and the MoA/Mock passthrough are exactly as before.

## Tests

`tests/run_agent/test_107475_shared_client_close_in_flight.py` (new, 4 tests, no fixed sleeps — `threading.Event` gates plus polling on events):

* `test_agent_close_leaves_the_transport_of_an_in_flight_request_alone` — a real `run_codex_stream` (shared primary, `client=None`) blocks mid-stream on a fake transport; a concurrent `agent.close()` must not close it, must not force-shut its sockets, and the parked close must run afterwards **on the request's own thread**, with the request completing normally (`output_text == "partial more"`). The fake stream models the report: if its transport is closed under the reader it never delivers another event and raises nothing.
* `test_agent_close_closes_the_shared_client_when_nothing_is_in_flight` — unchanged behaviour when idle.
* `test_release_clients_parks_the_shared_retirement_too` — the gateway cache-evict path shares the guard.
* `test_shared_checkout_releases_on_failure` — the counter cannot leak on an exception.

Verified locally: the two concurrency assertions fail (red) with the guard reverted to the pre-fix unconditional close, and with the checkout removed from `run_codex_stream` — i.e. the test is load-bearing for both halves of the fix — and pass with the fix in place. Existing suites (`tests/run_agent`, `tests/agent`, `tests/cron`) stay green, including `test_request_client_reuse*.py`, `test_tls_fd_recycle_corruption.py`, `test_70773_shared_client_fd_corruption.py` and `test_codex_app_server_lifecycle.py`.

Closes #107475
