### PR TITLE
fix(whatsapp): map html/txt/csv media to their real MIME types

### DIFF
--- a/scripts/whatsapp-bridge/bridge.media_mime.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.media_mime.test.mjs
@@ -1,0 +1,86 @@
+/**
+ * Regression tests for outbound document MIME mapping (#89074).
+ *
+ * The bridge's /send-media handler labels every document payload with
+ * MIME_MAP[ext] || 'application/octet-stream'. Plain text-ish documents
+ * (html/htm/txt/csv, ...) were absent from MIME_MAP, so WhatsApp received
+ * them as application/octet-stream and every phone rendered them as an
+ * unopenable "BIN" instead of a text/HTML attachment.
+ *
+ * These tests exercise the pure helper — they do NOT require a live
+ * WhatsApp socket (no Baileys import, no bridge.js side effects).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { mediaPayloadForFile, MIME_MAP } from './bridge_helpers.js';
+
+const asDocument = (filePath, extra = {}) =>
+  mediaPayloadForFile({ buffer: Buffer.from('body'), filePath, ...extra });
+
+test('html/htm/txt/csv documents keep their real MIME type', () => {
+  const cases = [
+    ['/tmp/report.html', 'text/html'],
+    ['/tmp/index.htm', 'text/html'],
+    ['/tmp/notes.txt', 'text/plain'],
+    ['/tmp/rows.csv', 'text/csv'],
+  ];
+  for (const [filePath, mime] of cases) {
+    const payload = asDocument(filePath);
+    assert.equal(payload.mimetype, mime, filePath);
+    // The reported repro sends a document, so the payload must stay a
+    // document attachment with the original basename, not a binary blob.
+    assert.ok(Buffer.isBuffer(payload.document), filePath);
+    assert.equal(payload.fileName, filePath.split('/').pop(), filePath);
+  }
+});
+
+test('extension matching is case-insensitive', () => {
+  assert.equal(asDocument('/tmp/REPORT.HTML').mimetype, 'text/html');
+  assert.equal(asDocument('/tmp/Notes.TXT').mimetype, 'text/plain');
+  assert.equal(asDocument('/tmp/ROWS.CSV').mimetype, 'text/csv');
+});
+
+test('multi-dot filenames use the last extension', () => {
+  assert.equal(asDocument('/tmp/report.final.html').mimetype, 'text/html');
+  assert.equal(asDocument('/tmp/data.2026.q3.csv').mimetype, 'text/csv');
+  assert.equal(asDocument('/tmp/notes.backup.txt').mimetype, 'text/plain');
+});
+
+test('extensionless paths still fall back to application/octet-stream', () => {
+  const payload = asDocument('/tmp/README');
+  assert.equal(payload.mimetype, 'application/octet-stream');
+  assert.equal(payload.fileName, 'README');
+  // A dotted directory above an extensionless file must not be mistaken for
+  // an extension either ("/tmp.reports/Makefile: no ext").
+  assert.equal(asDocument('/tmp.reports/Makefile').mimetype, 'application/octet-stream');
+});
+
+test('explicit document mediaType uses the same mapping', () => {
+  const payload = mediaPayloadForFile({
+    buffer: Buffer.from('body'),
+    filePath: '/tmp/report.html',
+    mediaType: 'document',
+    caption: 'see attached',
+  });
+  assert.equal(payload.mimetype, 'text/html');
+  assert.equal(payload.caption, 'see attached');
+});
+
+test('image/video MIME handling is unchanged', () => {
+  assert.equal(asDocument('/tmp/pic.png', { mediaType: 'image' }).mimetype, 'image/png');
+  assert.equal(asDocument('/tmp/clip.mp4', { mediaType: 'video' }).mimetype, 'video/mp4');
+  assert.equal(
+    asDocument('/tmp/unknown.zzz', { mediaType: 'image' }).mimetype,
+    'image/jpeg',
+    'unknown image extension keeps the image/jpeg default',
+  );
+  assert.equal(asDocument('/tmp/loop.gif', { mediaType: 'image' }).mimetype, 'image/gif');
+});
+
+test('MIME_MAP keeps the previously mapped types intact', () => {
+  assert.equal(MIME_MAP.pdf, 'application/pdf');
+  assert.equal(MIME_MAP.png, 'image/png');
+  assert.equal(MIME_MAP.docx, 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+});

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -2,6 +2,11 @@ import path from 'path';
 import { mkdirSync, writeFileSync } from 'fs';
 import { randomBytes } from 'crypto';
 
+// Extension → MIME. Keep this in sync with the gateway's document table in
+// gateway/platforms/base.py (SUPPORTED_DOCUMENT_TYPES) so a file the agent can
+// attach is labelled the same way on every path. A missing entry makes the
+// document branch below fall back to application/octet-stream, which WhatsApp
+// clients render as an unopenable "BIN" (#89074).
 export const MIME_MAP = {
   jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png',
   webp: 'image/webp', gif: 'image/gif',
@@ -10,8 +15,27 @@ export const MIME_MAP = {
   pdf: 'application/pdf',
   doc: 'application/msword',
   docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xls: 'application/vnd.ms-excel',
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ppt: 'application/vnd.ms-powerpoint',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  txt: 'text/plain', log: 'text/plain', ini: 'text/plain', cfg: 'text/plain',
+  md: 'text/markdown', csv: 'text/csv',
+  html: 'text/html', htm: 'text/html',
+  json: 'application/json', xml: 'application/xml',
+  yaml: 'application/yaml', yml: 'application/yaml', toml: 'application/toml',
+  zip: 'application/zip',
 };
+
+/**
+ * Lowercased extension without the dot, or '' when the path has none.
+ * `path.extname` keeps multi-dot names correct (`report.final.html` → `html`)
+ * and returns '' for extensionless paths, so those keys never collide with a
+ * real extension (and still fall back to application/octet-stream).
+ */
+function extName(filePath) {
+  return path.extname(String(filePath || '')).slice(1).toLowerCase();
+}
 
 export function normalizeWhatsAppId(value) {
   if (!value) return '';
@@ -524,7 +548,7 @@ export function inboundReadReceiptKeys({ key, enabled }) {
 }
 
 export function mediaPayloadForFile({ buffer, filePath, mediaType, caption, fileName }) {
-  const ext = filePath.toLowerCase().split('.').pop();
+  const ext = extName(filePath);
   const type = mediaType || inferMediaType(ext);
   if (type === 'image' && ext === 'gif') {
     // Pure helper fallback: do not lie and label raw GIF bytes as mp4.


### PR DESCRIPTION
## What Problem This Solves

The WhatsApp Baileys bridge sends `.html`, `.htm`, `.txt` and `.csv` documents as `application/octet-stream`, so phones show an unopenable **BIN** attachment instead of the file.

Root cause: `mediaPayloadForFile()` in `scripts/whatsapp-bridge/bridge_helpers.js` labels every document payload with

```js
mimetype: MIME_MAP[ext] || 'application/octet-stream',
```

and `MIME_MAP` in the same file had no entry for `html`, `htm`, `txt`, `csv` — nor for their text/office/archive siblings. Every document extension outside the small image/video/`pdf`/`doc`/`docx`/`xlsx` set fell through to the octet-stream default.

The Python side is not the deciding factor on this path: `plugins/platforms/whatsapp/adapter.py` posts to `/send-media` with only `mediaType` (`image|video|audio|document`) and no MIME, so the MIME WhatsApp actually receives is the one the bridge's `MIME_MAP` produces.

Closes #89074

## Evidence

Before the fix — `node --test scripts/whatsapp-bridge/bridge.media_mime.test.mjs`:

```
✖ html/htm/txt/csv documents keep their real MIME type
    actual 'application/octet-stream' - expected 'text/html'
✖ extension matching is case-insensitive
✖ multi-dot filenames use the last extension
✖ explicit document mediaType uses the same mapping
ℹ tests 7   ℹ pass 3   ℹ fail 4
```

After the fix:

```
✔ html/htm/txt/csv documents keep their real MIME type
✔ extension matching is case-insensitive
✔ multi-dot filenames use the last extension
✔ extensionless paths still fall back to application/octet-stream
✔ explicit document mediaType uses the same mapping
✔ image/video MIME handling is unchanged
✔ MIME_MAP keeps the previously mapped types intact
ℹ tests 7   ℹ pass 7   ℹ fail 0
```

Sabotage pass — each edit was applied to `bridge_helpers.js`, the tests were run, then the file was restored (`file restored: true`):

```
--- baseline (with fix):                                  GREEN   pass 7 fail 0
--- sabotage A: html/htm removed from MIME_MAP:           RED     fail 4
--- sabotage B: old split(".").pop() extension extraction: GREEN  (no behaviour change for the tested inputs)
--- sabotage C: txt re-mapped to octet-stream:             RED     fail 3
--- restored:                                              GREEN   pass 7 fail 0
```

Sabotage B is reported as it landed: the previous expression already handled case-insensitivity and multi-dot names, which is why the extension helper below is a robustness fix rather than the behaviour change. Sabotages A and C are the load-bearing part — drop a mapping and the suite goes red.

Whole bridge suite, each file run with `node --test`:

```
allowlist.test.mjs           5 pass 0 fail
bridge.media_mime.test.mjs   7 pass 0 fail   (new)
bridge.native.test.mjs       1 pass 0 fail
bridge.reconnect.test.mjs    1 pass 0 fail
bridge.sendqueue.test.mjs    1 pass 0 fail
outbound_ids.test.mjs        6 pass 0 fail
owner_message_gate.test.mjs  8 pass 0 fail
```

## Changes

- `scripts/whatsapp-bridge/bridge_helpers.js`
  - `MIME_MAP`: add `html`/`htm` → `text/html`, `txt`/`log`/`ini`/`cfg` → `text/plain`, `csv` → `text/csv`, `md` → `text/markdown`, `json`, `xml`, `yaml`/`yml`, `toml`, `zip`, and the office siblings `xls`/`ppt`/`pptx` that were missing next to the existing `doc`/`docx`/`xlsx`. The set mirrors `gateway/platforms/base.py` (`SUPPORTED_DOCUMENT_TYPES`) so a document is labelled the same way on both paths.
  - extension extraction in `mediaPayloadForFile()` now uses `path.extname()` (lower-cased, dot stripped) instead of `filePath.toLowerCase().split('.').pop()`, which returned the whole path for extensionless files and read a dot-prefixed basename as an extension. Case-insensitivity and the extensionless fallback to `application/octet-stream` are unchanged and are now locked in by tests.
- `scripts/whatsapp-bridge/bridge.media_mime.test.mjs` (new): behaviour coverage through `mediaPayloadForFile()` for the reported extensions, case variants, multi-dot names, extensionless paths, and regression guards for the existing image/video mappings.

No new dependencies (Node stdlib `path` only). No change to the Baileys runtime, so no live WhatsApp session is required to verify this.

## How to Test

```bash
node --test scripts/whatsapp-bridge/bridge.media_mime.test.mjs
node --test scripts/whatsapp-bridge/*.test.mjs
```

## Relationship to #27214

`#27214` is an older, broader PR that also carries these mappings, and the two earlier attempts at this issue were closed as duplicates of it. This PR is deliberately **not** a superset — it is the minimal outbound-bridge fix for the symptom in #89074 against the current tree:

- `#27214` patches `scripts/whatsapp-bridge/bridge.js` where `const MIME_MAP` used to live, plus `gateway/platforms/whatsapp.py`. The bridge has since been split — `MIME_MAP` now lives in `scripts/whatsapp-bridge/bridge_helpers.js` and the adapter is `plugins/platforms/whatsapp/adapter.py` — so that diff no longer applies as written (it reads UNKNOWN/CONFLICTING).
- The sweeper review on `#27214` asked for behaviour coverage on MIME inference rather than asserting raw source strings; this PR asserts `mediaPayloadForFile()` output.

If the intent is to land `#27214` as the single umbrella fix, this PR can be closed in its favour — but the bridge MIME table has to be re-homed into `bridge_helpers.js` first for that diff to apply.

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] Searched existing PRs and issues — see "Relationship to #27214" above
- [x] Only changes related to this fix (2 files, no lockfile drift)
- [x] Tests added for the change (RED → GREEN verified, plus sabotage)
- [x] Tested on Windows 11, Node v26.4.0 — unit level; no live Baileys session
