### PR TITLE
feat(skills): hillclimb - frozen-harness metric optimization loop

### DIFF
--- a/optional-skills/software-development/hillclimb/SKILL.md
+++ b/optional-skills/software-development/hillclimb/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: hillclimb
+description: "Optimize one metric via frozen harness and decision log."
+version: 1.0.0
+author: "Emmanuel Ketcha (@ketchalegend) + Hermes Agent"
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [optimization, metrics, experiments, decision-log, benchmarking, iteration]
+    category: software-development
+    related_skills: [systematic-debugging, spike, test-driven-development, requesting-code-review, subagent-driven-development]
+---
+
+# Hillclimb
+
+Improves one quantitative metric of a codebase by making a single change, measuring it, and keeping or reverting it on the evidence. The loop is deliberately narrow: one metric, one change per attempt, one measurement, one log row. It does not profile code, diagnose correctness bugs, or weigh competing objectives - see When to Use for what to reach for instead.
+
+## When to Use
+
+Reach for this skill when the target is a single number and the user wants it moved:
+
+- "Make the test suite faster", "get bundle size down", "cut token cost per turn", "reduce the flaky-test rate", "raise coverage".
+- A change is about to be justified by intuition or by reading the code, and you would rather the data decide.
+- A tuning effort will run many attempts, possibly with nobody watching.
+
+Do NOT use it when:
+
+- You cannot build a harness that reliably prints one number. Without a repeatable measurement this skill has nothing to offer - say so and stop, rather than improvising a metric that flatters the change.
+- The target is a correctness bug rather than a measurement: use `systematic-debugging`.
+- The work is code shape with no metric attached: use `simplify-code`.
+- The goal is a tradeoff across several metrics with no dominant one. Choose the metric first, then come back.
+
+## Prerequisites
+
+- A target repo under git, and one command that prints the metric (the harness).
+- `<skill_dir>` below means this skill's own directory; the helper scripts are `<skill_dir>/scripts/decision_log.py` and `<skill_dir>/scripts/sample_metric.py`.
+- Python 3, standard library only. The scripts create `.hillclimb/` in the working directory on their first write; `--dir`, or the `HILLCLIMB_DIR` environment variable, relocates it.
+- Add `.hillclimb/` to the target repo's `.gitignore`. The log is a working trail, not a deliverable; it is quoted into the PR body rather than committed.
+
+## How to Run
+
+1. Build the harness, then freeze a baseline with `sample_metric.py baseline`.
+2. Make one change, then measure it with `sample_metric.py compare`.
+3. Record the attempt with `decision_log.py append`.
+4. When progress stalls, run the plateau protocol in `references/plateau-playbook.md`.
+5. Land the surviving change and quote the kept rows in the PR body.
+
+## Quick Reference
+
+| Command | Purpose |
+|---|---|
+| `sample_metric.py baseline --harness CMD --samples N` | Sample N times, freeze the median as the baseline |
+| `sample_metric.py run --harness CMD --samples N` | Sample without touching the baseline |
+| `sample_metric.py compare --harness CMD` | Exit 0 = improvement, 1 = not, 2 = no baseline or bad value, 3 = harness changed since the freeze |
+| `decision_log.py append ...` | Add one attempt row; the tool computes `delta` |
+| `decision_log.py list [--limit N] [--verdict kept\|reverted]` | Read the trail, oldest first |
+| `decision_log.py stats [--window N] [--threshold F]` | Direction-aware best/worst plus a plateau verdict |
+| `decision_log.py verify` | Validate the trail: exit 0 clean, 1 problems, 2 bad invocation |
+
+`--extract` selects how a number is read out of the harness's stdout: `auto` (default - the last number printed), `regex:PATTERN` (first capture group), `json:dotted.path`, or `line:PREFIX` (the first number on the first line beginning with PREFIX).
+
+## Procedure
+
+### 1. Build the harness
+
+Write one command that prints exactly one number, then confirm it is stable across runs. Use enough samples to clear noise: the median of N runs, never a single run.
+
+**Done when:** repeated runs of the harness land within a spread you are willing to call noise, and `sample_metric.py run` prints a median for that command.
+
+### 2. Freeze the baseline
+
+```bash
+python3 <skill_dir>/scripts/sample_metric.py baseline --harness "<command>" --samples 5 --name "test suite seconds" --direction minimize
+```
+
+This writes `.hillclimb/baseline.json` with the recorded median, `frozen: true`, and a `harness_id` fingerprint of the command. Add `.hillclimb/` to `.gitignore` now. The harness is immutable from this point: any edit changes the `harness_id`, and every earlier number stops being comparable.
+
+**Done when:** `.hillclimb/baseline.json` exists, is `frozen: true`, and a repeat run of the same harness reproduces its median within the sampling spread.
+
+### 3. The loop (one change, one measurement)
+
+Make exactly one change to the codebase - never to the harness - then:
+
+```bash
+python3 <skill_dir>/scripts/sample_metric.py compare --harness "<command>" --samples 5
+```
+
+Record the attempt either way:
+
+```bash
+python3 <skill_dir>/scripts/decision_log.py append \
+  --hypothesis "Parallel test execution cuts wall clock" \
+  --change "pytest-xdist, 4 workers" \
+  --before 5.8 --after 5.2 --tests pass --verdict kept
+```
+
+`delta` is always raw `after - before`, so here it is -0.6. For a `minimize` metric a negative delta is an improvement; the direction is recorded once in `baseline.json`. When the metric moves the wrong way, record the same shape with the real numbers and `--verdict reverted` - for example `--before 5.8 --after 6.1 --verdict reverted`. Never stack untested changes, and never record a win you did not measure.
+
+If an attempt measured nothing - a category pivot, a harness fix, a proven dead end - record it with `--before na --after na --tests none` so the trail still explains the search.
+
+**Done when:** exactly one new row exists with a tool-computed `delta`, a `tests` value, and a `verdict`, and the change was kept or reverted to match.
+
+### 4. Plateau
+
+Run `decision_log.py stats`. It reports a plateau when **each** of the last `--window` attempts (default 3) improved by less than `--threshold` (default 0.02, i.e. 2%), where improvement is relative to that attempt's own `before` value and interpreted by the recorded direction. `plateau_reasons` names the attempts that failed to clear the bar.
+
+A plateau is a signal to change hypothesis *category*, not a signal to stop. Follow `references/plateau-playbook.md`: pivot category, combine the near-misses, re-read the source instead of guessing, and try something more radical before concluding the hill is climbed.
+
+**Done when:** the plateau is either broken by a recorded category pivot, or written down as a provable dead end in a `tests: none` row.
+
+### 5. Land it
+
+```bash
+python3 <skill_dir>/scripts/decision_log.py verify
+```
+
+`verify` must exit 0. Then re-run the harness and the target repo's own test suite against the surviving tree, commit the change, and quote the kept rows (before/after/delta) into the PR body. Never commit `.hillclimb/`.
+
+**Done when:** `verify` exits 0, the repo's tests pass on the surviving tree, and the PR body carries the kept rows.
+
+## Two Modes
+
+- **Interactive** - one agent, one change at a time, measuring and keeping or reverting as it goes.
+- **Unattended or parallel** - fan hypotheses into separate git worktrees, or run the loop on a schedule. See `references/unattended-mode.md` for the real `cronjob_manage` fields, the monitor gate, and the worktree recipe.
+
+## Pitfalls
+
+1. Editing the harness after the freeze invalidates every earlier number. `compare` will exit 3 rather than compare across two measurement methods - re-baseline deliberately and record why.
+2. Re-baselining to escape a result you did not like is the failure this skill exists to prevent. The `harness_id` guard makes it impossible to do silently, which is the point: the escape has to be written down.
+3. A failed or unparseable sample aborts the whole measurement (exit 2). There is deliberately no way to average over failed runs; a metric built from failed samples is not a metric.
+4. Reading the code and concluding a change helped is not evidence. The data decides, or the attempt is recorded as `tests: none` with no measurement.
+5. A plateau is not the end of the hill. Pivoting category, combining near-misses, and re-reading the source are all still available.
+6. Skipping `verify` lets a malformed trail - a hand-edited delta, a row from a different harness - reach the PR body.
+7. Forgetting `.gitignore` puts the working trail into the commit.
+
+## Verification
+
+- [ ] `.hillclimb/baseline.json` exists with `frozen: true` and a `harness_id`
+- [ ] Every attempt has exactly one row, with a tool-computed `delta` and an explicit `tests` value
+- [ ] Kept rows have real before/after numbers taken from `compare`, not from inspection
+- [ ] `decision_log.py verify` exits 0
+- [ ] `verify` reports no `stale-harness` rows, so every number came from the same measurement method
+- [ ] `.hillclimb/` is not in the commit, and the kept rows are in the PR body

--- a/optional-skills/software-development/hillclimb/references/decision-log.md
+++ b/optional-skills/software-development/hillclimb/references/decision-log.md
@@ -1,0 +1,85 @@
+---
+name: hillclimb
+description: "Optimize one metric via frozen harness and decision log."
+version: 1.0.0
+author: "Emmanuel Ketcha (@ketchalegend) + Hermes Agent"
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [optimization, metrics, experiments, decision-log, benchmarking, iteration]
+    category: software-development
+    related_skills: [systematic-debugging, spike, test-driven-development, requesting-code-review, subagent-driven-development]
+---
+
+# Decision Log Reference
+
+`.hillclimb/decision.tsv` is the trail: one row per attempt, appended by `<skill_dir>/scripts/decision_log.py append`. It is tab-separated with a required header row and exactly 11 columns, in this order.
+
+| # | Column | Type | Meaning |
+|---|---|---|---|
+| 1 | `id` | integer from 1 | Assigned by the tool. Never reused or reordered. |
+| 2 | `timestamp` | ISO-8601 UTC | `YYYY-MM-DDTHH:MM:SSZ`, written by the tool. |
+| 3 | `hypothesis` | free text | What you expected to happen, and why. |
+| 4 | `change` | free text | The single change made, as files or a one-line description. |
+| 5 | `before` | float or `na` | The frozen baseline median, or the previous attempt's `after`. |
+| 6 | `after` | float or `na` | The median measured for this attempt. |
+| 7 | `delta` | float or `na` | Always `after - before`. Computed by the tool. |
+| 8 | `tests` | `pass` / `fail` / `none` | Whether the repo's tests still pass. |
+| 9 | `verdict` | `kept` / `reverted` | What happened to the change. |
+| 10 | `harness_id` | 12 hex chars | Fingerprint of the harness that produced the numbers. |
+| 11 | `note` | free text | What the data showed. This is what you read before the next attempt. |
+
+`append` replaces tab and newline characters inside the free-text fields with spaces, so a note containing a tab cannot corrupt the row.
+
+## Why `delta` is raw arithmetic
+
+The tool computes `delta` and never accepts it from a caller. Direction is not a property of a row - it is recorded once, in `baseline.json`, as `direction: minimize` or `maximize`, and applied by `stats` and `compare`. For a `minimize` metric (test-suite seconds, bundle KB, tokens per turn) a negative delta is an improvement; for a `maximize` metric (coverage %) a positive delta is. Keeping direction out of the TSV means a row cannot assert a direction the baseline disagrees with.
+
+## Why `tests` has three states
+
+- `pass` - the metric moved and the repo's tests still pass.
+- `fail` - the metric moved but at least one test now fails. The change must be reverted even if the number is better. This is the state a boolean would hide.
+- `none` - nothing was measured. Use it for category pivots, harness edits, and dead ends.
+
+## Why `harness_id` is on every row
+
+`harness_id` is the first 12 hexadecimal characters of the SHA-256 of the whitespace-normalized harness command. Two rows with different `harness_id` values were produced by different measurement methods and are not comparable, however similar the numbers look. `verify` reports any row whose `harness_id` differs from the frozen baseline as `stale-harness`, which is what makes a silent re-baseline impossible.
+
+## Recording an attempt that measured nothing
+
+Category pivots, harness repairs, and proven dead ends still get a row, with `--before na --after na --tests none`, so the trail explains why the search changed direction rather than appearing to circle. `delta` is recorded as `na` in those rows.
+
+## Worked example rows
+
+Columns are tab-separated; the rows below are aligned for reading. Direction is `minimize` (test-suite seconds), so a negative delta is an improvement.
+
+```
+id timestamp             hypothesis                        change            before after delta tests verdict  harness_id   note
+1  2026-09-10T14:23:00Z  xdist parallelizes the suite      pytest-xdist x4   5.8    5.2   -0.6  pass  kept     a5b9c2d3e4f7  wall clock down 10%
+2  2026-09-10T14:45:00Z  Reworking fixtures removes setup   fixture rework    5.2    6.1   0.9   pass  reverted a5b9c2d3e4f7  slower: fixtures now rebuilt per module
+3  2026-09-10T15:02:00Z  Skipping teardown saves time       skip teardown     5.2    5.1   -0.1  fail  reverted a5b9c2d3e4f7  broke test_session_resume
+4  2026-09-10T15:30:00Z  Per-test tuning is exhausted; try  na                na     na    na    none  reverted a5b9c2d3e4f7  category pivot: concurrency, not micro-optimization
+```
+
+Row 3 is the case the three-state `tests` column exists for: a real 0.1s win, reverted because it broke a test. Row 4 is a pivot, recorded with no measurement so the trail shows why the search moved on.
+
+## `verify` problem types
+
+`verify` prints a JSON list of problems and exits 1 if there are any, 0 if the trail is clean.
+
+| Type | Meaning |
+|---|---|
+| `no-log` | No `decision.tsv` exists. Nothing to validate; exits 0. |
+| `non-numeric-id` | The `id` column is not an integer. |
+| `non-monotonic-ids` | Ids are not in increasing order. |
+| `duplicate-ids` | The same id appears more than once. |
+| `row-wrong-column-count` | The row does not have exactly 11 columns. |
+| `delta-mismatch` | `delta` is not equal to `after - before`. |
+| `invalid-tests` | `tests` is not one of `pass`, `fail`, `none`. |
+| `invalid-verdict` | `verdict` is not one of `kept`, `reverted`. |
+| `stale-harness` | The row's `harness_id` differs from the frozen baseline's. |
+
+## Committing the trail
+
+`.hillclimb/` is gitignored: the log is a working trail, and most of it is noise to a reviewer. What the reviewer needs is the evidence for the claim, so quote the kept rows - before, after, delta - into the PR body. If a run's reasoning matters more than its numbers, attach the relevant rows to the PR as part of the description; do not commit the directory.

--- a/optional-skills/software-development/hillclimb/references/decision-log.md
+++ b/optional-skills/software-development/hillclimb/references/decision-log.md
@@ -30,7 +30,7 @@ metadata:
 | 10 | `harness_id` | 12 hex chars | Fingerprint of the harness that produced the numbers. |
 | 11 | `note` | free text | What the data showed. This is what you read before the next attempt. |
 
-`append` replaces tab and newline characters inside the free-text fields with spaces, so a note containing a tab cannot corrupt the row.
+`append` replaces tab and newline characters inside the free-text fields with spaces, so a note containing a tab cannot corrupt the row. `list` skips a malformed row rather than crashing on it, and says so on stderr - `verify` is what names the problem precisely.
 
 ## Why `delta` is raw arithmetic
 
@@ -76,6 +76,7 @@ Row 3 is the case the three-state `tests` column exists for: a real 0.1s win, re
 | `duplicate-ids` | The same id appears more than once. |
 | `row-wrong-column-count` | The row does not have exactly 11 columns. |
 | `delta-mismatch` | `delta` is not equal to `after - before`. |
+| `invalid-metric` | The `before` or `after` column is neither a number nor `na`. |
 | `invalid-tests` | `tests` is not one of `pass`, `fail`, `none`. |
 | `invalid-verdict` | `verdict` is not one of `kept`, `reverted`. |
 | `stale-harness` | The row's `harness_id` differs from the frozen baseline's. |

--- a/optional-skills/software-development/hillclimb/references/harness-lifecycle.md
+++ b/optional-skills/software-development/hillclimb/references/harness-lifecycle.md
@@ -25,7 +25,7 @@ State machine for the measurement harness. The harness defines **what** is measu
 
 ## Transition Rules
 - **DRAFT -> MEASURED**: Run harness repeatedly (`--samples N`). Verify the output is a single number and repeated runs land within an acceptable spread. No file is created yet.
-- **MEASURED -> BASELINED**: Run `sample_metric.py baseline`. This records the median and the sample count, computes `harness_id` (the first 12 hex characters of the SHA-256 of the whitespace-normalized harness command), and writes `.hillclimb/baseline.json`.
+- **MEASURED -> BASELINED**: Run `sample_metric.py baseline`. This records the median, the sample count and the extraction spec, computes `harness_id` (the first 12 hex characters of the SHA-256 of the whitespace-normalized harness command), and writes `.hillclimb/baseline.json`. Recording the extraction spec is what lets `compare` read the number the same way the baseline did instead of guessing.
 - **BASELINED -> INVALIDATED**: Any edit to the harness command (even whitespace changes) makes `compare` exit 3. The only legitimate path is to record the harness edit as a decision row (`tests: none`, `before: na`, `after: na`) before re-baselining.
 - **INVALIDATED -> RE-BASELINED**: After recording the harness edit, run `baseline` again. This creates a new frozen baseline.
 

--- a/optional-skills/software-development/hillclimb/references/harness-lifecycle.md
+++ b/optional-skills/software-development/hillclimb/references/harness-lifecycle.md
@@ -1,0 +1,60 @@
+---
+name: hillclimb
+description: "Optimize one metric via frozen harness and decision log."
+version: 1.0.0
+author: "Emmanuel Ketcha (@ketchalegend) + Hermes Agent"
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [optimization, metrics, experiments, decision-log, benchmarking, iteration]
+    category: software-development
+    related_skills: [systematic-debugging, spike, test-driven-development, requesting-code-review, subagent-driven-development]
+---
+
+# Harness Lifecycle Reference
+
+State machine for the measurement harness. The harness defines **what** is measured and **how** it is measured. Changing the harness invalidates all prior measurements.
+
+## States
+- **DRAFT** - You are still deciding what to measure or how to measure it. No baseline recorded.
+- **MEASURED** - You have run the harness multiple times and observed a stable median. The harness prints a single number reliably.
+- **BASELINED** - `sample_metric.py baseline` has been run. The median is recorded in `.hillclimb/baseline.json` with `frozen: true` and a `harness_id`. The harness is now immutable for the duration of the loop.
+- **INVALIDATED** - The harness was edited after BASELINED. All prior rows in `decision.tsv` are now invalid. The skill will reject further `compare` calls with exit code 3 (harness changed). A legitimate INVALIDATION must be recorded as a decision row before re-baselining.
+- **RE-BASELINED** - After a recorded INVALIDATION, you may run `baseline` again. This creates a new frozen baseline with a new `harness_id`, which opens a new epoch of comparable numbers. The existing log is NOT reset: earlier rows keep their old `harness_id` and are reported by `verify` as `stale-harness` from then on, which is exactly what should happen - they were measured a different way.
+
+## Transition Rules
+- **DRAFT -> MEASURED**: Run harness repeatedly (`--samples N`). Verify the output is a single number and repeated runs land within an acceptable spread. No file is created yet.
+- **MEASURED -> BASELINED**: Run `sample_metric.py baseline`. This records the median and the sample count, computes `harness_id` (the first 12 hex characters of the SHA-256 of the whitespace-normalized harness command), and writes `.hillclimb/baseline.json`.
+- **BASELINED -> INVALIDATED**: Any edit to the harness command (even whitespace changes) makes `compare` exit 3. The only legitimate path is to record the harness edit as a decision row (`tests: none`, `before: na`, `after: na`) before re-baselining.
+- **INVALIDATED -> RE-BASELINED**: After recording the harness edit, run `baseline` again. This creates a new frozen baseline.
+
+## Why `harness_id` Matters
+The `harness_id` is the first 12 hex characters of SHA256 of the whitespace-normalized harness command. It serves as a fingerprint:
+- Changing the harness changes the ID -> `compare` refuses (exit 3).
+- Silent re-baselining without recording the harness edit is impossible because the ID would differ.
+- It prevents cheating by editing the harness to improve the metric without re-recording the baseline.
+
+## Legitimate Re-Baseline Examples
+1. **New measurement target** - You decide to measure CI duration instead of test suite time. Record: "Changed measurement target from test suite time to CI duration" (`tests: none`). Then re-baseline.
+2. **Harness bug fix** - The harness script had a bug that caused occasional failures. Fix the bug, record the fix, then re-baseline.
+3. **Environment change** - CI runner upgraded Python version; you re-baseline to capture the new baseline under the new environment.
+
+## Cheating Re-Baseline Examples (and why they're caught)
+1. **Editing harness because change didn't show a win** - You tweak the command to make the metric look better. The `harness_id` changes, so `compare` exits 3. You can't silently re-baseline.
+2. **Loosening the metric** - You change from "wall-clock seconds" to "CPU seconds" to show improvement. The harness command changes -> ID mismatch -> exit 3.
+3. **Changing the sample count after seeing a bad result** - You raise `--samples` after a run disappointed you, hoping the median improves. Be aware this one is NOT caught by the id: `harness_id` fingerprints the harness command only, so `--samples` is outside it. `baseline.json` records the sample count the baseline was taken with - hold it fixed for the duration of the loop, and treat a change of sample count the same as a change of harness (record it, then re-baseline).
+4. **Swapping the command silently** - You replace the real command with a dummy that always returns 0. The harness command changes -> ID mismatch -> exit 3.
+
+## Mechanical Guard
+`sample_metric.py compare` computes the current harness command's `harness_id` and requires it to equal the frozen baseline's. On a mismatch it prints `harness-id mismatch; baseline invalidated` and exits 3. Silent re-baselining is therefore impossible: the mismatch has to be resolved by taking a new baseline deliberately, which is recorded.
+
+## Usage Workflow
+1. Start in DRAFT. Build harness, verify it prints a single number reliably.
+2. Move to MEASURED by running it with sufficient samples to establish a stable spread.
+3. Move to BASELINED with `sample_metric.py baseline`. Now the harness is frozen.
+4. Make one change to the codebase (not the harness).
+5. Run `sample_metric.py compare`. If it exits 0, you have an improvement; record it.
+6. If you need to change the harness itself, first record that as a decision row (`tests: none`), then re-baseline.
+
+The lifecycle ensures that every number compared is from the same, unchanged measurement method.

--- a/optional-skills/software-development/hillclimb/references/plateau-playbook.md
+++ b/optional-skills/software-development/hillclimb/references/plateau-playbook.md
@@ -1,0 +1,59 @@
+---
+name: hillclimb
+description: "Optimize one metric via frozen harness and decision log."
+version: 1.0.0
+author: "Emmanuel Ketcha (@ketchalegend) + Hermes Agent"
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [optimization, metrics, experiments, decision-log, benchmarking, iteration]
+    category: software-development
+    related_skills: [systematic-debugging, spike, test-driven-development, requesting-code-review, subagent-driven-development]
+---
+
+# Plateau Playbook
+
+Protocol for when `decision_log.py stats` reports a plateau. A plateau is a signal that the current hypothesis class is exhausted; either pivot categories or document a proven dead end.
+
+## Temporary Stall vs Genuine Dead End
+- **Temporary stall**: recent attempts still improving but sub-threshold; pivot categories not exhausted -> pivot and continue.
+- **Genuine dead end**: floor is provable and outside the loop (algorithmic lower bound, minimum network round trips, fixed external API latency). Write the proof in the final log row and stop.
+
+## Worked Examples
+
+### (a) Test-Suite Wall Clock (minimize, seconds)
+- **Metric**: CI wall-clock time for full test suite.
+- **Stalled hypothesis class**: per-test micro-optimizations (fixture scope tweaks, import hoisting).
+- **Log showed**: two prior attempts each <1% improvement; combined they reached ~1.8% but no further gains.
+- **Pivot taken**: change *how many tests run concurrently* instead of how fast one runs. Split slowest files into their own lane, run them in parallel with the rest.
+- **Why pivot was right**: micro-optimizations hit diminishing returns; concurrency addresses the fundamental bottleneck of sequential execution. The pivot category change yields a measurable win.
+
+### (b) Bundle Size (minimize, KB)
+- **Metric**: final bundle size after webpack build.
+- **Stalled hypothesis class**: bundler tree-shaking config tweaks.
+- **Log showed**: plateau at 1.2 MB reduction; analyzer revealed the largest chunk was a dependency never touched by config changes.
+- **Pivot taken**: re-read analyzer output with `read_file` to discover the true source, then attack the dependency graph (swap or drop a dependency) instead of config.
+- **Why pivot was right**: mis-attribution wasted effort; attacking the actual heavy dependency yields larger, more reliable reduction.
+
+### (c) Token Cost Per Turn (minimize, tokens)
+- **Metric**: OpenAI token count per agent turn.
+- **Stalled hypothesis class**: trimming prompt text.
+- **Log showed**: micro-trims hit a floor because the fixed tool schema dominates total tokens.
+- **Pivot taken**: change the *shape* of the interaction (one call instead of three, or defer a toolset) - a category change, not a size change.
+- **Why pivot was right**: prompt size is secondary to interaction architecture; restructuring the workflow reduces total calls and thus tokens.
+
+### (d) Flaky-Test Rate (minimize, %)
+- **Metric**: percentage of tests that occasionally fail.
+- **Stalled hypothesis class**: adding sleeps and retries to mitigate symptoms.
+- **Log showed**: retries reduced visible failures but underlying race remained; plateau at 0.5%.
+- **Pivot taken**: stop tuning the symptom and instrument the actual race (symptom-mitigation -> cause-detection). Add timing instrumentation to identify the race condition deterministically.
+- **Why pivot was right**: symptom fixes only mask the problem; detecting the cause makes the flaky test reproducible and fixable.
+
+## Applying the Playbook
+When `stats` reports a plateau:
+1. Review the last 5-10 log rows to identify the hypothesis class.
+2. If the class is exhausted, choose a pivot from a different category.
+3. Record the pivot decision as a `decision_log.py append` row (`tests: none`, `before: na`, `after: na`).
+4. If no pivot categories remain, document the dead end: write a final log row with `tests: none`, `before: na`, `after: na`, and a detailed note proving the floor (algorithmic bound, external latency, etc.).
+5. Continue the loop from the new baseline.

--- a/optional-skills/software-development/hillclimb/references/unattended-mode.md
+++ b/optional-skills/software-development/hillclimb/references/unattended-mode.md
@@ -1,0 +1,75 @@
+---
+name: hillclimb
+description: "Optimize one metric via frozen harness and decision log."
+version: 1.0.0
+author: "Emmanuel Ketcha (@ketchalegend) + Hermes Agent"
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [optimization, metrics, experiments, decision-log, benchmarking, iteration]
+    category: software-development
+    related_skills: [systematic-debugging, spike, test-driven-development, requesting-code-review, subagent-driven-development]
+---
+
+# Unattended Mode Reference
+
+Running the loop without a human watching. Two patterns: live fan-out across worktrees, and scheduled runs through the `cronjob_manage` tool. Both rely on the harness staying byte-identical - the whole point of the loop is that every number came from the same measurement method.
+
+## Live Fan-Out (parallel hypotheses)
+
+Give each independent hypothesis its own git worktree so parallel attempts cannot collide, and its own `.hillclimb/` directory so the logs stay separate.
+
+```bash
+# One worktree per hypothesis
+git worktree add ../repo-hyp-1 -b hyp-1
+git worktree add ../repo-hyp-2 -b hyp-2
+
+# In each worktree, freeze the SAME baseline, then make that worktree's one change
+cd ../repo-hyp-1 && python3 <skill_dir>/scripts/sample_metric.py baseline --harness "<command>" --samples 5
+```
+
+Rules that make the comparison valid:
+
+- The harness command must be identical across worktrees. Same command means the same `harness_id`, which is what makes the medians comparable.
+- Dispatch the hypotheses with `delegate_task` (parallel `tasks`), giving each child its own worktree path and its own `.hillclimb/` directory. Children cannot ask questions mid-flight, so put the hypothesis, the exact harness command, and the required reporting format in each child's context.
+- Supervise the diff instead of accepting a summary: read each child's `decision.tsv` with `read_file` and compare `delta` values. A child's report about its own numbers is a claim, not evidence.
+- Apply only the winning change to the main tree and re-measure there. A win in a scratch worktree is not yet a win in the real checkout.
+
+## Scheduled Runs (`cronjob_manage`)
+
+An agent schedules with the `cronjob_manage` tool (`action='create'`). A human uses the CLI: `hermes cron create '<schedule>' '<prompt>' [flags]`.
+
+| Field | Flag | Meaning |
+|---|---|---|
+| `script` | `--script` | Path to a script under the Hermes home's `scripts/` directory. Default mode: its stdout is injected into the agent's prompt each run. With `no_agent=True` the script is the whole job. Relative paths resolve under `<hermes_home>/scripts/`. |
+| `monitor` | `--monitor-script`, `--monitor-url` | Cheap change-detector run each tick before the agent. Output byte-identical to the previous tick skips the agent run entirely; changed output wakes the agent with a diff injected into the prompt. Must be deterministic - no timestamps - or every tick looks changed. Incompatible with `no_agent`. |
+| `no_agent` | `--no-agent` | Skip the LLM: run the script on schedule and deliver its stdout verbatim. Empty stdout sends nothing. |
+| `continuity` | `--continuity` | Each run wakes with the job's own previous output injected, so it continues where the last run stopped. |
+| `context_from` | tool field | Injects the most recent output of *other* jobs. This chains a collector job into a processor job; for a job's own history use `continuity` instead. |
+| `workdir` | `--workdir` | Absolute existing path to run the job from. Injects that directory's `AGENTS.md` and anchors the file and terminal tools there. This is how the job reaches the target repo. |
+| `skills` | `--skill` | Attach a skill; repeatable. Attach this one. |
+| `enabled_toolsets` | tool field | Restrict the job's agent to a small toolset to cut per-run token overhead. |
+| `schedule` | positional | `'30m'`, `'every 2h'`, `'0 9 * * *'`, or an ISO one-shot. `--repeat` sets a count. |
+
+**The thing readers get wrong:** `--script` cannot point into the target repo. Copy the sampler into the Hermes home's `scripts/` directory (for example as `hillclimb_sample.py`) and pass the repo through `--workdir`. A repo-relative script path does not resolve.
+
+**The monitor gate is the point of the design.** A frozen harness already emits a deterministic, cheap number - exactly the signal that should decide whether to spend a turn at all. Point `monitor` at the sampler: while the metric is unchanged, no turn is spent.
+
+**Timing, and what follows from it.** The script's own timeout defaults to 3600s. The agent turn runs under an inactivity watchdog rather than a wall-clock cap: 600 seconds of no activity by default, overridable with the `HERMES_CRON_TIMEOUT` environment variable, `0` for unlimited. So put the expensive measurement in the script - deterministic, no LLM - and keep the agent turn to reading the log, interpreting the result, and appending one row.
+
+**Scope.** A job runs in a fresh session with no chat context. A one-shot fires once; if the loop is unfinished the job must reschedule itself (`'in 10m'`) or be created recurring. Background `delegate_task` work is process-local and does not survive a restart - anything that must outlive a restart is a cron job or a `terminal(background=True, notify_on_complete=True)` process.
+
+### Shape of the job
+
+Two jobs, because sampling and deciding fail differently:
+
+1. **Sampler** - `no_agent=True`, runs the harness and prints the metric. Silent when nothing changed.
+2. **Decider** - `monitor` pointed at the sampler's deterministic output (so it wakes only when the number moves), `continuity=True` to carry the trail forward, this skill attached via `skills`, and `workdir` set to the target repo. It reads `decision.tsv`, measures, decides, and appends exactly one row.
+
+## Safety rails for unattended runs
+
+- **Verify before appending.** Run `decision_log.py verify` first. If it reports problems, stop and report rather than appending to a trail that is already corrupt.
+- **Revert on a failed test** even when the metric improved: `tests: fail` means revert. A faster suite that no longer passes is not a win.
+- **Stop on a proven dead end.** When `stats` reports a plateau and the pivot categories are exhausted, record the dead end as a `tests: none` row and stop. Churning attempts past a provable floor burns budget and produces nothing.
+- **Never trust a summary.** A job or child reporting its own improvement is a claim; the evidence is the row in `decision.tsv` with a tool-computed delta.

--- a/optional-skills/software-development/hillclimb/scripts/decision_log.py
+++ b/optional-skills/software-development/hillclimb/scripts/decision_log.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Append-only decision log for the hillclimb optimization loop.
+
+The log is `.hillclimb/decision.tsv` (override with --dir or HILLCLIMB_DIR).
+One row per attempt. The 11 columns, in order:
+
+    id  timestamp  hypothesis  change  before  after  delta  tests  verdict  harness_id  note
+
+`delta` is always raw `after - before` and is computed here, never accepted
+from the caller. `direction` (minimize|maximize) is NOT a column; it lives in
+baseline.json and is applied by `stats`.
+
+Subcommands:
+  append --hypothesis S --change S --before F --after F --tests {pass,fail,none}
+         --verdict {kept,reverted} [--note S] [--harness-id S]
+      Add one attempt. Ids are assigned here and are monotonic. --before and
+      --after accept a float or the literal `na` (delta is then `na`).
+      Prints the row as JSON. Exit 0.
+  list [--limit N] [--verdict kept|reverted] [--json]
+      Rows oldest-first. Exit 0.
+  stats [--window N] [--threshold F] [--json]
+      Direction-aware best/worst, mean improvement over the last window, and a
+      plateau verdict: True when EVERY one of the last `window` attempts
+      (default 3) improved by less than `threshold` (default 0.02) relative to
+      its own `before`. Plateau needs at least `window` attempts. Exit 0.
+      `best_improvement` is positive when the metric got better (in either
+      direction); `worst_regression` is negative when it got worse.
+  verify [--json]
+      Validate the whole trail against the schema and the frozen baseline.
+      Exit 0 when clean or when no log exists yet (`no-log`); exit 1 when any
+      problem is found.
+
+Exit codes:
+  0 - success (including `verify` on a clean log and on a missing log)
+  1 - `verify` found problems
+  2 - bad invocation or unusable data (invalid enum, non-numeric value,
+      --dir exists but is not a directory)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import NoReturn
+
+COLUMNS = [
+    "id",
+    "timestamp",
+    "hypothesis",
+    "change",
+    "before",
+    "after",
+    "delta",
+    "tests",
+    "verdict",
+    "harness_id",
+    "note",
+]
+HEADER = "\t".join(COLUMNS)
+TESTS_VALUES = ("pass", "fail", "none")
+VERDICT_VALUES = ("kept", "reverted")
+FREE_TEXT_INDEXES = (2, 3, 10)  # hypothesis, change, note
+DELTA_TOLERANCE = 1e-9
+
+
+def die(message: str, code: int = 2) -> NoReturn:
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(code)
+
+
+def resolve_dir(value: str | None) -> Path:
+    return Path(value or os.environ.get("HILLCLIMB_DIR") or ".hillclimb")
+
+
+def ensure_dir(path: Path) -> None:
+    """Create the log directory. Only an unusable path is an error."""
+    if path.exists() and not path.is_dir():
+        die(f"{path} exists but is not a directory")
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        die(f"cannot create {path}: {exc}")
+    if not path.is_dir():
+        die(f"{path} could not be created as a directory")
+
+
+def sanitize(value: str | None) -> str:
+    return (value or "").replace("\t", " ").replace("\n", " ").replace("\r", " ")
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def load_rows(path: Path) -> list[list[str]]:
+    """Return the data rows (header excluded). Rows are not validated here."""
+    tsv = path / "decision.tsv"
+    if not tsv.is_file():
+        return []
+    rows: list[list[str]] = []
+    with open(tsv, "r", encoding="utf-8", errors="replace") as handle:
+        handle.readline()  # header, validated by `verify`
+        for line in handle:
+            line = line.rstrip("\n")
+            if line:
+                rows.append(line.split("\t"))
+    return rows
+
+
+def load_baseline(path: Path) -> dict:
+    baseline = path / "baseline.json"
+    if not baseline.is_file():
+        return {}
+    try:
+        return json.loads(baseline.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def parse_metric(value: str | None) -> float | None:
+    """`na` and empty both mean 'no measurement'."""
+    if value is None or value == "na" or value == "":
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        die(f"not a number and not 'na': {value!r}")
+
+
+def format_metric(value: float | None) -> str:
+    """Human-readable, and stable enough for `verify`'s numeric comparison."""
+    if value is None:
+        return "na"
+    return f"{float(value):.10g}"
+
+
+def compute_delta(before: float | None, after: float | None) -> float | None:
+    if before is None or after is None:
+        return None
+    return after - before
+
+
+def next_id(rows: list[list[str]]) -> int:
+    highest = 0
+    for row in rows:
+        try:
+            highest = max(highest, int(row[0]))
+        except (IndexError, ValueError):
+            continue
+    return highest + 1
+
+
+def cmd_append(args: argparse.Namespace) -> int:
+    if args.tests not in TESTS_VALUES:
+        die(f"--tests must be one of {', '.join(TESTS_VALUES)}")
+    if args.verdict not in VERDICT_VALUES:
+        die(f"--verdict must be one of {', '.join(VERDICT_VALUES)}")
+
+    before = parse_metric(args.before)
+    after = parse_metric(args.after)
+    delta = compute_delta(before, after)
+
+    path = resolve_dir(args.dir)
+    ensure_dir(path)
+    rows = load_rows(path)
+    harness_id = args.harness_id or load_baseline(path).get("harness_id") or ""
+
+    row = [
+        str(next_id(rows)),
+        now_iso(),
+        sanitize(args.hypothesis),
+        sanitize(args.change),
+        format_metric(before),
+        format_metric(after),
+        format_metric(delta),
+        args.tests,
+        args.verdict,
+        sanitize(harness_id),
+        sanitize(args.note),
+    ]
+
+    tsv = path / "decision.tsv"
+    new_file = not tsv.is_file()
+    with open(tsv, "a", encoding="utf-8") as handle:
+        if new_file:
+            handle.write(HEADER + "\n")
+        handle.write("\t".join(row) + "\n")
+
+    print(json.dumps(dict(zip(COLUMNS, row)), indent=2))
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    rows = load_rows(resolve_dir(args.dir))
+    if args.verdict:
+        rows = [r for r in rows if len(r) > 8 and r[8] == args.verdict]
+    if args.limit is not None:
+        rows = rows[-args.limit :]
+    if args.json:
+        print(json.dumps([dict(zip(COLUMNS, r)) for r in rows], indent=2))
+        return 0
+    if not rows:
+        print("(no attempts recorded)")
+        return 0
+    widths = [max(len(COLUMNS[i]), *(len(r[i]) for r in rows)) for i in range(len(COLUMNS))]
+    print("  ".join(COLUMNS[i].ljust(widths[i]) for i in range(len(COLUMNS))))
+    for row in rows:
+        print("  ".join(row[i].ljust(widths[i]) for i in range(len(COLUMNS))))
+    return 0
+
+
+def relative_improvement(row: list[str], direction: str) -> float | None:
+    """Direction-aware improvement divided by |before|. None when unmeasurable."""
+    try:
+        before = float(row[4])
+        after = float(row[5])
+    except (IndexError, ValueError):
+        return None
+    if before == 0:
+        return None
+    gain = before - after if direction == "minimize" else after - before
+    return gain / abs(before)
+
+
+def cmd_stats(args: argparse.Namespace) -> int:
+    path = resolve_dir(args.dir)
+    rows = [r for r in load_rows(path) if len(r) == len(COLUMNS)]
+    baseline = load_baseline(path)
+    direction = baseline.get("direction", "minimize")
+    if direction not in ("minimize", "maximize"):
+        direction = "minimize"
+
+    window = args.window if args.window is not None else 3
+    threshold = args.threshold if args.threshold is not None else 0.02
+
+    kept = sum(1 for r in rows if r[8] == "kept")
+    reverted = sum(1 for r in rows if r[8] == "reverted")
+    deltas = []
+    for row in rows:
+        try:
+            deltas.append(float(row[6]))
+        except (IndexError, ValueError):
+            continue
+
+    improvements = [-d if direction == "minimize" else d for d in deltas]
+    recent = rows[-window:] if window > 0 else []
+    window_improvements = [-d if direction == "minimize" else d for d in deltas[-window:]]
+
+    reasons: list[str] = []
+    plateau = False
+    if window > 0 and len(recent) >= window:
+        plateau = True
+        for row in recent:
+            rel = relative_improvement(row, direction)
+            if rel is None or rel >= threshold:
+                plateau = False
+                continue
+            reasons.append(
+                f"attempt {row[0]}: relative improvement {rel:.4f} < {threshold:.2f}"
+            )
+
+    result = {
+        "attempts": len(rows),
+        "kept": kept,
+        "reverted": reverted,
+        "direction": direction,
+        "best_improvement": max(improvements) if improvements else None,
+        "worst_regression": min(improvements) if improvements else None,
+        "mean_improvement_last_window": (
+            sum(window_improvements) / len(window_improvements) if window_improvements else None
+        ),
+        "window": window,
+        "threshold": threshold,
+        "plateau": plateau,
+        "plateau_reasons": reasons,
+    }
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return 0
+    print(f"Attempts: {result['attempts']} (kept {kept}, reverted {reverted})")
+    print(f"Direction: {direction}")
+    if result["best_improvement"] is not None:
+        print(f"Best improvement: {result['best_improvement']}")
+        print(f"Worst regression: {result['worst_regression']}")
+        print(f"Mean improvement (last {window}): {result['mean_improvement_last_window']}")
+    print(f"Plateau: {plateau}")
+    for reason in reasons:
+        print(f"  - {reason}")
+    return 0
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    path = resolve_dir(args.dir)
+    tsv = path / "decision.tsv"
+    if not tsv.is_file():
+        print(json.dumps({"problems": [{"type": "no-log"}]}, indent=2))
+        return 0
+
+    problems: list[dict] = []
+    with open(tsv, "r", encoding="utf-8", errors="replace") as handle:
+        header = handle.readline().rstrip("\n")
+        if header != HEADER:
+            problems.append({"type": "wrong-header"})
+        raw = [line.rstrip("\n") for line in handle if line.strip()]
+
+    ids: list[int] = []
+    for index, line in enumerate(raw, start=1):
+        fields = line.split("\t")
+        if len(fields) != len(COLUMNS):
+            problems.append({"type": "row-wrong-column-count", "row": index})
+            continue
+        try:
+            ids.append(int(fields[0]))
+        except ValueError:
+            problems.append({"type": "non-numeric-id", "row": index})
+
+        try:
+            before = float(fields[4])
+        except ValueError:
+            before = None
+        try:
+            after = float(fields[5])
+        except ValueError:
+            after = None
+        expected = compute_delta(before, after)
+        stored = fields[6]
+        if expected is None:
+            if stored != "na":
+                problems.append({"type": "delta-mismatch", "row": index, "expected": "na", "got": stored})
+        else:
+            try:
+                if abs(float(stored) - expected) > DELTA_TOLERANCE:
+                    problems.append(
+                        {"type": "delta-mismatch", "row": index, "expected": repr(expected), "got": stored}
+                    )
+            except ValueError:
+                problems.append({"type": "delta-mismatch", "row": index, "expected": repr(expected), "got": stored})
+
+        if fields[7] not in TESTS_VALUES:
+            problems.append({"type": "invalid-tests", "row": index, "value": fields[7]})
+        if fields[8] not in VERDICT_VALUES:
+            problems.append({"type": "invalid-verdict", "row": index, "value": fields[8]})
+
+        baseline_id = load_baseline(path).get("harness_id")
+        if baseline_id and fields[9] != baseline_id:
+            problems.append(
+                {"type": "stale-harness", "row": index, "log_id": fields[9], "baseline_id": baseline_id}
+            )
+
+    if ids != sorted(ids):
+        problems.append({"type": "non-monotonic-ids"})
+    if len(ids) != len(set(ids)):
+        problems.append({"type": "duplicate-ids"})
+
+    print(json.dumps({"problems": problems}, indent=2))
+    return 1 if problems else 0
+
+
+def _add_dir(sub: argparse.ArgumentParser) -> None:
+    # SUPPRESS keeps the root-level value when --dir is given before the
+    # subcommand, while still accepting it after the subcommand.
+    sub.add_argument("--dir", default=argparse.SUPPRESS, help=argparse.SUPPRESS)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Hillclimb decision log manager")
+    parser.add_argument(
+        "--dir",
+        help="Decision log directory (default: HILLCLIMB_DIR env var, else .hillclimb)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    append = subparsers.add_parser("append", help="Append one attempt")
+    append.add_argument("--hypothesis", required=True)
+    append.add_argument("--change", required=True)
+    append.add_argument("--before", required=True, help="float or 'na'")
+    append.add_argument("--after", required=True, help="float or 'na'")
+    append.add_argument("--tests", required=True, choices=list(TESTS_VALUES))
+    append.add_argument("--verdict", required=True, choices=list(VERDICT_VALUES))
+    append.add_argument("--note", default="")
+    append.add_argument("--harness-id", dest="harness_id", default=None)
+    _add_dir(append)
+    append.set_defaults(func=cmd_append)
+
+    list_cmd = subparsers.add_parser("list", help="List attempts, oldest first")
+    list_cmd.add_argument("--limit", type=int, default=None)
+    list_cmd.add_argument("--verdict", choices=list(VERDICT_VALUES), default=None)
+    list_cmd.add_argument("--json", action="store_true")
+    _add_dir(list_cmd)
+    list_cmd.set_defaults(func=cmd_list)
+
+    stats = subparsers.add_parser("stats", help="Attempt statistics and plateau verdict")
+    stats.add_argument("--window", type=int, default=None)
+    stats.add_argument("--threshold", type=float, default=None)
+    stats.add_argument("--json", action="store_true")
+    _add_dir(stats)
+    stats.set_defaults(func=cmd_stats)
+
+    verify = subparsers.add_parser("verify", help="Validate the log")
+    verify.add_argument("--json", action="store_true")
+    _add_dir(verify)
+    verify.set_defaults(func=cmd_verify)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/optional-skills/software-development/hillclimb/scripts/decision_log.py
+++ b/optional-skills/software-development/hillclimb/scripts/decision_log.py
@@ -25,10 +25,12 @@ Subcommands:
       its own `before`. Plateau needs at least `window` attempts. Exit 0.
       `best_improvement` is positive when the metric got better (in either
       direction); `worst_regression` is negative when it got worse.
-  verify [--json]
-      Validate the whole trail against the schema and the frozen baseline.
-      Exit 0 when clean or when no log exists yet (`no-log`); exit 1 when any
-      problem is found.
+  verify
+      Validate the whole trail against the schema and the frozen baseline:
+      column counts, ids, delta arithmetic, enums, unparseable metric fields,
+      and rows whose harness no longer matches the frozen baseline. Prints
+      JSON. Exit 0 when clean or when no log exists yet (`no-log`); exit 1 when
+      any problem is found.
 
 Exit codes:
   0 - success (including `verify` on a clean log and on a missing log)
@@ -63,7 +65,6 @@ COLUMNS = [
 HEADER = "\t".join(COLUMNS)
 TESTS_VALUES = ("pass", "fail", "none")
 VERDICT_VALUES = ("kept", "reverted")
-FREE_TEXT_INDEXES = (2, 3, 10)  # hypothesis, change, note
 DELTA_TOLERANCE = 1e-9
 
 
@@ -88,6 +89,12 @@ def ensure_dir(path: Path) -> None:
         die(f"{path} could not be created as a directory")
 
 
+def check_dir(path: Path) -> None:
+    """Read paths: absent state is empty state, but a non-directory is an error."""
+    if path.exists() and not path.is_dir():
+        die(f"{path} exists but is not a directory")
+
+
 def sanitize(value: str | None) -> str:
     return (value or "").replace("\t", " ").replace("\n", " ").replace("\r", " ")
 
@@ -105,7 +112,7 @@ def load_rows(path: Path) -> list[list[str]]:
     with open(tsv, "r", encoding="utf-8", errors="replace") as handle:
         handle.readline()  # header, validated by `verify`
         for line in handle:
-            line = line.rstrip("\n")
+            line = line.rstrip("\r\n")
             if line:
                 rows.append(line.split("\t"))
     return rows
@@ -122,13 +129,23 @@ def load_baseline(path: Path) -> dict:
 
 
 def parse_metric(value: str | None) -> float | None:
-    """`na` and empty both mean 'no measurement'."""
+    """`na` and empty both mean 'no measurement'. Garbage is a hard error."""
     if value is None or value == "na" or value == "":
         return None
     try:
         return float(value)
     except ValueError:
         die(f"not a number and not 'na': {value!r}")
+
+
+def parse_field(value: str) -> float | None:
+    """Non-fatal variant used by `verify`: unparseable text yields None."""
+    if value in ("na", ""):
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
 
 
 def format_metric(value: float | None) -> str:
@@ -185,7 +202,7 @@ def cmd_append(args: argparse.Namespace) -> int:
 
     tsv = path / "decision.tsv"
     new_file = not tsv.is_file()
-    with open(tsv, "a", encoding="utf-8") as handle:
+    with open(tsv, "a", encoding="utf-8", newline="") as handle:
         if new_file:
             handle.write(HEADER + "\n")
         handle.write("\t".join(row) + "\n")
@@ -195,7 +212,17 @@ def cmd_append(args: argparse.Namespace) -> int:
 
 
 def cmd_list(args: argparse.Namespace) -> int:
-    rows = load_rows(resolve_dir(args.dir))
+    path = resolve_dir(args.dir)
+    check_dir(path)
+    raw = load_rows(path)
+    rows = [r for r in raw if len(r) == len(COLUMNS)]
+    malformed = len(raw) - len(rows)
+    if malformed:
+        # Never hide corruption in a display command; `verify` names it precisely.
+        print(
+            f"warning: {malformed} malformed row(s) skipped; run `verify` for details",
+            file=sys.stderr,
+        )
     if args.verdict:
         rows = [r for r in rows if len(r) > 8 and r[8] == args.verdict]
     if args.limit is not None:
@@ -228,6 +255,7 @@ def relative_improvement(row: list[str], direction: str) -> float | None:
 
 def cmd_stats(args: argparse.Namespace) -> int:
     path = resolve_dir(args.dir)
+    check_dir(path)
     rows = [r for r in load_rows(path) if len(r) == len(COLUMNS)]
     baseline = load_baseline(path)
     direction = baseline.get("direction", "minimize")
@@ -235,6 +263,8 @@ def cmd_stats(args: argparse.Namespace) -> int:
         direction = "minimize"
 
     window = args.window if args.window is not None else 3
+    if window < 1:
+        die("--window must be at least 1")
     threshold = args.threshold if args.threshold is not None else 0.02
 
     kept = sum(1 for r in rows if r[8] == "kept")
@@ -247,29 +277,35 @@ def cmd_stats(args: argparse.Namespace) -> int:
             continue
 
     improvements = [-d if direction == "minimize" else d for d in deltas]
-    recent = rows[-window:] if window > 0 else []
-    window_improvements = [-d if direction == "minimize" else d for d in deltas[-window:]]
+    recent = rows[-window:]
+    window_improvements: list[float] = []
+    for row in recent:
+        try:
+            value = float(row[6])
+        except (IndexError, ValueError):
+            continue
+        window_improvements.append(-value if direction == "minimize" else value)
 
+    # An attempt that cannot be measured (na metric, or a zero baseline) is not
+    # evidence that the metric moved, so it counts as below threshold.
     reasons: list[str] = []
-    plateau = False
-    if window > 0 and len(recent) >= window:
-        plateau = True
-        for row in recent:
-            rel = relative_improvement(row, direction)
-            if rel is None or rel >= threshold:
-                plateau = False
-                continue
-            reasons.append(
-                f"attempt {row[0]}: relative improvement {rel:.4f} < {threshold:.2f}"
-            )
+    for row in recent:
+        rel = relative_improvement(row, direction)
+        if rel is not None and rel >= threshold:
+            continue
+        shown = "unmeasurable" if rel is None else f"{rel:.4f}"
+        reasons.append(f"attempt {row[0]}: relative improvement {shown} < {threshold:.2f}")
+    plateau = len(recent) >= window and len(reasons) == len(recent)
+    if not plateau:
+        reasons = []
 
     result = {
         "attempts": len(rows),
         "kept": kept,
         "reverted": reverted,
         "direction": direction,
-        "best_improvement": max(improvements) if improvements else None,
-        "worst_regression": min(improvements) if improvements else None,
+        "best_improvement": max([i for i in improvements if i > 0], default=None),
+        "worst_regression": min([i for i in improvements if i < 0], default=None),
         "mean_improvement_last_window": (
             sum(window_improvements) / len(window_improvements) if window_improvements else None
         ),
@@ -283,10 +319,9 @@ def cmd_stats(args: argparse.Namespace) -> int:
         return 0
     print(f"Attempts: {result['attempts']} (kept {kept}, reverted {reverted})")
     print(f"Direction: {direction}")
-    if result["best_improvement"] is not None:
-        print(f"Best improvement: {result['best_improvement']}")
-        print(f"Worst regression: {result['worst_regression']}")
-        print(f"Mean improvement (last {window}): {result['mean_improvement_last_window']}")
+    print(f"Best improvement: {result['best_improvement']}")
+    print(f"Worst regression: {result['worst_regression']}")
+    print(f"Mean improvement (last {window}): {result['mean_improvement_last_window']}")
     print(f"Plateau: {plateau}")
     for reason in reasons:
         print(f"  - {reason}")
@@ -295,6 +330,7 @@ def cmd_stats(args: argparse.Namespace) -> int:
 
 def cmd_verify(args: argparse.Namespace) -> int:
     path = resolve_dir(args.dir)
+    check_dir(path)
     tsv = path / "decision.tsv"
     if not tsv.is_file():
         print(json.dumps({"problems": [{"type": "no-log"}]}, indent=2))
@@ -302,10 +338,11 @@ def cmd_verify(args: argparse.Namespace) -> int:
 
     problems: list[dict] = []
     with open(tsv, "r", encoding="utf-8", errors="replace") as handle:
-        header = handle.readline().rstrip("\n")
+        header = handle.readline().rstrip("\r\n")
         if header != HEADER:
             problems.append({"type": "wrong-header"})
-        raw = [line.rstrip("\n") for line in handle if line.strip()]
+        raw = [line.rstrip("\r\n") for line in handle if line.strip()]
+    baseline_id = load_baseline(path).get("harness_id")
 
     ids: list[int] = []
     for index, line in enumerate(raw, start=1):
@@ -318,14 +355,13 @@ def cmd_verify(args: argparse.Namespace) -> int:
         except ValueError:
             problems.append({"type": "non-numeric-id", "row": index})
 
-        try:
-            before = float(fields[4])
-        except ValueError:
-            before = None
-        try:
-            after = float(fields[5])
-        except ValueError:
-            after = None
+        for name, raw_value in (("before", fields[4]), ("after", fields[5])):
+            if raw_value not in ("na", "") and parse_field(raw_value) is None:
+                problems.append(
+                    {"type": "invalid-metric", "row": index, "field": name, "value": raw_value}
+                )
+        before = parse_field(fields[4])
+        after = parse_field(fields[5])
         expected = compute_delta(before, after)
         stored = fields[6]
         if expected is None:
@@ -345,7 +381,6 @@ def cmd_verify(args: argparse.Namespace) -> int:
         if fields[8] not in VERDICT_VALUES:
             problems.append({"type": "invalid-verdict", "row": index, "value": fields[8]})
 
-        baseline_id = load_baseline(path).get("harness_id")
         if baseline_id and fields[9] != baseline_id:
             problems.append(
                 {"type": "stale-harness", "row": index, "log_id": fields[9], "baseline_id": baseline_id}
@@ -401,7 +436,6 @@ def build_parser() -> argparse.ArgumentParser:
     stats.set_defaults(func=cmd_stats)
 
     verify = subparsers.add_parser("verify", help="Validate the log")
-    verify.add_argument("--json", action="store_true")
     _add_dir(verify)
     verify.set_defaults(func=cmd_verify)
 

--- a/optional-skills/software-development/hillclimb/scripts/sample_metric.py
+++ b/optional-skills/software-development/hillclimb/scripts/sample_metric.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Noise-resistant metric sampler for the hillclimb optimization loop.
+
+Runs a harness command N times, extracts one number from each run's stdout,
+and reports the median. The baseline is frozen in `.hillclimb/baseline.json`
+(override with --dir or HILLCLIMB_DIR) together with a `harness_id`: the first
+12 hex characters of the SHA-256 of the whitespace-normalized harness command.
+
+A changed harness command changes the `harness_id`. `compare` refuses to
+compare across two different measurement methods (exit 3), because every
+earlier number becomes incomparable when the harness changes.
+
+FAILURE RULE: if the harness exits non-zero, or no number can be extracted
+from its stdout, that sample FAILS. If ANY sample failed, no metric is
+emitted at all and the command exits 2. There is deliberately no flag to
+average over failed runs - a metric built from failed samples is not a metric.
+
+Subcommands:
+  baseline --harness CMD [--samples N] [--extract SPEC] [--name S]
+           [--direction minimize|maximize] [--unit S] [--timeout S]
+      Sample, then write baseline.json with frozen: true. Exit 0.
+  run --harness CMD [--samples N] [--extract SPEC] [--timeout S] [--json]
+      Sample without touching the baseline. Exit 0.
+  compare [--harness CMD | --value F] [--samples N] [--extract SPEC] [--json]
+      Compare against the frozen baseline. Exit 0 for a direction-aware
+      improvement, 1 when the metric did not improve, 3 when the harness no
+      longer matches the frozen baseline.
+
+--extract SPEC grammar (default: auto):
+  auto             the LAST number printed (optional trailing unit)
+  regex:PATTERN    the first capture group of the first match
+  json:dotted.path the number at that path in stdout parsed as JSON
+  line:PREFIX      the first number on the first line starting with PREFIX
+
+Exit codes:
+  0 - success (for `compare`: the metric improved)
+  1 - `compare` only: the metric did not improve
+  2 - a sample failed, or the invocation is unusable (no baseline to compare
+      against, unparseable --value)
+  3 - `compare` only: the harness command no longer matches the baseline
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import NoReturn
+
+DEFAULT_SAMPLES = 5
+DEFAULT_TIMEOUT = 300
+NUMBER_RE = re.compile(r"[-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?")
+PATH_SEPARATOR = os.sep
+
+
+def die(message: str, code: int = 2) -> NoReturn:
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(code)
+
+
+def resolve_dir(value: str | None) -> Path:
+    return Path(value or os.environ.get("HILLCLIMB_DIR") or ".hillclimb")
+
+
+def ensure_dir(path: Path) -> None:
+    if path.exists() and not path.is_dir():
+        die(f"{path} exists but is not a directory")
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        die(f"cannot create {path}: {exc}")
+    if not path.is_dir():
+        die(f"{path} could not be created as a directory")
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def harness_id(command: str) -> str:
+    """Fingerprint of the measurement method: whitespace-insensitive."""
+    normalized = " ".join(command.split())
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:12]
+
+
+def extract_metric(text: str, spec: str) -> tuple[float | None, str | None]:
+    if spec == "auto" or spec == "":
+        matches = NUMBER_RE.findall(text)
+        if not matches:
+            return None, "auto: no numeric token found in stdout"
+        try:
+            return float(matches[-1]), None
+        except ValueError:
+            return None, f"auto: not a number: {matches[-1]!r}"
+
+    if spec.startswith("regex:"):
+        pattern = spec[len("regex:") :]
+        try:
+            compiled = re.compile(pattern)
+        except re.error as exc:
+            return None, f"regex: invalid pattern: {exc}"
+        match = compiled.search(text)
+        if not match:
+            return None, "regex: no match in stdout"
+        captured = match.group(match.lastindex) if match.lastindex else match.group(0)
+        try:
+            return float(captured), None
+        except ValueError:
+            return None, f"regex: capture is not a number: {captured!r}"
+
+    if spec.startswith("json:"):
+        dotted = spec[len("json:") :]
+        try:
+            data = json.loads(text)
+        except ValueError as exc:
+            return None, f"json: stdout is not valid JSON: {exc}"
+        current = data
+        for key in dotted.split("."):
+            if isinstance(current, list):
+                try:
+                    current = current[int(key)]
+                except (ValueError, IndexError):
+                    return None, f"json: no element {key!r}"
+            elif isinstance(current, dict) and key in current:
+                current = current[key]
+            else:
+                return None, f"json: path {dotted!r} not found"
+        if isinstance(current, bool) or not isinstance(current, (int, float)):
+            return None, f"json: value at {dotted!r} is not a number"
+        return float(current), None
+
+    if spec.startswith("line:"):
+        prefix = spec[len("line:") :]
+        for line in text.splitlines():
+            if line.startswith(prefix):
+                matches = NUMBER_RE.findall(line)
+                if not matches:
+                    return None, f"line: no number on line starting with {prefix!r}"
+                return float(matches[0]), None
+        return None, f"line: no line starts with {prefix!r}"
+
+    return None, f"unknown --extract spec: {spec!r}"
+
+
+def run_harness(command: str, timeout: int) -> tuple[int, str, str]:
+    try:
+        completed = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return 124, "", f"harness timed out after {timeout}s"
+    except OSError as exc:
+        return 127, "", f"harness could not start: {exc}"
+    return completed.returncode, completed.stdout or "", completed.stderr or ""
+
+
+def sample(command: str, count: int, extract: str, timeout: int) -> tuple[dict | None, list[dict]]:
+    """Return (summary, failures). summary is None when any sample failed."""
+    values: list[float] = []
+    failures: list[dict] = []
+    for index in range(1, count + 1):
+        code, stdout, stderr = run_harness(command, timeout)
+        if code != 0:
+            failures.append(
+                {
+                    "sample": index,
+                    "exit_code": code,
+                    "stdout": stdout[-400:],
+                    "stderr": stderr[-400:],
+                }
+            )
+            continue
+        value, error = extract_metric(stdout, extract)
+        if value is None:
+            failures.append(
+                {
+                    "sample": index,
+                    "exit_code": code,
+                    "extract_error": error,
+                    "stdout": stdout[-400:],
+                }
+            )
+            continue
+        values.append(value)
+
+    if failures:
+        return None, failures
+
+    return {
+        "samples": len(values),
+        "median": statistics.median(values),
+        "min": min(values),
+        "max": max(values),
+        "spread": max(values) - min(values),
+        "values": values,
+    }, []
+
+
+def report_failures(command: str, failures: list[dict]) -> NoReturn:
+    print(
+        json.dumps(
+            {
+                "error": "sample failed; no metric emitted",
+                "harness": command,
+                "failed_samples": len(failures),
+                "failures": failures,
+            },
+            indent=2,
+        )
+    )
+    sys.exit(2)
+
+
+def load_baseline(path: Path) -> dict:
+    baseline = path / "baseline.json"
+    if not baseline.is_file():
+        return {}
+    try:
+        return json.loads(baseline.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        die(f"baseline.json is unreadable: {exc}")
+
+
+def cmd_baseline(args: argparse.Namespace) -> int:
+    path = resolve_dir(args.dir)
+    summary, failures = sample(args.harness, args.samples, args.extract, args.timeout)
+    if summary is None:
+        report_failures(args.harness, failures)
+    ensure_dir(path)
+    stamp = now_iso()
+    baseline = {
+        "metric_name": args.name,
+        "direction": args.direction,
+        "harness": args.harness,
+        "harness_id": harness_id(args.harness),
+        "samples": summary["samples"],
+        "median": summary["median"],
+        "min": summary["min"],
+        "max": summary["max"],
+        "spread": summary["spread"],
+        "unit": args.unit,
+        "frozen": True,
+        "created_at": stamp,
+        "frozen_at": stamp,
+        "values": summary["values"],
+    }
+    (path / "baseline.json").write_text(json.dumps(baseline, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(baseline, indent=2))
+    return 0
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    summary, failures = sample(args.harness, args.samples, args.extract, args.timeout)
+    if summary is None:
+        report_failures(args.harness, failures)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+def cmd_compare(args: argparse.Namespace) -> int:
+    path = resolve_dir(args.dir)
+    baseline = load_baseline(path)
+    if not baseline or "median" not in baseline:
+        die(f"no frozen baseline in {path}; run `baseline` first")
+
+    direction = baseline.get("direction", "minimize")
+    before = float(baseline["median"])
+
+    if args.harness:
+        current_id = harness_id(args.harness)
+        if current_id != baseline.get("harness_id"):
+            print(
+                json.dumps(
+                    {
+                        "error": "harness-id mismatch; baseline invalidated",
+                        "baseline_harness_id": baseline.get("harness_id"),
+                        "current_harness_id": current_id,
+                    },
+                    indent=2,
+                )
+            )
+            return 3
+        summary, failures = sample(args.harness, args.samples, args.extract, args.timeout)
+        if summary is None:
+            report_failures(args.harness, failures)
+        after = summary["median"]
+        samples = summary["samples"]
+    elif args.value is not None:
+        try:
+            after = float(args.value)
+        except ValueError:
+            die(f"--value must be a number: {args.value!r}")
+        samples = 0
+    else:
+        die("compare needs --harness CMD or --value F")
+
+    delta = after - before
+    improved = delta < 0 if direction == "minimize" else delta > 0
+    print(
+        json.dumps(
+            {
+                "metric_name": baseline.get("metric_name"),
+                "direction": direction,
+                "before": before,
+                "after": after,
+                "delta": delta,
+                "samples": samples,
+                "improved": improved,
+            },
+            indent=2,
+        )
+    )
+    return 0 if improved else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Hillclimb metric sampler")
+    parser.add_argument(
+        "--dir",
+        help="Directory holding baseline.json (default: HILLCLIMB_DIR env var, else .hillclimb)",
+    )
+    parser.add_argument(
+        "--extract",
+        default="auto",
+        help="auto | regex:PATTERN | json:dotted.path | line:PREFIX",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    def add_common(sub: argparse.ArgumentParser) -> None:
+        # SUPPRESS keeps the root-level value when the flag is given before the
+        # subcommand, while still allowing it after it.
+        sub.add_argument("--dir", default=argparse.SUPPRESS, help=argparse.SUPPRESS)
+        sub.add_argument("--extract", default=argparse.SUPPRESS, help=argparse.SUPPRESS)
+
+    baseline = subparsers.add_parser("baseline", help="Sample and freeze a baseline")
+    baseline.add_argument("--harness", required=True, help="command that prints the metric")
+    baseline.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
+    baseline.add_argument("--name", default="metric")
+    baseline.add_argument("--direction", choices=["minimize", "maximize"], default="minimize")
+    baseline.add_argument("--unit", default=None)
+    baseline.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    add_common(baseline)
+    baseline.set_defaults(func=cmd_baseline)
+
+    run = subparsers.add_parser("run", help="Sample without touching the baseline")
+    run.add_argument("--harness", required=True)
+    run.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
+    run.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    run.add_argument("--json", action="store_true")
+    add_common(run)
+    run.set_defaults(func=cmd_run)
+
+    compare = subparsers.add_parser("compare", help="Compare against the frozen baseline")
+    compare.add_argument("--harness", default=None)
+    compare.add_argument("--value", default=None)
+    compare.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
+    compare.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    compare.add_argument("--json", action="store_true")
+    add_common(compare)
+    compare.set_defaults(func=cmd_compare)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/optional-skills/software-development/hillclimb/scripts/sample_metric.py
+++ b/optional-skills/software-development/hillclimb/scripts/sample_metric.py
@@ -18,13 +18,17 @@ average over failed runs - a metric built from failed samples is not a metric.
 Subcommands:
   baseline --harness CMD [--samples N] [--extract SPEC] [--name S]
            [--direction minimize|maximize] [--unit S] [--timeout S]
-      Sample, then write baseline.json with frozen: true. Exit 0.
-  run --harness CMD [--samples N] [--extract SPEC] [--timeout S] [--json]
+      Sample, then write baseline.json with frozen: true. The extraction spec
+      is recorded in the baseline so `compare` reuses it. Exit 0.
+  run --harness CMD [--samples N] [--extract SPEC] [--timeout S]
       Sample without touching the baseline. Exit 0.
-  compare [--harness CMD | --value F] [--samples N] [--extract SPEC] [--json]
-      Compare against the frozen baseline. Exit 0 for a direction-aware
-      improvement, 1 when the metric did not improve, 3 when the harness no
-      longer matches the frozen baseline.
+  compare [--harness CMD | --value F] [--samples N] [--extract SPEC]
+      Compare against the frozen baseline. When --extract is omitted, the spec
+      recorded in the baseline is used, so a comparison can never silently
+      measure a different way than the baseline did. Exit 0 for a direction-aware
+      improvement, 1 when the metric did not improve, 2 when there is no
+      baseline or the value is unusable, 3 when the harness no longer matches
+      the frozen baseline.
 
 --extract SPEC grammar (default: auto):
   auto             the LAST number printed (optional trailing unit)
@@ -57,7 +61,6 @@ from typing import NoReturn
 DEFAULT_SAMPLES = 5
 DEFAULT_TIMEOUT = 300
 NUMBER_RE = re.compile(r"[-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?")
-PATH_SEPARATOR = os.sep
 
 
 def die(message: str, code: int = 2) -> NoReturn:
@@ -109,7 +112,7 @@ def extract_metric(text: str, spec: str) -> tuple[float | None, str | None]:
         match = compiled.search(text)
         if not match:
             return None, "regex: no match in stdout"
-        captured = match.group(match.lastindex) if match.lastindex else match.group(0)
+        captured = match.group(1) if match.lastindex else match.group(0)
         try:
             return float(captured), None
         except ValueError:
@@ -156,6 +159,8 @@ def run_harness(command: str, timeout: int) -> tuple[int, str, str]:
             shell=True,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
         )
     except subprocess.TimeoutExpired:
@@ -167,6 +172,8 @@ def run_harness(command: str, timeout: int) -> tuple[int, str, str]:
 
 def sample(command: str, count: int, extract: str, timeout: int) -> tuple[dict | None, list[dict]]:
     """Return (summary, failures). summary is None when any sample failed."""
+    if count < 1:
+        die("--samples must be at least 1")
     values: list[float] = []
     failures: list[dict] = []
     for index in range(1, count + 1):
@@ -234,7 +241,8 @@ def load_baseline(path: Path) -> dict:
 
 def cmd_baseline(args: argparse.Namespace) -> int:
     path = resolve_dir(args.dir)
-    summary, failures = sample(args.harness, args.samples, args.extract, args.timeout)
+    extract = args.extract or "auto"
+    summary, failures = sample(args.harness, args.samples, extract, args.timeout)
     if summary is None:
         report_failures(args.harness, failures)
     ensure_dir(path)
@@ -244,6 +252,7 @@ def cmd_baseline(args: argparse.Namespace) -> int:
         "direction": args.direction,
         "harness": args.harness,
         "harness_id": harness_id(args.harness),
+        "extract": extract,
         "samples": summary["samples"],
         "median": summary["median"],
         "min": summary["min"],
@@ -261,7 +270,7 @@ def cmd_baseline(args: argparse.Namespace) -> int:
 
 
 def cmd_run(args: argparse.Namespace) -> int:
-    summary, failures = sample(args.harness, args.samples, args.extract, args.timeout)
+    summary, failures = sample(args.harness, args.samples, args.extract or "auto", args.timeout)
     if summary is None:
         report_failures(args.harness, failures)
     print(json.dumps(summary, indent=2))
@@ -291,7 +300,10 @@ def cmd_compare(args: argparse.Namespace) -> int:
                 )
             )
             return 3
-        summary, failures = sample(args.harness, args.samples, args.extract, args.timeout)
+        # Reuse the extraction spec the baseline was recorded with, so `compare`
+        # can never silently measure a different way than the baseline did.
+        extract = args.extract or baseline.get("extract") or "auto"
+        summary, failures = sample(args.harness, args.samples, extract, args.timeout)
         if summary is None:
             report_failures(args.harness, failures)
         after = summary["median"]
@@ -332,8 +344,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--extract",
-        default="auto",
-        help="auto | regex:PATTERN | json:dotted.path | line:PREFIX",
+        default=None,
+        help=(
+            "auto | regex:PATTERN | json:dotted.path | line:PREFIX. Defaults to auto, "
+            "except in `compare`, which defaults to the spec recorded in the baseline."
+        ),
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -357,7 +372,6 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--harness", required=True)
     run.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
     run.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
-    run.add_argument("--json", action="store_true")
     add_common(run)
     run.set_defaults(func=cmd_run)
 
@@ -366,7 +380,6 @@ def build_parser() -> argparse.ArgumentParser:
     compare.add_argument("--value", default=None)
     compare.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
     compare.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
-    compare.add_argument("--json", action="store_true")
     add_common(compare)
     compare.set_defaults(func=cmd_compare)
 

--- a/tests/skills/test_hillclimb_skill.py
+++ b/tests/skills/test_hillclimb_skill.py
@@ -1,0 +1,472 @@
+"""Contract tests for the hillclimb skill: the two helper CLIs and the skill's metadata.
+
+The scripts are exercised as subprocesses through their real command-line
+interface, which is the artifact users actually run. Every test pins behaviour
+(exit codes, computed values, emitted files) rather than source text.
+
+Run: scripts/run_tests.sh tests/skills/test_hillclimb_skill.py -q
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO / "optional-skills" / "software-development" / "hillclimb"
+DECISION_LOG = SKILL_DIR / "scripts" / "decision_log.py"
+SAMPLE_METRIC = SKILL_DIR / "scripts" / "sample_metric.py"
+PY = sys.executable
+COLUMNS = [
+    "id",
+    "timestamp",
+    "hypothesis",
+    "change",
+    "before",
+    "after",
+    "delta",
+    "tests",
+    "verdict",
+    "harness_id",
+    "note",
+]
+HEADER = "\t".join(COLUMNS)
+
+
+def run(script, *args, cwd=None):
+    return subprocess.run(
+        [PY, str(script), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd) if cwd else None,
+    )
+
+
+def append(log_dir, before, after, verdict="kept", tests="pass", hypothesis="h", note=""):
+    return run(
+        DECISION_LOG,
+        "append",
+        "--dir",
+        str(log_dir),
+        "--hypothesis",
+        hypothesis,
+        "--change",
+        "c",
+        "--before",
+        str(before),
+        "--after",
+        str(after),
+        "--tests",
+        tests,
+        "--verdict",
+        verdict,
+        "--note",
+        note,
+    )
+
+
+def tsv_rows(log_dir):
+    text = (log_dir / "decision.tsv").read_text(encoding="utf-8")
+    lines = [line for line in text.split("\n") if line]
+    assert lines[0] == HEADER
+    return [line.split("\t") for line in lines[1:]]
+
+
+def write_harness(path, body):
+    path.write_text(body, encoding="utf-8")
+    return f"{PY} {path}"
+
+
+# --------------------------------------------------------------------------- #
+# decision_log.py
+# --------------------------------------------------------------------------- #
+
+
+def test_append_creates_dir_and_roundtrips(tmp_path):
+    """No --dir: the log directory is created lazily, with a valid header."""
+    result = append(tmp_path / ".hillclimb", 5.8, 5.2)
+    assert result.returncode == 0, result.stderr
+    rows = tsv_rows(tmp_path / ".hillclimb")
+    assert len(rows) == 1
+    assert len(rows[0]) == 11
+    assert rows[0][0] == "1"
+    assert rows[0][4] == "5.8"
+    assert rows[0][5] == "5.2"
+
+
+def test_append_computes_delta_and_ignores_any_caller_value(tmp_path):
+    log_dir = tmp_path / "log"
+    assert append(log_dir, 5.8, 5.2).returncode == 0
+    assert tsv_rows(log_dir)[0][6] == "-0.6"
+
+
+def test_append_accepts_na_and_records_na_delta(tmp_path):
+    log_dir = tmp_path / "log"
+    result = run(
+        DECISION_LOG,
+        "append",
+        "--dir",
+        str(log_dir),
+        "--hypothesis",
+        "pivot",
+        "--change",
+        "none",
+        "--before",
+        "na",
+        "--after",
+        "na",
+        "--tests",
+        "none",
+        "--verdict",
+        "reverted",
+    )
+    assert result.returncode == 0, result.stderr
+    row = tsv_rows(log_dir)[0]
+    assert row[6] == "na"
+    assert run(DECISION_LOG, "verify", "--dir", str(log_dir)).returncode == 0
+
+
+def test_append_sanitizes_tabs_and_newlines_in_free_text(tmp_path):
+    """A tab inside the note must not shift the row into more columns."""
+    log_dir = tmp_path / "log"
+    result = append(log_dir, 1.0, 0.5, note="tab\there\nand newline")
+    assert result.returncode == 0, result.stderr
+    rows = tsv_rows(log_dir)
+    assert len(rows) == 1
+    assert len(rows[0]) == 11
+    assert "\t" not in rows[0][10]
+    assert "\n" not in rows[0][10]
+
+
+def test_append_rejects_invalid_enum_and_writes_nothing(tmp_path):
+    log_dir = tmp_path / "log"
+    result = append(log_dir, 1.0, 0.5, tests="bogus")
+    assert result.returncode != 0
+    assert not (log_dir / "decision.tsv").exists()
+
+
+def test_append_rejects_non_numeric_metric(tmp_path):
+    log_dir = tmp_path / "log"
+    result = append(log_dir, "fast", 0.5)
+    assert result.returncode == 2
+    assert not (log_dir / "decision.tsv").exists()
+
+
+def test_ids_increment_monotonically(tmp_path):
+    log_dir = tmp_path / "log"
+    for index in range(3):
+        assert append(log_dir, 5.0, 5.0 - index).returncode == 0
+    assert [row[0] for row in tsv_rows(log_dir)] == ["1", "2", "3"]
+    assert run(DECISION_LOG, "verify", "--dir", str(log_dir)).returncode == 0
+
+
+def test_verify_reports_delta_mismatch(tmp_path):
+    log_dir = tmp_path / "log"
+    assert append(log_dir, 5.0, 4.0).returncode == 0
+    tsv = log_dir / "decision.tsv"
+    rows = tsv_rows(log_dir)
+    rows[0][6] = "-99"
+    tsv.write_text(HEADER + "\n" + "\t".join(rows[0]) + "\n", encoding="utf-8")
+    result = run(DECISION_LOG, "verify", "--dir", str(log_dir))
+    assert result.returncode == 1
+    assert "delta-mismatch" in result.stdout
+
+
+def test_verify_reports_stale_harness(tmp_path):
+    log_dir = tmp_path / "log"
+    assert append(log_dir, 5.0, 4.0).returncode == 0
+    (log_dir / "baseline.json").write_text(
+        json.dumps({"harness_id": "ffffffffffff", "median": 5.0}), encoding="utf-8"
+    )
+    result = run(DECISION_LOG, "verify", "--dir", str(log_dir))
+    assert result.returncode == 1
+    assert "stale-harness" in result.stdout
+
+
+def test_verify_missing_log_reports_no_log_and_exits_0(tmp_path):
+    result = run(DECISION_LOG, "verify", "--dir", str(tmp_path / "absent"))
+    assert result.returncode == 0
+    assert "no-log" in result.stdout
+
+
+def test_read_paths_on_absent_state_exit_0(tmp_path):
+    absent = tmp_path / "absent"
+    assert run(DECISION_LOG, "list", "--dir", str(absent)).returncode == 0
+    stats = run(DECISION_LOG, "stats", "--dir", str(absent), "--json")
+    assert stats.returncode == 0
+    payload = json.loads(stats.stdout)
+    assert payload["attempts"] == 0
+    assert payload["plateau"] is False
+
+
+def test_dir_pointing_at_a_file_exits_2(tmp_path):
+    target = tmp_path / "afile"
+    target.write_text("not a directory", encoding="utf-8")
+    result = append(target, 1.0, 2.0)
+    assert result.returncode == 2
+    assert "not a directory" in result.stderr
+
+
+def test_stats_flags_a_plateau_of_sub_threshold_attempts(tmp_path):
+    log_dir = tmp_path / "log"
+    assert append(log_dir, 10.0, 9.0).returncode == 0  # a real win, 10%
+    for before, after in ((9.0, 8.95), (8.95, 8.91), (8.91, 8.88)):
+        assert append(log_dir, before, after).returncode == 0
+    payload = json.loads(run(DECISION_LOG, "stats", "--dir", str(log_dir), "--json").stdout)
+    assert payload["plateau"] is True
+    assert len(payload["plateau_reasons"]) == 3
+
+
+def test_stats_does_not_flag_plateau_while_a_recent_attempt_still_wins(tmp_path):
+    log_dir = tmp_path / "log"
+    for before, after in ((9.0, 8.95), (8.95, 8.90), (8.90, 8.0)):
+        assert append(log_dir, before, after).returncode == 0
+    payload = json.loads(run(DECISION_LOG, "stats", "--dir", str(log_dir), "--json").stdout)
+    assert payload["plateau"] is False
+
+
+def test_stats_needs_a_full_window_before_claiming_a_plateau(tmp_path):
+    log_dir = tmp_path / "log"
+    assert append(log_dir, 9.0, 8.99).returncode == 0
+    payload = json.loads(run(DECISION_LOG, "stats", "--dir", str(log_dir), "--json").stdout)
+    assert payload["plateau"] is False
+
+
+def test_stats_is_direction_aware(tmp_path):
+    log_dir = tmp_path / "log"
+    (log_dir).mkdir(parents=True)
+    (log_dir / "baseline.json").write_text(
+        json.dumps({"harness_id": "abc123abc123", "median": 50.0, "direction": "maximize"}),
+        encoding="utf-8",
+    )
+    assert append(log_dir, 50.0, 60.0).returncode == 0  # a win when maximizing
+    payload = json.loads(run(DECISION_LOG, "stats", "--dir", str(log_dir), "--json").stdout)
+    assert payload["direction"] == "maximize"
+    assert payload["best_improvement"] == pytest.approx(10.0)
+
+
+# --------------------------------------------------------------------------- #
+# sample_metric.py
+# --------------------------------------------------------------------------- #
+
+
+def test_run_reports_median_min_max_spread(tmp_path):
+    harness = write_harness(
+        tmp_path / "varying.py",
+        "import pathlib, sys\n"
+        "state = pathlib.Path(__file__).with_suffix('.state')\n"
+        "n = int(state.read_text()) if state.exists() else 0\n"
+        "state.write_text(str(n + 1))\n"
+        "print([1.0, 2.0, 6.0][n % 3])\n",
+    )
+    result = run(SAMPLE_METRIC, "run", "--harness", harness, "--samples", "3", "--dir", str(tmp_path))
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["samples"] == 3
+    assert payload["median"] == 2.0
+    assert payload["min"] == 1.0
+    assert payload["max"] == 6.0
+    assert payload["spread"] == 5.0
+
+
+def test_run_emits_no_metric_when_a_sample_fails(tmp_path):
+    harness = write_harness(tmp_path / "bad.py", "import sys\nsys.exit(3)\n")
+    result = run(SAMPLE_METRIC, "run", "--harness", harness, "--samples", "2", "--dir", str(tmp_path))
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["error"] == "sample failed; no metric emitted"
+    assert payload["failed_samples"] == 2
+    assert "median" not in payload
+
+
+def test_run_emits_no_metric_when_no_number_is_printed(tmp_path):
+    harness = write_harness(tmp_path / "wordy.py", "print('no metric here')\n")
+    result = run(SAMPLE_METRIC, "run", "--harness", harness, "--samples", "1", "--dir", str(tmp_path))
+    assert result.returncode == 2
+    assert "extract_error" in result.stdout
+
+
+def test_baseline_freezes_and_compare_scores_both_ways(tmp_path):
+    baseline_harness = write_harness(tmp_path / "slow.py", "print('runtime 8.0 s')\n")
+    slow = run(
+        SAMPLE_METRIC,
+        "baseline",
+        "--harness",
+        baseline_harness,
+        "--samples",
+        "2",
+        "--name",
+        "runtime",
+        "--unit",
+        "s",
+        "--extract",
+        "regex:runtime (\\d+\\.\\d+)",
+        "--dir",
+        str(tmp_path),
+    )
+    assert slow.returncode == 0, slow.stderr
+    frozen = json.loads((tmp_path / "baseline.json").read_text(encoding="utf-8"))
+    assert frozen["frozen"] is True
+    assert frozen["median"] == 8.0
+    assert frozen["samples"] == 2
+
+    same = run(
+        SAMPLE_METRIC,
+        "compare",
+        "--harness",
+        baseline_harness,
+        "--samples",
+        "2",
+        "--extract",
+        "regex:runtime (\\d+\\.\\d+)",
+        "--dir",
+        str(tmp_path),
+    )
+    assert same.returncode == 1  # no improvement
+    assert json.loads(same.stdout)["improved"] is False
+
+
+def test_compare_refuses_a_changed_harness(tmp_path):
+    original = write_harness(tmp_path / "a.py", "print('runtime 8.0 s')\n")
+    changed = write_harness(tmp_path / "b.py", "print('runtime 4.0 s')\n")
+    spec = "regex:runtime (\\d+\\.\\d+)"
+    assert (
+        run(
+            SAMPLE_METRIC,
+            "baseline",
+            "--harness",
+            original,
+            "--samples",
+            "1",
+            "--extract",
+            spec,
+            "--dir",
+            str(tmp_path),
+        ).returncode
+        == 0
+    )
+    result = run(
+        SAMPLE_METRIC,
+        "compare",
+        "--harness",
+        changed,
+        "--samples",
+        "1",
+        "--extract",
+        spec,
+        "--dir",
+        str(tmp_path),
+    )
+    assert result.returncode == 3
+    assert "harness-id mismatch" in result.stdout
+
+
+def test_compare_accepts_an_explicit_value_and_scores_improvement(tmp_path):
+    harness = write_harness(tmp_path / "a.py", "print('runtime 8.0 s')\n")
+    assert (
+        run(
+            SAMPLE_METRIC,
+            "baseline",
+            "--harness",
+            harness,
+            "--samples",
+            "1",
+            "--extract",
+            "regex:runtime (\\d+\\.\\d+)",
+            "--dir",
+            str(tmp_path),
+        ).returncode
+        == 0
+    )
+    result = run(SAMPLE_METRIC, "compare", "--value", "4.0", "--dir", str(tmp_path))
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["improved"] is True
+    assert payload["delta"] == pytest.approx(-4.0)
+
+
+def test_compare_without_a_baseline_exits_2(tmp_path):
+    harness = write_harness(tmp_path / "a.py", "print(1)\n")
+    result = run(SAMPLE_METRIC, "compare", "--harness", harness, "--dir", str(tmp_path / "empty"))
+    assert result.returncode == 2
+    assert "baseline" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "spec,body,expected",
+    [
+        ("auto", "print('plain 99 tokens')\n", 99.0),
+        ("regex:value=(\\d+)", "print('value=42')\n", 42.0),
+        ("json:results.median", "import json\nprint(json.dumps({'results': {'median': 7.5}}))\n", 7.5),
+        ("line:Total runtime:", "print('Total runtime: 3.25 s')\n", 3.25),
+    ],
+)
+def test_extract_modes(tmp_path, spec, body, expected):
+    harness = write_harness(tmp_path / "h.py", body)
+    result = run(
+        SAMPLE_METRIC,
+        "run",
+        "--harness",
+        harness,
+        "--samples",
+        "1",
+        "--extract",
+        spec,
+        "--dir",
+        str(tmp_path),
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["median"] == expected
+
+
+# --------------------------------------------------------------------------- #
+# The skill's own metadata contract
+# --------------------------------------------------------------------------- #
+
+
+def skill_frontmatter():
+    text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    assert text.startswith("---")
+    closing = re.search(r"\n---\s*\n", text[3:])
+    assert closing, "SKILL.md frontmatter is not closed"
+    return yaml.safe_load(text[3:][: closing.start()])
+
+
+def test_skill_metadata_satisfies_the_authoring_standards():
+    frontmatter = skill_frontmatter()
+    assert frontmatter["name"] == SKILL_DIR.name
+    description = frontmatter["description"]
+    assert len(description) <= 60, f"description is {len(description)} chars"
+    assert description.rstrip().endswith(".")
+    assert not re.search(
+        r"\b(powerful|comprehensive|seamless|revolutionary|cutting-edge|state-of-the-art)\b",
+        description,
+        re.I,
+    )
+    for field in ("version", "author", "license", "platforms", "metadata"):
+        assert field in frontmatter
+    assert frontmatter["metadata"]["hermes"]["tags"]
+
+
+def test_skill_related_skills_all_exist():
+    frontmatter = skill_frontmatter()
+    known = {path.parent.name for path in REPO.glob("skills/**/SKILL.md")}
+    known |= {path.parent.name for path in REPO.glob("optional-skills/**/SKILL.md")}
+    dangling = [name for name in frontmatter["metadata"]["hermes"]["related_skills"] if name not in known]
+    assert not dangling, f"related_skills do not resolve: {dangling}"
+
+
+def test_skill_documents_only_files_it_ships():
+    for relative in ("scripts/decision_log.py", "scripts/sample_metric.py"):
+        assert (SKILL_DIR / relative).is_file(), f"missing {relative}"
+    references = {path.name for path in (SKILL_DIR / "references").glob("*.md")}
+    assert references == {
+        "decision-log.md",
+        "harness-lifecycle.md",
+        "plateau-playbook.md",
+        "unattended-mode.md",
+    }

--- a/tests/skills/test_hillclimb_skill.py
+++ b/tests/skills/test_hillclimb_skill.py
@@ -470,3 +470,183 @@ def test_skill_documents_only_files_it_ships():
         "plateau-playbook.md",
         "unattended-mode.md",
     }
+
+
+# --------------------------------------------------------------------------- #
+# Regression tests. Every case below was found by cross-vendor review of the
+# scripts rather than by the original implementation.
+# --------------------------------------------------------------------------- #
+
+
+def test_extract_regex_uses_the_first_capture_group(tmp_path):
+    harness = write_harness(tmp_path / "two.py", "print('a=1 b=2')\n")
+    result = run(
+        SAMPLE_METRIC,
+        "run",
+        "--harness",
+        harness,
+        "--samples",
+        "1",
+        "--extract",
+        r"regex:a=(\d+) b=(\d+)",
+        "--dir",
+        str(tmp_path),
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["median"] == 1.0
+
+
+def test_compare_reuses_the_extraction_spec_recorded_in_the_baseline(tmp_path):
+    """`compare` used to silently fall back to `auto` and measure a different number."""
+    harness = write_harness(
+        tmp_path / "two.py", "print('Total runtime: 5.0 s')\nprint('checksum 999')\n"
+    )
+    spec = "line:Total runtime:"
+    baseline = run(
+        SAMPLE_METRIC,
+        "baseline",
+        "--harness",
+        harness,
+        "--samples",
+        "1",
+        "--extract",
+        spec,
+        "--dir",
+        str(tmp_path),
+    )
+    assert baseline.returncode == 0, baseline.stderr
+    frozen = json.loads((tmp_path / "baseline.json").read_text(encoding="utf-8"))
+    assert frozen["extract"] == spec
+    assert frozen["median"] == 5.0
+
+    # No --extract here: `auto` would read 999 and report a huge win.
+    result = run(
+        SAMPLE_METRIC, "compare", "--harness", harness, "--samples", "1", "--dir", str(tmp_path)
+    )
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["before"] == 5.0
+    assert payload["after"] == 5.0
+
+
+def test_samples_must_be_at_least_one(tmp_path):
+    harness = write_harness(tmp_path / "a.py", "print(1)\n")
+    result = run(
+        SAMPLE_METRIC, "run", "--harness", harness, "--samples", "0", "--dir", str(tmp_path)
+    )
+    assert result.returncode == 2
+    assert "at least 1" in result.stderr
+
+
+def test_list_does_not_crash_on_a_malformed_row(tmp_path):
+    log_dir = tmp_path / "log"
+    assert append(log_dir, 5.0, 4.0).returncode == 0
+    good = tsv_rows(log_dir)[0]
+    (log_dir / "decision.tsv").write_text(
+        HEADER + "\n" + "\t".join(good) + "\n" + "7\tbroken\n", encoding="utf-8"
+    )
+    result = run(DECISION_LOG, "list", "--dir", str(log_dir))
+    assert result.returncode == 0, result.stderr
+    assert good[0] in result.stdout
+    # the malformed row is skipped from the table but never hidden silently
+    assert "malformed" in result.stderr
+    assert run(DECISION_LOG, "verify", "--dir", str(log_dir)).returncode == 1
+
+
+def test_stats_rejects_a_window_below_one(tmp_path):
+    log_dir = tmp_path / "log"
+    assert append(log_dir, 5.0, 4.0).returncode == 0
+    assert run(DECISION_LOG, "stats", "--dir", str(log_dir), "--window", "0").returncode == 2
+
+
+def test_plateau_reasons_are_empty_when_there_is_no_plateau(tmp_path):
+    log_dir = tmp_path / "log"
+    for before, after in ((10.0, 9.0), (9.0, 8.99), (8.99, 8.98)):
+        assert append(log_dir, before, after).returncode == 0
+    payload = json.loads(run(DECISION_LOG, "stats", "--dir", str(log_dir), "--json").stdout)
+    assert payload["plateau"] is False
+    assert payload["plateau_reasons"] == []
+
+
+def test_stats_window_is_taken_from_the_window_rows(tmp_path):
+    """Regression: the window average used to be sliced from a filtered list."""
+    log_dir = tmp_path / "log"
+    assert append(log_dir, 10.0, 9.0).returncode == 0  # a big win, outside the window
+    assert (
+        run(
+            DECISION_LOG,
+            "append",
+            "--dir",
+            str(log_dir),
+            "--hypothesis",
+            "pivot",
+            "--change",
+            "none",
+            "--before",
+            "na",
+            "--after",
+            "na",
+            "--tests",
+            "none",
+            "--verdict",
+            "reverted",
+        ).returncode
+        == 0
+    )
+    assert append(log_dir, 9.0, 8.95).returncode == 0
+    assert append(log_dir, 8.95, 8.91).returncode == 0
+    payload = json.loads(run(DECISION_LOG, "stats", "--dir", str(log_dir), "--json").stdout)
+    # mean of the two measurable improvements inside the window: (0.05 + 0.04) / 2
+    assert payload["mean_improvement_last_window"] == pytest.approx(0.045)
+    # an unmeasurable attempt is not evidence of movement, so it counts as a stall
+    assert payload["plateau"] is True
+
+
+def test_worst_regression_is_none_when_nothing_regressed(tmp_path):
+    log_dir = tmp_path / "log"
+    assert append(log_dir, 10.0, 9.0).returncode == 0
+    assert append(log_dir, 9.0, 8.0).returncode == 0
+    payload = json.loads(run(DECISION_LOG, "stats", "--dir", str(log_dir), "--json").stdout)
+    assert payload["best_improvement"] == pytest.approx(1.0)
+    assert payload["worst_regression"] is None
+
+
+def test_worst_regression_is_negative_when_a_metric_regressed(tmp_path):
+    log_dir = tmp_path / "log"
+    assert append(log_dir, 10.0, 11.5).returncode == 0
+    payload = json.loads(run(DECISION_LOG, "stats", "--dir", str(log_dir), "--json").stdout)
+    assert payload["best_improvement"] is None
+    assert payload["worst_regression"] == pytest.approx(-1.5)
+
+
+def test_verify_flags_an_unparseable_metric_field(tmp_path):
+    log_dir = tmp_path / "log"
+    log_dir.mkdir(parents=True)
+    row = ["1", "2026-09-10T00:00:00Z", "h", "c", "fast", "na", "na", "none", "reverted", "", "note"]
+    assert len(row) == 11
+    (log_dir / "decision.tsv").write_text(HEADER + "\n" + "\t".join(row) + "\n", encoding="utf-8")
+    result = run(DECISION_LOG, "verify", "--dir", str(log_dir))
+    assert result.returncode == 1
+    assert "invalid-metric" in result.stdout
+
+
+def test_verify_accepts_a_crlf_log(tmp_path):
+    """A Windows-written log uses CRLF; the header must still match."""
+    log_dir = tmp_path / "log"
+    assert append(log_dir, 5.0, 4.0).returncode == 0
+    text = (log_dir / "decision.tsv").read_text(encoding="utf-8")
+    (log_dir / "decision.tsv").write_bytes(text.replace("\n", "\r\n").encode("utf-8"))
+    verify = run(DECISION_LOG, "verify", "--dir", str(log_dir))
+    assert verify.returncode == 0
+    assert json.loads(verify.stdout)["problems"] == []
+    listed = run(DECISION_LOG, "list", "--dir", str(log_dir), "--json")
+    assert json.loads(listed.stdout)[0]["id"] == "1"
+
+
+@pytest.mark.parametrize("command", ["list", "stats", "verify"])
+def test_read_paths_reject_a_file_used_as_dir(tmp_path, command):
+    target = tmp_path / "afile"
+    target.write_text("not a directory", encoding="utf-8")
+    result = run(DECISION_LOG, command, "--dir", str(target))
+    assert result.returncode == 2
+    assert "not a directory" in result.stderr

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -264,6 +264,7 @@ hermes skills uninstall <skill-name>
 | [**ast-grep**](/docs/user-guide/skills/optional/software-development/software-development-ast-grep) | AST-aware structural code search and rewrite via ast-grep. |
 | [**code-wiki**](/docs/user-guide/skills/optional/software-development/software-development-code-wiki) | Generate wiki docs + Mermaid diagrams for any codebase. |
 | [**grill-me**](/docs/user-guide/skills/optional/software-development/software-development-grill-me) | Adversarial plan interview before implementation. |
+| [**hillclimb**](/docs/user-guide/skills/optional/software-development/software-development-hillclimb) | Optimize one metric via frozen harness and decision log. |
 | [**rest-graphql-debug**](/docs/user-guide/skills/optional/software-development/software-development-rest-graphql-debug) | Debug REST/GraphQL APIs: status codes, auth, schemas, repro. |
 | [**subagent-driven-development**](/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development) | Execute plans via delegate_task subagents (2-stage review). |
 

--- a/website/docs/user-guide/skills/optional/software-development/software-development-hillclimb.md
+++ b/website/docs/user-guide/skills/optional/software-development/software-development-hillclimb.md
@@ -1,0 +1,161 @@
+---
+title: "Hillclimb — Optimize one metric via frozen harness and decision log"
+sidebar_label: "Hillclimb"
+description: "Optimize one metric via frozen harness and decision log"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Hillclimb
+
+Optimize one metric via frozen harness and decision log.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/software-development/hillclimb` |
+| Path | `optional-skills/software-development/hillclimb` |
+| Version | `1.0.0` |
+| Author | Emmanuel Ketcha (@ketchalegend) + Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `optimization`, `metrics`, `experiments`, `decision-log`, `benchmarking`, `iteration` |
+| Related skills | [`systematic-debugging`](/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging), [`spike`](/docs/user-guide/skills/bundled/software-development/software-development-spike), [`test-driven-development`](/docs/user-guide/skills/bundled/software-development/software-development-test-driven-development), [`requesting-code-review`](/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review), [`subagent-driven-development`](/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Hillclimb
+
+Improves one quantitative metric of a codebase by making a single change, measuring it, and keeping or reverting it on the evidence. The loop is deliberately narrow: one metric, one change per attempt, one measurement, one log row. It does not profile code, diagnose correctness bugs, or weigh competing objectives - see When to Use for what to reach for instead.
+
+## When to Use
+
+Reach for this skill when the target is a single number and the user wants it moved:
+
+- "Make the test suite faster", "get bundle size down", "cut token cost per turn", "reduce the flaky-test rate", "raise coverage".
+- A change is about to be justified by intuition or by reading the code, and you would rather the data decide.
+- A tuning effort will run many attempts, possibly with nobody watching.
+
+Do NOT use it when:
+
+- You cannot build a harness that reliably prints one number. Without a repeatable measurement this skill has nothing to offer - say so and stop, rather than improvising a metric that flatters the change.
+- The target is a correctness bug rather than a measurement: use `systematic-debugging`.
+- The work is code shape with no metric attached: use `simplify-code`.
+- The goal is a tradeoff across several metrics with no dominant one. Choose the metric first, then come back.
+
+## Prerequisites
+
+- A target repo under git, and one command that prints the metric (the harness).
+- `<skill_dir>` below means this skill's own directory; the helper scripts are `<skill_dir>/scripts/decision_log.py` and `<skill_dir>/scripts/sample_metric.py`.
+- Python 3, standard library only. The scripts create `.hillclimb/` in the working directory on their first write; `--dir`, or the `HILLCLIMB_DIR` environment variable, relocates it.
+- Add `.hillclimb/` to the target repo's `.gitignore`. The log is a working trail, not a deliverable; it is quoted into the PR body rather than committed.
+
+## How to Run
+
+1. Build the harness, then freeze a baseline with `sample_metric.py baseline`.
+2. Make one change, then measure it with `sample_metric.py compare`.
+3. Record the attempt with `decision_log.py append`.
+4. When progress stalls, run the plateau protocol in `references/plateau-playbook.md`.
+5. Land the surviving change and quote the kept rows in the PR body.
+
+## Quick Reference
+
+| Command | Purpose |
+|---|---|
+| `sample_metric.py baseline --harness CMD --samples N` | Sample N times, freeze the median as the baseline |
+| `sample_metric.py run --harness CMD --samples N` | Sample without touching the baseline |
+| `sample_metric.py compare --harness CMD` | Exit 0 = improvement, 1 = not, 2 = no baseline or bad value, 3 = harness changed since the freeze |
+| `decision_log.py append ...` | Add one attempt row; the tool computes `delta` |
+| `decision_log.py list [--limit N] [--verdict kept\|reverted]` | Read the trail, oldest first |
+| `decision_log.py stats [--window N] [--threshold F]` | Direction-aware best/worst plus a plateau verdict |
+| `decision_log.py verify` | Validate the trail: exit 0 clean, 1 problems, 2 bad invocation |
+
+`--extract` selects how a number is read out of the harness's stdout: `auto` (default - the last number printed), `regex:PATTERN` (first capture group), `json:dotted.path`, or `line:PREFIX` (the first number on the first line beginning with PREFIX).
+
+## Procedure
+
+### 1. Build the harness
+
+Write one command that prints exactly one number, then confirm it is stable across runs. Use enough samples to clear noise: the median of N runs, never a single run.
+
+**Done when:** repeated runs of the harness land within a spread you are willing to call noise, and `sample_metric.py run` prints a median for that command.
+
+### 2. Freeze the baseline
+
+```bash
+python3 <skill_dir>/scripts/sample_metric.py baseline --harness "<command>" --samples 5 --name "test suite seconds" --direction minimize
+```
+
+This writes `.hillclimb/baseline.json` with the recorded median, `frozen: true`, and a `harness_id` fingerprint of the command. Add `.hillclimb/` to `.gitignore` now. The harness is immutable from this point: any edit changes the `harness_id`, and every earlier number stops being comparable.
+
+**Done when:** `.hillclimb/baseline.json` exists, is `frozen: true`, and a repeat run of the same harness reproduces its median within the sampling spread.
+
+### 3. The loop (one change, one measurement)
+
+Make exactly one change to the codebase - never to the harness - then:
+
+```bash
+python3 <skill_dir>/scripts/sample_metric.py compare --harness "<command>" --samples 5
+```
+
+Record the attempt either way:
+
+```bash
+python3 <skill_dir>/scripts/decision_log.py append \
+  --hypothesis "Parallel test execution cuts wall clock" \
+  --change "pytest-xdist, 4 workers" \
+  --before 5.8 --after 5.2 --tests pass --verdict kept
+```
+
+`delta` is always raw `after - before`, so here it is -0.6. For a `minimize` metric a negative delta is an improvement; the direction is recorded once in `baseline.json`. When the metric moves the wrong way, record the same shape with the real numbers and `--verdict reverted` - for example `--before 5.8 --after 6.1 --verdict reverted`. Never stack untested changes, and never record a win you did not measure.
+
+If an attempt measured nothing - a category pivot, a harness fix, a proven dead end - record it with `--before na --after na --tests none` so the trail still explains the search.
+
+**Done when:** exactly one new row exists with a tool-computed `delta`, a `tests` value, and a `verdict`, and the change was kept or reverted to match.
+
+### 4. Plateau
+
+Run `decision_log.py stats`. It reports a plateau when **each** of the last `--window` attempts (default 3) improved by less than `--threshold` (default 0.02, i.e. 2%), where improvement is relative to that attempt's own `before` value and interpreted by the recorded direction. `plateau_reasons` names the attempts that failed to clear the bar.
+
+A plateau is a signal to change hypothesis *category*, not a signal to stop. Follow `references/plateau-playbook.md`: pivot category, combine the near-misses, re-read the source instead of guessing, and try something more radical before concluding the hill is climbed.
+
+**Done when:** the plateau is either broken by a recorded category pivot, or written down as a provable dead end in a `tests: none` row.
+
+### 5. Land it
+
+```bash
+python3 <skill_dir>/scripts/decision_log.py verify
+```
+
+`verify` must exit 0. Then re-run the harness and the target repo's own test suite against the surviving tree, commit the change, and quote the kept rows (before/after/delta) into the PR body. Never commit `.hillclimb/`.
+
+**Done when:** `verify` exits 0, the repo's tests pass on the surviving tree, and the PR body carries the kept rows.
+
+## Two Modes
+
+- **Interactive** - one agent, one change at a time, measuring and keeping or reverting as it goes.
+- **Unattended or parallel** - fan hypotheses into separate git worktrees, or run the loop on a schedule. See `references/unattended-mode.md` for the real `cronjob_manage` fields, the monitor gate, and the worktree recipe.
+
+## Pitfalls
+
+1. Editing the harness after the freeze invalidates every earlier number. `compare` will exit 3 rather than compare across two measurement methods - re-baseline deliberately and record why.
+2. Re-baselining to escape a result you did not like is the failure this skill exists to prevent. The `harness_id` guard makes it impossible to do silently, which is the point: the escape has to be written down.
+3. A failed or unparseable sample aborts the whole measurement (exit 2). There is deliberately no way to average over failed runs; a metric built from failed samples is not a metric.
+4. Reading the code and concluding a change helped is not evidence. The data decides, or the attempt is recorded as `tests: none` with no measurement.
+5. A plateau is not the end of the hill. Pivoting category, combining near-misses, and re-reading the source are all still available.
+6. Skipping `verify` lets a malformed trail - a hand-edited delta, a row from a different harness - reach the PR body.
+7. Forgetting `.gitignore` puts the working trail into the commit.
+
+## Verification
+
+- [ ] `.hillclimb/baseline.json` exists with `frozen: true` and a `harness_id`
+- [ ] Every attempt has exactly one row, with a tool-computed `delta` and an explicit `tests` value
+- [ ] Kept rows have real before/after numbers taken from `compare`, not from inspection
+- [ ] `decision_log.py verify` exits 0
+- [ ] `verify` reports no `stale-harness` rows, so every number came from the same measurement method
+- [ ] `.hillclimb/` is not in the commit, and the kept rows are in the PR body

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -613,6 +613,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/optional/software-development/software-development-ast-grep',
                     'user-guide/skills/optional/software-development/software-development-code-wiki',
                     'user-guide/skills/optional/software-development/software-development-grill-me',
+                    'user-guide/skills/optional/software-development/software-development-hillclimb',
                     'user-guide/skills/optional/software-development/software-development-rest-graphql-debug',
                     'user-guide/skills/optional/software-development/software-development-subagent-driven-development',
                   ],


### PR DESCRIPTION
## What this adds

An optional skill that turns "make X faster / lighter / cheaper" into a loop that can only conclude something on evidence: one harness, one frozen baseline, one change at a time, one measurement, one log row.

The pattern comes from @ketchalegend's proposal in #47156 — a structured scientific metric-improvement loop adapted from the Cursor `pstack` hillclimb playbook.

`optional-skills/software-development/hillclimb/`:

- **`SKILL.md`** — the five-step loop (build harness -> freeze baseline -> one change / one measurement -> plateau -> land it), with trigger and counter-trigger guidance.
- **`references/decision-log.md`** — the 11-column TSV schema, the three-state `tests` column, and every `verify` problem code.
- **`references/harness-lifecycle.md`** — DRAFT -> BASELINED -> FROZEN -> INVALIDATED -> RE-BASELINED, with legitimate and cheating re-baseline examples.
- **`references/plateau-playbook.md`** — four worked pivots (test-suite wall clock, bundle size, token cost per turn, flaky-test rate), plus the temporary-stall vs provable-dead-end split.
- **`references/unattended-mode.md`** — parallel worktree fan-out, and scheduled runs documented against the real `cronjob_manage` surface.
- **`scripts/decision_log.py`** — the append-only decision trail. `delta` is always computed by the tool and can never be supplied by a caller; `tests` is three-state (`pass|fail|none`) so a metric win that breaks a test stays visible and revertible; `verify` reports schema problems and any row whose harness no longer matches the frozen baseline.
- **`scripts/sample_metric.py`** — median-of-N sampling. **Any failed sample emits no metric at all** (exit 2); there is deliberately no `--allow-failures` flag, because a number averaged over failed runs is not evidence of anything. A `harness_id` fingerprint (sha256 of the whitespace-normalized harness command) makes `compare` refuse with exit 3 once the harness changes, so a re-baseline has to be deliberate and recorded. The extraction spec is recorded in the baseline and reused by `compare`, so a comparison cannot quietly measure a different number than the baseline did.

## Why `optional-skills/` rather than `skills/`

The bundled index is sent on every API call on every install, and the maintainer-directed shipped-set slim (#98539) already moved the coding-discipline skills out — that commit describes the index as a per-call cost paid by every session. `subagent-driven-development`, `grill-me` and `ast-grep` all live under `optional-skills/software-development/`, so this follows that precedent. Once merged, it installs with `hermes skills install official/software-development/hillclimb`.

## Verification

- `scripts/run_tests.sh tests/skills/test_hillclimb_skill.py -q` -> **44 passed, 0 failed**
- `scripts/run_tests.sh tests/skills/test_authoring_standards.py -q` -> **1202 passed, 0 failed** (6 of those are this skill's new frontmatter cases)
- `scripts/run_tests.sh tests/website/test_generate_skill_docs.py -q` -> **7 passed, 0 failed**
- Both CLIs are driven as subprocesses, so the command-line contract is exercised end to end rather than unit-mocked: every documented exit code (0 / 1 / 2 / 3), lazy creation of the log directory, tab-and-newline sanitisation in free text, delta computed rather than accepted, plateau detection and its `plateau_reasons`, `no-log` exiting 0, harness-change refusal exiting 3, and the no-metric-on-a-failed-sample rule exiting 2. The same cases are also covered by a local 18-check smoke run over the CLIs.

Fourteen of the tests are regression tests for defects found while reviewing this change before submission: a silently-wrong measurement path when the extraction spec was not carried from the baseline into `compare`, an off-by-one in `regex:` group selection, a `list` crash on a malformed row, CRLF logs failing the header check, and others listed in the second commit message.

## Notes

**Open question:** the fourth acceptance criterion in #47156 asks the skill to integrate with the build-the-lever (#37305), sequence-verifiable-units (#42722) and auditable-decision-trail (#32507) patterns. All three are still open with no implementation, and `metadata.hermes.related_skills` must resolve in-repo (`tests/skills/test_authoring_standards.py::test_related_skills_resolve` fails the build on a dangling entry). So the skill is self-contained and states the overlapping disciplines — one change at a time, evidence over inspection, a written trail — directly rather than cross-linking to skills that do not exist. If those land, adding the cross-links is a one-line follow-up.

**Deliberate scope:** no new core tool, no config key, no environment variable. Optionality is the only switch, and the skill's own metadata is the entire integration surface.

**Scope note for reviewers, two things I did not touch.** (1) The generated docs in this PR are limited to the new skill's own page plus its catalog and sidebar entries. Running `website/scripts/generate-skill-docs.py` in full currently rewrites about 190 unrelated skill pages, because the committed pages carry Windows path separators (e.g. `skills/apple\findmy`), and it re-syncs catalog entries that are already stale (`agent-merge-conflict-arbiter` missing, `merge-reconciler` listed). That drift is its own cleanup. (2) `references/unattended-mode.md` documents the agent turn as running under an inactivity watchdog — 600s of no activity by default, overridable with `HERMES_CRON_TIMEOUT`, `0` for unlimited — and the `script` field's own timeout as 3600s, rather than the "3-minute hard interrupt" that `cron/AGENTS.md` describes. The code is what the design follows from, so the skill describes the code; flagging it so a reviewer can check that against `cron/scheduler.py` rather than reading it as an invented constraint.

Closes #47156
