### PR TITLE
fix: expose valid context engine options

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1750,6 +1750,8 @@ def _select_context_engine(_agent_cfg):
     with suppress(Exception):
         _ctx_cfg = _agent_cfg.get("context", {}) if isinstance(_agent_cfg, dict) else {}
         _engine_name = _ctx_cfg.get("engine", "compressor") or "compressor"
+    if _engine_name in {"default", "custom"}:
+        _engine_name = "compressor"
     if _engine_name == "compressor":
         return None  # built-in; don't auto-activate plugins
     _selected_engine = None

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -234,7 +234,6 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   'agent.image_input_mode': ['auto', 'native', 'text'],
   'approvals.mode': ['manual', 'smart', 'off'],
   'code_execution.mode': ['project', 'strict'],
-  'context.engine': ['compressor', 'default', 'custom'],
   // '' = inherit the agent's own effort; the rest is the shared scale.
   'delegation.reasoning_effort': ['', ...REASONING_EFFORTS],
   // NOTE: memory.provider is intentionally NOT listed here. Its options are

--- a/hermes_cli/web_server_config.py
+++ b/hermes_cli/web_server_config.py
@@ -120,7 +120,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "display.resume_display": _select("How resumed sessions display history", "minimal", "full", "off"),
     "display.busy_input_mode": _select("Input behavior while agent is running", "interrupt", "queue", "steer"),
     "approvals.mode": _select("Dangerous command approval mode", "manual", "smart", "off"),
-    "context.engine": _select("Context management engine", "default", "custom"),
+    "context.engine": _select("Context management engine", "compressor"),
     "human_delay.mode": _select("Simulated typing delay mode", "off", "typing", "fixed"),
     "logging.level": _select("Log level for agent.log", "DEBUG", "INFO", "WARNING", "ERROR"),
     "agent.service_tier": _select(
@@ -324,6 +324,45 @@ def _memory_provider_schema_options(cfg: Dict[str, Any]) -> List[str]:
     return options
 
 
+def _context_engine_schema_options(cfg: Dict[str, Any]) -> List[str]:
+    """Built-in and discovered context engines, plus the configured plugin name."""
+    from plugins.context_engine import discover_context_engines
+
+    options = ["compressor"]
+    seen = {"compressor"}
+    try:
+        discovered = discover_context_engines()
+    except Exception:  # pragma: no cover - discovery must not break config schema
+        discovered = []
+    for name, _description, _available in discovered:
+        clean = name.strip() if isinstance(name, str) else ""
+        if clean and clean not in seen:
+            options.append(clean)
+            seen.add(clean)
+
+    try:
+        from hermes_cli.plugins import discover_plugins, get_plugin_context_engine
+
+        discover_plugins()
+        plugin_engine = get_plugin_context_engine()
+        plugin_name = getattr(plugin_engine, "name", "") if plugin_engine else ""
+        clean_plugin = plugin_name.strip() if isinstance(plugin_name, str) else ""
+        if clean_plugin and clean_plugin not in seen:
+            options.append(clean_plugin)
+            seen.add(clean_plugin)
+    except Exception:  # pragma: no cover - plugin discovery must not break config schema
+        pass
+
+    context = cfg.get("context")
+    current = context.get("engine") if isinstance(context, dict) else None
+    clean_current = current.strip() if isinstance(current, str) else ""
+    if clean_current in {"default", "custom"}:
+        clean_current = "compressor"
+    if clean_current and clean_current not in seen:
+        options.append(clean_current)
+    return options
+
+
 def _schema_select_options(key: str) -> Optional[List[str]]:
     entry = CONFIG_SCHEMA.get(key)
     options = entry.get("options") if isinstance(entry, dict) else None
@@ -358,6 +397,7 @@ def _schema_with_dynamic_provider_options() -> Dict[str, Dict[str, Any]]:
             merge(f"{kind}.provider", _custom_provider_options(kind, list(existing), cfg))
 
     merge("memory.provider", _memory_provider_schema_options(cfg))
+    merge("context.engine", _context_engine_schema_options(cfg))
 
     tb_options = _schema_select_options("terminal.backend")
     if tb_options is not None:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2479,6 +2479,31 @@ class TestBuildSchemaFromConfig:
         assert fields["memory.provider"]["type"] == "select"
         assert _web_server_config.CONFIG_SCHEMA["memory.provider"] is not fields["memory.provider"]
 
+    def test_dynamic_merge_recomputes_context_engine_options(self, monkeypatch):
+        monkeypatch.setattr(_cfg_mod, "load_config", lambda: {"context": {"engine": "lcm"}})
+        monkeypatch.setattr(
+            "plugins.context_engine.discover_context_engines",
+            lambda: [("lcm", "Long context memory", True)],
+        )
+        plugin_engine = type("PluginEngine", (), {"name": "external-engine"})()
+        monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_context_engine", lambda: plugin_engine)
+
+        fields = _web_server_config._schema_with_dynamic_provider_options()
+
+        assert fields["context.engine"]["options"] == ["compressor", "lcm", "external-engine"]
+        assert _web_server_config.CONFIG_SCHEMA["context.engine"]["options"] == ["compressor"]
+
+    def test_context_engine_legacy_placeholders_normalize_to_compressor(self, monkeypatch):
+        monkeypatch.setattr(_cfg_mod, "load_config", lambda: {"context": {"engine": "default"}})
+        monkeypatch.setattr("plugins.context_engine.discover_context_engines", lambda: [])
+        monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_context_engine", lambda: None)
+
+        fields = _web_server_config._schema_with_dynamic_provider_options()
+
+        assert fields["context.engine"]["options"] == ["compressor"]
+
 
 
 

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -37,6 +37,15 @@ class _ToolEngine(_StubEngine):
         ]
 
 
+def test_legacy_context_engine_placeholders_use_builtin_compressor():
+    from agent.agent_init import _select_context_engine
+
+    for legacy_name in ("default", "custom"):
+        with patch("plugins.context_engine.load_context_engine") as load_engine:
+            assert _select_context_engine({"context": {"engine": legacy_name}}) is None
+        load_engine.assert_not_called()
+
+
 def test_plugin_engine_gets_context_length_on_init():
     """Plugin context engine should have context_length set during AIAgent init."""
     engine = _StubEngine()
@@ -208,5 +217,4 @@ def test_codex_gpt55_autoraise_still_applies_to_builtin_compressor():
     assert agent.context_compressor.threshold_percent == 0.85
     # Gateway parity: the notice is stashed for replay on turn 1.
     assert agent._compression_warning and "85%" in agent._compression_warning
-
 


### PR DESCRIPTION
## What does this PR do?

Makes the context-engine setting expose only runtime-valid choices. The dashboard schema now lists the built-in `compressor`, bundled discovered engines, and the context engine registered by an installed plugin. The desktop no longer overrides that schema with the invalid `default` and `custom` placeholders.

Existing configs that still contain `default` or `custom` remain compatible: runtime selection treats them as the built-in compressor instead of attempting a bogus plugin lookup.

## Related Issue

Fixes #107664

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- derive `context.engine` options from bundled and installed-plugin discovery
- remove the stale desktop-only option override
- preserve legacy config compatibility at runtime
- add schema and runtime regression tests

## How to Test

1. Run the three focused context-engine schema/runtime tests.
2. Run desktop ESLint and Prettier on the changed settings file.
3. Run the desktop TypeScript check.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example`: N/A; no config key was added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered; behavior is platform-independent
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Focused regression tests: `3 passed`.
Desktop ESLint, Prettier, and TypeScript checks passed.