### PR TITLE
fix(mcp): preserve proxy env vars in stdio subprocess env (#106984)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -3157,3 +3157,23 @@ class TestRedirectHeaderStripper:
         asyncio.run(hook(response))
         assert next_request.headers["authorization"] == "Bearer x"
         assert next_request.headers["x-tenant"] == "t"
+
+
+class TestBuildSafeEnvProxyVars:
+    def test_build_safe_env_includes_proxy_env_vars(self, monkeypatch):
+        """Verify proxy env vars (http_proxy, HTTPS_PROXY, no_proxy, ALL_PROXY) are preserved in _build_safe_env."""
+        from tools.mcp_tool_config import _build_safe_env
+
+        monkeypatch.setenv("http_proxy", "http://proxy.internal:8080")
+        monkeypatch.setenv("HTTPS_PROXY", "http://secure-proxy.internal:8443")
+        monkeypatch.setenv("no_proxy", "localhost,127.0.0.1,.internal")
+        monkeypatch.setenv("ALL_PROXY", "socks5://socks.internal:1080")
+
+        env = _build_safe_env(None)
+
+        env_upper = {k.upper(): v for k, v in env.items()}
+        assert env_upper.get("HTTP_PROXY") == "http://proxy.internal:8080"
+        assert env_upper.get("HTTPS_PROXY") == "http://secure-proxy.internal:8443"
+        assert env_upper.get("NO_PROXY") == "localhost,127.0.0.1,.internal"
+        assert env_upper.get("ALL_PROXY") == "socks5://socks.internal:1080"
+

--- a/tools/mcp_tool_config.py
+++ b/tools/mcp_tool_config.py
@@ -56,14 +56,16 @@ def _write_stderr_log_header(server_name: str) -> None:
 # Env vars safe to pass to stdio subprocesses (no secrets).
 _SAFE_ENV_KEYS = frozenset({"PATH", "HOME", "USER", "LANG", "LC_ALL", "TERM", "SHELL", "TMPDIR"})
 
-# Windows process/location vars needed by launcher-style tools (e.g. Docker Desktop's MCP plugin discovery).
+# Process/location and proxy vars safe to pass to stdio subprocesses (no secrets).
 _SAFE_ENV_KEYS_CASE_INSENSITIVE = frozenset({
     "ALLUSERSPROFILE", "APPDATA", "COMMONPROGRAMFILES", "COMMONPROGRAMFILES(X86)",
     "COMMONPROGRAMW6432", "COMPUTERNAME", "COMSPEC", "HOMEDRIVE", "HOMEPATH",
     "LOCALAPPDATA", "NUMBER_OF_PROCESSORS", "OS", "PATHEXT", "PROCESSOR_ARCHITECTURE",
     "PROGRAMDATA", "PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMW6432", "PUBLIC",
     "SYSTEMDRIVE", "SYSTEMROOT", "TEMP", "TMP", "USERDOMAIN", "USERNAME",
-    "USERPROFILE", "WINDIR"})
+    "USERPROFILE", "WINDIR",
+    "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY",
+})
 
 # ${VAR_NAME} interpolation; any non-} chars allowed so MY-VAR / my.var work.
 _ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")


### PR DESCRIPTION
### Summary
Include HTTP/HTTPS/SOCKS proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `ALL_PROXY` and case variants) in `_SAFE_ENV_KEYS_CASE_INSENSITIVE` inside `tools/mcp_tool_config.py`.

### Context & Problem
When Hermes spawns a stdio MCP server subprocess, `_build_safe_env` filters `os.environ` against an explicit baseline allowlist (`_SAFE_ENV_KEYS`, `_SAFE_ENV_KEYS_CASE_INSENSITIVE`, `XDG_*`, secret sources, and server-configured `env`). Standard proxy variables (`http_proxy`, `https_proxy`, `no_proxy`, `all_proxy`, etc.) were missing from the allowlist.

In sandboxed or corporate environments where outbound network access must pass through an explicit L7/SOCKS proxy, tool calls within stdio MCP servers failed or timed out when making raw HTTP requests.

### Solution
- Added `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `ALL_PROXY` to `_SAFE_ENV_KEYS_CASE_INSENSITIVE` in `tools/mcp_tool_config.py`. Because check uses `key.upper() in _SAFE_ENV_KEYS_CASE_INSENSITIVE`, both uppercase and lowercase proxy variables present in host environment are inherited by the stdio subprocess.
- Added unit test `TestBuildSafeEnvProxyVars` in `tests/tools/test_mcp_tool.py`.

Closes #106984
