### PR TITLE
fix(dashboard): keep SessionDB read-only to avoid concurrent FTS corruption

### DIFF
--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -168,17 +168,22 @@ def _resolve_restart_drain_timeout() -> float:
 
 
 def _eager_reconcile_own_session_db() -> None:
-    """One writable open of this process's own state.db at startup.
+    """Read-only open of this process's own state.db at startup.
 
-    ``SessionDB.__init__`` runs ``_init_schema`` → ``_reconcile_columns`` with
-    open-time lock patience. Never raises: an unfixable store still gets the
-    per-poll read-probe heal in :func:`_open_session_db_at_path`.
+    When the gateway shares ``state.db``, a writable open here creates the
+    documented concurrent-FTS-rebuild corruption vector (PR #93200, issues
+    #89293 / #90950). ``_open_session_db_at_path(..., read_only=True)``
+    preserves startup bootstrap and schema heal via ONE writable open but
+    avoids a second writable ``SessionDB`` owner. Never raises: an unfixable
+    store still gets the per-poll read-probe heal inside
+    :func:`_open_session_db_at_path`.
     """
     try:
         from hermes_state import _default_db_path
-        from hermes_state_registry import acquire, release_or_close
+        from hermes_cli.web_server_sessions import _open_session_db_at_path
+        from hermes_state_registry import release_or_close
 
-        db = acquire(Path(_default_db_path()))
+        db = _open_session_db_at_path(Path(_default_db_path()), read_only=True)
         release_or_close(db)
     except Exception as exc:
         _log.warning(


### PR DESCRIPTION
Fixes #107688

Root cause: `hermes_cli/web_server_lifecycle.py::_eager_reconcile_own_session_db()` called `acquire()` for an unconditional writable `SessionDB` open. When gateway and dashboard share `state.db`, this creates two concurrent writable owners — the documented FTS-rebuild corruption vector (PR #93200, issues #89293/#90950).

**Evidence:**
- Two long-lived writable `SessionDB` PIDs on one store in the real install (gateway + dashboard, both alive for days).
- Preserved corrupt copy shows classic two-writer inverted-index signature: hundreds of `btreeInitPage() error 11` pages, garbage rowids in ~2^38 range for a store with ~27k messages.
- Corruption onset ~64s after a backup, with no gateway restart — the signature of a second process tripping on open, not media fault.

**Solution:**
Replace the `acquire()` call with `_open_session_db_at_path(_default_db_path(), read_only=True)`. This:
- Eliminates the second writable handle (the dashboard becomes a pure reader).
- Preserves startup bootstrap and schema heal: `_open_session_db_at_path(..., read_only=True)` still heals a missing/stale store via ONE writable open before reopening read-only, so healthy stores need no gratuitous second writer.
- No regression: every per-poll session read already goes through the same read-only path, which self-heals.

**Verification:**
Tested locally against 0.21.1 (Linux): after the dashboard restart the process holds only the bare `state.db` main file (shares the gateway WAL as a pure reader) and mints no `-wal`/`-shm` sidecars of its own. Session listing unaffected.