### PR TITLE
fix(tools): make DaemonThreadPoolExecutor compatible with Python 3.14+ (#107121)

### DIFF
--- a/tests/tools/test_daemon_pool.py
+++ b/tests/tools/test_daemon_pool.py
@@ -93,7 +93,27 @@ def test_submit_propagates_caller_contextvars():
         pool.shutdown(wait=True)
 
 
+def test_python314_compat_missing_initializer_attributes():
+    """Python 3.14 ThreadPoolExecutor removes _initializer / _initargs attributes.
+
+    DaemonThreadPoolExecutor._adjust_thread_count must not raise AttributeError.
+    """
+    pool = DaemonThreadPoolExecutor(max_workers=2)
+    try:
+        # Simulate Python 3.14 where ThreadPoolExecutor instance lacks _initializer and _initargs
+        if hasattr(pool, "_initializer"):
+            delattr(pool, "_initializer")
+        if hasattr(pool, "_initargs"):
+            delattr(pool, "_initargs")
+
+        res = pool.submit(lambda: 42).result(timeout=10)
+        assert res == 42
+    finally:
+        pool.shutdown(wait=True)
+
+
 def _repo_root():
     import pathlib
 
     return pathlib.Path(__file__).resolve().parents[2]
+

--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -50,7 +50,12 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
             # right profile (#54937).
             t = threading.Thread(
                 name=thread_name, target=_worker, daemon=True,
-                args=(weakref.ref(self, weakref_cb), self._work_queue, self._initializer, self._initargs),
+                args=(
+                    weakref.ref(self, weakref_cb),
+                    self._work_queue,
+                    getattr(self, "_initializer", None),
+                    getattr(self, "_initargs", ()),
+                ),
             )
             t.start()
             self._threads.add(t)


### PR DESCRIPTION
Fixes #107121

### Summary
In CPython 3.14+, `ThreadPoolExecutor` removed the internal `_initializer` and `_initargs` attributes. When Hermes runs on Python 3.14+ (or when invoked via system Python 3.14), `DaemonThreadPoolExecutor._adjust_thread_count()` raised an `AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'`.

### Changes
1. Use `getattr(self, "_initializer", None)` and `getattr(self, "_initargs", ())` in `DaemonThreadPoolExecutor._adjust_thread_count()`.
2. Add unit test `test_python314_compat_missing_initializer_attributes` in `tests/tools/test_daemon_pool.py`.
