### PR TITLE
fix(desktop): gate the composer model menu by Nous subscription tier

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -100,44 +100,68 @@ describe('the catalog owns model curation', () => {
     expect(screen.queryByText(/Gemini 3\.1 Pro/i)).toBeNull()
   })
 
-  it('drops subscription-locked models once the free tier is known', async () => {
+  it('drops subscription-locked Nous models once the free tier is known', async () => {
     getGlobalModelOptions.mockResolvedValue({
       providers: [
         {
           free_tier: true,
-          models: ['gemini-3.1-pro', 'gemini-2.5-flash'],
-          name: 'Google',
-          slug: 'google',
-          unavailable_models: ['gemini-3.1-pro']
+          models: ['anthropic/claude-opus-5', 'stepfun/step-3.7-flash:free'],
+          name: 'Nous Portal',
+          slug: 'nous',
+          unavailable_models: ['anthropic/claude-opus-5']
         }
       ]
     })
 
     renderMenu()
 
-    await screen.findByText(/Gemini 2\.5 Flash/i)
-    expect(screen.queryByText(/Gemini 3\.1 Pro/i)).toBeNull()
+    await screen.findByText(/Step 3\.7 Flash/i)
+    expect(screen.queryByText(/Opus 5/i)).toBeNull()
   })
 
-  it('keeps every model listed while entitlement is still pending (fail-closed marker is not a filter)', async () => {
-    // Cold cache: the backend marks ALL models unavailable until the tier
-    // resolves. Blanking the section then is worse than briefly listing them.
+  it('falls back to the :free suffix while Nous pricing is still pending', async () => {
+    // Tier is known (free) but pricing hasn't loaded, so the backend fails
+    // closed and marks EVERY model unavailable — that list is useless as a
+    // filter. The free picks are exactly the `:free` ids, so gate on shape
+    // instead of showing paid models a free account cannot spend on.
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        {
+          free_tier: true,
+          models: ['anthropic/claude-opus-5', 'stepfun/step-3.7-flash:free'],
+          name: 'Nous Portal',
+          pricing_pending: true,
+          slug: 'nous',
+          unavailable_models: ['anthropic/claude-opus-5', 'stepfun/step-3.7-flash:free']
+        }
+      ]
+    })
+
+    renderMenu()
+
+    await screen.findByText(/Step 3\.7 Flash/i)
+    expect(screen.queryByText(/Opus 5/i)).toBeNull()
+  })
+
+  it('keeps every model listed while the Nous tier itself is still pending', async () => {
+    // Cold cache: the backend doesn't know the tier yet. Blanking the section
+    // then is worse than briefly listing locked models, so nothing is filtered.
     getGlobalModelOptions.mockResolvedValue({
       providers: [
         {
           free_tier_pending: true,
-          models: ['gemini-3.1-pro', 'gemini-2.5-flash'],
-          name: 'Google',
-          slug: 'google',
-          unavailable_models: ['gemini-3.1-pro', 'gemini-2.5-flash']
+          models: ['anthropic/claude-opus-5', 'stepfun/step-3.7-flash:free'],
+          name: 'Nous Portal',
+          slug: 'nous',
+          unavailable_models: ['anthropic/claude-opus-5', 'stepfun/step-3.7-flash:free']
         }
       ]
     })
 
     renderMenu()
 
-    await screen.findByText(/Gemini 2\.5 Flash/i)
-    expect(screen.getByText(/Gemini 3\.1 Pro/i)).toBeTruthy()
+    await screen.findByText(/Step 3\.7 Flash/i)
+    expect(screen.getByText(/Opus 5/i)).toBeTruthy()
   })
 
   it('still finds a hidden model by search — curation narrows the default view, not the catalog', async () => {

--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -100,6 +100,46 @@ describe('the catalog owns model curation', () => {
     expect(screen.queryByText(/Gemini 3\.1 Pro/i)).toBeNull()
   })
 
+  it('drops subscription-locked models once the free tier is known', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        {
+          free_tier: true,
+          models: ['gemini-3.1-pro', 'gemini-2.5-flash'],
+          name: 'Google',
+          slug: 'google',
+          unavailable_models: ['gemini-3.1-pro']
+        }
+      ]
+    })
+
+    renderMenu()
+
+    await screen.findByText(/Gemini 2\.5 Flash/i)
+    expect(screen.queryByText(/Gemini 3\.1 Pro/i)).toBeNull()
+  })
+
+  it('keeps every model listed while entitlement is still pending (fail-closed marker is not a filter)', async () => {
+    // Cold cache: the backend marks ALL models unavailable until the tier
+    // resolves. Blanking the section then is worse than briefly listing them.
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        {
+          free_tier_pending: true,
+          models: ['gemini-3.1-pro', 'gemini-2.5-flash'],
+          name: 'Google',
+          slug: 'google',
+          unavailable_models: ['gemini-3.1-pro', 'gemini-2.5-flash']
+        }
+      ]
+    })
+
+    renderMenu()
+
+    await screen.findByText(/Gemini 2\.5 Flash/i)
+    expect(screen.getByText(/Gemini 3\.1 Pro/i)).toBeTruthy()
+  })
+
   it('still finds a hidden model by search — curation narrows the default view, not the catalog', async () => {
     setVisibleModels(new Set([modelVisibilityKey('google', 'gemini-2.5-flash')]))
 

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -710,7 +710,19 @@ function groupModels(
   const groups: ProviderGroup[] = []
 
   for (const provider of providers) {
-    const allFamilies = collapseModelFamilies(provider.models ?? [])
+    // Subscription gating (Nous free tier): the backend already decided which
+    // ids this account cannot spend on — drop them here so the composer menu
+    // lists exactly what's selectable. ONLY once the entitlement is actually
+    // known: while tier/pricing resolution is pending the backend fails
+    // closed and marks EVERY model unavailable, so filtering then would blank
+    // the whole section (and a blank menu is worse than briefly showing
+    // locked models). The dashboard's Models page keeps its locked-row
+    // rendering; this is the chat menu.
+    const gated =
+      provider.free_tier === true && !provider.free_tier_pending && !provider.pricing_pending
+    const unavailable = new Set(gated ? (provider.unavailable_models ?? []) : [])
+    const spendable = (provider.models ?? []).filter(model => !unavailable.has(model))
+    const allFamilies = collapseModelFamilies(spendable)
 
     if (allFamilies.length === 0) {
       continue

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -713,15 +713,24 @@ function groupModels(
     // Subscription gating (Nous free tier): the backend already decided which
     // ids this account cannot spend on — drop them here so the composer menu
     // lists exactly what's selectable. ONLY once the entitlement is actually
-    // known: while tier/pricing resolution is pending the backend fails
-    // closed and marks EVERY model unavailable, so filtering then would blank
-    // the whole section (and a blank menu is worse than briefly showing
-    // locked models). The dashboard's Models page keeps its locked-row
-    // rendering; this is the chat menu.
-    const gated =
-      provider.free_tier === true && !provider.free_tier_pending && !provider.pricing_pending
-    const unavailable = new Set(gated ? (provider.unavailable_models ?? []) : [])
-    const spendable = (provider.models ?? []).filter(model => !unavailable.has(model))
+    // known: while TIER resolution is pending (free_tier_pending) nothing is
+    // filtered — a blank menu is worse than briefly showing locked models.
+    // While only PRICING is pending the backend fails closed and marks EVERY
+    // model unavailable, so `unavailable_models` is useless as a filter — but
+    // the tier IS known, and on a free tier the Portal's free picks are
+    // exactly the `:free`-suffixed ids, so fall back to that shape instead of
+    // showing paid models a free account cannot spend on. The dashboard's
+    // Models page keeps its locked-row rendering; this is the chat menu.
+    const isNous = provider.slug.toLowerCase() === 'nous'
+    const gated = isNous && provider.free_tier === true && !provider.free_tier_pending
+    let spendable = provider.models ?? []
+
+    if (gated) {
+      spendable = provider.pricing_pending
+        ? spendable.filter(model => model.endsWith(':free'))
+        : spendable.filter(model => !(provider.unavailable_models ?? []).includes(model))
+    }
+
     const allFamilies = collapseModelFamilies(spendable)
 
     if (allFamilies.length === 0) {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -463,6 +463,10 @@ export interface ModelOptionProvider {
   pricing?: Record<string, ModelPricing>
   /** Nous only: whether the current account is on the free tier. */
   free_tier?: boolean
+  /** Nous only: tier not yet resolved — backend fails closed (all unavailable). */
+  free_tier_pending?: boolean
+  /** Nous only: pricing not yet loaded — backend fails closed (all unavailable). */
+  pricing_pending?: boolean
   /** Nous only: paid models a free-tier user cannot select (shown disabled). */
   unavailable_models?: string[]
   /** Per-model option support, keyed by model id (present when the picker


### PR DESCRIPTION
## Problem

On a free-tier Nous Portal account, the desktop composer's model menu lists **every** curated model — Opus, Sonnet, GPT-6-astra and friends included — as ordinary selectable rows, even though the account cannot spend on any of them. Picking one fails at call time.

The backend already does the subscription math: `inventory._apply_pricing` partitions the Nous row by tier and ships `unavailable_models` (+ `free_tier`) in every `model.options` payload. The dashboard's `model-picker.tsx` consumes it (locked rows + PRO badge). The composer's `model-catalog-menu.tsx` — the menu users actually live in — never reads the field, so the gating silently evaporates on the main chat surface.

## Fix

`groupModels` drops models the account cannot spend on for the Nous provider, so the composer menu lists exactly what's selectable. Hidden rather than greyed-out on purpose: this menu has no upgrade affordance, and a model that cannot be picked should not occupy a row.

The backend has two distinct fail-closed states and they need different handling:

| State | `unavailable_models` | Menu behaviour |
|---|---|---|
| `free_tier_pending` (tier unknown, cold start) | everything | **no filtering** — nothing is known yet; a blank section is worse than briefly listing locked models |
| `pricing_pending` (tier known = free, pricing cache cold) | everything | filter on the `:free` suffix — the tier IS known, and a free tier's spendable set is exactly the Portal's `:free` picks |
| neither | accurate paid list | filter on `unavailable_models` |

Filtering unconditionally on `unavailable_models` blanks the whole section during either pending window (this is how the first iteration of this patch misfired in the field); never filtering during `pricing_pending` shows free users paid models they cannot call (the second field report). The `:free` suffix is the Portal's own convention for no-cost tier models and is what `freeRecommendedModels` unions into the row.

Subscription changes sync through the existing backend caches (tier / Portal recommendations / explicit *Refresh models*) — no new sync machinery in this PR.

## Tests

`model-catalog-menu.test.tsx`, 3 cases covering all three states above (suite 10/10 green via `npx vitest run`).

`types/hermes.ts` gains the two pending flags the menu now reads (backend already sends them).
