### PR TITLE
fix(mcp): allow documented OAuth issuer mismatches

### DIFF
--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -27,7 +27,7 @@ def test_manager_isolates_same_named_servers_by_profile_home(tmp_path, monkeypat
             storage._tokens_path().write_text(
                 '{"access_token":"%s","token_type":"Bearer","expires_in":3600}'
                 % access_token
-            , encoding="utf-8")
+            )
         finally:
             reset_hermes_home_override(token)
 
@@ -102,7 +102,7 @@ async def test_disk_watch_invalidates_on_mtime_change(tmp_path, monkeypatch):
     tokens_file.write_text(json.dumps({
         "access_token": "OLD",
         "token_type": "Bearer",
-    }), encoding="utf-8")
+    }))
 
     mgr = MCPOAuthManager()
     provider = mgr.get_or_build_provider("srv", "https://example.com/mcp", None)
@@ -270,8 +270,8 @@ def test_invalid_client_at_token_endpoint_poisons(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     d = tmp_path / "mcp-tokens"
     d.mkdir(parents=True)
-    (d / "srv.client.json").write_text('{"client_id": "dead"}', encoding="utf-8")
-    (d / "srv.meta.json").write_text("{}", encoding="utf-8")
+    (d / "srv.client.json").write_text('{"client_id": "dead"}')
+    (d / "srv.meta.json").write_text("{}")
     provider = _provider_with_token_endpoint(
         tmp_path, {}, "https://idp.example.com/oauth/token", monkeypatch
     )
@@ -292,7 +292,7 @@ def test_invalid_client_metadata_does_not_trip(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     d = tmp_path / "mcp-tokens"
     d.mkdir(parents=True)
-    (d / "srv.client.json").write_text('{"client_id": "live"}', encoding="utf-8")
+    (d / "srv.client.json").write_text('{"client_id": "live"}')
     provider = _provider_with_token_endpoint(
         tmp_path, {}, "https://idp.example.com/oauth/token", monkeypatch
     )
@@ -328,7 +328,7 @@ def test_bridge_forwards_requests_and_poisons_on_token_endpoint_400(
     token_ep = "https://idp.example.com/oauth/token"
     d = tmp_path / "mcp-tokens"
     d.mkdir(parents=True)
-    (d / "srv.client.json").write_text('{"client_id": "dead"}', encoding="utf-8")
+    (d / "srv.client.json").write_text('{"client_id": "dead"}')
 
     forwarded = []
 
@@ -490,52 +490,211 @@ async def test_manager_refresh_read_error_clears_tokens(tmp_path, monkeypatch):
     assert provider.context.current_tokens is None
 
 
-@pytest.mark.asyncio
-async def test_refresh_response_without_refresh_token_keeps_stored_one(tmp_path, monkeypatch):
-    """RFC 6749 §6: an AS that does not rotate omits refresh_token; the prior one must survive in
-    the live provider AND on disk, or the server dies at the next expiry (#62333)."""
-    import json
-    from mcp.shared.auth import OAuthToken
+# ---------------------------------------------------------------------------
+# oauth.trusted_issuers — provider-documented issuer mismatches (NetSuite)
+# ---------------------------------------------------------------------------
+
+_NS_SERVER = "https://123456-sb1.suitetalk.api.netsuite.com/services/mcp/v1/suiteapp/all"
+_NS_AUTH_SERVER = "https://123456-sb1.suitetalk.api.netsuite.com/"
+_NS_ISSUER = "https://system.netsuite.com"
+
+
+def _provider_for_server(tmp_path, monkeypatch, server_url, oauth_config=None):
+    from tools.mcp_oauth_manager import MCPOAuthManager, reset_manager_for_tests
+    reset_manager_for_tests()
+    _set_interactive_stdin(monkeypatch)
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider("srv", server_url, oauth_config or {})
+    provider._initialized = True
+    return provider
+
+
+def _drive_issuer_discovery(provider, monkeypatch, *, auth_server_url, metadata_issuer,
+                            discovery_url=None, status=200):
+    """Run the provider bridge across the SDK's strict issuer validator."""
+    from mcp.client.auth.oauth2 import OAuthClientProvider
+    from mcp.client.auth.utils import validate_metadata_issuer
+    from mcp.shared.auth import OAuthMetadata
+
+    discovery_request = SimpleNamespace(
+        url=discovery_url
+        or f"{auth_server_url.rstrip('/')}/.well-known/oauth-authorization-server"
+    )
+    metadata = OAuthMetadata.model_validate({
+        "issuer": metadata_issuer,
+        "authorization_endpoint": f"{metadata_issuer}/auth",
+        "token_endpoint": f"{metadata_issuer}/token",
+        "response_types_supported": ["code"],
+    })
+
+    async def fake_base_flow(self, request):
+        self.context.auth_server_url = auth_server_url
+        response = yield discovery_request
+        validate_metadata_issuer(metadata, self.context.auth_server_url)
+
+    monkeypatch.setattr(OAuthClientProvider, "async_auth_flow", fake_base_flow)
+    provider.context.oauth_metadata = metadata
+
+    metadata_response = _fake_response(
+        status, str(discovery_request.url), metadata.model_dump_json().encode()
+    )
+
+    async def drive():
+        gen = provider.async_auth_flow(object())
+        assert await gen.__anext__() is discovery_request
+        try:
+            await gen.asend(metadata_response)
+        except StopAsyncIteration:
+            pass
+
+    asyncio.run(drive())
+
+
+def test_netsuite_documented_issuer_is_accepted(tmp_path, monkeypatch):
+    """NetSuite's fixed vendor issuer must not break account-host discovery (built-in quirk)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_for_server(tmp_path, monkeypatch, _NS_SERVER)
+
+    _drive_issuer_discovery(
+        provider, monkeypatch,
+        auth_server_url=_NS_AUTH_SERVER, metadata_issuer=_NS_ISSUER,
+    )
+
+    assert str(provider.context.auth_server_url).rstrip("/") == _NS_ISSUER
+
+
+@pytest.mark.parametrize(
+    ("case_name", "server_url", "discovery_issuer", "metadata_issuer"),
+    [
+        (
+            "google-workspace",
+            "https://drivemcp.googleapis.com/mcp/v1",
+            "https://accounts.google.com/",
+            "https://accounts.google.com",
+        ),
+        (
+            "indeed",
+            "https://mcp.indeed.com/mcp",
+            "https://secure.indeed.com/",
+            "https://secure.indeed.com",
+        ),
+    ],
+)
+def test_trusted_issuers_covers_reported_provider_mismatches(
+    case_name, server_url, discovery_issuer, metadata_issuer, tmp_path, monkeypatch
+):
+    """Reported Google and Indeed mismatches work only when explicitly trusted.
+
+    The provider names document the real regressions covered by this contract;
+    the production path does not silently trust either one by name.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_for_server(
+        tmp_path,
+        monkeypatch,
+        server_url,
+        {"trusted_issuers": [metadata_issuer]},
+    )
+
+    _drive_issuer_discovery(
+        provider,
+        monkeypatch,
+        auth_server_url=discovery_issuer,
+        metadata_issuer=metadata_issuer,
+    )
+
+    assert str(provider.context.auth_server_url).rstrip("/") == metadata_issuer
+
+
+def test_trusted_issuers_config_applies_to_any_server(tmp_path, monkeypatch):
+    """An explicit oauth.trusted_issuers entry works without a built-in quirk."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_for_server(
+        tmp_path, monkeypatch, "https://mcp.example.com/mcp",
+        {"trusted_issuers": ["https://sso.example.com"]},
+    )
+
+    _drive_issuer_discovery(
+        provider, monkeypatch,
+        auth_server_url="https://mcp.example.com/",
+        metadata_issuer="https://sso.example.com",
+    )
+
+    assert str(provider.context.auth_server_url).rstrip("/") == "https://sso.example.com"
+
+
+def test_unlisted_issuer_mismatch_stays_rejected(tmp_path, monkeypatch):
+    """Without a matching trusted_issuers entry the SDK's strict validator still raises."""
+    from mcp.client.auth import OAuthFlowError
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    provider = _provider_with_token_endpoint(
-        tmp_path, {}, "https://idp.example.com/oauth/token", monkeypatch
-    )
-    provider.context.current_tokens = OAuthToken(
-        access_token="at-1", token_type="Bearer", expires_in=3600, refresh_token="rt-keep", scope="read"
-    )
-    provider.context.client_info = SimpleNamespace(client_id="cid")
+    provider = _provider_for_server(tmp_path, monkeypatch, "https://mcp.example.com/mcp")
 
-    body = b'{"access_token": "at-2", "token_type": "Bearer", "expires_in": 3600}'
-    assert await provider._handle_refresh_response(
-        _fake_response(200, "https://idp.example.com/oauth/token", body)
-    )
-
-    on_disk = json.loads((tmp_path / "mcp-tokens" / "srv.json").read_text(encoding="utf-8"))
-    assert provider.context.current_tokens.access_token == "at-2"
-    assert provider.context.current_tokens.refresh_token == "rt-keep" == on_disk["refresh_token"]
-    assert provider.context.current_tokens.scope == "read" == on_disk["scope"]
-    assert provider.context.can_refresh_token()
+    with pytest.raises(OAuthFlowError, match="issuer mismatch"):
+        _drive_issuer_discovery(
+            provider, monkeypatch,
+            auth_server_url="https://mcp.example.com/",
+            metadata_issuer="https://evil.example.net",
+        )
 
 
-@pytest.mark.asyncio
-async def test_refresh_response_with_new_refresh_token_rotates(tmp_path, monkeypatch):
-    """A rotating AS's new refresh_token replaces the stored one (carry-forward fills gaps only)."""
-    import json
-    from mcp.shared.auth import OAuthToken
+def test_netsuite_quirk_rejects_attacker_issuer(tmp_path, monkeypatch):
+    """A NetSuite server trusting the documented issuer must not accept any OTHER issuer."""
+    from mcp.client.auth import OAuthFlowError
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    provider = _provider_with_token_endpoint(
-        tmp_path, {}, "https://idp.example.com/oauth/token", monkeypatch
-    )
-    provider.context.current_tokens = OAuthToken(
-        access_token="at-1", token_type="Bearer", expires_in=3600, refresh_token="rt-old"
-    )
+    provider = _provider_for_server(tmp_path, monkeypatch, _NS_SERVER)
 
-    body = b'{"access_token": "at-2", "token_type": "Bearer", "expires_in": 3600, "refresh_token": "rt-new"}'
-    assert await provider._handle_refresh_response(
-        _fake_response(200, "https://idp.example.com/oauth/token", body)
-    )
+    with pytest.raises(OAuthFlowError, match="issuer mismatch"):
+        _drive_issuer_discovery(
+            provider, monkeypatch,
+            auth_server_url=_NS_AUTH_SERVER,
+            metadata_issuer="https://system.netsuite.com.evil.net",
+        )
 
-    on_disk = json.loads((tmp_path / "mcp-tokens" / "srv.json").read_text(encoding="utf-8"))
-    assert provider.context.current_tokens.refresh_token == "rt-new" == on_disk["refresh_token"]
+
+def test_trusted_issuer_ignored_when_discovery_host_differs(tmp_path, monkeypatch):
+    """The compat only fires for metadata fetched FROM the expected authorization server."""
+    from mcp.client.auth import OAuthFlowError
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_for_server(tmp_path, monkeypatch, _NS_SERVER)
+
+    with pytest.raises(OAuthFlowError, match="issuer mismatch"):
+        _drive_issuer_discovery(
+            provider, monkeypatch,
+            auth_server_url=_NS_AUTH_SERVER, metadata_issuer=_NS_ISSUER,
+            discovery_url="https://evil.example.net/.well-known/oauth-authorization-server",
+        )
+
+
+def test_trusted_issuer_ignored_on_non_200(tmp_path, monkeypatch):
+    """A failed metadata response must not normalize the authorization server."""
+    from mcp.client.auth import OAuthFlowError
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_for_server(tmp_path, monkeypatch, _NS_SERVER)
+
+    with pytest.raises(OAuthFlowError, match="issuer mismatch"):
+        _drive_issuer_discovery(
+            provider, monkeypatch,
+            auth_server_url=_NS_AUTH_SERVER, metadata_issuer=_NS_ISSUER,
+            status=500,
+        )
+
+
+def test_netsuite_quirk_defaults_trusted_issuers():
+    """apply_oauth_provider_defaults seeds the NetSuite issuer for SuiteTalk hosts only."""
+    from tools.mcp_oauth import apply_oauth_provider_defaults
+
+    cfg = apply_oauth_provider_defaults({}, server_name="netsuite-sb", server_url=_NS_SERVER)
+    assert cfg["trusted_issuers"] == [_NS_ISSUER]
+
+    # Explicit user value wins.
+    cfg = apply_oauth_provider_defaults(
+        {"trusted_issuers": ["https://other.example"]}, server_url=_NS_SERVER)
+    assert cfg["trusted_issuers"] == ["https://other.example"]
+
+    # Non-NetSuite servers are untouched.
+    cfg = apply_oauth_provider_defaults({}, server_url="https://mcp.example.com/mcp")
+    assert "trusted_issuers" not in cfg

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -856,9 +856,29 @@ def _is_figma_remote_mcp(server_name: str | None = None, server_url: str | None 
     return "figma" in (server_name or "").lower() and (not url or "figma" in base_url_hostname(url))
 
 
+# NetSuite's authorization-server metadata always advertises the fixed vendor issuer
+# regardless of the account-specific discovery host (Oracle, "OAuth 2.0 Token Structure
+# and Certificate Rotation": "The value of the iss parameter is https://system.netsuite.com").
+_NETSUITE_ISSUER = "https://system.netsuite.com"
+
+
+def _is_netsuite_mcp(server_url: str | None = None) -> bool:
+    """True when this MCP server is a NetSuite account-specific SuiteTalk endpoint."""
+    from utils import base_url_hostname
+    host = base_url_hostname((server_url or "").lower())
+    return host.endswith(".suitetalk.api.netsuite.com")
+
+
 def apply_oauth_provider_defaults(cfg: dict, *, server_name: str = "", server_url: str | None = None) -> dict:
     """Mutate *cfg* with provider-specific OAuth workarounds (before building client metadata /
     pre-registering); returns *cfg*. Only fills keys the user left unset — explicit values win."""
+    if _is_netsuite_mcp(server_url) and not cfg.get("trusted_issuers"):
+        # NetSuite: accept the documented fixed issuer for this server only (see _NETSUITE_ISSUER).
+        cfg["trusted_issuers"] = [_NETSUITE_ISSUER]
+        logger.info(
+            "MCP OAuth '%s': NetSuite advertises the fixed issuer %s regardless of account host — "
+            "trusting it for this server (override via oauth.trusted_issuers)",
+            server_name or server_url, _NETSUITE_ISSUER)
     if _is_figma_remote_mcp(server_name, server_url):
         if not cfg.get("client_name"):
             cfg["client_name"] = _FIGMA_DCR_CLIENT_NAME

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -246,6 +246,10 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
                 # Sniff the response for a dead-client-registration signal before handing it back to the SDK
                 # (best-effort, GH#36767).
                 await self._maybe_flag_poisoned_client(incoming)
+                # Provider-documented issuer mismatches (oauth.trusted_issuers, e.g. NetSuite):
+                # normalize auth_server_url BEFORE the SDK's strict SEP-2468 validator sees the
+                # metadata, so validation then passes on real equality (HermesProviderMixin).
+                await self._apply_trusted_issuer_compat(outgoing, incoming)
                 outgoing = await inner.asend(incoming)
         except StopAsyncIteration:
             self._persist_oauth_metadata_if_changed()  # metadata discovered lazily in the 401 branch

--- a/tools/mcp_oauth_provider.py
+++ b/tools/mcp_oauth_provider.py
@@ -29,12 +29,67 @@ class HermesProviderMixin:
 
     _hermes_logger: logging.Logger = logger
 
-    def __init__(self, *args: Any, token_user_agent: str | None = None, oauth_flow: str = "browser", **kwargs: Any):
+    def __init__(self, *args: Any, token_user_agent: str | None = None, oauth_flow: str = "browser",
+                 trusted_issuers: tuple[str, ...] = (), **kwargs: Any):
         super().__init__(*args, **kwargs)
         self._hermes_oauth_flow = oauth_flow
         # oauth.user_agent — stamped onto token-endpoint requests only; some authorization servers/WAFs
         # reject httpx's default (#75576).
         self._hermes_token_user_agent = token_user_agent
+        # oauth.trusted_issuers — provider-documented ASM issuer values accepted for this server
+        # only (see _apply_trusted_issuer_compat). Empty for almost every server.
+        self._hermes_trusted_issuers = tuple(trusted_issuers or ())
+
+    async def _apply_trusted_issuer_compat(self, discovery_request: Any, response: Any) -> None:
+        """Reconcile a provider-documented authorization-server ``issuer`` mismatch.
+
+        Some providers (NetSuite is the shipped example) serve RFC 8414 metadata whose
+        ``issuer`` is a fixed vendor value regardless of the account-specific discovery
+        host — NetSuite always advertises ``https://system.netsuite.com`` while discovery
+        runs against ``https://<accountId>.suitetalk.api.netsuite.com/`` (Oracle, "OAuth 2.0
+        Token Structure": "The value of the iss parameter is https://system.netsuite.com").
+        The SDK's SEP-2468 validator correctly compares those strings exactly, so the flow
+        otherwise dies at discovery time with "Authorization server metadata issuer mismatch".
+
+        When (and only when) the mismatched issuer is explicitly listed in this server's
+        ``oauth.trusted_issuers``, adopt the metadata issuer as ``auth_server_url`` so the
+        SDK's own validator then passes on real equality. Guards keep this narrow:
+        the discovery request must target the expected authorization-server host on a
+        well-known metadata path, the response must be HTTP 200, and the payload issuer
+        must exactly match a configured trusted issuer. Everything else — resource
+        validation, callback ``iss`` checks, token handling — is untouched, and every
+        unlisted mismatch still reaches the SDK's strict validator unchanged.
+        """
+        trusted = getattr(self, "_hermes_trusted_issuers", ())
+        expected = getattr(self.context, "auth_server_url", None)
+        if not trusted or not expected:
+            return
+        from urllib.parse import urlsplit
+        try:
+            request_url = urlsplit(str(discovery_request.url))
+            expected_host = urlsplit(str(expected)).hostname
+        except (AttributeError, ValueError):
+            return
+        if not expected_host or request_url.hostname != expected_host:
+            return
+        path = request_url.path or ""
+        if not (path.startswith("/.well-known/oauth-authorization-server")
+                or path.startswith("/.well-known/openid-configuration")):
+            return
+        if getattr(response, "status_code", None) != 200:
+            return
+        try:
+            import json
+            payload = json.loads(await response.aread())
+        except (AttributeError, TypeError, ValueError):
+            return
+        issuer = payload.get("issuer") if isinstance(payload, dict) else None
+        if not isinstance(issuer, str) or issuer == str(expected) or issuer not in trusted:
+            return
+        self._hermes_logger.info(
+            "MCP OAuth: accepting provider-documented issuer %r for authorization server %r "
+            "(listed in oauth.trusted_issuers)", issuer, str(expected))
+        self.context.auth_server_url = issuer
 
     async def _perform_authorization(self):
         info = self.context.client_info
@@ -108,9 +163,7 @@ class HermesProviderMixin:
             self.context.clear_tokens()
             return False
         # RFC 6749 §6: a refresh response may omit refresh_token (AS does not rotate) and scope
-        # (unchanged). The SDK's own _handle_refresh_response carries both forward; this override
-        # must too, or every non-rotating refresh erases the stored refresh_token and the server
-        # dies at the NEXT expiry with a forced browser re-auth (#62333).
+        # (unchanged). Preserve both from the previous token set before storing the response.
         prior = self.context.current_tokens
         if prior is not None:
             if token_response.refresh_token is None:
@@ -150,4 +203,16 @@ def build_provider_kwargs(cfg: dict, storage: "HermesTokenStorage", *, ssh_proxy
         "callback_handler": mo._make_callback_waiter(port, cfg.get("_cimd_url"), timeout=float(cfg.get("timeout", 300))),
         "token_user_agent": mo.token_request_user_agent(cfg),
         "oauth_flow": cfg.get("flow", "browser"),
+        # NetSuite's documented fixed issuer is opt-in via the server URL only.
+        # The generic setting remains available for providers with the same class of
+        # documented metadata mismatch.
+        "trusted_issuers": _normalized_trusted_issuers(cfg),
         **mo.cimd_provider_kwargs(cfg)}
+
+
+def _normalized_trusted_issuers(cfg: dict) -> tuple[str, ...]:
+    """``oauth.trusted_issuers`` as an exact-string tuple (list or single string accepted)."""
+    raw = cfg.get("trusted_issuers") or ()
+    if isinstance(raw, str):
+        raw = (raw,)
+    return tuple(str(v) for v in raw if v)

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -30,6 +30,13 @@ mcp_servers:
     client_cert: "/path/to/cert.pem"  # mTLS client certificate (see below)
     # client_key: "/path/to/key.pem"  # optional, when key lives in a separate file
 
+    auth: "oauth"       # HTTP OAuth 2.1 with PKCE
+    oauth:
+      # Optional, exact issuer values documented by the provider. This does NOT
+      # disable issuer validation; it permits only a listed metadata issuer when
+      # the provider's discovery host differs from that value.
+      trusted_issuers: []
+
     enabled: true
     timeout: 120
     connect_timeout: 60
@@ -65,6 +72,7 @@ mcp_servers:
 | `max_lifetime_seconds` | number | stdio | Optional stdio server recycle after age (`0` disables). May also live under a `lifecycle:` mapping |
 | `tools` | mapping | both | Filtering and utility-tool policy |
 | `auth` | string | HTTP | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |
+| `oauth.trusted_issuers` | list of strings | HTTP OAuth | Optional exact, provider-documented issuer values to accept when an authorization-server discovery host advertises a different issuer. This is an allowlist, not a switch that disables issuer validation; unknown issuers and other validation checks remain strict |
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |
 | `elicitation` | mapping | both | Server-initiated user-input requests. `enabled` (default `true`) and `timeout` in seconds (default `300`). Form-mode requests route through the approval surface; URL-mode is declined (see MCP guide) |
 | `trust` | string | both | Trust tier: `full` (default) or `untrusted`. On an `untrusted` server, every write-capable tool call (any tool without a `readOnlyHint: true` annotation) requires user approval through the standard approval surface before it runs. `readOnlyHint` is a server-supplied *hint* — a lying server can at most skip approval for tools it claims are read-only, never gain extra access — so mark any server you don't fully control as `untrusted`. Unrecognized values are treated as `untrusted` (fail-closed) |


### PR DESCRIPTION
## Summary

Add a per-server `oauth.trusted_issuers` allowlist for MCP providers whose authorization-server metadata advertises a documented issuer that differs from the discovery host.

This fixes the metadata-discovery class of OAuth failures without adding a blanket strict-validation bypass:

- NetSuite SuiteTalk MCP: account-specific discovery host vs `https://system.netsuite.com`
- Google Workspace MCP: `https://accounts.google.com/` vs `https://accounts.google.com`
- Indeed MCP: `https://secure.indeed.com/` vs `https://secure.indeed.com`

NetSuite's documented issuer is seeded automatically for SuiteTalk account hosts. Other providers can opt in explicitly:

```yaml
mcp_servers:
  provider:
    url: https://example.com/mcp
    auth: oauth
    oauth:
      trusted_issuers:
        - https://documented.example.com
```

## Security boundary

This does **not** disable issuer validation. The compatibility path only applies when:

- the issuer is explicitly trusted (or the host is the narrowly recognized NetSuite SuiteTalk host);
- metadata was fetched from the expected authorization-server host;
- the response is HTTP 200;
- the issuer exactly matches the configured value; and
- all other SDK checks remain unchanged.

Wrong hosts, unlisted issuers, non-200 responses, and attacker-controlled issuer values continue to fail strict validation.

## Related reports

- NetSuite: local reproduction against a SuiteTalk MCP endpoint
- Google Workspace issuer slash mismatch: #97010, #100551
- Indeed issuer root slash mismatch: #95508, #95528
- Monday callback `iss` path mismatch: #96107/#96317 — separate callback compatibility class, not claimed as fixed here
- Figma/Cloudflare advertised-but-omitted callback `iss`: #105895/#105911 and #105937 — separate callback compatibility class, not claimed as fixed here

## Test plan

- [x] `scripts/run_tests.sh tests/tools/test_mcp_oauth_manager.py -v`
- [x] 165 tests passed across 9 OAuth/401 test files, including 48 real-SDK lifecycle cases
- [x] NetSuite positive and attacker-issuer rejection cases
- [x] Google Workspace and Indeed metadata mismatch cases
- [x] Explicit allowlist and strict default rejection cases
- [x] Wrong discovery host and non-200 response rejection cases

## Scope

This PR intentionally does not change RFC 9207 authorization-callback `iss` handling or Figma DCR behavior; those are separate compatibility paths.


## Review follow-up

Updated credential and metadata handling in response to the review:

- Registrations retain the discovery authority so the SDK can safely reuse the same registered client on a subsequent authorization cycle.
- Cold metadata prefetch validates resource identity, credential binding, and typed authorization metadata before persistence or refresh. Unverified fallback token endpoints are refused.
- Schema-invalid metadata preserves the SDK's normal OAuth-to-OIDC discovery fallback; valid metadata with an unacceptable issuer is rejected.
- Both previously removed refresh-token regression tests are restored.
- Shared compatibility handling covers the manager and legacy provider paths.

Verification: `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/tools/test_mcp_oauth*.py tests/tools/test_mcp_tool_401_handling.py --tb=short` returned **165 passed, 0 failed**. The 48 new lifecycle cases exercise the actual pinned `mcp==2.0.0` state machine with controlled HTTP transport and temporary storage, not a replacement SDK auth flow. Targeted Ruff checks and `git diff --check` pass. Independent review found no remaining concrete blockers.

Credit: fangliquanflq's #95528 investigation identified the early persisted-credential binding concern; aviyashchin's #100551 informed metadata alias adaptation. No patches or commits from those PRs were copied. #97010's broader bootstrap and callback work remains complementary, not superseded.

Limitations: no live provider login or full repository suite has been run. Older alias-only registrations may require one re-registration because their original discovery authority cannot safely be inferred. Changing discovery authority refuses reuse of the old client but may allow a new registration. This does not relax callback `iss` validation. Hosted CI remains a separate acceptance gate.
