### PR TITLE
fix(desktop): preserve MCP config deadlines and profile ownership

### DIFF
--- a/apps/desktop/src/api/config.test.ts
+++ b/apps/desktop/src/api/config.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { setApiRequestConnection, setApiRequestProfile, STARTUP_REQUEST_TIMEOUT_MS } from './client'
+import { getHermesConfigRecord } from './config'
+
+afterEach(() => {
+  setApiRequestConnection(null)
+  setApiRequestProfile(null)
+  vi.unstubAllGlobals()
+})
+
+describe('capability config startup reads', () => {
+  it('keeps the startup deadline and the selected owner on every MCP config read', async () => {
+    const api = vi.fn().mockResolvedValue({ mcp_servers: {} })
+    vi.stubGlobal('hermesDesktop', { api })
+    setApiRequestConnection('foreground')
+    setApiRequestProfile('chat')
+
+    await getHermesConfigRecord()
+    expect(api).toHaveBeenLastCalledWith({
+      connectionId: 'foreground',
+      profile: 'chat',
+      path: '/api/config',
+      timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
+    })
+    await getHermesConfigRecord({ connectionId: 'local', profile: 'unity' })
+    expect(api).toHaveBeenLastCalledWith({
+      connectionId: 'local',
+      profile: 'unity',
+      path: '/api/config',
+      timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
+    })
+    await getHermesConfigRecord({ connectionId: 'remote', profile: 'default' })
+    expect(api).toHaveBeenLastCalledWith({
+      connectionId: 'remote',
+      profile: 'default',
+      path: '/api/config',
+      timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
+    })
+  })
+})

--- a/apps/desktop/src/api/config.ts
+++ b/apps/desktop/src/api/config.ts
@@ -71,7 +71,8 @@ export function getHermesConfig(profile?: string): Promise<HermesConfig> {
 export function getHermesConfigRecord(profile?: ProfileScope): Promise<HermesConfigRecord> {
   return window.hermesDesktop.api<HermesConfigRecord>({
     ...capabilityScoped(profile),
-    path: '/api/config'
+    path: '/api/config',
+    timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
   })
 }
 

--- a/apps/desktop/src/app/skills/mcp-tab.test.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.test.tsx
@@ -1,0 +1,132 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ProfileScope } from '@/hermes'
+import { probeCache } from '@/lib/mcp-probe-cache'
+import { queryClient } from '@/lib/query-client'
+import { $activeGatewayProfile } from '@/store/profile'
+
+// Replace only the native editor, keeping the real pane, query cache, profile
+// subscriptions, controls and API scope resolver. Its keyed/uncontrolled draft
+// contract is the same as CodeMirror's; a mock config hook would hide the race.
+vi.mock('@/components/chat/code-editor', () => ({
+  CodeEditor: ({ initialValue, onChange }: { initialValue: string; onChange: (text: string) => void }) => (
+    <textarea aria-label="mcp.json" defaultValue={initialValue} onChange={event => onChange(event.target.value)} />
+  )
+}))
+vi.mock('@/components/chat/log-tail', () => ({ LogTail: () => null }))
+vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
+
+const api = vi.fn()
+let failReads = false
+
+const configs: Record<string, Record<string, unknown>> = {
+  a: { mcp_servers: { old: { command: 'old-server', enabled: false } } },
+  b: { mcp_servers: {} },
+  pinned: { mcp_servers: {} }
+}
+
+beforeEach(() => {
+  queryClient.clear()
+  queryClient.setDefaultOptions({ queries: { retry: false } })
+  probeCache.clear()
+  failReads = false
+  vi.stubGlobal('hermesDesktop', { api })
+  api.mockImplementation(async (request: { path: string; method?: string; profile?: string }) => {
+    if (request.path === '/api/config') {
+      if (failReads) {
+        throw new Error('Backend unavailable')
+      }
+
+      return configs[request.profile ?? 'a'] ?? {}
+    }
+
+    if (request.path === '/api/mcp/servers') {
+      return { ok: true }
+    }
+
+    if (request.path === '/api/mcp/catalog') {
+      return { entries: [] }
+    }
+
+    return { tools: [], lines: [], ok: true }
+  })
+  $activeGatewayProfile.set('a')
+})
+
+afterEach(() => {
+  cleanup()
+  queryClient.clear()
+  probeCache.clear()
+  $activeGatewayProfile.set('default')
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
+
+async function mount(profile?: ProfileScope) {
+  const { McpTab } = await import('./mcp-tab')
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <McpTab gateway={null} profile={profile} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+const editor = () => screen.getByRole('textbox', { name: 'mcp.json' }) as HTMLTextAreaElement
+const writes = () => api.mock.calls.map(([request]) => request).filter(request => request.method === 'PUT')
+
+describe('MCP profile ownership', { timeout: 60_000 }, () => {
+  it('keeps a pinned draft editable when the foreground profile changes and its refetch fails', async () => {
+    const scope = { connectionId: 'local', profile: 'pinned' }
+    await mount(scope)
+    await screen.findByRole('button', { name: 'New server' })
+    const draft = JSON.stringify({ mcpServers: { unity: { url: 'http://localhost:8080/mcp' } } })
+    fireEvent.change(editor(), { target: { value: draft } })
+
+    failReads = true
+    await act(async () => {
+      $activeGatewayProfile.set('b')
+    })
+    await waitFor(() =>
+      expect(queryClient.getQueryState(['hermes-config-record', 'local::pinned'])?.status).toBe('error')
+    )
+    expect(editor().value).toBe(draft)
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(writes()).toHaveLength(1))
+    expect(writes()[0]).toMatchObject({
+      ...scope,
+      body: { servers: { unity: { url: 'http://localhost:8080/mcp' } } }
+    })
+  })
+
+  it('never unlocks an ambient profile with another profile’s cached server map after a failed read', async () => {
+    await mount()
+    await screen.findByRole('textbox', { name: 'mcp.json' })
+    await waitFor(() => expect(editor().value).toContain('old-server'))
+
+    failReads = true
+    await act(async () => {
+      $activeGatewayProfile.set('b')
+    })
+    await screen.findByText('Backend unavailable')
+    expect(screen.queryByRole('textbox', { name: 'mcp.json' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'New server' })).toBeNull()
+    expect(writes()).toHaveLength(0)
+
+    failReads = false
+    fireEvent.click(screen.getByRole('button', { name: 'Reload MCP' }))
+    await screen.findByRole('button', { name: 'New server' })
+    expect(editor().value).not.toContain('old-server')
+    fireEvent.click(screen.getByRole('button', { name: 'New server' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(writes()).toHaveLength(1))
+    expect(writes()[0].profile).toBe('b')
+    expect(writes()[0].body.servers).not.toHaveProperty('old')
+    expect(writes()[0].body.servers).toHaveProperty('my-server')
+  })
+})

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -369,8 +369,7 @@ export function McpTab({ gateway, profile }: { gateway: HermesGateway | null; pr
     isError: configFailed,
     error: configError,
     refetch: refetchConfig,
-    dataUpdatedAt: configUpdatedAt,
-    errorUpdatedAt: configErroredAt
+    dataUpdatedAt: configUpdatedAt
   } = useHermesConfigRecord(profile)
 
   const setConfig = hermesConfigCacheWriter(profile)
@@ -380,7 +379,6 @@ export function McpTab({ gateway, profile }: { gateway: HermesGateway | null; pr
   // data, so any persist would write A's server list into B — block mutations.
   const [profilePending, setProfilePending] = useState(false)
   const staleConfigStamp = useRef<null | number>(null)
-  const staleErrorStamp = useRef<null | number>(null)
 
   const [saving, setSaving] = useState(false)
   const [probes, setProbes] = useState<Record<string, Probe>>({})
@@ -541,6 +539,14 @@ export function McpTab({ gateway, profile }: { gateway: HermesGateway | null; pr
   // seed latch, probes, and cursor — so everything reseeds for the new profile.
   // The probe cache is already profile-keyed, so this just forces a re-probe.
   useOnProfileSwitch(() => {
+    // Explicit scopes belong to the Capabilities selector, not the foreground
+    // chat. SkillsView keys this tab by that scope and remounts it on a REAL
+    // owner change. Resetting a pinned tab here loses its draft and can leave
+    // Add/Import waiting forever for an unrelated query timestamp to change.
+    if (profile != null) {
+      return
+    }
+
     profileEpoch.current += 1
     draftSeeded.current = false
     setProbes({})
@@ -553,26 +559,19 @@ export function McpTab({ gateway, profile }: { gateway: HermesGateway | null; pr
     // Mark stale until the config query replaces profile A's data — guards
     // sidebar mutations from persisting A's server list into B mid-refetch.
     staleConfigStamp.current = configUpdatedAt
-    staleErrorStamp.current = configErroredAt
     setProfilePending(true)
   })
 
-  // Clear once the config query settles for the new profile: dataUpdatedAt bumps
-  // on a fresh success, errorUpdatedAt on a fresh failure. Releasing on error too
-  // means a failed refetch surfaces the retry UI instead of leaving mutations
-  // silently no-op forever.
+  // Only a successful read may unlock writes for the new owner. React Query
+  // keeps cached data after a failed refetch: releasing on error would let A's
+  // server map be saved into B. The error pane below offers Retry while locked.
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
-    if (
-      profilePending &&
-      staleConfigStamp.current !== null &&
-      (configUpdatedAt !== staleConfigStamp.current || configErroredAt !== staleErrorStamp.current)
-    ) {
+    if (profilePending && staleConfigStamp.current !== null && configUpdatedAt !== staleConfigStamp.current) {
       setProfilePending(false)
       staleConfigStamp.current = null
-      staleErrorStamp.current = null
     }
-  }, [profilePending, configUpdatedAt, configErroredAt])
+  }, [profilePending, configUpdatedAt])
 
   useDeepLinkHighlight({
     block: 'nearest',
@@ -1008,7 +1007,7 @@ export function McpTab({ gateway, profile }: { gateway: HermesGateway | null; pr
 
   // Cached data paints instantly; a spinner only ever shows on the first-ever
   // load, and a failed load gets a real retry — never a silent blank pane.
-  if (configFailed && !config) {
+  if (configFailed && (!config || profilePending)) {
     return (
       <div className="flex h-full min-h-0 flex-1 items-center justify-center p-6">
         <ErrorBanner className="max-w-sm">
@@ -1023,7 +1022,7 @@ export function McpTab({ gateway, profile }: { gateway: HermesGateway | null; pr
     )
   }
 
-  if (!config) {
+  if (!config || profilePending) {
     return <PageLoader className="min-h-24" label={configLoading ? m.loading : t.skills.loading} />
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes three reproducible Desktop MCP editor failure paths: an unexpectedly short startup config timeout, pinned drafts being reset by unrelated foreground profile switches, and stale config becoming writable after an ambient profile switch fails to load.

**Scope: 4 files, +191/-18, one commit.** No network/WSL code, dependency changes, or validation-workflow files are included.

## Related Issue

Fixes #107706.

The original report was “MCP works in CLI but Desktop cannot see/add it.” The reporter's private config/logs were not available, so this PR claims the reproduced defects below, not certainty that every such incident shares this root cause.

## Type of Change

- [x] Bug fix
- [x] Regression tests

## Changes Made

- `src/api/config.ts`: pass the existing `STARTUP_REQUEST_TIMEOUT_MS` (60 seconds) through `getHermesConfigRecord`, matching other startup config reads instead of silently using the 15-second native API default. Preserve both explicit and ambient connection/profile ownership.
- `src/app/skills/mcp-tab.tsx`: ignore foreground profile switches when the pane has an explicit Capabilities scope. `SkillsView` already keys/remounts the pane when that actual owner changes; the extra ambient reset lost drafts and could leave Add/Import pending for an unrelated query timestamp change.
- For an ambient owner change, unlock mutations only on a successful fresh config read. A failed refetch can retain old data; it must show the retry-only error pane rather than allow profile A's server map to be edited/saved under profile B. While pending, hide the old editor and mutation controls.
- Add API-scope/deadline regression coverage and actual component/query-cache/profile-switch tests. The native code editor is replaced with an uncontrolled textarea in the component test, but the MCP pane, profile subscriptions, API ownership resolver, and React Query cache are real.

## Reproduction / How to Test

At base `564aef2946c436500a5e80ee117b66b789b3f99a`, the three new tests fail. With this branch they pass:

1. Read config using ambient ownership, a pinned local owner, and a pinned remote owner; every read must retain the startup timeout and intended owner.
2. Edit a pinned MCP draft, switch the foreground profile, and fail the pinned query's refetch. The draft must remain editable and save to its original explicit owner.
3. Switch an ambient MCP pane from A to B while the new config read fails. A's editor/Add controls must not be exposed. Retry, add a server, and save; the write must target B and contain no inherited A server.

From `apps/desktop`:

```bash
node ../../node_modules/vitest/vitest.mjs run --project ui \
  src/api/config.test.ts src/app/skills/mcp-tab.test.tsx \
  src/api/client.test.ts src/lib/mcp-servers.test.ts src/lib/mcp-import.test.ts
node ../../node_modules/typescript/bin/tsc -p . --noEmit
```

### Executed evidence

Fork validation: https://github.com/Xipong/hermes-agent/actions/runs/34528752723

The combined validation candidate ran **41 targeted Desktop tests, all passed**, plus renderer TypeScript, ESLint, and formatting. Its base run had **4 failed/11 passed**: the 3 new regressions in this PR and 1 separate network-cache regression belonging to #107707. The published branch is the independently scoped Desktop half of that tested candidate; the other half changes no files in this PR.

Evidence limits: component tests run under the UI test environment on Ubuntu, not an installed Electron application on the reporter's PC. No live Unity test or whole-repository/full Desktop suite is claimed.

## Checklist

- [x] Read the contributing and Desktop guidance.
- [x] Conventional commit; searched existing issues/PRs.
- [x] Only related product changes; no temporary CI harness included.
- [x] Added regressions and verified they fail before/pass after the fix.
- [x] Targeted tests, renderer typecheck and lint passed on Ubuntu.
- [ ] Full repository test suite executed (not claimed).
- [x] No config schema or dependency change; behavior documented in code comments.
- [x] Preserved backend/profile ownership and considered local/remote scope behavior.