### PR TITLE
fix(desktop): expose profile-scoped Kanban tools beside the board toggle

### DIFF
--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -70,21 +70,12 @@ import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
 import { EmbeddedHubPicker } from './embedded-hub-picker'
 import { McpTab } from './mcp-tab'
 import { PluginsTab } from './plugins-tab'
-import { $skillsSortDesc, $toolsetsSortDesc } from './store'
+import { $skillsSortDesc, $toolsetsSortDesc, SKILLS_QUERY_KEY, TOOLSETS_QUERY_KEY } from './store'
 
 // 'hub' is gone as a top-level tab — the Skills Hub browser lives inside the
 // Skills tab now (EmbeddedHubPicker below the installed list). Legacy
 // `?tab=hub` links fall back to 'skills' via useRouteEnumParam.
 const SKILLS_MODES = ['skills', 'toolsets', 'mcp', 'plugins'] as const
-
-// Skills + toolsets live in the RQ cache so switching tabs/pages paints the
-// cached lists instantly (no reload flash) and mount only fires a deduped
-// background refetch. A profile swap globally invalidates (see store/profile),
-// so these plain keys refetch against the new backend automatically.
-// Both are extended with the Capabilities scope key at the call sites so every
-// scoped profile keeps its own cached copy (prefix invalidations still match).
-const SKILLS_QUERY_KEY = ['skills-list'] as const
-const TOOLSETS_QUERY_KEY = ['toolsets-list'] as const
 
 // Per-tool call counts come from a 365-day message scan — heavy, and purely
 // cosmetic (Toolsets usage badges). Cache the result module-wide with a TTL so

--- a/apps/desktop/src/app/skills/kanban-toolset-control.tsx
+++ b/apps/desktop/src/app/skills/kanban-toolset-control.tsx
@@ -1,0 +1,124 @@
+import { useMutation, useQuery } from '@tanstack/react-query'
+
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
+import { Switch } from '@/components/ui/switch'
+import { Tip } from '@/components/ui/tooltip'
+import {
+  getApiRequestConnection,
+  getApiRequestProfile,
+  getToolsets,
+  type ProfileScope,
+  profileScopeKey,
+  setToolsetEnabled
+} from '@/hermes'
+import { useI18n } from '@/i18n'
+import { queryClient } from '@/lib/query-client'
+import { notify, notifyError } from '@/store/notifications'
+import type { ToolsetInfo } from '@/types/hermes'
+
+import { SKILLS_QUERY_KEY, TOOLSETS_QUERY_KEY } from './store'
+
+/** The built-in board has no installable agent-plugin half: its tools use the
+ * existing per-profile tool configurator. The Desktop switch stays UI-only. */
+export function KanbanToolsetControl({ profile, scopeLabel }: { profile: ProfileScope; scopeLabel: string }) {
+  const { t } = useI18n()
+  const p = t.skills.plugins
+  const scopeKey = profileScopeKey(profile)
+
+  const query = useQuery(
+    {
+      queryKey: [...TOOLSETS_QUERY_KEY, scopeKey],
+      queryFn: () => getToolsets(profile),
+      retry: false,
+      staleTime: 0
+    },
+    queryClient
+  )
+
+  const row = query.data?.find(toolset => toolset.name === 'kanban')
+
+  const mutation = useMutation(
+    {
+      mutationFn: async (input: { enabled: boolean; profile: ProfileScope; scopeKey: string; label: string }) => {
+        const result = await setToolsetEnabled('kanban', input.enabled, input.profile)
+
+        if (!result.ok || result.name !== 'kanban' || result.enabled !== input.enabled) {
+          throw new Error(p.toggleFailed('Kanban'))
+        }
+
+        return result
+      },
+      onMutate: async input => {
+        const key = [...TOOLSETS_QUERY_KEY, input.scopeKey]
+        await queryClient.cancelQueries({ queryKey: key, exact: true })
+        const previous = queryClient.getQueryData<ToolsetInfo[]>(key)?.find(item => item.name === 'kanban')
+        queryClient.setQueryData<ToolsetInfo[]>(key, items =>
+          items?.map(item => (item.name === 'kanban' ? { ...item, enabled: input.enabled } : item))
+        )
+
+        return { previous }
+      },
+      onError: (error, input, context) => {
+        const previous = context?.previous
+
+        if (previous) {
+          queryClient.setQueryData<ToolsetInfo[]>([...TOOLSETS_QUERY_KEY, input.scopeKey], items =>
+            items?.map(item => (item.name === 'kanban' ? previous : item))
+          )
+        }
+
+        notifyError(error, p.toggleFailed('Kanban'))
+      },
+      onSuccess: (_result, input) => {
+        notify({ kind: 'success', message: p.kanbanToolsSaved(input.label) })
+      },
+      onSettled: (_data, _error, input) => {
+        // Use the request's identity, never a newly selected foreground profile.
+        void queryClient.invalidateQueries({ queryKey: [...TOOLSETS_QUERY_KEY, input.scopeKey], exact: true })
+        void queryClient.invalidateQueries({ queryKey: [...SKILLS_QUERY_KEY, input.scopeKey], exact: true })
+      }
+    },
+    queryClient
+  )
+
+  const pending = mutation.isPending && mutation.variables?.scopeKey === scopeKey
+  const failed = query.isError
+  const label = `${p.halfAgentIn(scopeLabel)}: Kanban`
+
+  return (
+    <>
+      <Switch
+        aria-label={label}
+        checked={row?.enabled ?? false}
+        disabled={!row || failed || query.isFetching || pending}
+        onCheckedChange={enabled =>
+          mutation.mutate({
+            enabled,
+            // Pin ambient legacy scopes before onMutate yields to the event loop.
+            profile:
+              typeof profile === 'object' && profile
+                ? { ...profile }
+                : {
+                    connectionId: getApiRequestConnection(),
+                    profile: profile === undefined ? getApiRequestProfile() : profile
+                  },
+            scopeKey,
+            label: scopeLabel
+          })
+        }
+      />
+      {failed ? (
+        <Tip label={t.skills.toolsetsRefreshFailed}>
+          <Button aria-label={t.common.retry} onClick={() => void query.refetch()} size="icon-xs" variant="ghost">
+            <Codicon name="refresh" size="0.8rem" />
+          </Button>
+        </Tip>
+      ) : !query.isPending && !row ? (
+        <Tip label={p.kanbanToolsUnavailable}>
+          <span className="text-[0.65rem] text-(--ui-text-tertiary)">{p.kanbanToolsUpdateBackend}</span>
+        </Tip>
+      ) : null}
+    </>
+  )
+}

--- a/apps/desktop/src/app/skills/plugins-tab-kanban.test.tsx
+++ b/apps/desktop/src/app/skills/plugins-tab-kanban.test.tsx
@@ -1,0 +1,146 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+import type * as PluginStore from '@/contrib/plugins-store'
+import { $pluginRecords, setPluginEnabled } from '@/contrib/plugins-store'
+import type * as HermesApi from '@/hermes'
+import { getToolsets, profileScopeKey, setApiRequestConnection, setToolsetEnabled } from '@/hermes'
+import { queryClient } from '@/lib/query-client'
+import { $agentPlugins, $agentPluginsStatus } from '@/store/agent-plugins'
+import { notify, notifyError } from '@/store/notifications'
+import type { ToolsetInfo } from '@/types/hermes'
+
+import { PluginsTab } from './plugins-tab'
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<typeof HermesApi>()),
+  getToolsets: vi.fn(),
+  setToolsetEnabled: vi.fn()
+}))
+vi.mock('@/contrib/plugins-store', async importOriginal => ({
+  ...(await importOriginal<typeof PluginStore>()),
+  setPluginEnabled: vi.fn(async () => undefined)
+}))
+vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
+const requestGateway = vi.fn(async (_method: string, _params?: unknown) => ({ plugins: [] }))
+vi.mock('@/app/gateway/hooks/use-gateway-request', () => ({
+  useGatewayRequest: () => ({ requestGateway })
+}))
+
+const scopeA = { connectionId: 'remote-a', profile: 'planner' }
+const scopeB = { connectionId: 'remote-b', profile: 'planner' }
+
+const kanban = (enabled = false): ToolsetInfo => ({
+  configured: true,
+  description: 'Board tools',
+  enabled,
+  label: 'Kanban',
+  name: 'kanban',
+  tools: ['kanban_create']
+})
+
+const agentSwitch = () => screen.getByRole('switch', { name: 'Agent in planner: Kanban' }) as HTMLButtonElement
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  setApiRequestConnection(scopeA.connectionId)
+  queryClient.clear()
+  $agentPlugins.set([])
+  $agentPluginsStatus.set('ready')
+  $pluginRecords.set({ kanban: { id: 'kanban', name: 'Kanban', kind: 'bundled', status: 'loaded' } })
+  vi.mocked(getToolsets).mockResolvedValue([kanban()])
+  vi.mocked(setToolsetEnabled).mockResolvedValue({ ok: true, name: 'kanban', enabled: true })
+})
+afterEach(() => {
+  cleanup()
+  queryClient.clear()
+  setApiRequestConnection(null)
+})
+
+it.each(['explicit', 'legacy'] as const)(
+  'keeps Desktop separate and binds an in-flight tool grant to its %s scope',
+  async mode => {
+    const profileA = mode === 'legacy' ? scopeA.profile : scopeA
+    let finish!: (value: { ok: boolean; name: string; enabled: boolean }) => void
+    const save = new Promise<{ ok: boolean; name: string; enabled: boolean }>(resolve => {
+      finish = resolve
+    })
+    vi.mocked(setToolsetEnabled).mockReturnValue(save)
+    const { rerender } = render(<PluginsTab profile={profileA} scopeLabel="planner" />)
+    await waitFor(() => expect(agentSwitch().disabled).toBe(false))
+    expect(getToolsets).toHaveBeenCalledWith(profileA)
+    expect(setToolsetEnabled).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('switch', { name: 'Desktop: Kanban' }))
+    expect(setPluginEnabled).toHaveBeenCalledWith('kanban', false)
+    expect(setToolsetEnabled).not.toHaveBeenCalled()
+    fireEvent.click(agentSwitch())
+    setApiRequestConnection(scopeB.connectionId)
+    await waitFor(() => expect(setToolsetEnabled).toHaveBeenCalledWith('kanban', true, scopeA))
+    expect(agentSwitch().getAttribute('aria-checked')).toBe('true')
+    rerender(<PluginsTab profile={scopeB} scopeLabel="planner" />)
+    await waitFor(() => {
+      expect(getToolsets).toHaveBeenCalledWith(scopeB)
+      expect(agentSwitch().getAttribute('aria-checked')).toBe('false')
+      expect(agentSwitch().disabled).toBe(false)
+    })
+    await act(async () => {
+      finish({ ok: true, name: 'kanban', enabled: true })
+      await save
+    })
+    await waitFor(() =>
+      expect(notify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'success',
+          message: expect.stringContaining('Open a new chat')
+        })
+      )
+    )
+    expect(agentSwitch().getAttribute('aria-checked')).toBe('false')
+    expect(queryClient.getQueryData<ToolsetInfo[]>(['toolsets-list', profileScopeKey(scopeB)])?.[0].enabled).toBe(false)
+    expect(setToolsetEnabled).toHaveBeenCalledTimes(1)
+    expect(requestGateway.mock.calls.every(call => call[0] === 'plugins.manage')).toBe(true)
+  }
+)
+
+it.each(['missing', 'read-error', 'write-error', 'invalid-receipt'] as const)(
+  'does not pretend the tools were enabled on %s and leaves the board usable',
+  async mode => {
+    if (mode === 'missing') {
+      vi.mocked(getToolsets).mockResolvedValue([])
+    }
+
+    if (mode === 'read-error') {
+      vi.mocked(getToolsets).mockRejectedValueOnce(new Error('offline'))
+    }
+
+    if (mode === 'write-error') {
+      vi.mocked(setToolsetEnabled).mockRejectedValue(new Error('write denied'))
+    }
+
+    if (mode === 'invalid-receipt') {
+      vi.mocked(setToolsetEnabled).mockResolvedValue({ ok: false, name: 'kanban', enabled: true })
+    }
+    render(<PluginsTab profile={scopeA} scopeLabel="planner" />)
+    expect(screen.getByRole('switch', { name: 'Desktop: Kanban' }).getAttribute('aria-checked')).toBe('true')
+
+    if (mode === 'missing') {
+      await screen.findByText('Update backend')
+      expect(agentSwitch().disabled).toBe(true)
+      expect(setToolsetEnabled).not.toHaveBeenCalled()
+    } else if (mode === 'read-error') {
+      const retry = await screen.findByRole('button', { name: 'Retry' })
+      expect(agentSwitch().disabled).toBe(true)
+      expect(screen.queryByText('Update backend')).toBeNull()
+      fireEvent.click(retry)
+      await waitFor(() => expect(agentSwitch().disabled).toBe(false))
+    } else {
+      await waitFor(() => expect(agentSwitch().disabled).toBe(false))
+      fireEvent.click(agentSwitch())
+      await waitFor(() => expect(notifyError).toHaveBeenCalled())
+      await waitFor(() => expect(agentSwitch().getAttribute('aria-checked')).toBe('false'))
+      expect(notify).not.toHaveBeenCalled()
+    }
+
+    expect(setPluginEnabled).not.toHaveBeenCalled()
+  }
+)

--- a/apps/desktop/src/app/skills/plugins-tab.tsx
+++ b/apps/desktop/src/app/skills/plugins-tab.tsx
@@ -41,6 +41,7 @@ import { PanelEmpty } from '../overlays/panel'
 import { Pill } from '../settings/primitives'
 import { useDeepLinkHighlight } from '../settings/use-deep-link-highlight'
 
+import { KanbanToolsetControl } from './kanban-toolset-control'
 import { mergePluginPackages, type PackageKind, type PluginPackage } from './plugin-packages'
 
 // The REAL Plugin Catalog page (docs site) embedded as a one-click picker —
@@ -218,6 +219,7 @@ function PackageRow({
   pkg,
   scope,
   scopeLabel,
+  toolsetProfile,
   busy,
   onAgentToggle,
   onAgentUpdate
@@ -225,6 +227,7 @@ function PackageRow({
   pkg: PluginPackage
   scope: null | string
   scopeLabel: string
+  toolsetProfile: ProfileScope
   busy: boolean
   onAgentToggle: (row: AgentPluginRow, enable: boolean) => void
   onAgentUpdate: (row: AgentPluginRow) => void
@@ -255,6 +258,11 @@ function PackageRow({
             {agent?.portable && <Pill>{p.portableBadge}</Pill>}
             {desktop?.status === 'error' && <Pill tone="primary">{d.failed}</Pill>}
           </div>
+          {desktop?.id === 'kanban' && (
+            <div className="mt-0.5 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">
+              {p.kanbanToolsHint}
+            </div>
+          )}
           {(desktop?.status === 'error' ? desktop.error : pkg.description) && (
             <div
               className={cn(
@@ -332,6 +340,8 @@ function PackageRow({
               </Tip>
             )}
           </>
+        ) : desktop?.id === 'kanban' ? (
+          <KanbanToolsetControl profile={toolsetProfile} scopeLabel={scopeLabel} />
         ) : pkg.agentMissingInProfile && desktop ? (
           <Tip label={desktop.packageOrigin?.repo ? p.installAgentHereTip(scopeLabel) : p.installAgentHereNoOrigin}>
             <span>
@@ -579,6 +589,7 @@ export const PluginsTab = memo(function PluginsTab({
                 pkg={pkg}
                 scope={scope}
                 scopeLabel={label}
+                toolsetProfile={profile}
               />
             ))}
           </div>

--- a/apps/desktop/src/app/skills/store.ts
+++ b/apps/desktop/src/app/skills/store.ts
@@ -4,3 +4,12 @@ import { Codecs, persistentAtom } from '@/lib/persisted'
 // remembers most/least-used across navigations and restarts.
 export const $skillsSortDesc = persistentAtom('hermes.desktop.capabilities.skillsSortDesc', true, Codecs.bool)
 export const $toolsetsSortDesc = persistentAtom('hermes.desktop.capabilities.toolsetsSortDesc', true, Codecs.bool)
+
+// Skills + toolsets live in the RQ cache so switching tabs/pages paints the
+// cached lists instantly (no reload flash) and mount only fires a deduped
+// background refetch. A profile swap globally invalidates (see store/profile),
+// so these plain keys refetch against the new backend automatically.
+// Both are extended with the Capabilities scope key at the call sites so every
+// scoped profile keeps its own cached copy (prefix invalidations still match).
+export const SKILLS_QUERY_KEY = ['skills-list'] as const
+export const TOOLSETS_QUERY_KEY = ['toolsets-list'] as const

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1115,6 +1115,15 @@ export const ar = defineLocale({
     }
   },
   skills: {
+    plugins: {
+      kanbanToolsHint:
+        'يعرض مفتاح Desktop اللوحة. يمنح مفتاح Agent أدوات Kanban لمحادثات CLI وDesktop لهذا الملف الشخصي، ولا يشغّل موزّع المهام.',
+      kanbanToolsUnavailable:
+        'لا يعرض هذا الخادم Kanban في إعدادات الأدوات. حدّث Hermes على الخادم المحدد لتفعيل أدوات الوكيل من هنا.',
+      kanbanToolsUpdateBackend: 'حدّث الخادم',
+      kanbanToolsSaved: (profile: string) =>
+        `حُفظت إعدادات أدوات Kanban للملف ${profile}. افتح محادثة جديدة لتطبيقها؛ لن تتغير المحادثات الحالية.`
+    },
     tabSkills: 'المهارات',
     tabToolsets: 'مجموعات الأدوات',
     all: 'الكل',
@@ -3060,7 +3069,8 @@ export const ar = defineLocale({
     vaultCodeDesc: site =>
       `يطلب ${site} رمزًا لمرة واحدة (رسالة نصية أو بريد إلكتروني أو تطبيق مصادقة). أدخله هنا وسيكتبه Hermes في الصفحة؛ لا يراه النموذج أبدًا.`,
     vaultCodeLabel: 'الرمز',
-    vaultCodeFootnote: 'تلميح: احفظ مفتاح المصادقة مع بيانات الدخول هذه في الإعدادات ← كلمات المرور وتسجيلات الدخول وسيُدخل Hermes الرموز نيابةً عنك.',
+    vaultCodeFootnote:
+      'تلميح: احفظ مفتاح المصادقة مع بيانات الدخول هذه في الإعدادات ← كلمات المرور وتسجيلات الدخول وسيُدخل Hermes الرموز نيابةً عنك.',
     vaultCodeSkip: 'تخطٍ',
     vaultCodeConfirm: 'إدخال الرمز'
   },

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1586,6 +1586,14 @@ export const en: Translations = {
     skillArchivedMessage: 'Restorable via hermes curator restore.',
     tabPlugins: 'Plugins',
     plugins: {
+      kanbanToolsHint:
+        'The Desktop switch shows the board. The Agent switch grants Kanban tools to this profile’s CLI and Desktop chats; it does not start the dispatcher.',
+      kanbanToolsUnavailable:
+        'This backend does not expose Kanban in the tool configurator. Update Hermes on the selected backend to enable agent tools here.',
+      kanbanToolsUpdateBackend: 'Update backend',
+      kanbanToolsSaved: (profile: string) =>
+        `Kanban tools saved for ${profile}. Open a new chat to apply; existing chats are unchanged.`,
+
       agentTitle: 'Agent plugins',
       agentBlurb:
         'Extend the agent for the selected profile — tools, hooks, providers. Take effect after a gateway restart.',
@@ -3917,7 +3925,8 @@ export const en: Translations = {
     vaultCodeDesc: site =>
       `${site} is asking for a one-time code (text message, email or authenticator app). Enter it here and Hermes types it into the page; the model never sees it.`,
     vaultCodeLabel: 'Code',
-    vaultCodeFootnote: 'Tip: save the authenticator key with this login in Settings → Passwords & Logins and Hermes enters codes for you.',
+    vaultCodeFootnote:
+      'Tip: save the authenticator key with this login in Settings → Passwords & Logins and Hermes enters codes for you.',
     vaultCodeSkip: 'Skip',
     vaultCodeConfirm: 'Enter code'
   },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1405,6 +1405,15 @@ export const ja = defineLocale({
   },
 
   skills: {
+    plugins: {
+      kanbanToolsHint:
+        'Desktop スイッチはボードを表示します。Agent スイッチは、このプロファイルの CLI と Desktop チャットに Kanban ツールを許可します。ディスパッチャーは起動しません。',
+      kanbanToolsUnavailable:
+        'このバックエンドのツール設定には Kanban がありません。選択したバックエンドの Hermes を更新すると、ここでエージェントのツールを有効にできます。',
+      kanbanToolsUpdateBackend: 'バックエンドを更新',
+      kanbanToolsSaved: (profile: string) =>
+        `${profile} の Kanban ツール設定を保存しました。新しいチャットで適用されます。既存のチャットは変更されません。`
+    },
     tabSkills: 'スキル',
     tabToolsets: 'ツールセット',
     tabMcp: 'MCP',
@@ -3462,7 +3471,8 @@ export const ja = defineLocale({
     vaultCodeDesc: site =>
       `${site} がワンタイムコード（SMS、メール、または認証アプリ）を求めています。ここに入力すると Hermes がページに入力します。モデルはコードを一切見ません。`,
     vaultCodeLabel: 'コード',
-    vaultCodeFootnote: 'ヒント：「設定 → パスワードとログイン」でこのログインに認証キーを保存すると、Hermes がコードを自動入力します。',
+    vaultCodeFootnote:
+      'ヒント：「設定 → パスワードとログイン」でこのログインに認証キーを保存すると、Hermes がコードを自動入力します。',
     vaultCodeSkip: 'スキップ',
     vaultCodeConfirm: 'コードを入力'
   },

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -1509,6 +1509,15 @@ export const ru = defineLocale({
     }
   },
   skills: {
+    plugins: {
+      kanbanToolsHint:
+        'Переключатель Desktop показывает доску. Переключатель агента разрешает инструменты Kanban в CLI и Desktop этого профиля; диспетчер при этом не запускается.',
+      kanbanToolsUnavailable:
+        'Этот backend не показывает Kanban в настройках инструментов. Обновите Hermes на выбранном backend, чтобы включить инструменты агента здесь.',
+      kanbanToolsUpdateBackend: 'Обновите backend',
+      kanbanToolsSaved: (profile: string) =>
+        `Инструменты Kanban сохранены для ${profile}. Откройте новый чат для применения; существующие чаты не изменятся.`
+    },
     tabSkills: 'Навыки',
     tabToolsets: 'Инструменты',
     configuringProfile: 'Настраивается:',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1414,6 +1414,10 @@ export interface Translations {
       emptyHint: string
       loadFailed: string
       toggleFailed: (name: string) => string
+      kanbanToolsHint: string
+      kanbanToolsUnavailable: string
+      kanbanToolsUpdateBackend: string
+      kanbanToolsSaved: (profile: string) => string
       legacyBackend: string
       portableBadge: string
       catalogTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1349,6 +1349,14 @@ export const zhHant = defineLocale({
   },
 
   skills: {
+    plugins: {
+      kanbanToolsHint:
+        'Desktop 開關控制看板介面。Agent 開關為此設定檔的 CLI 和 Desktop 聊天啟用 Kanban 工具，不會啟動排程器。',
+      kanbanToolsUnavailable: '此後端的工具設定尚未提供 Kanban。請更新所選後端上的 Hermes，再於此啟用代理工具。',
+      kanbanToolsUpdateBackend: '更新後端',
+      kanbanToolsSaved: (profile: string) =>
+        `已為 ${profile} 儲存 Kanban 工具設定。建立新聊天後生效；現有聊天保持不變。`
+    },
     tabSkills: '技能',
     tabToolsets: '工具集',
     tabMcp: 'MCP',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1754,6 +1754,12 @@ export const zh: Translations = {
     skillArchivedMessage: '可通过 hermes curator restore 恢复。',
     tabPlugins: '插件',
     plugins: {
+      kanbanToolsHint:
+        'Desktop 开关控制看板界面。Agent 开关为此配置的 CLI 和 Desktop 聊天启用 Kanban 工具，不会启动调度器。',
+      kanbanToolsUnavailable: '此后端的工具配置器尚未提供 Kanban。请更新所选后端上的 Hermes，然后在此启用智能体工具。',
+      kanbanToolsUpdateBackend: '更新后端',
+      kanbanToolsSaved: (profile: string) => `已为 ${profile} 保存 Kanban 工具设置。新建聊天后生效；现有聊天保持不变。`,
+
       agentTitle: 'Agent 插件',
       agentBlurb: '为所选配置扩展 agent — 工具、钩子、模型提供方。重启网关后生效。',
       pageBlurb: '每个插件一行。插件可以扩展本应用、agent，或两者 — 每一半都有自己的开关。',


### PR DESCRIPTION
## What does this PR do?

Adds an explicit **Agent** switch to the built-in Kanban row in Capabilities → Plugins, beside its existing **Desktop** switch. Users can grant Kanban tools to the selected profile without editing YAML, while keeping board visibility independent from the agent's permissions.

The Desktop switch remains UI-only. Neither switch starts/stops the dispatcher, changes other profiles, or silently rebuilds an existing chat's tool schema/prompt cache.

## Related issues and companion

Addresses the Desktop portion of #96969; companion backend fix: **#107736**, which exposes Kanban in the normal tool configurator and makes saved platform selections reach the real model schema. Together they address the reported enable-panel-but-agent-has-no-tools flow. Related audit: #107718.

The branches are independent changes against `main`; this UI requires the backend capability provided by #107736 for its Agent switch to operate. Against an older backend whose tool catalog has no Kanban entry, it shows **Update backend** and keeps the board usable instead of pretending the tools were enabled.

Related open PR #101582 couples Desktop enable/disable with toolset configuration. This implementation deliberately keeps separate permissions: hiding the board must not revoke tools from a profile also used in CLI or unattended work.

## Changes made

- Reuse public `getToolsets` / `setToolsetEnabled` and the existing profile-aware tool configuration endpoint; no new endpoint, config key or dependency.
- Show the Agent switch for Kanban's built-in toolset even though there is no installable agent-plugin half.
- Preserve explicit connection + profile identity throughout a write. Legacy ambient scopes are captured before the first asynchronous step; changing the foreground connection cannot retarget the pending grant.
- Reuse shared Tools/Skills query keys; optimistic updates, rollback and invalidation are tied to the request's original scope.
- Validate the save receipt before reporting success. Distinguish an unavailable old-backend catalog from a failed read; failed reads offer Retry, failed writes roll back the switch.
- Explain board-only vs agent-tool behavior, and state that saved tool changes apply to **new chats** rather than silently changing existing conversations.
- Add the four user-facing strings in all six locales and the explicit i18n contract.

## Regression tests and validation

Validated against base `2ddeba9e17a1df5471802481e3efef20885a20b2` with the repository-root lockfile, Node 22.22.0, Ubuntu, and the existing Vitest UI/happy-dom project.

**Before:** the two profile-scope variants of the new interaction test fail because the Kanban Agent control does not exist.

**After:** **44 tests pass across 6 UI test files**, including 6 new cases covering:

- independent Desktop and Agent switches, with no automatic permission write on mount;
- a pending grant while switching between two connections with the same profile name, for both explicit and legacy input scopes;
- missing backend capability, read-error retry, write-error rollback and invalid save receipt;
- no chat-reset or dispatcher action triggered by the control.

The tests mount the real `PluginsTab` and use the existing switches/query client; only public backend/plugin/notification boundaries are mocked. These are renderer interaction tests, not native Electron or live-provider tests.

```bash
# Install from the repository root, not apps/desktop:
npm ci --ignore-scripts
cd apps/desktop
npx tsc -p tsconfig.json --noEmit
npx vitest run --project ui \
  src/app/skills/plugins-tab-kanban.test.tsx \
  src/app/skills/plugins-tab.test.tsx \
  src/app/skills/plugin-packages.test.ts \
  src/app/skills/index.test.tsx \
  src/lib/desktop-toolsets.test.ts \
  src/i18n/languages.test.ts
```

ESLint on all changed TS/TSX files, Prettier formatting, renderer TypeScript checking and `git diff --check` pass. The test log includes React `act(...)` warnings from the neighboring `plugins-tab.test.tsx` cases; no test failures are suppressed.

[Successful validation job, including pre-fix failures and post-fix results](https://github.com/Xipong/hermes-agent/actions/runs/34535485215/job/103065991599). Tested product commit: `27f0244e10ed1c5a8e53485c5f705286605ffb15`.

Validation harness/workflow files stay on a separate branch in the fork and are **not** part of this PR.

## Checklist

- [x] Existing related issue/PR checked; independent-switch design explained.
- [x] Public API and profile/connection scope preserved.
- [x] Focused renderer regression tests and neighboring tests pass.
- [x] Typecheck, lint and diff checks pass; all six locales updated.
- [x] No automatic permission grant, dispatcher startup or existing-chat cache reset.
- [ ] Native Windows/macOS Electron smoke test / visual screenshot (not run).
- [ ] Full repository test suite (not run).