### PR TITLE
fix(cron): publish worker ack file via atomic rename

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3257,11 +3257,23 @@ def _run_external_worker_payload(payload_path: Path, ack_path: Path) -> bool:
                 return False
             try:
                 ack_path.parent.mkdir(parents=True, exist_ok=True)
-                fd = os.open(ack_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-                with os.fdopen(fd, "w", encoding="utf-8") as ack_file:
-                    json.dump({"pid": os.getpid(), "execution_id": execution_id}, ack_file)
-                    ack_file.flush()
-                    os.fsync(ack_file.fileno())
+                # Publish via write-to-temp + atomic rename. Writing ack_path in place
+                # (the old approach) let O_CREAT make the empty file visible to the
+                # scheduler's exists()-then-read polling loop before the JSON body was
+                # written, occasionally handing it a 0-byte file and a JSONDecodeError.
+                # os.replace() is a single atomic syscall on the same filesystem, so
+                # readers only ever see the file fully absent or fully written.
+                ack_tmp_path = ack_path.with_name(f"{ack_path.name}.tmp{os.getpid()}")
+                fd = os.open(ack_tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+                try:
+                    with os.fdopen(fd, "w", encoding="utf-8") as ack_file:
+                        json.dump({"pid": os.getpid(), "execution_id": execution_id}, ack_file)
+                        ack_file.flush()
+                        os.fsync(ack_file.fileno())
+                    os.replace(ack_tmp_path, ack_path)
+                except BaseException:
+                    ack_tmp_path.unlink(missing_ok=True)
+                    raise
             except Exception:
                 logger.exception(
                     "Cron external worker could not publish ready acknowledgement for %s",


### PR DESCRIPTION
### Problem
`_run_external_worker_payload()` in `cron/scheduler.py` published the external cron worker's ready-acknowledgement by opening `ack_path` directly with `O_CREAT|O_EXCL` and then writing the JSON body into it. That makes an empty (0-byte) file visible to the scheduler's parent-side `ack_path.exists()` polling loop (every 50ms) before the JSON body is flushed. When the poll lands in that window, it reads an empty file and raises:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

logged as `Cron external worker published an unreadable acknowledgement; treating handoff as ownership-uncertain`. Handled gracefully (falls back to the slower wait path, no duplicated side effects, no dropped executions), but it is a real, reproducible race and produced 3 occurrences in one day in our deployment logs.

### Fix
Write the ack payload to a per-pid temp file in the same directory, then `os.replace()` it into place. `os.replace` is a single atomic syscall on the same filesystem, so readers only ever observe `ack_path` fully absent or fully written — never partial.

### Testing
- `python3 -m py_compile` on the changed file.
- Standalone repro: a writer thread with an exaggerated 200ms delay between writing content and flush/fsync, raced against a 1ms-interval poller. Old pattern would expose the empty-file window; with this fix, 0 bad reads across the run.
- Deployed to our own gemini-proxy-vm instance; no recurrence since.