### PR TITLE
fix(pet): row prompt forbids multi-character pose regions

### DIFF
--- a/agent/pet/generate/prompts.py
+++ b/agent/pet/generate/prompts.py
@@ -145,6 +145,15 @@ def build_row_prompt(state: str, frame_count: int, concept: str, *, style: str |
         f"than letting it cross the gap. Silhouettes must NEVER touch, overlap, "
         f"share a shadow, share a ground line, share motion trails, or merge into "
         f"one connected shape. "
+        # One character per region: the segmenter cannot recover a region that
+        # contains a duplicated or stacked figure (it slices as one connected
+        # blob or two half-bodies — the 'split into two beavers' hatch defect).
+        f"POPULATION (critical): each region contains EXACTLY ONE COMPLETE "
+        f"character — a single figure, whole and unmistakable. Never two "
+        f"characters, never one character split into stacked top-half and "
+        f"bottom-half fragments, never a half-body at a region edge. If a pose "
+        f"suggests fast motion, imply it with limb position alone; do NOT draw "
+        f"ghost, echo, duplicate, or after-image copies of the character. "
         # Registration: a clean sprite sheet keeps the character locked in place
         # so only the action moves — this is what stops the loop sliding/pulsing.
         "REGISTRATION (critical): the character is the SAME height and SAME width "

--- a/contributors/emails/phil.c.taylor@gmail.com
+++ b/contributors/emails/phil.c.taylor@gmail.com
@@ -1,0 +1,2 @@
+pctaylor
+# first contribution: pet hatch unsegmentable-strip gate (#87739)

--- a/tests/agent/test_pet_row_prompt.py
+++ b/tests/agent/test_pet_row_prompt.py
@@ -13,11 +13,7 @@ markers here — that is the contract, not the exact sentence.
 
 from __future__ import annotations
 
-import pytest
-
 from agent.pet.generate import atlas, prompts
-
-PIL = pytest.importorskip("PIL")
 
 # The incident phrase; see agent/pet/generate/prompts.py's POPULATION comment.
 _CLAUSE_MARKERS = ("EXACTLY ONE COMPLETE character", "duplicate")

--- a/tests/agent/test_pet_row_prompt.py
+++ b/tests/agent/test_pet_row_prompt.py
@@ -1,9 +1,14 @@
-"""Tests that the row prompt carries the one-character-per-region clause.
+"""Contract for the row prompt's one-character-per-region clause.
 
-The clause exists to prevent the hatch defect where the image model draws a
-duplicated or stacked figure inside one pose region (the segmenter cannot
-recover it — #87739's 'split into two beavers' rows). A behavior contract on
-the clause's presence, not a snapshot of the full prompt text.
+A prompt change has no observable behavior to assert, so this test pins the one
+relationship the fix depends on: the population rule is ROW-scoped and
+universal. It must appear in every animation-state row prompt (each row is a
+strip of adjacent poses, where the model is tempted to draw a doubled figure)
+and must stay out of the base-look prompt (a single centered mascot, where the
+clause would say nothing useful).
+
+If you rewrite the prompt text, keep those two properties and update the
+markers here — that is the contract, not the exact sentence.
 """
 
 from __future__ import annotations
@@ -14,11 +19,20 @@ from agent.pet.generate import atlas, prompts
 
 PIL = pytest.importorskip("PIL")
 
+# The incident phrase; see agent/pet/generate/prompts.py's POPULATION comment.
+_CLAUSE_MARKERS = ("EXACTLY ONE COMPLETE character", "duplicate")
 
-@pytest.mark.parametrize("state", [s for s, _r, _c in atlas.ROW_SPECS])
-def test_row_prompt_forbids_multi_character_regions(state):
-    text = prompts.build_row_prompt(state, 6, "a fox")
-    # The POPULATION clause — present for every state, whatever the pose.
-    assert "EXACTLY ONE COMPLETE" in text
-    assert "duplicate" in text.lower()
-    assert "ghost" in text.lower()
+
+def _has_population_clause(text: str) -> bool:
+    return all(marker in text for marker in _CLAUSE_MARKERS)
+
+
+def test_population_clause_is_in_every_row_prompt():
+    missing = [state for state, _row, _count in atlas.ROW_SPECS if not _has_population_clause(prompts.build_row_prompt(state, 6, "a fox"))]
+    assert not missing, f"row prompts missing the one-character-per-region clause: {missing}"
+
+
+def test_population_clause_stays_out_of_the_base_look_prompt():
+    # The base look is one centered figure by construction; a doubled-figure
+    # rule there would be noise that dilutes the rest of the base prompt.
+    assert not _has_population_clause(prompts.build_base_prompt("a shy ghost"))

--- a/tests/agent/test_pet_row_prompt.py
+++ b/tests/agent/test_pet_row_prompt.py
@@ -1,0 +1,24 @@
+"""Tests that the row prompt carries the one-character-per-region clause.
+
+The clause exists to prevent the hatch defect where the image model draws a
+duplicated or stacked figure inside one pose region (the segmenter cannot
+recover it — #87739's 'split into two beavers' rows). A behavior contract on
+the clause's presence, not a snapshot of the full prompt text.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.pet.generate import atlas, prompts
+
+PIL = pytest.importorskip("PIL")
+
+
+@pytest.mark.parametrize("state", [s for s, _r, _c in atlas.ROW_SPECS])
+def test_row_prompt_forbids_multi_character_regions(state):
+    text = prompts.build_row_prompt(state, 6, "a fox")
+    # The POPULATION clause — present for every state, whatever the pose.
+    assert "EXACTLY ONE COMPLETE" in text
+    assert "duplicate" in text.lower()
+    assert "ghost" in text.lower()


### PR DESCRIPTION
## What does this PR do?

The hatch defect behind #87739's worst rows isn't only touching poses — it's the image model drawing **more than one character inside a single pose region** (a duplicated/ghost figure, or one character split into stacked top-half and bottom-half fragments). The segmenter cannot recover either: the region slices as one connected blob (merged → unsegmentable) or as two half-bodies (a "split into two beavers" row that can still install via lenient slicing).

This adds a POPULATION clause to `build_row_prompt`, alongside the existing SPACING and REGISTRATION blocks: each region contains exactly one complete character; motion duplication is expressed with limb position, never ghost/echo/duplicate copies. Prompt-level prevention pairs with the structural `UnsegmentableStripError` retry skip and the pre-compose collapse gate in #107796, which catch what the prompt cannot prevent.

## Related Issue

Addresses #87739 (deliberately not `Fixes`: #107796 carries the closing link, and whichever of the two merges first should close the issue rather than having both PRs claim it). Independent branch off `main`; either PR merges alone.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/pet/generate/prompts.py`: POPULATION clause in `build_row_prompt`, with a why-comment (segmenter recovery, split-into-two defect).
- `tests/agent/test_pet_row_prompt.py` (new): 2 tests pinning the two properties the fix relies on — the clause is present in **every** animation state's row prompt, and stays out of the single-figure base-look prompt. Deliberately a relationship contract, not a snapshot of the sentence: a prompt rewrite should be able to change wording without turning CI red, but must not drop the rule or leak it into the base prompt.
- `contributors/emails/phil.c.taylor@gmail.com`: attribution mapping the Contributor Attribution Check requires for this branch's commits.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_pet_row_prompt.py` — **2 passed** (~0.5s).
2. Inspect the rendered prompt:
   ```
   python -c "from agent.pet.generate import prompts; print(prompts.build_row_prompt('running', 6, 'a fox'))"
   ```
   The POPULATION block appears between the SPACING and REGISTRATION blocks.
3. Negative case: `prompts.build_base_prompt('a shy ghost')` does **not** contain the clause — the base look is one centered figure by construction, and a doubled-figure rule there would dilute the rest of that prompt.

Tested on macOS 26.6.2 (arm64). Cross-platform: prompt strings only, no I/O.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(pet): …`, `test(pet): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (prompt-shape PRs exist for other failure modes — touching poses, backgrounds — but none name the multi-character region defect; intent signal posted on #87739)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the test suite and all tests pass (`scripts/run_tests.sh`, per CONTRIBUTING)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A: prompt text only; the why-comment for the new clause is in the diff
- [x] I've updated `cli-config.yaml.example` — N/A: no config keys added or changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A: no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) — N/A: no file, process, or env surface touched
- [x] I've updated tool descriptions/schemas — N/A: no tool behavior change

## Screenshots / Logs

N/A — prompt-only change with no runtime output. The rendered prompt can be printed with the command in How to Test, step 2.
