### PR TITLE
fix(desktop): clarify plugins pageBlurb and fix Agent dropdown overflow

### DIFF
--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -786,14 +786,16 @@ export function SkillsView({
     if (multiConnection && rosterData?.agents?.length) {
       const activeId = activeGatewayConnectionId() ?? 'local'
 
-      return rosterData.agents.map((agent: DesktopRosterAgent) => ({
-        key: `${agent.connectionId}::${agent.profile}`,
-        label:
-          agent.connectionId === activeId
-            ? `${agent.profile} — ${agent.connectionLabel} (current)`
-            : `${agent.profile} — ${agent.connectionLabel}`,
-        value: `${agent.connectionId}::${agent.profile}`
-      }))
+      return rosterData.agents.map((agent: DesktopRosterAgent) => {
+        const isDefault = agent.profile === 'default'
+        const displayLabel = isDefault ? agent.connectionLabel : `${agent.profile} — ${agent.connectionLabel}`
+        
+        return {
+          key: `${agent.connectionId}::${agent.profile}`,
+          label: displayLabel,
+          value: `${agent.connectionId}::${agent.profile}`
+        }
+      })
     }
 
     return (profilesData?.profiles ?? []).map(p => ({
@@ -841,7 +843,7 @@ export function SkillsView({
         )}
         <Select onValueChange={changeScope} value={scopeSelectValue}>
           <SelectTrigger className={cn('text-xs', compactSelector ? 'h-6 w-full max-w-64 px-2' : 'h-7 w-56')}>
-            <SelectValue />
+            <SelectValue className="min-w-0 truncate" />
           </SelectTrigger>
           <SelectContent>
             {scopeOptions.map(option => (

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1589,7 +1589,7 @@ export const en: Translations = {
       agentTitle: 'Agent plugins',
       agentBlurb:
         'Extend the agent for the selected profile — tools, hooks, providers. Take effect after a gateway restart.',
-      pageBlurb: 'One row per plugin. A plugin can extend this app, the agent, or both — each half has its own switch.',
+      pageBlurb: 'Each plugin can have a Desktop half (this app) and an Agent half (the selected profile), each with its own switch.',
       halfDesktop: 'Desktop',
       halfDesktopHint: 'this app, same for every profile',
       halfAgent: 'Agent',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1756,7 +1756,7 @@ export const zh: Translations = {
     plugins: {
       agentTitle: 'Agent 插件',
       agentBlurb: '为所选配置扩展 agent — 工具、钩子、模型提供方。重启网关后生效。',
-      pageBlurb: '每个插件一行。插件可以扩展本应用、agent，或两者 — 每一半都有自己的开关。',
+      pageBlurb: '每个插件可以有 Desktop 半部分(本应用)和 Agent 半部分(所选配置文件)，各有自己的开关。',
       halfDesktop: '桌面',
       halfDesktopHint: '本应用，所有配置相同',
       halfAgent: 'Agent',


### PR DESCRIPTION
Fixes #107635

## Summary

Two polish fixes for the Plugins page (comp/desktop, area/i18n):

1. **pageBlurb cleanup**: Removed "One row per plugin" from `en.ts:1588` and `zh.ts:1759` — the sentence described the implementation (merged rows per package), not anything a user of the page needs. The explanation now starts with the useful part: "Each plugin can have a Desktop half and an Agent half, each with its own switch."

2. **Agent dropdown overflow**: Fixed the profile-selector dropdown in the Agent column header:
   - Added `min-w-0 truncate` to `<SelectValue>` so selected labels no longer spill off the window when long.
   - Simplified label taxonomy: dropped the `(current)` suffix (redundant when the value is selected), and collapsed `profile — connection` to just `connection` when the profile is `default`.

## Testing

Manual verification:
- Built the desktop app and confirmed pageBlurb renders without dev-internal residue
- Checked that dropdown labels truncate in the trigger and fit within viewport bounds

## Checklist

- [x] i18n strings updated (en.ts, zh.ts)
- [x] Component logic cleaned (index.tsx)
- [x] No breaking changes
- [x] Follows project code style