### PR TITLE
docs(skills): route har-derived-api-client by trigger, add non-use scope

### DIFF
--- a/optional-skills/web-development/har-derived-api-client/SKILL.md
+++ b/optional-skills/web-development/har-derived-api-client/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: har-derived-api-client
-description: Record a site's XHR into a HAR, derive an HTTP client.
+description: Use when a site has no public API but fetches JSON.
 version: 0.1.0
 author: Hermes Agent
 license: MIT
@@ -37,6 +37,26 @@ HAR recording works differently in each case (see How to Run).
 - You're about to loop `browser_navigate` for the same query repeatedly — stop and derive the endpoint once.
 - Reverse-engineering an autocomplete, search, feed, or checkout XHR.
 - You captured a session on a cloud backend (Browserbase / Browser-Use / Firecrawl) or via `/browser connect` and want the API without re-renting the browser.
+
+## When NOT to Use
+
+Reach for this only when the payoff is a *repeated, browserless* call to a JSON
+endpoint you cannot otherwise reach. Do not use it when:
+
+- **The page is server-rendered.** No XHR means nothing to derive (`har_to_client.py` prints "No API-looking entries"). Scrape the HTML instead.
+  - *Observed 2026-09-10 (Goodreads):* the CAPTURE succeeded — 730 KB HAR, headed browser cleared the WAF — and the derive step still found nothing, because Goodreads delivers its data in HTML. The skill was no help for that job; HTML parsing was. **Cheap pre-flight: confirm a JSON XHR actually fires before paying for a capture.**
+- **A public/official API exists** (docs, OpenAPI, a documented REST endpoint). Use it.
+- **You need one or two page reads.** `browser_navigate` or a plain HTTP GET is cheaper than installing Playwright and standing up a real browser for a one-off.
+- **You were handed a `.har` file to read or analyze.** That is ordinary JSON analysis — load it and answer; you do not need the capture half (you may still reuse `har_to_client.py` for the parsing).
+- **The data is already fetchable** with a single unauthenticated GET (RSS, sitemap, public JSON). Capture is overhead.
+- **You need to get past login, CAPTCHA, or bot detection.** This skill carries the session you already have; it does not forge or bypass one.
+- **The interaction is a write, checkout, or anything irreversible.** Replaying a captured mutating endpoint is riskier than doing it once by hand; derive read paths only.
+- **You cannot launch a browser locally and have no reachable CDP endpoint.** Capture is impossible in that configuration.
+
+Cost reality check: the capture step needs Playwright plus a browser binary
+(heavy install) and a real page load. If the goal is a single answer, the
+browser tool is the cheaper path; if the goal is a *client* that runs many
+times a day, this skill pays for itself immediately.
 
 ## Prerequisites
 


### PR DESCRIPTION
## What does this PR do?

`har-derived-api-client` states what it does but not **when** to reach for it, and it never says when it is the wrong tool. In a live session the skill went unused on a job it might have helped with — the agent had no routing signal, because the only thing the skill index shows is the description line.

This PR fixes the routing signal and adds an explicit non-use scope. No behavior change: prose only, one file.

## Related Issue

No issue — docs improvement. Happy to open one first if that is preferred.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `optional-skills/web-development/har-derived-api-client/SKILL.md`
  - `description:` → `Use when a site has no public API but fetches JSON.` (51 chars, trigger-first, meets the ≤60 authoring standard). Was `Record a site's XHR into a HAR, derive an HTTP client.`
  - New `## When NOT to Use` section, placed after `## When to Use` (existing section order preserved), covering: server-rendered pages, an existing public API, one-off reads, a `.har` handed over for analysis, already-fetchable data, auth/CAPTCHA/bot-wall bypass, mutating or irreversible endpoints, and no reachable browser.
  - Records the observed case that motivated it: capture succeeded (730 KB HAR, headed browser cleared the WAF) but derivation found no XHR API, because the site is server-rendered — plus the cheap pre-flight that avoids paying for the capture.

## How to Test

1. Assert the description line is ≤60 chars (it is 51).
2. `scripts/run_tests.sh tests/skills/test_har_derived_api_client_skill.py tests/skills/test_authoring_standards.py -q` → **1205 passed** (structural/frontmatter contract + authoring standards, including the description-length rule).
3. Read the rendered section: it sits between `## When to Use` and `## Prerequisites`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — the open PRs on this skill address capture/derivation bugs and credential leakage; this one is scoped to routing + non-use guidance and does not touch the scripts
- [x] My PR contains only changes related to this fix (one file, based on current `main`)
- [x] I've run `pytest tests/ -q` on the affected suites: `test_har_derived_api_client_skill.py` + `test_authoring_standards.py` → 1205 passed
- [x] Tests: covered by the existing authoring-standards suite (description length, frontmatter, section order); no new test needed for prose
- [x] Tested on macOS 26.6

### Documentation & Housekeeping

- [x] This PR *is* the documentation change — N/A otherwise
- [x] No config keys added — N/A
- [x] No architecture/workflow change — N/A
- [x] Cross-platform impact: none (markdown prose only)
