### PR TITLE
feat(api): pass OpenAI request metadata into Relay turn tracking

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -922,7 +922,10 @@ class RelaySessionCoordinator:
             return host.register_subagent(event, metadata=metadata)
         return host.ensure_session({"session_id": session_id}, metadata=metadata)
 
-    def begin_turn(self, lease: ConversationLease, *, turn_id: str, task_id: str) -> RelayTurnContext:
+    def begin_turn(
+        self, lease: ConversationLease, *, turn_id: str, task_id: str,
+        request_metadata: dict[str, Any] | None = None,
+    ) -> RelayTurnContext:
         if lease.released:
             raise RuntimeError("Hermes Relay conversation lease is released")
         turn = RelayTurnContext(lease=lease, turn_id=turn_id, task_id=task_id)
@@ -942,10 +945,17 @@ class RelaySessionCoordinator:
         if host is not None:
             # Rotation happens HERE: no live turn scope on the stack, so the session scope can close/reopen LIFO.
             _warn_on_error("segment rotation", self._maybe_rotate_segment, host, lease.session)
+            metadata = runtime_metadata(host.runtime_id)
+            if isinstance(request_metadata, dict):
+                for meta_key, meta_value in request_metadata.items():
+                    if not isinstance(meta_key, str) or not meta_key or meta_key.startswith("hermes."):
+                        continue
+                    metadata[meta_key] = meta_value
+            metadata["hermes.execution_surface"] = lease.platform or "unknown"
             turn.handle = _warn_on_error(
                 "turn initialization", host.run_in_session, lease.session, host.relay.scope.push,
                 TURN_SCOPE, host.relay.ScopeType.Function, handle=lease.session.handle, input={},
-                metadata=runtime_metadata(host.runtime_id, **{"hermes.execution_surface": lease.platform or "unknown"}),
+                metadata=metadata,
                 timeout=_SCOPE_OP_TIMEOUT,
             )
         turn._previous_turn = _CURRENT_TURN.get()

--- a/agent/turn_facade.py
+++ b/agent/turn_facade.py
@@ -95,7 +95,8 @@ class TurnFacadeMixin:
                 model=str(getattr(self, "model", None) or ""),
             )
             relay_turn = relay_runtime.SESSION_COORDINATOR.begin_turn(
-                relay_lease, turn_id=relay_turn_id, task_id=effective_task_id
+                relay_lease, turn_id=relay_turn_id, task_id=effective_task_id,
+                request_metadata=getattr(self, "_relay_request_metadata", None),
             )
             # Minimal relay-runtime shims may lack the opt-out flag: default enabled.
             if getattr(relay_turn, "relay_enabled", True):

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3641,7 +3641,8 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         route: Optional[Dict[str, Any]] = None, session_model: Optional[str] = None,
         requested_runtime: Optional[Dict[str, Any]] = None, route_source: str = "global",
         confirmed_runtime_lock: bool = False, bind_declared_conversation: bool = False,
-        session_history_delivery: str = "", turn_author: Optional[Dict[str, Any]] = None) -> tuple:
+        session_history_delivery: str = "", turn_author: Optional[Dict[str, Any]] = None,
+        request_metadata: Optional[Dict[str, Any]] = None) -> tuple:
         """Create an agent and run one turn in a thread executor -> ``(result, usage)``.
         ``agent_ref[0]`` receives the agent so SSE writers can interrupt it; ``active_run_id``
         registers it in ``_active_run_agents``. Under a confirmed model lock the actual
@@ -3649,7 +3650,9 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         ``session_history_delivery`` declares #98619 session-id provenance and default-denies: only audited
         producers whose client can address the id again pass "1" (see
         ``_bind_api_server_session``).
-        ``turn_author`` only labels the turn for memory attribution. It grants nothing."""
+        ``turn_author`` only labels the turn for memory attribution. It grants nothing.
+        ``request_metadata`` is sanitized OpenAI request extras stamped onto the agent for Relay
+        turn-scope metadata; absent/empty is a no-op."""
         loop = asyncio.get_running_loop()
         # ContextVars do not follow run_in_executor threads: capture here, re-enter in _run().
         request_profile = _api_request_profile.get()
@@ -3674,6 +3677,8 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                         gateway_session_key=gateway_session_key, requested_model=requested_model,
                         requested_provider=requested_provider, model_options=model_options, route=route,
                         session_model=session_model, confirmed_runtime_lock=confirmed_runtime_lock)
+                    if isinstance(request_metadata, dict) and request_metadata:
+                        agent._relay_request_metadata = request_metadata
                     if agent_ref is not None:
                         agent_ref[0] = agent
                     if active_run_id:

--- a/gateway/platforms/api_server_openai_routes.py
+++ b/gateway/platforms/api_server_openai_routes.py
@@ -82,6 +82,40 @@ def _hermes_extras(completed, is_partial, is_failed, err_msg, finish_reason: str
         "error_code": "output_truncated" if finish_reason == "length" else "agent_error"}
 
 
+_REQUEST_METADATA_MAX_PAIRS = 16
+_REQUEST_METADATA_MAX_KEY_LEN = 64
+_REQUEST_METADATA_MAX_VALUE_LEN = 512
+_REQUEST_METADATA_VALUE_TYPES = (str, int, float, bool, type(None))
+
+
+def _sanitize_openai_request_metadata(raw: Any) -> Optional[Dict[str, Any]]:
+    """OpenAI-style request ``metadata`` → Relay extras, or None if absent/invalid.
+
+    Fail-open: missing / null / empty / non-dict / sanitize errors are treated as absent.
+    Reserved ``hermes.*`` keys are dropped so clients cannot overwrite Hermes stamps.
+    """
+    try:
+        if not isinstance(raw, dict):
+            return None
+        out: Dict[str, Any] = {}
+        for key, value in raw.items():
+            if len(out) >= _REQUEST_METADATA_MAX_PAIRS:
+                break
+            if not isinstance(key, str) or len(key) > _REQUEST_METADATA_MAX_KEY_LEN:
+                continue
+            if key.startswith("hermes."):
+                continue
+            if not isinstance(value, _REQUEST_METADATA_VALUE_TYPES):
+                continue
+            rendered = "" if value is None else str(value)
+            if len(rendered) > _REQUEST_METADATA_MAX_VALUE_LEN:
+                continue
+            out[key] = value
+        return out or None
+    except Exception:
+        return None
+
+
 def _message_item(text: Any) -> Dict[str, Any]:
     """Responses ``message`` output item carrying one ``output_text`` part."""
     return {"type": "message", "role": "assistant",
@@ -507,7 +541,8 @@ class OpenAICompatRoutesMixin:
             # and the client can resume the session by sending it again). A fingerprint-derived
             # id from a header-less client is NOT: delegate_task keeps its forced-sync fallback
             # there — the wake would hard-fail or land in history that client never reloads.
-            session_history_delivery=("1" if provided_session_id else ""))
+            session_history_delivery=("1" if provided_session_id else ""),
+            request_metadata=_sanitize_openai_request_metadata(body.get("metadata")))
         if stream:
             _stream_q = ThreadSafeAsyncQueue()
             # tool_call_ids with an emitted "running": a "completed" without one (internal/
@@ -846,7 +881,8 @@ class OpenAICompatRoutesMixin:
             user_message=user_message, conversation_history=conversation_history,
             ephemeral_system_prompt=instructions, session_id=session_id,
             gateway_session_key=gateway_session_key, bind_declared_conversation=_declared_selected,
-            **agent_overrides, route=route)
+            **agent_overrides, route=route,
+            request_metadata=_sanitize_openai_request_metadata(body.get("metadata")))
         if stream:
             _stream_q = ThreadSafeAsyncQueue()
 

--- a/tests/gateway/test_api_openai_relay_request_metadata.py
+++ b/tests/gateway/test_api_openai_relay_request_metadata.py
@@ -1,0 +1,283 @@
+"""OpenAI request ``metadata`` must reach Relay ``hermes.turn`` scope metadata (#107693)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from agent import relay_runtime
+from agent.relay_runtime import RelayRuntime, RelaySessionCoordinator
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+def _make_adapter() -> APIServerAdapter:
+    return APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    app.router.add_post("/v1/responses", adapter._handle_responses)
+    return app
+
+
+def _agent_ok():
+    return (
+        {"final_response": "ok", "messages": [], "api_calls": 1},
+        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+    )
+
+
+@pytest.fixture
+def adapter():
+    return _make_adapter()
+
+
+class _ScopeHandle:
+    def __init__(self, name: str, seq: int) -> None:
+        self.name = name
+        self.seq = seq
+
+
+class _FakeScopeModule:
+    def __init__(self) -> None:
+        self._seq = 0
+        self.pushes: list[dict[str, Any]] = []
+
+    def push(self, name: str, scope_type: Any, **kwargs: Any) -> _ScopeHandle:
+        self._seq += 1
+        self.pushes.append(
+            {
+                "name": name,
+                "metadata": dict(kwargs.get("metadata") or {}),
+                "parent": kwargs.get("handle"),
+                "seq": self._seq,
+            }
+        )
+        return _ScopeHandle(name, self._seq)
+
+    def pop(self, handle: _ScopeHandle, **kwargs: Any) -> None:
+        return None
+
+    def event(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+class _FakeSubscribers:
+    def flush(self) -> None:
+        return None
+
+
+class _FakeScopeType:
+    Function = "function"
+    Agent = "agent"
+
+
+class _FakeRelay:
+    def __init__(self) -> None:
+        self.scope = _FakeScopeModule()
+        self.subscribers = _FakeSubscribers()
+        self.ScopeType = _FakeScopeType()
+
+    def get_scope_stack(self) -> None:
+        return None
+
+
+def _turn_pushes(fake: _FakeRelay) -> list[dict[str, Any]]:
+    return [p for p in fake.scope.pushes if p["name"] == relay_runtime.TURN_SCOPE]
+
+
+def _acquire(coordinator: RelaySessionCoordinator, runtime: RelayRuntime, session_id: str = "sess-1"):
+    class _Registry:
+        def for_profile(self, key):
+            return runtime
+
+    coordinator.registry = _Registry()
+    coordinator._prepare_session = lambda host, ctx: None
+    return coordinator.acquire_conversation(
+        profile_key=runtime.profile_key,
+        session_id=session_id,
+        platform="api_server",
+    )
+
+
+@pytest.mark.asyncio
+async def test_responses_forwards_request_metadata_to_run_agent(adapter):
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = _agent_ok()
+            resp = await cli.post(
+                "/v1/responses",
+                json={
+                    "model": "hermes-agent",
+                    "input": "hello",
+                    "metadata": {"request_id": "request-123"},
+                },
+            )
+            assert resp.status == 200
+    kwargs = mock_run.call_args.kwargs
+    assert kwargs.get("request_metadata") is not None
+    assert kwargs["request_metadata"]["request_id"] == "request-123"
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_forwards_request_metadata_to_run_agent(adapter):
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = _agent_ok()
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "hermes-agent",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "metadata": {"request_id": "request-123"},
+                },
+            )
+            assert resp.status == 200
+    kwargs = mock_run.call_args.kwargs
+    assert kwargs.get("request_metadata") is not None
+    assert kwargs["request_metadata"]["request_id"] == "request-123"
+
+
+@pytest.mark.asyncio
+async def test_non_dict_metadata_is_fail_open(adapter):
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = _agent_ok()
+            resp = await cli.post(
+                "/v1/responses",
+                json={
+                    "model": "hermes-agent",
+                    "input": "hello",
+                    "metadata": "not-a-dict",
+                },
+            )
+            assert resp.status == 200
+    kwargs = mock_run.call_args.kwargs
+    assert kwargs.get("request_metadata") in (None, {})
+
+
+@pytest.mark.asyncio
+async def test_omitted_metadata_is_fail_open(adapter):
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = _agent_ok()
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "hermes-agent",
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+            )
+            assert resp.status == 200
+    kwargs = mock_run.call_args.kwargs
+    assert kwargs.get("request_metadata") in (None, {})
+
+
+def test_begin_turn_merges_request_metadata_into_hermes_turn_push():
+    fake = _FakeRelay()
+    runtime = RelayRuntime(relay=fake, profile_key="/tmp/test-profile-107693")
+    coordinator = RelaySessionCoordinator()
+    try:
+        lease = _acquire(coordinator, runtime)
+        turn = coordinator.begin_turn(
+            lease,
+            turn_id="turn-1",
+            task_id="task-1",
+            request_metadata={"request_id": "request-123"},
+        )
+        coordinator.end_turn(turn, outcome="success")
+        pushes = _turn_pushes(fake)
+        assert pushes, "expected a hermes.turn scope.push"
+        meta = pushes[0]["metadata"]
+        assert meta["request_id"] == "request-123"
+        assert meta.get("hermes.execution_surface")
+        assert meta.get(relay_runtime.RUNTIME_SCHEMA_KEY) == relay_runtime.RUNTIME_SCHEMA_VERSION
+        assert relay_runtime.RUNTIME_INSTANCE_KEY in meta
+    finally:
+        runtime.shutdown()
+
+
+def test_begin_turn_drops_client_hermes_execution_surface():
+    fake = _FakeRelay()
+    runtime = RelayRuntime(relay=fake, profile_key="/tmp/test-profile-107693-stamp")
+    coordinator = RelaySessionCoordinator()
+    try:
+        lease = _acquire(coordinator, runtime)
+        turn = coordinator.begin_turn(
+            lease,
+            turn_id="turn-2",
+            task_id="task-2",
+            request_metadata={
+                "request_id": "request-123",
+                "hermes.execution_surface": "attacker",
+            },
+        )
+        coordinator.end_turn(turn, outcome="success")
+        meta = _turn_pushes(fake)[0]["metadata"]
+        assert meta["request_id"] == "request-123"
+        assert meta["hermes.execution_surface"] != "attacker"
+        assert meta["hermes.execution_surface"] == "api_server"
+    finally:
+        runtime.shutdown()
+
+
+def test_begin_turn_accepts_client_runtime_id_key_without_crashing():
+    """A legal OpenAI metadata key ``runtime_id`` must not collide with runtime_metadata()."""
+    fake = _FakeRelay()
+    runtime = RelayRuntime(relay=fake, profile_key="/tmp/test-profile-107693-runtime-id")
+    coordinator = RelaySessionCoordinator()
+    try:
+        lease = _acquire(coordinator, runtime)
+        turn = coordinator.begin_turn(
+            lease,
+            turn_id="turn-3",
+            task_id="task-3",
+            request_metadata={
+                "runtime_id": "client-runtime",
+                "request_id": "request-123",
+            },
+        )
+        coordinator.end_turn(turn, outcome="success")
+        meta = _turn_pushes(fake)[0]["metadata"]
+        assert meta["runtime_id"] == "client-runtime"
+        assert meta["request_id"] == "request-123"
+        assert meta[relay_runtime.RUNTIME_SCHEMA_KEY] == relay_runtime.RUNTIME_SCHEMA_VERSION
+        assert meta[relay_runtime.RUNTIME_INSTANCE_KEY] == runtime.runtime_id
+        assert meta[relay_runtime.RUNTIME_INSTANCE_KEY] != "client-runtime"
+        assert meta["hermes.execution_surface"] == "api_server"
+    finally:
+        runtime.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_client_hermes_stamp_is_dropped_from_run_agent_kwargs(adapter):
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = _agent_ok()
+            resp = await cli.post(
+                "/v1/responses",
+                json={
+                    "model": "hermes-agent",
+                    "input": "hello",
+                    "metadata": {
+                        "request_id": "request-123",
+                        "hermes.execution_surface": "attacker",
+                    },
+                },
+            )
+            assert resp.status == 200
+    meta = mock_run.call_args.kwargs.get("request_metadata") or {}
+    assert meta.get("request_id") == "request-123"
+    assert "hermes.execution_surface" not in meta


### PR DESCRIPTION
## What does this PR do?

OpenAI `/v1/responses` and `/v1/chat/completions` already accept a client `metadata` object, but Hermes dropped it before Relay scopes opened. Concurrent API requests then had no user-defined key on ATOF / turn spans.

This keeps the existing Relay seam: sanitize the OpenAI map, stamp it on the API-server agent, and merge it into `hermes.turn` `scope.push` metadata. Reserved `hermes.*` stamps stay Hermes-owned. Missing or invalid `metadata` is fail-open (ignored, request still succeeds).

## Related Issue

Fixes #107693

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/api_server_openai_routes.py` — sanitize OpenAI `metadata` (≤16 pairs, key ≤64, value ≤512, scalars only; drop `hermes.*`) and pass it into `_run_agent` from both OpenAI POST handlers
- `gateway/platforms/api_server.py` — `_run_agent(..., request_metadata=)` stamps `agent._relay_request_metadata`
- `agent/turn_facade.py` — forward that stamp into `begin_turn`
- `agent/relay_runtime.py` — merge extras onto turn-scope metadata via dict assignment (so a client key `runtime_id` cannot collide with `runtime_metadata()`)
- `tests/gateway/test_api_openai_relay_request_metadata.py` — focused RED/GREEN for both routes, fail-open, reserved-key drop, and the `runtime_id` collision

## Proof Receipt

- Base: `origin/main` `564aef2946`
- BEFORE (tests on pre-fix HEAD): 5 failed / 2 passed — `_run_agent` had no `request_metadata`; `begin_turn` rejected the new kwarg
- AFTER: `scripts/run_tests.sh tests/gateway/test_api_openai_relay_request_metadata.py` → 8 passed
- CONTROL: omitted / non-dict `metadata` still 200 with no extras

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_api_openai_relay_request_metadata.py`
2. With Relay plugins enabled, POST `/v1/responses` with `"metadata": {"request_id": "request-123"}` and confirm the `hermes.turn` span / ATOF record carries `request_id`.
3. POST the same body with `"metadata": "not-a-dict"` or omit the field — request still succeeds and no extra keys are added.

## Compatibility / residual risk

- Session-scope metadata is unchanged; turn-scope is the concurrent-association surface.
- Over-long keys/values are dropped, not truncated.
- `/v1/runs` and non-API surfaces are unchanged.
- Concurrent-turn Relay skip / LIFO rotation is unchanged.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(api):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] Focused suite passed via `scripts/run_tests.sh` (not the full tree)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.6

### Documentation & Housekeeping

- [x] Documentation update — N/A (existing OpenAI `metadata` field, no new config)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — N/A (API-server + Relay Python path)
- [x] Tool descriptions/schemas — N/A

Independent review: P0=0 after one fix round (`runtime_metadata(**extras)` collision on client key `runtime_id`).

Made with [Cursor](https://cursor.com)