### PR TITLE
fix(gateway): clear stream consumer before queued follow-up to prevent swallowed delivery

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3517,6 +3517,10 @@ class GatewayTurnMixin:
         # guard will consult. Fail-safe in helper.
         await self._refresh_agent_cache_message_count(session_key, session_id)
 
+        # Clear the stream consumer holder before the recursive turn so the next inbound doesn't see
+        # the stale consumer and block follow-up delivery (#107668).
+        turn_ctx.stream_consumer_holder[0] = None
+
         followup_result = await self._run_agent(
             message=next_message, context_prompt=turn_ctx.context_prompt, history=updated_history,
             source=next_source, session_id=session_id, session_key=next_session_key,


### PR DESCRIPTION
## Summary
Fixes #107668 — the inverse failure mode of #55806: queued image follow-ups are silently swallowed instead of duplicated.

When a user sends multiple images in quick succession while a turn is in flight, the gateway builds a queued follow-up with pre-analyzed images but never delivers it to the agent. The root cause: the **outer turn's stream consumer** remains in `turn_ctx.stream_consumer_holder[0]` after the first response is sent. Although the recursive `_run_agent` creates its own `TurnContext` + holder, the **parent holder stays populated**. The next inbound from the user sees this stale consumer and can block follow-up delivery with the warning:

> Normal final-send NOT suppressed despite active stream consumer for session ...: streamed=False previewed=False content_delivered=False transformed=False — possible duplicate send

## Root cause
```python
# gateway/run_turn.py:3520 (before this fix)
followup_result = await self._run_agent(  # recursive turn
    message=next_message, ...
)
```

The outer `stream_consumer_holder[0]` is never cleared before the recursive call. The follow-up runs with a **new** `TurnContext`, but the **parent scope's holder** is still `!= None`. The next inbound message from the user inherits that parent scope and sees the stale consumer, triggering the duplicate-send guard even though no duplicate is actually occurring.

## Fix
Explicitly clear `turn_ctx.stream_consumer_holder[0] = None` **before** the recursive `_run_agent` call, so:
- The follow-up runs in a clean state
- The next inbound doesn't see residual stream-consumer state from the previous turn
- The queued follow-up is delivered **exactly once** (neither swallowed nor duplicated)

## Testing
Reproduced locally with WhatsApp burst photos mid-turn. After the fix:
- All 3 images reached the agent (1 in the initial turn, 2 in the queued follow-up)
- No duplicate-send warning on the next inbound
- `~/.hermes/cache/images/` matches the handled message count

## Related
- Closes #107668 (images silently dropped)
- Inverse symptom of #55806 (duplicate send)
- Same race window as #95369 (sweeper:risk-message-delivery family)