### PR TITLE
fix(desktop): preserve first space in free-text commands

### DIFF
--- a/apps/desktop/src/app/chat/composer/composer-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/composer-utils.test.ts
@@ -94,6 +94,23 @@ describe('acceptsTriggerCompletion', () => {
     expect(press(' ', { query: '' })).toBe(false)
   })
 
+  it('types the first space after a free-text command instead of chipping the command', () => {
+    // Before that first space is inserted, the query is still just `title`, so
+    // `freeTextArgStage` is false. The command itself must still protect the
+    // key: otherwise `/title First Last` becomes a `/title` chip plus unrelated
+    // prose, and the title action loses its argument.
+    expect(
+      acceptsTriggerCompletion({
+        activeExplicit: false,
+        freeTextCommand: true,
+        freeTextArgStage: false,
+        key: ' ',
+        kind: '/',
+        query: 'title'
+      })
+    ).toBe(false)
+  })
+
   // The `/goal <prose>` class: the popover may be live over free-form text, so
   // the keys that mean something else in prose must keep meaning it.
   it('sends the prose rather than the unchosen first row', () => {

--- a/apps/desktop/src/app/chat/composer/composer-utils.ts
+++ b/apps/desktop/src/app/chat/composer/composer-utils.ts
@@ -148,6 +148,9 @@ export interface TriggerAcceptInput {
   /** The user moved the highlight themselves (arrow keys) rather than
    *  inheriting the list's default first row. */
   activeExplicit: boolean
+  /** The typed slash command accepts arbitrary prose, even before its first
+   * argument character has landed in the editor. */
+  freeTextCommand?: boolean
   /** The trigger is a slash command whose argument is arbitrary prose. */
   freeTextArgStage: boolean
   key: string
@@ -168,6 +171,7 @@ export interface TriggerAcceptInput {
  */
 export function acceptsTriggerCompletion({
   activeExplicit,
+  freeTextCommand,
   freeTextArgStage,
   key,
   kind,
@@ -183,7 +187,7 @@ export function acceptsTriggerCompletion({
 
   // Space is slash-only (an `@` mention takes a literal space) and gated to a
   // non-empty query so a bare `/ ` still types a space.
-  return key === ' ' && kind === '/' && Boolean(query.trim()) && !freeTextArgStage
+  return key === ' ' && kind === '/' && Boolean(query.trim()) && !freeTextArgStage && !freeTextCommand
 }
 
 export interface QueueEditState {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.test.ts
@@ -161,6 +161,16 @@ describe('useComposerTrigger — slash anywhere in the prompt', () => {
 })
 
 describe('useComposerTrigger — free-text slash arguments', () => {
+  it('marks a bare free-text command before its first argument space', () => {
+    const editor = mountEditor('/title')
+    const { hook } = mountTrigger(editor, [item('/title', 'Commands')])
+
+    act(() => hook.result.current.refreshTrigger())
+
+    expect(hook.result.current.slashFreeTextArgStage).toBe(false)
+    expect(hook.result.current.slashFreeTextCommand).toBe(true)
+  })
+
   it('keeps a picked /goal command as editable text while retaining subcommand completion', () => {
     const editor = mountEditor('/go')
     const goal = item('/goal', 'Commands')

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.ts
@@ -233,12 +233,17 @@ export function useComposerTrigger({
   // Space/Tab — neither should dead-end on a popover.
   const argStageEmpty = trigger?.kind === '/' && slashArgStage(trigger.query) && !triggerLoading && !triggerItems.length
 
-  const slashArgumentMode =
-    trigger?.kind === '/' && slashArgStage(trigger.query)
-      ? desktopSlashCommandArgumentMode(slashCommandToken(trigger.query))
-      : null
+  const slashCommandArgumentMode =
+    trigger?.kind === '/' ? desktopSlashCommandArgumentMode(slashCommandToken(trigger.query)) : null
+
+  const slashArgumentMode = trigger?.kind === '/' && slashArgStage(trigger.query) ? slashCommandArgumentMode : null
 
   const slashFreeTextArgStage = slashArgumentMode === 'mixed' || slashArgumentMode === 'text'
+  // The first space is still part of the command token from the trigger's
+  // point of view (`/title` rather than `/title My`). Keep it literal for
+  // arbitrary-prose commands so the completion cannot chip the command before
+  // its argument has a chance to exist.
+  const slashFreeTextCommand = slashCommandArgumentMode === 'mixed' || slashCommandArgumentMode === 'text'
 
   const closeTrigger = () => {
     setTrigger(null)
@@ -468,6 +473,7 @@ export function useComposerTrigger({
     replaceTriggerWithChip,
     setTriggerActive,
     slashFreeTextArgStage,
+    slashFreeTextCommand,
     trigger,
     triggerActive,
     triggerActiveExplicit,

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -406,6 +406,7 @@ export function ChatBar({
     replaceTriggerWithChip,
     setTriggerActive,
     slashFreeTextArgStage,
+    slashFreeTextCommand,
     trigger,
     triggerActive,
     triggerActiveExplicit,
@@ -705,6 +706,7 @@ export function ChatBar({
       // the highlight.
       const accept = acceptsTriggerCompletion({
         activeExplicit: triggerActiveExplicit,
+        freeTextCommand: slashFreeTextCommand,
         freeTextArgStage: slashFreeTextArgStage,
         key: event.key,
         kind: trigger.kind,


### PR DESCRIPTION
## Summary
- identify free-text slash commands before an argument has been typed
- keep the first Space after commands such as `/title` as literal text instead of accepting/chipping the completion
- retain existing Space-to-accept behavior for finite-option commands

This closes the first-space boundary left by the existing free-text completion handling: before the first Space lands, `/title` has no argument yet, so the old argument-stage-only guard did not apply.

## Tests
- `npx vitest run --project ui src/app/chat/composer/composer-utils.test.ts src/app/chat/composer/hooks/use-composer-trigger.test.ts`
- `npx eslint src/app/chat/composer/composer-utils.ts src/app/chat/composer/composer-utils.test.ts src/app/chat/composer/hooks/use-composer-trigger.ts src/app/chat/composer/hooks/use-composer-trigger.test.ts src/app/chat/composer/index.tsx`
- `npm run typecheck`
- `npm run build`

Adds unit and hook-level regression coverage for bare `/title` and the first literal Space.