### PR TITLE
fix(tui-gateway): three more sibling sites of the hidden-seed-row leak

### DIFF
--- a/tests/tui_gateway/test_seeded_hidden_row_sibling_sites.py
+++ b/tests/tui_gateway/test_seeded_hidden_row_sibling_sites.py
@@ -1,0 +1,102 @@
+"""Sibling sites of the seeded-session hidden-row saga (#107549/#107562): session.active_list's
+live sidebar item, session.history, and session.branch all reported a raw ``len(history)``/preview
+built from raw history, letting a display_kind="hidden" row (model-facing scaffolding the gateway
+never paints) leak into a count or preview text the way session.list/session.create/session.resume
+were already fixed not to."""
+
+import threading
+from types import SimpleNamespace
+
+from hermes_state import SessionDB
+from tui_gateway import server
+
+
+def _quiet_create(monkeypatch, db):
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda _sid: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+
+
+def _create(params: dict) -> dict:
+    resp = server.handle_request({"id": "create", "method": "session.create", "params": params})
+    assert "result" in resp, resp
+    return resp["result"]
+
+
+def test_active_list_hides_the_seed_row_from_preview_and_count(monkeypatch, tmp_path):
+    """A seeded, not-yet-persisted-past-create session is already live in ``_sessions`` and shows up
+    in session.active_list (the running-sessions sidebar) before the first prompt — its hidden opening
+    row must not leak into the preview text or inflate the count, the same invariant session.list's
+    DB-backed query already enforces."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _quiet_create(monkeypatch, db)
+    sid = None
+    try:
+        result = _create({
+            "cols": 96, "source": "desktop", "title": "Welcome to Hermes",
+            "messages": [
+                {"role": "user", "content": "Private setup runbook", "display_kind": "hidden"},
+                {"role": "assistant", "content": "Welcome to Hermes"},
+            ]})
+        sid = result["session_id"]
+
+        active = server.handle_request({"id": "active", "method": "session.active_list", "params": {}})
+        row = next(r for r in active["result"]["sessions"] if r["id"] == sid)
+
+        assert row["message_count"] == 1  # hidden row not counted, as session.create/session.resume count it
+        assert "Private setup runbook" not in row["preview"]
+        assert row["preview"].startswith("Welcome to Hermes")
+    finally:
+        if sid:
+            server._sessions.pop(sid, None)
+        db.close()
+
+
+def test_session_history_count_matches_the_wire(monkeypatch, tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _quiet_create(monkeypatch, db)
+    sid = None
+    try:
+        result = _create({
+            "cols": 96, "source": "desktop", "title": "Welcome",
+            "messages": [
+                {"role": "user", "content": "Private setup runbook", "display_kind": "hidden"},
+                {"role": "assistant", "content": "hi there"},
+            ]})
+        sid, key = result["session_id"], result["stored_session_id"]
+
+        history = server.handle_request({"id": "h", "method": "session.history", "params": {"session_id": sid}})
+        assert history["result"]["count"] == len(history["result"]["messages"]) == 1
+    finally:
+        if sid:
+            server._sessions.pop(sid, None)
+        db.close()
+
+
+def test_session_branch_message_count_matches_the_wire(monkeypatch, tmp_path):
+    """A branch child copies its parent's history; a hidden row in that history must not inflate
+    session.branch's own message_count past what its own messages array actually carries."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_build_branch_agent", lambda *a, **k: SimpleNamespace())
+    old_key = "parent-branch-src"
+    db.create_session(old_key, source="desktop")
+    db.append_message(old_key, "user", "Private setup runbook", display_kind="hidden")
+    db.append_message(old_key, "user", "real question")
+    db.append_message(old_key, "assistant", "real answer")
+    sid = "live-branch-src"
+    server._sessions[sid] = {"session_key": old_key, "history": [], "cols": 96, "history_lock": threading.Lock()}
+    new_sid = None
+    try:
+        resp = server.handle_request({"id": "b", "method": "session.branch", "params": {"session_id": sid}})
+        assert "result" in resp, resp
+        result = resp["result"]
+        new_sid = result["session_id"]
+        assert result["message_count"] == len(result["messages"])
+        assert not any(m.get("text") == "Private setup runbook" for m in result["messages"])
+    finally:
+        server._sessions.pop(sid, None)
+        if new_sid:
+            server._sessions.pop(new_sid, None)
+        db.close()

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1695,7 +1695,9 @@ def _(rid, params: dict, session: dict) -> dict:
                     # use. See #87059.
                     history = db.get_messages_as_conversation(
                         session["session_key"], include_ancestors=True, include_row_ids=True)
-    return _ok(rid, {"count": len(history), "messages": _history_to_messages(history)})
+    # Hidden seed rows are not on the wire; count what is (as session.create/session.resume do).
+    messages = _history_to_messages(history)
+    return _ok(rid, {"count": len(messages), "messages": messages})
 
 
 @_session_method("session.undo", live=True)
@@ -1965,8 +1967,10 @@ def _(rid, params: dict, session: dict) -> dict:
         agent = _build_branch_agent(session, new_sid, new_key, history, source)
     except Exception as e:
         return _err(rid, 5000, f"agent init failed on branch: {e}")
+    # Hidden seed rows are not on the wire; count what is (as session.create/session.resume do).
+    branch_messages = _history_to_messages(history)
     return _ok(rid, {"session_id": new_sid, "stored_session_id": new_key, "title": title, "parent": old_key,
-                     "message_count": len(history), "messages": _history_to_messages(history),
+                     "message_count": len(branch_messages), "messages": branch_messages,
                      "info": _session_info(agent, _sessions.get(new_sid))})
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2604,8 +2604,11 @@ def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
     status = _session_live_status(sid, session)
     inflight = _inflight_snapshot(session)
     queued = _queued_prompt_snapshot(session)
+    # display_kind="hidden": model-facing scaffolding (e.g. a seeded session's opening row) the
+    # gateway never paints — must not become the sidebar preview any more than session.list's does.
     preview = next((" ".join(text.split())[:160] for msg in reversed(history)
-                    if (text := _content_display_text(msg.get("content", msg.get("text", ""))).strip())), "")
+                    if msg.get("display_kind") != "hidden"
+                    and (text := _content_display_text(msg.get("content", msg.get("text", ""))).strip())), "")
     if queued:
         preview = " ".join(str(queued.get("user") or preview).split())[:160]
     elif inflight:
@@ -2614,7 +2617,8 @@ def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
     return {
         "current": sid == current_sid, "id": sid,
         "last_active": float(session.get("last_active") or session.get("created_at") or now),
-        "message_count": len(history),
+        # Hidden seed rows are not on the wire; count what is (as every other resume/create path does).
+        "message_count": len(_history_to_messages(history)),
         "model": str(getattr(agent, "model", "") or _resolve_model()), "preview": preview,
         "session_key": key, "started_at": float(session.get("created_at") or now), "status": status,
         "title": _session_live_title(session, key),


### PR DESCRIPTION
## Summary

`#107549`/`#107562` (merged earlier today, 2 review rounds) fixed a seeded session's `display_kind="hidden"` opening row (model-facing scaffolding the gateway never paints) leaking into `session.list`'s DB-backed preview query, and fixed the `message_count`/`messages` mismatch on `session.create` and `session.resume` (cold and live-reuse). Three sibling sites in the same file family have the identical shape and were left untouched, on raw/unfiltered `history`.

## What was missed

1. **`session.active_list`'s `_session_live_item`** (the live/in-process running-sessions sidebar, distinct from the DB-backed `session.list`): built its `preview` string from raw in-memory `history` with no `display_kind` filter, and reported `message_count` as the raw length. A freshly seeded session is already registered in `_sessions` and shows up here *before the first prompt* — so this is the exact same "hidden scaffolding leaks into a list view" bug the DB-backed query was fixed for, just in the separate live listing path nobody re-checked.
2. **`session.history`**: returned `count: len(history)` while `messages` was already `_history_to_messages(history)` (filtered) — the identical count/wire mismatch already fixed on `session.create`/`session.resume`.
3. **`session.branch`**: same count/wire mismatch as #2, for the history copied into a branch child.

## Fix

All three now count/preview what's actually on the wire — reusing the established `_history_to_messages()` filter, the same rule `session.create`/`session.resume` already apply. No new mechanism.

## Test plan

New `tests/tui_gateway/test_seeded_hidden_row_sibling_sites.py` (3 cases, real `SessionDB` + `server.handle_request` dispatch, mirroring the established harness in `test_seeded_session_create.py`):
- `session.active_list` on a freshly seeded session: `message_count == 1` (not 2) and the hidden row's text is absent from `preview`.
- `session.history`: `count == len(messages)`.
- `session.branch`: `message_count == len(messages)` on a branch copied from a parent with a hidden row.

Mutation-verify: reverting the fix reproduces all 3 failures with the exact predicted symptom (raw counts of 2/2/3 instead of 1/1/2, hidden text present). Existing `test_seeded_session_create.py` (6 tests) and the broader RPC-touching suite (`test_compute_host_phase1.py`, `test_hosted_room_server_rpc.py`, `test_inline_rpc_gil_starvation.py`, `test_session_history_codex_sidecar.py` — 29 tests total) pass unaffected. `ruff check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)