### PR TITLE
fix(codex): reset post-tool watchdog on reasoning/progress notifications (#107028)

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -400,7 +400,8 @@ class CodexAppServerSession:
             projection, aborted = self._absorb_notification(result, projector, note)
             if projection.is_tool_iteration:
                 last_tool_completion_at = time.monotonic()
-            elif projection.messages or projection.final_text is not None:
+            else:
+                # Any non-tool activity for this turn (reasoning, progress, text) demonstrates Codex is alive (#107028).
                 last_tool_completion_at = None
             if method != "turn/completed":
                 return aborted

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -813,6 +813,38 @@ class TestSessionRetirement:
         assert r.should_retire is False
         assert r.interrupted is False
 
+    def test_post_tool_watchdog_resets_on_reasoning_or_progress_notification(self):
+        """Reasoning or progress notifications (empty projection) after a tool completion must reset the watchdog (#107028)."""
+        client = FakeClient()
+        client.queue_notification(
+            "item/completed",
+            item={
+                "type": "commandExecution", "id": "ex1",
+                "command": "echo hi", "cwd": "/tmp",
+                "status": "completed", "aggregatedOutput": "hi",
+                "exitCode": 0, "commandActions": [],
+            },
+            threadId="t", turnId="tu1",
+        )
+        # Reasoning item notification (empty transcript projection) immediately after — resets watchdog.
+        client.queue_notification(
+            "item/started",
+            item={"type": "reasoning", "id": "r1"},
+            threadId="t", turnId="tu1",
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        s = make_session(client)
+        r = s.run_turn(
+            "tool then reasoning", turn_timeout=2.0,
+            notification_poll_timeout=0.01,
+            post_tool_quiet_timeout=0.05,
+        )
+        assert r.should_retire is False
+        assert r.interrupted is False
+
 
 
 


### PR DESCRIPTION
Fixes #107028

### Summary of Changes
- Updated \on_note\ in \gent/transports/codex_app_server_session.py\ so that receiving any non-tool notification for the current turn (such as reasoning items, status updates, or progress deltas with empty transcript projections) resets the 90-second post-tool quiet watchdog (\last_tool_completion_at = None\).
- Added test \	est_post_tool_watchdog_resets_on_reasoning_or_progress_notification\ in \	ests/agent/transports/test_codex_app_server_session.py\ verifying that notifications with empty transcript projections keep the post-tool watchdog reset.