### PR TITLE
fix(tests): main is red — stale memo resetter + banner tests mocking the wrong seam

### DIFF
--- a/tests/hermes_cli/test_anon_auth_core.py
+++ b/tests/hermes_cli/test_anon_auth_core.py
@@ -94,7 +94,7 @@ def portal(monkeypatch, tmp_path):
     # resolve_nous_access_token memoises the last token for 5 s across the process; a token minted
     # by an earlier test must not be served to this one.
     from hermes_cli import auth as auth_mod
-    monkeypatch.setattr(auth_mod, "_RESOLVE_TOKEN_CACHE", None)
+    monkeypatch.setattr(auth_mod, "_RESOLVE_TOKEN_CACHE", {})
     return fake
 
 

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -64,7 +64,7 @@ def test_check_via_local_git_ssh_fastpath_ahead_not_behind(tmp_path):
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
-        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        patch.object(banner, "_github_branch_tip", return_value="a" * 40),
         # merge-base --is-ancestor exits 0: upstream tip IS an ancestor of HEAD
         patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=0)),
     ):
@@ -91,7 +91,7 @@ def test_check_via_local_git_ssh_fastpath_genuinely_behind(tmp_path):
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
-        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        patch.object(banner, "_github_branch_tip", return_value="a" * 40),
         # merge-base --is-ancestor exits 1: not an ancestor -> genuinely behind
         patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=1)),
         patch.object(banner, "_github_compare_behind", return_value=3),
@@ -119,7 +119,7 @@ def test_check_via_local_git_ssh_fastpath_offline_keeps_sentinel(tmp_path):
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
-        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        patch.object(banner, "_github_branch_tip", return_value="a" * 40),
         patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=1)),
         patch.object(banner, "_github_compare_behind", return_value=None),
     ):


### PR DESCRIPTION
Main's Python tests are red with two independent test-only breakages; this restores green. Both reproduce with an empty diff, so every open PR currently fails CI (e.g. #107825 hit both).

## Fix 1 — anon-auth fixture resets the token memo to a dead shape
#173105ce6f4 changed `_RESOLVE_TOKEN_CACHE` from a single tuple slot to a dict keyed by `hermes_home_key()`, updating the resetters in `test_resolve_token_memo.py` and `test_nous_portal_staging_allowlist.py` — but missed the third in `test_anon_auth_core.py`, which still set the memo to `None`. The new `_RESOLVE_TOKEN_CACHE.get(cache_key)` then raises `AttributeError: 'NoneType' object has no attribute 'get'` (2 failures). One line: reset to `{}`. Repo-wide grep confirms no other `None` resetters remain.

## Fix 2 — banner SSH fast-path tests mock a function production never calls
The three `test_check_via_local_git_ssh_fastpath_*` tests (from 338bf9ea9ac) patch `banner._upstream_main_sha`, but `_check_via_local_git` never calls it — for a github.com origin it calls `_github_branch_tip` directly. The tests pass only when the runner's UNMOCKED anonymous `api.github.com` request happens to succeed; CI runners are rate-limited, `_github_branch_tip` returns `None`, and all three fail (`assert None == 0 / 3 / -1`). Patch `_github_branch_tip` instead — the seam production reads. This is exactly the "patch where production reads" class from AGENTS.md.

**Live repro:**
- Fix 1: on `origin/main`, `scripts/run_tests.sh tests/hermes_cli/test_anon_auth_core.py` → 2 failed with `hermes_cli/auth.py:1639 AttributeError`; after → 0 failed.
- Fix 2: simulating the rate-limited API locally (`_github_branch_tip → None`, original patches in place) reproduces CI's `assert None == 0`; with the corrected patch target the tests pass with NO live network (verified under a dead `https_proxy`). CI itself showed all three failing on both attempts of two unrelated PRs.

## Validation
| Check | Result |
|---|---|
| 4 touched test files (`anon_auth_core`, `resolve_token_memo`, `nous_portal_staging_allowlist`, `banner_git_state`) | 48 passed, 0 failed |
| `banner_git_state` under dead `https_proxy` (no network) | 6 passed |
| ruff | clean |

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9ef9f/GQDWZ0u9_6zu7Xt6ucf2D_XqIlHdD1.png)
