### PR TITLE
fix(gateway): surface and log voice auto-transcription failures instead of stalling

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1501,6 +1501,13 @@ platform_toolsets:
 stt:
   enabled: true
   # provider: "local"          # auto-detected if omitted
+  # Hard cap (seconds) on ONE automatic inbound-voice transcription, default 180.
+  # Without it a call that never returns — local whisper wedged in model load / CUDA
+  # init on Windows, a stalled provider socket — leaves the inbound turn (and the
+  # platform's typing indicator) running forever, with no reply and no log. On
+  # timeout the neutral "[voice message could not be transcribed automatically]" note
+  # reaches the agent instead. Raise it for slow first-time model loads on weak GPUs.
+  # timeout_seconds: 180
   # --- Cloud pre-upload silence trim (groq/openai/mistral/xai/elevenlabs/deepinfra) ---
   # Local whisper gets Silero VAD; cloud endpoints otherwise receive raw audio —
   # silence inflates upload time, per-audio-minute billing, and hallucination risk.

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -34,6 +34,25 @@ if TYPE_CHECKING:  # string annotations only; never imported at runtime (cycle)
 # Log-record parity with the origin module.
 logger = logging.getLogger("gateway.run")
 
+# --- Automatic inbound-voice STT bounds (#105315) ---------------------------
+# One automatic transcription is a blocking call off-loaded with ``asyncio.to_thread``. Before
+# this, a call that never returned — local whisper wedged in CUDA init/model load on Windows, a
+# stalled provider socket — kept the inbound turn (and the platform's typing indicator) alive
+# forever with nothing in the logs: the start marker was DEBUG and no branch that emits the
+# neutral "could not be transcribed" note was ever reached. ``stt.timeout_seconds`` overrides.
+_AUTO_STT_TIMEOUT_SECONDS = 180.0
+
+
+def _auto_stt_timeout_seconds() -> float:
+    """Hard cap for ONE automatic inbound-voice STT call (``stt.timeout_seconds``, else 180s)."""
+    try:
+        from tools.transcription_tools import _load_stt_config
+        raw = _load_stt_config().get("timeout_seconds")
+        value = float(raw) if raw is not None else _AUTO_STT_TIMEOUT_SECONDS
+    except Exception:  # noqa: BLE001 - a missing/unparsable value must not remove the bound
+        return _AUTO_STT_TIMEOUT_SECONDS
+    return value if value > 0 else _AUTO_STT_TIMEOUT_SECONDS
+
 
 class GatewayInboundMixin:
     """Inbound message pipeline (_handle_message, text/media preparation, durable-turn markers, plugin injection) for GatewayRunner."""
@@ -1929,16 +1948,53 @@ class GatewayInboundMixin:
         agent_path = to_agent_visible_cache_path(os.path.abspath(path))
         return f"[voice message could not be transcribed automatically; the audio is available at: {agent_path}]"
 
+    async def _bounded_stt_call(
+        self, fn, args: tuple, *, path: str, stage: str, timeout_s: float
+    ) -> Optional[dict]:
+        """Await one blocking STT call off-loop, bounded by *timeout_s*; ``None`` = never returned."""
+        try:
+            return await asyncio.wait_for(asyncio.to_thread(fn, *args), timeout=timeout_s)
+        except asyncio.TimeoutError:
+            # ponytail: wait_for only abandons the future — the worker thread keeps running (usually
+            # wedged in model load / CUDA init) until the process exits, so callers must not stack a
+            # second backend call on top of a timed-out one.
+            logger.error(
+                "Auto-transcription (%s stage) did not return within %.1fs for %s — abandoning this "
+                "clip so the turn is not stuck behind STT; a wedged local model load / CUDA init is "
+                "the usual cause (#105315)", stage, timeout_s, path,
+            )
+            return None
+
     async def _transcribe_one_clip(self, path: str, transcribe_audio, transcribe_audio_local_fallback) -> Tuple[Optional[str], str]:
         """``(transcript_or_None, note)`` for one clip via configured STT with local fallback."""
-        result = await asyncio.to_thread(transcribe_audio, path, None, "gateway")
+        timeout_s = _auto_stt_timeout_seconds()
+        # INFO, not DEBUG: an operator must be able to tell "STT is wedged" from "STT never ran".
+        logger.info("Auto-transcribing inbound voice: %s (timeout %.0fs)", path, timeout_s)
+        try:
+            result = await self._bounded_stt_call(
+                transcribe_audio, (path, None, "gateway"), path=path,
+                stage="configured provider", timeout_s=timeout_s,
+            )
+        except Exception as e:
+            # A *raising* provider used to skip the local fallback entirely (the exception escaped
+            # to the caller's handler); treat it as a failed result so the recovery path still runs.
+            logger.warning("Configured STT raised for %s: %s", path, e)
+            result = {"success": False, "error": str(e)}
+        if result is None:
+            return None, self._untranscribed_audio_note(path)
         if not result.get("success"):
-            fallback = await asyncio.to_thread(transcribe_audio_local_fallback, path)
-            if fallback.get("success"):
+            fallback = await self._bounded_stt_call(
+                transcribe_audio_local_fallback, (path,), path=path,
+                stage="local fallback", timeout_s=timeout_s,
+            )
+            if fallback is not None and fallback.get("success"):
                 logger.info("Configured STT failed for %s; recovered with local STT", path)
                 result = fallback
-        if not result["success"]:
-            logger.info("Voice transcription failed for %s: %s", path, result.get("error", "unknown error"))
+        if result is None or not result.get("success"):
+            logger.warning(
+                "Voice transcription failed for %s: %s", path,
+                "the backend never returned" if result is None else result.get("error", "unknown error"),
+            )
             return None, self._untranscribed_audio_note(path)
         transcript = result["transcript"]
         # STT may return success=True with an empty/whitespace transcript (silence, cut-off);
@@ -1992,7 +2048,7 @@ class GatewayInboundMixin:
                     successful_transcripts.append(transcript)
                 enriched_parts.append(note)
             except Exception as e:
-                logger.error("Transcription error: %s", e)
+                logger.error("Transcription error for %s: %s", path, e, exc_info=True)
                 enriched_parts.append(self._untranscribed_audio_note(path))
 
         if enriched_parts:

--- a/tests/gateway/test_voice_stt_silent_failure_105315.py
+++ b/tests/gateway/test_voice_stt_silent_failure_105315.py
@@ -1,0 +1,148 @@
+"""#105315 — Telegram voice messages cached but never auto-transcribed.
+
+Local repro with fakes only: no Telegram, no real audio, no STT model. The gateway's
+automatic transcription runs as one blocking call off-loaded with
+``asyncio.to_thread``; when that call never returns (the reporter's faster-whisper /
+CUDA hang) the inbound turn — and the platform typing indicator — stays alive
+forever, because:
+
+  * the "transcribing" marker was logged at DEBUG only (default INFO logs show
+    nothing after "Cached user voice"), and
+  * no timeout bounded the call, so every failure branch that would have produced
+    the neutral ``[voice message could not be transcribed automatically; ...]``
+    note was never reached.
+"""
+
+import asyncio
+import logging
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from gateway.run import GatewayRunner  # noqa: E402
+
+
+VOICE = "/tmp/hermes-cache/audio/audio_3f20dbc49b73.ogg"
+
+
+def _runner():
+    runner = object.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(stt_enabled=True, stt_echo_transcripts=True)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_hanging_stt_call_is_bounded_and_marked(monkeypatch, caplog):
+    """A wedged STT call must not stall the turn: bounded, logged, and marked."""
+    runner = _runner()
+    entered = threading.Event()
+    release = threading.Event()
+    fallback_calls = []
+
+    def hanging_transcribe(path, model=None, source=None):
+        entered.set()
+        # The gateway cannot kill the worker thread; bounded so the test process can exit.
+        release.wait(15)
+        return {"success": True, "transcript": "ghost", "provider": "fake"}
+
+    def fallback(path, model=None):
+        fallback_calls.append(path)
+        return {"success": False, "error": "no local backend"}
+
+    monkeypatch.setattr(
+        "gateway.run_inbound._auto_stt_timeout_seconds", lambda: 0.3, raising=False
+    )
+
+    with patch("tools.transcription_tools.transcribe_audio", hanging_transcribe), patch(
+        "tools.transcription_tools.transcribe_audio_local_fallback", fallback
+    ):
+        try:
+            with caplog.at_level(logging.INFO, logger="gateway.run"):
+                enriched, transcripts = await asyncio.wait_for(
+                    runner._enrich_message_with_transcription("", [VOICE]), timeout=8
+                )
+        finally:
+            release.set()
+
+    assert entered.is_set(), "the fake STT call was never entered"
+    assert transcripts == []
+    # The agent still gets a turn: a neutral marker instead of an endless "typing...".
+    assert "could not be transcribed automatically" in enriched
+    # A timed-out backend is abandoned, not stacked behind a second (also wedged) backend.
+    assert fallback_calls == []
+    assert any(
+        record.levelno >= logging.ERROR and "did not return within" in record.getMessage()
+        for record in caplog.records
+    ), [record.getMessage() for record in caplog.records]
+
+
+@pytest.mark.asyncio
+async def test_auto_transcription_start_is_logged_at_info(caplog):
+    """Operators must be able to tell 'STT is wedged' from 'STT never ran'."""
+
+    def ok_transcribe(path, model=None, source=None):
+        return {"success": True, "transcript": "مرحبا", "provider": "fake"}
+
+    with patch("tools.transcription_tools.transcribe_audio", ok_transcribe):
+        with caplog.at_level(logging.INFO, logger="gateway.run"):
+            enriched, transcripts = await asyncio.wait_for(
+                _runner()._enrich_message_with_transcription("", [VOICE]), timeout=8
+            )
+
+    assert transcripts == ["مرحبا"]
+    assert enriched == '"مرحبا"'
+    assert any(
+        record.levelno == logging.INFO
+        and "Auto-transcribing inbound voice" in record.getMessage()
+        and VOICE in record.getMessage()
+        for record in caplog.records
+    ), [record.getMessage() for record in caplog.records]
+
+
+@pytest.mark.asyncio
+async def test_raising_provider_still_recovers_with_local_stt(caplog):
+    """A provider that *raises* must not skip the local recovery path it was designed to have."""
+
+    def raising_transcribe(path, model=None, source=None):
+        raise RuntimeError("cuda lib load failed")
+
+    def local_ok(path, model=None):
+        return {"success": True, "transcript": "hello from local", "provider": "local"}
+
+    with patch("tools.transcription_tools.transcribe_audio", raising_transcribe), patch(
+        "tools.transcription_tools.transcribe_audio_local_fallback", local_ok
+    ):
+        with caplog.at_level(logging.INFO, logger="gateway.run"):
+            enriched, transcripts = await asyncio.wait_for(
+                _runner()._enrich_message_with_transcription("", [VOICE]), timeout=8
+            )
+
+    assert transcripts == ["hello from local"]
+    assert enriched == '"hello from local"'
+    assert not any("could not be transcribed automatically" in record.getMessage() for record in caplog.records)
+
+
+def test_timeout_seconds_reads_config_with_a_safe_default(monkeypatch):
+    """``stt.timeout_seconds`` tunes the bound; a missing/unparsable/zero value keeps the default."""
+    from gateway import run_inbound
+
+    monkeypatch.setattr("tools.transcription_tools._load_stt_config", lambda: {"timeout_seconds": 42})
+    assert run_inbound._auto_stt_timeout_seconds() == 42.0
+
+    monkeypatch.setattr("tools.transcription_tools._load_stt_config", lambda: {"timeout_seconds": "nope"})
+    assert run_inbound._auto_stt_timeout_seconds() == run_inbound._AUTO_STT_TIMEOUT_SECONDS
+
+    monkeypatch.setattr("tools.transcription_tools._load_stt_config", lambda: {"timeout_seconds": 0})
+    assert run_inbound._auto_stt_timeout_seconds() == run_inbound._AUTO_STT_TIMEOUT_SECONDS
+
+    monkeypatch.setattr("tools.transcription_tools._load_stt_config", lambda: {})
+    assert run_inbound._auto_stt_timeout_seconds() == run_inbound._AUTO_STT_TIMEOUT_SECONDS


### PR DESCRIPTION
## What Problem This Solves

Reported in #105315: a Telegram voice note is downloaded and cached, the assistant shows
"typing…" forever, no reply ever arrives, and the gateway logs stop right after
`Cached user voice at …` — nothing at INFO level explains what happened. Manual
transcription of the *same* file from the CLI works in seconds.

The voice actually reaches the automatic STT pipeline (the reporter's `inbound message …
msg=''` line is the voice turn); what it reaches is a path that cannot report failure.
Two independent defects in `gateway/run_inbound.py`:

1. **The automatic STT call had no bound.** `_transcribe_one_clip` awaited
   `asyncio.to_thread(transcribe_audio, path, None, "gateway")` (`gateway/run_inbound.py:1934`
   on `main`) with no timeout, and the same for the local fallback (`:1936`). A backend that
   never returns — local whisper/Faster-Whisper wedged in model load or CUDA init, a stalled
   provider socket — leaves the inbound turn awaiting that future forever. The platform's
   typing task is driven by the *event loop*, which is still healthy, so the loop watchdog
   never fires and the indicator is refreshed indefinitely. Nothing is raised, so the
   `[voice message could not be transcribed automatically; …]` note that every failure branch
   emits was never produced, and no reply was ever generated.

2. **The one log line that would have distinguished "STT is wedged" from "STT never ran"
   was DEBUG.** `logger.debug("Transcribing user voice: %s", path)` (`:1987`) is invisible in
   the reporter's default INFO logs, which is exactly the ambiguity raised in the issue
   thread. The "transcription failed" line (`:1941`) was INFO too, with no traceback, so even
   a fast failure was easy to miss.

A third, smaller defect: `_transcribe_one_clip` only tried the local-STT recovery when the
configured provider *returned* `success=False`. If the provider **raised** (e.g. CUDA libs
failing to dlopen, a network exception), the exception escaped to the caller's handler at
`:1994` and the local fallback the code was written to provide never ran.

### The fix

* `_bounded_stt_call` (new) awaits each blocking STT call off-loop under
  `asyncio.wait_for(..., timeout=stt.timeout_seconds)`, default **180s**, and logs an explicit
  `ERROR` naming the stage, the timeout and the file ("…did not return within 180.0s … a wedged
  local model load / CUDA init is the usual cause"). On timeout the clip gets the existing
  neutral `_untranscribed_audio_note` marker, so the agent still gets a turn and the user gets a
  reply instead of an endless typing indicator.
* A timed-out backend is **not** retried through the second backend: `wait_for` can only abandon
  the future, not the worker thread, so stacking the local fallback on top would just pile a
  second wedged call behind the first (and, with the local provider configured, behind the same
  model lock).
* The start of automatic transcription is now logged at **INFO**
  (`Auto-transcribing inbound voice: <path> (timeout 180s)`), and the final failure line at
  **WARNING** — so an operator can tell "wedged" from "never called" from a default log.
* A raising configured provider is now treated as a failed result (`WARNING "Configured STT
  raised for …"`) and the local fallback still runs, i.e. the recovery path actually recovers.
* The caller's unexpected-error handler logs the path and a traceback
  (`Transcription error for <path>: …`, `exc_info=True`).
* The bound is configurable via `stt.timeout_seconds` (documented in `cli-config.yaml.example`)
  for slow first-time model loads on weak GPUs; missing/unparsable/zero values keep the 180s
  default.

**Partial fix for #105315** — the closing keyword is intentionally not used here (this PR does not close issue #105315): the gateway-side
silent stall is fixed and reproduced locally, but the reporter's *wedged Faster-Whisper/CUDA
call itself* needs their Windows/GTX 1650 Ti host to confirm (see the evidence boundary). What
this PR guarantees on any host: the turn can no longer hang behind STT unnoticed, and the logs
now say which stage wedged.

## Evidence

No Telegram, no real audio, no STT model: the fake download/STT fixtures drive
`GatewayRunner._enrich_message_with_transcription` (the single choke point every automatic
inbound-voice path routes through — the pending/interrupt `_transcribe_and_echo_pending_voice`
and the dispatch-time `_enrich_inbound_voice` both end here).

New test file `tests/gateway/test_voice_stt_silent_failure_105315.py`, run with
`HERMES_PYTHON=… bash scripts/run_tests.sh tests/gateway/test_voice_stt_silent_failure_105315.py`
(and directly per-file with the repo venv):

* RED before the change — 3 failed in 9.22s:
  * `test_hanging_stt_call_is_bounded_and_marked` → `asyncio.exceptions.TimeoutError` from the
    test's own 8s guard: a fake `transcribe_audio` that blocks forever (the stand-in for the
    wedged CUDA call) means `_enrich_message_with_transcription` **never returns** — the
    typing-forever stall, reproduced without a GPU.
  * `test_auto_transcription_start_is_logged_at_info` → captured records `[]`: nothing at INFO.
  * `test_raising_provider_still_recovers_with_local_stt` → recorded
    `ERROR gateway.run:run_inbound.py:1995 Transcription error: cuda lib load failed` and an
    empty transcript list: the exception skipped the local fallback.
* GREEN after the change — 4 passed in 2.23s (3 stall/log/recovery tests + the
  `stt.timeout_seconds` parsing test); the 3 behaviour tests alone went from
  `3 failed in 9.22s` to `3 passed in 1.44s` — the same hang now costs one bounded wait and
  yields the neutral marker instead of an 8s test timeout.
* Sabotage verification (each fix piece reverted in isolation, restored file confirmed
  byte-identical afterwards):
  * drop `timeout=timeout_s` → `test_hanging_stt_call_is_bounded_and_marked` FAILED
    (1 failed, 2 passed)
  * re-raise instead of falling back → `test_raising_provider_still_recovers_with_local_stt`
    FAILED (1 failed, 2 passed)
  * log the start marker at DEBUG again → `test_auto_transcription_start_is_logged_at_info`
    FAILED (1 failed, 2 passed)
* Related suites green (per-file subprocesses, repo venv, `TZ=UTC PYTHONHASHSEED=0`):
  `tests/gateway/test_telegram_voice_v0_regressions.py` 3 passed,
  `tests/gateway/test_telegram_audio_vs_voice.py` 2 passed, `tests/gateway/test_stt_config.py`
  4 passed, `tests/gateway/test_stt_transcript_echo_config.py` 2 passed,
  `tests/gateway/test_mixed_attachment_routing.py` 4 passed,
  `tests/gateway/test_feishu_voice_message_type.py` 1 passed,
  `tests/gateway/test_busy_session_ack.py` 11 passed,
  `tests/gateway/test_run_progress_interrupt.py` 3 passed,
  `tests/gateway/relay/test_wire_voice_media.py` 19 passed,
  `tests/gateway/relay/test_relay_media.py` 8 passed, `tests/tools/test_transcription.py`
  16 passed, `tests/tools/test_stt_idle_unload.py` 17 passed,
  `tests/gateway/test_voice_command.py` 70 passed, 7 skipped (one PCM→WAV test hit its own 10s
  ffmpeg subprocess timeout on a cold ffmpeg start in the first run; the whole file passes in
  21.54s on the warm re-run and the test is unrelated to this change).

**Evidence boundary.** The machine used here has **no NVIDIA GPU**, so no claim is made about
running Faster-Whisper/large-v3-turbo, CUDA init or any real STT model — the wedged call is
simulated with a blocking fake. What *is* proved locally is the gateway behaviour: with an STT
backend that never returns, `main` produces zero diagnostics, zero user-visible output and an
inbound turn that never completes; with this change the turn completes, the failure is logged at
ERROR with the stage that wedged, and the user still gets a reply. Confirming *why* the
reporter's local model hangs (and that 180s is the right cap for a 4GB GTX 1650 Ti cold load)
still needs their host; `stt.timeout_seconds` exists to tune that without a code change.
