### PR TITLE
fix(plugins): stop direct_result tool output from becoming the user reply

### DIFF
--- a/agent/turn_explainers.py
+++ b/agent/turn_explainers.py
@@ -64,6 +64,13 @@ _EXIT_REASON_EXPLANATIONS: Dict[str, str] = {
         "the model produced no follow-up text. Send `continue` to "
         "let it summarize."
     ),
+    # #102806 (defect 1): a direct_result-style tool promoted its raw output to the
+    # reply with no model-composed text behind it. The finalizer withholds it.
+    "uncomposed_tool_output": (
+        "the model produced no reply text, so the last tool's raw output "
+        "was withheld instead of being sent as the answer. Send `continue` "
+        "to have the model compose the reply."
+    ),
 }
 
 # Parameterised reasons (``max_iterations_reached(3/3)`` …) matched by prefix.

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -172,6 +172,50 @@ def _resolve_budget_fallback(
     return final_response, _turn_exit_reason, preserved_verification_fallback
 
 
+def _refuse_uncomposed_tool_output(
+    messages, final_response, _turn_exit_reason, interrupted, failed, logger,
+) -> Tuple[Any, Any]:
+    """#102806 (defect 1): a tool result must never be the user-visible reply.
+
+    The reporter registers ``archive_search`` with ``direct_result=True`` in an
+    out-of-tree plugin, so its raw FTS output gets promoted to the turn's final
+    response and forwarded to the platform verbatim — the user sees stale hits from
+    other sessions instead of the model's ``Saved and verified.``. ``direct_result``
+    has no consumer in core, so the class-level guard lives at the chokepoint every
+    turn flows through: when the reply is byte-identical to the newest tool row's
+    content and no assistant row with visible text follows it, the model never
+    composed a reply. Withhold the raw output (the turn-completion explainer then
+    surfaces why) instead of shipping tool output as the answer.
+
+    Returns ``(final_response, _turn_exit_reason)``; untouched when the reply is
+    model-composed text, absent, or from a prior turn. Interrupted/failed turns own
+    their own delivery path and are left alone.
+    """
+    if interrupted or failed or not isinstance(final_response, str) or not final_response.strip():
+        return final_response, _turn_exit_reason
+    target = final_response.strip()
+    for msg in reversed(messages):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role == "user":
+            return final_response, _turn_exit_reason  # turn boundary: prior-turn tool row
+        if role == "assistant":
+            if not _assistant_row_missing_visible_text(msg):
+                return final_response, _turn_exit_reason  # the model composed text
+            continue
+        if role == "tool":
+            content = msg.get("content")
+            if isinstance(content, str) and content.strip() == target:
+                logger.warning(
+                    "Withholding raw tool output as the turn reply (#102806): %.160s",
+                    target.replace("\n", " "),
+                )
+                return "", "uncomposed_tool_output"
+            return final_response, _turn_exit_reason  # a tool row, but not this text
+    return final_response, _turn_exit_reason
+
+
 def _rollback_interrupted_preflight_display(agent, interrupted) -> None:
     """Roll back the preflight-seeded display count only when an interrupt wins before
     any provider response; compaction state (incl. ``-1``) stays with the real-usage
@@ -447,6 +491,14 @@ def finalize_turn(
         _pending_verification_response=_pending_verification_response,
         _pending_verification_response_previewed=_pending_verification_response_previewed,
         logger=logger,
+    )
+
+    # #102806 (defect 1): whatever the caller put in ``final_response`` (a fork's
+    # ``direct_result`` promotion, a plugin harness), raw tool output must never reach
+    # the user as the reply. Runs before ``completed`` and the persist step so the
+    # durable transcript gets the explanation, not the tool echo.
+    final_response, _turn_exit_reason = _refuse_uncomposed_tool_output(
+        messages, final_response, _turn_exit_reason, interrupted, failed, logger,
     )
 
     completed = (

--- a/tests/agent/test_102806_direct_result_reply.py
+++ b/tests/agent/test_102806_direct_result_reply.py
@@ -1,0 +1,247 @@
+"""Regression tests for #102806 (defect 1): a tool result must never become the
+user-visible reply without the model composing it.
+
+The reporter's fork registers ``archive_search`` with ``direct_result=True`` in an
+out-of-tree plugin (``plugins/archive/__init__.py``), so the raw FTS output
+(``- [27] … | - [17] …``) is promoted to the turn's final response and forwarded to
+the platform verbatim — the user sees stale search hits from other sessions instead
+of the model's "Saved and verified.".
+
+``direct_result`` is not a core symbol (no consumer exists in origin/main — see the
+PR body), so the fix belongs at the single chokepoint every turn flows through:
+``agent.turn_finalizer.finalize_turn``. Whatever a caller (a fork, a plugin harness,
+a future delivery path) puts in ``final_response``, the finalizer must refuse to
+deliver a reply that is verbatim a tool row's output with no model-composed text
+after it.
+
+Two failure shapes, both driven through the real ``finalize_turn``:
+
+1. a stray ``archive_search`` right after a successful ``archive_save`` (the save
+   already produced the user-facing receipt, so the search output is pure noise);
+2. a bare ``archive_search`` with no subsequent model turn at all.
+"""
+
+from agent.turn_finalizer import finalize_turn
+
+# Raw FTS output as it reached the reporter's Telegram DM.
+RAW_FTS = "- [27] 2026-08-19 deploy checklist | - [17] 2026-08-24 milk and eggs"
+RECEIPT = "Saved and verified."
+
+
+class _StubBudget:
+    used = 1
+    max_total = 10
+    remaining = 9
+
+
+class _StubCompressor:
+    last_prompt_tokens = 0
+
+
+class _StubAgent:
+    """Minimal agent surface ``finalize_turn`` reads from."""
+
+    def __init__(self, *, explainer=True):
+        self.max_iterations = 10
+        self.iteration_budget = _StubBudget()
+        self.context_compressor = _StubCompressor()
+        self.model = "stub/model"
+        self.provider = "stub"
+        self.base_url = "http://stub"
+        self.session_id = "sess-102806"
+        self.quiet_mode = True
+        self.platform = "telegram"
+        self._interrupt_message = None
+        self._tool_guardrail_halt_decision = None
+        self._response_was_previewed = False
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        self._explainer = explainer
+        for attr in (
+            "session_input_tokens", "session_output_tokens", "session_cache_read_tokens",
+            "session_cache_write_tokens", "session_reasoning_tokens", "session_prompt_tokens",
+            "session_completion_tokens", "session_total_tokens", "session_estimated_cost_usd",
+        ):
+            setattr(self, attr, 0)
+        self.session_cost_status = "ok"
+        self.session_cost_source = "stub"
+
+    def _save_trajectory(self, *a, **k):
+        pass
+
+    def _cleanup_task_resources(self, *a, **k):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, *a, **k):
+        pass
+
+    def _persist_session(self, *a, **k):
+        pass
+
+    def _emit_status(self, *a, **k):
+        pass
+
+    def _safe_print(self, *a, **k):
+        pass
+
+    def _handle_max_iterations(self, messages, n):
+        return "SUMMARY FROM MODEL"
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return self._explainer
+
+    def _format_turn_completion_explanation(self, turn_exit_reason, persistence_cause=None):
+        from agent.turn_explainers import TurnExplainersMixin
+        return TurnExplainersMixin._format_turn_completion_explanation(
+            turn_exit_reason, persistence_cause
+        )
+
+    def _drain_pending_steer(self):
+        return None
+
+    def clear_interrupt(self):
+        pass
+
+    def _sync_external_memory_for_turn(self, **k):
+        pass
+
+
+def _call(agent, messages, *, final_response, turn_exit_reason="text_response(stop)"):
+    return finalize_turn(
+        agent,
+        final_response=final_response,
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=None,
+        effective_task_id="task-102806",
+        turn_id="turn-102806",
+        user_message="save https://example.com/post",
+        original_user_message="save https://example.com/post",
+        _should_review_memory=False,
+        _turn_exit_reason=turn_exit_reason,
+    )
+
+
+def _search_call(call_id):
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"id": call_id, "function": {"name": "archive_search", "arguments": "{}"}}],
+    }
+
+
+# --------------------------------------------------------------------------
+# Defect 1, failure shape 1: stray search immediately after a successful save
+# --------------------------------------------------------------------------
+
+def test_stray_search_after_save_does_not_become_the_reply():
+    messages = [
+        {"role": "user", "content": "save https://example.com/post"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "s1", "function": {"name": "archive_save", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "s1", "content": RECEIPT},
+        _search_call("q1"),
+        {"role": "tool", "tool_call_id": "q1", "content": RAW_FTS},
+    ]
+    result = _call(_StubAgent(), messages, final_response=RAW_FTS)
+    assert RAW_FTS not in result["final_response"]
+    assert "[27]" not in result["final_response"]
+
+
+# --------------------------------------------------------------------------
+# Defect 1, failure shape 2: bare search, no follow-up model turn
+# --------------------------------------------------------------------------
+
+def test_bare_search_with_no_model_turn_does_not_become_the_reply():
+    messages = [
+        {"role": "user", "content": "search the archive"},
+        _search_call("q1"),
+        {"role": "tool", "tool_call_id": "q1", "content": RAW_FTS},
+    ]
+    result = _call(_StubAgent(), messages, final_response=RAW_FTS)
+    assert RAW_FTS not in result["final_response"]
+    assert "[27]" not in result["final_response"]
+
+
+def test_withheld_raw_tool_output_is_explained_not_silent():
+    messages = [
+        {"role": "user", "content": "search the archive"},
+        _search_call("q1"),
+        {"role": "tool", "tool_call_id": "q1", "content": RAW_FTS},
+    ]
+    result = _call(_StubAgent(), messages, final_response=RAW_FTS)
+    assert result["final_response"].startswith("⚠️ No reply:")
+    assert result["turn_exit_reason"] == "uncomposed_tool_output"
+
+
+def test_withheld_raw_tool_output_fails_closed_when_explainer_disabled():
+    """No reply beats raw junk from another session when the explainer is off."""
+    messages = [
+        {"role": "user", "content": "search the archive"},
+        _search_call("q1"),
+        {"role": "tool", "tool_call_id": "q1", "content": RAW_FTS},
+    ]
+    result = _call(_StubAgent(explainer=False), messages, final_response=RAW_FTS)
+    assert result["final_response"] == ""
+
+
+# --------------------------------------------------------------------------
+# Bidirectional: the guard must not touch genuinely model-composed replies
+# --------------------------------------------------------------------------
+
+def test_model_composed_reply_is_delivered_unchanged():
+    messages = [
+        {"role": "user", "content": "save https://example.com/post"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "s1", "function": {"name": "archive_save", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "s1", "content": RECEIPT},
+        {"role": "assistant", "content": RECEIPT},
+    ]
+    result = _call(_StubAgent(), messages, final_response=RECEIPT)
+    assert result["final_response"] == RECEIPT
+
+
+def test_composed_reply_that_quotes_tool_output_is_untouched():
+    quoted = f"I searched the archive. Closest hit: {RAW_FTS} — want me to open it?"
+    messages = [
+        {"role": "user", "content": "search the archive"},
+        _search_call("q1"),
+        {"role": "tool", "tool_call_id": "q1", "content": RAW_FTS},
+        {"role": "assistant", "content": quoted},
+    ]
+    result = _call(_StubAgent(), messages, final_response=quoted)
+    assert result["final_response"] == quoted
+
+
+def test_plain_chat_reply_without_tools_is_untouched():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "Hello!"},
+    ]
+    result = _call(_StubAgent(), messages, final_response="Hello!")
+    assert result["final_response"] == "Hello!"
+
+
+def test_tool_output_text_mentioned_in_an_earlier_turn_is_not_matched():
+    """A tool row from a PRIOR turn must not suppress this turn's reply."""
+    messages = [
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "q0", "function": {"name": "archive_search", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "q0", "content": RAW_FTS},
+        {"role": "user", "content": "again"},
+        {"role": "assistant", "content": RAW_FTS},
+    ]
+    result = _call(_StubAgent(), messages, final_response=RAW_FTS)
+    assert result["final_response"] == RAW_FTS


### PR DESCRIPTION
## What Problem This Solves

Issue #102806 reports two user-facing defects on messaging platforms. This PR addresses
**defect 1 only**:

> `direct_result` tool output can become the user-visible reply, bypassing model
> composition (archive_save/archive_search on Telegram)

The reporter registers `archive_search` with `direct_result=True`, so when the model
issues a stray `archive_search` right after a successful `archive_save` the raw FTS
output (`- [27] … | - [17] …`) is promoted to the turn's final response and forwarded to
the platform verbatim: the user sees stale hits from other sessions instead of
"Saved and verified.".

Whatever promotes a tool's raw result to the turn's reply — a fork's `direct_result`
promotion, a plugin harness, a future delivery path — must not reach the platform as the
answer. The guard goes in `agent/turn_finalizer.py::finalize_turn`, the single chokepoint
every turn flows through to produce the user-visible reply. It withholds the reply when
**all** of these hold:

- the reply is byte-identical (whitespace-stripped) to the newest `tool` row's content,
- **and** no `assistant` row with visible text follows that row (the model never composed),
- **and** the matching tool row is inside the current turn (the first `user` row is the boundary),
- **and** the turn is not interrupted and not failed (those own their own delivery paths).

Withheld means: the raw output is not delivered, `turn_exit_reason` becomes
`uncomposed_tool_output`, and the existing turn-completion explainer renders
`⚠️ No reply: the model produced no reply text, so the last tool's raw output was
withheld instead of being sent as the answer. Send `continue` to have the model compose
the reply.` With the explainer disabled the reply is `""` — fail-closed, because no reply
beats stale search hits from another session. The guard runs before the persist step, so
the durable transcript stores the explanation rather than a persisted echo of the tool
result (the old path also appended the raw output as an assistant row via
`_close_transcript_tail`).

Both failure shapes in the report are covered: (1) a stray `archive_search` immediately
after a successful `archive_save` (the save already produced the user-facing receipt), and
(2) a bare `archive_search` with no subsequent model turn.

Bidirectional: genuinely composed replies are untouched — including a composed reply that
*quotes* the tool output, a plain chat reply with no tools, a reply that equals a tool row
from a **prior** turn, and the legitimate first `direct_result` receipt that the model
composed text for.

## Evidence

**`direct_result` has no consumer in this repository.** It is a fork/plugin-level concept,
not a core one:

- `git grep -n "direct_result"` on `origin/main` → only `tools/file_operations.py:688/749/827`
  (`_image_redirect_result`, unrelated). `git grep -n "archive_search"` → only
  `tests/acp/test_tools.py` (`memory_archive_search`, a formatter fixture). `plugins/archive/`
  does not exist.
- `gh api "search/code?q=direct_result+repo:NousResearch/hermes-agent"` → `total_count: 1`
  (same unrelated `tools/file_operations.py`).
- Neither registration surface has the flag: `PluginContext.register_tool()`
  (`hermes_cli/plugins.py:449`) and `ToolRegistry.register()` (`tools/registry.py:596`) take
  no `direct_result` parameter, and `ToolEntry` (`tools/registry.py:164`) has no such field.
  `plugins/AGENTS.md`: "A hook with no concrete consumer is speculative infrastructure and is
  rejected" — so the fix is a guard on the reply chokepoint, not a new delivery mechanism.
- The reporter's own fork carries no such commits: `gh api
  repos/NousResearch/hermes-agent/compare/main...Finn763:main` → `ahead_by: 0`.

That is why the guard sits at reply composition, where no caller can route around it, and
why the issue's requested behavior ("a `direct_result` tool result should not become the
user-visible final reply … the model should compose the final message") is enforced directly.

**Red → green on the real `finalize_turn`** (constructed tool rows → the reply-composition
function, exactly the shape the report describes):

```
# base (438a3135, no guard)
tests/agent/test_102806_direct_result_reply.py
  FAILED test_stray_search_after_save_does_not_become_the_reply
  FAILED test_bare_search_with_no_model_turn_does_not_become_the_reply
  FAILED test_withheld_raw_tool_output_is_explained_not_silent
  FAILED test_withheld_raw_tool_output_fails_closed_when_explainer_disabled
  4 failed, 4 passed
    AssertionError: assert '- [27] 2026...ilk and eggs' not in
                        '- [27] 2026...ilk and eggs'
```

The raw FTS text is returned verbatim as `result["final_response"]` by the unpatched
finalizer — the delivery path the report describes, reproduced in-process.

```
# this branch
tests/agent/test_102806_direct_result_reply.py — 8 passed in 50.9s
tests/agent/test_turn_finalizer_*.py tests/run_agent/test_turn_completion_explainer.py
tests/agent/test_surrogate_chokepoints.py tests/agent/test_close_interrupted_tool_sequence.py
tests/agent/test_micro_compaction.py tests/agent/test_skip_background_review.py
  → 9 files, 101 tests passed, 0 failed
```

**Sabotage**: neutralizing the guard (`return final_response, _turn_exit_reason` instead of
`return "", "uncomposed_tool_output"`) re-fails exactly those 4 assertions and leaves the 4
bidirectional ones green — the tests pin the behavior, not the diff.

## Scope note

- Defect 2 in #102806 (gateway status lines printing `sys.maxsize` as the iteration ceiling)
  is **already fixed on `main` by #104182** (merged; salvage of #102817/#102845). It is
  referenced as prior art only — not closed here.
- No `direct_result` kwarg, hook, or delivery path is added (plugin policy above).
- **Partial** for #102806: defect 1 (this PR) + defect 2 (#104182). Not `Closes #102806` —
  the issue's end-to-end reproduction needs the reporter's out-of-tree `plugins/archive`
  plugin, which is not in this repository and cannot be re-run here; the invariant it
  violated is what this PR enforces.

## How to Test

```bash
HERMES_PYTHON=<venv>/python.exe bash scripts/run_tests.sh tests/agent/test_102806_direct_result_reply.py
# reverse-verify: change `return "", "uncomposed_tool_output"` to pass final_response
# through in agent/turn_finalizer.py::_refuse_uncomposed_tool_output → 4 tests fail.
```
