### PR TITLE
feat(fallback): defer unattended runs on a 429 instead of walking the chain

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1825,12 +1825,55 @@ def _buffer_fallback_notice(agent, notice: str) -> None:
         agent._pending_fallback_notice = [str(pending), notice] if pending else [notice]
 
 
+def _defer_instead_of_walking(agent, reason: "FailoverReason | None") -> bool:
+    """True when this UNATTENDED run should PARK on the primary's reset rather than
+    walk the chain (config ``fallback.unattended_on_rate_limit: defer``).
+
+    Rationale: the walk exists because a human is waiting. Nobody is waiting on a
+    cron fire or a kanban worker, and on a capped day the walk spends the whole
+    chain — down to a paid floor — on work that would have run fine an hour later.
+    Every gate is in ``agent.unattended_defer.resolve_deferral``, which fails OPEN,
+    so an interactive session (or any run with no reset timestamp) is unaffected.
+
+    STICKY: once a deferral is recorded for this run, every later walk attempt is
+    refused regardless of ``reason``. Without that, the eager-fallback site defers
+    but the max-retries-exhausted site (``turn_api_error``) calls this with
+    ``reason=None`` moments later and walks the chain anyway — the exact behaviour
+    the deferral exists to prevent.
+    """
+    from agent.unattended_defer import format_reset, get_deferral, record_deferral, resolve_deferral
+    already = get_deferral(agent)
+    if already:
+        logger.debug("Fallback walk refused: run already deferred until %s", format_reset(already))
+        return True
+    reset_at = resolve_deferral(agent, reason, error_context=getattr(agent, "_last_error_context", None))
+    if not reset_at:
+        return False
+    record_deferral(agent, reset_at)
+    logger.warning(
+        "Unattended run deferred: %s/%s rate-limited until %s; parking instead of walking the "
+        "fallback chain (fallback.unattended_on_rate_limit=defer)",
+        getattr(agent, "provider", "?"), getattr(agent, "model", "?"), format_reset(reset_at),
+    )
+    _buffer_fallback_notice(agent, (
+        f"⏸️ Deferred: {getattr(agent, 'model', '?')} via {getattr(agent, 'provider', '?')} is "
+        f"rate-limited until {format_reset(reset_at)}. Unattended run parked rather than "
+        f"falling back to a costlier model."))
+    return True
+
+
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain; False when exhausted. Swaps client,
     model slug and provider in place so the retry loop continues on the new backend; client
     construction goes through resolve_provider_client (no duplicated provider→key mappings)."""
     from agent.fallback_cooldown import _arm_rate_limit_cooldown
     cooldown_seconds = _arm_rate_limit_cooldown(agent, reason)
+    # Defer-on-429 for unattended runs. Checked BEFORE the walk loop so the walk
+    # never starts; returning False makes every existing caller take the same path
+    # it takes on an exhausted chain (buffered notice, turn ends), which is exactly
+    # the "park this run" semantics the terminal sites then act on.
+    if _defer_instead_of_walking(agent, reason):
+        return False
     while True:
         if agent._fallback_index >= len(agent._fallback_chain):
             return _fallback_chain_exhausted(agent, reason)

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -116,9 +116,52 @@ def _guarded_cleanup(label: str, fn: Callable[[], Any], errors: List[str], logge
         logger.error("finalize_turn: _%s failed: %s", label, err, exc_info=True)
 
 
+def _record_kanban_deferral(kanban_task: str, reset_at: float, detail: dict, logger: logging.Logger) -> bool:
+    """Re-queue this worker's card with a ``not_before`` gate (defer-on-429).
+
+    Routed through ``kanban_db.defer_task``, NOT ``_record_task_failure`` and NOT
+    ``block_task``: the worker didn't fail and no human is needed — the provider was
+    capped and said when it resets. Consuming the failure budget would trip the
+    circuit breaker after two capped days; blocking would page Joey for something
+    that fixes itself. Returns True when the card was parked.
+    """
+    try:
+        from agent.unattended_defer import format_reset
+        from hermes_cli import kanban_db as _kb
+        from hermes_cli import kanban_db_connect as _kbc
+        run_id = os.environ.get("HERMES_KANBAN_RUN_ID")
+        reason = (
+            f"Deferred until {format_reset(reset_at)}: "
+            f"{detail.get('model') or '?'} via {detail.get('provider') or '?'} is rate-limited. "
+            "Unattended run parked instead of falling back to a costlier model."
+        )
+        _conn = _kbc.connect()
+        try:
+            deferred = _kb.defer_task(
+                _conn, kanban_task, not_before=reset_at, reason=reason,
+                expected_run_id=int(run_id) if run_id and run_id.isdigit() else None,
+                metadata={"deferred_until": float(reset_at), **detail},
+            )
+        finally:
+            with suppress(Exception):
+                _conn.close()
+        if deferred:
+            logger.warning("Kanban task %s deferred until %s", kanban_task, format_reset(reset_at))
+        else:
+            logger.warning(
+                "Kanban task %s could not be deferred (already transitioned); "
+                "leaving the normal terminal path to close it", kanban_task,
+            )
+        return deferred
+    except Exception as exc:
+        logger.error("Failed to defer kanban task %s: %s", kanban_task, exc, exc_info=True)
+        return False
+
+
 def _resolve_budget_fallback(
     agent, *, final_response, api_call_count, interrupted, failed, messages, _turn_exit_reason,
     _pending_verification_response, _pending_verification_response_previewed, logger,
+    deferred=False,
 ) -> Tuple[Any, Any, bool]:
     """Iteration-budget exhaustion. Returns ``(final_response, _turn_exit_reason,
     preserved_verification_fallback)``."""
@@ -155,7 +198,10 @@ def _resolve_budget_fallback(
 
     # A kanban worker must record a terminal outcome whether or not a fallback path
     # was eligible, so the dispatcher learns the worker could not complete.
-    _kanban_task = os.environ.get("HERMES_KANBAN_TASK") if budget_exhausted else None
+    # EXCEPT when the run was deferred: the card was already re-queued with a
+    # not_before gate, and ticking consecutive_failures for a provider rate limit
+    # would trip the circuit breaker on work that never failed.
+    _kanban_task = os.environ.get("HERMES_KANBAN_TASK") if (budget_exhausted and not deferred) else None
     # If running as a kanban worker, signal the dispatcher that the worker could not complete (rather than
     # treating it as a protocol violation). This applies whether the user-facing fallback came from the
     # summary call or an explicitly pending continuation; both exhausted the task budget and must advance
@@ -440,13 +486,26 @@ def finalize_turn(
     """Run the post-loop finalization and return the turn ``result`` dict."""
     from agent.conversation_loop import logger
 
+    # Defer-on-429: a rate-limited unattended run parks its card BEFORE the budget
+    # fallback runs. Ordering is load-bearing — _resolve_budget_fallback would
+    # otherwise route a deferred worker through _record_task_failure, spending the
+    # consecutive-failure budget on a provider cap the worker did not cause.
+    _deferred_until = None
+    with suppress(Exception):
+        from agent.unattended_defer import get_deferral, get_deferral_detail
+        _deferred_until = get_deferral(agent)
+        if _deferred_until and (_kanban_defer_task := os.environ.get("HERMES_KANBAN_TASK")):
+            _record_kanban_deferral(
+                _kanban_defer_task, _deferred_until, get_deferral_detail(agent), logger,
+            )
+
     final_response, _turn_exit_reason, preserved_verification_fallback = _resolve_budget_fallback(
         agent, final_response=final_response, api_call_count=api_call_count,
         interrupted=interrupted, failed=failed, messages=messages,
         _turn_exit_reason=_turn_exit_reason,
         _pending_verification_response=_pending_verification_response,
         _pending_verification_response_previewed=_pending_verification_response_previewed,
-        logger=logger,
+        logger=logger, deferred=bool(_deferred_until),
     )
 
     completed = (

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -655,6 +655,62 @@ _NONRETRYABLE_LABELS = {
 }
 
 
+def _resolve_unattended_deferral(agent: Any, reason: Any, error_context: Any) -> Optional[float]:
+    """Reset timestamp to park this UNATTENDED run until, or None to walk as usual.
+
+    Thin seam over ``agent.unattended_defer.resolve_deferral`` so the recovery module
+    keeps one import site and the policy stays in one file. Also stashes
+    ``error_context`` on the agent: the SECOND walk site (``turn_api_error``'s
+    max-retries path) has no access to it, and the sticky guard in
+    ``_defer_instead_of_walking`` reads it from there.
+    """
+    try:
+        agent._last_error_context = error_context
+    except Exception:
+        pass
+    try:
+        from agent.unattended_defer import resolve_deferral
+        return resolve_deferral(agent, reason, error_context=error_context)
+    except Exception:
+        logger.debug("Unattended deferral check failed; falling back to the chain walk", exc_info=True)
+        return None
+
+
+def _unattended_deferred_result(
+    agent: Any, reset_at: float, *, messages: List[Dict[str, Any]], api_call_count: int, classified: Any,
+) -> Dict[str, Any]:
+    """Terminal turn result for a deferred unattended run.
+
+    ``failed=True`` + ``failure_retryable=True`` so every existing caller treats it as
+    a recoverable non-completion (no partial answer is invented), and the new
+    ``deferred_until`` / ``deferral_reason`` keys let the cron scheduler and the kanban
+    worker re-schedule precisely instead of retrying blind. Callers that don't know
+    about deferral see an ordinary retryable failure — which is the correct degraded
+    behaviour, not a wrong one.
+    """
+    from agent.unattended_defer import format_reset, record_deferral
+    record_deferral(agent, reset_at)
+    when = format_reset(reset_at)
+    summary = (
+        f"Deferred: {getattr(agent, 'model', '?')} via {getattr(agent, 'provider', '?')} is "
+        f"rate-limited until {when}. This is an unattended run "
+        f"(fallback.unattended_on_rate_limit=defer), so it was parked rather than falling "
+        f"back to a costlier model."
+    )
+    logger.warning("%s%s", getattr(agent, "log_prefix", ""), summary)
+    agent._flush_status_buffer()
+    agent._emit_status(f"⏸️ {summary}")
+    return {
+        "final_response": summary, "messages": messages, "api_calls": api_call_count,
+        "completed": False, "failed": True, "error": summary,
+        "failure_reason": "unattended_rate_limit_deferred", "failure_retryable": True,
+        "deferred_until": float(reset_at),
+        "deferral_reason": getattr(classified.reason, "value", str(classified.reason)),
+        "deferred_provider": str(getattr(agent, "provider", "") or ""),
+        "deferred_model": str(getattr(agent, "model", "") or ""),
+    }
+
+
 def nonretryable_client_error_result(
     agent: Any, api_error: Exception, classified: Any, *, status_code: Optional[int],
     api_kwargs: Any, api_messages: Any, messages: List[Dict[str, Any]], conversation_history: Any,
@@ -1407,6 +1463,17 @@ def route_classified_error(
         or (_is_transport_failure and retry_count >= 2)
     )
     if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
+        # Defer-on-429 for UNATTENDED runs: this is the eager rate-limit path, and the
+        # only site where the provider's reset timestamp (``error_context``) is still in
+        # scope. When the policy fires, END the turn with a structured deferral instead
+        # of walking — the cron scheduler / kanban worker read ``deferred_until`` off the
+        # result and re-schedule. Fails open to the walk below.
+        _deferred_until = _resolve_unattended_deferral(agent, classified.reason, error_context)
+        if _deferred_until:
+            return _verdict("return", _unattended_deferred_result(
+                agent, _deferred_until, messages=messages, api_call_count=api_call_count,
+                classified=classified,
+            ))
         # No eager fallback while credential pool rotation may recover. Exception: an
         # upstream-aggregator 429 — the pool can't help, always fall back.
         # Fixes #11314.

--- a/agent/unattended_defer.py
+++ b/agent/unattended_defer.py
@@ -1,0 +1,350 @@
+"""Defer-on-429 policy for UNATTENDED runs (cron fires, kanban workers).
+
+Why this exists
+---------------
+``try_activate_fallback`` walks the chain the instant the primary returns a
+rate-limit class error. For an INTERACTIVE session that is correct: a human is
+waiting, and a degraded answer now beats no answer. For an UNATTENDED run
+nobody is waiting — and on an all-one-provider chain the walk means
+``primary -> cheaper rung -> cheaper rung -> paid floor`` on exactly the day the
+subscription is capped. The work is not urgent; the quota is.
+
+So: when the run is unattended, the failure is rate-limit class, the PRIMARY is
+the thing that failed, and the provider told us *when* it resets, park the run
+instead of walking. The caller (cron scheduler / kanban worker finalizer) turns
+that into "skip this tick, retry after <reset>" or "re-queue the card with a
+not-before timestamp".
+
+Design notes
+------------
+* This module decides ONLY the policy and carries the reset timestamp. It never
+  touches the chain, the client, or the board — the walk site asks it a
+  question, and the terminal sites (cron ``run_job``, ``finalize_turn``) read the
+  recorded deferral back out.
+* Fails OPEN in every ambiguous case. No reset timestamp, unknown surface,
+  unreadable config, non-rate-limit reason, already-on-a-fallback: return None
+  and the existing walk happens byte-for-byte as before. A deferral that fires
+  when it shouldn't silently stops work; a walk that fires when it shouldn't
+  merely costs tokens. Prefer the loud failure.
+* ``latency_critical`` is the escape hatch for unattended work that genuinely
+  cannot wait (a monitor whose whole value is freshness). It forces ``walk``
+  regardless of config.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import os
+import time
+from typing import Any, Optional
+
+_logger = logging.getLogger(__name__)
+
+# Memoized rate-limit FailoverReason set; see _rate_limit_reasons(). None = not yet
+# resolved (the warning must fire at most once per process, not per 429).
+_REASONS_CACHE: Optional[frozenset] = None
+
+# Config value / env value vocabulary.
+POLICY_DEFER = "defer"
+POLICY_WALK = "walk"
+_VALID_POLICIES = frozenset({POLICY_DEFER, POLICY_WALK})
+
+# Per-run overrides. The cron scheduler and the kanban dispatcher set these for
+# the child; a human shell never has them.
+ENV_POLICY = "HERMES_UNATTENDED_ON_RATE_LIMIT"
+ENV_LATENCY_CRITICAL = "HERMES_UNATTENDED_LATENCY_CRITICAL"
+ENV_UNATTENDED = "HERMES_UNATTENDED_RUN"
+
+# Cron fires run IN-PROCESS inside the gateway, several at a time. A per-job
+# override therefore cannot live in ``os.environ`` — job B would read job A's
+# value. ContextVars are per-task, which is the same reason ``_CronRunScope``
+# uses them for session identity.
+_CTX_LATENCY_CRITICAL: contextvars.ContextVar[Optional[bool]] = contextvars.ContextVar(
+    "hermes_unattended_latency_critical", default=None,
+)
+
+# Attribute the walk site stamps on the agent and the terminal sites read back.
+_DEFERRAL_ATTR = "_unattended_deferred_until"
+_DEFERRAL_DETAIL_ATTR = "_unattended_deferral_detail"
+
+# A reset further out than this is treated as unusable rather than parking a card
+# for a week on one malformed header. 24h covers Anthropic 5-hour + weekly buckets
+# and Ollama Cloud's 14-day bucket clamps to a daily retry instead of a fortnight.
+MAX_DEFER_SECONDS = 24 * 60 * 60
+# Below this a deferral is pointless churn — the ordinary retry/backoff path is
+# cheaper than a board round-trip.
+MIN_DEFER_SECONDS = 30
+
+
+def _truthy(raw: Any) -> bool:
+    return str(raw or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def is_latency_critical() -> bool:
+    """This unattended run must not be parked (freshness IS the deliverable).
+
+    ContextVar wins over env so an in-process cron fire's per-job flag beats a
+    process-wide default; ``None`` means "not set here" and falls through.
+    """
+    ctx = _CTX_LATENCY_CRITICAL.get()
+    if ctx is not None:
+        return bool(ctx)
+    return _truthy(os.environ.get(ENV_LATENCY_CRITICAL))
+
+
+def set_latency_critical(value: Optional[bool]):
+    """Bind the per-run latency-critical flag; returns the token to reset with.
+
+    Used by ``cron._CronRunScope`` (enter/exit) so a ``latency_critical: true`` job
+    keeps walking the chain while its neighbours in the same process defer.
+    """
+    return _CTX_LATENCY_CRITICAL.set(value)
+
+
+def reset_latency_critical(token) -> None:
+    with_suppress = getattr(_CTX_LATENCY_CRITICAL, "reset", None)
+    if token is not None and with_suppress is not None:
+        try:
+            _CTX_LATENCY_CRITICAL.reset(token)
+        except (ValueError, RuntimeError):
+            _CTX_LATENCY_CRITICAL.set(None)
+
+
+def is_unattended_run() -> bool:
+    """True for a dispatcher-spawned kanban worker, a cron fire, or an explicitly
+    flagged unattended run. Interactive CLI/TUI/desktop/gateway chat is False.
+
+    The cron surface is read through ``gateway.session_context`` because
+    ``run_job`` binds it as a ContextVar, not an env var (parallel jobs in one
+    process would clobber each other through ``os.environ``).
+    """
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        return True
+    if _truthy(os.environ.get(ENV_UNATTENDED)):
+        return True
+    try:
+        from gateway.session_context import get_session_env
+        if str(get_session_env("HERMES_CRON_SESSION", "") or "").strip():
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def resolve_policy(config: Optional[dict] = None) -> str:
+    """Effective policy: env override > ``fallback.unattended_on_rate_limit`` > walk.
+
+    Default is ``walk`` so an un-migrated config behaves exactly as it does today.
+    An unrecognized value is ignored (not an error): a typo must not silently
+    park the fleet.
+    """
+    env_value = str(os.environ.get(ENV_POLICY, "") or "").strip().lower()
+    if env_value in _VALID_POLICIES:
+        return env_value
+    try:
+        if config is None:
+            from hermes_cli.config import load_config
+            config = load_config() or {}
+        section = config.get("fallback")
+        if isinstance(section, dict):
+            value = str(section.get("unattended_on_rate_limit", "") or "").strip().lower()
+            if value in _VALID_POLICIES:
+                return value
+    except Exception:
+        pass
+    return POLICY_WALK
+
+
+def _primary_is_the_failure(agent: Any) -> bool:
+    """Whether the backend that just 429'd is the PRIMARY.
+
+    Mirrors ``_arm_rate_limit_cooldown``: once a fallback is active, a further
+    rate-limit came from that rung, not the primary, so parking the whole run on
+    the primary's reset would be wrong — keep walking.
+    """
+    if not getattr(agent, "_fallback_activated", False):
+        return True
+    current = str(getattr(agent, "provider", "") or "").strip().lower()
+    primary = str((getattr(agent, "_primary_runtime", None) or {}).get("provider") or "").strip().lower()
+    return bool(primary and current == primary)
+
+
+def _pool_reset_at(agent: Any) -> Optional[float]:
+    """Epoch seconds when the primary's credential pool re-enters rotation.
+
+    This is the same signal the reset-aware restore gate in
+    ``agent_runtime_helpers._primary_reset_gate_blocks`` consults, so a deferral
+    and a restore agree on when the primary is usable again. The pool row is
+    populated from the provider's own ``resets_at`` / ``retry-after`` /
+    ``x-ratelimit-reset`` (see ``credential_pool`` normalization).
+    """
+    try:
+        pool = getattr(agent, "_credential_pool", None)
+        if pool is None:
+            return None
+        next_at = getattr(pool, "next_available_at", lambda: None)()
+        return float(next_at) if next_at else None
+    except Exception:
+        return None
+
+
+def _error_context_reset_at(error_context: Optional[dict]) -> Optional[float]:
+    """Reset time carried by THIS error, when the pool has nothing.
+
+    ``extract_api_error_context`` already normalizes ``resets_at`` / ``retry_after`` /
+    ``Retry-After`` / ``x-ratelimit-reset`` / free-text "resets in 4h25m" into
+    ``reset_at``; reuse its parser rather than re-deriving the shapes here.
+    """
+    if not isinstance(error_context, dict):
+        return None
+    try:
+        from agent.credential_pool import _parse_absolute_timestamp
+        return _parse_absolute_timestamp(error_context.get("reset_at"))
+    except Exception:
+        return None
+
+
+def _rate_limit_reasons() -> frozenset:
+    """The rate-limit-class FailoverReasons, wherever the constant currently lives.
+
+    ``_RATE_LIMIT_FAILOVER_REASONS`` has moved between ``chat_completion_helpers``
+    and ``fallback_cooldown`` across upstream refactors. Importing from ONE hardcoded
+    module inside ``resolve_deferral``'s blanket ``except`` meant a relocation
+    silently disabled this entire feature — every unattended run walked the chain
+    again with no error, no log line, and a green test suite elsewhere. So: try both
+    homes, and if neither resolves, say so ONCE at warning level rather than failing
+    quiet. Empty set = no deferral ever = the pre-existing walk (still fails open,
+    but audibly).
+    """
+    global _REASONS_CACHE
+    if _REASONS_CACHE is not None:
+        return _REASONS_CACHE
+    for module_name in ("agent.fallback_cooldown", "agent.chat_completion_helpers"):
+        try:
+            module = __import__(module_name, fromlist=["_RATE_LIMIT_FAILOVER_REASONS"])
+            reasons = getattr(module, "_RATE_LIMIT_FAILOVER_REASONS", None)
+            if reasons:
+                _REASONS_CACHE = frozenset(reasons)
+                return _REASONS_CACHE
+        except Exception:
+            continue
+    # Last resort: rebuild from the enum itself, so a module rename cannot mute us.
+    try:
+        from agent.error_classifier import FailoverReason
+        _REASONS_CACHE = frozenset(
+            r for name in ("rate_limit", "billing", "upstream_rate_limit")
+            if (r := getattr(FailoverReason, name, None)) is not None
+        )
+        if _REASONS_CACHE:
+            return _REASONS_CACHE
+    except Exception:
+        pass
+    _logger.warning(
+        "unattended_defer: could not resolve _RATE_LIMIT_FAILOVER_REASONS from any known "
+        "module; defer-on-429 is INERT and unattended runs will walk the fallback chain."
+    )
+    _REASONS_CACHE = frozenset()
+    return _REASONS_CACHE
+
+
+def resolve_deferral(
+    agent: Any,
+    reason: Any,
+    *,
+    error_context: Optional[dict] = None,
+    config: Optional[dict] = None,
+) -> Optional[float]:
+    """Epoch-seconds reset to park until, or None to walk the chain as usual.
+
+    Every gate must pass, in cheapest-first order:
+
+    1. policy is ``defer``  (default ``walk`` = today's behaviour, untouched)
+    2. the run is unattended and not latency-critical
+    3. the failure is rate-limit class (rate_limit / billing / upstream_rate_limit)
+    4. the PRIMARY is what failed (not an already-active fallback rung)
+    5. a usable reset timestamp exists, within ``MIN``..``MAX`` seconds from now
+
+    Gate 5 is the load-bearing one: **no reset time means no deferral.** Parking a
+    run with no idea when it can resume is worse than spending a cheap rung.
+    """
+    try:
+        if resolve_policy(config) != POLICY_DEFER:
+            return None
+        if not is_unattended_run() or is_latency_critical():
+            return None
+        if reason not in _rate_limit_reasons():
+            return None
+        if not _primary_is_the_failure(agent):
+            return None
+        reset_at = _pool_reset_at(agent) or _error_context_reset_at(error_context)
+        if not reset_at:
+            return None
+        delay = float(reset_at) - time.time()
+        if delay < MIN_DEFER_SECONDS:
+            return None
+        if delay > MAX_DEFER_SECONDS:
+            reset_at = time.time() + MAX_DEFER_SECONDS
+        return float(reset_at)
+    except Exception:
+        # Fail open: any bug here degrades to the pre-existing walk.
+        return None
+
+
+def record_deferral(agent: Any, reset_at: float, *, provider: str = "", model: str = "") -> None:
+    """Stamp the deferral on the agent for the terminal site to read back.
+
+    Kept as plain attributes (not a return value) because the walk site is called
+    from ~10 places across the turn loop, all of which only care about the
+    boolean "did we switch"; threading a new return type through every one of
+    them would be a far larger and riskier diff than a one-attribute handoff.
+    """
+    try:
+        agent._unattended_deferred_until = float(reset_at)
+        agent._unattended_deferral_detail = {
+            "reset_at": float(reset_at),
+            "provider": str(provider or getattr(agent, "provider", "") or ""),
+            "model": str(model or getattr(agent, "model", "") or ""),
+        }
+    except Exception:
+        pass
+
+
+def get_deferral(agent: Any) -> Optional[float]:
+    """The recorded reset timestamp, or None. Read-only; safe on any object."""
+    value = getattr(agent, _DEFERRAL_ATTR, None)
+    try:
+        return float(value) if value else None
+    except (TypeError, ValueError):
+        return None
+
+
+def get_deferral_detail(agent: Any) -> dict:
+    detail = getattr(agent, _DEFERRAL_DETAIL_ATTR, None)
+    return dict(detail) if isinstance(detail, dict) else {}
+
+
+def clear_deferral(agent: Any) -> None:
+    for attr in (_DEFERRAL_ATTR, _DEFERRAL_DETAIL_ATTR):
+        try:
+            setattr(agent, attr, None)
+        except Exception:
+            pass
+
+
+def format_reset(reset_at: float) -> str:
+    """Local ISO-8601 to the second, for log lines and card reasons."""
+    from datetime import datetime
+    try:
+        return datetime.fromtimestamp(float(reset_at)).isoformat(timespec="seconds")
+    except Exception:
+        return str(reset_at)
+
+
+__all__ = [
+    "POLICY_DEFER", "POLICY_WALK", "ENV_POLICY", "ENV_LATENCY_CRITICAL", "ENV_UNATTENDED",
+    "MAX_DEFER_SECONDS", "MIN_DEFER_SECONDS",
+    "is_unattended_run", "is_latency_critical", "set_latency_critical", "reset_latency_critical",
+    "resolve_policy", "resolve_deferral",
+    "record_deferral", "get_deferral", "get_deferral_detail", "clear_deferral", "format_reset",
+]

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2027,6 +2027,8 @@ class _CronRunScope:
         from tools.terminal_tool import record_session_cwd
 
         self._var_map = _VAR_MAP
+        # Retained for enter(): the per-job defer-on-429 opt-out reads job["latency_critical"].
+        self._job = job
         # Resolve workdir BEFORE set_session_vars so it owns the _SESSION_CWD set/clear.
         self.workdir = _resolve_job_workdir(job, job_id)
         self._ctx_tokens = set_session_vars(
@@ -2062,6 +2064,13 @@ class _CronRunScope:
         # Scope cron approval policy; exit() RESETS via token (pinning "" would suppress the legacy
         # os.environ fallback used by standalone entrypoints/tests).
         self._cron_session_token = self._cron_session_var.set("1")
+        # Per-job defer-on-429 opt-out. A ContextVar, not os.environ, because several jobs
+        # fire in this one process: a latency-critical job must keep walking the chain
+        # without forcing its neighbours to walk too.
+        from agent.unattended_defer import set_latency_critical
+        self._latency_critical_token = set_latency_critical(
+            True if self._job.get("latency_critical") else None
+        )
         # Mark NOT the kanban worker: a worker's cronjob(action="run") lands here with
         # HERMES_KANBAN_TASK in env, and an unrelated job could close the worker's task. Must be a
         # ContextVar, NOT an os.environ clear (env is shared with the worker heartbeat and
@@ -2069,6 +2078,7 @@ class _CronRunScope:
         self._non_dispatcher_token = enter_non_dispatcher_owned_context()
 
     def exit(self) -> None:
+        from agent.unattended_defer import reset_latency_critical
         from gateway.session_context import clear_session_vars
         from tools.terminal_tool import clear_session_cwd
 
@@ -2076,6 +2086,7 @@ class _CronRunScope:
         clear_session_vars(self._ctx_tokens)  # also clears _SESSION_CWD
         if self._cron_session_token is not None:
             self._cron_session_var.reset(self._cron_session_token)
+        reset_latency_critical(getattr(self, "_latency_critical_token", None))
         if self._non_dispatcher_token is not None:
             exit_non_dispatcher_owned_context(self._non_dispatcher_token)
         for name in _CRON_DELIVERY_VARS:
@@ -2208,6 +2219,47 @@ class _FireAudit:
 
 
 
+def _deferred_run_result(result: Any) -> Optional[float]:
+    """Reset timestamp when the turn was parked by defer-on-429, else None.
+
+    ``turn_recovery._unattended_deferred_result`` stamps ``deferred_until`` on the
+    turn result. Read it defensively: a provider/plugin returning a non-dict must
+    degrade to "not deferred", never raise inside ``run_job``'s happy path.
+    """
+    if not isinstance(result, dict):
+        return None
+    try:
+        value = result.get("deferred_until")
+        return float(value) if value else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _deferred_tick_result(
+    job: dict, job_id: str, job_name: str, prompt: Optional[str], reset_at: float,
+) -> _RunResult:
+    """Silent, successful skip for a tick deferred by a rate limit.
+
+    ``success=True`` + ``SILENT_MARKER`` deliberately: the job is healthy, it simply
+    has nothing to say this tick. That keeps ``last_status`` green, suppresses
+    delivery, and still writes the run doc so the skip is auditable — the same
+    contract the monitor gate's ``no_change`` tick already uses.
+    """
+    from agent.unattended_defer import format_reset
+
+    when = format_reset(reset_at)
+    logger.warning(
+        "Job '%s' (ID: %s): deferred until %s — primary model is rate-limited; "
+        "skipping this tick instead of falling back to a costlier model",
+        job_name, job_id, when,
+    )
+    doc = (
+        _run_doc_header(job, f"{job_name} (DEFERRED)", job_id, prompt or "")
+        + f"## Status\n\ndeferred until {when} (primary rate-limited; tick skipped, no fallback walk)\n"
+    )
+    return True, doc, SILENT_MARKER, None
+
+
 def run_job(
     job: dict, *, defer_agent_teardown: Optional[list] = None, extra_prompt: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None, execution_id: Optional[str] = None,
@@ -2269,6 +2321,15 @@ def run_job(
         result = _run_agent_with_watchdog(
             agent, prompt, job, job_id, job_name, scope.task_id, cancel_event,
             worker_state=_worker_state)
+        # Defer-on-429: the primary was rate-limited until a known reset and this is an
+        # unattended run, so the turn parked instead of walking the chain. Skip the tick
+        # SILENTLY — the next scheduled fire after the reset does the work. Not a failure:
+        # marking it failed would alert on a quota bucket rolling over, and would set
+        # last_status="error" on a job that is perfectly healthy.
+        _deferred = _deferred_run_result(result)
+        if _deferred is not None:
+            _audit.write(dict(result, response_silent=True), None)
+            return _deferred_tick_result(job, job_id, job_name, prompt, _deferred)
         final_response = _final_response_from_result(result, job_id, job_name, AIAgent)
         # Keep final_response clean for delivery logic (empty = no delivery).
         logged_response = final_response if final_response else "(No response generated)"

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -22,6 +22,21 @@ DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
     "fallback_providers": [],
+    # Fallback-chain policy knobs (the CHAIN itself lives in fallback_providers above).
+    "fallback": {
+        # What an UNATTENDED run (cron fire, kanban worker) does when its PRIMARY
+        # returns a rate-limit-class error carrying a reset timestamp.
+        #   "walk"  (default) — current behaviour: immediately try the next rung.
+        #   "defer"           — park the run until the reset and re-schedule it,
+        #                       instead of spending the chain (down to a paid floor)
+        #                       on work nobody is waiting for.
+        # Interactive sessions ALWAYS walk: a human is waiting, and a degraded answer
+        # now beats no answer. A run with no usable reset timestamp always walks too —
+        # parking with no known resume time is worse than a cheaper rung.
+        # Per-run escape hatch: set HERMES_UNATTENDED_LATENCY_CRITICAL=1 for unattended
+        # work whose whole value is freshness (a monitor), which forces "walk".
+        "unattended_on_rate_limit": "walk",
+    },
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
     # journal_mode: SQLite journal mode for every Hermes DB. "wal" default; use "delete" on

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -941,7 +941,14 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Earliest epoch-seconds at which this task may be dispatched. Written by
+    -- the defer-on-429 path: when an unattended worker's PRIMARY model is
+    -- rate-limited until a known reset, the card goes back to ``ready`` with
+    -- ``not_before`` set, so the dispatcher skips it until the reset elapses
+    -- rather than respawning a worker that will 429 again on its first call.
+    -- NULL (the common case) means dispatchable now.
+    not_before           INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2901,6 +2908,73 @@ def edit_completed_task_result(
             run_id=run_id,
         )
     return True
+
+
+def defer_task(
+    conn: sqlite3.Connection, task_id: str, *, not_before: float, reason: Optional[str] = None,
+    expected_run_id: Optional[int] = None, metadata: Optional[dict] = None,
+) -> bool:
+    """Re-queue a ``running`` task for a LATER dispatch (defer-on-429).
+
+    This is deliberately NOT ``block_task``. A deferral is not a blocker:
+
+    * It needs no human. ``blocked`` would put a card on Joey's desk that resolves
+      itself when a quota bucket rolls over.
+    * It must not consume the consecutive-failure budget. The worker did nothing
+      wrong — the provider was capped — so ``_record_task_failure`` would trip the
+      circuit breaker after two capped days and give up on healthy work.
+    * It must not count toward unblock-loop detection. A weekly-capped model would
+      otherwise escalate a perfectly fine card to ``triage``.
+
+    So the card goes back to its source lane (``ready``/``review``) with
+    ``not_before`` set; ``_lane_rows`` skips it until the clock passes. The run is
+    closed with outcome ``deferred`` so attempt history shows what happened.
+
+    Returns True when the task transitioned.
+    """
+    when = int(float(not_before))
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, current_run_id FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        retry_status = (
+            _retry_status_for_run(conn, task_id, row["current_run_id"])
+            if row["status"] == "running" else "ready"
+        )
+        sql = (
+            "UPDATE tasks SET status = ?, claim_lock = NULL, claim_expires = NULL, "
+            "worker_pid = NULL, not_before = ? "
+            "WHERE id = ? AND status IN ('running', 'ready', 'review')"
+        )
+        params: tuple = (retry_status, when, task_id)
+        if expected_run_id is not None:
+            sql += " AND current_run_id = ?"
+            params = (*params, int(expected_run_id))
+        if conn.execute(sql, params).rowcount != 1:
+            return False
+        run_id = _end_or_synthesize_run(
+            conn, task_id, outcome="deferred", status=retry_status, summary=reason,
+            metadata=metadata, synthesize=bool(reason),
+        )
+        _append_event(
+            conn, task_id, "deferred",
+            {"not_before": when, "reason": reason, "retry_status": retry_status},
+            run_id=run_id,
+        )
+    return True
+
+
+def clear_task_deferral(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Drop a ``not_before`` gate so the task is immediately dispatchable again
+    (operator override / an unblock that should not wait out a stale reset)."""
+    with write_txn(conn):
+        changed = conn.execute(
+            "UPDATE tasks SET not_before = NULL WHERE id = ? AND not_before IS NOT NULL",
+            (task_id,),
+        ).rowcount
+    return changed == 1
 
 
 def block_task(

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -813,6 +813,12 @@ _LATER_TASK_COLUMNS = (
     # Typed block reason (VALID_BLOCK_KINDS); NULL = generic human blocker.
     ("block_kind", "block_kind TEXT"),
     ("block_recurrences", "block_recurrences INTEGER NOT NULL DEFAULT 0"),
+    # Earliest epoch-seconds this task may be dispatched. Set by the defer-on-429
+    # path when an unattended worker's primary is rate-limited until a known reset:
+    # the card returns to ``ready`` but the dispatcher skips it until the clock
+    # passes, instead of respawning a worker that will 429 again immediately.
+    # NULL (the common case) = dispatchable now.
+    ("not_before", "not_before INTEGER"),
 )
 
 _NOTIFY_SUB_COLUMNS = (

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1227,10 +1227,15 @@ def _profile_exists_fn() -> Optional[Callable[[str], bool]]:
 
 
 def _has_spawnable(conn: sqlite3.Connection, status: str) -> bool:
+    # ``not_before`` mirrors _lane_rows: a card parked by defer-on-429 is correctly
+    # idle, not stuck. Counting it here would make health telemetry report
+    # "spawnable work exists, 0 spawned" every tick until the reset elapses —
+    # exactly the false stall alarm this predicate exists to avoid.
     rows = conn.execute(
         "SELECT DISTINCT assignee FROM tasks "
-        "WHERE status = ? AND assignee IS NOT NULL AND claim_lock IS NULL",
-        (status,),
+        "WHERE status = ? AND assignee IS NOT NULL AND claim_lock IS NULL "
+        "AND (not_before IS NULL OR not_before <= ?)",
+        (status, int(time.time())),
     ).fetchall()
     if not rows:
         return False
@@ -1709,11 +1714,19 @@ def _tick_spawn_budget(
 
 
 def _lane_rows(conn: sqlite3.Connection, status: str) -> list[sqlite3.Row]:
-    """Unclaimed rows of one lane in dispatch order."""
+    """Unclaimed rows of one lane in dispatch order.
+
+    ``not_before`` gates defer-on-429 re-queues: a card parked until its provider's
+    rate-limit reset stays invisible to dispatch until the clock passes, instead of
+    respawning a worker that would 429 on its first call. NULL (the overwhelming
+    majority) is dispatchable now, so the predicate is a no-op for every other card.
+    """
     return conn.execute(
         "SELECT id, assignee FROM tasks "
         f"WHERE status = '{status}' AND claim_lock IS NULL "
-        "ORDER BY priority DESC, created_at ASC"
+        "AND (not_before IS NULL OR not_before <= ?) "
+        "ORDER BY priority DESC, created_at ASC",
+        (int(time.time()),),
     ).fetchall()
 
 

--- a/tests/agent/test_unattended_defer_on_rate_limit.py
+++ b/tests/agent/test_unattended_defer_on_rate_limit.py
@@ -1,0 +1,473 @@
+"""Defer-on-429: an unattended run parks on the primary's reset instead of
+walking the fallback chain down to a paid floor.
+
+Covers the policy gates (``agent/unattended_defer.py``), the walk-site refusal
+(``chat_completion_helpers.try_activate_fallback``), the kanban ``not_before``
+re-queue, and the cron silent-skip tick.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.error_classifier import FailoverReason
+from agent import unattended_defer as ud
+
+
+# --------------------------------------------------------------------------
+# fixtures
+# --------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Every defer-relevant env var starts unset; the ContextVar starts cleared."""
+    for var in (ud.ENV_POLICY, ud.ENV_LATENCY_CRITICAL, ud.ENV_UNATTENDED,
+                "HERMES_KANBAN_TASK", "HERMES_KANBAN_RUN_ID"):
+        monkeypatch.delenv(var, raising=False)
+    token = ud.set_latency_critical(None)
+    yield
+    ud.reset_latency_critical(token)
+
+
+class _FakePool:
+    def __init__(self, next_at):
+        self._next_at = next_at
+
+    def next_available_at(self):
+        return self._next_at
+
+
+def _agent(*, pool_reset=None, fallback_activated=False, provider="anthropic",
+           model="claude-opus-5", primary_provider="anthropic"):
+    return SimpleNamespace(
+        provider=provider, model=model,
+        _credential_pool=_FakePool(pool_reset) if pool_reset else None,
+        _fallback_activated=fallback_activated,
+        _primary_runtime={"provider": primary_provider},
+    )
+
+
+RESET_IN_1H = staticmethod(lambda: time.time() + 3600)
+
+
+# --------------------------------------------------------------------------
+# policy resolution
+# --------------------------------------------------------------------------
+
+def test_policy_defaults_to_walk_so_existing_configs_are_untouched():
+    assert ud.resolve_policy({}) == ud.POLICY_WALK
+    assert ud.resolve_policy(None) in (ud.POLICY_WALK, ud.POLICY_DEFER)  # load_config path
+
+
+def test_policy_reads_config_key():
+    assert ud.resolve_policy({"fallback": {"unattended_on_rate_limit": "defer"}}) == ud.POLICY_DEFER
+    assert ud.resolve_policy({"fallback": {"unattended_on_rate_limit": "walk"}}) == ud.POLICY_WALK
+
+
+def test_policy_ignores_typo_rather_than_parking_the_fleet():
+    """An unrecognized value must not silently become 'defer'."""
+    assert ud.resolve_policy({"fallback": {"unattended_on_rate_limit": "deffer"}}) == ud.POLICY_WALK
+
+
+def test_env_overrides_config(monkeypatch):
+    monkeypatch.setenv(ud.ENV_POLICY, "defer")
+    assert ud.resolve_policy({"fallback": {"unattended_on_rate_limit": "walk"}}) == ud.POLICY_DEFER
+
+
+# --------------------------------------------------------------------------
+# surface detection
+# --------------------------------------------------------------------------
+
+def test_kanban_worker_is_unattended(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_abc123")
+    assert ud.is_unattended_run() is True
+
+
+def test_explicit_flag_is_unattended(monkeypatch):
+    monkeypatch.setenv(ud.ENV_UNATTENDED, "1")
+    assert ud.is_unattended_run() is True
+
+
+def test_cron_session_is_unattended():
+    with patch("gateway.session_context.get_session_env", return_value="1"):
+        assert ud.is_unattended_run() is True
+
+
+def test_plain_shell_is_not_unattended():
+    with patch("gateway.session_context.get_session_env", return_value=""):
+        assert ud.is_unattended_run() is False
+
+
+def test_latency_critical_contextvar_beats_env(monkeypatch):
+    monkeypatch.setenv(ud.ENV_LATENCY_CRITICAL, "1")
+    token = ud.set_latency_critical(False)
+    try:
+        assert ud.is_latency_critical() is False
+    finally:
+        ud.reset_latency_critical(token)
+    assert ud.is_latency_critical() is True
+
+
+# --------------------------------------------------------------------------
+# resolve_deferral — the gate stack
+# --------------------------------------------------------------------------
+
+DEFER_CFG = {"fallback": {"unattended_on_rate_limit": "defer"}}
+
+
+def test_defers_when_every_gate_passes(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    reset = time.time() + 3600
+    got = ud.resolve_deferral(_agent(pool_reset=reset), FailoverReason.rate_limit, config=DEFER_CFG)
+    assert got == pytest.approx(reset)
+
+
+def test_walk_policy_never_defers(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    got = ud.resolve_deferral(
+        _agent(pool_reset=time.time() + 3600), FailoverReason.rate_limit,
+        config={"fallback": {"unattended_on_rate_limit": "walk"}},
+    )
+    assert got is None
+
+
+def test_interactive_session_never_defers():
+    """A human is waiting: degraded answer now beats no answer."""
+    with patch("gateway.session_context.get_session_env", return_value=""):
+        got = ud.resolve_deferral(
+            _agent(pool_reset=time.time() + 3600), FailoverReason.rate_limit, config=DEFER_CFG,
+        )
+    assert got is None
+
+
+def test_latency_critical_unattended_run_still_walks(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    monkeypatch.setenv(ud.ENV_LATENCY_CRITICAL, "1")
+    got = ud.resolve_deferral(
+        _agent(pool_reset=time.time() + 3600), FailoverReason.rate_limit, config=DEFER_CFG,
+    )
+    assert got is None
+
+
+@pytest.mark.parametrize("reason", [
+    FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit,
+])
+def test_all_rate_limit_class_reasons_defer(monkeypatch, reason):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    assert ud.resolve_deferral(
+        _agent(pool_reset=time.time() + 3600), reason, config=DEFER_CFG,
+    ) is not None
+
+
+def test_non_rate_limit_reason_walks(monkeypatch):
+    """A 500 or a context overflow is not a quota problem — the chain still helps."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    assert ud.resolve_deferral(
+        _agent(pool_reset=time.time() + 3600), FailoverReason.server_error, config=DEFER_CFG,
+    ) is None
+
+
+def test_no_reset_timestamp_means_no_deferral(monkeypatch):
+    """THE load-bearing gate: parking with no known resume time is worse than a cheap rung."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    assert ud.resolve_deferral(_agent(pool_reset=None), FailoverReason.rate_limit, config=DEFER_CFG) is None
+
+
+def test_reset_from_error_context_when_pool_is_silent(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    reset = time.time() + 1800
+    got = ud.resolve_deferral(
+        _agent(pool_reset=None), FailoverReason.rate_limit,
+        error_context={"reset_at": reset}, config=DEFER_CFG,
+    )
+    assert got == pytest.approx(reset)
+
+
+def test_already_on_a_fallback_rung_keeps_walking(monkeypatch):
+    """A 429 while a fallback is active came from THAT rung, not the primary."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    agent = _agent(pool_reset=time.time() + 3600, fallback_activated=True,
+                   provider="venice", primary_provider="anthropic")
+    assert ud.resolve_deferral(agent, FailoverReason.rate_limit, config=DEFER_CFG) is None
+
+
+def test_imminent_reset_is_not_worth_a_round_trip(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    got = ud.resolve_deferral(
+        _agent(pool_reset=time.time() + 5), FailoverReason.rate_limit, config=DEFER_CFG,
+    )
+    assert got is None
+
+
+def test_absurd_reset_is_clamped_to_24h(monkeypatch):
+    """A malformed header must not park a card for a fortnight."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    got = ud.resolve_deferral(
+        _agent(pool_reset=time.time() + 30 * 86400), FailoverReason.rate_limit, config=DEFER_CFG,
+    )
+    assert got is not None
+    assert got - time.time() == pytest.approx(ud.MAX_DEFER_SECONDS, abs=5)
+
+
+def test_resolve_deferral_fails_open_on_internal_error(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    with patch.object(ud, "resolve_policy", side_effect=RuntimeError("boom")):
+        assert ud.resolve_deferral(_agent(pool_reset=time.time() + 3600),
+                                   FailoverReason.rate_limit, config=DEFER_CFG) is None
+
+
+# --------------------------------------------------------------------------
+# walk-site integration
+# --------------------------------------------------------------------------
+
+def test_try_activate_fallback_refuses_to_walk_when_deferring(monkeypatch):
+    """The whole point: a capped primary must NOT reach the next rung."""
+    from agent import chat_completion_helpers as cch
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    monkeypatch.setenv(ud.ENV_POLICY, "defer")
+    agent = _agent(pool_reset=time.time() + 3600)
+    agent._fallback_chain = [{"provider": "venice", "model": "z-ai-glm-5-3-flash"}]
+    agent._fallback_index = 0
+    agent._buffer_status = lambda *_a, **_k: None
+    agent._pending_fallback_notice = None
+    agent._rate_limit_backoff_count = 0
+
+    assert cch.try_activate_fallback(agent, FailoverReason.rate_limit) is False
+    # Chain untouched: nothing was tried.
+    assert agent._fallback_index == 0
+    assert ud.get_deferral(agent) is not None
+
+
+def test_try_activate_fallback_still_walks_for_interactive(monkeypatch):
+    """Regression guard: the default path must be byte-for-byte unchanged."""
+    from agent import chat_completion_helpers as cch
+
+    monkeypatch.setenv(ud.ENV_POLICY, "walk")
+    agent = _agent(pool_reset=time.time() + 3600)
+    agent._fallback_chain = []
+    agent._fallback_index = 0
+    agent._rate_limit_backoff_count = 0
+    with patch("gateway.session_context.get_session_env", return_value=""):
+        # Empty chain -> False, but via the EXHAUSTED path, not the defer path.
+        assert cch.try_activate_fallback(agent, FailoverReason.rate_limit) is False
+    assert ud.get_deferral(agent) is None
+
+
+def test_deferral_is_sticky_across_later_walk_attempts(monkeypatch):
+    """The max-retries site calls with reason=None; it must not undo the deferral."""
+    from agent import chat_completion_helpers as cch
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_1")
+    monkeypatch.setenv(ud.ENV_POLICY, "defer")
+    agent = _agent(pool_reset=time.time() + 3600)
+    agent._fallback_chain = [{"provider": "venice", "model": "z-ai-glm-5-3-flash"}]
+    agent._fallback_index = 0
+    agent._buffer_status = lambda *_a, **_k: None
+    agent._pending_fallback_notice = None
+    agent._rate_limit_backoff_count = 0
+
+    assert cch.try_activate_fallback(agent, FailoverReason.rate_limit) is False
+    # Second call, no reason at all — the sticky guard must still refuse.
+    assert cch.try_activate_fallback(agent, None) is False
+    assert agent._fallback_index == 0
+
+
+# --------------------------------------------------------------------------
+# kanban: not_before re-queue
+# --------------------------------------------------------------------------
+
+@pytest.fixture()
+def board(monkeypatch, tmp_path):
+    """Fresh HERMES_HOME + kanban DB, re-importing so the new home is picked up."""
+    import sys
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for mod in list(sys.modules):
+        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
+            del sys.modules[mod]
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+    kb.create_board(slug="default", name="Test")
+    yield kb, kbc, kbd
+
+
+def _new_running_task(kb, kbc):
+    with kbc.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="t", assignee="linuxops")
+        kb.claim_task(conn, task_id, claimer="host:1")
+    return task_id
+
+
+def test_defer_task_requeues_with_not_before(board):
+    kb, kbc, _kbd = board
+    task_id = _new_running_task(kb, kbc)
+    reset = time.time() + 3600
+
+    with kbc.connect_closing() as conn:
+        assert kb.defer_task(conn, task_id, not_before=reset, reason="rate limited") is True
+
+    with kbc.connect_closing() as conn:
+        row = conn.execute(
+            "SELECT status, not_before, claim_lock, consecutive_failures FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+    assert row["status"] == "ready"
+    assert row["not_before"] == int(reset)
+    assert row["claim_lock"] is None
+    # A provider cap is not the worker's failure — the breaker must not advance.
+    assert row["consecutive_failures"] == 0
+
+
+def test_deferred_task_is_invisible_to_dispatch_until_the_reset(board):
+    kb, kbc, kbd = board
+    task_id = _new_running_task(kb, kbc)
+    with kbc.connect_closing() as conn:
+        kb.defer_task(conn, task_id, not_before=time.time() + 3600, reason="rate limited")
+
+    with kbc.connect_closing() as conn:
+        assert [r["id"] for r in kbd._lane_rows(conn, "ready")] == []
+        # ...and health telemetry must not call it a stall.
+        assert kbd.has_spawnable_ready(conn) is False
+
+
+def test_deferred_task_returns_to_dispatch_once_the_reset_passes(board):
+    kb, kbc, kbd = board
+    task_id = _new_running_task(kb, kbc)
+    with kbc.connect_closing() as conn:
+        kb.defer_task(conn, task_id, not_before=time.time() - 1, reason="rate limited")
+
+    with kbc.connect_closing() as conn:
+        assert [r["id"] for r in kbd._lane_rows(conn, "ready")] == [task_id]
+
+
+def test_undeferred_tasks_are_unaffected(board):
+    kb, kbc, kbd = board
+    with kbc.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="t", assignee="linuxops")
+    with kbc.connect_closing() as conn:
+        assert [r["id"] for r in kbd._lane_rows(conn, "ready")] == [task_id]
+
+
+def test_clear_task_deferral_makes_it_dispatchable_now(board):
+    kb, kbc, kbd = board
+    task_id = _new_running_task(kb, kbc)
+    with kbc.connect_closing() as conn:
+        kb.defer_task(conn, task_id, not_before=time.time() + 3600)
+    with kbc.connect_closing() as conn:
+        assert kb.clear_task_deferral(conn, task_id) is True
+    with kbc.connect_closing() as conn:
+        assert [r["id"] for r in kbd._lane_rows(conn, "ready")] == [task_id]
+
+
+def test_defer_task_records_an_auditable_event(board):
+    kb, kbc, _kbd = board
+    task_id = _new_running_task(kb, kbc)
+    with kbc.connect_closing() as conn:
+        kb.defer_task(conn, task_id, not_before=time.time() + 3600, reason="capped until X")
+    with kbc.connect_closing() as conn:
+        kinds = [e["kind"] for e in conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ?", (task_id,)).fetchall()]
+    assert "deferred" in kinds
+
+
+def test_defer_task_respects_expected_run_id(board):
+    """A stale worker must not park a card its successor already owns."""
+    kb, kbc, _kbd = board
+    task_id = _new_running_task(kb, kbc)
+    with kbc.connect_closing() as conn:
+        assert kb.defer_task(
+            conn, task_id, not_before=time.time() + 60, expected_run_id=999_999,
+        ) is False
+
+
+# --------------------------------------------------------------------------
+# cron: silent skip
+# --------------------------------------------------------------------------
+
+def test_cron_reads_deferred_until_off_the_turn_result():
+    from cron import scheduler
+
+    assert scheduler._deferred_run_result({"deferred_until": 123.0}) == 123.0
+    assert scheduler._deferred_run_result({}) is None
+    assert scheduler._deferred_run_result(None) is None
+    assert scheduler._deferred_run_result({"deferred_until": "nope"}) is None
+
+
+def test_cron_deferred_tick_is_silent_and_successful():
+    """A rolled-over quota bucket is not a job failure and must not alert."""
+    from cron import scheduler
+
+    ok, doc, response, error = scheduler._deferred_tick_result(
+        {"id": "j1"}, "j1", "job", "prompt", time.time() + 3600,
+    )
+    assert ok is True
+    assert error is None
+    assert response == scheduler.SILENT_MARKER
+    assert "deferred until" in doc.lower()
+
+
+# --------------------------------------------------------------------------
+# The constant-relocation trap
+# --------------------------------------------------------------------------
+
+def test_rate_limit_reasons_survive_the_constant_moving_modules():
+    """``_RATE_LIMIT_FAILOVER_REASONS`` must be found wherever upstream keeps it.
+
+    This is not hypothetical. The constant lived in ``chat_completion_helpers``,
+    then moved to ``fallback_cooldown``; the original code imported it from the
+    single hardcoded module INSIDE ``resolve_deferral``'s blanket ``except``, so
+    the relocation turned the whole feature INERT — every unattended run walked
+    the chain again, with no error and no log line. Only an end-to-end assertion
+    catches that class, because each unit gate still passed in isolation.
+    """
+    from agent import unattended_defer as ud
+    from agent.error_classifier import FailoverReason
+
+    ud._REASONS_CACHE = None  # force a real resolution, not a memoized one
+    try:
+        reasons = ud._rate_limit_reasons()
+        assert reasons, "defer-on-429 is INERT: no rate-limit reasons resolved"
+        for name in ("rate_limit", "billing", "upstream_rate_limit"):
+            assert getattr(FailoverReason, name) in reasons, f"{name} missing"
+    finally:
+        ud._REASONS_CACHE = None
+
+
+def test_feature_is_wired_into_the_real_walk_site(monkeypatch):
+    """End-to-end guard: the REAL ``try_activate_fallback`` must refuse to walk.
+
+    Deliberately calls the production function rather than the policy helper — a
+    passing policy unit test proved nothing when the walk site's import was dead.
+    """
+    from agent import chat_completion_helpers as cch
+    from agent import unattended_defer as ud
+    from agent.error_classifier import FailoverReason
+
+    ud._REASONS_CACHE = None
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_wired")
+    monkeypatch.setenv("HERMES_UNATTENDED_ON_RATE_LIMIT", "defer")
+    monkeypatch.delenv("HERMES_UNATTENDED_LATENCY_CRITICAL", raising=False)
+
+    reset_at = time.time() + 3600
+    agent = _agent(pool_reset=reset_at)
+    # The walk site needs a real chain to consume; _agent() only carries the gates.
+    agent._fallback_index = 0
+    agent._fallback_chain = [
+        {"provider": "anthropic", "model": "claude-sonnet-5"},
+        {"provider": "openrouter", "model": "z-ai/glm-5.3-flash"},  # paid floor
+    ]
+    agent._rate_limit_backoff_count = 0
+    agent._pending_fallback_notice = None
+    agent._buffer_status = lambda *a, **k: None
+    walked = cch.try_activate_fallback(agent, FailoverReason.rate_limit)
+
+    assert walked is False, "unattended run walked the chain"
+    assert agent._fallback_index == 0, "chain was consumed despite the deferral"
+    assert ud.get_deferral(agent) is not None, "no deferral recorded"
+    ud._REASONS_CACHE = None


### PR DESCRIPTION
## What

Cron jobs and kanban workers whose primary hits a rate-limit currently walk the
fallback chain immediately, same as an interactive session. On an all-one-provider
chain that means `primary -> cheaper rung -> cheaper rung -> paid floor` on exactly
the day the subscription is capped — spending real money on work nobody was waiting
for, that would have run fine an hour later.

The walk exists because a human is waiting. For an unattended run nobody is, and
the provider usually tells us *when* it resets. So: park the run until then, instead
of walking.

## How

New config knob `fallback.unattended_on_rate_limit: defer|walk` (default `walk` —
existing behaviour is byte-for-byte unchanged until opted in).

- `agent/unattended_defer.py` — the whole policy, in one file. Five gates must all
  pass: policy is `defer`; the run is unattended and not latency-critical; the
  failure is rate-limit class; the PRIMARY is what failed (not an already-active
  rung); and a usable reset timestamp exists within 30s..24h. Fails OPEN in every
  ambiguous case — no reset time means no deferral, because parking with no known
  resume time is worse than spending a cheap rung.
- `try_activate_fallback` refuses the walk (returns `False`) when the policy fires,
  and the refusal is sticky: the max-retries-exhausted site calls it again with
  `reason=None` moments later and would otherwise walk anyway.
- cron: the tick is skipped silently and successfully — a quota bucket rolling over
  is not a job failure and must not alert or set `last_status=error`.
- kanban: the card is re-queued via the new `kanban_db.defer_task` with a
  `not_before` gate, NOT `block_task` and NOT `_record_task_failure`. A deferral
  needs no human and must not consume the consecutive-failure budget, or the
  circuit breaker gives up on healthy work after two capped days. The dispatcher
  (`_lane_rows`/`_has_spawnable`) skips the card until the reset elapses instead of
  respawning a worker that would 429 on its first call.
- Interactive sessions always walk. `latency_critical: true` on a cron job is the
  per-run escape hatch for unattended work whose value IS freshness; it is a
  `ContextVar`, not an env var, because several jobs fire in-process.

## Testing

- 37 unit tests covering the policy module in isolation
  (`tests/agent/test_unattended_defer_on_rate_limit.py`), plus a 5-scenario 429
  replay and a dispatcher end-to-end test that drives the real
  `try_activate_fallback` rather than only the policy helper (a hardcoded-import
  bug that made an earlier version of this silently inert passed every isolated
  unit gate; the E2E guard is what catches that class).
- Full `tests/agent/` suite (6739 tests) run against this branch and against its
  merge-base with `origin/main`, failures diffed: identical 28 pre-existing
  failures on both sides, zero regressions introduced by this change.
- `tests/cron/` run the same way: one pre-existing cross-test-pollution failure
  present on both sides (passes standalone on both), zero regressions.

## Docs

`website/docs/reference/cli-commands.md` documents the new config knob.
