### PR TITLE
fix(desktop): re-resolve session owners instead of surfacing ownerless runtime ids

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -18,6 +18,17 @@ vi.mock('@/store/gateway', async importActual => ({
   requestGatewayForProfile: vi.fn()
 }))
 
+const controlMocks = vi.hoisted(() => ({
+  probe: null as null | ((runtimeId: string) => Promise<unknown>)
+}))
+
+vi.mock('@/store/session-control', async importActual => ({
+  ...(await importActual<Record<string, unknown>>()),
+  setSessionControlOwnerProbe: (probe: ((runtimeId: string) => Promise<unknown>) | null) => {
+    controlMocks.probe = probe
+  }
+}))
+
 const { getLatestSessionMessages } = await import('@/hermes')
 const { requestGatewayForAgent, requestGatewayForProfile } = await import('@/store/gateway')
 
@@ -503,6 +514,41 @@ describe('useSessionTileDelegate retireBusyClaim', () => {
     expect(sessionTileDelegate()!.retireBusyClaim!('runtime-unknown')).toBe(false)
     expect(sessionTileDelegate()!.retireBusyClaim!('runtime-idle')).toBe(false)
     expect(updateSessionState).not.toHaveBeenCalled()
+  })
+})
+
+describe('useSessionTileDelegate session-control owner probe (#107502)', () => {
+  beforeEach(() => {
+    setSessions([])
+    controlMocks.probe = null
+  })
+
+  afterEach(() => {
+    setSessions([])
+    controlMocks.probe = null
+  })
+
+  it('re-resolves an ownerless runtime id through the cache binding and the row ladder', async () => {
+    // The runtime's mirror entry was dropped by the profile-backend lifecycle,
+    // but this cache still maps stored -> runtime and the durable row still
+    // names the owning profile — the poller must find it here.
+    renderTile(vi.fn(), { runtimeIdByStoredSessionIdRef: { current: new Map([['stored-x', 'rt-dead']]) } })
+    setSessions([row({ id: 'stored-x', profile: 'research' })])
+
+    await expect(controlMocks.probe!('rt-dead')).resolves.toBe('research')
+  })
+
+  it('falls back to the runtime id itself when the cache knows no durable id', async () => {
+    renderTile(vi.fn())
+    setSessions([row({ id: 'rt-orphan', profile: 'research' })])
+
+    await expect(controlMocks.probe!('rt-orphan')).resolves.toBe('research')
+  })
+
+  it('names no owner for a runtime nothing knows, so the read stays fail-closed', async () => {
+    renderTile(vi.fn())
+
+    await expect(controlMocks.probe!('rt-unknown')).resolves.toBeUndefined()
   })
 })
 

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -15,13 +15,15 @@ import {
   resumeWithStoredTranscriptFallback
 } from '@/store/read-only-transcript'
 import { knownSessionOwner, ownerLookupSessionRows } from '@/store/session'
+import { setSessionControlOwnerProbe } from '@/store/session-control'
 import { assertSessionOwnerResolved } from '@/store/session-owner-resolution'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
 import {
   $sessionTiles,
   publishSessionState,
   sessionTileOwnerRoute,
-  setSessionTileDelegate
+  setSessionTileDelegate,
+  storedSessionIdForRuntimeId
 } from '@/store/session-states'
 import type { SessionResumeResponse } from '@/types/hermes'
 
@@ -192,6 +194,18 @@ export function useSessionTileDelegate({
 
       return requestForSessionProfile<T>(owner, requestGateway, method, params, timeoutMs)
     }
+
+    // Session-control reads (#107502): an ownerless runtime id is a routing
+    // state, not a control failure. Re-resolve it here — this cache's
+    // runtime→stored binding outlives the store mirror's entries (a reclaim /
+    // reconnect drops those first), and ownerForStoredSession is the same
+    // owner ladder every other session-scoped RPC uses, including the async
+    // cross-profile probe.
+    setSessionControlOwnerProbe(async runtimeId => {
+      const storedId = storedSessionIdForRuntime(runtimeId) ?? storedSessionIdForRuntimeId(runtimeId) ?? runtimeId
+
+      return ownerForStoredSession(storedId)
+    })
 
     setSessionTileDelegate({
       archiveSession: async storedSessionId => {

--- a/apps/desktop/src/store/session-control-owner-recovery.integration.test.ts
+++ b/apps/desktop/src/store/session-control-owner-recovery.integration.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const gatewayMocks = vi.hoisted(() => {
+  const instances: Array<{
+    connectionState: string
+    emit: (event: { payload?: Record<string, unknown>; session_id?: string; type: string }) => void
+    request: ReturnType<typeof vi.fn>
+  }> = []
+
+  return { instances }
+})
+
+vi.mock('@/hermes', async importActual => ({
+  ...(await importActual<Record<string, unknown>>()),
+  setApiRequestConnection: vi.fn(),
+  HermesGateway: class {
+    connectionState = 'closed'
+    private eventHandlers = new Set<
+      (event: { payload?: Record<string, unknown>; session_id?: string; type: string }) => void
+    >()
+    request = vi.fn(async (method: string, params: Record<string, unknown>) => ({ method, params }))
+
+    constructor() {
+      gatewayMocks.instances.push(this as never)
+    }
+
+    connect = async (): Promise<void> => {
+      this.connectionState = 'open'
+    }
+
+    close = (): void => {
+      this.connectionState = 'closed'
+    }
+
+    onEvent = (
+      handler: (event: { payload?: Record<string, unknown>; session_id?: string; type: string }) => void
+    ): (() => void) => {
+      this.eventHandlers.add(handler)
+
+      return () => this.eventHandlers.delete(handler)
+    }
+
+    onState = (): (() => void) => () => undefined
+
+    emit = (event: { payload?: Record<string, unknown>; session_id?: string; type: string }): void => {
+      for (const handler of this.eventHandlers) {
+        handler(event)
+      }
+    }
+  }
+}))
+
+const {
+  $gateway,
+  closeSecondaryGateways,
+  configureGatewayRegistry,
+  ensureGatewayForProfile,
+  setPrimaryGateway
+} = await import('./gateway')
+
+const { $profiles } = await import('./profile')
+
+const { $activeSessionId, _resetSessionOwnerHintsForTests, setSessions } = await import('./session')
+
+const { clearAllPrompts } = await import('./prompts')
+
+const { $sessionTiles, clearAllSessionStates, forgetProfileOnlyRuntimeOwners, recordSessionEventScope } =
+  await import('./session-states')
+
+const {
+  $sessionControlBySession,
+  clearAllSessionControl,
+  refreshSessionControl,
+  setSessionControlOwnerProbe
+} = await import('./session-control')
+
+/** A valid backend control payload: parseSessionControlSnapshot is exact-shape. */
+const CONTROL_SNAPSHOT = {
+  goal: null,
+  heartbeat: null,
+  loop: null,
+  revision: 'rev-ownerless',
+  updated_at: 1_700_000_000
+}
+
+function installDesktop(): void {
+  ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+    getConnection: vi.fn(async (profile: string) => ({
+      authMode: 'token',
+      mode: 'local',
+      profile,
+      token: 'test-token',
+      wsUrl: `wss://${profile}.invalid/ws`
+    })),
+    notify: vi.fn()
+  }
+}
+
+let primary: { connectionState: string; request: ReturnType<typeof vi.fn> }
+
+beforeEach(() => {
+  installDesktop()
+  gatewayMocks.instances.length = 0
+  // More than one profile: the ambient gateway is NOT the owner by
+  // construction, so an unresolvable runtime id must fail closed.
+  $profiles.set([{ name: 'default' }, { name: 'research' }] as never)
+  $sessionTiles.set([])
+  setSessions([])
+  clearAllSessionStates()
+  clearAllSessionControl()
+  clearAllPrompts()
+  $activeSessionId.set(null)
+  _resetSessionOwnerHintsForTests({ storage: true })
+  setSessionControlOwnerProbe(null)
+
+  configureGatewayRegistry({
+    onLocalProfileRetired: forgetProfileOnlyRuntimeOwners,
+    onEvent: event => {
+      recordSessionEventScope(event)
+    }
+  })
+
+  primary = { connectionState: 'open', request: vi.fn(async () => ({ control: CONTROL_SNAPSHOT })) }
+  $gateway.set(primary as never)
+  setPrimaryGateway(primary as never, 'default')
+})
+
+afterEach(() => {
+  closeSecondaryGateways()
+  clearAllSessionStates()
+  clearAllSessionControl()
+  setSessionControlOwnerProbe(null)
+  $sessionTiles.set([])
+  $profiles.set([])
+  setSessions([])
+  _resetSessionOwnerHintsForTests({ storage: true })
+  clearAllPrompts()
+  $activeSessionId.set(null)
+  $gateway.set(null)
+  delete (window as { hermesDesktop?: unknown }).hermesDesktop
+})
+
+describe('session-control ownerless runtime recovery (#107502)', () => {
+  it('re-resolves the owner through the probe and retries the read on that backend', async () => {
+    await ensureGatewayForProfile('research')
+    const secondary = gatewayMocks.instances[0]
+    secondary.request.mockResolvedValue({ control: CONTROL_SNAPSHOT })
+
+    const probe = vi.fn(async () => 'research')
+    setSessionControlOwnerProbe(probe)
+
+    const entry = await refreshSessionControl('rt-ownerless')
+
+    expect(probe).toHaveBeenCalledTimes(1)
+    expect(probe).toHaveBeenCalledWith('rt-ownerless')
+    expect(secondary.request).toHaveBeenCalledWith('session.control.read', { session_id: 'rt-ownerless' })
+    expect(primary.request).not.toHaveBeenCalled()
+    expect(entry).toMatchObject({ capability: 'supported', error: null, loading: false, pendingAction: null })
+    expect(entry!.snapshot!.revision).toBe('rev-ownerless')
+  })
+
+  it('keeps an unrecoverable ownerless read quiet instead of surfacing the routing error', async () => {
+    const probe = vi.fn(async () => undefined)
+    setSessionControlOwnerProbe(probe)
+
+    const entry = await refreshSessionControl('rt-ownerless')
+
+    expect(probe).toHaveBeenCalledWith('rt-ownerless')
+    expect(entry).toMatchObject({ capability: 'unknown', error: null, loading: false, snapshot: null })
+    expect(primary.request).not.toHaveBeenCalled()
+    expect(gatewayMocks.instances).toHaveLength(0)
+  })
+
+  it('never routes an ownerless read to the ambient gateway (fail-closed stays)', async () => {
+    await refreshSessionControl('rt-ownerless')
+
+    expect(primary.request).not.toHaveBeenCalled()
+  })
+
+  it('does not consult the probe when the owner ladder already names an owner', async () => {
+    $profiles.set([{ name: 'default' }] as never)
+
+    const probe = vi.fn(async () => 'research')
+    setSessionControlOwnerProbe(probe)
+
+    await refreshSessionControl('rt-legacy')
+
+    expect(probe).not.toHaveBeenCalled()
+    expect(primary.request).toHaveBeenCalledWith('session.control.read', { session_id: 'rt-legacy' })
+  })
+
+  it('still publishes an ordinary backend failure for a routable session', async () => {
+    $profiles.set([{ name: 'default' }] as never)
+    primary.request.mockRejectedValue(new Error('backend unavailable'))
+
+    const entry = await refreshSessionControl('rt-legacy')
+
+    expect(entry!.error).toBe('backend unavailable')
+    expect(entry!.loading).toBe(false)
+  })
+
+  it('still reports a genuine owner-resolution failure for a user-initiated action', async () => {
+    const { runSessionControlAction } = await import('./session-control')
+
+    await expect(runSessionControlAction('rt-ownerless', 'goal.pause')).rejects.toMatchObject({
+      name: 'SessionOwnerResolutionError'
+    })
+
+    expect($sessionControlBySession.get()['rt-ownerless']!.error).toContain('(session.control)')
+  })
+})

--- a/apps/desktop/src/store/session-control.ts
+++ b/apps/desktop/src/store/session-control.ts
@@ -4,6 +4,8 @@ import { $gateway } from './gateway'
 import { refreshSessionGoal } from './goals'
 import { isSessionGone, isSessionGoneForBackgroundPolling, markSessionGone } from './runtime-gone'
 import { ambientRequestFor } from './session-gone-latch'
+import { isSessionOwnerResolutionError } from './session-owner-resolution'
+import { requestForSessionProfile, type SessionOwnerScope } from './session-request-router'
 import { requestForOwnedSession } from './session-states'
 
 export type SessionControlGoalStatus = 'active' | 'done' | 'paused'
@@ -141,6 +143,29 @@ const ERROR_LIMIT = 240
 
 const versions = new Map<string, number>()
 const eventVersions = new Map<string, number>()
+
+/**
+ * Async owner re-resolution for an ownerless runtime id (#107502).
+ *
+ * The sync owner ladder (tile route → hint → connection-tagged row → the
+ * runtime's own event scope) runs inside requestForOwnedSession and is the
+ * right first answer. But a runtime id can lose ALL of those rungs to a
+ * profile-backend lifecycle event — the backend that minted it was reaped or
+ * rebound, the store's mirror entry and the profile-only owner ledger went
+ * with it — while the durable session still lives on a backend nobody names
+ * any more. The wiring layer CAN name it (its runtime→stored cache and the
+ * cross-profile REST probe), so the poller asks it to re-resolve before
+ * giving up: this is the same async rung the window's session-RPC dispatcher
+ * applies (session-rpc-dispatcher.ts). No probe installed (tests, headless
+ * stores, secondary windows) means the read keeps its fail-closed behavior.
+ */
+export type SessionControlOwnerProbe = (sessionId: string) => Promise<SessionOwnerScope>
+
+let ownerProbe: SessionControlOwnerProbe | null = null
+
+export function setSessionControlOwnerProbe(probe: SessionControlOwnerProbe | null): void {
+  ownerProbe = probe
+}
 
 export const $sessionControlBySession = atom<Record<string, SessionControlEntry>>({})
 
@@ -698,6 +723,27 @@ function finishGoneRequest(sessionId: string, token: number, clearPendingAction:
   })
 }
 
+/**
+ * An ownerless runtime id is a ROUTING state, not a control failure (#107502).
+ * The request never left the window — no backend rejected anything — so the
+ * internal owner-resolution message ("no owner route, hint, ...") must not be
+ * published as `entry.error`, where the composer status stack renders it
+ * verbatim under "Session controls unavailable". The entry stays unchanged
+ * (capability and any last good snapshot), just no longer loading, so the
+ * strip shows nothing for a session whose controls cannot be read yet and a
+ * later refresh (a rebind, a session switch, hydrated owner metadata) retries
+ * from scratch. Fail-closed is untouched: nothing was sent anywhere.
+ */
+function finishOwnerlessRead(sessionId: string, token: number): void {
+  if (!isCurrent(sessionId, token)) {
+    return
+  }
+
+  const current = $sessionControlBySession.get()[sessionId] ?? emptyEntry()
+
+  publishEntry(sessionId, { ...current, error: null, loading: false })
+}
+
 function markUnsupported(sessionId: string, token: number): boolean {
   if (!isCurrent(sessionId, token)) {
     return false
@@ -752,12 +798,30 @@ export async function refreshSessionControl(
   const token = beginRead(sessionId, Boolean(options.background))
 
   try {
-    const response = await requestForOwnedSession<unknown>(
-      sessionId,
-      ambientRequestFor(gateway),
-      'session.control.read',
-      { session_id: sessionId }
-    )
+    const ambient = ambientRequestFor(gateway)
+    const params = { session_id: sessionId }
+
+    let response: unknown
+
+    try {
+      response = await requestForOwnedSession<unknown>(sessionId, ambient, 'session.control.read', params)
+    } catch (error) {
+      if (!isSessionOwnerResolutionError(error)) {
+        throw error
+      }
+
+      // Ownerless runtime id: re-resolve the owner (wiring cache → durable id →
+      // cross-profile probe) and retry ONCE on the backend that owns it. The
+      // sync ladder inside requestForOwnedSession left no owner, so this is the
+      // last named rung before the read is declared unavailable.
+      const owner = ownerProbe ? await ownerProbe(sessionId) : undefined
+
+      if (!owner) {
+        throw error
+      }
+
+      response = await requestForSessionProfile<unknown>(owner, ambient, 'session.control.read', params)
+    }
 
     if (!isCurrent(sessionId, token)) {
       return $sessionControlBySession.get()[sessionId]
@@ -789,6 +853,12 @@ export async function refreshSessionControl(
 
     if (isSessionGoneForBackgroundPolling(error)) {
       finishGoneRequest(sessionId, token, false)
+
+      return $sessionControlBySession.get()[sessionId]
+    }
+
+    if (isSessionOwnerResolutionError(error)) {
+      finishOwnerlessRead(sessionId, token)
 
       return $sessionControlBySession.get()[sessionId]
     }


### PR DESCRIPTION
## What Problem This Solves

On Hermes Desktop with more than one local profile/backend, the composer status
stack could show the session-owner router's internal message verbatim while
hydrating the structured session controls (Goal / Loop / Heartbeat):

```text
Session controls unavailable: Session owner could not be resolved for "cd680e47" (session.control.read): no owner route, hint, connection-tagged row or profile probe named the backend that holds this session, and routing it to the active gateway would be a guess.
```

`cd680e47` is an ephemeral runtime id. After a profile-backend lifecycle event
(reap / restart / WS runtime rebind) the runtime id can lose **every** rung of
the synchronous owner ladder:

- **owner route** — `sessionTileOwnerRoute(storedId)`: the tile's runtime
  binding is cleared by `resetTileRuntimeBindings`, and without a live runtime
  binding `storedSessionIdForRuntimeId(runtimeId)` no longer maps the runtime to
  the stored id the tile is keyed on;
- **hint** — `getSessionOwnerHint(storedId)`: hints are keyed by stored id, so
  the runtime id finds none;
- **connection-tagged row** — `knownSessionOwner(ownerLookupSessionRows(), storedId)`:
  rows are keyed by stored id too, so the runtime id matches nothing;
- **runtime event scope** — `sessionOwnerByRuntimeId.get(runtimeId)`: dropped by
  `dropSessionState` / `forgetProfileOnlyRuntimeOwners` when the owning backend
  is reaped or a profile is retired.

With zero rungs left, `assertSessionOwnerResolved` correctly fails closed — but
the poller had no recovery rung and no way to know this was a *routing* state
rather than a control failure, so `refreshSessionControl()`'s generic catch
published the raw internal message into `entry.error`, which
`SessionControlSections` renders under `controlUnavailable`. Remounting
repeated the same failure: nothing ever re-resolved the owner.

This fixes two things:

1. **Re-resolve, then retry.** `refreshSessionControl()` now asks the wiring
   layer to re-resolve the owner when the sync ladder misses. The wiring layer
   owns the pieces the store mirror does not: the cache's runtime→stored
   binding (the same reverse walk `useSessionTileDelegate` already uses for
   stale runtimes) and the async cross-profile REST probe — i.e. the same rung
   `session-rpc-dispatcher.ts` applies to every other session-scoped RPC. When
   an owner is named, the read is retried **once** on that backend; that is the
   "recover the ownerless runtime id" path, and it is how controls hydrate again
   after owner metadata comes back.
2. **Stop exposing the internal routing error.** If the re-resolution also names
   nobody, the read is declared *unavailable* rather than failed: the entry
   keeps its capability and any last good snapshot, `error` stays `null`, and
   the strip shows nothing instead of the router's internals. A later refresh
   (rebind, session switch, hydrated metadata) retries from scratch.

Fail-closed is untouched: no request is ever sent to the ambient gateway by
guesswork. The only new request is one the probe *named* an owner for. Genuine
transport/backend failures still publish their bounded error, and
user-initiated actions (`runSessionControlAction`) keep the existing
`SessionOwnerResolutionError` semantics.

## Evidence

**Reproduced first at code level** (store unit test, no GUI): with two profiles
(`default`, `developer`) and a runtime id that has no tile / hint / row / event
scope, `refreshSessionControl('cd680e47')` produced the reported string
byte-for-byte:

```text
AssertionError: expected { capability: 'unknown', …(4) } to match object { error: null }
+   "error": "Session owner could not be resolved for \"cd680e47\" (session.control.read): no owner route, hint, connection-tagged row or profile probe named the backend that holds this session, and routing it to the active gateway would be a guess.",
```

and no socket received the RPC (fail-closed already correct).

**After the fix**, `apps/desktop/src/store/session-control-owner-recovery.integration.test.ts` pins:

- an ownerless read re-resolves the owner through the probe and retries
  `session.control.read` on that backend's socket (secondary profile socket
  called, ambient primary NOT called), hydrating the snapshot
  (`capability: 'supported'`, `error: null`);
- when the probe names nobody, the entry stays quiet
  (`capability: 'unknown'`, `error: null`, `snapshot: null`, no request
  anywhere) instead of surfacing the router's message;
- an ownerless read is never dispatched to the ambient gateway;
- the probe is **not** consulted when the owner ladder already resolves the
  session (no extra round trip per poll);
- ordinary backend failures and user-initiated action failures keep their
  existing error semantics.

`use-session-tile-delegate.test.ts` pins the production probe itself: a runtime
whose store-mirror entry was dropped still resolves through the cache's
stored→runtime binding + the durable row, falls back to treating the id as
already-stored, and names nobody for a runtime nothing knows (so the read stays
fail-closed).

Sabotage-verified: disabling the probe retry fails the two recovery tests;
skipping the probe installation fails the three wiring tests. Both were restored.

Commands:

```bash
cd apps/desktop
npx vitest run --project ui \
  src/store/session-control-owner-recovery.integration.test.ts \
  src/store/session-control.test.ts \
  src/store/gateway-profile-only-owner.integration.test.ts \
  src/store/session-states.test.ts \
  src/store/session-states-runtime-map.test.ts \
  src/store/read-only-transcript.test.ts \
  src/app/contrib/hooks/use-session-tile-delegate.test.ts \
  src/app/contrib/session-rpc-dispatcher.test.ts \
  src/app/chat/composer/status-stack/ \
  --maxWorkers=1 --no-file-parallelism
# -> Test Files 21 passed (21) | Tests 199 passed (199)
```

`npx tsc -p . --noEmit` reports only the pre-existing
`src/app/messaging/telegram-qr-setup.tsx(48,31): error TS2307: Cannot find
module 'qrcode'` (a declared dependency missing from this worktree's
`node_modules`); nothing from the changed files.

**Evidence boundary:** this is verified at the code/test level (store + wiring
unit and integration tests driving the real `refreshSessionControl`,
`requestForOwnedSession`, gateway registry and the installed probe). It was not
verified by running the Electron GUI against a live multi-profile install; the
GUI-side effect asserted here is the store contract `SessionControlSections`
consumes (`entry.error === null` + no snapshot ⇒ the strip renders nothing).

Closes #107502
