### PR TITLE
fix(tools): capture all shell functions in bash snapshot, not just non-private ones

### DIFF
--- a/tests/tools/test_snapshot_captures_all_functions.py
+++ b/tests/tools/test_snapshot_captures_all_functions.py
@@ -1,0 +1,38 @@
+"""Bash snapshot must capture every shell function, not filter private helpers.
+
+Regression coverage for the ``_safe_eval: command not found`` failure class: a
+user shell tool (e.g. scm_breeze) aliases core commands (``ls``, ``cd``, ``cat``…)
+to a wrapper function that delegates to a *private*, underscore-prefixed helper
+(``_safe_eval``). The old snapshot bootstrap filtered function names with
+``grep -vE '^_[^_]'``, dropping the helper while keeping its dependents, so
+sourcing the snapshot left a dangling reference and every command touching those
+aliases failed.
+
+The fix captures ALL functions (``declare -F`` without a name filter); function
+bodies are inert until called, so capturing them is safe.
+"""
+
+from tools.environments.base_session_env import _snapshot_bootstrap_script
+
+
+def _capture_line(script: str) -> str:
+    for line in script.splitlines():
+        if "__hermes_fns=" in line:
+            return line
+    raise AssertionError("no __hermes_fns capture line in bootstrap script")
+
+
+def test_bootstrap_captures_all_functions_without_name_filter():
+    script = _snapshot_bootstrap_script(
+        quoted_cwd="/tmp",
+        quoted_snap="/tmp/snap.sh",
+        snap_tmp_template="/tmp/snap.sh.tmp.XXXXXX",
+        excluded_names=[],
+        cwd_marker="__HERMES_TEST__",
+    )
+    line = _capture_line(script)
+    # A captured alias/function may depend on a private underscore-prefixed helper
+    # (scm_breeze's _safe_eval); filtering names by prefix drops the helper and leaves
+    # the dependents dangling. The capture must be name-filter-free.
+    assert "grep -vE" not in line
+    assert "awk '{print $3}'" in line

--- a/tools/environments/base_session_env.py
+++ b/tools/environments/base_session_env.py
@@ -83,16 +83,19 @@ def _snapshot_bootstrap_script(
     """Login-shell bootstrap that captures env/functions/aliases into the snapshot. Atomic publish:
     assemble in a ``mktemp`` file, then ``mv`` over the final path so a concurrent ``source`` never
     reads a half-written snapshot (``$$`` is the parent PID in ``&``-launched subshells and macOS
-    bash 3.2 lacks ``$BASHPID``, so only ``mktemp`` is portable). Functions are filtered by NAME via
-    ``declare -F`` (a line-based ``declare -f | grep -v`` strips the header and leaves an orphaned
-    body that breaks every sourced command); the non-empty guard matters because bare ``declare -f``
-    dumps ALL functions. The trailing ``cd`` restores the configured cwd after profile scripts (e.g.
+    bash 3.2 lacks ``$BASHPID``, so only ``mktemp`` is portable). Functions are captured by NAME via
+    ``declare -F`` + ``declare -f $names`` (a line-based ``declare -f | grep -v`` strips the header
+    and leaves an orphaned body that breaks every sourced command). We capture ALL functions — do not
+    filter underscore-prefixed names — because a captured alias/function may depend on a private
+    helper (e.g. scm_breeze's ``_safe_eval``); dropping the helper but keeping its dependents leaves a
+    dangling reference that fails every command touching it. Function bodies are inert until called,
+    so capturing them is safe. The trailing ``cd`` restores the configured cwd after profile scripts (e.g.
     ``cd ~``) so ``pwd -P`` reports terminal.cwd, not the profile's directory."""
     return (
         "umask 077\n"
         f"__hermes_snap_tmp=$(mktemp {snap_tmp_template}) || exit 1\n"
         f"{_export_dump_excluding_session_vars(_SNAP_TMP, excluded_names)}\n"
-        "__hermes_fns=$(declare -F | awk '{print $3}' | grep -vE '^_[^_]') || true\n"
+        "__hermes_fns=$(declare -F | awk '{print $3}') || true\n"
         f"[ -n \"$__hermes_fns\" ] && declare -f $__hermes_fns >> {_SNAP_TMP} 2>/dev/null || true\n"
         f"alias -p >> {_SNAP_TMP}\n"
         f"echo 'shopt -s expand_aliases' >> {_SNAP_TMP}\n"


### PR DESCRIPTION
## Problem

Terminal/`write_file`/`search_files` intermittently fail in cron (and interactive) sessions on macOS with:

```
/var/folders/.../hermes-snap-XXXX.sh: line 296: _safe_eval: command not found
```

## Root cause

A user's login shell (here: [scm_breeze](https://github.com/scmbreeze/scm_breeze)) aliases core commands to a wrapper that delegates to a *private*, underscore-prefixed helper:

```bash
alias ls='exec_scmb_expand_args /bin/ls'
alias cd='exec_scmb_expand_args builtin cd'
alias cat/cp/mv/rm/less/ln/vim='exec_scmb_expand_args ...'
```

`exec_scmb_expand_args` calls `_safe_eval`. The snapshot bootstrap in `tools/environments/base_session_env.py` captured functions by name and **filtered out single-underscore names**:

```
__hermes_fns=$(declare -F | awk '{print $3}' | grep -vE '^_[^_]')
```

so `_safe_eval` was dropped while its dependents (the wrapper + aliases) were kept. Sourcing the snapshot left a dangling reference, and any command touching those aliases failed.

## Fix

Capture **all** functions — drop the `grep -vE '^_[^_]'` filter. Function bodies are inert until called, so re-defining them in the snapshot is safe. This matches the existing intent comment (the non-empty guard is about bare `declare -f` dumping ALL functions; the name filter was what caused the orphaned-reference breakage).

## Verification

- End-to-end on macOS (bash 3.2): regenerated the snapshot with the patched bootstrap, confirmed `_safe_eval ()` is now present, sourced it, and `ls` runs clean (previously `_safe_eval: command not found`).
- Regression test `tests/tools/test_snapshot_captures_all_functions.py` asserts the bootstrap capture line is name-filter-free (proven red against the old line).

Note: I could not run `scripts/run_tests.sh` locally because no venv with pytest is present in this checkout; the regression test's assertions were exercised directly against the patched function.
