### PR TITLE
fix(dashboard): eager session-store reconcile opens read-only, removing second writable owner

### DIFF
--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -168,18 +168,23 @@ def _resolve_restart_drain_timeout() -> float:
 
 
 def _eager_reconcile_own_session_db() -> None:
-    """One writable open of this process's own state.db at startup.
+    """Bring this process's own state.db schema current at startup.
 
-    ``SessionDB.__init__`` runs ``_init_schema`` → ``_reconcile_columns`` with
-    open-time lock patience. Never raises: an unfixable store still gets the
-    per-poll read-probe heal in :func:`_open_session_db_at_path`.
+    Read-only by default: surrounding the bootstrapping/heal in the read-only
+    open path (`_open_session_db_at_path`) means a HEALTHY store never gets a
+    gratuitous second writable SessionDB open. Previously this did an
+    unconditional writable `acquire()` — a second writable owner on a `state.db`
+    shared with the gateway, which can trip the documented concurrent-FTS-
+    rebuild corruption vector when `_init_schema` -> `_init_fts` detects missing
+    or stale triggers. The read-only path still bootstraps a missing store and
+    heals a stale schema through ONE writable open, then reopens read-only.
     """
     try:
+        from pathlib import Path as _Path
         from hermes_state import _default_db_path
-        from hermes_state_registry import acquire, release_or_close
+        from hermes_cli.web_server_sessions import _open_session_db_at_path
 
-        db = acquire(Path(_default_db_path()))
-        release_or_close(db)
+        _open_session_db_at_path(_Path(_default_db_path()), read_only=True)
     except Exception as exc:
         _log.warning(
             "startup schema reconcile of state.db failed (%s); session "

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -581,6 +581,40 @@ class TestWebServerEndpoints:
         # Must swallow — reads fall back to the per-poll probe heal.
         _web_server_lifecycle._eager_reconcile_own_session_db()
 
+    def test_startup_eager_reconcile_opens_read_only(self, monkeypatch):
+        """A healthy store must NOT get a gratuitous second writable SessionDB open.
+
+        Regression for the concurrent-FTS-rebuild corruption vector: the
+        dashboard's startup reconcile used to call the unconditional writable
+        ``acquire()``, making it a second writable SessionDB owner on a
+        `state.db` shared with the gateway (hermes_state_common.py documents two
+        concurrent rebuilds corrupt state.db in production). The reconcile now
+        routes through the read-only ``_open_session_db_at_path`` so a healthy
+        store is opened read-only (the read path still heals a stale schema via
+        one writable open when the probe fails).
+        """
+        from pathlib import Path
+
+        import hermes_state
+        import hermes_cli.web_server_sessions as _web_server_sessions
+
+        calls = []
+
+        def fake_open(db_path: Path, *, read_only: bool):
+            calls.append((str(db_path), read_only))
+            return SimpleNamespace(close=lambda: None)
+
+        monkeypatch.setattr(hermes_state, "_default_db_path", lambda: "/tmp/fake-state.db")
+        monkeypatch.setattr(
+            _web_server_sessions, "_open_session_db_at_path", fake_open,
+        )
+
+        _web_server_lifecycle._eager_reconcile_own_session_db()
+
+        assert calls == [("/tmp/fake-state.db", True)], (
+            "eager reconcile must open state.db read-only on a healthy store"
+        )
+
     def test_heal_gives_up_when_reconcile_cannot_fix_the_store(self, monkeypatch):
         """A probe failure reconciliation can't cure must not retry forever.
 


### PR DESCRIPTION
## Summary

The headless dashboard's startup reconcile (`_eager_reconcile_own_session_db`) called the unconditional **writable** `acquire()` on `state.db`. With the gateway already holding that store writable, the dashboard became a **second writable SessionDB owner** on one database. `SessionDB.__init__` -> `_init_schema` -> `_init_fts` can fire a full FTS5 rebuild when it detects missing/stale triggers — the exact concurrent-rebuild condition that `hermes_state_common.py` documents as structurally corrupting `state.db` in production (PR #93200; 2026-08-15 / 2026-08-23 incidents; issues #89293 / #90950).

This routes the eager reconcile through the already-proven **read-only** `_open_session_db_at_path()` instead, so a healthy store never gets a gratuitous second writable open.

## Why this is safe

The read-only path (`_open_session_db_at_path(db_path, read_only=True)`) already does everything the old writable open did, only on demand:
- bootstraps a missing/zero-byte store via one writable open,
- heals a stale/malformed schema via one writable open before reopening read-only (see #80401),
- and its docstring / tests confirm *"the healthy read path never takes a write lock"*.

So the startup schema-reconcile behavior is preserved, but a healthy store no longer sees a second writer.

## Changes

- `hermes_cli/web_server_lifecycle.py` — `_eager_reconcile_own_session_db()` now opens via `_open_session_db_at_path(_default_db_path(), read_only=True)` instead of `acquire()`.
- `tests/hermes_cli/test_web_server.py` — new `test_startup_eager_reconcile_opens_read_only` regression covering the read-only routing.

## Test plan

- `test_web_server.py -k "reconcile or read_only"` → **4 passed** (existing heal + never-raises + corrupt-read tests, plus the new read-only regression).
- Also verified live on a real install: after a dashboard restart the process holds only the bare `state.db` main file (shares the gateway's WAL as a pure reader) and mints no `-wal`/`-shm` sidecars of its own.

## Related

- Closes #107688 (the issue for this fix)
- #93200 (the concurrent-rebuild corruption vector)
- #80401 (confirms the dashboard's session store is supposed to be read-only)