### PR TITLE
fix(desktop): support fish login-shell PATH probe syntax (#107845)

### DIFF
--- a/apps/desktop/electron/shell-path.test.ts
+++ b/apps/desktop/electron/shell-path.test.ts
@@ -9,6 +9,7 @@ import {
   extractSentinelPath,
   loginShellExecutable,
   mergeLoginShellPath,
+  probeCommandForShell,
   resetLoginShellPathForTests
 } from './shell-path'
 
@@ -184,3 +185,24 @@ test('ensureLoginShellPath never rejects', async () => {
   const result = await ensureLoginShellPath({ env: { SHELL: '/bin/zsh' }, platform: 'darwin', execFileFn })
   assert.equal(result.applied, false)
 })
+
+test('probeCommandForShell returns fish-safe command for fish shells', () => {
+  assert.ok(probeCommandForShell('/usr/local/bin/fish').includes('printenv PATH'))
+  assert.ok(!probeCommandForShell('/usr/local/bin/fish').includes('${PATH}'))
+  assert.ok(probeCommandForShell('/bin/zsh').includes('${PATH}'))
+})
+
+test('applyLoginShellPath supports fish shell probe', async () => {
+  const env: any = { SHELL: '/usr/local/bin/fish', PATH: '/usr/bin:/bin' }
+  const calls: any[] = []
+  const execFileFn = fakeExecFile({ '-ilc': `${START}/opt/homebrew/bin:/Users/u/.cargo/bin:/usr/bin${END}` }, { calls })
+
+  const result = await applyLoginShellPath({ env, platform: 'darwin', execFileFn })
+
+  assert.equal(result.applied, true)
+  assert.equal(env.PATH, '/opt/homebrew/bin:/Users/u/.cargo/bin:/usr/bin:/bin')
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].file, '/usr/local/bin/fish')
+  assert.ok(calls[0].args[1].includes('printenv PATH'))
+})
+

--- a/apps/desktop/electron/shell-path.ts
+++ b/apps/desktop/electron/shell-path.ts
@@ -26,8 +26,15 @@ import { appendUniquePathEntries, delimiterForPlatform, pathEnvKey } from './bac
 
 const PATH_START = '__HERMES_LOGIN_PATH_START__'
 const PATH_END = '__HERMES_LOGIN_PATH_END__'
-const PROBE_COMMAND = "printf '%s' \"" + PATH_START + '${PATH}' + PATH_END + '"'
 const ATTEMPT_TIMEOUT_MS = 5000
+
+export function probeCommandForShell(shellPath: string): string {
+  const name = String(shellPath || '').toLowerCase()
+  if (name.endsWith('fish') || name.includes('/fish')) {
+    return `printf '%s' "${PATH_START}"; printenv PATH; printf '%s' "${PATH_END}"`
+  }
+  return "printf '%s' \"" + PATH_START + '${PATH}' + PATH_END + '"'
+}
 
 function loginShellExecutable(env: any = process.env, platform = process.platform) {
   const shell = typeof env?.SHELL === 'string' ? env.SHELL.trim() : ''
@@ -86,9 +93,10 @@ function runProbe(shell, flags, execFileFn, timeoutMs): Promise<string | null> {
     }
 
     try {
+      const probeCmd = probeCommandForShell(shell)
       const child = execFileFn(
         shell,
-        [...flags, PROBE_COMMAND],
+        [...flags, probeCmd],
         { encoding: 'utf8', timeout: timeoutMs, windowsHide: true },
         (_error, stdout) => {
           // A profile script may exit nonzero after the sentinel already


### PR DESCRIPTION
Fixes #107845

### Summary
The login-shell PATH probe in `apps/desktop/electron/shell-path.ts` previously used POSIX brace expansion (`${PATH}`) inside double quotes. When the user's login shell is `fish`, fish rejects bracketed variable expansion with an exit error (`Variables cannot be bracketed. In fish, please use "$PATH"`), causing `captureLoginShellPath()` to fail and silently fall back to the minimal launchd PATH.

### Changes
1. Added `probeCommandForShell(shellPath)` in `apps/desktop/electron/shell-path.ts` which uses `printenv PATH` between sentinels for `fish` shells.
2. Updated `runProbe` to construct shell-appropriate probe commands.
3. Added unit tests in `apps/desktop/electron/shell-path.test.ts`.
