### PR TITLE
fix(providers): stop routing loopback and LAN endpoints through the proxy

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -15,10 +15,9 @@ import socket
 import sys
 import threading
 import time
-import urllib.request
 from typing import Any, Optional
 
-from utils import base_url_hostname, normalize_proxy_url
+from utils import base_url_hostname, base_url_origin, normalize_proxy_url, should_bypass_proxy
 
 
 _OPENAI_CLS_CACHE = None
@@ -293,13 +292,20 @@ def _get_proxy_from_env() -> Optional[str]:
 
 
 def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
-    """Env-configured proxy unless NO_PROXY excludes this base URL."""
+    """Env-configured proxy unless NO_PROXY excludes this base URL.
+
+    Uses the same curl-compatible NO_PROXY matcher as the gateway (exact host, ``.domain`` /
+    ``*.domain`` suffix, IP literal, **CIDR**, ``host:port``, ``*``). urllib's
+    ``proxy_bypass_environment`` — used here before #101803 — understands neither CIDR nor
+    ``*.domain``, so ``NO_PROXY=127.0.0.0/8,192.168.0.0/16`` sent every local/LAN Ollama
+    request to the proxy while curl went direct (instant connect error, reported as
+    ``[Errno 65] No route to host``).
+    """
     proxy = _get_proxy_from_env()
-    host = base_url_hostname(base_url) if proxy and base_url else ""
-    try:
-        return None if host and urllib.request.proxy_bypass_environment(host) else proxy
-    except Exception:
+    if not proxy or not base_url:
         return proxy
+    _, host, port = base_url_origin(base_url)
+    return None if host and should_bypass_proxy(f"{host}:{port}" if port else host) else proxy
 
 
 def _shared_transport_cls():

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -19,7 +19,7 @@ import weakref
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
-from utils import normalize_proxy_url
+from utils import normalize_proxy_url, should_bypass_proxy
 
 logger = logging.getLogger(__name__)
 
@@ -262,71 +262,6 @@ def _detect_macos_system_proxy() -> str | None:
         if props.get(enable_key) == "1" and props.get(host_key) and props.get(port_key):
             return f"http://{props[host_key]}:{props[port_key]}"
     return None
-
-
-def _split_host_port(value: str) -> tuple[str, int | None]:
-    """``(host, port)`` from a URL, ``[v6]:port``, ``host:port`` or bare host; host lowercased."""
-    raw = str(value or "").strip()
-    if not raw:
-        return "", None
-    if "://" in raw:
-        parsed = urlsplit(raw)
-        host, port = parsed.hostname or "", parsed.port
-    elif raw.startswith("[") and "]" in raw:
-        host, _, rest = raw[1:].partition("]")
-        port = int(rest[1:]) if rest.startswith(":") and rest[1:].isdigit() else None
-    elif raw.count(":") == 1 and raw.rpartition(":")[2].isdigit():
-        host, _, port_s = raw.rpartition(":")
-        port = int(port_s)
-    else:
-        host, port = raw.strip("[]"), None
-    return host.lower().rstrip("."), port
-
-
-def _no_proxy_entries() -> list[str]:
-    return [
-        part.strip() for key in ("NO_PROXY", "no_proxy")
-        for part in os.environ.get(key, "").split(",") if part.strip()]
-
-
-def _ip_or_none(value: str, parse=ipaddress.ip_address):
-    """``parse(value)`` or None on ``ValueError`` (``parse`` is ip_address / ip_network)."""
-    try:
-        return parse(value)
-    except ValueError:
-        return None
-
-
-def _no_proxy_entry_matches(entry: str, host: str, port: int | None = None) -> bool:
-    token = str(entry or "").strip().lower()
-    if not token:
-        return False
-    if token == "*":
-        return True
-    token_host, token_port = _split_host_port(token)
-    if not token_host or (token_port is not None and (port is None or token_port != port)):
-        return False
-    host_ip = _ip_or_none(host)
-    network = _ip_or_none(token_host, lambda v: ipaddress.ip_network(v, strict=False))
-    if network is not None:  # CIDR or bare IP literal (a /32 / /128 network)
-        return host_ip is not None and host_ip in network
-    if token_host.startswith("*."):
-        return host.endswith(token_host[1:])
-    if token_host.startswith("."):
-        return host == token_host[1:] or host.endswith(token_host)
-    return host == token_host or host.endswith(f".{token_host}")
-
-
-def should_bypass_proxy(target_hosts: str | list[str] | tuple[str, ...] | set[str] | None) -> bool:
-    """True when NO_PROXY/no_proxy matches at least one target host (exact hosts, domain /
-    wildcard suffixes, IP literals, CIDR ranges, optional host:port entries, ``*``)."""
-    entries = _no_proxy_entries()
-    if not entries or not target_hosts:
-        return False
-    candidates = [target_hosts] if isinstance(target_hosts, str) else list(target_hosts)
-    return any(
-        host and any(_no_proxy_entry_matches(entry, host, port) for entry in entries)
-        for host, port in map(_split_host_port, map(str, candidates)))
 
 
 def resolve_proxy_url(

--- a/tests/agent/test_auxiliary_client_proxy_env.py
+++ b/tests/agent/test_auxiliary_client_proxy_env.py
@@ -55,3 +55,38 @@ def test_get_proxy_for_base_url_respects_no_proxy(monkeypatch):
     assert _get_proxy_for_base_url("https://api.openai.com/v1") == "http://127.0.0.1:7897"
 
 
+def test_get_proxy_for_base_url_honors_cidr_no_proxy(monkeypatch):
+    """CIDR NO_PROXY entries must bypass the proxy, exactly as curl does.
+
+    urllib.request.proxy_bypass_environment() only understands exact hosts, `.domain`
+    suffixes and `*`, so `NO_PROXY=127.0.0.0/8,10.0.0.0/8,192.168.0.0/16` (the shape
+    Clash/v2ray exporters write) silently sent every local/LAN Ollama request to the
+    proxy while curl went direct (#101803).
+    """
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+    monkeypatch.setenv("NO_PROXY", "127.0.0.0/8,10.0.0.0/8,192.168.0.0/16")
+
+    assert _get_proxy_for_base_url("http://127.0.0.1:11434/v1") is None
+    assert _get_proxy_for_base_url("http://192.168.1.50:11434/v1") is None
+    assert _get_proxy_for_base_url("http://10.4.0.9:11434/v1") is None
+    # ...and a real remote host still goes through the proxy.
+    assert _get_proxy_for_base_url("https://api.openai.com/v1") == "http://127.0.0.1:7897"
+
+
+def test_get_proxy_for_base_url_honors_wildcard_and_host_port_entries(monkeypatch):
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:7897")
+    monkeypatch.setenv("NO_PROXY", "*.lan.example,ollama-box:11434")
+
+    assert _get_proxy_for_base_url("http://gpu.lan.example:11434/v1") is None
+    assert _get_proxy_for_base_url("http://ollama-box:11434/v1") is None
+    # A host:port entry is port-specific, and an unrelated host stays proxied.
+    assert _get_proxy_for_base_url("http://ollama-box:9999/v1") == "http://127.0.0.1:7897"
+    assert _get_proxy_for_base_url("https://api.openai.com/v1") == "http://127.0.0.1:7897"
+
+

--- a/tests/agent/test_local_endpoint_proxy_bypass.py
+++ b/tests/agent/test_local_endpoint_proxy_bypass.py
@@ -1,0 +1,129 @@
+"""#101803 — a local/LAN Ollama endpoint must not be routed through an env proxy.
+
+Reported shape: every chat completion to a local or LAN Ollama failed *instantly* with
+``[Errno 65] No route to host`` while ``curl`` to the same endpoint succeeded at the same
+moment. The request was being sent to the proxy host instead of the Ollama box, so the
+failure was a connect error to an (often unreachable) proxy, not an Ollama error — hence
+instant, while curl (which understands the CIDR NO_PROXY entries the reporter had) went
+direct.
+
+These tests drive the real client factory (``build_keepalive_http_client``) against a mock
+Ollama plus a trap proxy, and assert both directions:
+  * local endpoint + NO_PROXY CIDR  -> the mock Ollama is hit, the proxy is never used
+  * remote endpoint + the same env  -> the proxy IS used (unchanged behaviour)
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from agent import process_bootstrap
+from agent.process_bootstrap import build_keepalive_http_client
+
+PROXY_KEYS = ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+              "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy")
+HITS = {"ollama": [], "proxy": []}
+
+
+class _Recorder(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"  # keep-alive: pooled connections persist across calls
+    bucket = ""
+
+    def log_message(self, *_args):
+        pass
+
+    def _reply(self):
+        self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        HITS[self.bucket].append(self.path)
+        body = json.dumps({"via": self.bucket, "choices": [{"message": {"content": "ok"}}],
+                           "usage": {}}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    do_GET = do_POST = _reply
+
+
+def _recorder(bucket):
+    handler = type(f"_{bucket}Recorder", (_Recorder,), {"bucket": bucket})
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    server.daemon_threads = True
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server
+
+
+@pytest.fixture
+def servers():
+    ollama, proxy = _recorder("ollama"), _recorder("proxy")
+    HITS["ollama"].clear()
+    HITS["proxy"].clear()
+    try:
+        yield f"http://127.0.0.1:{ollama.server_address[1]}", f"http://127.0.0.1:{proxy.server_address[1]}"
+    finally:
+        for server in (ollama, proxy):
+            server.shutdown()
+            server.server_close()
+        HITS["ollama"].clear()
+        HITS["proxy"].clear()
+
+
+@pytest.fixture(autouse=True)
+def clean_proxy_env(monkeypatch):
+    for name in PROXY_KEYS:
+        monkeypatch.delenv(name, raising=False)
+    process_bootstrap.close_shared_transports()
+    yield
+    process_bootstrap.close_shared_transports()
+
+
+def _post(base_url, timeout=5.0):
+    client = build_keepalive_http_client(base_url)
+    try:
+        response = client.post(f"{base_url}/v1/chat/completions",
+                               json={"model": "qwen", "messages": [{"role": "user", "content": "hi"}]},
+                               timeout=timeout)
+        return response.json()
+    finally:
+        client.close()
+
+
+def test_local_ollama_bypasses_env_proxy_with_cidr_no_proxy(servers, monkeypatch):
+    ollama, proxy = servers
+    monkeypatch.setenv("HTTP_PROXY", proxy)
+    monkeypatch.setenv("NO_PROXY", "127.0.0.0/8")
+
+    assert _post(ollama)["via"] == "ollama"
+    assert HITS["ollama"], "local Ollama endpoint was not reached directly"
+    assert not HITS["proxy"], f"local request was routed through the proxy: {HITS['proxy']}"
+
+
+def test_lan_ollama_bypasses_env_proxy_with_cidr_no_proxy(servers, monkeypatch):
+    """The LAN half of #101803: decide by policy, the fake box need not be reachable."""
+    _, proxy = servers
+    monkeypatch.setenv("HTTP_PROXY", proxy)
+    monkeypatch.setenv("NO_PROXY", "192.168.0.0/16")
+
+    assert process_bootstrap._get_proxy_for_base_url("http://192.168.1.50:11434/v1") is None
+
+
+def test_remote_endpoint_still_uses_env_proxy(servers, monkeypatch):
+    _, proxy = servers
+    monkeypatch.setenv("HTTP_PROXY", proxy)
+    monkeypatch.setenv("NO_PROXY", "127.0.0.0/8")
+
+    # Unreachable directly — a 200 here can only have come from the proxy.
+    assert _post("http://remote-provider.example:8080")["via"] == "proxy"
+    assert HITS["proxy"], "remote request no longer goes through the env proxy"
+
+
+def test_local_ollama_without_no_proxy_still_uses_env_proxy(servers, monkeypatch):
+    """Unchanged, curl-compatible behaviour: no NO_PROXY entry means the proxy IS used."""
+    ollama, proxy = servers
+    monkeypatch.setenv("HTTP_PROXY", proxy)
+
+    assert _post(ollama)["via"] == "proxy"
+    assert HITS["proxy"] and not HITS["ollama"]

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 """Shared utility functions for hermes-agent."""
 
 import errno
+import ipaddress
 import json
 import logging
 import os
@@ -11,7 +12,7 @@ import time
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, Union
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlsplit
 
 import yaml
 
@@ -489,3 +490,69 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     hostname = base_url_hostname(base_url)
     domain = (domain or "").strip().lower().rstrip(".")
     return bool(hostname and domain) and (hostname == domain or hostname.endswith("." + domain))
+
+
+def split_host_port(value: str) -> tuple[str, int | None]:
+    """``(host, port)`` from a URL, ``[v6]:port``, ``host:port`` or bare host; host lowercased."""
+    raw = str(value or "").strip()
+    if not raw:
+        return "", None
+    if "://" in raw:
+        parsed = urlsplit(raw)
+        host, port = parsed.hostname or "", parsed.port
+    elif raw.startswith("[") and "]" in raw:
+        host, _, rest = raw[1:].partition("]")
+        port = int(rest[1:]) if rest.startswith(":") and rest[1:].isdigit() else None
+    elif raw.count(":") == 1 and raw.rpartition(":")[2].isdigit():
+        host, _, port_s = raw.rpartition(":")
+        port = int(port_s)
+    else:
+        host, port = raw.strip("[]"), None
+    return host.lower().rstrip("."), port
+
+
+def _no_proxy_entries() -> list[str]:
+    return [
+        part.strip() for key in ("NO_PROXY", "no_proxy")
+        for part in os.environ.get(key, "").split(",") if part.strip()
+    ]
+
+
+def _ip_or_none(value: str, parse=ipaddress.ip_address):
+    """``parse(value)`` or None on ``ValueError`` (``parse`` is ip_address / ip_network)."""
+    try:
+        return parse(value)
+    except ValueError:
+        return None
+
+
+def _no_proxy_entry_matches(entry: str, host: str, port: int | None = None) -> bool:
+    token = str(entry or "").strip().lower()
+    if not token:
+        return False
+    if token == "*":
+        return True
+    token_host, token_port = split_host_port(token)
+    if not token_host or (token_port is not None and (port is None or token_port != port)):
+        return False
+    host_ip = _ip_or_none(host)
+    network = _ip_or_none(token_host, lambda v: ipaddress.ip_network(v, strict=False))
+    if network is not None:  # CIDR or bare IP literal (a /32 / /128 network)
+        return host_ip is not None and host_ip in network
+    if token_host.startswith("*."):
+        return host.endswith(token_host[1:])
+    if token_host.startswith("."):
+        return host == token_host[1:] or host.endswith(token_host)
+    return host == token_host or host.endswith(f".{token_host}")
+
+
+def should_bypass_proxy(target_hosts: str | list[str] | tuple[str, ...] | set[str] | None) -> bool:
+    """True when NO_PROXY/no_proxy matches at least one target host (exact hosts, domain /
+    wildcard suffixes, IP literals, CIDR ranges, optional host:port entries, ``*``)."""
+    entries = _no_proxy_entries()
+    if not entries or not target_hosts:
+        return False
+    candidates = [target_hosts] if isinstance(target_hosts, str) else list(target_hosts)
+    return any(
+        host and any(_no_proxy_entry_matches(entry, host, port) for entry in entries)
+        for host, port in map(split_host_port, map(str, candidates)))


### PR DESCRIPTION
## What Problem This Solves

A local or LAN Ollama endpoint was being routed through the environment proxy, so every chat
completion failed **instantly** with a connect error (`[Errno 65] No route to host` /
`WinError 10051`) while `curl` to the same endpoint succeeded at the same moment. The failure was
never Ollama's — the request went to the proxy host, and the proxy host was unreachable, which is
why it returned in ~10 ms instead of timing out.

Root cause: `_get_proxy_for_base_url()` in `agent/process_bootstrap.py` (the proxy policy behind
`build_keepalive_http_client()`, which the OpenAI-SDK chat-completion clients are built on) decided
NO_PROXY membership with `urllib.request.proxy_bypass_environment()`. That matcher understands
only exact hosts, `.domain` suffixes and `*`. It does **not** understand CIDR ranges or `*.domain`
wildcards — but **curl does**, and so does Hermes' own gateway matcher
(`gateway/platforms/base.py:should_bypass_proxy`). With the CIDR-shaped NO_PROXY that Clash/v2ray
exporters write, e.g.

```
HTTP_PROXY=http://192.168.1.9:7890
NO_PROXY=127.0.0.0/8,10.0.0.0/8,192.168.0.0/16
```

curl went direct to Ollama, Hermes went to the proxy. That single mismatch explains every symptom
in the report: instant failure, `curl` working on the same endpoint, local **and** LAN, and both
the OpenAI-SDK client and httpx.

The fix gives the model client the same curl-compatible NO_PROXY matcher the gateway already uses
(moved to `utils.should_bypass_proxy` and imported in both places — one implementation, no
behaviour change for gateway callers). Local and LAN endpoints now bypass the proxy; genuinely
remote hosts still go through it.

## Evidence

Harness (Windows 11, Python 3.11, httpx 0.28.1, curl 8.19.0): a mock Ollama on `127.0.0.1` plus a
"trap" proxy on `127.0.0.1` that records every request it is asked to proxy. The *same* request is
sent through (A) Hermes' real client factory `build_keepalive_http_client()`, (B) the
probe-style `httpx.Client(timeout=2.0)`, (C) `curl`, under identical env.

Before the fix (request destinations, `NO_PROXY=127.0.0.0/8`):

```
=== HTTP_PROXY + NO_PROXY=127.0.0.0/8 (CIDR)
  A hermes build_keepalive_http_client : HTTP 200 {"via":"trap-proxy"} -> TRAP(proxied)
  B httpx.Client(timeout=2.0) probe    : HTTP 200 {"via":"trap-proxy"} -> TRAP(proxied)
  C curl                               : HTTP 200 {"choices":[...]}   -> MOCK(direct)   <- curl works
```

and the exact reported shape — an unroutable egress proxy (the Tailscale/VPN-address-after-drop
case) with that NO_PROXY:

```
== unroutable proxy + NO_PROXY=127.0.0.0/8
  A hermes: ConnectError: [WinError 10051] ... in 0ms        <- instant failure, never arrived
  C curl  : exit=0 {"via":"mock-ollama", ...} in 31ms        <- same endpoint, same moment
```

The LAN half, decided by policy (`base_url=http://192.168.1.50:11434/v1`, `NO_PROXY=192.168.0.0/16`):

```
  A hermes: HTTP 200 {"via":"trap-proxy"}          -> proxied (wrong)
  C curl  : curl: (28) Connection timed out ...    -> tried a DIRECT connect (bypassed)
```

After the fix:

```
=== HTTP_PROXY + NO_PROXY=127.0.0.0/8 (CIDR)
  A hermes build_keepalive_http_client : HTTP 200 {"choices":[...]} -> MOCK(direct)
  C curl                               : HTTP 200 {"choices":[...]} -> MOCK(direct)

== unroutable proxy + NO_PROXY=127.0.0.0/8
  A hermes: HTTP 200 {"via":"mock-ollama", ...} in 297ms    -> MOCK(direct)
  C curl  : exit=0 {"via":"mock-ollama", ...} in 1109ms     -> MOCK(direct)

remote-host direction (base_url=http://remote-provider.example:8080, trap as proxy)
  A hermes: HTTP 200 {"via":"trap-proxy"}    -> still proxied (unchanged)
```

Tests (`HERMES_PYTHON=... bash scripts/run_tests.sh <files>`):

* new `tests/agent/test_local_endpoint_proxy_bypass.py` — real mock Ollama + trap proxy, both
  directions: local/LAN bypass when NO_PROXY has a CIDR entry, remote host still proxied, and
  (pinned, curl-identical) no NO_PROXY entry at all still means proxied.
* extended `tests/agent/test_auxiliary_client_proxy_env.py` — CIDR / `*.domain` / `host:port`
  NO_PROXY entries on `_get_proxy_for_base_url`.
* RED first: 4 failed / 2 passed before the change; GREEN after: 8/8.
* Sabotage check: restoring the old `urllib.request.proxy_bypass_environment` call turns exactly
  those 4 tests red again (the two "unchanged behaviour" tests stay green).
* Related suites: `tests/agent/test_{shared_http_transport,codex_happy_eyeballs,auxiliary_client_ssl_verify,model_metadata,local_endpoint_proxy_bypass,auxiliary_client_proxy_env}.py`,
  `tests/run_agent/test_create_openai_client_{proxy_env,ssl_verify}.py`,
  `tests/gateway/test_{gateway_trust_env,proxy_mode,telegram_network,telegram_closewait_limits_31599,telegram_polling_progress,slack}.py`,
  `tests/tools/test_send_message_telegram_proxy.py`, `tests/test_base_url_hostname.py`,
  `tests/hermes_cli/test_base_url_host_identity.py`, `tests/test_stale_utils_module_import.py`
  → **18 files, 471 passed, 0 failed, 1 skipped**.

## Changed files

* `agent/process_bootstrap.py` — `_get_proxy_for_base_url()` uses `should_bypass_proxy()` with the
  URL's `host:port`; drops the `urllib.request` dependency.
* `utils.py` — the curl-compatible matcher (`split_host_port`, `should_bypass_proxy` + helpers)
  moved here from the gateway so both the model client and the gateway share one implementation.
* `gateway/platforms/base.py` — imports `should_bypass_proxy` from `utils` (same semantics, same
  call sites, no gateway behaviour change).
* tests as listed above.

## Scope / not verified

* `NO_PROXY` *not* containing a curl-only entry (CIDR / `*.domain`) means curl proxies local
  endpoints too — pinned by a test, so this patch deliberately does **not** add a blanket
  "never proxy loopback" rule (curl 8.19 does not do that either).
* Raw `httpx.Client(...)` probe call sites (`agent/model_metadata.py` server-type / num_ctx /
  vision probes) still use httpx's own NO_PROXY parser, which also lacks CIDR support. They are a
  separate code path from chat completions; not touched here.
* `hermes-ollama-native` is not in this repository, so it could not be inspected or tested.
* I could not reproduce the reporter's exact machine. The mechanism above was proven with a local
  mock and matches every symptom (instant error, curl unaffected, local + LAN): the report's own
  premise — curl succeeding where Hermes fails on the same endpoint — requires a NO_PROXY entry
  that curl understands and Hermes did not, i.e. exactly the matcher fixed here. If the environment
  instead resolves the endpoint over IPv6-only or uses another NO_PROXY syntax, please paste the
  output of `env | grep -i proxy` on the affected machine.

Partial fix for #101803 — the closing keyword is intentionally not used here (this PR does not close
the issue): the proxy-matcher mismatch above is proven with a local mock and accounts for every
reported symptom, but the reporter's exact environment could not be reproduced.

