### PR TITLE
fix(tui): improve dark theme diff contrast

### DIFF
--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -620,6 +620,44 @@ describe('background-aware adaptation (OSC-11 light terminals)', () => {
     expect(color.diffRemovedWord).toBe('#f00')
   })
 
+  it('gives the dark theme dark diff backgrounds with high-contrast foregrounds (#38359)', async () => {
+    const { DARK_THEME, LIGHT_THEME } = await importThemeWithCleanEnv()
+
+    // WCAG relative luminance, local to the test so assertions are independent
+    // of the implementation under test.
+    const relLuminance = (rgb: string) => {
+      const [r, g, b] = rgb.match(/\d+/g)!.map(Number)
+
+      const channel = (v: number) => {
+        const c = v / 255
+
+        return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+      }
+
+      return 0.2126 * channel(r!) + 0.7152 * channel(g!) + 0.0722 * channel(b!)
+    }
+
+    const contrast = (a: string, b: string) => {
+      const la = relLuminance(a)
+      const lb = relLuminance(b)
+      const [hi, lo] = la >= lb ? [la, lb] : [lb, la]
+
+      return (hi + 0.05) / (lo + 0.05)
+    }
+
+    // Dark diff backgrounds must actually be darker than their light-theme counterparts.
+    expect(relLuminance(DARK_THEME.color.diffAdded)).toBeLessThan(relLuminance(LIGHT_THEME.color.diffAdded))
+    expect(relLuminance(DARK_THEME.color.diffRemoved)).toBeLessThan(relLuminance(LIGHT_THEME.color.diffRemoved))
+
+    // Foreground/background pairs need WCAG AA-level (4.5:1) readable contrast
+    // on the dark backgrounds.
+    expect(contrast(DARK_THEME.color.diffAddedWord, DARK_THEME.color.diffAdded)).toBeGreaterThanOrEqual(4.5)
+    expect(contrast(DARK_THEME.color.diffRemovedWord, DARK_THEME.color.diffRemoved)).toBeGreaterThanOrEqual(4.5)
+
+    // Added/removed dark foregrounds follow the same high-contrast foreground model.
+    expect(DARK_THEME.color.diffAddedWord).toBe(DARK_THEME.color.diffRemovedWord)
+  })
+
   it('maps the status bar from skin status_bar_* keys', async () => {
     const { fromSkin } = await importThemeWithCleanEnv()
 

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -301,10 +301,10 @@ export interface ThemeSeeds {
 }
 
 const DIFF_DARK = {
-  diffAdded: 'rgb(220,255,220)',
-  diffRemoved: 'rgb(255,220,220)',
-  diffAddedWord: 'rgb(36,138,61)',
-  diffRemovedWord: 'rgb(207,34,46)'
+  diffAdded: 'rgb(20,90,20)',
+  diffRemoved: 'rgb(120,20,20)',
+  diffAddedWord: 'rgb(255,255,255)',
+  diffRemovedWord: 'rgb(255,255,255)'
 }
 
 const DIFF_LIGHT = {


### PR DESCRIPTION
## What does this PR do?

Fixes the TUI dark-theme inline diff palette so added/removed lines use the same white-on-dark contrast model as the classic CLI instead of light green/red backgrounds.

The previous PR for this issue only changed the backgrounds; this completes the fix by updating both backgrounds and diff foregrounds together, matching the current CLI truecolor defaults.

## Related Issue

Fixes #38359

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/theme.ts`: change `DIFF_DARK` to white foregrounds on dark green/red backgrounds matching the CLI defaults.
- `ui-tui/src/__tests__/theme.test.ts`: add behavioral coverage for dark-vs-light backgrounds and WCAG-style contrast of the dark diff pairs.

## How to Test

1. `npm exec --workspace ui-tui -- vitest run src/__tests__/theme.test.ts`
2. `npm run typecheck --workspace ui-tui`
3. `npm exec --workspace ui-tui -- eslint src/theme.ts src/__tests__/theme.test.ts`

Observed locally:
- Vitest: 1 file passed, 50/50 tests passed.
- TypeScript typecheck: passed.
- ESLint: passed.
- `git diff --check`: passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A for this TypeScript-only change; focused Vitest, typecheck, and ESLint checks are listed above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Intel)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; no docs change required
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — palette-only TUI change, no platform-specific code path
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; focused automated coverage verifies the palette behavior and contrast relationships.