### PR TITLE
feat(web): send Hermes identity headers on Perplexity requests

### DIFF
--- a/plugins/web/perplexity/provider.py
+++ b/plugins/web/perplexity/provider.py
@@ -40,11 +40,23 @@ from urllib.parse import urlparse
 import httpx
 
 from agent.web_search_provider import WebSearchProvider
+from hermes_cli import __version__ as _HERMES_VERSION
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_BASE_URL = "https://api.perplexity.ai"
 _KEY_URL = "https://www.perplexity.ai/account/api"
+
+# Identify Hermes to Perplexity: the same static harness identity Hermes sends Kimi and
+# OpenCode, plus Perplexity's integration header. No per-user identifier and no separate
+# request; the call already carries the user's own API key.
+_HEADERS = {
+    "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+    "X-Title": "Hermes Agent",
+    "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
+    "X-Pplx-Integration": "hermes-agent",
+}
+
 
 # Search API hard cap for search_type=web.
 _MAX_SEARCH_RESULTS = 20
@@ -80,6 +92,7 @@ def _perplexity_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any
         headers={
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
+            **_HEADERS,
         },
     )
     if response.status_code >= 400:

--- a/tests/tools/test_web_tools_perplexity.py
+++ b/tests/tools/test_web_tools_perplexity.py
@@ -16,6 +16,17 @@ def _ok(payload):
     return resp
 
 
+def _assert_hermes_identity_headers(headers):
+    """Both Perplexity endpoints carry the Hermes identity headers (same set as Kimi/OpenCode)
+    plus Perplexity's integration header."""
+    from hermes_cli import __version__
+
+    assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
+    assert headers["X-Title"] == "Hermes Agent"
+    assert headers["User-Agent"] == f"HermesAgent/{__version__}"
+    assert headers["X-Pplx-Integration"] == "hermes-agent"
+
+
 def test_search_dispatch_maps_search_api_shape():
     """web_search on backend=perplexity hits /search with Bearer auth and maps snippet→description."""
     import tools.web_tools as wt
@@ -35,6 +46,7 @@ def test_search_dispatch_maps_search_api_shape():
 
     assert post.call_args.args[0] == "https://api.perplexity.ai/search"
     assert post.call_args.kwargs["headers"]["Authorization"] == "Bearer pplx-test"
+    _assert_hermes_identity_headers(post.call_args.kwargs["headers"])
     body = post.call_args.kwargs["json"]
     assert body["query"] == "bloom filter"
     assert 1 <= body["max_results"] <= 20  # dispatcher bucket-rounds the fetch limit
@@ -65,6 +77,7 @@ def test_extract_dispatch_snippets_per_url_and_missing_key():
         out = json.loads(asyncio.run(wt.web_extract_tool(urls)))
 
     assert post.call_args.args[0] == "https://api.perplexity.ai/sdk/content/snippets"
+    _assert_hermes_identity_headers(post.call_args.kwargs["headers"])
     body = post.call_args.kwargs["json"]
     assert body["urls"] == urls
     assert body["query"] == "tokio tutorial smol"


### PR DESCRIPTION
## What does this PR do?

Adds identity headers to the Perplexity web provider so Perplexity can tell Hermes traffic apart from other clients. Right now requests from `plugins/web/perplexity` go out with httpx's default User-Agent.

Headers added to both `/search` and `/sdk/content/snippets`:

- `HTTP-Referer: https://hermes-agent.nousresearch.com`
- `X-Title: Hermes Agent`
- `User-Agent: HermesAgent/<version>`
- `X-Pplx-Integration: hermes-agent`


## Related Issue

None.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/web/perplexity/provider.py`: `_HEADERS` constant, merged into the request headers in `_perplexity_request` (covers both endpoints).
- `tests/tools/test_web_tools_perplexity.py`: both dispatch tests now assert the four headers.

## How to Test

```bash
pytest tests/tools/test_web_tools_perplexity.py tests/plugins/web -q
```

Both Perplexity tests fail on `main` (`KeyError: 'HTTP-Referer'`) and pass with this change. I also hit both endpoints with an invalid key: normal 401, headers accepted.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. Ran `tests/plugins/web` and `tests/tools/test_web_*.py`: 114 passed, 2 pre-existing failures in `TestParallelClientConfig` that also fail on clean `main` here (missing `parallel-web`). Didn't run the full suite locally.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
