### PR TITLE
fix(google-workspace): fall back to the Python API when the gws CLI fails

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -19,7 +19,7 @@ metadata:
 
 # Google Workspace
 
-Gmail, Calendar, Drive, Contacts, Sheets, and Docs — through Hermes-managed OAuth and a thin CLI wrapper. When `gws` is installed, the skill uses it as the execution backend for broader Google Workspace coverage; otherwise it falls back to the bundled Python client implementation.
+Gmail, Calendar, Drive, Contacts, Sheets, and Docs — through Hermes-managed OAuth and a thin CLI wrapper. When `gws` is installed, the skill uses it as the execution backend for broader Google Workspace coverage; otherwise — or when a `gws` call fails — it falls back to the bundled Python client implementation.
 
 ## References
 
@@ -29,7 +29,7 @@ Gmail, Calendar, Drive, Contacts, Sheets, and Docs — through Hermes-managed OA
 ## Scripts
 
 - `scripts/setup.py` — OAuth2 setup (run once to authorize)
-- `scripts/google_api.py` — compatibility wrapper CLI. It prefers `gws` for operations when available, while preserving Hermes' existing JSON output contract.
+- `scripts/google_api.py` — compatibility wrapper CLI. It prefers `gws` for operations when available and falls back to the Python client when `gws` is missing or a call fails, while preserving Hermes' existing JSON output contract.
 
 ## First-Time Setup
 

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -61,11 +61,31 @@ def _normalize_authorized_user_payload(payload: dict) -> dict:
     return normalized
 
 
+def _normalize_token_file() -> None:
+    """Keep the on-disk token readable by ``gws``.
+
+    The CLI requires the ``type`` field; the Python client library does not, so
+    a token written by a code path that omitted it makes gws fail while the
+    Python API keeps working. Normalize in place rather than only on refresh.
+    """
+    try:
+        data = json.loads(TOKEN_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return
+    normalized = _normalize_authorized_user_payload(data)
+    if normalized != data:
+        try:
+            TOKEN_PATH.write_text(json.dumps(normalized, indent=2), encoding="utf-8")
+        except OSError:
+            pass
+
+
 def _ensure_authenticated():
     if not TOKEN_PATH.exists():
         print("Not authenticated. Run the setup script first:", file=sys.stderr)
         print(f"  python {Path(__file__).parent / 'setup.py'}", file=sys.stderr)
         sys.exit(1)
+    _normalize_token_file()
 
 
 def _stored_token_scopes() -> list[str]:
@@ -92,6 +112,18 @@ def _gws_env() -> dict[str, str]:
     return env
 
 
+class GwsError(RuntimeError):
+    """The ``gws`` CLI is installed but the call failed.
+
+    Raised instead of exiting so callers can fall through to the Python API
+    path, which works with the same token.
+    """
+
+
+def _gws_fallback_notice(exc: Exception) -> None:
+    print(f"gws failed ({exc}); falling back to the Python API", file=sys.stderr)
+
+
 def _run_gws(parts: list[str], *, params: dict | None = None, body: dict | None = None):
     binary = _gws_binary()
     if not binary:
@@ -113,8 +145,7 @@ def _run_gws(parts: list[str], *, params: dict | None = None, body: dict | None 
     )
     if result.returncode != 0:
         err = result.stderr.strip() or result.stdout.strip() or "Unknown gws error"
-        print(err, file=sys.stderr)
-        sys.exit(result.returncode or 1)
+        raise GwsError(err)
 
     stdout = result.stdout.strip()
     if not stdout:
@@ -123,9 +154,7 @@ def _run_gws(parts: list[str], *, params: dict | None = None, body: dict | None 
     try:
         return json.loads(stdout)
     except json.JSONDecodeError:
-        print("ERROR: Unexpected non-JSON output from gws:", file=sys.stderr)
-        print(stdout, file=sys.stderr)
-        sys.exit(1)
+        raise GwsError(f"unexpected non-JSON output from gws: {stdout[:200]}")
 
 
 def _headers_dict(msg: dict) -> dict[str, str]:
@@ -213,37 +242,40 @@ def build_service(api, version):
 
 def gmail_search(args):
     if _gws_binary():
-        results = _run_gws(
-            ["gmail", "users", "messages", "list"],
-            params={"userId": "me", "q": args.query, "maxResults": args.max},
-        )
-        messages = results.get("messages", [])
-        output = []
-        for msg_meta in messages:
-            msg = _run_gws(
-                ["gmail", "users", "messages", "get"],
-                params={
-                    "userId": "me",
-                    "id": msg_meta["id"],
-                    "format": "metadata",
-                    "metadataHeaders": ["From", "To", "Subject", "Date"],
-                },
+        try:
+            results = _run_gws(
+                ["gmail", "users", "messages", "list"],
+                params={"userId": "me", "q": args.query, "maxResults": args.max},
             )
-            headers = _headers_dict(msg)
-            output.append(
-                {
-                    "id": msg["id"],
-                    "threadId": msg["threadId"],
-                    "from": headers.get("from", ""),
-                    "to": headers.get("to", ""),
-                    "subject": headers.get("subject", ""),
-                    "date": headers.get("date", ""),
-                    "snippet": msg.get("snippet", ""),
-                    "labels": msg.get("labelIds", []),
-                }
-            )
-        print(json.dumps(output, indent=2, ensure_ascii=False))
-        return
+            messages = results.get("messages", [])
+            output = []
+            for msg_meta in messages:
+                msg = _run_gws(
+                    ["gmail", "users", "messages", "get"],
+                    params={
+                        "userId": "me",
+                        "id": msg_meta["id"],
+                        "format": "metadata",
+                        "metadataHeaders": ["From", "To", "Subject", "Date"],
+                    },
+                )
+                headers = _headers_dict(msg)
+                output.append(
+                    {
+                        "id": msg["id"],
+                        "threadId": msg["threadId"],
+                        "from": headers.get("from", ""),
+                        "to": headers.get("to", ""),
+                        "subject": headers.get("subject", ""),
+                        "date": headers.get("date", ""),
+                        "snippet": msg.get("snippet", ""),
+                        "labels": msg.get("labelIds", []),
+                    }
+                )
+            print(json.dumps(output, indent=2, ensure_ascii=False))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("gmail", "v1")
     results = service.users().messages().list(
@@ -277,23 +309,26 @@ def gmail_search(args):
 
 def gmail_get(args):
     if _gws_binary():
-        msg = _run_gws(
-            ["gmail", "users", "messages", "get"],
-            params={"userId": "me", "id": args.message_id, "format": "full"},
-        )
-        headers = _headers_dict(msg)
-        result = {
-            "id": msg["id"],
-            "threadId": msg["threadId"],
-            "from": headers.get("from", ""),
-            "to": headers.get("to", ""),
-            "subject": headers.get("subject", ""),
-            "date": headers.get("date", ""),
-            "labels": msg.get("labelIds", []),
-            "body": _extract_message_body(msg),
-        }
-        print(json.dumps(result, indent=2, ensure_ascii=False))
-        return
+        try:
+            msg = _run_gws(
+                ["gmail", "users", "messages", "get"],
+                params={"userId": "me", "id": args.message_id, "format": "full"},
+            )
+            headers = _headers_dict(msg)
+            result = {
+                "id": msg["id"],
+                "threadId": msg["threadId"],
+                "from": headers.get("from", ""),
+                "to": headers.get("to", ""),
+                "subject": headers.get("subject", ""),
+                "date": headers.get("date", ""),
+                "labels": msg.get("labelIds", []),
+                "body": _extract_message_body(msg),
+            }
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("gmail", "v1")
     msg = service.users().messages().get(
@@ -317,26 +352,29 @@ def gmail_get(args):
 
 def gmail_send(args):
     if _gws_binary():
-        message = MIMEText(args.body, "html" if args.html else "plain")
-        message["To"] = args.to
-        message["Subject"] = args.subject
-        if args.cc:
-            message["Cc"] = args.cc
-        if args.from_header:
-            message["From"] = args.from_header
-
-        raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
-        body = {"raw": raw}
-        if args.thread_id:
-            body["threadId"] = args.thread_id
-
-        result = _run_gws(
-            ["gmail", "users", "messages", "send"],
-            params={"userId": "me"},
-            body=body,
-        )
-        print(json.dumps({"status": "sent", "id": result["id"], "threadId": result.get("threadId", "")}, indent=2))
-        return
+        try:
+            message = MIMEText(args.body, "html" if args.html else "plain")
+            message["To"] = args.to
+            message["Subject"] = args.subject
+            if args.cc:
+                message["Cc"] = args.cc
+            if args.from_header:
+                message["From"] = args.from_header
+    
+            raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
+            body = {"raw": raw}
+            if args.thread_id:
+                body["threadId"] = args.thread_id
+    
+            result = _run_gws(
+                ["gmail", "users", "messages", "send"],
+                params={"userId": "me"},
+                body=body,
+            )
+            print(json.dumps({"status": "sent", "id": result["id"], "threadId": result.get("threadId", "")}, indent=2))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("gmail", "v1")
     message = MIMEText(args.body, "html" if args.html else "plain")
@@ -360,38 +398,41 @@ def gmail_send(args):
 
 def gmail_reply(args):
     if _gws_binary():
-        original = _run_gws(
-            ["gmail", "users", "messages", "get"],
-            params={
-                "userId": "me",
-                "id": args.message_id,
-                "format": "metadata",
-                "metadataHeaders": ["From", "Subject", "Message-ID"],
-            },
-        )
-        headers = _headers_dict(original)
-
-        subject = headers.get("subject", "")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
-
-        message = MIMEText(args.body)
-        message["To"] = headers.get("from", "")
-        message["Subject"] = subject
-        if args.from_header:
-            message["From"] = args.from_header
-        if headers.get("message-id"):
-            message["In-Reply-To"] = headers["message-id"]
-            message["References"] = headers["message-id"]
-
-        raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
-        result = _run_gws(
-            ["gmail", "users", "messages", "send"],
-            params={"userId": "me"},
-            body={"raw": raw, "threadId": original["threadId"]},
-        )
-        print(json.dumps({"status": "sent", "id": result["id"], "threadId": result.get("threadId", "")}, indent=2))
-        return
+        try:
+            original = _run_gws(
+                ["gmail", "users", "messages", "get"],
+                params={
+                    "userId": "me",
+                    "id": args.message_id,
+                    "format": "metadata",
+                    "metadataHeaders": ["From", "Subject", "Message-ID"],
+                },
+            )
+            headers = _headers_dict(original)
+    
+            subject = headers.get("subject", "")
+            if not subject.startswith("Re:"):
+                subject = f"Re: {subject}"
+    
+            message = MIMEText(args.body)
+            message["To"] = headers.get("from", "")
+            message["Subject"] = subject
+            if args.from_header:
+                message["From"] = args.from_header
+            if headers.get("message-id"):
+                message["In-Reply-To"] = headers["message-id"]
+                message["References"] = headers["message-id"]
+    
+            raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
+            result = _run_gws(
+                ["gmail", "users", "messages", "send"],
+                params={"userId": "me"},
+                body={"raw": raw, "threadId": original["threadId"]},
+            )
+            print(json.dumps({"status": "sent", "id": result["id"], "threadId": result.get("threadId", "")}, indent=2))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("gmail", "v1")
     original = service.users().messages().get(
@@ -423,10 +464,13 @@ def gmail_reply(args):
 
 def gmail_labels(args):
     if _gws_binary():
-        results = _run_gws(["gmail", "users", "labels", "list"], params={"userId": "me"})
-        labels = [{"id": l["id"], "name": l["name"], "type": l.get("type", "")} for l in results.get("labels", [])]
-        print(json.dumps(labels, indent=2))
-        return
+        try:
+            results = _run_gws(["gmail", "users", "labels", "list"], params={"userId": "me"})
+            labels = [{"id": l["id"], "name": l["name"], "type": l.get("type", "")} for l in results.get("labels", [])]
+            print(json.dumps(labels, indent=2))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("gmail", "v1")
     results = service.users().labels().list(userId="me").execute()
@@ -443,13 +487,16 @@ def gmail_modify(args):
         body["removeLabelIds"] = args.remove_labels.split(",")
 
     if _gws_binary():
-        result = _run_gws(
-            ["gmail", "users", "messages", "modify"],
-            params={"userId": "me", "id": args.message_id},
-            body=body,
-        )
-        print(json.dumps({"id": result["id"], "labels": result.get("labelIds", [])}, indent=2))
-        return
+        try:
+            result = _run_gws(
+                ["gmail", "users", "messages", "modify"],
+                params={"userId": "me", "id": args.message_id},
+                body=body,
+            )
+            print(json.dumps({"id": result["id"], "labels": result.get("labelIds", [])}, indent=2))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("gmail", "v1")
     result = service.users().messages().modify(userId="me", id=args.message_id, body=body).execute()
@@ -467,31 +514,34 @@ def calendar_list(args):
     time_max = _datetime_with_timezone(args.end or (now + timedelta(days=7)).isoformat())
 
     if _gws_binary():
-        results = _run_gws(
-            ["calendar", "events", "list"],
-            params={
-                "calendarId": args.calendar,
-                "timeMin": time_min,
-                "timeMax": time_max,
-                "maxResults": args.max,
-                "singleEvents": True,
-                "orderBy": "startTime",
-            },
-        )
-        events = []
-        for e in results.get("items", []):
-            events.append({
-                "id": e["id"],
-                "summary": e.get("summary", "(no title)"),
-                "start": e.get("start", {}).get("dateTime", e.get("start", {}).get("date", "")),
-                "end": e.get("end", {}).get("dateTime", e.get("end", {}).get("date", "")),
-                "location": e.get("location", ""),
-                "description": e.get("description", ""),
-                "status": e.get("status", ""),
-                "htmlLink": e.get("htmlLink", ""),
-            })
-        print(json.dumps(events, indent=2, ensure_ascii=False))
-        return
+        try:
+            results = _run_gws(
+                ["calendar", "events", "list"],
+                params={
+                    "calendarId": args.calendar,
+                    "timeMin": time_min,
+                    "timeMax": time_max,
+                    "maxResults": args.max,
+                    "singleEvents": True,
+                    "orderBy": "startTime",
+                },
+            )
+            events = []
+            for e in results.get("items", []):
+                events.append({
+                    "id": e["id"],
+                    "summary": e.get("summary", "(no title)"),
+                    "start": e.get("start", {}).get("dateTime", e.get("start", {}).get("date", "")),
+                    "end": e.get("end", {}).get("dateTime", e.get("end", {}).get("date", "")),
+                    "location": e.get("location", ""),
+                    "description": e.get("description", ""),
+                    "status": e.get("status", ""),
+                    "htmlLink": e.get("htmlLink", ""),
+                })
+            print(json.dumps(events, indent=2, ensure_ascii=False))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("calendar", "v3")
     results = service.events().list(
@@ -529,18 +579,21 @@ def calendar_create(args):
         event["attendees"] = [{"email": e.strip()} for e in args.attendees.split(",") if e.strip()]
 
     if _gws_binary():
-        result = _run_gws(
-            ["calendar", "events", "insert"],
-            params={"calendarId": args.calendar},
-            body=event,
-        )
-        print(json.dumps({
-            "status": "created",
-            "id": result["id"],
-            "summary": result.get("summary", ""),
-            "htmlLink": result.get("htmlLink", ""),
-        }, indent=2))
-        return
+        try:
+            result = _run_gws(
+                ["calendar", "events", "insert"],
+                params={"calendarId": args.calendar},
+                body=event,
+            )
+            print(json.dumps({
+                "status": "created",
+                "id": result["id"],
+                "summary": result.get("summary", ""),
+                "htmlLink": result.get("htmlLink", ""),
+            }, indent=2))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("calendar", "v3")
     result = service.events().insert(calendarId=args.calendar, body=event).execute()
@@ -555,9 +608,12 @@ def calendar_create(args):
 
 def calendar_delete(args):
     if _gws_binary():
-        _run_gws(["calendar", "events", "delete"], params={"calendarId": args.calendar, "eventId": args.event_id})
-        print(json.dumps({"status": "deleted", "eventId": args.event_id}))
-        return
+        try:
+            _run_gws(["calendar", "events", "delete"], params={"calendarId": args.calendar, "eventId": args.event_id})
+            print(json.dumps({"status": "deleted", "eventId": args.event_id}))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("calendar", "v3")
     service.events().delete(calendarId=args.calendar, eventId=args.event_id).execute()
@@ -572,16 +628,19 @@ def calendar_delete(args):
 def drive_search(args):
     query = args.query if args.raw_query else f"fullText contains '{args.query}'"
     if _gws_binary():
-        results = _run_gws(
-            ["drive", "files", "list"],
-            params={
-                "q": query,
-                "pageSize": args.max,
-                "fields": "files(id, name, mimeType, modifiedTime, webViewLink)",
-            },
-        )
-        print(json.dumps(results.get("files", []), indent=2, ensure_ascii=False))
-        return
+        try:
+            results = _run_gws(
+                ["drive", "files", "list"],
+                params={
+                    "q": query,
+                    "pageSize": args.max,
+                    "fields": "files(id, name, mimeType, modifiedTime, webViewLink)",
+                },
+            )
+            print(json.dumps(results.get("files", []), indent=2, ensure_ascii=False))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("drive", "v3")
     results = service.files().list(
@@ -595,12 +654,15 @@ def drive_get(args):
     """Get metadata for a single Drive file by ID."""
     fields = "id, name, mimeType, modifiedTime, size, webViewLink, parents, owners(emailAddress)"
     if _gws_binary():
-        result = _run_gws(
-            ["drive", "files", "get"],
-            params={"fileId": args.file_id, "fields": fields},
-        )
-        print(json.dumps(result, indent=2, ensure_ascii=False))
-        return
+        try:
+            result = _run_gws(
+                ["drive", "files", "get"],
+                params={"fileId": args.file_id, "fields": fields},
+            )
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("drive", "v3")
     result = service.files().get(fileId=args.file_id, fields=fields).execute()
@@ -697,18 +759,21 @@ def drive_create_folder(args):
         body["parents"] = [args.parent]
 
     if _gws_binary():
-        result = _run_gws(
-            ["drive", "files", "create"],
-            params={"fields": "id, name, webViewLink"},
-            body=body,
-        )
-        print(json.dumps({
-            "status": "created",
-            "id": result["id"],
-            "name": result.get("name", ""),
-            "webViewLink": result.get("webViewLink", ""),
-        }, indent=2, ensure_ascii=False))
-        return
+        try:
+            result = _run_gws(
+                ["drive", "files", "create"],
+                params={"fields": "id, name, webViewLink"},
+                body=body,
+            )
+            print(json.dumps({
+                "status": "created",
+                "id": result["id"],
+                "name": result.get("name", ""),
+                "webViewLink": result.get("webViewLink", ""),
+            }, indent=2, ensure_ascii=False))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("drive", "v3")
     result = service.files().create(body=body, fields="id, name, webViewLink").execute()
@@ -737,22 +802,25 @@ def drive_share(args):
         permission["domain"] = args.domain
 
     if _gws_binary():
-        result = _run_gws(
-            ["drive", "permissions", "create"],
-            params={
+        try:
+            result = _run_gws(
+                ["drive", "permissions", "create"],
+                params={
+                    "fileId": args.file_id,
+                    "sendNotificationEmail": args.notify,
+                },
+                body=permission,
+            )
+            print(json.dumps({
+                "status": "shared",
+                "permissionId": result.get("id", ""),
                 "fileId": args.file_id,
-                "sendNotificationEmail": args.notify,
-            },
-            body=permission,
-        )
-        print(json.dumps({
-            "status": "shared",
-            "permissionId": result.get("id", ""),
-            "fileId": args.file_id,
-            "role": permission["role"],
-            "type": permission["type"],
-        }, indent=2, ensure_ascii=False))
-        return
+                "role": permission["role"],
+                "type": permission["type"],
+            }, indent=2, ensure_ascii=False))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("drive", "v3")
     result = service.permissions().create(
@@ -774,9 +842,12 @@ def drive_delete(args):
     """Trash or permanently delete a Drive file. Defaults to trash (reversible)."""
     if args.permanent:
         if _gws_binary():
-            _run_gws(["drive", "files", "delete"], params={"fileId": args.file_id})
-            print(json.dumps({"status": "deleted", "fileId": args.file_id, "permanent": True}))
-            return
+            try:
+                _run_gws(["drive", "files", "delete"], params={"fileId": args.file_id})
+                print(json.dumps({"status": "deleted", "fileId": args.file_id, "permanent": True}))
+                return
+            except GwsError as exc:
+                _gws_fallback_notice(exc)
         service = build_service("drive", "v3")
         service.files().delete(fileId=args.file_id).execute()
         print(json.dumps({"status": "deleted", "fileId": args.file_id, "permanent": True}))
@@ -785,13 +856,16 @@ def drive_delete(args):
     # Trash (reversible). Use files.update with trashed=True.
     body = {"trashed": True}
     if _gws_binary():
-        _run_gws(
-            ["drive", "files", "update"],
-            params={"fileId": args.file_id},
-            body=body,
-        )
-        print(json.dumps({"status": "trashed", "fileId": args.file_id, "permanent": False}))
-        return
+        try:
+            _run_gws(
+                ["drive", "files", "update"],
+                params={"fileId": args.file_id},
+                body=body,
+            )
+            print(json.dumps({"status": "trashed", "fileId": args.file_id, "permanent": False}))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("drive", "v3")
     service.files().update(fileId=args.file_id, body=body).execute()
@@ -805,26 +879,29 @@ def drive_delete(args):
 
 def contacts_list(args):
     if _gws_binary():
-        results = _run_gws(
-            ["people", "people", "connections", "list"],
-            params={
-                "resourceName": "people/me",
-                "pageSize": args.max,
-                "personFields": "names,emailAddresses,phoneNumbers",
-            },
-        )
-        contacts = []
-        for person in results.get("connections", []):
-            names = person.get("names", [{}])
-            emails = person.get("emailAddresses", [])
-            phones = person.get("phoneNumbers", [])
-            contacts.append({
-                "name": names[0].get("displayName", "") if names else "",
-                "emails": [e.get("value", "") for e in emails],
-                "phones": [p.get("value", "") for p in phones],
-            })
-        print(json.dumps(contacts, indent=2, ensure_ascii=False))
-        return
+        try:
+            results = _run_gws(
+                ["people", "people", "connections", "list"],
+                params={
+                    "resourceName": "people/me",
+                    "pageSize": args.max,
+                    "personFields": "names,emailAddresses,phoneNumbers",
+                },
+            )
+            contacts = []
+            for person in results.get("connections", []):
+                names = person.get("names", [{}])
+                emails = person.get("emailAddresses", [])
+                phones = person.get("phoneNumbers", [])
+                contacts.append({
+                    "name": names[0].get("displayName", "") if names else "",
+                    "emails": [e.get("value", "") for e in emails],
+                    "phones": [p.get("value", "") for p in phones],
+                })
+            print(json.dumps(contacts, indent=2, ensure_ascii=False))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("people", "v1")
     results = service.people().connections().list(
@@ -852,12 +929,15 @@ def contacts_list(args):
 
 def sheets_get(args):
     if _gws_binary():
-        result = _run_gws(
-            ["sheets", "spreadsheets", "values", "get"],
-            params={"spreadsheetId": args.sheet_id, "range": args.range},
-        )
-        print(json.dumps(result.get("values", []), indent=2, ensure_ascii=False))
-        return
+        try:
+            result = _run_gws(
+                ["sheets", "spreadsheets", "values", "get"],
+                params={"spreadsheetId": args.sheet_id, "range": args.range},
+            )
+            print(json.dumps(result.get("values", []), indent=2, ensure_ascii=False))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("sheets", "v4")
     result = service.spreadsheets().values().get(
@@ -872,17 +952,20 @@ def sheets_update(args):
     body = {"values": values}
 
     if _gws_binary():
-        result = _run_gws(
-            ["sheets", "spreadsheets", "values", "update"],
-            params={
-                "spreadsheetId": args.sheet_id,
-                "range": args.range,
-                "valueInputOption": "USER_ENTERED",
-            },
-            body=body,
-        )
-        print(json.dumps({"updatedCells": result.get("updatedCells", 0), "updatedRange": result.get("updatedRange", "")}, indent=2))
-        return
+        try:
+            result = _run_gws(
+                ["sheets", "spreadsheets", "values", "update"],
+                params={
+                    "spreadsheetId": args.sheet_id,
+                    "range": args.range,
+                    "valueInputOption": "USER_ENTERED",
+                },
+                body=body,
+            )
+            print(json.dumps({"updatedCells": result.get("updatedCells", 0), "updatedRange": result.get("updatedRange", "")}, indent=2))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("sheets", "v4")
     result = service.spreadsheets().values().update(
@@ -898,18 +981,21 @@ def sheets_append(args):
     body = {"values": values}
 
     if _gws_binary():
-        result = _run_gws(
-            ["sheets", "spreadsheets", "values", "append"],
-            params={
-                "spreadsheetId": args.sheet_id,
-                "range": args.range,
-                "valueInputOption": "USER_ENTERED",
-                "insertDataOption": "INSERT_ROWS",
-            },
-            body=body,
-        )
-        print(json.dumps({"updatedCells": result.get("updates", {}).get("updatedCells", 0)}, indent=2))
-        return
+        try:
+            result = _run_gws(
+                ["sheets", "spreadsheets", "values", "append"],
+                params={
+                    "spreadsheetId": args.sheet_id,
+                    "range": args.range,
+                    "valueInputOption": "USER_ENTERED",
+                    "insertDataOption": "INSERT_ROWS",
+                },
+                body=body,
+            )
+            print(json.dumps({"updatedCells": result.get("updates", {}).get("updatedCells", 0)}, indent=2))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("sheets", "v4")
     result = service.spreadsheets().values().append(
@@ -926,14 +1012,17 @@ def sheets_create(args):
         body["sheets"] = [{"properties": {"title": args.sheet_name}}]
 
     if _gws_binary():
-        result = _run_gws(["sheets", "spreadsheets", "create"], body=body)
-        print(json.dumps({
-            "status": "created",
-            "spreadsheetId": result.get("spreadsheetId", ""),
-            "title": result.get("properties", {}).get("title", ""),
-            "spreadsheetUrl": result.get("spreadsheetUrl", ""),
-        }, indent=2, ensure_ascii=False))
-        return
+        try:
+            result = _run_gws(["sheets", "spreadsheets", "create"], body=body)
+            print(json.dumps({
+                "status": "created",
+                "spreadsheetId": result.get("spreadsheetId", ""),
+                "title": result.get("properties", {}).get("title", ""),
+                "spreadsheetUrl": result.get("spreadsheetUrl", ""),
+            }, indent=2, ensure_ascii=False))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("sheets", "v4")
     result = service.spreadsheets().create(
@@ -954,14 +1043,17 @@ def sheets_create(args):
 
 def docs_get(args):
     if _gws_binary():
-        doc = _run_gws(["docs", "documents", "get"], params={"documentId": args.doc_id})
-        result = {
-            "title": doc.get("title", ""),
-            "documentId": doc.get("documentId", ""),
-            "body": _extract_doc_text(doc),
-        }
-        print(json.dumps(result, indent=2, ensure_ascii=False))
-        return
+        try:
+            doc = _run_gws(["docs", "documents", "get"], params={"documentId": args.doc_id})
+            result = {
+                "title": doc.get("title", ""),
+                "documentId": doc.get("documentId", ""),
+                "body": _extract_doc_text(doc),
+            }
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("docs", "v1")
     doc = service.documents().get(documentId=args.doc_id).execute()
@@ -977,9 +1069,13 @@ def docs_create(args):
     """Create a new Doc. Optionally seed it with initial body text."""
     body = {"title": args.title}
 
+    doc = None
     if _gws_binary():
-        doc = _run_gws(["docs", "documents", "create"], body=body)
-    else:
+        try:
+            doc = _run_gws(["docs", "documents", "create"], body=body)
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
+    if doc is None:
         service = build_service("docs", "v1")
         doc = service.documents().create(body=body).execute()
 
@@ -998,9 +1094,13 @@ def docs_create(args):
 
 def docs_append(args):
     """Append text to the end of an existing Doc."""
+    doc = None
     if _gws_binary():
-        doc = _run_gws(["docs", "documents", "get"], params={"documentId": args.doc_id})
-    else:
+        try:
+            doc = _run_gws(["docs", "documents", "get"], params={"documentId": args.doc_id})
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
+    if doc is None:
         service = build_service("docs", "v1")
         doc = service.documents().get(documentId=args.doc_id).execute()
 
@@ -1035,12 +1135,15 @@ def _docs_insert_text(doc_id: str, text: str, index: int) -> None:
         }
     }]
     if _gws_binary():
-        _run_gws(
-            ["docs", "documents", "batchUpdate"],
-            params={"documentId": doc_id},
-            body={"requests": requests},
-        )
-        return
+        try:
+            _run_gws(
+                ["docs", "documents", "batchUpdate"],
+                params={"documentId": doc_id},
+                body={"requests": requests},
+            )
+            return
+        except GwsError as exc:
+            _gws_fallback_notice(exc)
 
     service = build_service("docs", "v1")
     service.documents().batchUpdate(documentId=doc_id, body={"requests": requests}).execute()

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -195,3 +195,69 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+def test_api_run_gws_raises_gws_error_instead_of_exiting(api_module):
+    """A failing gws CLI raises GwsError; it must not terminate the process."""
+    def failing_run(cmd, **kwargs):
+        return MagicMock(returncode=3, stdout="", stderr="auth failed")
+
+    with patch.object(api_module.subprocess, "run", side_effect=failing_run):
+        with pytest.raises(api_module.GwsError):
+            api_module._run_gws(["gmail", "users", "messages", "list"])
+
+
+def test_api_gmail_search_falls_back_when_gws_fails(api_module, capsys, monkeypatch):
+    """Regression: a present-but-failing gws aborted the command with no output.
+
+    The Python API path works with the same token, so a gws failure must fall
+    through to it rather than ending the run.
+    """
+    def failing_run(cmd, **kwargs):
+        return MagicMock(returncode=3, stdout="", stderr="auth failed")
+
+    service = MagicMock()
+    service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+        "messages": [{"id": "m1"}],
+    }
+    service.users.return_value.messages.return_value.get.return_value.execute.return_value = {
+        "id": "m1",
+        "threadId": "t1",
+        "snippet": "snip",
+        "labelIds": ["UNREAD"],
+        "payload": {"headers": [{"name": "Subject", "value": "hello"}]},
+    }
+    monkeypatch.setattr(api_module, "build_service", lambda *a, **k: service)
+
+    args = api_module.argparse.Namespace(query="is:unread", max=1)
+    with patch.object(api_module.subprocess, "run", side_effect=failing_run):
+        api_module.gmail_search(args)
+
+    captured = capsys.readouterr()
+    assert "falling back to the Python API" in captured.err
+    payload = json.loads(captured.out)
+    assert payload[0]["id"] == "m1"
+    assert payload[0]["subject"] == "hello"
+
+
+def test_api_docs_append_falls_back_when_gws_fails(api_module, monkeypatch):
+    """The if/else gate sites must still bind a document on the fallback path."""
+    def failing_run(cmd, **kwargs):
+        return MagicMock(returncode=3, stdout="", stderr="boom")
+
+    service = MagicMock()
+    service.documents.return_value.get.return_value.execute.return_value = {
+        "body": {"content": [{"endIndex": 5}]},
+    }
+    calls = {}
+    monkeypatch.setattr(api_module, "build_service", lambda *a, **k: service)
+    monkeypatch.setattr(
+        api_module, "_docs_insert_text",
+        lambda doc_id, text, index: calls.update(doc_id=doc_id, index=index),
+    )
+
+    args = api_module.argparse.Namespace(doc_id="doc1", text="hi")
+    with patch.object(api_module.subprocess, "run", side_effect=failing_run):
+        api_module.docs_append(args)
+
+    assert calls == {"doc_id": "doc1", "index": 4}


### PR DESCRIPTION
## What does this PR do?

Fixes `google_api.py` aborting every Google Workspace command when the `gws` CLI is **installed but failing**.

`_run_gws()` calls `sys.exit()` when the CLI returns a non-zero exit code, and again when it emits non-JSON output. Because the fallback to the Python client is gated on `if _gws_binary():` — a presence check, evaluated before any call — a gws that is present and erroring is never caught. gmail, calendar, drive, sheets, docs, and contacts all terminate with no output, even though the Python API path works fine with the exact same token.

This PR makes a gws *failure* behave the same as an absent gws: `GwsError` is raised instead of exiting, and every `if _gws_binary():` block falls through to the Python path.

This is the right approach because the fallback machinery already exists and is already trusted for the missing-binary case; the only thing that made a failing binary worse than a missing one was the `sys.exit()`. No new dependency, no new command surface, and the switch is announced on stderr rather than happening silently.

The PR also normalizes the on-disk token in `_ensure_authenticated()`. `gws` requires a `type` field in `google_token.json`; the Python client library does not, so a token written by a code path that omitted it makes gws fail while the Python API keeps working. This reuses the existing `_normalize_authorized_user_payload()` helper instead of duplicating the logic, so the file stops being gws-hostile the moment any command runs.

## Related Issue

No issue filed — reproduction is below and the bug is a single call site class.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/productivity/google-workspace/scripts/google_api.py`
  - Added `GwsError` (a `RuntimeError`) and `_gws_fallback_notice()`.
  - `_run_gws()` raises `GwsError` on a non-zero exit code and on non-JSON output, instead of `sys.exit()`.
  - Wrapped all 24 `if _gws_binary():` blocks in `try/except GwsError` so a failed call falls through to the Python path. The two `if/else` sites (`docs_create`, `docs_append`) now bind `doc = None` and take the Python branch when the gws call fails.
  - Added `_normalize_token_file()`, called from `_ensure_authenticated()`.
- `skills/productivity/google-workspace/SKILL.md` — two sentences that described the fallback as applying only when `gws` is not installed now also cover a failed call.
- `tests/skills/test_google_workspace_api.py` — 3 tests (proven red on base, see below).

## How to Test

1. Create a stub that behaves like an installed-but-failing `gws`:

   ```sh
   printf '#!/bin/sh\necho "gws: simulated auth failure" >&2\nexit 3\n' > /tmp/fake_gws_fail
   chmod +x /tmp/fake_gws_fail
   ```

2. Run any command with the failing binary selected:

   ```sh
   HERMES_GWS_BIN=/tmp/fake_gws_fail python3 \
     skills/productivity/google-workspace/scripts/google_api.py \
     gmail search "is:unread" --max 1
   ```

   Before: exit code 3, 0 bytes on stdout, nothing but the gws error on stderr.
   After: exit code 0, the message list on stdout, and `gws failed (simulated auth failure); falling back to the Python API` on stderr.

3. Confirm no regression in the two healthy paths: the same command with the real `gws` on PATH uses gws (no fallback notice), and with `gws` removed from PATH it takes the Python path as before.

4. Tests: `scripts/run_tests.sh tests/skills/test_google_workspace_api.py -q` → 7 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux Mint 22.3 (kernel 7.0.0)

On the full-suite box: I ran the targeted file only (`tests/skills/test_google_workspace_api.py`, 7 passed). I did not run the full suite locally, so the box is left unticked — CI runs it.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Cross-platform note: the change is stdlib-only (`RuntimeError`, `try/except`, `json`) and introduces no platform-specific paths or subprocess behavior. `_normalize_token_file()` swallows `OSError` on the write so a read-only token directory cannot turn a working command into a failure.

Related, but not a duplicate: #31628 (`fix(skills/google-workspace): real gws-native auth mode`) changes *which* credentials gws uses. This PR is about what happens when a gws call fails, and is independent of that change — both can land.

## Screenshots / Logs

Reproduction on `origin/main` (45a6101f36), with the failing stub from step 1:

```
$ HERMES_GWS_BIN=/tmp/fake_gws_fail python3 google_api.py gmail search "is:unread" --max 1
gws: simulated auth failure
$ echo $?
3                      # stdout: 0 bytes
```

Control — same command, gws simply absent, shows the Python path works with the same token:

```
$ env -u HERMES_GWS_BIN PATH=/usr/bin:/bin python3 google_api.py gmail search "is:unread" --max 1
[ { "id": "1a08e060190f65fd", "from": "Discover Card <discover@services.discover.com>", ... } ]
$ echo $?
0
```

With this PR, the first command returns that same payload and reports the fallback on stderr instead of exiting:

```
$ HERMES_GWS_BIN=/tmp/fake_gws_fail python3 google_api.py gmail search "is:unread" --max 1
gws failed (gws: simulated auth failure); falling back to the Python API   # stderr
[ { "id": "1a08e060190f65fd", ... } ]                                     # stdout
$ echo $?
0
```

The 3 new tests are red on base (`3 failed, 4 deselected`) and green with the change:

```
=== Summary: 1 files, 7 tests passed, 0 failed (100% complete) ===
```
