### PR TITLE
fix(desktop): surface the expensive-model confirmation instead of silently reverting

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -3,6 +3,8 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { $notifications, clearNotifications } from '@/store/notifications'
+
 // Radix Select calls scrollIntoView on its items when the content opens; jsdom
 // doesn't implement it (nor hasPointerCapture / releasePointerCapture), so stub
 // them to let the dropdown open in tests.
@@ -78,6 +80,7 @@ beforeEach(() => {
   setEnvVar.mockResolvedValue({ ok: true })
   getHermesConfigRecord.mockResolvedValue({ agent: { reasoning_effort: 'medium', service_tier: 'normal' } })
   saveHermesConfig.mockResolvedValue({ ok: true })
+  clearNotifications()
 })
 
 afterEach(() => {
@@ -340,6 +343,44 @@ describe('ModelSettings', () => {
         scope: 'auxiliary',
         task: 'vision'
       })
+    )
+  })
+
+  it('surfaces the guard confirm instead of silently dropping a guarded aux pick', async () => {
+    // #102729: a guarded aux pick answers confirm_required and writes NOTHING.
+    // Ignoring that dropped the selection and the next refresh repainted the old
+    // model — the silent revert. It must become a VISIBLE confirm instead.
+    setModelAssignment.mockResolvedValueOnce({
+      ok: false,
+      scope: 'auxiliary',
+      provider: 'nous',
+      model: 'hermes-4',
+      confirm_required: true,
+      confirm_message: 'Confirm this expensive model.'
+    })
+
+    await renderModelSettings()
+
+    const setToMainButtons = await screen.findAllByRole('button', { name: 'Set to main' })
+    fireEvent.click(setToMainButtons[0])
+
+    const confirm = await waitFor(() => {
+      const toast = $notifications.get().find(item => item.id.startsWith('model-warning-confirm-'))
+
+      expect(toast).toBeDefined()
+
+      return toast!
+    })
+
+    expect(confirm.kind).toBe('warning')
+    expect(confirm.message).toBe('Confirm this expensive model.')
+
+    act(() => confirm.action?.onClick())
+
+    await waitFor(() =>
+      expect(setModelAssignment).toHaveBeenLastCalledWith(
+        expect.objectContaining({ confirm_expensive_model: true, scope: 'auxiliary', task: 'vision' })
+      )
     )
   })
 

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -13,8 +13,7 @@ import {
   getRecommendedDefaultModel,
   saveHermesConfig,
   saveMoaModels,
-  setEnvVar,
-  setModelAssignment
+  setEnvVar
 } from '@/hermes'
 import type {
   AuxiliaryModelsResponse,
@@ -29,7 +28,7 @@ import { isCodeSkewRestartRequired } from '@/lib/code-skew-error'
 import { AlertTriangle, Cpu, Loader2 } from '@/lib/icons'
 import { DEFAULT_REASONING_EFFORT, REASONING_EFFORT_VALUES } from '@/lib/reasoning-effort'
 import { cn } from '@/lib/utils'
-import { setMainModelAssignment } from '@/store/cron-model-impact'
+import { applyModelAssignment, setMainModelAssignment } from '@/store/cron-model-impact'
 import { notifyError, readableError } from '@/store/notifications'
 import { startManualLocalEndpoint, startManualOnboarding, startManualProviderOAuth } from '@/store/onboarding'
 
@@ -723,7 +722,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
       setError('')
 
       try {
-        await setModelAssignment(
+        await applyModelAssignment(
           {
             model: mainModel.model,
             provider: mainModel.provider,
@@ -753,7 +752,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
       setError('')
 
       try {
-        await setModelAssignment(
+        await applyModelAssignment(
           {
             model: auxDraft.model,
             provider: auxDraft.provider,
@@ -797,7 +796,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
     setError('')
 
     try {
-      await setModelAssignment(
+      await applyModelAssignment(
         {
           model: mainModel.model,
           provider: mainModel.provider,

--- a/apps/desktop/src/store/cron-model-impact.test.ts
+++ b/apps/desktop/src/store/cron-model-impact.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/hermes', () => ({
 }))
 
 import {
+  applyModelAssignment,
   CRON_MODEL_IMPACT_NOTIFICATION_ID,
   invalidateCronModelImpactScope,
   setMainModelAssignment
@@ -269,6 +270,71 @@ describe('setMainModelAssignment', () => {
     dismissNotification(CRON_MODEL_IMPACT_NOTIFICATION_ID)
 
     expect($notifications.get()).toEqual([])
+    expect(setModelAssignment).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('applyModelAssignment (auxiliary scope)', () => {
+  // #102729: the aux rows in Settings → Model wrote through the raw API, so a
+  // guarded pick (contributor / expensive tier) was dropped on the floor and
+  // the next refresh repainted the old model — a silent revert. The confirm
+  // contract is per-scope, not per-main.
+  const guarded = {
+    ok: false,
+    scope: 'auxiliary',
+    provider: 'opencode-go',
+    model: 'muse-spark-1.3-contributor',
+    confirm_required: true,
+    confirm_message: 'Confirm this expensive model.'
+  } satisfies ModelAssignmentResponse
+
+  it('surfaces the guard confirm instead of dropping a guarded auxiliary pick', async () => {
+    setModelAssignment.mockResolvedValueOnce(guarded)
+    setModelAssignment.mockResolvedValueOnce({
+      ok: true,
+      scope: 'auxiliary',
+      provider: 'opencode-go',
+      model: 'muse-spark-1.3-contributor'
+    } satisfies ModelAssignmentResponse)
+
+    const pending = applyModelAssignment({
+      model: 'muse-spark-1.3-contributor',
+      provider: 'opencode-go',
+      scope: 'auxiliary',
+      task: 'vision'
+    })
+
+    const confirm = await waitForConfirmToast()
+
+    expect(confirm.kind).toBe('warning')
+    expect(confirm.message).toBe('Confirm this expensive model.')
+    expect(confirm.action?.label).toBe('Confirm')
+    // The first write carries NO ack — consent is what the confirm collects.
+    expect(setModelAssignment.mock.calls[0][0]).not.toHaveProperty('confirm_expensive_model')
+
+    confirm.action?.onClick()
+
+    await expect(pending).resolves.toMatchObject({ ok: true })
+    expect(setModelAssignment).toHaveBeenLastCalledWith(
+      expect.objectContaining({ confirm_expensive_model: true, scope: 'auxiliary', task: 'vision' })
+    )
+  })
+
+  it('declining keeps the previous model and reports it instead of reverting', async () => {
+    setModelAssignment.mockResolvedValueOnce(guarded)
+
+    const pending = applyModelAssignment({
+      model: 'muse-spark-1.3-contributor',
+      provider: 'opencode-go',
+      scope: 'auxiliary',
+      task: 'vision'
+    })
+
+    const confirm = await waitForConfirmToast()
+
+    dismissNotification(confirm.id)
+
+    await expect(pending).rejects.toThrow('Model change cancelled')
     expect(setModelAssignment).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/store/cron-model-impact.ts
+++ b/apps/desktop/src/store/cron-model-impact.ts
@@ -145,27 +145,28 @@ function publishImpact(impact: CronModelImpact, profile: string, connection: str
   })
 }
 
-export async function setMainModelAssignment(
-  request: Omit<ModelAssignmentRequest, 'scope'>,
+/**
+ * Selection-guard handshake for `/api/model/set`, shared by EVERY scope (the
+ * Settings main apply via setMainModelAssignment, the auxiliary rows). The
+ * backend answers `ok: false, confirm_required: true` + `confirm_message` for
+ * a guarded model (expensive / data-training tiers like `*-contributor`) and
+ * writes NOTHING until the client resends with `confirm_expensive_model: true`.
+ * A caller that ignores that drops the pick on the floor — the next refresh
+ * repaints the old model, which reads as a silent revert. Prompt, retry on
+ * Confirm, and throw on decline / any other non-ok so the caller can show it.
+ */
+export async function applyModelAssignment(
+  request: ModelAssignmentRequest,
   scopeProfile?: null | string,
   options?: { skipConfirmPrompt?: boolean }
 ): Promise<ModelAssignmentResponse> {
-  const { connection, generation } = beginCronModelImpactAssignment()
-  const profile = profileIdentity()
-
   // Only pass the extra arg when a scope override exists, so unscoped callers
   // keep the exact legacy call shape.
-  const assign = (body: Omit<ModelAssignmentRequest, 'scope'>) =>
-    scopeProfile == null
-      ? setModelAssignment({ ...body, scope: 'main' })
-      : setModelAssignment({ ...body, scope: 'main' }, scopeProfile)
+  const assign = (body: ModelAssignmentRequest) =>
+    scopeProfile == null ? setModelAssignment(body) : setModelAssignment(body, scopeProfile)
 
   let result = await assign(request)
 
-  // Backend demands an explicit ack before persisting a model that trips a
-  // selection guard (expensive / data-training tiers like *-contributor).
-  // Settings used to throw confirm_message as a red error, so Apply could
-  // never persist. Prompt, then retry with confirm_expensive_model.
   if (result.confirm_required) {
     if (request.confirm_expensive_model || options?.skipConfirmPrompt) {
       // Already acked, or headless onboarding (nothing mounted to click).
@@ -187,6 +188,23 @@ export async function setMainModelAssignment(
   } else if (result.ok !== true) {
     throw new Error(result.confirm_message?.trim() || translateNow('cron.modelImpact.saveFailed'))
   }
+
+  return result
+}
+
+export async function setMainModelAssignment(
+  request: Omit<ModelAssignmentRequest, 'scope'>,
+  scopeProfile?: null | string,
+  options?: { skipConfirmPrompt?: boolean }
+): Promise<ModelAssignmentResponse> {
+  const { connection, generation } = beginCronModelImpactAssignment()
+  const profile = profileIdentity()
+
+  // Backend demands an explicit ack before persisting a model that trips a
+  // selection guard (expensive / data-training tiers like *-contributor).
+  // Settings used to throw confirm_message as a red error, so Apply could
+  // never persist. Prompt, then retry with confirm_expensive_model.
+  const result = await applyModelAssignment({ ...request, scope: 'main' }, scopeProfile, options)
 
   // A scoped assignment targets ANOTHER profile's backend: its cron impact
   // belongs to that profile, and the review action would open the ACTIVE


### PR DESCRIPTION
## What Problem This Solves

Desktop model selection could still silently revert to the previous model when the backend's expensive / data-training selection guard (`hermes_cli/model_selection_guards.py`) demanded a confirmation. Every Desktop surface that receives `confirm_required` must turn it into a visible confirm, apply the pick on Confirm, and keep the old model with visible feedback on Cancel — the same contract the CLI already implements (`hermes_cli/cli_model_switch_mixin.py:436` `_confirm_expensive_model_switch`: prompt, then "Model switch cancelled" + keep current).

Contract, and where it broke:

- Backend: `POST /api/model/set` runs the unified guard for **every** scope and answers `{ok: false, confirm_required: true, confirm_message}` while writing nothing (`hermes_cli/web_routers/models.py:302-312`). The ack is `confirm_expensive_model` (`hermes_cli/web_models.py:105`).
- Already handled (server + client): the composer / tile / overlay pickers via `config.set` (`apps/desktop/src/app/session/hooks/use-model-controls.ts:299`), Settings → Model → main Apply via `setMainModelAssignment` (`apps/desktop/src/store/cron-model-impact.ts`), the Bots editor via `profiles.configure` (`apps/desktop/src/plugins/hermes-bots/profile-config.tsx:616`).
- **Not handled — the remaining path:** the Settings → Model **auxiliary** rows called the raw API (`apps/desktop/src/app/settings/model-settings.tsx:726`, `:756`, `:800` → `apps/desktop/src/api/models.ts:119`) and ignored the response body entirely — no `ok` check, no `confirm_required` handling. The guarded pick was dropped server-side and the follow-up `refresh()` repainted the previous model: exactly the silent revert in the report. Declining had no visible effect at all, because nothing ever asked.

Fix: the guard handshake moves into one shared applier, `applyModelAssignment` (`apps/desktop/src/store/cron-model-impact.ts`), and every `/api/model/set` scope routes through it — main (`setMainModelAssignment` delegates, identical behavior) and the three auxiliary writes. Guarded pick → warning notification with a Confirm action; Confirm → ONE resend carrying `confirm_expensive_model: true`; a resend that still answers `confirm_required` is a failure, never a loop; Cancel/dismiss → the previous model stays and the existing error surface reports the cancel (the aux handlers already route errors through `setCaughtError`) instead of silence. No new UI mechanism: the confirm toast is the one the Settings main apply and the in-session picker already use.

Closes #102729.

## Evidence

Regression tests (store + component), red first / green after.

RED — only the component call site reverted to the old raw-API code, new test kept:

```
cd apps/desktop && npx vitest run --project ui src/app/settings/model-settings.test.tsx --maxWorkers=1 --no-file-parallelism
× surfaces the guard confirm instead of silently dropping a guarded aux pick 12830ms
  src/app/settings/model-settings.test.tsx:370  expect(toast).toBeDefined()
Tests  1 failed | 25 passed (26)
```

GREEN — fix in place:

```
cd apps/desktop && npx vitest run --project ui src/app/settings/model-settings.test.tsx src/store/cron-model-impact.test.ts --maxWorkers=1 --no-file-parallelism
Test Files  2 passed (2)
     Tests  38 passed (38)
```

All guarded-switch suites together:

```
cd apps/desktop && npx vitest run --project ui src/app/settings/model-settings.test.tsx src/store/cron-model-impact.test.ts src/store/onboarding.test.ts src/app/session/hooks/use-model-controls.test.tsx src/app/shell/model-menu-panel.test.tsx src/plugins/hermes-bots/profile-config.test.ts --maxWorkers=1 --no-file-parallelism
Test Files  6 passed (6)
     Tests  113 passed (113)
```

New assertions: a guarded auxiliary pick must produce a visible warning notification (not a dropped pick), the first write must carry no ack, Confirm must resend ONCE with `confirm_expensive_model: true` + `scope: 'auxiliary'`, and dismiss must reject with the cancel copy while writing nothing further.

Sabotage — ack removed from the confirmed resend in `applyModelAssignment`:

```
Test Files  1 failed (1)
     Tests  2 failed | 10 passed (12)
× prompts and retries with confirm_expensive_model when the user accepts
× surfaces the guard confirm instead of dropping a guarded auxiliary pick
```

Both the pre-existing main-scope retry test and the new aux test catch it; sabotage reverted before commit.

Typecheck / lint:

```
cd apps/desktop && npx tsc -p .   # only pre-existing, environment-only:
src/app/messaging/telegram-qr-setup.tsx(48,31): error TS2307: Cannot find module 'qrcode'
npx eslint <4 changed files>      # exit 0
npx prettier --check <4 changed files>   # exit 0
```

Verification boundary: store + component level with a mocked `/api/model/set` under jsdom — no live Electron/GUI run and no real backend guard round-trip, so the click path is proven by the component test rather than a screenshot. Adjacent gap deliberately NOT touched (different defect: the guard never fires there): `profiles.create` pins a bot's model without consulting the selection guard (`tui_gateway/methods_profiles.py:337` vs `:580`), so a guarded pick in the Bots **create** dialog is applied without a confirm — a silent *apply*, not the silent revert reported here.
