### PR TITLE
kanban: make the block-loop triage limit configurable

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -95,6 +95,22 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # Same-reason block -> unblock -> re-block cycles before routing to ``triage``.
 # Counts unblock recurrences, NOT dispatcher failures (``DEFAULT_FAILURE_LIMIT``).
 BLOCK_RECURRENCE_LIMIT = 2
+
+
+def block_recurrence_limit() -> int:
+    """``kanban.block_recurrence_limit`` from config, else ``BLOCK_RECURRENCE_LIMIT``.
+
+    ``0`` (or negative) disables the loop breaker: repeated same-cause blocks
+    stay in ``blocked`` instead of routing to ``triage``. For boards where
+    agents resolve every block by comment and no human works triage.
+    """
+    try:
+        from hermes_cli.config import load_config
+        return int((load_config() or {}).get("kanban", {}).get("block_recurrence_limit", BLOCK_RECURRENCE_LIMIT))
+    except Exception:
+        return BLOCK_RECURRENCE_LIMIT
+
+
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 
 
@@ -2964,8 +2980,8 @@ def _route_block(
     recurrences: block_task only fires from running/ready (AFTER an unblock
     returned the task to the pool), so a stored ``block_kind`` equal to the
     incoming one means blocked -> unblocked -> re-block for the same cause
-    (un-typed None compares equal to a prior un-typed block). At
-    ``BLOCK_RECURRENCE_LIMIT`` the task routes to ``triage`` for a human.
+    (un-typed None compares equal to a prior un-typed block). At the
+    configured :func:`block_recurrence_limit` the task routes to ``triage``.
     """
     payload = {"reason": reason, "kind": kind, "source_status": source_status}
     if kind == "dependency":
@@ -2973,8 +2989,9 @@ def _route_block(
     recurrences = prev_recurrences + 1 if prev_kind == kind else 1
     set_sql = "block_kind    = ?,\n                       block_recurrences = ?"
     payload = {"reason": reason, "kind": kind, "recurrences": recurrences, "source_status": source_status}
-    if recurrences >= BLOCK_RECURRENCE_LIMIT:
-        payload["limit"] = BLOCK_RECURRENCE_LIMIT
+    limit = block_recurrence_limit()
+    if limit > 0 and recurrences >= limit:
+        payload["limit"] = limit
         return "triage", "block_loop_detected", set_sql, (kind, recurrences), payload
     return "blocked", "blocked", set_sql, (kind, recurrences), payload
 

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -79,6 +79,51 @@ def test_block_loop_detected_event_emitted(kanban_home: Path) -> None:
         assert payload.get("kind") == "capability"
 
 
+def test_block_recurrence_limit_zero_never_routes_to_triage(kanban_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``kanban.block_recurrence_limit: 0`` keeps every same-cause re-block in ``blocked``."""
+    monkeypatch.setattr(kb, "block_recurrence_limit", lambda: 0)
+    with kbc.connect_closing() as conn:
+        tid = _running_task(conn)
+        for _ in range(5):
+            kb.block_task(conn, tid, reason="x", kind="needs_input")
+            assert kb.get_task(conn, tid).status == "blocked"
+            kb.unblock_task(conn, tid)
+            _make_running_again(conn, tid)
+        kb.block_task(conn, tid, reason="x", kind="needs_input")
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_recurrences == 6
+        assert not [e for e in kb.list_events(conn, tid) if e.kind == "block_loop_detected"]
+
+
+def test_block_recurrence_limit_configured_value(kanban_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A configured limit replaces the default of 2."""
+    monkeypatch.setattr(kb, "block_recurrence_limit", lambda: 3)
+    with kbc.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="x", kind="capability")
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+        kb.block_task(conn, tid, reason="x", kind="capability")
+        assert kb.get_task(conn, tid).status == "blocked"
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+        kb.block_task(conn, tid, reason="x", kind="capability")
+        assert kb.get_task(conn, tid).status == "triage"
+        payload = [e for e in kb.list_events(conn, tid) if e.kind == "block_loop_detected"][-1].payload or {}
+        assert payload.get("limit") == 3
+
+
+def test_block_recurrence_limit_reads_config(kanban_home: Path) -> None:
+    """The helper reads ``kanban.block_recurrence_limit`` and falls back to the default."""
+    for text, expected in (("kanban:\n  block_recurrence_limit: 0\n", 0),
+                           ("kanban:\n  block_recurrence_limit: 7\n", 7),
+                           ("kanban: {}\n", kb.BLOCK_RECURRENCE_LIMIT),
+                           ("kanban:\n  block_recurrence_limit: null\n", kb.BLOCK_RECURRENCE_LIMIT)):
+        (kanban_home / "config.yaml").write_text(text)
+        assert kb.block_recurrence_limit() == expected
+
+
 # ---------------------------------------------------------------------------
 # Dependency routing
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -282,6 +282,11 @@ kanban:
   review_dispatch: true            # default: spawn the assigned profile with
                                    # the bundled sdlc-review skill. Set false
                                    # for human-only review boards.
+  block_recurrence_limit: 2        # default: same-cause block -> unblock ->
+                                   # re-block cycles before a task routes to
+                                   # triage for a human. Set 0 to disable on
+                                   # agent-to-agent boards where blocks are
+                                   # always resolved by comment.
 ```
 
 Override the config flag at runtime via `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0`


### PR DESCRIPTION
## What

Adds `kanban.block_recurrence_limit` (default `2`, behavior unchanged). Setting it to `0` (or negative) disables the loop breaker that routes a task to `triage` after repeated same-cause blocks.

## Why

On a fully agent-to-agent board, a worker's `needs_input` block is answered by an operator comment and unblocked by another agent. Nobody works the triage column, so a task that asks two questions in a row gets parked there and nothing can resume it (`unblock` and `promote` both refuse `triage`). A configurable limit lets those boards keep the loop breaker off while the default protects everyone else.

## Changes

- `hermes_cli/kanban_db.py`: `block_recurrence_limit()` reads the config key with the same shape as `review_dispatch_enabled()`; `_route_block` uses it.
- `tests/hermes_cli/test_kanban_block_kinds.py`: disabled limit never routes to triage; a custom limit routes at that value; config parsing and fallback.
- `website/docs/user-guide/features/kanban.md`: config example.

`pytest tests/hermes_cli/test_kanban_block_kinds.py` passes.

https://claude.ai/code/session_01Ksmv3KHyXkfciLggETHdJB