### PR TITLE
test(desktop): guard plugin SDK namespaces against init-order regressions

### DIFF
--- a/apps/desktop/src/sdk/runtime.test.ts
+++ b/apps/desktop/src/sdk/runtime.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Guards `installPluginSdk()` against the initialisation-order regression
+ * fixed in 6c3d4a4af7.
+ *
+ * `sdk/runtime` sits in an import cycle (`sdk/index` -> `contrib/*` ->
+ * `contrib/runtime-loader` -> `sdk/runtime`). A module-scope literal such as
+ * `const GLOBALS = { __HERMES_PLUGIN_SDK__: sdk }` is therefore evaluated
+ * before `sdk/index` has run. Unbundled that is harmless (live namespace
+ * object); bundled, the namespace is a hoisted `var` assigned later, so the
+ * capture froze as `undefined` and `Object.keys()` in `shimUrl()` threw --
+ * breaking EVERY runtime-loaded plugin, content-independently.
+ *
+ * Two layers, because each misses what the other catches:
+ *   1. source shape  -- runs on any checkout, including CI with no build.
+ *   2. emitted chunk -- catches a bundler/config change that reintroduces the
+ *      hazard while the source still looks correct.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { parse } from 'acorn'
+import { transpileModule } from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
+
+type AstNode = Record<string, unknown>
+
+const GLOBAL_KEYS = [
+  '__HERMES_PLUGIN_SDK__',
+  '__HERMES_REACT__',
+  '__HERMES_REACT_JSX__',
+  '__HERMES_REACT_JSX_DEV__'
+] as const
+
+/** Node types whose body runs on call, not during chunk evaluation. */
+const FUNCTION_NODES = new Set([
+  'ArrowFunctionExpression',
+  'FunctionDeclaration',
+  'FunctionExpression'
+])
+
+/**
+ * Walk an AST, reporting every `__HERMES_PLUGIN_SDK__` property and whether it
+ * sits inside a function. Deliberately shape-agnostic: an arrow
+ * (`() => ({ ... })`) and a declaration (`function f() { return { ... } }`)
+ * are both lazy, and a guard that only recognises one silently passes the
+ * other.
+ */
+function findNamespaceReads(
+  root: AstNode[]
+): { eager: { identifier: null | string; stmtIndex: number }[]; lazy: number } {
+  const eager: { identifier: null | string; stmtIndex: number }[] = []
+  let lazy = 0
+
+  const walk = (node: unknown, stmtIndex: number, insideFunction: boolean): void => {
+    if (!node || typeof node !== 'object') {
+      return
+    }
+
+    const n = node as AstNode
+    const nested = insideFunction || FUNCTION_NODES.has(n.type as string)
+
+    if (n.type === 'Property') {
+      const key = n.key as { name?: string; value?: string } | undefined
+
+      if ((key?.name ?? key?.value) === '__HERMES_PLUGIN_SDK__') {
+        if (nested) {
+          lazy += 1
+        } else {
+          const value = n.value as { name?: string; type: string }
+
+          eager.push({
+            identifier: value.type === 'Identifier' ? (value.name as string) : null,
+            stmtIndex
+          })
+        }
+      }
+    }
+
+    for (const child of Object.values(n)) {
+      if (Array.isArray(child)) {
+        child.forEach(item => walk(item, stmtIndex, nested))
+      } else if (child && typeof child === 'object') {
+        walk(child, stmtIndex, nested)
+      }
+    }
+  }
+
+  root.forEach((stmt, i) => walk(stmt, i, false))
+
+  return { eager, lazy }
+}
+
+function parseProgram(source: string): AstNode[] {
+  return (parse(source, { ecmaVersion: 'latest', sourceType: 'module' }) as unknown as { body: AstNode[] })
+    .body
+}
+
+describe('installPluginSdk', () => {
+  it('installs every namespace as a real object, never undefined', () => {
+    installPluginSdk()
+
+    for (const key of GLOBAL_KEYS) {
+      const value = (globalThis as Record<string, unknown>)[key]
+
+      expect(value, `${key} must be installed`).toBeTypeOf('object')
+      expect(value, `${key} must not be undefined`).not.toBeUndefined()
+    }
+  })
+
+  it('exposes the SDK members plugins actually render with', () => {
+    installPluginSdk()
+
+    const sdk = (globalThis as unknown as Record<string, Record<string, unknown>>)
+      .__HERMES_PLUGIN_SDK__
+
+    // Had the namespace frozen as undefined, none of these would resolve.
+    for (const name of ['Tip', 'Codicon', 'cn', 'haptic']) {
+      expect(sdk[name], `SDK must export ${name}`).toBeDefined()
+    }
+  })
+
+  it('builds shim modules for every specifier plugins may import', () => {
+    const map = sdkImportMap()
+
+    for (const specifier of ['@hermes/plugin-sdk', 'react', 'react/jsx-runtime']) {
+      expect(map[specifier], `${specifier} must map to a shim`).toMatch(/^blob:/)
+    }
+  })
+})
+
+describe('source shape', () => {
+  // Runs everywhere, including a fresh CI checkout with no dist/.
+  it('never captures the namespaces in a module-scope object literal', () => {
+    const source = readFileSync(join(__dirname, 'runtime.ts'), 'utf8')
+
+    // Transpile rather than regex-stripping types: a hand-rolled stripper
+    // silently mis-parses new syntax and turns this guard into a no-op.
+    const { outputText } = transpileModule(source, {
+      compilerOptions: { target: 99 }
+    })
+
+    const { eager, lazy } = findNamespaceReads(parseProgram(outputText))
+
+    expect(lazy, 'runtime.ts must build the namespaces inside a function').toBeGreaterThan(0)
+    expect(
+      eager,
+      'runtime.ts must not capture the namespaces at module scope: the bundler ' +
+        'can emit that literal before the SDK namespace is assigned, freezing it ' +
+        'as undefined and breaking every runtime-loaded plugin.'
+    ).toEqual([])
+  })
+})
+
+/** The shipped chunk defining `__HERMES_PLUGIN_SDK__`, if the app was built. */
+function findBuiltSdkChunk(): { file: string; source: string } | null {
+  const assets = join(__dirname, '..', '..', 'dist', 'assets')
+
+  if (!existsSync(assets)) {
+    return null
+  }
+
+  for (const name of readdirSync(assets)) {
+    if (!name.endsWith('.js')) {
+      continue
+    }
+
+    const source = readFileSync(join(assets, name), 'utf8')
+
+    if (source.includes('__HERMES_PLUGIN_SDK__:')) {
+      return { file: name, source }
+    }
+  }
+
+  return null
+}
+
+describe('emitted chunk', () => {
+  const chunk = findBuiltSdkChunk()
+
+  // Skipped VISIBLY when the app has not been built, rather than passing as a
+  // green test that asserted nothing.
+  it.skipIf(!chunk)('assigns the SDK namespace before anything reads it', () => {
+    if (!chunk) {
+      return
+    }
+
+    const body = parseProgram(chunk.source)
+
+    // Statement index at which each top-level binding receives its value.
+    const declaredAt = new Map<string, number>()
+
+    body.forEach((stmt, i) => {
+      if (stmt.type !== 'VariableDeclaration') {
+        return
+      }
+
+      const declarations = stmt.declarations as {
+        id: { name?: string; type: string }
+        init: unknown
+      }[]
+
+      for (const d of declarations) {
+        if (d.id.type === 'Identifier' && d.init && !declaredAt.has(d.id.name as string)) {
+          declaredAt.set(d.id.name as string, i)
+        }
+      }
+    })
+
+    const { eager, lazy } = findNamespaceReads(body)
+
+    expect(eager.length + lazy, 'chunk must define __HERMES_PLUGIN_SDK__').toBeGreaterThan(0)
+
+    for (const { identifier, stmtIndex } of eager) {
+      // Built inline (call, spread, ...) rather than from a hoisted binding:
+      // there is no earlier binding that could still be undefined.
+      if (identifier === null) {
+        continue
+      }
+
+      const initIndex = declaredAt.get(identifier)
+
+      expect(
+        initIndex === undefined || initIndex < stmtIndex,
+        `${chunk.file}: namespace '${identifier}' is assigned at statement #${initIndex} but ` +
+          `read at #${stmtIndex} -- __HERMES_PLUGIN_SDK__ would be undefined and every ` +
+          `runtime-loaded plugin would fail to load`
+      ).toBe(true)
+    }
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       ],
       "devDependencies": {
         "@eslint/js": "9.39.5",
+        "acorn": "8.17.0",
         "eslint-plugin-perfectionist": "5.10.0",
         "eslint-plugin-react-hooks": "7.1.1",
         "eslint-plugin-unused-imports": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://github.com/NousResearch/Hermes-Agent#readme",
   "devDependencies": {
     "@eslint/js": "9.39.5",
+    "acorn": "8.17.0",
     "typescript-eslint": "8.64.0",
     "eslint-plugin-perfectionist": "5.10.0",
     "eslint-plugin-react-hooks": "7.1.1",


### PR DESCRIPTION

6c3d4a4af7 fixed the module-scope capture that froze the plugin SDK
namespaces as `undefined` in bundled builds, breaking every runtime-loaded
plugin. That commit shipped without a test, noting that a vitest unit test
cannot reproduce it: the dev module graph keeps the namespace live, so the
failure only exists after bundling.

That is true of a behavioural test, but the invariant itself is checkable.
This adds two guards:

- source shape: transpile runtime.ts and walk the AST, asserting the
  namespaces are never captured by a module-scope object literal. Runs on
  any checkout, including CI with no build output. Shape-agnostic, so a
  `function` declaration and an arrow both count as lazy.

- emitted chunk: when dist/ exists, parse the shipped chunk and compare
  statement indices, so a bundler or config change that reintroduces the
  hazard fails even while the source still looks correct. Skipped visibly
  via `it.skipIf` rather than an early return that would report as a
  passing test which asserted nothing.

Verified by reintroducing the regression: the module-scope form fails with
the intended message, while both the current function declaration and an
arrow rewrite pass.

Adds acorn as an explicit devDependency; it was previously only transitive.

Follow-up to 6c3d4a4af7 (test-only; no runtime change).

## Verification

```
upstream function decl (must PASS)     -> Tests  4 passed | 1 skipped (5)
arrow function (must PASS)             -> Tests  4 passed | 1 skipped (5)
module-scope const (must FAIL)         -> Tests  1 failed | 3 passed | 1 skipped (5)
```

Full `src/sdk/` + `src/contrib/`: 103 passed, 1 skipped (the chunk guard, no dist/ in a fresh checkout). `tsc --noEmit` and `eslint` clean.