### PR TITLE
feat(config): reuse explicit static model presets

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3570,6 +3570,23 @@ def _fallback_entry_timeout(task: Optional[str], fb_label: str) -> Optional[floa
     return _coerce_positive_timeout(entry.get("timeout") if entry else None)
 
 
+def _fallback_reasoning_config(task: Optional[str], fb_label: str, primary: Optional[dict], client: Any = None) -> Optional[dict]:
+    """Use the selected fallback route's effort, including main-chain candidates."""
+    entry = _fallback_chain_entry(task, fb_label)
+    attached_effort = getattr(client, "_hermes_fallback_reasoning_effort", None)
+    if entry is None and isinstance(attached_effort, str):
+        entry = {"reasoning_effort": attached_effort}
+    if not isinstance(entry, dict) or "reasoning_effort" not in entry:
+        return primary
+    from hermes_constants import parse_reasoning_effort
+    parsed = parse_reasoning_effort(entry["reasoning_effort"])
+    if parsed is None:
+        logger.warning("Auxiliary %s: %s has invalid fallback reasoning_effort %r; retaining primary setting",
+                       task or "call", fb_label, entry["reasoning_effort"])
+        return primary
+    return parsed
+
+
 def _fallback_provider_from_label(label: str) -> str:
     """Recover the provider identifier from a fallback display label."""
     match = re.match(r"(?:fallback_chain\[\d+\]|fallback_providers\[\d+\]|main-agent)\(([^)]+)\)$", label or "")
@@ -3685,6 +3702,7 @@ def _plan_fallback_candidate(
         task=task, effective_timeout=effective_timeout, fallback_entry=fallback_entry,
         task_config=task_config, apply_fast_lane=apply_fast_lane, **request,
     )
+    common["reasoning_config"] = _fallback_reasoning_config(task, fb_label, request.get("reasoning_config"), fb_client)
 
     def _rebuild(provider: str, client: Any, model: Optional[str]) -> Tuple[_FallbackDestination, Dict[str, Any]]:
         retry_destination = _FallbackDestination(
@@ -4104,6 +4122,9 @@ def _try_main_fallback_chain(
                 continue
             logger.info("Auxiliary %s: %s on %s — main fallback chain to %s (%s)",
                         task or "call", reason, failed_provider or "auto", label, resolved_model or fb_model)
+            # Carry the selected main-chain effort with the concrete candidate; do not
+            # re-read a mutable config when building or retrying this request.
+            fb_client._hermes_fallback_reasoning_effort = entry.get("reasoning_effort")
             return fb_client, resolved_model or fb_model, fb_provider
         tried.append(label)
     if tried:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1776,14 +1776,27 @@ def _update_fallback_context_compressor(agent) -> None:
     )
 
 
-def _reresolve_fallback_reasoning_config(agent) -> None:
-    """Per-model override > global reasoning_effort (YAML False = disabled); a config load
-    failure keeps the current reasoning_config rather than killing the swap."""
+def _reresolve_fallback_reasoning_config(agent, fallback: dict | None = None) -> None:
+    """Apply a fallback route's reasoning setting, else per-model/global config.
+
+    Preset fallbacks carry ``reasoning_effort`` on the concrete chain entry; resolving only
+    from the global config silently discarded that route-level contract.
+    """
     try:
-        # Re-resolve reasoning_config for the new fallback model (Closes #21256). Wrapped in try/except
-        # because a config load failure must not kill the swap.
+        from hermes_constants import parse_reasoning_effort, resolve_reasoning_config
+        if getattr(agent, "_reasoning_effort_pinned", False):
+            logger.info("Fallback %s: retaining explicitly pinned reasoning_config", agent.model)
+            return
+        if isinstance(fallback, dict) and "reasoning_effort" in fallback:
+            parsed = parse_reasoning_effort(fallback["reasoning_effort"])
+            if parsed is None:
+                logger.warning("Fallback %s: invalid reasoning_effort %r; using config resolution", agent.model, fallback["reasoning_effort"])
+            else:
+                agent.reasoning_config = parsed
+                logger.info("Fallback %s: using route reasoning_config: %s", agent.model, parsed)
+                return
+        # Re-resolve for non-preset/legacy fallbacks. A config failure must not kill the swap.
         from hermes_cli.config import load_config
-        from hermes_constants import resolve_reasoning_config
         agent.reasoning_config = resolve_reasoning_config(load_config() or {}, agent.model)
         logger.info("Fallback %s: reasoning_config resolved: %s", agent.model, agent.reasoning_config)
     except Exception as _reasoning_err:
@@ -1900,7 +1913,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 provider=fb_provider, base_url=fb_base_url, api_mode=fb_api_mode, model=fb_model)
             agent._ensure_lmstudio_runtime_loaded()  # LM Studio: preload before probing context length
             _update_fallback_context_compressor(agent)
-            _reresolve_fallback_reasoning_config(agent)
+            _reresolve_fallback_reasoning_config(agent, fb)
             _rescope_fallback_extra_body(agent, old_model, old_provider, old_base_url)
             rewrite_prompt_model_identity(agent, fb_model, fb_provider)
 

--- a/cli.py
+++ b/cli.py
@@ -475,10 +475,15 @@ def load_cli_config() -> Dict[str, Any]:
                 from hermes_cli.config import _normalize_root_model_keys
 
                 file_config = _normalize_root_model_keys(fast_safe_load(f) or {})
+                from hermes_cli.model_presets import expand_model_presets
+                file_config = expand_model_presets(file_config)
 
-            _file_has_terminal_config = "terminal" in file_config
+                _file_has_terminal_config = "terminal" in file_config
             _merge_file_config(defaults, file_config)
         except Exception as e:
+            from hermes_cli.model_presets import ModelPresetError
+            if isinstance(e, ModelPresetError):
+                raise
             logger.warning("Failed to load cli-config.yaml: %s", e)
 
     # Expand ${ENV_VAR} references before bridging to env vars.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -437,7 +437,9 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
         return None
 
 
-def _resolve_job_reasoning_config(job: dict, cfg: dict, model: str) -> dict | None:
+def _resolve_job_reasoning_config(
+    job: dict, cfg: dict, model: str, fallback_entry: dict | None = None,
+) -> dict | None:
     """Effective reasoning config for a cron run. A per-job ``reasoning_effort`` pin beats global
     and per-model config and is model-independent by design (also governs an auth-fallback swap);
     clamping stays with provider transports. An unparseable pin warns and falls back to config."""
@@ -457,6 +459,13 @@ def _resolve_job_reasoning_config(job: dict, cfg: dict, model: str) -> dict | No
             job.get("id", "?"),
             pinned,
             job.get("id", "?"))
+    if isinstance(fallback_entry, dict) and "reasoning_effort" in fallback_entry:
+        parsed = parse_reasoning_effort(fallback_entry["reasoning_effort"])
+        if parsed is not None:
+            logger.info("Job '%s': using startup fallback reasoning_effort '%s'", job.get("id", "?"), fallback_entry["reasoning_effort"])
+            return parsed
+        logger.warning("Job '%s': invalid startup fallback reasoning_effort %r; retaining primary reasoning",
+                       job.get("id", "?"), fallback_entry["reasoning_effort"])
     return resolve_reasoning_config(cfg if isinstance(cfg, dict) else {}, str(model))
 
 
@@ -1369,6 +1378,8 @@ def _load_cron_job_config(job: dict, job_id: str, job_name: str) -> _CronJobConf
                 from hermes_cli import managed_scope
                 _cfg = managed_scope.apply_managed_overlay(_cfg)
             _cfg = _expand_env_vars(_cfg)
+            from hermes_cli.model_presets import expand_model_presets
+            _cfg = expand_model_presets(_cfg)
             # Coerce null to {} so a falsy default never clobbers a resolved env value.
             _model_cfg = _cfg.get("model") or {}
             _cron_cfg_for_model = _cfg.get("cron") or {}
@@ -1383,6 +1394,9 @@ def _load_cron_job_config(job: dict, job_id: str, job_name: str) -> _CronJobConf
                     _, _global_model = resolve_cron_model_drift_defaults(_cfg)
                     model = _snapshot_pin(job, "model", _global_model, job_id) or _global_model or model
     except Exception as e:
+        from hermes_cli.model_presets import ModelPresetError
+        if isinstance(e, ModelPresetError):
+            raise
         logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 
     # Fail fast: an empty model otherwise reaches the provider as an opaque 400.
@@ -1543,6 +1557,7 @@ def _resolve_job_runtime(job: dict, job_id: str, jc: _CronJobConfig) -> tuple[di
                 logger.info(
                     "Job '%s': fallback resolved to %s model %s",
                     job_id, runtime.get("provider"), fb_model)
+                runtime["_hermes_fallback_entry"] = entry
                 return runtime, fb_model
             except Exception as fb_exc:
                 logger.debug("Job '%s': fallback %s failed: %s", job_id, fb_provider, fb_exc)
@@ -2136,10 +2151,18 @@ def _resolve_cron_agent_setup(job: dict, job_id: str, job_name: str, jc) -> _Cro
     if setup.blocked is not None:
         return setup
 
+    # A startup auth fallback retains the resolved primary setting unless its own concrete
+    # fallback route selects a reasoning_effort.
+    primary_reasoning = _resolve_job_reasoning_config(
+        job, _cfg if isinstance(_cfg, dict) else {}, str(jc.model)
+    )
     setup.runtime, setup.model = _resolve_job_runtime(job, job_id, jc)
     setup.reasoning_config = _resolve_job_reasoning_config(
-        job, _cfg if isinstance(_cfg, dict) else {}, str(setup.model)
+        job, _cfg if isinstance(_cfg, dict) else {}, str(jc.model),
+        setup.runtime.get("_hermes_fallback_entry"),
     )
+    if "_hermes_fallback_entry" not in setup.runtime:
+        setup.reasoning_config = primary_reasoning
     setup.fallback_model = get_fallback_chain(_cfg) or None
     setup.credential_pool = _load_credential_pool(setup.runtime, job_id)
     # MCP servers must be registered before AIAgent is constructed.
@@ -2150,7 +2173,7 @@ def _resolve_cron_agent_setup(job: dict, job_id: str, job_name: str, jc) -> _Cro
 def _construct_cron_agent(AIAgent, job: dict, _cfg: dict, setup: _CronAgentSetup, *, workdir, session_id, session_db):
     runtime = setup.runtime
     pr = _cfg.get("provider_routing") or {}
-    return AIAgent(
+    agent = AIAgent(
         model=setup.model,
         api_key=runtime.get("api_key"),
         base_url=runtime.get("base_url"),
@@ -2182,6 +2205,11 @@ def _construct_cron_agent(AIAgent, job: dict, _cfg: dict, setup: _CronAgentSetup
         session_id=session_id,
         session_db=session_db,
     )
+    # Later agent-level failovers honour an explicit cron pin over a route fallback.
+    from hermes_constants import parse_reasoning_effort
+    if parse_reasoning_effort(job.get("reasoning_effort")) is not None:
+        agent._reasoning_effort_pinned = True
+    return agent
 
 
 class _FireAudit:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2276,11 +2276,13 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
     resolved_model = model or _resolve_gateway_model()
     config_context_length = provider = base_url = api_key = custom_providers = None
     configured_model = configured_provider = configured_base_url = None
+    requested_provider = None
+    # Invalid authored routes must fail before optional metadata/auth best-effort reads.
+    data = _load_gateway_runtime_config()
 
     def _read_config() -> None:
         nonlocal config_context_length, provider, base_url, custom_providers
         nonlocal configured_model, configured_provider, configured_base_url
-        data = _load_gateway_config()
         if not data:
             return
         model_cfg = data.get("model", {})
@@ -2299,8 +2301,9 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
             custom_providers = data.get("custom_providers")
 
     def _read_runtime() -> None:
-        nonlocal provider, base_url, api_key
+        nonlocal provider, base_url, api_key, requested_provider
         runtime = _resolve_runtime_agent_kwargs()
+        requested_provider = runtime.get("requested_provider")
         provider = runtime.get("provider") or provider
         base_url = runtime.get("base_url") or base_url
         api_key = runtime.get("api_key")
@@ -2309,7 +2312,8 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
         # Drop a configured context_length pin when the effective route no longer matches (or on error).
         from hermes_cli.route_identity import should_clear_context_pin
         return not should_clear_context_pin(
-            configured_model, resolved_model, configured_base_url, base_url, configured_provider, provider)
+            configured_model, resolved_model, configured_base_url, base_url,
+            configured_provider, requested_provider or provider)
 
     def _custom_ctx() -> Optional[int]:
         from hermes_cli.config import get_custom_provider_context_length
@@ -2844,11 +2848,11 @@ def _checkpoint_agent_kwargs(config: dict | None) -> dict:
         "checkpoint_max_file_size_mb": cp_cfg.get("max_file_size_mb", defaults["max_file_size_mb"])}
 
 
-def _load_gateway_runtime_config() -> dict:
-    """Load gateway config for runtime reads, expanding supported ``${VAR}`` refs.
+def _load_gateway_runtime_config(config: dict | None = None) -> dict:
+    """Expand raw gateway config for runtime reads, including environment and model-preset refs.
     Expansion failures are deliberately NOT swallowed: an unexpanded dict would mask the bug fixed here.
     """
-    cfg = _load_gateway_config()
+    cfg = _load_gateway_config() if config is None else config
     if not isinstance(cfg, dict) or not cfg:
         return {}
     from hermes_cli.config import _expand_env_vars
@@ -2862,7 +2866,7 @@ def _load_gateway_runtime_config() -> dict:
 def _resolve_gateway_model(config: dict | None = None) -> str:
     """Read model from config.yaml (single source of truth), else temporary AIAgents (e.g. /compress)
     use the hardcoded default, which fails under openai-codex."""
-    cfg = config if config is not None else _load_gateway_config()
+    cfg = _load_gateway_runtime_config(config)
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, str):
         return model_cfg

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2396,8 +2396,10 @@ def _try_resolve_fallback_provider() -> dict | None:
             except Exception as fb_exc:
                 logger.debug("Fallback entry %s failed: %s", entry.get("provider"), fb_exc)
                 continue
-    except Exception:
-        pass
+    except Exception as exc:
+        from hermes_cli.model_presets import ModelPresetError
+        if isinstance(exc, ModelPresetError):
+            raise
     return None
 
 
@@ -2851,7 +2853,10 @@ def _load_gateway_runtime_config() -> dict:
         return {}
     from hermes_cli.config import _expand_env_vars
     expanded = _expand_env_vars(cfg)
-    return expanded if isinstance(expanded, dict) else {}
+    if not isinstance(expanded, dict):
+        return {}
+    from hermes_cli.model_presets import expand_model_presets
+    return expand_model_presets(expanded)
 
 
 def _resolve_gateway_model(config: dict | None = None) -> str:

--- a/gateway/run_config_loaders.py
+++ b/gateway/run_config_loaders.py
@@ -412,7 +412,10 @@ class GatewayConfigLoadersMixin:
         try:
             # Canonical gateway loader (fail-open): managed overlay + ${VAR} expansion apply here too.
             return get_fallback_chain(_load_gateway_runtime_config()) or None
-        except Exception:
+        except Exception as exc:
+            from hermes_cli.model_presets import ModelPresetError
+            if isinstance(exc, ModelPresetError):
+                raise
             return None
 
     def _refresh_fallback_model(self) -> list | None:
@@ -446,7 +449,12 @@ class GatewayConfigLoadersMixin:
                 expanded = _expand_env_vars(cfg)
                 if isinstance(expanded, dict):
                     cfg = expanded
-        except Exception:
+            from hermes_cli.model_presets import expand_model_presets
+            cfg = expand_model_presets(cfg)
+        except Exception as exc:
+            from hermes_cli.model_presets import ModelPresetError
+            if isinstance(exc, ModelPresetError):
+                raise
             logger.debug("fallback_providers refresh: config.yaml read failed; keeping last known-good chain", exc_info=True)
             return self._fallback_model
         self._fallback_model = get_fallback_chain(cfg) or None

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1024,6 +1024,7 @@ def check_config_version(*, raise_on_parse_error: bool = False) -> Tuple[int, in
 # defaults are accepted automatically. These optional/legacy roots are valid on disk but
 # intentionally absent from DEFAULT_CONFIG (omitted when unused / alternate schema forms).
 _EXTRA_KNOWN_ROOT_KEYS = {
+    "model_presets",    # named static routes expanded by hermes_cli.model_presets at runtime
     "custom_providers",  # legacy list form; modern equivalent is providers: {}
     "fallback_model",    # optional single dict or chain list; omitted when disabled
     "mcp_servers",       # MCP server definitions written by setup/tools flows
@@ -2182,8 +2183,15 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                     user_config["agent"] = agent_user_config
                     user_config.pop("max_turns", None)
 
+                # Expand authoring-time model routes before defaults are merged: a default empty
+                # fallback list must not look like an inline override of a named preset.
+                from hermes_cli.model_presets import expand_model_presets
+                user_config = expand_model_presets(user_config)
                 config = _deep_merge(config, user_config)
             except Exception as e:
+                from hermes_cli.model_presets import ModelPresetError
+                if isinstance(e, ModelPresetError):
+                    raise
                 lkg_copy = _last_known_good_fallback(config_path, path_key, cache_sig, e)
                 if lkg_copy is not None:
                     return copy.deepcopy(lkg_copy) if want_deepcopy else lkg_copy
@@ -2305,6 +2313,8 @@ def save_config(
         current_normalized = _canonicalize_config(config)
         normalized = current_normalized
         if _raw_for_paths:
+            from hermes_cli.model_presets import preserve_model_preset_references
+            normalized = preserve_model_preset_references(normalized, _raw_for_paths)
             normalized = _preserve_env_ref_templates(
                 normalized, _canonicalize_config(_raw_for_paths),
                 _LAST_EXPANDED_CONFIG_BY_PATH.get(str(config_path)))

--- a/hermes_cli/model_presets.py
+++ b/hermes_cli/model_presets.py
@@ -1,0 +1,374 @@
+"""Static expansion of named model routes in configuration.
+
+Model presets are authoring conveniences, not runtime providers: every consumer receives
+an ordinary inline route before provider and credential resolution begins.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+_ROUTE_KEYS = frozenset({"provider", "model", "reasoning_effort", "fallbacks"})
+_MAIN_FORBIDDEN_REFERENCE_FIELDS = frozenset({
+    # Presets select provider/model only. Credentials and endpoints are provider-owned;
+    # accepting them here would silently discard a user setting during expansion.
+    "base_url", "api_base", "api_key", "api", "key_env", "api_key_env", "api_mode", "transport",
+})
+_EMPTY_DEFAULT_ROUTE_FIELDS = _MAIN_FORBIDDEN_REFERENCE_FIELDS | frozenset({"extra_body"})
+
+
+class ModelPresetError(ValueError):
+    """A model preset cannot be expanded safely."""
+
+
+def _error(path: str, message: str) -> ModelPresetError:
+    return ModelPresetError(f"model_presets: {path}: {message}")
+
+
+def _text(value: Any, path: str, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise _error(path, f"'{field}' must be a non-empty string")
+    return value.strip()
+
+
+def _validate_reasoning(value: Any, path: str) -> None:
+    if value is None:
+        return
+    from hermes_constants import parse_reasoning_effort
+    if parse_reasoning_effort(value) is None:
+        raise _error(path, "'reasoning_effort' must be one of none, minimal, low, medium, high, xhigh, max, ultra")
+
+
+def _validate_route(value: Any, path: str, *, allow_fallbacks: bool) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise _error(path, "must be a mapping")
+    unknown = set(value) - _ROUTE_KEYS
+    if unknown:
+        raise _error(path, "unsupported field(s): " + ", ".join(sorted(map(str, unknown))))
+    route: dict[str, Any] = {
+        "provider": _text(value.get("provider"), path, "provider"),
+        "model": _text(value.get("model"), path, "model"),
+    }
+    if "reasoning_effort" in value:
+        _validate_reasoning(value["reasoning_effort"], path)
+        route["reasoning_effort"] = value["reasoning_effort"]
+    if "fallbacks" in value:
+        if not allow_fallbacks:
+            raise _error(path, "fallbacks are not supported in a fallback route")
+        fallbacks = value["fallbacks"]
+        if not isinstance(fallbacks, list):
+            raise _error(path, "'fallbacks' must be an ordered list of inline routes")
+        route["fallbacks"] = [
+            _validate_route(item, f"{path}.fallbacks[{index}]", allow_fallbacks=False)
+            for index, item in enumerate(fallbacks)
+        ]
+    return route
+
+
+def _definitions(config: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    raw = config.get("model_presets")
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise _error("model_presets", "must be a mapping of names to flat route definitions")
+    definitions: dict[str, dict[str, Any]] = {}
+    for name, route in raw.items():
+        if not isinstance(name, str) or not name.strip():
+            raise _error("model_presets", "preset names must be non-empty strings")
+        clean_name = name.strip()
+        if clean_name in definitions:
+            raise _error("model_presets", f"duplicate preset name '{clean_name}'")
+        definitions[clean_name] = _validate_route(route, f"model_presets.{clean_name}", allow_fallbacks=True)
+    return definitions
+
+
+def _reference(site: Any, path: str, definitions: dict[str, dict[str, Any]], *, conflicts: set[str]) -> dict[str, Any] | None:
+    if not isinstance(site, dict) or "model_preset" not in site:
+        return None
+    name = _text(site["model_preset"], path, "model_preset")
+    inline = sorted(str(key) for key in set(site).intersection(conflicts))
+    if inline:
+        raise _error(path, f"'model_preset: {name}' cannot be combined with inline route field(s): {', '.join(inline)}")
+    route = definitions.get(name)
+    if route is None:
+        available = ", ".join(definitions) or "(none)"
+        raise _error(path, f"unknown preset '{name}'. Available presets: {available}")
+    return deepcopy(route)
+
+
+def _fallbacks_disabled(site: Any, path: str) -> bool:
+    """The sole reference-site override: ``fallbacks: []`` disables a preset chain."""
+    if not isinstance(site, dict) or "model_preset" not in site or "fallbacks" not in site:
+        return False
+    if site["fallbacks"] == []:
+        return True
+    raise _error(path, "'fallbacks' may only be [] with model_preset (to disable preset fallbacks)")
+
+
+def _route_fields(route: dict[str, Any], *, fallback_key: str | None = None) -> dict[str, Any]:
+    result = {key: deepcopy(route[key]) for key in ("provider", "model", "reasoning_effort") if key in route}
+    if "fallbacks" in route:
+        if fallback_key is None:
+            raise _error("route", "fallbacks are unsupported at this reference site")
+        result[fallback_key] = deepcopy(route["fallbacks"])
+    return result
+
+
+def _expand_model(config: dict[str, Any], definitions: dict[str, dict[str, Any]]) -> None:
+    model = config.get("model")
+    if not isinstance(model, dict):
+        return
+    disabled_fallbacks = _fallbacks_disabled(model, "model")
+    route = _reference(
+        model, "model", definitions,
+        conflicts={"provider", "default", "model", "reasoning_effort", *_MAIN_FORBIDDEN_REFERENCE_FIELDS},
+    )
+    if route is None:
+        return
+    # Preserve non-route model metadata such as context_length.
+    config["model"] = {
+        **{key: deepcopy(value) for key, value in model.items() if key not in {"model_preset", "fallbacks"}},
+        "provider": route["provider"], "default": route["model"],
+    }
+    agent = config.get("agent")
+    if "reasoning_effort" in route:
+        if isinstance(agent, dict) and "reasoning_effort" in agent:
+            raise _error("model", "preset reasoning_effort cannot be combined with agent.reasoning_effort")
+        if not isinstance(agent, dict):
+            agent = {}
+            config["agent"] = agent
+        agent["reasoning_effort"] = route["reasoning_effort"]
+    if disabled_fallbacks:
+        # Explicit opt-out must survive raw gateway loads and default/overlay inheritance.
+        config["fallback_providers"] = []
+    elif "fallbacks" in route:
+        if "fallback_providers" in config:
+            raise _error("model", "preset fallbacks cannot be combined with top-level fallback_providers (including an empty list)")
+        config["fallback_providers"] = deepcopy(route["fallbacks"])
+
+
+def _expand_delegation(config: dict[str, Any], definitions: dict[str, dict[str, Any]]) -> None:
+    site = config.get("delegation")
+    disabled_fallbacks = _fallbacks_disabled(site, "delegation")
+    route = _reference(site, "delegation", definitions, conflicts={"provider", "model", "base_url", "api_key", "reasoning_effort", "fallback_providers", "fallback_chain"})
+    if route is not None:
+        assert isinstance(site, dict)
+        fields = _route_fields({key: value for key, value in route.items() if key != "fallbacks"} if disabled_fallbacks else route, fallback_key="fallback_providers")
+        if disabled_fallbacks:
+            fields["fallback_providers"] = []
+        config["delegation"] = {**{key: value for key, value in site.items() if key not in {"model_preset", "fallbacks"}}, **fields}
+
+
+def _expand_auxiliary(config: dict[str, Any], definitions: dict[str, dict[str, Any]]) -> None:
+    auxiliary = config.get("auxiliary")
+    if not isinstance(auxiliary, dict):
+        return
+    for task, site in list(auxiliary.items()):
+        path = f"auxiliary.{task}"
+        disabled_fallbacks = _fallbacks_disabled(site, path)
+        route = _reference(site, path, definitions, conflicts={"provider", "model", "base_url", "api_key", "api_mode", "reasoning_effort", "fallback_chain", "fallback_providers"})
+        if route is not None:
+            assert isinstance(site, dict)
+            fields = _route_fields({key: value for key, value in route.items() if key != "fallbacks"} if disabled_fallbacks else route, fallback_key="fallback_chain")
+            if disabled_fallbacks:
+                fields["fallback_chain"] = []
+            auxiliary[task] = {**{key: value for key, value in site.items() if key not in {"model_preset", "fallbacks"}}, **fields}
+
+
+def _expand_fallback_entries(config: dict[str, Any], definitions: dict[str, dict[str, Any]]) -> None:
+    for key in ("fallback_providers", "fallback_model"):
+        raw = config.get(key)
+        entries = raw if isinstance(raw, list) else [raw] if isinstance(raw, dict) else None
+        if entries is None:
+            continue
+        expanded = []
+        for index, entry in enumerate(entries):
+            route = _reference(entry, f"{key}[{index}]", definitions, conflicts={"provider", "model", "base_url", "api_key", "key_env", "api_key_env", "reasoning_effort", "fallbacks", "fallback_chain", "fallback_providers"})
+            if route is not None:
+                if "fallbacks" in route:
+                    raise _error(f"{key}[{index}]", "a fallback entry cannot reference a preset that declares fallbacks")
+                expanded.append(_route_fields(route))
+            else:
+                expanded.append(entry)
+        config[key] = expanded if isinstance(raw, list) else expanded[0]
+
+
+def _expand_moa_slot(site: Any, path: str, definitions: dict[str, dict[str, Any]]) -> Any:
+    route = _reference(site, path, definitions, conflicts={"provider", "model", "reasoning_effort", "fallbacks"})
+    if route is None:
+        return site
+    if "fallbacks" in route:
+        raise _error(path, "a MoA slot cannot reference a preset that declares fallbacks")
+    return {**{key: value for key, value in site.items() if key != "model_preset"}, **_route_fields(route)}
+
+
+def _expand_moa(config: dict[str, Any], definitions: dict[str, dict[str, Any]]) -> None:
+    moa = config.get("moa")
+    if not isinstance(moa, dict):
+        return
+    named_presets = isinstance(moa.get("presets"), dict)
+    blocks = moa["presets"] if named_presets else {"default": moa}
+    for name, block in blocks.items():
+        if not isinstance(block, dict):
+            continue
+        prefix = f"moa.presets.{name}" if named_presets else "moa"
+        refs = block.get("reference_models")
+        if isinstance(refs, list):
+            block["reference_models"] = [_expand_moa_slot(slot, f"{prefix}.reference_models[{index}]", definitions) for index, slot in enumerate(refs)]
+        if "aggregator" in block:
+            block["aggregator"] = _expand_moa_slot(block["aggregator"], f"{prefix}.aggregator", definitions)
+
+
+def expand_model_presets(config: Any) -> dict[str, Any]:
+    """Return a copied config with every supported ``model_preset`` reference expanded.
+
+    The source mapping is never mutated so callers that save configuration retain the user's
+    named references rather than a flattened implementation detail.
+    """
+    if not isinstance(config, dict):
+        return config
+    expanded = deepcopy(config)
+    definitions = _definitions(expanded)
+    _expand_model(expanded, definitions)
+    _expand_delegation(expanded, definitions)
+    _expand_auxiliary(expanded, definitions)
+    _expand_fallback_entries(expanded, definitions)
+    _expand_moa(expanded, definitions)
+    return expanded
+
+
+def preserve_model_preset_references(config: dict[str, Any], authored: Any) -> dict[str, Any]:
+    """Put unchanged named-route references back before a config write.
+
+    ``load_config`` returns runtime-ready inline routes.  An unrelated config edit must not
+    turn those routes into permanently flattened YAML, but an edited route must remain edited.
+    """
+    if not isinstance(authored, dict) or not authored.get("model_presets"):
+        return config
+    expanded_authored = expand_model_presets(authored)
+    result = deepcopy(config)
+
+    def same_route(actual: Any, expected: Any, fallback_key: str | None = None) -> bool:
+        if not isinstance(actual, dict) or not isinstance(expected, dict):
+            return False
+        keys = {"provider", "model", "reasoning_effort"} | _EMPTY_DEFAULT_ROUTE_FIELDS
+        def value(site: dict[str, Any], key: str) -> Any:
+            item = site.get(key)
+            return None if item in (None, "", {}, []) else item
+        if any(value(actual, key) != value(expected, key) for key in keys):
+            return False
+        return fallback_key is None or value(actual, fallback_key) == value(expected, fallback_key)
+
+    raw_model = authored.get("model")
+    expected_model = expanded_authored.get("model")
+    if isinstance(raw_model, dict) and "model_preset" in raw_model and isinstance(expected_model, dict):
+        actual_model = result.get("model")
+        unsafe_model_fields = any(
+            key in actual_model and key not in raw_model and actual_model[key] not in (None, "", {}, [])
+            for key in _MAIN_FORBIDDEN_REFERENCE_FIELDS
+        ) if isinstance(actual_model, dict) else True
+        preset = _definitions(authored)[raw_model["model_preset"].strip()]
+        reasoning_unchanged = (
+            "reasoning_effort" not in preset
+            or (result.get("agent") or {}).get("reasoning_effort")
+            == (expanded_authored.get("agent") or {}).get("reasoning_effort")
+        )
+        fallbacks_unchanged = (
+            "fallbacks" not in preset and "fallbacks" not in raw_model
+            or result.get("fallback_providers") == expanded_authored.get("fallback_providers")
+        )
+        if (isinstance(actual_model, dict) and not unsafe_model_fields
+                and reasoning_unchanged and fallbacks_unchanged
+                and actual_model.get("provider") == expected_model.get("provider") and actual_model.get("default") == expected_model.get("default")):
+            restored_model = deepcopy(actual_model)
+            restored_model.pop("provider", None)
+            restored_model.pop("default", None)
+            for key in _MAIN_FORBIDDEN_REFERENCE_FIELDS:
+                if key not in raw_model and restored_model.get(key) in (None, "", {}, []):
+                    restored_model.pop(key, None)
+            restored_model["model_preset"] = raw_model["model_preset"]
+            if raw_model.get("fallbacks") == []:
+                restored_model["fallbacks"] = []
+            result["model"] = restored_model
+            expected_agent = (expanded_authored.get("agent") or {}).get("reasoning_effort")
+            raw_agent = authored.get("agent")
+            if (expected_agent is not None and not (isinstance(raw_agent, dict) and "reasoning_effort" in raw_agent)
+                    and isinstance(result.get("agent"), dict) and result["agent"].get("reasoning_effort") == expected_agent):
+                result["agent"].pop("reasoning_effort", None)
+            if (("fallbacks" in preset or "fallbacks" in raw_model)
+                    and "fallback_providers" not in authored
+                    and result.get("fallback_providers") == expanded_authored.get("fallback_providers")):
+                result.pop("fallback_providers", None)
+
+    def restore_site(container: dict[str, Any], raw_container: Any, expected_container: Any, key: str, fallback_key: str | None = None) -> None:
+        raw_site = raw_container.get(key) if isinstance(raw_container, dict) else None
+        expected_site = expected_container.get(key) if isinstance(expected_container, dict) else None
+        actual_site = container.get(key)
+        if isinstance(raw_site, dict) and "model_preset" in raw_site and same_route(actual_site, expected_site, fallback_key):
+            assert isinstance(actual_site, dict)
+            # Keep edits to unrelated site settings (timeouts, concurrency, MoA enabled),
+            # but remove only fields injected by expansion before restoring the reference.
+            restored = deepcopy(actual_site)
+            for route_key in ("provider", "model", "reasoning_effort"):
+                if isinstance(expected_site, dict) and route_key in expected_site:
+                    restored.pop(route_key, None)
+            if fallback_key and isinstance(expected_site, dict) and fallback_key in expected_site:
+                restored.pop(fallback_key, None)
+            # strip_defaults=False exposes empty provider-owned defaults which would otherwise
+            # become inline route fields and make a saved reference fail on its next load.
+            for route_key in _EMPTY_DEFAULT_ROUTE_FIELDS:
+                if route_key not in raw_site and restored.get(route_key) in (None, "", {}, []):
+                    restored.pop(route_key, None)
+            restored["model_preset"] = raw_site["model_preset"]
+            if raw_site.get("fallbacks") == []:
+                restored["fallbacks"] = []
+            container[key] = restored
+
+    restore_site(result, authored, expanded_authored, "delegation", "fallback_providers")
+    actual = result.get("auxiliary")
+    raw = authored.get("auxiliary")
+    expected = expanded_authored.get("auxiliary")
+    if isinstance(actual, dict) and isinstance(raw, dict):
+        for key in raw:
+            restore_site(actual, raw, expected, key, "fallback_chain")
+
+    def restore_slot(actual_slot: Any, raw_slot: Any, expected_slot: Any) -> Any:
+        if not (isinstance(actual_slot, dict) and isinstance(raw_slot, dict) and "model_preset" in raw_slot):
+            return actual_slot
+        if not same_route(actual_slot, expected_slot):
+            return actual_slot
+        restored = deepcopy(actual_slot)
+        for route_key in ("provider", "model", "reasoning_effort"):
+            if isinstance(expected_slot, dict) and route_key in expected_slot:
+                restored.pop(route_key, None)
+        restored["model_preset"] = raw_slot["model_preset"]
+        return restored
+
+    for fallback_key in ("fallback_providers", "fallback_model"):
+        raw_entries = authored.get(fallback_key)
+        actual_entries = result.get(fallback_key)
+        expected_entries = expanded_authored.get(fallback_key)
+        raw_list = raw_entries if isinstance(raw_entries, list) else [raw_entries] if isinstance(raw_entries, dict) else None
+        actual_list = actual_entries if isinstance(actual_entries, list) else [actual_entries] if isinstance(actual_entries, dict) else None
+        expected_list = expected_entries if isinstance(expected_entries, list) else [expected_entries] if isinstance(expected_entries, dict) else None
+        if raw_list is not None and actual_list is not None and expected_list is not None and len(raw_list) == len(actual_list) == len(expected_list):
+            restored = [restore_slot(actual, raw, expected) for actual, raw, expected in zip(actual_list, raw_list, expected_list)]
+            result[fallback_key] = restored if isinstance(actual_entries, list) else restored[0]
+
+    raw_moa, actual_moa, expected_moa = authored.get("moa"), result.get("moa"), expanded_authored.get("moa")
+    if isinstance(raw_moa, dict) and isinstance(actual_moa, dict) and isinstance(expected_moa, dict):
+        raw_blocks = raw_moa.get("presets") if isinstance(raw_moa.get("presets"), dict) else {"default": raw_moa}
+        actual_blocks = actual_moa.get("presets") if isinstance(actual_moa.get("presets"), dict) else {"default": actual_moa}
+        expected_blocks = expected_moa.get("presets") if isinstance(expected_moa.get("presets"), dict) else {"default": expected_moa}
+        for name, raw_block in raw_blocks.items():
+            actual_block, expected_block = actual_blocks.get(name), expected_blocks.get(name)
+            if not (isinstance(raw_block, dict) and isinstance(actual_block, dict) and isinstance(expected_block, dict)):
+                continue
+            assert isinstance(actual_block, dict) and isinstance(expected_block, dict)
+            for slot_key in ("aggregator",):
+                actual_block[slot_key] = restore_slot(actual_block.get(slot_key), raw_block.get(slot_key), expected_block.get(slot_key))
+            raw_refs, actual_refs, expected_refs = raw_block.get("reference_models"), actual_block.get("reference_models"), expected_block.get("reference_models")
+            if isinstance(raw_refs, list) and isinstance(actual_refs, list) and isinstance(expected_refs, list) and len(raw_refs) == len(actual_refs) == len(expected_refs):
+                actual_block["reference_models"] = [restore_slot(actual, raw, expected) for actual, raw, expected in zip(actual_refs, raw_refs, expected_refs)]
+    return result

--- a/tests/gateway/test_model_preset_runtime.py
+++ b/tests/gateway/test_model_preset_runtime.py
@@ -1,0 +1,91 @@
+"""Gateway primary-route model-preset regression coverage."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+import yaml
+
+
+def test_gateway_primary_session_expands_preset_for_model_provider_reasoning_and_context(tmp_path, monkeypatch):
+    """The raw config passed into a primary gateway turn is expanded at the runtime boundary."""
+    import socket
+
+    def deny_network(*args, **kwargs):
+        raise AssertionError("Gateway route resolution must not require network access")
+
+    monkeypatch.setattr(socket, "getaddrinfo", deny_network)
+    monkeypatch.setattr(socket.socket, "connect", deny_network)
+    from gateway import run as gateway_run
+    from gateway.config import GatewayConfig
+    from hermes_cli.model_presets import ModelPresetError
+
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    authored = {
+        "model_presets": {
+            "primary": {
+                "provider": "custom:gateway-test",
+                "model": "gateway-primary-model",
+                "reasoning_effort": "high",
+            },
+        },
+        "model": {"model_preset": "primary", "context_length": 65432},
+        "providers": {"gateway-test": {
+            "base_url": "https://gateway-test.invalid/v1",
+            "api_key": "test-key",
+            "api_mode": "chat_completions",
+        }},
+    }
+    (home / "config.yaml").write_text(yaml.safe_dump(authored), encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(gateway_run, "_hermes_home", home)
+
+    raw = gateway_run._load_gateway_config()
+    assert raw == authored
+
+    runner = gateway_run.GatewayRunner(GatewayConfig())
+    model, runtime = runner._resolve_session_agent_runtime(user_config=raw)
+
+    assert model == "gateway-primary-model"
+    assert runtime["provider"] == "custom"
+    assert runtime["requested_provider"] == "custom:gateway-test"
+    assert runtime["base_url"] == "https://gateway-test.invalid/v1"
+    assert runtime["api_mode"] == "chat_completions"
+    assert runtime["api_key"] == "test-key"
+    assert not runner._refresh_fallback_model()
+    assert gateway_run.GatewayRunner._load_reasoning_config(model) == {"enabled": True, "effort": "high"}
+    assert gateway_run._resolve_gateway_model() == model
+    assert gateway_run._resolve_gateway_model(raw) == model
+    assert raw == authored
+
+    captured = {}
+
+    def fake_context_length(model, **kwargs):
+        captured.update(model=model, **kwargs)
+        return kwargs["config_context_length"]
+
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", fake_context_length)
+    context = gateway_run._resolve_gateway_model_context()
+    assert (context.model, context.provider, context.context_length, context.context_source) == (
+        "gateway-primary-model", "custom", 65432, "config",
+    )
+    assert captured["provider"] == "custom"
+
+    unknown = copy.deepcopy(authored)
+    unknown["model"] = {"model_preset": "missing"}
+    with pytest.raises(ModelPresetError, match="model: unknown preset 'missing'"):
+        gateway_run._resolve_gateway_model(unknown)
+
+
+def test_gateway_explicit_context_rejects_invalid_preset(tmp_path, monkeypatch):
+    from gateway import run as gateway_run
+    from hermes_cli.model_presets import ModelPresetError
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text("model:\n  model_preset: missing\n")
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", lambda *args, **kwargs: 8192)
+    with pytest.raises(ModelPresetError, match="unknown preset 'missing'"):
+        gateway_run._resolve_gateway_model_context("explicit-model")

--- a/tests/hermes_cli/test_model_presets.py
+++ b/tests/hermes_cli/test_model_presets.py
@@ -8,6 +8,14 @@ import yaml
 from hermes_cli.model_presets import ModelPresetError, expand_model_presets
 
 
+def test_documented_preset_example_expands():
+    from pathlib import Path
+    doc = Path(__file__).resolve().parents[2] / "website/docs/user-guide/configuring-models.md"
+    block = doc.read_text().split("## Reusing a named route", 1)[1].split("```yaml", 1)[1].split("```", 1)[0]
+    expanded = expand_model_presets(yaml.safe_load(block))
+    assert expanded["delegation"]["fallback_providers"][0]["provider"] == "openai"
+
+
 def routes():
     return {"model_presets": {
         "primary": {"provider": "provider-a", "model": "model-a", "reasoning_effort": "high", "fallbacks": [{"provider": "provider-b", "model": "model-b", "reasoning_effort": "low"}]},

--- a/tests/hermes_cli/test_model_presets.py
+++ b/tests/hermes_cli/test_model_presets.py
@@ -1,0 +1,262 @@
+"""Behavioral coverage for static named model-route expansion."""
+from __future__ import annotations
+
+import copy
+import pytest
+import yaml
+
+from hermes_cli.model_presets import ModelPresetError, expand_model_presets
+
+
+def routes():
+    return {"model_presets": {
+        "primary": {"provider": "provider-a", "model": "model-a", "reasoning_effort": "high", "fallbacks": [{"provider": "provider-b", "model": "model-b", "reasoning_effort": "low"}]},
+        "fast": {"provider": "provider-c", "model": "model-c", "reasoning_effort": "minimal"},
+    }}
+
+
+def test_expands_all_runtime_consumers_without_mutating_authored_routes():
+    config = {**routes(), "model": {"model_preset": "fast"}, "delegation": {"model_preset": "primary", "max_concurrent_children": 3}, "auxiliary": {"compression": {"model_preset": "primary", "timeout": 20}}, "fallback_providers": [{"model_preset": "fast"}], "moa": {"presets": {"review": {"reference_models": [{"model_preset": "fast"}], "aggregator": {"model_preset": "fast"}}}}}
+    authored = copy.deepcopy(config)
+    expanded = expand_model_presets(config)
+    assert expanded["model"] == {"provider": "provider-c", "default": "model-c"}
+    assert expanded["agent"]["reasoning_effort"] == "minimal"
+    assert expanded["fallback_providers"] == [{"provider": "provider-c", "model": "model-c", "reasoning_effort": "minimal"}]
+    assert expanded["delegation"]["fallback_providers"][0]["provider"] == "provider-b"
+    assert expanded["auxiliary"]["compression"]["fallback_chain"][0]["model"] == "model-b"
+    assert expanded["moa"]["presets"]["review"]["aggregator"]["reasoning_effort"] == "minimal"
+    assert config == authored
+
+
+@pytest.mark.parametrize("config, fragment", [
+    ({**routes(), "auxiliary": {"vision": {"model_preset": "missing"}}}, "auxiliary.vision: unknown preset 'missing'"),
+    ({**routes(), "delegation": {"model_preset": "fast", "provider": "x"}}, "delegation: 'model_preset: fast' cannot be combined"),
+    ({**routes(), "moa": {"aggregator": {"model_preset": "primary"}}}, "moa.aggregator: a MoA slot cannot reference a preset that declares fallbacks"),
+])
+def test_invalid_references_are_actionable(config, fragment):
+    with pytest.raises(ModelPresetError, match=fragment):
+        expand_model_presets(config)
+
+
+def test_real_config_loader_expands_and_save_keeps_authored_reference(tmp_path, monkeypatch):
+    from hermes_cli import config as config_mod
+    home = tmp_path / "hermes-home"; home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    raw = {**routes(), "model": {"model_preset": "fast"}, "auxiliary": {"vision": {"model_preset": "fast"}}}
+    (home / "config.yaml").write_text(yaml.safe_dump(raw), encoding="utf-8")
+    config_mod._RAW_CONFIG_CACHE.clear(); config_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    loaded = config_mod.load_config()
+    assert (loaded["model"]["provider"], loaded["model"]["default"]) == ("provider-c", "model-c")
+    assert loaded["auxiliary"]["vision"]["reasoning_effort"] == "minimal"
+    loaded["display"]["show_thinking"] = False
+    config_mod.save_config(loaded)
+    saved = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+    assert saved["model"] == {"model_preset": "fast"}
+    assert saved["auxiliary"]["vision"]["model_preset"] == "fast"
+
+
+def test_save_without_default_stripping_reloads_preset_and_removes_injected_route_defaults(tmp_path, monkeypatch):
+    from hermes_cli import config as config_mod
+    home = tmp_path / "hermes-home"; home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    raw = {**routes(), "model": {"model_preset": "fast", "context_length": 12345},
+           "auxiliary": {"vision": {"model_preset": "fast"}}}
+    (home / "config.yaml").write_text(yaml.safe_dump(raw), encoding="utf-8")
+    config_mod._RAW_CONFIG_CACHE.clear(); config_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    loaded = config_mod.load_config()
+    # Simulate defaults injected by provider/auxiliary normalization before an all-default save.
+    loaded["model"].update({"base_url": "", "api_key": "", "api_mode": ""})
+    loaded["auxiliary"]["vision"].update({"base_url": "", "api_key": "", "api_mode": ""})
+    config_mod.save_config(loaded, strip_defaults=False)
+    saved = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+    assert saved["model"] == {"model_preset": "fast", "context_length": 12345}
+    assert saved["auxiliary"]["vision"]["model_preset"] == "fast"
+    assert not {"base_url", "api_key", "api_mode"} & set(saved["auxiliary"]["vision"])
+    config_mod._RAW_CONFIG_CACHE.clear(); config_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    assert config_mod.load_config()["model"]["default"] == "model-c"
+
+
+def test_main_reference_preserves_context_and_authored_global_route_settings():
+    from hermes_cli.model_presets import preserve_model_preset_references
+    authored = {**routes(), "model_presets": {**routes()["model_presets"], "plain": {"provider": "plain-p", "model": "plain-m"}},
+                "model": {"model_preset": "plain", "context_length": 9000},
+                "agent": {"reasoning_effort": "low"},
+                "fallback_providers": [{"provider": "global", "model": "global-model"}]}
+    # A separately-authored global agent/fallback is not expansion output and must survive save.
+    actual = {**copy.deepcopy(authored), "model": {"provider": "plain-p", "default": "plain-m", "context_length": 12000}}
+    restored = preserve_model_preset_references(actual, authored)
+    assert restored["model"] == {"model_preset": "plain", "context_length": 12000}
+    assert restored["agent"]["reasoning_effort"] == "low"
+    assert restored["fallback_providers"] == authored["fallback_providers"]
+
+
+def test_edited_main_route_flattens_instead_of_restoring_a_conflicting_reference():
+    from hermes_cli.model_presets import preserve_model_preset_references
+    authored = {**routes(), "model": {"model_preset": "fast", "context_length": 9000}}
+    actual = {**copy.deepcopy(authored), "model": {"provider": "edited-provider", "default": "edited-model", "context_length": 12000}}
+    restored = preserve_model_preset_references(actual, authored)
+    assert restored["model"] == actual["model"]
+
+
+@pytest.mark.parametrize("field", ["base_url", "api_base", "api_key", "api", "key_env", "api_key_env", "api_mode", "transport"])
+def test_main_reference_rejects_provider_owned_fields(field):
+    with pytest.raises(ModelPresetError, match="cannot be combined"):
+        expand_model_presets({**routes(), "model": {"model_preset": "fast", field: "value"}})
+
+
+def test_gateway_and_delegation_loaders_do_not_swallow_invalid_preset_errors(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+    from gateway.run import GatewayRunner
+    from tools import delegate_tool_config
+
+    err = ModelPresetError("invalid preset")
+    monkeypatch.setattr("gateway.run._load_gateway_runtime_config", lambda: (_ for _ in ()).throw(err))
+    with pytest.raises(ModelPresetError, match="invalid preset"):
+        GatewayRunner._load_fallback_model()
+
+    monkeypatch.setattr(delegate_tool_config.os, "environ", {}, raising=False)
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: (_ for _ in ()).throw(err))
+    with pytest.raises(ModelPresetError, match="invalid preset"):
+        delegate_tool_config._load_config()
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(yaml.safe_dump({"model": {"model_preset": "missing"}}), encoding="utf-8")
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    runner = SimpleNamespace(_fallback_model=None)
+    with pytest.raises(ModelPresetError, match="unknown preset"):
+        GatewayRunner._refresh_fallback_model.__get__(runner)()
+
+
+def test_auxiliary_fallback_reasoning_uses_route_or_retains_primary(monkeypatch):
+    from agent.auxiliary_client import _fallback_reasoning_config
+    primary = {"enabled": True, "effort": "high"}
+    monkeypatch.setattr("agent.auxiliary_client._fallback_chain_entry", lambda *_: {"reasoning_effort": "low"})
+    assert _fallback_reasoning_config("compression", "fallback_chain[0](x)", primary) == {"enabled": True, "effort": "low"}
+    monkeypatch.setattr("agent.auxiliary_client._fallback_chain_entry", lambda *_: {})
+    assert _fallback_reasoning_config("compression", "fallback_chain[0](x)", primary) == primary
+
+
+def test_gateway_and_cron_raw_loaders_expand_temp_home_config(tmp_path, monkeypatch):
+    from cron import scheduler
+    from gateway import run as gateway_run
+    home = tmp_path / "hermes-home"; home.mkdir()
+    (home / "config.yaml").write_text(yaml.safe_dump({**routes(), "model": {"model_preset": "fast"}}), encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: yaml.safe_load((home / "config.yaml").read_text()))
+    assert gateway_run._resolve_gateway_model(gateway_run._load_gateway_runtime_config()) == "model-c"
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: home)
+    job_cfg = scheduler._load_cron_job_config({"id": "job-1"}, "job-1", "preset job")
+    assert (job_cfg.model, job_cfg.model_cfg["provider"]) == ("model-c", "provider-c")
+
+
+def test_missing_definitions_and_unsupported_route_keys_fail_at_the_shared_boundary():
+    with pytest.raises(ModelPresetError, match="model: unknown preset 'missing'"):
+        expand_model_presets({"model": {"model_preset": "missing"}})
+    with pytest.raises(ModelPresetError, match="unsupported field\\(s\\): base_url"):
+        expand_model_presets({"model_presets": {"bad": {"provider": "x", "model": "y", "base_url": "https://x"}}})
+    with pytest.raises(ModelPresetError, match=r"fallbacks' may only be \[\]"):
+        expand_model_presets({**routes(), "delegation": {"model_preset": "fast", "fallbacks": [{"provider": "x", "model": "y"}]}})
+
+
+def test_explicit_empty_fallbacks_and_save_preserve_unrelated_delegation_moa_and_fallback_values():
+    authored = {
+        **routes(),
+        "delegation": {"model_preset": "primary", "fallbacks": [], "max_concurrent_children": 2},
+        "fallback_providers": [{"model_preset": "fast", "label": "cheap"}],
+        "moa": {"aggregator": {"model_preset": "fast", "enabled": False}},
+    }
+    expanded = expand_model_presets(authored)
+    main_opt_out = expand_model_presets({**routes(), "model": {"model_preset": "primary", "fallbacks": []}})
+    aux_opt_out = expand_model_presets({**routes(), "auxiliary": {"vision": {"model_preset": "primary", "fallbacks": []}}})
+    assert main_opt_out["fallback_providers"] == []
+    assert aux_opt_out["auxiliary"]["vision"]["fallback_chain"] == []
+    assert expanded["delegation"]["fallback_providers"] == []
+    actual = copy.deepcopy(expanded)
+    actual["delegation"]["max_concurrent_children"] = 7
+    actual["fallback_providers"][0]["label"] = "re-priced"
+    actual["moa"]["aggregator"]["enabled"] = True
+    from hermes_cli.model_presets import preserve_model_preset_references
+    restored = preserve_model_preset_references(actual, authored)
+    assert restored["delegation"] == {"model_preset": "primary", "fallbacks": [], "max_concurrent_children": 7}
+    assert restored["fallback_providers"] == [{"model_preset": "fast", "label": "re-priced"}]
+    assert restored["moa"]["aggregator"] == {"model_preset": "fast", "enabled": True}
+
+
+def test_delegation_and_fallback_consumers_receive_preset_reasoning_and_chain(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+    from agent.chat_completion_helpers import _reresolve_fallback_reasoning_config
+    from tools.delegate_tool_config import _resolve_child_runtime
+    cfg = expand_model_presets({**routes(), "delegation": {"model_preset": "primary"}})
+    parent = SimpleNamespace(model="parent", provider="parent-provider", base_url="", api_mode="chat_completions", acp_command=None, acp_args=[], reasoning_config={"enabled": False}, _fallback_chain=[], request_overrides=None, capabilities=None)
+    child = _resolve_child_runtime(parent, cfg["delegation"], "parent-key", model=None, override_provider=None, override_base_url=None, override_api_key=None, override_api_mode=None, override_acp_command=None, override_acp_args=None)
+    assert child["reasoning_config"] == {"enabled": True, "effort": "high"}
+    assert child["fallback_model"] == [{"provider": "provider-b", "model": "model-b", "reasoning_effort": "low"}]
+    fallback_agent = SimpleNamespace(model="model-b", reasoning_config=None)
+    _reresolve_fallback_reasoning_config(fallback_agent, child["fallback_model"][0])
+    assert fallback_agent.reasoning_config == {"enabled": True, "effort": "low"}
+
+
+@pytest.mark.parametrize("strip_defaults", [True, False])
+@pytest.mark.parametrize("edit", ["unchanged", "reasoning", "fallbacks"])
+def test_main_preset_roundtrip_and_deliberate_projected_edits(tmp_path, monkeypatch, strip_defaults, edit):
+    from hermes_cli import config as c
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    raw = {**routes(), "model": {"model_preset": "primary"}}
+    if edit == "fallbacks":
+        raw["model"]["fallbacks"] = []
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(raw))
+    c._RAW_CONFIG_CACHE.clear(); c._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    loaded = c.load_config()
+    if edit == "reasoning":
+        loaded["agent"]["reasoning_effort"] = "low"
+    elif edit == "fallbacks":
+        loaded["fallback_providers"] = [{"provider": "edited", "model": "edited"}]
+    c.save_config(loaded, strip_defaults=strip_defaults)
+    saved = yaml.safe_load(path.read_text())
+    assert ("model_preset" in saved["model"]) == (edit == "unchanged")
+    c._RAW_CONFIG_CACHE.clear(); c._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    reloaded = c.load_config()
+    assert reloaded["agent"]["reasoning_effort"] == ("low" if edit == "reasoning" else "high")
+    assert reloaded["fallback_providers"] == loaded["fallback_providers"]
+
+
+@pytest.mark.parametrize("site,field,value", [("delegation", "reasoning_effort", "low"), ("auxiliary", "api_key", "nonsecret-fixture")])
+def test_new_route_fields_are_saved_inline_not_as_conflicting_reference(tmp_path, monkeypatch, site, field, value):
+    from hermes_cli import config as c
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    raw: dict = {"model_presets": {"plain": {"provider": "openrouter", "model": "test/model"}}}
+    raw[site] = {"model_preset": "plain"} if site == "delegation" else {"vision": {"model_preset": "plain"}}
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(raw))
+    c._RAW_CONFIG_CACHE.clear(); c._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    loaded = c.load_config()
+    target = loaded[site] if site == "delegation" else loaded[site]["vision"]
+    target[field] = value
+    c.save_config(loaded)
+    saved = yaml.safe_load(path.read_text())
+    target = saved[site] if site == "delegation" else saved[site]["vision"]
+    assert "model_preset" not in target
+    c._RAW_CONFIG_CACHE.clear(); c._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    reloaded = c.load_config()
+    target = reloaded[site] if site == "delegation" else reloaded[site]["vision"]
+    assert target[field] == value
+
+
+def test_main_fallback_preset_reasoning_reaches_auxiliary_wire_request(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+    from hermes_cli import config as c
+    from agent import auxiliary_client as a
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    raw = {"model_presets": {"fallback": {"provider": "openrouter", "model": "test/fallback", "reasoning_effort": "low"}},
+           "model": {"provider": "openrouter", "default": "test/main"}, "fallback_providers": [{"model_preset": "fallback"}]}
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(raw))
+    c._RAW_CONFIG_CACHE.clear(); c._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    client = SimpleNamespace(base_url="https://openrouter.ai/api/v1", _hermes_fallback_destination=a._FallbackDestination("openrouter", "https://openrouter.ai/api/v1", "chat_completions", "test/fallback"))
+    monkeypatch.setattr(a, "_resolve_fallback_entry", lambda entry: (client, entry["model"]))
+    monkeypatch.setattr(a, "_is_provider_unhealthy", lambda *args: False)
+    monkeypatch.setattr(a, "_context_too_small", lambda *args, **kwargs: None)
+    fb_client, model, label = a._try_main_fallback_chain("title_generation", "openrouter", failed_model="test/main")
+    _, kwargs, _ = a._plan_fallback_candidate(fb_client, model, label, task="title_generation", effective_timeout=30,
+        apply_fast_lane=False, messages=[{"role": "user", "content": "test"}], tools=None, temperature=None, max_tokens=50,
+        effective_extra_body={}, reasoning_config={"enabled": True, "effort": "high"})
+    assert kwargs["extra_body"]["reasoning"]["effort"] == "low"

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -394,8 +394,10 @@ def _load_config() -> dict:
             cfg = load_config_readonly().get("delegation") or {}
             if isinstance(cfg, dict):
                 return cfg
-        except Exception:
-            pass
+        except Exception as exc:
+            from hermes_cli.model_presets import ModelPresetError
+            if isinstance(exc, ModelPresetError):
+                raise
     try:
         from cli import CLI_CONFIG
         cfg = CLI_CONFIG.get("delegation") or {}

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -43,7 +43,7 @@ model_presets:
     model: google/gemini-3-flash-preview
 
 model:
-  model_preset: coding
+  model_preset: quick
 delegation:
   model_preset: coding
 auxiliary:
@@ -63,10 +63,15 @@ moa:
 A preset definition is flat: `provider`, `model`, optional `reasoning_effort`, and optional
 ordered `fallbacks` only. Fallback entries are themselves inline flat routes; presets cannot
 reference other presets or inherit from one another. At a reference site, do not combine
-`model_preset` with inline route fields (including an empty fallback override). Hermes rejects
-unknown names, malformed definitions, route conflicts, and preset fallbacks in a fallback or
-MoA slot with the affected config path. Config writes preserve an unchanged named reference
-instead of flattening it.
+`model_preset` with inline route fields. The exception is `fallbacks: []`, which explicitly
+turns off a preset's fallback chain for main, delegation, and auxiliary consumers. A main preset
+that declares fallbacks cannot also be combined with a top-level fallback chain. Hermes rejects
+unknown names, malformed definitions, route conflicts, and recursive fallback routes with the
+affected config path. Config writes preserve unchanged references; deliberate route edits stay
+inline instead of restoring a conflicting reference.
+
+MoA slots cannot reference presets declaring fallbacks: this upstream configuration does not
+support per-slot fallback chains. Use a preset without fallbacks for those slots.
 
 ## The Models page
 

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -21,6 +21,53 @@ This page covers configuring both from the dashboard. If you prefer config files
 On a brand-new install the bundled default config has `model: ""` (an empty string sentinel meaning "not configured yet"). The first time you run `hermes setup` or `hermes model`, that key is upgraded in-place to a mapping with `provider`, `default`, `base_url`, and `api_mode` sub-keys — the shape shown throughout this page and in [`profiles.md`](./profiles.md) / [`configuration.md`](./configuration.md). If you ever see an empty string in `config.yaml`, run `hermes model` (or click **Change** in the dashboard) and Hermes will write the dict form for you.
 :::
 
+## Reusing a named route
+
+`model_presets` gives one provider/model route a name and expands it before Hermes creates a
+main agent, delegated child, auxiliary task, fallback, cron job, gateway session, or MoA slot.
+It does not create a provider identity or share credentials: each expanded route still uses the
+normal credential resolver for its own `provider`.
+
+```yaml
+model_presets:
+  coding:
+    provider: openrouter
+    model: anthropic/claude-sonnet-4.6
+    reasoning_effort: high
+    fallbacks:
+      - provider: openai
+        model: gpt-5.4
+        reasoning_effort: medium
+  quick:
+    provider: openrouter
+    model: google/gemini-3-flash-preview
+
+model:
+  model_preset: coding
+delegation:
+  model_preset: coding
+auxiliary:
+  compression:
+    model_preset: quick
+fallback_providers:
+  - model_preset: quick
+moa:
+  presets:
+    compare:
+      reference_models:
+        - model_preset: quick
+      aggregator:
+        model_preset: quick
+```
+
+A preset definition is flat: `provider`, `model`, optional `reasoning_effort`, and optional
+ordered `fallbacks` only. Fallback entries are themselves inline flat routes; presets cannot
+reference other presets or inherit from one another. At a reference site, do not combine
+`model_preset` with inline route fields (including an empty fallback override). Hermes rejects
+unknown names, malformed definitions, route conflicts, and preset fallbacks in a fallback or
+MoA slot with the affected config path. Config writes preserve an unchanged named reference
+instead of flattening it.
+
 ## The Models page
 
 Open the dashboard and click **Models** in the sidebar. You get two sections:


### PR DESCRIPTION
## Summary

Add flat, reusable `model_presets` and explicit `model_preset` references. References expand statically into existing main-agent, delegation, auxiliary, fallback, and supported MoA configuration shapes. Unrelated config saves preserve the references; deliberate route edits remain inline.

## Motivation

The same provider/model/reasoning/fallback bundle currently needs to be copied across consumers. Those copies drift. A shared authoring-time definition avoids repetition without introducing model-selected routing or changing provider/credential authority.

This explicitly revisits #12658 and #15593, both closed as not planned. #12658 received automated sweeper rejection, and #15593 was treated as its duplicate; static reuse was already part of that discussion. This is a request to reconsider a bounded implementation, not a claim that maintainers reversed the earlier decision.

## Related Issue

Closes #107745

## Type of Change

- [x] New feature (existing inline configuration remains supported)

## Changes Made

- Validate flat definitions and explicit references before runtime/default merging. Reject unknown references, recursive fallback definitions, unsupported fields and conflicting inline route settings.
- Normalize main model/reasoning/fallback fields and delegation/auxiliary fields into their existing shapes. Support `fallbacks: []` to disable a referenced chain.
- Preserve authored references through config writes, including load/save/reload with defaults; retain deliberate edits rather than restoring a conflicting reference.
- Honor reasoning on concrete fallback routes at agent, auxiliary and cron boundaries. Keep explicit cron reasoning pins authoritative.
- Document configuration examples and deliberate exclusions. MoA slots in upstream reject presets carrying fallbacks because this base does not support per-slot fallback chains.

## How to Test

```sh
scripts/run_tests.sh tests/hermes_cli/test_model_presets.py tests/hermes_cli/test_config.py tests/agent/test_auxiliary_client.py tests/agent/test_compression_fallback_budget.py tests/gateway/test_fallback_chain_reload.py tests/cron/test_scheduler.py
```

Observed: 466 passed, 1 timing-sensitive failure, 4 platform skips. The failure was `TestCodexAuxiliaryAdapterTimeout.test_enforces_total_timeout_while_stream_keeps_emitting_events` (elapsed wall time exceeded its 0.14s bound).

Rerun:
```sh
scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/hermes_cli/test_moa_config.py tests/agent/test_moa_reasoning_effort.py
```
Observed: 214 passed, 0 failed (all 204 auxiliary tests passed). The new preset suite contains 31 passing cases, including real temporary-home config load/save/reload and main-fallback reasoning reaching request kwargs.

`ruff check hermes_cli/model_presets.py tests/hermes_cli/test_model_presets.py` and `git diff --check` passed. TruffleHog scanned changed-file snapshots plus the outgoing patch: no findings. Its git scanner could not handle the local partial-clone/worktree configuration, so the equivalent file/patch snapshot was scanned instead.

## Risk and Exclusions

Config-loading and persistence are the main risk surfaces. No dependencies or migrations; remove references/use existing inline settings to roll back. No picker-alias changes, recursive presets, dynamic routing, model-visible selection tool, aggregator-default policy, profile switching, or active-session mutation. Provider definitions still own credentials/endpoints. No local installation or activation was performed. Full repository and cross-platform suites were not run.

## Checklist

- [x] Read contribution guidance and searched existing issues/PRs
- [x] Conventional commit; only feature-related changes
- [x] Added regression tests and documentation
- [x] Tested on macOS with the canonical per-file runner
- [ ] Full repository test suite and other OS lanes
