### PR TITLE
fix(agent): preserve max reasoning for Daybreak alias

### DIFF
--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -35,6 +35,9 @@ CODEX_LEGACY_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh
 # wire level; callers normalize those requests to ``low`` at the transport boundary.
 CODEX_ASTRA_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 ASTRA_MODEL_IDS: frozenset[str] = frozenset({"gpt-6-astra", "gpt-6-astra-900k"})
+DAYBREAK_MODEL_IDS: frozenset[str] = frozenset(
+    {"gpt-daybreak-blue-latest", "gpt-daybreak-blue-latest-900k"}
+)
 
 #: xAI Responses — Grok 4.6+ accepts xhigh; older Grok tops out at high.
 XAI_GROK46_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
@@ -93,7 +96,12 @@ def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for an OpenAI/Codex Responses model."""
     if is_astra_model(model):
         return CODEX_ASTRA_EFFORTS
-    return CODEX_GPT56_EFFORTS if "gpt-5.6" in (model or "").lower() else CODEX_LEGACY_EFFORTS
+    bare = (model or "").strip().lower().rsplit("/", 1)[-1]
+    return (
+        CODEX_GPT56_EFFORTS
+        if "gpt-5.6" in bare or bare in DAYBREAK_MODEL_IDS
+        else CODEX_LEGACY_EFFORTS
+    )
 
 
 def kimi_supported_efforts(model: Optional[str]) -> tuple[str, ...]:

--- a/tests/agent/test_reasoning_effort_module.py
+++ b/tests/agent/test_reasoning_effort_module.py
@@ -160,6 +160,19 @@ class TestCodexVocabulary:
         assert clamp_effort("ultra", CODEX_LEGACY_EFFORTS) == "xhigh"
         assert clamp_effort("minimal", CODEX_LEGACY_EFFORTS) == "low"
 
+    @pytest.mark.parametrize(
+        "model",
+        ["gpt-daybreak-blue-latest", "gpt-daybreak-blue-latest-900k"],
+    )
+    def test_daybreak_alias_uses_gpt56_max_support(self, model):
+        """Daybreak Blue is a GPT-5.6 Sol alias, so its base and 900k picker
+        slugs must preserve Sol's max reasoning level."""
+        from agent.reasoning_effort import codex_supported_efforts
+
+        supported = codex_supported_efforts(model)
+        assert clamp_effort("max", supported) == "max"
+        assert clamp_effort("ultra", supported) == "max"
+
 
 class TestRequestedEffort:
     def test_extracts_effort(self):


### PR DESCRIPTION
## What changed

- Classify the documented `gpt-daybreak-blue-latest` alias as GPT-5.6 when selecting the Codex Responses reasoning-effort vocabulary.
- Cover both the base model ID and Hermes' `-900k` picker alias.
- Add a regression test showing that `max` remains `max` and Hermes-internal `ultra` clamps to `max`, rather than both being reduced to `xhigh`.

## Why

OpenAI documents Daybreak Blue's current snapshot as `gpt-5.6-sol`. Hermes already gives GPT-5.6 models the `max` wire level, but `codex_supported_efforts()` recognized that family only by the literal `gpt-5.6` substring. The Daybreak alias therefore fell through to the legacy vocabulary and silently reduced the strongest configured efforts to `xhigh`.

Model reference: https://developers.openai.com/api/docs/models/daybreak-blue-latest

## Verification

- Regression test was observed failing before the implementation (`max` resolved to `xhigh` for both Daybreak IDs).
- `scripts/run_tests.sh tests/agent/test_reasoning_effort_module.py tests/agent/transports/test_reasoning_effort_sibling_sites.py tests/agent/transports/test_codex_transport.py tests/agent/test_astra_baseline_runtime.py tests/agent/test_model_metadata.py`: **294 passed**.
- Full canonical test run: **47,180 passed, 96 failed, 405 skipped**. The same 96 failures across the same 27 files reproduce on `origin/main` in this release venv; they are baseline environment failures from unavailable optional dependencies and live-system guards, not changes introduced here.
- `ruff check agent/reasoning_effort.py tests/agent/test_reasoning_effort_module.py`: passed.
- Direct transport smoke check confirms:
  - Daybreak base: `max -> max`, `ultra -> max`
  - Daybreak `-900k`: alias stripped on wire, `max -> max`, `ultra -> max`

## Platform tested

Fedora Linux, Python 3.11.
