### PR TITLE
fix(deepseek): recognize deepseek-flash as the canonical V4.1-Flash id

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -339,10 +339,11 @@ DEFAULT_CONTEXT_LENGTHS = {
     # Google / Gemma ("gemma4" is Ollama-style naming, e.g. gemma4:31b-cloud)
     "gemini": 1048576,
     "gemma-4": 256000, "gemma4": 256000, "gemma-4-31b": 256000, "gemma-3": 131072, "gemma": 8192,
-    # DeepSeek — V4 family is 1M; deepseek-chat/-reasoner alias v4-flash modes.
+    # DeepSeek — V4 family is 1M; ``deepseek-flash`` is the canonical id of the current flash model
+    # (V4.1-Flash), and deepseek-chat/-reasoner alias its non-thinking/thinking modes.
     # https://api-docs.deepseek.com/zh-cn/quick_start/pricing
-    "deepseek-v4-pro": 1_000_000, "deepseek-v4-flash": 1_000_000, "deepseek-chat": 1_000_000,
-    "deepseek-reasoner": 1_000_000, "deepseek": 128000,
+    "deepseek-flash": 1_000_000, "deepseek-v4-pro": 1_000_000, "deepseek-v4-flash": 1_000_000,
+    "deepseek-chat": 1_000_000, "deepseek-reasoner": 1_000_000, "deepseek": 128000,
     # Meta; Muse Spark family (1.1/1.2/1.3, -contributor(-free), meta/ prefixed) is 1M per OpenRouter,
     # models.dev and api.commandcode.ai /models — keep the "muse-spark" prefix (bare "muse" would match
     # muse-image/muse-voice). Thinking Machines inkling (covers inkling-small and :free/:batch variants)

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -20,7 +20,8 @@ _REASONING_STALE_TIMEOUT_FLOORS: dict[int, tuple[str, ...]] = {
         # NVIDIA Nemotron behind hosted NIM: documented 60-180s upstream idle kill.
         "nemotron-3-ultra", "nemotron-3-super",
         # DeepSeek R1 / V4 (reasoning_content streamed before final content).
-        "deepseek-r1", "deepseek-reasoner", "deepseek-v4-flash", "deepseek-v4-pro",
+        # ``deepseek-flash`` (V4.1-Flash) defaults to thinking mode, so it belongs here too.
+        "deepseek-r1", "deepseek-reasoner", "deepseek-flash", "deepseek-v4-flash", "deepseek-v4-pro",
         # OpenAI o-series: each variant enumerated so bare ``o1`` cannot over-match ``olmo-1``.
         "o1", "o1-mini", "o1-pro", "o1-preview", "o3", "o3-pro",
         # Mythos-class named models (claude-fable-5): 1M ctx + 128K output, a heavier thinking

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -192,6 +192,18 @@ _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
         ("deepseek-chat", "deepseek-reasoner", "deepseek-v4-flash"): ("0.14", "0.28", "0.0028"),
         "deepseek-v4-pro": ("0.435", "0.87", "0.003625"),
     }),
+    # DeepSeek-V4.1-Flash, released 2026-09-10. ``deepseek-flash`` is the canonical id; the
+    # predecessor names (deepseek-v4-flash, and the deepseek-chat/-reasoner aliases) are all served
+    # by V4.1-Flash now, so they share these rates — without this the new canonical id had NO row
+    # and resolved to `unknown` cost while the legacy names kept stale 2026-07 pricing.
+    # DeepSeek bills PEAK 01:00-04:00 and 06:00-10:00 UTC Mon-Fri, with OFF-PEAK exactly HALF of
+    # the figures below (miss 0.15 / hit 0.003 / out 0.60). We record the PEAK (list) rates so an
+    # estimate never UNDERSTATES a bill; a time-of-day-aware estimate is out of scope for a static
+    # snapshot. https://api-docs.deepseek.com/quick_start/pricing
+    ("deepseek", "https://api-docs.deepseek.com/quick_start/pricing", "deepseek-pricing-2026-09-10", {
+        ("deepseek-flash", "deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"):
+            ("0.30", "1.20", "0.006"),
+    }),
     ("google", "https://ai.google.dev/gemini-api/docs/pricing", "google-pricing-2026-09-02", {
         ("gemini-3.8-flash", "gemini-3.7-flash"): ("0.75", "3.75", "0.075"),
     }),

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -87,13 +87,21 @@ _LOWERCASE_MODEL_PROVIDERS: frozenset[str] = frozenset({
     "xiaomi"})
 
 # DeepSeek's direct API only accepts first-class V-series IDs after the 2026-07-24 cut-off (HTTP 400
-# otherwise). Both retired aliases map to deepseek-v4-flash per the official docs (thinking mode is
-# controlled by extra_body.thinking on the profile), so saved configs can't keep sending them.
+# otherwise). Both retired aliases map to the current flash model per the official docs (thinking
+# mode is controlled by extra_body.thinking on the profile), so saved configs can't keep sending them.
 _DEEPSEEK_RETIRED_ALIASES: frozenset[str] = frozenset({
     "deepseek-chat", "deepseek-reasoner"})
 
+# ``deepseek-flash`` is the canonical id of the CURRENT flash model (DeepSeek-V4.1-Flash, released
+# 2026-09-10). It has no digit directly after ``-v``, so it does NOT match ``_DEEPSEEK_V_SERIES_RE``
+# and must be listed explicitly here — otherwise it falls through to the fallback below and is
+# silently rewritten to the retired ``deepseek-v4-flash``, which DeepSeek keeps only as a TEMPORARY
+# compatibility alias (its removal would then break every deepseek request).
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-v4-pro", "deepseek-v4-flash"})
+    "deepseek-flash", "deepseek-v4-pro", "deepseek-v4-flash"})
+
+# Retired aliases and unrecognised inputs resolve here. Keep pointed at the current flash model.
+_DEEPSEEK_FALLBACK_MODEL = "deepseek-flash"
 
 # First-class V-series IDs incl. future ``deepseek-v5-*`` and dated variants
 # (``deepseek-v4-flash-20260423``): verified real model ids, NOT aliases of ``deepseek-chat``.
@@ -103,11 +111,11 @@ _DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v\d+([-.].+)?$")
 def _normalize_for_deepseek(model_name: str) -> str:
     """Map a model input to a DeepSeek-accepted id: canonicals and ``deepseek-v<digit>…`` pass
     through (future V-series work without a release); retired aliases and everything else become
-    ``deepseek-v4-flash``."""
+    the current flash model (``_DEEPSEEK_FALLBACK_MODEL``)."""
     bare = _strip_vendor_prefix(model_name).lower()
     if bare in _DEEPSEEK_CANONICAL_MODELS or _DEEPSEEK_V_SERIES_RE.match(bare):
         return bare
-    return "deepseek-v4-flash"
+    return _DEEPSEEK_FALLBACK_MODEL
 
 
 def _strip_vendor_prefix(model_name: str) -> str:

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -205,7 +205,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-sonnet-4-6", "claude-opus-4-5-20251101", "claude-sonnet-4-5-20250929",
         "claude-opus-4-20250514", "claude-sonnet-4-20250514", "claude-haiku-4-5-20251001",
     ],
-    "deepseek": ["deepseek-v4-pro", "deepseek-v4-flash"],
+    "deepseek": ["deepseek-flash", "deepseek-v4-pro", "deepseek-v4-flash"],
     "xiaomi": ["mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "mimo-v2-flash"],
     "tencent-tokenhub": list(_TENCENT_MODELS),
     "tencent-tokenplan": list(_TENCENT_MODELS),

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -42,8 +42,9 @@ class DeepSeekProfile(ProviderProfile):
 deepseek = DeepSeekProfile(
     name="deepseek", aliases=("deepseek-chat",), env_vars=("DEEPSEEK_API_KEY",), display_name="DeepSeek",
     description="DeepSeek — native DeepSeek API", signup_url="https://platform.deepseek.com/",
-    fallback_models=("deepseek-v4-pro", "deepseek-v4-flash"), base_url="https://api.deepseek.com/v1",
-    default_aux_model="deepseek-v4-flash",
+    fallback_models=("deepseek-flash", "deepseek-v4-pro", "deepseek-v4-flash"),
+    base_url="https://api.deepseek.com/v1",
+    default_aux_model="deepseek-flash",
 )
 
 register_provider(deepseek)

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -6,6 +6,7 @@ from agent.usage_pricing import (
     format_cost_label,
     estimate_usage_cost,
     get_pricing_entry,
+    has_known_pricing,
     normalize_usage,
     resolve_billing_route,
 )
@@ -962,3 +963,53 @@ def test_flat_entries_unaffected_by_tier_machinery():
     )
     # 250k * $0.25/M + 10k * $1.50/M
     assert result.amount_usd == Decimal("0.0775")
+
+
+# ── DeepSeek-V4.1-Flash pricing (2026-09-10) ───────────────────────────
+
+def test_deepseek_flash_canonical_id_has_pricing():
+    """The canonical current DeepSeek flash id must resolve to a pricing entry.
+
+    Regression: only the legacy ids carried rows, so the canonical id reported unknown
+    cost while the retired names kept stale 2026-07 rates.
+    """
+    assert has_known_pricing("deepseek-flash", provider="deepseek")
+    assert get_pricing_entry("deepseek-flash", provider="deepseek") is not None
+
+
+def test_deepseek_flash_shares_rates_with_legacy_ids():
+    """DeepSeek serves V4.1-Flash for every one of these names, so they must bill identically —
+    otherwise the same request is priced differently depending on which id the caller used."""
+    canonical = get_pricing_entry("deepseek-flash", provider="deepseek")
+    assert canonical is not None
+    for legacy in ("deepseek-v4-flash", "deepseek-chat", "deepseek-reasoner"):
+        assert get_pricing_entry(legacy, provider="deepseek") == canonical
+
+
+def test_deepseek_flash_is_priced_above_zero():
+    """A zero/absent rate would silently report a free model for paid traffic."""
+    entry = get_pricing_entry("deepseek-flash", provider="deepseek")
+    assert entry is not None
+    assert entry.input_cost_per_million > 0
+    assert entry.output_cost_per_million > 0
+
+
+def test_deepseek_flash_estimate_derives_from_the_entry():
+    """Assert the relationship between tokens and cost, not a frozen dollar figure."""
+    entry = get_pricing_entry("deepseek-flash", provider="deepseek")
+    assert entry is not None
+
+    result = estimate_usage_cost(
+        "deepseek-flash",
+        CanonicalUsage(input_tokens=1_000_000, output_tokens=1_000_000),
+        provider="deepseek",
+    )
+    assert result.amount_usd == (
+        Decimal(1_000_000) * entry.input_cost_per_million
+        + Decimal(1_000_000) * entry.output_cost_per_million
+    ) / Decimal(1_000_000)
+
+
+def test_deepseek_pricing_survives_the_vendor_prefix_form():
+    """Users paste ``deepseek/deepseek-flash``; the route must still find the row."""
+    assert get_pricing_entry("deepseek/deepseek-flash", provider="deepseek") is not None

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -8,6 +8,8 @@ import pytest
 from hermes_cli.model_normalize import (
     normalize_model_for_provider,
     _DOT_TO_HYPHEN_PROVIDERS,
+    _DEEPSEEK_CANONICAL_MODELS,
+    _DEEPSEEK_V_SERIES_RE,
     _normalize_for_deepseek,
     detect_vendor,
 )
@@ -114,18 +116,26 @@ class TestDeepseekVSeriesPassThrough:
 # ── DeepSeek post-2026-07-24 alias remapping ───────────────────────────
 
 class TestDeepseekCanonicalAndReasonerMapping:
-    """Retired aliases and fuzzy names rewrite to deepseek-v4-flash.
+    """Retired aliases and fuzzy names rewrite to the CURRENT flash model.
 
     DeepSeek cut off ``deepseek-chat`` / ``deepseek-reasoner`` on
-    2026-07-24; sending them on the wire returns HTTP 400.
+    2026-07-24; sending them on the wire returns HTTP 400. The rewrite target is
+    asserted as a *contract* — "a DeepSeek-accepted id, and the same one the canonical
+    flash id resolves to" — rather than a frozen literal, so this class does not need
+    editing every time DeepSeek renames the flash model (it was pinned to the now-retired
+    ``deepseek-v4-flash`` and had to be updated when ``deepseek-flash`` became canonical).
     """
 
+    @staticmethod
+    def _assert_deepseek_accepted(model_id: str) -> None:
+        assert (
+            model_id in _DEEPSEEK_CANONICAL_MODELS or _DEEPSEEK_V_SERIES_RE.match(model_id)
+        ), f"{model_id!r} is not an id DeepSeek will accept"
 
     def test_provider_path_rewrites_reasoner(self):
-        assert (
-            normalize_model_for_provider("deepseek-reasoner", "deepseek")
-            == "deepseek-v4-flash"
-        )
+        rewritten = normalize_model_for_provider("deepseek-reasoner", "deepseek")
+        self._assert_deepseek_accepted(rewritten)
+        assert rewritten == normalize_model_for_provider("deepseek-flash", "deepseek")
 
     @pytest.mark.parametrize("model", [
         "deepseek-r1",
@@ -134,8 +144,10 @@ class TestDeepseekCanonicalAndReasonerMapping:
         "deepseek-reasoning-preview",
         "deepseek-cot-experimental",
     ])
-    def test_reasoner_keywords_map_to_v4_flash(self, model):
-        assert _normalize_for_deepseek(model) == "deepseek-v4-flash"
+    def test_reasoner_keywords_map_to_the_live_flash_model(self, model):
+        rewritten = _normalize_for_deepseek(model)
+        self._assert_deepseek_accepted(rewritten)
+        assert rewritten == _normalize_for_deepseek("deepseek-flash")
 
 
 # ── Regression: issue #78796 ───────────────────────────────────────────
@@ -186,4 +198,48 @@ class TestIssue78796NvidiaPrefixRepair:
             normalize_model_for_provider("claude-sonnet-4.6", "openrouter")
             == "anthropic/claude-sonnet-4.6"
         )
+
+
+# ── Regression: DeepSeek-V4.1-Flash canonical id (2026-09-10) ──────────
+
+class TestDeepSeekFlashCanonicalId:
+    """``deepseek-flash`` is the canonical id of the CURRENT flash model (V4.1-Flash).
+
+    Regression: the id has no digit directly after ``-v``, so it never matched
+    ``_DEEPSEEK_V_SERIES_RE`` and was absent from ``_DEEPSEEK_CANONICAL_MODELS``.
+    It therefore fell through to the legacy fallback and was silently rewritten to the
+    retired ``deepseek-v4-flash``, which DeepSeek keeps only as a TEMPORARY compat alias.
+    """
+
+    @pytest.mark.parametrize("model", [
+        "deepseek-flash",
+        "deepseek-v4-flash",
+        "deepseek-v4-pro",
+    ])
+    def test_accepted_ids_pass_through_unchanged(self, model):
+        assert _normalize_for_deepseek(model) == model
+        assert normalize_model_for_provider(model, "deepseek") == model
+
+    def test_vendor_prefixed_canonical_id_survives(self):
+        assert normalize_model_for_provider("deepseek/deepseek-flash", "deepseek") == "deepseek-flash"
+
+    def test_matching_is_case_insensitive(self):
+        assert _normalize_for_deepseek("DeepSeek-Flash") == "deepseek-flash"
+        assert normalize_model_for_provider("deepseek-flash", "DEEPSEEK") == "deepseek-flash"
+
+    def test_retired_aliases_resolve_to_the_live_flash_model(self):
+        """deepseek-chat / deepseek-reasoner are aliases of the flash model's modes, so they
+        must land on the same target as the canonical id rather than a legacy literal."""
+        assert (
+            _normalize_for_deepseek("deepseek-chat")
+            == _normalize_for_deepseek("deepseek-reasoner")
+            == _normalize_for_deepseek("deepseek-flash")
+        )
+
+    def test_unknown_input_falls_back_to_the_live_flash_model(self):
+        assert _normalize_for_deepseek("some-retired-model") == _normalize_for_deepseek("deepseek-flash")
+
+    def test_future_v_series_still_passes_through_without_release(self):
+        """The explicit canonical list must not regress the generic V-series escape hatch."""
+        assert _normalize_for_deepseek("deepseek-v5-flash") == "deepseek-v5-flash"
 


### PR DESCRIPTION
## What does this PR do?

DeepSeek released **DeepSeek-V4.1-Flash** on 2026-09-10 and made **`deepseek-flash` the canonical model id**. Per the [official changelog](https://api-docs.deepseek.com/updates/):

> Change the model name to `deepseek-flash` to call the latest V4.1 Flash model. The previous-generation models V4 Flash and V4 Flash Vision Exp have been retired; for compatibility, the model names `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` are **temporarily** routed to V4.1 Flash.

Hermes did not know the new id, which produced two bugs.

**Bug 1 — the canonical id was silently rewritten to a retiring alias.**
`_normalize_for_deepseek` passed through only `_DEEPSEEK_CANONICAL_MODELS` or ids matching `_DEEPSEEK_V_SERIES_RE` (`^deepseek-v\d+...`). `deepseek-flash` has no digit directly after `-v`, so it matched neither and fell through to the hardcoded fallback, becoming `deepseek-v4-flash`:

```
⚠️  Normalized model 'deepseek-flash' to 'deepseek-v4-flash' for deepseek.
```

That works today only because the compat alias exists. It is explicitly temporary, so when DeepSeek removes it **every deepseek request from Hermes fails**. The fallback target is moved onto the live flash id as well — that hardcoded legacy id is the same bug class.

**Bug 2 — the canonical id had no pricing row.**
`_SNAPSHOTS` only carried the legacy names, so `has_known_pricing("deepseek-flash")` was `False` while the retired names kept stale 2026-07 rates. Cost reporting therefore diverged depending on which id a caller used.

## Related Issue

Fixes — no issue filed; reporting against the vendor release above.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_normalize.py` — add `deepseek-flash` to `_DEEPSEEK_CANONICAL_MODELS`; extract `_DEEPSEEK_FALLBACK_MODEL` and point it at the live flash id instead of the retiring one.
- `agent/usage_pricing.py` — new `deepseek-pricing-2026-09-10` snapshot pricing `deepseek-flash` and the three names DeepSeek serves it under (`deepseek-v4-flash`, `deepseek-chat`, `deepseek-reasoner`). The 2026-07 snapshot is left intact for historical accuracy (later snapshots win).
- `agent/model_metadata.py` — declare `deepseek-flash` (1M context) alongside the legacy ids.
- `agent/reasoning_timeouts.py` — add `deepseek-flash` to the reasoning stale-timeout floors; V4.1-Flash **defaults to thinking mode**.
- `plugins/model-providers/deepseek/__init__.py` — list the new id in `fallback_models`, and use it as `default_aux_model`.
- `hermes_cli/models_catalog_static.py` — surface the new id in the picker's model list.

## How to Test

1. `python -c "from hermes_cli.model_normalize import _normalize_for_deepseek as n; print(n('deepseek-flash'))"` → prints `deepseek-flash` (before: `deepseek-v4-flash`).
2. `python -c "from agent.usage_pricing import has_known_pricing as h; print(h('deepseek-flash', provider='deepseek'))"` → `True` (before: `False`).
3. `pytest tests/hermes_cli/test_model_normalize.py tests/agent/test_usage_pricing.py -q`

## Pricing note — a judgement call reviewers may want to change

V4.1-Flash is billed **peak/off-peak**: off-peak is exactly half of peak, and peak is 01:00–04:00 and 06:00–10:00 UTC Mon–Fri. `PricingEntry` cannot express time-of-day, so a single tuple has to be chosen.

This PR records the **peak (list) rates** — in `0.30` / out `1.20` / cache-read `0.006` — on the principle that an estimate should never *understate* a bill, with the off-peak halving documented in the source comment. If you would rather track off-peak (the majority of hours, and therefore closer to a typical bill), the change is one tuple: `0.15` / `0.60` / `0.003`. Happy to flip it.

## Tests

New tests assert **contracts, not frozen values**, so they survive the next model rename:

- the canonical id survives normalization (also vendor-prefixed and uppercase forms);
- `deepseek-chat` / `deepseek-reasoner` / fuzzy reasoner names still rewrite to a **DeepSeek-accepted id**, and to the same target as the canonical flash id;
- every name DeepSeek serves from V4.1-Flash bills identically;
- the estimate is derived from the pricing entry rather than a hardcoded dollar figure.

`tests/hermes_cli/test_model_normalize.py::TestDeepseekCanonicalAndReasonerMapping` previously pinned its rewrite target to the literal `deepseek-v4-flash`, which is exactly what went stale here. Its intent ("retired aliases and fuzzy names rewrite to the flash model") is preserved; only the frozen literal is gone. That class was touched because the fallback moved — including it in the diff keeps the suite green and prevents the same rot next release.

### Test evidence (branch vs clean `main`)

The affected modules were run on this branch and on a clean `main` worktree with the same
interpreter, so the delta is attributable:

| tree | result |
|---|---|
| this branch | `566 passed, 1 skipped` |
| clean `main` | `553 passed, 1 skipped` |

The difference is exactly the 13 tests added here, with **zero failures on either side**.
(The full `tests/hermes_cli` directory reports unrelated, environment-dependent failures in
this sandbox; none are in the modules touched by this PR.)

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to avoid a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] Tested on my platform: Ubuntu 24.04 / aarch64

### Documentation & Housekeeping

- [x] Docstrings/comments updated where the behavior changed — or N/A
- [x] No config keys added — `cli-config.yaml.example` N/A
- [x] No architecture/workflow change — `AGENTS.md` N/A
- [x] Cross-platform impact considered (pure string/table changes) — N/A
- [x] No tool descriptions/schemas changed — N/A

## Screenshots / Logs

Verified end-to-end against the live API on a real install (Ubuntu/aarch64) before and after, using model `deepseek-flash`:

```
served_by: deepseek-flash    # text + thinking mode
tool_call: {"name": "get_weather", "arguments": "{\"city\": \"Seattle\"}"}
vision: "The image contains a red circle in the upper left and a blue square in the lower right."
```

Streaming also verified (38–160 SSE chunks, no broken pipe), including with `thinking: {"type": "disabled"}` and `reasoning_effort` set, which is relevant to the documented flash-model stream-drop pitfall in `skills/devops/cron-job-patterns` — that pitfall does **not** reproduce on V4.1-Flash.
