### PR TITLE
fix(agent): drop kimi-coding from vision skip list — /coding accepts images again

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -811,8 +811,12 @@ def _resolve_provider_vision_default(provider: str) -> Optional[str]:
 
 
 # Endpoints that reject image input: vision auto-detect skips these to the aggregator chain
-# instead of returning a client that 404s (Kimi Coding Plan Anthropic wire has no image_in).
-_PROVIDERS_WITHOUT_VISION: frozenset = frozenset({"kimi-coding", "kimi-coding-cn"})
+# instead of returning a client that 404s. Currently empty: the Kimi Coding Plan /coding wire
+# accepts Anthropic-format image blocks again (the /v1/models entry declares supports_image_in
+# and a live request returns a correct image description, verified 2026-09-10), so the
+# kimi-coding / kimi-coding-cn entries added for #17076 were removed. Only re-add a provider
+# here with evidence its endpoint rejects image input.
+_PROVIDERS_WITHOUT_VISION: frozenset = frozenset()
 
 # OpenRouter app attribution (always sent). `X-Title` is what the dashboard reads.
 _OR_HEADERS_BASE = {

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3355,61 +3355,18 @@ class TestCodexAdapterGithubResponsesMessageIdDrop:
         assert message_item["id"] == "msg_short_but_connection_scoped"
 
 
-class TestVisionAutoSkipsKimiCoding:
-    """_resolve_auto_route vision branch skips providers that have no vision on
-    their main endpoint (e.g. Kimi Coding Plan /coding) and falls through
-    to the aggregator chain instead of handing back a client that will 404
-    on every request (#17076).
+class TestProvidersWithoutVisionSkipList:
+    """The skip list exists so providers whose main endpoint rejects image
+    input fall through to the aggregator chain instead of handing back a
+    client that 404s (#17076). It is currently empty: the Kimi Coding Plan
+    /coding wire accepts Anthropic-format image blocks again (verified
+    2026-09-10 against the live endpoint), so its entries were removed.
     """
 
-    def test_kimi_coding_skipped_falls_through_to_openrouter(self, monkeypatch):
-        """kimi-coding as main + vision auto → OpenRouter (not kimi)."""
-        fake_or_client = MagicMock(name="openrouter_client")
-
-        monkeypatch.setattr(
-            "agent.auxiliary_client._read_main_provider", lambda: "kimi-coding",
-        )
-        monkeypatch.setattr(
-            "agent.auxiliary_client._read_main_model", lambda: "kimi-code",
-        )
-        # Guard: if the skip doesn't fire, _resolve_strict_vision_backend
-        # and resolve_provider_client both would try kimi-coding — detect
-        # either via the main-provider call and fail loud.
-        rpc_mock = MagicMock(side_effect=AssertionError(
-            "resolve_provider_client should NOT be called for kimi-coding "
-            "on the vision auto path"))
-        monkeypatch.setattr(
-            "agent.auxiliary_client.resolve_provider_client", rpc_mock,
-        )
-
-        def fake_strict(provider, model=None):
-            if provider == "openrouter":
-                return fake_or_client, "google/gemini-3-flash-preview"
-            if provider == "nous":
-                return None, None
-            raise AssertionError(
-                f"strict vision backend should not be called for {provider!r} "
-                "when main provider is kimi-coding"
-            )
-        monkeypatch.setattr(
-            "agent.auxiliary_client._resolve_strict_vision_backend",
-            fake_strict,
-        )
-
-        provider, client, model = resolve_vision_provider_client()
-        assert provider == "openrouter"
-        assert client is fake_or_client
-        assert model == "google/gemini-3-flash-preview"
-
-
-
-    def test_skip_set_covers_exactly_known_entries(self):
-        """Guard against accidental widening of the skip list."""
+    def test_skip_set_is_empty(self):
+        """Guard: re-add an entry only with evidence the endpoint rejects images."""
         from agent.auxiliary_client import _PROVIDERS_WITHOUT_VISION
-        assert _PROVIDERS_WITHOUT_VISION == frozenset({
-            "kimi-coding",
-            "kimi-coding-cn",
-        })
+        assert _PROVIDERS_WITHOUT_VISION == frozenset()
 
 
 class TestCodexAuxiliaryAdapterTimeout:


### PR DESCRIPTION
## What & why

`_PROVIDERS_WITHOUT_VISION` still contains `kimi-coding` / `kimi-coding-cn`, added in #17451 (fixing #17076) back when the Kimi Coding Plan `/coding` endpoint rejected image input and every vision request 404'd.

That premise no longer holds: the endpoint accepts Anthropic-format image blocks now. With the entries still in the list, kimi-coding users get the opposite failure — `vision_analyze` / the vision auto-detector answers `No LLM provider configured for task=vision` when no aggregator keys (OpenRouter/Nous/…) are configured, even though the user's main model is vision-capable. The stale skip also hides the endpoint's native vision behind the aggregator chain for users who do have keys.

## Evidence (live endpoint, verified 2026-09-10)

- `GET https://api.kimi.com/coding/v1/models` declares `supports_image_in: true` (and `supports_video_in: true`) on the `k3` and `kimi-for-coding` entries
- `POST /v1/messages` with an Anthropic-format base64 PNG block (`model: k3`) returns a correct natural-language description of the image (HTTP 200)

## How to test

1. Configure a kimi-coding key as the main provider, no OpenRouter/Nous keys
2. Before: any image analysis errors with `No LLM provider configured for task=vision provider=auto`
3. After this change: the image is passed to the kimi-coding endpoint natively and analyzed

`uv run --dev pytest tests/agent/test_auxiliary_client.py` → 203 passed (the obsolete fall-through test was removed; the guard test now pins the set to empty).

## Platforms

macOS (arm64); change is platform-independent (a frozenset literal + test updates).

Related: #17076, #17451