### PR TITLE
fix(gateway): retarget non-compression completions to active session (#96850)

### DIFF
--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -237,19 +237,23 @@ class GatewayNotificationsMixin:
             switched = await self.async_session_store.advance_compression_session(
                 session_entry.session_key, prior_session_id, target_session_id,
             )
-        else:
-            switched = await self.async_session_store.switch_session(session_entry.session_key, target_session_id)
-        if switched is None:
-            logger.warning(
-                "Async-delegation completion could not bind routing key %s to "
-                "owning session %s; dropping injection.", session_entry.session_key, target_session_id,
+            if switched is None:
+                logger.warning(
+                    "Async-delegation completion could not bind routing key %s to "
+                    "owning session %s; dropping injection.", session_entry.session_key, target_session_id,
+                )
+                return None
+            logger.info(
+                "Pinned async-delegation completion to owning session %s (was %s) for routing key %s (#57498)",
+                target_session_id, prior_session_id, session_entry.session_key,
             )
-            return None
+            return switched
         logger.info(
-            "Pinned async-delegation completion to owning session %s (was %s) for routing key %s (#57498)",
-            target_session_id, prior_session_id, session_entry.session_key,
+            "Async-delegation completion pinned to non-compression session %s; "
+            "retargeting to chat's current session %s.",
+            pinned_session_id, session_entry.session_id,
         )
-        return switched
+        return session_entry
 
     async def _deliver_media_from_response(
         self, response: str, event: MessageEvent, adapter, thread_metadata: Optional[Dict[str, Any]] = None

--- a/tests/gateway/test_async_delegation_session_binding.py
+++ b/tests/gateway/test_async_delegation_session_binding.py
@@ -100,7 +100,7 @@ class TestGatewayPinningFailsClosed:
 
 
     @pytest.mark.asyncio
-    async def test_live_spawning_session_rebinds_from_different_route(self):
+    async def test_live_spawning_session_retargets_to_current_session(self):
         current = self._entry("sess_current")
         pinned = self._entry("sess_live")
         runner = self._make_runner(
@@ -112,10 +112,8 @@ class TestGatewayPinningFailsClosed:
             current, "sess_live"
         )
 
-        assert resolved is pinned
-        getattr(runner.session_store, "switch_session").assert_called_once_with(
-            current.session_key, "sess_live"
-        )
+        assert resolved is current
+        getattr(runner.session_store, "switch_session").assert_not_called()
 
     @pytest.mark.asyncio
     async def test_non_compression_ended_parent_drops(self):


### PR DESCRIPTION
Fixes #96850

### Summary of Changes
- Updated \_resolve_async_delegation_session\ in \gateway/run_notifications.py\ so that non-compression background completions deliver directly to \session_entry\ (the chat route's current active session) rather than calling \switch_session\ back to a stale spawning session ID.
- Added test coverage in \	ests/gateway/test_async_delegation_session_binding.py\ verifying retargeting to the chat's current active session without forcing a route switch to a stale session ID.