### PR TITLE
test(auth): fix main-red anon-auth fixture after the per-profile token memo (#107611 × #107697)

### DIFF
--- a/tests/hermes_cli/test_anon_auth_core.py
+++ b/tests/hermes_cli/test_anon_auth_core.py
@@ -91,10 +91,10 @@ def portal(monkeypatch, tmp_path):
     anon_auth._mint_failed = False
     from hermes_cli import free_tier_bootstrap as _fb
     _fb.reset_for_tests()
-    # resolve_nous_access_token memoises the last token for 5 s across the process; a token minted
+    # resolve_nous_access_token memoises the last token for 5 s per profile home (dict); a token minted
     # by an earlier test must not be served to this one.
     from hermes_cli import auth as auth_mod
-    monkeypatch.setattr(auth_mod, "_RESOLVE_TOKEN_CACHE", None)
+    monkeypatch.setattr(auth_mod, "_RESOLVE_TOKEN_CACHE", {})
     return fake
 
 


### PR DESCRIPTION
Main is red after two same-hour merges disagreed on the shape of `hermes_cli/auth.py::_RESOLVE_TOKEN_CACHE`: #107697 added a test fixture resetting it to `None` (old single slot), #107611 made it a dict keyed by profile home. `resolve_nous_access_token` then does `None.get()` → two `test_anon_auth_core.py` tests fail on `main`.

- Fixture resets the memo to `{}` (2 lines).

| | before | after |
|---|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_anon_auth_core.py tests/hermes_cli/test_resolve_token_memo.py` | 2 failed on main | 38 passed |

Root cause: merge-order skew between #107697 and #107611, not a runtime defect (the fixture is test-only).

## Infographic
(test-only two-line fix; omitted)
