### PR TITLE
fix: recognise DeepSeek V4.1-Flash (deepseek-flash) across the model tables

### DIFF
--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -19,8 +19,10 @@ _REASONING_STALE_TIMEOUT_FLOORS: dict[int, tuple[str, ...]] = {
     600: (
         # NVIDIA Nemotron behind hosted NIM: documented 60-180s upstream idle kill.
         "nemotron-3-ultra", "nemotron-3-super",
-        # DeepSeek R1 / V4 (reasoning_content streamed before final content).
-        "deepseek-r1", "deepseek-reasoner", "deepseek-v4-flash", "deepseek-v4-pro",
+        # DeepSeek R1 / V4 / V4.1 (reasoning_content streamed before final content). V4.1-Flash is
+        # addressed as ``deepseek-flash`` — without it here the stale detector trips the circuit
+        # breaker on long thinking phases.
+        "deepseek-r1", "deepseek-reasoner", "deepseek-flash", "deepseek-v4-flash", "deepseek-v4-pro",
         # OpenAI o-series: each variant enumerated so bare ``o1`` cannot over-match ``olmo-1``.
         "o1", "o1-mini", "o1-pro", "o1-preview", "o3", "o3-pro",
         # Mythos-class named models (claude-fable-5): 1M ctx + 128K output, a heavier thinking

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -192,6 +192,15 @@ _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
         ("deepseek-chat", "deepseek-reasoner", "deepseek-v4-flash"): ("0.14", "0.28", "0.0028"),
         "deepseek-v4-pro": ("0.435", "0.87", "0.003625"),
     }),
+    # V4.1-Flash (2026-09-10) is addressed as ``deepseek-flash``; the retired ids
+    # ``deepseek-v4-flash`` / ``deepseek-v4-flash-vision-exp`` are still accepted but are served
+    # by V4.1-Flash and billed at its price. The official table is peak/off-peak (off-peak = 1/2
+    # peak; peak = 01:00-04:00 and 06:00-10:00 UTC, Mon-Fri) and this table holds one rate set per
+    # model, so the off-peak base row is recorded (same figures models.dev publishes).
+    # https://api-docs.deepseek.com/quick_start/pricing
+    ("deepseek", "https://api-docs.deepseek.com/quick_start/pricing", "deepseek-pricing-2026-09", {
+        "deepseek-flash": ("0.15", "0.60", "0.003"),
+    }),
     ("google", "https://ai.google.dev/gemini-api/docs/pricing", "google-pricing-2026-09-02", {
         ("gemini-3.8-flash", "gemini-3.7-flash"): ("0.75", "3.75", "0.075"),
     }),

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -92,8 +92,20 @@ _LOWERCASE_MODEL_PROVIDERS: frozenset[str] = frozenset({
 _DEEPSEEK_RETIRED_ALIASES: frozenset[str] = frozenset({
     "deepseek-chat", "deepseek-reasoner"})
 
+# DeepSeek's newest family drops the ``v<digit>`` infix: V4.1-Flash (released 2026-09-10, addressed
+# as ``deepseek-flash``) is the live flagship, and ``deepseek-v4-flash`` survives only as a
+# temporary server-side compat route ("for compatibility, deepseek-v4-flash ... temporarily route
+# to V4.1-Flash"). The V-series regex below cannot recognise it (no ``v<digit>``), so it needs an
+# explicit entry or the normalizer silently rewrites the live id back to the compat one.
+# The marketing spelling (``deepseek-v4.1-flash``) is not a real id and 400s, so it is repaired to
+# the canonical name instead of riding the V-series regex through to the API.
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
-    "deepseek-v4-pro", "deepseek-v4-flash"})
+    "deepseek-flash", "deepseek-v4-pro", "deepseek-v4-flash"})
+
+_DEEPSEEK_ALIAS_REPAIRS: dict[str, str] = {
+    "deepseek-v4.1-flash": "deepseek-flash",
+    "deepseek-v4-1-flash": "deepseek-flash",
+}
 
 # First-class V-series IDs incl. future ``deepseek-v5-*`` and dated variants
 # (``deepseek-v4-flash-20260423``): verified real model ids, NOT aliases of ``deepseek-chat``.
@@ -105,6 +117,9 @@ def _normalize_for_deepseek(model_name: str) -> str:
     through (future V-series work without a release); retired aliases and everything else become
     ``deepseek-v4-flash``."""
     bare = _strip_vendor_prefix(model_name).lower()
+    repaired = _DEEPSEEK_ALIAS_REPAIRS.get(bare)
+    if repaired:
+        return repaired
     if bare in _DEEPSEEK_CANONICAL_MODELS or _DEEPSEEK_V_SERIES_RE.match(bare):
         return bare
     return "deepseek-v4-flash"

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -205,7 +205,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-sonnet-4-6", "claude-opus-4-5-20251101", "claude-sonnet-4-5-20250929",
         "claude-opus-4-20250514", "claude-sonnet-4-20250514", "claude-haiku-4-5-20251001",
     ],
-    "deepseek": ["deepseek-v4-pro", "deepseek-v4-flash"],
+    "deepseek": ["deepseek-flash", "deepseek-v4-pro", "deepseek-v4-flash"],
     "xiaomi": ["mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "mimo-v2-flash"],
     "tencent-tokenhub": list(_TENCENT_MODELS),
     "tencent-tokenplan": list(_TENCENT_MODELS),

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -138,6 +138,38 @@ class TestDeepseekCanonicalAndReasonerMapping:
         assert _normalize_for_deepseek(model) == "deepseek-v4-flash"
 
 
+# ── DeepSeek V4.1-Flash: the live flagship id has no ``v<digit>`` infix ──
+
+class TestDeepseekV41Flash:
+    """V4.1-Flash (released 2026-09-10) is addressed as ``deepseek-flash``; the retired
+    ``deepseek-v4-flash`` / ``deepseek-v4-flash-vision-exp`` ids survive only as temporary
+    server-side compat routes.
+
+    ``_DEEPSEEK_V_SERIES_RE`` requires a ``v<digit>`` infix, so an id it cannot see falls
+    through to the blanket ``deepseek-v4-flash`` rewrite — silently putting every request on the
+    compat route and reporting a model the user never selected.
+    """
+
+    def test_v41_flash_id_survives_normalization(self):
+        assert normalize_model_for_provider("deepseek-flash", "deepseek") == "deepseek-flash"
+        assert (
+            normalize_model_for_provider("deepseek/deepseek-flash", "deepseek")
+            == "deepseek-flash"
+        )
+
+    def test_v4_flash_compat_route_is_left_alone(self):
+        assert (
+            normalize_model_for_provider("deepseek-v4-flash", "deepseek")
+            == "deepseek-v4-flash"
+        )
+
+    @pytest.mark.parametrize("alias", ["deepseek-v4.1-flash", "deepseek-v4-1-flash"])
+    def test_marketing_spelling_repaired_to_canonical(self, alias):
+        """The marketing spelling is not an API id (the API answers HTTP 400), and it would
+        otherwise ride the V-series regex through to the wire."""
+        assert normalize_model_for_provider(alias, "deepseek") == "deepseek-flash"
+
+
 # ── Regression: issue #78796 ───────────────────────────────────────────
 
 class TestIssue78796NvidiaPrefixRepair:


### PR DESCRIPTION
## Problem

DeepSeek released **V4.1-Flash** on 2026-09-10 and renamed the live model id: the Flash line is
addressed as `deepseek-flash`. `deepseek-v4-flash` / `deepseek-v4-flash-vision-exp` are accepted
only as *temporary* server-side compat routes ("the previous-generation models ... have been
retired; for compatibility ... temporarily routed"), and V4-Pro is phased out from 2026-09-14.

Hermes already offers `deepseek-flash` (models.dev lists it as "DeepSeek V4.1 Flash" and the
provider's live `/v1/models` returns it), but selecting it does not stick:

```
$ hermes chat -q "..."        # model.default: deepseek-flash, provider: deepseek
Normalized model 'deepseek-flash' to 'deepseek-v4-flash' for deepseek.
```

`_DEEPSEEK_V_SERIES_RE` matches `deepseek-v<digit>...`, so `deepseek-flash` (no `v<digit>` infix)
falls through `_normalize_for_deepseek()` to the blanket `deepseek-v4-flash` rewrite: every request
silently rides the compat route and the session reports a model the user never selected.

`deepseek-v4.1-flash` — the spelling the release announcement uses — is worse: it *does* match the
V-series regex, passes through untouched, and the API answers HTTP 400
("The supported API model names are deepseek-flash, deepseek-v4-pro").

## Changes

- **`hermes_cli/model_normalize.py`** — add `deepseek-flash` to `_DEEPSEEK_CANONICAL_MODELS`, and
  repair the marketing spelling (`deepseek-v4.1-flash` / `deepseek-v4-1-flash`) to the canonical id.
- **`hermes_cli/models_catalog_static.py`** — lead the curated deepseek list with the live flagship.
- **`agent/usage_pricing.py`** — new `deepseek-pricing-2026-09` row. The pricing table is the only
  cost source (`estimate_usage_cost` has no models.dev fallback), so without it the model reports
  `status='unknown', amount_usd=None`. Rates are the off-peak base figures the official page
  publishes; peak is 2x (01:00-04:00 and 06:00-10:00 UTC, Mon-Fri) and the table holds one rate set
  per model — happy to store peak instead if that reads better.
- **`agent/reasoning_timeouts.py`** — `deepseek-flash` streams `reasoning_content` before final
  content like the rest of the family, so it needs the 600s stale-timeout floor.

## Tests

`tests/hermes_cli/test_model_normalize.py::TestDeepseekV41Flash` — red on base, green with the fix:

```
FAILED tests/hermes_cli/test_model_normalize.py::TestDeepseekV41Flash::test_v41_flash_id_survives_normalization
FAILED tests/hermes_cli/test_model_normalize.py::TestDeepseekV41Flash::test_marketing_spelling_repaired_to_canonical[deepseek-v4.1-flash]
FAILED tests/hermes_cli/test_model_normalize.py::TestDeepseekV41Flash::test_marketing_spelling_repaired_to_canonical[deepseek-v4-1-flash]
3 failed, 1 passed, 23 deselected
```

Verified against the live API with `model.default: deepseek-flash` (provider `deepseek`): sessions
record `model=deepseek-flash` in `session_model_usage` and stream real completions;
`estimate_usage_cost("deepseek-flash", ...)` moves from `unknown` to
`estimated/official_docs_snapshot/deepseek-pricing-2026-09`;
`get_reasoning_stale_timeout_floor("deepseek-flash")` -> `600.0`. Suites run:
`test_model_normalize.py`, `test_usage_pricing.py`, `test_reasoning_stale_timeout_floor.py`,
`test_provider_live_curated_merge.py` — 118 passed.
