### PR TITLE
fix(gateway): stop dropping in-flight replies when the shutdown drain times out

### DIFF
--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -30,6 +30,12 @@ from gateway.shutdown_watchdog import arm_shutdown_watchdog, resolve_shutdown_wa
 # Log-record parity with the origin module.
 logger = logging.getLogger("gateway.run")
 
+# Bounded window for replies whose agent loop already ended but whose send has not reached the adapter
+# yet (see ``_settle_reply_deliveries``). ``_running_agents`` is released when the agent loop returns,
+# so the drain is blind to them; without the window the adapter is disconnected under the send. Clamped
+# to the remaining shutdown-watchdog leash by the caller, so it can never cost us the watchdog.
+_REPLY_DELIVERY_GRACE_S = 5.0
+
 
 def _exit_with_failure_verdict(runner) -> bool:
     """True (after logging the reason) when the runner asked for a failure exit."""
@@ -1573,6 +1579,65 @@ class GatewayShutdownMixin:
         await self._notify_active_sessions_of_shutdown()
         logger.info("Shutdown phase: notify_active_sessions done at +%.2fs", ctx.elapsed())
 
+    def _undelivered_reply_session_keys(self) -> list:
+        """Sessions whose turn already left ``_running_agents`` but has not handed its reply to the adapter.
+
+        ``gateway/run_turn.py`` releases the session slot as soon as the agent loop returns
+        (``_run_agent_cleanup_turn_tasks``), while the reply is shaped, persisted and sent afterwards in
+        ``_handle_message_with_agent``. The durable active-turn marker is the accurate signal: it is set
+        before the turn runs and cleared (``_clear_durable_active_turn``) only once delivery is done.
+        Best-effort — a shutdown must never fail on this probe.
+        """
+        entries = getattr(getattr(self, "session_store", None), "_entries", None)
+        if not isinstance(entries, dict):
+            return []
+        with suppress(Exception):
+            return [
+                key for key, entry in list(entries.items())
+                if getattr(entry, "active_turn_token", None)
+            ]
+        return []
+
+    async def _settle_reply_deliveries(self, timeout: float, ctx: "GatewayShutdownMixin._StopContext") -> None:
+        """Give replies that are mid-delivery a bounded window, then arm recovery for any that miss it.
+
+        Adapters are disconnected in the next ``_stop_*`` phase, so a reply still in flight here would
+        be lost with no trace: its session is absent from ``_running_agents``, so the drain reported no
+        work, nothing gets a ``resume_pending`` marker, and ``.clean_shutdown`` makes the next boot
+        discard the active-turn marker (``discard_active_turn_markers``) instead of recovering the turn.
+        """
+        left = self._undelivered_reply_session_keys()
+        if not left:
+            return
+        # Never eat the shutdown watchdog's leash: it hard-exits past it.
+        budget = max(0.0, min(
+            _REPLY_DELIVERY_GRACE_S,
+            resolve_shutdown_watchdog_delay(timeout) - ctx.elapsed() - 1.0,
+        ))
+        logger.info(
+            "Shutdown drain: %d reply/replies still mid-delivery (the agent loop already ended) — "
+            "holding the transport open for up to %.1fs", len(left), budget,
+        )
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + budget
+        while left and loop.time() < deadline:
+            await asyncio.sleep(0.05)
+            left = self._undelivered_reply_session_keys()
+        if not left:
+            return
+        # Out of budget: the reply cannot land. Mark the session resumable and report the drain as
+        # timed out so ``.clean_shutdown`` is skipped (see ``_stop_persist_exit_state``) and the next
+        # boot auto-resumes the turn instead of discarding its marker as an orphan.
+        logger.warning(
+            "Shutdown: %d reply/replies were still mid-delivery after %.1fs — arming resume_pending so "
+            "the next boot recovers them", len(left), budget,
+        )
+        reason = "restart_timeout" if self._restart_requested else "shutdown_timeout"
+        for _key in left:
+            with _log_suppressed(logging.DEBUG, "mark_resume_pending for an undelivered reply failed for %s: %s", _key):
+                await self.async_session_store.mark_resume_pending(_key, reason)
+        ctx.timed_out = True
+
     async def _stop_drain_active_work(self, timeout: float, ctx: "GatewayShutdownMixin._StopContext") -> None:
         """Pre-mark resume_pending, drain agents/cron/API work into ``ctx``."""
         from gateway.run import GatewayRunner
@@ -1606,6 +1671,9 @@ class GatewayShutdownMixin:
             self._active_cron_job_count(), _api_at_start, self._active_api_run_count(),
             _deferred_at_start, ctx.deferred_count(),
         )
+        # Replies that already left ``_running_agents`` but have not reached the adapter are invisible
+        # to the drain above; settle them while the transport is still connected.
+        await self._settle_reply_deliveries(timeout, ctx)
         if ctx.timed_out:
             return
         # Graceful drain: clear the pre-drain resume_pending markers so sessions that finished

--- a/tests/gateway/test_105364_undelivered_reply_shutdown.py
+++ b/tests/gateway/test_105364_undelivered_reply_shutdown.py
@@ -1,0 +1,111 @@
+"""Regression: a reply that is mid-delivery when the gateway stops must not vanish silently.
+
+A turn's agent loop ends inside ``_run_agent``, which releases the session's ``_running_agents``
+slot (``gateway/run_turn.py::_run_agent_cleanup_turn_tasks``) as soon as the agent returns. The
+reply itself is shaped, persisted and handed to the adapter *after* that, in
+``_handle_message_with_agent``. The shutdown drain only counts ``_running_agents`` / cron / api /
+deferred work, so a reply in that window is invisible: the drain reports no work, the adapter is
+disconnected underneath the send, and because ``ctx.timed_out`` stayed False the shutdown writes
+``.clean_shutdown`` — which makes the next boot call ``discard_active_turn_markers()`` and throw the
+session's durable active-turn marker away instead of recovering the interrupted turn. The reply is
+lost with no user-visible notice. See #105364.
+
+``active_turn_token`` is the accurate \"this session still owes the user a reply\" signal:
+``_mark_durable_active_turn`` sets it before the turn runs and ``_clear_durable_active_turn`` clears
+it only once delivery is done.
+"""
+
+import asyncio
+import time
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, SessionStore
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+def _runner_with_active_turn(tmp_path):
+    """Runner whose only in-flight work is a turn that has not delivered its reply yet."""
+    runner, _adapter = make_restart_runner()
+    store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", user_id="u1")
+    entry = store.get_or_create_session(source)
+    entry.active_turn_token = "tok-1"
+    entry.active_turn_started_at = datetime.now()
+    runner.session_store = store
+    return runner, entry
+
+
+def _ctx():
+    ctx = GatewayRunner._StopContext(deferred_count=lambda: 0)
+    ctx.started_at = time.monotonic()
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_drain_waits_for_a_reply_that_is_mid_delivery(tmp_path, monkeypatch):
+    """The shutdown must hold the transport open until the in-flight reply lands.
+
+    The delivery task is only spawned from the drain's *first* probe, so it can only complete if the
+    drain yields — a drain that returns without waiting never sees the reply land.
+    """
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    runner, entry = _runner_with_active_turn(tmp_path)
+    delivered: list[str] = []
+
+    async def _finish_delivery() -> None:
+        # Stands in for the turn's adapter send, still in flight when the drain starts.
+        delivered.append(entry.session_key)
+        entry.active_turn_token = None  # runner._clear_durable_active_turn
+
+    probes = {"n": 0}
+
+    def _probe() -> list:
+        probes["n"] += 1
+        if probes["n"] == 1:
+            asyncio.get_running_loop().create_task(_finish_delivery())
+            return [entry.session_key]
+        return [entry.session_key] if entry.active_turn_token else []
+
+    monkeypatch.setattr(runner, "_undelivered_reply_session_keys", _probe)
+
+    await runner._stop_drain_active_work(0.0, _ctx())
+
+    assert probes["n"] > 1, (
+        "the drain returned without waiting for a reply that was still mid-delivery"
+    )
+    assert delivered == [entry.session_key]
+    assert entry.active_turn_token is None
+
+
+@pytest.mark.asyncio
+async def test_reply_that_never_lands_arms_recovery_instead_of_a_clean_shutdown(tmp_path, monkeypatch):
+    """A reply that cannot be delivered must be recoverable, never a silent loss."""
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    monkeypatch.setattr("gateway.run_shutdown._REPLY_DELIVERY_GRACE_S", 0.3)
+    runner, entry = _runner_with_active_turn(tmp_path)
+    ctx = _ctx()
+
+    await runner._stop_drain_active_work(0.0, ctx)
+
+    # No delivery happened, so the turn must be resumable on the next boot ...
+    assert entry.resume_pending is True
+    assert entry.resume_reason == "shutdown_timeout"
+    # ... and the drain must report the timeout so the shutdown does not write .clean_shutdown:
+    # a clean receipt makes the next boot discard the active-turn marker
+    # (discard_active_turn_markers) instead of recovering the turn.
+    assert ctx.timed_out is True
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.release_gateway_runtime_lock"), \
+            patch("gateway.run._shutdown_gateway_health_export"):
+        runner._update_runtime_status = MagicMock()
+        runner._stop_persist_exit_state(ctx)
+
+    assert not (tmp_path / ".clean_shutdown").exists(), (
+        "a reply was still undelivered, yet the shutdown wrote .clean_shutdown — the next boot will "
+        "discard the active-turn marker and never recover the turn"
+    )


### PR DESCRIPTION
## What Problem This Solves

A turn's agent loop ends inside `_run_agent`, which releases the session's `_running_agents` slot
(`gateway/run_turn.py::_run_agent_cleanup_turn_tasks`) as soon as the agent returns. The reply
itself is shaped, persisted and handed to the adapter *after* that, back in
`_handle_message_with_agent` (`gateway/run_turn.py:1992-2019`).

The shutdown drain only counts `_running_agents` / cron / api_server / deferred work
(`gateway/run_shutdown.py::_drain_work_counts`). So a reply in that window is invisible to it: the
drain reports "no work", `ctx.timed_out` stays `False`, the next phase disconnects every adapter
(`_stop_finalize_agents_and_adapters`) with the send still in flight, and because the drain was
considered clean the shutdown writes `.clean_shutdown` (`_stop_persist_exit_state`). On the next
boot that receipt makes `_consume_clean_shutdown_marker` call `discard_active_turn_markers()`, which
throws the session's durable active-turn marker away instead of recovering the interrupted turn. The
user gets no reply and no notice — the reply is gone with no trace on disk.

The fix keys off the marker that already means exactly "this session still owes the user a reply":
`SessionEntry.active_turn_token`, set by `_mark_durable_active_turn` before the turn runs and cleared
by `_clear_durable_active_turn` only once delivery is done (`gateway/run_inbound.py`). After the
existing drain, `_stop_drain_active_work` now:

1. holds the transport open for a bounded window (`_REPLY_DELIVERY_GRACE_S = 5.0`, additionally
   clamped to the remaining shutdown-watchdog leash so it can never cost us the watchdog) for any
   session still carrying an active-turn marker — the common case, and the reply lands normally; and
2. if the budget runs out, marks those sessions `resume_pending` with the same
   `restart_timeout` / `shutdown_timeout` reason the drain-timeout path uses and sets
   `ctx.timed_out = True`, so `.clean_shutdown` is skipped and the next boot auto-resumes the turn
   (both reasons are in `GatewayRunner._AUTO_RESUME_REASONS`) instead of discarding the marker.

The change is additive: when no session carries an active-turn marker the probe returns an empty list
and the phase reaches no `await`, so a normal shutdown is byte-for-byte the same as before.

## Evidence

Reporter's timeline (`[00:14:00] Inbound` → `[00:15:29]` shutdown, agent turn `time=89.9s
api_calls=4 response=0 chars`) is consistent with a reply being dropped at the stop boundary rather
than with a generation failure: the reply's own log line lands in the same second the teardown
begins.

Code paths confirmed by reading the tree at `438a3135` (branch base = `origin/main`):

- `gateway/run_shutdown.py::_drain_work_counts` — the four sources the drain waits on; none of them
  is "a reply that has not been sent yet".
- `gateway/run_turn.py:3560` — `_release_running_agent_state(session_key, ...)` runs inside
  `_run_agent_cleanup_turn_tasks`, i.e. *before* `_handle_message_with_agent` shapes and delivers the
  reply at `gateway/run_turn.py:1992-2019`.
- `gateway/run_shutdown.py::_stop_finalize_agents_and_adapters` disconnects every adapter in the phase
  immediately after the drain.
- `gateway/run_shutdown.py::_stop_persist_exit_state` writes `.clean_shutdown` only when
  `not ctx.timed_out`, and `gateway/run_startup.py::_consume_clean_shutdown_marker` responds to that
  receipt with `discard_active_turn_markers()`.

Local, deterministic regression tests (no wall-clock racing — the delivery task is only spawned from
the drain's first probe, so it can complete only if the drain yields):

```
HERMES_PYTHON=<venv>/python.exe bash scripts/run_tests.sh tests/gateway/test_105364_undelivered_reply_shutdown.py
# RED (before the fix), 2 failed:
#   test_drain_waits_for_a_reply_that_is_mid_delivery            -> probes["n"] > 1 (drain never waited)
#   test_reply_that_never_lands_arms_recovery_instead_of_a_clean_shutdown -> resume_pending is False
# GREEN (after the fix): 1 files, 2 tests passed, 0 failed
# SABOTAGE (fix neutered with an early `return`): 2 failed again -> both tests really pin the fix
```

Related suites re-run on this Windows host, 3x each, with and without the change (same tree, same
command):

```
HERMES_PYTHON=<venv>/python.exe bash scripts/run_tests.sh \
  tests/gateway/test_gateway_shutdown.py tests/gateway/test_shutdown_watchdog.py
```

| run | without the change (`git stash push -- gateway/run_shutdown.py`) | with the change |
|---|---|---|
| 1 | 20 passed, 1 failed | 20 passed, 1 failed |
| 2 | 19 passed, 2 failed | 20 passed, 1 failed (attempt 1 flaked, retried green — reported `FLAKY`) |
| 3 | 20 passed, 1 failed | 20 passed, 1 failed |

Same residual failure set either way, so neither is caused here:

- `tests/gateway/test_shutdown_watchdog.py::test_loop_tick_witness_arms_over_tcp_on_windows` fails
  3/3 both ways — pre-existing on this host (Windows loop-tick witness / TCP arming), untouched by
  this PR.
- `tests/gateway/test_gateway_shutdown.py::test_unexpected_signal_starts_teardown_after_bounded_interrupt_grace`
  is a 0.75s `asyncio.wait_for` flake around teardown start: it failed on the first attempt in 1 of 3
  baseline runs and 1 of 3 with-the-change runs. It cannot be reached by this change — that test's
  runner has an empty `session_store._entries`, so the new probe returns an empty list and
  `_settle_reply_deliveries` returns without a single `await`.

Wider batch also run unchanged: `test_restart_drain.py`, `test_restart_resume_pending.py`,
`test_clean_shutdown_marker.py`, `test_active_turn_recovery.py`, `test_shutdown_flush.py`,
`test_cron_shutdown_drain.py`, `test_13121_shutdown_inflight_transcript_flush.py`,
`test_delivery_ledger.py` — 144 passed, 2 failed, where the 2 failures are the two pre-existing ones
above.

Contract touched: the shutdown-phase ordering contracts (kill tool subprocesses before adapter
disconnect, teardown within the bounded interrupt grace, watchdog leash) are unchanged. The new wait
is bounded, clamped to the shutdown-watchdog leash minus the elapsed teardown, and reaches zero
`await`s when no session carries an active-turn marker — so it only extends a shutdown that would
otherwise have dropped a reply.

`Partial:` — what this PR does **not** verify, and should not be read as fixing:

- No end-to-end run against a real Telegram bot on Windows 11. The reproduction is a unit-level
  reproduction of the delivery-window drop, not of the reporter's live incident.
- The reporter's specific event logged `Gateway drain timed out after ... with N active agent(s)`,
  i.e. an agent *was* still in `_running_agents`. That is a different sub-case from the window fixed
  here (agent already returned, reply not yet sent), whose symptom is a *clean* drain line, not a
  timeout line. If the reporter's loss was the timeout sub-case, the recovery path there is the
  existing auto-resume (`_schedule_resume_pending_sessions` → `_AUTO_RESUME_REASONS` contains
  `shutdown_timeout`), which this PR leaves untouched and does not claim to have fixed.
- The external signal source (`signal=UNKNOWN` in the report) is not identified here. On this tree
  `hermes_cli`/`gateway` contain no config key named `graceful_shutdown_timeout` (full-tree scan over
  10192 source/doc files, 0 hits), so the reporter's `graceful_shutdown_timeout: 120` was inert; the
  chat-turn drain budget is `agent.restart_drain_timeout`, which defaults to `0`. That is an
  observation, not a fix — the PR does not add or honour such a key.
- Session-level auto-resume after a `resume_pending` mark (i.e. "did the next boot actually
  redeliver?") is not exercised end to end here.
