### PR TITLE
fix(pet): skip strict row retries on structurally unsegmentable strips (#87739)

### DIFF
--- a/agent/pet/generate/atlas.py
+++ b/agent/pet/generate/atlas.py
@@ -46,6 +46,17 @@ class UnsegmentableStripError(ValueError):
     """
 
 
+class CollapsedRowError(ValueError):
+    """Sliced frames are slivers of the body rather than whole poses.
+
+    Deliberately distinct from :class:`UnsegmentableStripError`: the strip *was*
+    sliceable, so a fresh roll deserves a normal retry. Sharing the type would
+    silently give a collapsed row the skip-strict-retries policy, which saves a
+    paid call but never re-rolls the art that caused the collapse.
+    """
+
+
+
 _ALPHA_FLOOR = 16  # alpha at/below which a pixel is "background"
 _CELL_PAD = 10  # padding kept around a fitted sprite
 _NORMALIZE_PAD = 14  # normalized cells fill like real petdex pets (~5px from the edges)
@@ -453,7 +464,8 @@ def row_frames_collapsed(frames: list, reference_size: tuple[int, int] | None = 
     :func:`_validate_extracted_frames` (they match each other, so no frame is a
     *relative* outlier) and only surface once compose's global-median collapse
     guard rejects the whole atlas — after every row has been paid for. Comparing
-    each frame's aspect against the reference silhouette catches that per row.
+    the row's median frame width against the width the reference silhouette
+    implies at that median height catches that per row.
     """
     boxes = [box for f in frames if (box := f.getchannel("A").point(lambda a: 255 if a > _ALPHA_FLOOR else 0).getbbox()) is not None]
     if not boxes:

--- a/agent/pet/generate/atlas.py
+++ b/agent/pet/generate/atlas.py
@@ -36,6 +36,16 @@ ROW_SPECS: list[tuple[str, int, int]] = [
 ATLAS_WIDTH = max(count for _, _, count in ROW_SPECS) * CELL_WIDTH
 ATLAS_HEIGHT = len(ROW_SPECS) * CELL_HEIGHT
 
+
+class UnsegmentableStripError(ValueError):
+    """A row strip has the defect in the art itself (merged/touching poses) — no slicing method can recover it.
+
+    Raised in strict ``components`` mode where lenient fallbacks would only
+    forgive the defect, not fix it; the orchestrator treats it as a signal to
+    skip remaining strict (paid) retries and go straight to lenient slicing.
+    """
+
+
 _ALPHA_FLOOR = 16  # alpha at/below which a pixel is "background"
 _CELL_PAD = 10  # padding kept around a fitted sprite
 _NORMALIZE_PAD = 14  # normalized cells fill like real petdex pets (~5px from the edges)
@@ -460,18 +470,30 @@ def extract_strip_frames(
     """Turn one generated row strip into *frame_count* frames.
 
     Keys out the background, then isolates padded subjects (components, then equal slots). When that fails ``components``
-    raises while ``auto`` salvages leniently. *fit* centers each frame into a cell; hatching passes ``fit=False`` so
-    :func:`normalize_cells` can register the whole pet with one shared scale.
+    raises :class:`UnsegmentableStripError` while ``auto`` salvages leniently. *fit* centers each frame into a cell;
+    hatching passes ``fit=False`` so :func:`normalize_cells` can register the whole pet with one shared scale.
     """
     strip = remove_background(_load_rgba(strip), chroma_key=chroma_key)
-    frames = _component_crops(strip, frame_count, require_padding=True) or _slot_crops(strip, frame_count, require_padding=True)
-    if frames is None:
+    try:
+        frames = _component_crops(strip, frame_count, require_padding=True) or _slot_crops(strip, frame_count, require_padding=True)
+        if frames is None:
+            if method == "components":
+                raise UnsegmentableStripError(f"could not segment {frame_count} padded sprites from strip")
+            frames = _component_crops(strip, frame_count, require_padding=False)
+        if frames is None:
+            frames = _salvage_frames(strip, frame_count)
+        _validate_extracted_frames(frames, frame_count)
+    except UnsegmentableStripError:
+        raise
+    except ValueError as exc:
+        # A strip that fails strict extraction or validation has the defect in
+        # the art itself (merged/touching poses) — lenient slicing can only
+        # forgive it, not fix it. Surface that structurally so the orchestrator
+        # can skip the remaining strict (paid) retries instead of substring-
+        # matching error text (#87739).
         if method == "components":
-            raise ValueError(f"could not segment {frame_count} padded sprites from strip")
-        frames = _component_crops(strip, frame_count, require_padding=False)
-    if frames is None:
-        frames = _salvage_frames(strip, frame_count)
-    _validate_extracted_frames(frames, frame_count)
+            raise UnsegmentableStripError(str(exc)) from exc
+        raise
     return [_fit_to_cell(f) for f in frames] if fit else frames
 
 

--- a/agent/pet/generate/atlas.py
+++ b/agent/pet/generate/atlas.py
@@ -445,6 +445,42 @@ def _is_multi_pose_outlier(width: int, height: int, med_w: int, med_h: int) -> b
     return width > max(med_w * 3.0, med_w + 96) and height <= med_h * 1.6
 
 
+def row_frames_collapsed(frames: list, reference_size: tuple[int, int] | None = None) -> str | None:
+    """Describe a row whose frames are slivers of a body rather than whole poses, else ``None``.
+
+    Lenient slicing salvages a strip the strict pass rejected by cutting at gutters
+    or equal slots, which can yield thin vertical fragments that still pass
+    :func:`_validate_extracted_frames` (they match each other, so no frame is a
+    *relative* outlier) and only surface once compose's global-median collapse
+    guard rejects the whole atlas — after every row has been paid for. Comparing
+    each frame's aspect against the reference silhouette catches that per row.
+    """
+    boxes = [box for f in frames if (box := f.getchannel("A").point(lambda a: 255 if a > _ALPHA_FLOOR else 0).getbbox()) is not None]
+    if not boxes:
+        return "row has no visible frames"
+    med_w, med_h = _median_box_size(boxes)
+    if reference_size is None:
+        return None
+    ref_w, ref_h = reference_size
+    if ref_w <= 0 or ref_h <= 0:
+        return None
+    # A pose may legitimately be narrower than the reference (a jump tucks the
+    # limbs in, a run leans); only a silhouette far thinner than the character
+    # at the SAME height is a sliver.
+    expected_w = med_h * (ref_w / ref_h)
+    if med_w < expected_w * 0.40:
+        return f"frames are {med_w}x{med_h}px slivers (expected ~{round(expected_w)}px wide for a {ref_w}x{ref_h}px character)"
+    return None
+
+
+def silhouette_box(image) -> tuple[int, int] | None:
+    """``(width, height)`` of the opaque silhouette in *image*, else ``None`` — the identity anchor's proportions."""
+    rgba = _load_rgba(image)
+    box = rgba.getchannel("A").point(lambda a: 255 if a > _ALPHA_FLOOR else 0).getbbox()
+    return (box[2] - box[0], box[3] - box[1]) if box else None
+
+
+
 def _validate_extracted_frames(frames: list, frame_count: int) -> None:
     """Reject rows where one "frame" is really multiple poses (normalization would shrink the whole pet)."""
     if len(frames) != frame_count:

--- a/agent/pet/generate/atlas.py
+++ b/agent/pet/generate/atlas.py
@@ -56,7 +56,6 @@ class CollapsedRowError(ValueError):
     """
 
 
-
 _ALPHA_FLOOR = 16  # alpha at/below which a pixel is "background"
 _CELL_PAD = 10  # padding kept around a fitted sprite
 _NORMALIZE_PAD = 14  # normalized cells fill like real petdex pets (~5px from the edges)
@@ -490,7 +489,6 @@ def silhouette_box(image) -> tuple[int, int] | None:
     rgba = _load_rgba(image)
     box = rgba.getchannel("A").point(lambda a: 255 if a > _ALPHA_FLOOR else 0).getbbox()
     return (box[2] - box[0], box[3] - box[1]) if box else None
-
 
 
 def _validate_extracted_frames(frames: list, frame_count: int) -> None:

--- a/agent/pet/generate/atlas.py
+++ b/agent/pet/generate/atlas.py
@@ -455,16 +455,31 @@ def _is_multi_pose_outlier(width: int, height: int, med_w: int, med_h: int) -> b
     return width > max(med_w * 3.0, med_w + 96) and height <= med_h * 1.6
 
 
+def collapse_limits(ref_w: int, ref_h: int) -> tuple[int, int]:
+    """Minimum ``(width, height)`` a whole pose may have against a *ref_w* x *ref_h* reference.
+
+    ONE home for the collapse thresholds. :func:`_check_atlas_cells` compares each
+    state's median box against the atlas-wide median; the pre-compose gate
+    (:func:`row_frames_collapsed`) compares a row's median box against the base
+    silhouette. Sharing them keeps the cheap per-row gate from being a strict
+    subset of the expensive post-compose crash, where one bad row sinks the whole
+    atlas after every row has been paid for.
+    """
+    return max(32, round(ref_w * 0.42)), max(40, round(ref_h * 0.50))
+
+
 def row_frames_collapsed(frames: list, reference_size: tuple[int, int] | None = None) -> str | None:
-    """Describe a row whose frames are slivers of a body rather than whole poses, else ``None``.
+    """Describe a row whose frames are fragments of a body rather than whole poses, else ``None``.
 
     Lenient slicing salvages a strip the strict pass rejected by cutting at gutters
-    or equal slots, which can yield thin vertical fragments that still pass
+    or equal slots, which can yield fragments that still pass
     :func:`_validate_extracted_frames` (they match each other, so no frame is a
     *relative* outlier) and only surface once compose's global-median collapse
-    guard rejects the whole atlas — after every row has been paid for. Comparing
-    the row's median frame width against the width the reference silhouette
-    implies at that median height catches that per row.
+    guard rejects the whole atlas — after every row has been paid for. Rejecting on
+    EITHER axis (:func:`collapse_limits` against the reference silhouette) is what
+    makes the gate a superset of that crash: a uniformly shrunk row fails the
+    height floor even though a width-only test scaled by measured height — which is
+    invariant under uniform shrink — would let it pass.
     """
     boxes = [box for f in frames if (box := f.getchannel("A").point(lambda a: 255 if a > _ALPHA_FLOOR else 0).getbbox()) is not None]
     if not boxes:
@@ -475,12 +490,11 @@ def row_frames_collapsed(frames: list, reference_size: tuple[int, int] | None = 
     ref_w, ref_h = reference_size
     if ref_w <= 0 or ref_h <= 0:
         return None
-    # A pose may legitimately be narrower than the reference (a jump tucks the
-    # limbs in, a run leans); only a silhouette far thinner than the character
-    # at the SAME height is a sliver.
-    expected_w = med_h * (ref_w / ref_h)
-    if med_w < expected_w * 0.40:
-        return f"frames are {med_w}x{med_h}px slivers (expected ~{round(expected_w)}px wide for a {ref_w}x{ref_h}px character)"
+    min_w, min_h = collapse_limits(ref_w, ref_h)
+    if med_w < min_w:
+        return f"frames are {med_w}x{med_h}px slivers (expected >={min_w}px wide for a {ref_w}x{ref_h}px character)"
+    if med_h < min_h:
+        return f"frames are {med_w}x{med_h}px too short (expected >={min_h}px tall for a {ref_w}x{ref_h}px character)"
     return None
 
 
@@ -520,23 +534,23 @@ def extract_strip_frames(
     hatching passes ``fit=False`` so :func:`normalize_cells` can register the whole pet with one shared scale.
     """
     strip = remove_background(_load_rgba(strip), chroma_key=chroma_key)
+    frames = _component_crops(strip, frame_count, require_padding=True) or _slot_crops(strip, frame_count, require_padding=True)
+    if frames is None:
+        if method == "components":
+            raise UnsegmentableStripError(f"could not segment {frame_count} padded sprites from strip")
+        frames = _component_crops(strip, frame_count, require_padding=False)
+    if frames is None:
+        frames = _salvage_frames(strip, frame_count)
     try:
-        frames = _component_crops(strip, frame_count, require_padding=True) or _slot_crops(strip, frame_count, require_padding=True)
-        if frames is None:
-            if method == "components":
-                raise UnsegmentableStripError(f"could not segment {frame_count} padded sprites from strip")
-            frames = _component_crops(strip, frame_count, require_padding=False)
-        if frames is None:
-            frames = _salvage_frames(strip, frame_count)
         _validate_extracted_frames(frames, frame_count)
-    except UnsegmentableStripError:
-        raise
     except ValueError as exc:
-        # A strip that fails strict extraction or validation has the defect in
-        # the art itself (merged/touching poses) — lenient slicing can only
-        # forgive it, not fix it. Surface that structurally so the orchestrator
-        # can skip the remaining strict (paid) retries instead of substring-
-        # matching error text (#87739).
+        # A strip that passes slicing but fails validation has the defect in the
+        # art itself (merged/touching poses) — lenient slicing can only forgive
+        # it, not fix it. Surface that structurally so the orchestrator can skip
+        # the remaining strict (paid) retries instead of substring-matching error
+        # text (#87739). Raise the dedicated type HERE, at the decision point,
+        # rather than wrapping the whole block: any other ValueError from the
+        # slicing helpers is a bug, not an unsegmentable strip.
         if method == "components":
             raise UnsegmentableStripError(str(exc)) from exc
         raise
@@ -679,7 +693,8 @@ def _check_atlas_cells(atlas) -> tuple[list[str], list[str], list[str]]:
             errors.append(f"state '{state}' contains a multi-pose frame outlier")
         # Per-state collapse guard: one malformed row must not pass on the
         # strength of the healthy ones.
-        collapsed = med_w < max(32, round(global_med_w * 0.42)) or med_h < max(40, round(global_med_h * 0.50))
+        min_w, min_h = collapse_limits(global_med_w, global_med_h)
+        collapsed = med_w < min_w or med_h < min_h
         if (global_med_w and global_med_h) and collapsed:
             errors.append(f"state '{state}' appears collapsed (median {med_w}x{med_h}px, global median {global_med_w}x{global_med_h}px)")
     data = atlas.tobytes()

--- a/agent/pet/generate/orchestrate.py
+++ b/agent/pet/generate/orchestrate.py
@@ -202,19 +202,14 @@ def _generate_row(
             )
             # fit=False keeps raw columns so normalize_cells registers the whole pet at once.
             strict = attempt < _ROW_GEN_ATTEMPTS - 1
-            method = "components" if strict else "auto"
             try:
-                frames = atlas.extract_strip_frames(strips[0], count, method=method, fit=False)
+                frames = atlas.extract_strip_frames(strips[0], count, method="components" if strict else "auto", fit=False)
             except atlas.UnsegmentableStripError as exc:
-                # The art itself is unsegmentable (merged poses): a stricter
-                # re-roll would fail identically and cost another image call.
-                # Jump straight to the lenient attempt.
+                # Only strict mode raises this. The art itself is unsegmentable
+                # (merged poses), so a strict re-roll would fail identically and
+                # cost another image call: salvage the SAME strip leniently.
                 logger.warning("pet hatch %r: row %r unsegmentable (attempt %d/%d) — skipping strict retries: %s", slug, state, attempt + 1, _ROW_GEN_ATTEMPTS, exc)
-                if strict:
-                    method = "auto"
-                    frames = atlas.extract_strip_frames(strips[0], count, method="auto", fit=False)
-                else:
-                    raise
+                frames = atlas.extract_strip_frames(strips[0], count, method="auto", fit=False)
             if collapsed := atlas.row_frames_collapsed(frames, reference_size):
                 # Lenient slicing can "succeed" with slivers of the body; those
                 # pass relative frame checks but sink the atlas later. A

--- a/agent/pet/generate/orchestrate.py
+++ b/agent/pet/generate/orchestrate.py
@@ -168,7 +168,10 @@ def _humanize_image_error(error: str) -> str:
     return hint or error.splitlines()[0].strip()[:200]  # first line, sans provider envelope
 
 
-def _generate_row(spec: tuple[str, int, int], *, base: Path, label: str, style: str, slug: str, sprite, cancelled) -> tuple[str, list | None]:
+def _generate_row(
+    spec: tuple[str, int, int], *, base: Path, label: str, style: str, slug: str, sprite, cancelled,
+    reference_size: tuple[int, int] | None = None,
+) -> tuple[str, list | None]:
     """Generate + slice one animation row, retrying up to ``_ROW_GEN_ATTEMPTS`` times.
 
     Self-healing: a roll whose poses touch (no gutters) slices badly, so
@@ -185,7 +188,8 @@ def _generate_row(spec: tuple[str, int, int], *, base: Path, label: str, style: 
     state, _row, count = spec
     t0 = time.monotonic()
     last_exc: Exception | None = None
-    reference_size = atlas.silhouette_box(base)
+    if reference_size is None:
+        reference_size = atlas.silhouette_box(base)
     for attempt in range(_ROW_GEN_ATTEMPTS):
         if cancelled():
             return state, None
@@ -213,8 +217,10 @@ def _generate_row(spec: tuple[str, int, int], *, base: Path, label: str, style: 
                     raise
             if collapsed := atlas.row_frames_collapsed(frames, reference_size):
                 # Lenient slicing can "succeed" with slivers of the body; those
-                # pass relative frame checks but sink the atlas later.
-                raise atlas.UnsegmentableStripError(f"row {state} collapsed: {collapsed}")
+                # pass relative frame checks but sink the atlas later. A
+                # distinct type keeps the normal retry ladder (a fresh roll can
+                # still segment cleanly) instead of the skip-strict shortcut.
+                raise atlas.CollapsedRowError(f"row {state} collapsed: {collapsed}")
             logger.info("pet hatch %r: row %r ready in %.1fs (attempt %d)", slug, state, time.monotonic() - t0, attempt + 1)
             return state, frames
         except Exception as exc:  # noqa: BLE001 - retried; one bad row is tolerated
@@ -256,10 +262,12 @@ def hatch_pet(
     label = concept or display_name or slug
     frames_by_state: dict[str, list] = {}
     total_rows = len(atlas.ROW_SPECS)
+    # Decode the identity anchor's proportions once, not per row per attempt.
+    reference_size = atlas.silhouette_box(base)
     logger.info("pet hatch %r: generating %d animation rows", slug, total_rows)
 
     def _gen_row(spec: tuple[str, int, int]) -> tuple[str, list | None]:
-        return _generate_row(spec, base=base, label=label, style=style, slug=slug, sprite=sprite, cancelled=cancelled)
+        return _generate_row(spec, base=base, label=label, style=style, slug=slug, sprite=sprite, cancelled=cancelled, reference_size=reference_size)
 
     # running-left is mirrored from running-right (consistent, one fewer generation).
     generated_specs = [spec for spec in atlas.ROW_SPECS if spec[0] != "running-left"]

--- a/agent/pet/generate/orchestrate.py
+++ b/agent/pet/generate/orchestrate.py
@@ -176,12 +176,16 @@ def _generate_row(spec: tuple[str, int, int], *, base: Path, label: str, style: 
     final attempt uses lenient ``auto`` slicing. A
     :class:`~agent.pet.generate.atlas.UnsegmentableStripError` skips the
     remaining strict retries — the defect is in the art, and each strict retry
-    is a paid image call that will fail the same way (#87739). Returns
-    ``(state, None)`` when cancelled or every attempt failed.
+    is a paid image call that will fail the same way (#87739). Sliced frames are
+    then checked against the base silhouette *before* compose: a collapsed row
+    is retried (or dropped) here, instead of poisoning every other state through
+    normalize's shared scale and failing the whole hatch after all rows are paid
+    for. Returns ``(state, None)`` when cancelled or every attempt failed.
     """
     state, _row, count = spec
     t0 = time.monotonic()
     last_exc: Exception | None = None
+    reference_size = atlas.silhouette_box(base)
     for attempt in range(_ROW_GEN_ATTEMPTS):
         if cancelled():
             return state, None
@@ -207,6 +211,10 @@ def _generate_row(spec: tuple[str, int, int], *, base: Path, label: str, style: 
                     frames = atlas.extract_strip_frames(strips[0], count, method="auto", fit=False)
                 else:
                     raise
+            if collapsed := atlas.row_frames_collapsed(frames, reference_size):
+                # Lenient slicing can "succeed" with slivers of the body; those
+                # pass relative frame checks but sink the atlas later.
+                raise atlas.UnsegmentableStripError(f"row {state} collapsed: {collapsed}")
             logger.info("pet hatch %r: row %r ready in %.1fs (attempt %d)", slug, state, time.monotonic() - t0, attempt + 1)
             return state, frames
         except Exception as exc:  # noqa: BLE001 - retried; one bad row is tolerated

--- a/agent/pet/generate/orchestrate.py
+++ b/agent/pet/generate/orchestrate.py
@@ -173,8 +173,11 @@ def _generate_row(spec: tuple[str, int, int], *, base: Path, label: str, style: 
 
     Self-healing: a roll whose poses touch (no gutters) slices badly, so
     ``components`` (raises on touching poses) drives regeneration and only the
-    final attempt uses lenient ``auto`` slicing. Returns ``(state, None)`` when
-    cancelled or every attempt failed.
+    final attempt uses lenient ``auto`` slicing. A
+    :class:`~agent.pet.generate.atlas.UnsegmentableStripError` skips the
+    remaining strict retries — the defect is in the art, and each strict retry
+    is a paid image call that will fail the same way (#87739). Returns
+    ``(state, None)`` when cancelled or every attempt failed.
     """
     state, _row, count = spec
     t0 = time.monotonic()
@@ -190,8 +193,20 @@ def _generate_row(spec: tuple[str, int, int], *, base: Path, label: str, style: 
                 provider=sprite, prefix=f"pet_row_{state}", aspect_ratio="landscape",
             )
             # fit=False keeps raw columns so normalize_cells registers the whole pet at once.
-            method = "components" if attempt < _ROW_GEN_ATTEMPTS - 1 else "auto"
-            frames = atlas.extract_strip_frames(strips[0], count, method=method, fit=False)
+            strict = attempt < _ROW_GEN_ATTEMPTS - 1
+            method = "components" if strict else "auto"
+            try:
+                frames = atlas.extract_strip_frames(strips[0], count, method=method, fit=False)
+            except atlas.UnsegmentableStripError as exc:
+                # The art itself is unsegmentable (merged poses): a stricter
+                # re-roll would fail identically and cost another image call.
+                # Jump straight to the lenient attempt.
+                logger.warning("pet hatch %r: row %r unsegmentable (attempt %d/%d) — skipping strict retries: %s", slug, state, attempt + 1, _ROW_GEN_ATTEMPTS, exc)
+                if strict:
+                    method = "auto"
+                    frames = atlas.extract_strip_frames(strips[0], count, method="auto", fit=False)
+                else:
+                    raise
             logger.info("pet hatch %r: row %r ready in %.1fs (attempt %d)", slug, state, time.monotonic() - t0, attempt + 1)
             return state, frames
         except Exception as exc:  # noqa: BLE001 - retried; one bad row is tolerated

--- a/contributors/emails/phil.c.taylor@gmail.com
+++ b/contributors/emails/phil.c.taylor@gmail.com
@@ -1,0 +1,2 @@
+pctaylor
+# first contribution: pet hatch unsegmentable-strip gate (#87739)

--- a/tests/agent/test_pet_generate.py
+++ b/tests/agent/test_pet_generate.py
@@ -528,6 +528,62 @@ def test_hatch_pet_retries_row_whose_frames_collapse_to_slivers(monkeypatch, tmp
     assert "sliver" in (atlas_mod.row_frames_collapsed(slivers, atlas_mod.silhouette_box(base)) or "")
 
 
+def test_row_frames_collapsed_without_reference_and_when_empty():
+    """The gate must abstain when it has no reference to judge against, and say
+    so when a row produced no art at all — neither case may silently pass as
+    'collapsed' or crash the hatch."""
+    from agent.pet.generate import atlas as atlas_mod
+
+    whole = atlas_mod.extract_strip_frames(_strip(6), 6, fit=False)
+    assert atlas_mod.row_frames_collapsed(whole, None) is None  # no reference → no verdict
+    empty = [atlas_mod._blank() for _ in range(6)]
+    assert "no visible frames" in (atlas_mod.row_frames_collapsed(empty, (100, 100)) or "")
+
+
+def test_collapsed_row_keeps_the_normal_retry_ladder(monkeypatch, tmp_path):
+    """A collapse is NOT an unsegmentable strip: the strip sliced fine, so a
+    fresh roll deserves the normal strict retry. Pins the policy that a
+    collapsed row does not take the skip-strict shortcut."""
+    from agent.pet.generate import atlas as atlas_mod
+    from agent.pet.generate import imagegen, orchestrate
+
+    base = tmp_path / "base.png"
+    _strip(1).save(base)
+
+    attempts: dict[str, int] = {}
+    idle_methods: list[str] = []
+
+    def fake_generate(prompt, *, n=1, reference_images=None, provider=None, prefix="pet", aspect_ratio="square"):
+        attempts[prefix] = attempts.get(prefix, 0) + 1
+        state = prefix.replace("pet_row_", "")
+        count = dict((s, c) for s, _, c in atlas_mod.ROW_SPECS).get(state, 6)
+        path = tmp_path / f"{prefix}_{attempts[prefix]}.png"
+        _strip(count).save(path)
+        return [path]
+
+    real_extract = atlas_mod.extract_strip_frames
+
+    def collapse_once(strip, count, *args, method="auto", **kwargs):
+        frames = real_extract(strip, count, *args, method=method, **kwargs)
+        name = Path(strip).name if isinstance(strip, (str, Path)) else ""
+        if name.startswith("pet_row_idle"):
+            idle_methods.append(method)
+            if len(idle_methods) == 1:
+                return [f.crop((0, 0, f.width // 4, f.height)) for f in frames]
+        return frames
+
+    monkeypatch.setattr(imagegen, "resolve_provider", lambda **_: object())
+    monkeypatch.setattr(imagegen, "generate", fake_generate)
+    monkeypatch.setattr(atlas_mod, "extract_strip_frames", collapse_once)
+
+    result = orchestrate.hatch_pet(base_image=base, slug="collapse-policy", concept="a fox")
+
+    # Two paid calls, both strict — the collapse did not skip to lenient.
+    assert attempts["pet_row_idle"] == 2
+    assert idle_methods == ["components", "components"]
+    assert "idle" in result.states
+
+
 
 
 

--- a/tests/agent/test_pet_generate.py
+++ b/tests/agent/test_pet_generate.py
@@ -56,6 +56,30 @@ def test_extract_strip_frames_transparent_returns_centered_cells():
         assert frame.getchannel("A").getextrema()[1] > 0
 
 
+def test_extract_strip_frames_components_raises_unsegmentable_not_valueerror():
+    # Two poses merged into ONE connected blob spanning the gutter: strict mode
+    # must fail with the STRUCTURAL error type, not a bare ValueError — the
+    # orchestrator keys off this class to skip remaining strict (paid) retries
+    # instead of substring-matching error text (#87739).
+    img = Image.new("RGBA", (6 * 208, 208), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    for i in (0, 1, 2, 5):
+        cx = i * 208 + 104
+        draw.ellipse((cx - 70, 34, cx + 70, 174), fill=(60, 80, 200, 255))
+    # One wide ellipse where slots 3+4 should be — a "two beavers" frame.
+    draw.ellipse((3 * 208 - 140, 24, 5 * 208 - 76, 184), fill=(200, 80, 80, 255))
+    with pytest.raises(atlas.UnsegmentableStripError):
+        atlas.extract_strip_frames(img, 6, method="components")
+
+
+def test_extract_strip_frames_auto_still_lenient_on_unsegmentable():
+    # The lenient path keeps salvaging a strip strict mode rejects — the
+    # exception must not change ``auto``'s behavior.
+    frames = atlas.extract_strip_frames(_strip(6), 6, method="auto")
+    assert len(frames) == 6
+
+
+
 
 
 def test_remove_background_defringes_antialiased_edge():
@@ -407,6 +431,50 @@ def test_hatch_pet_idle_fallback_when_row_fails(monkeypatch, tmp_path):
 
     result = orchestrate.hatch_pet(base_image=base, slug="fallbacky", concept="a fox")
     assert "idle" in result.states  # filled by the base-image fallback
+
+
+def test_hatch_pet_skips_strict_retries_on_unsegmentable_row(monkeypatch, tmp_path):
+    """A row whose poses are merged (unsegmentable under strict ``components``)
+    goes straight to lenient ``auto`` on the SAME strip instead of paying for
+    more strict re-rolls — the #87739 retry-amplification case."""
+    from agent.pet.generate import atlas as atlas_mod
+    from agent.pet.generate import imagegen, orchestrate
+
+    base = tmp_path / "base.png"
+    _strip(1).save(base)
+
+    attempts: dict[str, int] = {}
+    idle_methods: list[str] = []
+
+    def fake_generate(prompt, *, n=1, reference_images=None, provider=None, prefix="pet", aspect_ratio="square"):
+        attempts[prefix] = attempts.get(prefix, 0) + 1
+        state = prefix.replace("pet_row_", "")
+        count = dict((s, c) for s, _, c in atlas_mod.ROW_SPECS).get(state, 6)
+        path = tmp_path / f"{prefix}_{attempts[prefix]}.png"
+        _strip(count).save(path)
+        return [path]
+
+    real_extract = atlas_mod.extract_strip_frames
+
+    def tracking_extract(strip, count, *args, method="auto", **kwargs):
+        if Path(strip).name.startswith("pet_row_idle"):
+            idle_methods.append(method)
+            if method == "components":
+                raise atlas_mod.UnsegmentableStripError("could not segment 6 padded sprites from strip")
+        return real_extract(strip, count, *args, method=method, **kwargs)
+
+    monkeypatch.setattr(imagegen, "resolve_provider", lambda **_: object())
+    monkeypatch.setattr(imagegen, "generate", fake_generate)
+    monkeypatch.setattr(atlas_mod, "extract_strip_frames", tracking_extract)
+
+    result = orchestrate.hatch_pet(base_image=base, slug="unseg-skip", concept="a fox")
+
+    # One paid call for idle: strict failed → lenient salvaged the SAME strip.
+    assert attempts["pet_row_idle"] == 1
+    assert idle_methods == ["components", "auto"]
+    assert "idle" in result.states
+    assert not list(tmp_path.glob("pet_row_*"))  # strips still cleaned up
+
 
 
 

--- a/tests/agent/test_pet_generate.py
+++ b/tests/agent/test_pet_generate.py
@@ -56,32 +56,6 @@ def test_extract_strip_frames_transparent_returns_centered_cells():
         assert frame.getchannel("A").getextrema()[1] > 0
 
 
-def test_extract_strip_frames_components_raises_unsegmentable_not_valueerror():
-    # Two poses merged into ONE connected blob spanning the gutter: strict mode
-    # must fail with the STRUCTURAL error type, not a bare ValueError — the
-    # orchestrator keys off this class to skip remaining strict (paid) retries
-    # instead of substring-matching error text (#87739).
-    img = Image.new("RGBA", (6 * 208, 208), (0, 0, 0, 0))
-    draw = ImageDraw.Draw(img)
-    for i in (0, 1, 2, 5):
-        cx = i * 208 + 104
-        draw.ellipse((cx - 70, 34, cx + 70, 174), fill=(60, 80, 200, 255))
-    # One wide ellipse where slots 3+4 should be — a "two beavers" frame.
-    draw.ellipse((3 * 208 - 140, 24, 5 * 208 - 76, 184), fill=(200, 80, 80, 255))
-    with pytest.raises(atlas.UnsegmentableStripError):
-        atlas.extract_strip_frames(img, 6, method="components")
-
-
-def test_extract_strip_frames_auto_still_lenient_on_unsegmentable():
-    # The lenient path keeps salvaging a strip strict mode rejects — the
-    # exception must not change ``auto``'s behavior.
-    frames = atlas.extract_strip_frames(_strip(6), 6, method="auto")
-    assert len(frames) == 6
-
-
-
-
-
 def test_remove_background_defringes_antialiased_edge():
     # The contaminated antialiased ring where sprite meets backdrop survives the
     # key (it's a blend, too far from pure magenta). Defringe shaves that 1px ring:
@@ -526,18 +500,6 @@ def test_hatch_pet_retries_row_whose_frames_collapse_to_slivers(monkeypatch, tmp
     assert atlas_mod.row_frames_collapsed(whole, atlas_mod.silhouette_box(base)) is None
     slivers = [f.crop((0, 0, f.width // 4, f.height)) for f in whole]
     assert "sliver" in (atlas_mod.row_frames_collapsed(slivers, atlas_mod.silhouette_box(base)) or "")
-
-
-def test_row_frames_collapsed_without_reference_and_when_empty():
-    """The gate must abstain when it has no reference to judge against, and say
-    so when a row produced no art at all — neither case may silently pass as
-    'collapsed' or crash the hatch."""
-    from agent.pet.generate import atlas as atlas_mod
-
-    whole = atlas_mod.extract_strip_frames(_strip(6), 6, fit=False)
-    assert atlas_mod.row_frames_collapsed(whole, None) is None  # no reference → no verdict
-    empty = [atlas_mod._blank() for _ in range(6)]
-    assert "no visible frames" in (atlas_mod.row_frames_collapsed(empty, (100, 100)) or "")
 
 
 def test_collapsed_row_keeps_the_normal_retry_ladder(monkeypatch, tmp_path):

--- a/tests/agent/test_pet_generate.py
+++ b/tests/agent/test_pet_generate.py
@@ -476,6 +476,59 @@ def test_hatch_pet_skips_strict_retries_on_unsegmentable_row(monkeypatch, tmp_pa
     assert not list(tmp_path.glob("pet_row_*"))  # strips still cleaned up
 
 
+def test_hatch_pet_retries_row_whose_frames_collapse_to_slivers(monkeypatch, tmp_path):
+    """Lenient slicing can "succeed" with thin slivers of the body. Those pass the
+    frame-relative checks, then sink the WHOLE atlas at compose (every state
+    shares one normalized scale) after every row has been paid for. The gate
+    retries that row instead — the failure the live hatch hit on 2026-09-10
+    (running-right median 32x145px vs global 92x145px)."""
+    from agent.pet.generate import atlas as atlas_mod
+    from agent.pet.generate import imagegen, orchestrate
+
+    base = tmp_path / "base.png"
+    _strip(1).save(base)  # reference silhouette: one full-size ellipse
+
+    attempts: dict[str, int] = {}
+    idle_extractions: list[str] = []
+
+    def fake_generate(prompt, *, n=1, reference_images=None, provider=None, prefix="pet", aspect_ratio="square"):
+        attempts[prefix] = attempts.get(prefix, 0) + 1
+        state = prefix.replace("pet_row_", "")
+        count = dict((s, c) for s, _, c in atlas_mod.ROW_SPECS).get(state, 6)
+        path = tmp_path / f"{prefix}_{attempts[prefix]}.png"
+        _strip(count).save(path)
+        return [path]
+
+    real_extract = atlas_mod.extract_strip_frames
+
+    def sliver_then_real(strip, count, *args, method="auto", **kwargs):
+        frames = real_extract(strip, count, *args, method=method, **kwargs)
+        name = Path(strip).name if isinstance(strip, (str, Path)) else ""
+        if name.startswith("pet_row_idle"):
+            idle_extractions.append(method)
+            if len(idle_extractions) == 1:
+                # First extraction "succeeds" but with a 4th-width sliver: the
+                # exact shape of the live failure.
+                return [f.crop((0, 0, f.width // 4, f.height)) for f in frames]
+        return frames
+
+    monkeypatch.setattr(imagegen, "resolve_provider", lambda **_: object())
+    monkeypatch.setattr(imagegen, "generate", fake_generate)
+    monkeypatch.setattr(atlas_mod, "extract_strip_frames", sliver_then_real)
+
+    result = orchestrate.hatch_pet(base_image=base, slug="sliver-gate", concept="a fox")
+
+    assert attempts["pet_row_idle"] == 2, "sliver row must be re-rolled, not accepted"
+    assert "idle" in result.states
+
+    # And the gate itself: a sliver row is reported, a whole-body row is not.
+    whole = atlas_mod.extract_strip_frames(_strip(6), 6, fit=False)
+    assert atlas_mod.row_frames_collapsed(whole, atlas_mod.silhouette_box(base)) is None
+    slivers = [f.crop((0, 0, f.width // 4, f.height)) for f in whole]
+    assert "sliver" in (atlas_mod.row_frames_collapsed(slivers, atlas_mod.silhouette_box(base)) or "")
+
+
+
 
 
 

--- a/tests/agent/test_pet_segmentation.py
+++ b/tests/agent/test_pet_segmentation.py
@@ -103,3 +103,28 @@ def test_row_frames_collapsed_abstains_without_a_reference():
 
 def test_row_frames_collapsed_reports_a_row_with_no_art():
     assert atlas.row_frames_collapsed([_frame(92, 145, opaque=False) for _ in range(6)], (92, 145)) == "row has no visible frames"
+
+
+def test_row_frames_collapsed_rejects_a_uniformly_shrunk_row():
+    # A uniformly shrunk row (reference 92x145, frames ~40x60) walks past a
+    # width-only test scaled by measured height — expected_w = med_h * ref_w /
+    # ref_h is invariant under uniform shrink — yet compose rejects each cell
+    # for being too short once ``validate_atlas`` runs, after every row has been
+    # paid for. Rejecting on EITHER axis closes that gap.
+    reference = (92, 145)
+    reason = atlas.row_frames_collapsed([_frame(40, 60) for _ in range(6)], reference)
+    assert reason is not None and "short" in reason
+
+
+def test_unrelated_segmentation_valueerror_is_not_reclassified(monkeypatch):
+    # A broad ``except ValueError`` around the whole slicing block turns ANY
+    # ValueError into UnsegmentableStripError, which tells the orchestrator to
+    # skip its remaining strict (paid) retries — even when the failure is not in
+    # the art at all. Only the decision points may raise the structural type.
+    def boom(*_args, **_kwargs):
+        raise ValueError("unrelated failure deep in segmentation")
+
+    monkeypatch.setattr(atlas, "_component_crops", boom)
+    with pytest.raises(ValueError) as excinfo:
+        atlas.extract_strip_frames(_strip_of([140] * 6), 6, method="components")
+    assert not isinstance(excinfo.value, atlas.UnsegmentableStripError)

--- a/tests/agent/test_pet_segmentation.py
+++ b/tests/agent/test_pet_segmentation.py
@@ -1,0 +1,105 @@
+"""Segmentation contracts for pet row strips.
+
+Fast, hermetic, no generation mocks — these are the structural contracts the
+hatch retry policy keys off, so they belong in the default suite. The
+image-processing suite in ``tests/agent/test_pet_generate.py`` is opt-in behind
+``HERMES_RUN_SLOW_PET_TESTS``, which CI does not set; contracts that guard a
+paid-retry decision should not live only there.
+"""
+
+from __future__ import annotations
+
+import pytest
+from PIL import Image, ImageDraw
+
+from agent.pet.generate import atlas
+
+SLOT = 208
+HEIGHT = 208
+
+
+def _strip_of(widths: list[int]) -> Image.Image:
+    """One row strip with one opaque ellipse per slot, each *widths[i]* px wide."""
+    img = Image.new("RGBA", (SLOT * len(widths), HEIGHT), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    for i, width in enumerate(widths):
+        cx = i * SLOT + SLOT // 2
+        draw.ellipse((cx - width // 2, 34, cx + width // 2, 174), fill=(60, 80, 200, 255))
+    return img
+
+
+def _merged_pair_strip(count: int = 6) -> Image.Image:
+    """Slots 3 and 4 drawn as ONE connected blob straddling the gutter."""
+    img = _strip_of([140] * count)
+    draw = ImageDraw.Draw(img)
+    draw.ellipse((3 * SLOT - 140, 24, 5 * SLOT - 76, 184), fill=(200, 80, 80, 255))
+    return img
+
+
+def _two_poses_in_one_slot_strip(count: int = 6) -> Image.Image:
+    """One slot holds two poses merged side by side — wide, not tall.
+
+    This is the reported "split into two" frame: padded segmentation succeeds
+    (the blob sits inside its slot with margins), so only frame validation can
+    reject it.
+    """
+    return _strip_of([60] * 3 + [300] + [60] * (count - 4))
+
+
+def _frame(width: int, height: int, *, opaque: bool = True) -> Image.Image:
+    img = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    if opaque:
+        ImageDraw.Draw(img).rectangle((0, 0, width - 1, height - 1), fill=(60, 80, 200, 255))
+    return img
+
+
+def test_merged_poses_raise_the_structural_error_not_a_bare_valueerror():
+    # Strict mode must fail with the STRUCTURAL error type: the orchestrator
+    # keys off this class to skip the remaining strict (paid) retries instead of
+    # substring-matching error text (#87739).
+    with pytest.raises(atlas.UnsegmentableStripError):
+        atlas.extract_strip_frames(_merged_pair_strip(), 6, method="components")
+
+
+def test_strict_mode_surfaces_validation_failures_structurally_too():
+    # Extraction can succeed while the ART is still unusable — a slot holding
+    # two merged poses is one connected subject with margins, so padded slicing
+    # accepts it and only validation rejects it. That is the same defect class
+    # as an unsegmentable strip (the model drew two characters), so it must
+    # reach the orchestrator as the same structural error, not a bare ValueError
+    # that would trigger more paid strict re-rolls.
+    with pytest.raises(atlas.UnsegmentableStripError):
+        atlas.extract_strip_frames(_two_poses_in_one_slot_strip(), 6, method="components")
+
+
+def test_auto_still_salvages_a_strip_strict_mode_rejects():
+    # ``auto`` is the lenient path: the new exception must not change its
+    # behavior. Uses a strip strict mode genuinely rejects, so this exercises
+    # the salvage path rather than a strip both methods accept.
+    strip = _merged_pair_strip()
+    with pytest.raises(atlas.UnsegmentableStripError):
+        atlas.extract_strip_frames(strip, 6, method="components")
+    assert len(atlas.extract_strip_frames(strip, 6, method="auto")) == 6
+
+
+def test_row_frames_collapsed_flags_slivers_and_passes_whole_poses():
+    # A lenient salvage can "succeed" with thin fragments of a body that match
+    # each other, so nothing marks them as outliers until compose rejects the
+    # whole atlas. Compare the row's median width against what the character's
+    # silhouette implies at that height.
+    reference = (92, 145)
+    assert atlas.row_frames_collapsed([_frame(92, 145) for _ in range(6)], reference) is None
+    reason = atlas.row_frames_collapsed([_frame(32, 145) for _ in range(6)], reference)
+    assert reason is not None and "sliver" in reason
+
+
+def test_row_frames_collapsed_abstains_without_a_reference():
+    # No identity anchor decoded (or an empty one) means no judgement: the gate
+    # must not guess, and must not reject a row on a missing reference.
+    frames = [_frame(32, 145) for _ in range(6)]
+    assert atlas.row_frames_collapsed(frames, None) is None
+    assert atlas.row_frames_collapsed(frames, (0, 0)) is None
+
+
+def test_row_frames_collapsed_reports_a_row_with_no_art():
+    assert atlas.row_frames_collapsed([_frame(92, 145, opaque=False) for _ in range(6)], (92, 145)) == "row has no visible frames"


### PR DESCRIPTION
## What does this PR do?

`/hatch` pays for strict row re-rolls that cannot succeed, and can accept sliced rows that poison the whole atlas. Two related defects, one logical change: **a row that cannot be sliced well should not cost more paid calls, and should not be accepted into compose.**

1. **Structural unsegmentable detection.** When a generated row strip has its poses merged into one connected blob, strict `components` extraction fails with a bare `ValueError`, which `_generate_row` treats like any transient failure — it re-rolls the row (a paid image call per retry) before falling back to lenient `auto` slicing on a *fresh* strip. `extract_strip_frames` now raises a dedicated `UnsegmentableStripError` (subclass of `ValueError`) in strict mode — for segmentation failure **and** for strict-mode frame-validation failure, since both mean the defect is in the art itself and lenient slicing can only forgive it, not fix it. `_generate_row` catches it and immediately re-slices the **same strip** leniently: no image call between the strict failure and the lenient attempt. Other errors keep the existing strict→strict→lenient ladder.

2. **Pre-compose collapse gate.** Lenient slicing can also "succeed" with thin vertical fragments of the body. Those pass the existing frame-relative checks (they match each other, so none is a *relative* outlier) and only surface at compose — where the global-median collapse guard rejects the **entire atlas** after every row has been paid for, wiping out the hatch. Each row's median frame width is now compared against the width the base silhouette implies at that height, before compose; a collapsed row is retried (or dropped) at that row instead of being accepted into a hatch that is about to die. It raises `CollapsedRowError`, deliberately a *different* type from `UnsegmentableStripError`: the strip did slice, so a fresh roll deserves the normal retry ladder rather than the skip-strict shortcut.

## Related Issue

Fixes #87739. Supersedes #87803 — @webtecnica has closed it and pointed here; credit for the original approach and its review direction (structural detection over keyword lists) is theirs.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/pet/generate/atlas.py`: `UnsegmentableStripError` + `CollapsedRowError`; strict-mode raising in `extract_strip_frames` at the two decision points (segmentation failure and strict-mode validation failure — an unrelated `ValueError` is no longer reclassified as an art defect); `row_frames_collapsed()` + `silhouette_box()` for the per-row proportion check; `collapse_limits(ref_w, ref_h)` as the single home for the collapse thresholds, now shared by `_check_atlas_cells` (against the atlas-wide median, thresholds unchanged) and by the pre-compose gate (against the base silhouette, rejecting on **either** axis — a uniformly shrunk row fails the height floor even though a width test scaled by measured height is invariant under uniform shrink).
- `agent/pet/generate/orchestrate.py`: `_generate_row` catches `UnsegmentableStripError` → lenient re-slice of the same strip; then gates the sliced frames on the base silhouette before returning; the silhouette is decoded once per hatch, not per row per attempt.
- `tests/agent/test_pet_segmentation.py` (new): 8 fast contracts, ungated — merged poses raise the structural error; a slot holding two merged poses raises it through the validation path; `auto` still salvages; the gate flags slivers **and** uniformly shrunk rows, abstains without a reference, and reports an art-less row; an unrelated `ValueError` inside slicing is not reclassified.
- `tests/agent/test_pet_generate.py`: 3 orchestration tests — an unsegmentable row costs ONE paid call (`attempts == 1`); a sliver row is re-rolled rather than accepted; a collapsed row keeps the normal retry ladder.
- `contributors/emails/phil.c.taylor@gmail.com`: attribution mapping the Contributor Attribution Check requires for this branch's commits.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_pet_segmentation.py` — **8 passed** (~4s). Runs in the default suite; the image-processing file beside it is opt-in behind `HERMES_RUN_SLOW_PET_TESTS`, which CI does not set, so the contracts that decide whether a row costs another paid image call are asserted where CI will actually run them.
2. `HERMES_RUN_SLOW_PET_TESTS=1 scripts/run_tests.sh tests/agent/test_pet_generate.py tests/agent/test_pet_segmentation.py` — **28 passed**.
3. Mutation-checked (each mutation makes a test fail): deleting the strict-mode raise at a decision point fails `test_strict_mode_surfaces_validation_failures_structurally_too`; disabling the gate fails 2 tests; removing the lenient re-slice fails the `attempts == 1` contract; dropping the height criterion fails `test_row_frames_collapsed_rejects_a_uniformly_shrunk_row`; restoring the broad `except ValueError` fails the classification test.
4. Hermetic repro of the failure sequence, no API calls — one row drawn with its poses merged, with the new gate disabled, shows strict failure → lenient salvage of the same strip:
   ```
   WARNING agent.pet.generate.orchestrate: pet hatch 'repro-ghost': row 'running-right' unsegmentable (attempt 1/3) — skipping strict retries: could not segment 8 padded sprites from strip
   INFO agent.pet.generate.orchestrate: pet hatch 'repro-ghost': row 'running-right' ready in 3.7s (attempt 1)
   ```
   (Script kept out of the PR as QA tooling. It demonstrates the strict → lenient re-slice on the same strip; the collapse itself is asserted by the mocked-frame tests in step 1, not by this script — with the gate disabled the mocked hatch completes, because reproducing the exact live sliver geometry needs a real model.)
5. Live hatch on macOS (OpenRouter `google/gemini-3.1-flash-image`, 9 states) — observation, not a controlled A/B. With part 1's structural skip in place but **before** the collapse gate: `running-right` reported unsegmentable on its strict attempt, its lenient salvage "succeeded" with 32x145px frames against a 92x145px global median, and compose then failed the whole hatch — every row already paid for, no pet installed:
   ```
   GenerationError: state 'running-right' appears collapsed (median 32x145px, global median 92x145px); state 'running-left' appears collapsed …
   ```
   (Message format as emitted by `validate_atlas`; values from the live run, which I am quoting from that run's terminal output rather than reproducing here.) After the gate, the same character hatched clean: 9/9 states, validation `ok`, 32.5s. Because generation is stochastic, that is a regression check on the gate rather than proof of a changed failure rate.

   **Known limit of this PR, found after the run.** A bbox-based per-cell audit of that installed sheet passes, but a connected-component audit does not: the `review` row's third cell holds **two** ghost figures (178px wide vs 69-81px for its siblings; two separate components of ~5.6k px each). Neither this PR nor the existing checks catch that class — the two figures merge into a single subject box, so the "multiple separated subjects" branch never fires, and every ratio in play (the existing width-outlier test, `row_frames_collapsed`, and the offline audit) is tuned for frames ~3x too wide or far too thin, not ~2x too wide. A connected-component sweep of the 10 pets installed on this machine found it in **3 pets / 7 cells** (side-by-side duplicates and bodies split into stacked halves). Treat this PR as covering the *unsegmentable* and *collapsed* halves of #87739, not multi-figure frames; a follow-up puts the acceptance criteria behind one shared invariant (eroded-core count plus an area ratio anchored to the reference) so the pre-compose gate, `validate_atlas`, and the offline audit cannot disagree. This PR deliberately does not grow to cover it.
6. Pre-existing contracts untouched: strip cleanup after a successful and a failed attempt, and the idle-fallback path, still pass.

Tested on macOS 26.6.2 (arm64). Cross-platform: no new file/process/env surface — exception flow plus PIL ops already in use here; `scripts/check-windows-footguns.py --diff origin/main` clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(pet): …`, `test(pet): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (found #87803; superseded with the author's agreement; intent signals posted on #87739 and #87803 before coding)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the test suite and all tests pass (`scripts/run_tests.sh`, per CONTRIBUTING; pet image-processing suite opt-in respected)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A: no doc-visible behavior change (log text only); the docstrings for the new helpers are in the diff
- [x] I've updated `cli-config.yaml.example` — N/A: no config keys added or changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A: no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) — no new file/process/env surface; `scripts/check-windows-footguns.py --diff origin/main` reports none
- [x] I've updated tool descriptions/schemas — N/A: no tool behavior change

## Screenshots / Logs

Both excerpts are in **How to Test**: step 4 is a hermetic, no-cost repro of the retry sequence; step 5 is the compose-time failure line from the live hatch that motivated the gate.
