### PR TITLE
fix(tools): hosted OCR resolves FIRECRAWL_API_KEY through the profile secret scope

### DIFF
--- a/tests/tools/test_read_extract_secret_scope.py
+++ b/tests/tools/test_read_extract_secret_scope.py
@@ -1,0 +1,77 @@
+"""Hosted OCR resolves its credential through the profile secret scope.
+
+The desktop cron ticker installs a profile secret scope WITHOUT the multiplex flag
+(``cron/scheduler.py`` builds the scope per job; ``set_multiplex_active`` is only set by a
+multiplexing gateway and the external worker), so a raw ``os.environ`` read resolves the
+launch profile's key for a routed profile's job.
+"""
+
+import pytest
+
+from agent.secret_scope import (UnscopedSecretError, build_profile_secret_scope,
+                                reset_secret_scope, set_multiplex_active, set_secret_scope)
+from hermes_cli.env_loader import hydrate_profile_secret_sources
+
+
+def _routed_home(tmp_path, monkeypatch, key="company-ZZZZ"):
+    """A routed profile home whose .env key differs from the launch profile's os.environ one."""
+    home = tmp_path / "routed"
+    home.mkdir()
+    (home / ".env").write_text(f"FIRECRAWL_API_KEY={key}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "personal-AAAA")
+    return home
+
+
+def test_hosted_ocr_uses_routed_scope_without_the_multiplex_flag(tmp_path, monkeypatch):
+    """The desktop-ticker shape: scope installed, multiplex flag off."""
+    home = _routed_home(tmp_path, monkeypatch)
+    hydrate_profile_secret_sources(home)
+    token = set_secret_scope(build_profile_secret_scope(home))
+    try:
+        from tools import read_extract
+        assert read_extract._hosted_ocr_config() == (True, "company-ZZZZ", None)
+    finally:
+        reset_secret_scope(token)
+
+
+def test_hosted_ocr_uses_routed_scope_under_multiplex(tmp_path, monkeypatch):
+    """The multiplexing gateway shape: scope installed, flag on."""
+    home = _routed_home(tmp_path, monkeypatch)
+    hydrate_profile_secret_sources(home)
+    set_multiplex_active(True)
+    token = set_secret_scope(build_profile_secret_scope(home))
+    try:
+        from tools import read_extract
+        assert read_extract._hosted_ocr_config() == (True, "company-ZZZZ", None)
+    finally:
+        reset_secret_scope(token)
+        set_multiplex_active(False)
+
+
+def test_hosted_ocr_keeps_single_profile_environment_fallback(monkeypatch):
+    """No scope, no multiplex: the process env stays the source (systemd / ``op run`` installs)."""
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "personal-AAAA")
+    token = set_secret_scope(None)
+    try:
+        from tools import read_extract
+        assert read_extract._hosted_ocr_config() == (True, "personal-AAAA", None)
+    finally:
+        reset_secret_scope(token)
+
+
+def test_hosted_ocr_probe_survives_the_multiplex_fail_closed_path(monkeypatch):
+    """Boot-time check_fns run before any scope exists; the probe reports unavailable, never raises."""
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "personal-AAAA")
+    set_multiplex_active(True)
+    token = set_secret_scope(None)
+    try:
+        from agent.secret_scope import get_secret
+        with pytest.raises(UnscopedSecretError):
+            get_secret("FIRECRAWL_API_KEY", "")
+        from tools import read_extract
+        assert read_extract._hosted_ocr_config() == (False, None, None)
+        assert read_extract.hosted_ocr_available() is False
+    finally:
+        reset_secret_scope(token)
+        set_multiplex_active(False)

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -147,7 +147,15 @@ def _hosted_ocr_config() -> tuple:
     is a direct ``FIRECRAWL_API_KEY`` (anydoc defaults api_url); the Nous gateway's Parse proxy
     live-probed broken, so it is NOT used. ``file_tools.hosted_ocr: false`` disables even with a
     key."""
-    api_key = os.environ.get("FIRECRAWL_API_KEY") or None
+    # Profile-scoped, like every other tool credential: a cron job ticked for a routed profile
+    # resolves ITS key, never the launch profile's os.environ value. UnscopedSecretError is the
+    # multiplex fail-closed probe (registry.py runs check_fns before any scope exists) and keeps
+    # this "never raises" — the tool re-probes on the first scoped turn.
+    from agent.secret_scope import UnscopedSecretError, get_secret
+    try:
+        api_key = get_secret("FIRECRAWL_API_KEY", "") or None
+    except UnscopedSecretError:
+        api_key = None
     enabled = api_key is not None
     with contextlib.suppress(Exception):
         from hermes_cli.config import load_config_readonly


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/NousResearch/hermes-agent/issues/107692
`tools/read_extract.py::_hosted_ocr_config()` resolved its Firecrawl credential with a raw

```python
api_key = os.environ.get("FIRECRAWL_API_KEY") or None
```

It is the only tool credential left in `tools/` that bypasses `agent.secret_scope.get_secret()`. Every sibling already goes through it — `discord_tool.py:52`, `homeassistant_tool.py:23-24`, `browser_camofox.py:61,67`, `send_message_tool.py:342-349`, `skills_hub_github.py:101,117`, `cronjob_tools.py:130`, `managed_tool_gateway.py:75`, `openrouter_client.py:15`, `terminal_tool_backends.py:243`.

That matters because a routed profile's credentials deliberately live **only** in its secret scope. `agent/secret_scope.py`'s module docstring states the rule outright: a multiplexing process "**cannot** be unioned into `os.environ` (profile A's keys would leak into profile B's turns and subprocesses)". The desktop cron ticker installs such a scope per job (`cron/scheduler.py`, `hydrate_profile_secret_sources` + `set_secret_scope(build_profile_secret_scope(...))`), and a multiplexing gateway does the same per turn.

So under a scope the routed key is reachable via `get_secret`, while this function reads the **launch** profile's value out of the shared process env.

### Reproduction

Real imports on `main` (`6c3d4a4af7`), a temp `HERMES_HOME` with two profiles, the scope installed exactly the way cron installs it:

```
multiplex_active   = False
get_secret         = company-ZZZZ      <- the routed profile's key
_hosted_ocr_config = (True, 'personal-AAAA', None)   <- the LAUNCH profile's key
```

**Impact.** A secondary profile's cron job or turn runs hosted OCR under another profile's Firecrawl identity — wrong account, wrong billing, a credential used by an agent the operator did not select for it. The mirror case is just as bad: when the launch profile has no key and the routed one does, `hosted_ocr_available()` reports OCR unavailable and `read_file` silently degrades to `[NEEDS OCR]` for a profile that paid for the key.

## The fix

```python
from agent.secret_scope import UnscopedSecretError, get_secret
try:
    api_key = get_secret("FIRECRAWL_API_KEY", "") or None
except UnscopedSecretError:
    api_key = None
```

Two details that are load-bearing rather than stylistic:

- **`UnscopedSecretError` is caught narrowly, not `Exception`.** It is not an incidental error — it is the multiplex fail-closed probe that `tools/registry.py:275-279` already documents and expects ("boot-time check_fns run before any profile secret scope exists, so get_secret raises by design"). Catching exactly it preserves the function's documented *"never raises, no network"* contract, which is required because `tools/file_tools.py:1243` calls `hosted_ocr_available()` at schema-build time.
- **The `""` default keeps the single-profile fallback.** `get_secret` is an overlay, not a blindfold: with no scope and multiplex inactive it reads `os.environ`, so systemd / `op run` style installs that inject the key into the process env are unaffected.

### Scope, deliberately narrow

I checked the neighbouring raw reads rather than sweeping them in:

| Path | Verdict |
|---|---|
| `tools/web_tools.py:35` `_env_value()` | Already scope-aware — it goes through `hermes_cli.config.get_env_value()`. No change. |
| anydoc's own `os.environ.get("FIRECRAWL_API_KEY")` fallback | Unreachable from Hermes: `read_extract.py:195` passes the resolved `api_key` explicitly. No change. |

## Related Issue

Sibling of #107692 (desktop cron ticker / profile credential isolation), and a case of exactly the class its PR #107695 calls out and explicitly leaves for its own issue:

> "Reads that bypass `get_secret` no longer resolve for a ticked secondary profile ... They deserve their own issues"

**This PR does not touch `hermes_cli/env_loader.py`'s suppression guard or #107695's scheduler hydration ordering** — the two files that PR changes. It is complementary, not competing, and the two can merge in either order. This defect is independently reproducible today with any profile secret scope, including a plain multiplexing gateway, so it does not depend on #107695 landing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `tools/read_extract.py` — `_hosted_ocr_config()` resolves through `get_secret`, catching only `UnscopedSecretError`, with the reasoning (and the schema-build-time caller that forbids raising) in the comment.
- `tests/tools/test_read_extract_secret_scope.py` — four behaviour contracts, no snapshots, no source reading.

## How to Test

`scripts/run_tests.sh tests/tools/test_read_extract_secret_scope.py tests/tools/test_read_extract.py` → **57 passed** (2 files).

The four new tests pin both directions of the guard:

| Test | Contract |
|---|---|
| `..._routed_scope_without_the_multiplex_flag` | The desktop-ticker shape — scope installed, flag **off** — resolves the routed key. |
| `..._routed_scope_under_multiplex` | The multiplexing-gateway shape — scope installed, flag **on** — resolves the routed key. |
| `..._keeps_single_profile_environment_fallback` | No scope, no multiplex: `os.environ` still wins, so systemd / `op run` installs keep working. |
| `..._probe_survives_the_multiplex_fail_closed_path` | Multiplex on with no scope: the probe reports unavailable and does **not** raise (the `file_tools` schema-build path). |

**Proven RED**, reverting only `tools/read_extract.py` and keeping the tests:

```
FAILED ..._routed_scope_without_the_multiplex_flag
FAILED ..._routed_scope_under_multiplex
FAILED ..._probe_survives_the_multiplex_fail_closed_path
3 failed, 1 passed
```

with `AssertionError: assert (True, 'personal-AAAA', None) == (True, 'company-ZZZZ', None)` — the exact user-visible symptom. The fourth (the single-profile control) passes on both, which is what keeps the fix from over-reaching into a blindfold.

Neighbouring suites: `tests/agent/test_secret_scope.py`, `tests/test_env_loader_secret_sources.py` and `tests/tools/test_registry_check_fn.py` pass. `tests/tools/test_file_tools.py` shows **6 failures that are pre-existing** — identical with my source change reverted on the same checkout (sensitive-path / macOS carve-out tests on this Windows host), untouched by this PR.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — no open PR covers `read_extract` / hosted OCR credential scoping; the Firecrawl PRs in flight concern provider fallback, browser profiles, key rotation and self-hosted detection. #107695 fixes the ticker's dotenv write, a different file and a different mechanism.
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected and neighbouring suites through `scripts/run_tests.sh` (above) rather than the full tree.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the mechanism is stated in the code comment; `docs/design/multiplexing-gateway.md` already describes the scope rule this restores compliance with.
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — pure credential-resolution change, no platform branch.
