### PR TITLE
fix(desktop): keep a URL-less Browser tab off the strip, and never name one about:blank

### DIFF
--- a/apps/desktop/src/app/chat/preview-tile.test.ts
+++ b/apps/desktop/src/app/chat/preview-tile.test.ts
@@ -42,6 +42,17 @@ describe('browserTabLabel', () => {
     expect(browserTabLabel(target, { title: '', url: 'about:blank' })).toBe('Browser')
   })
 
+  // A guest that has not navigated yet reports Chromium's DEFAULT document
+  // title — `about:blank` — and a tab whose address never landed records no
+  // page URL, so the `title !== url` guard above has nothing to compare it
+  // against and the placeholder became the tab's name in the strip (#89196).
+  it('refuses the guest default document title as a label', () => {
+    expect(browserTabLabel(target, { title: 'about:blank', url: '' })).toBe('Browser')
+    expect(browserTabLabel({ ...target, url: 'https://example.com' }, { title: 'ABOUT:BLANK', url: '' })).toBe(
+      'example.com'
+    )
+  })
+
   // A tab restored from storage has reported nothing yet, so its target is all
   // there is to name it by.
   it('names an unreported tab from its target', () => {

--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -115,6 +115,11 @@ function previewTitle(tabId: string): string {
   return tail || value || 'Preview'
 }
 
+/** Chromium's DEFAULT document title — what an `<webview>` reports before its
+ *  address has landed. Not a name: a tab whose guest says this has no page
+ *  yet (#89196). */
+const BLANK_DOCUMENT_TITLE = /^about:blank\/?$/i
+
 /**
  * What to call a Browser tab. Its page title, else the host it is on, else
  * the surface — the ladder every browser walks, and the reason more than one
@@ -122,13 +127,16 @@ function previewTitle(tabId: string): string {
  *
  * A page that never set a title reports its own address as one, which is a
  * worse label than the host it came from, so an address-shaped title falls
- * through.
+ * through. Chromium's default document title falls through too: a guest that
+ * has not navigated reports `about:blank`, and with no page URL recorded yet
+ * there is nothing to compare it against — it reached the strip as a tab
+ * named ABOUT:BLANK (#89196).
  */
 export function browserTabLabel(target: PreviewTarget, page?: BrowserPage): string {
   const url = page?.url || target.url
   const title = page?.title.trim()
 
-  if (title && title !== url) {
+  if (title && title !== url && !BLANK_DOCUMENT_TITLE.test(title)) {
     return title
   }
 

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -12,6 +12,7 @@ import {
   closeRightRail,
   closeRightRailTab,
   commitBrowserTabLocation,
+  decodePreviewTabs,
   newBrowserTab,
   openPreview,
   previewTabId,
@@ -173,6 +174,31 @@ describe('preview store', () => {
     closeRightRailTab('file:file:///nowhere.html')
 
     expect($previewTabs.get()).toHaveLength(0)
+  })
+
+  // An address-less Browser has nothing to load: its pane mounts a webview
+  // with an empty `src`, the guest never navigates, and Chromium's default
+  // document title (`about:blank`) is what the strip ends up showing (#89196).
+  // The open door refuses it — the same rule `commitBrowserTabLocation` uses
+  // for an empty address — so no such tab ever reaches the tab strip.
+  it('refuses to open a Browser tab with no address', () => {
+    openPreview(urlTarget(''), 'tool-result')
+    openPreview({ kind: 'url', label: 'Browser', source: '   ', url: '   ' }, 'explicit-link')
+
+    expect($previewTabs.get()).toHaveLength(0)
+    expect($rightRailActiveTabId.get()).toBeNull()
+  })
+
+  // Reopening the stale persisted tab on every boot is how the stray tab came
+  // back (the issue's reporter saw it after the v0.20.4 layout heal), so the
+  // restore filter drops it the same way.
+  it('drops a persisted address-less Browser tab instead of restoring it', () => {
+    const raw = JSON.stringify([
+      { id: 'url:browser-blank', target: { kind: 'url', label: 'Browser', source: 'about:blank', url: '' } },
+      { id: 'url:browser-live', target: { kind: 'url', label: 'Browser', source: 'about:blank', url: 'about:blank' } }
+    ])
+
+    expect(decodePreviewTabs(raw).map(tab => tab.id)).toEqual(['url:browser-live'])
   })
 
   it('closes by the raw source the composer rows were handed', () => {

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -77,7 +77,12 @@ function isPreviewTarget(value: unknown): value is PreviewTarget {
     (r.kind === 'artifact' || r.kind === 'file' || r.kind === 'url') &&
     typeof r.label === 'string' &&
     typeof r.source === 'string' &&
-    typeof r.url === 'string'
+    typeof r.url === 'string' &&
+    // An address-less Browser tab has nothing to load and nothing to name it by:
+    // its pane mounts a webview with an empty `src`, the guest never navigates,
+    // and Chromium's default document title (`about:blank`) is what the strip
+    // shows. Drop it instead of restoring it (#89196).
+    !(r.kind === 'url' && !r.url.trim())
   )
 }
 
@@ -384,6 +389,17 @@ function previewTargetForSource(target: PreviewTarget, source: PreviewRecordSour
  *  only way anything reaches a preview. */
 export function openPreview(target: PreviewTarget, source: PreviewRecordSource = 'manual') {
   const resolved = previewTargetForSource(target, source)
+
+  // A Browser with no address isn't a surface you can use — there is nothing to
+  // load, so the pane sits on a webview that never navigates and the tab's name
+  // degrades to the guest's default document title (`about:blank`). Refuse it at
+  // the door, the same way `commitBrowserTabLocation` refuses an empty address
+  // (#89196). A blank VESSEL (`about:blank`) is still a real address: that one
+  // opens, and the pane's empty state invites an address.
+  if (resolved.kind === 'url' && !resolved.url.trim()) {
+    return
+  }
+
   const current = $previewTabs.get()
   const id = resolved.kind === 'url' ? browserTabId(current) : previewTabId(resolved)
   const index = current.findIndex(tab => tab.id === id)


### PR DESCRIPTION
## What Problem This Solves

Issue #89196: the tabbed SESSIONS | BOTS sidebar occasionally grows a third tab whose label reads `ABOUT:BLANK`, with nothing behind it.

Root cause is the Browser (URL) preview tab's live label. The zone strip resolves a label as `paneChrome(pane).tabTitle?.() ?? pane.title ?? paneId` (`components/pane-shell/tree/renderer/tree-group.tsx:407`); for a URL preview tile that is `<BrowserTabLabel/>` → `browserTabLabel()` (`src/app/chat/preview-tile.tsx`). The page record it reads comes from `guestPage()` (`src/app/chat/right-rail/preview-pane.tsx:101`), which stores the guest's `getTitle()` verbatim — and Chromium reports a document's own address as its title until the page sets one, with `about:blank` the default for a guest whose URL has not landed. `browserTabLabel` trusted any title that merely differed from the URL (`title !== url`); a tab whose address never landed records no page URL, so that guard has nothing to compare against and the placeholder became the tab's name — `PaneTabLabel` uppercases it, hence `ABOUT:BLANK` (`store/preview.ts` is where such a tab is admitted: a `url` target with a blank address passes every filter, and its pane mounts a webview with an empty `src` that never navigates).

Fix, all on the preview road that already exists:

- `openPreview` (the one door onto a preview tab) refuses a `url` target whose address is blank — the same rule `commitBrowserTabLocation` already applies to an empty address (`store/preview.ts`). The address-less Browser no longer enters the strip at all.
- The restore filter `isPreviewTarget` drops such a persisted record instead of reviving it, so a stale one cannot re-enter the strip on the next boot.
- `browserTabLabel` ignores the guest's default blank-document title, so any tab whose guest has not navigated is named from its address (the host) or the surface (`Browser`) — the ladder every other Browser tab walks.

`about:blank` itself stays a real address: the blank vessel the Browser hotkey opens still works, empty state and all (`preview-open-browser.test.ts` unchanged and green).

Boundary: verified at store/component level plus the preview suites. The reporter's stray chip sat in the SESSIONS | BOTS zone, and no store-level path docks a preview tile there (preview tiles dock beside main; only the Bots pane is force-docked into the sessions strip), so the zone placement itself was not reproduced on a real GUI. The naming path that produced `ABOUT:BLANK` is this one, and both halves of it are closed.

## Evidence

Failing-first tests (added in this PR). Before the fix, the same command reported `Test Files 2 failed (2) / Tests 3 failed | 31 passed (34)` — and the sabotage run below is that same pre-fix code, captured verbatim:

```
cd apps/desktop && npx vitest run --project ui src/store/preview.test.ts src/app/chat/preview-tile.test.ts --maxWorkers=1 --no-file-parallelism

 FAIL  |ui| src/store/preview.test.ts > preview store > refuses to open a Browser tab with no address
AssertionError: expected [ { …(2) } ] to have a length of +0 but got 1
 FAIL  |ui| src/store/preview.test.ts > preview store > drops a persisted address-less Browser tab instead of restoring it
AssertionError: expected [ 'url:browser-blank', …(1) ] to deeply equal [ 'url:browser-live' ]
 FAIL  |ui| src/app/chat/preview-tile.test.ts > browserTabLabel > refuses the guest default document title as a label
AssertionError: expected 'ABOUT:BLANK' to be 'example.com' // Object.is equality
 Test Files  2 failed (2)
      Tests  3 failed | 31 passed (34)
```

Green after the fix, same command:

```
 Test Files  2 passed (2)
      Tests  38 passed (38)
```

Sabotage: all three guards reverted by rewinding the exact patched substrings, same command → the three failures above, then the fix restored and the suite re-run green.

Related preview suites, one targeted run (`--maxWorkers=1 --no-file-parallelism`, 18 files):

```
src/app/chat/close-tab.test.ts, src/app/chat/composer/status-stack/preview-row.test.tsx,
src/app/chat/preview-tile.test.ts, src/app/chat/right-rail/preview-{act,annotate-card,annotate-host,
artifact,browser-bar,file,nav,pane,reader}.test.*, src/app/session/hooks/preview-open.test.tsx,
src/lib/local-preview.test.ts, src/store/preview-{open-browser,persistence,status}.test.ts, src/store/preview.test.ts

 Test Files  18 passed (18)
      Tests  194 passed (194)
```

Pane-shell tree suites (the strip/label path): `tree-group.test.tsx` + `dock-enforce.test.ts` → `Test Files 2 passed (2) / Tests 13 passed (13)`.

`npx tsc -p . --noEmit` → the only error is the pre-existing, environmental `src/app/messaging/telegram-qr-setup.tsx(48,31): error TS2307: Cannot find module 'qrcode'` (`qrcode` is in `package.json` but not installed in this worktree); nothing from the changed files. `npx eslint` and `npx prettier --check` on all four changed files: clean.

Closes #89196
