### PR TITLE
fix(review): never persist credentials from background-review git sync

### DIFF
--- a/hermes_cli/git_credentials.py
+++ b/hermes_cli/git_credentials.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import re
 import shutil
 import subprocess
 import urllib.parse
@@ -32,6 +33,34 @@ from hermes_cli._subprocess_compat import noninteractive_git_env, windows_hide_f
 logger = logging.getLogger(__name__)
 
 _GITHUB_HOSTS = {"github.com", "gist.github.com"}
+
+_HTTP_URL_RE = re.compile(r"https?://[^\s'\"<>|]+")
+
+
+def without_credentials(text: str) -> str:
+    """*text* with credentials stripped from every HTTP(S) URL it contains.
+
+    Pass a bare URL and the URL comes back with its ``user:password@`` userinfo
+    (and its query/fragment, which can carry a ``?token=``) removed. Pass a git
+    error line and each embedded URL is scrubbed in place, so a remote URL git
+    echoed into stderr cannot smuggle a PAT into a toast, a log, or a pasted bug
+    report. One implementation for both directions — there is deliberately no
+    second scrubber for a call site to pick instead.
+
+    Non-HTTP transports (``git@host:owner/repo``) and already-clean URLs are
+    returned unchanged; URLs with no hostname are left alone rather than
+    mangled.
+    """
+    def _scrub(match: "re.Match[str]") -> str:
+        parsed = urllib.parse.urlsplit(match.group(0))
+        if not parsed.hostname:
+            return match.group(0)
+        host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+        if parsed.port is not None:
+            host = f"{host}:{parsed.port}"
+        return urllib.parse.urlunsplit((parsed.scheme, host, parsed.path, "", ""))
+
+    return _HTTP_URL_RE.sub(_scrub, text or "")
 
 
 def _https_origin(url: str) -> Optional[str]:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -511,14 +511,14 @@ def _checkout_exact_revision(repo: Path, git_exe: str, revision: str, source_url
 
 
 def _scrub_git_url(git_url: str) -> str:
-    """Strip credentials and query/fragment data from an HTTP Git URL."""
-    parsed = urllib.parse.urlsplit(git_url)
-    if parsed.scheme in {"http", "https"} and parsed.hostname:
-        host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
-        if parsed.port is not None:
-            host = f"{host}:{parsed.port}"
-        return urllib.parse.urlunsplit((parsed.scheme, host, parsed.path, "", ""))
-    return git_url
+    """Strip credentials and query/fragment data from an HTTP Git URL.
+
+    Delegates to the shared ``git_credentials.without_credentials`` so the
+    installer and the review-pane git ops scrub identically — see #101351.
+    """
+    from hermes_cli.git_credentials import without_credentials
+
+    return without_credentials(git_url)
 
 
 def _canonical_source(git_url: str, subdir: Optional[str]) -> str:

--- a/hermes_cli/web_git.py
+++ b/hermes_cli/web_git.py
@@ -17,6 +17,7 @@ import subprocess
 from pathlib import Path
 
 from hermes_cli._subprocess_compat import harden_git_argv, noninteractive_git_env
+from hermes_cli.git_credentials import without_credentials
 
 _GIT_TIMEOUT = 30
 _GH_TIMEOUT = 30
@@ -60,10 +61,42 @@ def _git_line(cwd: str, args: list[str]) -> str:
 
 
 def _git_ok(cwd: str, args: list[str]) -> None:
-    """Run a git mutation, raising RuntimeError with stderr on failure."""
+    """Run a git mutation, raising RuntimeError with stderr on failure.
+
+    Git echoes the remote URL on a failed fetch/push, and this message is what
+    the renderer toasts and the gateway logs — so an embedded credential is
+    stripped before it leaves the process (#101351).
+    """
     code, _, err = _git(cwd, args)
     if code != 0:
-        raise RuntimeError(err.strip() or f"git {' '.join(args)} failed")
+        raise RuntimeError(without_credentials(err.strip()) or f"git {' '.join(args)} failed")
+
+
+def _scrub_recorded_origin(cwd: str) -> None:
+    """Strip credentials from this repo's recorded ``origin`` URL.
+
+    ``git clone https://user:token@host/…`` — and a hand-edited config — leave
+    the token in ``.git/config``, where ``git remote -v``, every later push and
+    any pasted bug report echo it. Repo-scoped and idempotent: only THIS repo's
+    origin is touched, only when it actually carries userinfo. Best-effort —
+    credential hygiene must never be what fails the verb the caller came for.
+    """
+    try:
+        recorded = _git_line(cwd, ["remote", "get-url", "origin"])
+        scrubbed = without_credentials(recorded)
+        if recorded and scrubbed != recorded:
+            _git(cwd, ["remote", "set-url", "origin", scrubbed])
+    except Exception:
+        return
+
+
+def _fetch_best_effort(cwd: str, remote: str, branch: str) -> None:
+    """Refresh one remote-tracking ref, ignoring failure (offline, branch gone).
+
+    A network verb, so it first scrubs a credentialed ``origin``.
+    """
+    _scrub_recorded_origin(cwd)
+    _git(cwd, ["fetch", remote, branch])
 
 
 def _is_dir(cwd: str) -> bool:
@@ -348,6 +381,7 @@ def review_commit(cwd: str, message: str, push: bool) -> dict:
 
 
 def _review_push(cwd: str) -> None:
+    _scrub_recorded_origin(cwd)
     if _git_line(cwd, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]):
         _git_ok(cwd, ["push"])
         return
@@ -600,7 +634,7 @@ def _worktree_for_existing(root: str, raw_name: str) -> dict:
     if remote:
         # Best-effort freshness; on failure (offline, branch gone) the last known ref is still
         # there to branch from.
-        _git(root, ["fetch", remote, existing])
+        _fetch_best_effort(root, remote, existing)
         _git_ok(root, ["worktree", "add", "--track", "-b", existing, target, requested])
     else:
         _git_ok(root, ["worktree", "add", target, existing])
@@ -624,7 +658,7 @@ def worktree_add(cwd: str, options: dict) -> dict:
         # (offline / no remote) are ignored — git uses the local ref or raises a clear error
         # below if it is entirely missing.
         if base.startswith("origin/"):
-            _git(root, ["fetch", "origin", base[len("origin/"):]])
+            _fetch_best_effort(root, "origin", base[len("origin/"):])
             # Branching off a remote-tracking ref auto-wires upstream tracking; the user wants
             # a standalone local branch (Electron-op parity).
             args.append("--no-track")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -302,6 +302,25 @@ def _close_time_checkpoint_configurable() -> bool:
             and hasattr(sqlite3.Connection, "setconfig"))
 
 
+def _redact_transcript_record(value: Any) -> Any:
+    """``value`` with secrets masked inside every string, structure preserved.
+
+    The diverted breadcrumb is a persisted recovery artifact, not a wire copy, so
+    it is redacted unconditionally (``force=True``) rather than gated on the
+    user's display-redaction preference: the token would otherwise outlive the
+    debug session in a file an agent may go on to commit (#101351).
+    """
+    from agent.redact import redact_sensitive_text
+
+    if isinstance(value, str):
+        return redact_sensitive_text(value, force=True)
+    if isinstance(value, dict):
+        return {key: _redact_transcript_record(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_redact_transcript_record(item) for item in value]
+    return value
+
+
 def divert_session_transcript_jsonl(session_id: str, messages) -> "Optional[Path]":
     """Append pending messages to HERMES_HOME/sessions/<id>.jsonl (state.db was replaced under a
     live process). Returns the path, or None if nothing to write."""
@@ -315,7 +334,7 @@ def divert_session_transcript_jsonl(session_id: str, messages) -> "Optional[Path
         for msg in messages:
             if msg is not None:
                 record = msg if isinstance(msg, dict) else {"content": str(msg)}
-                handle.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+                handle.write(json.dumps(_redact_transcript_record(record), ensure_ascii=False, default=str) + "\n")
     return path
 
 

--- a/tests/hermes_cli/test_review_git_credentials.py
+++ b/tests/hermes_cli/test_review_git_credentials.py
@@ -1,0 +1,132 @@
+"""Issue #101351 — the review-pane git helpers must never carry credentials.
+
+Two shapes are covered:
+
+1. A recorded ``origin`` URL that already embeds a PAT. ``git clone
+   https://x-access-token:<token>@host/…`` writes the credential straight into
+   ``.git/config``, and ``git remote -v`` / every later push echo it out. The
+   review-pane helpers must scrub it before running any network verb.
+2. Git's own stderr echoes the remote URL on a failed fetch/push. That text is
+   what the helper raises, so it lands in the dashboard toast and in the
+   gateway log — it must be scrubbed before it leaves the process.
+
+Every test runs against a throwaway repo under ``tmp_path``; the credentialed
+remote points at ``127.0.0.1:9`` (discard port) so a push fails instantly and
+nothing touches the network or a real credential.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import git_credentials, plugins_cmd, web_git
+
+TOKEN = "ghp_" + "A1b2C3d4E5f6G7h8I9j0"  # matches agent/redact.py's ghp_ PAT shape
+CREDENTIALED = f"http://x-access-token:{TOKEN}@127.0.0.1:9/acme/private.git"
+SCRUBBED = "http://127.0.0.1:9/acme/private.git"
+CLEAN = "http://127.0.0.1:9/acme/private.git"
+
+
+def _run(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True,
+                   capture_output=True, text=True, encoding="utf-8", errors="replace")
+
+
+def _committed_repo(tmp_path: Path, origin: str = CREDENTIALED) -> Path:
+    root = tmp_path / "repo"
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    _run(root, "remote", "add", "origin", origin)
+    _run(root, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "--allow-empty", "-qm", "init")
+    return root
+
+
+def _config(root: Path) -> str:
+    return (root / ".git" / "config").read_text(encoding="utf-8")
+
+
+# ── the shared helper ────────────────────────────────────────────────────────
+
+
+def test_without_credentials_strips_userinfo_and_query() -> None:
+    assert git_credentials.without_credentials(CREDENTIALED) == SCRUBBED
+    assert git_credentials.without_credentials(
+        "https://user:pw@github.com/o/r.git?token=abc#frag") == "https://github.com/o/r.git"
+    # Non-HTTP transports and already-clean URLs are returned unchanged.
+    assert git_credentials.without_credentials(CLEAN) == CLEAN
+    assert git_credentials.without_credentials("git@github.com:o/r.git") == "git@github.com:o/r.git"
+    assert git_credentials.without_credentials("") == ""
+
+
+def test_plugins_cmd_shares_the_one_implementation() -> None:
+    """One scrubber, not two: the plugin installer's helper delegates."""
+    assert plugins_cmd._scrub_git_url(CREDENTIALED) == SCRUBBED
+    assert plugins_cmd._scrub_git_url(CREDENTIALED) == git_credentials.without_credentials(CREDENTIALED)
+
+
+# ── the review-pane helpers ──────────────────────────────────────────────────
+
+
+def test_git_ok_scrubs_the_remote_url_out_of_raised_errors(monkeypatch) -> None:
+    """git echoes the remote URL on failure; the raised message must not."""
+    stderr = f"fatal: unable to access '{CREDENTIALED}/': Failed to connect to 127.0.0.1 port 9"
+    monkeypatch.setattr(web_git, "_git", lambda cwd, args, **kw: (128, "", stderr))
+
+    with pytest.raises(RuntimeError) as exc:
+        web_git._git_ok("/tmp/repo", ["push"])
+
+    message = str(exc.value)
+    assert TOKEN not in message
+    assert "x-access-token" not in message
+    assert "Failed to connect" in message  # the diagnosis survives
+
+
+def test_recorded_origin_credentials_are_scrubbed(tmp_path: Path) -> None:
+    root = _committed_repo(tmp_path)
+    assert TOKEN in _config(root)
+
+    web_git._scrub_recorded_origin(str(root))
+
+    assert TOKEN not in _config(root)
+    assert "x-access-token" not in _config(root)
+    assert web_git._git_line(str(root), ["remote", "get-url", "origin"]) == SCRUBBED
+
+    # Idempotent: a second pass changes nothing.
+    before = _config(root)
+    web_git._scrub_recorded_origin(str(root))
+    assert _config(root) == before
+
+
+def test_recorded_origin_without_credentials_is_left_alone(tmp_path: Path) -> None:
+    root = _committed_repo(tmp_path, origin=CLEAN)
+    before = _config(root)
+
+    web_git._scrub_recorded_origin(str(root))
+
+    assert _config(root) == before
+
+
+def test_review_push_never_persists_credentials(tmp_path: Path) -> None:
+    """End to end: a failing push must not leave the PAT in .git/config nor in the error."""
+    root = _committed_repo(tmp_path)
+
+    with pytest.raises(RuntimeError) as exc:
+        web_git.review_push(str(root))
+
+    assert TOKEN not in str(exc.value)
+    assert TOKEN not in _config(root)
+    assert "x-access-token" not in _config(root)
+
+
+def test_worktree_add_from_a_remote_branch_never_persists_credentials(tmp_path: Path) -> None:
+    """The fetch path (worktree from ``origin/<branch>``) is the other network verb."""
+    root = _committed_repo(tmp_path)
+    _run(root, "update-ref", "refs/remotes/origin/feature", "HEAD")
+
+    created = web_git.worktree_add(str(root), {"existingBranch": "origin/feature"})
+
+    assert Path(created["path"]).is_dir()
+    assert TOKEN not in _config(root)
+    assert "x-access-token" not in _config(root)

--- a/tests/test_session_breadcrumb_redaction.py
+++ b/tests/test_session_breadcrumb_redaction.py
@@ -1,0 +1,55 @@
+"""Issue #101351 — the diverted session transcript must not persist live keys.
+
+When ``state.db`` is replaced under a live process the pending message batch is
+appended verbatim to ``HERMES_HOME/sessions/<id>.jsonl``. Tool output in that
+batch routinely carries an ``export OPENAI_API_KEY=…`` line or a raw key in a
+command body, and the file sits in a path an agent may go on to commit. The
+breadcrumb must be written through the repo's existing secret redactor while
+keeping the message shape recoverable.
+"""
+
+from __future__ import annotations
+
+import json
+
+from hermes_state import divert_session_transcript_jsonl
+
+KEY = "sk-" + "a1B2c3D4e5F6g7H8i9J0kLmN"
+
+
+def test_diverted_breadcrumb_redacts_keys_but_keeps_structure(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    messages = [
+        {"role": "tool", "tool_call_id": "call-1", "name": "terminal",
+         "content": f"$ export OPENAI_API_KEY={KEY}\nwrote 3 files"},
+        {"role": "assistant", "content": [
+            {"type": "text", "text": f"the key is {KEY}"},
+            {"type": "image_url", "image_url": {"url": "file:///tmp/a.png"}},
+        ]},
+        "a bare string record",
+    ]
+
+    path = divert_session_transcript_jsonl("sess-1", messages)
+    raw = path.read_text(encoding="utf-8")
+
+    assert KEY not in raw
+    records = [json.loads(line) for line in raw.splitlines()]
+    assert len(records) == 3
+    assert records[0]["role"] == "tool"
+    assert records[0]["tool_call_id"] == "call-1"
+    assert records[0]["name"] == "terminal"
+    assert "wrote 3 files" in records[0]["content"]  # non-secret text survives
+    # Nested multimodal parts keep their shape and their non-secret fields.
+    assert records[1]["content"][0]["type"] == "text"
+    assert records[1]["content"][1]["image_url"]["url"] == "file:///tmp/a.png"
+    # A non-dict record is wrapped by the (unchanged) writer as {"content": str(msg)}.
+    assert records[2] == {"content": "a bare string record"}
+
+
+def test_diverted_breadcrumb_leaves_secret_free_messages_byte_identical(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    message = {"role": "user", "content": "no secrets here: 42 lines changed in main.py"}
+
+    path = divert_session_transcript_jsonl("sess-2", [message])
+
+    assert json.loads(path.read_text(encoding="utf-8").splitlines()[0]) == message


### PR DESCRIPTION
Partial #101351

## What Problem This Solves

Issue #101351 reports two credential-exposure paths in the review flow: a background
reviewer git helper that writes a literal GitHub PAT into the working repo's
`.git/config` when a network verb fails, and a review capture that lands raw API keys in a
path an agent may later commit.

**Reproduction boundary — read before the diff.** This tree has no `_sync_to_origin()` or
any equivalent that writes a credentialed URL into `.git/config`. The only
`git remote set-url` in the codebase is `hermes_cli/plugins_cmd.py::_scrub_cloned_origin`,
and it *removes* credentials; every internal network verb authenticates through
`hermes_cli/git_credentials.py::with_git_auth`, which injects a `GIT_CONFIG_*`
`http.<origin>/.extraheader` into the child's **environment** and never writes config
(its own module docstring says so, and `tests/hermes_cli/test_plugin_private_repo_auth.py`
locks that in). So the reported *write* is **not reproducible from this source tree** — I
could not construct a Hermes code path that introduces a credentialed `origin` URL, and I
did not fabricate one to have something to fix. Reproducing that mechanism needs the
reporter's stack trace plus the real helper name; `Partial` above reflects that.

What I *could* reproduce, and did fix:

### 1. A credentialed `origin` survives every review-pane git verb, and is echoed onward

`hermes_cli/web_git.py` is the server-side backend of the desktop coding rail + review pane
(`hermes_cli/_subprocess_compat.py` names it verbatim: "desktop review-pane
fetch/push"). `git clone https://user:token@host/…` — or a hand-edited config, or any
tool that ever recorded one — leaves the token in `.git/config`. `web_git._review_push`
(`["push"]`, `["push","-u","origin",branch]`) and the two `git fetch` sites in
`_worktree_for_existing` / `worktree_add` all ran with that URL untouched, so
`git remote -v`, every later push, and any captured error kept echoing the PAT.

* `hermes_cli/git_credentials.py::without_credentials(text)` — one scrubber, handling both
  a bare URL and a git error line with URLs embedded, so no call site can pick the wrong
  one. Non-HTTP transports (`git@host:owner/repo`) and already-clean URLs come back
  unchanged.
* `hermes_cli/plugins_cmd.py::_scrub_git_url` now delegates to it — the installer and the
  review pane share exactly one implementation (the installer's credential tests still pass
  unchanged).
* `hermes_cli/web_git.py::_scrub_recorded_origin(cwd)` — repo-scoped, idempotent repair of
  an already-dirty `origin` (`remote get-url` → `without_credentials` → `remote set-url`
  only when it changed). Called before every review-pane network verb: `_review_push` and
  the new `_fetch_best_effort` used by both fetch sites. Best-effort by design — credential
  hygiene must never be what fails the verb the caller came for.
* `hermes_cli/web_git.py::_git_ok` scrubs the stderr it raises, so a git-echoed remote URL
  cannot reach the dashboard toast or the gateway log with the credential intact.

### 2. The diverted session transcript persisted raw API keys

`hermes_state.py::divert_session_transcript_jsonl` appends the pending batch to
`HERMES_HOME/sessions/<id>.jsonl` when `state.db` is replaced under a live process. It
wrote every message **verbatim** — including tool output such as
`export OPENAI_API_KEY=sk-…` — while every logging surface in the repo goes through
`agent/redact.py`. It now writes through `_redact_transcript_record`, reusing that existing
redactor recursively over string values, preserving message shape and key order. Redaction
is unconditional (`force=True`): this artifact is persisted to disk and outlives the debug
session, unlike live display output a user can opt out of with `security.redact_secrets`.

### Hardening scope (what is deliberately NOT touched)

`noninteractive_git_env`, `harden_git_argv`, `bounded_git_probe` / `bounded_probe_run`, and
every other git spawn are unchanged. The hardening here is the review-pane git verbs, the
shared URL scrubber, and the session breadcrumb. `hermes_cli/web_git.py::_git` itself is
untouched — no git invocation was moved onto or off a hardened path.

## Evidence

Failure mechanism, first: a repo whose recorded `origin` carries a PAT
(`http://x-access-token:ghp_…@127.0.0.1:9/acme/private.git`, discard port so the verb fails
in milliseconds with no network) keeps that token in `.git/config` across `review_push` and
a worktree fetch, and `web_git._git_ok` re-raises git's stderr containing the URL.

Red before the fix (`scripts/run_tests.sh tests/hermes_cli/test_review_git_credentials.py tests/test_session_breadcrumb_redaction.py`):

```
============================== 7 failed in 5.85s ==============================
=== 2 files with test failures (8 tests failed) ===
E       AssertionError: assert 'ghp_A1...I9j0' not in '[core]\n\tr...s/origin/*\n'
E           ess-token:ghp_A1...I9j0@127.0.0.1:9/acme/private.git
FAILED tests/hermes_cli/test_review_git_credentials.py::test_without_credentials_strips_userinfo_and_query
FAILED tests/hermes_cli/test_review_git_credentials.py::test_plugins_cmd_shares_the_one_implementation
FAILED tests/hermes_cli/test_review_git_credentials.py::test_git_ok_scrubs_the_remote_url_out_of_raised_errors
FAILED tests/hermes_cli/test_review_git_credentials.py::test_recorded_origin_credentials_are_scrubbed
FAILED tests/hermes_cli/test_review_git_credentials.py::test_review_push_never_persists_credentials
FAILED tests/hermes_cli/test_review_git_credentials.py::test_worktree_add_from_a_remote_branch_never_persists_credentials
FAILED tests/test_session_breadcrumb_redaction.py::test_diverted_breadcrumb_redacts_keys_but_keeps_structure
```

Green after the fix (same command):

```
=== Summary: 2 files, 9 tests passed, 0 failed (100% complete) in 14.9s (40 workers) ===
```

Sabotage check — reverting each behaviour (`without_credentials` → identity,
`_git_ok` → raw stderr, the `remote set-url` repair → `if False`,
`_fetch_best_effort` → the old raw fetch, breadcrumb → `json.dumps(record)`) turns the suite
red again, then restoring the same files turns it green:

```
=== Summary: 2 files, 2 tests passed, 7 failed (100% complete) in 38.9s (40 workers) ===
FAILED tests/test_session_breadcrumb_redaction.py::test_diverted_breadcrumb_redacts_keys_but_keeps_structure
FAILED tests/hermes_cli/test_review_git_credentials.py::{test_without_credentials_strips_userinfo_and_query,
  test_plugins_cmd_shares_the_one_implementation, test_git_ok_scrubs_the_remote_url_out_of_raised_errors,
  test_recorded_origin_credentials_are_scrubbed, test_review_push_never_persists_credentials,
  test_worktree_add_from_a_remote_branch_never_persists_credentials}
--- restored ---
=== Summary: 2 files, 9 tests passed, 0 failed (100% complete) in 14.9s (40 workers) ===
```

Note on one assertion: on this git (2.55.0.windows.1) a real failed `push` already comes
back with the URL's userinfo stripped by git itself, so `test_review_push_never_persists_credentials`
passes pre-fix on that one clause and fails on the `.git/config` clause. The
`_git_ok` invariant is therefore pinned by a deterministic mocked-stderr test rather than
relying on whatever the local git happens to print.

Related suites, same runner:

* `tests/security/test_gitspawn_config_injection.py` — **15 passed, 1 failed**, identical
  with the fix stashed (`git stash push` over the four changed files) and applied. The
  failure is `test_baseline_unhardened_git_fires_sinks`, and it is pre-existing: that test
  fires a **bare** `subprocess.run(["git", "-C", repo, "diff", "HEAD"])`, so no Hermes code
  is on the path at all — its `assert "fsmonitor" in fired and "extdiff" in fired` yields
  `[]` because the fixture's armed payload (a `core.fsmonitor = "touch <WINPATH>"` command
  string and a `[diff "evil"] command`) never fires on git 2.55 for Windows. It is a
  fixture/toolchain incompatibility, not a regression, and it is left untouched: adding an
  opt-out that bypasses hardening would be the wrong fix, because nothing in this PR
  hardens the path it exercises.
* `tests/hermes_cli/test_plugin_install_ref.py` — **20 passed, 2 failed**, identical
  patched and unpatched. Both failures are `PermissionError: [WinError 5]` raised while
  pytest's `tmp_path` teardown unlinks a git object under `plugins/demo/.git/objects/…`;
  the file's credential tests (`test_canonical_source_never_persists_http_credentials`,
  `test_cloned_origin_never_persists_http_credentials`,
  `test_git_errors_never_echo_source_credentials`) pass with the delegated scrubber.
* `tests/hermes_cli/test_review_git_credentials.py`, `tests/test_session_breadcrumb_redaction.py`,
  `tests/run_agent/test_flush_diverts_on_corrupt_state_db.py`, `tests/agent/test_redact.py`,
  `tests/hermes_cli/test_noninteractive_git.py` — the only reported failure in that combined
  run was the pre-existing baseline test above (`=== 1 file with test failures (1 test failed) ===`).

### Not covered (why this is `Partial`)

1. **The reported write path itself.** No Hermes code here introduces a credentialed
   `origin` URL, so the "failed sync persists a PAT" mechanism could not be reproduced and
   is not claimed fixed. The invariant added (`_scrub_recorded_origin` + `_git_ok` scrub)
   closes the exposure *once such a URL exists*, whatever put it there. If you can paste the
   stack trace / the helper's real name, the guard moves to that call site in one line.
2. **No retention policy for `~/.hermes/sessions/`.** The redaction in (2) stops new keys
   from landing in the breadcrumb, but there is no TTL/prune for transcripts and the
   state.db transcript itself stays byte-verbatim by design (replay needs the exact prompt
   bytes). `.gitignore` already covers an in-repo `.hermes/`, which is what keeps the
   default layout out of a commit.
3. **Private-repo push from the review pane still does not authenticate** — `web_git` runs
   under `noninteractive_git_env()`, which forces `credential.helper=""`, and it attaches no
   credential. Routing those verbs through `with_git_auth` is a behaviour change (enabling
   private pushes) that cannot be verified without a real token, so it is deliberately left
   out of this security fix.
