### PR TITLE
fix(process): make systemd scope probe non-FHS portable

### DIFF
--- a/evals/subagent_process_handoff/stress_handoff_live.py
+++ b/evals/subagent_process_handoff/stress_handoff_live.py
@@ -14,7 +14,7 @@ import time
 WORKTREE = os.environ["HERMES_WORKTREE"]
 sys.path.insert(0, WORKTREE)
 import tools.process_registry as pr  # noqa: E402
-pr._SYSTEMD_SCOPE_AVAILABLE = False
+pr._systemd_run_user_scope_available = lambda: False
 from tools.process_registry import process_registry  # noqa: E402
 import tools.async_delegation as ad  # noqa: E402
 from run_agent import AIAgent  # noqa: E402

--- a/tests/cron/test_restart_safe_worker.py
+++ b/tests/cron/test_restart_safe_worker.py
@@ -83,12 +83,123 @@ def test_restart_safe_gateway_child_fails_closed_without_scope(monkeypatch):
 
     monkeypatch.setattr(process_registry, "_is_supervised_gateway_process", lambda: True)
     monkeypatch.setenv("INVOCATION_ID", "managed-service")
-    monkeypatch.setattr(process_registry, "_systemd_run_user_scope_available", lambda: False)
+    monkeypatch.setattr(
+        process_registry, "_systemd_run_user_scope_result",
+        lambda: process_registry._SystemdScopeResult(False, "", False, 0.0),
+    )
 
     with pytest.raises(RuntimeError, match="systemd-run --user --scope is unavailable"):
         process_registry.restart_safe_gateway_child_argv(
             ["python", "worker.py"], unit_suffix="cron-job-1"
         )
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize(
+    "probe_failure,is_bus_failure",
+    [
+        pytest.param(
+            b"Failed to find executable true: No such file or directory",
+            False,
+            id="command-not-found",
+        ),
+        pytest.param(
+            FileNotFoundError(2, "No such file or directory", "/missing/systemd-run"),
+            False,
+            id="probe-exec-failure",
+        ),
+        pytest.param(
+            b"Failed to connect to user bus: No medium found",
+            True,
+            id="user-bus-unavailable",
+        ),
+    ],
+)
+def test_restart_safe_gateway_child_distinguishes_probe_failure_from_user_bus(
+    monkeypatch, probe_failure, is_bus_failure
+):
+    """Cron's persisted error must prescribe linger only for a user-bus failure."""
+    import tools.process_registry as process_registry
+
+    monkeypatch.setattr(process_registry, "_is_supervised_gateway_process", lambda: True)
+    monkeypatch.setenv("INVOCATION_ID", "managed-service")
+    monkeypatch.setattr(process_registry, "_SYSTEMD_SCOPE_RESULT", None)
+    monkeypatch.setattr(
+        "shutil.which", lambda name: "/test/systemd-run" if name == "systemd-run" else None
+    )
+
+    def fail_probe(argv, **kwargs):
+        if isinstance(probe_failure, OSError):
+            raise probe_failure
+        return subprocess.CompletedProcess(
+            argv, 1 if is_bus_failure else 127, stderr=probe_failure
+        )
+
+    probe = Mock(side_effect=fail_probe)
+    monkeypatch.setattr(process_registry.subprocess, "run", probe)
+
+    # The diagnosis must survive caching: a second cron handoff sees the same cause.
+    for _ in range(2):
+        with pytest.raises(RuntimeError) as raised:
+            process_registry.restart_safe_gateway_child_argv(
+                [sys.executable, "worker.py"], unit_suffix="cron-probe-diagnostic"
+            )
+        message = str(raised.value).lower()
+        if is_bus_failure:
+            assert "user" in message and ("bus" in message or "d-bus" in message)
+            assert "loginctl enable-linger" in message
+        else:
+            assert "d-bus" not in message and "user bus" not in message, message
+            assert "linger" not in message, message
+            assert "probe" in message, message
+            assert "execut" in message or "command" in message, message
+    assert probe.call_count == 1
+
+    # Hold a caller's result while another thread expires and refreshes the cache
+    # with the opposite diagnosis. Its error must still use the retained snapshot.
+    from concurrent.futures import ThreadPoolExecutor
+    from dataclasses import FrozenInstanceError
+    import threading
+
+    get_result = process_registry._systemd_run_user_scope_result
+    original = get_result()
+    with pytest.raises(FrozenInstanceError):
+        original.bus_failure = not original.bus_failure
+    captured = threading.Event()
+    release = threading.Event()
+
+    def paused_result():
+        result = get_result()
+        captured.set()
+        assert release.wait(timeout=5)
+        return result
+
+    monkeypatch.setattr(process_registry, "_systemd_run_user_scope_result", paused_result)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        pending = executor.submit(
+            process_registry.restart_safe_gateway_child_argv,
+            [sys.executable, "worker.py"], unit_suffix="cron-refresh-race",
+        )
+        try:
+            assert captured.wait(timeout=5)
+            monkeypatch.setattr(
+                process_registry.time, "monotonic",
+                lambda: original.probed_at + process_registry._SYSTEMD_SCOPE_FAILURE_TTL_SECONDS + 1,
+            )
+            probe.side_effect = lambda argv, **kwargs: subprocess.CompletedProcess(
+                argv, 127 if is_bus_failure else 1,
+                stderr=(b"Failed to find executable true: No such file or directory"
+                        if is_bus_failure else b"Failed to connect to user bus: No medium found"),
+            )
+            refreshed = get_result()
+            assert refreshed is not original
+            assert refreshed.bus_failure is not original.bus_failure
+            assert probe.call_count == 2
+        finally:
+            release.set()
+        with pytest.raises(RuntimeError) as raced:
+            pending.result(timeout=5)
+    assert str(raced.value).lower() == message
 
 
 def test_restart_safe_gateway_child_is_unchanged_outside_managed_gateway(monkeypatch):
@@ -109,7 +220,7 @@ def test_restart_safe_gateway_child_never_probes_systemd_off_linux(monkeypatch):
     probe = Mock(side_effect=AssertionError("systemd probe ran off Linux"))
     monkeypatch.setattr(process_registry, "_IS_LINUX", False)
     monkeypatch.setattr(process_registry, "_is_supervised_gateway_process", lambda: True)
-    monkeypatch.setattr(process_registry, "_systemd_run_user_scope_available", probe)
+    monkeypatch.setattr(process_registry, "_systemd_run_user_scope_result", probe)
     monkeypatch.setenv("INVOCATION_ID", "managed-service")
 
     assert process_registry.restart_safe_gateway_child_argv(

--- a/tests/hermes_cli/test_kanban_gateway_restart_handoff.py
+++ b/tests/hermes_cli/test_kanban_gateway_restart_handoff.py
@@ -12,6 +12,7 @@ import pytest
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_db_dispatch as kbd
+from tools.process_registry import _SystemdScopeResult
 
 
 @pytest.fixture
@@ -73,7 +74,10 @@ def test_managed_gateway_worker_is_spawned_in_restart_safe_scope(
     monkeypatch.setattr("agent.secret_scope.is_multiplex_active", lambda: True)
     monkeypatch.setattr(subprocess, "Popen", fake_popen)
     monkeypatch.setattr("tools.process_registry._is_supervised_gateway_process", lambda: True)
-    monkeypatch.setattr("tools.process_registry._systemd_run_user_scope_available", lambda: True)
+    monkeypatch.setattr(
+        "tools.process_registry._systemd_run_user_scope_result",
+        lambda: _SystemdScopeResult(True, "", False, 0.0),
+    )
     monkeypatch.setattr("tools.process_registry._worker_memory_max_bytes", lambda: 536_870_912)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
 
@@ -99,7 +103,15 @@ def test_managed_gateway_worker_spawn_fails_closed_without_scope(
     monkeypatch.setenv("INVOCATION_ID", "managed-gateway-test")
     monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kwargs: popen_calls.append(list(cmd)))
     monkeypatch.setattr("tools.process_registry._is_supervised_gateway_process", lambda: True)
-    monkeypatch.setattr("tools.process_registry._systemd_run_user_scope_available", lambda: False)
+    monkeypatch.setattr(
+        "tools.process_registry._systemd_run_user_scope_result",
+        lambda: _SystemdScopeResult(
+            False,
+            "scope probe exited with status 1: Failed to connect to user bus: No medium found",
+            True,
+            0.0,
+        ),
+    )
 
     with pytest.raises(RuntimeError, match="restart-safe systemd scope"):
         kbd._default_spawn(task, str(workspace))
@@ -113,11 +125,14 @@ def test_managed_gateway_scope_builder_fails_closed_if_binary_disappears(
     workspace, task = worker_setup
     monkeypatch.setenv("INVOCATION_ID", "managed-gateway-test")
     monkeypatch.setattr("tools.process_registry._is_supervised_gateway_process", lambda: True)
-    monkeypatch.setattr("tools.process_registry._systemd_run_user_scope_available", lambda: True)
+    monkeypatch.setattr(
+        "tools.process_registry._systemd_run_user_scope_result",
+        lambda: _SystemdScopeResult(True, "", False, 0.0),
+    )
     monkeypatch.setattr("shutil.which", lambda _name: None)
     monkeypatch.setattr(subprocess, "Popen", lambda *_args, **_kwargs: pytest.fail("unsafe direct spawn"))
 
-    with pytest.raises(RuntimeError, match="restart-safe systemd scope"):
+    with pytest.raises(RuntimeError, match="systemd-run disappeared after the availability probe"):
         kbd._default_spawn(task, str(workspace))
 
 
@@ -133,7 +148,7 @@ def test_standalone_dispatcher_keeps_direct_worker_spawn(
     monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kwargs: captured_cmd.extend(cmd) or FakeProc())
     monkeypatch.setattr("tools.process_registry._is_supervised_gateway_process", lambda: False)
     monkeypatch.setattr(
-        "tools.process_registry._systemd_run_user_scope_available",
+        "tools.process_registry._systemd_run_user_scope_result",
         lambda: pytest.fail("scope probe must not run outside managed gateway"),
     )
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -36,10 +36,10 @@ def _reset_systemd_scope_cache():
     cache themselves."""
     import tools.process_registry as _pr
 
-    original = _pr._SYSTEMD_SCOPE_AVAILABLE
-    _pr._SYSTEMD_SCOPE_AVAILABLE = False
+    original = _pr._SYSTEMD_SCOPE_RESULT
+    _pr._SYSTEMD_SCOPE_RESULT = _pr._SystemdScopeResult(False, "", False, float("inf"))
     yield
-    _pr._SYSTEMD_SCOPE_AVAILABLE = original
+    _pr._SYSTEMD_SCOPE_RESULT = original
 
 
 def _make_session(
@@ -2359,7 +2359,7 @@ class TestSystemdCgroupIsolation:
         import tools.process_registry as pr
 
         # Reset the cache.
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_RESULT", None)
         probe_calls = []
 
         def fake_run(*args, **kwargs):
@@ -2408,7 +2408,7 @@ class TestSystemdCgroupIsolation:
 
         monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
         monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_RESULT", None)
         monkeypatch.setattr(pr, "_default_user_runtime_dir", lambda: runtime_dir)
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
         derived = pr.systemd_user_bus_env(
@@ -2435,8 +2435,7 @@ class TestSystemdCgroupIsolation:
         """An absent ``/bin/true`` must not make a usable scope fail its probe."""
         import tools.process_registry as pr
 
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_PROBED_AT", 0.0)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_RESULT", None)
         real_run = subprocess.run
         executed = []
 
@@ -2448,11 +2447,79 @@ class TestSystemdCgroupIsolation:
             executed.append(payload)
             return real_run(payload, **kwargs)
 
-        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+        real_which = shutil.which
+        monkeypatch.setattr(
+            shutil, "which",
+            lambda name: "/usr/bin/systemd-run" if name == "systemd-run" else real_which(name),
+        )
         monkeypatch.setattr("subprocess.run", systemd_run_on_nixos_shaped_root)
 
         assert pr._systemd_run_user_scope_available() is True
         assert len(executed) == 1, "payload must really run (exit 0) on the host, not just be spelled right"
+
+    @pytest.mark.linux_only
+    def test_probe_without_true_and_scope_cleanup_use_derived_bus_env(
+        self, tmp_path, monkeypatch
+    ):
+        """A minimal service PATH supports a real no-op and cleanup on its user bus."""
+        import socket
+        import tempfile
+
+        import tools.process_registry as pr
+
+        monkeypatch.setenv("PATH", str(tmp_path))
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_RESULT", None)
+        real_which = shutil.which
+        binaries = {"systemd-run": "/test/systemd-run", "systemctl": "/test/systemctl"}
+        monkeypatch.setattr(
+            shutil, "which", lambda name: binaries.get(name) or real_which(name)
+        )
+        assert shutil.which("true") is None
+        real_run = subprocess.run
+        calls = []
+        payload_results = []
+
+        def run_systemd_command(argv, **kwargs):
+            calls.append((argv, kwargs))
+            if argv[0] == binaries["systemd-run"]:
+                payload = argv[argv.index("--") + 1:]
+                # Emulate a non-FHS host: no hardcoded /bin payload exists. Execute
+                # any resolved replacement with the sanitized PATH, so bare `true`
+                # also fails and only an absolute resolved executable is accepted.
+                if payload[0].startswith("/bin/"):
+                    return subprocess.CompletedProcess(
+                        argv, 127, stderr=f"{payload[0]}: No such file or directory".encode()
+                    )
+                result = real_run(payload, **kwargs)
+                payload_results.append(result)
+                return result
+            return subprocess.CompletedProcess(argv, 0, stderr=b"")
+
+        monkeypatch.setattr(subprocess, "run", run_systemd_command)
+        # AF_UNIX paths need a short directory, independent of pytest's long node ids.
+        with tempfile.TemporaryDirectory(prefix="hbus-", dir="/tmp") as directory:
+            runtime_dir = pr.Path(directory)
+            bus_path = runtime_dir / "bus"
+            with socket.socket(socket.AF_UNIX) as bus_socket:
+                bus_socket.bind(str(bus_path))
+                monkeypatch.setattr(pr, "_default_user_runtime_dir", lambda: runtime_dir)
+
+                assert pr._systemd_run_user_scope_available() is True
+                assert len(payload_results) == 1
+                assert payload_results[0].returncode == 0
+                unit = "hermes-worker-portable-probe.scope"
+                assert pr._stop_systemd_unit(unit) is True
+
+                assert len(calls) == 2
+                assert calls[1][0] == [binaries["systemctl"], "--user", "stop", unit]
+                for _, kwargs in calls:
+                    assert kwargs["env"]["PATH"] == str(tmp_path)
+                    assert kwargs["env"]["XDG_RUNTIME_DIR"] == str(runtime_dir)
+                    assert kwargs["env"]["DBUS_SESSION_BUS_ADDRESS"] == f"unix:path={bus_path}"
+                assert "XDG_RUNTIME_DIR" not in os.environ
+                assert "DBUS_SESSION_BUS_ADDRESS" not in os.environ
 
     @pytest.mark.linux_only
     def test_systemd_scope_first_probe_is_serialized(self, monkeypatch):
@@ -2463,7 +2530,7 @@ class TestSystemdCgroupIsolation:
         """
         import tools.process_registry as pr
 
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_RESULT", None)
         probe_started = threading.Event()
         release_probe = threading.Event()
         probe_calls = []
@@ -2506,8 +2573,7 @@ class TestSystemdCgroupIsolation:
     def test_failed_systemd_probe_retries_after_cache_ttl(self, monkeypatch):
         import tools.process_registry as pr
 
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_PROBED_AT", 0.0, raising=False)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_RESULT", None)
         clock = [100.0]
         probe_results = [1, 0]
         probe_calls = []
@@ -2561,7 +2627,7 @@ class TestSystemdCgroupIsolation:
 
         monkeypatch.setattr(pr, "_IS_LINUX", False)
         monkeypatch.setattr(pr, "_IS_WINDOWS", False)
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_RESULT", None)
         monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
         monkeypatch.setattr(
             "gateway.restart.is_gateway_supervisor_process", lambda: True
@@ -2604,7 +2670,7 @@ class TestSystemdCgroupIsolation:
         import tools.process_registry as pr
 
         monkeypatch.setattr(pr, "_IS_LINUX", False)
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_RESULT", None)
         monkeypatch.setattr("shutil.which", lambda name: "/usr/local/bin/systemd-run")
         probe_runs = []
         monkeypatch.setattr(

--- a/tests/tools/test_process_registry_windows_live.py
+++ b/tests/tools/test_process_registry_windows_live.py
@@ -75,7 +75,7 @@ class TestWindowsSpawnParity:
         monkeypatch.setattr(
             "gateway.restart.is_gateway_supervisor_process", lambda: True
         )
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_RESULT", None)
 
         scope_builds = []
         monkeypatch.setattr(
@@ -92,7 +92,7 @@ class TestWindowsSpawnParity:
         assert done.systemd_unit == ""
         assert scope_builds == [], "Windows must never build a systemd scope argv"
         # The availability probe must not have flipped to True on Windows.
-        assert pr._SYSTEMD_SCOPE_AVAILABLE is not True
+        assert pr._SYSTEMD_SCOPE_RESULT is None or not pr._SYSTEMD_SCOPE_RESULT.available
 
     def test_kill_process_windows_plain_path(self, registry):
         """kill_process on Windows works without any systemd unit cleanup."""

--- a/tests/tools/test_subagent_process_handoff.py
+++ b/tests/tools/test_subagent_process_handoff.py
@@ -37,7 +37,7 @@ def _register(sid, child):
 def _plain_spawn(monkeypatch):
     """Spawn plain children: the systemd-run --user --scope wrapper is irrelevant here and stalls under pytest."""
     import tools.process_registry as _pr
-    monkeypatch.setattr(_pr, "_SYSTEMD_SCOPE_AVAILABLE", False)
+    monkeypatch.setattr(_pr, "_systemd_run_user_scope_available", lambda: False)
 
 
 @pytest.fixture

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -14,6 +14,7 @@ import shlex
 import signal
 import stat
 import subprocess
+import sys
 import threading
 import time
 import uuid
@@ -78,9 +79,16 @@ WATCH_GLOBAL_COOLDOWN_SECONDS = 30
 # active turn. We probe *once* whether ``systemd-run --user --scope`` is actually usable (the binary can
 # exist on the PATH while the user D-Bus session is unavailable — common for system services and
 # containers), and cache the result for the process lifetime. See #70716.
-_SYSTEMD_SCOPE_AVAILABLE: Optional[bool] = None
+@dataclass(frozen=True)
+class _SystemdScopeResult:
+    available: bool
+    reason: str
+    bus_failure: bool
+    probed_at: float
+
+
+_SYSTEMD_SCOPE_RESULT: Optional[_SystemdScopeResult] = None
 _SYSTEMD_SCOPE_PROBE_LOCK = threading.Lock()
-_SYSTEMD_SCOPE_PROBED_AT = 0.0
 _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS = 60.0
 _MIN_WORKER_MEMORY_MAX_BYTES = 64 * 1024 * 1024
 _DEFAULT_WORKER_MEMORY_MAX_BYTES = 1024 * 1024 * 1024
@@ -194,24 +202,29 @@ def systemd_user_bus_env(base_env: Optional[Dict[str, str]] = None) -> Dict[str,
     return env
 
 
-def _systemd_scope_cached() -> Optional[bool]:
-    """Cached probe verdict, or None when a (re)probe is due. True is permanent; False
-    expires after ``_SYSTEMD_SCOPE_FAILURE_TTL_SECONDS`` so a D-Bus blip isn't sticky."""
-    if _SYSTEMD_SCOPE_AVAILABLE is True:
-        return True
-    stale = time.monotonic() - _SYSTEMD_SCOPE_PROBED_AT >= _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS
-    return None if _SYSTEMD_SCOPE_AVAILABLE is None or stale else False
+def _systemd_scope_cached() -> Optional[_SystemdScopeResult]:
+    """Successful snapshots are permanent; failures expire so bus blips can recover."""
+    result = _SYSTEMD_SCOPE_RESULT
+    if result is None or (
+        not result.available
+        and time.monotonic() - result.probed_at >= _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS
+    ):
+        return None
+    return result
 
 
 def _systemd_run_user_scope_available() -> bool:
-    """True if ``systemd-run --user --scope`` can create a cgroup.
+    return _systemd_run_user_scope_result().available
+
+
+def _systemd_run_user_scope_result() -> _SystemdScopeResult:
+    """One immutable verdict and diagnosis for ``systemd-run --user --scope``.
     ``shutil.which`` alone is insufficient: system services and containers may lack
     the user D-Bus bus even with the binary on PATH (every spawn would fail with
     ``Failed to connect to user bus``), so a cheap probe is run and cached.
 
-    Use ``/bin/sh -c 'exit 0'``: NixOS provides ``/bin/sh`` but not ``/bin/true``
-    (#105365), regardless of the gateway service's PATH."""
-    global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SCOPE_PROBED_AT
+    Resolve the no-op from the service PATH, without assuming an FHS layout."""
+    global _SYSTEMD_SCOPE_RESULT
     verdict = _systemd_scope_cached()
     if verdict is not None:
         return verdict
@@ -222,31 +235,52 @@ def _systemd_run_user_scope_available() -> bool:
         if verdict is not None:
             return verdict
         available = False
+        reason = "scope probe requires Linux"
+        bus_failure = False
         if _IS_LINUX:
             try:
                 import shutil
 
                 binary = shutil.which("systemd-run")
+                reason = "scope probe command systemd-run was not found on PATH"
                 if binary:
+                    true_binary = shutil.which("true")
+                    # The running interpreter is usable without a PATH lookup.
+                    # Isolated mode and no site initialization prevent startup hooks;
+                    # `pass` has no side effects and exits successfully, like true.
+                    payload = ([os.path.abspath(true_binary)] if true_binary else
+                               [os.path.abspath(sys.executable), "-I", "-S", "-c", "pass"])
                     # Unique unit avoids collisions; the timeout bounds D-Bus.
                     probe_unit = f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
                     result = subprocess.run(
-                        _systemd_scope_argv(binary, probe_unit, "/bin/sh", "-c", "exit 0"),
+                        _systemd_scope_argv(binary, probe_unit, *payload),
                         capture_output=True,
                         timeout=3,
                         env=systemd_user_bus_env(),
                     )
                     available = result.returncode == 0
                     if not available:
-                        logger.debug(
-                            "systemd-run --user --scope probe failed (rc=%s): %s",
-                            result.returncode, (result.stderr or b"").decode("utf-8", "replace").strip(),
+                        stderr = (result.stderr or b"").decode("utf-8", "replace").strip()
+                        reason = f"scope probe exited with status {result.returncode}"
+                        if stderr:
+                            reason += f": {stderr}"
+                        bus_failure = result.returncode not in (126, 127) and any(
+                            line.lower().startswith(("failed to connect to bus:",
+                                                     "failed to connect to user bus:"))
+                            for line in stderr.splitlines()
                         )
+            except OSError as exc:
+                reason = f"scope probe command execution failed ({type(exc).__name__}): {exc}"
             except Exception as exc:
-                logger.debug("systemd-run --user --scope probe error: %s", exc)
-        _SYSTEMD_SCOPE_AVAILABLE = available
-        _SYSTEMD_SCOPE_PROBED_AT = time.monotonic()
-        return available
+                reason = f"scope probe failed ({type(exc).__name__}): {exc}"
+        if not available:
+            logger.debug("systemd-run --user --scope %s", reason)
+        result = _SystemdScopeResult(
+            available, "" if available else reason, bus_failure, time.monotonic()
+        )
+        # Publish once; callers retain this diagnosis even if another thread refreshes.
+        _SYSTEMD_SCOPE_RESULT = result
+        return result
 
 
 def _is_supervised_gateway_process() -> bool:
@@ -297,14 +331,21 @@ def restart_safe_gateway_child_argv(
         return command
     if not _is_supervised_gateway_process() or not os.environ.get("INVOCATION_ID"):
         return command
-    if not _systemd_run_user_scope_available():
-        # Stored as the cron execution's error and shown on the job row: name the remedy.
-        raise RuntimeError(
+    result = _systemd_run_user_scope_result()
+    if not result.available:
+        # Stored on the cron job: preserve the cached cause, and only prescribe
+        # bus remediation when systemd actually reported a connection failure.
+        message = (
             "cannot create restart-safe systemd scope for gateway child: "
-            "systemd-run --user --scope is unavailable (usually no reachable user D-Bus session at "
-            f"/run/user/{os.getuid()}/bus). On a system-level service install, run "  # windows-footgun: ok — behind the _IS_LINUX return above
-            "`sudo loginctl enable-linger <gateway-user>` and restart the gateway."
+            "systemd-run --user --scope is unavailable: "
+            + (result.reason or "scope probe failed without a recorded cause")
         )
+        if result.bus_failure:
+            message += (
+                ". Check the gateway user's bus. On a system-level service install, run "
+                "`sudo loginctl enable-linger <gateway-user>` and restart the gateway."
+            )
+        raise RuntimeError(message)
     scoped = _build_systemd_scope_argv(command, unit_suffix=unit_suffix)
     if scoped == command:
         raise RuntimeError(


### PR DESCRIPTION
## Summary
- resolve the scope-probe no-op through PATH, with the running Python executable as a safe absolute fallback when service PATH is sanitized
- publish cached availability and diagnosis as one immutable snapshot, distinguishing exec failures from genuine user-bus failures
- preserve scope cleanup and migrate affected test seams

## Regression coverage
- absent `/bin/true` and all hardcoded `/bin/*` probe payloads
- sanitized PATH without `true`
- command-not-found vs D-Bus remediation
- cached-diagnosis refresh race
- successful user-scope cleanup

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_gateway_restart_handoff.py tests/cron/test_restart_safe_worker.py tests/tools/test_process_registry.py tests/tools/test_subagent_process_handoff.py` (135 passed, 4 skipped)
- `ruff check .`
- `python scripts/check_compat_pointers.py`
- `HERMES_NIX_BUILD=1 uv build --no-sources`
- live NixOS probe with PATH containing only `systemd-run`/`systemctl` (true unavailable): available=True and cleanup=True
- independent Codex review: APPROVE

The wider `tests/tools/ tests/cron/` run reached 10k passing tests but has 69 environment/baseline failures from absent optional SDKs and FHS `/bin/bash`; the directly affected suites are green.

Follow-up to #106274.