### PR TITLE
fix(tools): mid-turn steer releases a blocking process_manage wait (port kimi-code#3697)

### DIFF
--- a/tests/tools/test_process_wait_clarity.py
+++ b/tests/tools/test_process_wait_clarity.py
@@ -62,3 +62,46 @@ class TestWaitTimeoutClarity:
         r = registry.wait(session.id, timeout=10)
         assert r["status"] == "exited"
         assert "process_running" not in r
+
+
+class TestWaitYieldRelease:
+    """A mid-turn steer/redirect (request_yield on the tool-worker tid) releases a
+    process wait instead of parking the user's message behind it (kimi-code#3697 class)."""
+
+    def test_yield_releases_wait_and_keeps_process_running(self, registry):
+        import threading
+        import time
+
+        from tools.interrupt import request_yield
+
+        sid = _spawn_sleeper(registry)
+        try:
+            result = {}
+
+            def waiter():
+                result["r"] = registry.wait(sid, timeout=15)
+
+            t = threading.Thread(target=waiter)
+            t.start()
+            time.sleep(0.3)
+            request_yield(t.ident)
+            t.join(5)
+            assert not t.is_alive(), "wait did not release within 5s of the yield request"
+            r = result["r"]
+            assert r["status"] == "interrupted"
+            assert r["process_running"] is True
+            assert "still running" in r["note"]
+            # The process was not killed and the yield bit was consumed.
+            assert registry.poll(sid)["status"] == "running"
+            from tools.interrupt import is_thread_yield_requested
+            assert not is_thread_yield_requested(t.ident)
+        finally:
+            registry.kill_process(sid)
+
+    def test_wait_without_yield_still_times_out(self, registry):
+        sid = _spawn_sleeper(registry)
+        try:
+            r = registry.wait(sid, timeout=1)
+            assert r["status"] == "timeout"
+        finally:
+            registry.kill_process(sid)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1673,10 +1673,11 @@ class ProcessRegistry(ProcessCheckpointMixin):
         return result
 
     def wait(self, session_id: str, timeout: int = None) -> dict:
-        """Block until the process exits, the timeout elapses, or the user interrupts.
+        """Block until the process exits, the timeout elapses, the user interrupts, or a
+        mid-turn user message (steer/redirect → ``request_yield``) releases the wait.
         ``timeout`` defaults to (and is clamped by) TERMINAL_TIMEOUT. Returns a dict
         with status exited|timeout|interrupted|not_found|error and an output snapshot."""
-        from tools.interrupt import is_interrupted as _is_interrupted
+        from tools.interrupt import consume_yield as _consume_yield, is_interrupted as _is_interrupted
 
         try:
             max_timeout = int(os.getenv("TERMINAL_TIMEOUT", "180"))
@@ -1708,6 +1709,16 @@ class ProcessRegistry(ProcessCheckpointMixin):
                 result = {
                     "status": "interrupted", "command": session.command, "output": _output_tail(session, 1000),
                     "note": "User sent a new message -- wait interrupted"}
+            elif _consume_yield(threading.current_thread().ident):
+                # A steer/redirect landed mid-turn: redirect() asks tool workers to YIELD so
+                # the user's message is delivered instead of parked behind this wait. The
+                # process is untouched and still notify-tracked; the model should read the
+                # steer text and respond, not re-issue the wait (kimi-code#3697 class).
+                result = {
+                    "status": "interrupted", "command": session.command, "output": _output_tail(session, 1000),
+                    "process_running": True,
+                    "note": ("User sent a new message -- wait released; the process is still "
+                             "running and you will be notified on exit. Respond to the user now.")}
             if result is not None:
                 if timeout_note:
                     result["timeout_note"] = timeout_note


### PR DESCRIPTION
A user message sent while the model sits in `process_manage(action='wait')` no longer waits out the full wait window — the wait releases in under a second, the process keeps running, and the model answers the user.

## Symptom

Mid-turn user messages (CLI `busy_input_mode=interrupt`, gateway priority redirect, ACP redirect) route through `AIAgent.redirect()`, which during tool execution degrades to `steer()` + `request_yield()` on the tool worker threads. The local terminal backend's **foreground** wait honours that yield (463292351fe adopts the live process into the background registry), but `ProcessRegistry.wait()` — the `process_manage(action='wait')` path used to watch an already-background process (CI watchers, builds, servers) — never checked it. The steer text rides the tool result, so the user's message was parked until the wait timed out: up to 180s by default, more with a raised `TERMINAL_TIMEOUT`.

## Change

- `ProcessRegistry.wait()` consumes a pending yield on its own thread each poll pass (the same 1s-granularity loop that already checks interrupt) and returns `status="interrupted"` with `process_running: true` plus a note telling the model the process is untouched, still notify-tracked, and that it should respond to the user now.
- Plain interrupt, exit, and timeout paths unchanged. `consume_yield` clears the bit, so subsequent waits behave normally.

Port of MoonshotAI/kimi-code#3697 ("let steer interrupt background task waits" — their `WaitFor` tool had the same shape: steer added input for the next step but the active wait ran to its 600s cap), adapted to Hermes' per-thread yield mechanism.

## Live repro

| | origin/main | this branch |
|---|---|---|
| `request_yield(waiter_tid)` against a thread blocked in `wait(timeout=12)` | no effect — wait ran the full 12s to `timeout` | releases in **0.5s**, `status=interrupted`, `process_running=true`, process alive |

Reproduced and confirmed via real `ProcessRegistry.adopt_local` + `sleep 30` subprocess with fresh imports against a temp `HERMES_HOME` (positive and negative: a wait with no yield still times out normally).

## Validation

- New `TestWaitYieldRelease` (2 invariant tests): yield releases the wait, keeps the process running, and clears the yield bit; a wait without a yield still times out.
- `tests/tools/test_process_wait_clarity.py` + `tests/tools/test_process_registry.py`: 105 passed, 0 failed.
- `ruff check` clean; Windows-footgun scan clean; compat-pointer check clean.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9f0be/SBNk7fBSznYBo7M_aQhpE_6tC1WlPh.png)
