### PR TITLE
fix(tools): read_file counts unterminated final lines and stops rendering a phantom trailing line (salvage #106888, #49453)

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -418,6 +418,34 @@ class TestShellFileOpsHelpers:
         assert result.error is None
         assert result.content == "alpha\n"
 
+    def test_newline_terminated_content_has_no_phantom_line(self, file_ops):
+        # A file ending in a newline (the normal, well-formed case) has its
+        # last line terminated, NOT followed by an empty line. The gutter must
+        # match `cat -n`: three lines in, three numbered lines out.
+        result = file_ops._add_line_numbers("line1\nline2\nline3\n")
+        assert result == "1|line1\n2|line2\n3|line3"
+        assert "4|" not in result
+        assert len(result.split("\n")) == 3
+
+    def test_non_terminated_content_still_numbered_correctly(self, file_ops):
+        # Content with no trailing newline was already correct; guard it.
+        result = file_ops._add_line_numbers("line1\nline2\nline3")
+        assert result == "1|line1\n2|line2\n3|line3"
+
+    def test_trailing_blank_line_is_kept(self, file_ops):
+        # "a" then a genuine blank line, then the terminating newline: that is
+        # two lines (a, blank), so only the single terminator is dropped.
+        result = file_ops._add_line_numbers("a\n\n")
+        assert result == "1|a\n2|"
+        assert "3|" not in result
+
+    def test_newline_terminated_with_offset_has_no_phantom_line(self, file_ops):
+        # A truncated page (offset>1) that ends on a newline must not append a
+        # phantom numbered line at the page boundary.
+        result = file_ops._add_line_numbers("def f():\n    return 1\n", start_line=10)
+        assert result == "10|def f():\n11|    return 1"
+        assert "12|" not in result
+
 
 class TestSearchPathValidation:
     """Test that search() returns an error for non-existent paths."""

--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -314,3 +314,74 @@ class TestSearchContextParsing:
         assert result.matches[0].path == "dir/file-12-name.py"
         assert result.matches[0].line_number == 8
         assert result.matches[0].content == "context here"
+
+
+# =========================================================================
+# total_lines for files without a trailing newline (#3907)
+# =========================================================================
+
+
+class TestNoTrailingNewlineTotalLines:
+    """``wc -l`` counts newlines, not lines: a final unterminated line must
+    still count. Covers the live read paths plus the assembler contract."""
+
+    @pytest.fixture()
+    def ops(self):
+        from tools.environments.local import LocalEnvironment
+
+        return ShellFileOperations(LocalEnvironment())
+
+    def test_total_lines_counts_final_unterminated_line(self, tmp_path, ops):
+        target = tmp_path / "no_trailing.txt"
+        target.write_bytes(b"line1\nline2\nline3")  # no trailing newline
+
+        result = ops.read_file(str(target))
+
+        assert result.error is None
+        assert result.total_lines == 3
+        assert result.content.split("\n") == ["1|line1", "2|line2", "3|line3"]
+
+    def test_pagination_admits_final_unterminated_line(self, tmp_path, ops):
+        target = tmp_path / "no_trailing.txt"
+        target.write_bytes(b"line1\nline2\nline3")
+
+        first = ops.read_file(str(target), offset=1, limit=2)
+        assert first.truncated is True
+        assert "of 3 lines" in (first.hint or "")
+
+        last = ops.read_file(str(target), offset=3)
+        assert last.error is None
+        assert last.content == "3|line3"
+        assert last.total_lines == 3
+
+    def test_terminated_and_empty_files_unchanged(self, tmp_path, ops):
+        terminated = tmp_path / "terminated.txt"
+        terminated.write_bytes(b"a\nb\nc\n")
+        assert ops.read_file(str(terminated)).total_lines == 3
+
+        empty = tmp_path / "empty.txt"
+        empty.write_bytes(b"")
+        result = ops.read_file(str(empty))
+        assert result.total_lines == 0
+
+    def test_native_path_counts_final_unterminated_line(self, tmp_path, ops):
+        target = tmp_path / "no_trailing.txt"
+        target.write_bytes(b"line1\nline2\nline3")
+
+        result = ops._read_file_native(str(target), 1, 2000)
+
+        assert result.error is None
+        assert result.total_lines == 3
+
+    def test_assembler_bumps_count_only_on_proven_missing_newline(self):
+        ops = ShellFileOperations.__new__(ShellFileOperations)
+
+        proved = ops._assemble_read_result(
+            "a\nb\nc\n", offset=1, end_line=2000, total_lines=2,
+            file_size=5, file_ends_with_newline=False)
+        assert proved.total_lines == 3
+
+        unknown = ops._assemble_read_result(
+            "a\nb\nc\n", offset=1, end_line=2000, total_lines=2,
+            file_size=5, file_ends_with_newline=None)
+        assert unknown.total_lines == 2

--- a/tests/tools/test_file_ops_single_roundtrip.py
+++ b/tests/tools/test_file_ops_single_roundtrip.py
@@ -75,9 +75,9 @@ class TestReadFileOneRoundTrip:
         r = ops.read_file(p)
         assert len(calls) == 1 and READ_PROBE_MARK in calls[0]
         assert r.error is None
-        # ``_add_line_numbers`` numbers the empty tail after the final
-        # newline: long-standing behaviour, preserved byte for byte.
-        assert r.content == "1|one\n2|two\n3|three\n4|"
+        # The final newline terminates line 3; it does not start a phantom
+        # ``4|`` line (`cat -n` semantics).
+        assert r.content == "1|one\n2|two\n3|three"
         assert (r.total_lines, r.file_size, r.truncated) == (3, 14, False)
 
     def test_no_trailing_newline_needs_no_extra_probe(self, shell, tmp_path):
@@ -88,14 +88,15 @@ class TestReadFileOneRoundTrip:
         # ``cut`` newline-terminates the last line; the artifact is stripped
         # from the same reply that used to need a fifth ``tail -c 1`` call.
         assert r.content == "1|a\n2|b"
-        assert r.total_lines == 1  # wc -l semantics, unchanged
+        # The unterminated final line counts: 2 lines, not wc -l's 1 (#3907).
+        assert r.total_lines == 2
 
     def test_pagination_window_and_hint(self, shell, tmp_path):
         ops, calls = shell
         p = _write(tmp_path, "c.txt", b"".join(b"l%d\n" % i for i in range(1, 11)))
         r = ops.read_file(p, offset=3, limit=2)
         assert len(calls) == 1
-        assert r.content == "3|l3\n4|l4\n5|"
+        assert r.content == "3|l3\n4|l4"
         assert r.truncated is True and r.total_lines == 10
         assert "offset=5" in r.hint
 
@@ -118,26 +119,26 @@ class TestReadFileOneRoundTrip:
         ops, calls = shell
         r = ops.read_file(_write(tmp_path, "f.txt", "﻿hello\n".encode("utf-8")))
         assert len(calls) == 1
-        assert r.content == "1|hello\n2|"
+        assert r.content == "1|hello"
 
     def test_crlf_bytes_survive(self, shell, tmp_path):
         ops, calls = shell
         r = ops.read_file(_write(tmp_path, "g.txt", b"x\r\ny\r\n"))
-        assert r.content == "1|x\r\n2|y\r\n3|"
+        assert r.content == "1|x\r\n2|y\r"
 
     def test_long_line_clamped_and_marked(self, shell, tmp_path):
         ops, calls = shell
         r = ops.read_file(_write(tmp_path, "L.txt", b"a" * 9000 + b"\nshort\n"))
         assert len(calls) == 1
-        first, second, tail = r.content.split("\n")
+        first, second = r.content.split("\n")
         assert first.endswith("... [truncated]") and len(first) < 9000
-        assert second == "2|short" and tail == "3|"
+        assert second == "2|short"
 
     def test_relative_path_resolves_against_env_cwd(self, shell, tmp_path):
         ops, calls = shell
         _write(tmp_path, "rel.txt", b"here\n")
         r = ops.read_file("rel.txt")
-        assert r.error is None and r.content == "1|here\n2|"
+        assert r.error is None and r.content == "1|here"
 
     def test_sentinel_lookalike_in_content_reads_intact(self, shell, tmp_path):
         ops, calls = shell
@@ -145,7 +146,7 @@ class TestReadFileOneRoundTrip:
         p = _write(tmp_path, "s.txt", f"x\n{lookalike}\ny\n".encode("utf-8"))
         r = ops.read_file(p)
         assert r.error is None and r.total_lines == 3
-        assert r.content == f"1|x\n2|{lookalike}\n3|y\n4|"
+        assert r.content == f"1|x\n2|{lookalike}\n3|y"
 
 
 class TestReadFileNonTextPaths:
@@ -168,7 +169,7 @@ class TestReadFileNonTextPaths:
         assert on_disk != typed
         _write(tmp_path, on_disk, b"accent\n")
         r = ops.read_file(str(tmp_path / typed))
-        assert r.error is None and r.content == "1|accent\n2|"
+        assert r.error is None and r.content == "1|accent"
         assert r.hint is not None and "unicode-equivalent" in r.hint
 
     def test_directory_is_not_regular(self, shell, tmp_path):
@@ -289,7 +290,7 @@ class TestNativeRead:
         ops, calls = native
         r = ops.read_file(_write(tmp_path, "a.txt", b"one\ntwo\n"))
         assert calls == []
-        assert r.error is None and r.content == "1|one\n2|two\n3|"
+        assert r.error is None and r.content == "1|one\n2|two"
         assert (r.total_lines, r.file_size) == (2, 8)
 
     def test_kill_switch_routes_to_the_shell(self, native, tmp_path, monkeypatch):
@@ -449,7 +450,7 @@ class TestCompoundFallback:
 
         with patch.object(ops, "_exec", side_effect=garbled):
             r = ops.read_file(p)
-        assert r.error is None and r.content == "1|one\n2|two\n3|"
+        assert r.error is None and r.content == "1|one\n2|two"
         assert r.total_lines == 2
 
     def test_fallback_is_logged_at_debug(self, shell, tmp_path, caplog):
@@ -466,7 +467,7 @@ class TestCompoundFallback:
         with caplog.at_level(logging.DEBUG, logger="tools.file_operations"), \
              patch.object(ops, "_exec", side_effect=garbled):
             r = ops.read_file(p)
-        assert r.error is None and r.content == "1|one\n2|"
+        assert r.error is None and r.content == "1|one"
         assert any(
             "falling back to sequential probes" in rec.getMessage()
             and str(p) in rec.getMessage()

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -869,6 +869,12 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
         read path so the BOM strip, pagination hint, ``cut`` newline-artifact fix and
         the ambiguous-silence guards never drift apart. ``file_ends_with_newline`` is
         None when the caller could not tell (artifact left alone, as before)."""
+        # ``wc -l`` counts newlines, not lines: a nonempty file whose last byte
+        # is not a newline holds one more line than the count (#3907). Adjust
+        # here — the single choke point — so total_lines, truncation, and the
+        # past-EOF guard agree on every read path (compound, sequential, native).
+        if file_size > 0 and file_ends_with_newline is False:
+            total_lines += 1
         if offset == 1:  # only the first chunk can carry a BOM (byte 0)
             read_output, _ = _strip_bom(read_output)
         truncated = total_lines > end_line

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -312,6 +312,13 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
         A/B, while dropping numbers regressed line-referencing."""
         from tools.tool_output_limits import get_max_line_length
         max_line_length = get_max_line_length()
+        # A trailing newline terminates the final line — it does not start a new,
+        # empty one. Splitting without dropping it rendered a phantom "<N+1>|"
+        # gutter line on every newline-terminated file (`cat -n` semantics).
+        # Exactly ONE terminator is dropped, so a genuinely selected trailing
+        # blank line in a page keeps its own number.
+        if content.endswith('\n'):
+            content = content[:-1]
         return '\n'.join(
             f"{i}|{line if len(line) <= max_line_length else line[:max_line_length] + '... [truncated]'}"
             for i, line in enumerate(content.split('\n'), start=start_line))


### PR DESCRIPTION
`read_file` now reports line counts and gutters that match `cat -n` on every read path — no more phantom trailing line on well-formed files, and no more silently unreachable final line on files without a trailing newline.

## What was wrong

- **Undercount:** `total_lines` came from `wc -l`, which counts newline *bytes*. A file whose final line is unterminated was undercounted by one; for a 2001-line file read in 2000-line pages, `truncated` stayed `False` and the last line was never offered. The past-EOF guard then refused `offset=<real last line>` with "beyond the end of the file".
- **Phantom line:** `_add_line_numbers()` split on `\n` without dropping the single terminating newline, so every newline-terminated file (the normal case) rendered a phantom `N+1|` empty gutter line that isn't in the file.

## Changes

- `_assemble_read_result()` (the shared choke point) bumps `total_lines` by one when the probe proves the last byte is not a newline — compound, sequential, and native paths all flow through it, so counts, truncation, and the past-EOF guard agree.
- `_add_line_numbers()` drops exactly ONE terminating newline before numbering (`cat -n` semantics). A genuinely selected trailing blank line keeps its own number.
- 12 existing tests that froze the phantom rendering as expected output updated to the corrected contract; new invariant tests from the salvaged PRs cover unterminated-final-line counting, pagination admission of the final line, and phantom-line absence (incl. offset pages and trailing-blank preservation).

## Validation

| Check | Before | After |
|---|---|---|
| `"alpha\nbeta\n"` full read | `1\|alpha\n2\|beta\n3\|` (phantom) | `1\|alpha\n2\|beta` |
| `"alpha\nbeta"` total_lines | 1 | 2 |
| `"alpha\nbeta"` `offset=2` | "beyond the end of the file" | `2\|beta` |
| `"alpha\n\n"` (real trailing blank) | kept | kept (`1\|alpha\n2\|`) |
| native / sequential / compound paths | disagree | byte-identical |

**Live repro:** before — fresh-import E2E on origin/main showed all three failures above (phantom `3|`, `total_lines=1`, past-EOF refusal of a real line); after — same harness on this branch shows the fixed table, all three read paths agreeing (native + sequential probed directly).

`scripts/run_tests.sh tests/tools/` — 9,111 passed; 5 failures are pre-existing on main (ImportError-class env issues in modal/web-config/execution-flag tests, reproduced on the main checkout unchanged).

## Credit

Salvages #106888 (@nikkoxgonzales, unterminated-line count) and #49453 (@MaxFreedomPollard, phantom line) — cherry-picked with authorship intact. Same class independently reported in #3907/#3908, #3927, #20814, #22945, #42929, #55696, #91306. Cross-validated against anomalyco/opencode#47420 (their read-page trailing-blank-line serialization fix; hermes' page path is blank-line-safe once terminator handling is right — verified live).

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9ee03/HnzGxrqJ_-xRGWzogdOQk_oNarulNv.png)
