### PR TITLE
fix(slack): dedupe startup ack across synthetic per-message thread_ids

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2949,12 +2949,18 @@ class SlackAdapter(BasePlatformAdapter):
         return (ts, team_id, marker) if ts and marker in self._reacting_message_ids else None
 
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Add an in-progress reaction when message processing begins."""
+        """Acknowledge immediately, then add the in-progress reaction."""
+        channel_id = getattr(event.source, "chat_id", None)
+        if channel_id:
+            metadata: Dict[str, Any] = {"_interim_send": True}
+            thread_id = getattr(event.source, "thread_id", None)
+            if thread_id:
+                metadata["thread_id"] = str(thread_id)
+            await self.send(channel_id, "Getting started…", metadata=metadata)
         target = self._reacting_target(event)
         if target is None:
             return
         ts, team_id, _marker = target
-        channel_id = getattr(event.source, "chat_id", None)
         if channel_id:
             await self._react(channel_id, ts, "eyes", team_id, remove=False)
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2954,7 +2954,16 @@ class SlackAdapter(BasePlatformAdapter):
         """Send one startup intro, then add the per-turn in-progress reaction."""
         channel_id = getattr(event.source, "chat_id", None)
         thread_id = getattr(event.source, "thread_id", None)
-        conversation_key = (str(channel_id), str(thread_id or ""))
+        own_message_id = getattr(event, "message_id", None)
+        # In Slack's Agent messaging view (flat DM, no real threads), thread_id is set to
+        # the message's OWN ts for every top-level message (see _resolve_thread_ts comment
+        # above) — i.e. it's synthetic and unique per message, not per conversation. Using
+        # it verbatim in the dedup key made "Getting started…" fire on every single turn
+        # instead of once. Normalize: a synthetic thread_id collapses to "no thread" so the
+        # dedup key is per-channel, matching a real conversation.
+        is_synthetic_thread = bool(thread_id) and own_message_id and str(thread_id) == str(own_message_id)
+        effective_thread_id = None if is_synthetic_thread else thread_id
+        conversation_key = (str(channel_id), str(effective_thread_id or ""))
         if channel_id and conversation_key not in self._startup_ack_sent_for:
             # Claim before awaiting network I/O so concurrent first turns cannot each send it.
             self._startup_ack_sent_for.add(conversation_key)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -951,8 +951,8 @@ class SlackAdapter(BasePlatformAdapter):
         # never reached the session. Keys follow the thread session-key scoping. See #63530.
         self._thread_rehydration_checked: set = set()
         self._reacting_message_ids: set = set()
-        # A startup acknowledgement is an intro, not a per-turn status message.
-        self._startup_ack_sent = False
+        # A startup acknowledgement is an intro for each conversation, not a per-turn status.
+        self._startup_ack_sent_for: set[Tuple[str, str]] = set()
         # Active Assistant statuses by (team_id, channel_id, thread_ts) so cleanup
         # can't clear an overlapping Slack Connect workspace; evicted oldest-thread-first.
         self._active_status_threads: Dict[Tuple[str, str, str], Dict[str, Any]] = {}
@@ -2953,11 +2953,12 @@ class SlackAdapter(BasePlatformAdapter):
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Send one startup intro, then add the per-turn in-progress reaction."""
         channel_id = getattr(event.source, "chat_id", None)
-        if channel_id and not self._startup_ack_sent:
+        thread_id = getattr(event.source, "thread_id", None)
+        conversation_key = (str(channel_id), str(thread_id or ""))
+        if channel_id and conversation_key not in self._startup_ack_sent_for:
             # Claim before awaiting network I/O so concurrent first turns cannot each send it.
-            self._startup_ack_sent = True
+            self._startup_ack_sent_for.add(conversation_key)
             metadata: Dict[str, Any] = {"_interim_send": True}
-            thread_id = getattr(event.source, "thread_id", None)
             if thread_id:
                 metadata["thread_id"] = str(thread_id)
             await self.send(channel_id, "Getting started…", metadata=metadata)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -951,6 +951,8 @@ class SlackAdapter(BasePlatformAdapter):
         # never reached the session. Keys follow the thread session-key scoping. See #63530.
         self._thread_rehydration_checked: set = set()
         self._reacting_message_ids: set = set()
+        # A startup acknowledgement is an intro, not a per-turn status message.
+        self._startup_ack_sent = False
         # Active Assistant statuses by (team_id, channel_id, thread_ts) so cleanup
         # can't clear an overlapping Slack Connect workspace; evicted oldest-thread-first.
         self._active_status_threads: Dict[Tuple[str, str, str], Dict[str, Any]] = {}
@@ -2949,9 +2951,11 @@ class SlackAdapter(BasePlatformAdapter):
         return (ts, team_id, marker) if ts and marker in self._reacting_message_ids else None
 
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Acknowledge immediately, then add the in-progress reaction."""
+        """Send one startup intro, then add the per-turn in-progress reaction."""
         channel_id = getattr(event.source, "chat_id", None)
-        if channel_id:
+        if channel_id and not self._startup_ack_sent:
+            # Claim before awaiting network I/O so concurrent first turns cannot each send it.
+            self._startup_ack_sent = True
             metadata: Dict[str, Any] = {"_interim_send": True}
             thread_id = getattr(event.source, "thread_id", None)
             if thread_id:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2924,6 +2924,35 @@ class TestReactions:
         )
 
     @pytest.mark.asyncio
+    async def test_processing_start_dedupes_synthetic_thread_ids_in_agent_view(self, adapter):
+        """Slack's Agent messaging view (flat DM) sets thread_id == the message's own ts
+        for every top-level message, so each new turn gets a distinct-looking thread_id.
+        The dedup key must collapse these synthetic per-message thread_ids back to a
+        single per-channel conversation, or "Getting started..." fires on every turn."""
+        adapter.send = AsyncMock()
+        from gateway.platforms.base import SessionSource
+        from gateway.platforms.event import MessageEvent, MessageType
+        from gateway.config import Platform
+
+        def make_event(ts: str) -> MessageEvent:
+            source = SessionSource(
+                platform=Platform.SLACK, chat_id="C123", chat_type="im",
+                user_id="U_USER", thread_id=ts,
+            )
+            return MessageEvent(
+                text="hi", message_type=MessageType.TEXT, source=source, message_id=ts,
+            )
+
+        await adapter.on_processing_start(make_event("1111.000001"))
+        await adapter.on_processing_start(make_event("2222.000002"))
+        await adapter.on_processing_start(make_event("3333.000003"))
+
+        adapter.send.assert_awaited_once_with(
+            "C123", "Getting started\u2026",
+            metadata={"thread_id": "1111.000001", "_interim_send": True},
+        )
+
+    @pytest.mark.asyncio
     async def test_reactions_in_message_flow(self, adapter):
         """Reactions should be bracketed around actual processing via hooks."""
         adapter._app.client.reactions_add = AsyncMock()

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2881,6 +2881,29 @@ class TestReactions:
         assert result is True
 
     @pytest.mark.asyncio
+    async def test_processing_start_sends_immediate_thread_ack(self, adapter):
+        adapter.send = AsyncMock()
+        adapter._reacting_message_ids.add("1234567890.000001")
+        from gateway.platforms.base import SessionSource
+        from gateway.platforms.event import MessageEvent, MessageType
+        from gateway.config import Platform
+
+        source = SessionSource(
+            platform=Platform.SLACK, chat_id="C123", chat_type="group",
+            user_id="U_USER", thread_id="111.222",
+        )
+        event = MessageEvent(
+            text="do work", message_type=MessageType.TEXT, source=source,
+            message_id="1234567890.000001",
+        )
+        await adapter.on_processing_start(event)
+
+        adapter.send.assert_awaited_once_with(
+            "C123", "Getting started…",
+            metadata={"thread_id": "111.222", "_interim_send": True},
+        )
+
+    @pytest.mark.asyncio
     async def test_reactions_in_message_flow(self, adapter):
         """Reactions should be bracketed around actual processing via hooks."""
         adapter._app.client.reactions_add = AsyncMock()

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2900,12 +2900,27 @@ class TestReactions:
             text="do more work", message_type=MessageType.TEXT, source=source,
             message_id="1234567890.000002",
         )
+        other_source = SessionSource(
+            platform=Platform.SLACK, chat_id="C123", chat_type="group",
+            user_id="U_USER", thread_id="333.444",
+        )
+        other_thread = MessageEvent(
+            text="new conversation", message_type=MessageType.TEXT, source=other_source,
+            message_id="1234567890.000003",
+        )
         await adapter.on_processing_start(first)
         await adapter.on_processing_start(second)
 
         adapter.send.assert_awaited_once_with(
             "C123", "Getting started…",
             metadata={"thread_id": "111.222", "_interim_send": True},
+        )
+
+        await adapter.on_processing_start(other_thread)
+        assert adapter.send.await_count == 2
+        adapter.send.assert_awaited_with(
+            "C123", "Getting started…",
+            metadata={"thread_id": "333.444", "_interim_send": True},
         )
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2881,9 +2881,9 @@ class TestReactions:
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_processing_start_sends_immediate_thread_ack(self, adapter):
+    async def test_processing_start_sends_immediate_ack_only_once_per_gateway_start(self, adapter):
         adapter.send = AsyncMock()
-        adapter._reacting_message_ids.add("1234567890.000001")
+        adapter._reacting_message_ids.update({"1234567890.000001", "1234567890.000002"})
         from gateway.platforms.base import SessionSource
         from gateway.platforms.event import MessageEvent, MessageType
         from gateway.config import Platform
@@ -2892,11 +2892,16 @@ class TestReactions:
             platform=Platform.SLACK, chat_id="C123", chat_type="group",
             user_id="U_USER", thread_id="111.222",
         )
-        event = MessageEvent(
+        first = MessageEvent(
             text="do work", message_type=MessageType.TEXT, source=source,
             message_id="1234567890.000001",
         )
-        await adapter.on_processing_start(event)
+        second = MessageEvent(
+            text="do more work", message_type=MessageType.TEXT, source=source,
+            message_id="1234567890.000002",
+        )
+        await adapter.on_processing_start(first)
+        await adapter.on_processing_start(second)
 
         adapter.send.assert_awaited_once_with(
             "C123", "Getting started…",


### PR DESCRIPTION
Bug: "Getting started..." was posted repeatedly (once per turn) in Slack DMs instead of once per conversation.

Root cause: Slack's Agent messaging view (agent_view) is a flat DM with no real threads, so `thread_id` is set to the message's own ts for every top-level message (see `_resolve_thread_ts`). `on_processing_start` keyed its once-per-conversation dedup on `(channel_id, thread_id)` verbatim, so every turn had a unique thread_id and looked like a brand-new conversation.

Fix: detect when thread_id == the event's own message_id (the synthetic-thread case) and collapse it to "no thread" for the dedup key, so the key is per-channel again for flat DMs while still respecting real threads.

Testing:
- New regression test `test_processing_start_dedupes_synthetic_thread_ids_in_agent_view` reproduces the bug (3 sends instead of 1) against the pre-fix code, and passes with the fix.
- Full `tests/gateway/test_slack.py` suite: 237 passed.

What was NOT tested: not verified live against production Slack from this environment (no direct write access to deploy this branch); recommend a quick live DM smoke test after merge+deploy.
