### PR TITLE
feat(kanban): add named capacity pools for shared contexts

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -345,6 +345,24 @@ model:
 # Disable this only when every review is performed manually from the dashboard.
 kanban:
   review_dispatch: true
+  # Host-wide Running cap (Mini RAM). Unset derives from MemTotal on Linux;
+  # macOS/Windows stay unlimited unless you set this.
+  # max_in_progress: 8
+  # Per-profile Running cap. One integer applied to every assignee.
+  # max_in_progress_per_profile: 1
+  # Named pools: one in-flight budget per context, shared across all boards.
+  # A context is whatever you name — grok, spark, claude, codex, a person.
+  # Cards over the cap stay Ready (skipped_pool_capped); they are not dropped.
+  # capacity_pools:
+  #   grok:
+  #     max_in_progress: 6
+  #     members: [rooke, builder, reviewer]
+  #   spark:
+  #     max_in_progress: 1
+  #     members: [coder]
+  #   claude:
+  #     max_in_progress: 3
+  #     members: [planner]
 
 # =============================================================================
 # Terminal Tool Configuration

--- a/cron/AGENTS.md
+++ b/cron/AGENTS.md
@@ -46,6 +46,10 @@ zero outside a kanban task (footprint ladder rung 3).
 - **Dispatcher:** long-lived loop (default 60s) that reclaims stale claims, promotes ready tasks,
   atomically claims, and spawns assigned profiles. Runs **inside the gateway** by default
   (`kanban.dispatch_in_gateway: true`). Standalone: `plugins/kanban/systemd/hermes-kanban-dispatcher.service`.
+  Host cap: `kanban.max_in_progress` (cross-board). Per-profile cap: `kanban.max_in_progress_per_profile`.
+  Named pools: `kanban.capacity_pools.<name>.{max_in_progress, members}` — one budget per
+  operator-named context (vendor, local role, person), counted across every board before
+  claim; overflow stays Ready as `skipped_pool_capped`.
 - **Plugin assets:** `plugins/kanban/dashboard/` (web UI) + systemd unit. `kanban_db.connect` is its
   own connection helper — do not alias it to `projects_db.connect` (a path-proximity generator did).
 

--- a/gateway/kanban_watchers_dispatcher.py
+++ b/gateway/kanban_watchers_dispatcher.py
@@ -41,6 +41,7 @@ class _DispatcherSettings:
     reconcile_orphans: bool
     default_assignee: Optional[str]
     max_in_progress_per_profile: Optional[int]
+    capacity_pools: dict
 
 
 def _resolve_dispatcher_settings(kanban_cfg: dict, kb: Any) -> _DispatcherSettings:
@@ -114,6 +115,8 @@ def _resolve_dispatcher_settings(kanban_cfg: dict, kb: Any) -> _DispatcherSettin
         # Per-profile concurrency cap: no single profile's local model / API
         # quota / browser pool gets overwhelmed by a fan-out.
         max_in_progress_per_profile=_positive_int_setting(kanban_cfg, "max_in_progress_per_profile"),
+        # Named host-wide pools (several profiles share one backend budget).
+        capacity_pools=_kbd().normalize_capacity_pools(kanban_cfg.get("capacity_pools")),
     )
 
 
@@ -181,6 +184,10 @@ class _KanbanDispatcher:
         if not self._quarantine_lifted(slug, fingerprint):
             return None
         kwargs = {k: v for k, v in asdict(self.settings).items() if k != "interval"}
+        # asdict() turns CapacityPool dataclasses into nested dicts; dispatch_once
+        # re-normalizes that mapping. Keep the parsed objects when present.
+        if self.settings.capacity_pools:
+            kwargs["capacity_pools"] = self.settings.capacity_pools
         try:
             # No explicit init_db(): connect() runs the migration once per
             # process (see the matching note in the notifier collector).

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1737,6 +1737,14 @@ DEFAULT_CONFIG = {
         # fan-out workflows that would otherwise saturate one profile's local model / API quota / browser
         # pool while leaving other profiles idle. See #21582.
         "max_in_progress_per_profile": None,
+        # Named host-wide admission pools. Each name is an operator-chosen
+        # context (a vendor, a local role, a person, a browser farm — the
+        # dispatcher does not care). Profiles in ``members`` share one
+        # in-flight budget across every board; extras stay Ready as
+        # skipped_pool_capped. Empty = off. Example:
+        #   grok: {max_in_progress: 6, members: [reviewer, researcher]}
+        #   spark: {max_in_progress: 1, members: [coder]}
+        "capacity_pools": {},
         # Auto-run the decomposer on Triage tasks every tick. False = manual via `hermes kanban
         # decompose <id>` or the dashboard's Decompose button.
         "auto_decompose": True,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -219,8 +219,8 @@ def notify_task_updated(
 _TICK_ACTIVITY_FIELDS = (
     "spawned", "reclaimed", "promoted", "reconciled_orphans", "crashed", "stale",
     "timed_out", "auto_blocked", "rate_limited", "auto_assigned_default",
-    "respawn_guarded", "skipped_per_profile_capped", "skipped_unassigned",
-    "skipped_nonspawnable",
+    "respawn_guarded", "skipped_per_profile_capped", "skipped_pool_capped",
+    "skipped_unassigned", "skipped_nonspawnable",
 )
 
 
@@ -4094,6 +4094,9 @@ _PLUGIN_COMPAT_LAZY = {
     'check_respawn_guard': ('hermes_cli.kanban_db_dispatch', 'check_respawn_guard'),
     'claim_unseen_events_for_sub': ('hermes_cli.kanban_db_notify', 'claim_unseen_events_for_sub'),
     'configured_max_in_progress': ('hermes_cli.kanban_db_dispatch', 'configured_max_in_progress'),
+    'configured_capacity_pools': ('hermes_cli.kanban_db_dispatch', 'configured_capacity_pools'),
+    'normalize_capacity_pools': ('hermes_cli.kanban_db_dispatch', 'normalize_capacity_pools'),
+    'CapacityPool': ('hermes_cli.kanban_db_dispatch', 'CapacityPool'),
     'connect': ('hermes_cli.kanban_db_connect', 'connect'),
     'connect_closing': ('hermes_cli.kanban_db_connect', 'connect_closing'),
     'count_notify_subs': ('hermes_cli.kanban_db_notify', 'count_notify_subs'),

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -20,6 +20,7 @@ from dataclasses import field
 from pathlib import Path
 from typing import Any
 from typing import Callable
+from typing import Iterable
 from typing import Mapping
 from typing import Optional
 from typing import TYPE_CHECKING
@@ -133,6 +134,13 @@ class DispatchResult:
     """Memory pressure that restricted this tick: ``"critical"`` (no new
     workers), ``"elevated"`` (at most one), ``None`` (no restriction).
     Reclaim/promotion bookkeeping still ran; deferred tasks stay queued."""
+    skipped_pool_capped: list[tuple[str, str, int, int]] = field(default_factory=list)
+    """``(task_id, pool, current_running_count, cap)`` deferred because a named
+    ``kanban.capacity_pools`` entry is full. Host-wide and cross-board; the
+    card stays ready. Appended after existing fields so positional
+    ``DispatchResult(...)`` construction in plugins keeps working.
+    Separate from per-profile so several assignees that share one context
+    (a vendor, a local role, a person) share one budget."""
 
 
 # Bounded registry of recently-reaped worker exits, filled by the reap loop in
@@ -1342,24 +1350,44 @@ def configured_max_in_progress() -> Optional[int]:
     return ival if ival >= 1 else None
 
 
-def count_running_tasks(conn: sqlite3.Connection) -> int:
+def count_running_tasks(
+    conn: sqlite3.Connection,
+    assignees: Optional[Iterable[str]] = None,
+) -> int:
     """Number of tasks in ``status='running'``.
 
     Used by the multi-board sweep to count OTHER boards' workers against the
     host-level budget — the memory-derived cap bounds the machine, not the
     board. Fails open to 0 so a broken board doesn't brick dispatch on healthy ones.
+    ``assignees`` restricts the count to those profile names (capacity pools);
+    an empty iterable is 0. ``None`` counts every running task.
     """
     try:
+        if assignees is None:
+            return int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+                ).fetchone()[0]
+            )
+        members = tuple(assignees)
+        if not members:
+            return 0
+        placeholders = ",".join("?" * len(members))
         return int(
             conn.execute(
-                "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+                "SELECT COUNT(*) FROM tasks WHERE status = 'running' "
+                f"AND assignee IN ({placeholders})",
+                members,
             ).fetchone()[0]
         )
     except Exception:
         return 0
 
 
-def count_running_tasks_other_boards(board: Optional[str] = None) -> int:
+def count_running_tasks_other_boards(
+    board: Optional[str] = None,
+    assignees: Optional[Iterable[str]] = None,
+) -> int:
     """Total ``running`` tasks across every board EXCEPT ``board``.
 
     Caps bound the HOST, but each board's tick only sees its own DB; without
@@ -1387,13 +1415,171 @@ def count_running_tasks_other_boards(board: Optional[str] = None) -> int:
                 continue
             other = _kbc.connect(board=slug)
             try:
-                total += count_running_tasks(other)
+                total += count_running_tasks(other, assignees=assignees)
             finally:
                 with contextlib.suppress(Exception):
                     other.close()
         except Exception:
             continue
     return total
+
+
+@dataclass(frozen=True)
+class CapacityPool:
+    """One named context: several profiles share one in-flight budget."""
+
+    name: str
+    max_in_progress: int
+    members: tuple[str, ...]
+
+
+def normalize_capacity_pools(raw: Any) -> dict[str, CapacityPool]:
+    """Parse ``kanban.capacity_pools`` into named host-wide admission pools.
+
+    Opt-in. Empty / unset / invalid input returns ``{}`` so existing installs
+    dispatch exactly as they do today. A typo in one pool is ignored; valid
+    siblings still apply. A profile listed in two pools keeps the first.
+    """
+    if raw is None or raw == {}:
+        return {}
+    if not isinstance(raw, Mapping):
+        _kb._log.warning(
+            "kanban dispatcher: invalid kanban.capacity_pools=%r; "
+            "expected a mapping of pool name to {max_in_progress, members}",
+            raw,
+        )
+        return {}
+    pools: dict[str, CapacityPool] = {}
+    claimed: dict[str, str] = {}
+    for raw_name, raw_spec in raw.items():
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            _kb._log.warning(
+                "kanban dispatcher: invalid capacity pool name %r; ignoring",
+                raw_name,
+            )
+            continue
+        name = raw_name.strip()
+        if not isinstance(raw_spec, Mapping):
+            _kb._log.warning(
+                "kanban dispatcher: invalid capacity pool %r spec %r; "
+                "expected a mapping with max_in_progress and members",
+                name, raw_spec,
+            )
+            continue
+        try:
+            cap = int(raw_spec.get("max_in_progress"))
+        except (TypeError, ValueError):
+            cap = 0
+        if cap < 1:
+            cap = None
+        if cap is None:
+            _kb._log.warning(
+                "kanban dispatcher: capacity pool %r missing a positive "
+                "max_in_progress; ignoring",
+                name,
+            )
+            continue
+        raw_members = raw_spec.get("members") or ()
+        if isinstance(raw_members, str):
+            raw_members = (raw_members,)
+        if not isinstance(raw_members, (list, tuple, set)):
+            _kb._log.warning(
+                "kanban dispatcher: capacity pool %r members %r is not a list; ignoring",
+                name, raw_members,
+            )
+            continue
+        members: list[str] = []
+        for raw_member in raw_members:
+            if not isinstance(raw_member, str) or not raw_member.strip():
+                _kb._log.warning(
+                    "kanban dispatcher: capacity pool %r ignoring invalid member %r",
+                    name, raw_member,
+                )
+                continue
+            member = raw_member.strip()
+            previous = claimed.get(member)
+            if previous is not None:
+                _kb._log.warning(
+                    "kanban dispatcher: profile %r is already in capacity pool %r; "
+                    "not adding it to %r",
+                    member, previous, name,
+                )
+                continue
+            claimed[member] = name
+            members.append(member)
+        if not members:
+            _kb._log.warning(
+                "kanban dispatcher: capacity pool %r has no valid members; ignoring",
+                name,
+            )
+            continue
+        pools[name] = CapacityPool(
+            name=name, max_in_progress=cap, members=tuple(members),
+        )
+    return pools
+
+
+def configured_capacity_pools() -> dict[str, CapacityPool]:
+    """Read ``kanban.capacity_pools`` from config, or ``{}`` when unset/invalid."""
+    try:
+        from hermes_cli.config import load_config_readonly
+        raw = (load_config_readonly() or {}).get("kanban", {}).get("capacity_pools")
+    except Exception:
+        return {}
+    return normalize_capacity_pools(raw)
+
+
+def dispatch_caps_from_config(kanban_cfg: Optional[Mapping[str, Any]] = None) -> dict[str, Any]:
+    """Kwargs every ``dispatch_once`` caller must pass so no entry point is uncapped.
+
+    Dashboard nudge, CLI ``hermes kanban dispatch``, the gateway watcher and
+    the standalone daemon all go through this so a UI default of ``max=8``
+    cannot bypass host / per-profile / pool admission.
+    """
+    loaded_from_disk = False
+    if kanban_cfg is None:
+        loaded_from_disk = True
+        try:
+            from hermes_cli.config import load_config_readonly
+            raw_cfg = load_config_readonly() or {}
+            kanban_cfg = raw_cfg.get("kanban", {}) if isinstance(raw_cfg, dict) else {}
+        except Exception:
+            kanban_cfg = {}
+    if not isinstance(kanban_cfg, Mapping):
+        kanban_cfg = {}
+    default_assignee = (kanban_cfg.get("default_assignee") or "").strip() or None
+
+    def _opt_positive(raw: Any) -> Optional[int]:
+        if raw is None:
+            return None
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return None
+        return value if value >= 1 else None
+
+    host_cap = (
+        configured_max_in_progress() if loaded_from_disk
+        else _opt_positive(kanban_cfg.get("max_in_progress"))
+    )
+    return {
+        "default_assignee": default_assignee,
+        "max_in_progress": resolve_max_in_progress(host_cap),
+        "max_in_progress_per_profile": _opt_positive(
+            kanban_cfg.get("max_in_progress_per_profile")
+        ),
+        "max_spawn": _opt_positive(kanban_cfg.get("max_spawn")),
+        "capacity_pools": normalize_capacity_pools(kanban_cfg.get("capacity_pools")),
+    }
+
+
+def _pool_index(pools: Mapping[str, CapacityPool]) -> dict[str, str]:
+    """``{profile: pool_name}`` for every member of every pool."""
+    index: dict[str, str] = {}
+    for pool in pools.values():
+        for member in pool.members:
+            index.setdefault(member, pool.name)
+    return index
 
 
 def _memory_pressure_level(sample: Optional[Mapping[str, Any]] = None) -> str:
@@ -1429,6 +1615,7 @@ def dispatch_once(
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
     reconcile_orphans: bool = True,
+    capacity_pools: Optional[Mapping[str, Any]] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
 
@@ -1452,6 +1639,7 @@ def dispatch_once(
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
             reconcile_orphans=reconcile_orphans,
+            capacity_pools=capacity_pools,
         )
 
     try:
@@ -1501,6 +1689,9 @@ def _dispatch_lane_task(
     spawn_fn,
     per_profile_cap: Optional[int],
     per_profile_running: dict[str, int],
+    capacity_pools: Mapping[str, CapacityPool],
+    pool_by_assignee: Mapping[str, str],
+    pool_running: dict[str, int],
 ) -> bool:
     """Guard, claim, resolve the workspace and spawn one ready/review row.
     Returns True when a spawn slot was consumed (real or ``dry_run``); every
@@ -1522,6 +1713,15 @@ def _dispatch_lane_task(
         if current >= per_profile_cap:
             result.skipped_per_profile_capped.append((task_id, assignee, current))
             return False
+    pool_name = pool_by_assignee.get(assignee)
+    pool = capacity_pools.get(pool_name) if pool_name else None
+    if pool is not None:
+        current_pool = pool_running.get(pool.name, 0)
+        if current_pool >= pool.max_in_progress:
+            result.skipped_pool_capped.append(
+                (task_id, pool.name, current_pool, pool.max_in_progress)
+            )
+            return False
     guard_reason = check_respawn_guard(conn, task_id, lane=lane)
     if guard_reason is not None:
         result.respawn_guarded.append((task_id, guard_reason))
@@ -1538,10 +1738,13 @@ def _dispatch_lane_task(
         return False
 
     def _count_spawn(name: str) -> None:
-        # Later rows in this tick respect the per-profile cap; subsequent
-        # ticks re-query from the DB.
+        # Later rows in this tick respect the per-profile and pool caps;
+        # subsequent ticks re-query from the DB.
         if per_profile_cap is not None and name:
             per_profile_running[name] = per_profile_running.get(name, 0) + 1
+        spawned_pool = pool_by_assignee.get(name) if name else None
+        if spawned_pool:
+            pool_running[spawned_pool] = pool_running.get(spawned_pool, 0) + 1
 
     if dry_run:
         result.spawned.append((task_id, assignee, ""))
@@ -1761,6 +1964,7 @@ def _dispatch_once_locked(
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
     reconcile_orphans: bool = True,
+    capacity_pools: Optional[Mapping[str, Any]] = None,
 ) -> DispatchResult:
     """One dispatcher tick: reclaim stale/crashed running tasks, promote
     todo -> ready, then atomically claim each spawnable ready/review row and
@@ -1807,10 +2011,24 @@ def _dispatch_once_locked(
             "GROUP BY assignee"
         ):
             per_profile_running[prow["assignee"]] = int(prow["n"])
+    pools = (
+        capacity_pools if isinstance(capacity_pools, dict)
+        and all(isinstance(v, CapacityPool) for v in capacity_pools.values())
+        else normalize_capacity_pools(capacity_pools)
+    )
+    pool_by_assignee = _pool_index(pools)
+    pool_running: dict[str, int] = {}
+    for pool in pools.values():
+        pool_running[pool.name] = (
+            count_running_tasks(conn, assignees=pool.members)
+            + count_running_tasks_other_boards(board, assignees=pool.members)
+        )
     lane_kwargs: dict[str, Any] = dict(
         dry_run=dry_run, ttl_seconds=ttl_seconds, board=board,
         failure_limit=failure_limit, spawn_fn=spawn_fn,
         per_profile_cap=per_profile_cap, per_profile_running=per_profile_running,
+        capacity_pools=pools, pool_by_assignee=pool_by_assignee,
+        pool_running=pool_running,
     )
     default_assignee = _resolve_default_assignee(default_assignee)
     spawned = 0
@@ -2324,13 +2542,14 @@ def run_daemon(
         try:
             # Re-resolved every tick (config load is mtime-cached) so operator
             # edits apply without a restart.
-            max_in_progress = resolve_max_in_progress(configured_max_in_progress())
+            caps = dispatch_caps_from_config()
+            if max_spawn is not None:
+                caps["max_spawn"] = max_spawn
             with contextlib.closing(_kbc.connect()) as conn:
                 res = dispatch_once(
                     conn,
-                    max_spawn=max_spawn,
-                    max_in_progress=max_in_progress,
                     failure_limit=failure_limit,
+                    **caps,
                 )
             if on_tick is not None:
                 with contextlib.suppress(Exception):

--- a/hermes_cli/kanban_ops.py
+++ b/hermes_cli/kanban_ops.py
@@ -65,31 +65,25 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         from hermes_cli.config import load_config
         _cfg = load_config()
         _kanban_cfg = _cfg.get("kanban", {}) if isinstance(_cfg, dict) else {}
-        default_assignee = (_kanban_cfg.get("default_assignee") or "").strip() or None
-        max_in_progress_per_profile = kbd._positive_int(
-            _kanban_cfg.get("max_in_progress_per_profile"), None
-        )
-        # Memory-derived default when unset — same fallback the gateway applies.
-        max_in_progress = kbd.resolve_max_in_progress(
-            kbd._positive_int(_kanban_cfg.get("max_in_progress"), None)
-        )
+        caps = kbd.dispatch_caps_from_config(_kanban_cfg)
         # CLI --max is the more explicit signal, so it wins over kanban.max_spawn.
         cli_max = getattr(args, "max", None)
-        max_spawn = (
-            cli_max if cli_max is not None else kbd._positive_int(_kanban_cfg.get("max_spawn"), None)
-        )
+        if cli_max is not None:
+            caps["max_spawn"] = cli_max
     except Exception:
-        default_assignee = max_in_progress_per_profile = max_in_progress = None
-        max_spawn = getattr(args, "max", None)
+        caps = {
+            "default_assignee": None,
+            "max_in_progress": None,
+            "max_in_progress_per_profile": None,
+            "max_spawn": getattr(args, "max", None),
+            "capacity_pools": {},
+        }
     with kbc.connect_closing() as conn:
         res = kbd.dispatch_once(
             conn,
             dry_run=args.dry_run,
-            max_spawn=max_spawn,
-            max_in_progress=max_in_progress,
             failure_limit=getattr(args, "failure_limit", kbd.DEFAULT_FAILURE_LIMIT),
-            default_assignee=default_assignee,
-            max_in_progress_per_profile=max_in_progress_per_profile,
+            **caps,
         )
     if getattr(args, "json", False):
         _print_json({
@@ -103,6 +97,15 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             "skipped_per_profile_capped": [
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
+            ],
+            "skipped_pool_capped": [
+                {
+                    "task_id": tid,
+                    "pool": pool,
+                    "current": current,
+                    "cap": cap,
+                }
+                for (tid, pool, current, cap) in res.skipped_pool_capped
             ],
             "auto_assigned_default": res.auto_assigned_default,
         }, ascii=True)
@@ -124,13 +127,15 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         print(f"  - {tid}  ->  {who}  @ {ws or '-'}{tag}")
     if res.auto_assigned_default:
         print(
-            f"Auto-assigned to kanban.default_assignee={default_assignee!r}: "
+            f"Auto-assigned to kanban.default_assignee={caps.get('default_assignee')!r}: "
             f"{', '.join(res.auto_assigned_default)}"
         )
     if res.skipped_unassigned:
         print(f"Skipped (unassigned): {', '.join(res.skipped_unassigned)}")
     for tid, who, current in res.skipped_per_profile_capped:
         print(f"Deferred ({who} at per-profile cap, {current} running): {tid}")
+    for tid, pool, current, cap in res.skipped_pool_capped:
+        print(f"Deferred ({pool} pool {current}/{cap} in flight): {tid}")
     if res.skipped_nonspawnable:
         print(
             f"Skipped (non-spawnable assignee — terminal lane, OK): "

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -168,7 +168,7 @@ VALID_HOOKS: Set[str] = {
     # section. Kwargs: board: str | None, profile_name: str, dry_run: bool, outcome: "ok" | "skipped_locked"
     # | "idle", result: hermes_cli.kanban_db.DispatchResult (spawned, reclaimed, promoted,
     # reconciled_orphans, crashed, stale, timed_out, auto_blocked, rate_limited, auto_assigned_default,
-    # respawn_guarded, skipped_per_profile_capped, skipped_unassigned, skipped_nonspawnable,
+    # respawn_guarded, skipped_per_profile_capped, skipped_pool_capped, skipped_unassigned, skipped_nonspawnable,
     # skipped_locked). Privacy: result carries task ids, assignees, and workspace paths.
     # Gateway platform-boundary observer hooks (#64176). Observer-only; each callback isolated by
     # invoke_hook. This surface grants no adapter handles or platform actions. Fired today: Telegram

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1209,7 +1209,13 @@ def get_task_log(task_id: str, tail: Optional[int] = Query(None, ge=1, le=2_000_
 def dispatch(dry_run: bool = Query(False), max_n: int = Query(8, alias="max"), board: Optional[str] = Query(None)):
     """Dispatch nudge so the UI doesn't wait out the 60 s dispatcher tick."""
     with _board_conn(board) as (board, conn):
-        result = kbd.dispatch_once(conn, dry_run=dry_run, max_spawn=max_n, board=board)
+        caps = kbd.dispatch_caps_from_config()
+        # Query ``max`` is a per-nudge spawn ceiling, never a way around host /
+        # pool admission. The smaller of the two wins when both are set.
+        configured_spawn = caps.get("max_spawn")
+        if configured_spawn is None or max_n < configured_spawn:
+            caps["max_spawn"] = max_n
+        result = kbd.dispatch_once(conn, dry_run=dry_run, board=board, **caps)
         try:
             return asdict(result)  # DispatchResult is a dataclass
         except TypeError:

--- a/tests/hermes_cli/test_kanban_capacity_pools.py
+++ b/tests/hermes_cli/test_kanban_capacity_pools.py
@@ -1,0 +1,278 @@
+"""Named kanban.capacity_pools: several profiles share one host-wide context.
+
+Implements the admission shape requested in #96299 (shared named pools) without
+a separate lease ledger. A pool name is an operator-chosen context (vendor,
+local role, person). Running members are counted across every board; extras
+stay Ready as skipped_pool_capped. Tests use ``spark`` as one such name.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_kanban_home_with_profiles(monkeypatch):
+    test_home = tempfile.mkdtemp(prefix="kanban_capacity_pools_")
+    for prof in ("coder", "paul-coder", "reviewer", "default"):
+        os.makedirs(os.path.join(test_home, "profiles", prof), exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+    yield kanban_db
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+def _spark_pool():
+    from hermes_cli.kanban_db_dispatch import CapacityPool
+    return {
+        "spark": CapacityPool(
+            name="spark", max_in_progress=1, members=("coder", "paul-coder"),
+        )
+    }
+
+
+def test_normalize_capacity_pools_ignores_invalid_entries():
+    from hermes_cli.kanban_db_dispatch import normalize_capacity_pools
+    pools = normalize_capacity_pools({
+        "spark": {"max_in_progress": 1, "members": ["coder", "paul-coder"]},
+        "": {"max_in_progress": 1, "members": ["x"]},
+        "bad-cap": {"max_in_progress": 0, "members": ["y"]},
+        "no-members": {"max_in_progress": 2, "members": []},
+        "not-a-map": "nope",
+    })
+    assert set(pools) == {"spark"}
+    assert pools["spark"].members == ("coder", "paul-coder")
+
+
+def test_normalize_capacity_pools_first_pool_keeps_shared_member():
+    from hermes_cli.kanban_db_dispatch import normalize_capacity_pools
+    pools = normalize_capacity_pools({
+        "spark": {"max_in_progress": 1, "members": ["coder"]},
+        "other": {"max_in_progress": 2, "members": ["coder", "reviewer"]},
+    })
+    assert pools["spark"].members == ("coder",)
+    assert pools["other"].members == ("reviewer",)
+
+
+def test_unset_pools_leave_dispatch_uncapped(isolated_kanban_home_with_profiles):
+    kb = isolated_kanban_home_with_profiles
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        for i in range(3):
+            kb.create_task(conn, title=f"c{i}", assignee="coder")
+        res = kbd.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    assert len(res.spawned) == 3
+    assert res.skipped_pool_capped == []
+
+
+def test_pool_caps_two_profiles_on_one_board(isolated_kanban_home_with_profiles):
+    kb = isolated_kanban_home_with_profiles
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        kb.create_task(conn, title="c0", assignee="coder")
+        kb.create_task(conn, title="p0", assignee="paul-coder")
+        kb.create_task(conn, title="r0", assignee="reviewer")
+        res = kbd.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=True,
+            capacity_pools=_spark_pool(),
+        )
+    spawn_assignees = [s[1] for s in res.spawned]
+    assert spawn_assignees.count("coder") + spawn_assignees.count("paul-coder") == 1
+    assert spawn_assignees.count("reviewer") == 1
+    assert len(res.skipped_pool_capped) == 1
+    assert res.skipped_pool_capped[0][1] == "spark"
+    assert res.skipped_pool_capped[0][3] == 1
+
+
+def test_pool_counts_running_on_other_boards(isolated_kanban_home_with_profiles):
+    kb = isolated_kanban_home_with_profiles
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+    kb.create_board("second")
+    with kbc.connect(board="second") as conn:
+        tid = kb.create_task(conn, title="busy-spark", assignee="coder")
+        assert kb.claim_task(conn, tid) is not None
+    with kbc.connect() as conn:
+        kb.create_task(conn, title="wants-spark", assignee="paul-coder")
+        kb.create_task(conn, title="cloud", assignee="reviewer")
+        res = kbd.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=True,
+            capacity_pools=_spark_pool(),
+        )
+    spawn_assignees = [s[1] for s in res.spawned]
+    assert "paul-coder" not in spawn_assignees
+    assert spawn_assignees == ["reviewer"]
+    assert res.skipped_pool_capped[0][1] == "spark"
+    assert res.skipped_pool_capped[0][2] == 1
+
+
+def test_pool_deferred_card_stays_ready(isolated_kanban_home_with_profiles):
+    kb = isolated_kanban_home_with_profiles
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        first = kb.create_task(conn, title="first", assignee="coder")
+        second = kb.create_task(conn, title="second", assignee="paul-coder")
+        res = kbd.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            capacity_pools=_spark_pool(),
+        )
+    assert len(res.spawned) == 1
+    spawned_id = res.spawned[0][0]
+    deferred_id = second if spawned_id == first else first
+    assert res.skipped_pool_capped[0][0] == deferred_id
+    with kbc.connect_closing() as conn:
+        deferred = kb.get_task(conn, deferred_id)
+        assert deferred.status == "ready"
+        assert deferred.claim_lock is None
+
+
+def test_pool_slot_frees_on_complete(isolated_kanban_home_with_profiles):
+    kb = isolated_kanban_home_with_profiles
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        kb.create_task(conn, title="first", assignee="coder")
+        kb.create_task(conn, title="second", assignee="paul-coder")
+        res1 = kbd.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            capacity_pools=_spark_pool(),
+        )
+    assert len(res1.spawned) == 1
+    spawned_id = res1.spawned[0][0]
+    with kbc.connect_closing() as conn:
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'done', claim_lock = NULL WHERE id = ?",
+                (spawned_id,),
+            )
+        res2 = kbd.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False,
+            capacity_pools=_spark_pool(),
+        )
+    assert len(res2.spawned) == 1
+    assert res2.spawned[0][0] != spawned_id
+
+
+def test_cli_dispatch_passes_capacity_pools(isolated_kanban_home_with_profiles, monkeypatch):
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+    from hermes_cli import kanban_db_dispatch as kbd
+    import argparse
+
+    fake_config = {
+        "kanban": {
+            "capacity_pools": {
+                "spark": {"max_in_progress": 1, "members": ["coder"]},
+            }
+        }
+    }
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: fake_config)
+    captured = {}
+
+    def fake_dispatch_once(conn, **kwargs):
+        captured.update(kwargs)
+        return kanban_db.DispatchResult()
+
+    monkeypatch.setattr(kbd, "dispatch_once", fake_dispatch_once)
+    args = argparse.Namespace(dry_run=True, max=None, failure_limit=2, json=False)
+    kb_cli._cmd_dispatch(args)
+    pools = captured.get("capacity_pools") or {}
+    assert "spark" in pools
+    assert pools["spark"].max_in_progress == 1
+    assert pools["spark"].members == ("coder",)
+
+
+def test_two_named_contexts_are_independent(isolated_kanban_home_with_profiles):
+    """A full spark pool must not freeze an unrelated grok pool."""
+    kb = isolated_kanban_home_with_profiles
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+    from hermes_cli.kanban_db_dispatch import CapacityPool
+    pools = {
+        "spark": CapacityPool(
+            name="spark", max_in_progress=1, members=("coder",),
+        ),
+        "grok": CapacityPool(
+            name="grok", max_in_progress=2, members=("reviewer",),
+        ),
+    }
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        for i in range(3):
+            kb.create_task(conn, title=f"s{i}", assignee="coder")
+        for i in range(3):
+            kb.create_task(conn, title=f"g{i}", assignee="reviewer")
+        res = kbd.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=True,
+            capacity_pools=pools,
+        )
+    spawn_assignees = [s[1] for s in res.spawned]
+    assert spawn_assignees.count("coder") == 1
+    assert spawn_assignees.count("reviewer") == 2
+    spark_deferred = [c for c in res.skipped_pool_capped if c[1] == "spark"]
+    grok_deferred = [c for c in res.skipped_pool_capped if c[1] == "grok"]
+    assert len(spark_deferred) == 2
+    assert len(grok_deferred) == 1
+
+
+def test_review_lane_shares_the_same_pool(isolated_kanban_home_with_profiles):
+    kb = isolated_kanban_home_with_profiles
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        ready_id = kb.create_task(conn, title="ready-spark", assignee="coder")
+        review_id = kb.create_task(conn, title="review-spark", assignee="coder")
+        claimed = kb.claim_task(conn, review_id)
+        assert claimed is not None
+        assert kb.request_review(
+            conn, review_id, summary="ready",
+            expected_run_id=claimed.current_run_id,
+        )
+        assert kb.get_task(conn, review_id).status == "review"
+        res = kbd.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=True,
+            capacity_pools=_spark_pool(),
+        )
+    spawned_ids = [s[0] for s in res.spawned]
+    spark_spawned = [s for s in res.spawned if s[1] == "coder"]
+    assert len(spark_spawned) == 1
+    assert (ready_id in spawned_ids) ^ (review_id in spawned_ids)
+    assert any(c[1] == "spark" for c in res.skipped_pool_capped)
+
+
+def test_host_cap_still_wins_over_a_roomy_pool(isolated_kanban_home_with_profiles):
+    kb = isolated_kanban_home_with_profiles
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+    from hermes_cli.kanban_db_dispatch import CapacityPool
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        for i in range(4):
+            kb.create_task(conn, title=f"r{i}", assignee="reviewer")
+        res = kbd.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=True,
+            max_in_progress=2,
+            capacity_pools={
+                "grok": CapacityPool(
+                    name="grok", max_in_progress=8, members=("reviewer",),
+                )
+            },
+        )
+    assert len(res.spawned) == 2

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -516,6 +516,39 @@ def test_dispatch_dry_run(client):
     assert isinstance(body, dict)
 
 
+def test_dispatch_nudge_forwards_capacity_pools(client, monkeypatch):
+    """Dashboard Nudge must load kanban.capacity_pools; max= is a spawn
+    ceiling, not a way around named-context admission (#81381 shape)."""
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    captured = {}
+
+    def fake_dispatch_once(conn, **kwargs):
+        captured.update(kwargs)
+        return kb.DispatchResult()
+
+    monkeypatch.setattr(kbd, "dispatch_once", fake_dispatch_once)
+    monkeypatch.setattr(
+        kbd, "dispatch_caps_from_config",
+        lambda: {
+            "default_assignee": None,
+            "max_in_progress": 8,
+            "max_in_progress_per_profile": None,
+            "max_spawn": None,
+            "capacity_pools": kbd.normalize_capacity_pools({
+                "spark": {"max_in_progress": 1, "members": ["coder"]},
+            }),
+        },
+    )
+    r = client.post("/api/plugins/kanban/dispatch?dry_run=true&max=8")
+    assert r.status_code == 200
+    assert captured.get("max_in_progress") == 8
+    assert captured.get("max_spawn") == 8
+    pools = captured.get("capacity_pools") or {}
+    assert "spark" in pools
+    assert pools["spark"].max_in_progress == 1
+
+
 # ---------------------------------------------------------------------------
 # Triage column (new v1 status)
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -856,6 +856,7 @@ All commands are also available as a slash command in the interactive CLI and in
 |------------|---------|--------------|
 | `kanban.max_in_progress` | unset (unlimited) | Caps the number of simultaneously running tasks. When the board already has N running, the dispatcher skips spawning more — useful for slow workers (local LLMs, resource-constrained hosts) so they finish what they have before more pile up and time out. Invalid or below-1 values log a warning and behave as unlimited. |
 | `kanban.max_in_progress_per_profile` | unset (unlimited) | Per-profile variant of `max_in_progress` — caps how many tasks any single assignee profile may run concurrently. Useful when one profile is slow or rate-limited but others should keep flowing. Applies alongside the board-wide `max_in_progress`; both must allow a spawn for it to proceed. |
+| `kanban.capacity_pools` | unset (`{}`) | Named host-wide admission pools. Each name is an operator-chosen context (a vendor, a local role, a person). Each pool has `max_in_progress` and a `members` list of assignee profiles that share that budget. Running members are counted across every board and both dispatch lanes. Extra cards stay Ready (`skipped_pool_capped`); they are not dropped. Unlisted profiles are unpooled. Opt-in: empty/absent leaves existing installs unchanged. |
 | `kanban.auto_promote_children` | `true` | After `decompose_triage_task()` produces children with no parent-blocker dependencies, they're automatically promoted to `ready` so the dispatcher can pick them up. Set to `false` to require manual review — children stay in `todo` until you promote them. |
 | `kanban.default_workdir` | unset | Board-level default working directory applied to new tasks when neither `--workspace` nor the task itself overrides it. Per-task `workspace:` still wins. |
 
@@ -864,6 +865,16 @@ kanban:
   max_in_progress: 2
   auto_promote_children: false
   default_workdir: ~/work/active-project
+  capacity_pools:
+    grok:
+      max_in_progress: 6
+      members: [reviewer, researcher]
+    spark:
+      max_in_progress: 1
+      members: [coder, implementer]
+    claude:
+      max_in_progress: 3
+      members: [planner]
 ```
 
 ### Scheduled task starts (`scheduled_at`)


### PR DESCRIPTION
## What does this PR do?

Kanban can cap all Running work (`max_in_progress`) and cap every
assignee with one integer (`max_in_progress_per_profile`). It cannot
express that several profiles share one scarce *context* — a vendor
quota, a local GPU pair, a person's review lane — and that this budget
is host-wide, across every board.

This adds opt-in `kanban.capacity_pools`: named contexts, each with
`max_in_progress` and a `members` list of assignee profiles. Before
claim, the dispatcher counts Running members of that pool on every
board (Ready and Review). At cap, the card stays Ready
(`skipped_pool_capped`). It is not dropped and does not count as a
failure.

Pool names are operator-chosen. `spark`, `grok`, `claude`, `codex`,
or a person are the same object. Unset/empty config is today's
behaviour.

Fixes the stampede where N boards × M profiles that all hit one
backend start N×M workers. Does not talk to the inference engine:
size each pool to what that context actually holds.

Related: #96299 (named pools). Distinct from #91266 (per-profile
override map) and #76242 (per-board WIP).

## Related Issue

Fixes #96299

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/kanban_db_dispatch.py` — `CapacityPool`,
  `normalize_capacity_pools`, host-wide member counts, defer-before-claim,
  `skipped_pool_capped` (appended on `DispatchResult`)
- Gateway / CLI / dashboard Nudge / standalone daemon all pass pools via
  `dispatch_caps_from_config()` so no entry point is uncapped
- `hermes_cli/config_defaults.py`, `cli-config.yaml.example`
- `website/docs/user-guide/features/kanban.md`, `cron/AGENTS.md`
- `tests/hermes_cli/test_kanban_capacity_pools.py`
- `tests/plugins/test_kanban_dashboard_plugin.py` (Nudge forwards pools)

## How to Test

```yaml
kanban:
  max_in_progress: 8
  capacity_pools:
    grok:
      max_in_progress: 6
      members: [reviewer, researcher]
    local:
      max_in_progress: 1
      members: [coder, implementer]
```

1. Two boards, one Running `coder` on board B, Ready `implementer` on
   board A, `local` cap 1 → A stays Ready; `hermes kanban dispatch --json`
   shows `skipped_pool_capped`.
2. Same tick, Ready `reviewer` still spawns (`grok` is a different pool).
3. Complete the Running card; next tick the waiting card claims.
4. `hermes kanban dispatch --dry-run --json` reports who would wait
   without claiming.
5. Dashboard Nudge with `?max=8` still honours the pool.

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_capacity_pools.py \
  tests/hermes_cli/test_kanban_host_cap.py \
  tests/hermes_cli/test_kanban_per_profile_cap.py \
  tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`feat(kanban): …`)
- [x] Searched existing PRs (#91266 profile map, #76242 board WIP — different axis)
- [x] Only this feature
- [ ] `scripts/run_tests.sh` (focused 26 passed locally; full suite in CI)
- [x] Tests added
- [x] Tested on macOS 15 (unit tests; no live gateway swap)

### Documentation & Housekeeping

- [x] User guide + `cron/AGENTS.md`
- [x] `cli-config.yaml.example`
- [x] `cron/AGENTS.md` dispatcher note
- [x] Cross-platform: SQLite counts, same fail-open as host cap; no `/proc`
- [x] Tool schemas unchanged — N/A