### PR TITLE
feat(desktop): show canonical model slugs in the model picker

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -22,7 +22,7 @@ import type { HermesGateway } from '@/hermes'
 import { getLocalModelsStatus } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { catalogProviderMatches, modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
-import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
+import { displayModelName, modelDisplayParts, modelSlugSuffix } from '@/lib/model-status-label'
 import { DEFAULT_REASONING_EFFORT, reasoningEffortLabel } from '@/lib/reasoning-effort'
 import { foldIncludes, normalize } from '@/lib/text'
 import { useStoreSelector } from '@/lib/use-session-slice'
@@ -470,6 +470,12 @@ export function ModelCatalogMenu({
                 >
                   <span className="truncate">
                     <HighlightMatches foldSeparators query={search} text={group.provider.name} />
+                    {group.provider.slug.toLowerCase() !== group.provider.name.toLowerCase() ? (
+                      <span className="font-normal normal-case tracking-normal text-(--ui-text-quaternary)">
+                        {' '}
+                        {group.provider.slug}
+                      </span>
+                    ) : null}
                   </span>
                   <DisclosureCaret
                     className="shrink-0 text-(--ui-text-tertiary) opacity-0 transition group-hover/label:opacity-100"
@@ -488,7 +494,8 @@ export function ModelCatalogMenu({
                         : null
 
                     const isCurrent = activeId !== null
-                    const name = modelDisplayParts(family.id).name
+                    const { name, tag } = modelDisplayParts(family.id)
+                    const slugSuffix = modelSlugSuffix(family.id)
                     const caps = group.provider.capabilities?.[family.id]
 
                     // Managed local model loading into memory right now:
@@ -541,10 +548,21 @@ export function ModelCatalogMenu({
                           }}
                           {...kbRowProps(`${group.provider.slug}:${family.id}`)}
                         >
-                          <span className="min-w-0 flex-1 truncate">
-                            <HighlightMatches foldSeparators query={search} text={name} />
-                            {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
-                          </span>
+                          <div className="min-w-0 flex-1">
+                            <span className="block truncate">
+                              <HighlightMatches foldSeparators query={search} text={name} />
+                              {tag && (!meta || !meta.includes(tag)) ? (
+                                <span className="text-(--ui-text-tertiary)"> {tag}</span>
+                              ) : null}
+                              {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
+                            </span>
+                            <span
+                              className="block truncate text-[0.625rem] text-(--ui-text-quaternary)"
+                              title={family.id}
+                            >
+                              {slugSuffix}
+                            </span>
+                          </div>
                           {loadProgress ? (
                             <span
                               className="ml-auto flex shrink-0 items-center gap-1.5"

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -13,7 +13,7 @@ import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { Search } from '@/lib/icons'
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
-import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
+import { displayModelName, modelDisplayParts, modelSlugSuffix } from '@/lib/model-status-label'
 import { foldIncludes, normalize } from '@/lib/text'
 import {
   $visibleModels,
@@ -145,6 +145,7 @@ export function ModelVisibilityDialog({
                   {!collapsed &&
                     models.map(family => {
                       const { name, tag } = modelDisplayParts(family.id)
+                      const slugSuffix = modelSlugSuffix(family.id)
                       const key = modelVisibilityKey(provider.slug, family.id)
 
                       return (
@@ -152,10 +153,18 @@ export function ModelVisibilityDialog({
                           className="flex cursor-pointer items-center gap-2 px-3 py-1 text-xs hover:bg-(--ui-control-active-background)"
                           key={key}
                         >
-                          <span className="min-w-0 flex-1 truncate">
-                            <HighlightMatches foldSeparators query={search} text={name} />
-                            {tag ? <span className="text-(--ui-text-tertiary)"> {tag}</span> : null}
-                          </span>
+                          <div className="min-w-0 flex-1">
+                            <span className="block truncate">
+                              <HighlightMatches foldSeparators query={search} text={name} />
+                              {tag ? <span className="text-(--ui-text-tertiary)"> {tag}</span> : null}
+                            </span>
+                            <span
+                              className="block truncate text-[0.625rem] text-(--ui-text-quaternary)"
+                              title={family.id}
+                            >
+                              {slugSuffix}
+                            </span>
+                          </div>
                           <Switch
                             checked={visible.has(key)}
                             onCheckedChange={() => toggle(provider, family.id)}

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -4,7 +4,8 @@ import {
   currentPickerSelection,
   displayModelName,
   formatModelStatusLabel,
-  modelDisplayParts
+  modelDisplayParts,
+  modelSlugSuffix
 } from './model-status-label'
 import { reasoningEffortLabel } from './reasoning-effort'
 
@@ -31,6 +32,16 @@ describe('model-status-label', () => {
     expect(modelDisplayParts('some-model-Q6_K')).toEqual({ name: 'Some Model', tag: 'Q6' })
     // Cloud ids keep their existing behavior.
     expect(modelDisplayParts('anthropic/claude-opus-4.8-fast').tag).toBe('Fast')
+  })
+
+  it('returns the full provider-qualified slug for disambiguation', () => {
+    expect(modelSlugSuffix('gc/grok-4.6')).toBe('gc/grok-4.6')
+    expect(modelSlugSuffix('kilo/deepseek-v4-flash-0731')).toBe('kilo/deepseek-v4-flash-0731')
+    expect(modelSlugSuffix('openrouter/anthropic/claude-opus-4.8')).toBe('openrouter/anthropic/claude-opus-4.8')
+    expect(modelSlugSuffix('  kilo/deepseek-v4-flash-0731  ')).toBe('kilo/deepseek-v4-flash-0731')
+    expect(modelSlugSuffix('gpt-5.5')).toBe('')
+    expect(modelSlugSuffix('')).toBe('')
+    expect(modelSlugSuffix('  ')).toBe('')
   })
 
   it('maps reasoning effort to compact labels', () => {

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -109,6 +109,19 @@ export function displayModelName(model: string): string {
   return modelDisplayParts(model).name
 }
 
+/** Provider-qualified slug for a model id (`kilo/deepseek-v4-flash-0731`).
+ *  Empty when the id carries no provider segment — bare ids need no
+ *  disambiguation. Aggregators serve the same base name under many upstream
+ *  prefixes, and the pretty display name collapses them to identical labels,
+ *  so rows render this as a subtitle beneath the display name (#58566, #94706). */
+export function modelSlugSuffix(model: string): string {
+  const trimmed = model.trim()
+  if (!trimmed || !trimmed.includes('/')) {
+    return ''
+  }
+  return trimmed
+}
+
 /** Status bar trigger label — model name plus the live session state (effort/fast).
  *  `defaultEffort` is the profile's configured level, used when the surface has
  *  no explicit effort so the label never advertises a default the agent won't use. */


### PR DESCRIPTION
# Title
feat(desktop): show canonical model slugs in the model picker

# Base
main

# Head
b3nw:feat/desktop-model-slug

# Body
## Summary
Aggregators and multi-endpoint providers prefix models with upstream routing segments (e.g. `gc/grok-4.6` vs `grok-cli/grok-4.6`, `kilo/deepseek` vs `infrex/deepseek`), but the desktop model picker prettifier collapses them into identical labels (`Grok 4.6`, `Deepseek`), making it impossible to distinguish active upstreams or know which target is toggled in the visibility settings.

This PR:
- Unconditionally renders a muted subtitle line (`text-[0.625rem] text-(--ui-text-quaternary)`) with the canonical provider-qualified slug beneath every model item in both the model catalog menu and the "Edit Models" visibility dialog.
- Displays the provider slug in group headers when it differs from the provider display name.
- Exports and tests `modelSlugSuffix()` in `apps/desktop/src/lib/model-status-label.ts`.
- Wraps two-line model rows in `<div className="min-w-0 flex-1">` so existing test queries matching `span` continue targeting the single label span without collision.
- Guards variant tag rendering so tags do not duplicate qualifiers already present in `meta`.

Addresses #58566
Fixes #94706
Refs #88881

## Test Plan
- `npm run typecheck` in `apps/desktop`: 0 errors.
- `npx vitest run src/lib/model-status-label.test.ts src/app/shell/model-menu-panel.test.tsx`: 35/35 passing.
- `npx vitest run src/app/shell/model-catalog-menu.test.tsx src/app/shell/model-catalog-menu.search-fold.test.tsx src/components/model-picker.test.tsx`: 12/12 passing.
- Prettier check clean across all modified files.
