### PR TITLE
fix(git): carry user safe.directory past non-interactive config isola…

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -233,12 +233,20 @@ _GIT_CONFIG_OVERRIDES = {
 
 
 def _user_safe_directories(base_env: "Mapping[str, str]") -> list[str]:
-    """The user's configured ``safe.directory`` values, read from their real global/system config.
+    """The user's configured ``safe.directory`` values, in git's own effective order.
 
-    Read with ``git config --get-all`` under *base_env* (the caller's untouched environment) so an
-    explicit ``GIT_CONFIG_GLOBAL``/``GIT_CONFIG_SYSTEM`` still points at the file the user means.
+    Read with ``git config -z --get-all`` under *base_env* (the caller's untouched environment) so
+    an explicit ``GIT_CONFIG_GLOBAL``/``GIT_CONFIG_SYSTEM`` still points at the file the user means.
     Best-effort: any failure (git missing, malformed config, timeout) yields no entries and leaves
     the caller exactly as it behaved before.
+
+    ``safe.directory`` is an *ordered* multi-valued setting and an empty value resets every entry
+    seen so far, so a user can revoke a system-wide ``safe.directory=*`` and then name only the
+    repositories they actually trust. Order and empty resets are therefore policy, not formatting:
+    scopes are read lowest-precedence first (system, then global) and every value is preserved
+    verbatim -- no de-duplication (it is a sequence, not a set) and no dropping of the reset
+    marker, either of which would resurrect a revoked wildcard and widen trust. ``-z`` keeps a
+    value containing whitespace or a newline as the single entry git reads it as.
     """
     env = dict(base_env)
     # --get-all itself must not be derailed by ambient injection or an interactive prompt.
@@ -248,11 +256,10 @@ def _user_safe_directories(base_env: "Mapping[str, str]") -> list[str]:
     env.pop("GIT_CONFIG_COUNT", None)
     env["GIT_TERMINAL_PROMPT"] = "0"
     values: list[str] = []
-    seen: set[str] = set()
-    for scope in ("--global", "--system"):
+    for scope in ("--system", "--global"):
         try:
             proc = subprocess.run(
-                ["git", "config", scope, "--get-all", "safe.directory"],
+                ["git", "config", scope, "-z", "--get-all", "safe.directory"],
                 capture_output=True, text=True, encoding="utf-8", errors="replace",
                 timeout=5, stdin=subprocess.DEVNULL, env=env, check=False,
             )
@@ -260,11 +267,12 @@ def _user_safe_directories(base_env: "Mapping[str, str]") -> list[str]:
             continue
         if proc.returncode != 0:
             continue
-        for line in proc.stdout.splitlines():
-            entry = line.strip()
-            if entry and entry not in seen:
-                seen.add(entry)
-                values.append(entry)
+        # -z terminates every value with NUL, so the trailing split field is always empty and is
+        # not a config entry; interior empty fields are real reset markers and must survive.
+        records = proc.stdout.split("\0")
+        if records and records[-1] == "":
+            records.pop()
+        values.extend(records)
     return values
 
 
@@ -318,9 +326,11 @@ def noninteractive_git_env(base: "Mapping[str, str] | None" = None) -> dict[str,
     # st_uid != geteuid() -- NFS/CIFS mounts without idmapping, shared checkouts, containers with
     # a remapped uid -- even though the user's own `git config --global --add safe.directory` is
     # correctly set and their interactive git works fine. Carried over the GIT_CONFIG_KEY_n
-    # channel, which survives GIT_CONFIG_GLOBAL=/dev/null. Read-only: it never widens the set
-    # beyond what the user already trusts, and the hardening overrides above still win because a
-    # later key of the same name takes precedence in git's config order.
+    # channel, which survives GIT_CONFIG_GLOBAL=/dev/null. Read-only and non-widening: the values
+    # are replayed in git's own effective order, empty reset markers included (see
+    # _user_safe_directories), so a global reset still revokes a system-wide wildcard exactly as it
+    # does for the user's interactive git. Appended last, but the hardening overrides above are
+    # distinct keys, so they are unaffected by ordering within safe.directory.
     overrides.extend(("safe.directory", value) for value in safe_directories)
     env["GIT_CONFIG_COUNT"] = str(len(overrides))
     for idx, (key, value) in enumerate(overrides):

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -232,6 +232,42 @@ _GIT_CONFIG_OVERRIDES = {
 }
 
 
+def _user_safe_directories(base_env: "Mapping[str, str]") -> list[str]:
+    """The user's configured ``safe.directory`` values, read from their real global/system config.
+
+    Read with ``git config --get-all`` under *base_env* (the caller's untouched environment) so an
+    explicit ``GIT_CONFIG_GLOBAL``/``GIT_CONFIG_SYSTEM`` still points at the file the user means.
+    Best-effort: any failure (git missing, malformed config, timeout) yields no entries and leaves
+    the caller exactly as it behaved before.
+    """
+    env = dict(base_env)
+    # --get-all itself must not be derailed by ambient injection or an interactive prompt.
+    for key in list(env):
+        if key == "GIT_CONFIG_PARAMETERS" or key.startswith(_GIT_CONFIG_INJECT_PREFIXES):
+            env.pop(key, None)
+    env.pop("GIT_CONFIG_COUNT", None)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    values: list[str] = []
+    seen: set[str] = set()
+    for scope in ("--global", "--system"):
+        try:
+            proc = subprocess.run(
+                ["git", "config", scope, "--get-all", "safe.directory"],
+                capture_output=True, text=True, encoding="utf-8", errors="replace",
+                timeout=5, stdin=subprocess.DEVNULL, env=env, check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if proc.returncode != 0:
+            continue
+        for line in proc.stdout.splitlines():
+            entry = line.strip()
+            if entry and entry not in seen:
+                seen.add(entry)
+                values.append(entry)
+    return values
+
+
 def noninteractive_git_env(base: "Mapping[str, str] | None" = None) -> dict[str, str]:
     """Environment for *internal* git invocations that must never prompt.
 
@@ -258,6 +294,9 @@ def noninteractive_git_env(base: "Mapping[str, str] | None" = None) -> dict[str,
     for input nobody can type.
     """
     env = dict(base if base is not None else os.environ)
+    # Captured before the isolation below rewrites GIT_CONFIG_GLOBAL/SYSTEM to /dev/null --
+    # reading after that point would resolve the user's config to an empty file.
+    safe_directories = _user_safe_directories(base if base is not None else os.environ)
     env["GIT_TERMINAL_PROMPT"] = "0"
     env["GCM_INTERACTIVE"] = "Never"
     # Drop caller-supplied config injection; the GIT_CONFIG_COUNT block is rebuilt below so
@@ -272,8 +311,19 @@ def noninteractive_git_env(base: "Mapping[str, str] | None" = None) -> dict[str,
     env["GIT_PAGER"] = "cat"
     env["PAGER"] = "cat"
     env["GIT_EDITOR"] = "true"
-    env["GIT_CONFIG_COUNT"] = str(len(_GIT_CONFIG_OVERRIDES))
-    for idx, (key, value) in enumerate(_GIT_CONFIG_OVERRIDES.items()):
+    overrides = list(_GIT_CONFIG_OVERRIDES.items())
+    # safe.directory is honoured ONLY from global/system config (git rejects it from repo-level
+    # config so a hostile repo cannot self-authorise), and both are blanked just above. Without
+    # re-injection every internal git call fails "detected dubious ownership" on any repo whose
+    # st_uid != geteuid() -- NFS/CIFS mounts without idmapping, shared checkouts, containers with
+    # a remapped uid -- even though the user's own `git config --global --add safe.directory` is
+    # correctly set and their interactive git works fine. Carried over the GIT_CONFIG_KEY_n
+    # channel, which survives GIT_CONFIG_GLOBAL=/dev/null. Read-only: it never widens the set
+    # beyond what the user already trusts, and the hardening overrides above still win because a
+    # later key of the same name takes precedence in git's config order.
+    overrides.extend(("safe.directory", value) for value in safe_directories)
+    env["GIT_CONFIG_COUNT"] = str(len(overrides))
+    for idx, (key, value) in enumerate(overrides):
         env[f"GIT_CONFIG_KEY_{idx}"] = key
         env[f"GIT_CONFIG_VALUE_{idx}"] = value
     return env

--- a/tests/hermes_cli/test_noninteractive_git.py
+++ b/tests/hermes_cli/test_noninteractive_git.py
@@ -177,6 +177,95 @@ class TestNoninteractiveGitEnv:
         assert "/attacker/controlled" not in safe
         assert "/mnt/nfs/repo" in safe
 
+    def test_safe_directory_preserves_git_ordering_and_reset_markers(self, tmp_path, monkeypatch):
+        """The user's effective trust policy is replayed verbatim, resets included.
+
+        ``safe.directory`` is an ordered multi-valued setting where an empty value resets every
+        earlier entry, which is how a user revokes a system-wide ``safe.directory=*`` and then
+        names only the repositories they trust. Reading global-before-system, dropping the empty
+        marker, or de-duplicating turns ``* -> reset -> /trusted/only`` into ``/trusted/only, *``
+        and silently restores the wildcard the user revoked. Contract: the injected sequence equals
+        what git itself reports for the same config (system scope first, then global, verbatim).
+        """
+        system_config = tmp_path / "system-gitconfig"
+        system_config.write_text("[safe]\n\tdirectory = *\n", encoding="utf-8")
+        global_config = tmp_path / "gitconfig"
+        global_config.write_text(
+            "[safe]\n\tdirectory = \n\tdirectory = /trusted/only\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(system_config))
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+
+        env = noninteractive_git_env()
+        injected = [
+            env[f"GIT_CONFIG_VALUE_{idx}"]
+            for idx in range(int(env["GIT_CONFIG_COUNT"]))
+            if env[f"GIT_CONFIG_KEY_{idx}"] == "safe.directory"
+        ]
+
+        # git's own effective view of the same two files, lowest-precedence scope first.
+        expected = subprocess.run(
+            ["git", "config", "-z", "--get-all", "safe.directory"],
+            capture_output=True, text=True, check=True,
+            env={**os.environ, "GIT_CONFIG_SYSTEM": str(system_config),
+                 "GIT_CONFIG_GLOBAL": str(global_config)},
+        ).stdout.split("\0")[:-1]
+
+        assert expected == ["*", "", "/trusted/only"], "git's documented reset shape changed"
+        assert injected == expected
+
+    def test_safe_directory_reset_still_revokes_wildcard_for_real_git(self, tmp_path):
+        """End-to-end: a revoked wildcard stays revoked, and the named repo stays usable.
+
+        Proves the injected sequence produces the same *trust decision* real git makes, not merely
+        the same list. Both repos are made cross-owner via ``safe.directory=*`` being the only
+        thing that could authorise them, so the negative control fails exactly as the user's
+        interactive git does.
+        """
+        if not shutil.which("git"):
+            pytest.skip("git not installed")
+
+        def _repo(name: str) -> Path:
+            path = tmp_path / name
+            path.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+            subprocess.run(
+                ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                 "commit", "-q", "--allow-empty", "-m", "x"],
+                cwd=path, check=True,
+            )
+            return path
+
+        trusted = _repo("trusted")
+        unrelated = _repo("unrelated")
+
+        system_config = tmp_path / "system-gitconfig"
+        system_config.write_text("[safe]\n\tdirectory = *\n", encoding="utf-8")
+        global_config = tmp_path / "gitconfig"
+        global_config.write_text(
+            f"[safe]\n\tdirectory = \n\tdirectory = {trusted}\n", encoding="utf-8"
+        )
+
+        env = noninteractive_git_env(
+            {**os.environ, "GIT_CONFIG_SYSTEM": str(system_config),
+             "GIT_CONFIG_GLOBAL": str(global_config)}
+        )
+        # Force the ownership check that safe.directory governs; without it git trusts the repo
+        # because the test process owns the checkout it just created.
+        env["GIT_TEST_ASSUME_DIFFERENT_OWNER"] = "1"
+
+        def _rev_parse(repo: Path) -> int:
+            return subprocess.run(
+                ["git", "-C", str(repo), "rev-parse", "HEAD"],
+                capture_output=True, text=True, env=env, stdin=subprocess.DEVNULL,
+            ).returncode
+
+        assert _rev_parse(trusted) == 0, "the explicitly trusted repo must stay usable"
+        assert _rev_parse(unrelated) != 0, (
+            "the global empty reset revoked the system wildcard, so an unrelated cross-owner "
+            "repo must still be refused"
+        )
+
     def test_ssh_host_key_prompts_fail_closed(self):
         """core.sshCommand is pinned to BatchMode ssh (#104591).
 

--- a/tests/hermes_cli/test_noninteractive_git.py
+++ b/tests/hermes_cli/test_noninteractive_git.py
@@ -97,6 +97,86 @@ class TestNoninteractiveGitEnv:
         assert values["sequence.editor"] == "true"
         assert values["diff.external"] == ""
 
+    def test_carries_user_safe_directory_past_config_isolation(self, tmp_path, monkeypatch):
+        """safe.directory survives GIT_CONFIG_GLOBAL=/dev/null (#dubious-ownership on NFS).
+
+        git honours safe.directory only from global/system config, and both are blanked here. If
+        it is not re-injected, every internal git call fails "detected dubious ownership" on a
+        repo whose st_uid != geteuid() -- an NFS/CIFS mount without idmapping, a shared checkout,
+        a container with a remapped uid -- even though the user configured it correctly.
+        """
+        gitconfig = tmp_path / "gitconfig"
+        gitconfig.write_text(
+            "[safe]\n\tdirectory = /mnt/nfs/repo\n\tdirectory = /srv/shared/other\n",
+            encoding="utf-8",
+        )
+        empty_system = tmp_path / "system-gitconfig"
+        empty_system.write_text("", encoding="utf-8")
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(gitconfig))
+        monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(empty_system))
+
+        env = noninteractive_git_env()
+        pairs = [
+            (env[f"GIT_CONFIG_KEY_{idx}"], env[f"GIT_CONFIG_VALUE_{idx}"])
+            for idx in range(int(env["GIT_CONFIG_COUNT"]))
+        ]
+        safe = [value for key, value in pairs if key == "safe.directory"]
+
+        assert "/mnt/nfs/repo" in safe
+        assert "/srv/shared/other" in safe
+        # Isolation is still in force: the values ride the KEY_n channel, not the config file.
+        assert env["GIT_CONFIG_GLOBAL"] == os.devnull
+        assert env["GIT_CONFIG_SYSTEM"] == os.devnull
+        # And the hardening overrides are untouched by the appended entries.
+        assert ("core.pager", "cat") in pairs
+        assert ("credential.helper", "") in pairs
+
+    def test_safe_directory_absent_when_user_configured_none(self, tmp_path, monkeypatch):
+        """No user entries -> no injected entries; the env is exactly as it was before."""
+        gitconfig = tmp_path / "gitconfig"
+        gitconfig.write_text("[user]\n\tname = nobody\n", encoding="utf-8")
+        empty_system = tmp_path / "system-gitconfig"
+        empty_system.write_text("", encoding="utf-8")
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(gitconfig))
+        # Pin the system scope too: a real /etc/gitconfig on the test host may carry its own
+        # safe.directory entries, which would otherwise leak in and mask the assertion.
+        monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(empty_system))
+
+        env = noninteractive_git_env()
+        keys = [env[f"GIT_CONFIG_KEY_{idx}"] for idx in range(int(env["GIT_CONFIG_COUNT"]))]
+
+        assert "safe.directory" not in keys
+
+    def test_ambient_safe_directory_injection_is_not_trusted(self, tmp_path, monkeypatch):
+        """A caller-supplied GIT_CONFIG_KEY_n=safe.directory is dropped, not laundered through.
+
+        Only what the user's own config file says is carried; ambient injection stays stripped so
+        this cannot become a path-trust escalation vector.
+        """
+        gitconfig = tmp_path / "gitconfig"
+        gitconfig.write_text("[safe]\n\tdirectory = /mnt/nfs/repo\n", encoding="utf-8")
+        empty_system = tmp_path / "system-gitconfig"
+        empty_system.write_text("", encoding="utf-8")
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(gitconfig))
+        monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(empty_system))
+
+        env = noninteractive_git_env(
+            {
+                **os.environ,
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "safe.directory",
+                "GIT_CONFIG_VALUE_0": "/attacker/controlled",
+            }
+        )
+        safe = [
+            env[f"GIT_CONFIG_VALUE_{idx}"]
+            for idx in range(int(env["GIT_CONFIG_COUNT"]))
+            if env[f"GIT_CONFIG_KEY_{idx}"] == "safe.directory"
+        ]
+
+        assert "/attacker/controlled" not in safe
+        assert "/mnt/nfs/repo" in safe
+
     def test_ssh_host_key_prompts_fail_closed(self):
         """core.sshCommand is pinned to BatchMode ssh (#104591).
 


### PR DESCRIPTION
## What does this PR do?

`noninteractive_git_env()` blanks `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` to `/dev/null`
so a user's config cannot hang Hermes's internal git plumbing with pagers, hooks or
credential prompts. Sound intent — but it also discards `safe.directory`, and git honours
that key **only** from global/system config (it is rejected from repo-level config by
design, so a hostile repo cannot self-authorise).

Result: every internal git call fails on a repo whose `st_uid != geteuid()`:

    $ hermes -w
    ✗ Failed to create worktree: fatal: detected dubious ownership in
      repository at '/mnt/nas/py/repo'

That hits NFS/CIFS mounts without idmapping, shared checkouts, and containers with a
remapped uid. The user's own `git config --global --add safe.directory` is set correctly
and their interactive git works fine — Hermes throws the setting away before git reads it,
so the error's own suggested remedy can never fix it. There is no config or env escape
hatch: the blanking is unconditional, and `safe.directory` in repo-level config is ignored
by git.

**Fix:** read the user's real `safe.directory` values *before* the isolation is applied,
then re-inject them over the `GIT_CONFIG_KEY_n` channel, which survives
`GIT_CONFIG_GLOBAL=/dev/null`. Isolation is unchanged — global/system config stay pointed
at `/dev/null` and every hardening override still applies, since a later key of the same
name wins in git's config order.

Read-only and non-widening: only values already in the user's own config are carried, so
this grants no trust they had not already granted. Ambient `GIT_CONFIG_KEY_n` injection is
still stripped first, so a caller cannot launder an attacker-controlled path through this
path — covered by a regression test.

**Update (review round 2, `170b4a12`):** the first version of this change got the
*serialization* of that policy wrong, and the mistake could widen trust rather than merely
reformat it. `safe.directory` is an ordered multi-valued setting in which an empty value
resets all earlier entries — the documented way to revoke a system-wide `safe.directory=*`
and then name only the repositories you trust. Reading `--global` before `--system`,
dropping empty entries, and de-duplicating turned `* → reset → /trusted/only` into
`/trusted/only, *`, restoring a wildcard the user had deliberately revoked. Reproduced with
real git (2.55.0 locally, 2.47.3 by the reviewer): the user's own config rejects an
unrelated cross-owner repo with `rc=128`, the old reconstruction accepted it with `rc=0`,
and the current one is back to `rc=128`.

Now: scopes are read lowest-precedence first (system, then global), every value is replayed
verbatim with no de-duplication and no dropping of reset markers, and the read uses
`git config -z` so a value containing whitespace or a newline stays the single entry git
reads it as instead of being split into several bogus trust entries. Two invariant tests
cover it, both proven red on the previous implementation: one pins the injected sequence to
`git config -z --get-all safe.directory` for the same config files, the other asserts the
real trust decision end-to-end (named repo usable, unrelated cross-owner repo still
refused) under `GIT_TEST_ASSUME_DIFFERENT_OWNER=1`, which needs no root or `chown`.

## Related Issue

No existing issue found — searched open/merged PRs and issues for `safe.directory` and
`dubious ownership`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/_subprocess_compat.py`
  - New `_user_safe_directories(base_env)` helper: reads `git config --global/--system
    --get-all safe.directory` under the caller's untouched environment, de-duplicated,
    order-preserving. Best-effort — git missing, malformed config or timeout yields no
    entries and behaviour is exactly as before.
  - `noninteractive_git_env()` captures those values **before** rewriting
    `GIT_CONFIG_GLOBAL`/`SYSTEM`, then appends them to the injected
    `GIT_CONFIG_KEY_n`/`VALUE_n` block. The block stays dense and contiguous, so existing
    `range(GIT_CONFIG_COUNT)` readers are unaffected.
- `tests/hermes_cli/test_noninteractive_git.py` — three regression tests (below).

## How to Test

**Reproduce** (any repo whose checkout uid differs from the caller's — an NFS mount without
idmapping is the easy case):

```bash
cd /path/to/repo-on-nfs
git rev-parse HEAD                                      # works
GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
  GIT_CONFIG_NOSYSTEM=1 git rev-parse HEAD              # fatal: detected dubious ownership
```

The second command is exactly the environment Hermes builds, and is why `hermes -w` fails
there while the user's shell git succeeds.

**Verify the fix:**

```bash
python -c "
import subprocess
from hermes_cli._subprocess_compat import noninteractive_git_env
env = noninteractive_git_env()
r = subprocess.run(['git','worktree','add','/tmp/wt_probe','-b','probe'],
                   cwd='/path/to/repo-on-nfs', capture_output=True, text=True, env=env)
print(r.returncode, (r.stdout + r.stderr).strip())
"
```

Before: `fatal: detected dubious ownership`. After: `rc=0`, worktree created.

**Tests:**

```bash
pytest tests/hermes_cli/test_noninteractive_git.py \
       tests/security/test_gitspawn_config_injection.py \
       tests/tools/test_checkpoint_manager.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (1 commit, 2 files)
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially**: ran the three suites
      covering this code path, **80 passed**. The full suite does not collect in my
      environment (missing optional deps such as `prompt_toolkit`); I confirmed those
      collection errors are pre-existing by stashing this patch — 51 errors without it, 50
      with it. CI should be treated as the authority on the full suite.
- [x] I've added tests for my changes — three cases in `TestNoninteractiveGitEnv`:
      entries carried past isolation; nothing injected when the user configured none;
      ambient `GIT_CONFIG_KEY_n=safe.directory` injection not trusted. All three pin
      `GIT_CONFIG_SYSTEM` at an empty file, since a real `/etc/gitconfig` on the test host
      can otherwise leak entries and mask the assertions.
- [x] I've tested on my platform: Arch Linux (kernel 7.2.2), git 2.x, Python 3.11,
      repo on an NFSv4 mount (files uid 1024, caller uid 1000)

### Documentation & Housekeeping

- [x] Documentation — N/A (behaviour is internal; the `noninteractive_git_env()` docstring
      and inline comments explain the carve-out and why it is safe)
- [x] `cli-config.yaml.example` — N/A (no config keys added or changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] Cross-platform impact — considered. The helper shells out to `git config --get-all`,
      available wherever git is; failures degrade to the previous behaviour. On Windows the
      dubious-ownership check fires on different conditions, but the carve-out is
      platform-neutral and adds no POSIX-only assumptions.
- [x] Tool descriptions/schemas — N/A (no tool behaviour change)

## Screenshots / Logs

Before — the environment Hermes constructs:

```
$ GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null GIT_CONFIG_NOSYSTEM=1 \
    git rev-parse --short HEAD
fatal: detected dubious ownership in repository at '/mnt/nasirjones/py/harvestr'
To add an exception for this directory, call:

    git config --global --add safe.directory /mnt/nasirjones/py/harvestr
```

(The suggested remedy was already applied — Hermes discards it before git reads it.)

After — same call site, patched:

```
$ python -c "...noninteractive_git_env() ... git worktree add ..."
rc: 0
Preparing worktree (new branch 'patched_probe')
HEAD is now at 48549e45 ...
```

Tests:

```
$ pytest tests/hermes_cli/test_noninteractive_git.py \
         tests/security/test_gitspawn_config_injection.py \
         tests/tools/test_checkpoint_manager.py -q
80 passed in 4.97s
```

