### PR TITLE
fix(desktop): read plugin SDK globals at call time, not module-init time

### DIFF
--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -13,21 +13,38 @@ import * as jsxRuntime from 'react/jsx-runtime'
 
 import * as sdk from './index'
 
-const GLOBALS = {
-  __HERMES_PLUGIN_SDK__: sdk,
-  __HERMES_REACT__: React,
-  __HERMES_REACT_JSX__: jsxRuntime,
-  __HERMES_REACT_JSX_DEV__: jsxDevRuntime
-} as const
+type Globals = {
+  __HERMES_PLUGIN_SDK__: typeof sdk
+  __HERMES_REACT__: typeof React
+  __HERMES_REACT_JSX__: typeof jsxRuntime
+  __HERMES_REACT_JSX_DEV__: typeof jsxDevRuntime
+}
+
+/** Read the namespace bindings at CALL time, never at module-init time. The
+ *  bundler may place this module's body BEFORE the SDK barrel's namespace
+ *  assignment in the chunk (it did in the 2026-09-10 build), so a
+ *  module-level `const GLOBALS = { __HERMES_PLUGIN_SDK__: sdk, ... }`
+ *  captures `undefined` and every plugin load then dies on
+ *  `Object.keys(undefined)`. React imports survive that ordering by luck of
+ *  placement; the SDK barrel does not. A function body defers the read past
+ *  all module bodies, making chunk layout irrelevant. */
+function globals(): Globals {
+  return {
+    __HERMES_PLUGIN_SDK__: sdk,
+    __HERMES_REACT__: React,
+    __HERMES_REACT_JSX__: jsxRuntime,
+    __HERMES_REACT_JSX_DEV__: jsxDevRuntime
+  }
+}
 
 export function installPluginSdk(): void {
-  Object.assign(globalThis, GLOBALS)
+  Object.assign(globalThis, globals())
 }
 
 /** Build a shim ESM blob that re-exports a global namespace's live members.
  *  Export names come from the namespace itself, so the list can't drift. */
-function shimUrl(globalKey: keyof typeof GLOBALS): string {
-  const names = Object.keys(GLOBALS[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
+function shimUrl(globalKey: keyof Globals): string {
+  const names = Object.keys(globals()[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
 
   const source =
     `const m = globalThis.${globalKey};\n` +


### PR DESCRIPTION
## Problem

After the 2026-09-10 desktop update, every runtime-loaded plugin fails at load:

```
[plugins] runtime load failed (<name>) TypeError: Cannot convert undefined or null to object
```

All disk plugins are affected, including a plugin that contains only `export default { id, register(){} }`. Bundled plugins keep working. Two successive builds that day show the same failure, so it is not a one-off artifact.

## Root cause

`apps/desktop/src/sdk/runtime.ts` built its globals map at module-init time:

```ts
const GLOBALS = {
  __HERMES_PLUGIN_SDK__: sdk,
  __HERMES_REACT__: React,
  ...
} as const
```

In the broken build, the bundler places this module body BEFORE the SDK barrel's namespace assignment in the chunk. `var` hoisting means `GLOBALS.__HERMES_PLUGIN_SDK__` captures `undefined` and is never updated. `installPluginSdk()` then installs the undefined value, and `shimUrl()` dies on `Object.keys(GLOBALS['__HERMES_PLUGIN_SDK__'])` for every plugin.

Evidence from the affected build (`sdk-Cyjld4y7.js`), captured over CDP after a page reload:

- `globalThis.__HERMES_PLUGIN_SDK__` is `undefined`; the three React globals are proper objects.
- The globals map literal sits at offset ~157k in the chunk; the SDK namespace assignment (`Rb=t({...})`) at ~231k, after it.
- Stack: `Object.keys <- shimUrl <- sdkImportMap <- unsupportedImports <- loadRuntimePlugin`.

Whether the old code works depends entirely on where the bundler happens to place the SDK barrel's assignment relative to this module. This build orders it wrong; the previous build ordered it right. Same source, different luck.

## Fix

Read the namespace bindings at call time instead of module-init time. `globals()` is a plain function, so the read is deferred past all module bodies and chunk layout no longer matters:

- `installPluginSdk()` calls `Object.assign(globalThis, globals())`.
- `shimUrl()` reads `globals()[globalKey]`.

No behavior change in dev or in correctly ordered builds; the read just happens later and always sees initialized bindings.

## Verification

- `tsc -p . --noEmit` passes.
- `vitest run --project ui`: 7476 passed, 4 failed in 2 files (`billing/index.test.tsx`, `store/voice-prefs.test.ts`). Both files fail identically on clean `main` in a separate worktree, so the failures are pre-existing and unrelated.
