### PR TITLE
fix(state): sum lineage costs in _project_compression_tips and include continuations in usage_totals

### DIFF
--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -954,7 +954,8 @@ class SessionSessionsMixin:
     def _project_compression_tips(self, sessions: List[Dict[str, Any]], compact_rows: bool) -> List[Dict[str, Any]]:
         """Replace each compression root's surfaced fields with its live tip's (root ``started_at`` kept
         for stable ordering), one batched query. ``_lineage_ids`` carries every chain id (a tile may
-        hold a MIDDLE segment's id)."""
+        hold a MIDDLE segment's id).  Cost is summed across the whole lineage so the projected row
+        shows total spend, not the root's frozen-at-rotation snapshot (#105535)."""
         chain_by_root: Dict[str, List[str]] = {}  # only roots whose tip differs from themselves
         for s in sessions:
             if s.get("end_reason") == "compression":
@@ -966,6 +967,22 @@ class SessionSessionsMixin:
                 {chain[-1] for chain in chain_by_root.values()}, compact_rows=compact_rows,
             ) if chain_by_root else {}
         )
+        # Batch-query lineage cost sums: one query covering all chain member IDs.
+        lineage_cost: Dict[str, float] = {}
+        if chain_by_root:
+            all_chain_ids: set[str] = set()
+            for chain in chain_by_root.values():
+                all_chain_ids.update(chain)
+            if all_chain_ids:
+                placeholders = ",".join("?" for _ in all_chain_ids)
+                cost_rows = self._read_all(
+                    f"SELECT id, COALESCE(actual_cost_usd, estimated_cost_usd, 0) AS cost"
+                    f" FROM sessions WHERE id IN ({placeholders})",
+                    list(all_chain_ids),
+                )
+                cost_by_id = {r["id"]: float(r["cost"] or 0) for r in cost_rows}
+                for root_id, chain in chain_by_root.items():
+                    lineage_cost[root_id] = sum(cost_by_id.get(cid, 0) for cid in chain)
         projected = []
         for s in sessions:
             chain = chain_by_root.get(s["id"])
@@ -985,10 +1002,17 @@ class SessionSessionsMixin:
                 # between leaves it on the ended root, and exact-title lookups (`hermes peer dm` ->
                 # canonical "Bot Chat") must still see the lineage under its name (#106165).
                 merged["title"] = s.get("title")
+            # Project lineage-summed cost so the sidebar row shows total spend, not the
+            # root's frozen snapshot.  Clear actual_cost_usd so consumers reading
+            # COALESCE(actual, estimated) see the sum.
+            if s["id"] in lineage_cost:
+                merged["estimated_cost_usd"] = lineage_cost[s["id"]]
+                merged["actual_cost_usd"] = None
             merged["_lineage_root_id"] = s["id"]
             merged["_lineage_ids"] = chain
             projected.append(merged)
         return projected
+
 
     def list_recent_sessions_bounded(
         self,

--- a/hermes_state_usage.py
+++ b/hermes_state_usage.py
@@ -386,8 +386,13 @@ class SessionUsageMixin:
 
     def usage_totals(self, *, min_message_count: int = 1, include_archived: bool = False) -> Dict[str, float]:
         """Tokens and spend across the whole store (one scan), so the sidebar total does not
-        shrink with paging. Spend prefers the billed figure over the estimate."""
-        where = ["parent_session_id IS NULL", "message_count >= ?"]
+        shrink with paging. Spend prefers the billed figure over the estimate.
+
+        Pre-#105535 this filtered ``parent_session_id IS NULL`` which excluded every
+        post-compression segment (and branch/reset children).  Now counts all non-delegate,
+        non-archived rows with messages, so compression continuations contribute."""
+        from hermes_state_sessions import _delegate_from_json
+        where = [f"{_delegate_from_json()} IS NULL", "message_count >= ?"]
         params: List[Any] = [min_message_count]
         if not include_archived:
             where.append("COALESCE(archived, 0) = 0")
@@ -398,3 +403,4 @@ class SessionUsageMixin:
              WHERE {' AND '.join(where)}
             """, params)
         return {"tokens": int(row[0] or 0), "cost_usd": float(row[1] or 0.0)}
+

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1724,6 +1724,66 @@ class TestSessionTitleLineage:
         assert [(r["id"], r["title"]) for r in rows] == [("tip", "renamed tip")]
 
 
+class TestCompressionCostLineage:
+    """Verify that compressed conversations correctly sum and project cost across the
+    entire lineage chain, and that usage_totals counts post-compression segments (#105535)."""
+
+    def _make_three_tier_chain(self, db, t0):
+        import json
+        # Root session
+        db.create_session("root", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, ended_at=?, end_reason='compression', "
+            "message_count=10, input_tokens=800, output_tokens=200, estimated_cost_usd=0.05, actual_cost_usd=0.04 WHERE id='root'",
+            (t0, t0 + 100),
+        )
+        # Middle session
+        db.create_session("middle", "cli", parent_session_id="root")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, ended_at=?, end_reason='compression', "
+            "message_count=5, input_tokens=400, output_tokens=100, estimated_cost_usd=0.03, actual_cost_usd=0.03 WHERE id='middle'",
+            (t0 + 200, t0 + 300),
+        )
+        # Tip session
+        db.create_session("tip", "cli", parent_session_id="middle")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, message_count=3, input_tokens=250, output_tokens=50, "
+            "estimated_cost_usd=0.02, actual_cost_usd=NULL WHERE id='tip'",
+            (t0 + 400,),
+        )
+        # Subagent delegate session (should be excluded by usage_totals)
+        db.create_session("delegate", "cli", parent_session_id="root")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, message_count=2, input_tokens=150, output_tokens=50, "
+            "estimated_cost_usd=0.01, model_config=? WHERE id='delegate'",
+            (t0 + 50, json.dumps({"_delegate_from": "root"})),
+        )
+        db._conn.commit()
+
+    def test_projected_tip_sums_lineage_costs(self, db):
+        import time as _time
+        self._make_three_tier_chain(db, _time.time() - 3600)
+
+        rows = db.list_sessions_rich(limit=50, order_by_last_active=True)
+        # Root is projected onto tip; delegate has parent_session_id and isn't a root, so only the projected chain root shows
+        matching = [r for r in rows if r["_lineage_root_id"] == "root"]
+        assert len(matching) == 1
+        merged = matching[0]
+        assert merged["id"] == "tip"
+        # Total cost is 0.04 (root actual) + 0.03 (middle actual) + 0.02 (tip estimated) = 0.09
+        assert merged["estimated_cost_usd"] == pytest.approx(0.09)
+        assert merged["actual_cost_usd"] is None
+
+    def test_usage_totals_includes_compression_continuations(self, db):
+        import time as _time
+        self._make_three_tier_chain(db, _time.time() - 3600)
+
+        totals = db.usage_totals(min_message_count=1)
+        # Tokens: root(1000) + middle(500) + tip(300) = 1800 (delegate 200 is excluded)
+        assert totals["tokens"] == 1800
+        # Cost: root(0.04) + middle(0.03) + tip(0.02) = 0.09 (delegate 0.01 is excluded)
+        assert totals["cost_usd"] == pytest.approx(0.09)
+
 
 class TestSanitizeTitle:
     """Tests for SessionDB.sanitize_title() validation and cleaning."""


### PR DESCRIPTION
## What does this PR do?

Fixes two cost-accounting bugs on conversations that undergo context compaction (`/compress`):
1. **Per-row projection:** `_project_compression_tips` in `hermes_state_sessions.py` copied message count, active timestamp, title, etc., from the tip row to the root row, but omitted cost fields (`estimated_cost_usd`, `actual_cost_usd`). The UI/picker row retained the root's snapshot value from rotation time, never updating as subsequent turns accrued cost on continuation segments.
2. **Store-wide usage totals:** `usage_totals` in `hermes_state_usage.py` filtered rows with `parent_session_id IS NULL`. This legacy roots-only filter excluded all post-compression segments (as well as branch/reset child sessions) from global token and spend totals.

## Related Issue

Fixes #105535

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`hermes_state_sessions.py` (`SessionSessionsMixin._project_compression_tips`):** Added a batched query calculating `COALESCE(actual_cost_usd, estimated_cost_usd, 0)` across all segments in each compression lineage chain. Projected the summed lineage cost onto `estimated_cost_usd` with `actual_cost_usd = None` on the merged root row so that `COALESCE(actual, estimated)` displays the true total lineage spend.
- **`hermes_state_usage.py` (`SessionUsageMixin.usage_totals`):** Replaced `parent_session_id IS NULL` with `_delegate_from_json() IS NULL` so that subagent delegate runs remain excluded while all compression continuations, branch children, and reset children are counted towards total tokens and spend.
- **`tests/test_hermes_state.py` (`TestCompressionCostLineage`):** Added unit test coverage for multi-tier compression chains (root -> middle -> tip) asserting that `list_sessions_rich` accurately sums lineage cost and `usage_totals` includes post-compression segments while filtering out delegate runs.

## How to Test

1. Run the targeted test suite:
   ```bash
   python -m pytest tests/test_hermes_state.py -k "TestCompressionCostLineage" -v
   ```
2. Verify full state suite passes:
   ```bash
   python -m pytest tests/test_hermes_state.py -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
tests/test_hermes_state.py::TestCompressionCostLineage::test_projected_tip_sums_lineage_costs PASSED [ 50%]
tests/test_hermes_state.py::TestCompressionCostLineage::test_usage_totals_includes_compression_continuations PASSED [100%]

================= 264 passed, 2 skipped in 197.61s (0:03:17) ==================
```
