### PR TITLE
fix(desktop): commit Quick Entry route before submitting

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.tsx
@@ -1,0 +1,144 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { useRef } from 'react'
+import { HashRouter, useLocation, useNavigate } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { NEW_CHAT_ROUTE, sessionRoute } from '@/app/routes'
+import { routeTargetFromToken, sessionContextDrift } from '@/app/session/hooks/session-context-drift'
+
+import { useQuickEntryBridge } from './use-quick-entry-bridge'
+
+const bridge = vi.hoisted(() => ({
+  handler: null as null | ((payload: { target: string; text: string }) => void)
+}))
+
+vi.mock('@/store/quick-entry', () => ({
+  QUICK_TARGET_CURRENT: 'current',
+  QUICK_TARGET_NEW: 'new',
+  initQuickEntryBridge: () => () => undefined,
+  setQuickEntrySubmitHandler: (fn: typeof bridge.handler) => {
+    bridge.handler = fn
+  }
+}))
+vi.mock('@/store/session', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $gatewayState: atom('open'), $sessions: atom([]) }
+})
+vi.mock('@/store/session-states', () => ({
+  sessionTileDelegate: () => null
+}))
+vi.mock('@/store/windows', () => ({ isAuxiliaryWindow: () => false }))
+vi.mock('@/components/pane-shell/tree/store', () => ({ noteActiveTreeGroup: vi.fn(), revealTreePane: vi.fn() }))
+vi.mock('@/contrib/registry', () => ({ registry: { getArea: () => [] } }))
+
+interface Pending {
+  startRoute: string
+  text: string
+  finish: () => void
+}
+
+// Real React + the same HashRouter mode as main.tsx; the backend round-trip
+// is deferred. The route-ref publication and drift guard match ContribWiring
+// and createBackendSessionForSend rather than mocking flushSync or navigation.
+function mountHarness(initial = 'old-session') {
+  window.history.replaceState(null, '', `#${sessionRoute(initial)}`)
+  const pending: Pending[] = []
+  const sent: string[] = []
+  const aborted: string[] = []
+
+  let navigateTo = (_path: string) => {}
+
+  function Harness() {
+    const location = useLocation()
+    const navigate = useNavigate()
+    navigateTo = navigate
+    const routeRef = useRef('')
+    routeRef.current = `${location.pathname}:${location.search}:${location.hash}`
+    const selectedRef = useRef<string | null>(initial)
+
+    useQuickEntryBridge({
+      startFreshSessionDraft: () => {
+        navigate(NEW_CHAT_ROUTE)
+        selectedRef.current = null
+      },
+      submitText: async text => {
+        const startRoute = routeRef.current
+        const startSelected = selectedRef.current
+        await new Promise<void>(finish => pending.push({ startRoute, text, finish }))
+
+        const drift = sessionContextDrift({
+          startRouteToken: startRoute,
+          nowRouteToken: routeRef.current,
+          startSelectedStoredId: startSelected,
+          nowSelectedStoredId: selectedRef.current
+        })
+
+        if (drift) {
+          aborted.push(drift)
+
+          return false
+        }
+
+        sent.push(text)
+        selectedRef.current = `created-${sent.length}`
+        navigate(sessionRoute(selectedRef.current))
+
+        return true
+      }
+    })
+
+    return null
+  }
+
+  render(
+    <HashRouter useTransitions={false}>
+      <Harness />
+    </HashRouter>
+  )
+
+  return { pending, sent, aborted, navigate: (path: string) => navigateTo(path) }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+afterEach(() => {
+  cleanup()
+  bridge.handler = null
+})
+
+describe('Quick Entry new-chat route handoff', () => {
+  it('repeated quick entries each submit once after transitioning away from the previous chat', async () => {
+    const h = mountHarness()
+
+    for (const text of ['one', 'two', 'three']) {
+      await act(async () => {
+        bridge.handler!({ target: 'new', text })
+      })
+      expect(routeTargetFromToken(h.pending.at(-1)!.startRoute)).toBe('__new__')
+      await act(async () => {
+        h.pending.at(-1)!.finish()
+      })
+    }
+
+    expect(h.sent).toEqual(['one', 'two', 'three'])
+    expect(h.pending).toHaveLength(3)
+    expect(h.aborted).toEqual([])
+  })
+
+  it('still aborts if the user changes to another chat during the backend round-trip', async () => {
+    const h = mountHarness()
+    await act(async () => {
+      bridge.handler!({ target: 'new', text: 'do not misroute' })
+    })
+    await act(async () => {
+      h.navigate(sessionRoute('unrelated-session'))
+    })
+    await act(async () => {
+      h.pending[0].finish()
+    })
+    expect(h.sent).toEqual([])
+    expect(h.aborted).toEqual(['route:__new__->unrelated-session'])
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { flushSync } from 'react-dom'
 
 import {
   initQuickEntryBridge,
@@ -65,7 +66,10 @@ export function useQuickEntryBridge({ startFreshSessionDraft, submitText }: Quic
       if (target === QUICK_TARGET_NEW) {
         // Same as the user clicking New Chat and typing: fresh draft, then the
         // normal submit creates the backend session.
-        startFreshRef.current()
+        // IPC delivers both actions in one task. Commit the fresh route before
+        // submit snapshots the route refs, or our own navigation looks like a
+        // user switch and the session-context drift guard aborts the first send.
+        flushSync(() => startFreshRef.current())
         void submitTextRef.current(text)
 
         return


### PR DESCRIPTION
## What does this PR do?

Fix the Quick Entry **New session** route-publication race with a narrow change to the existing renderer bridge.

Quick Entry delivers `startFreshSessionDraft()` and `submitText()` in the same IPC task. The draft callback resets session refs synchronously, but React has not necessarily committed the new route when submission snapshots `getRouteToken()`. Once navigation commits, the normal session-context guard observes `route:<previous-session>->__new__`, closes the newly created runtime, and aborts before the prompt is persisted. This was reproduced in a macOS desktop client connected to a remote backend, and in a deterministic React/HashRouter regression test on current main.

Wrap the existing fresh-draft callback in `flushSync`, then read and invoke the current submit callback. The app's `HashRouter` already uses `useTransitions={false}`. The route and render-published refs are therefore committed before submission captures its context. No timeout, new RPC, alternate submission pipeline, or drift-guard exemption is introduced.

## Related Issue

Addresses the **New session race portion** of #85590. It does not claim to fix that issue's separate geometry, focus, or delivery-acknowledgement concerns.

**Overlap disclosed:** #89920 also addresses this race as part of a substantially broader Quick Entry acknowledgement/atomic-submission change. This PR is a minimal alternative for the currently reproducible route race, preserving the existing submit pipeline and guard. It can be considered independently of the broader UX/protocol changes. The existing PR and issue were inspected before submission.

## Type of Change

- [x] Bug fix

## Changes Made

- `apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.ts`: flush the fresh route before submitting a New session prompt.
- `apps/desktop/src/app/contrib/hooks/use-quick-entry-bridge.test.tsx`: two invariant tests using the actual bridge hook, React, HashRouter, and production `sessionContextDrift`, with a deferred backend boundary. Cover repeated new-chat submission and preserved abort behavior for genuine user navigation during the request.

Current chat remains the upstream default. No target-selection preference, server code, authentication, configuration, or dependency changes are included.

## How to Test

1. Run Desktop with an existing conversation selected.
2. Open Quick Entry, explicitly select **New session**, and submit a prompt.
3. Repeat after each newly created conversation becomes the current route.
4. Verify each prompt creates a usable conversation rather than logging `[submit-drift-abort] route:<previous-session>->__new__`.
5. Verify genuine navigation to another conversation during an in-flight create still aborts rather than misrouting the prompt.

Automated validation from `apps/desktop`:

```sh
node --max-old-space-size=512 ../../node_modules/vitest/vitest.mjs run --project ui \
  src/app/contrib/hooks/use-quick-entry-bridge.test.tsx \
  src/store/quick-entry.test.ts \
  src/app/session/hooks/session-context-drift.test.ts \
  src/app/session/hooks/use-route-resume.test.tsx \
  src/app/session/hooks/use-session-actions.test.tsx \
  src/app/session/hooks/use-prompt-actions/index.test.tsx \
  --maxWorkers=1
```

**Results:** 282 tests passed across six files. Both new tests were separately observed failing on the unmodified upstream implementation, then passing with the fix. Targeted ESLint (`--max-warnings=0`), Prettier, and `git diff --check` passed. The Windows-footgun checker found no applicable Python files in this TypeScript-only change.

**Platforms and limits:** Linux ARM64, Node 22.22.0, React/jsdom tests with the production router mode. The original failure was reported on macOS 26.5.1 ARM64 with Electron 40.10.2 and a remote backend. Native Mac validation of the patched app was confirmed working by the author. The test defers the backend boundary; it does not launch Electron or make live model calls. The full repository Python/desktop test suites and a full app build/typecheck were not run on the shared service host.

## Checklist

- [x] Read CONTRIBUTING.md, root and Desktop AGENTS.md, and the PR template
- [x] Conventional Commit message
- [x] Searched existing PRs/issues; overlap is explicitly disclosed above
- [x] Only changes related to this race
- [x] Added invariant regression tests, observed red on upstream
- [x] Targeted tests and lint passed
- [ ] Full `pytest tests/ -q` suite (not run; TypeScript-only change)
- [x] Native Mac retest of the patched app (confirmed working by the author)
- [x] Considered cross-platform impact: renderer-only React API, no OS-specific branch
- [x] Documentation/config/tool-schema updates: N/A, no public contract or configuration changes
