### PR TITLE
fix(computer_use): honor --yolo / approvals.mode=off in the CLI approval gate

### DIFF
--- a/tests/tools/test_computer_use_yolo_bypass.py
+++ b/tests/tools/test_computer_use_yolo_bypass.py
@@ -1,0 +1,81 @@
+"""``--yolo`` / ``approvals.mode: off`` must bypass the computer_use CLI approval prompt.
+
+The terminal tool consults ``tools.approval.is_approval_bypass_active_for_session``
+before ever calling the CLI approval callback. ``computer_use`` escalated the
+cua-driver daemon to ``unrestricted`` under yolo but still routed every
+destructive action (click / key / type / focus) through the CLI prompt, so a
+headless ``hermes chat --yolo -q ...`` run blocked on a prompt nobody could
+answer and timed out after ``approvals.timeout`` seconds per action.
+"""
+
+import json
+
+
+def _install_backend(cu_tool):
+    class _RecordingBackend:
+        def __init__(self):
+            self.calls = []
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def is_available(self):
+            return True
+
+        def click(self, **kw):
+            self.calls.append(("click", kw))
+            from tools.computer_use.backend import ActionResult
+
+            return ActionResult(ok=True, action="click")
+
+    backend = _RecordingBackend()
+    cu_tool.reset_backend_for_tests()
+    cu_tool._backend = backend
+    return backend
+
+
+def test_yolo_bypasses_computer_use_approval_prompt(monkeypatch):
+    from tools import approval
+    from tools.computer_use import tool as cu_tool
+
+    prompts = []
+
+    def prompting_callback(action, args, summary):
+        prompts.append(action)
+        return "timeout"  # what an unattended CLI prompt returns
+
+    cu_tool.set_approval_callback(prompting_callback)
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", True)
+    backend = _install_backend(cu_tool)
+
+    result = cu_tool.handle_computer_use({"action": "click", "element": 3})
+
+    assert prompts == [], "yolo run must not raise the CLI approval prompt"
+    assert [c[0] for c in backend.calls] == ["click"]
+    payload = json.loads(result) if isinstance(result, str) else result
+    assert not (isinstance(payload, dict) and payload.get("error"))
+
+
+def test_prompt_still_runs_without_bypass(monkeypatch):
+    from tools import approval
+    from tools.computer_use import tool as cu_tool
+
+    prompts = []
+
+    def denying_callback(action, args, summary):
+        prompts.append(action)
+        return "deny"
+
+    cu_tool.set_approval_callback(denying_callback)
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", False)
+    backend = _install_backend(cu_tool)
+
+    result = cu_tool.handle_computer_use({"action": "click", "element": 3})
+
+    assert prompts == ["click"]
+    assert backend.calls == []
+    payload = json.loads(result)
+    assert payload["error"] == "denied by user"

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -278,6 +278,16 @@ def _request_approval(action: str, args: Dict[str, Any], session_id: str = "") -
     leak unlocks into one another. See #67052.
     """
     scope_key = (action, "foreground" if args.get("delivery_mode") == "foreground" else "background")
+    # Honor the process/session approval bypass (--yolo / -z / approvals.mode: off) the same way
+    # terminal_tool does, so headless yolo runs never block on an unanswerable CLI prompt.
+    try:
+        from tools.approval import is_approval_bypass_active_for_session
+        from tools.approval_context import get_current_session_key
+        if is_approval_bypass_active_for_session(session_id) or (
+                bool(key := get_current_session_key(default="")) and is_approval_bypass_active_for_session(key)):
+            return None
+    except Exception:
+        pass
     with _approval_lock:
         if _session_auto_approve.get(session_id) or scope_key in _always_allow.get(session_id, set()):
             return None


### PR DESCRIPTION
## Problem

`--yolo` (and `approvals.mode: off`) bypasses the terminal tool's approval prompt, and `computer_use` correctly escalates the cua-driver daemon to `unrestricted` under yolo (`_cua_permission_mode`). But `_request_approval` in `tools/computer_use/tool.py` never checks the bypass before calling the CLI approval callback, so in a headless run (`hermes chat -Q --oneshot --yolo -q ...`) every destructive action (click / key / type / focus_app with raise) blocks on a prompt nobody can answer, times out after `approvals.timeout` (300s), and is denied:

```
⚠ Approval: computer_use: key 'cmd+t' → timed out (no response)
{"error": "approval prompt timed out — the user did not respond. ...", "action": "key"}
```

## Fix

Consult `is_approval_bypass_active_for_session` (DB `session_id` and gateway `session_key`, the same pair `_cua_permission_mode` uses) at the top of `_request_approval`, mirroring `terminal_tool`. The hard-block list in `_reject_unsafe` still runs before this and is unaffected, as is the daemon-side permission mode.

## Tests

`tests/tools/test_computer_use_yolo_bypass.py`: with yolo the prompt is skipped and the action dispatches; without yolo the prompt still runs and a deny still blocks. Ran alongside `test_computer_use_approval_isolation.py`: 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPyhWGLawA1y7aXxRGn4pk
