### PR TITLE
fix(agent): guard against post-dispatch fake-pickup status babble

### DIFF
--- a/tests/tools/test_delegate_status_once_guard.py
+++ b/tests/tools/test_delegate_status_once_guard.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Guard tests for the write-the-status-ONCE anti-babble rule.
+
+2026-09-11 (music-master session 20260911_014738_20329d): a MiniMax-M3 parent,
+told to "stop with a one-line status" after a background dispatch, serialized
+five simulated re-wake/status cycles into ONE assistant message ("Pickup
+continues...", "Status unchanged..."). The UI looked stuck in a loop, the user
+typed "stop", and a healthy child was killed mid-analysis. The rule text these
+tests pin is what forbids that pattern; if it is edited out, these fail.
+
+Run with:  python -m pytest tests/tools/test_delegate_status_once_guard.py -v
+"""
+
+import unittest
+
+from tools.delegate_tool import _build_top_level_description
+from tools.delegate_tool_dispatch import _BACKGROUND_NOTES, _STATUS_ONCE_RULE
+
+
+class TestStatusOnceGuard(unittest.TestCase):
+    def test_rule_present_in_single_dispatch_note(self):
+        self.assertIn(_STATUS_ONCE_RULE, _BACKGROUND_NOTES["one"])
+
+    def test_rule_present_in_batch_dispatch_note(self):
+        self.assertIn(_STATUS_ONCE_RULE, _BACKGROUND_NOTES["many"])
+
+    def test_rule_forbids_serialized_status_updates(self):
+        # The phrasing that makes the prohibition unambiguous must survive edits.
+        self.assertIn("ONCE", _STATUS_ONCE_RULE)
+        self.assertIn("simulated re-wakes", _STATUS_ONCE_RULE)
+
+    def test_top_level_description_carries_the_guard(self):
+        desc = _build_top_level_description()
+        self.assertIn("ONCE", desc)
+        self.assertIn("re-wakes", desc)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -535,6 +535,8 @@ _DESCRIPTION_HEAD = (
     "as a new message when subagents finish ({delivery}). Background results are delivered only "
     "BETWEEN your turns: finish whatever does not depend on them, then give a one-line status and END YOUR TURN. Never "
     "wait or poll on transcripts, artifact files, or CI for a child. "
+    "Write the status ONCE — no 'still running' follow-up series or narrated re-wakes; only the real completion "
+    "message re-wakes you. "
     "While children run, `action` (list/steer/stop) controls them live — steer when a transcript shows a "
     "child drifting.\n\n"
     "USE FOR: reasoning-heavy subtasks, work that would flood your context with intermediate data, or independent "

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -291,17 +291,28 @@ def _batch_progress_token(child_agents: List[Any]) -> tuple:
             parts.append(None)
     return tuple(parts), in_tool
 
+# 2026-09-11: a MiniMax-M3 parent serialized 5 fake re-wake/status cycles into ONE message after
+# dispatch ("Pickup continues…", "Status unchanged…"); the UI looked stuck in a loop, the user typed
+# "stop", and a healthy child was killed mid-analysis. This sentence exists to forbid that pattern.
+_STATUS_ONCE_RULE = (
+    "Write the status ONCE, then stop generating. Do not emit a series of status updates or narrate future "
+    "wake-ups ('continuing', 'still running', 'pickup') — the completion message is the only thing that "
+    "re-wakes you; simulated re-wakes look like a stuck loop to the user."
+)
+
 _BACKGROUND_NOTES = {
     "one": (
         "Subagent is running in the background; its full result re-enters the conversation as a new message when it "
         "finishes. Results are delivered only after you END YOUR TURN: do anything that does not depend on it, then "
-        "stop with a one-line status. Do not poll its transcript or artifacts to wait for it."
+        "stop with a one-line status. Do not poll its transcript or artifacts to wait for it. "
+        + _STATUS_ONCE_RULE
     ),
     "many": (
         "{n} subagents are running in parallel in the background as {k} completion unit(s); each unit's results "
         "re-enter the conversation as their own new message when THAT unit finishes. Results are delivered only "
         "after you END YOUR TURN: do anything that does not depend on them, then stop with a one-line status. Do not "
-        "poll transcripts or artifacts to wait for them."
+        "poll transcripts or artifacts to wait for them. "
+        + _STATUS_ONCE_RULE
     ),
     "control_hint": (
         "While a child runs you can orchestrate it live with this same tool: delegate_task(action='list') to see live "


### PR DESCRIPTION
## Problem

Observed live (2026-09-11, MiniMax-M3 parent, Desktop session): after a background `delegate_task` dispatch returns its `note` ("...stop with a one-line status. Do not poll..."), the parent model serialized **five simulated re-wake/status cycles into ONE assistant message** ("Pickup continues...", "Continuing from where I left off...", "Status unchanged..."). The DB confirmed zero intervening messages — the model hallucinated the multi-turn pickup loop inside a single completion.

The UI looked like the agent was stuck in a loop, so the user typed `stop` — which killed a healthy child 52s into real analysis work. The framework behaved correctly end-to-end (dispatch, interrupt, delivery of the partial result); the failure was purely the model pattern-extending its own status text. The current wording ("stop with a one-line status") says *what* to do but never explicitly forbids the failure mode.

## Fix

- Add `_STATUS_ONCE_RULE` to `tools/delegate_tool_dispatch.py` and append it to both `_BACKGROUND_NOTES["one"]` and `["many"]` — the text the model reads immediately before composing its post-dispatch status: *"Write the status ONCE, then stop generating. Do not emit a series of status updates or narrate future wake-ups ('continuing', 'still running', 'pickup') — the completion message is the only thing that re-wakes you; simulated re-wakes look like a stuck loop to the user."*
- Shorter clause in the standing tool description (`tools/delegate_tool.py::_DESCRIPTION_HEAD`), kept within the existing 2200-char description cap.
- `tests/tools/test_delegate_status_once_guard.py` pins the rule in both notes and the description so it can't be silently edited out.

## Tests

`pytest tests/tools/test_delegate_status_once_guard.py` — 4 passed. Full `tests/tools/test_delegate*.py` subset (163 tests) otherwise unchanged.