### PR TITLE
fix(state): kanban stays available when agent.session_activity is missing (#107661)

### DIFF
--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -10,9 +10,27 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from agent.session_activity import (
-    ActivityProvenance, bound_activity_description, normalize_activity_provenance,
-)
+try:
+    from agent.session_activity import (
+        ActivityProvenance, bound_activity_description, normalize_activity_provenance,
+    )
+except ModuleNotFoundError:  # pragma: no cover — defensive: kanban must load even if agent/ is absent
+    import enum as _enum
+
+    class ActivityProvenance(str, _enum.Enum):  # type: ignore[no-redef]
+        UNKNOWN = "unknown"
+
+    def bound_activity_description(description=None):  # type: ignore[no-redef]
+        text = (description or "").strip()
+        return text if len(text) <= 120 else text[:119] + "…"
+
+    def normalize_activity_provenance(provenance=None):  # type: ignore[no-redef]
+        if isinstance(provenance, ActivityProvenance):
+            return provenance
+        try:
+            return ActivityProvenance((provenance or "").strip())
+        except ValueError:
+            return ActivityProvenance.UNKNOWN
 from hermes_state_common import (
     _LISTABLE_CHILD_SQL, _PREVIEW_ELIGIBLE_SQL, _PREVIEW_RAW_SELECT, _RECOVERABLE_END_REASONS,
     _RECOVERABLE_END_REASONS_SQL, _RESET_END_REASONS, _legacy_reset_child_sql, _shape_preview,


### PR DESCRIPTION
Fixes #107661.

`hermes_state_sessions` imported `agent.session_activity` at module level, so any environment where `agent/` is absent (stale Docker layer, volume shadow, external `hermes-webui` PYTHONPATH) made every `SessionDB` import fail. The kanban dashboard plugin loads at import time via `kanban_db_dispatch -> SessionDB`, so the whole board rendered as `No module named 'agent.session_activity'` instead of degrading gracefully.

Wrap the import in `try/except ModuleNotFoundError` with a minimal fallback (UNKNOWN-only `ActivityProvenance` + clamped helpers) so kanban and other `SessionDB` consumers remain importable and functional; only the activity-heartbeat labels fall back to `UNKNOWN`.

Test: `tests/agent/test_session_activity.py`, `tests/run_agent/test_session_activity_persist.py`, `tests/hermes_cli/test_kanban_db.py` (55 passed), `tests/plugins/test_kanban_dashboard_plugin.py` (38 passed). Verified fallback path via mocked missing module.