### PR TITLE
fix(tools): malformed plugin tool schemas are rejected at registration, not at the provider (port pi#9300)

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -6,6 +6,8 @@ import threading
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from tools.registry import (
     ToolRegistry,
     _MAX_LOGGED_ERROR_CHARS,
@@ -39,6 +41,23 @@ class TestRegisterAndDispatch:
         )
         result = json.loads(reg.dispatch("alpha", {}))
         assert result == {"ok": True}
+
+    def test_register_rejects_non_dict_parameters(self):
+        """A list/str ``parameters`` fails at registration, not in a provider request (pi acaa253cc)."""
+        reg = ToolRegistry()
+        bad = {"name": "bad", "description": "x", "parameters": ["not", "an", "object"]}
+        with pytest.raises(ValueError, match="parameters"):
+            reg.register(name="bad", toolset="core", schema=bad, handler=_dummy_handler)
+        assert reg.get_entry("bad") is None
+
+    def test_register_rejects_non_dict_schema(self):
+        reg = ToolRegistry()
+        with pytest.raises(ValueError, match="schema must be a dict"):
+            reg.register(name="bad2", toolset="core", schema=None, handler=_dummy_handler)
+        # Omitted parameters stays allowed (some tools take no arguments).
+        reg.register(name="noargs", toolset="core",
+                     schema={"name": "noargs", "description": "x"}, handler=_dummy_handler)
+        assert reg.get_entry("noargs") is not None
 
 
     def test_cross_mcp_toolsets_do_not_overwrite_atomically(self, caplog):

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -602,6 +602,17 @@ class ToolRegistry:
         """Register a tool (called at import time by each tool file). ``override=True`` is an
         explicit opt-in for plugins replacing a built-in implementation (e.g. a headed-Chrome
         browser backend); without it, cross-toolset shadowing is rejected."""
+        # Reject malformed schemas at registration, not at request time: a non-dict
+        # ``parameters`` (e.g. a list) serializes into every provider request and 400s the
+        # whole turn far from the offending plugin. Failing here names the culprit instead.
+        if not isinstance(schema, dict):
+            raise ValueError(
+                f"Tool {name!r}: schema must be a dict, got {type(schema).__name__}")
+        params = schema.get("parameters")
+        if params is not None and not isinstance(params, dict):
+            raise ValueError(
+                f"Tool {name!r}: schema['parameters'] must be an object (JSON Schema dict), "
+                f"got {type(params).__name__}")
         handler_owner = self._plugin_owner_of(handler)
         caller_owner = self._plugin_namespace_of_module(self._caller_module())
         owner = caller_owner or handler_owner


### PR DESCRIPTION
A plugin registering a tool with a malformed `parameters` schema no longer poisons every provider request — it is rejected at registration with the tool named in the error.

## What changed
- `tools/registry.py::ToolRegistry.register` validates the schema shape up front: `schema` must be a dict, and `schema["parameters"]`, when present, must be a dict (JSON Schema object). Violations raise `ValueError` naming the tool.
- Schemas that omit `parameters` remain valid (no-argument tools).
- 2 invariant tests in `tests/tools/test_registry.py`, sabotage-proven (red with the fix reverted).

## Root cause
`register()` accepted any schema object; a non-dict `parameters` flowed unchanged through `model_tools._fn_def()` into the OpenAI wire and 400'd the whole turn at the provider, far from the offending plugin.

## Why registration-time is the right seam
- The plugin loader already catches registration exceptions and marks the plugin errored (`hermes_cli/plugins_loader.py` failure path sweeps its registrations), so a broken plugin degrades gracefully instead of breaking every session.
- MCP tools are unaffected: their schemas pass through `_normalize_mcp_input_schema()` first, which always returns a dict.
- All 89 built-in tools register cleanly (verified live).

## Live repro
**Live repro:** before — on `origin/main`, registering `{"parameters": ["not", "an", "object"]}` succeeded and the list flowed into `_fn_def()` / the OpenAI tool definition unchanged (probe output in-session); after — the same registration raises `ValueError: Tool 'bad_tool': schema['parameters'] must be an object (JSON Schema dict), got list`, the tool is absent from the registry, and a no-`parameters` schema still registers.

## Validation
| Check | Result |
|---|---|
| `tests/tools/test_registry.py` | 41 passed |
| Sabotage (fix reverted) | 2 new tests fail |
| E2E: fresh imports, temp `HERMES_HOME`, full builtin discovery | 89 tools, negative + positive paths pass |
| `tests/tools/` full dir | 5 failures, all pre-existing on base (fail with change stashed) |
| ruff / windows-footguns / compat pointers / `git diff --check` | clean |

Port of earendil-works/pi acaa253cc ("validate extension tool parameter schemas", fixes pi#9300), adapted to hermes' registry seam. Found by the weekly Pi Agent PR scout.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9ef5a/6TRp923bqaw7Wi8oLEEx1_nxFcszKK.png)
