### PR TITLE
fix(custom): respect supports_reasoning and explicit model overrides (#107221)

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -36,6 +36,22 @@ class CustomProfile(ProviderProfile):
         top_level: dict[str, Any] = {}
         if ollama_num_ctx:
             extra_body["options"] = {"num_ctx": ollama_num_ctx}
+
+        supports_reasoning = ctx.get("supports_reasoning")
+        model = ctx.get("model")
+        provider = ctx.get("provider") or "custom"
+        if model and supports_reasoning is not False:
+            try:
+                from agent.models_dev import _explicit_model_override
+                ov = _explicit_model_override(provider, model)
+                if ov and ov.get("supports_reasoning") is False:
+                    supports_reasoning = False
+            except Exception:
+                pass
+
+        if supports_reasoning is False:
+            return extra_body, top_level
+
         # disabled -> top-level reasoning_effort="none" (Ollama's /v1 ignores
         # extra_body.think) plus think=False only on Ollama URLs; enabled+effort ->
         # top-level reasoning_effort clamped to the OpenAI-compat wire (GLM/ARK,

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -169,6 +169,32 @@ class TestCustomReasoningWireShape:
         )
         assert eb.get("think") is not True
 
+    def test_supports_reasoning_false_omits_reasoning_params(self, custom_profile):
+        """When supports_reasoning is False, omit top-level reasoning_effort and think."""
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="non-thinking-model",
+            supports_reasoning=False,
+            base_url="http://127.0.0.1:11434/v1",
+        )
+        assert "reasoning_effort" not in tl
+        assert "think" not in eb
+
+    def test_supports_reasoning_override_false_omits_reasoning_params(self, custom_profile, monkeypatch):
+        """When explicit model override disables reasoning, omit reasoning params."""
+        monkeypatch.setattr(
+            "agent.models_dev._explicit_model_override",
+            lambda provider, model: {"supports_reasoning": False} if model == "override-no-reason" else None,
+        )
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="override-no-reason",
+            provider="custom",
+            base_url="http://127.0.0.1:11434/v1",
+        )
+        assert "reasoning_effort" not in tl
+        assert "think" not in eb
+
 
 class TestCustomReasoningWithNumCtx:
     """Ollama num_ctx and reasoning are independent and compose."""
@@ -179,4 +205,5 @@ class TestCustomReasoningWithNumCtx:
         )
         assert eb == {"options": {"num_ctx": 8192}}
         assert tl == {}
+
 


### PR DESCRIPTION
Fixes #107221

### Summary
When configured models on custom OpenAI-compatible providers (Ollama, vLLM, llama.cpp) explicitly specify \supports_reasoning: false\ or pass \supports_reasoning=False\, \CustomProfile.build_api_kwargs_extras\ currently still emits top-level \easoning_effort\ or \	hink\ parameters. This causes local servers like Ollama/vLLM to reject completion calls with HTTP 400 (\BadRequestError: think value is not supported for this model\).

### Changes
1. Check \supports_reasoning\ in \CustomProfile.build_api_kwargs_extras\.
2. Inspect \_explicit_model_override(provider, model)\ to verify if \supports_reasoning\ is set to \False\ in model overrides.
3. Skip emitting \easoning_effort\ or \	hink\ wire parameters when reasoning is disabled for the model.
4. Added unit tests in \	ests/plugins/model_providers/test_custom_profile.py\.