### PR TITLE
send-approval plugin: effect-class approval gate for send / spend / hard-to-undo tool calls

### DIFF
--- a/plugins/send-approval/__init__.py
+++ b/plugins/send-approval/__init__.py
@@ -1,0 +1,161 @@
+"""send-approval plugin — effect-class approval gate for send / spend / hard-to-undo calls.
+
+Instinct safety parity: draft → show recipient + final content → send only after
+approval; never spend without confirmation; never make a hard-to-undo change from a
+guess. This plugin classifies every dispatched tool call into an effect class
+(``send-to-person`` / ``spend`` / ``hard-to-undo``) and — for flagged calls — returns
+the documented ``pre_tool_call`` directive ``{"action": "approve", "message": ...,
+"rule_key": ...}`` (``plugins/AGENTS.md``). Core (``hermes_cli/plugins.py``) then
+escalates the call through ``tools/approval.py:request_tool_approval`` — the SAME
+human gate as Tier-2 dangerous shell patterns: session cache, the ``[a]lways``
+allowlist (grained by ``rule_key``), the CLI prompt, the blocking gateway
+round-trip (``tools/approval_gateway_wait.py``), cron ``approvals.cron_mode``, and
+fail-closed when no human is present.
+
+The classifier NEVER blocks by itself: a refusal is the user's deny verdict (or the
+gate's fail-closed default), never a classifier decision. Destructive shell commands
+keep their own core gate (``tools/approval.py`` dangerous-command detection +
+``tools/write_approval.py``); this plugin adds the missing policy layer for the
+piece/MCP families below:
+
+* ``mcp__activepieces__ap_run_action`` — the ActivePieces piece runner, classified
+  from the piece/action name in its args (send/create/delete/pay/charge/post verbs).
+* Piece actions surfacing as ``<piece>_<action>`` MCP names: ``gmail_send*``,
+  ``slack_send*``, ``*_send_message``, ``stripe_*`` (spend), calendar
+  create/delete, file/repo destructive ops (``*_delete_*`` and friends).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+SEND = "send-to-person"
+SPEND = "spend"
+UNDO = "hard-to-undo"
+
+# Explicit families from the parity contract: (needle, effect, human label).
+# Substring matches against the FULL lowercased tool name, so they hit every wire
+# form (bare ``gmail_send_email``, ``mcp__activepieces__gmail_send_email``, legacy
+# ``mcp_activepieces_gmail_send_email``). Checked before the generic verb scan so
+# calendar create classifies as send-to-person (it invites attendees), not create.
+_NAME_RULES: Tuple[Tuple[str, str, str], ...] = (
+    ("gmail_send", SEND, "Gmail send"),
+    ("slack_send", SEND, "Slack send"),
+    ("stripe_", SPEND, "Stripe"),  # every stripe_* action moves money or card data
+    ("send_message", SEND, "outbound message"),  # *_send_message and bare send_message
+    ("calendar_create", SEND, "calendar create"),
+    ("calendar_delete", UNDO, "calendar delete"),
+)
+
+# Generic verb scan, applied to MCP-scoped names only (native toolsets — terminal,
+# file, memory — already have their own core gates). First group with a token-boundary
+# hit wins, so "create_charge" classifies as spend, not create.
+_VERB_RULES: Tuple[Tuple[Tuple[str, ...], str], ...] = (
+    (("send", "post", "reply", "forward", "invite"), SEND),
+    (("pay", "charge", "purchase", "checkout"), SPEND),
+    (("delete", "remove", "trash", "purge", "revoke"), UNDO),
+    (("create",), UNDO),  # creating external state from a guess is the hard-to-undo risk
+)
+
+_EFFECT_REASON = {
+    SEND: ("send-to-person: this action sends content to a person ({detail}). Confirm "
+           "the recipient and the final content before anything goes out."),
+    SPEND: ("spend: this action moves money ({detail}). Confirm the amount and the "
+            "recipient before any payment goes through."),
+    UNDO: ("hard-to-undo: this action is hard to undo ({detail}). Confirm before it "
+           "runs — never make a hard-to-undo change from a guess."),
+}
+
+# The ActivePieces action runner: classification comes from its args, not its name.
+_RUNNER_SERVER = "activepieces"
+_RUNNER_BASES = ("ap_run_action", "run_action")
+_RUNNER_KEY_SUBSTRINGS = ("piece", "action")
+
+
+def _split_mcp_name(tool_name: str) -> Tuple[str, str]:
+    """``(server, base)`` from ``mcp__<server>__<tool>`` / ``mcp_<server>_<tool>``;
+    bare names get the leading component as server (harmless — no rule needs it)."""
+    name = (tool_name or "").strip().lower()
+    if name.startswith("mcp__"):
+        server, _, base = name[5:].partition("__")
+        return server, base
+    server, _, base = name.removeprefix("mcp_").partition("_")
+    return server, base
+
+
+def _verb_hit(text: str) -> Optional[str]:
+    """First flagged verb at a token boundary in *text* (``resend_`` does not match
+    ``send``; the underscore of snake_case does not hide a verb)."""
+    for verbs, effect in _VERB_RULES:
+        for verb in verbs:
+            if re.search(rf"(?<![A-Za-z]){re.escape(verb)}", text):
+                return effect
+    return None
+
+
+def _action_strings(args: Any, depth: int = 2) -> List[str]:
+    """Piece/action identifier strings from the runner args. Only values under keys
+    naming the piece or action are scanned — never user content like an email body."""
+    if not isinstance(args, dict):
+        return []
+    found: List[str] = []
+    for key, value in args.items():
+        key_l = str(key).lower()
+        if not any(marker in key_l for marker in _RUNNER_KEY_SUBSTRINGS):
+            continue
+        found.extend(_string_values(value, depth))
+    return found
+
+
+def _string_values(value: Any, depth: int) -> List[str]:
+    if isinstance(value, str):
+        return [value]
+    if depth <= 0:
+        return []
+    if isinstance(value, dict):
+        return [s for v in value.values() for s in _string_values(v, depth - 1)]
+    if isinstance(value, (list, tuple)):
+        return [s for v in value for s in _string_values(v, depth - 1)]
+    return []
+
+
+def _classify(tool_name: str, args: Any) -> Optional[Dict[str, str]]:
+    """Classify one tool call; ``None`` when it is not flagged, else
+    ``{"effect", "message", "rule_key"}`` for the approval gate."""
+    name = (tool_name or "").strip().lower()
+    if not name:
+        return None
+    for needle, effect, label in _NAME_RULES:
+        if needle in name:
+            return _verdict(effect, label, name)
+    server, base = _split_mcp_name(name)
+    if not server:
+        return None
+    effect = _verb_hit(base)
+    if effect is not None:
+        return _verdict(effect, base, name)
+    if _RUNNER_SERVER in server and base in _RUNNER_BASES:
+        for action_name in _action_strings(args):
+            effect = _verb_hit(action_name)
+            if effect is not None:
+                return _verdict(effect, action_name, name)
+    return None
+
+
+def _verdict(effect: str, label: str, tool_name: str) -> Dict[str, str]:
+    rule_key = f"send-approval:{re.sub(r'[^a-z0-9]+', '-', label.lower()).strip('-')}"
+    message = _EFFECT_REASON[effect].format(detail=f"{label} via {tool_name}")
+    return {"effect": effect, "message": message, "rule_key": rule_key}
+
+
+def _on_pre_tool_call(tool_name: str = "", args: Any = None, **_: Any) -> Optional[Dict[str, str]]:
+    """pre_tool_call hook: escalate flagged calls to the human gate (None = let it through)."""
+    verdict = _classify(tool_name, args)
+    if verdict is None:
+        return None
+    return {"action": "approve", "message": verdict["message"], "rule_key": verdict["rule_key"]}
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_tool_call", _on_pre_tool_call)

--- a/plugins/send-approval/plugin.yaml
+++ b/plugins/send-approval/plugin.yaml
@@ -1,0 +1,6 @@
+name: send-approval
+version: "0.1.0"
+description: "Effect-class approval gate for tool calls that send to a person, spend money, or are hard to undo (Instinct safety parity). Classifies MCP piece actions (gmail_send*, slack_send*, *_send_message, stripe_*, calendar create/delete, file/repo destructive ops) and the ActivePieces action runner, and escalates flagged calls to the SAME human-approval gate as dangerous shell commands — approve over the CLI or the blocking gateway round-trip, deny refused, unattended contexts fail closed. The classifier never blocks by itself: a refusal is always the user's verdict (or the fail-closed default)."
+author: "NousResearch"
+hooks:
+  - pre_tool_call

--- a/tests/plugins/test_send_approval_plugin.py
+++ b/tests/plugins/test_send_approval_plugin.py
@@ -1,0 +1,330 @@
+"""Tests for the send-approval plugin.
+
+Covers ``plugins/send-approval/``:
+
+  * Classification table — effect classes {send-to-person, spend,
+    hard-to-undo} over the parity families: the AP piece runner
+    (``mcp__activepieces__ap_run_action``, classified from the piece action
+    name in its args), ``gmail_send*``, ``slack_send*``, ``*_send_message``,
+    ``stripe_*``, calendar create/delete, and file/repo destructive piece
+    actions. Read-only piece actions and native tools are NOT flagged.
+  * Gate integration through the REAL ``pre_tool_call`` dispatch —
+    ``hermes_cli.plugins._dispatch_pre_tool_call_hooks`` reuses
+    ``tools/approval.py:request_tool_approval``: approve → the tool
+    proceeds, deny → refused, unattended (no human) → refused (never
+    fails open).
+  * Bundled-plugin discovery via ``PluginManager.discover_and_load``.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module loading
+# ---------------------------------------------------------------------------
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_plugin_init():
+    """Import the plugin __init__.py in isolation under a plugin namespace."""
+    plugin_dir = _repo_root() / "plugins" / "send-approval"
+    if "hermes_plugins" not in sys.modules:
+        ns = types.ModuleType("hermes_plugins")
+        ns.__path__ = []
+        sys.modules["hermes_plugins"] = ns
+    spec = importlib.util.spec_from_file_location(
+        "hermes_plugins.send_approval_under_test",
+        plugin_dir / "__init__.py",
+        submodule_search_locations=[str(plugin_dir)],
+    )
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "hermes_plugins.send_approval_under_test"
+    mod.__path__ = [str(plugin_dir)]
+    sys.modules["hermes_plugins.send_approval_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+AP_SEND = {
+    "pieceName": "gmail",
+    "actionName": "send_email",
+    "input": {"to": "dana@example.com", "subject": "Lunch?"},
+}
+
+
+# ---------------------------------------------------------------------------
+# Classification table
+# ---------------------------------------------------------------------------
+
+class TestClassificationTable:
+    def _flag(self, mod, tool_name, args=None):
+        return mod._classify(tool_name, args if args is not None else {})
+
+    def test_runner_args_send_to_person(self):
+        """ap_run_action with a send-flavored piece action name is flagged as send-to-person."""
+        mod = _load_plugin_init()
+        out = self._flag(mod, "mcp__activepieces__ap_run_action", AP_SEND)
+        assert out is not None
+        assert out["effect"] == "send-to-person"
+
+    def test_runner_args_spend(self):
+        mod = _load_plugin_init()
+        out = self._flag(mod, "mcp__activepieces__ap_run_action",
+                         {"pieceName": "stripe", "actionName": "create_charge"})
+        assert out is not None
+        assert out["effect"] == "spend"
+
+    def test_runner_args_hard_to_undo(self):
+        mod = _load_plugin_init()
+        out = self._flag(mod, "mcp__activepieces__ap_run_action",
+                         {"pieceName": "google-drive", "actionName": "delete_file"})
+        assert out is not None
+        assert out["effect"] == "hard-to-undo"
+
+    def test_runner_read_only_piece_action_not_flagged(self):
+        mod = _load_plugin_init()
+        assert self._flag(mod, "mcp__activepieces__ap_run_action",
+                          {"pieceName": "gmail", "actionName": "list_threads"}) is None
+
+    def test_runner_without_action_args_not_flagged(self):
+        mod = _load_plugin_init()
+        assert self._flag(mod, "mcp__activepieces__ap_run_action", {}) is None
+        assert self._flag(mod, "mcp__activepieces__ap_run_action", None) is None
+
+    def test_piece_action_tool_name_send(self):
+        """Piece actions surfacing as <piece>_<action> MCP tool names are classified by name."""
+        mod = _load_plugin_init()
+        out = self._flag(mod, "mcp__activepieces__gmail_send_email")
+        assert out is not None
+        assert out["effect"] == "send-to-person"
+
+    def test_legacy_single_underscore_mcp_form(self):
+        mod = _load_plugin_init()
+        out = self._flag(mod, "mcp_activepieces_gmail_send_email")
+        assert out is not None
+        assert out["effect"] == "send-to-person"
+
+    def test_gmail_send_family(self):
+        mod = _load_plugin_init()
+        out = self._flag(mod, "gmail_send_email")
+        assert out is not None
+        assert out["effect"] == "send-to-person"
+
+    def test_slack_send_family(self):
+        mod = _load_plugin_init()
+        out = self._flag(mod, "slack_send_channel_message")
+        assert out is not None
+        assert out["effect"] == "send-to-person"
+
+    def test_send_message_suffix_family(self):
+        """Any *_send_message (twilio, whatsapp, chat platforms, ...) is flagged."""
+        mod = _load_plugin_init()
+        for name in ("twilio_send_message", "whatsapp_send_message", "send_message"):
+            out = self._flag(mod, name)
+            assert out is not None, name
+            assert out["effect"] == "send-to-person", name
+
+    def test_stripe_family(self):
+        """Every stripe_* action moves money or card data: flagged as spend."""
+        mod = _load_plugin_init()
+        for name in ("stripe_create_charge", "stripe_create_payment_intent", "stripe_refund"):
+            out = self._flag(mod, name)
+            assert out is not None, name
+            assert out["effect"] == "spend", name
+
+    def test_calendar_create_flagged(self):
+        mod = _load_plugin_init()
+        out = self._flag(mod, "google_calendar_create_event")
+        assert out is not None
+        assert out["effect"] == "send-to-person"
+
+    def test_outlook_calendar_create_flagged(self):
+        mod = _load_plugin_init()
+        out = self._flag(mod, "microsoft_outlook_calendar_create_event")
+        assert out is not None
+        assert out["effect"] == "send-to-person"
+
+    def test_calendar_delete_hard_to_undo(self):
+        mod = _load_plugin_init()
+        out = self._flag(mod, "microsoft_outlook_calendar_delete_event")
+        assert out is not None
+        assert out["effect"] == "hard-to-undo"
+
+    def test_repo_file_destructive_hard_to_undo(self):
+        mod = _load_plugin_init()
+        for name in ("github_delete_branch", "google_drive_delete_file",
+                     "mcp__activepieces__github_delete_file"):
+            out = self._flag(mod, name)
+            assert out is not None, name
+            assert out["effect"] == "hard-to-undo", name
+
+    def test_read_only_piece_actions_not_flagged(self):
+        mod = _load_plugin_init()
+        for name in ("gmail_list_threads", "slack_read_channel",
+                     "google_calendar_list_events", "github_get_issue"):
+            assert self._flag(mod, f"mcp__activepieces__{name}") is None, name
+
+    def test_native_non_mcp_tools_not_flagged(self):
+        """Native toolsets (file/terminal/memory) are NOT gated here — destructive
+        shell commands already run through the core approval machinery."""
+        mod = _load_plugin_init()
+        for name in ("read_file", "write_file", "terminal", "memory", "browser", "todo"):
+            assert self._flag(mod, name, {"command": "rm -rf /"}) is None, name
+
+    def test_distinct_rule_keys_per_family(self):
+        mod = _load_plugin_init()
+        a = self._flag(mod, "gmail_send_email")
+        b = self._flag(mod, "stripe_create_charge")
+        assert a["rule_key"] != b["rule_key"]
+
+    def test_reason_names_effect_class(self):
+        mod = _load_plugin_init()
+        out = self._flag(mod, "mcp__activepieces__ap_run_action", AP_SEND)
+        assert "send-to-person" in out["message"]
+        assert "gmail" in out["message"].lower() or "send" in out["message"].lower()
+
+
+class TestHookDirective:
+    def test_returns_approve_directive_for_flagged_call(self):
+        mod = _load_plugin_init()
+        out = mod._on_pre_tool_call(tool_name="mcp__activepieces__ap_run_action", args=AP_SEND)
+        assert isinstance(out, dict)
+        assert out["action"] == "approve"
+        assert out["message"]
+        assert out["rule_key"]
+
+    def test_returns_none_for_unflagged_call(self):
+        mod = _load_plugin_init()
+        assert mod._on_pre_tool_call(tool_name="gmail_list_threads", args={}) is None
+
+
+# ---------------------------------------------------------------------------
+# Gate integration — through the real pre_tool_call dispatch
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def _hermes_home(tmp_path, monkeypatch):
+    """Temp HERMES_HOME with send-approval enabled through the real config path."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    import yaml
+
+    config = {"plugins": {"enabled": ["send-approval"]}}
+    (tmp_path / ".hermes").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".hermes" / "config.yaml").write_text(yaml.safe_dump(config))
+    for k in list(sys.modules):
+        if k.startswith(("hermes_plugins", "hermes_cli.plugins")):
+            del sys.modules[k]
+    from hermes_cli.plugins import _ensure_plugins_discovered
+
+    mgr = _ensure_plugins_discovered(force=True)
+    loaded = set(getattr(mgr, "_plugins", {}).keys())
+    assert "send-approval" in loaded
+    yield tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _isolate_approval_state(monkeypatch):
+    """Clean approval state: fixed session key, empty allowlists, not yolo."""
+    import tools.approval as approval
+    import tools.approval_context as approval_context
+
+    monkeypatch.setattr(approval, "get_current_session_key", lambda default="default": "test-session")
+    monkeypatch.setattr(approval_context, "get_current_session_key", lambda default="default": "test-session")
+    monkeypatch.setattr(approval, "is_approved", lambda sk, pk: False)
+    monkeypatch.setattr(approval, "is_current_session_yolo_enabled", lambda: False)
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", False, raising=False)
+    monkeypatch.setattr("tools.terminal_tool._get_approval_callback", lambda: None, raising=False)
+    yield
+
+
+class TestGateIntegration:
+    """The plugin's approve directive must reuse tools/approval.py's human gate."""
+
+    def _dispatch(self, tool_name="mcp__activepieces__ap_run_action", args=None):
+        from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
+
+        return _dispatch_pre_tool_call_hooks(tool_name, args if args is not None else AP_SEND)
+
+    def test_approved_call_proceeds(self, _hermes_home, monkeypatch):
+        """Gate verdict 'once' → the tool call proceeds (block message None)."""
+        import tools.approval as approval
+        import tools.approval_context as approval_context
+        import tools.approval_prompt as approval_prompt
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(approval_context, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", lambda *a, **k: "once")
+        monkeypatch.setattr(approval_prompt, "prompt_dangerous_approval", lambda *a, **k: "once")
+        assert self._dispatch() == (None, None)
+
+        import tools.approval as approval
+        import tools.approval_context as approval_context
+        import tools.approval_prompt as approval_prompt
+
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(approval_context, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", lambda *a, **k: "deny")
+        monkeypatch.setattr(approval_prompt, "prompt_dangerous_approval", lambda *a, **k: "deny")
+        block_message, _modified = self._dispatch()
+        assert block_message is not None
+        assert "denied" in block_message.lower()
+
+    def test_unattended_refused_never_fails_open(self, _hermes_home, monkeypatch):
+        """No interactive user / gateway / cron present → fail CLOSED."""
+        import tools.approval as approval
+        import tools.approval_context as approval_context
+
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(approval_context, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(approval_context, "_is_cron_approval_context", lambda: False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        block_message, _modified = self._dispatch()
+        assert block_message is not None
+        assert "no interactive user or gateway" in block_message.lower()
+
+    def test_unflagged_call_never_enters_gate(self, _hermes_home, monkeypatch):
+        """Read-only piece actions run without any approval round-trip."""
+        prompts = []
+        import tools.approval as approval
+        import tools.approval_prompt as approval_prompt
+
+        monkeypatch.setattr(approval, "prompt_dangerous_approval",
+                            lambda *a, **k: prompts.append(1) or "deny")
+        monkeypatch.setattr(approval_prompt, "prompt_dangerous_approval",
+                            lambda *a, **k: prompts.append(1) or "deny")
+        block_message, _modified = self._dispatch(
+            tool_name="mcp__activepieces__ap_run_action",
+            args={"pieceName": "gmail", "actionName": "list_threads"},
+        )
+        assert block_message is None
+        assert prompts == []
+
+
+# ---------------------------------------------------------------------------
+# Bundled-plugin discovery
+# ---------------------------------------------------------------------------
+
+class TestPluginDiscovery:
+    def test_manifest_declares_pre_tool_call_hook(self):
+        import yaml
+
+        manifest = yaml.safe_load(
+            (_repo_root() / "plugins" / "send-approval" / "plugin.yaml").read_text())
+        assert manifest["name"] == "send-approval"
+        assert manifest["hooks"] == ["pre_tool_call"]
+
+    def test_loads_via_plugin_manager(self, _hermes_home):
+        """End-to-end: enabled in config.yaml → PluginManager discovers it."""
+        from hermes_cli.plugins import get_plugin_manager
+
+        mgr = get_plugin_manager()
+        assert "send-approval" in set(getattr(mgr, "_plugins", {}).keys())


### PR DESCRIPTION
## What

New bundled plugin `plugins/send-approval/` (manifest + one `pre_tool_call` hook, `register()` only — no core changes). Instinct safety parity: tool calls that **send to a person**, **spend money**, or are **hard to undo** are escalated to the SAME human-approval gate as Tier-2 dangerous shell patterns, via the documented plugin directive `{"action": "approve", "message", "rule_key"}` → `tools/approval.py:request_tool_approval` (session cache, `[a]lways` allowlist, CLI prompt, blocking gateway round-trip, cron `approvals.cron_mode`, **fail-closed unattended**).

## Classification table

| Family | Effect class |
|---|---|
| `mcp__activepieces__ap_run_action` (piece/action name in args: send/post/reply/forward/invite, pay/charge/purchase/checkout, delete/remove/trash/purge/revoke, create) | send-to-person / spend / hard-to-undo |
| `gmail_send*` | send-to-person |
| `slack_send*` | send-to-person |
| `*_send_message` (incl. bare) | send-to-person |
| `stripe_*` | spend |
| `*calendar_create*` | send-to-person (invite goes to attendees) |
| `*calendar_delete*` | hard-to-undo |
| MCP piece verbs `*_delete_*` etc. (file/repo destructive ops) | hard-to-undo |

Matches all wire forms (`mcp__<server>__<tool>`, legacy `mcp_<server>_<tool>`, bare). Read-only piece actions and native toolsets (terminal/file/memory — destructive shell already has its core gate + write gate) are NOT flagged. The classifier never returns `block`: a refusal is the user's deny verdict or the fail-closed default. `rule_key` grains the `[a]lways` allowlist per family.

## Tests

26 tests, red-first per family/effect class, in `tests/plugins/test_send_approval_plugin.py`:

- classification table per family + read-only/native negatives + distinct rule keys
- gate integration through the REAL dispatch path (`_dispatch_pre_tool_call_hooks` → `request_tool_approval`): approve → proceeds, deny → refused, unattended → refused (fail-closed), unflagged → never enters the gate
- discovery via `PluginManager` with `plugins.enabled: ["send-approval"]`

All green (26 passed). Scoped neighbors `tests/tools/test_request_tool_approval.py`, `tests/plugins/test_security_guidance_plugin.py` pass; the 3 pre-existing environment-dependent failures in `tests/hermes_cli/test_plugins.py` reproduce identically without this change (timeout/whitelist timing tests). Ruff clean.

## Consumers

The qwen-live meeting agent seeds `plugins.enabled: ["send-approval"]` into its hermes home; in gateway sessions the ask rides `tools/approval_gateway_wait.py`, so in-meeting approvals surface as the agent speaking + the draft in meeting chat.