### PR TITLE
feat(kanban): aggregate token and cost usage by task

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2290,6 +2290,8 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
             )
+            from agent.tool_executor import _kanban_session_usage
+            dispatch_kwargs["session_usage"] = _kanban_session_usage(agent, function_name)
             if skip_tool_execution_middleware:
                 dispatch_kwargs["skip_tool_execution_middleware"] = True
             import model_tools

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2291,7 +2291,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 tool_request_middleware_trace=list(_tool_middleware_trace),
             )
             from agent.tool_executor import _kanban_session_usage
-            dispatch_kwargs["session_usage"] = _kanban_session_usage(agent, function_name)
+            dispatch_kwargs["session_usage"] = _kanban_session_usage(agent, function_name, next_args)
             if skip_tool_execution_middleware:
                 dispatch_kwargs["skip_tool_execution_middleware"] = True
             import model_tools

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2291,7 +2291,10 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 tool_request_middleware_trace=list(_tool_middleware_trace),
             )
             from agent.tool_executor import _kanban_session_usage
-            dispatch_kwargs["session_usage"] = _kanban_session_usage(agent, function_name, next_args)
+            # Lifecycle handlers resolve this only when they are ready to close
+            # the run, after any goal-mode judge has recorded its own usage.
+            dispatch_kwargs["session_usage"] = lambda: _kanban_session_usage(
+                agent, function_name, next_args)
             if skip_tool_execution_middleware:
                 dispatch_kwargs["skip_tool_execution_middleware"] = True
             import model_tools

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -197,7 +197,12 @@ def _flush_session_db_after_tool_progress(agent, messages: list, *, stage: str) 
         return False
 
 
-_KANBAN_USAGE_TERMINALS = frozenset({"kanban_complete", "kanban_block"})
+_KANBAN_USAGE_TERMINALS = frozenset({
+    "kanban_complete",
+    "kanban_block",
+    "kanban_request_review",
+    "kanban_request_changes",
+})
 
 
 def _kanban_session_usage(agent, tool_name: str, function_args: Optional[dict] = None) -> dict | None:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -205,24 +205,33 @@ def _kanban_session_usage(agent, tool_name: str) -> dict | None:
         return None
     session_id = str(getattr(agent, "session_id", "") or "").strip()
     session = None
+    auxiliary_usage = {}
     db = getattr(agent, "_session_db", None)
     if db is not None and session_id:
         try:
             # get_session drains this SessionDB's queued token deltas first.
             session = db.get_session(session_id)
+            auxiliary_usage = db.auxiliary_usage_totals(session_id)
         except Exception as exc:
             logger.debug("Could not read exact Kanban worker session usage: %s", exc)
     session = session if isinstance(session, dict) else {}
+    auxiliary_usage = auxiliary_usage if isinstance(auxiliary_usage, dict) else {}
+
+    def _with_auxiliary(field: str):
+        return (getattr(agent, f"session_{field}", 0) or 0) + (auxiliary_usage.get(field) or 0)
+
     return {
         "session_id": session_id or None,
-        "input_tokens": getattr(agent, "session_input_tokens", 0),
-        "output_tokens": getattr(agent, "session_output_tokens", 0),
-        "cache_read_tokens": getattr(agent, "session_cache_read_tokens", 0),
-        "cache_write_tokens": getattr(agent, "session_cache_write_tokens", 0),
-        "reasoning_tokens": getattr(agent, "session_reasoning_tokens", 0),
-        "api_call_count": getattr(agent, "session_api_calls", 0),
+        "input_tokens": _with_auxiliary("input_tokens"),
+        "output_tokens": _with_auxiliary("output_tokens"),
+        "cache_read_tokens": _with_auxiliary("cache_read_tokens"),
+        "cache_write_tokens": _with_auxiliary("cache_write_tokens"),
+        "reasoning_tokens": _with_auxiliary("reasoning_tokens"),
+        "api_call_count": (getattr(agent, "session_api_calls", 0) or 0)
+        + (auxiliary_usage.get("api_call_count") or 0),
         "turns": getattr(agent, "_user_turn_count", 0),
-        "estimated_cost_usd": getattr(agent, "session_estimated_cost_usd", 0.0),
+        "estimated_cost_usd": (getattr(agent, "session_estimated_cost_usd", 0.0) or 0.0)
+        + (auxiliary_usage.get("estimated_cost_usd") or 0.0),
         "actual_cost_usd": session.get("actual_cost_usd"),
         "model": getattr(agent, "model", None) or session.get("model"),
         "provider": getattr(agent, "provider", None) or session.get("billing_provider"),

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1593,7 +1593,9 @@ def _resolve_sequential_dispatch(agent, ref: _ToolCallRef, messages: list) -> _S
                 tool_request_middleware_trace=list(middleware_trace),
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
-                session_usage=_kanban_session_usage(agent, function_name, next_args),
+                # Lifecycle handlers resolve this only when they are ready to close
+                # the run, after any goal-mode judge has recorded its own usage.
+                session_usage=lambda: _kanban_session_usage(agent, function_name, next_args),
             )
 
     return _SequentialDispatch(

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -42,6 +42,7 @@ from agent.tool_dispatch_helpers import (
     _is_multimodal_tool_result,
     _multimodal_text_summary,
     _append_subdir_hint_to_multimodal,
+    _peel_bridge_call,
     _plan_tool_batch_segments,
     make_tool_result_message,
 )
@@ -199,9 +200,10 @@ def _flush_session_db_after_tool_progress(agent, messages: list, *, stage: str) 
 _KANBAN_USAGE_TERMINALS = frozenset({"kanban_complete", "kanban_block"})
 
 
-def _kanban_session_usage(agent, tool_name: str) -> dict | None:
+def _kanban_session_usage(agent, tool_name: str, function_args: Optional[dict] = None) -> dict | None:
     """Exact numeric/route usage for a worker's terminal lifecycle call."""
-    if tool_name not in _KANBAN_USAGE_TERMINALS or not os.environ.get("HERMES_KANBAN_TASK"):
+    effective_name, _ = _peel_bridge_call(tool_name, function_args or {})
+    if effective_name not in _KANBAN_USAGE_TERMINALS or not os.environ.get("HERMES_KANBAN_TASK"):
         return None
     session_id = str(getattr(agent, "session_id", "") or "").strip()
     session = None
@@ -232,6 +234,7 @@ def _kanban_session_usage(agent, tool_name: str) -> dict | None:
         "turns": getattr(agent, "_user_turn_count", 0),
         "estimated_cost_usd": (getattr(agent, "session_estimated_cost_usd", 0.0) or 0.0)
         + (auxiliary_usage.get("estimated_cost_usd") or 0.0),
+        "auxiliary_estimated_cost_usd": auxiliary_usage.get("estimated_cost_usd") or 0.0,
         "actual_cost_usd": session.get("actual_cost_usd"),
         "model": getattr(agent, "model", None) or session.get("model"),
         "provider": getattr(agent, "provider", None) or session.get("billing_provider"),
@@ -1590,7 +1593,7 @@ def _resolve_sequential_dispatch(agent, ref: _ToolCallRef, messages: list) -> _S
                 tool_request_middleware_trace=list(middleware_trace),
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
-                session_usage=_kanban_session_usage(agent, function_name),
+                session_usage=_kanban_session_usage(agent, function_name, next_args),
             )
 
     return _SequentialDispatch(

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -196,6 +196,40 @@ def _flush_session_db_after_tool_progress(agent, messages: list, *, stage: str) 
         return False
 
 
+_KANBAN_USAGE_TERMINALS = frozenset({"kanban_complete", "kanban_block"})
+
+
+def _kanban_session_usage(agent, tool_name: str) -> dict | None:
+    """Exact numeric/route usage for a worker's terminal lifecycle call."""
+    if tool_name not in _KANBAN_USAGE_TERMINALS or not os.environ.get("HERMES_KANBAN_TASK"):
+        return None
+    session_id = str(getattr(agent, "session_id", "") or "").strip()
+    session = None
+    db = getattr(agent, "_session_db", None)
+    if db is not None and session_id:
+        try:
+            # get_session drains this SessionDB's queued token deltas first.
+            session = db.get_session(session_id)
+        except Exception as exc:
+            logger.debug("Could not read exact Kanban worker session usage: %s", exc)
+    session = session if isinstance(session, dict) else {}
+    return {
+        "session_id": session_id or None,
+        "input_tokens": getattr(agent, "session_input_tokens", 0),
+        "output_tokens": getattr(agent, "session_output_tokens", 0),
+        "cache_read_tokens": getattr(agent, "session_cache_read_tokens", 0),
+        "cache_write_tokens": getattr(agent, "session_cache_write_tokens", 0),
+        "reasoning_tokens": getattr(agent, "session_reasoning_tokens", 0),
+        "api_call_count": getattr(agent, "session_api_calls", 0),
+        "turns": getattr(agent, "_user_turn_count", 0),
+        "estimated_cost_usd": getattr(agent, "session_estimated_cost_usd", 0.0),
+        "actual_cost_usd": session.get("actual_cost_usd"),
+        "model": getattr(agent, "model", None) or session.get("model"),
+        "provider": getattr(agent, "provider", None) or session.get("billing_provider"),
+        "usage_recorded_at": int(time.time()),
+    }
+
+
 def _image_generate_parallel_limit() -> int:
     """Configured image-generation parallelism cap (conservative: backend bursts hit rate limits)."""
     try:
@@ -1547,6 +1581,7 @@ def _resolve_sequential_dispatch(agent, ref: _ToolCallRef, messages: list) -> _S
                 tool_request_middleware_trace=list(middleware_trace),
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                session_usage=_kanban_session_usage(agent, function_name),
             )
 
     return _SequentialDispatch(

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -32,6 +32,7 @@ from hermes_cli.kanban_ops import (
     _cmd_daemon, _kanban_config, _cmd_dispatch, _cmd_gc, _cmd_repair, _cmd_tail, _cmd_watch,
 )
 from hermes_cli.kanban_parser import build_parser  # noqa: F401  (re-exported: hermes_cli.main, run_slash)
+from hermes_cli.kanban_usage import task_usage
 
 
 # --- Flag parsing helpers ---
@@ -485,6 +486,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
         parents = kb.parent_ids(conn, args.task_id)
         children = kb.child_ids(conn, args.task_id)
         runs = kb.list_runs(conn, args.task_id, **rsk)
+        usage = task_usage(conn, args.task_id)
         # Workers hand off via task_runs.summary; tasks.result stays NULL unless set.
         latest_summary = kb.latest_summary(conn, args.task_id)
         if not want_json:
@@ -496,6 +498,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
             "comments": [_obj_dict(c, ("author", "body", "created_at")) for c in comments],
             "events": [_obj_dict(e, ("kind", "payload", "created_at", "run_id")) for e in events],
             "runs": [_obj_dict(r, _SHOW_RUN_FIELDS) for r in runs],
+            "usage": usage,
         })
         return 0
 
@@ -525,6 +528,12 @@ def _cmd_show(args: argparse.Namespace) -> int:
         else:
             print(f"  max-retries: {kb.DEFAULT_FAILURE_LIMIT} (default)")
     field("created", f"{_fmt_ts(task.created_at)} by {task.created_by or '-'}")
+    if usage["runs"]:
+        field(
+            "usage",
+            f"{usage['input_tokens'] + usage['output_tokens']:,} tokens, "
+            f"${usage['cost_usd']:.6f}, {usage['runs']} run(s)",
+        )
 
     # Diagnostics up top so CLI users see distress signals before scrolling.
     from hermes_cli import kanban_diagnostics as kd

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -782,6 +782,7 @@ class Run:
     api_call_count: int = 0
     turns: int = 0
     estimated_cost_usd: float = 0.0
+    auxiliary_estimated_cost_usd: float = 0.0
     actual_cost_usd: Optional[float] = None
     model: Optional[str] = None
     provider: Optional[str] = None
@@ -810,6 +811,7 @@ class Run:
             api_call_count=int(g("api_call_count") or 0),
             turns=int(g("turns") or 0),
             estimated_cost_usd=float(g("estimated_cost_usd") or 0.0),
+            auxiliary_estimated_cost_usd=float(g("auxiliary_estimated_cost_usd") or 0.0),
             actual_cost_usd=(float(g("actual_cost_usd")) if g("actual_cost_usd") is not None else None),
             model=g("model") or None,
             provider=g("provider") or None,
@@ -1031,6 +1033,7 @@ CREATE TABLE IF NOT EXISTS task_runs (
     api_call_count       INTEGER NOT NULL DEFAULT 0,
     turns                INTEGER NOT NULL DEFAULT 0,
     estimated_cost_usd   REAL NOT NULL DEFAULT 0,
+    auxiliary_estimated_cost_usd REAL NOT NULL DEFAULT 0,
     actual_cost_usd      REAL,
     model                TEXT,
     provider             TEXT,
@@ -1921,7 +1924,8 @@ def _end_run(
                worker_pid    = NULL,
                session_id = ?, input_tokens = ?, output_tokens = ?,
                cache_read_tokens = ?, cache_write_tokens = ?, reasoning_tokens = ?,
-               api_call_count = ?, turns = ?, estimated_cost_usd = ?, actual_cost_usd = ?,
+               api_call_count = ?, turns = ?, estimated_cost_usd = ?, auxiliary_estimated_cost_usd = ?,
+               actual_cost_usd = ?,
                model = ?, provider = ?, usage_recorded_at = ?
          WHERE id = ?
            AND ended_at IS NULL
@@ -1931,7 +1935,8 @@ def _end_run(
             run_usage["session_id"], run_usage["input_tokens"], run_usage["output_tokens"],
             run_usage["cache_read_tokens"], run_usage["cache_write_tokens"],
             run_usage["reasoning_tokens"], run_usage["api_call_count"], run_usage["turns"],
-            run_usage["estimated_cost_usd"], run_usage["actual_cost_usd"], run_usage["model"],
+            run_usage["estimated_cost_usd"], run_usage["auxiliary_estimated_cost_usd"],
+            run_usage["actual_cost_usd"], run_usage["model"],
             run_usage["provider"], run_usage["usage_recorded_at"], run_id,
         ),
     )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -773,9 +773,23 @@ class Run:
     summary: Optional[str]
     metadata: Optional[dict]
     error: Optional[str]
+    session_id: Optional[str] = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    reasoning_tokens: int = 0
+    api_call_count: int = 0
+    turns: int = 0
+    estimated_cost_usd: float = 0.0
+    actual_cost_usd: Optional[float] = None
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    usage_recorded_at: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Run":
+        g = lambda col, default=None: _row_get(row, col, default)  # noqa: E731
         return cls(
             **{
                 col: row[col] for col in (
@@ -787,6 +801,19 @@ class Run:
             started_at=int(row["started_at"]),
             ended_at=_opt_int(row["ended_at"]),
             metadata=_json_or(row["metadata"]),
+            session_id=g("session_id") or None,
+            input_tokens=int(g("input_tokens") or 0),
+            output_tokens=int(g("output_tokens") or 0),
+            cache_read_tokens=int(g("cache_read_tokens") or 0),
+            cache_write_tokens=int(g("cache_write_tokens") or 0),
+            reasoning_tokens=int(g("reasoning_tokens") or 0),
+            api_call_count=int(g("api_call_count") or 0),
+            turns=int(g("turns") or 0),
+            estimated_cost_usd=float(g("estimated_cost_usd") or 0.0),
+            actual_cost_usd=(float(g("actual_cost_usd")) if g("actual_cost_usd") is not None else None),
+            model=g("model") or None,
+            provider=g("provider") or None,
+            usage_recorded_at=_opt_int(g("usage_recorded_at")),
         )
 
 
@@ -993,7 +1020,21 @@ CREATE TABLE IF NOT EXISTS task_runs (
     --          gave_up | reclaimed | (null while still running)
     summary             TEXT,
     metadata            TEXT,
-    error               TEXT
+    error               TEXT,
+    -- Immutable worker-session usage snapshot written when this run closes.
+    session_id           TEXT,
+    input_tokens         INTEGER NOT NULL DEFAULT 0,
+    output_tokens        INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens    INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens   INTEGER NOT NULL DEFAULT 0,
+    reasoning_tokens     INTEGER NOT NULL DEFAULT 0,
+    api_call_count       INTEGER NOT NULL DEFAULT 0,
+    turns                INTEGER NOT NULL DEFAULT 0,
+    estimated_cost_usd   REAL NOT NULL DEFAULT 0,
+    actual_cost_usd      REAL,
+    model                TEXT,
+    provider             TEXT,
+    usage_recorded_at    INTEGER
 );
 
 -- Files attached to a task (PDFs, images, source documents). The blob
@@ -1855,6 +1896,7 @@ def _append_event(
 def _end_run(
     conn: sqlite3.Connection, task_id: str, *, outcome: str, summary: Optional[str] = None,
     error: Optional[str] = None, metadata: Optional[dict] = None, status: Optional[str] = None,
+    usage: Optional[dict] = None,
 ) -> Optional[int]:
     """Close the active run (``status`` defaults to ``outcome``) and clear
     ``current_run_id``; None when no run was active (never-claimed task)."""
@@ -1862,6 +1904,9 @@ def _end_run(
     run_id = _current_run_id(conn, task_id)
     if run_id is None:
         return None
+    from hermes_cli.kanban_usage import normalized_run_usage
+
+    run_usage = normalized_run_usage(usage)
     conn.execute(
         """
         UPDATE task_runs
@@ -1873,11 +1918,22 @@ def _end_run(
                ended_at      = ?,
                claim_lock    = NULL,
                claim_expires = NULL,
-               worker_pid    = NULL
+               worker_pid    = NULL,
+               session_id = ?, input_tokens = ?, output_tokens = ?,
+               cache_read_tokens = ?, cache_write_tokens = ?, reasoning_tokens = ?,
+               api_call_count = ?, turns = ?, estimated_cost_usd = ?, actual_cost_usd = ?,
+               model = ?, provider = ?, usage_recorded_at = ?
          WHERE id = ?
            AND ended_at IS NULL
         """,
-        (status or outcome, outcome, summary, error, _json_or_null(metadata), now, run_id),
+        (
+            status or outcome, outcome, summary, error, _json_or_null(metadata), now,
+            run_usage["session_id"], run_usage["input_tokens"], run_usage["output_tokens"],
+            run_usage["cache_read_tokens"], run_usage["cache_write_tokens"],
+            run_usage["reasoning_tokens"], run_usage["api_call_count"], run_usage["turns"],
+            run_usage["estimated_cost_usd"], run_usage["actual_cost_usd"], run_usage["model"],
+            run_usage["provider"], run_usage["usage_recorded_at"], run_id,
+        ),
     )
     conn.execute("UPDATE tasks SET current_run_id = NULL WHERE id = ?", (task_id,))
     return run_id
@@ -1913,10 +1969,14 @@ def _current_run_id(conn: sqlite3.Connection, task_id: str) -> Optional[int]:
 def _end_or_synthesize_run(
     conn: sqlite3.Connection, task_id: str, *, outcome: str, status: str,
     summary: Optional[str] = None, metadata: Optional[dict] = None, synthesize: bool,
+    usage: Optional[dict] = None,
 ) -> Optional[int]:
     """:func:`_end_run`; when no run was active and ``synthesize`` holds, record a
     zero-duration run instead so the handoff fields survive in attempt history."""
-    run_id = _end_run(conn, task_id, outcome=outcome, status=status, summary=summary, metadata=metadata)
+    run_id = _end_run(
+        conn, task_id, outcome=outcome, status=status, summary=summary, metadata=metadata,
+        usage=usage,
+    )
     if run_id is None and synthesize:
         run_id = _synthesize_ended_run(conn, task_id, outcome=outcome, summary=summary, metadata=metadata)
     return run_id
@@ -2530,7 +2590,7 @@ def complete_task(
     conn: sqlite3.Connection, task_id: str, *, result: Optional[str] = None,
     summary: Optional[str] = None, metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None, expected_run_id: Optional[int] = None,
-    fire_lifecycle_hook: bool = True,
+    fire_lifecycle_hook: bool = True, usage: Optional[dict] = None,
 ) -> bool:
     """``running|ready|blocked|review -> done``; records ``result``.
 
@@ -2586,7 +2646,7 @@ def complete_task(
             _stage_completion_artifacts(conn, task_id, metadata, now)
         run_id = _end_run(
             conn, task_id, outcome="completed", status="done", summary=handoff_summary,
-            metadata=metadata,
+            metadata=metadata, usage=usage,
         )
         # Never-claimed task: synthesize a run so the handoff fields survive.
         if run_id is None and (summary or metadata or result or prior_status == "review"):
@@ -2906,6 +2966,7 @@ def edit_completed_task_result(
 def block_task(
     conn: sqlite3.Connection, task_id: str, *, reason: Optional[str] = None,
     kind: Optional[str] = None, expected_run_id: Optional[int] = None,
+    usage: Optional[dict] = None,
 ) -> bool:
     """``running``/``ready`` -> ``blocked`` (or ``todo`` / ``triage``, see
     :func:`_route_block`). ``transient`` still counts toward the loop breaker
@@ -2940,7 +3001,8 @@ def block_task(
         if conn.execute(sql, params).rowcount != 1:
             return False
         run_id = _end_or_synthesize_run(
-            conn, task_id, outcome="blocked", status="blocked", summary=reason, synthesize=bool(reason),
+            conn, task_id, outcome="blocked", status="blocked", summary=reason,
+            synthesize=bool(reason), usage=usage,
         )
         _append_event(conn, task_id, event_kind, payload, run_id=run_id)
         blocked_task = get_task(conn, task_id)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3065,6 +3065,7 @@ def request_review(
     conn: sqlite3.Connection, task_id: str, *, summary: Optional[str] = None,
     metadata: Optional[dict] = None, reviewer: Optional[str] = None,
     expected_run_id: Optional[int] = None, force: bool = False, with_reason: bool = False,
+    usage: Optional[dict] = None,
 ):
     """``running``/``ready`` -> ``review``; never touches block recurrence accounting.
 
@@ -3138,6 +3139,7 @@ def request_review(
         run_id = _end_or_synthesize_run(
             conn, task_id, outcome="review_requested", status="review",
             summary=summary, metadata=metadata, synthesize=bool(summary or metadata),
+            usage=usage,
         )
         _append_event(
             conn,
@@ -3175,6 +3177,7 @@ def _nonblank_str(value: Any) -> Optional[str]:
 
 def request_changes(
     conn: sqlite3.Connection, task_id: str, *, reason: str, expected_run_id: Optional[int] = None,
+    usage: Optional[dict] = None,
 ) -> tuple[bool, Optional[str]]:
     """Close an active reviewer run (claimed from ``review``) and hand the task
     back to the implementer from the latest ``review_requested`` event, parent
@@ -3227,6 +3230,7 @@ def request_changes(
             return False, "task changed during review handoff"
         run_id = _end_run(
             conn, task_id, outcome="changes_requested", status=new_status, summary=reason,
+            usage=usage,
         )
         _append_event(
             conn,

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -827,6 +827,22 @@ _NOTIFY_SUB_COLUMNS = (
     ("delivery_metadata", "delivery_metadata TEXT"),
 )
 
+_RUN_USAGE_COLUMNS = (
+    ("session_id", "session_id TEXT"),
+    ("input_tokens", "input_tokens INTEGER NOT NULL DEFAULT 0"),
+    ("output_tokens", "output_tokens INTEGER NOT NULL DEFAULT 0"),
+    ("cache_read_tokens", "cache_read_tokens INTEGER NOT NULL DEFAULT 0"),
+    ("cache_write_tokens", "cache_write_tokens INTEGER NOT NULL DEFAULT 0"),
+    ("reasoning_tokens", "reasoning_tokens INTEGER NOT NULL DEFAULT 0"),
+    ("api_call_count", "api_call_count INTEGER NOT NULL DEFAULT 0"),
+    ("turns", "turns INTEGER NOT NULL DEFAULT 0"),
+    ("estimated_cost_usd", "estimated_cost_usd REAL NOT NULL DEFAULT 0"),
+    ("actual_cost_usd", "actual_cost_usd REAL"),
+    ("model", "model TEXT"),
+    ("provider", "provider TEXT"),
+    ("usage_recorded_at", "usage_recorded_at INTEGER"),
+)
+
 
 def _column_names(conn: sqlite3.Connection, table: str) -> set[str]:
     return {row["name"] for row in conn.execute(f"PRAGMA table_info({table})")}
@@ -901,6 +917,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
                 )
 
     if _table_exists(conn, "task_runs"):
+        run_cols = _column_names(conn, "task_runs")
+        for name, ddl in _RUN_USAGE_COLUMNS:
+            if name not in run_cols:
+                _add_column_if_missing(conn, "task_runs", name, ddl)
         _backfill_legacy_inflight_runs(conn)
 
     # One-shot event-kind rename: old names still worked but were awkward on
@@ -1003,7 +1023,16 @@ _REBUILD_SPECS = {
         " worker_pid INTEGER, max_runtime_seconds INTEGER,"
         " last_heartbeat_at INTEGER, started_at INTEGER NOT NULL,"
         " ended_at INTEGER, outcome TEXT, summary TEXT, metadata TEXT,"
-        " error TEXT)",
+        " error TEXT, session_id TEXT,"
+        " input_tokens INTEGER NOT NULL DEFAULT 0,"
+        " output_tokens INTEGER NOT NULL DEFAULT 0,"
+        " cache_read_tokens INTEGER NOT NULL DEFAULT 0,"
+        " cache_write_tokens INTEGER NOT NULL DEFAULT 0,"
+        " reasoning_tokens INTEGER NOT NULL DEFAULT 0,"
+        " api_call_count INTEGER NOT NULL DEFAULT 0,"
+        " turns INTEGER NOT NULL DEFAULT 0,"
+        " estimated_cost_usd REAL NOT NULL DEFAULT 0, actual_cost_usd REAL,"
+        " model TEXT, provider TEXT, usage_recorded_at INTEGER)",
         (
             "CREATE INDEX idx_runs_task ON task_runs(task_id, started_at)",
             "CREATE INDEX idx_runs_status ON task_runs(status)",

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -837,6 +837,7 @@ _RUN_USAGE_COLUMNS = (
     ("api_call_count", "api_call_count INTEGER NOT NULL DEFAULT 0"),
     ("turns", "turns INTEGER NOT NULL DEFAULT 0"),
     ("estimated_cost_usd", "estimated_cost_usd REAL NOT NULL DEFAULT 0"),
+    ("auxiliary_estimated_cost_usd", "auxiliary_estimated_cost_usd REAL NOT NULL DEFAULT 0"),
     ("actual_cost_usd", "actual_cost_usd REAL"),
     ("model", "model TEXT"),
     ("provider", "provider TEXT"),
@@ -1031,7 +1032,8 @@ _REBUILD_SPECS = {
         " reasoning_tokens INTEGER NOT NULL DEFAULT 0,"
         " api_call_count INTEGER NOT NULL DEFAULT 0,"
         " turns INTEGER NOT NULL DEFAULT 0,"
-        " estimated_cost_usd REAL NOT NULL DEFAULT 0, actual_cost_usd REAL,"
+        " estimated_cost_usd REAL NOT NULL DEFAULT 0,"
+        " auxiliary_estimated_cost_usd REAL NOT NULL DEFAULT 0, actual_cost_usd REAL,"
         " model TEXT, provider TEXT, usage_recorded_at INTEGER)",
         (
             "CREATE INDEX idx_runs_task ON task_runs(task_id, started_at)",

--- a/hermes_cli/kanban_output.py
+++ b/hermes_cli/kanban_output.py
@@ -27,14 +27,14 @@ _SHOW_RUN_FIELDS = (
     "metadata", "worker_pid", "started_at", "ended_at", "session_id",
     "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
     "reasoning_tokens", "api_call_count", "turns", "estimated_cost_usd",
-    "actual_cost_usd", "model", "provider", "usage_recorded_at",
+    "auxiliary_estimated_cost_usd", "actual_cost_usd", "model", "provider", "usage_recorded_at",
 )
 _RUNS_RUN_FIELDS = (
     "id", "profile", "status", "outcome", "started_at", "ended_at",
     "summary", "error", "metadata", "worker_pid", "step_key", "session_id",
     "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
     "reasoning_tokens", "api_call_count", "turns", "estimated_cost_usd",
-    "actual_cost_usd", "model", "provider", "usage_recorded_at",
+    "auxiliary_estimated_cost_usd", "actual_cost_usd", "model", "provider", "usage_recorded_at",
 )
 _ATTACHMENT_FIELDS = ("id", "filename", "content_type", "size", "uploaded_by", "stored_path", "created_at")
 

--- a/hermes_cli/kanban_output.py
+++ b/hermes_cli/kanban_output.py
@@ -24,11 +24,17 @@ _TASK_DICT_FIELDS = (
 )
 _SHOW_RUN_FIELDS = (
     "id", "profile", "step_key", "status", "outcome", "summary", "error",
-    "metadata", "worker_pid", "started_at", "ended_at",
+    "metadata", "worker_pid", "started_at", "ended_at", "session_id",
+    "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
+    "reasoning_tokens", "api_call_count", "turns", "estimated_cost_usd",
+    "actual_cost_usd", "model", "provider", "usage_recorded_at",
 )
 _RUNS_RUN_FIELDS = (
     "id", "profile", "status", "outcome", "started_at", "ended_at",
-    "summary", "error", "metadata", "worker_pid", "step_key",
+    "summary", "error", "metadata", "worker_pid", "step_key", "session_id",
+    "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
+    "reasoning_tokens", "api_call_count", "turns", "estimated_cost_usd",
+    "actual_cost_usd", "model", "provider", "usage_recorded_at",
 )
 _ATTACHMENT_FIELDS = ("id", "filename", "content_type", "size", "uploaded_by", "stored_path", "created_at")
 

--- a/hermes_cli/kanban_usage.py
+++ b/hermes_cli/kanban_usage.py
@@ -1,0 +1,87 @@
+"""Run-level usage snapshots and per-task aggregation for Kanban."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+
+_TOKEN_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_read_tokens",
+    "cache_write_tokens",
+    "reasoning_tokens",
+    "api_call_count",
+    "turns",
+)
+_COST_FIELDS = ("estimated_cost_usd", "actual_cost_usd")
+
+
+def _nonnegative_int(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _nonnegative_float(value: Any, *, nullable: bool = False) -> Optional[float]:
+    if value is None and nullable:
+        return None
+    try:
+        return max(0.0, float(value or 0.0))
+    except (TypeError, ValueError, OverflowError):
+        return None if nullable else 0.0
+
+
+def normalized_run_usage(usage: Optional[dict]) -> dict[str, Any]:
+    """Return a bounded, column-ready snapshot; absent usage becomes zeroes."""
+    raw = usage if isinstance(usage, dict) else {}
+    recorded_at = raw.get("usage_recorded_at")
+    return {
+        **{field: _nonnegative_int(raw.get(field)) for field in _TOKEN_FIELDS},
+        "estimated_cost_usd": _nonnegative_float(raw.get("estimated_cost_usd")),
+        "actual_cost_usd": _nonnegative_float(raw.get("actual_cost_usd"), nullable=True),
+        "session_id": str(raw.get("session_id") or "").strip() or None,
+        "model": str(raw.get("model") or "").strip() or None,
+        "provider": str(raw.get("provider") or "").strip() or None,
+        "usage_recorded_at": (
+            _nonnegative_int(recorded_at)
+            if recorded_at is not None
+            else (int(time.time()) if raw else None)
+        ),
+    }
+
+
+def task_usage(conn, task_id: str) -> dict[str, Any]:
+    """Aggregate immutable closed-run snapshots, including profile segments."""
+    sum_columns = ", ".join(f"COALESCE(SUM({field}), 0) AS {field}" for field in (*_TOKEN_FIELDS, "estimated_cost_usd"))
+    actual = "COALESCE(SUM(CASE WHEN actual_cost_usd IS NOT NULL THEN actual_cost_usd ELSE estimated_cost_usd END), 0) AS cost_usd"
+
+    def _summary(where: str, params: tuple[Any, ...]) -> dict[str, Any]:
+        row = conn.execute(
+            f"SELECT COUNT(*) AS runs, {sum_columns}, {actual} FROM task_runs WHERE {where}",
+            params,
+        ).fetchone()
+        return {
+            "runs": int(row["runs"] or 0),
+            **{field: int(row[field] or 0) for field in _TOKEN_FIELDS},
+            "estimated_cost_usd": float(row["estimated_cost_usd"] or 0.0),
+            "cost_usd": float(row["cost_usd"] or 0.0),
+        }
+
+    total = _summary("task_id = ? AND ended_at IS NOT NULL", (task_id,))
+    profiles = []
+    rows = conn.execute(
+        "SELECT DISTINCT COALESCE(profile, '') AS profile FROM task_runs "
+        "WHERE task_id = ? AND ended_at IS NOT NULL ORDER BY profile",
+        (task_id,),
+    ).fetchall()
+    for row in rows:
+        profile = row["profile"] or None
+        segment = _summary(
+            "task_id = ? AND ended_at IS NOT NULL AND COALESCE(profile, '') = ?",
+            (task_id, row["profile"]),
+        )
+        profiles.append({"profile": profile, **segment})
+    return {**total, "profiles": profiles}

--- a/hermes_cli/kanban_usage.py
+++ b/hermes_cli/kanban_usage.py
@@ -15,9 +15,6 @@ _TOKEN_FIELDS = (
     "api_call_count",
     "turns",
 )
-_COST_FIELDS = ("estimated_cost_usd", "actual_cost_usd")
-
-
 def _nonnegative_int(value: Any) -> int:
     try:
         return max(0, int(value or 0))
@@ -41,6 +38,7 @@ def normalized_run_usage(usage: Optional[dict]) -> dict[str, Any]:
     return {
         **{field: _nonnegative_int(raw.get(field)) for field in _TOKEN_FIELDS},
         "estimated_cost_usd": _nonnegative_float(raw.get("estimated_cost_usd")),
+        "auxiliary_estimated_cost_usd": _nonnegative_float(raw.get("auxiliary_estimated_cost_usd")),
         "actual_cost_usd": _nonnegative_float(raw.get("actual_cost_usd"), nullable=True),
         "session_id": str(raw.get("session_id") or "").strip() or None,
         "model": str(raw.get("model") or "").strip() or None,
@@ -55,18 +53,26 @@ def normalized_run_usage(usage: Optional[dict]) -> dict[str, Any]:
 
 def task_usage(conn, task_id: str) -> dict[str, Any]:
     """Aggregate immutable closed-run snapshots, including profile segments."""
-    sum_columns = ", ".join(f"COALESCE(SUM({field}), 0) AS {field}" for field in (*_TOKEN_FIELDS, "estimated_cost_usd"))
-    actual = "COALESCE(SUM(CASE WHEN actual_cost_usd IS NOT NULL THEN actual_cost_usd ELSE estimated_cost_usd END), 0) AS cost_usd"
+    sum_columns = ", ".join(
+        f"COALESCE(SUM({field}), 0) AS {field}"
+        for field in (*_TOKEN_FIELDS, "estimated_cost_usd", "auxiliary_estimated_cost_usd")
+    )
+    preferred_cost = (
+        "COALESCE(SUM(CASE WHEN actual_cost_usd IS NOT NULL "
+        "THEN actual_cost_usd + auxiliary_estimated_cost_usd "
+        "ELSE estimated_cost_usd END), 0) AS cost_usd"
+    )
 
     def _summary(where: str, params: tuple[Any, ...]) -> dict[str, Any]:
         row = conn.execute(
-            f"SELECT COUNT(*) AS runs, {sum_columns}, {actual} FROM task_runs WHERE {where}",
+            f"SELECT COUNT(*) AS runs, {sum_columns}, {preferred_cost} FROM task_runs WHERE {where}",
             params,
         ).fetchone()
         return {
             "runs": int(row["runs"] or 0),
             **{field: int(row[field] or 0) for field in _TOKEN_FIELDS},
             "estimated_cost_usd": float(row["estimated_cost_usd"] or 0.0),
+            "auxiliary_estimated_cost_usd": float(row["auxiliary_estimated_cost_usd"] or 0.0),
             "cost_usd": float(row["cost_usd"] or 0.0),
         }
 

--- a/hermes_state_usage.py
+++ b/hermes_state_usage.py
@@ -384,6 +384,20 @@ class SessionUsageMixin:
         self._insert_session_row(session_id, "unknown")
         self._execute_write(lambda conn: self._record_model_usage(conn, session_id, task=task, **usage))
 
+    def auxiliary_usage_totals(self, session_id: str) -> Dict[str, Any]:
+        """Return persisted side-LLM usage for one session, excluding main-loop rows."""
+        self.flush_token_counts()
+        fields = (*_TOKEN_COUNTERS, "api_call_count", "estimated_cost_usd")
+        sums = ", ".join(f"COALESCE(SUM({field}), 0) AS {field}" for field in fields)
+        row = self._read_one(
+            f"SELECT {sums} FROM session_model_usage WHERE session_id = ? AND task <> ''",
+            (session_id,),
+        )
+        return {
+            **{field: int(row[field] or 0) for field in (*_TOKEN_COUNTERS, "api_call_count")},
+            "estimated_cost_usd": float(row["estimated_cost_usd"] or 0.0),
+        }
+
     def usage_totals(self, *, min_message_count: int = 1, include_archived: bool = False) -> Dict[str, float]:
         """Tokens and spend across the whole store (one scan), so the sidebar total does not
         shrink with paging. Spend prefers the billed figure over the estimate."""

--- a/model_tools.py
+++ b/model_tools.py
@@ -802,10 +802,13 @@ def _approval_observability(ids: _CallIds):
 
 
 def _execute_tool(function_name: str, function_args: Dict[str, Any], original_args: Dict[str, Any], ids: _CallIds,
-                  *, user_task: Optional[str], enabled_tools: Optional[List[str]], skip_tool_execution_middleware: bool) -> Any:
+                  *, user_task: Optional[str], enabled_tools: Optional[List[str]], skip_tool_execution_middleware: bool,
+                  session_usage: Optional[Dict[str, Any]] = None) -> Any:
     """Run the registry handler (through tool-execution middleware unless skipped)
     with the approval observability context bound for the duration."""
     dispatch_kwargs: Dict[str, Any] = {"task_id": ids.task_id, "session_id": ids.session_id}
+    if session_usage is not None:
+        dispatch_kwargs["session_usage"] = session_usage
     if function_name == "execute_code":
         # Prefer the caller's list so subagents can't overwrite the parent's
         # tool set via the process-global.
@@ -856,6 +859,7 @@ def handle_function_call(
     function_name: str, function_args: Dict[str, Any], task_id: Optional[str] = None,
     tool_call_id: Optional[str] = None, session_id: Optional[str] = None, turn_id: Optional[str] = None,
     api_request_id: Optional[str] = None, user_task: Optional[str] = None, enabled_tools: Optional[List[str]] = None,
+    session_usage: Optional[Dict[str, Any]] = None,
     skip_pre_tool_call_hook: bool = False, skip_tool_request_middleware: bool = False,
     skip_tool_execution_middleware: bool = False, tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None, disabled_toolsets: Optional[List[str]] = None,
@@ -903,6 +907,7 @@ def handle_function_call(
             skip_pre_tool_call_hook=skip_pre_tool_call_hook, skip_tool_request_middleware=skip_tool_request_middleware,
             skip_tool_execution_middleware=skip_tool_execution_middleware, tool_request_middleware_trace=list(trace),
             enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets,
+            session_usage=session_usage,
         )
 
     from tools.tool_gateway.names import is_connector_name, parse_connector_name
@@ -935,8 +940,11 @@ def handle_function_call(
 
         # duration_ms (monotonic) is exposed to post_tool_call / transform_tool_result.
         start = time.monotonic()
-        result = _execute_tool(function_name, function_args, original_args, ids, user_task=user_task,
-                               enabled_tools=enabled_tools, skip_tool_execution_middleware=skip_tool_execution_middleware)
+        result = _execute_tool(
+            function_name, function_args, original_args, ids, user_task=user_task,
+            enabled_tools=enabled_tools, skip_tool_execution_middleware=skip_tool_execution_middleware,
+            session_usage=session_usage,
+        )
         duration_ms = _elapsed_ms(start)
         _emit(result, duration_ms=duration_ms)
         return _apply_transform_tool_result_hook(function_name, function_args, result, duration_ms, ids)

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -36,6 +36,7 @@ from hermes_cli import kanban_db_dispatch as kbd
 from hermes_cli import kanban_db_workspace as kbw
 from hermes_cli import kanban_diagnostics as kd
 from hermes_cli.kanban_db import KANBAN_ATTACHMENT_MAX_BYTES, _collision_free_path, _safe_attachment_name
+from hermes_cli.kanban_usage import task_usage
 
 log = logging.getLogger(__name__)
 
@@ -365,6 +366,7 @@ def get_task(
             "child_results": [
                 {"id": c.id, "title": c.title, "status": c.status, "latest_summary": child_summaries.get(c.id), "result": c.result}
                 for c in children],
+            "usage": task_usage(conn, task_id),
             "runs": [asdict(r) for r in kanban_db.list_runs(conn, task_id, state_type=run_state_type, state_name=run_state_name)]}
 
 

--- a/tests/hermes_cli/test_kanban_usage.py
+++ b/tests/hermes_cli/test_kanban_usage.py
@@ -317,3 +317,85 @@ def test_goal_gate_usage_is_captured_after_final_judge_call(worker_task, monkeyp
     assert run.api_call_count == 2
     assert run.estimated_cost_usd == pytest.approx(1.25)
     assert run.auxiliary_estimated_cost_usd == pytest.approx(0.25)
+
+
+def test_request_review_preserves_implementation_usage(worker_task):
+    from model_tools import handle_function_call
+
+    out = json.loads(handle_function_call(
+        "kanban_request_review",
+        {"summary": "Implementation verified; ready for review."},
+        session_usage=_usage("session-builder", scale=1),
+    ))
+    assert out["ok"] is True
+
+    with kbc.connect_closing() as conn:
+        task = kb.get_task(conn, worker_task)
+        run = kb.latest_run(conn, worker_task)
+        usage = task_usage(conn, worker_task)
+
+    assert task is not None and run is not None
+    assert task.status == "review"
+    assert run.outcome == "review_requested"
+    assert run.ended_at is not None
+    assert run.session_id == "session-builder"
+    assert usage["input_tokens"] == 100
+    assert usage["estimated_cost_usd"] == pytest.approx(0.1)
+
+
+def test_request_changes_preserves_reviewer_usage(worker_task, monkeypatch):
+    from model_tools import handle_function_call
+
+    with kbc.connect_closing() as conn:
+        task = kb.get_task(conn, worker_task)
+        assert task is not None
+        assert kb.request_review(
+            conn,
+            worker_task,
+            reviewer="reviewer",
+            summary="Ready for review.",
+            expected_run_id=task.current_run_id,
+        )
+        claimed = kb.claim_review_task(conn, worker_task)
+    assert claimed is not None
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+
+    out = json.loads(handle_function_call(
+        "kanban_request_changes",
+        {"reason": "Add coverage for the retry path."},
+        session_usage=_usage("session-reviewer", scale=2, actual_cost_usd=0.15),
+    ))
+    assert out["ok"] is True
+
+    with kbc.connect_closing() as conn:
+        task = kb.get_task(conn, worker_task)
+        run = kb.latest_run(conn, worker_task)
+        usage = task_usage(conn, worker_task)
+
+    assert task is not None and run is not None
+    assert task.status == "ready"
+    assert task.assignee == "builder"
+    assert run.outcome == "changes_requested"
+    assert run.ended_at is not None
+    assert run.session_id == "session-reviewer"
+    assert usage["input_tokens"] == 200
+    assert usage["estimated_cost_usd"] == pytest.approx(0.2)
+    assert usage["cost_usd"] == pytest.approx(0.15)
+    assert [(row["profile"], row["input_tokens"]) for row in usage["profiles"]] == [
+        ("builder", 0),
+        ("reviewer", 200),
+    ]
+
+
+@pytest.mark.parametrize("tool_name", ["kanban_request_review", "kanban_request_changes"])
+def test_review_terminals_collect_worker_usage(worker_task, monkeypatch, tool_name):
+    from agent.tool_executor import _kanban_session_usage
+
+    agent = SimpleNamespace(session_id="session-builder", session_input_tokens=100)
+    usage = _kanban_session_usage(agent, tool_name)
+    assert usage is not None
+    assert usage["session_id"] == "session-builder"
+    assert usage["input_tokens"] == 100
+    assert _kanban_session_usage(agent, "kanban_heartbeat") is None
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
+    assert _kanban_session_usage(agent, tool_name) is None

--- a/tests/hermes_cli/test_kanban_usage.py
+++ b/tests/hermes_cli/test_kanban_usage.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -91,3 +93,79 @@ def test_manual_completion_keeps_usage_unrecorded(worker_task):
     assert run.input_tokens == 0
     assert run.actual_cost_usd is None
     assert run.usage_recorded_at is None
+
+
+@pytest.mark.parametrize(
+    ("auxiliary", "expected_input", "expected_calls", "expected_cost"),
+    [
+        (False, 100, 1, 1.0),
+        (True, 150, 2, 1.5),
+    ],
+)
+def test_model_tools_lifecycle_snapshot_includes_auxiliary_without_double_counting(
+    worker_task, auxiliary, expected_input, expected_calls, expected_cost,
+):
+    from agent.tool_executor import _kanban_session_usage
+    from hermes_state import SessionDB
+    import model_tools
+
+    session_id = f"worker-{'aux' if auxiliary else 'main-only'}"
+    session_db = SessionDB(Path(os.environ["HERMES_HOME"]) / "state.db")
+    session_db.create_session(session_id, source="cli", model="main-model")
+    session_db.update_token_counts(
+        session_id,
+        input_tokens=100,
+        output_tokens=10,
+        model="main-model",
+        billing_provider="main-provider",
+        estimated_cost_usd=1.0,
+        api_call_count=1,
+    )
+    if auxiliary:
+        session_db.record_auxiliary_usage(
+            session_id,
+            "compression",
+            model="aux-model",
+            billing_provider="aux-provider",
+            input_tokens=50,
+            output_tokens=5,
+            estimated_cost_usd=0.5,
+        )
+
+    agent = SimpleNamespace(
+        session_id=session_id,
+        _session_db=session_db,
+        session_input_tokens=100,
+        session_output_tokens=10,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_reasoning_tokens=0,
+        session_api_calls=1,
+        session_estimated_cost_usd=1.0,
+        _user_turn_count=1,
+        model="main-model",
+        provider="main-provider",
+    )
+    snapshot = _kanban_session_usage(agent, "kanban_complete")
+    response = json.loads(model_tools.handle_function_call(
+        "kanban_complete",
+        {"summary": "done"},
+        session_usage=snapshot,
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+        skip_tool_execution_middleware=True,
+    ))
+    assert response["ok"] is True
+
+    with kbc.connect_closing() as conn:
+        run = kb.latest_run(conn, worker_task)
+        usage = task_usage(conn, worker_task)
+    session_db.close()
+
+    assert run.input_tokens == expected_input
+    assert run.output_tokens == (15 if auxiliary else 10)
+    assert run.api_call_count == expected_calls
+    assert run.estimated_cost_usd == pytest.approx(expected_cost)
+    assert usage["input_tokens"] == expected_input
+    assert usage["api_call_count"] == expected_calls
+    assert usage["estimated_cost_usd"] == pytest.approx(expected_cost)

--- a/tests/hermes_cli/test_kanban_usage.py
+++ b/tests/hermes_cli/test_kanban_usage.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli.kanban_usage import task_usage
+from tools import kanban_tools as kt
+
+
+@pytest.fixture
+def worker_task(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kbc._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    with kbc.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="usage", assignee="builder")
+        claimed = kb.claim_task(conn, task_id)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+    return task_id
+
+
+def _usage(session_id: str, *, scale: int, actual_cost_usd=None):
+    return {
+        "session_id": session_id,
+        "input_tokens": 100 * scale,
+        "output_tokens": 20 * scale,
+        "cache_read_tokens": 50 * scale,
+        "cache_write_tokens": 5 * scale,
+        "reasoning_tokens": 3 * scale,
+        "api_call_count": scale,
+        "turns": 1,
+        "estimated_cost_usd": 0.1 * scale,
+        "actual_cost_usd": actual_cost_usd,
+        "model": f"model-{scale}",
+        "provider": "provider",
+        "usage_recorded_at": 1_700_000_000 + scale,
+    }
+
+
+def test_lifecycle_usage_accumulates_across_retries_and_profiles(worker_task, monkeypatch):
+    blocked = json.loads(kt._handle_block(
+        {"reason": "retry", "kind": "transient"},
+        session_usage=_usage("session-builder", scale=1),
+    ))
+    assert blocked["ok"] is True
+
+    with kbc.connect_closing() as conn:
+        assert kb.unblock_task(conn, worker_task)
+        assert kb.assign_task(conn, worker_task, "tester")
+        claimed = kb.claim_task(conn, worker_task)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(claimed.current_run_id))
+
+    completed = json.loads(kt._handle_complete(
+        {"summary": "done"},
+        session_usage=_usage("session-tester", scale=2, actual_cost_usd=0.15),
+    ))
+    assert completed["ok"] is True
+
+    with kbc.connect_closing() as conn:
+        runs = kb.list_runs(conn, worker_task)
+        usage = task_usage(conn, worker_task)
+    assert [run.session_id for run in runs] == ["session-builder", "session-tester"]
+    assert usage["input_tokens"] == 300
+    assert usage["output_tokens"] == 60
+    assert usage["turns"] == 2
+    assert usage["estimated_cost_usd"] == pytest.approx(0.3)
+    assert usage["cost_usd"] == pytest.approx(0.25)
+    assert [(row["profile"], row["input_tokens"]) for row in usage["profiles"]] == [
+        ("builder", 100),
+        ("tester", 200),
+    ]
+
+    shown = json.loads(kc.run_slash(f"show {worker_task} --json"))
+    assert shown["usage"] == usage
+    assert shown["runs"][1]["model"] == "model-2"
+
+
+def test_manual_completion_keeps_usage_unrecorded(worker_task):
+    with kbc.connect_closing() as conn:
+        assert kb.complete_task(conn, worker_task, summary="manual", expected_run_id=None)
+        run = kb.latest_run(conn, worker_task)
+    assert run.input_tokens == 0
+    assert run.actual_cost_usd is None
+    assert run.usage_recorded_at is None

--- a/tests/hermes_cli/test_kanban_usage.py
+++ b/tests/hermes_cli/test_kanban_usage.py
@@ -41,6 +41,7 @@ def _usage(session_id: str, *, scale: int, actual_cost_usd=None):
         "api_call_count": scale,
         "turns": 1,
         "estimated_cost_usd": 0.1 * scale,
+        "auxiliary_estimated_cost_usd": 0.0,
         "actual_cost_usd": actual_cost_usd,
         "model": f"model-{scale}",
         "provider": "provider",
@@ -146,7 +147,7 @@ def test_model_tools_lifecycle_snapshot_includes_auxiliary_without_double_counti
         model="main-model",
         provider="main-provider",
     )
-    snapshot = _kanban_session_usage(agent, "kanban_complete")
+    snapshot = _kanban_session_usage(agent, "kanban_complete", {"summary": "done"})
     response = json.loads(model_tools.handle_function_call(
         "kanban_complete",
         {"summary": "done"},
@@ -166,6 +167,77 @@ def test_model_tools_lifecycle_snapshot_includes_auxiliary_without_double_counti
     assert run.output_tokens == (15 if auxiliary else 10)
     assert run.api_call_count == expected_calls
     assert run.estimated_cost_usd == pytest.approx(expected_cost)
+    assert run.auxiliary_estimated_cost_usd == pytest.approx(0.5 if auxiliary else 0.0)
     assert usage["input_tokens"] == expected_input
     assert usage["api_call_count"] == expected_calls
     assert usage["estimated_cost_usd"] == pytest.approx(expected_cost)
+
+
+@pytest.mark.parametrize("lifecycle", ["kanban_complete", "kanban_block"])
+def test_bridged_lifecycle_snapshot_keeps_worker_usage(worker_task, lifecycle, monkeypatch):
+    from agent.tool_executor import _kanban_session_usage
+    from tools import tool_search
+    import model_tools
+
+    monkeypatch.setattr(
+        tool_search,
+        "is_deferrable_tool_name",
+        lambda name, defer_tools=None: name == lifecycle,
+    )
+    lifecycle_args = (
+        {"summary": "done"}
+        if lifecycle == "kanban_complete"
+        else {"reason": "retry", "kind": "transient"}
+    )
+    bridge_args = {"name": lifecycle, "arguments": lifecycle_args}
+    agent = SimpleNamespace(
+        session_id="bridged-worker",
+        _session_db=None,
+        session_input_tokens=321,
+        session_output_tokens=45,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_reasoning_tokens=0,
+        session_api_calls=2,
+        session_estimated_cost_usd=0.25,
+        _user_turn_count=1,
+        model="main-model",
+        provider="main-provider",
+    )
+
+    snapshot = _kanban_session_usage(agent, "tool_call", bridge_args)
+    response = json.loads(model_tools.handle_function_call(
+        "tool_call",
+        bridge_args,
+        session_usage=snapshot,
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+        skip_tool_execution_middleware=True,
+    ))
+    assert response["ok"] is True
+
+    with kbc.connect_closing() as conn:
+        run = kb.latest_run(conn, worker_task)
+    assert run.session_id == "bridged-worker"
+    assert run.input_tokens == 321
+    assert run.output_tokens == 45
+    assert run.api_call_count == 2
+
+
+def test_task_usage_combines_main_actual_with_auxiliary_estimate(worker_task):
+    usage = _usage("mixed-cost", scale=1, actual_cost_usd=0.8)
+    usage["estimated_cost_usd"] = 1.5
+    usage["auxiliary_estimated_cost_usd"] = 0.5
+    completed = json.loads(kt._handle_complete({"summary": "done"}, session_usage=usage))
+    assert completed["ok"] is True
+
+    with kbc.connect_closing() as conn:
+        run = kb.latest_run(conn, worker_task)
+        aggregate = task_usage(conn, worker_task)
+
+    assert run.estimated_cost_usd == pytest.approx(1.5)
+    assert run.actual_cost_usd == pytest.approx(0.8)
+    assert run.auxiliary_estimated_cost_usd == pytest.approx(0.5)
+    assert aggregate["estimated_cost_usd"] == pytest.approx(1.5)
+    assert aggregate["auxiliary_estimated_cost_usd"] == pytest.approx(0.5)
+    assert aggregate["cost_usd"] == pytest.approx(1.3)

--- a/tests/hermes_cli/test_kanban_usage.py
+++ b/tests/hermes_cli/test_kanban_usage.py
@@ -241,3 +241,79 @@ def test_task_usage_combines_main_actual_with_auxiliary_estimate(worker_task):
     assert aggregate["estimated_cost_usd"] == pytest.approx(1.5)
     assert aggregate["auxiliary_estimated_cost_usd"] == pytest.approx(0.5)
     assert aggregate["cost_usd"] == pytest.approx(1.3)
+
+    shown = json.loads(kt._handle_show({}))
+    assert shown["runs"][0]["auxiliary_estimated_cost_usd"] == pytest.approx(0.5)
+
+
+def test_goal_gate_usage_is_captured_after_final_judge_call(worker_task, monkeypatch):
+    from agent.tool_executor import _kanban_session_usage
+    from hermes_state import SessionDB
+    import model_tools
+
+    session_id = "goal-mode-worker"
+    session_db = SessionDB(Path(os.environ["HERMES_HOME"]) / "state.db")
+    session_db.create_session(session_id, source="cli", model="main-model")
+    session_db.update_token_counts(
+        session_id,
+        input_tokens=100,
+        output_tokens=10,
+        model="main-model",
+        billing_provider="main-provider",
+        estimated_cost_usd=1.0,
+        api_call_count=1,
+    )
+    with kbc.connect_closing() as conn:
+        conn.execute("UPDATE tasks SET goal_mode = 1 WHERE id = ?", (worker_task,))
+        conn.commit()
+
+    agent = SimpleNamespace(
+        session_id=session_id,
+        _session_db=session_db,
+        session_input_tokens=100,
+        session_output_tokens=10,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_reasoning_tokens=0,
+        session_api_calls=1,
+        session_estimated_cost_usd=1.0,
+        _user_turn_count=1,
+        model="main-model",
+        provider="main-provider",
+    )
+
+    def record_final_judge_usage(tool_name, task, tid, evidence):
+        assert tool_name == "kanban_complete"
+        assert task.goal_mode
+        assert tid == worker_task
+        assert evidence == "done"
+        session_db.record_auxiliary_usage(
+            session_id,
+            "goal_judge",
+            model="judge-model",
+            billing_provider="judge-provider",
+            input_tokens=25,
+            output_tokens=5,
+            estimated_cost_usd=0.25,
+        )
+
+    monkeypatch.setattr(kt, "_goal_gate", record_final_judge_usage)
+    response = json.loads(model_tools.handle_function_call(
+        "kanban_complete",
+        {"summary": "done"},
+        session_usage=lambda: _kanban_session_usage(agent, "kanban_complete"),
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+        skip_tool_execution_middleware=True,
+    ))
+    assert response["ok"] is True
+
+    with kbc.connect_closing() as conn:
+        run = kb.latest_run(conn, worker_task)
+    session_db.close()
+
+    assert run.input_tokens == 125
+    assert run.output_tokens == 15
+    assert run.api_call_count == 2
+    assert run.estimated_cost_usd == pytest.approx(1.25)
+    assert run.auxiliary_estimated_cost_usd == pytest.approx(0.25)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -669,9 +669,10 @@ def _handle_request_review(args: dict, **kw) -> str:
                f"Installed profiles: {', '.join(list_profile_names())}")
     with _board(args.get("board")) as (kb, conn):
         _goal_gate("kanban_request_review", kb.get_task(conn, tid), tid, summary)
+        usage = _resolve_session_usage(kw.get("session_usage"))
         ok, fail_reason = kb.request_review(
             conn, tid, summary=summary, metadata=metadata, reviewer=reviewer,
-            expected_run_id=_worker_run_id(tid), with_reason=True)
+            expected_run_id=_worker_run_id(tid), with_reason=True, usage=usage)
         _check(ok, f"could not request review for {tid}: "
                    f"{fail_reason or 'unknown id or not in running/ready'}")
         return _ok_landed(kb, conn, tid, "review")
@@ -684,8 +685,9 @@ def _handle_request_changes(args: dict, **kw) -> str:
     reason = _redact(
         _require_text(args, "reason", "reason is required — describe the changes needed"))
     with _board(args.get("board")) as (kb, conn):
+        usage = _resolve_session_usage(kw.get("session_usage"))
         ok, detail = kb.request_changes(
-            conn, tid, reason=reason, expected_run_id=_worker_run_id(tid))
+            conn, tid, reason=reason, expected_run_id=_worker_run_id(tid), usage=usage)
         _check(ok, f"could not request changes for {tid}: {detail or 'invalid review state'}")
         return _ok_landed(kb, conn, tid, "ready", implementer=detail)
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -313,7 +313,11 @@ _TASK_FIELDS = tuple(
 _TASK_SUMMARY_FIELDS = tuple(
     "id title assignee status priority tenant workspace_kind workspace_path project_id created_by "
     "created_at started_at completed_at current_run_id model_override provider_override".split())
-_RUN_FIELDS = tuple("id profile status outcome summary error metadata started_at ended_at".split())
+_RUN_FIELDS = tuple(
+    "id profile status outcome summary error metadata started_at ended_at session_id "
+    "input_tokens output_tokens cache_read_tokens cache_write_tokens reasoning_tokens "
+    "api_call_count turns estimated_cost_usd actual_cost_usd model provider usage_recorded_at".split()
+)
 _COMMENT_FIELDS = ("author", "body", "created_at")
 _EVENT_FIELDS = ("kind", "payload", "created_at", "run_id")
 _ATTACHMENT_FIELDS = tuple(
@@ -495,6 +499,8 @@ def _handle_show(args: dict, **kw) -> str:
     """Full task state: row, parents, children, comments, runs, last 50 events."""
     tid = _require_task_id(args)
     with _board(args.get("board")) as (kb, conn):
+        from hermes_cli.kanban_usage import task_usage
+
         task = _existing_task(kb, conn, tid)
         return json.dumps({
             "task": _fields(task, _TASK_FIELDS),
@@ -504,6 +510,7 @@ def _handle_show(args: dict, **kw) -> str:
             # Capped; full log via CLI.
             "events": [_fields(e, _EVENT_FIELDS) for e in kb.list_events(conn, tid)[-50:]],
             "runs": [_fields(r, _RUN_FIELDS) for r in kb.list_runs(conn, tid)],
+            "usage": task_usage(conn, tid),
             # Same string build_worker_context hands the dispatcher at spawn time.
             "worker_context": kb.build_worker_context(conn, tid)})
 
@@ -565,7 +572,8 @@ def _handle_complete(args: dict, **kw) -> str:
         try:
             ok = kb.complete_task(
                 conn, tid, result=result, summary=summary, metadata=metadata,
-                created_cards=created_cards, expected_run_id=_worker_run_id(tid))
+                created_cards=created_cards, expected_run_id=_worker_run_id(tid),
+                usage=kw.get("session_usage"))
         except kb.ArtifactPreservationError as artifact_err:
             # Structured rejection — surface the phantom ids so the worker can retry with a corrected list
             # or drop the field. Audit event already landed in the DB. The task itself was NOT mutated (the
@@ -620,7 +628,10 @@ def _handle_block(args: dict, **kw) -> str:
                f"{sorted(_GOAL_MODE_BLOCK_ALLOWED_KINDS)} (got {kind!r}). If the task is actually "
                f"finished or cannot proceed for another reason, call kanban_complete instead — "
                f"the completion judge will evaluate it.")
-        ok = kb.block_task(conn, tid, reason=reason, kind=kind, expected_run_id=_worker_run_id(tid))
+        ok = kb.block_task(
+            conn, tid, reason=reason, kind=kind, expected_run_id=_worker_run_id(tid),
+            usage=kw.get("session_usage"),
+        )
         _check(ok, f"could not block {tid} (unknown id or not in running/ready)")
         return _ok_landed(kb, conn, tid, "blocked", block_kind=kind)
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -316,7 +316,8 @@ _TASK_SUMMARY_FIELDS = tuple(
 _RUN_FIELDS = tuple(
     "id profile status outcome summary error metadata started_at ended_at session_id "
     "input_tokens output_tokens cache_read_tokens cache_write_tokens reasoning_tokens "
-    "api_call_count turns estimated_cost_usd actual_cost_usd model provider usage_recorded_at".split()
+    "api_call_count turns estimated_cost_usd auxiliary_estimated_cost_usd actual_cost_usd "
+    "model provider usage_recorded_at".split()
 )
 _COMMENT_FIELDS = ("author", "body", "created_at")
 _EVENT_FIELDS = ("kind", "payload", "created_at", "run_id")
@@ -328,6 +329,11 @@ _CREATED_FIELDS = ("status", "workspace_kind", "workspace_path", "project_id")
 def _fields(obj: Any, names: tuple[str, ...]) -> dict[str, Any]:
     """``{name: getattr(obj, name)}``; every value None when ``obj`` is None."""
     return {n: getattr(obj, n) if obj is not None else None for n in names}
+
+
+def _resolve_session_usage(value: Any) -> Any:
+    """Materialize deferred worker usage at the lifecycle write boundary."""
+    return value() if callable(value) else value
 
 
 def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
@@ -569,11 +575,12 @@ def _handle_complete(args: dict, **kw) -> str:
         # actually reachable — see _goal_judge_available for why an unavailable judge fails open.
         task = kb.get_task(conn, tid)
         _goal_gate("kanban_complete", task, tid, (summary or result or "").strip())
+        usage = _resolve_session_usage(kw.get("session_usage"))
         try:
             ok = kb.complete_task(
                 conn, tid, result=result, summary=summary, metadata=metadata,
                 created_cards=created_cards, expected_run_id=_worker_run_id(tid),
-                usage=kw.get("session_usage"))
+                usage=usage)
         except kb.ArtifactPreservationError as artifact_err:
             # Structured rejection — surface the phantom ids so the worker can retry with a corrected list
             # or drop the field. Audit event already landed in the DB. The task itself was NOT mutated (the
@@ -628,9 +635,10 @@ def _handle_block(args: dict, **kw) -> str:
                f"{sorted(_GOAL_MODE_BLOCK_ALLOWED_KINDS)} (got {kind!r}). If the task is actually "
                f"finished or cannot proceed for another reason, call kanban_complete instead — "
                f"the completion judge will evaluate it.")
+        usage = _resolve_session_usage(kw.get("session_usage"))
         ok = kb.block_task(
             conn, tid, reason=reason, kind=kind, expected_run_id=_worker_run_id(tid),
-            usage=kw.get("session_usage"),
+            usage=usage,
         )
         _check(ok, f"could not block {tid} (unknown id or not in running/ready)")
         return _ok_landed(kb, conn, tid, "blocked", block_kind=kind)


### PR DESCRIPTION
## Summary
- persist immutable token, cost, model, provider, session, and turn usage on each closed Kanban run
- aggregate task usage across retries with per-profile segmentation
- expose task and run usage through the Kanban CLI, worker tool, and dashboard API

## Test plan
- [ ] `scripts/run_tests.sh tests/hermes_cli/test_kanban_usage.py tests/tools/test_kanban_tools.py`
- [ ] `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_db_init.py tests/hermes_cli/test_kanban_cli.py`
- [ ] `scripts/run_tests.sh tests/test_model_tools.py tests/run_agent/test_tool_call_incremental_persistence.py`

Closes #107744