### PR TITLE
fix(desktop): Make /skills and subcommands available in desktop chat

### DIFF
--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -124,7 +124,6 @@ describe('desktop slash command curation', () => {
     expect(isDesktopSlashSuggestion('/redraw')).toBe(false)
     expect(isDesktopSlashSuggestion('/approve')).toBe(false)
     expect(isDesktopSlashSuggestion('/model')).toBe(false)
-    expect(isDesktopSlashSuggestion('/skills')).toBe(false)
     expect(isDesktopSlashSuggestion('/voice')).toBe(false)
     expect(isDesktopSlashSuggestion('/curator')).toBe(false)
   })
@@ -379,7 +378,6 @@ describe('desktop slash command curation', () => {
 
   it('explains known commands that desktop owns elsewhere', () => {
     expect(desktopSlashUnavailableMessage('/model sonnet')).toContain('model picker')
-    expect(desktopSlashUnavailableMessage('/skills')).toContain('desktop sidebar')
     expect(desktopSlashUnavailableMessage('/clear')).toContain('terminal interface')
   })
 

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -317,7 +317,7 @@ const NO_DESKTOP_SURFACE: Record<DesktopUnavailableReason, readonly string[]> = 
     '/verbose'
   ],
   messaging: ['/approve', '/deny'],
-  settings: ['/skills', '/pets'],
+  settings: ['/pets'],
   advanced: [
     '/curator',
     '/fast',

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -212,11 +212,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("toolsets", "List available toolsets", "Tools & Skills",
                cli_only=True, desktop="terminal"),
     CommandDef("skills", "Search, install, inspect, or manage skills",
-               "Tools & Skills", cli_only=True,
+               "Tools & Skills",
                gateway_config_gate="skills.write_approval",
                subcommands=("search", "browse", "inspect", "install", "audit",
-                            "pending", "approve", "reject", "diff", "approval"),
-               desktop="settings"),
+                            "pending", "approve", "reject", "diff", "approval")),
     CommandDef("memory", "Review pending memory writes / toggle the approval gate",
                "Tools & Skills", args_hint="[pending|approve|reject|approval] [id|on|off]",
                subcommands=("pending", "approve", "reject", "approval")),
@@ -358,9 +357,13 @@ for _cmd in COMMAND_REGISTRY:
 
 _PIPE_SUBS_RE = re.compile(r"[a-z]+(?:\|[a-z]+)+")
 for _cmd in COMMAND_REGISTRY:
-    _m = _PIPE_SUBS_RE.search(_cmd.args_hint) if _cmd.args_hint else None
-    if _m and f"/{_cmd.name}" not in SUBCOMMANDS:
-        SUBCOMMANDS[f"/{_cmd.name}"] = _m.group(0).split("|")
+    if f"/{_cmd.name}" not in SUBCOMMANDS:
+        if _cmd.subcommands:
+            SUBCOMMANDS[f"/{_cmd.name}"] = list(_cmd.subcommands)
+        else:
+            _m = _PIPE_SUBS_RE.search(_cmd.args_hint) if _cmd.args_hint else None
+            if _m:
+                SUBCOMMANDS[f"/{_cmd.name}"] = _m.group(0).split("|")
 
 
 # /help sub-groups for the large "Session" category (category itself is load-bearing for gateway


### PR DESCRIPTION
This PR fixes a bug where `/skills` and subcommands like `/skills approve` were completely missing from the Desktop App chat autocomplete.

### Changes
1. `hermes_cli/commands.py`: `SUBCOMMANDS` manifest generation was completely ignoring explicit `_cmd.subcommands` tuples, causing `/skills approve` and others to be dropped.
2. `apps/desktop/src/lib/desktop-slash-commands.ts`: The entire `/skills` namespace was being artificially blocked via `NO_DESKTOP_SURFACE.settings`. I've removed it, allowing backend-level availability gates (`skills.write_approval`) to dictate visibility as intended.
3. Updated the desktop test accordingly.