### PR TITLE
fix(desktop): resolve runtime plugin SDK namespaces lazily and break sdk cycle

### DIFF
--- a/apps/desktop/src/app/skills/plugins-tab.test.tsx
+++ b/apps/desktop/src/app/skills/plugins-tab.test.tsx
@@ -395,4 +395,14 @@ describe('PluginsTab catalog UX', () => {
 
     await waitFor(() => expect($pluginInstallRequest.get()).not.toBeNull())
   })
+
+  it('triggers rescanAll when the rescan button is clicked', async () => {
+    render(<PluginsTab profile={null} />)
+
+    const initialCalls = requestGateway.mock.calls.length
+    const rescanBtn = screen.getByRole('button', { name: 'Rescan' })
+    fireEvent.click(rescanBtn)
+
+    await waitFor(() => expect(requestGateway.mock.calls.length).toBeGreaterThan(initialCalls))
+  })
 })

--- a/apps/desktop/src/app/skills/plugins-tab.tsx
+++ b/apps/desktop/src/app/skills/plugins-tab.tsx
@@ -15,7 +15,6 @@ import { Codicon } from '@/components/ui/codicon'
 import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
 import { $pluginRecords, type PluginRecord, setPluginEnabled } from '@/contrib/plugins-store'
-import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
 import type { ProfileScope } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
@@ -117,6 +116,7 @@ async function revealPluginsDir() {
  *  rescan the root — a concurrent scan would read the pre-copy state. */
 async function rescanAll(requestGateway: GatewayRequest, scope: null | string) {
   await window.hermesDesktop?.reconcileDesktopPlugins?.().catch(() => undefined)
+  const { discoverRuntimePlugins } = await import('@/contrib/runtime-loader')
   await discoverRuntimePlugins()
   await loadAgentPlugins(requestGateway, scope)
 }

--- a/apps/desktop/src/sdk/runtime.test.ts
+++ b/apps/desktop/src/sdk/runtime.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSdk = vi.hoisted(() => ({
+  $accentOverride: () => 'accent',
+  Button: () => 'ButtonComponent',
+  SkillsView: () => 'SkillsViewComponent'
+}))
+
+vi.mock('./index', () => mockSdk)
+
+import { installPluginSdk, sdkImportMap } from './runtime'
+
+describe('sdk/runtime', () => {
+  beforeEach(() => {
+    delete (globalThis as Record<string, unknown>).__HERMES_PLUGIN_SDK__
+    delete (globalThis as Record<string, unknown>).__HERMES_REACT__
+    delete (globalThis as Record<string, unknown>).__HERMES_REACT_JSX__
+    delete (globalThis as Record<string, unknown>).__HERMES_REACT_JSX_DEV__
+  })
+
+  it('installs all runtime SDK namespaces onto globalThis lazily at call time', () => {
+    installPluginSdk()
+
+    const g = globalThis as Record<string, unknown>
+    expect(g.__HERMES_PLUGIN_SDK__).toBeDefined()
+    expect(g.__HERMES_REACT__).toBeDefined()
+    expect(g.__HERMES_REACT_JSX__).toBeDefined()
+    expect(g.__HERMES_REACT_JSX_DEV__).toBeDefined()
+
+    const installed = g.__HERMES_PLUGIN_SDK__ as Record<string, unknown>
+    expect(installed.Button).toBeDefined()
+    expect(installed.SkillsView).toBeDefined()
+    expect(installed.$accentOverride).toBeDefined()
+  })
+
+  it('provides the runtime import map for all expected specifiers', () => {
+    const map = sdkImportMap()
+
+    expect(map['@hermes/plugin-sdk']).toBeDefined()
+    expect(map['react/jsx-dev-runtime']).toBeDefined()
+    expect(map['react/jsx-runtime']).toBeDefined()
+    expect(map.react).toBeDefined()
+
+    expect(typeof map['@hermes/plugin-sdk']).toBe('string')
+    expect(map['@hermes/plugin-sdk']).toMatch(/^(blob:|data:)/)
+  })
+
+  it('does not throw when namespaces are accessed or evaluated at call time', () => {
+    // Calling installPluginSdk and sdkImportMap repeatedly is idempotent and does not throw
+    expect(() => installPluginSdk()).not.toThrow()
+    expect(() => sdkImportMap()).not.toThrow()
+  })
+})

--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -14,10 +14,18 @@ import * as jsxRuntime from 'react/jsx-runtime'
 import * as sdk from './index'
 
 const GLOBALS = {
-  __HERMES_PLUGIN_SDK__: sdk,
-  __HERMES_REACT__: React,
-  __HERMES_REACT_JSX__: jsxRuntime,
-  __HERMES_REACT_JSX_DEV__: jsxDevRuntime
+  get __HERMES_PLUGIN_SDK__() {
+    return sdk
+  },
+  get __HERMES_REACT__() {
+    return React
+  },
+  get __HERMES_REACT_JSX__() {
+    return jsxRuntime
+  },
+  get __HERMES_REACT_JSX_DEV__() {
+    return jsxDevRuntime
+  }
 } as const
 
 export function installPluginSdk(): void {
@@ -27,7 +35,8 @@ export function installPluginSdk(): void {
 /** Build a shim ESM blob that re-exports a global namespace's live members.
  *  Export names come from the namespace itself, so the list can't drift. */
 function shimUrl(globalKey: keyof typeof GLOBALS): string {
-  const names = Object.keys(GLOBALS[globalKey]).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
+  const namespace = GLOBALS[globalKey]
+  const names = Object.keys(namespace ?? {}).filter(name => name !== 'default' && /^[A-Za-z_$][\w$]*$/.test(name))
 
   const source =
     `const m = globalThis.${globalKey};\n` +


### PR DESCRIPTION
## Summary

Resolves #107288 by breaking the static module cycle between `sdk/index.ts` and `contrib/runtime-loader.ts`, and making runtime plugin SDK namespace resolution lazy and null-safe.

## Problem & Mechanism

Following the Capabilities → Plugins consolidation (#107212 and subsequent consolidation in commit `248ff2d3e8`), `sdk/index.ts` was caught in a static module cycle:
```
sdk/index.ts
  → app/skills/index.tsx (re-exports SkillsView)
  → app/skills/plugins-tab.tsx (statically imported discoverRuntimePlugins)
  → contrib/runtime-loader.ts (statically imported sdk/runtime.ts)
  → sdk/runtime.ts (statically imported sdk/index.ts)
  → sdk/index.ts
```

In production and packaged desktop builds, Rolldown's module topological sorting emitted `sdk/runtime.ts`'s `GLOBALS` object literal before the `sdk` export namespace was evaluated (hoisted unassigned `var` / TDZ). Consequently:
- `GLOBALS.__HERMES_PLUGIN_SDK__` was captured as `undefined` at module evaluation.
- On desktop startup, when loading any runtime (disk) plugin, `contrib/runtime-loader.ts:113` calls `installPluginSdk()`, which runs `sdkImportMap()` and `shimUrl('__HERMES_PLUGIN_SDK__')`.
- `shimUrl` executed `Object.keys(GLOBALS[globalKey])` on `undefined`, throwing `TypeError: Cannot convert undefined or null to object`.
- Every disk plugin failed to load on boot regardless of contents.

## Solution

1. **Cycle Break**: In `apps/desktop/src/app/skills/plugins-tab.tsx`, removed the top-level static import `import { discoverRuntimePlugins } from '@/contrib/runtime-loader'`. `discoverRuntimePlugins` is only called inside `rescanAll()` (an asynchronous action triggered by the user clicking the Rescan button or after an agent plugin update), so it is now loaded lazily:
   ```ts
   const { discoverRuntimePlugins } = await import('@/contrib/runtime-loader')
   await discoverRuntimePlugins()
   ```
   This severs the sole static link from `app/skills` to `contrib/runtime-loader.ts`, reducing paths from `sdk/index.ts` to `contrib/runtime-loader.ts` to 0.

2. **Call-Time Namespace Evaluation**: In `apps/desktop/src/sdk/runtime.ts`, converted `GLOBALS` properties to getters:
   ```ts
   const GLOBALS = {
     get __HERMES_PLUGIN_SDK__() { return sdk },
     get __HERMES_REACT__() { return React },
     get __HERMES_REACT_JSX__() { return jsxRuntime },
     get __HERMES_REACT_JSX_DEV__() { return jsxDevRuntime }
   } as const
   ```
   When `installPluginSdk()` executes, `Object.assign(globalThis, GLOBALS)` evaluates the getters at call time, assigning the fully initialized namespace objects.

3. **Null-Guarded Shim Generation**: In `shimUrl()`, guarded `Object.keys(namespace ?? {})` against nullish values to ensure graceful link-time handling instead of throwing in the host loader.

## Validation

- **Import Graph Analysis**: Verified via graph traversal that directed paths from `sdk/index.ts` to `contrib/runtime-loader.ts` and `sdk/runtime.ts` are 0.
- **Unit Tests**:
  - Added `apps/desktop/src/sdk/runtime.test.ts` testing global namespace assignment, import map construction, and safe evaluation.
  - Added test case to `apps/desktop/src/app/skills/plugins-tab.test.tsx` verifying rescan behavior.
  - All tests in `plugins-tab.test.tsx` (17 tests) and `runtime.test.ts` (3 tests) pass.
- **Typecheck & Lint**:
  - `npm run typecheck` (`tsc` for renderer, electron, e2e): passed (exit code 0).
  - `npm run lint` (`eslint` across `src/` and `electron/`): passed (0 errors).

Fixes #107288.
