### PR TITLE
fix(tui_gateway): handle deleted profiles gracefully in _response_profile_name (#107829)

### DIFF
--- a/tests/tui_gateway/test_default_profile_session_name.py
+++ b/tests/tui_gateway/test_default_profile_session_name.py
@@ -168,3 +168,16 @@ def test_custom_default_root_real_session_db_owner_stamping(tmp_path, monkeypatc
         assert launch_db.get_session("lazy-default") is None
         assert launch_db.get_session("seeded-default") is None
         assert launch_db.get_session("branched-default") is None
+
+
+def test_deleted_profile_falls_back_to_current_profile(tmp_path, monkeypatch):
+    """Deleted/non-existent profiles must not raise FileNotFoundError in _response_profile_name."""
+    from tui_gateway import server
+
+    default_home, launch_home = _profile_layout(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+
+    assert server._response_profile_name("non-existent-profile-123") == server._current_profile_name()
+

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -462,7 +462,12 @@ def _canonical_profile_request(name: str) -> str:
 def _response_profile_name(profile: str | None = None) -> str:
     """Profile name for session.* payloads: the requested real non-launch profile, else the launch one."""
     name = _canonical_profile_request((profile or "").strip())
-    return name if name and _profile_home(name) is not None else _current_profile_name()
+    if not name:
+        return _current_profile_name()
+    try:
+        return name if _profile_home(name) is not None else _current_profile_name()
+    except FileNotFoundError:
+        return _current_profile_name()
 
 
 def _db_unavailable_error(rid, *, code: int):


### PR DESCRIPTION
Fixes #107829

### Summary
When a desktop or gateway client requests a session operation carrying a profile reference that was deleted while the client held a reference to it, \_response_profile_name()\ calls \_profile_home(name)\ which raises \FileNotFoundError\. This exception escapes the RPC handler and causes a WebSocket dispatch crash (\ws dispatch crash peer=...\).

### Changes
1. Safely catch \FileNotFoundError\ in \_response_profile_name\ and return \_current_profile_name()\.
2. Add regression unit test in \	ests/tui_gateway/test_default_profile_session_name.py\.