### PR TITLE
fix(cron): do not treat a busy fire fence as ownership loss

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -87,6 +87,9 @@ _jobs_lock_state = threading.local()
 _fire_fence_locks: Dict[str, threading.RLock] = {}
 _fire_fence_locks_guard = threading.Lock()
 _fire_fence_lock_state = threading.local()
+# Who currently holds each in-process fire fence (thread name/ident + monotonic start).
+# Logged on acquire timeout so a 30s fail-closed is attributable, not just "the lock key".
+_fire_fence_holders: Dict[str, Dict[str, Any]] = {}
 
 # Upper bound on waiting for the cross-process .jobs.lock. Every cron function funnels through
 # _jobs_lock(), so blocking forever on a wedged sibling process would freeze the ticker and every
@@ -299,7 +302,22 @@ def _fire_job_lock(job_id: str):
         local_lock = _fire_fence_locks.setdefault(lock_key, threading.RLock())
 
     if not local_lock.acquire(timeout=_JOBS_LOCK_TIMEOUT_SECONDS):
-        logger.error("Timed out waiting for local fire fence %s; failing closed", lock_key)
+        holder = _fire_fence_holders.get(lock_key) or {}
+        held_for = (
+            time.monotonic() - float(holder["since"])
+            if "since" in holder else -1.0
+        )
+        logger.error(
+            "Timed out waiting for local fire fence %s after %.1fs; failing closed "
+            "(holder_thread=%s holder_ident=%s held_for=%.1fs wait_thread=%s wait_ident=%s)",
+            lock_key,
+            _JOBS_LOCK_TIMEOUT_SECONDS,
+            holder.get("thread", "?"),
+            holder.get("ident", "?"),
+            held_for,
+            threading.current_thread().name,
+            threading.get_ident(),
+        )
         yield False
         return
 
@@ -310,6 +328,13 @@ def _fire_job_lock(job_id: str):
         finally:
             local_lock.release()
         return
+
+    with _fire_fence_locks_guard:
+        _fire_fence_holders[lock_key] = {
+            "thread": threading.current_thread().name,
+            "ident": threading.get_ident(),
+            "since": time.monotonic(),
+        }
 
     try:
         ensure_dirs()
@@ -339,6 +364,8 @@ def _fire_job_lock(job_id: str):
                 else:
                     lock_fd.close()
     finally:
+        with _fire_fence_locks_guard:
+            _fire_fence_holders.pop(lock_key, None)
         local_lock.release()
 
 
@@ -2592,11 +2619,20 @@ def claim_job_for_fire(
 
 def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
     """Refresh an active ``fire_claim`` without extending another owner's lease: an execution may
-    outlive the TTL, and the owner check stops a stale runner from refreshing a recovered claim."""
+    outlive the TTL, and the owner check stops a stale runner from refreshing a recovered claim.
+
+    A local fire-fence timeout is not ownership loss. Delivery holds that fence across Discord
+    send; the heartbeat thread then times out at 30s and must skip this refresh rather than
+    interrupt a still-owned run. Return True so the scheduler does not set lost_ownership.
+    Owner mismatch after acquiring the fence still returns False.
+    """
     def apply(jobs, _i, job):
         return _refresh_claim(jobs, job.get("fire_claim"), expected_owner)
 
-    return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
+    with _fire_job_lock(job_id) as acquired:
+        if not acquired:
+            return True
+        return _with_job(job_id, apply, False)
 
 
 # Completed one-shots are retained in jobs.json (final status stays inspectable) and pruned by

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -242,6 +242,76 @@ def test_same_process_fire_fence_refuses_second_claim_after_timeout(temp_home, m
     assert jobs.claim_job_for_fire(job["id"]) is True
 
 
+def test_fire_fence_timeout_logs_holder_thread(temp_home, monkeypatch, caplog):
+    """A 30s local-fence timeout must name the holder thread, not only the lock key."""
+    import logging
+    import cron.jobs as jobs
+
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="fence-holder-log")
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.15)
+    caplog.set_level(logging.ERROR, logger="cron.jobs")
+    holder_ready = threading.Event()
+    waiter_done = threading.Event()
+    result = {}
+
+    def holder():
+        with jobs._fire_job_lock(job["id"]) as acquired:
+            assert acquired is True
+            holder_ready.set()
+            time.sleep(0.45)
+
+    def waiter():
+        assert holder_ready.wait(timeout=2)
+        with jobs._fire_job_lock(job["id"]) as acquired:
+            result["acquired"] = acquired
+        waiter_done.set()
+
+    holder_thread = threading.Thread(name="fence-holder", target=holder)
+    waiter_thread = threading.Thread(name="fence-waiter", target=waiter)
+    holder_thread.start()
+    waiter_thread.start()
+    assert waiter_done.wait(timeout=3), "waiter did not finish after fence timeout"
+    holder_thread.join(timeout=2)
+    waiter_thread.join(timeout=2)
+    assert result.get("acquired") is False
+    text = caplog.text
+    assert "holder_thread=fence-holder" in text, text
+    assert "wait_thread=fence-waiter" in text, text
+    assert "held_for=" in text, text
+
+
+def test_heartbeat_during_held_fire_fence_is_not_ownership_loss(temp_home, monkeypatch):
+    """A heartbeat that cannot acquire the local fire fence is not a stolen claim.
+
+    Delivery holds that fence across Discord/Telegram send. The 60s heartbeat
+    thread then times out at 30s, returns False, and the scheduler marks
+    last_status=error AFTER a successful deliver. Live: GitHub Pulse 434a5159ba47
+    2026-09-09/10. Fence timeout is not owner mismatch.
+    """
+    import cron.jobs as jobs
+
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="heartbeat-during-deliver")
+    assert jobs.claim_job_for_fire(job["id"]) is True
+    owner = jobs.get_job(job["id"])["fire_claim"]["by"]
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.15)
+    holder_ready = threading.Event()
+    result = {}
+
+    def holder():
+        with jobs._fire_job_lock(job["id"]) as acquired:
+            assert acquired is True
+            holder_ready.set()
+            time.sleep(0.45)
+
+    holder_thread = threading.Thread(name="deliver-holder", target=holder)
+    holder_thread.start()
+    assert holder_ready.wait(timeout=2), "holder did not acquire the fire fence"
+    result["heartbeat"] = jobs.heartbeat_fire_claim(job["id"], expected_owner=owner)
+    holder_thread.join(timeout=2)
+    assert result["heartbeat"] is True
+    assert jobs.get_job(job["id"])["fire_claim"]["by"] == owner
+
+
 def test_same_thread_fire_fence_reentrancy_preserves_ownership(temp_home):
     """Nested same-thread callers retain the existing fire fence."""
     import cron.jobs as jobs


### PR DESCRIPTION
## Bug Description

`heartbeat_fire_claim()` returns `False` when the 30s local fire-fence acquire times out. The scheduler treats that as ownership loss:

```python
if not heartbeat_fire_claim(job_id, expected_owner=owner):
    lost_ownership.set()
```

A run that still owns the claim and later delivers successfully is then recorded as `last_status=error`.

Related: #100401, #106737, #100418, #106745

## Root Cause

The run thread holds `_fire_job_lock` across delivery I/O. The heartbeat runs on a different thread, so the RLock's thread-local reentrancy does not apply. A send slower than 30s makes the heartbeat time out. That timeout is not an owner mismatch.

## Fix

- If the local fire fence is not acquired, skip this refresh and return `True`. The holder still owns the claim; the same fence excludes other claimers.
- Owner mismatch after acquiring the fence still returns `False`.
- On fence timeout, log the holder thread/ident and wait thread so the fail-closed path is attributable.

## How to Verify

1. `scripts/run_tests.sh tests/cron/test_claim_job_for_fire.py tests/cron/test_script_claim_heartbeat.py tests/cron/test_shutdown_interrupt.py`
2. Confirm `test_heartbeat_during_held_fire_fence_is_not_ownership_loss` (heartbeat returns `True` while another thread holds the fence; claim owner unchanged).
3. Confirm `test_fire_fence_timeout_logs_holder_thread`.
4. Existing owner-mismatch and shutdown-interrupt tests still pass.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass (61 passed in the three cron files above)
- [ ] Manual verification of the fix

## Risk Assessment

Low — blast radius is `heartbeat_fire_claim` only. `claim_job_for_fire` / `mark_job_run` still fail closed on fence timeout. Skipping one TTL refresh while the fence is held cannot let another process steal the claim, because they need that same fence.
