### PR TITLE
fix: plugin SDK globals no longer freeze as undefined

### DIFF
--- a/apps/desktop/src/sdk/runtime.test.ts
+++ b/apps/desktop/src/sdk/runtime.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Guards the plugin-SDK global installation against a bundler-ordering
+ * regression that source-level tests cannot see.
+ *
+ * The bug: `sdk/runtime.ts` used to hoist its namespaces into a module-level
+ * `const GLOBALS = { __HERMES_PLUGIN_SDK__: sdk, … }`. Rolldown is free to
+ * merge `sdk/runtime` and `sdk/index` into a single chunk and emit the
+ * GLOBALS statement BEFORE the statement that assigns the SDK namespace
+ * object. `__HERMES_PLUGIN_SDK__` then froze as `undefined`, the runtime
+ * loader handed plugins an empty namespace, and every plugin (Follow-up
+ * included) rendered as bare text with no components.
+ *
+ * Two layers of defence:
+ *   1. a behavioural test that the namespaces really land on globalThis, and
+ *   2. an AST check over the SHIPPED chunk proving the SDK namespace is
+ *      initialised before it is read.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { parse } from 'acorn'
+import { describe, expect, it } from 'vitest'
+
+import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
+
+const GLOBAL_KEYS = ['__HERMES_PLUGIN_SDK__', '__HERMES_REACT__', '__HERMES_REACT_JSX__', '__HERMES_REACT_JSX_DEV__'] as const
+
+describe('installPluginSdk', () => {
+  it('installs every namespace as a real object, never undefined', () => {
+    installPluginSdk()
+
+    for (const key of GLOBAL_KEYS) {
+      const value = (globalThis as Record<string, unknown>)[key]
+
+      expect(value, `${key} must be installed`).toBeTypeOf('object')
+      expect(value, `${key} must not be undefined`).not.toBeUndefined()
+    }
+  })
+
+  it('exposes the SDK components plugins actually render with', () => {
+    installPluginSdk()
+
+    const sdk = (globalThis as unknown as Record<string, Record<string, unknown>>).__HERMES_PLUGIN_SDK__
+
+    // A representative slice: if the namespace were the empty/undefined
+    // object of the regression, none of these would exist.
+    for (const name of ['Tip', 'Codicon', 'Button', 'cn', 'haptic', 'host']) {
+      expect(sdk[name], `SDK must export ${name}`).toBeDefined()
+    }
+  })
+
+  it('builds shim modules that re-export named members', () => {
+    const map = sdkImportMap()
+
+    expect(map['@hermes/plugin-sdk']).toMatch(/^blob:/)
+    expect(map.react).toMatch(/^blob:/)
+    expect(map['react/jsx-runtime']).toMatch(/^blob:/)
+  })
+})
+
+/** The shipped chunk that defines `__HERMES_PLUGIN_SDK__`, if the app has been built. */
+function findBuiltSdkChunk(): { file: string; source: string } | null {
+  const assets = join(__dirname, '..', '..', 'dist', 'assets')
+
+  if (!existsSync(assets)) {
+    return null
+  }
+
+  for (const name of readdirSync(assets)) {
+    if (!name.endsWith('.js')) {
+      continue
+    }
+
+    const source = readFileSync(join(assets, name), 'utf8')
+
+    if (source.includes('__HERMES_PLUGIN_SDK__:')) {
+      return { file: name, source }
+    }
+  }
+
+  return null
+}
+
+describe('source shape', () => {
+  // This guard runs everywhere, including a fresh CI checkout with no dist/.
+  // It encodes the invariant the regression violated: the namespaces must not
+  // be captured by a MODULE-LEVEL object literal, because the bundler may
+  // evaluate that literal before the SDK namespace object exists.
+  it('never captures the namespaces in a module-level object literal', () => {
+    const source = readFileSync(join(__dirname, 'runtime.ts'), 'utf8')
+
+    // Strip the type annotations acorn cannot parse, then look for a
+    // top-level (non-function) property named __HERMES_PLUGIN_SDK__.
+    const stripped = source
+      .replace(/^import .*$/gm, '')
+      .replace(/\bas const\b/g, '')
+      .replace(/: Record<string, string> \| null/g, '')
+      .replace(/: Record<string, string>/g, '')
+      .replace(/: GlobalKey/g, '')
+      .replace(/: string/g, '')
+      .replace(/: void/g, '')
+      .replace(/\bexport /g, '')
+      .replace(/type GlobalKey =[^\n]*\n/g, '')
+
+    const ast = parse(stripped, { ecmaVersion: 'latest', sourceType: 'module' }) as unknown as {
+      body: Record<string, unknown>[]
+    }
+
+    const FUNCTION_NODES = new Set(['FunctionDeclaration', 'FunctionExpression', 'ArrowFunctionExpression'])
+    let eager = false
+
+    const walk = (node: unknown, insideFunction: boolean): void => {
+      if (!node || typeof node !== 'object') {
+        return
+      }
+
+      const n = node as Record<string, unknown>
+      const nested = insideFunction || FUNCTION_NODES.has(n.type as string)
+
+      if (n.type === 'Property' && !insideFunction) {
+        const key = n.key as { name?: string; value?: string }
+
+        if ((key?.name ?? key?.value) === '__HERMES_PLUGIN_SDK__') {
+          eager = true
+        }
+      }
+
+      for (const value of Object.values(n)) {
+        if (Array.isArray(value)) {
+          value.forEach(child => walk(child, nested))
+        } else if (value && typeof value === 'object') {
+          walk(value, nested)
+        }
+      }
+    }
+
+    ast.body.forEach(stmt => walk(stmt, false))
+
+    expect(
+      eager,
+      'runtime.ts must build its globals inside a function. A module-level ' +
+        '`{ __HERMES_PLUGIN_SDK__: sdk }` can be emitted before the SDK ' +
+        'namespace is assigned, freezing it as undefined and making every ' +
+        'plugin render as plain text.'
+    ).toBe(false)
+  })
+})
+
+describe('built bundle', () => {
+  const chunk = findBuiltSdkChunk()
+
+  // Skipped VISIBLY (reported by the runner) when the app has not been built,
+  // rather than passing silently as a green test that never asserted.
+  it.skipIf(!chunk)('initialises the SDK namespace before __HERMES_PLUGIN_SDK__ reads it', () => {
+    if (!chunk) {
+      return
+    }
+
+    const ast = parse(chunk.source, { ecmaVersion: 'latest', sourceType: 'module' }) as unknown as {
+      body: Record<string, unknown>[]
+    }
+
+    // Statement index at which each top-level `var X = …` is initialised.
+    const declaredAt = new Map<string, number>()
+
+    ast.body.forEach((stmt, i) => {
+      if (stmt.type !== 'VariableDeclaration') {
+        return
+      }
+
+      for (const d of stmt.declarations as { id: { type: string; name?: string }; init: unknown }[]) {
+        if (d.id.type === 'Identifier' && d.init && !declaredAt.has(d.id.name as string)) {
+          declaredAt.set(d.id.name as string, i)
+        }
+      }
+    })
+
+    // Locate the object literal carrying __HERMES_PLUGIN_SDK__.
+    //
+    // Only an EAGER read is dangerous: one evaluated as part of the chunk's
+    // top-level statement sequence. A read inside a function body (the fix:
+    // `() => ({ __HERMES_PLUGIN_SDK__: sdk, … })`) runs when the loader
+    // calls it, long after every top-level `var` is assigned — so we track
+    // whether the walk has descended through a function.
+    const FUNCTION_NODES = new Set(['FunctionDeclaration', 'FunctionExpression', 'ArrowFunctionExpression'])
+
+    let eagerRead: { stmtIndex: number; identifier: string | null } | null = null
+    let lazyRead = false
+
+    const walk = (node: unknown, stmtIndex: number, insideFunction: boolean): void => {
+      if (!node || typeof node !== 'object') {
+        return
+      }
+
+      const n = node as Record<string, unknown>
+      const nested = insideFunction || FUNCTION_NODES.has(n.type as string)
+
+      if (n.type === 'Property') {
+        const key = n.key as { name?: string; value?: string }
+
+        if ((key?.name ?? key?.value) === '__HERMES_PLUGIN_SDK__') {
+          if (nested) {
+            lazyRead = true
+          } else {
+            const value = n.value as { type: string; name?: string }
+
+            eagerRead = { stmtIndex, identifier: value.type === 'Identifier' ? (value.name as string) : null }
+          }
+        }
+      }
+
+      for (const key of Object.keys(n)) {
+        const child = n[key]
+
+        if (Array.isArray(child)) {
+          child.forEach(c => walk(c, stmtIndex, nested))
+        } else if (child && typeof child === 'object') {
+          walk(child, stmtIndex, nested)
+        }
+      }
+    }
+
+    ast.body.forEach((stmt, i) => walk(stmt, i, false))
+
+    expect(eagerRead !== null || lazyRead, 'chunk must define __HERMES_PLUGIN_SDK__').toBe(true)
+
+    // Deferred behind a function — safe by construction.
+    if (eagerRead === null) {
+      return
+    }
+
+    const { stmtIndex, identifier } = eagerRead
+
+    // Produced inline (call expression, spread…) rather than referencing a
+    // hoisted binding — nothing can be read before it exists.
+    if (identifier === null) {
+      return
+    }
+
+    const initIndex = declaredAt.get(identifier)
+
+    expect(
+      initIndex === undefined || initIndex < stmtIndex,
+      `${chunk.file}: SDK namespace '${identifier}' is initialised at statement #${initIndex} but ` +
+        `read eagerly at #${stmtIndex} — __HERMES_PLUGIN_SDK__ would be undefined and every ` +
+        `plugin would render as plain text`
+    ).toBe(true)
+  })
+})

--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -13,21 +13,42 @@ import * as jsxRuntime from 'react/jsx-runtime'
 
 import * as sdk from './index'
 
-const GLOBALS = {
-  __HERMES_PLUGIN_SDK__: sdk,
-  __HERMES_REACT__: React,
-  __HERMES_REACT_JSX__: jsxRuntime,
-  __HERMES_REACT_JSX_DEV__: jsxDevRuntime
-} as const
+/** The namespaces exposed to runtime plugins.
+ *
+ *  Built ON CALL, never hoisted into a module-level object literal. The
+ *  bundler is free to merge this module with `./index` into one chunk and
+ *  emit our statements BEFORE the SDK namespace object is assigned; a
+ *  module-level `{ __HERMES_PLUGIN_SDK__: sdk }` would then capture
+ *  `undefined` forever and every plugin would fall back to plain text.
+ *  Reading `sdk` inside a function defers it past chunk initialisation. */
+const globals = () =>
+  ({
+    __HERMES_PLUGIN_SDK__: sdk,
+    __HERMES_REACT__: React,
+    __HERMES_REACT_JSX__: jsxRuntime,
+    __HERMES_REACT_JSX_DEV__: jsxDevRuntime
+  }) as const
+
+type GlobalKey = keyof ReturnType<typeof globals>
 
 export function installPluginSdk(): void {
-  Object.assign(globalThis, GLOBALS)
+  const ns = globals()
+
+  // Fail loudly instead of shipping a namespace that silently resolves to
+  // `undefined` — a plugin importing it would render nothing but its text.
+  for (const [key, value] of Object.entries(ns)) {
+    if (!value || typeof value !== 'object') {
+      throw new Error(`[plugin-sdk] ${key} is not initialised — SDK namespace evaluated too early`)
+    }
+  }
+
+  Object.assign(globalThis, ns)
 }
 
 /** Build a shim ESM blob that re-exports a global namespace's live members.
  *  Export names come from the namespace itself, so the list can't drift. */
-function shimUrl(globalKey: keyof typeof GLOBALS): string {
-  const names = Object.keys(GLOBALS[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
+function shimUrl(globalKey: GlobalKey): string {
+  const names = Object.keys(globals()[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
 
   const source =
     `const m = globalThis.${globalKey};\n` +

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       ],
       "devDependencies": {
         "@eslint/js": "9.39.5",
+        "acorn": "8.17.0",
         "eslint-plugin-perfectionist": "5.10.0",
         "eslint-plugin-react-hooks": "7.1.1",
         "eslint-plugin-unused-imports": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://github.com/NousResearch/Hermes-Agent#readme",
   "devDependencies": {
     "@eslint/js": "9.39.5",
+    "acorn": "8.17.0",
     "typescript-eslint": "8.64.0",
     "eslint-plugin-perfectionist": "5.10.0",
     "eslint-plugin-react-hooks": "7.1.1",


### PR DESCRIPTION
Plugins that import the SDK rendered as **plain text**. `__HERMES_PLUGIN_SDK__` was `undefined` at runtime, so `Tip`, `Codicon` and the rest resolved to nothing and the JSX degraded to bare strings. Nothing threw, which is why this reads as a plugin bug until you look at the emitted bundle.

## Cause

Initialisation order in the bundle, not the source. `runtime.ts` captured the namespaces in a module-level object literal:

```js
const GLOBALS = { __HERMES_PLUGIN_SDK__: sdk, ... }   // evaluated at chunk init
```

The bundler merges `sdk/runtime` and `sdk/index` into one chunk and emits that literal at **statement #349**, while the SDK namespace binding is assigned at **#517**. The literal captures `undefined` and freezes it. Every later read sees `undefined`, forever.

Source-level tests cannot see this: the source is correct in isolation. Only statement order in the built chunk shows it.

## Fix

Build the map lazily in `globals()` so each lookup reads the namespace at call time, once all bindings are live. `shimUrl()` calls `globals()` instead of closing over the stale object.

`installPluginSdk()` now throws when a namespace is missing instead of installing `undefined`. A future ordering regression fails loudly at startup rather than degrading to text-only plugins.

## Tests

Two layers, because either alone leaves a hole:

- **Source guard** — parses `runtime.ts` and asserts the namespaces are never captured in a module-level object literal. Runs on any checkout, including a fresh CI clone with no `dist/`.
- **Bundle guard** — parses the built chunk and compares statement order, catching a bundler change that reintroduces the hazard even if the source stays fine. `skipIf`-gated on `dist/` so CI reports it as **skipped**, never as a green test that silently asserted nothing.

Both were verified against the regression, not just against the fix: reintroducing the module-level literal fails the source guard with the intended message, and reverting makes it pass. The bundle guard was likewise checked against the old chunk (fails) and the new one (passes).

`acorn` is promoted from transitive to an explicit devDependency, since the tests now import it directly. `package.json` and `package-lock.json` each change by exactly one line.

## Verification

- `vitest run src/sdk/ src/contrib/` — 103 passed, 1 skipped (the bundle guard, no `dist/` in a clean worktree)
- `tsc --noEmit` — clean
- `eslint` on both touched files — clean
- Packaged build launched under CDP: `__HERMES_PLUGIN_SDK__` resolves to a live 155-export namespace, and a plugin registers and renders through the real host
