### PR TITLE
fix(kanban): board-path priority + event-signing sidecar restore (t_f7bd0237)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -473,15 +473,40 @@ def _dir_holds_board(d: Path) -> bool:
 def _board_path(
     env_var: Optional[str], board: Optional[str], default_parts: tuple[str, ...], leaf: str,
 ) -> Path:
-    """Shared resolver: ``env_var`` override, else legacy ``<root>/<default_parts>``
-    for the ``default`` board, else ``board_dir(slug)/leaf``."""
+    """Shared resolver: explicit ``board`` parameter (when set) takes priority
+    over any env-var pin; a scoped ``--board`` context (:func:`scoped_current_board`)
+    is the same explicit caller intent and trumps the env pin too; otherwise the
+    ``env_var`` override, else legacy ``<root>/<default_parts>`` for the
+    ``default`` board, else ``board_dir(slug)/leaf``."""
+    slug = _normalize_board_slug(board)
+    if slug is None:
+        # A caller-scoped board (CLI `hermes kanban --board B ...`, dashboard
+        # plugin_api) is explicit intent just like a direct board= argument —
+        # it must also trump any ambient env pin, not merely fall through to
+        # get_current_board() after the env check has already won. Without
+        # this, a worker-pinned HERMES_KANBAN_DB silently outranks --board
+        # (os-reviewer P1 on PR#107195 / t_11c4afd8).
+        ctx = (_CURRENT_BOARD_OVERRIDE.get() or "").strip()
+        if ctx:
+            try:
+                ctx_slug = _normalize_board_slug(ctx)
+            except ValueError:
+                ctx_slug = None
+            if ctx_slug:
+                slug = ctx_slug
+    if slug is not None:
+        # Explicit board parameter (or scoped --board context) trumps
+        # everything — essential for cross-board routing from MCP-only
+        # sessions where the env pins one board (HERMES_KANBAN_DB) but the
+        # caller needs another.
+        if slug == DEFAULT_BOARD:
+            return kanban_home().joinpath(*default_parts)
+        return board_dir(slug) / leaf
     if env_var:
         override = os.environ.get(env_var, "").strip()
         if override:
             return Path(override).expanduser()
-    slug = _normalize_board_slug(board)
-    if slug is None:
-        slug = get_current_board()
+    slug = get_current_board()
     if slug == DEFAULT_BOARD:
         return kanban_home().joinpath(*default_parts)
     return board_dir(slug) / leaf
@@ -1846,10 +1871,46 @@ def _append_event(
     run_id: Optional[int] = None,
 ) -> None:
     """Insert an event row inside the caller's txn; ``run_id`` groups it by attempt (NULL = task-scoped)."""
-    conn.execute(
+    now = int(time.time())
+    pl = _json_or_null(payload)
+    cur = conn.execute(
         "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
-        "VALUES (?, ?, ?, ?, ?)", (task_id, run_id, kind, _json_or_null(payload), int(time.time())),
+        "VALUES (?, ?, ?, ?, ?)", (task_id, run_id, kind, pl, now),
     )
+    # Per-agent authorship signing (t_3f244a06 / t_22d998fd source-only restore).
+    # In-process with the acting profile/seat key; FAIL-OPEN — a signing
+    # failure must never block the event insert. Signatures live in the
+    # sidecar DB (kanban-event-signatures.db), NOT a task_events column,
+    # because the hash-chain halts append on schema drift of task_events
+    # (compose-safety: chain=integrity, sig=authorship).
+    event_id = cur.lastrowid if cur and cur.lastrowid else None
+    if event_id is not None:
+        try:
+            from hermes_cli.kanban_event_signing import (
+                DEFAULT_SIDECAR,
+                board_for_conn,
+                event_content,
+                resolve_signing_key,
+                sign_event_payload,
+                store_signature,
+            )
+
+            key = resolve_signing_key()
+            if key is not None:
+                identity, key_path = key
+                board = board_for_conn(conn)
+                sig = sign_event_payload(
+                    event_id, task_id, run_id, kind, pl, now, key_path
+                )
+                content = event_content(event_id, task_id, run_id, kind, pl, now)
+                store_signature(
+                    DEFAULT_SIDECAR, board, event_id, identity, sig, content, now
+                )
+        except Exception as exc:  # noqa: BLE001 - fail-open
+            _log.debug(
+                "kanban event signing skipped for event %s: %s: %s",
+                event_id, type(exc).__name__, exc,
+            )
 
 
 def _end_run(

--- a/hermes_cli/kanban_event_signing.py
+++ b/hermes_cli/kanban_event_signing.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""
+kanban_event_signing.py — per-agent ed25519 authorship signatures for kanban
+task_events. Kanban card t_3f244a06 (jarvis-os board). Design source:
+obsidian/fleet-vault/Architecture/agent-signing-keys-design-2026-08-01.md §4b.
+
+WHAT THIS IS
+  Attribution of kanban events to the acting agent. Today a `kind`/payload
+  string is the only author signal; any process on the box can forge it.
+  This module adds a cryptographic authorship signature over the canonical
+  JSON of each event row, produced in-process with the acting agent's
+  profile-local ed25519 key and stored in a SIDECAR signature store.
+
+COMPOSE-SAFETY (non-negotiable)
+  The kanban hash-chain (t_21781f08, ~/.hermes/scripts/kanban-audit-chain.py)
+  records `source_columns` of task_events and HALTS append on any schema
+  drift of that table. Therefore this module NEVER alters the task_events
+  schema and NEVER writes to the live kanban DB. Signatures live in their own
+  sidecar SQLite DB (~/.hermes/audit/kanban-event-signatures.db), keyed by
+  (board, event_id) — exactly as the chain keeps its own kanban-chain.db.
+  chain  = tamper-evidence for ordering/content
+  sig    = authorship of the same canonical content
+
+ROLE OF allowed_signers
+  The registered-principal root is /home/frank/.hermes/governance/allowed_signers
+  (canonical) — the SAME root git commit-signing uses. An event signature is
+  GOOD only if it (a) cryptographically verifies against the signer's public
+  key AND (b) that signer is registered in allowed_signers. A valid signature
+  from an unregistered key is UNTRUSTED — the same policy the commit
+  verifier uses (see verify-commit-signatures.sh).
+
+POLICY (verify-and-report first)
+  Everything here is report-only. No event is ever blocked for being unsigned
+  or untrusted. Enforcement is a separate future card
+  (signing-keys-enforcement-gate) gated through the PM layer.
+
+MODES
+  sign-one --content <canonical-json> --key <path>         -> print base64 sig
+  selftest                                                -> red/green proof
+  verify --kanban-db PATH --sidecar PATH --allowed-signers PATH  (report-only)
+  resolve-key [profile]                                  -> print signing key path
+
+IMPORTANT: this module is stdlib + `cryptography` only (available in the
+hermes-agent venv and system python on DGX). No ssh-keygen subprocess for the
+signature itself — pure in-process Ed25519 via the same OpenSSH key material.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+
+# ---- paths / constants -----------------------------------------------------
+DEFAULT_ALLOWED_SIGNERS = "/home/frank/.hermes/governance/allowed_signers"
+DEFAULT_SIDECAR = "/home/frank/.hermes/audit/kanban-event-signatures.db"
+HERMES_HOME = "/home/frank/.hermes"
+
+SIDECAR_STATEMENTS = [
+    "CREATE TABLE IF NOT EXISTS event_signatures ("
+    "    board       TEXT NOT NULL,"
+    "    event_id    INTEGER NOT NULL,"
+    "    signer      TEXT NOT NULL,"
+    "    signature   TEXT NOT NULL,"
+    "    content     TEXT NOT NULL,"
+    "    created_at  INTEGER NOT NULL,"
+    "    PRIMARY KEY (board, event_id)"
+    ")",
+    "CREATE INDEX IF NOT EXISTS idx_sig_board ON event_signatures(board, created_at)",
+]
+
+
+def open_sidecar(path: str) -> sqlite3.Connection:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    con = sqlite3.connect(path)
+    for stmt in SIDECAR_STATEMENTS:
+        con.execute(stmt)
+    con.commit()
+    return con
+
+
+def board_for_conn(conn: sqlite3.Connection) -> str:
+    """Derive the board slug from a live kanban connection's main database
+    file path. The parent dir name of the DB file IS the board slug for
+    named boards (e.g. .../kanban/boards/jarvis-os/kanban.db -> jarvis-os);
+    the legacy default board lives at <root>/kanban.db -> 'default'."""
+    try:
+        row = conn.execute("PRAGMA database_list").fetchone()
+        # row: (seq, name, file); main DB is name == 'main'
+        for r in conn.execute("PRAGMA database_list"):
+            if r[1] == "main" and r[2] and not r[2].startswith(":"):
+                dbpath = os.path.abspath(r[2])
+                parent = os.path.basename(os.path.dirname(dbpath))
+                if parent == "boards":
+                    return "default"
+                if parent and parent != "kanban":
+                    return parent
+                return "default"
+    except Exception:
+        pass
+    return os.environ.get("HERMES_KANBAN_BOARD", "default").strip() or "default"
+def canonical_json(d: dict) -> str:
+    """Deterministic serialization identical to the hash-chain's convention
+    (sort_keys, compact separators, ensure_ascii). Signing and hashing the
+    same bytes means sig (authorship) and chain (integrity) compose cleanly."""
+    return json.dumps(d, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def event_content(event_id: int, task_id, run_id, kind, payload, created_at) -> str:
+    """Build the canonical content of a task_events row over the SAME columns
+    the hash-chain hashes. payload may be a dict or JSON string."""
+    if isinstance(payload, dict):
+        payload = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    return canonical_json({
+        "id": event_id,
+        "task_id": task_id,
+        "run_id": run_id,
+        "kind": kind,
+        "payload": payload,
+        "created_at": created_at,
+    })
+
+
+# ---- key resolution --------------------------------------------------------
+def resolve_signing_key(profile: str | None = None) -> tuple[str, str] | None:
+    """Return (identity, private_key_path) for the acting agent, or None.
+    Resolution order:
+      1. HERMES_PROFILE -> ~/.hermes/profiles/<profile>/keys/<profile>-signing
+      2. explicit profile arg -> same
+      3. HERMES_SEAT -> ~/.hermes/seats/<seat>/keys/<seat>-signing
+      4. profiles/<name>/keys/<name>-signing for each known profile
+    Returns the FIRST key that exists. Never falls back to a shared/global key.
+    """
+    def cand(identity: str) -> str:
+        for base in (
+            os.path.join(HERMES_HOME, "profiles", identity, "keys"),
+            os.path.join(HERMES_HOME, "seats", identity, "keys"),
+        ):
+            p = os.path.join(base, f"{identity}-signing")
+            if os.path.isfile(p):
+                return p
+        return ""
+
+    candidates = []
+    env_profile = os.environ.get("HERMES_PROFILE") or ""
+    if profile:
+        candidates.append(profile)
+    if env_profile:
+        candidates.append(env_profile)
+    seat = os.environ.get("HERMES_SEAT") or ""
+    if seat:
+        candidates.append(seat)
+
+    seen = set()
+    for ident in candidates:
+        if not ident or ident in seen:
+            continue
+        seen.add(ident)
+        p = cand(ident)
+        if p:
+            return f"{ident}@hermes-fleet", p
+
+    # Last resort: scan known profile key dirs (never a shared key).
+    prof_root = os.path.join(HERMES_HOME, "profiles")
+    try:
+        for name in sorted(os.listdir(prof_root)):
+            if name in seen or not os.path.isdir(os.path.join(prof_root, name)):
+                continue
+            seen.add(name)
+            p = cand(name)
+            if p:
+                return f"{name}@hermes-fleet", p
+    except FileNotFoundError:
+        pass
+    return None
+
+
+# ---- sign / verify ---------------------------------------------------------
+def sign_content(content: str, key_path: str) -> str:
+    """Sign canonical content with an OpenSSH ed25519 private key (no
+    passphrase). Returns base64 raw Ed25519 signature."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    with open(key_path, "rb") as f:
+        key = serialization.load_ssh_private_key(f.read(), password=None)
+    if not isinstance(key, Ed25519PrivateKey):
+        raise TypeError(f"key {key_path} is not an ed25519 private key")
+    sig = key.sign(content.encode("utf-8"))
+    return base64.b64encode(sig).decode("ascii")
+
+
+def sign_event_payload(
+    event_id: int,
+    task_id,
+    run_id,
+    kind,
+    payload,
+    created_at: int,
+    key_path: str,
+) -> str:
+    """Sign an event row's canonical content. Returns base64 sig."""
+    return sign_content(event_content(event_id, task_id, run_id, kind, payload, created_at), key_path)
+
+
+def _load_pubkey(signer: str, allowed_signers: str):
+    """Return the ssh-ed25519 public key object registered for `signer`, or
+    None if the signer is not registered."""
+    from cryptography.hazmat.primitives import serialization
+
+    if not os.path.isfile(allowed_signers):
+        return None
+    with open(allowed_signers, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if not parts:
+                continue
+            principal = parts[0]
+            if principal != signer:
+                continue
+            # find <keytype> <base64>
+            for i in range(1, len(parts) - 1):
+                if parts[i].startswith("ssh-") or parts[i].startswith("ecdsa-") or parts[i].startswith("sk-"):
+                    try:
+                        return serialization.load_ssh_public_key(
+                            f"{parts[i]} {parts[i+1]}".encode("ascii")
+                        )
+                    except Exception:
+                        return None
+    return None
+
+
+def verify_signature(content: str, signature_b64: str, signer: str, allowed_signers: str):
+    """Return one of: GOOD / UNTRUSTED / BAD / KEY-MISSING.
+    GOOD = verifies AND signer registered. UNTRUSTED = verifies but signer
+    not in allowed_signers (registered-principal policy). BAD = does not
+    verify against the registered key. KEY-MISSING = signer registered but
+    key unparseable (shouldn't happen)."""
+    pubkey = _load_pubkey(signer, allowed_signers)
+    if pubkey is None:
+        return "UNTRUSTED"  # cryptographically-present sig, principal not registered
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+        if not isinstance(pubkey, Ed25519PublicKey):
+            return "BAD"  # only ed25519 signing keys are supported for events
+        sig = base64.b64decode(signature_b64)
+        pubkey.verify(sig, content.encode("utf-8"))
+        return "GOOD"
+    except Exception:
+        return "BAD"
+
+
+# ---- sidecar store (read/write) -------------------------------------------
+def store_signature(
+    sidecar_path: str,
+    board: str,
+    event_id: int,
+    signer: str,
+    signature: str,
+    content: str,
+    created_at: int,
+) -> None:
+    """Fail-open write: never raises. Duplicate (board,event_id) is replaced
+    (re-sign) so re-appending the same event id is idempotent."""
+    try:
+        con = open_sidecar(sidecar_path)
+        try:
+            con.execute(
+                "INSERT INTO event_signatures (board,event_id,signer,signature,content,created_at) "
+                "VALUES (?,?,?,?,?,?) "
+                "ON CONFLICT(board,event_id) DO UPDATE SET "
+                "signer=excluded.signer, signature=excluded.signature, "
+                "content=excluded.content, created_at=excluded.created_at",
+                (board, event_id, signer, signature, content, created_at),
+            )
+            con.commit()
+        finally:
+            con.close()
+    except Exception as e:  # noqa: BLE001 - fail-open
+        print(f"WARN: store_signature failed ({type(e).__name__}: {e}) — event {event_id} left unsigned", file=sys.stderr)
+
+
+def verify_sidecar(kanban_db: str, sidecar_path: str, allowed_signers: str, board: str | None = None):
+    """Report-only reconciliation of event signatures against the live kanban
+    DB. Never blocks. Returns a dict of counts. `board` is the kanban board
+    slug; if omitted it is derived from the kanban DB parent dir name."""
+    counts = {"GOOD": 0, "UNTRUSTED": 0, "BAD": 0, "UNSIGNED": 0, "STALE": 0}
+    if board is None:
+        board = os.path.basename(os.path.dirname(kanban_db)) or "?"
+    try:
+        kdb = sqlite3.connect(f"file:{kanban_db}?mode=ro", uri=True, timeout=3)
+        try:
+            # live event ids for freshness of the report
+            live_ids = {r[0] for r in kdb.execute("SELECT id FROM task_events")}
+        finally:
+            kdb.close()
+    except Exception as e:
+        print(f"ERROR: cannot open kanban DB {kanban_db}: {e}", file=sys.stderr)
+        return counts
+
+    if not os.path.isfile(sidecar_path):
+        counts["UNSIGNED"] = len(live_ids)
+        return counts
+
+    con = sqlite3.connect(f"file:{sidecar_path}?mode=ro", uri=True, timeout=3)
+    rows = con.execute(
+        "SELECT event_id, signer, signature, content, created_at "
+        "FROM event_signatures WHERE board=? ORDER BY event_id",
+        (board,),
+    ).fetchall()
+    con.close()
+
+    signed_ids = set()
+    for event_id, signer, signature, content, created_at in rows:
+        signed_ids.add(event_id)
+        if event_id not in live_ids:
+            counts["STALE"] += 1
+            continue
+        status = verify_signature(content, signature, signer, allowed_signers)
+        counts[status] = counts.get(status, 0) + 1
+
+    counts["UNSIGNED"] = len(live_ids - signed_ids)
+    return counts
+
+
+# ---- CLI -------------------------------------------------------------------
+def _cmd_sign_one(args):
+    sig = sign_content(args.content, args.key)
+    print(sig)
+
+
+def _cmd_resolve_key(args):
+    resolved = resolve_signing_key(args.profile)
+    if not resolved:
+        print("NO KEY", file=sys.stderr)
+        return 1
+    ident, path = resolved
+    print(f"{ident}\t{path}")
+    return 0
+
+
+def _cmd_verify(args):
+    counts = verify_sidecar(args.kanban_db, args.sidecar, args.allowed_signers)
+    parts = " ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+    print(f"EVENT-SIG-VERIFY: board={os.path.basename(os.path.dirname(args.kanban_db))} {parts}")
+    return 0
+
+
+def _cmd_selftest(args=None):
+    """Red/green proof on scratch copies. Never touches live data."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    ok = True
+    def check(name, cond):
+        nonlocal ok
+        print(f"  {'PASS' if cond else 'FAIL'}  {name}")
+        if not cond:
+            ok = False
+
+    with tempfile.TemporaryDirectory() as td:
+        # two independent keys
+        keypaths = {}
+        for ident in ("alice", "bob"):
+            priv = Ed25519PrivateKey.generate()
+            kp = os.path.join(td, f"{ident}-signing")
+            with open(kp, "wb") as f:
+                f.write(priv.private_bytes(
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PrivateFormat.OpenSSH,
+                    encryption_algorithm=serialization.NoEncryption(),
+                ))
+            pub = priv.public_key().public_bytes(
+                encoding=serialization.Encoding.OpenSSH,
+                format=serialization.PublicFormat.OpenSSH,
+            ).decode("ascii")
+            with open(os.path.join(td, f"{ident}.pub"), "w") as f:
+                f.write(f"{ident}@hermes-fleet namespaces=\"git\" ssh-ed25519 {pub.split()[1]}\n")
+            keypaths[ident] = kp
+
+        allowed = os.path.join(td, "allowed_signers")
+        with open(allowed, "w") as f:
+            f.write(open(os.path.join(td, "alice.pub")).read())
+            f.write(open(os.path.join(td, "bob.pub")).read())
+
+        content = event_content(1, "t_000001", None, "heartbeat", None, 1700000000)
+        # 1. sign+verify roundtrip (alice)
+        sig = sign_content(content, keypaths["alice"])
+        check("alice sign+verify roundtrip",
+              verify_signature(content, sig, "alice@hermes-fleet", allowed) == "GOOD")
+        # 2. wrong key rejected (bob's sig, verified as bob's principal)
+        sigb = sign_content(content, keypaths["bob"])
+        check("bob signs, verifies as bob (independent)",
+              verify_signature(content, sigb, "bob@hermes-fleet", allowed) == "GOOD")
+        # 3. tampered content detected
+        check("tampered content -> BAD",
+              verify_signature(content + "x", sig, "alice@hermes-fleet", allowed) == "BAD")
+        # 4. registered-principal policy: unregistered signer -> UNTRUSTED
+        check("unregistered signer -> UNTRUSTED",
+              verify_signature(content, sig, "carol@hermes-fleet", allowed) == "UNTRUSTED")
+        # 5. sidecar verify roundtrip
+        sidecar = os.path.join(td, "sig.db")
+        store_signature(sidecar, "testboard", 1, "alice@hermes-fleet", sig, content, 1700000000)
+        # build a minimal kanban db with event id 1
+        kdb = os.path.join(td, "kanban.db")
+        kc = sqlite3.connect(kdb)
+        kc.execute("CREATE TABLE task_events (id INTEGER PRIMARY KEY, task_id TEXT, run_id INTEGER, kind TEXT, payload TEXT, created_at INTEGER)")
+        kc.execute("INSERT INTO task_events (id,task_id,run_id,kind,payload,created_at) VALUES (1,'t_000001',NULL,'heartbeat',NULL,1700000000)")
+        kc.commit(); kc.close()
+        counts = verify_sidecar(kdb, sidecar, allowed, board="testboard")
+        check("sidecar verify: GOOD=1 unsigned=0",
+              counts.get("GOOD") == 1 and counts.get("UNSIGNED") == 0)
+        # 6. missing signature reported as unsigned (not a block)
+        sidecar2 = os.path.join(td, "sig2.db")
+        counts2 = verify_sidecar(kdb, sidecar2, allowed, board="testboard")
+        check("no sidecar -> all unsigned (report-only, no block)",
+              counts2.get("UNSIGNED") == 1)
+        # 7. sign_event_payload full-row convenience
+        sigrow = sign_event_payload(1, "t_000001", None, "heartbeat", None, 1700000000, keypaths["alice"])
+        check("sign_event_payload matches sign_content",
+              sigrow == sig)
+
+    print("SELFTEST:", "ALL PASS" if ok else "FAILURES PRESENT")
+    return 0 if ok else 1
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__)
+    sub = p.add_subparsers(dest="cmd", required=True)
+    s1 = sub.add_parser("sign-one")
+    s1.add_argument("--content", required=True)
+    s1.add_argument("--key", required=True)
+    s1.set_defaults(func=_cmd_sign_one)
+    rk = sub.add_parser("resolve-key")
+    rk.add_argument("--profile", default=None)
+    rk.set_defaults(func=_cmd_resolve_key)
+    v = sub.add_parser("verify")
+    v.add_argument("--kanban-db", required=True)
+    v.add_argument("--sidecar", default=DEFAULT_SIDECAR)
+    v.add_argument("--allowed-signers", default=DEFAULT_ALLOWED_SIGNERS)
+    v.set_defaults(func=_cmd_verify)
+    st = sub.add_parser("selftest")
+    st.set_defaults(func=_cmd_selftest)
+    args = p.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/hermes_cli/test_kanban_board_path_priority.py
+++ b/tests/hermes_cli/test_kanban_board_path_priority.py
@@ -1,0 +1,174 @@
+"""Regression tests for _board_path priority: explicit board trumps env pin.
+
+t_3f1c63a5: MCP-only sessions (dispatcher workers) always run with
+HERMES_KANBAN_DB pinned to their own board. Before this fix, that ambient
+env var was consulted BEFORE the caller's explicit board= argument, so
+kanban_create(board="other-board") / kanban_show(board="other-board")
+silently landed on the caller's own board instead of the requested one —
+exactly the failure mode that stalled t_8239fc9c / t_09015699.
+"""
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_constants import get_default_hermes_root
+
+
+@pytest.fixture(autouse=True)
+def _clean_env_board(monkeypatch):
+    """Remove env vars that would pin the board during these tests."""
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+
+
+def test_explicit_board_trumps_kanban_db_env(monkeypatch, tmp_path):
+    """When HERMES_KANBAN_DB pins to a dispatcher-injected path (the exact
+    shape every kanban worker/MCP session runs with), an explicit
+    board=<slug> must still resolve to that slug's own board dir."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "pinned.db"))
+    path = kb.kanban_db_path(board="sycode-trading")
+    assert "sycode-trading" in str(path), (
+        f"explicit board should override env pin, got {path}"
+    )
+
+
+def test_explicit_board_trumps_kanban_board_env(monkeypatch, tmp_path):
+    """When HERMES_KANBAN_BOARD pins to board A, explicit board=slug
+    must resolve to slug's board dir."""
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "jarvis-os")
+    path = kb.kanban_db_path(board="sycode-trading")
+    assert "sycode-trading" in str(path), (
+        f"explicit board should override HERMES_KANBAN_BOARD, got {path}"
+    )
+
+
+def test_none_board_falls_back_to_kanban_db_env(monkeypatch, tmp_path):
+    """When no board is passed, HERMES_KANBAN_DB should still win (back-compat
+    for dispatcher-spawned workers with no board= override)."""
+    pinned = tmp_path / "pinned.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(pinned))
+    path = kb.kanban_db_path(board=None)
+    assert path == pinned, f"None board with env pin should use env, got {path}"
+
+
+def test_none_board_falls_back_to_kanban_board_env(monkeypatch, tmp_path):
+    """When no board is passed, HERMES_KANBAN_BOARD should resolve normally
+    IF the named board exists on disk."""
+    kanban_home = tmp_path / "hermes_test"
+    boards_dir = kanban_home / "kanban" / "boards" / "jarvis-os"
+    boards_dir.mkdir(parents=True, exist_ok=True)
+    (boards_dir / "board.json").write_text('{"name": "Jarvis OS"}')
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(kanban_home))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "jarvis-os")
+    path = kb.kanban_db_path(board=None)
+    assert "jarvis-os" in str(path), (
+        f"None board should fall back to HERMES_KANBAN_BOARD, got {path}"
+    )
+
+
+def test_explicit_board_does_not_mutate_env(monkeypatch, tmp_path):
+    """Calling kanban_db_path(board=...) must not alter env state — a
+    subsequent call without board= must still honor the original env pin."""
+    pinned = tmp_path / "pinned.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(pinned))
+    _ = kb.kanban_db_path(board="sycode-trading")
+    path2 = kb.kanban_db_path()
+    assert path2 == pinned, (
+        f"env pin should survive after explicit-board call, got {path2}"
+    )
+
+
+def test_explicit_board_works_without_any_env(monkeypatch):
+    """Explicit board= should resolve correctly even without env vars."""
+    path = kb.kanban_db_path(board="sycode-trading")
+    assert "sycode-trading" in str(path), (
+        f"explicit board should work without env, got {path}"
+    )
+
+
+def test_workspaces_root_also_honors_explicit_board_over_env(monkeypatch, tmp_path):
+    """The same ambient-env-vs-explicit-board priority bug applied to every
+    _board_path() caller, not just kanban_db_path — workspaces_root must
+    honor board= over HERMES_KANBAN_WORKSPACES_ROOT too."""
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", str(tmp_path / "pinned-workspaces"))
+    path = kb.workspaces_root(board="sycode-trading")
+    assert "sycode-trading" in str(path), (
+        f"explicit board should override HERMES_KANBAN_WORKSPACES_ROOT, got {path}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI --board boundary (os-reviewer P1 on PR#107195 / t_11c4afd8): a
+# worker-pinned env (HERMES_KANBAN_DB/HERMES_KANBAN_BOARD) must not outrank
+# an explicit `hermes kanban --board B ...` invocation, which resolves via
+# scoped_current_board() rather than a direct board= call argument. The
+# original fix only prioritized the direct argument; --board went through
+# _board_path(..., board=None) and so still lost to the env pin.
+# ---------------------------------------------------------------------------
+
+def test_scoped_current_board_context_trumps_kanban_db_env(monkeypatch, tmp_path):
+    """kb.scoped_current_board() (what CLI --board and the dashboard
+    plugin_api use) must resolve like an explicit board= call even while
+    HERMES_KANBAN_DB pins a different, worker-injected path."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "worker-pinned.db"))
+    with kb.scoped_current_board("sycode-trading"):
+        path = kb.kanban_db_path()
+    assert "sycode-trading" in str(path), (
+        f"scoped --board context should override HERMES_KANBAN_DB, got {path}"
+    )
+
+
+def test_cli_board_flag_trumps_worker_env_pin_end_to_end(monkeypatch, tmp_path):
+    """Real boundary: a worker shell pinned via HERMES_KANBAN_DB/BOARD (the
+    exact env every dispatcher-spawned kanban worker runs with) invokes
+    `hermes kanban --board B create ...` through the actual CLI parser.
+    Only board B's physical database may receive the write; the pinned
+    board's database must not also contain the task."""
+    import argparse
+
+    from hermes_cli import kanban as kc
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    kb.create_board("worker-own-board")
+    kb.create_board("target-board")
+
+    # Simulate the ambient env every MCP/dispatcher-spawned worker carries:
+    # pinned to its OWN board, distinct from the one it explicitly targets.
+    worker_pinned_db = kb.kanban_db_path(board="worker-own-board")
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(worker_pinned_db))
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "worker-own-board")
+
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    args = parser.parse_args(["kanban", "--board", "target-board", "create", "cross-board task"])
+    rc = kc.kanban_command(args)
+    assert rc == 0
+
+    target_db = kb.kanban_db_path(board="target-board")
+    assert target_db != worker_pinned_db
+
+    from hermes_cli import kanban_db_connect as kbc
+    with kbc.connect(board="target-board") as conn:
+        rows = conn.execute("SELECT title FROM tasks").fetchall()
+    assert any(r[0] == "cross-board task" for r in rows), (
+        "explicit --board flag must land the write on the target board, "
+        f"got rows={rows!r} in {target_db}"
+    )
+
+    # And the worker's own pinned board must NOT have received the write —
+    # this is the exact silent-misroute failure class the fix closes.
+    with kbc.connect(board="worker-own-board") as conn:
+        own_rows = conn.execute("SELECT title FROM tasks").fetchall()
+    assert not any(r[0] == "cross-board task" for r in own_rows), (
+        f"--board must not fall through to the worker's env-pinned board, "
+        f"but found the task there too: {own_rows!r}"
+    )

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -100,12 +100,27 @@ class TestPathResolution:
         assert p == fresh_home / "kanban" / "boards" / "atm10-server" / "kanban.db"
 
 
-    def test_env_var_db_override_still_wins(self, fresh_home, tmp_path, monkeypatch):
-        """``HERMES_KANBAN_DB`` pins the file regardless of board= arg."""
+    def test_env_var_db_override_wins_when_board_not_passed(self, fresh_home, tmp_path, monkeypatch):
+        """``HERMES_KANBAN_DB`` pins the file when no explicit ``board=`` is given
+        (back-compat for dispatcher-spawned workers with no board override)."""
         forced = tmp_path / "custom.db"
         monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
         assert kb.kanban_db_path() == forced
-        assert kb.kanban_db_path(board="ignored") == forced
+        assert kb.kanban_db_path(board=None) == forced
+
+    def test_explicit_board_trumps_env_var_db_override(self, fresh_home, tmp_path, monkeypatch):
+        """Documented priority (module docstring, predates this test): explicit
+        ``board=`` arg > ``HERMES_KANBAN_BOARD`` > ``HERMES_KANBAN_DB`` > current >
+        default. An explicit ``board=`` must resolve to that board's own path even
+        when ``HERMES_KANBAN_DB`` pins a different file — this is the exact shape
+        every MCP-only / dispatcher-spawned kanban worker runs with, and is what
+        makes cross-board ``kanban_create(board=...)`` / ``kanban_show(board=...)``
+        work instead of silently landing on the worker's own pinned board (t_3f1c63a5)."""
+        forced = tmp_path / "custom.db"
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
+        p = kb.kanban_db_path(board="atm10-server")
+        assert p == fresh_home / "kanban" / "boards" / "atm10-server" / "kanban.db"
+        assert p != forced
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_event_append_signing.py
+++ b/tests/hermes_cli/test_kanban_event_append_signing.py
@@ -1,0 +1,142 @@
+"""Scratch-only proofs for the fail-open _append_event signing hunk (t_22d998fd).
+
+Never writes ~/.hermes/audit/kanban-event-signatures.db. Sidecar is a tempfile.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_event_signing as signing
+
+LIVE_SIDECAR = "/home/frank/.hermes/audit/kanban-event-signatures.db"
+
+
+def _write_test_key(td: Path, ident: str = "alice") -> tuple[str, str, str]:
+    priv = Ed25519PrivateKey.generate()
+    key_path = td / f"{ident}-signing"
+    key_path.write_bytes(
+        priv.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.OpenSSH,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    pub = (
+        priv.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.OpenSSH,
+            format=serialization.PublicFormat.OpenSSH,
+        )
+        .decode("ascii")
+    )
+    identity = f"{ident}@hermes-fleet"
+    allowed = td / "allowed_signers"
+    allowed.write_text(
+        f'{identity} namespaces="git" ssh-ed25519 {pub.split()[1]}\n',
+        encoding="utf-8",
+    )
+    return identity, str(key_path), str(allowed)
+
+
+def _scratch_board(tmp_path: Path) -> tuple[Path, sqlite3.Connection]:
+    db_path = tmp_path / "kanban" / "boards" / "scratch-t22d998fd" / "kanban.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = kb.connect(db_path)
+    return db_path, conn
+
+
+def test_append_event_sidecar_verify_good(tmp_path, monkeypatch):
+    sidecar = str(tmp_path / "kanban-event-signatures.db")
+    assert os.path.abspath(sidecar) != os.path.abspath(LIVE_SIDECAR)
+    identity, key_path, allowed = _write_test_key(tmp_path)
+
+    monkeypatch.setattr(signing, "DEFAULT_SIDECAR", sidecar)
+    monkeypatch.setattr(
+        signing, "resolve_signing_key", lambda profile=None: (identity, key_path)
+    )
+
+    db_path, conn = _scratch_board(tmp_path)
+    try:
+        with kb.write_txn(conn):
+            tid = kb.create_task(conn, title="t_22d998fd sign proof")
+        row = conn.execute(
+            "SELECT id, task_id, run_id, kind, payload, created_at "
+            "FROM task_events ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        assert row is not None
+        event_id = int(row["id"])
+        sc = sqlite3.connect(sidecar)
+        try:
+            sig_row = sc.execute(
+                "SELECT signer, signature, content FROM event_signatures "
+                "WHERE board=? AND event_id=?",
+                ("scratch-t22d998fd", event_id),
+            ).fetchone()
+        finally:
+            sc.close()
+        assert sig_row is not None, "sidecar row missing — live sidecar must not be used"
+        status = signing.verify_signature(
+            sig_row[2], sig_row[1], sig_row[0], allowed
+        )
+        assert status == "GOOD"
+        counts = signing.verify_sidecar(
+            str(db_path), sidecar, allowed, board="scratch-t22d998fd"
+        )
+        assert counts.get("GOOD", 0) >= 1
+        assert counts.get("BAD", 0) == 0
+        assert counts.get("UNTRUSTED", 0) == 0
+    finally:
+        conn.close()
+    assert not os.path.samefile(sidecar, LIVE_SIDECAR) if os.path.exists(LIVE_SIDECAR) else True
+
+
+def test_append_event_fail_open_on_signing_exception(tmp_path, monkeypatch):
+    sidecar = str(tmp_path / "kanban-event-signatures.db")
+    identity, key_path, _allowed = _write_test_key(tmp_path, ident="bob")
+
+    monkeypatch.setattr(signing, "DEFAULT_SIDECAR", sidecar)
+    monkeypatch.setattr(
+        signing, "resolve_signing_key", lambda profile=None: (identity, key_path)
+    )
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("forced signing exception t_22d998fd")
+
+    monkeypatch.setattr(signing, "sign_event_payload", _boom)
+
+    _db_path, conn = _scratch_board(tmp_path)
+    try:
+        with kb.write_txn(conn):
+            tid = kb.create_task(conn, title="t_22d998fd fail-open")
+        n_before = conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=?", (tid,)
+        ).fetchone()[0]
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "heartbeat", {"probe": "fail-open"})
+        n_after = conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=?", (tid,)
+        ).fetchone()[0]
+        assert n_after == n_before + 1
+        kinds = [
+            r[0]
+            for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id=? ORDER BY id", (tid,)
+            )
+        ]
+        assert "heartbeat" in kinds
+        if os.path.isfile(sidecar):
+            sc = sqlite3.connect(sidecar)
+            try:
+                n_sig = sc.execute("SELECT COUNT(*) FROM event_signatures").fetchone()[0]
+            finally:
+                sc.close()
+            assert n_sig == 0
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Root-cause fix for the recurring `overlay-drift-monitor` cron alert (11+ duplicate fires, chain t_6bd3bd35 → t_f7bd0237 → … → t_a3b1832b). Ports 3 changes that were sitting **uncommitted in the live install** (`/home/frank/.hermes/hermes-agent`) onto a clean branch off freshly-fetched `origin/main`, so they can land through normal review instead of staying as permanent tree drift.

1. **`hermes_cli/kanban_db.py`** — `_board_path()` resolver now treats an explicit `board=` parameter (or a scoped `--board` context via `scoped_current_board()`) as caller intent that trumps an ambient env-var pin (`HERMES_KANBAN_DB` / `HERMES_KANBAN_BOARD`). Needed for cross-board routing from MCP-only / dispatcher-spawned sessions where the env pins one board but the caller explicitly targets another. Falls back to the env var, then `get_current_board()`, only when no explicit board is given.
2. **`hermes_cli/kanban_event_signing.py`** (new) — per-agent Ed25519 authorship signatures for kanban `task_events`, restored verbatim from previously-reviewed commit `a693b6cc91`. Signatures live in a **sidecar** SQLite DB (`~/.hermes/audit/kanban-event-signatures.db`), never in `task_events` itself (the hash-chain halts append on any schema drift of that table). Verify-and-report only — never blocks a write (fail-open).
3. Wired `kanban_event_signing` into `hermes_cli/kanban_db.py::_append_event` (restoration of the `a693b6cc91` wiring hunk, matching the source-only restore already reviewed at `79c7f820f4`).

Plus regression tests:
- `tests/hermes_cli/test_kanban_board_path_priority.py` (new)
- `tests/hermes_cli/test_kanban_event_append_signing.py` (new)
- `tests/hermes_cli/test_kanban_boards.py` — updated `test_env_var_db_override_still_wins` (asserted the OLD pre-fix priority, which change #1 intentionally reverses); split into `test_env_var_db_override_wins_when_board_not_passed` (still-valid back-compat case) + `test_explicit_board_trumps_env_var_db_override` (new fix behavior).

5 files changed: 2 production (+68/-7, +456/-0 new), 3 test (+174/-0 new, +18/-3, +142/-0 new).

## Review status

Independently reviewed and **APPROVED** by os-reviewer on kanban task `t_f7bd0237` (round 1, artifact+execution lens — not transcript-trusted):
- Fork branch existence + exact SHA verified via `gh api`; base-commit ancestry verified via `git merge-base --is-ancestor`.
- `_board_path()` fix diffed against externally-reviewed `aea28d406d` candidate: matches.
- `_append_event` signing hunk diffed against previously-approved `79c7f820f4`/`a693b6cc91`: byte-identical.
- New/touched test files: 33/33 pass in isolation. `kanban_event_signing.py` selftest: all pass. `py_compile` on all 5 changed files: clean.
- Full `-k kanban` suite on this branch: 16 failed/346 passed. Same suite on a fresh baseline `origin/main@c22a8d8e3f` checkout: 15 failed/335 passed. The single delta failure was bisected and reproduced identically on the *unpatched* baseline — confirmed pre-existing test-isolation/ordering pollution (`test_kanban_default_assignee.py` → `test_kanban_dispatch_tick_hook.py` and neighbors), **not caused by this change**.
- Live install `/home/frank/.hermes/hermes-agent` confirmed untouched at review time (not merged, no substrate sync run) — out of scope for this PR, tracked separately and Frank/A3-gated.

## Landing status

Per `a3-gate-enforcement` + `hermetic-core-patching` skills, this is a core-Hermes source change: **do not merge without Frank's explicit A3 exact-phrase approval.** An A3 packet citing this PR is posted on kanban task `t_148cbc8f`; merge will only proceed after Frank's matching exact-phrase approval lands there.

Base: `origin/main` (this branch's parent `c22a8d8e3f` is a confirmed ancestor of current `main`, 14 commits behind — no functional overlap expected in the touched files).
