### PR TITLE
fix(gateway): make failed-turn persistence exactly-once

### DIFF
--- a/evals/gateway_failure_ownership/probe.py
+++ b/evals/gateway_failure_ownership/probe.py
@@ -13,6 +13,7 @@ os.environ.update(keep)
 os.environ.update(
     HOME=str(HOME),
     HERMES_HOME=str(HOME),
+    USERPROFILE=str(HOME),
     HERMES_DISABLE_PLUGINS="1",
     NO_PROXY="127.0.0.1,localhost",
 )

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1666,13 +1666,8 @@ class GatewayTurnMixin:
                 # Transient failure / hidden-reasoning incomplete: persist only the user message (the
                 # assistant error text is a gateway hint, not model output). Dedupe on platform
                 # message_id (Telegram retries after transient failures).
-                if event.message_id and await store.has_platform_message_id(sid, str(event.message_id)):
-                    logger.info(
-                        "Skipping duplicate user turn (message_id=%s) in session %s",
-                        event.message_id, sid,
-                    )
-                else:
-                    await store.append_to_transcript(sid, _user_row, skip_db=agent_persisted)
+                if not agent_persisted:
+                    await store.append_user_message_if_absent(sid, _user_row)
             else:
                 # Only the NEW messages: history_offset (what the agent saw), not len(history), which
                 # counts session_meta entries stripped before the agent saw them.
@@ -1770,13 +1765,9 @@ class GatewayTurnMixin:
         # Replay can coalesce inputs; only this input's durable marker establishes ownership.
         try:
             if prepared.message_text is not None and session_entry is not None:
-                _owned = await self.async_session_store.has_input_owner(
-                    prepared.persistence_session_id, prepared.persistence_owner,
+                await self.async_session_store.append_user_message_if_absent(
+                    session_entry.session_id, self._hmwa_user_transcript_entry(event, prepared, time.time()),
                 )
-                if not _owned:
-                    await self.async_session_store.append_to_transcript(
-                        session_entry.session_id, self._hmwa_user_transcript_entry(event, prepared, time.time()),
-                    )
         except Exception:
             logger.debug("Failed to persist inbound user message after agent exception", exc_info=True)
         # Never expose raw exception types/messages to end users (info-leakage risk).

--- a/gateway/session_transcript.py
+++ b/gateway/session_transcript.py
@@ -51,6 +51,17 @@ _ASSISTANT_ONLY_KEYS = (
 
 
 class SessionTranscriptMixin:
+    def append_user_message_if_absent(self, session_id: str, message: Dict[str, Any]) -> bool:
+        """Append a gateway-owned user row with the check in the write transaction."""
+        db = self._db_for_session_id(session_id)
+        if not db:
+            return False
+        with self._get_transcript_drain_lock():
+            canonical = self._follow_reroutes(session_id)
+            if self.has_input_owner(canonical, (message.get("display_metadata") or {}).get("gateway_input_owner", "")):
+                return False
+            return db.append_user_message_if_absent(canonical, message)
+
     """SessionStore transcript I/O: SQLite append with a per-session retry queue,
     compression-reroute following, FTS corruption recovery, rewrite/rewind/load."""
 

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -100,6 +100,24 @@ def _stale_holder(row, now: float) -> bool:
 
 
 class SessionMessagesMixin:
+    def append_user_message_if_absent(self, session_id: str, message: Dict[str, Any]) -> bool:
+        """Atomically append an unobserved gateway-owned user message once."""
+        owner = (message.get("display_metadata") or {}).get("gateway_input_owner")
+        if not owner:
+            self.append_message(session_id, "user", **{k: v for k, v in message.items() if k != "role"})
+            return True
+        msg = dict(message)
+        msg["display_metadata"] = self._encode_display_metadata(msg.get("display_metadata"))
+        params = self._message_row_params(session_id, "user", msg, _parse_tool_calls(msg.get("tool_calls")),
+                                          _coerce_timestamp(msg.get("timestamp"), time.time()), keep_reasoning=True)
+        def _do(conn):
+            if conn.execute("SELECT 1 FROM messages WHERE session_id = ? AND role = 'user' AND active = 1 AND observed = 0 AND json_valid(display_metadata) AND json_extract(display_metadata, '$.gateway_input_owner') = ? LIMIT 1", (session_id, owner)).fetchone():
+                return False
+            row_id = conn.execute(_INSERT_MESSAGE_SQL, params).lastrowid
+            self._bump_session_counters(conn, session_id, 1, 0, unit=True)
+            return bool(row_id)
+        return bool(self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S))
+
     """Message append/replace/rewind, reactions, resume conversations, replay dedupe."""
 
     def _bump_conversation_generation(self, conn, session_id: str, end_reason: str) -> None:


### PR DESCRIPTION
Fixes #107561.

Fresh implementation on top of main; no commits from the previously closed PR were cherry-picked or rewritten.

Root cause: failed-turn retry ownership used a non-atomic read-then-write path, and inactive undone lineage rows could be treated as live owners. The fix makes ownership persistence atomic and limits ownership to active lineage.

Verification:
- scripts/run_tests.sh tests/gateway/test_dedupe_user_turns.py: 3 passed
- scripts/run_tests.sh tests/gateway/test_run_progress_interrupt.py: 3 passed
- scripts/run_tests.sh tests/agent/test_turn_finalizer_final_response_persistence.py: 8 passed
- scripts/run_tests.sh tests/run_agent/test_413_compression.py: 32 passed
- ruff check: passed
- git diff --check: passed

The existing failure-ownership subprocess probe fails on baseline before reaching the provider due to environment setup; the patched probe reaches execution but retains that baseline failure.