### PR TITLE
fix(desktop): resolve plugin SDK namespaces at call time

### DIFF
--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -13,21 +13,32 @@ import * as jsxRuntime from 'react/jsx-runtime'
 
 import * as sdk from './index'
 
-const GLOBALS = {
-  __HERMES_PLUGIN_SDK__: sdk,
-  __HERMES_REACT__: React,
-  __HERMES_REACT_JSX__: jsxRuntime,
-  __HERMES_REACT_JSX_DEV__: jsxDevRuntime
-} as const
+/** Namespaces resolve at CALL time, never captured at module-eval time: the
+ *  built `sdk` chunk concatenates module sections, and a dependency cycle can
+ *  order this module's section BEFORE the sections that assign the imported
+ *  bindings — a module-level object then captured `undefined`, and every
+ *  runtime-plugin load died in the shim builder (`Object.keys(undefined)` →
+ *  TypeError "Cannot convert undefined or null to object"). Both callers
+ *  below run after boot, when every binding is assigned. */
+function sdkGlobals() {
+  return {
+    __HERMES_PLUGIN_SDK__: sdk,
+    __HERMES_REACT__: React,
+    __HERMES_REACT_JSX__: jsxRuntime,
+    __HERMES_REACT_JSX_DEV__: jsxDevRuntime
+  } as const
+}
+
+type SdkGlobalKey = keyof ReturnType<typeof sdkGlobals>
 
 export function installPluginSdk(): void {
-  Object.assign(globalThis, GLOBALS)
+  Object.assign(globalThis, sdkGlobals())
 }
 
 /** Build a shim ESM blob that re-exports a global namespace's live members.
  *  Export names come from the namespace itself, so the list can't drift. */
-function shimUrl(globalKey: keyof typeof GLOBALS): string {
-  const names = Object.keys(GLOBALS[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
+function shimUrl(globalKey: SdkGlobalKey): string {
+  const names = Object.keys(sdkGlobals()[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
 
   const source =
     `const m = globalThis.${globalKey};\n` +


### PR DESCRIPTION
## What does this PR do?

Fixes every runtime (disk-door) desktop plugin failing to load after the recent bundle change:

```
[plugins] runtime load failed (<id>) TypeError: Cannot convert undefined or null to object (…/app.asar.unpacked/dist/assets/sdk-*.js:5)
```

Root cause: inside the built `sdk` chunk, `src/sdk/runtime.ts`'s module section can evaluate BEFORE the section that assigns the `./index` namespace binding it reads — the module cycle (`sdk/index` → `contrib/*` → `contrib/runtime-loader` → `sdk/runtime`) is preserved as concatenated sections, and the namespace read is a hoisted `var` that is still `undefined` at that point. The module-level `GLOBALS` object then froze those `undefined` values, so the first shim built on plugin load died on `Object.keys(undefined)` — for every plugin, including a zero-import probe plugin (the error points at the app's own chunk, not plugin code).

The fix resolves the namespaces at CALL time (`sdkGlobals()` read by `installPluginSdk()` and the shim builder) instead of capturing them at module-eval time. Both call sites only run after boot, when every binding is assigned. Single file, no API change.

> Transparency note: this is the same lazy-read direction as #107303 and is submitted at the author's request as a minimal corroborating variant (maintainers: prefer whichever candidate you pick — happy to close this one in favor of the canonical fix). Related issue: #107288.

## Related Issue

Related: #107288 — same regression and same diagnosis (this intentionally does not claim uniqueness; see note above).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/sdk/runtime.ts`: replace the module-level `GLOBALS` constant with a `sdkGlobals()` accessor called by `installPluginSdk()` and `shimUrl()`, so the SDK/React namespaces are resolved at call time (post-boot) rather than captured during chunk evaluation.

## How to Test

Repro on base (any packaged build of current `main`):

1. Drop any runtime plugin at `$HERMES_HOME/desktop-plugins/<id>/plugin.js` — an empty probe (`export default { id: 'probe', register() {} }`) is enough.
2. It fails with the TypeError above; `logs/desktop.log` shows `[plugins] runtime load failed (…)` pointing at `sdk-*.js:5`.

Proof the fix works (packaged Windows build, `release/win-unpacked`, Electron 40.10.2, desktop 0.17.2 / core v0.21.1):

1. **Chunk-level probe** (instrumented the built shim builder to log the namespace object per shim key, then invoked the import-map builder in real Electron): base build logs `__HERMES_PLUGIN_SDK__ → undefined` and throws on the first `Object.keys`; with this patch all four namespaces log `object` and the import map builds.
2. **App level** (patched build swapped into `release/win-unpacked`): all runtime plugins load — no `runtime load failed` lines after boot — and the affected statusbar chips render.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — it IS related to #107303/#107301/#107309 (see transparency note; submitted knowingly, at the reporter's request, cross-linked for triage)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for this change: it is a desktop TypeScript-only change; the Python suite is untouched (CI runs the full matrix)
- [ ] I've added tests for my changes — not in this PR: the failure requires the bundled chunk's section order (module cycle), which a vitest/ESM graph cannot reproduce; a behaviour-level test companion for this lazy-read direction exists in #107405
- [x] I've tested on my platform: Windows 11 (packaged `release/win-unpacked` build, Electron 40.10.2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (code comment in `runtime.ts` documents the cycle and the lazy-read requirement)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the fix is renderer-side and platform-agnostic; verified on Windows, the same lazy-read approach was independently verified on Linux in #107303's thread
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (base build, instrumented probe):

```
Cg key= __HERMES_PLUGIN_SDK__ typeof= undefined
TypeError: Cannot convert undefined or null to object
    at Object.keys (<anonymous>)
    at Cg (…/sdk-*.js:5:26820) …
```

After (same probe, patched build):

```
Cg key= __HERMES_PLUGIN_SDK__ typeof= object
Cg key= __HERMES_REACT_JSX_DEV__ typeof= object
Cg key= __HERMES_REACT_JSX__ typeof= object
Cg key= __HERMES_REACT__ typeof= object
→ import map builds, plugins load, no `runtime load failed` lines after restart
```
