### PR TITLE
feat(cli): opt-in 'limits' status-bar field for Codex and Claude Code session usage

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -366,6 +366,24 @@ def _plural(count: int) -> str:
     return "s" if count != 1 else ""
 
 
+def _anthropic_scoped_weekly_windows(payload: dict) -> list[AccountUsageWindow]:
+    """Per-model weekly caps from ``payload["limits"]`` (``kind: weekly_scoped``, e.g. a Fable-only
+    week). They are separate from the account-wide ``seven_day`` window: a model can be out for the
+    week while the session window and the shared week are free. Unscoped entries duplicate the
+    ``five_hour`` / ``seven_day`` fields and are skipped."""
+    windows: list[AccountUsageWindow] = []
+    for entry in payload.get("limits") or ():
+        if not isinstance(entry, dict) or entry.get("kind") != "weekly_scoped":
+            continue
+        model_name = (((entry.get("scope") or {}).get("model") or {}).get("display_name") or "").strip()
+        percent = entry.get("percent")
+        if not model_name or not _is_num(percent):
+            continue
+        windows.append(AccountUsageWindow(label=f"{model_name} week", used_percent=float(percent),
+                                          reset_at=_parse_dt(entry.get("resets_at"))))
+    return windows
+
+
 def _fetch_codex_account_usage(
     base_url: Optional[str] = None, api_key: Optional[str] = None,
 ) -> Optional[AccountUsageSnapshot]:
@@ -512,6 +530,7 @@ def _fetch_anthropic_account_usage(
         payload, (("five_hour", "Current session"), ("seven_day", "Current week"), ("seven_day_opus", "Opus week"),
                   ("seven_day_sonnet", "Sonnet week")), "utilization", "resets_at", fraction=True,
     )
+    windows.extend(_anthropic_scoped_weekly_windows(payload))
     details: list[str] = []
     extra = payload.get("extra_usage") or {}
     used_credits, monthly_limit = extra.get("used_credits"), extra.get("monthly_limit")

--- a/hermes_cli/cli_status_bar_mixin.py
+++ b/hermes_cli/cli_status_bar_mixin.py
@@ -956,8 +956,8 @@ class CLIStatusBarMixin:
 
         Fields: model, context_detail, context_pct, cache_hit, latency, tps, compressions,
         bg_tasks, bg_processes, bg_subagents, goal, duration, prompt_elapsed, idle_since,
-        focus, yolo, stash, battery, title, total_tokens (opt-in only). Order is fixed; the
-        config controls visibility only.
+        focus, yolo, stash, battery, title, limits and total_tokens (both opt-in only). Order
+        is fixed; the config controls visibility only.
         """
         from cli import CLI_CONFIG
         if hasattr(self, "_status_bar_field_set_cache"):
@@ -973,6 +973,18 @@ class CLIStatusBarMixin:
             result = None
         self._status_bar_field_set_cache = result
         return result
+
+    def _account_limits(self) -> list:
+        """``[(label, used_percent), ...]`` for the ``limits`` segment. The poller is started on
+        first use and only ever read here, so repaints never wait on the network."""
+        poller = getattr(self, "_account_limits_poller", None)
+        if poller is None:
+            from hermes_cli.status_bar_limits import AccountLimitsPoller
+            # Idle bars repaint only on input, so a fresh reading asks for one (throttled).
+            poller = self._account_limits_poller = AccountLimitsPoller(
+                on_change=lambda: self._invalidate(min_interval=0.0))
+            poller.start()
+        return poller.read()
 
     def _status_bar_segments(
         self, snapshot, width: int, field_set, yolo_active: bool, *, styled: bool) -> list:
@@ -1028,6 +1040,13 @@ class CLIStatusBarMixin:
                     ])
                 else:
                     segs.append([(bar_style, percent_label)])
+            # Subscription rate limits (5-hour window per provider) - opt-in only via an
+            # explicit fields list, like total_tokens. Same color ladder as the context bar:
+            # the number closest to blocking you is the reddest.
+            if field_set is not None and "limits" in field_set:
+                from hermes_cli.status_bar_limits import format_limit
+                for label, used in self._account_limits():
+                    segs.append([(self._status_bar_context_style(round(used)), format_limit(label, used))])
             cache = self._cache_hit_rate(snapshot, precision=1 if wide else 0)
             if cache:
                 add("cache_hit", self._cache_hit_rate_style(cache[0]), cache[1])

--- a/hermes_cli/cli_status_bar_mixin.py
+++ b/hermes_cli/cli_status_bar_mixin.py
@@ -1040,7 +1040,7 @@ class CLIStatusBarMixin:
                     ])
                 else:
                     segs.append([(bar_style, percent_label)])
-            # Subscription rate limits (5-hour window per provider) - opt-in only via an
+            # Subscription rate limits (shortest window per provider, per-model weeks) - opt-in via an
             # explicit fields list, like total_tokens. Same color ladder as the context bar:
             # the number closest to blocking you is the reddest.
             if field_set is not None and "limits" in field_set:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -897,7 +897,7 @@ DEFAULT_CONFIG = {
         # context_detail, context_pct, cache_hit, latency, tps, compressions, bg_tasks,
         # bg_processes, bg_subagents, goal, duration, prompt_elapsed, idle_since, focus, yolo,
         # stash, battery, title, plus two opt-in only fields: limits (Codex + Claude Code
-        # subscription usage, 5-hour window per account, polled every 60s) and total_tokens
+        # subscription usage: shortest window per account plus per-model weekly caps, polled every 60s) and total_tokens
         # (session Σ). Narrow terminals still drop context_detail/prompt_elapsed/idle_since.
         "status_bar": {
             "fields": [],

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -896,8 +896,9 @@ DEFAULT_CONFIG = {
         # config controls visibility not ordering); empty = default set. Available: model,
         # context_detail, context_pct, cache_hit, latency, tps, compressions, bg_tasks,
         # bg_processes, bg_subagents, goal, duration, prompt_elapsed, idle_since, focus, yolo,
-        # stash, battery, title, total_tokens (session Σ, opt-in only). Narrow terminals still drop
-        # context_detail/prompt_elapsed/idle_since.
+        # stash, battery, title, plus two opt-in only fields: limits (Codex + Claude Code
+        # subscription usage, 5-hour window per account, polled every 60s) and total_tokens
+        # (session Σ). Narrow terminals still drop context_detail/prompt_elapsed/idle_since.
         "status_bar": {
             "fields": [],
         },

--- a/hermes_cli/status_bar_limits.py
+++ b/hermes_cli/status_bar_limits.py
@@ -1,0 +1,94 @@
+"""Subscription usage read-out for the status bar (``limits`` in ``display.status_bar.fields``).
+
+Polls ``agent.account_usage`` for the Codex and Claude Code subscriptions on a daemon thread and
+keeps the 5-hour session window per provider - the one that moves while you work; the weekly
+windows stay in ``/usage``. The render path only reads the cached snapshot, so a slow or failed
+fetch never stalls a repaint.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# provider id -> short bar label. The order is the bar order.
+PROVIDERS: tuple[tuple[str, str], ...] = (("openai-codex", "cx"), ("anthropic", "cc"))
+
+DEFAULT_INTERVAL_S = 60.0
+
+
+def session_window_percent(snapshot) -> Optional[float]:
+    """``used_percent`` of the 5-hour window; None when the snapshot has none.
+
+    Both providers label that window "Session" / "Current session" (``agent.account_usage``),
+    while the weekly and per-model windows never carry the word.
+    """
+    if snapshot is None:
+        return None
+    for window in getattr(snapshot, "windows", ()):
+        if "session" in window.label.lower() and window.used_percent is not None:
+            return max(0.0, min(100.0, float(window.used_percent)))
+    return None
+
+
+def format_limit(label: str, used_percent: float) -> str:
+    """``cx 100%`` / ``cc  27%`` - the percent is right-aligned to three cells so the bar never shifts."""
+    return f"{label} {round(used_percent):>3d}%"
+
+
+class AccountLimitsPoller:
+    """Background refresh of per-provider session-window usage. ``read()`` is lock-free and cheap."""
+
+    def __init__(self, fetch: Optional[Callable] = None, interval_s: float = DEFAULT_INTERVAL_S,
+                 on_change: Optional[Callable[[], None]] = None):
+        self._fetch = fetch
+        self._interval_s = max(5.0, float(interval_s))
+        self._on_change = on_change
+        self._limits: dict[str, float] = {}
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self._lock = threading.Lock()
+
+    def start(self) -> None:
+        with self._lock:
+            if self._thread is not None:
+                return
+            self._thread = threading.Thread(target=self._loop, name="status-bar-limits", daemon=True)
+            self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def read(self) -> list[tuple[str, float]]:
+        """``[(label, used_percent), ...]`` in bar order; providers without data are omitted."""
+        limits = self._limits
+        return [(label, limits[provider]) for provider, label in PROVIDERS if provider in limits]
+
+    def refresh_once(self) -> None:
+        fetch = self._fetch
+        if fetch is None:
+            from agent.account_usage import fetch_account_usage
+            fetch = fetch_account_usage
+        fresh = dict(self._limits)
+        for provider, _label in PROVIDERS:
+            try:
+                used = session_window_percent(fetch(provider))
+            except Exception:
+                logger.debug("status bar limits: %s fetch failed", provider, exc_info=True)
+                continue  # keep the last good reading rather than blanking the segment
+            if used is None:
+                fresh.pop(provider, None)
+            else:
+                fresh[provider] = used
+        changed = fresh != self._limits
+        self._limits = fresh  # single reference swap: readers never see a half-built dict
+        if changed and self._on_change is not None:
+            self._on_change()
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            self.refresh_once()
+            self._stop.wait(self._interval_s)

--- a/hermes_cli/status_bar_limits.py
+++ b/hermes_cli/status_bar_limits.py
@@ -1,9 +1,10 @@
 """Subscription usage read-out for the status bar (``limits`` in ``display.status_bar.fields``).
 
-Polls ``agent.account_usage`` for the Codex and Claude Code subscriptions on a daemon thread and
-keeps the 5-hour session window per provider - the one that moves while you work; the weekly
-windows stay in ``/usage``. The render path only reads the cached snapshot, so a slow or failed
-fetch never stalls a repaint.
+Polls ``agent.account_usage`` for the Codex and Claude Code subscriptions on a daemon thread. Per
+provider it keeps the shortest window the plan reports (the 5-hour session window; weekly only on
+plans without one) plus any per-model weekly cap (``fable 57%``), since a model can be out for the
+week while the session window is free. The render path only reads the cached list, so a slow or
+failed fetch never stalls a repaint.
 """
 
 from __future__ import annotations
@@ -20,18 +21,33 @@ PROVIDERS: tuple[tuple[str, str], ...] = (("openai-codex", "cx"), ("anthropic", 
 DEFAULT_INTERVAL_S = 60.0
 
 
-def session_window_percent(snapshot) -> Optional[float]:
-    """``used_percent`` of the 5-hour window; None when the snapshot has none.
+def _clamp(value) -> float:
+    return max(0.0, min(100.0, float(value)))
 
-    Both providers label that window "Session" / "Current session" (``agent.account_usage``),
-    while the weekly and per-model windows never carry the word.
+
+def bar_readings(snapshot, label: str) -> list[tuple[str, float]]:
+    """``[(label, used_percent), ...]`` for one provider, or ``[]`` when nothing is reported.
+
+    First the shortest window the plan reports: the one labelled "Session" / "Current session"
+    (``agent.account_usage`` names both providers' 5-hour windows that way), else the first
+    account-wide weekly window (plans that only meter weekly). Then one reading per per-model
+    weekly cap (labels ending in " week" other than the account-wide one), keyed by the model name
+    in lower case - a model can be out for the week while the session window is free.
     """
     if snapshot is None:
-        return None
-    for window in getattr(snapshot, "windows", ()):
-        if "session" in window.label.lower() and window.used_percent is not None:
-            return max(0.0, min(100.0, float(window.used_percent)))
-    return None
+        return []
+    windows = [w for w in getattr(snapshot, "windows", ()) if w.used_percent is not None]
+    session = next((w for w in windows if "session" in w.label.lower()), None)
+    account_week = next((w for w in windows if w.label.lower() in ("weekly", "current week")), None)
+    readings: list[tuple[str, float]] = []
+    shortest = session or account_week
+    if shortest is not None:
+        readings.append((label, _clamp(shortest.used_percent)))
+    for w in windows:
+        name = w.label.lower()
+        if name.endswith(" week") and w is not account_week and name != "current week":
+            readings.append((name[: -len(" week")], _clamp(w.used_percent)))
+    return readings
 
 
 def format_limit(label: str, used_percent: float) -> str:
@@ -40,14 +56,14 @@ def format_limit(label: str, used_percent: float) -> str:
 
 
 class AccountLimitsPoller:
-    """Background refresh of per-provider session-window usage. ``read()`` is lock-free and cheap."""
+    """Background refresh of per-provider bar readings. ``read()`` is lock-free and cheap."""
 
     def __init__(self, fetch: Optional[Callable] = None, interval_s: float = DEFAULT_INTERVAL_S,
                  on_change: Optional[Callable[[], None]] = None):
         self._fetch = fetch
         self._interval_s = max(5.0, float(interval_s))
         self._on_change = on_change
-        self._limits: dict[str, float] = {}
+        self._limits: dict[str, tuple[tuple[str, float], ...]] = {}
         self._thread: Optional[threading.Thread] = None
         self._stop = threading.Event()
         self._lock = threading.Lock()
@@ -65,7 +81,7 @@ class AccountLimitsPoller:
     def read(self) -> list[tuple[str, float]]:
         """``[(label, used_percent), ...]`` in bar order; providers without data are omitted."""
         limits = self._limits
-        return [(label, limits[provider]) for provider, label in PROVIDERS if provider in limits]
+        return [reading for provider, _label in PROVIDERS for reading in limits.get(provider, ())]
 
     def refresh_once(self) -> None:
         fetch = self._fetch
@@ -73,16 +89,16 @@ class AccountLimitsPoller:
             from agent.account_usage import fetch_account_usage
             fetch = fetch_account_usage
         fresh = dict(self._limits)
-        for provider, _label in PROVIDERS:
+        for provider, label in PROVIDERS:
             try:
-                used = session_window_percent(fetch(provider))
+                readings = bar_readings(fetch(provider), label)
             except Exception:
                 logger.debug("status bar limits: %s fetch failed", provider, exc_info=True)
                 continue  # keep the last good reading rather than blanking the segment
-            if used is None:
-                fresh.pop(provider, None)
+            if readings:
+                fresh[provider] = tuple(readings)
             else:
-                fresh[provider] = used
+                fresh.pop(provider, None)
         changed = fresh != self._limits
         self._limits = fresh  # single reference swap: readers never see a half-built dict
         if changed and self._on_change is not None:

--- a/tests/agent/test_account_usage_scoped_weekly.py
+++ b/tests/agent/test_account_usage_scoped_weekly.py
@@ -1,0 +1,23 @@
+"""Anthropic OAuth usage: per-model weekly caps from ``limits[]`` become their own windows."""
+
+from agent.account_usage import _anthropic_scoped_weekly_windows
+
+
+def _limit(kind, percent, model=None, resets_at="2026-09-13T21:00:00+00:00"):
+    scope = {"model": {"id": None, "display_name": model}, "surface": None} if model else None
+    return {"kind": kind, "group": "weekly", "percent": percent, "severity": "normal",
+            "resets_at": resets_at, "scope": scope, "is_active": bool(model)}
+
+
+def test_scoped_weekly_limits_become_model_week_windows():
+    payload = {"limits": [_limit("session", 36), _limit("weekly_all", 30), _limit("weekly_scoped", 57, model="Fable")]}
+    windows = _anthropic_scoped_weekly_windows(payload)
+    assert [(w.label, w.used_percent) for w in windows] == [("Fable week", 57.0)]
+    assert windows[0].reset_at is not None and windows[0].reset_at.year == 2026
+
+
+def test_unscoped_and_malformed_limit_entries_are_ignored():
+    payload = {"limits": [_limit("weekly_scoped", 57), {"kind": "weekly_scoped"}, "junk", None,
+                          {"kind": "weekly_scoped", "percent": "n/a", "scope": {"model": {"display_name": "X"}}}]}
+    assert _anthropic_scoped_weekly_windows(payload) == []
+    assert _anthropic_scoped_weekly_windows({}) == []

--- a/tests/cli/test_cli_status_bar_limits.py
+++ b/tests/cli/test_cli_status_bar_limits.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import cli as cli_mod
 from cli import HermesCLI
-from hermes_cli.status_bar_limits import AccountLimitsPoller, format_limit, session_window_percent
+from hermes_cli.status_bar_limits import AccountLimitsPoller, bar_readings, format_limit
 
 
 def _window(label, used):
@@ -17,9 +17,9 @@ def _codex(session=None, weekly=None):
     return SimpleNamespace(windows=(_window("Session", session), _window("Weekly", weekly)))
 
 
-def _claude(session=None, week=None, opus=None):
+def _claude(session=None, week=None, opus=None, fable=None):
     return SimpleNamespace(windows=(_window("Current session", session), _window("Current week", week),
-                                    _window("Opus week", opus)))
+                                    _window("Opus week", opus), _window("Fable week", fable)))
 
 
 def _cli_with_poller(poller):
@@ -32,12 +32,22 @@ def _cli_with_poller(poller):
     return cli_obj
 
 
-def test_session_window_is_shown_not_the_weekly_one():
-    assert session_window_percent(_codex(session=22, weekly=100)) == 22
-    assert session_window_percent(_claude(session=27, week=90, opus=95)) == 27
-    assert session_window_percent(_codex(session=None, weekly=27)) is None
-    assert session_window_percent(_claude()) is None
-    assert session_window_percent(None) is None
+def test_shortest_window_is_shown_and_account_week_is_not():
+    assert bar_readings(_codex(session=22, weekly=100), "cx") == [("cx", 22.0)]
+    assert bar_readings(_claude(session=27, week=90), "cc") == [("cc", 27.0)]
+    assert bar_readings(_claude(), "cc") == []
+    assert bar_readings(None, "cc") == []
+
+
+def test_weekly_only_plan_falls_back_to_the_weekly_window():
+    # Codex Pro reports no 5-hour window: the weekly cap is then the one that blocks you.
+    assert bar_readings(_codex(session=None, weekly=27), "cx") == [("cx", 27.0)]
+
+
+def test_per_model_weekly_caps_get_their_own_reading():
+    assert bar_readings(_claude(session=36, week=30, fable=57), "cc") == [("cc", 36.0), ("fable", 57.0)]
+    assert bar_readings(_claude(session=36, week=30, opus=12, fable=57), "cc") == [
+        ("cc", 36.0), ("opus", 12.0), ("fable", 57.0)]
 
 
 def test_format_is_fixed_width_across_magnitudes():
@@ -63,8 +73,8 @@ def test_poller_keeps_last_good_reading_when_a_fetch_fails():
     assert poller.read() == [("cx", 22.0), ("cc", 27.0)]
 
 
-def test_poller_drops_provider_that_reports_no_session_window():
-    poller = AccountLimitsPoller(fetch=lambda p: _claude(session=40) if p == "anthropic" else _codex(weekly=80))
+def test_poller_drops_provider_that_reports_no_windows():
+    poller = AccountLimitsPoller(fetch=lambda p: _claude(session=40) if p == "anthropic" else _codex())
     poller.refresh_once()
     assert poller.read() == [("cc", 40.0)]
 
@@ -79,14 +89,14 @@ def test_poller_requests_repaint_only_when_a_reading_changes():
 
 def test_limits_segment_renders_after_context_and_respects_field_gate():
     poller = AccountLimitsPoller(
-        fetch=lambda p: _codex(session=100, weekly=22) if p == "openai-codex" else _claude(session=27, week=90))
+        fetch=lambda p: _codex(session=100, weekly=22) if p == "openai-codex" else _claude(session=27, week=90, fable=57))
     poller.refresh_once()
     cli_obj = _cli_with_poller(poller)
 
     cli_obj._status_bar_field_set_cache = frozenset({"model", "context_pct", "limits"})
     text = cli_obj._build_status_bar_text(width=120)
-    assert "cx 100%" in text and "cc  27%" in text
-    assert text.index("--") < text.index("cx 100%") < text.index("cc  27%")  # after the context read-out
+    assert "cx 100%" in text and "cc  27%" in text and "fable  57%" in text
+    assert text.index("--") < text.index("cx 100%") < text.index("cc  27%") < text.index("fable  57%")
 
     cli_obj._status_bar_field_set_cache = frozenset({"model", "context_pct"})
     text = cli_obj._build_status_bar_text(width=120)

--- a/tests/cli/test_cli_status_bar_limits.py
+++ b/tests/cli/test_cli_status_bar_limits.py
@@ -1,0 +1,103 @@
+"""Status-bar ``limits`` segment: subscription rate limits for Codex and Claude Code."""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import cli as cli_mod
+from cli import HermesCLI
+from hermes_cli.status_bar_limits import AccountLimitsPoller, format_limit, session_window_percent
+
+
+def _window(label, used):
+    return SimpleNamespace(label=label, used_percent=used)
+
+
+def _codex(session=None, weekly=None):
+    return SimpleNamespace(windows=(_window("Session", session), _window("Weekly", weekly)))
+
+
+def _claude(session=None, week=None, opus=None):
+    return SimpleNamespace(windows=(_window("Current session", session), _window("Current week", week),
+                                    _window("Opus week", opus)))
+
+
+def _cli_with_poller(poller):
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.model = "openai-codex/gpt-5"
+    cli_obj.session_start = datetime.now() - timedelta(minutes=3)
+    cli_obj.conversation_history = []
+    cli_obj.agent = None
+    cli_obj._account_limits_poller = poller
+    return cli_obj
+
+
+def test_session_window_is_shown_not_the_weekly_one():
+    assert session_window_percent(_codex(session=22, weekly=100)) == 22
+    assert session_window_percent(_claude(session=27, week=90, opus=95)) == 27
+    assert session_window_percent(_codex(session=None, weekly=27)) is None
+    assert session_window_percent(_claude()) is None
+    assert session_window_percent(None) is None
+
+
+def test_format_is_fixed_width_across_magnitudes():
+    widths = {len(format_limit("cx", v)) for v in (0, 7, 27, 100)}
+    assert widths == {len("cx 100%")}
+
+
+def test_poller_keeps_last_good_reading_when_a_fetch_fails():
+    calls = {"n": 0}
+
+    def fetch(provider):
+        calls["n"] += 1
+        if provider == "openai-codex":
+            if calls["n"] > 2:
+                raise RuntimeError("network")
+            return _codex(session=22, weekly=100)
+        return _claude(session=27, week=10)
+
+    poller = AccountLimitsPoller(fetch=fetch)
+    poller.refresh_once()
+    assert poller.read() == [("cx", 22.0), ("cc", 27.0)]
+    poller.refresh_once()  # codex fetch now raises; cx must survive
+    assert poller.read() == [("cx", 22.0), ("cc", 27.0)]
+
+
+def test_poller_drops_provider_that_reports_no_session_window():
+    poller = AccountLimitsPoller(fetch=lambda p: _claude(session=40) if p == "anthropic" else _codex(weekly=80))
+    poller.refresh_once()
+    assert poller.read() == [("cc", 40.0)]
+
+
+def test_poller_requests_repaint_only_when_a_reading_changes():
+    repaints = []
+    poller = AccountLimitsPoller(fetch=lambda p: _codex(session=40), on_change=lambda: repaints.append(1))
+    poller.refresh_once()
+    poller.refresh_once()  # same values: no second repaint
+    assert len(repaints) == 1
+
+
+def test_limits_segment_renders_after_context_and_respects_field_gate():
+    poller = AccountLimitsPoller(
+        fetch=lambda p: _codex(session=100, weekly=22) if p == "openai-codex" else _claude(session=27, week=90))
+    poller.refresh_once()
+    cli_obj = _cli_with_poller(poller)
+
+    cli_obj._status_bar_field_set_cache = frozenset({"model", "context_pct", "limits"})
+    text = cli_obj._build_status_bar_text(width=120)
+    assert "cx 100%" in text and "cc  27%" in text
+    assert text.index("--") < text.index("cx 100%") < text.index("cc  27%")  # after the context read-out
+
+    cli_obj._status_bar_field_set_cache = frozenset({"model", "context_pct"})
+    text = cli_obj._build_status_bar_text(width=120)
+    assert "cx" not in text and "cc" not in text
+
+
+def test_limits_is_opt_in_and_never_polls_by_default():
+    """The default field set (no ``fields`` list) hides the segment and must not start a network
+    poller: users who never asked for it should not have Hermes calling provider APIs."""
+    cli_obj = _cli_with_poller(None)
+    with patch.object(cli_mod, "CLI_CONFIG", {"display": {"status_bar": {"fields": []}}}):
+        text = cli_obj._build_status_bar_text(width=120)
+    assert "cx" not in text and "cc" not in text
+    assert cli_obj._account_limits_poller is None

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2104,12 +2104,12 @@ display:
     fields: ["model", "duration", "total_tokens"]   # visibility only; built-in order is preserved
 ```
 
-Supported fields: `model`, `context_detail` (used/total tokens), `context_pct` (percent + meter), `cache_hit` (prompt cache hit ratio — resets on model switch and compression), `latency` (rolling mean API latency, last 10 calls), `tps` (rolling output tokens/sec, last 10 calls), `compressions`, `bg_tasks`, `bg_processes`, `bg_subagents`, `goal`, `duration`, `prompt_elapsed`, `idle_since`, `focus`, `yolo`, `stash`, `battery`, `title` (right-aligned session badge), and two opt-in only fields that are never shown by default: `limits` (Codex and Claude Code subscription usage, e.g. `cx 100% │ cc  27%`) and `total_tokens` (session Σ).
+Supported fields: `model`, `context_detail` (used/total tokens), `context_pct` (percent + meter), `cache_hit` (prompt cache hit ratio — resets on model switch and compression), `latency` (rolling mean API latency, last 10 calls), `tps` (rolling output tokens/sec, last 10 calls), `compressions`, `bg_tasks`, `bg_processes`, `bg_subagents`, `goal`, `duration`, `prompt_elapsed`, `idle_since`, `focus`, `yolo`, `stash`, `battery`, `title` (right-aligned session badge), and two opt-in only fields that are never shown by default: `limits` (Codex and Claude Code subscription usage, e.g. `cx 100% │ cc  27% │ fable  57%`) and `total_tokens` (session Σ).
 
 Notes:
 
 - An empty list (the default) keeps the standard set — everything except `limits` and `total_tokens`.
-- `limits` shows the 5-hour session window per subscription, `cx` for OpenAI Codex and `cc` for Claude Code, polled every 60 seconds in the background using the same account data as `/usage`. Accounts that are not signed in are omitted; the weekly windows and reset times stay in `/usage`.
+- `limits` shows, per subscription, the shortest window the plan reports (the 5-hour session window; weekly on plans that only meter weekly) - `cx` for OpenAI Codex, `cc` for Claude Code - plus one reading per model-specific weekly cap when the account has one (for example `fable  57%`). Polled every 60 seconds in the background from the same account data as `/usage`. Accounts that are not signed in are omitted; account-wide weekly windows and reset times stay in `/usage`.
 - The config controls **visibility, not order**; fields render in their built-in positions.
 - Narrow terminals still drop wide-mode-only fields (`context_detail`, `cache_hit`, `latency`, `tps`, `prompt_elapsed`, `idle_since`) regardless of config (`cache_hit` also shows in the medium ≥52-col tier).
 - `latency`/`tps` stay hidden until API calls have been recorded (e.g. the Codex app-server backend reports no latency).

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2104,11 +2104,12 @@ display:
     fields: ["model", "duration", "total_tokens"]   # visibility only; built-in order is preserved
 ```
 
-Supported fields: `model`, `context_detail` (used/total tokens), `context_pct` (percent + meter), `cache_hit` (prompt cache hit ratio — resets on model switch and compression), `latency` (rolling mean API latency, last 10 calls), `tps` (rolling output tokens/sec, last 10 calls), `compressions`, `bg_tasks`, `bg_processes`, `bg_subagents`, `goal`, `duration`, `prompt_elapsed`, `idle_since`, `focus`, `yolo`, `stash`, `battery`, `title` (right-aligned session badge), and `total_tokens` (session Σ — opt-in only, never shown by default).
+Supported fields: `model`, `context_detail` (used/total tokens), `context_pct` (percent + meter), `cache_hit` (prompt cache hit ratio — resets on model switch and compression), `latency` (rolling mean API latency, last 10 calls), `tps` (rolling output tokens/sec, last 10 calls), `compressions`, `bg_tasks`, `bg_processes`, `bg_subagents`, `goal`, `duration`, `prompt_elapsed`, `idle_since`, `focus`, `yolo`, `stash`, `battery`, `title` (right-aligned session badge), and two opt-in only fields that are never shown by default: `limits` (Codex and Claude Code subscription usage, e.g. `cx 100% │ cc  27%`) and `total_tokens` (session Σ).
 
 Notes:
 
-- An empty list (the default) keeps the standard set — everything except `total_tokens`.
+- An empty list (the default) keeps the standard set — everything except `limits` and `total_tokens`.
+- `limits` shows the 5-hour session window per subscription, `cx` for OpenAI Codex and `cc` for Claude Code, polled every 60 seconds in the background using the same account data as `/usage`. Accounts that are not signed in are omitted; the weekly windows and reset times stay in `/usage`.
 - The config controls **visibility, not order**; fields render in their built-in positions.
 - Narrow terminals still drop wide-mode-only fields (`context_detail`, `cache_hit`, `latency`, `tps`, `prompt_elapsed`, `idle_since`) regardless of config (`cache_hit` also shows in the medium ≥52-col tier).
 - `latency`/`tps` stay hidden until API calls have been recorded (e.g. the Codex app-server backend reports no latency).


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `limits` field to `display.status_bar.fields` for the classic CLI status bar. It shows the 5-hour session window of the OpenAI Codex and Claude Code subscriptions right after the context bar, using the context bar's color ladder:

```
⚕ gpt-5 │ 12k/272k │ ▁▁▁▁▁▁▁▁ 5% │ cx 100% │ cc  25% │ ◎ 91% │ 3m
```

`cx` is Codex, `cc` is Claude Code. Both accounts are shown whenever they are signed in, independent of which provider the session is using, because a user on Codex still wants to know if the Claude Code window is about to block them (and the other way round). The weekly windows and reset times stay in `/usage`; the bar shows the number that moves while you work.

Nothing is polled unless `limits` is listed. It is never shown by default, following the `total_tokens` precedent.

```yaml
display:
  status_bar:
    fields: [model, context_pct, limits, cache_hit, duration]
```

## Design

- `hermes_cli/status_bar_limits.py` (new sibling, 94 lines): a daemon thread polls `agent.account_usage.fetch_account_usage` every 60s and keeps one float per provider. `read()` is a lock-free dict read, so repaints never wait on the network. When a reading changes it calls `_invalidate(min_interval=0.0)` so an idle bar updates without a keypress. A failed fetch keeps the last good value; an account that reports no session window is dropped from the bar.
- `hermes_cli/cli_status_bar_mixin.py`: 23 lines - the segment inside `_status_bar_segments` (so plain-text and prompt_toolkit renderers stay in sync) plus the lazy poller accessor.
- `config_defaults.py` and `website/docs/user-guide/configuration.md`: the field is documented in the existing lists. No new config key, no env var, no slash command.
- Reuses `agent/account_usage.py` unchanged.

## Related

- #78997 asks for subscription usage in the desktop status bar; #103095 covers that surface. This PR is the classic CLI bar only and does not touch `agent/account_usage.py`, so the two are independent.
- #84516 adds a Codex-only segment for the active provider plus a `/planusage` command and a second refresh path in `cli.py`. Differences here: both subscriptions regardless of active provider, one window per account, no new command, new code in a sibling module rather than the facade. Happy to consolidate if maintainers prefer that PR's shape.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing

- `scripts/run_tests.sh tests/cli/test_cli_status_bar_limits.py tests/cli/test_cli_status_bar.py tests/cli/test_cli_status_bar_goal.py tests/cli/test_focus_view.py tests/hermes_cli/test_config.py` - 208 passed.
- New tests cover: session window chosen over weekly, fixed-width formatting, last-good value kept on fetch failure, provider without a session window dropped, repaint requested only on change, segment position and field gate, and no poller started with the default field set.
- Live: ran the classic CLI with the field enabled against real Codex and Claude Code OAuth credentials; the segment appeared within one poll interval without input and tracked `/usage`.
