### PR TITLE
fix(cli): keep gateway restart alive when the installed unit is read-only

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2966,7 +2966,14 @@ def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
     if _refuse_temp_home_service_write(new_unit, "systemd unit"):
         return False
 
-    unit_path.write_text(new_unit, encoding="utf-8")
+    # An externally managed unit (Home Manager/Nix symlink into a read-only store) makes the write fail;
+    # the restart/install that only wanted a current definition must still proceed with the installed unit (#107727).
+    try:
+        unit_path.write_text(new_unit, encoding="utf-8")
+    except OSError as e:
+        print(f"⚠ Could not refresh the gateway {_service_scope_label(system)} unit at {unit_path}: {e}")
+        print("  Continuing with the installed unit definition — it may be managed by an external tool.")
+        return False
     _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
     print(f"↻ Updated gateway {_service_scope_label(system)} service definition to match the current Hermes install")
     return True

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -141,6 +141,52 @@ class TestSystemdServiceRefresh:
             "daemon-reload" in str(c) for c in ran
         ), "daemon-reload must not run when write was refused"
 
+    def test_refresh_survives_readonly_unit_and_skips_reload(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A non-writable installed unit (Home Manager/Nix symlink into a
+        read-only store, #107727) must not crash ``gateway restart``: warn,
+        leave the installed unit untouched, skip daemon-reload, and report
+        the refresh as not performed.
+        """
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text("old unit\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "generate_systemd_unit",
+            lambda system=False, run_as_user=None: (
+                "[Service]\nExecStart=/nix/store/fhs-wrapper hermes serve\n"
+            ),
+        )
+
+        ran = []
+
+        def fake_run(cmd, check=True, **kwargs):
+            ran.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        def readonly_write(self, data, encoding=None):
+            raise OSError(30, "Read-only file system")
+
+        monkeypatch.setattr(gateway_cli.Path, "write_text", readonly_write)
+
+        result = gateway_cli.refresh_systemd_unit_if_needed(system=False)
+
+        assert result is False, "a failed refresh must report False, not crash"
+        assert (
+            unit_path.read_text(encoding="utf-8") == "old unit\n"
+        ), "installed unit must be left untouched"
+        assert not any(
+            "daemon-reload" in str(c) for c in ran
+        ), "daemon-reload must not run when the write failed"
+        assert "Could not refresh" in capsys.readouterr().out
+
 
 
 class TestTempHomeServiceDefinitionGuard:


### PR DESCRIPTION
## What does this PR do?

`refresh_systemd_unit_if_needed()` unconditionally rewrote the installed systemd user unit with `unit_path.write_text()`. On NixOS / Home Manager installs the unit is a symlink into the read-only Nix store, and the installed `ExecStart` intentionally differs from `generate_systemd_unit()` (e.g. an FHS wrapper), so every `hermes gateway restart` crashed with `OSError: [Errno 30] Read-only file system` before ever reaching `systemctl restart` (#107727).

This wraps the unit write in a targeted `except OSError`: print a warning naming the unit path and the cause, leave the installed definition untouched, skip `daemon-reload`, and return `False` (the existing "not refreshed" signal), so the restart proceeds with the installed unit. This matches the gateway boot path, which already wraps the same refresh in a best-effort `except Exception`.

The install path (`gateway install` writing a brand-new unit) is deliberately left fail-loud — an explicit install that cannot write its unit file should surface the error.

## Related Issue

Fixes #107727

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: catch `OSError` around the unit write in `refresh_systemd_unit_if_needed()`; warn and return `False` so `systemd_restart()` (and the other callers) proceed with the installed unit.
- `tests/hermes_cli/test_gateway_service.py`: regression test — a read-only unit write must not raise, must leave the installed unit untouched, must skip `daemon-reload`, and must report `False`.

## How to Test

1. `python -m pytest tests/hermes_cli/test_gateway_service.py::TestSystemdServiceRefresh -q` → 3 passed (includes the new `test_refresh_survives_readonly_unit_and_skips_reload`).
2. Red check: reverting only the `hermes_cli/gateway.py` hunk makes the new test fail with `OSError` escaping the refresh, confirming it locks the fix.
3. Full gateway suites: `python -m pytest tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_linger.py -q` → 161 passed, 4 skipped.
4. Observed result: with the fix, a simulated read-only unit (`OSError(30, "Read-only file system")` on write) produces the `⚠ Could not refresh ... Continuing with the installed unit definition` warning and `refresh_systemd_unit_if_needed()` returns `False` instead of raising.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the failing path is Linux/systemd-specific and is exercised via the unit test's simulated read-only write

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
