### PR TITLE
fix(providers): drive every ACP provider from its profile, not from one vendor's name

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -471,14 +471,15 @@ def _finalize_routing(agent, api_mode, credential_pool):
         # GPT-5.x models usually require the Responses API path, but some providers have exceptions (for
         # example Copilot's gpt-5-mini still uses chat completions). ACP runtimes are excluded: an ACP
         # client handles its own routing and does not implement the Responses API surface. Keyed on the
-        # `acp://` scheme, not one vendor, so every ACP client is covered. When api_mode was explicitly
-        # provided, respect it — the user knows what their endpoint supports (#10473). Exception: Azure
+        # `acp://` scheme plus the provider profile's auth_type, not on one vendor's name, so every ACP
+        # client is covered. When api_mode was explicitly provided, respect it — the user knows what
+        # their endpoint supports (#10473). Exception: Azure
         # OpenAI serves gpt-5.x on /chat/completions and does NOT support the Responses API — skip the
         # upgrade for Azure (openai.azure.com), even though it looks OpenAI-compatible.
         api_mode is None
         and agent.api_mode == "chat_completions"
         and not is_actual_route(agent.provider, agent.base_url)
-        and agent.provider != "copilot-acp"
+        and not _acp_provider(agent.provider)
         and not _base_lower.startswith(("acp://", "acp+tcp://"))
         and not agent._is_azure_openai_url()
         and (
@@ -806,6 +807,31 @@ def _init_bedrock_client(agent, base_url):
         print(f"🤖 AI Agent initialized with model: {agent.model} (AWS Bedrock, {agent._bedrock_region}{_gr_label})")
 
 
+def _acp_provider(provider: str) -> bool:
+    """True when the provider launches an external ACP CLI (profile-driven, no name list)."""
+    from providers import is_external_process_provider
+
+    return is_external_process_provider(provider)
+
+
+def _acp_launch_spec(agent) -> tuple[str, list[str]]:
+    """Launch command/args for an ACP provider, else ``("", [])``.
+
+    Explicit runtime credentials win; otherwise the provider's own profile
+    supplies them, so a newly-registered external-process provider is driven
+    without core knowing its name.
+    """
+    from providers import acp_launch_spec, get_provider_profile
+
+    if not _acp_provider(agent.provider):
+        return "", []
+    command = str(getattr(agent, "acp_command", "") or "")
+    args = list(getattr(agent, "acp_args", None) or [])
+    if command or args:
+        return command, args
+    return acp_launch_spec(get_provider_profile(agent.provider)) or ("", [])
+
+
 def _explicit_client_kwargs(agent, api_key, base_url, _provider_timeout) -> Dict[str, Any]:
     """OpenAI-client kwargs from explicit CLI/gateway credentials (auth already resolved)."""
     _parsed_url = urlparse(base_url)
@@ -815,9 +841,10 @@ def _explicit_client_kwargs(agent, api_key, base_url, _provider_timeout) -> Dict
         client_kwargs["default_query"] = {k: v[0] for k, v in parse_qs(_parsed_url.query).items()}
     if _provider_timeout is not None:
         client_kwargs["timeout"] = _provider_timeout
-    if agent.provider == "copilot-acp":
-        client_kwargs["command"] = agent.acp_command
-        client_kwargs["args"] = agent.acp_args
+    command, args = _acp_launch_spec(agent)
+    if command or args:
+        client_kwargs["command"] = command
+        client_kwargs["args"] = args
     # OpenCode Zen free tier is served ANONYMOUSLY and 401s any bearer (incl. our keyless
     # placeholder): send an empty Authorization header to override the SDK's "Bearer <key>".
     with suppress(Exception):

--- a/agent/turn_api_call.py
+++ b/agent/turn_api_call.py
@@ -42,12 +42,15 @@ class ApiCallVerdict:
 
 def _should_stream(agent: Any) -> bool:
     """Streaming is preferred even without consumers (stale-stream / read-timeout health
-    checks); disabled on provider signal, ACP schemes, MoA without a display consumer, or
-    Mock clients in tests (SimpleNamespace, not stream iterators)."""
+    checks); disabled on provider signal, ACP providers (``acp://`` scheme or an
+    external-process provider profile), MoA without a display consumer, or Mock clients in
+    tests (SimpleNamespace, not stream iterators)."""
     if getattr(agent, "_disable_streaming", False):
         return False
     _base = str(agent.base_url or "").lower()
-    if agent.provider in {"copilot-acp"} or _base.startswith(("acp://", "acp+tcp://")):
+    from providers import is_external_process_provider
+
+    if _base.startswith(("acp://", "acp+tcp://")) or is_external_process_provider(agent.provider):
         return False
     if not agent._has_stream_consumers():
         if agent.provider == "moa":

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -35,6 +35,8 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import logging
+import os
+import shlex
 import sys
 from pathlib import Path
 
@@ -81,6 +83,39 @@ def get_provider_profile(name: str) -> ProviderProfile | None:
     if profile is None and isinstance(name, str) and name.lower().startswith("custom:"):
         profile = _REGISTRY.get("custom")
     return profile
+
+
+def is_external_process_provider(name: str) -> bool:
+    """True when ``name`` resolves to a profile that launches an external ACP CLI.
+
+    Call sites keyed on the hardcoded ``"copilot-acp"`` name instead of this
+    predicate break every other ACP provider: their launch command never reaches
+    the client, they inherit the Responses-API upgrade, and their turns try to
+    stream a completion object that is not iterable.
+    """
+    profile = get_provider_profile(name)
+    return bool(profile) and getattr(profile, "auth_type", "") == "external_process"
+
+
+def acp_launch_spec(profile: ProviderProfile | None) -> tuple[str, list[str]] | None:
+    """Launch command/args for an external-process profile.
+
+    Env overrides named by the profile win over its static defaults; ``None``
+    when the profile describes no launchable command (e.g. a remote
+    ``acp+tcp://`` endpoint the caller resolves elsewhere).
+    """
+    if profile is None or getattr(profile, "auth_type", "") != "external_process":
+        return None
+    env_names = tuple(getattr(profile, "process_command_env_vars", ()) or ())
+    command = next(
+        (os.environ[n].strip() for n in env_names if os.environ.get(n, "").strip()), ""
+    ) or str(getattr(profile, "process_command", "") or "")
+    args_env = str(getattr(profile, "process_args_env_var", "") or "")
+    raw_args = os.environ.get(args_env, "").strip() if args_env else ""
+    args = shlex.split(raw_args) if raw_args else list(getattr(profile, "process_args", ()) or [])
+    if not command and not args:
+        return None
+    return command, args
 
 
 def list_providers() -> list[ProviderProfile]:

--- a/tests/agent/test_acp_provider_rails.py
+++ b/tests/agent/test_acp_provider_rails.py
@@ -89,3 +89,94 @@ def test_an_acp_provider_turn_never_asks_for_a_stream(monkeypatch):
     assert result["final_response"].startswith("ok")
     assert client.chat.completions.calls, "the client was never called"
     assert not any(c.get("stream") for c in client.chat.completions.calls)
+
+
+def _register_acp_profile(
+    monkeypatch,
+    name: str,
+    *,
+    auth_type: str = "external_process",
+    process_command: str = "",
+    process_args: tuple = (),
+    process_command_env_vars: tuple = (),
+) -> None:
+    """Register a profile through the real registry, auto-removed by monkeypatch."""
+    from providers import _REGISTRY
+    from providers.base import ProviderProfile
+
+    monkeypatch.setitem(
+        _REGISTRY,
+        name,
+        ProviderProfile(
+            name=name,
+            auth_type=auth_type,
+            base_url=f"acp://{name}",
+            process_command=process_command,
+            process_args=process_args,
+            process_command_env_vars=process_command_env_vars,
+        ),
+    )
+
+
+def _launch_kwargs(provider: str):
+    from types import SimpleNamespace
+
+    from agent.agent_init import _explicit_client_kwargs
+
+    agent = SimpleNamespace(provider=provider, acp_command=None, acp_args=None)
+    return _explicit_client_kwargs(agent, "placeholder", f"acp://{provider}", None)
+
+
+def test_an_external_process_profile_supplies_the_launch_command(monkeypatch):
+    """Any ACP provider is driven from its own profile — core must not match on one name."""
+    _register_acp_profile(
+        monkeypatch, "fake-acp", process_command="/usr/bin/fake-acp", process_args=("acp", "--stdio")
+    )
+
+    kwargs = _launch_kwargs("fake-acp")
+
+    assert kwargs["command"] == "/usr/bin/fake-acp"
+    assert kwargs["args"] == ["acp", "--stdio"]
+
+
+def test_the_profile_env_override_wins_over_its_static_command(monkeypatch):
+    monkeypatch.setenv("HERMES_FAKE_ACP_COMMAND", "/opt/elsewhere/fake-acp")
+    _register_acp_profile(
+        monkeypatch,
+        "fake-acp-env",
+        process_command="/usr/bin/fake-acp",
+        process_args=("acp",),
+        process_command_env_vars=("HERMES_FAKE_ACP_COMMAND",),
+    )
+
+    assert _launch_kwargs("fake-acp-env")["command"] == "/opt/elsewhere/fake-acp"
+
+
+def test_an_http_provider_gets_no_launch_command(monkeypatch):
+    """Guard against the ACP branch widening onto ordinary API-key providers."""
+    _register_acp_profile(
+        monkeypatch, "fake-http", auth_type="api_key", process_command="/usr/bin/nope"
+    )
+
+    kwargs = _launch_kwargs("fake-http")
+
+    assert "command" not in kwargs
+    assert "args" not in kwargs
+
+
+def test_an_external_process_provider_never_streams_or_upgrades(monkeypatch):
+    """Streaming and the Responses upgrade follow the profile, not the base_url scheme."""
+    from types import SimpleNamespace
+
+    from agent.turn_api_call import _should_stream
+
+    _register_acp_profile(
+        monkeypatch, "fake-acp-plain", process_command="/usr/bin/fake-acp", process_args=("acp",)
+    )
+
+    assert not _should_stream(
+        SimpleNamespace(provider="fake-acp-plain", base_url="https://example.invalid/v1")
+    )
+
+    agent, _ = _agent(monkeypatch, "https://example.invalid/v1", provider="fake-acp-plain")
+    assert agent.api_mode == "chat_completions"


### PR DESCRIPTION
## Problem

Three call sites spell out `"copilot-acp"` by name, so every *other* ACP provider silently inherits the wrong defaults. Reproduced with an out-of-tree model-provider plugin (`~/.hermes/plugins/model-providers/omp-acp/`, same three-line shape as the bundled `copilot-acp` profile) driving `omp acp` over stdio:

- `agent_init._explicit_client_kwargs` only forwards the launch command when `agent.provider == "copilot-acp"`, so the ACP client falls back to its hardcoded `copilot` binary → `RuntimeError: Could not start Copilot ACP command 'copilot'`, even though the profile carries `process_command`/`process_args`.
- `agent_init`'s Responses-API upgrade excludes Copilot by name, so an ACP runtime that is not served from an `acp://` base_url can be switched to a transport its shim does not implement.
- `turn_api_call._should_stream` likewise keys on the name, so such a provider asks for a stream it cannot serve (`api_mode` mismatch on the first turn).

The profile fields (`process_command`, `process_args`, `process_command_env_vars`, `process_args_env_var`, `auth_type="external_process"`) already exist precisely so core does not need to know one vendor's binary — they just were not consulted at these three sites.

## Change

Two helpers in `providers/__init__.py`:

- `is_external_process_provider(name)` — profile-driven predicate, alias-aware.
- `acp_launch_spec(profile)` — launch command/args: env overrides named by the profile first, then the static defaults; `None` when the profile describes nothing launchable.

Then:

- `agent_init._acp_launch_spec(agent)` feeds `client_kwargs` from the profile. Explicit runtime credentials (`agent.acp_command`/`acp_args`) still win, so gateway/CLI-resolved credentials keep overriding the profile.
- The Responses-upgrade guard and `_should_stream` use `is_external_process_provider()` instead of the name list. The existing `acp://` / `acp+tcp://` scheme checks are unchanged, so runtime-resolved ACP routes are unaffected.

`copilot-acp` behaviour is unchanged — it is now covered by its own profile rather than a special case.

## Tests

4 invariant tests added to `tests/agent/test_acp_provider_rails.py` (profiles registered through the real registry, `monkeypatch.setitem` cleanup):

- an external-process profile supplies the launch command and args;
- the profile's env override wins over its static command;
- an API-key provider gets no launch command (guard against widening);
- an external-process provider neither streams nor upgrades, even with an `https://` base_url.

```
tests/agent/test_acp_provider_rails.py            7 passed
tests/agent, tests/hermes_cli, tests/providers    109 passed, 0 failed
tests/run_agent/ (+acp bridge, delegate)          328 passed, 0 failed
```

## E2E verification

Registering the out-of-tree `omp-acp` plugin and running `hermes chat -q "Reply with exactly: ACP_OK" --provider omp-acp`, with a **deliberately bogus** `HERMES_COPILOT_ACP_COMMAND=/nonexistent/bogus-omp`:

- this branch → `ACP_OK` (command came from the profile, env ignored)
- unpatched `main` → `API call failed after 3 retries: Could not start Copilot ACP command '/nonexistent/bogus-omp'`

Tool turn verified too: `hermes chat -q "Run: echo ACP_TOOL_OK ..." --provider omp-acp` → `ACP_TOOL_OK`.
