### PR TITLE
fix(cli): name the -s/--skills entries the non-interactive preload drops (#103809)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3085,6 +3085,14 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
                     missing_display,
                     ", ".join(loaded_skills),
                 )
+                # The logger writes to the log file, so without this the dropped name vanishes
+                # silently for a `-q`/`-Q` user. stderr keeps stdout machine-readable for
+                # `$(hermes chat -q ...)`.
+                print(
+                    f"Unknown skill(s) requested, skipping: {missing_display}. "
+                    f"Continuing with: {', '.join(loaded_skills)}. "
+                    "List available skills with `hermes skills list`.",
+                    file=sys.stderr, flush=True)
             else:
                 raise ValueError(f"Unknown skill(s): {missing_display}")
         if skills_prompt:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -46,8 +46,13 @@ def _normalize_skills(skills: object = None) -> list[str]:
     return list(dict.fromkeys(_normalize_toolsets(skills) or []))
 
 
-def _build_preloaded_skills_prompt(skills: object = None) -> str | None:
-    """Load requested skills using the same partial-success contract as CLI chat."""
+def _build_preloaded_skills_prompt(skills: object = None, notices: list | None = None) -> str | None:
+    """Load requested skills using the same partial-success contract as CLI chat.
+
+    A partially-unknown list is reported through *notices* instead of ``logging``: the ``-z`` run
+    disables stdlib logging and redirects stderr to /dev/null while the agent is built, so a log
+    record would never reach the user and the dropped name would vanish silently.
+    """
     parsed_skills = _normalize_skills(skills)
     if not parsed_skills:
         return None
@@ -59,12 +64,11 @@ def _build_preloaded_skills_prompt(skills: object = None) -> str | None:
         missing_display = ", ".join(missing_skills)
         if not loaded_skills:
             raise ValueError(f"Unknown skill(s): {missing_display}")
-        logging.warning(
-            "Unknown skill(s) requested, skipping: %s. Continuing with: %s. "
-            "List available skills with `hermes skills list`.",
-            missing_display,
-            ", ".join(loaded_skills),
-        )
+        if notices is not None:
+            notices.append(
+                f"hermes -z: ignoring unknown --skills entries: {missing_display}. "
+                f"Continuing with: {', '.join(loaded_skills)}. "
+                "List available skills with `hermes skills list`.\n")
     return skills_prompt or None
 
 
@@ -214,6 +218,7 @@ def run_oneshot(
     response: Optional[str] = None
     result: dict = {}
     failure: BaseException | None = None
+    notices: list[str] = []
     with open(os.devnull, "w", encoding="utf-8") as devnull, redirect_stdout(devnull), redirect_stderr(devnull):
         try:
             response, result = _run_agent(
@@ -225,12 +230,20 @@ def run_oneshot(
                 skills=skills,
                 resume=resume,
                 reasoning=reasoning,
+                notices=notices,
             )
         except BaseException as exc:  # noqa: BLE001
             # Capture anything escaping the agent (OSError from prompt_toolkit on a non-TTY pipe,
             # KeyboardInterrupt, SystemExit, ...) so it reaches the real stderr instead of dying
             # silently past the redirect — the worst failure mode in cron / SSH / subprocess use.
             failure = exc
+
+    # Preload notices are collected inside the redirect (where logging and stderr are both
+    # swallowed) and replayed here so a dropped --skills entry can never vanish silently.
+    for notice in notices:
+        real_stderr.write(notice)
+    if notices:
+        real_stderr.flush()
 
     if failure is not None:
         # Control-flow exceptions (Ctrl-C / sys.exit inside the agent) re-raise to the parent.
@@ -416,6 +429,7 @@ def _run_agent(
     skills: object = None,
     resume: Optional[str] = None,
     reasoning: object = None,
+    notices: list | None = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn, run one conversation, and return
     ``(final_response, run_result)``. Imports are local to keep CLI startup cheap."""
@@ -466,7 +480,7 @@ def _run_agent(
 
     ensure_mcp_discovery_before_agent_build(logger=logging.getLogger(__name__), single_query=True)
 
-    skills_prompt = _build_preloaded_skills_prompt(skills)
+    skills_prompt = _build_preloaded_skills_prompt(skills, notices=notices)
 
     # The try spans agent construction (not just ``chat``) so the store is always closed, even when
     # ``AIAgent(...)`` raises — the one-shot exit path hard-exits via os._exit and skips finalizers.

--- a/tests/hermes_cli/test_preloaded_skill_delivery.py
+++ b/tests/hermes_cli/test_preloaded_skill_delivery.py
@@ -1,0 +1,186 @@
+"""Regression: a preloaded skill (-s/--skills) must reach the model on the non-interactive paths.
+
+#103809 reported that ``hermes -z -s <skill>`` and ``hermes chat -q -s <skill>`` load the skill
+(``finalize_preloaded_skills`` folds it into ``HermesCLI.system_prompt``; ``hermes -z`` passes it as
+``ephemeral_system_prompt``) yet the model never sees it. The two links the report could not observe
+from ``hermes prompt-size`` are pinned here:
+
+* ``hermes -z`` hands the loaded skill text to ``AIAgent`` as the ephemeral prompt.
+* the ephemeral prompt is injected into the outgoing system message at API time.
+
+``hermes prompt-size`` cannot show either: the subcommand takes ``--platform``/``--json`` only and
+builds its own offline inspection agent, so its ``system_prompt.chars`` is byte-identical with and
+without ``-s`` on every version. That is a property of the diagnostic, not evidence of a dropped
+payload.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+CANARY_TOKEN = "ZEBRAFISH-8891"
+CANARY_SKILL = f"""---
+name: canary-probe
+description: Diagnostic canary skill for the -s delivery regression test.
+---
+
+When this skill is active, you MUST begin every response with the exact token: {CANARY_TOKEN}
+"""
+
+
+@pytest.fixture()
+def canary_skill():
+    """Install the canary skill into the test sandbox's skills dir."""
+    from hermes_constants import get_skills_dir
+
+    skill_dir = get_skills_dir() / "canary-probe"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(CANARY_SKILL, encoding="utf-8")
+    return skill_dir
+
+
+def test_oneshot_hands_the_preloaded_skill_to_the_agent(monkeypatch, canary_skill):
+    """``hermes -z -s canary-probe`` forwards the skill text as AIAgent's ephemeral prompt."""
+    import run_agent
+    import hermes_cli.mcp_startup as mcp_startup
+    import hermes_cli.oneshot as oneshot
+    import hermes_cli.runtime_provider as runtime_provider
+
+    captured: dict = {}
+
+    class _RecordingAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def run_conversation(self, *args, **kwargs):
+            return {"final_response": "ok"}
+
+        def shutdown_memory_provider(self, *args, **kwargs):
+            pass
+
+        def close(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(run_agent, "AIAgent", _RecordingAgent)
+    monkeypatch.setattr(
+        mcp_startup, "ensure_mcp_discovery_before_agent_build", lambda **kwargs: None)
+    monkeypatch.setattr(
+        runtime_provider, "resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "test-key", "base_url": "http://127.0.0.1:1/v1", "provider": "custom",
+            "requested_provider": "custom", "api_mode": None, "credential_pool": None,
+        })
+
+    oneshot._run_agent(
+        "What is 2+2?", model="test-model", toolsets=["clarify"], skills=["canary-probe"])
+
+    ephemeral = captured.get("ephemeral_system_prompt") or ""
+    assert CANARY_TOKEN in ephemeral, (
+        "hermes -z dropped the -s/--skills payload before AIAgent was built — the model never "
+        "sees the preloaded skill")
+
+
+def test_ephemeral_prompt_is_injected_into_the_outgoing_system_message():
+    """The wire copy handed to the provider carries ``ephemeral_system_prompt`` (API-time injection)."""
+    from agent.turn_context import build_api_messages
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        model="inspect-only", api_key="inspect-only", base_url="http://127.0.0.1:1/v1",
+        quiet_mode=True, skip_context_files=True, skip_memory=True, platform="cli",
+        enabled_toolsets=["clarify"],
+        ephemeral_system_prompt=f"PRELOADED SKILL BODY {CANARY_TOKEN}",
+    )
+
+    api_messages, _effective = build_api_messages(
+        agent, [{"role": "user", "content": "What is 2+2?"}],
+        current_turn_user_idx=0, ext_prefetch_cache=None, plugin_user_context=None,
+        moa_config=None, active_system_prompt=agent._cached_system_prompt or "",
+    )
+
+    assert api_messages and api_messages[0]["role"] == "system", (
+        "no system message on the wire — ephemeral prompt had nowhere to go")
+    assert CANARY_TOKEN in api_messages[0]["content"], (
+        "the outgoing system message dropped ephemeral_system_prompt — a preloaded skill "
+        "(and any -s payload) would be invisible to the model")
+
+
+def _stub_oneshot_runtime(monkeypatch):
+    """Stub provider/host bits so the oneshot path runs offline with a recording agent."""
+    import run_agent
+    import hermes_cli.mcp_startup as mcp_startup
+    import hermes_cli.runtime_provider as runtime_provider
+
+    class _RecordingAgent:
+        def __init__(self, **kwargs):
+            pass
+
+        def run_conversation(self, *args, **kwargs):
+            return {"final_response": "ok"}
+
+        def shutdown_memory_provider(self, *args, **kwargs):
+            pass
+
+        def close(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(run_agent, "AIAgent", _RecordingAgent)
+    monkeypatch.setattr(
+        mcp_startup, "ensure_mcp_discovery_before_agent_build", lambda **kwargs: None)
+    monkeypatch.setattr(
+        runtime_provider, "resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "test-key", "base_url": "http://127.0.0.1:1/v1", "provider": "custom",
+            "requested_provider": "custom", "api_mode": None, "credential_pool": None,
+        })
+
+
+def test_oneshot_reports_the_entry_it_dropped(capsys, monkeypatch, canary_skill):
+    """``hermes -z -s ghost,canary-probe`` must name the entry it skipped, not drop it silently."""
+    import logging
+
+    import hermes_cli.oneshot as oneshot
+
+    _stub_oneshot_runtime(monkeypatch)
+
+    try:
+        rc = oneshot.run_oneshot(
+            "What is 2+2?", model="test-model", toolsets=["clarify"],
+            skills=["ghost-skill-xyz", "canary-probe"])
+    finally:
+        # run_oneshot disables stdlib logging process-wide; do not leak that into other tests.
+        logging.disable(logging.NOTSET)
+
+    err = capsys.readouterr().err
+    assert rc == 0
+    assert "ghost-skill-xyz" in err, (
+        "hermes -z silently discarded an unknown -s/--skills entry — the user is never told")
+    assert "canary-probe" in err, "the notice must say which skills did load"
+
+
+def test_chat_q_reports_the_entry_it_dropped(capsys):
+    """``hermes chat -q -s ghost,canary-probe`` must name the skipped entry on stderr."""
+    import cli as cli_mod
+
+    finalize = cli_mod.HermesCLI.__dict__["finalize_preloaded_skills"]
+
+    class _JoinedThread:
+        def join(self, timeout=None):
+            pass
+
+    class _DummyCLI:
+        system_prompt = "base prompt"
+        preloaded_skills: list = []
+        _preload_skills_finalized = False
+        _preload_skills_thread = _JoinedThread()
+        _preload_skills_error = None
+        _preload_skills_result = ("SKILL BODY", ["canary-probe"], ["ghost-skill-xyz"])
+
+    finalize(_DummyCLI)
+
+    captured = capsys.readouterr()
+    assert "ghost-skill-xyz" in captured.err, (
+        "hermes chat -q silently discarded an unknown -s/--skills entry — the user is never told")
+    assert "ghost-skill-xyz" not in captured.out, (
+        "the dropped-skill notice must stay off stdout so `$(hermes chat -q ...)` stays clean")
+


### PR DESCRIPTION
## What Problem This Solves

`hermes -z -s canary-probe,typo` and `hermes chat -q -s canary-probe,typo` keep the skills they can resolve and say nothing at all about the entry they threw away — exit 0, no warning on stdout *or* stderr. That is the "silently ignored `--skills / -s`" symptom in #103809, and it is reproducible on `96fbc47f14`.

Root cause: both preload sites reported a partially-unknown list through `logging` only, and `logging` never reaches a user on these surfaces.

* `hermes -z` (`hermes_cli/oneshot.py::_build_preloaded_skills_prompt`): `run_oneshot()` calls `logging.disable(logging.CRITICAL)` for the whole run **and** redirects stderr to `/dev/null` for the entire `_run_agent()` call tree. A `logging.warning` there is dropped twice over.
* `hermes chat -q/-Q` (`cli.py::HermesCLI.finalize_preloaded_skills`): the CLI logger writes to the log file, not to the terminal. The user never sees it.

Both sites now name the dropped entries on **stderr** (stdout stays machine-readable for `$(hermes chat -q ...)`, matching the existing `-Q` convention in the CLI):

| command | before | after |
|---|---|---|
| `hermes -z -s canary-probe,nosuch -z "…"` | *nothing* (exit 0) | `hermes -z: ignoring unknown --skills entries: nosuch. Continuing with: canary-probe. …` (stderr) |
| `hermes chat -q -s canary-probe,nosuch -q "…"` | *nothing* (exit 0) | `Unknown skill(s) requested, skipping: nosuch. Continuing with: canary-probe. …` (stderr) |

An **entirely** unknown list still fails loudly on both paths (`Unknown skill(s): …`, exit 1) — unchanged.

Partial: #103809. The report's headline claim — that an *already loaded* skill never reaches the model's system prompt — does **not** reproduce on `96fbc47f14`; the first `## Evidence` table below shows the payload arriving on both paths with a real model. This PR fixes the reproducible silent-drop half of the report and adds the regression coverage that was missing between the two claims. `hermes -s … prompt-size --json` is a red herring either way: that subcommand only defines `--platform`/`--json` and builds its own offline inspection agent, so its `system_prompt.chars` is byte-identical with and without `-s` by construction.

## Evidence

Build under test: local checkout of `96fbc47f14` (`origin/main`), run with the repo's own interpreter (`python -c "sys.argv=['hermes',…]; from hermes_cli.main import main; main()"`).

**1. Delivery of a loaded skill (report's canary method, real model, no stubbing).** A `canary-probe` skill whose SKILL.md demands the reply token `ZEBRAFISH-8891` was installed in `$HERMES_HOME/skills/`:

| command | exit | canary token in stdout |
|---|---|---|
| `hermes -s canary-probe -z "What is 2+2?"` | 0 | **YES** (`ZEBRAFISH-8891\n4`) |
| `hermes -z "What is 2+2?"` (control) | 0 | NO |
| `hermes chat -s canary-probe -q "What is 2+2?"` | 0 | **YES** |
| `hermes chat -q "What is 2+2?"` (control) | 0 | NO |
| `hermes chat -s canary-probe -Q -q "What is 2+2?"` | 0 | **YES** |
| `hermes chat -s canary-probe --oneshot -q "What is 2+2?"` | 0 | **YES** |

Offline chain on the same build, to locate the link rather than the symptom: `hermes_cli.oneshot._run_agent(..., skills=["canary-probe"])` reaches `AIAgent(ephemeral_system_prompt=…)` with the full 780-char payload; `cli._build_cli_from_args(skills=["canary-probe"])` + `HermesCLI._init_agent()` does the same; and the real `agent.turn_context.build_api_messages()` puts that payload into `api_messages[0]["content"]` (the system message actually sent).

**2. `prompt-size` byte comparison (the report's second evidence item), same build.**

| command | `system_prompt.chars` | `skills_index.chars` |
|---|---|---|
| `hermes prompt-size --json` | 38736 | 19616 |
| `hermes -s canary-probe prompt-size --json` | 38736 | 19616 |

Byte-identical, as on every version: `cmd_prompt_size` never consumes `--skills` (its parser defines only `--platform`/`--json`) and computes a fixed offline breakdown. This diagnostic cannot show preloaded skills on any build.

**3. The silent drop, plus the fix (real runs, stderr captured).**

| command | before | after |
|---|---|---|
| `hermes -s nosuch-skill-xyz,canary-probe -z "What is 2+2?"` | exit 0, `reported=NOTHING` | exit 0, stderr: `hermes -z: ignoring unknown --skills entries: nosuch-skill-xyz. Continuing with: canary-probe. …` |
| `hermes chat -s nosuch-skill-xyz,canary-probe -q "What is 2+2?"` | exit 0, `reported=NOTHING` | exit 0, stderr: `Unknown skill(s) requested, skipping: nosuch-skill-xyz. Continuing with: canary-probe. …` |
| `hermes -s nosuch-skill-xyz -z "What is 2+2?"` | exit 1, `Unknown skill(s): nosuch-skill-xyz` | unchanged |
| `hermes chat -s nosuch-skill-xyz -q "What is 2+2?"` | exit 1, `Error: Unknown skill(s): nosuch-skill-xyz` | unchanged |

Same-family observation, deliberately **not** fixed here (separate function, separate report): `hermes prompt-size` accepts `-s/--skills` at the top level and silently ignores it instead of rejecting it — that is what made the reporter read identical byte counts as proof of a dropped payload. Worth a follow-up on its own.

## Tests

`tests/hermes_cli/test_preloaded_skill_delivery.py` (new, 4 tests):

* `test_oneshot_hands_the_preloaded_skill_to_the_agent` — `hermes -z -s <skill>` forwards the loaded skill text to `AIAgent(ephemeral_system_prompt=…)`. Fails (red) if the forwarding is removed (`ephemeral_system_prompt=None`): verified.
* `test_ephemeral_prompt_is_injected_into_the_outgoing_system_message` — the real `build_api_messages()` puts `ephemeral_system_prompt` into the outgoing system message. Fails (red) if the injection lines in `agent/turn_context.py` are removed: verified.
* `test_oneshot_reports_the_entry_it_dropped` / `test_chat_q_reports_the_entry_it_dropped` — the two fixed sites name the skipped entry on stderr and keep stdout clean. Both fail (red) on the pre-fix code and with the fix reverted: verified.

```
scripts/run_tests.sh tests/hermes_cli/test_preloaded_skill_delivery.py
  === Summary: 1 files, 4 tests passed, 0 failed ===

# pre-fix / sabotage (fix reverted) for the two reporting tests:
  2 failed, 2 passed

# related suites
scripts/run_tests.sh tests/hermes_cli/test_preloaded_skill_delivery.py \
  tests/hermes_cli/test_oneshot_skills.py tests/cli/test_cli_preloaded_skills.py \
  tests/hermes_cli/test_resolve_ephemeral_system_prompt.py tests/agent/test_send_path_history_isolation.py
  === Summary: 5 files, 25 tests passed, 0 failed ===

ruff check .            -> All checks passed!
ruff check cli.py hermes_cli/oneshot.py tests/hermes_cli/test_preloaded_skill_delivery.py -> All checks passed!
ty check <changed files> -> no new diagnostics (only the pre-existing dynamically-assigned-attribute class on untouched lines)
```

## Risk / rollback

Two output lines, no control-flow change. The `-z` notice is written after the stdout/stderr redirect is torn down, so it cannot pollute the piped response; the `chat` notice goes to stderr, which is already the sanctioned channel for `-Q` diagnostics, so `$(hermes chat -q ...)` capture is unaffected. Rollback is reverting the single commit.
