### PR TITLE
fix(qqbot): allow grouptalk.c2c.qq.com in the url_safety private-IP bypass (#47123)

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -157,6 +157,20 @@ class TestProxyEnvironmentDnsDelegation:
         with _resolves_to("198.18.0.23"):
             assert is_safe_url(url) is expected
 
+    @pytest.mark.parametrize("url, expected", [
+        # the C2C file-attachment host, over https, on a network (Clash TUN /
+        # corporate proxy / VPN) that resolves it into the 198.18.0.0/15
+        # benchmark range — downloads were silently dropped before #47123
+        ("https://grouptalk.c2c.qq.com/asn.com/qqdownloadftnv5?id=xxx", True),
+        # exception is an exact host match — subdomains stay blocked
+        ("https://evil.grouptalk.c2c.qq.com/download?id=xxx", False),
+        # ... and requires https
+        ("http://grouptalk.c2c.qq.com/asn.com/qqdownloadftnv5?id=xxx", False),
+    ])
+    def test_qq_c2c_grouptalk_hostname_exception(self, url, expected):
+        with _resolves_to("198.18.2.16"):
+            assert is_safe_url(url) is expected
+
 
 class TestAsyncIsSafeUrl:
     """async_is_safe_url must match is_safe_url (runs DNS in a thread pool)."""

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -110,8 +110,9 @@ _ALWAYS_BLOCKED_IPS = frozenset(
 _ALWAYS_BLOCKED_NETWORKS = tuple(ipaddress.ip_network(n) for n in ("169.254.0.0/16", "::ffff:169.254.0.0/112"))
 
 # Exact HTTPS hostnames allowed to resolve to private/benchmark-space IPs
-# (QQ media legitimately resolves to 198.18.0.0/15 behind local proxy infra).
-_TRUSTED_PRIVATE_IP_HOSTS = frozenset({"multimedia.nt.qq.com.cn"})
+# (QQ downloads legitimately resolve to 198.18.0.0/15 behind local proxy infra:
+# multimedia.nt.qq.com.cn = media, grouptalk.c2c.qq.com = C2C file attachments).
+_TRUSTED_PRIVATE_IP_HOSTS = frozenset({"multimedia.nt.qq.com.cn", "grouptalk.c2c.qq.com"})
 _MAX_SSRF_CONNECT_IPS = 8
 
 # 100.64.0.0/10 (CGNAT, RFC 6598) is neither is_private nor is_global in


### PR DESCRIPTION
## What does this PR do?

Adds `grouptalk.c2c.qq.com` — the QQ Bot C2C file-attachment host — to `tools/url_safety._TRUSTED_PRIVATE_IP_HOSTS`, the exact-hostname, HTTPS-only allowlist of hosts permitted to resolve into private/benchmark IP space.

QQ media legitimately resolves into `198.18.0.0/15` behind Clash TUN / corporate proxy / VPN networks. That host was not on the list, so `is_safe_url()` returned `False` inside `QQAdapter._download_and_cache()`, and the `ValueError` was swallowed at `gateway/platforms/qqbot/adapter.py:949` (`logger.debug`): the greeting text arrived, the attachment never reached `cache/documents/`.

Keeping the fix inside the existing allowlist is deliberate — the bypass stays an exact host match, HTTPS-only, with the cloud-metadata floor untouched. A config-extendable list would widen that surface (see Notes).

## Related Issue

Fixes #47123

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/url_safety.py` — adds `grouptalk.c2c.qq.com` to `_TRUSTED_PRIVATE_IP_HOSTS` and documents both entries' purpose in the existing comment. No code path changes.
- `tests/tools/test_url_safety.py` — adds `test_qq_c2c_grouptalk_hostname_exception`, parametrized over the positive case (host resolving into `198.18.0.0/15` over HTTPS) and both negatives (a subdomain of the host, and plain `http://`), mirroring the sibling `multimedia.nt.qq.com.cn` test.
- Both readers of the allowlist are covered: the pre-flight `is_safe_url()` and the connect-time validator behind the adapter's `create_ssrf_safe_async_client()` client.

**Provenance:** this is a salvage of #47177. The fix and its tests are @Tranquil-Flow's work, cherry-picked here with authorship preserved (commit `97e9693b25` is still authored by them). Their branch no longer merges — `tools/url_safety.py` was rewritten on 2026-09-02, so #47177 reports `CONFLICTING` and has been idle since 2026-07-14. In the resolution the allowlist entry is unchanged in substance, and their three test functions are folded into the one parametrized test above. If a maintainer would rather salvage #47177 directly, this branch adds nothing the original does not already contain, and I can close it.

## How to Test

1. Pin the resolver for the host to a benchmark-range address and run the pre-flight check:

   ```python
   import socket
   from unittest.mock import patch
   from tools.url_safety import is_safe_url

   addr = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("198.18.2.16", 0))]
   with patch("socket.getaddrinfo", return_value=addr):
       print(is_safe_url("https://grouptalk.c2c.qq.com/asn.com/qqdownloadftnv5?id=xxx"))
   ```

   Before: `False`, logging `Blocked request to private/internal address: grouptalk.c2c.qq.com -> 198.18.2.16`. After: `True`.

2. Same pinning against the connect-time validator: `_resolved_http_connect_ips("grouptalk.c2c.qq.com", 443, "https")` raised `SSRFConnectionBlocked` before, and returns the dialable IP after.

3. Controls, unchanged in both states: `multimedia.nt.qq.com.cn` → `True`; an unrelated host resolving into the same range → `False`.

4. Suites: `scripts/run_tests.sh tests/tools/test_url_safety.py` → 64 passed, 0 failed. `scripts/run_tests.sh tests/gateway/test_qqbot.py` → 63 passed, 0 failed.

   Full suite on macOS: 90 failing tests across 39 files — concentrated in Daytona-sandbox, launchd, git-autostash and whisper/voice suites, in the absence of the optional `hindsight_client_api` dependency, and in some search and worker-timing flakes. 86 of those 90 also fail at the base commit `2ddeba9e17` when the same 39 files are run there (92 failures there); the remaining 4 pass standalone on both this branch and the base. No failing file references `url_safety`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(qqbot): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — this change is the salvage of #47177 (see Provenance)
- [x] My PR contains **only** changes related to this fix/feature (1 commit, 2 files)
- [ ] I've run `pytest tests/ -q` and all tests pass — run; the failures are pre-existing at the base commit or load flakes (see How to Test item 4). The lanes covering this change are green.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2 (arm64)

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing behavior change beyond attachments downloading)
- [x] `cli-config.yaml.example` — N/A (no config keys added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] Cross-platform impact — N/A (one hostname in a data constant; no platform-specific code)
- [x] Tool descriptions/schemas — N/A (no tool behavior change)

## Screenshots / Logs

Reporting log line from #47123, reproduced on current `main` with the resolver pinned to `198.18.2.16`:

```
WARNING tools.url_safety: Blocked request to private/internal address: grouptalk.c2c.qq.com -> 198.18.2.16
```

Probe output after the change (same pinning):

```
preflight  grouptalk.c2c.qq.com  : True
preflight  multimedia.nt.qq.com.cn: True
preflight  unrelated host        : False
connect    grouptalk.c2c.qq.com  : ['198.18.2.16']
```

## Notes

**Open question:** the allowlist is exact-host, so every new QQ attachment host needs its own entry. #47123's own follow-up #2 suggested a config-extendable list. Worth deciding deliberately: a `security.*` key of that kind is writable through `hermes config set`, so it would be agent-settable rather than an operator-only control — the generic trusted-host bypass may be better off staying a code constant.
