### PR TITLE
fix: update dangling references to removed ocr-and-documents skill

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2471,7 +2471,7 @@ def _build_document_context_note(
         f"[The user sent a document: '{display_name}'. It is saved at: {agent_path}. "
         f"Its text is not inlined here (it's a binary format such as PDF or DOCX). "
         f"To read it, extract the document's text yourself — for example with the "
-        f"terminal tool or the ocr-and-documents skill — before answering, instead "
+        f"terminal tool or the pdf skill's OCR support — before answering, instead "
         f"of asking the user to paste the contents.]")
 
 

--- a/tests/tools/test_read_extract.py
+++ b/tests/tools/test_read_extract.py
@@ -743,7 +743,7 @@ class TestPdfCoverageNote(unittest.TestCase):
         self.assertIn("pages 4-9", note)        # contiguous empty gap
         self.assertIn("(6 pages)", note)        # gap size stated
         self.assertIn("vision_analyze", note)   # recovery path is named
-        self.assertIn("ocr-and-documents", note)
+        self.assertIn("pdf skill", note)   # ocr-and-documents was merged into pdf
         self.assertIn("do NOT OCR or render everything", note)
 
     def test_gap_labels_carry_preceding_section_text(self):

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -304,7 +304,7 @@ def _pdf_coverage_note(path: str, display_path: Optional[str] = None) -> str:
         "everything. For the gaps that matter, render just that range with "
         f"`pdftoppm -jpeg -r 150 -f <first> -l <last> '{shown}' /tmp/page` "
         "and inspect each image with the vision_analyze tool, or use the "
-        "ocr-and-documents skill (marker-pdf) for bulk OCR of large "
+        "pdf skill (marker-pdf) for bulk OCR of large "
         "ranges.]\n")
 
 


### PR DESCRIPTION
## Summary

The `ocr-and-documents` skill was absorbed into the `pdf` skill months ago. Two runtime-generated context notes still referenced the removed skill name, silently directing agents to a skill that doesn't exist.

## Changes

| File | Before → After |
|------|---------------|
| `gateway/run.py:2410` | `ocr-and-documents skill` → `pdf skill's OCR support` |
| `tools/read_extract.py:307` | `ocr-and-documents skill (marker-pdf)` → `pdf skill (marker-pdf)` |
| `tests/tools/test_read_extract.py:746` | `assertIn("ocr-and-documents")` → `assertIn("pdf skill")` |

## Verification

```
$ pytest tests/tools/test_read_extract.py -x -q
50 passed, 3 skipped in 3.10s
```

## Scope

This fix targets only **runtime-generated context notes** — the paths that every Hermes user hits when sending documents. The 20+ remaining references to `ocr-and-documents` in website docs, skill READMEs, and CONTRIBUTING.md are documentation-only references and are intentionally left for a separate pass.

Closes #105689

## Signed-off-by

Signed-off-by: Joerg Peetz <j.peetz69@gmail.com>