### PR TITLE
fix(curator): seed the review read-mark store in the fork's context

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1047,6 +1047,17 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         # write guards (external/bundled/hub) fire; turn_context binds this onto
         # the write-origin ContextVar at turn start.
         review_agent._memory_write_origin = "background_review"
+        # Seed the fork's read-mark store in THIS context. Tool calls run in worker
+        # threads that copy the context at submit time, so a mark created lazily
+        # inside a thread is discarded when that call ends: every skill_view →
+        # skill_manage pair was then refused with "the current SKILL.md content has
+        # not been loaded in this review turn" and the whole pass died on the
+        # repeat-failure guardrail. Seeding here makes the copied contexts share one
+        # marks object (the same call background_review.py makes).
+        with contextlib.suppress(Exception):
+            from tools.skill_manager_guards import _reset_background_review_read_marks
+
+            _reset_background_review_read_marks()
         # Silence the fork's tool-call chatter (CLI synchronous foreground runs).
         with open(os.devnull, "w", encoding="utf-8") as devnull, \
              contextlib.redirect_stdout(devnull), contextlib.redirect_stderr(devnull):

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -950,3 +950,103 @@ def test_review_prompt_does_not_steer_terminal_writes():
             "write_file/remove_file instead"
         )
         assert "&& mv" not in text
+
+
+def test_review_fork_read_marks_survive_tool_context_copies(curator_env, monkeypatch):
+    """A skill_view mark must still be visible to a later skill_manage in the fork.
+
+    Tool calls are dispatched through ``propagate_context_to_thread``, which
+    snapshots the context with ``contextvars.copy_context()`` at submit time — so a
+    ContextVar *set* inside the worker is discarded when that call returns. If the
+    fork never seeds the read-mark store in the parent context,
+    ``mark_background_review_skill_read`` lazily creates its own store inside the
+    worker and the write guard's ``_background_review_has_read`` never sees it:
+    every skill_view -> skill_manage pair is refused ("the current SKILL.md content
+    has not been loaded in this review turn"), the fork retries the same write, and
+    the pass dies on the repeat-failure guardrail without consolidating anything.
+    Seed via ``_reset_background_review_read_marks()`` before the fork's
+    conversation starts — the same call agent/background_review.py already makes.
+    """
+    curator = curator_env["curator"]
+
+    # curator_env stubs _run_llm_review wholesale; reload to get the real one.
+    import importlib
+
+    importlib.reload(curator)
+
+    from concurrent.futures import ThreadPoolExecutor
+
+    from tools.skill_manager_guards import (
+        _background_review_has_read,
+        mark_background_review_skill_read,
+    )
+    from tools.skill_provenance import (
+        BACKGROUND_REVIEW,
+        reset_current_write_origin,
+        set_current_write_origin,
+    )
+    from tools.thread_context import propagate_context_to_thread
+
+    skill_md = curator_env["home"] / "skills" / "demo-skill" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True, exist_ok=True)
+    skill_md.write_text("# demo skill\n", encoding="utf-8")
+    seen = {}
+
+    class _StubAgent:
+        def __init__(self, *args, **kwargs):
+            self._memory_write_origin = "assistant_tool"
+            self._session_messages = []
+
+        def run_conversation(self, user_message=None, **kwargs):
+            # One fork turn: bind the review write origin (turn_context does this
+            # for real), then dispatch two tool calls the way
+            # agent/tool_executor.py does — each in a worker thread whose context
+            # is copied at submit time.
+            token = set_current_write_origin(BACKGROUND_REVIEW)
+            try:
+                with ThreadPoolExecutor(max_workers=1) as pool:
+                    pool.submit(
+                        propagate_context_to_thread(mark_background_review_skill_read),
+                        skill_md,
+                    ).result()
+                    seen["has_read"] = pool.submit(
+                        propagate_context_to_thread(_background_review_has_read),
+                        skill_md,
+                    ).result()
+            finally:
+                reset_current_write_origin(token)
+            return {"final_response": "no change"}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"provider": "custom:gateway", "default": "gateway"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"model": {"provider": "custom:gateway", "default": "gateway"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {
+            "provider": "custom",
+            "model": "review-model",
+            "api_key": "test-key",
+            "base_url": "https://gateway.example/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("run_agent.AIAgent", _StubAgent)
+
+    meta = curator._run_llm_review("review prompt")
+
+    assert meta.get("error") is None, meta.get("error")
+    assert seen.get("has_read") is True, (
+        "the fork's read mark did not reach the next tool context, so every "
+        "skill_view -> skill_manage pair is refused with 'the current SKILL.md "
+        "content has not been loaded in this review turn'; seed "
+        "_reset_background_review_read_marks() in the parent context before the "
+        "fork's conversation starts"
+    )


### PR DESCRIPTION
## What does this PR do?

The read-before-write guard (the shared-store design merged in #94511) keeps its
marks in a mutable `_BackgroundReviewReadMarks` object held by a `ContextVar`, and
that store has to be installed on the fork's **own** context. `agent/tool_executor.py`
dispatches every tool call through `propagate_context_to_thread()`, which runs the
call inside `copy_context()` — so a store created lazily inside a worker copy is
discarded the moment that call returns (`ContextVar.set` inside a copied context
never reaches the parent).

`agent/background_review.py` installs the store before its loop starts. The curator
fork (`agent/curator.py::_run_llm_review`) never did. Result: in a curator pass,
`skill_view` records its mark inside a worker copy that is thrown away, the next
`skill_manage` worker sees `None`, and the guard refuses with

```
Refusing background curator patch for skill 'X': the current SKILL.md content has
not been loaded in this review turn. Call skill_view(name) for SKILL.md ...
```

The refusal happens no matter how recently (or how many times) `skill_view` ran,
because the retry lands in a fresh copy too. The fork keeps obeying the guard's
instructions until `same_tool_failure_halt` ends the pass — observed on a live
profile as 46 tool calls (38 `skill_view`, 8 `skill_manage`), all refused, zero
consolidation work done.

This PR seeds the store in the fork's context with the same call the sibling
background-review fork already makes, so the copied worker contexts share one
marks object.

## Related Issue

Refs #63388, #64131 (curator-side refusals), and the same class of store-install
fix as #95449 / #88198 — both of those PRs predate the `skill_manager_guards` split
and no longer apply to `main`, so this is the minimal curator-side seeding rather
than a rebase of either. Distinct from #95976, which is about the `skill_view`
repeat-view dedup stub not marking the read at all (#95993).

Fixes #95976

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/curator.py` — `_run_llm_review()`: install a fresh read-mark store in the
  context the fork's tool calls are dispatched from, mirroring
  `agent/background_review.py`. Placement is per review pass, so marks never leak
  between passes.
- `tests/agent/test_curator.py` — regression test that drives the real
  `_run_llm_review()` with a stub agent whose turn dispatches `skill_view` and
  `skill_manage` through worker threads exactly like the executor does
  (`propagate_context_to_thread` + `ThreadPoolExecutor`), then asserts the write
  sees the mark.

## How to Test

1. `pytest tests/agent/test_curator.py -k read_marks` → passes.
2. Revert the `agent/curator.py` hunk and re-run the same test → it fails with
   `assert False is True` on `has_read`, i.e. it reproduces the reported refusal.
3. Live check on a profile with agent-created skills and
   `curator.consolidate: true`: before the fix, `hermes curator run --consolidate`
   ends in `same_tool_failure_halt` after 8 non-progressing `skill_manage` calls;
   after the fix the same pass archives/absorbs its skill clusters.

## Screenshots / Logs

Without the fix (regression test):

```
E   AssertionError: the fork's read mark did not reach the next tool context, so every
E   skill_view -> skill_manage pair is refused with 'the current SKILL.md content has
E   not been loaded in this review turn'
E   assert False is True
tests/agent/test_curator.py:1046: AssertionError
1 failed, 30 deselected in 0.98s
```

With the fix:

```
$ pytest tests/agent/test_curator.py -q -k read_marks
1 passed, 30 deselected in 1.02s
```

Production log from the failing pass (Hermes 0.21.1, main `6e07eb48`) — 38
`skill_view` + 8 refused `skill_manage` calls, then the guardrail:

```
I stopped retrying skill_manage because it hit the tool-call guardrail
(same_tool_failure_halt) after 8 repeated non-progressing attempts
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see the note under *Related Issue* on #95449 / #88198
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the suites touched by this change: `pytest tests/agent/test_curator*.py tests/tools/test_skill_manager_tool.py -q` → 127 passed. Full `pytest tests/ -q` is running on my host; I'll tick this once it reports.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 7.0.0-31-generic (Ubuntu, Python 3.11.16), editable install of `main` @ `6e07eb48`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (comment in place at the call site)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (stdlib `contextvars` only, no new I/O)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

---

*Diagnosis and patch drafted while dogfooding Hermes Agent on a self-hosted profile
(the failing curator pass and the fix were both observed live on this install).*

