### PR TITLE
fix(gateway): keep one-question clarify batches renderable by simple clients

### DIFF
--- a/tests/tui_gateway/test_clarify_single_question_legacy_renderer.py
+++ b/tests/tui_gateway/test_clarify_single_question_legacy_renderer.py
@@ -1,0 +1,127 @@
+"""A one-question clarify batch must stay renderable and answerable by a client that only
+speaks the historical single-question shape.
+
+Concrete consumer: the Hermes-Relay Android client
+(https://github.com/Codename-11/hermes-relay). Its `GatewayEventMapper.interactionRequest`
+reads ONLY `question` / `choices` / `multi_select` off a `clarify.request` payload and falls
+back to the literal string "The agent needs clarification" when `question` is absent; it
+answers with `{request_id, answer}` and never sends a `question_id`. A `questions`-only
+payload therefore renders as a bare text box with the question AND the options lost, and the
+reply is discarded.
+
+Two contracts, both proven against the real `tui_gateway.server` bridge:
+
+1. WIRE — the emitted `clarify.request` payload carries `question`/`choices` alongside
+   `questions`, so a renderer that never learned the batch shape still draws pickable rows.
+2. ANSWER — a reply WITHOUT `question_id` must reach the caller as the answer to the sole
+   question, not be parsed as a batch-result dict and dropped (which returned a blank
+   `user_response` for every question).
+"""
+
+import json
+import threading
+
+import pytest
+
+from tui_gateway import server
+
+
+@pytest.fixture
+def clarify_bridge(monkeypatch):
+    """Capture emitted events and run `_clarify_block` off-thread so a reply can race in."""
+    emitted: list[tuple[str, dict]] = []
+    monkeypatch.setattr(server, "_emit", lambda event, sid, payload: emitted.append((event, payload)))
+    monkeypatch.setattr(server, "_clarify_timeout_seconds", lambda: 10)
+    return emitted
+
+
+def _one_question(qid="q0"):
+    return [{"qid": qid, "question": "Do the options show up as tappable rows?",
+             "choices": ["Yes (Recommended)", "No"], "multi_select": False}]
+
+
+def _run_block(questions):
+    """Run the blocking bridge in a worker; return (thread, result_holder)."""
+    result: dict[str, str] = {}
+
+    def target():
+        result["value"] = server._clarify_block("sid-1", None, None, questions=questions)
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    return thread, result
+
+
+def _wait_for_request(emitted, timeout=5.0):
+    deadline = threading.Event()
+    for _ in range(int(timeout * 100)):
+        if emitted:
+            return emitted[0]
+        deadline.wait(0.01)
+    raise AssertionError("clarify.request was never emitted")
+
+
+def test_single_question_batch_also_carries_the_simple_shape(clarify_bridge):
+    """A legacy renderer reads `question`/`choices`; a batch-aware one still reads `questions`."""
+    questions = _one_question()
+    thread, _ = _run_block(questions)
+    try:
+        event, payload = _wait_for_request(clarify_bridge)
+        assert event == "clarify.request"
+        # Batch-aware clients keep their key.
+        assert [q["qid"] for q in payload["questions"]] == ["q0"]
+        # Legacy clients find the question AND the choices at the top level.
+        assert payload["question"] == questions[0]["question"]
+        assert payload["choices"] == questions[0]["choices"]
+    finally:
+        server._respond(1, {"request_id": payload["request_id"]}, "answer")
+        thread.join(timeout=5)
+
+
+def test_multi_question_batch_keeps_only_the_batch_shape(clarify_bridge):
+    """The compatibility keys are meaningless for >1 question and must not be invented."""
+    questions = _one_question("q0") + [
+        {"qid": "q1", "question": "Second?", "choices": None, "multi_select": False}]
+    thread, _ = _run_block(questions)
+    try:
+        _, payload = _wait_for_request(clarify_bridge)
+        assert len(payload["questions"]) == 2
+        assert "question" not in payload and "choices" not in payload
+    finally:
+        server._respond(1, {"request_id": payload["request_id"]}, "answer")
+        thread.join(timeout=5)
+
+
+def test_bare_reply_answers_the_sole_question_instead_of_being_dropped(clarify_bridge):
+    """No `question_id` (legacy renderer) still lands as the answer to the only question."""
+    thread, result = _run_block(_one_question())
+    _, payload = _wait_for_request(clarify_bridge)
+
+    # Exactly what a renderer that never learned `question_id` sends.
+    server._respond(1, {"request_id": payload["request_id"], "answer": "Yes (Recommended)"}, "answer")
+    thread.join(timeout=5)
+
+    assert json.loads(result["value"]) == {"answers": {"q0": "Yes (Recommended)"}}
+
+
+def test_bare_empty_reply_is_still_a_cancel(clarify_bridge):
+    """An empty bare reply keeps its cancel-all meaning — it is not an answer of ""."""
+    thread, result = _run_block(_one_question())
+    _, payload = _wait_for_request(clarify_bridge)
+
+    server._respond(1, {"request_id": payload["request_id"], "answer": ""}, "answer")
+    thread.join(timeout=5)
+
+    assert result["value"] == ""
+
+
+def test_question_id_reply_still_locks_per_question(clarify_bridge):
+    """The batch-aware path is unchanged: a qid-addressed answer resolves through the registry."""
+    thread, result = _run_block(_one_question())
+    _, payload = _wait_for_request(clarify_bridge)
+
+    server._respond(1, {"request_id": payload["request_id"], "question_id": "q0",
+                        "answer": "No"}, "answer")
+    thread.join(timeout=5)
+
+    assert json.loads(result["value"]) == {"answers": {"q0": "No"}}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1283,6 +1283,11 @@ def _block(event: str, sid: str, payload: dict, timeout: float | None = 300, bat
     if batch_qids is not None:
         # Cancel-all (respond with no question_id) resolves via _answers with "" — a plain cancel, not a partial result.
         if answer_present:
+            # A renderer that does not speak `question_id` answers bare. For a one-question batch that
+            # reply IS the answer; filing it under the sole qid keeps it from being parsed as a batch
+            # result dict and silently discarded (every response returning blank). Empty stays a cancel.
+            if answer and len(batch_qids) == 1:
+                return json.dumps({"answers": {batch_qids[0]: answer}}, ensure_ascii=False)
             return answer
         result: dict[str, object] = {"answers": batch_answers or {}}
         if not answered:
@@ -1312,7 +1317,16 @@ def _clarify_block(sid: str, q, c, multi_select=False, questions=None) -> str:
     if questions:
         wire = [{"qid": e["qid"], "question": e["question"], "choices": e["choices"], "multi_select": bool(e["multi_select"])}
                 for e in questions]
-        return _block("clarify.request", sid, {"questions": wire}, timeout=_clarify_timeout_seconds(),
+        payload = {"questions": wire}
+        if len(wire) == 1:
+            # A one-question batch is semantically identical to a single-question clarify, but a
+            # `questions`-only payload is invisible to renderers that predate the batch shape: the
+            # Hermes-Relay Android client reads only `question`/`choices` and degrades to a bare
+            # "The agent needs clarification" text box, losing the question AND the options. Both key
+            # sets ride along — batch-aware clients keep reading `questions`, simple ones render rows.
+            payload.update(question=wire[0]["question"], choices=wire[0]["choices"],
+                           multi_select=wire[0]["multi_select"])
+        return _block("clarify.request", sid, payload, timeout=_clarify_timeout_seconds(),
                       batch_qids=[e["qid"] for e in questions])
     payload = {"question": q, "choices": c, "multi_select": True} if multi_select else {"question": q, "choices": c}
     return _block("clarify.request", sid, payload, timeout=_clarify_timeout_seconds())


### PR DESCRIPTION
## Problem

A single-question `clarify()` call is emitted as a **batch**. `clarify_tool` always populates `questions=`, so `_clarify_block` takes the batch path even for one question and emits a payload keyed only by `questions`. Clients that predate the batch shape read `question`/`choices` and find neither.

The [Hermes-Relay Android client](https://github.com/Codename-11/hermes-relay) is a concrete consumer. Its `GatewayEventMapper.interactionRequest` reads only `question`, `choices` and `multi_select`, and falls back to the literal string `"The agent needs clarification"` when `question` is absent:

```kotlin
"clarify.request" -> {
    val choices = (payload?.get("choices") as? JsonArray)
        ?.mapNotNull { (it as? JsonPrimitive)?.contentOrNull?.trim() }
        // ...
    GatewayAsk(
        kind = GatewayAsk.Kind.CLARIFY,
        text = payload.string("question") ?: "The agent needs clarification",
        choices = choices,
```

So every single-question prompt renders as that stub plus a bare text box. The question text and all of the tappable options are gone.

**The reply path fails too, and silently.** `_respond` only files an answer under a qid when the client sends `question_id`. Relay never sends one — it answers with `{request_id, answer}`. The bare reply lands in `_answers`, `_block` returns it verbatim, and the batch reader in `clarify_tool` parses that string as a result dict, gets `None`, and reports every answer blank. A user who typed a perfect answer got an empty `user_response` with no `timed_out` flag to explain why.

Net effect on such a client: single-question clarify prompts are both unreadable and unanswerable.

## Fix

Two narrow changes in `tui_gateway/server.py`, both scoped to **single-question batches only**:

1. **Wire shape** — the emitted `clarify.request` payload carries `question`/`choices`/`multi_select` alongside `questions`. Batch-aware clients keep reading `questions`; simple ones now render pickable rows. Multi-question batches are untouched.
2. **Answer path** — a reply with no `question_id` is filed as the sole question's answer instead of being parsed as a batch-result dict and dropped. An empty answer still means cancel, and the qid-addressed path is unchanged.

Purely additive on the wire: no key is removed or renamed, so batch-aware renderers (desktop, TUI) see no behavioural change.

## Tests

New `tests/tui_gateway/test_clarify_single_question_legacy_renderer.py` — 5 tests covering both contracts against the real `tui_gateway.server` bridge, including the multi-question and qid-addressed paths as regression guards.

Verified **red before the fix** (the two failures correspond exactly to the two bugs):

```
FAILED ...::test_single_question_batch_also_carries_the_simple_shape
FAILED ...::test_bare_reply_answers_the_sole_question_instead_of_being_dropped
2 failed, 3 passed
```

Green after, together with the existing clarify and protocol suites:

```
scripts/run_tests.sh \
  tests/tui_gateway/test_clarify_single_question_legacy_renderer.py \
  tests/tui_gateway/test_protocol.py \
  tests/tools/test_clarify_tool.py \
  tests/gateway/test_discord_clarify_buttons.py

=== Summary: 4 files, 129 tests passed, 0 failed ===
```

## Notes

Found while debugging why clarify prompts arrived on Android as an untappable text stub. The gateway change is sufficient on its own — no client update is required for the prompt to render, and no upstream renderer has to learn a new key.
