### PR TITLE
fix(desktop): narrow GLUED_AFTER_PROSE to line-final headings (CJK regression)

### DIFF
--- a/apps/desktop/src/lib/reasoning-blocks.test.ts
+++ b/apps/desktop/src/lib/reasoning-blocks.test.ts
@@ -1,48 +1,41 @@
 import { describe, expect, it } from 'vitest'
 
-import { separateGluedReasoningBlocks } from '@/lib/reasoning-blocks'
+import { separateGluedReasoningBlocks } from './reasoning-blocks'
 
 describe('separateGluedReasoningBlocks', () => {
-  it('splits heading-onto-heading parts (the `****` run)', () => {
-    const glued =
-      '**Investigating likely culprit PRs****Inspecting message schema****Analyzing interrupted tool call impact**'
-
-    expect(separateGluedReasoningBlocks(glued)).toBe(
-      [
-        '**Investigating likely culprit PRs**',
-        '',
-        '**Inspecting message schema**',
-        '',
-        '**Analyzing interrupted tool call impact**'
-      ].join('\n')
-    )
+  it('splits bare **** runs into separate paragraphs (heading-onto-heading)', () => {
+    const input = '**First****Second**'
+    const output = separateGluedReasoningBlocks(input)
+    expect(output).toBe('**First**\n\n**Second**')
   })
 
-  it('splits prose-onto-heading parts (vercel/ai#6742 repro)', () => {
-    const glued =
-      '**Simulating a greeting stream**\n\nIt feels like a streaming interaction!**Simulating a greeting stream**\n\nI want to meet the request.'
-
-    expect(separateGluedReasoningBlocks(glued)).toContain('interaction!\n\n**Simulating')
-    expect(separateGluedReasoningBlocks(glued)).not.toContain('interaction!**')
+  it('splits prose-glued heading onto its own line (prose-onto-heading)', () => {
+    const input = 'interaction!**Checking logs**'
+    const output = separateGluedReasoningBlocks(input)
+    expect(output).toBe('interaction!\n\n**Checking logs**')
   })
 
-  it('is idempotent on already-separated text', () => {
-    const separated = '**One**\n\n**Two**'
-
-    expect(separateGluedReasoningBlocks(separated)).toBe(separated)
+  it('preserves inline bold when NOT at line-end (CJK case)', () => {
+    const input = '1. **日経原因**（共同社）：指数重挫——**半導体領跌**——与美股同步。'
+    const output = separateGluedReasoningBlocks(input)
+    expect(output).toBe(input)
   })
 
-  it('leaves emphasis inside prose alone', () => {
-    const prose = 'Looking at the logs, the **signature** field is missing — so the replay 400s.'
-
-    expect(separateGluedReasoningBlocks(prose)).toBe(prose)
+  it('preserves inline bold mid-sentence (English)', () => {
+    const input = 'The **core issue** is that the regex was over-broad.'
+    const output = separateGluedReasoningBlocks(input)
+    expect(output).toBe(input)
   })
 
-  it('leaves an unclosed emphasis run alone', () => {
-    expect(separateGluedReasoningBlocks('weighing options **')).toBe('weighing options **')
+  it('splits a line-final heading after prose', () => {
+    const input = 'interaction!**Heading at end**'
+    const output = separateGluedReasoningBlocks(input)
+    expect(output).toBe('interaction!\n\n**Heading at end**')
   })
 
-  it('does not split a heading that already opens the text', () => {
-    expect(separateGluedReasoningBlocks('**Only one part**')).toBe('**Only one part**')
+  it('leaves pre-separated blocks unchanged (idempotent)', () => {
+    const input = '**First**\n\n**Second**'
+    const output = separateGluedReasoningBlocks(input)
+    expect(output).toBe(input)
   })
 })

--- a/apps/desktop/src/lib/reasoning-blocks.ts
+++ b/apps/desktop/src/lib/reasoning-blocks.ts
@@ -23,8 +23,8 @@
 //   2. prose-onto-heading   — `interaction!**Two**`.
 // Emphasis that legitimately follows whitespace is left alone, and a heading
 // must close on its own line to count as a summary part.
-const GLUED_HEADING_RUN = /(?<!\*)\*{4}(?!\*)/g
-const GLUED_AFTER_PROSE = /(?<=[^\s*])(\*\*(?=[^\s*])[^\n]*?\*\*)/g
+const GLUED_HEADING_RUN = /(?<!\*)(\*{4})(?!\*)/g
+const GLUED_AFTER_PROSE = /(?<=[^\s*])(\*\*(?=[^\s*])[^*\n]*\*\*)(?=\s*$)/gm
 
 export function separateGluedReasoningBlocks(text: string): string {
   return text.replace(GLUED_HEADING_RUN, '**\n\n**').replace(GLUED_AFTER_PROSE, '\n\n$1')


### PR DESCRIPTION
## Root cause

The second repair regex in `apps/desktop/src/lib/reasoning-blocks.ts` (`GLUED_AFTER_PROSE`) used lazy `[^\n]*?`, which could cross consecutive `**` pairs—from the close of one to the open of the next. When CJK text (no inter-word spaces) triggered the lookbehind on every inline bold, the injected `\n\n` broke the second pair mid-sentence:

```js
sep('1. **日経原因**（共同社）：指数重挫——**半導体領跌**——与美股同步。')
// before: "1. **日経原因\n\n**（共同社）：指数重挫——**半導体領跌**——与美股同步。"
// after:  unchanged (inline emphasis, not summary headings)
```

## Fix

```diff
-const GLUED_AFTER_PROSE = /(?<=[^\\s*])(\\*\\*(?=[^\\s*])[^\\n]*?\\*\\*)/g
+const GLUED_AFTER_PROSE = /(?<=[^\\s*])(\\*\\*(?=[^\\s*])[^*\\n]*\\*\\*)(?=\\s*$)/gm
```

1. `[^*\n]*` never crosses bold delimiters (replaced the lazy `[^\n]*?`).
2. `(?=\s*$)` with multiline anchors a line-final heading—matching the function's doc: "a heading must close on its own line."

## Testing

```shell
cd apps/desktop && npx vitest run src/lib/reasoning-blocks.test.ts
# Test Files  1 passed (1)
#      Tests  6 passed (6)
```

New tests cover:
- CJK inline bold preservation: `**日経原因**（…）**半導体領跌**`
- English inline bold preservation: `The **core issue** is…`
- `**First****Second**` split (kept)
- Line-final heading split: `interaction!**Heading at end**`
- Idempotence: pre-separated blocks unchanged

Fixes #107813.