### PR TITLE
fix(desktop): restore minimized sessions from sidebar toggle

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -1673,6 +1673,11 @@ function paneGroup(paneId: string) {
   return tree ? findGroupOfPane(tree, paneId) : null
 }
 
+/** Whether the zone containing `paneId` is minimized to its rail/header. */
+export function isPaneZoneMinimized(paneId: string): boolean {
+  return Boolean(paneGroup(paneId)?.minimized)
+}
+
 /** Collapse/restore a pane's ZONE to a minimized rail — its tab stays visible.
  *  Store-driven (one-way): a tool panel's $open store mirrors here via
  *  bindPaneCollapse, so a toggle collapses rather than hides. */

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -2,7 +2,7 @@ import { atom, computed, type ReadableAtom, type WritableAtom } from 'nanostores
 
 import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '@/app/layout-constants'
 import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
-import { isPaneVisible, revealTreePane } from '@/components/pane-shell/tree/store'
+import { isPaneVisible, isPaneZoneMinimized, revealTreePane } from '@/components/pane-shell/tree/store'
 import { matchesQuery } from '@/hooks/use-media-query'
 import { connectionScopedAtom } from '@/lib/connection-scoped'
 import { type Codec, Codecs, persistentAtom } from '@/lib/persisted'
@@ -534,6 +534,18 @@ export function setSidebarOpen(open: boolean) {
 
 export function toggleSidebarOpen() {
   if (!revealNarrowPane(CHAT_SIDEBAR_PANE_ID, 'toggle')) {
+    // The zone chevron minimizes the Sessions group without changing the
+    // side's persisted open flag. In that state the titlebar still says
+    // "Hide sidebar", so blindly toggling the flag hides an already invisible
+    // zone and Cmd+B / the titlebar button appear dead even after a restart.
+    // Treat an open-but-not-visible Sessions pane as a reveal request first:
+    // un-minimize its group while preserving the user's persisted side choice.
+    if ($sidebarOpen.get() && isPaneZoneMinimized('sessions')) {
+      revealTreePane('sessions')
+
+      return
+    }
+
     togglePane(CHAT_SIDEBAR_PANE_ID)
   }
 }

--- a/apps/desktop/src/store/sidebar-collapse-persistence.test.ts
+++ b/apps/desktop/src/store/sidebar-collapse-persistence.test.ts
@@ -61,4 +61,36 @@ describe('sidebar collapse persistence', () => {
     s2.bind()
     expect(s2.leftCollapsed()).toBe(true)
   })
+
+  it('restores a minimized Sessions zone when the sidebar toggle still reads open', async () => {
+    const s = await loadStores()
+    const { findGroupOfPane, group, split } = await import('@/components/pane-shell/tree/model')
+    s.tree.declareDefaultTree(split('row', [group(['sessions']), group(['workspace'])], [1, 3]))
+    s.bind()
+
+    const sessions = findGroupOfPane(s.tree.$layoutTree.get()!, 'sessions')!
+    s.tree.setTreeGroupMinimized(sessions.id, true) // titlebar zone-chevron click
+
+    expect(s.layout.$sidebarOpen.get()).toBe(true)
+    expect(findGroupOfPane(s.tree.$layoutTree.get()!, 'sessions')?.minimized).toBe(true)
+
+    s.layout.toggleSidebarOpen()
+
+    expect(s.layout.$sidebarOpen.get()).toBe(true)
+    expect(findGroupOfPane(s.tree.$layoutTree.get()!, 'sessions')?.minimized).toBe(false)
+  })
+
+  it('still hides the sidebar when a visible sibling tab is active', async () => {
+    const s = await loadStores()
+    const { group, split } = await import('@/components/pane-shell/tree/model')
+    s.tree.declareDefaultTree(
+      split('row', [group(['sessions', 'hermes-bots:pane'], { active: 'hermes-bots:pane' }), group(['workspace'])], [1, 3])
+    )
+    s.bind()
+
+    s.layout.toggleSidebarOpen()
+
+    expect(s.layout.$sidebarOpen.get()).toBe(false)
+    expect(s.leftCollapsed()).toBe(true)
+  })
 })


### PR DESCRIPTION
## What does this PR do?

Clicking the downward chevron at the far right of the SESSIONS / BOTS / TERMINAL tab row minimizes that pane group while the separate sidebar visibility setting remains open. The titlebar sidebar toggle and Cmd+B then appear unresponsive because they only toggle the outer sidebar setting and never clear the persisted group-minimized state. Restarting restores both persisted values and reproduces the same unusable layout.

This change makes the existing sidebar toggle restore the minimized Sessions zone when the outer sidebar is already marked open. It preserves the chevron's persistent minimize behavior and adds no new button.

## Related Issue

Fixes #106009

Related reports: #107196, #107774

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/store.ts`: expose whether a pane's zone is minimized, independently of the active sibling tab.
- `apps/desktop/src/store/layout.ts`: restore a minimized Sessions zone from the existing sidebar toggle or Cmd+B when the outer sidebar is already open.
- `apps/desktop/src/store/sidebar-collapse-persistence.test.ts`: cover the persisted downward-chevron state and retain normal hide behavior when Bots is the active sibling.

## How to Test

1. Launch Hermes Desktop and keep the left sidebar open.
2. Click the downward chevron at the far right of the SESSIONS / BOTS / TERMINAL tab row; confirm that pane group is minimized.
3. Click the existing titlebar sidebar toggle, or press Cmd+B; confirm the full Sessions sidebar is restored in one action.
4. Restart after minimizing and repeat step 3; confirm the persisted state is recoverable.
5. Select Bots without minimizing the zone, then use the sidebar toggle; confirm it still hides the sidebar normally.

Automated validation:

- `npm test -- --run --project ui src/store/sidebar-collapse-persistence.test.ts` — 4 passed
- `npx eslint src/components/pane-shell/tree/store.ts src/store/layout.ts src/store/sidebar-collapse-persistence.test.ts --quiet` — passed
- `npm run typecheck` — passed
- `git diff --check` — passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run; this is a desktop TypeScript-only change, with targeted UI tests and typecheck run above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5, Apple silicon, locally packaged Electron app

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing API or configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — shared renderer/store logic, no platform-specific behavior added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool behavior changed

## Screenshots / Logs

Manual packaged-app verification on macOS 26.5:

- Reproduced the persisted broken state by clicking the downward chevron at the far right of the SESSIONS / BOTS / TERMINAL tab row.
- Verified the existing titlebar sidebar button restores the full Sessions pane in one click.
- Verified the app remained connected and the gateway returned to Ready.

The regression test output is included under **How to Test** above.
