### PR TITLE
Keep process management directly available

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -201,6 +201,29 @@ class TestClassification:
         assert "clarify" in names
         assert "computer_use" not in names
 
+    def test_process_management_stays_direct_by_default(self):
+        """Process control is a core operational capability and must be
+        available directly, not hidden behind progressive tool discovery."""
+        from tools.tool_search import (
+            _DEFAULT_DEFERRED_TOOLS,
+            ToolSearchConfig,
+            assemble_tool_defs,
+        )
+
+        assert "process_manage" not in _DEFAULT_DEFERRED_TOOLS
+
+        assembled = assemble_tool_defs(
+            [
+                _td("process_manage", "Manage a background process"),
+                _td("computer_use", "Drive the OS"),
+            ],
+            context_length=200_000,
+            config=ToolSearchConfig.from_raw({"enabled": "on"}),
+        )
+        names = {td["function"]["name"] for td in assembled.tool_defs}
+        assert "process_manage" in names
+        assert "computer_use" not in names
+
     def test_unknown_tool_not_deferrable(self):
         """Defensive: a tool name we cannot resolve to a registry entry must
         not be claimed as deferrable. This protects against the OpenClaw

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -132,7 +132,7 @@ _DIRECT_SURFACE_TOOLSETS = frozenset({"desktop_ui", "project"})
 # (18/18 -> 7/18) — the ask-the-user affordance must be ambient, a stub is not enough.
 _DEFAULT_DEFERRED_TOOLS = frozenset({
     "computer_use", "session_search", "image_generate",
-    "todo_list", "process_manage", "cronjob_manage",
+    "todo_list", "cronjob_manage",
     # Desktop GUI surface (desktop_ui + project toolsets)
     "drive_preview", "gui_tour", "desktop_preview", "annotate_preview",
     "show_tip", "setup_mcp", "desktop_project", "close_terminal",


### PR DESCRIPTION
## Summary
- keep the existing `process_manage` capability directly available
- remove it from the deferred-tool classification
- update tool-search regression expectations

## Verification
- focused tool-search tests passed
- full local Hermes suite was run
- clean publication branch contains only the scoped change