### PR TITLE
fix(desktop): stop MEDIA paths swallowing emphasis and truncated spaces

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -477,6 +477,35 @@ describe('renderMediaTags', () => {
 
     expect(text).toBe('ok\n[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3)')
   })
+
+  it('keeps path spaces on a directive that owns its line', () => {
+    expect(renderMediaTags('MEDIA:/Volumes/2TB/Toronto Startup Ecosystem/PLAN-v2-2026-09-10.md')).toBe(
+      '[File: PLAN-v2-2026-09-10.md](#media:%2FVolumes%2F2TB%2FToronto%20Startup%20Ecosystem%2FPLAN-v2-2026-09-10.md)'
+    )
+  })
+
+  it('still stops at the path when prose follows it', () => {
+    expect(renderMediaTags('MEDIA:/tmp/report.md trailing words')).toBe(
+      '[File: report.md](#media:%2Ftmp%2Freport.md) trailing words'
+    )
+  })
+
+  it('drops the emphasis an agent bolds a MEDIA line with', () => {
+    expect(renderMediaTags('**MEDIA:/tmp/report.md**')).toBe('[File: report.md](#media:%2Ftmp%2Freport.md)')
+    expect(renderMediaTags('- **MEDIA:/tmp/report.md**')).toBe('- [File: report.md](#media:%2Ftmp%2Freport.md)')
+    expect(renderMediaTags('__MEDIA:/tmp/report.md__')).toBe('[File: report.md](#media:%2Ftmp%2Freport.md)')
+    expect(renderMediaTags('*MEDIA:/tmp/report.md*')).toBe('[File: report.md](#media:%2Ftmp%2Freport.md)')
+  })
+
+  it('leaves no stray emphasis markers behind the wrapper it strips', () => {
+    expect(renderMediaTags('Two files.\n\n**MEDIA:/tmp/a b/report.md**\n\n## Next')).toBe(
+      'Two files.\n\n[File: report.md](#media:%2Ftmp%2Fa%20b%2Freport.md)\n\n## Next'
+    )
+  })
+
+  it('keeps a quoted path with spaces intact', () => {
+    expect(renderMediaTags('MEDIA:"/tmp/a b/report.md"')).toBe('[File: report.md](#media:%2Ftmp%2Fa%20b%2Freport.md)')
+  })
 })
 
 describe('interleaved reasoning/text boundaries', () => {

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -10,15 +10,53 @@ export function reasoningPart(text: string, timestamp?: number): ChatMessagePart
   return { type: 'reasoning', text, ...(timestamp !== undefined ? { timestamp } : {}) }
 }
 
-const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?[\t ]*(\n|$)/g
+// A MEDIA directive names a real file, and agents write it in two shapes: bare
+// (quoted when the path holds spaces), or wrapped in the emphasis of a bolded
+// attachment list (`**MEDIA:/path/report.md**`). Only the path is literal — the
+// emphasis is markdown decoration, and a path that keeps the closing markers
+// (`/path/report.md**`) exists on no disk: the file card offers a preview and
+// the rail then refuses with "file does not exist". A line whose path-shaped
+// value holds spaces counts whole only when it ends in a file extension, so
+// `MEDIA:/path.md trailing words` still yields `/path.md`.
+const MEDIA_VALUE_ALTERNATIVES = [
+  '`[^`\\n]+`',
+  '"[^"\\n]+"',
+  "'[^'\\n]+'",
+  '(?:\\/|~[\\\\/]|[a-zA-Z]:[\\\\/]|file:)[^\\n]*?[^\\S\\n][^\\n]*?\\.\\w{1,8}',
+  '\\S+'
+]
 
-const MEDIA_TAG_RE = /[`"']?MEDIA:\s*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
+// The bold/italic wrapper around a directive, matched as a pair on one line so
+// the markers leave with it (a leftover `**` would render as literal prose).
+const MEDIA_WRAPPED_RE = /([*_]{1,3}|~{2})(MEDIA:[^\n]*?)\1/g
+
+// A backtick cannot appear inside the template literals below, so the optional
+// quote characters the directive may sit in get their own constant.
+const MEDIA_QUOTES = '["\'`]?'
+
+const MEDIA_LINE_RE = new RegExp(
+  `(^|\\n)[\\t ]*${MEDIA_QUOTES}MEDIA:\\s*(${MEDIA_VALUE_ALTERNATIVES.join('|')})${MEDIA_QUOTES}[\\t ]*(\\n|$)`,
+  'g'
+)
+
+const MEDIA_TAG_RE = new RegExp(`${MEDIA_QUOTES}MEDIA:\\s*(${MEDIA_VALUE_ALTERNATIVES.join('|')})${MEDIA_QUOTES}`, 'g')
+
+const MEDIA_QUOTE_CHARS = ['"', "'", '`']
+
+// A dangling closing run is decoration: no filename ends in `**` or `~~`. A
+// single trailing marker is left alone — an unpaired `*` is more likely to be
+// path text than emphasis.
+const TRAILING_EMPHASIS_RE = /[*_~]{2,3}$/
 
 function unquoteMediaPath(value: string): string {
   const trimmed = value.trim()
   const quote = trimmed[0]
 
-  return quote && quote === trimmed.at(-1) && ['"', "'", '`'].includes(quote) ? trimmed.slice(1, -1) : trimmed
+  if (quote && quote === trimmed.at(-1) && MEDIA_QUOTE_CHARS.includes(quote)) {
+    return trimmed.slice(1, -1)
+  }
+
+  return trimmed.replace(TRAILING_EMPHASIS_RE, '')
 }
 
 function mediaLink(value: string): string {
@@ -29,6 +67,7 @@ function mediaLink(value: string): string {
 
 export function renderMediaTags(text: string): string {
   return text
+    .replace(MEDIA_WRAPPED_RE, (_match, _marker: string, directive: string) => directive)
     .replace(
       MEDIA_LINE_RE,
       (_match, lead: string, value: string, trailer: string) => `${lead}${mediaLink(value)}${trailer}`


### PR DESCRIPTION
## What does this PR do?

Fixes two shapes of `MEDIA:` directive that render a file card pointing at a path no disk has, so the right-rail preview answers **"Preview unavailable — Text preview failed: file does not exist."**

`renderMediaTags` captures a directive's value with a `\S+` fallback, which loses the boundary between the path and the markdown around it:

| Directive an agent wrote | Card path produced | |
|---|---|---|
| `**MEDIA:/reports/README.md**` | `/reports/README.md**` | closing emphasis swallowed into the path |
| `MEDIA:/Volumes/2TB/Toronto Startup Ecosystem/PLAN.md` | `/Volumes/2TB/Toronto` | truncated at the first space |

Both are directive-rendering bugs, not preview-rail bugs — the rail reads exactly the path it is handed, and the same file opens fine when the path is correct. The right fix is in the parser, which is what this does:

- **Unwrap an emphasis wrapper as a pair** before parsing (`**…**`, `__…__`, `*…*`, `~~…~~`), so the markers leave with the directive rather than leaving a stray `**` in the rendered prose.
- **Accept a path-shaped value containing whitespace when it ends in a file extension**, so a directive that owns its line keeps its spaces, while `MEDIA:/path.md trailing words` still yields `/path.md`.
- **Strip a dangling trailing emphasis run** — no filename ends in `**`.

## Related Issue

No existing issue found for this. Happy to file one first if that's preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/chat-messages/parts.ts` — `renderMediaTags` now unwraps an emphasis-wrapped directive, accepts spaced paths ending in an extension, and normalises a trailing emphasis run before building the card link.
- `apps/desktop/src/lib/chat-messages.test.ts` — 8 cases: bold, bullet+bold, italic, `__…__`, no-stray-markers, spaced path, prose following the path, quoted path.

## How to Test

1. In a session where the agent emits `**MEDIA:/absolute/path/report.md**`, click the resulting file card → the right rail renders the markdown instead of "file does not exist".
2. `renderMediaTags('**MEDIA:/tmp/report.md**')` → `[File: report.md](#media:%2Ftmp%2Freport.md)`.
3. `renderMediaTags('MEDIA:/tmp/report.md trailing words')` → `[File: report.md](#media:%2Ftmp%2Freport.md) trailing words` (the spaced-path allowance must not swallow following prose).
4. `npx vitest run src/lib/chat-messages.test.ts` — 80 passed.

Beyond the unit tests, I replayed a real transcript corpus (~40 stored messages carrying MEDIA directives) through the patched parser and checked every resulting card path against the filesystem: paths resolving to real files went **17 → 23**, and every card in the message that produced the original "file does not exist" report now resolves.

## Checklist

- [x] `npx prettier --check` passes on both changed files
- [x] `npx eslint` passes on both changed files
- [x] `npx tsc -p . --noEmit` passes
- [x] `npx vitest run src/lib/chat-messages.test.ts` passes (80)
