### PR TITLE
fix(update): report why the update check failed instead of a bare unreachable

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -391,6 +391,7 @@ import {
   resolveCommitLogSelection,
   shouldCountCommits
 } from './update-count'
+import { describeUpdateCheckFailure } from './update-diagnostics'
 import { waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
@@ -3174,7 +3175,12 @@ async function checkUpdates() {
         supported: true,
         branch,
         error: 'fetch-failed',
-        message: firstLine(target.stderr) || 'git ls-remote failed.',
+        message: describeUpdateCheckFailure({
+          remote: OFFICIAL_REPO_HTTPS_URL,
+          branch,
+          code: target.code,
+          stderr: target.stderr
+        }),
         hermesRoot: updateRoot,
         fetchedAt: Date.now()
       }
@@ -3223,7 +3229,12 @@ async function checkUpdates() {
       supported: true,
       branch,
       error: 'fetch-failed',
-      message: firstLine(fetched.stderr) || 'git fetch failed.',
+      message: describeUpdateCheckFailure({
+        remote: originUrl || 'origin',
+        branch,
+        code: fetched.code,
+        stderr: fetched.stderr
+      }),
       hermesRoot: updateRoot,
       fetchedAt: Date.now()
     }

--- a/apps/desktop/electron/update-diagnostics.test.ts
+++ b/apps/desktop/electron/update-diagnostics.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { classifyUpdateCheckFailure, describeUpdateCheckFailure, proxyHint } from './update-diagnostics'
+
+// Real stderr captured on Windows from the desktop check's own git invocation
+// (`git -c windows.appendAtomically=false fetch --quiet origin main`).
+const LOCAL_PATH_REMOTE_STDERR = [
+  "fatal: 'D:/definitely-not-a-repo-105855.git' does not appear to be a git repository",
+  'fatal: Could not read from remote repository.',
+  '',
+  'Please make sure you have the correct access rights'
+].join('\n')
+
+const DNS_STDERR =
+  "fatal: unable to access 'https://nonexistent-host.invalid/foo.git/': Could not resolve host: nonexistent-host.invalid"
+
+const LOCK_STDERR = "fatal: Unable to create 'C:/x/.git/shallow.lock': File exists."
+
+const TLS_STDERR =
+  "fatal: unable to access 'https://github.com/NousResearch/hermes-agent.git/': SSL certificate problem: unable to get local issuer certificate"
+
+const IMPLICIT_PROMPT_STDERR = "fatal: could not read Username for 'https://github.com': terminal prompts disabled"
+
+test('a non-network failure is never described as an unreachable server', () => {
+  const message = describeUpdateCheckFailure({
+    remote: 'D:/definitely-not-a-repo-105855.git',
+    branch: 'main',
+    code: 128,
+    stderr: LOCAL_PATH_REMOTE_STDERR,
+    env: {}
+  })
+
+  assert.doesNotMatch(message, /unreachable|reach the update server/i)
+  assert.match(message, /not a git repository/i)
+})
+
+test('a locked git metadata failure is classified as a lock, not as the network', () => {
+  const cause = classifyUpdateCheckFailure(LOCK_STDERR)
+
+  assert.match(cause, /lock/i)
+  assert.doesNotMatch(cause, /network|unreachable/i)
+})
+
+test('a TLS certificate failure is classified as a certificate problem', () => {
+  const cause = classifyUpdateCheckFailure(TLS_STDERR)
+
+  assert.match(cause, /certificate/i)
+  assert.doesNotMatch(cause, /unreachable/i)
+})
+
+test('a disabled credential prompt is classified as credentials, not as the network', () => {
+  const cause = classifyUpdateCheckFailure(IMPLICIT_PROMPT_STDERR)
+
+  assert.match(cause, /credential|login|auth/i)
+  assert.doesNotMatch(cause, /unreachable/i)
+})
+
+test('a genuine name-resolution failure is classified as a network failure', () => {
+  const cause = classifyUpdateCheckFailure(DNS_STDERR)
+
+  assert.match(cause, /DNS|network|connection/i)
+})
+
+test('the diagnostic names the URL, the exit code and the proxy state', () => {
+  const message = describeUpdateCheckFailure({
+    remote: 'https://github.com/NousResearch/hermes-agent.git',
+    branch: 'main',
+    code: 128,
+    stderr: DNS_STDERR,
+    env: { HTTPS_PROXY: 'http://user:secret@corp-proxy:8080' }
+  })
+
+  assert.match(message, /https:\/\/github\.com\/NousResearch\/hermes-agent\.git/)
+  assert.match(message, /exit 128/)
+  assert.match(message, /proxy/i)
+  // Which proxy variables are set, never their (credential-bearing) values.
+  assert.match(message, /HTTPS_PROXY/)
+  assert.doesNotMatch(message, /secret/)
+})
+
+test('the diagnostic survives a git failure that printed no stderr at all', () => {
+  const message = describeUpdateCheckFailure({
+    remote: 'origin',
+    branch: 'main',
+    code: 128,
+    stderr: '',
+    env: {}
+  })
+
+  assert.match(message, /exit 128/)
+  assert.match(message, /origin/)
+  assert.match(message, /no stderr/i)
+})
+
+test('proxyHint reports none set when the environment carries no proxy', () => {
+  assert.match(proxyHint({}), /none set/i)
+})
+
+test('proxyHint reports the variable names, never their values', () => {
+  const hint = proxyHint({ HTTPS_PROXY: 'http://user:secret@corp-proxy:8080', NO_PROXY: 'localhost' })
+
+  assert.match(hint, /HTTPS_PROXY/)
+  assert.match(hint, /NO_PROXY/)
+  assert.doesNotMatch(hint, /secret|corp-proxy/)
+})

--- a/apps/desktop/electron/update-diagnostics.ts
+++ b/apps/desktop/electron/update-diagnostics.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure diagnostics for a failed desktop update check.
+ *
+ * `checkUpdates()` in main.ts shells out to git; every nonzero exit used to come
+ * back to the UI as a bare `error: 'fetch-failed'` plus one raw stderr line.
+ * Both renderer surfaces then discarded even that line and worded the failure
+ * as "We couldn't reach the update server." That is true for only a subset of
+ * the failures: a misconfigured `origin`, a stale `.git/*.lock`, a disabled
+ * credential prompt or a TLS-intercepting proxy all arrive with exit code 128
+ * and look identical to an outage in the UI. On Windows those non-network
+ * failures are the common ones, so the bare wording sent users chasing the
+ * wrong problem.
+ *
+ * Extracted from main.ts so the classification is unit-testable without booting
+ * Electron (main.ts requires('electron') at load).
+ */
+
+type Env = Record<string, string | undefined>
+
+/** Proxy variables git honours. Their values routinely embed credentials
+ *  (`http://user:pass@host`), so only the NAMES are ever surfaced. */
+const PROXY_ENV_KEYS = ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy', 'ALL_PROXY', 'all_proxy'] as const
+const NO_PROXY_ENV_KEYS = ['NO_PROXY', 'no_proxy'] as const
+
+export interface UpdateCheckFailure {
+  /** Remote the check contacted: the origin URL, or the official HTTPS URL
+   *  substituted for passive SSH-official checks. */
+  remote?: string
+  branch?: string
+  /** git's exit code, or null when the process never started (spawn ENOENT). */
+  code?: number | null
+  /** Raw git stderr. */
+  stderr?: string
+  /** Injectable for tests; defaults to process.env. */
+  env?: Env
+}
+
+// Ordered; first match wins. Specific causes must precede the generic
+// "unable to access" rule, which git/curl also use for 429s and TLS failures.
+const FAILURE_RULES: readonly (readonly [RegExp, string])[] = [
+  [/HTTP 429|returned error: 429|rate limit/i, 'GitHub is rate limiting or having an outage (HTTP 429)'],
+  [/HTTP (?:500|502|503|504)|returned error: (?:500|502|503|504)/i, 'GitHub appears to be having an outage (HTTP 5xx)'],
+  [
+    /SSL certificate problem|certificate verify failed|unable to get local issuer certificate|schannel: next InitializeSecurityContext failed/i,
+    'TLS certificate not trusted (an intercepting proxy or antivirus root CA is the usual cause)'
+  ],
+  [
+    /Unable to create .*\.lock|\.lock'?: File exists|index\.lock/i,
+    'git metadata is locked by another git process (stale .git/*.lock)'
+  ],
+  [
+    /does not appear to be a git repository/i,
+    'the remote is not a git repository (misconfigured remote URL, not a network failure)'
+  ],
+  [
+    /Repository not found|repository .* not found|ERROR: Repository not found/i,
+    'the remote repository was not found (renamed, private, or wrong URL)'
+  ],
+  [
+    /could not read Username|terminal prompts disabled|Authentication failed|Permission denied \(publickey\)/i,
+    'the remote asked for credentials, and background checks never prompt'
+  ],
+  [
+    /Could not resolve host|Temporary failure in name resolution|getaddrinfo|Name or service not known/i,
+    'DNS lookup failed'
+  ],
+  [
+    /unable to access|Failed to connect|Connection (?:refused|timed out|reset)|network is unreachable|Could not read from remote repository|early EOF|proxy/i,
+    'network/connection failure'
+  ]
+]
+
+/** Map git stderr to a one-line cause. Never claims the network when stderr says otherwise. */
+export function classifyUpdateCheckFailure(stderr?: string): string {
+  const text = stderr || ''
+
+  return FAILURE_RULES.find(([pattern]) => pattern.test(text))?.[1] ?? 'unclassified git failure'
+}
+
+/** Which proxy variables the spawning process actually had. git reads these, so
+ *  "none set" in a GUI process whose shell exports them is itself the finding. */
+export function proxyHint(env: Env = process.env): string {
+  const keys = [...PROXY_ENV_KEYS, ...NO_PROXY_ENV_KEYS].filter(key => (env[key] || '').trim())
+
+  return keys.length ? `proxy: ${keys.join(', ')} set` : 'proxy: none set'
+}
+
+/** `user:pass@` in a URL is never worth emitting into a UI or a log. */
+function redactCredentials(text: string): string {
+  return text.replace(/(\/\/)[^/@\s]*@/g, '$1***@')
+}
+
+/**
+ * Build the message the update surfaces show verbatim: the remote actually
+ * contacted, git's exit code, the classified cause, git's own first stderr line
+ * and whether any proxy variable was set.
+ */
+export function describeUpdateCheckFailure(failure: UpdateCheckFailure): string {
+  const remote = redactCredentials(failure.remote || 'origin')
+  const where = failure.branch ? `${remote} (${failure.branch})` : remote
+  const code = failure.code === null || failure.code === undefined ? 'unknown' : failure.code
+  const rawLine = (failure.stderr || '').split('\n').find(line => line.trim())
+  const line = redactCredentials(rawLine?.trim() || '(git exited with no stderr)')
+
+  return `git failed (exit ${code}) contacting ${where} — ${classifyUpdateCheckFailure(failure.stderr)}. ${line} [${proxyHint(failure.env)}]`
+}

--- a/apps/desktop/src/app/settings/about-settings.tsx
+++ b/apps/desktop/src/app/settings/about-settings.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { type Translations, useI18n } from '@/i18n'
 import { AlertTriangle, CheckCircle2, ExternalLink, Loader2, RefreshCw } from '@/lib/icons'
+import { updateFailureDetail } from '@/lib/update-failure-detail'
 import { cn } from '@/lib/utils'
 import {
   $desktopVersion,
@@ -83,7 +84,7 @@ export function AboutSettings() {
     statusLine = status?.message ?? a.cantUpdate
     statusTone = 'error'
   } else if (status?.error) {
-    statusLine = a.cantReach
+    statusLine = updateFailureDetail(status, a.cantReach)
     statusTone = 'error'
   } else if (applying) {
     statusLine = a.installing

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -19,6 +19,7 @@ import { useI18n } from '@/i18n'
 import { buildCommitChangelog, type CommitGroup } from '@/lib/commit-changelog'
 import { AlertCircle, Check, Copy, Terminal } from '@/lib/icons'
 import { resolveUpdateCopy, type UpdateTarget } from '@/lib/update-copy'
+import { updateFailureDetail } from '@/lib/update-failure-detail'
 import { cn } from '@/lib/utils'
 import {
   $backendUpdateApply,
@@ -214,7 +215,7 @@ function IdleView({
             {u.tryAgain}
           </Button>
         }
-        body={u.connectionRetry}
+        body={updateFailureDetail(status, u.connectionRetry)}
         icon={<ErrorIcon />}
         title={u.checkFailedTitle}
       />

--- a/apps/desktop/src/lib/update-failure-detail.test.ts
+++ b/apps/desktop/src/lib/update-failure-detail.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { updateFailureDetail } from './update-failure-detail'
+
+test("a backend/bridge diagnostic is shown verbatim instead of the surface's generic line", () => {
+  const detail = updateFailureDetail(
+    { message: 'git failed (exit 128) talking to origin — remote is not a git repository' },
+    "We couldn't reach the update server."
+  )
+
+  assert.match(detail, /exit 128/)
+  assert.doesNotMatch(detail, /couldn't reach the update server/i)
+})
+
+test('the generic line is the fallback only when there is nothing to report', () => {
+  const fallback = "We couldn't reach the update server."
+
+  assert.equal(updateFailureDetail(null, fallback), fallback)
+  assert.equal(updateFailureDetail(undefined, fallback), fallback)
+  assert.equal(updateFailureDetail({}, fallback), fallback)
+  assert.equal(updateFailureDetail({ message: '' }, fallback), fallback)
+  assert.equal(updateFailureDetail({ message: '   \n  ' }, fallback), fallback)
+})
+
+test('the detail is trimmed so a trailing newline from git stderr cannot break layout', () => {
+  assert.equal(updateFailureDetail({ message: ' fatal: boom\n' }, 'fallback'), 'fatal: boom')
+})

--- a/apps/desktop/src/lib/update-failure-detail.ts
+++ b/apps/desktop/src/lib/update-failure-detail.ts
@@ -1,0 +1,17 @@
+/**
+ * What a failed update check should say.
+ *
+ * The Electron bridge/backend already reports WHY a check failed (git's exit
+ * code, the remote it contacted, the classified cause). Both update surfaces
+ * used to drop that on the floor and print a fixed "we couldn't reach the
+ * update server" line instead, which is a false diagnosis for everything that
+ * is not actually a network failure — a misconfigured remote, a locked
+ * `.git/*.lock`, a disabled credential prompt, a TLS-intercepting proxy. This
+ * helper is the single place the detail is surfaced, so a new surface cannot
+ * silently reintroduce the bare wording.
+ */
+export function updateFailureDetail(status: { message?: string } | null | undefined, fallback: string): string {
+  const message = typeof status?.message === 'string' ? status.message.trim() : ''
+
+  return message || fallback
+}


### PR DESCRIPTION
## What Problem This Solves

The Desktop update UI answers **"We couldn't reach the update server."** ("Check your connection and try again." in the overlay) for *every* way a check can fail, with no detail a user can act on. The reporter's own machine can disprove the claim with a plain `git ls-remote`/`git fetch` or a system HTTPS request, and the panel gives them nothing — no URL, no exit code, no cause.

Why the message is a misdiagnosis rather than just terse:

- `checkUpdates()` in `apps/desktop/electron/main.ts` shells out to git and returns `error: 'fetch-failed'` for **any** nonzero exit, plus one raw stderr line;
- **both** surfaces then threw that line away and printed a hard-coded string instead — `apps/desktop/src/app/settings/about-settings.tsx` and `apps/desktop/src/app/updates-overlay.tsx`;
- exit code 128 is shared by failures that have nothing to do with the network: a misconfigured `origin`, a stale `.git/*.lock`, a disabled credential prompt, a TLS-intercepting proxy, the Git-for-Windows trampoline shim. On Windows those are the common ones, so "unreachable" is the *least* likely correct answer while being the only one ever shown.

After this change the failure reports itself: the remote actually contacted, git's exit code, a classified cause, git's own first stderr line, and which proxy variables the spawned git actually had. Proxy **values** are never printed (they routinely embed credentials) and `user:pass@` inside URLs is redacted.

## Changes

- `apps/desktop/electron/update-diagnostics.ts` (new, pure, no Electron import): `classifyUpdateCheckFailure()` (HTTP 429/5xx → TLS certificate → git lock → not-a-git-repository → repository-not-found → credentials → DNS → network → unclassified, first match wins) and `describeUpdateCheckFailure()`.
- `apps/desktop/electron/main.ts`: both failure paths of `checkUpdates()` — the passive `ls-remote` used for official SSH remotes and the `fetch` used everywhere else — now build that message instead of `firstLine(stderr) || 'git fetch failed.'`.
- `apps/desktop/src/lib/update-failure-detail.ts` (new, pure): the one place both surfaces read the detail from, so a new surface cannot silently reintroduce the bare wording; the old string survives only as the empty-message fallback.
- Regression tests for both files (`apps/desktop/electron/update-diagnostics.test.ts`, `apps/desktop/src/lib/update-failure-detail.test.ts`).

No i18n keys were added or removed, so the translations stay as they are.

## Evidence

### Not reproduced: the reporter's network failure

This machine is Windows 11 with a git install (`git version 2.55.0.windows.1`, no proxy env vars, no `git config http.proxy`). The update-check network path **succeeds** here, both through the backend CLI and through the exact git command shape the desktop check uses:

```
$ python -m hermes_cli.main update --check
→ Fetching from origin...
⚕ Update available: 2 commits behind origin/main.
  Run 'hermes update' to install.
elapsed_ms=50055
```

```
# desktop command shape, three ways of resolving git — all exit 0
shim(desktop-resolved: C:/Program Files/Git/cmd/git.exe)  exit=0 elapsed_ms=3996
git-core (…/mingw64/libexec/git-core/git.exe)              exit=0 elapsed_ms=3396
bash-PATH-git (git)                                        exit=0 elapsed_ms=8111
```

So the reporter's *network* condition is **unconfirmed** — I could not reproduce "the server is unreachable while direct HTTPS and git work". Nothing in this PR claims otherwise.

### Reproduced: the misdiagnosis (what the issue is actually asking for)

Using the desktop check's own git invocation against a **non-network** broken remote, on this machine:

```
origin = D:/definitely-not-a-repo-105855.git
  git -c windows.appendAtomically=false fetch --quiet origin main  -> exit=128
  fatal: 'D:/definitely-not-a-repo-105855.git' does not appear to be a git repository
  fatal: Could not read from remote repository.

origin = https://nonexistent-host-105855.invalid/foo.git
  git -c windows.appendAtomically=false fetch --quiet origin main  -> exit=128
  fatal: unable to access 'https://nonexistent-host-105855.invalid/foo.git/': Could not resolve host: nonexistent-host-105855.invalid
```

Both are `error: 'fetch-failed'`, and before this change About rendered both as *"We couldn't reach the update server."* — a network claim for a local misconfiguration. After the change the first one reads:

```
git failed (exit 128) contacting D:/definitely-not-a-repo-105855.git (main) — the remote is not a
git repository (misconfigured remote URL, not a network failure). fatal: 'D:/…' does not appear to
be a git repository [proxy: none set]
```

**Evidence boundary:** the classification fix is verified by real git invocations on this machine (above) plus the unit tests; the *reporter's* failure is code analysis only.

### Conditions that would still be reported as unreachable (code analysis, not observed here)

1. Any non-network nonzero exit — misconfigured/renamed remote, Git-for-Windows trampoline shim failure (`#87876`), filesystem/AV interference. Addressed: classified and named now.
2. A proxy exported only in the user's shell profile (`HTTPS_PROXY` in `.bashrc`/profile): the Electron GUI is not launched from that shell, so the spawned git gets no proxy while the user's terminal git does. Same binary, different environment — the classic "works in my terminal, fails in the app". The new message ends with `[proxy: …]`, so this is now visible instead of invisible.
3. A nonzero exit with empty stderr previously produced the literal `git fetch failed.`; now it produces the exit code, remote and `(git exited with no stderr)`.

### Tests

Runner (this checkout has no `scripts/run-vitest.mjs`):

```
cd apps/desktop
node ../../node_modules/vitest/vitest.mjs run electron/update-diagnostics.test.ts \
  src/lib/update-failure-detail.test.ts --maxWorkers=1 --no-file-parallelism
```

**Red before the implementation** (files absent):

```
FAIL |electron| electron/update-diagnostics.test.ts
  Error: Cannot find module './update-diagnostics' imported from …
FAIL |ui| src/lib/update-failure-detail.test.ts
  Error: Failed to resolve import "./update-failure-detail" … Does the file exist?
Test Files  2 failed (2) | Tests  no tests
```

**Green after**:

```
Test Files  2 passed (2)
     Tests  12 passed (12)
```

**Sabotage check** (classifier forced to return the generic network cause; `updateFailureDetail` forced to always return the fallback):

```
Test Files  2 failed (2)
     Tests  6 failed | 6 passed (12)
EXIT=1
```

Reverted → `12 passed (12)`, `EXIT=0`.

Related suites:

- `node ../../node_modules/vitest/vitest.mjs run src/lib/update-failure-detail.test.ts src/store/updates.test.ts --maxWorkers=1 --no-file-parallelism` → `Test Files 2 passed (2) | Tests 68 passed (68)`.
- `tsc -p tsconfig.electron.json --noEmit` → `EXIT=0`.
- `tsc -p . --noEmit` → `EXIT=2`, reporting only `src/app/messaging/telegram-qr-setup.tsx(48,31): error TS2307: Cannot find module 'qrcode'`. This is **pre-existing**: with all of this PR's changes stashed away, the same command reports the identical single error. It is a local/node_modules gap in this checkout, untouched here.
- Full `--project electron` run: `12 failed | 148 passed | 1 skipped` files, `40 failed | 2134 passed | 6 skipped` tests. Every failure is pre-existing/environmental and reproducible on the unmodified tree: with `apps/desktop` checked out at the PR base I get the same `10 failed` files and the same count per file (38 tests). The 2 extra files in the full run (`git-review-ops.test.ts`, `pool-spawn-coordinator.test.ts`) are `Test timed out in 5000ms` on tests that spawn real child processes under full-suite load; both pass in isolation at this PR's HEAD (`Test Files 2 passed (2) | Tests 30 passed (30)`). The rest are Windows platform assumptions: 8.3 short paths (`ADMINI~1`), `chmod` modes, ssh `Include` handling.
- `prettier --check` on all 7 touched files → `All matched files use Prettier code style!`. `eslint` is not installed in this checkout, so lint was not run locally.

## Remaining

This is a diagnosis fix, not a repair of the reporter's environment. The condition that made their check fail on Windows is still unconfirmed; the app now says which of the candidates it was instead of blaming the network, which is what the report asked for. Two follow-ups belong in a separate change and are deliberately not here: a timeout on `runGit` (the check has none, and a hung credential-manager prompt can hang the check indefinitely — note it does not set `GCM_INTERACTIVE=Never`, unlike the backend's `hermes_cli/update_cmd.py`), and surfacing the same classification in the `hermes:updates:check` IPC catch handler.

**Not closing #105855:** this is a partial fix — the environment condition behind the report is unconfirmed, so the issue should stay open for the reporter's data. The `Closes #105855` keyword is deliberately absent for that reason.
