### PR TITLE
fix(cli): preserve Enter through first-run startup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -22,7 +22,7 @@ import textwrap
 from collections import deque
 from dataclasses import dataclass
 from urllib.parse import unquote, urlparse
-from contextlib import contextmanager, suppress
+from contextlib import ExitStack, contextmanager, suppress
 from pathlib import Path
 from datetime import datetime
 from typing import List, Dict, Any, Optional, Mapping
@@ -50,7 +50,7 @@ from agent.interrupt_compat import request_hard_interrupt
 from agent.pet import render as pet_render
 
 from prompt_toolkit.patch_stdout import patch_stdout
-from prompt_toolkit.application import Application
+from prompt_toolkit.application import Application, get_app_session
 from prompt_toolkit import print_formatted_text as _pt_print
 from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
 try:
@@ -3822,104 +3822,110 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         if not self._claim_active_session("cli"):
             return
 
-        self._tui_print_startup()
-        self._tui_init_run_state()
-        kb = self._tui_build_key_bindings()
-        layout, style = self._tui_build_layout(kb)
+        # Preserve Enter/CR across startup; only blocking setup dialogs borrow
+        # cooked mode. The Application reuses this same input and raw-mode owner.
+        with ExitStack() as input_mode:
+            input_mode.enter_context(get_app_session().input.raw_mode())
+            self._tui_print_startup()
+            self._tui_init_run_state()
+            kb = self._tui_build_key_bindings()
+            layout, style = self._tui_build_layout(kb)
 
-        app = self._tui_build_application(layout, kb, style)
-        _disable_prompt_toolkit_cpr_warning(app)
-        app.after_render += self._pet_flush_kitty_frame
-        self._app = app
+            app = self._tui_build_application(layout, kb, style)
+            _disable_prompt_toolkit_cpr_warning(app)
+            app.after_render += self._pet_flush_kitty_frame
+            self._app = app
 
-        # Ghost status-bar lines on resize: pt's renderer scrolls the terminal after each
-        # paint, pushing chrome into scrollback where a column-shrink reflows it into
-        # duplicates. Wrapping _output_screen_diff keeps its reserve-space branch from firing.
-        try:
-            # Background: prompt_toolkit's renderer (renderer.py L232-242) explicitly moves the cursor to
-            # the bottom of the canvas after painting "to make sure the terminal scrolls up, even when the
-            # lower lines of the canvas just contain whitespace". In non-fullscreen mode this scrolls chrome
-            # content (status bar, input rules) into terminal scrollback on every render. When the terminal
-            # column-shrinks, the emulator reflows the previously rendered full-width rows into multiple
-            # narrower rows that get pushed up — leaving ghost duplicates AND polluting scrollback. Same
-            # issue as pt #29 (open since 2014), #1675, #1933. Surgical fix: wrap _output_screen_diff so
-            # that when its internal `if current_height > previous_screen.height` branch fires (the one that
-            # does the bottom-cursor-move), we make it fall through by inflating previous_screen.height
-            # first.
-            import prompt_toolkit.renderer as _pt_renderer
-            from prompt_toolkit.renderer import _output_screen_diff as _orig_osd
+            # Ghost status-bar lines on resize: pt's renderer scrolls the terminal after each
+            # paint, pushing chrome into scrollback where a column-shrink reflows it into
+            # duplicates. Wrapping _output_screen_diff keeps its reserve-space branch from firing.
+            try:
+                # Background: prompt_toolkit's renderer (renderer.py L232-242) explicitly moves the cursor to
+                # the bottom of the canvas after painting "to make sure the terminal scrolls up, even when the
+                # lower lines of the canvas just contain whitespace". In non-fullscreen mode this scrolls chrome
+                # content (status bar, input rules) into terminal scrollback on every render. When the terminal
+                # column-shrinks, the emulator reflows the previously rendered full-width rows into multiple
+                # narrower rows that get pushed up — leaving ghost duplicates AND polluting scrollback. Same
+                # issue as pt #29 (open since 2014), #1675, #1933. Surgical fix: wrap _output_screen_diff so
+                # that when its internal `if current_height > previous_screen.height` branch fires (the one that
+                # does the bottom-cursor-move), we make it fall through by inflating previous_screen.height
+                # first.
+                import prompt_toolkit.renderer as _pt_renderer
+                from prompt_toolkit.renderer import _output_screen_diff as _orig_osd
 
-            if not getattr(_pt_renderer, "_hermes_osd_patched", False):
-                _pt_renderer._output_screen_diff = functools.partial(
-                    _hermes_call_output_screen_diff, _orig_osd
-                )
-                _pt_renderer._hermes_osd_patched = True
-        except Exception:
-            pass
-
-        _apply_bracketed_paste_timeout_patch()
-
-        self._install_resize_recovery(app)
-
-        threading.Thread(target=self._tui_spinner_loop, daemon=True).start()
-        threading.Thread(target=self._tui_process_loop, daemon=True).start()
-        # Wake word listener off-thread so a first-run engine install never blocks the prompt.
-        threading.Thread(target=self._tui_wake_startup, daemon=True, name="wake-startup").start()
-
-        atexit.register(_run_cleanup)
-        self._tui_install_signal_handlers()
-
-        if not self._tui_stdin_usable():
-            _run_cleanup()
-            self._print_exit_summary()
-            return
-
-        try:
-            with patch_stdout():
-                try:
-                    # run_in_terminal() may return either: • a coroutine / Future (prompt_toolkit ≥ 3.0) —
-                    # must be scheduled via ensure_future so the coroutine is actually awaited; calling it
-                    # bare would leave it unawaited and silently drop the output (fixes #23185 Bug A). •
-                    # None (some mocks / older PT builds) — just call the inner function directly since PT
-                    # already executed it synchronously. Do NOT fall back to a bare _pt_print when
-                    # ensure_future raises, because run_in_terminal already invoked the lambda in that case
-                    # (the mock path), which would double-print the line.
-                    import asyncio as _aio
-                    _aio.get_running_loop().set_exception_handler(self._tui_suppress_closed_loop_errors)
-                except Exception:
-                    pass  # no running loop -- nothing to patch
-                # Record that the app enables focus reporting + mouse tracking so _run_cleanup
-                # resets them; extended key modes are popped by the same reset.
-                # When multiline shortcuts are on, also ask supported terminals (e.g. iTerm2) to report
-                # modified keys distinctly (kitty protocol + modifyOtherKeys); the cleanup reset pops both
-                # modes. See #36823.
-                _mark_tui_input_modes_active()
-                if self._tui_multiline_shortcuts:
-                    _enable_extended_enter_keys(app.output)
-                self._pet_start_anim()
-                app.run()
-        except (EOFError, KeyboardInterrupt, BrokenPipeError):
-            pass
-        except (KeyError, OSError) as _stdin_err:
-            # Selector registration failures from broken stdin and I/O errors from a
-            # broken stdout during interrupt (EIO is suppressed).
-            _errno = getattr(_stdin_err, "errno", None) if isinstance(_stdin_err, OSError) else None
-            _msg = str(_stdin_err)
-            if _errno == errno.EIO:
+                if not getattr(_pt_renderer, "_hermes_osd_patched", False):
+                    _pt_renderer._output_screen_diff = functools.partial(
+                        _hermes_call_output_screen_diff, _orig_osd
+                    )
+                    _pt_renderer._hermes_osd_patched = True
+            except Exception:
                 pass
-            elif _errno in {errno.EINVAL, errno.EBADF} or any(
-                s in _msg for s in ("is not registered", "Bad file descriptor", "Invalid argument")
-            ):
-                print(
-                    f"\nError: stdin is not usable ({_stdin_err}).\n"
-                    "This can happen with certain Python installations (e.g. uv-managed cPython on macOS)\n"
-                    "where kqueue cannot register fd 0.\n"
-                    "Try reinstalling Python via pyenv or Homebrew, then re-run: hermes setup"
-                )
-            else:
-                raise
-        finally:
-            self._tui_shutdown()
+
+            _apply_bracketed_paste_timeout_patch()
+
+            self._install_resize_recovery(app)
+
+            threading.Thread(target=self._tui_spinner_loop, daemon=True).start()
+            threading.Thread(target=self._tui_process_loop, daemon=True).start()
+            # Wake word listener off-thread so a first-run engine install never blocks the prompt.
+            threading.Thread(target=self._tui_wake_startup, daemon=True, name="wake-startup").start()
+
+            atexit.register(_run_cleanup)
+            self._tui_install_signal_handlers()
+
+            if not self._tui_stdin_usable():
+                input_mode.close()
+                _run_cleanup()
+                self._print_exit_summary()
+                return
+
+            try:
+                with patch_stdout():
+                    try:
+                        # run_in_terminal() may return either: • a coroutine / Future (prompt_toolkit ≥ 3.0) —
+                        # must be scheduled via ensure_future so the coroutine is actually awaited; calling it
+                        # bare would leave it unawaited and silently drop the output (fixes #23185 Bug A). •
+                        # None (some mocks / older PT builds) — just call the inner function directly since PT
+                        # already executed it synchronously. Do NOT fall back to a bare _pt_print when
+                        # ensure_future raises, because run_in_terminal already invoked the lambda in that case
+                        # (the mock path), which would double-print the line.
+                        import asyncio as _aio
+                        _aio.get_running_loop().set_exception_handler(self._tui_suppress_closed_loop_errors)
+                    except Exception:
+                        pass  # no running loop -- nothing to patch
+                    # Record that the app enables focus reporting + mouse tracking so _run_cleanup
+                    # resets them; extended key modes are popped by the same reset.
+                    # When multiline shortcuts are on, also ask supported terminals (e.g. iTerm2) to report
+                    # modified keys distinctly (kitty protocol + modifyOtherKeys); the cleanup reset pops both
+                    # modes. See #36823.
+                    _mark_tui_input_modes_active()
+                    if self._tui_multiline_shortcuts:
+                        _enable_extended_enter_keys(app.output)
+                    self._pet_start_anim()
+                    app.run()
+            except (EOFError, KeyboardInterrupt, BrokenPipeError):
+                pass
+            except (KeyError, OSError) as _stdin_err:
+                # Selector registration failures from broken stdin and I/O errors from a
+                # broken stdout during interrupt (EIO is suppressed).
+                _errno = getattr(_stdin_err, "errno", None) if isinstance(_stdin_err, OSError) else None
+                _msg = str(_stdin_err)
+                if _errno == errno.EIO:
+                    pass
+                elif _errno in {errno.EINVAL, errno.EBADF} or any(
+                    s in _msg for s in ("is not registered", "Bad file descriptor", "Invalid argument")
+                ):
+                    print(
+                        f"\nError: stdin is not usable ({_stdin_err}).\n"
+                        "This can happen with certain Python installations (e.g. uv-managed cPython on macOS)\n"
+                        "where kqueue cannot register fd 0.\n"
+                        "Try reinstalling Python via pyenv or Homebrew, then re-run: hermes setup"
+                    )
+                else:
+                    raise
+            finally:
+                input_mode.close()
+                self._tui_shutdown()
 
         # /update relaunch happens here, after prompt_toolkit restored terminal modes, on the
         # main thread (the process_loop thread would skip cleanup / only exit itself on Windows).

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -345,13 +345,16 @@ class CLIAgentSetupMixin:
         """Offer the provider picker when no provider is configured at all (interactive
         startup, TTY). Runs the same flow as ``hermes model`` so onboarding has a single
         source of truth. True when a provider was configured."""
+        from prompt_toolkit.application import get_app_session
+
         from cli import _cprint, logger
         _cprint("")
         _cprint("⚕ No inference provider is configured yet — let's fix that.")
         _cprint("  You'll pick a provider (Nous Portal OAuth is the fastest; "
                 "no API key needed) and a model.")
         try:
-            answer = input("  Set up a provider now? [Y/n]: ").strip().lower()
+            with get_app_session().input.cooked_mode():
+                answer = input("  Set up a provider now? [Y/n]: ").strip().lower()
         except (KeyboardInterrupt, EOFError):
             print()
             answer = "n"
@@ -360,7 +363,8 @@ class CLIAgentSetupMixin:
             return False
         try:
             from hermes_cli.main import select_provider_and_model
-            select_provider_and_model()
+            with get_app_session().input.cooked_mode():
+                select_provider_and_model()
         except (KeyboardInterrupt, EOFError, SystemExit):
             print()
             _cprint("  Setup cancelled. Run 'hermes model' any time.")

--- a/tests/cli/test_startup_input_handoff.py
+++ b/tests/cli/test_startup_input_handoff.py
@@ -1,0 +1,120 @@
+"""Startup must preserve Enter/newline identity and return the inherited TTY mode."""
+
+import os
+import sys
+from contextlib import closing
+
+import pytest
+
+
+@pytest.fixture
+def terminal(monkeypatch):
+    import termios
+
+    from prompt_toolkit.application import create_app_session
+    from prompt_toolkit.input import create_input
+    from prompt_toolkit.output import DummyOutput
+
+    master, slave = os.openpty()
+    inherited = termios.tcgetattr(slave)
+    try:
+        with os.fdopen(os.dup(slave), "r", encoding="utf-8") as stream:
+            monkeypatch.setattr(sys, "stdin", stream)
+            with closing(create_input(stdin=stream)) as terminal_input:
+                with create_app_session(input=terminal_input, output=DummyOutput()):
+                    yield master, slave, terminal_input, inherited
+    finally:
+        os.close(master)
+        os.close(slave)
+
+
+class HandoffObserved(Exception):
+    pass
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("reply", ["n", "interrupt", "eof"])
+@pytest.mark.parametrize("ending", [b"\r", b"\n"])
+def test_startup_preserves_queued_key_identity_and_restores_tty(terminal, monkeypatch, reply, ending):
+    import select
+    import termios
+
+    from prompt_toolkit.keys import Keys
+
+    from cli import HermesCLI
+
+    master, slave, terminal_input, inherited = terminal
+    shell = HermesCLI.__new__(HermesCLI)
+    shell._claim_active_session = lambda _kind: True
+    observed = []
+
+    def answer(_prompt):
+        if reply == "interrupt":
+            raise KeyboardInterrupt
+        if reply == "eof":
+            raise EOFError
+        return reply
+
+    def startup():
+        assert shell._offer_first_run_setup() is False
+        # Type ahead at the real onboarding-to-REPL boundary, before the
+        # Application has entered its own raw-mode context.
+        os.write(master, b"draft" + ending)
+        # Wait for the line discipline to receive the write before changing
+        # modes; write completion alone does not order those kernel operations.
+        assert select.select([slave], [], [], 2)[0] == [slave]
+
+    def observe_handoff():
+        with terminal_input.raw_mode():
+            observed.extend(key.key for key in terminal_input.read_keys())
+        # A failure during startup must restore the mode just like a normal exit.
+        raise HandoffObserved
+
+    monkeypatch.setattr("builtins.input", answer)
+    shell._tui_print_startup = startup
+    shell._tui_init_run_state = observe_handoff
+    with pytest.raises(HandoffObserved):
+        shell.run()
+
+    assert termios.tcgetattr(slave) == inherited
+    expected = Keys.ControlM if ending == b"\r" else Keys.ControlJ
+    assert observed == [*"draft", expected]
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("outcome", ["configured", "cancelled", "failed"])
+def test_first_run_dialog_borrows_cooked_mode_without_releasing_raw_owner(terminal, monkeypatch, outcome):
+    import termios
+
+    from cli import HermesCLI
+
+    _master, slave, terminal_input, inherited = terminal
+    shell = HermesCLI.__new__(HermesCLI)
+    shell.requested_provider = "unchanged"
+    shell.model = "unchanged"
+    shell._runtime_credentials_ready = lambda: True
+    dialog_modes = []
+
+    def answer(_prompt):
+        dialog_modes.append(termios.tcgetattr(slave)[3])
+        return "y"
+
+    def picker():
+        dialog_modes.append(termios.tcgetattr(slave)[3])
+        if outcome == "cancelled":
+            raise KeyboardInterrupt
+        if outcome == "failed":
+            raise RuntimeError("provider setup failed")
+
+    monkeypatch.setattr("builtins.input", answer)
+    monkeypatch.setattr("hermes_cli.main.select_provider_and_model", picker)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    with terminal_input.raw_mode():
+        raw = termios.tcgetattr(slave)
+        result = shell._offer_first_run_setup()
+        assert termios.tcgetattr(slave) == raw
+
+    assert result is (outcome == "configured")
+    assert len(dialog_modes) == 2
+    assert all(mode & termios.ICANON and mode & termios.ECHO for mode in dialog_modes)
+    assert termios.tcgetattr(slave) == inherited


### PR DESCRIPTION
## What does this PR do?

Preserve Enter as submit when the user types immediately after declining first-run provider setup, before the classic CLI's prompt_toolkit Application is ready. On Linux and macOS, the startup gap currently leaves `ICRNL` enabled: Enter/CR becomes LF, which Hermes correctly interprets as its Ctrl+J newline binding. The first command then remains pending until another Enter.

The existing AppSession input now owns raw mode across startup. Blocking setup dialogs temporarily borrow cooked mode, and inherited terminal settings are restored before shutdown or when startup raises. Key bindings and submitted bytes are unchanged.

## Related Issue

Follow-up to the first-run onboarding introduced in #76437. No separate issue; the reproduction and regression tests are included here. Searched open/merged PRs and issues for the startup/ICRNL handoff and `_offer_first_run_setup`; #98413 concerns a different problem, modified-key escape decoding in other prompts.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: scope the existing AppSession input's raw mode around startup and the Application. `ExitStack.close()` releases it before cleanup, including the unusable-stdin path; scope unwinding also restores it on startup exceptions.
- `hermes_cli/cli_agent_setup_mixin.py`: borrow cooked mode only for the actual setup `input()` and provider picker, returning to raw mode before completion/cancellation messages.
- `tests/cli/test_startup_input_handoff.py`: two real-PTY invariant tests, parametrized across CR/LF, setup decline/interruption/EOF, and configured/cancelled/failed picker outcomes. No new input queue, dependency, flag or keystroke rewriting.

Most of the `run()` diff is indentation under the input lifetime; existing application setup, cleanup and relaunch behavior stays in place.

## How to Test

1. Start the real classic `hermes` launcher on Linux or macOS with an isolated, unconfigured home and no inherited provider credentials. See the macOS credential-isolation note below.
2. Decline the provider setup prompt. As soon as `Skipped. Run 'hermes model' or 'hermes setup' any time.` appears, send `/quit` followed by one CR (`0x0d`) through the PTY, before Application startup completes.
3. On base `6c3d4a4af70d76b7365bf19e9420ffdcbb9830ad`, the command remains pending with a newline. With this patch, that single Enter exits 0. Sending explicit LF (`0x0a`, Ctrl+J) still inserts a newline and waits for Enter.

The new test deterministically covers the same kernel handoff using `os.openpty()` and prompt_toolkit's real key decoder, with descriptor readiness ordering the input receipt before mode changes.

```bash
# Linux invariant tests: 6 failed / 3 passed on base; 9 passed with the patch.
HERMES_TEST_FILE_RETRIES=0 HERMES_TEST_WORKERS=1 \
  scripts/run_tests.sh tests/cli/test_startup_input_handoff.py -q

# Final patched source on Linux: 28 passed, 1 Windows-only skipped.
HERMES_TEST_FILE_RETRIES=0 HERMES_TEST_WORKERS=1 \
  scripts/run_tests.sh tests/cli/test_startup_input_handoff.py \
  tests/cli/test_ctrl_enter_newline.py tests/cli/test_cli_shift_enter_newline.py -q

python scripts/check-windows-footguns.py --diff 6c3d4a4af70d76b7365bf19e9420ffdcbb9830ad
```

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] Commit messages follow Conventional Commits.
- [x] I searched existing PRs for duplicates.
- [x] This PR contains only changes related to this fix.
- [ ] Full test suite: not run locally. The focused suites above ran through the canonical `scripts/run_tests.sh`; no bare pytest invocation or retry was used.
- [x] Added behavioral regression tests, proven failing on base.
- [x] Tested on Ubuntu 24.04 ARM64 and macOS 15.5 ARM64, Python 3.11.16, Hermes 0.21.1, prompt_toolkit 3.0.52. The macOS addition is native PTY verification; pytest counts above are Linux results.

### Documentation & Housekeeping

- [x] Documentation: N/A; preserves the existing Enter/Ctrl+J contract.
- [x] Config example: N/A; no configuration changes.
- [x] Architecture/workflow documentation: N/A; reuses existing input ownership.
- [x] Cross-platform impact considered. Windows native behavior remains unverified; Linux-only tests use the named OS marker. The Windows-footguns check passed on all three changed files.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

The following native matrix was exercised on both Ubuntu 24.04 ARM64 and macOS 15.5 ARM64 with the actual launcher, without submitting any model request:

| Native observation | Before | Patched |
| --- | --- | --- |
| Direct PTY, Enter at setup handoff | Pending; needs a second Enter | Exits 0 after one Enter |
| Hmux PTY, same handoff | Pending; needs a second Enter | Exits 0 after one Enter |
| Hmux PTY, explicit Ctrl+J | — | Remains pending until Enter |
| Hmux PTY, actual setup Ctrl+C then Enter | — | Exits 0 after one Enter |
| Direct PTY, ordinary ready input | — | Exits 0; inherited terminal settings restored |

Startup-exception restoration is covered by the regression test. An observation-only wrapper around the real shutdown method in the ready-input run confirmed that `ICANON` and `ICRNL` were already restored before cleanup; the other native runs used the unmodified launcher. Ruff passed on all three changed files. Authenticated provider-picker completion was covered through mocked collaborators, not a live login. This verification does not cover later conversation-time `run_in_terminal` transitions.

### Additional macOS verification (2026-09-11)

Verified the unchanged PR head `2fb96dcd656514230f9bd5d4a472cceb9461d371` against its original base: the first Enter failed in both direct PTY and Hmux before the patch, and all five patched native cases in the table passed. The draft command was sent once; only an extra Enter was used to clean up the two base failures and the intentional-newline case. Full inherited terminal attributes were restored on normal direct-PTY exit, and the ready-input observation confirmed restoration before the real shutdown method began.

Each provider used disposable data and discovery roots. Its PATH excluded `security`, `gh`, `claude` and `codex` so keyless onboarding could not borrow personal Keychain or CLI credentials; no real Keychain access, login or model request was performed. This adds native macOS input/lifecycle evidence, not authenticated-provider or Windows coverage. The seven owned QA process trees and all eleven provider/Host generations were verified exited.
