### PR TITLE
fix(docker): bind container reuse to runtime posture

### DIFF
--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -14,6 +14,19 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
+def _hermetic_docker_runtime_reuse_key(monkeypatch, tmp_path):
+    """Keep Docker tests from reading or writing the operator's real Hermes root."""
+    from tools.environments import docker as module
+
+    saved_keys = dict(module._RUNTIME_REUSE_KEYS)
+    module._RUNTIME_REUSE_KEYS.clear()
+    monkeypatch.setattr(module, "get_default_hermes_root", lambda: tmp_path / "hermes-home")
+    yield
+    module._RUNTIME_REUSE_KEYS.clear()
+    module._RUNTIME_REUSE_KEYS.update(saved_keys)
+
+
+@pytest.fixture(autouse=True)
 def _no_host_browser_use_cli():
     """Keep the host's browser-use/uvx install out of tests.
 

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,5 +1,9 @@
+import errno
 import logging
 import os
+import secrets
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from io import StringIO
 import subprocess
 
@@ -18,7 +22,7 @@ def _mock_subprocess_run(monkeypatch):
     captured call list — these tests inspect the real sandbox-start ``run``.
     Tests that exercise the probe itself live in test_docker_cgroup_limits.py.
     """
-    docker_env._cgroup_limits_ok = True
+    monkeypatch.setattr(docker_env, "_cgroup_limits_ok", True)
     calls = []
 
     def _run(cmd, **kwargs):
@@ -755,7 +759,312 @@ def test_labels_attribute_populated_after_init(monkeypatch):
         "hermes-task-id": "abc",
         "hermes-profile": "default",
         "hermes-egress": "off",
+        "hermes-runtime": docker_env._runtime_reuse_fingerprint(
+            env._image, env._all_run_args, env._run_env_values
+        ),
     }
+
+
+def test_runtime_reuse_identity_tracks_image_and_run_args_without_exposing_them():
+    """The label changes with immutable posture but contains no image, mount, env, or arg text."""
+    private_mount = "/private/operator/workspace:/workspace"
+    private_env = {"PRIVATE_TOKEN": "operator-secret-a"}
+    baseline = docker_env._runtime_reuse_fingerprint(
+        "python:3.11", ["--network", "none", "-v", private_mount], private_env
+    )
+
+    assert baseline == docker_env._runtime_reuse_fingerprint(
+        "python:3.11", ["--network", "none", "-v", private_mount], private_env
+    )
+    assert baseline != docker_env._runtime_reuse_fingerprint(
+        "python:3.12", ["--network", "none", "-v", private_mount], private_env
+    )
+    assert baseline != docker_env._runtime_reuse_fingerprint(
+        "python:3.11", ["--network", "none"], private_env
+    )
+    assert baseline != docker_env._runtime_reuse_fingerprint(
+        "python:3.11",
+        ["--network", "none", "-v", private_mount],
+        {"PRIVATE_TOKEN": "operator-secret-b"},
+    )
+    assert len(baseline) == 24
+    assert set(baseline) <= set("0123456789abcdef")
+
+
+def test_runtime_reuse_identity_is_keyed(monkeypatch):
+    """A readable label must not be an offline oracle for guessed env values or host paths."""
+    args = ["--network", "none", "-v", "/private/operator/workspace:/workspace"]
+    env = {"PRIVATE_TOKEN": "operator-secret-a"}
+
+    monkeypatch.setattr(docker_env, "_runtime_reuse_key", lambda: b"a" * 32)
+    first_installation = docker_env._runtime_reuse_fingerprint("python:3.11", args, env)
+    monkeypatch.setattr(docker_env, "_runtime_reuse_key", lambda: b"b" * 32)
+    second_installation = docker_env._runtime_reuse_fingerprint("python:3.11", args, env)
+
+    assert first_installation != second_installation
+
+
+def test_runtime_reuse_identity_handles_surrogate_escaped_posture():
+    """POSIX paths and env values may contain bytes decoded through surrogateescape."""
+    label = docker_env._runtime_reuse_fingerprint(
+        "python:3.11",
+        ["-v", "/mnt/caf\udce9:/workspace"],
+        {"PRIVATE_TOKEN": "a\udcffb"},
+    )
+
+    assert len(label) == 24
+    assert set(label) <= set("0123456789abcdef")
+
+
+def test_runtime_reuse_key_is_private_and_stable(tmp_path):
+    """Concurrent Hermes processes need one persistent machine-local HMAC key."""
+    load_key = getattr(docker_env, "_load_or_create_runtime_reuse_key", lambda _path: None)
+    key_path = tmp_path / "docker-runtime-reuse.key"
+
+    first = load_key(key_path)
+    second = load_key(key_path)
+
+    assert isinstance(first, bytes)
+    assert len(first) == 32
+    assert second == first
+    if os.name != "nt":
+        assert key_path.stat().st_mode & 0o777 == 0o600
+
+
+def test_runtime_reuse_key_creation_is_race_safe(tmp_path):
+    key_path = tmp_path / "docker-runtime-reuse.key"
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        keys = list(pool.map(docker_env._load_or_create_runtime_reuse_key, [key_path] * 32))
+
+    assert len(set(keys)) == 1
+    assert key_path.read_bytes() == keys[0]
+    assert not list(tmp_path.glob(f".{key_path.name}.*.tmp"))
+
+
+def test_runtime_reuse_key_rejects_fifo_without_hanging(tmp_path):
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("FIFOs are not available on this platform")
+    fifo = tmp_path / "fifo-key"
+    os.mkfifo(fifo)
+    result = {}
+
+    def _load():
+        try:
+            docker_env._load_or_create_runtime_reuse_key(fifo)
+        except BaseException as exc:  # noqa: BLE001 - captured for the parent test thread
+            result["exc"] = exc
+
+    worker = threading.Thread(target=_load, daemon=True)
+    worker.start()
+    worker.join(timeout=1)
+
+    assert not worker.is_alive(), "opening a FIFO key path blocked indefinitely"
+    assert isinstance(result.get("exc"), RuntimeError)
+    assert "not a regular file" in str(result["exc"])
+
+
+def test_runtime_reuse_lock_opens_nonblocking(tmp_path, monkeypatch):
+    lock_path = tmp_path / ".docker-runtime-reuse.key.lock"
+
+    class _OSProxy:
+        def __getattr__(self, name):
+            return getattr(os, name)
+
+        @staticmethod
+        def open(path, flags, *args):
+            assert path == lock_path
+            assert flags & os.O_NONBLOCK
+            raise RuntimeError("open flags verified")
+
+    monkeypatch.setattr(docker_env, "os", _OSProxy())
+
+    with pytest.raises(RuntimeError, match="open flags verified"):
+        with docker_env._RuntimeReuseFileLock(lock_path):
+            pass
+
+
+@pytest.mark.parametrize(
+    "link_errno",
+    [errno.EPERM, errno.EACCES, errno.EINVAL, errno.EOPNOTSUPP, errno.ENOSYS],
+)
+def test_runtime_reuse_key_falls_back_when_hardlinks_are_unsupported(
+    tmp_path, monkeypatch, link_errno
+):
+    key_path = tmp_path / "docker-runtime-reuse.key"
+    real_link = os.link
+
+    class _OSProxy:
+        def __getattr__(self, name):
+            return getattr(os, name)
+
+        @staticmethod
+        def link(_source, _target):
+            raise OSError(link_errno, "hardlinks unsupported")
+
+    monkeypatch.setattr(docker_env, "os", _OSProxy())
+
+    first = docker_env._load_or_create_runtime_reuse_key(key_path)
+    second = docker_env._load_or_create_runtime_reuse_key(key_path)
+
+    assert os.link is real_link
+    assert second == first
+    assert key_path.read_bytes() == first
+    assert not list(tmp_path.glob(f".{key_path.name}.*.tmp"))
+
+
+def test_runtime_reuse_key_converges_without_hardlinks_under_race(tmp_path, monkeypatch):
+    """Two simultaneous fallback publishers must return one atomically published key."""
+    key_path = tmp_path / "docker-runtime-reuse.key"
+    link_barrier = threading.Barrier(2)
+    link_attempts = []
+    replace_calls = []
+
+    class _OSProxy:
+        def __getattr__(self, name):
+            return getattr(os, name)
+
+        @staticmethod
+        def link(_source, _target):
+            link_attempts.append(threading.get_ident())
+            link_barrier.wait(timeout=5)
+            raise OSError(errno.EOPNOTSUPP, "hardlinks unsupported")
+
+        @staticmethod
+        def replace(source, target):
+            replace_calls.append((source, target))
+            return os.replace(source, target)
+
+    monkeypatch.setattr(docker_env, "os", _OSProxy())
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        keys = list(pool.map(docker_env._load_or_create_runtime_reuse_key, [key_path] * 2))
+
+    assert len(link_attempts) == 2, "the fallback publishers never raced"
+    assert len(replace_calls) == 1, "more than one publisher replaced the final key"
+    assert len(set(keys)) == 1
+    assert key_path.read_bytes() == keys[0]
+    assert not list(tmp_path.glob(f".{key_path.name}.*.tmp"))
+
+
+def test_runtime_reuse_key_recovers_when_target_vanishes_after_eexist(tmp_path, monkeypatch):
+    key_path = tmp_path / "docker-runtime-reuse.key"
+    link_calls = []
+
+    class _OSProxy:
+        def __getattr__(self, name):
+            return getattr(os, name)
+
+        @staticmethod
+        def link(source, target):
+            link_calls.append((source, target))
+            if len(link_calls) == 1:
+                raise FileExistsError(errno.EEXIST, "target vanished")
+            return os.link(source, target)
+
+    monkeypatch.setattr(docker_env, "os", _OSProxy())
+
+    key = docker_env._load_or_create_runtime_reuse_key(key_path)
+
+    assert len(link_calls) >= 1
+    assert key_path.read_bytes() == key
+    assert not list(tmp_path.glob(f".{key_path.name}.*.tmp"))
+
+
+def test_runtime_reuse_key_recovers_abandoned_empty_target(tmp_path):
+    key_path = tmp_path / "docker-runtime-reuse.key"
+    key_path.write_bytes(b"")
+
+    key = docker_env._load_or_create_runtime_reuse_key(key_path)
+
+    assert isinstance(key, bytes)
+    assert len(key) == 32
+    assert key_path.read_bytes() == key
+    assert docker_env._load_or_create_runtime_reuse_key(key_path) == key
+
+
+def test_runtime_reuse_key_rejects_corrupt_and_non_regular_files(tmp_path):
+    corrupt = tmp_path / "corrupt-key"
+    corrupt.write_bytes(b"short")
+    with pytest.raises(RuntimeError, match="exactly 32 bytes"):
+        docker_env._load_or_create_runtime_reuse_key(corrupt)
+
+    directory = tmp_path / "directory-key"
+    directory.mkdir()
+    with pytest.raises(RuntimeError, match="not a regular file"):
+        docker_env._load_or_create_runtime_reuse_key(directory)
+
+
+def test_runtime_reuse_key_error_uses_safe_ephemeral_identity(monkeypatch, caplog):
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+    docker_env._RUNTIME_REUSE_KEYS.clear()
+    ephemeral_keys = iter((b"a" * 32, b"b" * 32))
+
+    class _SecretsProxy:
+        def __getattr__(self, name):
+            return getattr(secrets, name)
+
+        @staticmethod
+        def token_bytes(_size):
+            return next(ephemeral_keys)
+
+    monkeypatch.setattr(docker_env, "secrets", _SecretsProxy())
+
+    def _denied(_path):
+        raise PermissionError("owner-only key cannot be written")
+
+    monkeypatch.setattr(docker_env, "_load_or_create_runtime_reuse_key", _denied)
+
+    with caplog.at_level(logging.WARNING):
+        first = _make_dummy_env(task_id="unreadable-runtime-key")
+        second = _make_dummy_env(task_id="unreadable-runtime-key")
+        docker_env._RUNTIME_REUSE_KEYS.clear()  # simulate a fresh process
+        third = _make_dummy_env(task_id="unreadable-runtime-key")
+
+    assert first._labels["hermes-runtime"] == second._labels["hermes-runtime"]
+    assert third._labels["hermes-runtime"] != first._labels["hermes-runtime"]
+    assert "cross-process Docker reuse is disabled" in caplog.text
+
+
+def test_runtime_label_changes_with_constructed_image_and_env_posture(monkeypatch):
+    """The DockerEnvironment call site must bind image and env values into its label."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+
+    baseline = _make_dummy_env(
+        task_id="runtime-posture", image="python:3.11", env={"PRIVATE_TOKEN": "secret-a"}
+    )
+    changed_image = _make_dummy_env(
+        task_id="runtime-posture", image="python:3.12", env={"PRIVATE_TOKEN": "secret-a"}
+    )
+    changed_env = _make_dummy_env(
+        task_id="runtime-posture", image="python:3.11", env={"PRIVATE_TOKEN": "secret-b"}
+    )
+
+    assert baseline._labels["hermes-runtime"] != changed_image._labels["hermes-runtime"]
+    assert baseline._labels["hermes-runtime"] != changed_env._labels["hermes-runtime"]
+    for other_key in ("hermes-agent", "hermes-task-id", "hermes-profile", "hermes-egress"):
+        assert baseline._labels[other_key] == changed_image._labels[other_key]
+        assert baseline._labels[other_key] == changed_env._labels[other_key]
+
+
+def test_runtime_label_changes_with_automatic_cwd_mount(monkeypatch, tmp_path):
+    """The auto-mounted host cwd is resolved before the runtime label is captured."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+
+    isolated = _make_dummy_env(task_id="cwd-posture", host_cwd=str(tmp_path))
+    host_bound = _make_dummy_env(
+        task_id="cwd-posture", host_cwd=str(tmp_path), auto_mount_cwd=True
+    )
+
+    assert isolated._labels["hermes-runtime"] != host_bound._labels["hermes-runtime"]
+    assert f"{tmp_path}:/workspace" not in isolated._all_run_args
+    assert f"{tmp_path}:/workspace" in host_bound._all_run_args
 
 
 def test_shared_container_key_replaces_profile_identity(monkeypatch):
@@ -811,8 +1120,12 @@ def test_empty_shared_container_key_preserves_profile_isolation(monkeypatch):
 # ── Cross-process container reuse (issue #20561) ──────────────────
 
 
-def _mock_subprocess_run_with_reuse(monkeypatch, ps_state: str | None,
-                                     start_succeeds: bool = True):
+def _mock_subprocess_run_with_reuse(
+    monkeypatch,
+    ps_state: str | None,
+    start_succeeds: bool = True,
+    expected_runtime_label: str | None = None,
+):
     """Reuse-aware subprocess.run mock.
 
     ``ps_state`` controls what ``docker ps -a --filter ...`` returns:
@@ -825,6 +1138,7 @@ def _mock_subprocess_run_with_reuse(monkeypatch, ps_state: str | None,
     Returns the captured call list so the test can verify which docker
     commands actually ran.
     """
+    monkeypatch.setattr(docker_env, "_cgroup_limits_ok", True)
     calls = []
 
     def _run(cmd, **kwargs):
@@ -836,8 +1150,13 @@ def _mock_subprocess_run_with_reuse(monkeypatch, ps_state: str | None,
             if sub == "ps":
                 if ps_state is None:
                     return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-                # 2-field format: ID, State. The egress posture is enforced
-                # by the label filters on the ps command itself (#99213).
+                if (
+                    expected_runtime_label is not None
+                    and f"label=hermes-runtime={expected_runtime_label}" not in cmd
+                ):
+                    return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+                # 2-field format: ID, State. The egress and runtime posture are
+                # enforced by exact label filters on the ps command itself.
                 return subprocess.CompletedProcess(
                     cmd, 0,
                     stdout=f"reused-cid\t{ps_state}\n",
@@ -864,11 +1183,16 @@ def test_reuse_attaches_to_running_container_without_docker_run(monkeypatch):
     despite docs claiming "ONE long-lived container shared across sessions"."""
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
     monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
-    calls = _mock_subprocess_run_with_reuse(monkeypatch, ps_state="running")
+    _mock_subprocess_run(monkeypatch)
+    created = _make_dummy_env(task_id="reuse-test", persist_across_processes=False)
+    expected_runtime_label = created._labels["hermes-runtime"]
+    calls = _mock_subprocess_run_with_reuse(
+        monkeypatch, ps_state="running", expected_runtime_label=expected_runtime_label
+    )
 
     env = _make_dummy_env(task_id="reuse-test")
 
-    # The reuse path must populate _container_id from the ps probe output.
+    assert env._labels["hermes-runtime"] == expected_runtime_label
     assert env._container_id == "reused-cid", (
         f"expected reused container id, got {env._container_id!r}"
     )
@@ -882,6 +1206,60 @@ def test_reuse_attaches_to_running_container_without_docker_run(monkeypatch):
     assert not start_invocations, (
         f"docker start should be skipped when container already running, got: {start_invocations}"
     )
+
+
+def test_reuse_rejects_container_from_different_mount_posture(monkeypatch):
+    """Removing a host bind must not retain it through cross-process reuse.
+
+    The terminal guard derives ``has_host_access`` from the current config. If
+    Docker reuses an older container whose bind mounts differ, the guard sees
+    an isolated sandbox while commands still reach the host.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(docker_env, "_cgroup_limits_ok", True)
+    calls = []
+    stale_runtime_label = None
+
+    def _run(cmd, **kwargs):
+        calls.append(list(cmd) if isinstance(cmd, list) else cmd)
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            if cmd[1] == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+            if cmd[1] == "ps":
+                # Model Docker's exact label filtering. The stale host-bound
+                # container is visible only if the requested runtime label is
+                # identical to the one captured under the old mount posture.
+                stale_filter = f"label=hermes-runtime={stale_runtime_label}"
+                stdout = (
+                    "stale-host-bound\trunning\n"
+                    if stale_runtime_label is not None and stale_filter in cmd
+                    else ""
+                )
+                return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+            if cmd[1] == "run":
+                return subprocess.CompletedProcess(cmd, 0, stdout="fresh-container\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    host_bound = _make_dummy_env(
+        task_id="mount-posture",
+        volumes=["/private/operator/workspace:/workspace"],
+        persist_across_processes=False,
+    )
+    stale_runtime_label = host_bound._labels["hermes-runtime"]
+    calls.clear()
+
+    isolated = _make_dummy_env(task_id="mount-posture", volumes=[])
+
+    assert isolated._labels["hermes-runtime"] != stale_runtime_label
+    assert isolated._container_id == "fresh-container"
+    ps_call = next(cmd for cmd in calls if isinstance(cmd, list) and cmd[1] == "ps")
+    run_call = next(cmd for cmd in calls if isinstance(cmd, list) and cmd[1] == "run")
+    runtime_label = isolated._labels["hermes-runtime"]
+    assert f"label=hermes-runtime={runtime_label}" in ps_call
+    assert f"hermes-runtime={runtime_label}" in run_call
 
 
 def test_egress_enabled_does_not_reuse_pre_egress_container(monkeypatch):

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -6,13 +6,17 @@ bind mounts.
 """
 
 import datetime
+import errno
 import hashlib
+import hmac
 import json
 import logging
 import os
 import re
+import secrets
 import shlex
 import shutil
+import stat
 import subprocess
 import sys
 import threading
@@ -21,6 +25,7 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
+from hermes_constants import get_default_hermes_root
 from tools.environments.base import BaseEnvironment, EnvironmentConnectionError, _SHELL_ENV_NAME_RE
 from tools.environments.base_output import _popen_bash
 from tools.environments.docker_egress import (
@@ -87,6 +92,7 @@ _load_hermes_env_vars = load_hermes_env_vars
 # Docker label values must match [a-zA-Z0-9_.-] and stay <=63 chars to round-trip
 # through `docker ps --filter label=key=value`.
 _LABEL_VALUE_OK_RE = re.compile(r"[^A-Za-z0-9_.-]")
+_RUNTIME_LABEL_KEY = "hermes-runtime"
 
 
 def _sanitize_label_value(value: str) -> str:
@@ -120,6 +126,202 @@ def _container_identity(shared_key: str = "") -> str:
         return _sanitize_label_value(_get_active_profile_name())
     digest = hashlib.sha256(shared_key.encode("utf-8")).hexdigest()[:12]
     return f"{_sanitize_label_value(shared_key)[:50]}-{digest}"
+
+
+_RUNTIME_REUSE_KEY_FILE = ".docker-runtime-reuse.key"
+_RUNTIME_REUSE_KEYS: dict[str, bytes] = {}
+_RUNTIME_REUSE_KEY_LOCK = threading.Lock()
+
+
+class _IncompleteRuntimeReuseKey(RuntimeError):
+    def __init__(self, message: str, *, size: int):
+        super().__init__(message)
+        self.size = size
+
+
+def _read_runtime_reuse_key(path: Path) -> bytes:
+    flags = (
+        os.O_RDONLY | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    )
+    fd = os.open(path, flags)
+    try:
+        file_stat = os.fstat(fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise RuntimeError(f"Docker runtime reuse key is not a regular file: {path}")
+        if os.name != "nt" and file_stat.st_mode & 0o077:
+            os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "rb") as handle:
+            fd = -1
+            key = handle.read(33)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+    if len(key) != 32:
+        raise _IncompleteRuntimeReuseKey(
+            f"Docker runtime reuse key must contain exactly 32 bytes: {path}", size=len(key)
+        )
+    return key
+
+
+def _set_runtime_reuse_file_lock(fd: int, *, lock: bool) -> None:
+    """Acquire or release a cross-process advisory lock on an open lock file."""
+    if os.name == "nt":
+        import msvcrt
+
+        os.lseek(fd, 0, os.SEEK_SET)
+        if os.fstat(fd).st_size == 0:
+            os.write(fd, b"\0")
+            os.fsync(fd)
+            os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, msvcrt.LK_LOCK if lock else msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(fd, fcntl.LOCK_EX if lock else fcntl.LOCK_UN)
+
+
+class _RuntimeReuseFileLock:
+    def __init__(self, path: Path):
+        self.path = path
+        self.fd = -1
+
+    def __enter__(self):
+        flags = (
+            os.O_RDWR | os.O_CREAT
+            | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+        )
+        self.fd = os.open(self.path, flags, 0o600)
+        try:
+            file_stat = os.fstat(self.fd)
+            if not stat.S_ISREG(file_stat.st_mode):
+                raise RuntimeError(f"Docker runtime reuse lock is not a regular file: {self.path}")
+            if os.name != "nt" and file_stat.st_mode & 0o077:
+                os.fchmod(self.fd, 0o600)
+            _set_runtime_reuse_file_lock(self.fd, lock=True)
+        except BaseException:
+            os.close(self.fd)
+            self.fd = -1
+            raise
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        fd, self.fd = self.fd, -1
+        if fd >= 0:
+            try:
+                _set_runtime_reuse_file_lock(fd, lock=False)
+            finally:
+                os.close(fd)
+
+
+def _publish_runtime_reuse_key_locked(path: Path, temp_path: Path, key: bytes) -> bytes:
+    """Atomically publish a complete key while serializing fallback publishers."""
+    lock_path = path.with_name(f".{path.name}.lock")
+    with _RuntimeReuseFileLock(lock_path):
+        try:
+            return _read_runtime_reuse_key(path)
+        except FileNotFoundError:
+            pass
+        except _IncompleteRuntimeReuseKey as exc:
+            # An empty file is crash residue from the former direct-O_EXCL
+            # fallback. Non-empty malformed keys remain a hard failure.
+            if exc.size != 0:
+                raise
+        os.replace(temp_path, path)
+        return key
+
+
+def _load_or_create_runtime_reuse_key(path: Path) -> bytes:
+    """Load or atomically create the private key used for Docker reuse labels."""
+    try:
+        return _read_runtime_reuse_key(path)
+    except _IncompleteRuntimeReuseKey:
+        # Let the serialized publisher distinguish recoverable empty crash
+        # residue from non-empty corruption.
+        pass
+    except FileNotFoundError:
+        pass
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    key = secrets.token_bytes(32)
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(8)}.tmp")
+    flags = (
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    )
+    fd = os.open(temp_path, flags, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            fd = -1
+            handle.write(key)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            # Linking a fully written inode into place is an atomic create-if-absent.
+            # A direct O_EXCL write exposes a zero-length target to a racing reader.
+            os.link(temp_path, path)
+        except FileExistsError:
+            return _publish_runtime_reuse_key_locked(path, temp_path, key)
+        except OSError as exc:
+            unsupported = {
+                errno.EPERM,
+                errno.EACCES,
+                errno.EINVAL,
+                getattr(errno, "EOPNOTSUPP", -1),
+                getattr(errno, "ENOTSUP", -1),
+                getattr(errno, "ENOSYS", -1),
+            }
+            if exc.errno not in unsupported:
+                raise
+            # Some managed-home filesystems reject hardlinks. Serialize
+            # publishers, then atomically replace from the fully-written temp.
+            return _publish_runtime_reuse_key_locked(path, temp_path, key)
+        return key
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _runtime_reuse_key() -> bytes:
+    path = get_default_hermes_root() / _RUNTIME_REUSE_KEY_FILE
+    cache_key = str(path.expanduser().resolve(strict=False))
+    with _RUNTIME_REUSE_KEY_LOCK:
+        key = _RUNTIME_REUSE_KEYS.get(cache_key)
+        if key is None:
+            try:
+                key = _load_or_create_runtime_reuse_key(path)
+            except (OSError, RuntimeError) as exc:
+                # A missing persistent identity must disable reuse, not Docker.
+                # A process-local random key cannot match any prior process's
+                # runtime label, so this degradation fails closed for reuse.
+                key = secrets.token_bytes(32)
+                logger.warning(
+                    "Docker runtime reuse key is unavailable (%s); "
+                    "cross-process Docker reuse is disabled for this process",
+                    exc,
+                )
+            _RUNTIME_REUSE_KEYS[cache_key] = key
+        return key
+
+
+def _runtime_reuse_fingerprint(
+    image: str, run_args: list[str], run_env_values: dict[str, str],
+) -> str:
+    """Keyed label value for immutable posture, including private paths and env values."""
+    payload = json.dumps(
+        [image, run_args, run_env_values],
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hmac.new(
+        _runtime_reuse_key(), payload.encode("utf-8"), hashlib.sha256
+    ).hexdigest()[:24]
 
 
 def reap_orphan_containers(
@@ -576,22 +778,30 @@ class DockerEnvironment(BaseEnvironment):
         # Labels identify hermes containers to the orphan reaper (hermes-agent=1),
         # cross-process reuse (task-id/profile) and operators. The reuse identity
         # is captured at start and never changes for the container's lifetime.
-        # Egress posture gets its own label: env/CA mounts are immutable after
-        # creation, so reusing a pre-egress container would bypass the firewall.
+        # Immutable image/run posture gets an opaque label so config changes
+        # cannot attach current policy decisions to an older container.
         profile_name = _container_identity(shared_container_key)
         task_label = _sanitize_label_value(task_id)
+        try:
+            runtime_label = _runtime_reuse_fingerprint(
+                image, all_run_args, self._run_env_values)
+        except (OSError, RuntimeError) as exc:
+            raise EnvironmentConnectionError(
+                f"Docker runtime reuse identity could not load its private key: {exc}"
+            ) from exc
         self._labels = {
             "hermes-agent": "1",
             "hermes-task-id": task_label,
             "hermes-profile": profile_name,
-            _EGRESS_LABEL_KEY: egress_label}
+            _EGRESS_LABEL_KEY: egress_label,
+            _RUNTIME_LABEL_KEY: runtime_label}
         # Saved for container recreation on "No such container" recovery.
         self._image = image
         self._image_uses_s6_init = image_uses_s6_init
         self._all_run_args = all_run_args
 
         reused = persist_across_processes and self._attach_existing_container(
-            task_label, profile_name, egress_label, network)
+            task_label, profile_name, egress_label, runtime_label, network)
         if not reused:
             self._container_id = self._docker_run(cwd)
 
@@ -713,13 +923,16 @@ class DockerEnvironment(BaseEnvironment):
             logger.debug("Skipping docker cwd mount: /workspace already mounted by user config")
         return volume_args, writable_args
 
-    def _attach_existing_container(self, task_label, profile_name, egress_label, network: bool) -> bool:
+    def _attach_existing_container(
+        self, task_label, profile_name, egress_label, runtime_label, network: bool,
+    ) -> bool:
         """Attach to a prior process's labeled container ("ONE long-lived container shared
         across sessions"; opt out via ``docker_persist_across_processes: false``).
         Network guard is lockdown-only: a bridge container under ``docker_network: false``
         is removed and recreated, but a ``none`` container under default config is kept so
         ``--network=none`` in extra args doesn't churn containers every startup."""
-        existing = self._find_reusable_container(task_label, profile_name, egress_label)
+        existing = self._find_reusable_container(
+            task_label, profile_name, egress_label, runtime_label)
         if existing is None:
             return False
         container_id, state = existing
@@ -882,7 +1095,8 @@ class DockerEnvironment(BaseEnvironment):
         existing = self._find_reusable_container(
             self._labels.get("hermes-task-id", ""),
             self._labels.get("hermes-profile", ""),
-            self._labels.get(_EGRESS_LABEL_KEY, "off"))
+            self._labels.get(_EGRESS_LABEL_KEY, "off"),
+            self._labels.get(_RUNTIME_LABEL_KEY, ""))
         if existing is not None:
             cid, state = existing
             if state == "running":
@@ -963,18 +1177,20 @@ class DockerEnvironment(BaseEnvironment):
         return (result.stdout.strip() or None) if result is not None else None
 
     def _find_reusable_container(
-        self, task_label: str, profile_label: str, egress_label: str) -> Optional[tuple[str, str]]:
-        """``(container_id, state)`` of an existing container labeled for this task/profile/
-        egress posture, or ``None`` on miss or any failure. The egress posture is a label
-        FILTER for every posture, "off" included: a container built with egress on must not be
-        reused after ``hermes egress disable`` (baked-in proxy env and CA mounts), and every
-        container this class creates carries the label. The ``{{.Label "key"}}`` template
-        function is Docker-only — podman ps exits 125 on it — so the probe never uses it (#99213)."""
+        self, task_label: str, profile_label: str, egress_label: str,
+        runtime_label: str,
+    ) -> Optional[tuple[str, str]]:
+        """``(container_id, state)`` matching this task/profile and immutable posture.
+
+        Egress and runtime identities are label filters, so containers created
+        under any different posture are excluded by Docker/Podman itself.
+        """
         filters = [
             "--filter", "label=hermes-agent=1",
             "--filter", f"label=hermes-task-id={task_label}",
             "--filter", f"label=hermes-profile={profile_label}",
-            "--filter", f"label={_EGRESS_LABEL_KEY}={egress_label}"]
+            "--filter", f"label={_EGRESS_LABEL_KEY}={egress_label}",
+            "--filter", f"label={_RUNTIME_LABEL_KEY}={runtime_label}"]
         result = _docker_query(
             [self._docker_exe, "ps", "-a", *filters, "--format", "{{.ID}}\t{{.State}}"], timeout=10,
             fail="docker ps probe failed: %s — will start a fresh container",

--- a/website/docs/guides/secure-hermes-on-a-work-machine.md
+++ b/website/docs/guides/secure-hermes-on-a-work-machine.md
@@ -90,7 +90,11 @@ terminal:
   docker_forward_env: []  # Explicit allowlist only; empty keeps secrets out of the container
 ```
 
-Every Docker container runs with hardened settings — all Linux capabilities dropped (with a minimal add-back set), `no-new-privileges`, a process-count limit, and size-limited tmpfs mounts. With a container backend, destructive commands inside the container can't harm the host, which is why dangerous-command checks are skipped there.
+Every Docker container runs with hardened settings — all Linux capabilities dropped (with a minimal add-back set), a process-count limit, and size-limited tmpfs mounts. Hermes also enables `no-new-privileges` unless `docker_snap_compat` is enabled; that compatibility mode omits the setting because Snap-packaged Docker otherwise blocks every process from starting. With the default empty `docker_volumes` and `docker_mount_cwd_to_workspace: false`, host `config.yaml` and `.env` are not mounted into the container; selected skills, credentials, and caches are mounted read-only. Destructive commands inside that container cannot reach the host, so dangerous-command checks are skipped there.
+
+:::caution
+A host bind mount changes that boundary. Setting `docker_volumes` to a host path or enabling `docker_mount_cwd_to_workspace` exposes that path to container commands, and Hermes therefore re-enables dangerous-command checks. Those checks are still guardrails, not containment: never mount `~/.hermes` (or a parent directory containing it) into the agent container when approval policy must remain operator-owned.
+:::
 
 For `ssh`, set `terminal.backend: ssh` in `config.yaml` and provide host details via `TERMINAL_SSH_HOST`, `TERMINAL_SSH_USER`, and `TERMINAL_SSH_KEY` in `~/.hermes/.env`. See [Network Isolation](/user-guide/security#network-isolation).
 


### PR DESCRIPTION
## Summary
- bind cross-process Docker reuse to a keyed fingerprint of the immutable image, mounts, run arguments, and forwarded environment values
- publish the installation-local reuse key atomically across processes, including filesystems without hardlink support; degrade to a process-local identity when persistent storage is unavailable
- pin the existing host-bind approval behavior with regression coverage, and document that boundary

## Verification
- `scripts/run_tests.sh tests/tools/test_docker*.py tests/tools/test_terminal_environment_selection.py tests/tools/test_terminal_degraded_mode.py -q` (177 passed)
- Ruff, `py_compile`, and `git diff --check`
- live Docker: same-posture processes reused one container and retained a marker
- live Docker: changed bind-mount posture used a distinct runtime label/container and did not expose the marker
- 8-process forced no-hardlink publication race converged on one persisted key with no temp files
- clean exact-HEAD Claude Code review (0 findings)