### PR TITLE
fix(dashboard): custom-endpoint Context field can clear a stored pin

### DIFF
--- a/apps/desktop/src/app/settings/custom-endpoints-settings.test.ts
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// The component module reaches its data helpers through '@/hermes'; the pure
+// payload mapper under test needs none of them, so stub the module to keep the
+// import light and avoid touching the network layer.
+vi.mock('@/hermes', () => ({
+  activateCustomEndpoint: vi.fn(),
+  deleteCustomEndpoint: vi.fn(),
+  getCustomEndpoints: vi.fn(),
+  saveCustomEndpoint: vi.fn(),
+  validateCustomEndpoint: vi.fn()
+}))
+
+import { toPayload } from './custom-endpoints-settings'
+
+function form(overrides: Record<string, unknown> = {}) {
+  return {
+    apiKey: '',
+    baseUrl: ' http://192.168.1.69:11434/v1 ',
+    contextLength: '',
+    discoverModels: true,
+    id: 'nasty',
+    makeDefault: true,
+    model: 'qwen3:8b',
+    name: 'NASty',
+    ...overrides
+  } as Parameters<typeof toPayload>[0]
+}
+
+describe('toPayload', () => {
+  it('sends an explicit 0 for a blank Context field so the backend clears the pin', () => {
+    // Omitting the key would read as "unchanged" on the backend and leave a stale
+    // override on disk, so the panel would show the old value again on reload.
+    expect(toPayload(form({ contextLength: '' })).context_length).toBe(0)
+  })
+
+  it('treats a literal 0 or unparseable input as auto', () => {
+    expect(toPayload(form({ contextLength: '0' })).context_length).toBe(0)
+    expect(toPayload(form({ contextLength: 'abc' })).context_length).toBe(0)
+  })
+
+  it('passes a positive override through', () => {
+    expect(toPayload(form({ contextLength: '65536' })).context_length).toBe(65536)
+  })
+})

--- a/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
@@ -59,7 +59,7 @@ function formFromEndpoint(endpoint: CustomEndpoint): EndpointForm {
   }
 }
 
-function toPayload(form: EndpointForm, models?: string[]): CustomEndpointUpdate {
+export function toPayload(form: EndpointForm, models?: string[]): CustomEndpointUpdate {
   const contextLength = Number.parseInt(form.contextLength, 10)
 
   return {
@@ -68,7 +68,10 @@ function toPayload(form: EndpointForm, models?: string[]): CustomEndpointUpdate 
     base_url: form.baseUrl.trim(),
     model: form.model.trim(),
     api_key: form.apiKey.trim() || undefined,
-    context_length: Number.isFinite(contextLength) && contextLength > 0 ? contextLength : undefined,
+    // An empty Context field means "Auto". Send an explicit 0 so the endpoint writer
+    // clears any stored override; omitting the key reads as "unchanged" and leaves a
+    // stale pin that the panel reloads, so the value appeared to revert on save.
+    context_length: Number.isFinite(contextLength) && contextLength > 0 ? contextLength : 0,
     discover_models: form.discoverModels,
     make_default: form.makeDefault,
     models: models?.length ? models : undefined

--- a/hermes_cli/web_routers/config_env.py
+++ b/hermes_cli/web_routers/config_env.py
@@ -474,9 +474,19 @@ def _write_custom_endpoint(cfg: Dict[str, Any], body: CustomEndpointUpdate) -> T
         current = models_map.get(model_id)
         models_map[model_id] = dict(current) if isinstance(current, dict) else {}
     entry["models"] = models_map
-    if body.context_length and body.context_length > 0:
-        entry["context_length"] = int(body.context_length)
-        entry["models"][model]["context_length"] = int(body.context_length)
+    # ``context_length`` <= 0 is the panel's "Auto" and must CLEAR a stored override:
+    # the old guard (``if body.context_length and body.context_length > 0``) silently
+    # ignored an explicit 0, so clearing the field left the previous pin on disk and the
+    # panel reloaded it — the value appeared to revert the instant it was saved. An
+    # omitted field (None) is a partial update and leaves the override untouched, the same
+    # contract the Settings write-back documents in web_server_config.py.
+    if body.context_length is not None:
+        if body.context_length > 0:
+            entry["context_length"] = int(body.context_length)
+            entry["models"][model]["context_length"] = int(body.context_length)
+        else:
+            entry.pop("context_length", None)
+            entry["models"][model].pop("context_length", None)
 
     # API keys never belong in config.yaml: write to .env and reference it via
     # ``key_env`` — the indirection built-in providers use and that

--- a/tests/hermes_cli/test_custom_endpoint_context_length.py
+++ b/tests/hermes_cli/test_custom_endpoint_context_length.py
@@ -1,0 +1,67 @@
+"""Behaviour contract for the custom-endpoint ``context_length`` write path.
+
+The desktop panel's "Context" field stores an optional ``context_length``
+override on a custom provider (blank / 0 = auto-detect). Saving it must be able
+to CLEAR a stored pin: an explicit 0 used to be silently ignored, so the old
+value stayed on disk and the panel reloaded it — the field appeared to revert
+the instant it was saved.
+
+An *omitted* field is a partial update and must leave the override alone. That
+is the same contract the Settings write-back documents in web_server_config.py.
+"""
+
+from hermes_cli.web_models import CustomEndpointUpdate
+from hermes_cli.web_routers.config_env import _write_custom_endpoint
+
+_BASE_URL = "http://192.168.1.69:11434/v1"
+_MODEL = "qwen3:8b"
+
+
+def _cfg_with_pin() -> dict:
+    return {
+        "providers": {
+            "nasty": {
+                "name": "NASty",
+                "base_url": _BASE_URL,
+                "model": _MODEL,
+                "context_length": 131072,
+                "models": {_MODEL: {"context_length": 131072}},
+            }
+        }
+    }
+
+
+def _body(**overrides) -> CustomEndpointUpdate:
+    payload = {"id": "nasty", "name": "NASty", "base_url": _BASE_URL, "model": _MODEL}
+    payload.update(overrides)
+    return CustomEndpointUpdate(**payload)
+
+
+def test_explicit_zero_clears_the_stored_pin():
+    cfg = _cfg_with_pin()
+
+    _write_custom_endpoint(cfg, _body(context_length=0))
+
+    entry = cfg["providers"]["nasty"]
+    assert "context_length" not in entry
+    assert "context_length" not in entry["models"][_MODEL]
+
+
+def test_positive_context_length_is_written_to_both_levels():
+    cfg = _cfg_with_pin()
+
+    _write_custom_endpoint(cfg, _body(context_length=65536))
+
+    entry = cfg["providers"]["nasty"]
+    assert entry["context_length"] == 65536
+    assert entry["models"][_MODEL]["context_length"] == 65536
+
+
+def test_omitted_context_length_leaves_the_pin_untouched():
+    cfg = _cfg_with_pin()
+
+    _write_custom_endpoint(cfg, _body())  # context_length defaults to None
+
+    entry = cfg["providers"]["nasty"]
+    assert entry["context_length"] == 131072
+    assert entry["models"][_MODEL]["context_length"] == 131072


### PR DESCRIPTION
## What's wrong

In **Settings → Custom Endpoints**, the "Context" field can never be cleared. Set it to Auto, hit Save, and the previous value comes straight back — the only way out is deleting the endpoint and re-adding it.

## Root cause

`hermes_cli/web_routers/config_env.py`, in `_write_custom_endpoint`:

```python
if body.context_length and body.context_length > 0:
    entry["context_length"] = int(body.context_length)
    entry["models"][model]["context_length"] = int(body.context_length)
```

The guard means an explicit `0` — the panel's "Auto" — is silently ignored, so the stored override is left on disk. The read path (`_custom_endpoint_response` → `_endpoint_row`, which surfaces `raw_entry.get("context_length")`) then reloads the pinned value, and the field looks like it reverted the moment it was saved.

The panel contributes: `toPayload()` maps a blank field to `undefined`, so the request omits `context_length` entirely and the backend has no way to tell "clear this" from "leave this alone".

## Fix

Honour the convention the Settings write-back already documents in `web_server_config.py` — **a present value `<= 0` clears the override; an absent one leaves it untouched**:

```python
if body.context_length is not None:
    if body.context_length > 0:
        entry["context_length"] = int(body.context_length)
        entry["models"][model]["context_length"] = int(body.context_length)
    else:
        entry.pop("context_length", None)
        entry["models"][model].pop("context_length", None)
```

and send an explicit `0` from the panel so "Auto" is actually expressible:

```ts
context_length: Number.isFinite(contextLength) && contextLength > 0 ? contextLength : 0,
```

`toPayload` is exported so the mapping is testable on its own.

## Tests

`tests/hermes_cli/test_custom_endpoint_context_length.py` — clear on explicit 0, write on positive, untouched on omitted. **1 of 3 fails on base** (`assert 'context_length' not in entry`), passes on the fix.

`apps/desktop/src/app/settings/custom-endpoints-settings.test.ts` — **3 of 3 fail on base**, pass on the fix.

```
=== Summary: 6 files, 208 tests passed, 0 failed ===
tests/hermes_cli/{test_web_server,test_config_env_expansion,test_config_env_ref_parity,
                  test_config_env_refs,test_web_routers_endpoint_probe,
                  test_custom_endpoint_context_length}.py
```

```
cd apps/desktop && npx vitest run --project ui src/app/settings/custom-endpoints-settings.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```
