### PR TITLE
fix(providers): send opencode-compatible headers on zen free-tier routes

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1762,11 +1762,23 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # keeps SDK retries because it is NOT wrapped by the conversation loop.
     client_kwargs.setdefault("max_retries", 0)
     _ensure_copilot_headers(client_kwargs)
-    # OpenCode Free is served anonymously: any unrecognized bearer is a 401, so an empty
-    # Authorization default_header overrides the SDK's "Bearer <api_key>".
-    if agent.provider == "opencode-free":
-        from hermes_cli.models import opencode_zen_free_headers
-        client_kwargs["default_headers"] = {**(client_kwargs.get("default_headers") or {}), **opencode_zen_free_headers()}
+    # OpenCode Zen free tier is served anonymously: any bearer the relay doesn't recognize is a
+    # 401, and the canonical Hermes attribution headers get the free tier 429'd
+    # (FreeUsageLimitError), so every keyless route sends the empty-Authorization + OpenCode
+    # fingerprint set. The keyless placeholder — not the provider name — is the identity: a free
+    # slug selected under opencode-zen/opencode-go heals to this same keyless route.
+    try:
+        from hermes_cli.models import (
+            OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER as _zen_free_key,
+            opencode_zen_free_headers as _zen_free_headers,
+        )
+    except Exception:  # a broken catalog module must not break every other provider's client
+        _zen_free_key = None
+        _zen_free_headers = None
+    if _zen_free_headers is not None and (
+            agent.provider == "opencode-free" or client_kwargs.get("api_key") == _zen_free_key):
+        client_kwargs["default_headers"] = {
+            **(client_kwargs.get("default_headers") or {}), **_zen_free_headers()}
     # All primary construction and recovery paths must identify Hermes to the official Codex
     # endpoint, including snapshots with custom header overrides.
     from agent.codex_headers import apply_required_codex_headers

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from typing import TypeGuard
 
 from hermes_cli import __version__ as _HERMES_VERSION
+from hermes_cli.opencode_client_headers import opencode_client_headers
 from hermes_cli.urllib_security import open_credentialed_url
 from hermes_cli.models_catalog_static import (
     CANONICAL_PROVIDERS,
@@ -2020,7 +2021,9 @@ def normalize_opencode_model_id(provider_id: Optional[str], model_id: Optional[s
 # OpenCode Zen free-tier models (``*-free`` slugs plus unsuffixed ones like big-pickle) are
 # served ANONYMOUSLY on the Zen relay: no Authorization header succeeds, while ANY unrecognized
 # non-empty bearer — including our placeholder and OpenCode GO subscription keys — is 401'd (the
-# Go relay doesn't serve the free tier at all).
+# Go relay doesn't serve the free tier at all). The relay also gates the free tier on the request
+# identifying as the OpenCode client: the canonical Hermes attribution headers draw HTTP 429
+# ``FreeUsageLimitError``, the OpenCode fingerprint gets 200 (#106495).
 OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER = "opencode-zen-free-keyless"
 _OPENCODE_ZEN_FREE_BASE_URL = "https://opencode.ai/zen/v1"
 
@@ -2039,18 +2042,17 @@ _OPENCODE_FREE_LIVE_MEMO_TTL = 300.0  # 5 min; SWR disk cache handles the rest
 
 
 def opencode_zen_free_headers() -> dict:
-    """Client default_headers for anonymous Zen free-tier requests. ``Authorization: ""`` overrides the
-    OpenAI SDK's ``Bearer <api_key>`` so the placeholder never reaches the wire (the relay 401s any
-    unknown bearer). Attribution headers mirror the opencode provider profile."""
-    try:
-        from hermes_cli import __version__ as _v
-    except Exception:
-        _v = "0"
-    return {
-        "Authorization": "",
-        "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-        "X-Title": "Hermes Agent",
-        "User-Agent": f"HermesAgent/{_v}"}
+    """Client default_headers for anonymous Zen free-tier requests.
+
+    ``Authorization: ""`` overrides the OpenAI SDK's ``Bearer <api_key>`` so the placeholder never
+    reaches the wire (the relay 401s any unknown bearer). The rest of the set is the OpenCode
+    client fingerprint — the free tier 429s the canonical Hermes attribution headers and answers
+    200 to this identity (#106495); keyed Zen/Go traffic keeps the Hermes attribution, and
+    ``x-opencode-session`` still rides on every OpenCode request via ``agent.opencode_affinity``.
+    """
+    headers = {"Authorization": ""}
+    headers.update(opencode_client_headers())
+    return headers
 
 
 def _fetch_opencode_free_models(

--- a/hermes_cli/opencode_client_headers.py
+++ b/hermes_cli/opencode_client_headers.py
@@ -1,0 +1,38 @@
+"""Request identity of the OpenCode client — shared by every keyless Zen free-tier path.
+
+The Zen relay's free tier (``https://opencode.ai/zen/v1``, served anonymously) answers HTTP 429
+``FreeUsageLimitError`` to requests carrying the canonical Hermes attribution set
+(``User-Agent: HermesAgent/<v>`` + ``HTTP-Referer: https://hermes-agent.nousresearch.com`` +
+``X-Title: Hermes Agent``), while the same model returns 200 when the request looks like the
+OpenCode client (#106495). Keyed Zen/Go traffic keeps the Hermes attribution — only the anonymous
+free tier needs this fingerprint.
+
+Two callers need these values and they must never drift:
+``hermes_cli.models.opencode_zen_free_headers`` (the runtime/client-build owner for keyless routes)
+and the ``opencode-free`` provider profile's ``default_headers``. This module is deliberately
+stdlib-only: model-provider plugin discovery runs *during* ``hermes_cli.models``' own import, so a
+plugin importing ``hermes_cli.models`` at module scope would import a half-built module.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+OPENCODE_CLIENT_USER_AGENT = "opencode/0.20.5"
+OPENCODE_CLIENT_REFERER = "https://opencode.ai/"
+OPENCODE_CLIENT_TITLE = "opencode"
+
+
+def opencode_client_headers() -> dict[str, str]:
+    """The OpenCode client fingerprint, with a fresh opaque session id.
+
+    ``X-Session-ID`` only has to be opaque and stable for the client's lifetime; conversation
+    affinity across main and auxiliary calls stays on ``x-opencode-session``
+    (``agent.opencode_affinity``), which rides on every OpenCode request either way.
+    """
+    return {
+        "HTTP-Referer": OPENCODE_CLIENT_REFERER,
+        "X-Title": OPENCODE_CLIENT_TITLE,
+        "User-Agent": OPENCODE_CLIENT_USER_AGENT,
+        "X-Session-ID": str(uuid.uuid4()),
+    }

--- a/plugins/model-providers/opencode-free/__init__.py
+++ b/plugins/model-providers/opencode-free/__init__.py
@@ -4,11 +4,16 @@ KEYLESS: the relay serves free-tier models anonymously and 401s any bearer it
 doesn't recognize, so this provider never sends a credential (the runtime
 resolver pins the keyless placeholder and an empty Authorization header; see
 hermes_cli.models.opencode_zen_free_runtime). Select via ``/model free``.
+
+The free tier is also gated on the request identifying as the OpenCode client:
+the canonical Hermes attribution headers draw HTTP 429 ``FreeUsageLimitError``,
+the OpenCode fingerprint gets 200 (#106495), so the header set below is that
+fingerprint rather than the Hermes attribution used by keyed zen/go routes.
 """
 
 from typing import Any
 
-from hermes_cli import __version__ as _HERMES_VERSION
+from hermes_cli.opencode_client_headers import opencode_client_headers
 from providers import register_provider
 from providers.base import ProviderProfile
 
@@ -40,16 +45,15 @@ opencode_free = OpenCodeFreeProfile(
     env_vars=(),  # keyless — nothing to configure
     base_url="https://opencode.ai/zen/v1", display_name="OpenCode Free",
     description="OpenCode free models — keyless, no account needed",
-    # Attribution headers (same values as opencode-zen/go) plus the empty Authorization
-    # override that keeps the SDK's "Bearer <placeholder>" off the wire (free tier 401s it).
-    default_headers={
-        "Authorization": "",
-        "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-        "X-Title": "Hermes Agent",
-        "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
-    },
-    # laguna is the fastest non-UA-gated free model; big-pickle 429s every
-    # client except the opencode CLI's own User-Agent.
+    # Attribution-free keyless identity: the empty Authorization override keeps the SDK's
+    # "Bearer <placeholder>" off the wire (the free tier 401s it), and the rest is the OpenCode
+    # client fingerprint the Zen relay's free tier requires instead of the Hermes attribution
+    # headers — which it 429s (FreeUsageLimitError, #106495). Runtime owner of the same set:
+    # hermes_cli.models.opencode_zen_free_headers (both read hermes_cli.opencode_client_headers
+    # so the copies cannot drift).
+    default_headers={"Authorization": "", **opencode_client_headers()},
+    # laguna is the fastest non-UA-gated free model; big-pickle only answers the
+    # opencode CLI's own User-Agent, which the fingerprint above now carries.
     default_aux_model="laguna-s-2.1-free",
 )
 

--- a/tests/hermes_cli/test_opencode_zen_free_keyless.py
+++ b/tests/hermes_cli/test_opencode_zen_free_keyless.py
@@ -63,7 +63,12 @@ class TestFreeRuntime:
     def test_headers_override_sdk_bearer(self):
         headers = opencode_zen_free_headers()
         assert headers["Authorization"] == ""
-        assert headers["X-Title"] == "Hermes Agent"
+        # The free tier 429s the Hermes attribution headers and answers the OpenCode
+        # fingerprint (#106495); keyed zen/go keep the Hermes identity.
+        assert headers["User-Agent"] == "opencode/0.20.5"
+        assert headers["HTTP-Referer"] == "https://opencode.ai/"
+        assert headers["X-Title"] == "opencode"
+        assert headers["X-Session-ID"]
 
 
 class TestRuntimeProviderKeylessRouting:

--- a/tests/run_agent/test_opencode_free_client_headers.py
+++ b/tests/run_agent/test_opencode_free_client_headers.py
@@ -7,8 +7,14 @@ the relay doesn't recognize — placeholders included — is rejected with 401
 
 The client therefore must ship an EMPTY ``Authorization`` default header for
 every opencode-free build, which overrides the OpenAI SDK's always-injected
-``Authorization: Bearer <api_key>`` so no credential-shaped value ever
-reaches the wire.
+``Authorization: Bearer <api_key>`` so no credential-shaped value ever reaches
+the wire.
+
+The free tier is additionally gated on the request identifying as the OpenCode
+client rather than as Hermes (Hermes' canonical attribution headers draw HTTP
+429 ``FreeUsageLimitError``, the OpenCode fingerprint gets 200), so this client
+also carries that fingerprint — see the wire-level guard in
+``test_opencode_zen_free_wire_headers.py`` (#106495).
 """
 from unittest.mock import MagicMock, patch
 
@@ -63,9 +69,9 @@ def test_opencode_free_blanks_authorization_header(mock_openai):
 
 
 @patch("agent.process_bootstrap.OpenAI")
-def test_opencode_free_sends_hermes_attribution(mock_openai):
-    """Keyless requests still identify as Hermes (attribution headers match
-    the opencode zen/go profiles)."""
+def test_opencode_free_sends_opencode_fingerprint(mock_openai):
+    """Keyless requests identify as the OpenCode client, not as Hermes: the relay's free
+    tier 429s (FreeUsageLimitError) the canonical Hermes attribution headers (#106495)."""
     mock_openai.return_value = MagicMock()
     create_openai_client(
         _FakeAgent(api_key="opencode-zen-free-keyless"),
@@ -74,8 +80,29 @@ def test_opencode_free_sends_hermes_attribution(mock_openai):
         shared=False,
     )
     headers = _zen_call_headers(mock_openai)
-    assert headers.get("X-Title") == "Hermes Agent"
-    assert str(headers.get("User-Agent", "")).startswith("HermesAgent/")
+    assert headers.get("X-Title") == "opencode"
+    assert headers.get("User-Agent") == "opencode/0.20.5"
+    assert headers.get("HTTP-Referer") == "https://opencode.ai/"
+    assert headers.get("X-Session-ID")
+    assert not str(headers.get("User-Agent", "")).startswith("HermesAgent/")
+
+
+@patch("agent.process_bootstrap.OpenAI")
+def test_zen_free_model_selected_under_keyed_provider_gets_the_same_fingerprint(mock_openai):
+    """A free slug picked under ``opencode-zen`` heals to the same keyless runtime, so the
+    client build must key the header set off the keyless placeholder, not the provider name."""
+    mock_openai.return_value = MagicMock()
+    agent = _FakeAgent(api_key="opencode-zen-free-keyless")
+    agent.provider = "opencode-zen"
+    create_openai_client(
+        agent,
+        {"api_key": "opencode-zen-free-keyless", "base_url": ZEN_V1},
+        reason="test",
+        shared=False,
+    )
+    headers = _zen_call_headers(mock_openai)
+    assert headers.get("User-Agent") == "opencode/0.20.5"
+    assert headers.get("X-Session-ID")
 
 
 @patch("agent.process_bootstrap.OpenAI")

--- a/tests/run_agent/test_opencode_zen_free_wire_headers.py
+++ b/tests/run_agent/test_opencode_zen_free_wire_headers.py
@@ -1,0 +1,252 @@
+"""Wire-level guard for #106495 — the OpenCode Zen FREE tier must leave Hermes carrying the
+OpenCode client's request fingerprint.
+
+The free tier of the Zen relay (``https://opencode.ai/zen/v1``, served anonymously) rate-limits
+HTTP 429 ``FreeUsageLimitError`` any request that carries the canonical Hermes attribution set
+(``User-Agent: HermesAgent/<v>`` + ``HTTP-Referer: https://hermes-agent.nousresearch.com`` +
+``X-Title: Hermes Agent``), while the very same model answers 200 when the request looks like the
+OpenCode client (``User-Agent: opencode/0.20.5``, ``X-Session-ID: <uuid>``,
+``HTTP-Referer: https://opencode.ai/``, ``X-Title: opencode``).
+
+Evidence shape: a local HTTP mock IS the provider base_url, so every assertion below runs against
+the header set the OpenAI SDK actually puts on the wire — not against the kwargs Hermes intended
+to pass. Both keyless routes are covered (a free model selected under ``opencode-zen``/
+``opencode-go``, which ``opencode_zen_free_runtime`` heals to the Zen relay, and the keyless
+``opencode-free`` provider), and the keyed Zen/Go chains are pinned as unchanged so the
+free-tier fingerprint can never leak into them.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import threading
+from contextlib import contextmanager
+
+import httpx
+import pytest
+
+from agent.agent_runtime_helpers import create_openai_client
+from hermes_cli.models import OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER
+
+# The fingerprint the OpenCode client itself sends and the relay's free tier accepts.
+OC_USER_AGENT = "opencode/0.20.5"
+OC_REFERER = "https://opencode.ai/"
+OC_TITLE = "opencode"
+
+_PROXY_VARS = (
+    "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY",
+    "http_proxy", "https_proxy", "all_proxy",
+)
+
+
+class _Recorder(http.server.BaseHTTPRequestHandler):
+    requests: list = []
+
+    def do_POST(self):  # noqa: N802 — stdlib handler API
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length) if length else b"{}"
+        type(self).requests.append({
+            "path": self.path,
+            "headers": {k.lower(): v for k, v in self.headers.items()},
+            "body": json.loads(body or b"{}"),
+        })
+        payload = json.dumps({
+            "id": "chatcmpl-mock", "object": "chat.completion", "created": 0,
+            "model": "big-pickle",
+            "choices": [{
+                "index": 0, "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "pong"},
+            }],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args):  # keep pytest output clean
+        pass
+
+
+@contextmanager
+def _mock_zen_relay():
+    """Local stand-in for the Zen relay base_url; records every incoming header set."""
+    _Recorder.requests = []
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Recorder)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/v1"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+class _Agent:
+    """Minimal stand-in for the pieces ``create_openai_client`` reads off the agent."""
+
+    def __init__(self, provider: str, api_key: str, base_url: str = ""):
+        self.provider = provider
+        self.api_key = api_key
+        self.base_url = base_url
+        self.model = "big-pickle"
+        self.api_mode = "chat_completions"
+
+    def _client_log_context(self):
+        return {}
+
+    def _build_keepalive_http_client(self, base_url, verify=True):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_proxy(monkeypatch):
+    """The box running the suite may export a proxy; the mock relay is on loopback."""
+    for var in _PROXY_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("NO_PROXY", "127.0.0.1,localhost")
+
+
+def _post(provider, api_key, base_url, *, default_headers=None, extra_headers=None):
+    """Build a real client against the mock relay, POST once, return what the relay saw."""
+    agent = _Agent(provider, api_key, base_url)
+    kwargs = {
+        "api_key": api_key,
+        "base_url": base_url,
+        "http_client": httpx.Client(trust_env=False),
+    }
+    if default_headers:
+        kwargs["default_headers"] = dict(default_headers)
+    client = create_openai_client(agent, kwargs, reason="test", shared=False)
+    try:
+        client.chat.completions.create(
+            model="big-pickle",
+            messages=[{"role": "user", "content": "ping"}],
+            max_tokens=5,
+            extra_headers=extra_headers or None,
+        )
+    finally:
+        client.close()
+    assert _Recorder.requests, "the mock relay never saw a request"
+    return _Recorder.requests[-1]["headers"]
+
+
+def _profile_headers(provider):
+    from providers import get_provider_profile
+
+    profile = get_provider_profile(provider)
+    assert profile is not None, f"provider {provider!r} is not registered"
+    return dict(profile.default_headers or {})
+
+
+def _assert_opencode_fingerprint(headers):
+    assert headers.get("user-agent") == OC_USER_AGENT, headers
+    assert headers.get("http-referer") == OC_REFERER, headers
+    assert headers.get("x-title") == OC_TITLE, headers
+    assert headers.get("x-session-id"), "free tier must identify a session to the relay"
+
+
+def _assert_no_bearer(headers):
+    auth = (headers.get("authorization") or "").lower()
+    assert "bearer" not in auth, f"keyless free tier must not send a credential: {headers}"
+    assert OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER not in auth
+
+
+def _assert_hermes_attribution(headers):
+    assert str(headers.get("user-agent", "")).startswith("HermesAgent/"), headers
+    assert headers.get("x-title") == "Hermes Agent", headers
+    assert "x-session-id" not in headers, "the free-tier fingerprint must not leak here"
+
+
+# ---------------------------------------------------------------------------
+# Keyless free tier — the #106495 repro
+# ---------------------------------------------------------------------------
+
+
+def test_zen_free_model_wire_headers_are_opencode_compatible():
+    """A free slug under ``opencode-zen`` (the reported ``opencode-zen/big-pickle``) routes
+    keylessly through the Zen relay and must carry the OpenCode fingerprint."""
+    with _mock_zen_relay() as base_url:
+        headers = _post("opencode-zen", OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER, base_url)
+    _assert_opencode_fingerprint(headers)
+    _assert_no_bearer(headers)
+
+
+def test_opencode_free_provider_wire_headers_are_opencode_compatible():
+    with _mock_zen_relay() as base_url:
+        headers = _post("opencode-free", OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER, base_url)
+    _assert_opencode_fingerprint(headers)
+    _assert_no_bearer(headers)
+
+
+def test_free_tier_keeps_101864_session_affinity_alongside_fingerprint():
+    """#101864's ``x-opencode-session`` (the MissingSessionID fix) must survive on the same
+    request as the free-tier fingerprint — the two header policies coexist."""
+    with _mock_zen_relay() as base_url:
+        headers = _post(
+            "opencode-free", OPENCODE_ZEN_FREE_KEYLESS_PLACEHOLDER, base_url,
+            extra_headers={"x-opencode-session": "sess-wire-1"},
+        )
+    _assert_opencode_fingerprint(headers)
+    assert headers.get("x-opencode-session") == "sess-wire-1", headers
+
+
+# ---------------------------------------------------------------------------
+# Regression pins — keyed Zen / Go / other providers are untouched
+# ---------------------------------------------------------------------------
+
+
+def test_keyed_zen_still_identifies_as_hermes():
+    with _mock_zen_relay() as base_url:
+        headers = _post(
+            "opencode-zen", "sk-zen-real", base_url,
+            default_headers=_profile_headers("opencode-zen"),
+        )
+    _assert_hermes_attribution(headers)
+
+
+def test_keyed_go_chain_still_identifies_as_hermes():
+    with _mock_zen_relay() as base_url:
+        headers = _post(
+            "opencode-go", "sk-go-real", base_url,
+            default_headers=_profile_headers("opencode-go"),
+        )
+    _assert_hermes_attribution(headers)
+
+
+@pytest.mark.parametrize("provider", ["fireworks", "openrouter", "ai-gateway"])
+def test_non_opencode_provider_still_identifies_as_hermes(provider):
+    with _mock_zen_relay() as base_url:
+        headers = _post(
+            provider, "sk-other-real", base_url,
+            default_headers=_profile_headers(provider),
+        )
+    # Only the opencode-free identity is allowed to say "opencode"; these providers must never
+    # pick up the fingerprint nor lose the headers their own profile declares.
+    assert headers.get("user-agent") != OC_USER_AGENT, headers
+    assert headers.get("x-title") != OC_TITLE, headers
+    assert "x-session-id" not in headers, headers
+
+
+# ---------------------------------------------------------------------------
+# Profile declarations (the "compatible headers profile" itself)
+# ---------------------------------------------------------------------------
+
+
+def test_keyed_profiles_declare_hermes_attribution():
+    for provider in ("opencode-zen", "opencode-go"):
+        headers = _profile_headers(provider)
+        assert headers["User-Agent"].startswith("HermesAgent/"), (provider, headers)
+        assert headers["X-Title"] == "Hermes Agent", (provider, headers)
+
+
+def test_free_profile_declares_opencode_fingerprint():
+    headers = _profile_headers("opencode-free")
+    assert headers["Authorization"] == ""
+    assert headers["User-Agent"] == OC_USER_AGENT, headers
+    assert headers["HTTP-Referer"] == OC_REFERER, headers
+    assert headers["X-Title"] == OC_TITLE, headers
+    assert headers.get("X-Session-ID"), headers


### PR DESCRIPTION
## What Problem This Solves

OpenCode Zen's **free tier** (the anonymous `*-free` slugs plus `big-pickle` on `https://opencode.ai/zen/v1`) answers **HTTP 429 `FreeUsageLimitError`** to any request that carries Hermes' canonical attribution set, and **200** to the very same model when the request looks like the OpenCode client. #101864's `x-opencode-session` fixed the `MissingSessionID` 400 and that fix stands, but the fingerprint half was never done: the free-tier header set Hermes ships is exactly the set the relay rate-limits.

Root cause — the free-tier header set had one owner, and it sent the 429'ing identity:

| Location | What it sent before |
| --- | --- |
| `hermes_cli/models.py:2041` `opencode_zen_free_headers()` | `User-Agent: HermesAgent/<version>`, `HTTP-Referer: https://hermes-agent.nousresearch.com`, `X-Title: Hermes Agent`, `Authorization: ""` |
| `plugins/model-providers/opencode-free/__init__.py:45` (profile `default_headers`, a second copy of the same four values) | same Hermes attribution |
| `agent/agent_runtime_helpers.py:1767` | applied the set only when `agent.provider == "opencode-free"` — so a free slug picked under `opencode-zen`/`opencode-go` (which `opencode_zen_free_runtime` heals onto the same keyless Zen route) could miss it |

Both copies are now sourced from one stdlib-only leaf module, `hermes_cli/opencode_client_headers.py`, so they cannot drift again, and the client-build chokepoint keys off the **keyless placeholder** rather than the provider name, so every keyless route (provider name or healed free slug) gets the same set.

**How it works now — the priority rule, so #101864 and this fix coexist:**

1. **Per-request `x-opencode-session`** (`agent/opencode_affinity.py`) still rides on *every* OpenCode request on every transport — main turn, auxiliary calls, all api modes — for free, Zen and Go alike. This is #101864 and is unchanged.
2. **Client `default_headers` for keyless free-tier routes only** carry the OpenCode fingerprint — `User-Agent: opencode/0.20.5`, `X-Session-ID: <opaque per-client id>`, `HTTP-Referer: https://opencode.ai/`, `X-Title: opencode` — plus the empty `Authorization` that keeps the SDK's `Bearer <placeholder>` off the wire. Existing per-request headers always win the merge, so a caller-pinned value is never overwritten.
3. **Keyed Zen and Go are untouched**: they keep `HermesAgent/<version>` attribution and never receive `X-Session-ID`.

The free tier is anonymous, so nothing is lost by dropping Hermes attribution there; the relay has no dashboard to attribute to, and it 429s that identity.

## Evidence

The guard is **wire-level**, not a kwargs assertion: a local HTTP mock is the provider `base_url`, and the tests assert the header set the OpenAI SDK actually puts on the wire (new file `tests/run_agent/test_opencode_zen_free_wire_headers.py`, 10 tests).

```
$ HERMES_PYTHON=... bash scripts/run_tests.sh tests/run_agent/test_opencode_zen_free_wire_headers.py
```

**1. Red before the fix** (only the new file, on unmodified `main`):

```
FAILED test_zen_free_model_wire_headers_are_opencode_compatible
FAILED test_opencode_free_provider_wire_headers_are_opencode_compatible
FAILED test_free_tier_keeps_101864_session_affinity_alongside_fingerprint
FAILED test_free_profile_declares_opencode_fingerprint
E  - opencode/0.20.5
E  + HermesAgent/0.21.1          # what the mock relay actually received
6 failed, 4 passed
```

**2. Green after the fix:** `1 files, 10 tests passed, 0 failed`.

**3. Sabotage run** — reverting just the fingerprint in `hermes_cli/opencode_client_headers.py` to the pre-fix Hermes values:

```
FAILED test_zen_free_model_wire_headers_are_opencode_compatible
FAILED test_opencode_free_provider_wire_headers_are_opencode_compatible
FAILED test_free_tier_keeps_101864_session_affinity_alongside_fingerprint
FAILED test_free_profile_declares_opencode_fingerprint
4 failed, 6 passed          # the keyed-zen / keyed-go / other-provider pins still pass
```

The keyed Zen, keyed Go, and non-OpenCode provider pins passing *during* sabotage is the point: they prove the free-tier assertion is the only thing the fix moves.

**4. Affected suites** (all green, 162 tests): `test_opencode_zen_free_wire_headers.py`, `test_opencode_free_client_headers.py`, `test_opencode_zen_free_keyless.py`, `test_opencode_free_provider.py`, `test_opencode_session_affinity.py`, `test_provider_attribution_headers.py`, `test_opencode_free_live_catalog.py`, `test_switch_model_reapplies_headers.py`, `test_anthropic_adapter.py`.

**5. Unchanged behaviour is pinned, not assumed:** keyed `opencode-zen`/`opencode-go` profiles must keep `User-Agent: HermesAgent/…` + `X-Title: Hermes Agent` and must not grow `X-Session-ID`; `x-opencode-session` must still appear on the same request as the free-tier fingerprint (asserted on the wire in the same POST).

**6. Live relay probe — run once, and it did NOT reproduce the 429.** One A/B pair against `https://opencode.ai/zen/v1/chat/completions` (`model: big-pickle`, no key, same IP, ~20s apart, exactly the two header sets from the report):

```
A) User-Agent: HermesAgent/0.21.1 + x-opencode-session + hermes referer/title  -> HTTP 200
B) User-Agent: opencode/0.20.5 + X-Session-ID + opencode.ai referer/title      -> HTTP 200
```

Both answered normally, so this box could not reproduce the relay-side 429 for either identity today. The fix therefore rests on the reporter's verified contract (429 for the Hermes set, 200 for the OpenCode set) plus the wire-level regression guard above, not on a locally reproduced failure — the gate looks state/config dependent (free-quota bucket per install/IP, or relaxed since 0.21.1), which is exactly why the header set should match the client the relay expects. If the maintainers' own repro still shows 429 with this build, the remaining variable is outside the header set.

## Verification limits

- The 429 itself was not reproduced from this environment (see item 6); the mock guard proves which headers leave Hermes, not what the relay does with them.
- Only `big-pickle` was probed live; the `*-free` slugs are covered by the same keyless runtime path and the same header set.
- A broad local sweep (`tests/hermes_cli tests/agent tests/run_agent tests/plugins`) reports unrelated failures on this contended Windows box (tempfile `WinError 32` file-in-use during teardown). The same 12 failures reproduce with the three changed source files reverted to `main`, so they are pre-existing/environmental and not from this diff.

## Notes for review

- One behaviour widened deliberately: the keyless header set is now keyed off the keyless placeholder as well as the provider name, so a free slug picked under `opencode-zen`/`opencode-go` gets it. The import of `hermes_cli.models` there sits in the same defensive `try/except` shape the sibling call sites (`agent_init._explicit_client_kwargs`, `auxiliary_client._create_openai_client`) already use, so a broken catalog module can't break every other provider's client build.

## Scope / non-goals

- No change to the Go relay chain, to keyed Zen requests, or to any non-OpenCode provider.
- No change to credential handling: the empty `Authorization` for the keyless placeholder is preserved.
- The auxiliary paths that omit `x-opencode-session` outright (#105132 / #105841 / #105504) are separate and not touched here; the free-tier header set itself is applied centrally (`agent_init`, `agent_runtime_helpers`, `auxiliary_client`), so those calls now carry the fingerprint too.
- Related open PRs #101324 and #105941 target the same relay gate; this one keeps the fix inside the existing single-owner free-tier header set instead of a per-path spoof.

Partial fix for #106495 — the closing keyword is intentionally not used here (this PR does not
close the issue): the header set the issue blames is now the single source of truth and is sent on
every keyless free-tier route, but a live 429 could not be reproduced from this machine (A/B probe
returned HTTP 200 for both header sets), so the relay-side throttling behaviour is unverified.
