### PR TITLE
fix(desktop): Ctrl+A before a completion accept no longer duplicates the command

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.test.ts
@@ -7,7 +7,7 @@ import { rememberDesktopCommandsCatalog } from '@/lib/desktop-slash-commands'
 
 import { composerPlainText, renderComposerContents, RICH_INPUT_SLOT } from '../rich-editor'
 
-import { useComposerTrigger } from './use-composer-trigger'
+import { collapseSelectionOntoTrigger, rebuildAroundCaret, useComposerTrigger } from './use-composer-trigger'
 
 beforeEach(() => {
   rememberDesktopCommandsCatalog({
@@ -239,6 +239,54 @@ describe('useComposerTrigger — free-text slash arguments', () => {
   })
 })
 
+describe('collapseSelectionOntoTrigger + rebuildAroundCaret (non-collapsed selection)', () => {
+  /** Ctrl+A shape: whole editor selected. Fires no input event, so the
+   *  composer never normalizes it — the accept path has to. */
+  function selectAllIn(editor: HTMLElement) {
+    const range = document.createRange()
+    range.selectNodeContents(editor)
+    const selection = window.getSelection()!
+    selection.removeAllRanges()
+    selection.addRange(range)
+  }
+
+  it('collapses a whole-editor selection onto the end of the trigger token', () => {
+    const editor = mountEditor('/ne')
+    selectAllIn(editor)
+
+    expect(collapseSelectionOntoTrigger(editor, '/', 'ne')).toBe(true)
+
+    const selection = window.getSelection()!
+    expect(selection.getRangeAt(0).collapsed).toBe(true)
+  })
+
+  it('re-marks emptiness after a fragment rebuild so the placeholder stops painting', () => {
+    // The rebuild renders an empty prefix (which sets data-empty), then appends
+    // the chip + suffix — appends that fire no input event. Without the re-mark
+    // the placeholder hint painted over the committed content.
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    editor.contentEditable = 'true'
+    document.body.append(editor)
+    renderComposerContents(editor, '/new')
+    selectAllIn(editor)
+
+    expect(collapseSelectionOntoTrigger(editor, '/', 'new')).toBe(true)
+
+    const chip = document.createElement('span')
+    chip.contentEditable = 'false'
+    chip.dataset.refText = '/new '
+    chip.append(document.createTextNode('/new '))
+    const chipFragment = document.createDocumentFragment()
+    chipFragment.append(chip)
+
+    rebuildAroundCaret(editor, 4, chipFragment)
+
+    expect(composerPlainText(editor)).toBe('/new ')
+    expect(editor.dataset.empty).toBeUndefined()
+  })
+})
+
 describe('useComposerTrigger — chip survival (the plaintext-demotion bug class)', () => {
   it('keeps a leading command pill through a Backspace path-ascend', () => {
     // The reported repro: `/work @folder…` then Backspace — both chips went
@@ -305,5 +353,61 @@ describe('useComposerTrigger — chip survival (the plaintext-demotion bug class
 
     expect(composerPlainText(editor)).toBe('please run /clean ')
     expect(editor.querySelector('[data-slash-kind]')).not.toBeNull()
+  })
+
+  it('replaces the token when the editor is selected-all (Ctrl+A) at accept time', () => {
+    // Ctrl+A (native select-all) leaves a NON-COLLAPSED selection behind; it
+    // fires no input event, so the composer never normalizes it. An accept
+    // must treat the selected token as the thing being replaced — the rebuild
+    // used to read the caret at the selection's document-order START (0),
+    // re-appending the typed token after the chip.
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    editor.contentEditable = 'true'
+    document.body.append(editor)
+    renderComposerContents(editor, '/ne')
+    const all = document.createRange()
+    all.selectNodeContents(editor)
+    const selection = window.getSelection()!
+    selection.removeAllRanges()
+    selection.addRange(all)
+
+    const { hook } = mountTrigger(editor, [item('/new', 'Commands')])
+
+    act(() => hook.result.current.refreshTrigger())
+    act(() => hook.result.current.moveTriggerActive(1))
+    act(() => hook.result.current.moveTriggerActive(-1))
+    act(() => hook.result.current.replaceTriggerWithChip(item('/new', 'Commands')))
+
+    expect(composerPlainText(editor)).toBe('/new ')
+    expect(editor.querySelector('[data-slash-kind]')).not.toBeNull()
+    // The stale-empty regression: the rebuild set data-empty while wiping the
+    // editor, and nothing re-marked it after the append — the placeholder hint
+    // painted over the chip.
+    expect(editor.dataset.empty).toBeUndefined()
+  })
+
+  it('replaces the token under select-all when prose precedes it', () => {
+    // The selection's DOM offsets are (node, child-index) pairs, NOT character
+    // offsets: with prose in front, the whole-editor selection's endOffset is
+    // the number of child nodes, which used to be read as an absolute text
+    // offset and made the token search conclude the selection didn't reach it.
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    editor.contentEditable = 'true'
+    document.body.append(editor)
+    renderComposerContents(editor, 'please run /cle')
+    const all = document.createRange()
+    all.selectNodeContents(editor)
+    const selection = window.getSelection()!
+    selection.removeAllRanges()
+    selection.addRange(all)
+
+    const { hook } = mountTrigger(editor, [item('/clean')])
+
+    act(() => hook.result.current.refreshTrigger())
+    act(() => hook.result.current.replaceTriggerWithChip(item('/clean')))
+
+    expect(composerPlainText(editor)).toBe('please run /clean ')
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-trigger.ts
@@ -15,6 +15,7 @@ import {
   appendComposerContents,
   caretOffsetInEditor,
   composerPlainText,
+  markEditorEmptiness,
   placeCaretAtOffset,
   refChipElement,
   renderComposerContents,
@@ -56,6 +57,69 @@ export function triggerKeyUpHandler(consumedRef: MutableRefObject<boolean>, refr
   }
 }
 
+/**
+ * An accepted completion means "the token becomes the chip", so a selection
+ * that merely SPANS the token (Ctrl+A select-all fires no input event and the
+ * composer never normalizes it) must not be read as caret context. Collapse
+ * the caret onto the end of the trigger token before any replacement runs:
+ * `replaceBeforeCaret` requires a collapsed caret, and the rebuild fallback
+ * slices the editor around `caretOffsetInEditor`, which reports a non-collapsed
+ * selection's document-order START — re-appending the very token being
+ * replaced. Returns whether a collapse happened.
+ *
+ * The token is located by its serialized text (kind + query) rather than by
+ * offset arithmetic, so a selection ending mid-token or before it still
+ * resolves; the occurrence INTERSECTING the selection wins when the text
+ * appears more than once. Nothing changes when the token can't be located —
+ * the pre-existing fallback behavior stands.
+ */
+export function collapseSelectionOntoTrigger(editor: HTMLElement, kind: '@' | '/' | ':', query: string): boolean {
+  const selection = window.getSelection()
+
+  if (!selection || selection.rangeCount === 0) {
+    return false
+  }
+
+  const range = selection.getRangeAt(0)
+
+  if (range.collapsed || !editor.contains(range.commonAncestorContainer)) {
+    return false
+  }
+
+  const token = `${kind}${query}`
+  const current = composerPlainText(editor)
+
+  // Selection boundaries are DOM (node, offset) pairs — child indices, NOT
+  // character offsets. Convert both ends to absolute composerPlainText
+  // coordinates before any string math (caretOffsetInEditor already performs
+  // this conversion for the start boundary).
+  const start = caretOffsetInEditor(editor)
+  const probe = range.cloneRange()
+  probe.selectNodeContents(editor)
+  probe.setEnd(range.endContainer, range.endOffset)
+  const scratch = document.createElement('div')
+  scratch.dataset.slot = RICH_INPUT_SLOT
+  scratch.append(probe.cloneContents())
+  const end = Math.min(composerPlainText(scratch).length, current.length)
+
+  for (let index = current.indexOf(token); index !== -1; index = current.indexOf(token, index + 1)) {
+    if (index >= end) {
+      break
+    }
+
+    if (index + token.length > start) {
+      placeCaretAtOffset(editor, index + token.length)
+      const after = window.getSelection()
+
+      if (after && after.rangeCount > 0 && after.getRangeAt(0).collapsed) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
 export function rebuildAroundCaret(editor: HTMLDivElement, tokenLength: number, insert: DocumentFragment | string) {
   const current = composerPlainText(editor)
   const caret = caretOffsetInEditor(editor)
@@ -82,6 +146,9 @@ export function rebuildAroundCaret(editor: HTMLDivElement, tokenLength: number, 
   renderComposerContents(editor, prefix)
   editor.append(insert)
   appendComposerContents(editor, suffix)
+  // The render wiped the editor and set data-empty; these appends fire no
+  // input event, so re-mark here or the placeholder paints over the content.
+  markEditorEmptiness(editor)
   placeCaretAtOffset(editor, prefix.length + inserted.length)
 }
 
@@ -301,6 +368,12 @@ export function useComposerTrigger({
     // Bank the pre-commit state first — every path below mutates the editor,
     // and a pick must be exactly one undo step.
     recordUndoPoint?.()
+
+    // An accepted pick replaces the token, so a selection that merely spans
+    // it (Ctrl+A never fires an input event) must collapse onto the token
+    // first — the rebuild fallback slices the editor around a non-collapsed
+    // selection's START and would re-append the token being replaced.
+    collapseSelectionOntoTrigger(editor, trigger.kind, trigger.query)
 
     const rebuildAround = (insert: DocumentFragment | string) => rebuildAroundCaret(editor, trigger.tokenLength, insert)
 

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -24,7 +24,7 @@ import {
   releaseActiveComposer
 } from '@/app/chat/composer/focus'
 import { useAtCompletions } from '@/app/chat/composer/hooks/use-at-completions'
-import { rebuildAroundCaret, triggerKeyUpHandler } from '@/app/chat/composer/hooks/use-composer-trigger'
+import { collapseSelectionOntoTrigger, rebuildAroundCaret, triggerKeyUpHandler } from '@/app/chat/composer/hooks/use-composer-trigger'
 import { useComposerUndo } from '@/app/chat/composer/hooks/use-composer-undo'
 import { useEmojiCompletions } from '@/app/chat/composer/hooks/use-emoji-completions'
 import { useSlashCompletions } from '@/app/chat/composer/hooks/use-slash-completions'
@@ -383,6 +383,11 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
       directive
         ? fragment.append(refChipElement(directive[1], directive[2]), document.createTextNode(' '))
         : fragment.append(document.createTextNode(text))
+
+      // Same select-all normalization as the main composer: a selection
+      // spanning the token is not caret context — collapse it onto the token
+      // before the replacement math runs.
+      collapseSelectionOntoTrigger(editor, trigger.kind, trigger.query)
 
       if (!replaceBeforeCaret(editor, trigger.tokenLength, fragment)) {
         rebuildAroundCaret(editor, trigger.tokenLength, text)


### PR DESCRIPTION
## Summary

Fixes a Desktop composer defect where pressing **Ctrl+A** (select-all) while the slash-command completion menu is open, then accepting a completion with **Enter**, duplicates the command text and leaves the placeholder hint painting over the content. Closes #107673.

Native select-all leaves a non-collapsed selection and fires no `input` event, so the composer never normalizes it. The accept path then runs against caret context that no longer exists:

1. `replaceBeforeCaret` declines (it requires a collapsed caret), so the rebuild fallback runs — and it measures the caret at the selection's document-order **start** (`caretOffsetInEditor`), re-appending the very token the pick was supposed to replace (`[chip '/new '][' ']['/new']`, serialized `/new  /new`).
2. The rebuild wipes the editor via `renderComposerContents(editor, '')`, which sets `data-empty` while the editor is momentarily empty; the subsequent appends fire no `input` event and nothing re-marks emptiness, so the placeholder's paint gate (`:is(:empty, [data-empty])::before`) stays open over the committed chip.

## What this PR does

- **`collapseSelectionOntoTrigger`** (new, `use-composer-trigger.ts`): at accept time, if the live selection is non-collapsed, locate the trigger token by its serialized text (`kind + query`) and collapse the caret onto the token's end. Selection boundaries are converted from DOM (node, offset) pairs to absolute `composerPlainText` coordinates before any string math — the same conversion `caretOffsetInEditor` performs for the start boundary. The first occurrence intersecting `[start, end]` wins; non-intersecting selections fall through to the existing behavior untouched. Called from the main composer's `replaceTriggerWithChip` and the message-edit composer's accept, so the `@` descend/ascend paths inherit the same pre-condition.
- **`markEditorEmptiness` at the end of `rebuildAroundCaret`'s fragment branch**: its appends fire no `input` event, so every fallback caller (main composer, edit composer, descend/ascend) keeps the placeholder marker in step with content.
- **Deliberately not changed:** `caretOffsetInEditor`'s selection-start semantics — undo caret-restore and draft hydration legitimately read document-order position; the normalization happens at the accept site instead.

## Test plan

4 new tests, all RED on the reverted source and GREEN with the fix (RED-check performed by stashing the fix):

- primitive: collapse a whole-editor selection onto the trigger token's end
- primitive: emptiness re-mark after a fragment rebuild (`data-empty` cleared)
- hook: full Ctrl+A → accept flow yields exactly `/new ` with a chip and no `data-empty`
- hook: select-all with **prose before the token** (`please run /cle` → `please run /clean `) — the case that exposed a DOM-offset-vs-character-offset bug in the first implementation

Verification: 447/447 composer + message-edit-composer tests pass; `tsc --noEmit` clean; `eslint` clean on all three changed files. The mechanism was additionally verified against a real Chromium renderer over CDP before and after the fix (final DOM: single chip, `dataEmpty` cleared).

## Notes

- **Open question:** the token-locating loop picks the first occurrence of the serialized token intersecting the selection. For the pathological case where the same token appears twice and both occurrences are inside the selection, the earlier one wins — arbitrary but predictable, and the collapse target is character-identical either way. Happy to adjust if maintainers prefer last-occurrence.
- Diagnostic and fix were cross-vendor reviewed (Gemini 3.1 Pro + GPT-OSS 120B, two rounds; round 1 caught a real BLOCKER in the round-1 diff — DOM offsets treated as character offsets — which is fixed and regression-tested here).
