### PR TITLE
fix(anthropic): fall back to messages.create() when streaming fails on malformed JSON (#107830)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -666,6 +666,12 @@ def create_anthropic_message(
             return _stream_final_message(stream_fn, api_kwargs, log_prefix, on_stream_event, on_response)
         except TimeoutError:
             raise
+        except (ValueError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "%sAnthropic Messages stream failed with JSON parse error (%s); falling back to non-streaming messages.create()",
+                log_prefix,
+                exc,
+            )
         except Exception as exc:
             if not _is_stream_unavailable_error(exc):
                 raise

--- a/tests/agent/test_aux_stream_host_deadline_sibling_wires.py
+++ b/tests/agent/test_aux_stream_host_deadline_sibling_wires.py
@@ -187,3 +187,37 @@ def test_anthropic_stream_without_host_deadline_runs_to_completion():
         )
     assert message.content[0].text == "summary"
     assert stream.yielded == 5
+
+
+def test_anthropic_stream_json_parse_error_falls_back_to_create():
+    """ValueError / JSONDecodeError during streaming must fall back to messages.create()."""
+    class FailingStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def __iter__(self):
+            raise ValueError("expected value at line 1 column 11")
+
+        def get_final_message(self):
+            raise ValueError("expected value at line 1 column 11")
+
+    expected_msg = SimpleNamespace(content=[SimpleNamespace(type="text", text="repaired_result")])
+    create_called = {"v": False}
+
+    def _mock_create(**_kw):
+        create_called["v"] = True
+        return expected_msg
+
+    client = SimpleNamespace(
+        messages=SimpleNamespace(
+            stream=lambda **_kw: FailingStream(),
+            create=_mock_create,
+        )
+    )
+    res = create_anthropic_message(client, {"model": "claude-sonnet-4-5", "messages": []})
+    assert res == expected_msg
+    assert create_called["v"] is True
+


### PR DESCRIPTION
Fixes #107830

### Summary
When using the `fine-grained-tool-streaming-2025-05-14` beta header with Anthropic's API, the Anthropic SDK incrementally parses streamed tool call JSON deltas via `from_json(..., partial_mode=True)`. When the model emits malformed JSON (e.g. `{"names": cronjob_manage}`), the incremental parser raises `ValueError: expected value at line 1 column 11`. Because `create_anthropic_message()` did not catch `ValueError` or `json.JSONDecodeError`, this exception was unhandled, causing turns to fail permanently after 3 retries and rendering gateways silent.

### Changes
1. In `create_anthropic_message()`, catch `ValueError` and `json.JSONDecodeError` thrown during stream consumption and fall back to non-streaming `messages.create()`.
2. `messages.create()` relies on Anthropic's server-side repair pass which fixes malformed JSON tool calls before returning the response.
3. Added unit test in `tests/agent/test_aux_stream_host_deadline_sibling_wires.py`.
