### PR TITLE
main is green again: anon-auth fixture resets the token memo to its dict shape

### DIFF
--- a/tests/hermes_cli/test_anon_auth_core.py
+++ b/tests/hermes_cli/test_anon_auth_core.py
@@ -94,7 +94,7 @@ def portal(monkeypatch, tmp_path):
     # resolve_nous_access_token memoises the last token for 5 s across the process; a token minted
     # by an earlier test must not be served to this one.
     from hermes_cli import auth as auth_mod
-    monkeypatch.setattr(auth_mod, "_RESOLVE_TOKEN_CACHE", None)
+    monkeypatch.setattr(auth_mod, "_RESOLVE_TOKEN_CACHE", {})
     return fake
 
 


### PR DESCRIPTION
`tests/hermes_cli/test_anon_auth_core.py` is green again on main (2 tests were red: `test_tool_gateway_token_path_reexchanges`, `test_connector_path_replaces_a_dead_credential_once`).

Two PRs crossed: #107611 changed `hermes_cli.auth._RESOLVE_TOKEN_CACHE` from `Optional[tuple]` to a per-profile `dict`; #107697, merged an hour later from an older base, added a fixture resetting it to `None`. `resolve_nous_access_token` raised `AttributeError: 'NoneType' object has no attribute 'get'`, `read_nous_access_token` swallowed it and handed back the expired token.

Test-only, one token: reset to `{}` (matching `test_resolve_token_memo.py` and `test_nous_portal_staging_allowlist.py`). No production change.

| Check | Before | After |
|---|---|---|
| `test_anon_auth_core.py` + `test_resolve_token_memo.py` | 2 failed | 38 passed |

Surfaced as an unrelated red on #107815.
