### PR TITLE
fix(anthropic): recover malformed streamed tool JSON

### DIFF
--- a/agent/api_error_summary.py
+++ b/agent/api_error_summary.py
@@ -142,7 +142,9 @@ class ApiErrorSummaryMixin:
                 )
             current = current.__cause__ or current.__context__
 
-        if isinstance(error, ValueError) and "expected ident at line" in raw.lower():
+        if isinstance(error, ValueError) and any(
+            marker in raw.lower() for marker in ("expected ident at line", "expected value at line")
+        ):
             return f"Malformed provider streaming response: {raw[:300]}"
 
         prefix = _http_prefix(error)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2984,6 +2984,7 @@ class _StreamingCall(StreamingWaitMonitor):
         self._writer_token = None
         _stream_context = {"manager": None, "stream": None}
         base_final_message = None
+        stream_parse_error = None
 
         from agent import relay_llm
         from agent.anthropic_adapter import sanitize_anthropic_kwargs
@@ -3039,6 +3040,17 @@ class _StreamingCall(StreamingWaitMonitor):
                         raise EmptyStreamError(
                             "Provider returned an empty stream with no events (possible upstream error or malformed event stream).") from None
                     raise
+        except ValueError as exc:
+            # Fine-grained tool streaming exposes raw partial JSON. The Anthropic SDK
+            # may fail while incrementally decoding it before get_final_message() can
+            # return its buffered/repaired representation. Only recover after a tool
+            # block started; unrelated ValueErrors retain their normal handling.
+            _error_text = str(exc).strip().lower()
+            if not has_tool_use or not any(
+                marker in _error_text for marker in ("expected value at line", "expected ident at line")
+            ):
+                raise
+            stream_parse_error = exc
         finally:
             try:
                 self._close_managed_stream()
@@ -3049,6 +3061,19 @@ class _StreamingCall(StreamingWaitMonitor):
 
         if self.agent._interrupt_requested:
             return None
+        if stream_parse_error is not None:
+            fallback_kwargs = dict(self.api_kwargs)
+            fallback_kwargs.pop("stream", None)
+            sanitize_anthropic_kwargs(
+                fallback_kwargs, log_prefix=getattr(self.agent, "log_prefix", "")
+            )
+            logger.warning(
+                "%sAnthropic tool stream JSON parsing failed (%s); retrying once with buffered messages.create()",
+                getattr(self.agent, "log_prefix", ""),
+                stream_parse_error,
+            )
+            base_final_message = request_client.messages.create(**fallback_kwargs)
+            return self._check_anthropic_message(base_final_message)
         if base_final_message is not None:
             self._check_anthropic_message(base_final_message, tool_drop=False)
             if not stream.output_modified:

--- a/run_agent.py
+++ b/run_agent.py
@@ -485,7 +485,8 @@ class AIAgent(
         that is wire trouble, not local validation, so it follows the truncated-JSON retry path."""
         return (getattr(self, "api_mode", None) == "anthropic_messages" and isinstance(error, ValueError)
                 and not isinstance(error, (UnicodeEncodeError, json.JSONDecodeError))
-                and "expected ident at line" in str(error).strip().lower())
+                and any(marker in str(error).strip().lower() for marker in (
+                    "expected ident at line", "expected value at line")))
 
     _log_stream_retry = _forward("agent.stream_diag", "log_stream_retry")
     _emit_stream_drop = _forward("agent.stream_diag", "emit_stream_drop")

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1096,6 +1096,52 @@ class TestAnthropicStreamCallbacks:
         assert mock_rebuild.call_count == 0
         assert agent._anthropic_client.close.call_count >= 1
 
+    def test_anthropic_malformed_tool_json_falls_back_to_buffered_message(self):
+        """Malformed fine-grained tool JSON uses Anthropic's buffered response."""
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.anthropic.com",
+            model="claude-sonnet-4-5",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "anthropic_messages"
+        agent._interrupt_requested = False
+
+        class _MalformedToolStream:
+            response = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(
+                    type="content_block_start",
+                    content_block=SimpleNamespace(type="tool_use", name="cronjob_manage"),
+                )
+                raise ValueError("expected value at line 1 column 11")
+
+        repaired_message = SimpleNamespace(
+            content=[SimpleNamespace(type="tool_use", name="cronjob_manage", input={"names": "cronjob_manage"})],
+            stop_reason="tool_use",
+        )
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_client.messages.stream.return_value = _MalformedToolStream()
+        agent._anthropic_client.messages.create.return_value = repaired_message
+        agent._create_request_anthropic_client = lambda *a, **k: agent._anthropic_client
+
+        response = agent._interruptible_streaming_api_call({"model": agent.model})
+
+        assert response is repaired_message
+        assert agent._anthropic_client.messages.stream.call_count == 1
+        assert agent._anthropic_client.messages.create.call_count == 1
+
     @patch("run_agent.AIAgent._replace_primary_openai_client")
     def test_generic_anthropic_valueerror_still_propagates_without_stream_retry(
         self, mock_replace, monkeypatch,


### PR DESCRIPTION
## Summary

Fixes the native Anthropic streaming path that can permanently fail when fine-grained tool streaming emits syntactically malformed JSON such as `{"names": cronjob_manage}`.

This is an independent implementation from #107833. The existing PR catches the error in `create_anthropic_message()`, but normal streaming turns call `request_client.messages.stream()` directly from `_StreamingCall._call_anthropic()`. This PR fixes that actual execution path.

## Investigation

The failure sequence on the current base is:

1. `_StreamingCall._call_anthropic()` consumes `messages.stream()`.
2. Anthropic emits `input_json_delta` fragments for a tool call.
3. The SDK incremental parser raises `ValueError: expected value at line 1 column 11` while iterating or finalizing the stream.
4. The unconditional `raw_stream.get_final_message()` path prevents Hermes' accumulator result from being used.
5. The stream retry classifier only recognized `expected ident at line`, so the reported variant was treated as non-transient after partial delivery.
6. The gateway retries the same deterministic request and eventually becomes silent.

The failure was reproduced with a synthetic Anthropic stream through `_interruptible_streaming_api_call()`. The stream path called `messages.stream()` once, never called `messages.create()`, and propagated the reported `ValueError`.

## Root cause

The recovery was implemented in a helper that is not used by the failing native streaming turn. The native worker owns the stream lifecycle and must handle the SDK parser failure after a tool block has started.

## Implementation

- Catch only the known Anthropic malformed-JSON parser messages after a tool block has started.
- Close the managed stream through the existing `finally` lifecycle before fallback.
- Retry the same sanitized request once with non-streaming `messages.create()`, allowing Anthropic's buffered response to provide repaired `input` data.
- Preserve normal propagation for unrelated `ValueError`, timeout, cancellation, and non-tool stream failures.
- Expand the duplicated stream-error summary/classification logic to recognize both `expected ident at line` and `expected value at line`.
- Do not locally rewrite malformed JSON, convert it to `{}`, or execute uncertain tool arguments.

## Safety and behavior

- Tool execution still occurs only after the normal completed-message validation.
- The fallback is restricted to a stream that already announced a tool block and to the specific Anthropic parser error variants.
- Existing retry and role/message handling remain unchanged for other providers and failure classes.
- Credentials and full malformed payloads are not logged.

## Tests and verification

Passed on the isolated branch:

```text
HERMES_PYTHON='C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe' scripts/run_tests.sh tests/run_agent/test_streaming.py -k 'anthropic_malformed_tool_json_falls_back_to_buffered_message or anthropic_stream_parser_valueerror_retries_before_delivery or generic_anthropic_valueerror_still_propagates_without_stream_retry' -v
HERMES_PYTHON='C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe' scripts/run_tests.sh tests/run_agent/test_streaming.py tests/run_agent/test_anthropic_mid_tool_call_drop.py -q
C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe -m ruff check agent/chat_completion_helpers.py agent/api_error_summary.py run_agent.py tests/run_agent/test_streaming.py
C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe -m compileall -q agent/chat_completion_helpers.py agent/api_error_summary.py run_agent.py tests/run_agent/test_streaming.py
git diff --check
```

The regression test exercises the real `_interruptible_streaming_api_call()` path and asserts that a malformed tool stream calls `messages.create()` exactly once and returns the buffered repaired message.

Fixes #107830
