### PR TITLE
fix(mcp): treat Streamable-HTTP 401 session expiry as transport reconnect (#106094)

### DIFF
--- a/tests/tools/test_mcp_failure_classification.py
+++ b/tests/tools/test_mcp_failure_classification.py
@@ -261,3 +261,20 @@ def test_initial_auth_failure_parks_and_revives_after_relogin(
     ]
     assert len(auth_warnings) == 1
     assert "hermes mcp login figma" in auth_warnings[0].getMessage()
+
+
+def test_http_session_expired_401_detected():
+    from tools.mcp_tool import _is_http_session_expired_401
+    import httpx
+
+    # A 401 request WITH MCP-Session-ID header is session expiry, not credential revocation
+    req_with_session = httpx.Request("POST", "https://mcp.composio.dev/message", headers={"MCP-Session-ID": "sess-123"})
+    resp_401 = httpx.Response(401, request=req_with_session)
+    exc_with_session = httpx.HTTPStatusError("401 Unauthorized", request=req_with_session, response=resp_401)
+    assert _is_http_session_expired_401(exc_with_session) is True
+
+    # A 401 request WITHOUT MCP-Session-ID header is genuine auth failure
+    req_no_session = httpx.Request("POST", "https://mcp.composio.dev/message", headers={"Authorization": "Bearer key"})
+    resp_401_no_session = httpx.Response(401, request=req_no_session)
+    exc_no_session = httpx.HTTPStatusError("401 Unauthorized", request=req_no_session, response=resp_401_no_session)
+    assert _is_http_session_expired_401(exc_no_session) is False

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -670,6 +670,7 @@ _PLUGIN_COMPAT_LAZY = {
     'InvalidMcpUrlError': ('tools.mcp_tool_errors', 'InvalidMcpUrlError'),
     'MCP_TOOL_NAME_PREFIX': ('tools.mcp_tool_schema', 'MCP_TOOL_NAME_PREFIX'),
     'NonMcpEndpointError': ('tools.mcp_tool_errors', 'NonMcpEndpointError'),
+    '_is_http_session_expired_401': ('tools.mcp_tool_errors', '_is_http_session_expired_401'),
     'discover_mcp_tools': ('tools.mcp_tool_discovery', 'discover_mcp_tools'),
     'get_mcp_status': ('tools.mcp_tool_discovery', 'get_mcp_status'),
     'get_registered_mcp_server_names': ('tools.mcp_tool_discovery', 'get_registered_mcp_server_names'),

--- a/tools/mcp_tool_errors.py
+++ b/tools/mcp_tool_errors.py
@@ -283,6 +283,35 @@ def _is_auth_error(exc: BaseException) -> bool:
     return getattr(exc.response, "status_code", None) == 401 if isinstance(exc, http_types) else True
 
 
+def _is_http_session_expired_401(exc: BaseException) -> bool:
+    """True when ``exc`` is an HTTP 401 caused by **server-side session GC**, not credential revocation.
+
+    Streamable-HTTP servers (e.g. Composio) issue a session ID on first connect and include it as
+    ``MCP-Session-ID`` in every subsequent POST.  After the server idles and GCs that session
+    (~3 min for Composio) it returns 401 — not because the API key expired, but because it no
+    longer recognises the session.  The correct recovery is a fresh transport reconnect, not an
+    OAuth token refresh.
+
+    Detection: the failing request carried an ``MCP-Session-ID`` header (proving we had an
+    established transport session) AND the response status is 401.  Credential-rejection 401s
+    happen on the very first request (no session ID yet) or after an explicit token revocation.
+
+    See #106094.
+    """
+    _, http_types = _get_auth_error_types()
+    if not http_types or not isinstance(exc, http_types):
+        return False
+    if getattr(getattr(exc, "response", None), "status_code", None) != 401:
+        return False
+    # The request that failed must have carried an MCP-Session-ID header: that means we already
+    # had a proven server-side session that the server subsequently GC'd.
+    request = getattr(exc, "request", None) or getattr(getattr(exc, "response", None), "request", None)
+    if request is None:
+        return False
+    req_headers = getattr(request, "headers", {})
+    return any(str(k).lower() == "mcp-session-id" for k in req_headers)
+
+
 # Lower-cased substrings meaning the transport session expired / was GC'd (OAuth token still valid).
 # Substrings (lower-cased match) that indicate the MCP server rejected the request because its server-side
 # transport session expired / was garbage-collected. See #13383.

--- a/tools/mcp_tool_server_run.py
+++ b/tools/mcp_tool_server_run.py
@@ -353,6 +353,21 @@ class MCPServerRunMixin:
         return not self._shutdown_event.is_set()
 
     async def _on_permanent_error(self, root: BaseException, budget: "_RetryBudget") -> bool:
+        # Streamable-HTTP servers (e.g. Composio) return 401 when their server-side transport session
+        # is GC'd after an idle window (~3 min) — the credentials are still valid.  The tell is that
+        # the failing request already carried an MCP-Session-ID header: a first-auth rejection never
+        # includes a session ID.  Treat this as a transport reconnect, not a credential failure, so
+        # the connection revives without consuming the one-time permanent-grace budget.  See #106094.
+        if _errors._is_http_session_expired_401(root):
+            logger.warning(
+                "MCP server '%s': 401 on a request with MCP-Session-ID — server GC'd the transport "
+                "session (not a credential error); triggering transport reconnect "
+                "(state: connected → reconnecting): %s: %s",
+                self.name, type(root).__name__, root)
+            self.mark_suspect(f"HTTP session expired (401 with MCP-Session-ID): {root}")
+            self._reconnect_retries, budget.backoff = 0, 1.0
+            await asyncio.sleep(_jittered(1.0))
+            return not self._shutdown_event.is_set()
         # Auth failure on a PROVEN session is often a raced-teardown OAuth lock, not revoked
         # credentials: grant ONE suspect+reconnect cycle first.
         if _errors._is_auth_error(root) and self._session_proven and not self._permanent_grace_used:


### PR DESCRIPTION
Fixes #106094.

### Root Cause
Streamable-HTTP MCP servers (e.g. Composio) issue a session ID on connect and attach it as an \MCP-Session-ID\ request header on subsequent POSTs. After ~3 minutes of idle time, Composio's server garbage-collects its internal session state and returns HTTP 401 Unauthorized for follow-up POST requests.

Previously, \_on_permanent_error()\ classified all 401 status codes as permanent credential failures. After a single grace reconnect cycle (\_permanent_grace_used\), subsequent 401s immediately parked the server task, forcing a manual reconnect or restart even though the API key remained completely valid.

### Fix
1. Added \_is_http_session_expired_401()\ helper in \	ools/mcp_tool_errors.py\ to detect when a 401 status code occurred on a request carrying an \MCP-Session-ID\ header (proving an established transport session was GC'd by the server).
2. Updated \_on_permanent_error()\ in \	ools/mcp_tool_server_run.py\ to handle server-side session expiry 401s as transport reconnects without consuming the one-time permanent grace budget.
3. Added unit tests in \	ests/tools/test_mcp_failure_classification.py\.