### PR TITLE
fix(cli): skip non-gateway runtimes during fleet restart reconciliation (#107817)

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -137,7 +137,9 @@ def _receipt_reports_stale_runtime(expected_sha: str | None = None) -> bool:
     if not isinstance(plan, dict):
         return False
     return any(
-        isinstance(runtime, dict) and _sha_mismatch(runtime.get("code_sha"))
+        isinstance(runtime, dict)
+        and runtime.get("kind", "gateway") == "gateway"
+        and _sha_mismatch(runtime.get("code_sha"))
         for runtime in plan.get("runtimes") or []
     )
 
@@ -166,7 +168,9 @@ def _live_fleet_covers_receipt(expected_sha: str | None) -> bool:
                 return False
             kind = entry.get("kind", default_kind)
             profile = entry.get("profile")
-            if kind != "gateway" or not profile or profile == "unknown":
+            if kind != "gateway":
+                continue
+            if not profile or profile == "unknown":
                 return False
             owed.add((kind, profile))
         if not owed:

--- a/tests/hermes_cli/test_update_obligation_identity.py
+++ b/tests/hermes_cli/test_update_obligation_identity.py
@@ -47,7 +47,6 @@ def test_current_successors_settle_historical_obligations(monkeypatch, profiles)
         "down",
         "stale",
         "wrong-sha",
-        "wrong-kind",
         "unknown-profile",
         "marker",
     ],
@@ -59,8 +58,6 @@ def test_every_owed_identity_requires_current_evidence(monkeypatch, bad):
     if bad == "marker":
         (home / "fleet_restart_pending").write_text("expected_sha=new\n")
     owed = {"kind": "gateway", "profile": "beta", "code_sha": "old"}
-    if bad == "wrong-kind":
-        owed["kind"] = "serve"
     if bad == "unknown-profile":
         owed["profile"] = "unknown"
     (directory / "latest.json").write_text(
@@ -84,3 +81,25 @@ def test_every_owed_identity_requires_current_evidence(monkeypatch, bad):
     monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: "new")
     monkeypatch.setattr(update_receipt, "collect_fleet_versions", lambda: rows)
     assert update_cmd_fleet._pending_fleet_restart_needed()
+
+
+def test_non_gateway_runtimes_do_not_block_gateway_reconciliation(monkeypatch):
+    """Non-gateway runtimes (dashboard/serve) in update receipt plan do not block gateway fleet restart reconciliation (#107817)."""
+    home = get_hermes_home()
+    directory = home / "logs" / "update_receipts"
+    directory.mkdir(parents=True)
+    (directory / "latest.json").write_text(
+        json.dumps({
+            "outcome": "success",
+            "plan": {
+                "runtimes": [
+                    {"kind": "gateway", "profile": "default", "code_sha": "old"},
+                    {"kind": "dashboard", "profile": "default", "code_sha": "old"},
+                ]
+            },
+        })
+    )
+    rows = [{"profile": "default", "state": "current", "code_sha": "new"}]
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: "new")
+    monkeypatch.setattr(update_receipt, "collect_fleet_versions", lambda: rows)
+    assert not update_cmd_fleet._pending_fleet_restart_needed()


### PR DESCRIPTION
Fixes #107817

### Summary of Changes
- Updated \_live_fleet_covers_receipt\ and \_receipt_reports_stale_runtime\ in \hermes_cli/update_cmd_fleet.py\ to skip non-gateway runtimes (such as \dashboard\ or \serve\ entries in \plan.runtimes\) during fleet restart reconciliation.
- Added test \	est_non_gateway_runtimes_do_not_block_gateway_reconciliation\ in \	ests/hermes_cli/test_update_obligation_identity.py\ verifying that recording a non-gateway runtime does not leave a permanent pending gateway restart warning once gateways are updated.