### PR TITLE
fix(auth): isolate profile-owned OAuth credentials

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -784,6 +784,40 @@ def _profile_owns_pool_provider(provider: str) -> bool:
     return isinstance(entries, list) and bool(entries)
 
 
+def _codex_principal_identity(access_token: Any) -> Optional[Tuple[str, str]]:
+    """Local routing identity for comparing already-loaded Codex credentials.
+
+    JWT claims are decoded without signature verification. They are used only to prevent
+    cross-principal singleton synchronization, never as authentication or authorization proof.
+    """
+    claims = _decode_jwt_claims(access_token)
+    if not isinstance(claims, dict):
+        return None
+    auth_claims = claims.get("https://api.openai.com/auth")
+    if not isinstance(auth_claims, dict):
+        return None
+    account_id, subject = auth_claims.get("chatgpt_account_id"), claims.get("sub")
+    if not isinstance(account_id, str) or not isinstance(subject, str):
+        return None
+    identity = account_id.strip(), subject.strip()
+    return identity if all(identity) else None
+
+
+def _codex_entry_tracks_singleton(
+    entry: PooledCredential, singleton_tokens: Dict[str, Any], source_path: Optional[Path],
+) -> bool:
+    """Whether a Codex row may adopt token state from this singleton source."""
+    if entry.source == "device_code":
+        return True
+    if entry.source != SOURCE_MANUAL_DEVICE_CODE:
+        return False
+    if source_path is None or not _same_path(source_path, auth_mod._auth_file_path()):
+        return False
+    entry_identity = _codex_principal_identity(entry.access_token)
+    singleton_identity = _codex_principal_identity(singleton_tokens.get("access_token"))
+    return bool(entry_identity and singleton_identity and entry_identity == singleton_identity)
+
+
 def _borrowed_single_use_pool_root() -> Optional[Path]:
     """Global-root auth.json when persisting a BORROWED single-use pool, else None.
 
@@ -1106,12 +1140,13 @@ class CredentialPool(CredentialPoolAdminMixin):
         *,
         persist: bool = True,
         failure_reason: Optional[str] = None,
+        force_terminal: bool = False,
     ) -> PooledCredential:
         normalized_error = _normalize_error_context(error_context)
         # Permanent OAuth failures become STATUS_DEAD, not STATUS_EXHAUSTED:
         # otherwise a revoked credential re-enters rotation every hour and
         # fails immediately until the user removes it (#32849).
-        terminal = self._is_terminal_auth_failure(status_code, normalized_error)
+        terminal = force_terminal or self._is_terminal_auth_failure(status_code, normalized_error)
         # Carry the classifier's verdict so the cooldown is sized by what
         # actually failed (a billing 403 must not get the sole-credential
         # transient cooldown); absent a classification, clear a stale one.
@@ -1238,19 +1273,12 @@ class CredentialPool(CredentialPoolAdminMixin):
             with _auth_store_lock():
                 auth_store = _load_auth_store()
                 state, source_path = _load_provider_state_with_source(auth_store, self.provider)
-            if (
-                is_codex
-                and entry.source == SOURCE_MANUAL_DEVICE_CODE
-                and source_path is not None
-                and not _same_path(source_path, auth_mod._auth_file_path())
-            ):
-                # An independently added profile grant has no singleton shadow. Root fallback
-                # state belongs to another owner and must never replace this entry before refresh.
-                return entry
             if not isinstance(state, dict):
                 return entry
             tokens = state.get("tokens")
             if not isinstance(tokens, dict):
+                return entry
+            if is_codex and not _codex_entry_tracks_singleton(entry, tokens, source_path):
                 return entry
             store_access = tokens.get("access_token", "")
             store_refresh = tokens.get("refresh_token", "")
@@ -1675,6 +1703,30 @@ class CredentialPool(CredentialPoolAdminMixin):
             # re-seed the revoked credentials, and drop singleton-seeded
             # entries from the pool (mirrors the Nous quarantine path).
             if getattr(auth_mod, terminal_fn_name)(exc):
+                if self.provider == "openai-codex" and entry.source == SOURCE_MANUAL_DEVICE_CODE:
+                    try:
+                        with _auth_store_lock():
+                            auth_store = _load_auth_store()
+                            state, source_path = _load_provider_state_with_source(
+                                auth_store, self.provider,
+                            )
+                        singleton_tokens = state.get("tokens") if isinstance(state, dict) else None
+                    except Exception:
+                        singleton_tokens = None
+                        source_path = None
+                    if not isinstance(singleton_tokens, dict) or not _codex_entry_tracks_singleton(
+                        entry, singleton_tokens, source_path,
+                    ):
+                        self._mark_exhausted(
+                            entry,
+                            401,
+                            {
+                                "reason": getattr(exc, "code", None),
+                                "message": str(exc),
+                            },
+                            force_terminal=True,
+                        )
+                        return None
                 logger.debug("%s OAuth refresh token is terminally invalid; clearing local token state", display)
                 self._clear_terminal_tokens_state(entry, exc)
                 self._quarantine_sources(entry, {"device_code"})

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1236,8 +1236,20 @@ class CredentialPool(CredentialPoolAdminMixin):
             return entry
         try:
             with _auth_store_lock():
-                state = _load_provider_state(_load_auth_store(), self.provider)
-            tokens = state.get("tokens") if isinstance(state, dict) else None
+                auth_store = _load_auth_store()
+                state, source_path = _load_provider_state_with_source(auth_store, self.provider)
+            if (
+                is_codex
+                and entry.source == SOURCE_MANUAL_DEVICE_CODE
+                and source_path is not None
+                and not _same_path(source_path, auth_mod._auth_file_path())
+            ):
+                # An independently added profile grant has no singleton shadow. Root fallback
+                # state belongs to another owner and must never replace this entry before refresh.
+                return entry
+            if not isinstance(state, dict):
+                return entry
+            tokens = state.get("tokens")
             if not isinstance(tokens, dict):
                 return entry
             store_access = tokens.get("access_token", "")
@@ -2483,8 +2495,17 @@ def _seed_tokens_singleton(seed: _Seeder, auth_store: Dict[str, Any]) -> None:
     Codex CLI / VS Code causes refresh_token_reused races. Adoption is an
     explicit one-time prompt via `hermes auth openai-codex`.
     """
-    state = _load_provider_state(auth_store, seed.provider)
-    tokens = state.get("tokens") if isinstance(state, dict) else None
+    # A profile-owned pool shadows the root pool for this provider. Its singleton state must
+    # obey the same boundary; otherwise root's device-code grant is re-seeded into the profile
+    # and persisted beside an independently added credential, recreating a refresh-token fork.
+    state = (
+        auth_mod._provider_state_in(auth_store, seed.provider)
+        if _profile_owns_pool_provider(seed.provider)
+        else _load_provider_state(auth_store, seed.provider)
+    )
+    if not isinstance(state, dict):
+        return
+    tokens = state.get("tokens")
     if not (isinstance(tokens, dict) and tokens.get("access_token")):
         return
     if seed.provider == "openai-codex":

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -8,6 +8,7 @@ a second POST returns ``invalid_grant``).
 """
 from __future__ import annotations
 
+import base64
 import io
 import json
 import os
@@ -385,6 +386,160 @@ def test_independent_codex_profile_refresh_sync_does_not_adopt_root_tokens(fleet
 
     assert (synced.id, synced.refresh_token) == ("own-codex", "profile-RT")
     assert (root / "auth.json").read_bytes() == root_before
+
+
+def _codex_jwt(account_id, subject, token_id):
+    payload = base64.urlsafe_b64encode(json.dumps({
+        "sub": subject,
+        "jti": token_id,
+        "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
+    }, separators=(",", ":")).encode()).decode().rstrip("=")
+    return f"header.{payload}.signature"
+
+
+def test_independent_codex_profile_refresh_uses_own_pair_with_local_singleton(
+    fleet, monkeypatch,
+):
+    """Local singleton A must not replace independent manual account B before refresh."""
+    from agent.credential_pool import load_pool
+
+    singleton_access = _codex_jwt("shared-workspace", "user-a", "singleton")
+    manual_access = _codex_jwt("shared-workspace", "user-b", "manual-old")
+    refreshed_access = _codex_jwt("shared-workspace", "user-b", "manual-new")
+    kid = _profile(fleet, "independent-codex-local-singleton")
+    kid.mkdir(parents=True, exist_ok=True)
+    (kid / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {"openai-codex": {"tokens": {
+            "access_token": singleton_access,
+            "refresh_token": "singleton-RT",
+        }}},
+        "credential_pool": {"openai-codex": [{
+            "id": "manual-b",
+            "label": "profile-account-b",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": manual_access,
+            "refresh_token": "manual-RT",
+        }]},
+    }))
+    refresh_calls = []
+
+    def refresh(access_token, refresh_token):
+        refresh_calls.append((access_token, refresh_token))
+        return {
+            "access_token": refreshed_access,
+            "refresh_token": "manual-RT-2",
+            "last_refresh": "2026-09-11T00:00:00Z",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", refresh)
+    fleet["use"](kid)
+    pool = load_pool("openai-codex")
+    manual = next(entry for entry in pool.entries() if entry.id == "manual-b")
+
+    refreshed = pool._refresh_entry(manual, force=True)
+
+    assert refreshed is not None
+    assert refresh_calls == [(manual_access, "manual-RT")]
+    assert (refreshed.access_token, refreshed.refresh_token) == (
+        refreshed_access, "manual-RT-2",
+    )
+    store = json.loads((kid / "auth.json").read_text())
+    assert store["providers"]["openai-codex"]["tokens"] == {
+        "access_token": singleton_access,
+        "refresh_token": "singleton-RT",
+    }
+
+
+def test_same_principal_legacy_codex_alias_still_adopts_local_singleton(fleet):
+    """A local manual alias with the same principal retains singleton recovery."""
+    from agent.credential_pool import load_pool
+
+    stale_access = _codex_jwt("workspace-a", "user-a", "stale")
+    fresh_access = _codex_jwt("workspace-a", "user-a", "fresh")
+    kid = _profile(fleet, "legacy-codex-local-singleton")
+    kid.mkdir(parents=True, exist_ok=True)
+    (kid / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {"openai-codex": {"tokens": {
+            "access_token": fresh_access,
+            "refresh_token": "fresh-RT",
+        }}},
+        "credential_pool": {"openai-codex": [{
+            "id": "legacy-alias",
+            "label": "legacy-alias",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": stale_access,
+            "refresh_token": "stale-RT",
+        }]},
+    }))
+
+    fleet["use"](kid)
+    pool = load_pool("openai-codex")
+    legacy = next(entry for entry in pool.entries() if entry.id == "legacy-alias")
+    synced = pool._sync_entry_from_auth_store(legacy)
+
+    assert (synced.access_token, synced.refresh_token) == (fresh_access, "fresh-RT")
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["refresh_token_reused", "codex_refresh_failed", "codex_auth_missing_refresh_token"],
+)
+def test_independent_codex_terminal_refresh_marks_only_manual_account_dead(
+    fleet, monkeypatch, reason,
+):
+    """Terminal failure for manual B must not quarantine local singleton A."""
+    from hermes_cli.auth import AuthError
+    from agent.credential_pool import STATUS_DEAD, load_pool
+
+    singleton_access = _codex_jwt("shared-workspace", "user-a", "singleton")
+    manual_access = _codex_jwt("shared-workspace", "user-b", "manual")
+    kid = _profile(fleet, "terminal-codex-local-singleton")
+    kid.mkdir(parents=True, exist_ok=True)
+    (kid / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {"openai-codex": {"tokens": {
+            "access_token": singleton_access,
+            "refresh_token": "singleton-RT",
+        }}},
+        "credential_pool": {"openai-codex": [{
+            "id": "manual-b",
+            "label": "profile-account-b",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": manual_access,
+            "refresh_token": "manual-RT",
+        }]},
+    }))
+
+    def fail_refresh(*_args):
+        raise AuthError(
+            "synthetic terminal Codex refresh failure",
+            provider="openai-codex",
+            code=reason,
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", fail_refresh)
+    fleet["use"](kid)
+    pool = load_pool("openai-codex")
+    manual = next(entry for entry in pool.entries() if entry.id == "manual-b")
+
+    assert pool._refresh_entry(manual, force=True) is None
+
+    by_id = {entry.id: entry for entry in pool.entries()}
+    assert by_id["manual-b"].last_status == STATUS_DEAD
+    store = json.loads((kid / "auth.json").read_text())
+    assert store["providers"]["openai-codex"]["tokens"] == {
+        "access_token": singleton_access,
+        "refresh_token": "singleton-RT",
+    }
 
 
 def test_classic_mode_persist_is_unchanged(fleet):

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -314,6 +314,79 @@ def test_profile_auth_add_owns_only_its_own_rows(fleet):
     assert [e["id"] for e in fleet["rows"](fleet["root"])] == ["abc123"]
 
 
+def test_independent_codex_profile_credential_shadows_root_singleton(fleet):
+    """A profile-owned Codex grant must not re-import root's device-code grant."""
+    from agent.credential_pool import load_pool
+
+    root = fleet["root"]
+    _seed_codex_grant(root)
+    root_before = (root / "auth.json").read_bytes()
+
+    kid = _profile(fleet, "independent-codex")
+    kid.mkdir(parents=True, exist_ok=True)
+    (kid / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {"openai-codex": [{
+            "id": "own-codex",
+            "label": "profile-account",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "profile-AT",
+            "refresh_token": "profile-RT",
+        }]},
+    }))
+
+    fleet["use"](kid)
+    pool = load_pool("openai-codex")
+    selected = pool.peek()
+
+    assert [(entry.id, entry.refresh_token) for entry in pool.entries()] == [
+        ("own-codex", "profile-RT"),
+    ]
+    assert selected is not None
+    assert (selected.id, selected.refresh_token) == ("own-codex", "profile-RT")
+    profile_store = json.loads((kid / "auth.json").read_text())
+    assert [row["id"] for row in profile_store["credential_pool"]["openai-codex"]] == [
+        "own-codex",
+    ]
+    assert (root / "auth.json").read_bytes() == root_before
+
+
+def test_independent_codex_profile_refresh_sync_does_not_adopt_root_tokens(fleet):
+    """Pre-refresh sync must not replace a profile-owned grant from root state."""
+    from agent.credential_pool import load_pool
+
+    root = fleet["root"]
+    _seed_codex_grant(root)
+    root_before = (root / "auth.json").read_bytes()
+
+    kid = _profile(fleet, "independent-codex-sync")
+    kid.mkdir(parents=True, exist_ok=True)
+    (kid / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {"openai-codex": [{
+            "id": "own-codex",
+            "label": "profile-account",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "profile-AT",
+            "refresh_token": "profile-RT",
+        }]},
+    }))
+
+    fleet["use"](kid)
+    pool = load_pool("openai-codex")
+    profile_entry = pool.entries()[0]
+    synced = pool._sync_entry_from_auth_store(profile_entry)
+
+    assert (synced.id, synced.refresh_token) == ("own-codex", "profile-RT")
+    assert (root / "auth.json").read_bytes() == root_before
+
+
 def test_classic_mode_persist_is_unchanged(fleet):
     from agent.credential_pool import load_pool
 


### PR DESCRIPTION
## Summary

- keep root singleton/provider-state fallback from re-seeding a credential when a named profile already owns that provider's pool
- require both local store ownership and matching `(chatgpt_account_id, sub)` identity before a legacy Codex `manual:device_code` row may adopt singleton state
- isolate terminal refresh failure to an independent manual credential instead of quarantining an unrelated singleton
- add profile-isolation regressions covering load, persistence, real refresh, terminal failure, and legacy-alias recovery

## Problem

A named profile can add its own independent Codex OAuth credential, which should shadow the global-root credential for that provider. The pool read path already enforces that boundary. A later singleton-seeding path still resolves `providers.openai-codex` through the root fallback, however, and can append the root device-code grant to the profile-owned pool. Persistence then recreates the single-use refresh-token fork that the existing healer is intended to remove.

The pre-refresh synchronization path has the same ownership gap: `manual:device_code` historically means either a true legacy singleton alias or an independently added account. Store location alone does not distinguish those meanings, so a local singleton for account A could replace an independent local row for account B.

## Behavior after this change

- Profiles with no local credential continue borrowing the root credential.
- A profile with local pool rows reads singleton state only from its active auth store.
- Borrowed root `device_code` rows retain root synchronization.
- A local legacy manual alias follows the singleton only when both access-token JWTs expose the same non-empty `(chatgpt_account_id, sub)` routing identity.
- Missing, malformed, cross-store, cross-workspace, or same-workspace/different-subject identity fails closed.
- Terminal failure marks only an independent manual row dead and leaves the unrelated singleton intact.

JWT claims are decoded only as a local equality discriminator between already-loaded credentials. They are not used as authentication or authorization proof.

## Test plan

- [x] New tests reproduced root re-seeding, root-to-profile synchronization, same-workspace cross-user refresh, and independent terminal-failure defects before their implementation changes.
- [x] Positive control preserves same-principal legacy-alias recovery.
- [x] `scripts/run_tests.sh tests/agent/test_credential_pool.py tests/agent/test_credential_pool_operations.py tests/agent/test_credential_pool_oauth_writethrough.py tests/agent/test_credential_pool_profile_oauth_fork.py tests/hermes_cli/test_auth_profile_fallback.py tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_xai_oauth_writethrough.py -v`
  - 131 passed, 0 failed on revised head `d7149f7fd3`
- [x] Ruff passed for both changed files.
- [x] `git diff --check` passed.
- [ ] Full CI

## Overlap and attribution

The initial duplicate search did not surface the differently worded open PRs #92198 and #100423. Independent review identified them. This revision retains StreamTec1's root/profile ownership projection and ports the principal-aware invariant and terminal-failure isolation from Marc Caelier's #100423 onto current `main`; commit `d7149f7fd3` credits Marc as co-author. PR #92198 remains the source-only alternative and positive canonical-device-code recovery reference.
