### PR TITLE
fix(kanban): make initial_status=blocked sticky from birth

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1366,6 +1366,27 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                # ``initial_status="blocked"`` parks the task for human ops
+                # (R3 gate). The blocked status alone is NOT durable:
+                # ``recompute_ready`` treats a blocked row with no
+                # ``blocked``/``unblocked`` event as auto-recoverable (the
+                # "direct DB manipulation" path preserved by #28712), so the
+                # next dispatcher tick promotes AND spawns it — bypassing the
+                # human gate this initial status exists to enforce. Emit the
+                # same ``blocked`` event a ``kanban_block`` would write so the
+                # sticky guard in ``recompute_ready`` keeps the card parked
+                # until an explicit ``unblock_task``.
+                if task_status == "blocked":
+                    _append_event(
+                        conn, task_id, "blocked",
+                        {"reason": "created with initial_status=blocked",
+                         "kind": "needs_input", "recurrences": 1,
+                         "source_status": "created"},
+                    )
+                    conn.execute(
+                        "UPDATE tasks SET block_kind = 'needs_input', "
+                        "block_recurrences = 1 WHERE id = ?", (task_id,),
+                    )
                 # ACK-edge: the originating channel hears a child BLOCK, not just the fan-in.
                 inherit_creator_origin(conn, task_id, creator_task_id, created_at=now)
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -162,3 +162,61 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
 # (landed via #28754 / #28781).  The original PR shipped a duplicate test
 # here; dropped during salvage to avoid two assertions of the same contract.
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# initial_status="blocked" must be sticky from birth
+# ---------------------------------------------------------------------------
+#
+# ``create_task(initial_status="blocked")`` is the documented way to park a
+# task for human-ops review ("parks the task directly in the blocked column
+# for human-ops review", commit fb96208892).  Before this fix it wrote only a
+# ``created`` event, so ``recompute_ready`` classified the row as
+# auto-recoverable (the "direct DB manipulation" path preserved by #28712)
+# and promoted AND spawned it on the next dispatcher tick — the human gate
+# the initial status exists to enforce never engaged.
+#
+# Contract: a task created directly in ``blocked`` behaves identically to one
+# blocked via ``block_task`` — sticky across ticks, releasable only by an
+# explicit ``unblock_task``.
+
+
+def test_initial_status_blocked_survives_recompute_ready(kanban_home: Path) -> None:
+    """A task created with initial_status="blocked" must not be auto-promoted.
+
+    Red on base: ``recompute_ready`` promotes the fresh blocked row on the
+    first tick because no ``blocked``/``unblocked`` event exists yet.
+    """
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="human-ops gate", initial_status="blocked")
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        for _ in range(5):
+            promoted = kb.recompute_ready(conn)
+            assert promoted == 0, (
+                "task created in blocked must not auto-promote — "
+                "the human-ops gate was bypassed"
+            )
+            assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_initial_status_blocked_is_released_by_unblock_task(kanban_home: Path) -> None:
+    """unblock_task is the only exit from an initial_status="blocked" park.
+
+    Pins the release path of the human-ops gate: after an explicit unblock
+    the task resumes its normal lifecycle (ready), like any other
+    sticky-blocked task.
+    """
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="human-ops gate", initial_status="blocked")
+
+        assert kb.unblock_task(conn, tid) is True
+        assert kb.get_task(conn, tid).status == "ready"
+
+        # The release is durable: subsequent ticks keep it schedulable.
+        conn.execute(
+            "UPDATE tasks SET status = 'todo' WHERE id = ?", (tid,)
+        )
+        conn.commit()
+        assert kb.recompute_ready(conn) == 1
+        assert kb.get_task(conn, tid).status == "ready"


### PR DESCRIPTION
## Summary

`hermes kanban create --initial-status blocked` (and the equivalent
`kanban_create(initial_status="blocked")` tool call) is the documented way to
park a task for human-ops review — commit `fb96208892` introduced it as
*"parks the task directly in the blocked column for human-ops review"*. It
does not do that: the dispatcher takes the task into work within one tick
(~60 s), with no human action.

## Root cause

- `create_task()` (`hermes_cli/kanban_db.py`) sets `status = "blocked"` but
  writes **only a `created` event** — there is no `blocked` event.
- Every dispatcher tick calls `recompute_ready()`, which keeps a blocked task
  parked only when its newest `blocked`/`unblocked` event is a `blocked`
  event (the sticky guard added by #28712, preserving the "direct DB
  manipulation → auto-recover" path from #40c1decb3).
- A freshly created blocked task has neither event, so the guard does not
  apply. With no parents (`all([]) == True`) and a clean failure counter, the
  task is promoted to `ready` **and spawned in the same tick**.

Two independent features (`initial-status` from fb96208892 and the sticky
guard from #28712) were designed separately and compose into a bypass: the
feature that exists to enforce a human gate is exactly the shape the
auto-recovery path treats as recoverable.

## Evidence

Observed live on a multi-board deployment (Hermes v0.21.1):

- Card A: `created 01:19:05` → `promoted + claimed + spawned 01:19:31`
  (**26 s**, one dispatcher tick; `gateway.log`: `dispatcher [n8n]: spawned=1
  ... promoted=1`).
- Card B: `created 01:35:55` → `promoted 01:36:33` (**38 s**), same pattern.
- Control: a card blocked via a manual `kanban_block` (which writes a
  `blocked` event) stayed parked — confirming the sticky guard itself works
  and only the creation path is missing the event.

Also reproduced deliberately as experiment E1 on a live board: a fresh
`initial-status=blocked` card was promoted and spawned on the next tick, then
completed by the spawned worker — while a control card parked with an
explicit `blocked` event stayed blocked.

## Fix

When `task_status == "blocked"`, `create_task()` now emits the same `blocked`
event a `kanban_block` would write (`reason`, `kind=needs_input`,
`recurrences=1`, `source_status=created`) and sets `block_kind` /
`block_recurrences`. A task created directly in `blocked` is now **sticky
from birth**: `recompute_ready` leaves it parked until an explicit
`unblock_task` — identical semantics to a worker-initiated block.

### Why this shape

- **Reuses the existing sticky guard** (`_has_sticky_block` from #28712) with
  zero new branches in the dispatcher — the recovery path for genuinely
  recoverable blocks (circuit breaker, #40c1decb3) is untouched.
- **One atomic write**: the event and the status are committed in the same
  transaction inside `create_task`, so there is no race window between
  "create" and "protect" (a create-then-block workaround has a ~1 s race
  window).
- **`unblock_task` is the single release path**, matching the manual-block
  lifecycle; no new status, no new config, no API change.

The alternative — teaching `recompute_ready` to distinguish "created in
blocked" from "reset by the breaker" — was rejected: it would widen the
auto-recovery semantics that #28712 deliberately guards.

## Testing

Two invariant tests in `tests/hermes_cli/test_kanban_blocked_sticky.py`
(red on base, green with the fix), following the file's existing pattern:

- `test_initial_status_blocked_survives_recompute_ready` — a task created
  with `initial_status="blocked"` survives 5 consecutive `recompute_ready`
  ticks. Red on base: promoted on tick 1 (`promoted == 1`).
- `test_initial_status_blocked_is_released_by_unblock_task` — `unblock_task`
  releases the park and the release is durable across subsequent ticks.

```
scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py
=== Summary: 1 files, 4 tests passed, 0 failed (100% complete)

scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py \
    tests/hermes_cli/test_kanban_block_kinds.py \
    tests/hermes_cli/test_kanban_review_lifecycle_complete.py \
    tests/hermes_cli/test_kanban_specify_db.py
=== Summary: 4 files, 58 tests passed, 0 failed, 1 skipped
```

## Notes for reviewers

- No schema migration is needed: `blocked` is an existing event kind and
  `block_kind`/`block_recurrences` are existing columns. Existing parked
  cards that were created before this fix still lack the sticky event (same
  exposure as before); a one-off backfill would be a separate, opt-in step.
- The full write happens inside `create_task`'s existing `write_txn`
  transaction, so callers that already wrap creation in a transaction
  (kanban-park-style wrappers composing savepoints) compose cleanly.
