### PR TITLE
feat(catalog): add four ChuggiesMart plugins

### DIFF
--- a/plugin-catalog/doc-tools.yaml
+++ b/plugin-catalog/doc-tools.yaml
@@ -1,0 +1,14 @@
+name: doc-tools
+repo: https://github.com/chuggies510/ChuggiesMart
+sha: 378011efed6a8b464b36a37b9093a034c54d1b1c
+subdir: doc-tools
+description: PDF extraction for LLM and RAG pipelines.
+maintainer: chuggies510
+tier: community
+docs_url: https://github.com/chuggies510/ChuggiesMart/tree/378011efed6a8b464b36a37b9093a034c54d1b1c/doc-tools
+platforms: []
+capabilities:
+  provides_tools: []
+  provides_hooks: []
+  provides_middleware: []
+  requires_env: []

--- a/plugin-catalog/home-assistant.yaml
+++ b/plugin-catalog/home-assistant.yaml
@@ -1,0 +1,14 @@
+name: home-assistant
+repo: https://github.com/chuggies510/ChuggiesMart
+sha: 378011efed6a8b464b36a37b9093a034c54d1b1c
+subdir: home-assistant
+description: Home Assistant operations with a cascade-prevention workflow.
+maintainer: chuggies510
+tier: community
+docs_url: https://github.com/chuggies510/ChuggiesMart/tree/378011efed6a8b464b36a37b9093a034c54d1b1c/home-assistant
+platforms: []
+capabilities:
+  provides_tools: []
+  provides_hooks: []
+  provides_middleware: []
+  requires_env: []

--- a/plugin-catalog/workspace-toolkit.yaml
+++ b/plugin-catalog/workspace-toolkit.yaml
@@ -1,0 +1,16 @@
+name: workspace-toolkit
+repo: https://github.com/chuggies510/ChuggiesMart
+sha: 378011efed6a8b464b36a37b9093a034c54d1b1c
+subdir: workspace-toolkit
+description: Injects first-turn prompt routing and provides session lifecycle, memory-bank, and problem-solving skills.
+maintainer: chuggies510
+tier: community
+docs_url: https://github.com/chuggies510/ChuggiesMart/tree/378011efed6a8b464b36a37b9093a034c54d1b1c/workspace-toolkit
+platforms: []
+capabilities:
+  provides_tools: []
+  provides_hooks:
+    - pre_llm_call
+    - subagent_stop
+  provides_middleware: []
+  requires_env: []

--- a/plugin-catalog/writing-tools.yaml
+++ b/plugin-catalog/writing-tools.yaml
@@ -1,0 +1,14 @@
+name: writing-tools
+repo: https://github.com/chuggies510/ChuggiesMart
+sha: 378011efed6a8b464b36a37b9093a034c54d1b1c
+subdir: writing-tools
+description: Writing craft, blog authorship, brand guidelines, and Minto distillation.
+maintainer: chuggies510
+tier: community
+docs_url: https://github.com/chuggies510/ChuggiesMart/tree/378011efed6a8b464b36a37b9093a034c54d1b1c/writing-tools
+platforms: []
+capabilities:
+  provides_tools: []
+  provides_hooks: []
+  provides_middleware: []
+  requires_env: []


### PR DESCRIPTION
## What does this PR do?

Adds community catalog entries for four independently installable ChuggiesMart leaf packages:

- `workspace-toolkit`
- `writing-tools`
- `doc-tools`
- `home-assistant`

Each entry pins commit `378011efed6a8b464b36a37b9093a034c54d1b1c` and selects its self-contained package root with `subdir`. The ChuggiesMart repository root is intentionally not a Hermes plugin.

> [!IMPORTANT]
> This is a draft because the pinned commit reaches the catalog's two-week maturity threshold on **2026-09-24 at 13:48:47 UTC-07:00**. Do not merge before then.

The deprecated `voice-memos` package is intentionally excluded.

## Related Issue

https://github.com/chuggies510/ChuggiesMart/issues/843

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Add one catalog file per ChuggiesMart leaf package.
- Pin all entries to one reviewed, reachable commit on `master`.
- Declare the Workspace Toolkit native hooks and otherwise empty native capability sets.

## How to Test

1. Run `uv run python scripts/validate_plugin_catalog.py plugin-catalog/`.
2. Clone `https://github.com/chuggies510/ChuggiesMart`, check out `378011efed6a8b464b36a37b9093a034c54d1b1c`, and run `uv run hermes plugins validate` against each declared subdirectory.
3. Confirm all four validations pass.

## Checklist

### Code

- [ ] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this catalog addition
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes, N/A for catalog data
- [x] I've tested on macOS 26.6.2

### Documentation & Housekeeping

- [x] Relevant documentation update is N/A
- [x] `cli-config.yaml.example` update is N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update is N/A
- [x] Cross-platform impact considered; entries declare no platform restriction
- [x] Tool description and schema updates are N/A

## Screenshots / Logs

```text
OK: 14 file(s) valid
workspace-toolkit=ok
writing-tools=ok
doc-tools=ok
home-assistant=ok
catalog_entries=4
```
