### PR TITLE
fix(tests): repair two main-branch test breakages (anon-auth memo shape, banner live-API seam)

### DIFF
--- a/tests/hermes_cli/test_anon_auth_core.py
+++ b/tests/hermes_cli/test_anon_auth_core.py
@@ -92,9 +92,10 @@ def portal(monkeypatch, tmp_path):
     from hermes_cli import free_tier_bootstrap as _fb
     _fb.reset_for_tests()
     # resolve_nous_access_token memoises the last token for 5 s across the process; a token minted
-    # by an earlier test must not be served to this one.
+    # by an earlier test must not be served to this one. The memo is a dict keyed by
+    # hermes_home_key() (173105ce6f4), so an empty dict is the reset shape — None breaks .get().
     from hermes_cli import auth as auth_mod
-    monkeypatch.setattr(auth_mod, "_RESOLVE_TOKEN_CACHE", None)
+    monkeypatch.setattr(auth_mod, "_RESOLVE_TOKEN_CACHE", {})
     return fake
 
 

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -64,7 +64,7 @@ def test_check_via_local_git_ssh_fastpath_ahead_not_behind(tmp_path):
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
-        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        patch.object(banner, "_github_branch_tip", return_value="a" * 40),
         # merge-base --is-ancestor exits 0: upstream tip IS an ancestor of HEAD
         patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=0)),
     ):
@@ -91,7 +91,7 @@ def test_check_via_local_git_ssh_fastpath_genuinely_behind(tmp_path):
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
-        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        patch.object(banner, "_github_branch_tip", return_value="a" * 40),
         # merge-base --is-ancestor exits 1: not an ancestor -> genuinely behind
         patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=1)),
         patch.object(banner, "_github_compare_behind", return_value=3),
@@ -119,7 +119,7 @@ def test_check_via_local_git_ssh_fastpath_offline_keeps_sentinel(tmp_path):
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
-        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        patch.object(banner, "_github_branch_tip", return_value="a" * 40),
         patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=1)),
         patch.object(banner, "_github_compare_behind", return_value=None),
     ):


### PR DESCRIPTION
Two pre-existing main-branch test breakages fixed — every current PR's `Python tests` job was red on them (seen on #107858's CI, which touches only `tools/process_registry.py`).

## Fix 1 — anon-auth fixture resets the token memo to the wrong shape

`TestTokenAcquisitionSeam::test_tool_gateway_token_path_reexchanges` and `TestConnectorTokenPath::test_connector_path_replaces_a_dead_credential_once` fail on origin/main with `AttributeError: 'NoneType' object has no attribute 'get'`.

173105ce6f4 (profile-scoped token memo, salvage of @pierrenode's fix) changed `hermes_cli.auth._RESOLVE_TOKEN_CACHE` from a single tuple slot (reset shape `None`) to a **dict keyed by `hermes_home_key()`**. The `portal` fixture still reset it with `None`, so the first `_RESOLVE_TOKEN_CACHE.get(cache_key)` crashed. Reset with `{}` — fixture semantics (no token leaks from an earlier test) unchanged.

## Fix 2 — banner SSH fast-path tests patch a seam that is never called (live API call on CI)

`test_check_via_local_git_ssh_fastpath_{ahead_not_behind,genuinely_behind,offline_keeps_sentinel}` (added in 338bf9ea9ac) patch `_upstream_main_sha`, but for a GitHub origin `_check_via_local_git` resolves the remote tip via **`_github_branch_tip`** — the patched function is never called on that path. The real `_github_branch_tip` then made a live GitHub API request: green on developer machines, red on CI where the unauthenticated call is rate-limited (`target_rev=None` → `behind=None` instead of 3/0/sentinel). Patch `_github_branch_tip` directly; deterministic and offline-safe.

## Validation

| Suite | origin/main | this branch |
|---|---|---|
| `tests/hermes_cli/test_anon_auth_core.py` | 32 passed, 2 failed | **34 passed, 0 failed** |
| `tests/hermes_cli/test_banner_git_state.py` | 6 passed locally (network), 3 failed on CI | **6 passed, 0 failed** (no network needed) |

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9f11d/K3LKzZtAI0hDAFW2ELrzY_LEjdCVJe.png)
