### PR TITLE
fix(gateway): kill timed-out exec quick commands instead of orphaning them

### DIFF
--- a/contributors/emails/wdjessica24@gmail.com
+++ b/contributors/emails/wdjessica24@gmail.com
@@ -1,0 +1,1 @@
+wodesiku

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -932,6 +932,7 @@ class GatewayInboundMixin:
     async def _hm_run_exec_quick_command(self, command: str, exec_cmd: str) -> str:
         """Run a ``type: exec`` quick command in the gateway process (30 s cap, sanitized env — the
         gateway process has every API key in os.environ; output is redacted too)."""
+        proc = None
         try:
             from tools.environments.local import build_subprocess_env
             proc = await asyncio.create_subprocess_shell(
@@ -948,6 +949,12 @@ class GatewayInboundMixin:
             return "Quick command timed out (30s)."
         except Exception as e:
             return f"Quick command error: {e}"
+        finally:
+            if proc is not None and proc.returncode is None:
+                # wait_for() only cancels communicate(): on timeout or task cancellation the shell and
+                # everything it spawned keep running under the gateway. Take the whole tree down.
+                from agent.deadline import kill_process_tree
+                kill_process_tree(proc.pid)
 
     async def _hm_dispatch_quick_and_plugin_commands(
         self, event: "MessageEvent", source: SessionSource, command: Optional[str]

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -160,6 +160,93 @@ class TestGatewayQuickCommands:
         assert "timed out" in result.lower()
 
     @pytest.mark.asyncio
+    async def test_timeout_kills_the_command_process_tree(self, tmp_path):
+        """A timed-out exec quick command must not keep running under the gateway, nor its children."""
+        import asyncio
+        import contextlib
+        import sys
+        import time
+        import psutil
+        from gateway.run import GatewayRunner
+
+        pid_file = tmp_path / "pids"
+        script = tmp_path / "tree.py"
+        script.write_text(
+            "import os, subprocess, sys, time\n"
+            "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)'])\n"
+            f"with open({str(pid_file)!r}, 'w', encoding='utf-8') as f:\n"
+            "    f.write(f'{os.getpid()}\\n{child.pid}\\n')\n"
+            "time.sleep(120)\n",
+            encoding="utf-8",
+        )
+
+        def _pids():
+            try:
+                return [int(p) for p in pid_file.read_text(encoding="utf-8").split()]
+            except (OSError, ValueError):
+                return []
+
+        real_wait_for = asyncio.wait_for
+
+        async def _expire_once_tree_is_up(aw, timeout):
+            # Behave like wait_for() hitting its 30 s cap, without waiting 30 s: cancel the inner
+            # communicate() and raise TimeoutError once the command's process tree exists.
+            if getattr(aw, "__qualname__", "") != "Process.communicate":
+                return await real_wait_for(aw, timeout)
+            task = asyncio.ensure_future(aw)
+            deadline = time.monotonic() + 15
+            while len(_pids()) < 2 and time.monotonic() < deadline:
+                await asyncio.sleep(0.05)
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            raise asyncio.TimeoutError
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"hang": {"type": "exec", "command": f'"{sys.executable}" "{script}"'}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        with patch("asyncio.wait_for", _expire_once_tree_is_up):
+            result = await runner._handle_message(self._make_event("hang"))
+
+        assert "timed out" in result.lower()
+        pids = _pids()
+        assert len(pids) == 2, "the quick command never started its process tree"
+
+        def _running(pid):
+            # Read-only probe: waiting on the direct child here would steal asyncio's reap.
+            try:
+                return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+            except psutil.NoSuchProcess:
+                return False
+
+        alive = pids
+        deadline = time.monotonic() + 5
+        while alive and time.monotonic() < deadline:
+            await asyncio.sleep(0.05)
+            alive = [pid for pid in alive if _running(pid)]
+        for pid in alive:  # never leak the sleepers into the rest of the run, even on failure
+            with contextlib.suppress(psutil.NoSuchProcess):
+                psutil.Process(pid).kill()
+        assert not alive, f"timed-out quick command left processes running: {alive}"
+
+    @pytest.mark.asyncio
+    async def test_completed_command_is_not_killed(self):
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"limits": {"type": "exec", "command": "echo ok"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        with patch("agent.deadline.kill_process_tree") as kill_tree:
+            result = await runner._handle_message(self._make_event("limits"))
+        assert result == "ok"
+        kill_tree.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_gateway_config_object_supports_quick_commands(self):
         from gateway.config import GatewayConfig
         from gateway.run import GatewayRunner


### PR DESCRIPTION
## What does this PR do?

A gateway `type: exec` quick command that runs past its 30 s cap is reported to the user as timed out, but it is **never killed**. The shell and everything it spawned keep running as children of the gateway process. Every later run of the same slow or hanging command leaks another process tree.

`GatewayInboundMixin._hm_run_exec_quick_command` (`gateway/run_inbound.py`) bounds the command with `asyncio.wait_for(proc.communicate(), timeout=30)`. On timeout, `wait_for` only cancels the `communicate()` coroutine. It does not touch the process. The `except asyncio.TimeoutError` branch returns the message and nothing else. Cancelling the task (for example, the gateway shutting down mid-command) leaks the same way.

The other quick-command and subprocess paths already handle this:

| Path | On timeout |
|---|---|
| Classic CLI quick command (`cli.py`, `subprocess.run(timeout=30)`) | kills the shell |
| Buzz adapter `_exec_buzz` (same `wait_for(communicate())` shape) | `proc.kill(); await proc.wait()` |
| **Gateway quick command** (`gateway/run_inbound.py`) | **nothing — process keeps running** |

## Reproduction (released gateway, any platform)

1. Add a quick command to `config.yaml`:
   ```yaml
   quick_commands:
     hang:
       type: exec
       command: "sleep 3141; echo never"
   ```
2. Send `/hang` to the bot (Telegram, Discord, etc.).
3. After 30 s the bot replies `Quick command timed out (30s).`
4. `ps -ef | grep 3141` on the gateway host: the shell and `sleep` are still running, parented to the gateway. Send `/hang` again and a second pair appears.

The same thing happens when driving the real method directly against current `main` (`6c3d4a4af7`) on Ubuntu 22.04 / Python 3.11:

```
gateway reply after 30.1s: 'Quick command timed out (30s).'
surviving processes after the reply: 2
   pid=371 ppid=312 cmd='/bin/sh -c sleep 3141; echo never'
   pid=373 ppid=371 cmd='sleep 3141'
```

With this PR applied:

```
gateway reply after 30.3s: 'Quick command timed out (30s).'
surviving processes after the reply: 0
```

Cancellation variant (task cancelled while the command runs): `main` leaves 2 processes running, this PR leaves 0.

## Related Issue

No existing issue. I found this while comparing the gateway quick-command path with the CLI and Buzz subprocess paths. I searched open and closed PRs and issues for quick-command timeout, orphan and kill handling. #46057 hardens the **classic CLI** quick-command runner only and does not touch `gateway/run_inbound.py`. #67628 and #67789 are about the TUI RPC reader.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/run_inbound.py`: added a `finally` block. If the process has not been reaped (`proc.returncode is None`), the whole tree is taken down with `agent.deadline.kill_process_tree(proc.pid)`, the portable helper that the CLI, cron and shell-hook runners already use. It covers the timeout path and task cancellation. A command that completes normally is untouched: `communicate()` only returns after the process exits, so `returncode` is set and nothing is signalled. There are no new abstractions, config keys, or spawn-flag changes.
- `tests/cli/test_quick_commands.py` (next to the existing gateway quick-command tests):
  - `test_timeout_kills_the_command_process_tree`: runs a real command that spawns a grandchild through `_handle_message`, then triggers the timeout deterministically. A stand-in for `wait_for` acts only on `Process.communicate`: once the tree is up it cancels the inner call and raises `TimeoutError`, as the real `wait_for` does at 30 s, so the test does not sleep 30 s. The test then asserts that the child and the grandchild are both gone.
  - `test_completed_command_is_not_killed`: a normal `echo ok` returns its output and never calls `kill_process_tree`.
- `contributors/emails/`: contributor attribution mapping for @wodesiku, in a separate `chore:` commit.

## How to Test

1. `scripts/run_tests.sh tests/cli/test_quick_commands.py`
2. Red before green: with only `gateway/run_inbound.py` restored to `origin/main`, the new test fails:
   ```
   E       AssertionError: timed-out quick command left processes running: [527, 529]
   1 failed, 9 deselected
   ```
   With the fix: `10 passed`. It passed 5 of 5 repeated runs.
3. For a manual check, use the reproduction steps above.

Focused suites I ran on Ubuntu 22.04 (WSL2), Python 3.11:

```
scripts/run_tests.sh tests/cli/test_quick_commands.py tests/e2e/test_platform_commands.py \
  tests/gateway/test_slash_access_dispatch.py tests/gateway/test_config.py tests/agent/test_deadline.py
=== Summary: 5 files, 182 tests passed, 0 failed, 4 skipped ===
```

`ruff check` passes on both files, and so do `scripts/check-windows-footguns.py` and `scripts/check_compat_pointers.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (plus the contributor attribution mapping)
- [ ] I've run `pytest tests/ -q` and all tests pass. *I ran only the focused suites listed above, not the full suite.*
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 22.04 (WSL2), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior now matches the documented 30 s cap)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact: `kill_process_tree` uses `taskkill /T /F` on Windows and signals the process group plus the psutil-snapshotted descendants on POSIX. It runs only on the timeout or cancel path, after the 30 s wait has already happened.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Notes

Two other gateway call sites use the same `wait_for(proc.communicate())` shape without killing on timeout: the `ffprobe` duration probe in `gateway/run.py` (5 s cap) and the Telegram gmail-triage callback in `plugins/platforms/telegram/adapter.py` (60 s cap). I kept this PR to the user-configurable quick-command path. I can follow up on those two if you want them handled the same way.
