### PR TITLE
fix(gateway): keep model.context_length when the provider URL lives in providers.<name>

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -38,7 +38,10 @@ from agent.tool_guardrails import (
     ToolCallGuardrailConfig, ToolCallGuardrailController
 )
 from hermes_cli.config import cfg_get
-from hermes_cli.route_identity import normalize_route_base_url
+from hermes_cli.route_identity import (
+    configured_default_base_url, custom_provider_runtime_ids, normalize_custom_provider_name,
+    normalize_route_base_url,
+)
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
 from utils import base_url_host_matches, is_truthy_value
@@ -142,19 +145,6 @@ def _context_route_mismatch(
     return bool(
         configured_provider and active_provider and configured_provider != active_provider
     )
-
-
-def _normalize_custom_provider_name(value: Any) -> str:
-    """Mirror runtime normalization for a requested custom-provider identity."""
-    return str(value or "").strip().lower().replace(" ", "-")
-
-
-def _custom_provider_runtime_ids(value: Any) -> set[str]:
-    """Return raw/menu identities that runtime accepts for a configured name."""
-    normalized = _normalize_custom_provider_name(value)
-    if not normalized:
-        return set()
-    return {normalized, f"custom:{normalized}"}
 
 
 def _build_codex_gpt5_autoraise_notice(
@@ -1521,72 +1511,6 @@ def _warn_invalid_config_int(
     )
 
 
-def _custom_provider_configured_base_url(
-    _configured_provider: str, _agent_cfg, _custom_providers
-) -> str:
-    """Base URL of a named custom provider (``providers.<name>`` first, then
-    ``custom_providers``), normalized for route comparison; "" if unknown.
-    Disabled ``providers.*`` entries also mask their ``custom_providers`` twin.
-    """
-    _wanted = _normalize_custom_provider_name(_configured_provider)
-    _user_providers = _agent_cfg.get("providers")
-    _disabled_ids: set[str] = set()
-    if isinstance(_user_providers, dict):
-        from hermes_cli.config import is_provider_enabled
-        for _key, _entry in _user_providers.items():
-            if not isinstance(_entry, dict):
-                continue
-            _ids = _custom_provider_runtime_ids(_key) | _custom_provider_runtime_ids(_entry.get("name"))
-            if not is_provider_enabled(_entry):
-                _disabled_ids.update(_ids)
-                continue
-            if _wanted in _ids:
-                _url = normalize_route_base_url(
-                    _entry.get("api") or _entry.get("url") or _entry.get("base_url")
-                )
-                if _url:
-                    return _url
-    for _entry in _custom_providers:
-        if not isinstance(_entry, dict):
-            continue
-        _key_ids = _custom_provider_runtime_ids(_entry.get("provider_key"))
-        if _key_ids & _disabled_ids:
-            continue
-        if _wanted in _key_ids | _custom_provider_runtime_ids(_entry.get("name")):
-            _url = normalize_route_base_url(_entry.get("base_url"))
-            if _url:
-                return _url
-    return ""
-
-
-# Provider ids whose runtime is resolved first-hand (never a named custom provider).
-_RUNTIME_FIRST_PROVIDER_IDS = {
-    "auto", "moa", "vertex", "google-vertex", "vertex-ai", "gcp-vertex", "vertexai",
-}
-
-
-def _configured_default_base_url(_agent_cfg, _model_cfg, _custom_providers) -> str:
-    """Normalized route of the configured default model (``model.base_url``, else the named
-    custom provider's URL when ``model.provider`` is not a first-class/auth provider)."""
-    _configured_base_url = normalize_route_base_url(_model_cfg.get("base_url"))
-    _configured_provider = str(_model_cfg.get("provider") or "").strip()
-    _norm = _normalize_custom_provider_name(_configured_provider)
-    _custom_provider_candidate = bool(_norm)
-    if _norm in _RUNTIME_FIRST_PROVIDER_IDS:
-        _custom_provider_candidate = False
-    elif _custom_provider_candidate and _norm != "custom" and not _norm.startswith("custom:"):
-        with suppress(Exception):
-            from hermes_cli.auth import resolve_provider as resolve_auth_provider
-            _custom_provider_candidate = (
-                str(resolve_auth_provider(_norm) or "").strip().lower() != _norm
-            )
-    if not _configured_base_url and _custom_provider_candidate:
-        _configured_base_url = _custom_provider_configured_base_url(
-            _configured_provider, _agent_cfg, _custom_providers
-        )
-    return _configured_base_url
-
-
 def _active_route_url(agent, base_url) -> str:
     """The runtime route, keeping the requested URL's query string when it is the same route."""
     _active = str(agent.base_url or "")
@@ -1622,7 +1546,7 @@ def _scope_context_length_to_default_runtime(
                 _configured_default_model, agent.provider
             )
             _active_runtime_model = normalize_model_for_provider(agent.model, agent.provider)
-    _configured_base_url = _configured_default_base_url(_agent_cfg, _model_cfg, _custom_providers)
+    _configured_base_url = configured_default_base_url(_agent_cfg, _model_cfg, _custom_providers)
     _active_base_url = _active_route_url(agent, base_url)
     _route_mismatch = _context_route_mismatch(
         _configured_base_url, _active_base_url, str(_model_cfg.get("provider") or "").strip(),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2283,6 +2283,11 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
         data = _load_gateway_config()
         if not data:
             return
+        try:
+            from hermes_cli.config import get_compatible_custom_providers
+            custom_providers = get_compatible_custom_providers(data)
+        except Exception:
+            custom_providers = data.get("custom_providers")
         model_cfg = data.get("model", {})
         if isinstance(model_cfg, dict):
             configured_model = model_cfg.get("default") or model_cfg.get("model")
@@ -2291,12 +2296,15 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
                 with suppress(TypeError, ValueError):
                     config_context_length = int(raw_ctx)
             configured_provider = provider = model_cfg.get("provider") or None
-            configured_base_url = base_url = model_cfg.get("base_url") or None
-        try:
-            from hermes_cli.config import get_compatible_custom_providers
-            custom_providers = get_compatible_custom_providers(data)
-        except Exception:
-            custom_providers = data.get("custom_providers")
+            base_url = model_cfg.get("base_url") or None
+            # ``configured_base_url`` is the pin's OWNER route, not the raw config value: a custom
+            # endpoint declared under ``providers.<name>`` keeps ``model.base_url`` empty and its
+            # runtime identity is the bare ``custom`` class, so only the resolved URL tells the pin
+            # check that the route is unchanged (agent_init resolves the same way before comparing).
+            from hermes_cli.route_identity import configured_default_base_url
+            configured_base_url = configured_default_base_url(
+                data, model_cfg,
+                custom_providers if isinstance(custom_providers, list) else []) or None
 
     def _read_runtime() -> None:
         nonlocal provider, base_url, api_key

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1555,11 +1555,18 @@ class GatewayInboundMixin:
             _msg_config_ctx = None
         if _msg_config_ctx is not None:
             try:
-                from hermes_cli.route_identity import should_clear_context_pin_async
+                from hermes_cli.route_identity import (
+                    configured_default_base_url, should_clear_context_pin_async,
+                )
 
                 if await should_clear_context_pin_async(
                     None, None,  # model match already checked above
-                    _msg_model_cfg.get("base_url"), _msg_base_url,
+                    # Resolved owner route: a ``providers.<name>`` block owns the URL while
+                    # model.base_url stays empty, and the runtime reports that entry as ``custom``.
+                    configured_default_base_url(
+                        _msg_cfg if isinstance(_msg_cfg, dict) else {}, _msg_model_cfg,
+                        _msg_custom_providers) or None,
+                    _msg_base_url,
                     _msg_model_cfg.get("provider"), _msg_runtime.get("provider"),
                 ):
                     _msg_config_ctx = None

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -567,7 +567,24 @@ class GatewayTurnMixin:
             hs.data = _load_gateway_config()
             if hs.data:
                 self._hmwa_hygiene_read_config(hs, hs.data)
-            configured_model, configured_provider, configured_base_url = hs.model, hs.provider, hs.base_url
+            configured_model, configured_provider = hs.model, hs.provider
+            # ``configured_base_url`` must be the pin's OWNER route: a custom endpoint declared under
+            # ``providers.<name>`` keeps ``model.base_url`` empty and its runtime identity is the bare
+            # ``custom`` class, so the raw value would clear the pin for an unchanged route (#107606).
+            configured_base_url = hs.base_url
+            _hyg_custom_providers = []
+            if isinstance(hs.data, dict):
+                from hermes_cli.config import get_compatible_custom_providers
+                try:
+                    _hyg_custom_providers = get_compatible_custom_providers(hs.data)
+                except Exception:
+                    _raw_custom = hs.data.get("custom_providers")
+                    _hyg_custom_providers = _raw_custom if isinstance(_raw_custom, list) else []
+                _hyg_model_cfg = hs.data.get("model")
+                if isinstance(_hyg_model_cfg, dict):
+                    from hermes_cli.route_identity import configured_default_base_url
+                    configured_base_url = configured_default_base_url(
+                        hs.data, _hyg_model_cfg, _hyg_custom_providers) or None
 
             with suppress(Exception):
                 hs.model, _hyg_runtime = self._resolve_session_agent_runtime(
@@ -593,16 +610,8 @@ class GatewayTurnMixin:
             # custom_providers per-model context_length fallback (as in run_agent.py); needs base_url.
             if hs.config_context_length is None and hs.base_url:
                 with suppress(TypeError, ValueError):
-                    try:
-                        from hermes_cli.config import (
-                            get_compatible_custom_providers as _gw_gcp,
-                            get_custom_provider_context_length as _gw_gccl,
-                        )
-                        _hyg_custom_providers = _gw_gcp(hs.data)
-                    except Exception:
-                        _hyg_custom_providers = hs.data.get("custom_providers")
-                        if not isinstance(_hyg_custom_providers, list):
-                            _hyg_custom_providers = []
+                    from hermes_cli.config import get_custom_provider_context_length as _gw_gccl
+
                     _hyg_custom_ctx = _gw_gccl(
                         model=hs.model, base_url=hs.base_url, custom_providers=_hyg_custom_providers,
                     )

--- a/gateway/slash_commands_model.py
+++ b/gateway/slash_commands_model.py
@@ -61,7 +61,7 @@ async def _persist_model_switch_to_config(result, config_path) -> None:
     dict first. Named providers re-resolve base_url/api_mode, so leftovers are cleared; custom
     providers have no registry entry to re-derive from and need an explicit set-or-clear.
     """
-    from hermes_cli.config import read_user_config_raw, save_config
+    from hermes_cli.config import get_compatible_custom_providers, read_user_config_raw, save_config
 
     cfg = read_user_config_raw(config_path)
     raw_model = cfg.get("model")
@@ -72,10 +72,18 @@ async def _persist_model_switch_to_config(result, config_path) -> None:
     else:
         model_cfg = cfg["model"] = {}
     try:
-        from hermes_cli.route_identity import should_clear_context_pin_async
+        from hermes_cli.route_identity import configured_default_base_url, should_clear_context_pin_async
+        # The pin belongs to the configured default's ROUTE, which a ``providers.<name>`` block owns
+        # while model.base_url stays empty — resolve it before comparing against the switch target.
+        try:
+            _custom_providers = get_compatible_custom_providers(cfg)
+        except Exception:
+            _raw_custom = cfg.get("custom_providers")
+            _custom_providers = _raw_custom if isinstance(_raw_custom, list) else []
         clear_pin = await should_clear_context_pin_async(
             model_cfg.get("default") or model_cfg.get("model"), result.new_model,
-            model_cfg.get("base_url"), result.base_url, model_cfg.get("provider"), result.target_provider,
+            configured_default_base_url(cfg, model_cfg, _custom_providers) or None, result.base_url,
+            model_cfg.get("provider"), result.target_provider,
         )
     except Exception:
         clear_pin = True
@@ -302,6 +310,7 @@ class GatewayModelCommandsMixin:
         """Confirmation text with full metadata (display form shortens opaque Palantir IDs)."""
         from gateway.run import _load_gateway_config
         from hermes_cli.model_switch import format_model_for_display, resolve_display_context_length_async
+        from hermes_cli.route_identity import configured_default_base_url
 
         lines = [
             t("gateway.model.switched", model=format_model_for_display(result.new_model)),
@@ -310,9 +319,11 @@ class GatewayModelCommandsMixin:
         # Provider-aware chain: Codex OAuth, Copilot and Nous caps win over the raw models.dev entry.
         mi = result.model_info
         model_cfg: dict = {}
+        gateway_cfg: dict = {}
         config_ctx = None
         with contextlib.suppress(Exception):  # fail-open on config read errors
-            model_cfg = _load_gateway_config().get("model", {})
+            gateway_cfg = _load_gateway_config()
+            model_cfg = gateway_cfg.get("model", {})
             if isinstance(model_cfg, dict) and model_cfg.get("context_length") is not None:
                 config_ctx = int(model_cfg["context_length"])
         if not isinstance(model_cfg, dict):
@@ -324,7 +335,10 @@ class GatewayModelCommandsMixin:
             custom_providers=ctx.custom_provs, config_context_length=config_ctx,
             configured_model=model_cfg.get("default") or model_cfg.get("model"),
             configured_provider=model_cfg.get("provider"),
-            configured_base_url=model_cfg.get("base_url"),
+            # The pin's route may live in a ``providers.<name>`` block with model.base_url empty; the
+            # comparison needs the resolved URL or it clears the pin for an unchanged route (#107606).
+            configured_base_url=configured_default_base_url(
+                gateway_cfg, model_cfg, ctx.custom_provs if isinstance(ctx.custom_provs, list) else []) or None,
         )
         if ctx_len:
             lines.append(t("gateway.model.context_label", tokens=f"{ctx_len:,}"))

--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -549,15 +549,22 @@ class CLIModelSwitchMixin:
         """Drop a global context pin when its configured owner changes."""
         from cli import save_config_value
         try:
-            from hermes_cli.config import load_config_readonly
-            from hermes_cli.route_identity import should_clear_context_pin
+            from hermes_cli.config import get_compatible_custom_providers, load_config_readonly
+            from hermes_cli.route_identity import configured_default_base_url, should_clear_context_pin
             config = load_config_readonly()
             model_cfg = config.get("model", {}) if isinstance(config, dict) else {}
             if not isinstance(model_cfg, dict) or "context_length" not in model_cfg:
                 return
+            try:
+                custom_providers = get_compatible_custom_providers(config)
+            except Exception:
+                raw_custom = config.get("custom_providers") if isinstance(config, dict) else None
+                custom_providers = raw_custom if isinstance(raw_custom, list) else []
             if should_clear_context_pin(
                 model_cfg.get("default") or model_cfg.get("model"), result.new_model,
-                model_cfg.get("base_url"), result.base_url,
+                # Resolved route: a ``providers.<name>`` block owns the URL while model.base_url stays
+                # empty, and comparing the raw value would drop the pin for an unchanged route.
+                configured_default_base_url(config, model_cfg, custom_providers) or None, result.base_url,
                 model_cfg.get("provider"), result.target_provider):
                 save_config_value("model.context_length", None)
         except Exception:

--- a/hermes_cli/context_switch_guard.py
+++ b/hermes_cli/context_switch_guard.py
@@ -139,11 +139,23 @@ def enrich_model_switch_warnings_for_gateway(
             cfg = load_gateway_config()
             model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
             if isinstance(model_cfg, dict) and model_cfg.get("context_length") is not None:
+                from hermes_cli.route_identity import configured_default_base_url
+                try:
+                    _custom = custom_providers
+                    if _custom is None:
+                        from hermes_cli.config import get_compatible_custom_providers
+                        _custom = get_compatible_custom_providers(cfg)
+                except Exception:
+                    _raw_custom = cfg.get("custom_providers")
+                    _custom = _raw_custom if isinstance(_raw_custom, list) else []
                 configured.update(
                     config_context_length=int(model_cfg["context_length"]),
                     configured_model=model_cfg.get("default") or model_cfg.get("model"),
                     configured_provider=model_cfg.get("provider"),
-                    configured_base_url=model_cfg.get("base_url"))
+                    # Resolved route, not the raw value: a ``providers.<name>`` block owns the URL
+                    # while model.base_url stays empty (see hermes_cli.route_identity).
+                    configured_base_url=configured_default_base_url(
+                        cfg, model_cfg, _custom if isinstance(_custom, list) else []) or None)
         except Exception:
             pass
 

--- a/hermes_cli/route_identity.py
+++ b/hermes_cli/route_identity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
@@ -42,6 +43,89 @@ def normalize_route_base_url(base_url: Any) -> str:
     if had_query_delimiter and not parsed.query:
         normalized += "?"
     return normalized
+
+
+# Provider ids whose runtime is resolved first-hand (never a named custom provider).
+_RUNTIME_FIRST_PROVIDER_IDS = {
+    "auto", "moa", "vertex", "google-vertex", "vertex-ai", "gcp-vertex", "vertexai",
+}
+
+
+def normalize_custom_provider_name(value: Any) -> str:
+    """Mirror runtime normalization for a requested custom-provider identity."""
+    return str(value or "").strip().lower().replace(" ", "-")
+
+
+def custom_provider_runtime_ids(value: Any) -> set[str]:
+    """Return raw/menu identities that runtime accepts for a configured name."""
+    normalized = normalize_custom_provider_name(value)
+    if not normalized:
+        return set()
+    return {normalized, f"custom:{normalized}"}
+
+
+def custom_provider_configured_base_url(
+    configured_provider: str, agent_cfg: Any, custom_providers: Any
+) -> str:
+    """Base URL of a named custom provider (``providers.<name>`` first, then
+    ``custom_providers``), normalized for route comparison; "" if unknown.
+    Disabled ``providers.*`` entries also mask their ``custom_providers`` twin.
+    """
+    wanted = normalize_custom_provider_name(configured_provider)
+    user_providers = agent_cfg.get("providers")
+    disabled_ids: set[str] = set()
+    if isinstance(user_providers, dict):
+        from hermes_cli.config import is_provider_enabled
+        for key, entry in user_providers.items():
+            if not isinstance(entry, dict):
+                continue
+            ids = custom_provider_runtime_ids(key) | custom_provider_runtime_ids(entry.get("name"))
+            if not is_provider_enabled(entry):
+                disabled_ids.update(ids)
+                continue
+            if wanted in ids:
+                url = normalize_route_base_url(
+                    entry.get("api") or entry.get("url") or entry.get("base_url")
+                )
+                if url:
+                    return url
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        key_ids = custom_provider_runtime_ids(entry.get("provider_key"))
+        if key_ids & disabled_ids:
+            continue
+        if wanted in key_ids | custom_provider_runtime_ids(entry.get("name")):
+            url = normalize_route_base_url(entry.get("base_url"))
+            if url:
+                return url
+    return ""
+
+
+def configured_default_base_url(agent_cfg: Any, model_cfg: Any, custom_providers: Any) -> str:
+    """Normalized route of the configured default model: ``model.base_url`` when set, else the URL of
+    the named custom provider in ``model.provider`` (``""`` when neither identifies a route).
+
+    Every caller that asks whether the ``model.context_length`` pin still matches "the route it was
+    written for" must resolve through this first. A custom endpoint is declared under
+    ``providers.<name>`` with ``model.base_url`` left empty (the block owns the URL), and its runtime
+    identity collapses to the bare ``custom`` billing class while ``model.provider`` still names the
+    entry — so comparing the raw config value against the runtime route finds neither a URL nor a
+    matching provider id, and the pin is dropped for an unchanged route.
+    """
+    base_url = normalize_route_base_url(model_cfg.get("base_url"))
+    configured_provider = str(model_cfg.get("provider") or "").strip()
+    norm = normalize_custom_provider_name(configured_provider)
+    candidate = bool(norm)
+    if norm in _RUNTIME_FIRST_PROVIDER_IDS:
+        candidate = False
+    elif candidate and norm != "custom" and not norm.startswith("custom:"):
+        with suppress(Exception):
+            from hermes_cli.auth import resolve_provider as resolve_auth_provider
+            candidate = str(resolve_auth_provider(norm) or "").strip().lower() != norm
+    if base_url or not candidate:
+        return base_url
+    return custom_provider_configured_base_url(configured_provider, agent_cfg, custom_providers)
 
 
 def should_clear_context_pin(configured_model: Any, active_model: Any, configured_base_url: Any, active_base_url: Any,

--- a/tests/gateway/test_model_picker_persist.py
+++ b/tests/gateway/test_model_picker_persist.py
@@ -253,3 +253,57 @@ async def test_multiplex_picker_global_persists_only_named_profile(
     assert written["marker"] == "named"
     assert written["model"]["default"] == "gpt-5.5"
     assert written["model"]["provider"] == "openrouter"
+
+
+@pytest.mark.asyncio
+async def test_persist_keeps_context_pin_for_providers_block_route(tmp_path, monkeypatch):
+    """A same-route ``/model`` re-selection must not delete ``model.context_length``.
+
+    The pin's owner route is declared by ``providers.<name>`` while ``model.base_url``
+    stays empty, and the runtime reports that entry as the bare ``custom`` class. Comparing
+    the raw empty value dropped the pin and ``_persist_model_switch_to_config`` deleted it
+    from config.yaml for a route that never changed (#107606). ``_context_route_mismatch``
+    is unchanged, so a real switch still clears the pin — that half is asserted by
+    ``test_picker_tap_global_flag_persists`` above (``context_length`` must be absent).
+    """
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    proxy_url = "https://proxy.example.com/v1"
+    pin = 1_048_576
+    cfg_path = _setup_isolated_home(tmp_path, monkeypatch, {"default": "my-model"})
+    cfg_path.write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "my-model",
+                    "provider": "my-proxy",
+                    "base_url": "",
+                    "context_length": pin,
+                },
+                "providers": {"my-proxy": {"base_url": proxy_url, "key_env": "MY_PROXY_KEY"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    from gateway.slash_commands_model import _persist_model_switch_to_config
+
+    await _persist_model_switch_to_config(
+        ModelSwitchResult(
+            success=True,
+            new_model="my-model",
+            target_provider="custom",
+            provider_changed=False,
+            api_key="",
+            base_url=proxy_url,
+            api_mode=None,
+            provider_label="Custom",
+            is_global=True,
+        ),
+        cfg_path,
+    )
+
+    written = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    assert written["model"].get("context_length") == pin, (
+        "same-route /model re-selection deleted the configured context pin: %r" % (written["model"],)
+    )

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -1815,3 +1815,40 @@ async def test_hygiene_unwind_records_cooldown(monkeypatch, tmp_path):
         await asyncio.wait_for(asyncio.to_thread(cleanup_done.wait), timeout=2)
     finally:
         db.close()
+
+
+@pytest.mark.asyncio
+async def test_hygiene_settings_keep_pin_for_providers_block_endpoint(monkeypatch, tmp_path):
+    """Hygiene must resolve the configured provider's route before dropping the context pin.
+
+    A custom endpoint declared under ``providers:`` resolves to the bare ``custom`` runtime
+    billing class while ``model.provider`` still names the entry, so the provider-id comparison
+    cleared ``model.context_length`` and the 85% valve scaled off the hardcoded catalog window
+    (108,800 instead of 850,000 for a configured 1M) even though the model never changed
+    (#107606).
+    """
+    from gateway.run import GatewayRunner
+
+    (tmp_path / "config.yaml").write_text(
+        "model:\n"
+        "  default: deepseek-flash\n"
+        "  provider: my-proxy\n"
+        "  base_url: ''\n"
+        "  context_length: 1000000\n"
+        "providers:\n"
+        "  my-proxy:\n"
+        "    base_url: https://proxy.example.com/v1\n"
+        "    key_env: MY_PROXY_KEY\n"
+    )
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._resolve_session_agent_runtime = lambda **kwargs: (
+        "deepseek-flash",
+        {"provider": "custom", "base_url": "https://proxy.example.com/v1", "api_key": "k"},
+    )
+
+    hs = await runner._hmwa_hygiene_settings(None, "telegram:1:u1")
+
+    assert hs.config_context_length == 1000000
+    assert hs.base_url == "https://proxy.example.com/v1"

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -116,6 +116,51 @@ class TestFormatSessionInfo:
         assert "config" in info
         assert "131K" not in info
 
+    def test_providers_block_endpoint_keeps_context_pin_for_bare_custom_runtime(
+        self, runner, tmp_path
+    ):
+        """A ``providers:``-declared endpoint must keep model.context_length.
+
+        The runtime reports such an entry as the bare ``custom`` billing class while
+        ``model.provider`` still names the entry, so the empty configured route fell through to
+        the provider-id comparison, the pin was cleared, and the banner reported the hardcoded
+        catalog window (``128K tokens (detected)``) instead of the configured 1M (#107606).
+        """
+        model = "deepseek-flash"
+        config_yaml = (
+            "model:\n"
+            f"  default: {model}\n"
+            "  provider: my-proxy\n"
+            "  base_url: ''\n"
+            "  context_length: 1000000\n"
+            "providers:\n"
+            "  my-proxy:\n"
+            "    base_url: https://proxy.example.com/v1\n"
+            "    key_env: MY_PROXY_KEY\n"
+        )
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            config_yaml,
+            model,
+            {
+                "provider": "custom",
+                "base_url": "https://proxy.example.com/v1",
+                "api_key": "k",
+            },
+        )
+        with p1, p2, p3, patch(
+            "agent.model_metadata.get_model_context_length",
+            side_effect=lambda *args, **kwargs: (
+                kwargs.get("config_context_length")
+                if kwargs.get("config_context_length")
+                else 128000
+            ),
+        ):
+            info = runner._format_session_info()
+        assert "1.0M" in info
+        assert "config" in info
+        assert "128K" not in info
+
 
 class TestResetNoticeSessionInfo:
     """#59003: the auto-reset banner must report the serving profile's config,


### PR DESCRIPTION
## What does this PR do?

`hermes setup` / the model-switch flow writes a custom endpoint as a `providers.<name>` block and deliberately leaves `model.base_url` empty (the block owns the URL). The context-length pin carries a route check: `model.context_length` is only honored while the route it was written for still matches the runtime route. The agent startup path resolves the `providers.<name>` URL before that check, so the pin survives. Five other call sites compared the **raw** `model.base_url` instead — empty for this config shape — so `should_clear_context_pin` fell through to the provider-id comparison, where the named entry (`my-proxy`) never matches the runtime's bare `custom` billing class and `_provider_default_routes` has no catalog routes for it, and dropped a pin whose route had not changed.

Consequences on such an install:

- `/status` reported the hardcoded catalog window (`DEFAULT_CONTEXT_LENGTHS`, e.g. `deepseek` → 128K) or `DEFAULT_FALLBACK_CONTEXT` as `detected`, which reads like a successful probe. Reported in #107606 as `◆ Context: 128K tokens (detected)` against a configured 1,000,000.
- Gateway hygiene's 85%/95% valves scaled off that wrong window (108,800 instead of 850,000).
- `/model` re-selecting the **same** route deleted `model.context_length` from `config.yaml` (silent config loss).
- The CLI `/model` path, the switch-confirmation line, the gateway preflight-compression warning and the per-turn inbound context resolution used the same wrong window.

The fix is a single resolution step: route identity now lives in `hermes_cli/route_identity.py` (next to `normalize_route_base_url` and `should_clear_context_pin`), and every pin check resolves the configured default's route through `configured_default_base_url(...)` before comparing. `agent_init` imports the helper from there — `agent → hermes_cli` was already the module-level direction, and the reverse import the gateway sinks would otherwise have needed is what this move avoids (`#107615` solves the same issue by keeping the helper in `agent.agent_init` and importing it lazily from `gateway/`).

`_context_route_mismatch` / `should_clear_context_pin` are unchanged: a real route change, a model mismatch, an explicit non-empty `model.base_url` mismatch, a disabled `providers.<name>` block and helper errors all still drop the pin (asserted below).

## Related Issue

Fixes #107606

This supersedes / overlaps #107615, which opened ~20 minutes after the report and fixes the two paths named in the issue (its tests pass on its branch — I ran them: 7/7 green, and 5 passed / 2 failed when applied to `872bafd58d`, matching its description). This PR covers the same two paths plus the three sibling call sites in the same bug class, moves the helper to a shared module, and adds a receipt for the config-deletion path. Happy to close this one and let #107615 land if you prefer the smaller diff — say the word and I'll re-file the remaining call sites as a follow-up against it instead.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

Commit 1 — `fix(gateway): resolve the configured route before the context-pin check` (issue scope)

- `hermes_cli/route_identity.py`: `configured_default_base_url`, `custom_provider_configured_base_url`, `custom_provider_runtime_ids`, `normalize_custom_provider_name` moved here from `agent/agent_init.py` (unchanged logic).
- `agent/agent_init.py`: imports them from the new home; `_scope_context_length_to_default_runtime` now calls `configured_default_base_url`.
- `gateway/run.py`: `_resolve_gateway_model_context._read_config` sets `configured_base_url` from the resolved route (the raw value still feeds `base_url`, so the runtime overlay is unaffected).
- `gateway/run_turn.py`: `_hmwa_hygiene_settings` resolves the pin's owner route before `should_clear_context_pin_async`; the `get_custom_provider_context_length` fallback is unchanged.
- `tests/gateway/test_session_info.py`, `tests/gateway/test_session_hygiene.py`: one invariant each, reproducing the reported `/status` string and the hygiene valve.

Commit 2 — `fix(model-switch): resolve the configured route before clearing the context pin` (same bug class)

- `gateway/slash_commands_model.py`: `_persist_model_switch_to_config` (the deletion path) and `_model_switch_confirmation`.
- `hermes_cli/cli_model_switch_mixin.py`: `_clear_persisted_context_for_model_switch`.
- `hermes_cli/context_switch_guard.py`: `enrich_model_switch_warnings_for_gateway`.
- `gateway/run_inbound.py`: `_inbound_model_context_length`.
- `tests/gateway/test_model_picker_persist.py`: `test_persist_keeps_context_pin_for_providers_block_route`.

## How to Test

Config shape (no live endpoint needed — detection is stubbed or the pin is asserted directly):

```yaml
model:
  default: my-model
  provider: my-proxy
  base_url: ''
  context_length: 1048576
providers:
  my-proxy:
    base_url: https://proxy.example.com/v1
    key_env: MY_PROXY_KEY
```

Focused, on this branch:

```bash
scripts/run_tests.sh tests/gateway/test_session_info.py tests/gateway/test_session_hygiene.py tests/gateway/test_model_picker_persist.py
  -> 33 passed
```

RED on the merge base (`872bafd58d`) with only the test changes applied:

```bash
scripts/run_tests.sh tests/gateway/test_session_info.py tests/gateway/test_session_hygiene.py
  -> 28 passed, 2 failed
     test_providers_block_endpoint_keeps_context_pin_for_bare_custom_runtime
        AssertionError: assert '1.0M' in '◆ Model: `deepseek-flash`\n◆ Provider: custom\n◆ Context: 128K tokens (detected)'
     test_hygiene_settings_keep_pin_for_providers_block_endpoint
        AssertionError: assert None == 1000000

scripts/run_tests.sh tests/gateway/test_model_picker_persist.py
  -> 3 passed, 1 failed
     test_persist_keeps_context_pin_for_providers_block_route
        AssertionError: same-route /model re-selection deleted the configured context pin:
        {'base_url': 'https://proxy.example.com/v1', 'default': 'my-model', 'provider': 'custom'}
```

After the fix, the three paths agree (temp `HERMES_HOME`, no per-model workaround in the config):

```
[gateway status path]  _resolve_gateway_model_context()  -> 1048576 (source='config')
[gateway hygiene path] _hmwa_hygiene_settings()          -> config_context_length = 1048576 (85% valve 891289)
[agent startup path]   _scope_context_length_to_default_runtime() -> 1048576
```

Whole area (`tests/gateway`, `tests/hermes_cli`, `tests/agent`; 2210 files, 48 workers):

- this branch: 23977 passed, 10 failed
- merge base `872bafd58d`: 23975 passed, 10 failed

The two failure sets are identical except for three timing-sensitive files (`test_compression_concurrent_sessions`, `test_external_drain_control`, `test_codex_aux_timeout_fd_ownership`); re-running them on this branch in isolation gives 42 passed, 0 failed. `tests/gateway/test_session_hygiene.py::test_hygiene_does_not_wait_ceiling_after_fence_cancel` fails on both trees under 48-worker load and passes in isolation — same story.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway):`, `fix(model-switch):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see the #107615 note above; I am flagging the overlap rather than hiding it
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the area suites and the comparison above is honest about the pre-existing failures
- [x] I've added tests for my changes (one per commit, both proven red on the merge base)
- [x] I've tested on my platform: Ubuntu 24.04.5 LTS, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A. The moved helpers carry the same docstrings; `configured_default_base_url` gained one explaining why the resolution must precede the pin check.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no rule change; the helper move follows the existing `agent → hermes_cli` direction)
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python, no OS branch)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The RED/GREEN output blocks above are the receipts.

One more fix worth considering and deliberately left out of scope: `context_source` labels only `DEFAULT_FALLBACK_CONTEXT` as `default`, so a `DEFAULT_CONTEXT_LENGTHS` hit is reported as `detected` — that mislabel is why #107606 read as a successful probe for weeks on my install. Distinguishing a catalog hit from a live/cache detection would make this failure class self-reporting; happy to file it separately if useful.
