### PR TITLE
fix(dashboard): eager session-store reconcile opens read-only to avoid concurrent FTS rebuilds (#107688)

### DIFF
--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -168,17 +168,25 @@ def _resolve_restart_drain_timeout() -> float:
 
 
 def _eager_reconcile_own_session_db() -> None:
-    """One writable open of this process's own state.db at startup.
+    """Bring this process's own state.db schema current at startup.
 
-    ``SessionDB.__init__`` runs ``_init_schema`` → ``_reconcile_columns`` with
-    open-time lock patience. Never raises: an unfixable store still gets the
-    per-poll read-probe heal in :func:`_open_session_db_at_path`.
+    Read-only by default: routing through :func:`_open_session_db_at_path`
+    ensures a healthy store never incurs a gratuitous second writable
+    SessionDB open when the dashboard shares state.db with a running gateway
+    (eliminating the concurrent-FTS-rebuild corruption vector documented in
+    #93200 / #107688). If the store is missing or behind on schema, the
+    read-only opener transparently bootstraps or heals via one guarded
+    writable open before returning the read-only handle.
+    Never raises: an unfixable store still gets the per-poll read-probe heal
+    in :func:`_open_session_db_at_path`.
     """
     try:
+        from pathlib import Path
         from hermes_state import _default_db_path
-        from hermes_state_registry import acquire, release_or_close
+        from hermes_cli.web_server_sessions import _open_session_db_at_path
+        from hermes_state_registry import release_or_close
 
-        db = acquire(Path(_default_db_path()))
+        db = _open_session_db_at_path(Path(_default_db_path()), read_only=True)
         release_or_close(db)
     except Exception as exc:
         _log.warning(

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -581,6 +581,74 @@ class TestWebServerEndpoints:
         # Must swallow — reads fall back to the per-poll probe heal.
         _web_server_lifecycle._eager_reconcile_own_session_db()
 
+    def test_startup_eager_reconcile_opens_read_only_and_closes_handle(self, monkeypatch):
+        """A healthy store must NOT get a gratuitous second writable SessionDB open.
+
+        Regression for #107688 (concurrent-FTS-rebuild corruption vector): the
+        dashboard's startup reconcile previously called unconditional writable
+        ``acquire()`` on `state.db`, creating a second writable SessionDB owner
+        alongside the running gateway. It now routes through read-only
+        ``_open_session_db_at_path(..., read_only=True)`` and explicitly closes
+        the handle via ``release_or_close(db)`` to prevent file descriptor leaks.
+        """
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        import hermes_state
+        import hermes_state_registry
+        import hermes_cli.web_server_sessions as _web_server_sessions
+
+        open_calls = []
+        closed_handles = []
+
+        fake_db = SimpleNamespace(closed=False, close=lambda: None)
+
+        def fake_open(db_path: Path, *, read_only: bool):
+            open_calls.append((str(db_path), read_only))
+            return fake_db
+
+        def fake_release_or_close(db):
+            closed_handles.append(db)
+
+        monkeypatch.setattr(hermes_state, "_default_db_path", lambda: "/tmp/fake-state.db")
+        monkeypatch.setattr(
+            _web_server_sessions, "_open_session_db_at_path", fake_open,
+        )
+        monkeypatch.setattr(
+            hermes_state_registry, "release_or_close", fake_release_or_close,
+        )
+
+        _web_server_lifecycle._eager_reconcile_own_session_db()
+
+        assert open_calls == [(str(Path("/tmp/fake-state.db")), True)], (
+            "eager reconcile must open state.db read-only on a healthy store"
+        )
+        assert closed_handles == [fake_db], (
+            "eager reconcile must release/close the opened handle to prevent descriptor leaks"
+        )
+
+    def test_startup_eager_reconcile_healthy_db_real_path(self):
+        """Real-path execution of eager reconcile against a healthy state.db."""
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        db_path = get_hermes_home() / "state.db"
+        seed = SessionDB(db_path=db_path)
+        try:
+            seed.create_session("real-reconcile-test", source="cli")
+        finally:
+            seed.close()
+
+        # Must succeed on real database and keep it healthy
+        _web_server_lifecycle._eager_reconcile_own_session_db()
+
+        verify = SessionDB(db_path=db_path, read_only=True)
+        try:
+            rows = verify.list_sessions_rich(limit=5, compact_rows=True)
+            assert [r["id"] for r in rows] == ["real-reconcile-test"]
+        finally:
+            verify.close()
+
     def test_heal_gives_up_when_reconcile_cannot_fix_the_store(self, monkeypatch):
         """A probe failure reconciliation can't cure must not retry forever.
 


### PR DESCRIPTION
Fixes #107688.

Canonical implementation on top of current `main` (`2ddeba9e17`); no commits were cherry-picked or taken from other PRs.

### Summary & Root Cause
The headless dashboard (`hermes dashboard --isolated`, `hermes-dashboard.service`) runs `_eager_reconcile_own_session_db()` at startup in a daemon thread to bring `state.db` current before the first session-list poll (#79531 / #80037). Previously, it called unconditional writable `acquire(Path(_default_db_path()))`.

When the dashboard shares `state.db` with a running gateway service, this creates a second concurrent writable `SessionDB` owner on one database. In `SessionDB.__init__`, `_init_schema` -> `_init_fts` executes and can fire a full FTS5 rebuild or drop triggers when missing/stale triggers are detected — the exact concurrent-rebuild condition documented in `hermes_state_common.py` and PR #93200 as structurally corrupting `state.db` in production (#89293, #90950). Furthermore, releasing the sole acquired reference in the dashboard process invoked an immediate `PRAGMA wal_checkpoint(PASSIVE)` against the gateway's active WAL.

### Solution
Route the startup eager reconcile through `_open_session_db_at_path(Path(_default_db_path()), read_only=True)` and explicitly close the returned handle via `release_or_close(db)`:
1. **Zero unnecessary writes on healthy stores:** `_open_session_db_at_path(..., read_only=True)` opens read-only and probes the schema via `_session_db_read_probe_statements()`. On healthy databases, no write lock is taken, no FTS rebuilds fire, and no close-time WAL checkpoints run.
2. **Preserved self-healing & bootstrap:** If the store is missing/zero-byte or has a stale/malformed schema, `_open_session_db_at_path` automatically performs its guarded one-time writable bootstrap/heal before returning the read-only handle.
3. **No file descriptor leaks:** Explicitly passing `db` to `release_or_close(db)` guarantees that the connection is immediately closed and file handles are released (unlike omitting teardown which leaks connections until GC).

### Verification
- `python scripts/run_tests_parallel.py tests/hermes_cli/test_web_server.py -k "reconcile or read_only"`: 5 passed (100%)
- `python scripts/run_tests_parallel.py tests/hermes_cli/test_web_server.py`: 185 passed, 0 failed
- `git diff --check`: clean
- `scripts/check_compat_pointers.py`: verified zero in-tree dependencies on compat pointers
