### PR TITLE
fix(analytics): show long-session tokens on actual usage days

### DIFF
--- a/hermes_cli/web_routers/analytics.py
+++ b/hermes_cli/web_routers/analytics.py
@@ -81,7 +81,7 @@ def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
     try:
         cutoff = time.time() - (days * 86400)
         daily = _rows(db, """
-            SELECT date(started_at, 'unixepoch') as day,
+            SELECT day,
                    SUM(input_tokens) as input_tokens,
                    SUM(output_tokens) as output_tokens,
                    SUM(cache_read_tokens) as cache_read_tokens,
@@ -90,7 +90,7 @@ def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
                    COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
                    COUNT(*) as sessions,
                    SUM(COALESCE(api_call_count, 0)) as api_calls
-            FROM sessions WHERE started_at > ?
+            FROM session_daily_usage WHERE day >= date(?, 'unixepoch')
             GROUP BY day ORDER BY day
         """, cutoff)
 
@@ -119,9 +119,9 @@ def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
                    SUM(reasoning_tokens) as total_reasoning,
                    COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
-                   COUNT(*) as total_sessions,
+                   COUNT(DISTINCT session_id) as total_sessions,
                    SUM(COALESCE(api_call_count, 0)) as total_api_calls
-            FROM sessions WHERE started_at > ?
+            FROM session_daily_usage WHERE day >= date(?, 'unixepoch')
         """, cutoff)[0]
         usage = InsightsEngine(db).get_usage_breakdown(days=days)
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -194,7 +194,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
         f"(SELECT started_at FROM sessions _act_s WHERE _act_s.id = {session_id_expr})")
 
 
-SCHEMA_VERSION = 30
+SCHEMA_VERSION = 31
 
 # Auto-maintenance VACUUMs only above this freelist fraction; below it a rewrite costs more I/O than it returns.
 # Auto-maintenance only VACUUMs when at least this fraction of the database file is reclaimable (``PRAGMA
@@ -390,6 +390,20 @@ CREATE TABLE IF NOT EXISTS session_model_usage (
     PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
 );
 
+CREATE TABLE IF NOT EXISTS session_daily_usage (
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    day TEXT NOT NULL,
+    api_call_count INTEGER NOT NULL DEFAULT 0,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+    reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+    estimated_cost_usd REAL NOT NULL DEFAULT 0,
+    actual_cost_usd REAL NOT NULL DEFAULT 0,
+    PRIMARY KEY (session_id, day)
+);
+
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
     value TEXT
@@ -507,6 +521,7 @@ CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(ex
 CREATE INDEX IF NOT EXISTS idx_session_turn_leases_expires ON session_turn_leases(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
+CREATE INDEX IF NOT EXISTS idx_session_daily_usage_day ON session_daily_usage(day);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery
     ON async_delegations(delivery_state, completed_at);
 """

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -976,6 +976,28 @@ class SessionSchemaMixin:
         if current_version < 25:
             # v25: de-duplicate system prompt snapshots (old column stays a read fallback).
             self._dedupe_legacy_system_prompts(cursor)
+        if current_version < 31:
+            # Historical aggregates have no activity-day grain. Preserve them on the only
+            # day known for certain; all future calls are recorded on their actual UTC day.
+            cursor.execute("""INSERT OR IGNORE INTO session_daily_usage (
+                       session_id, day, api_call_count, input_tokens, output_tokens,
+                       cache_read_tokens, cache_write_tokens, reasoning_tokens,
+                       estimated_cost_usd, actual_cost_usd
+                   )
+                   SELECT id, date(started_at, 'unixepoch'), COALESCE(api_call_count, 0),
+                          COALESCE(input_tokens, 0), COALESCE(output_tokens, 0),
+                          COALESCE(cache_read_tokens, 0), COALESCE(cache_write_tokens, 0),
+                          COALESCE(reasoning_tokens, 0), COALESCE(estimated_cost_usd, 0),
+                          COALESCE(actual_cost_usd, 0)
+                   FROM sessions
+                   WHERE COALESCE(api_call_count, 0) != 0
+                      OR COALESCE(input_tokens, 0) != 0
+                      OR COALESCE(output_tokens, 0) != 0
+                      OR COALESCE(cache_read_tokens, 0) != 0
+                      OR COALESCE(cache_write_tokens, 0) != 0
+                      OR COALESCE(reasoning_tokens, 0) != 0
+                      OR COALESCE(estimated_cost_usd, 0) != 0
+                      OR COALESCE(actual_cost_usd, 0) != 0""")
         fts_migrations_complete = True
         if current_version < 30 and fts5_available:
             # v29: cron sessions leave the trigram substring index (they stay in the word index);

--- a/hermes_state_usage.py
+++ b/hermes_state_usage.py
@@ -17,6 +17,10 @@ logger = logging.getLogger("hermes_state")
 _TOKEN_COUNTERS = ("input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens", "reasoning_tokens")
 
 
+def _utc_usage_day() -> str:
+    return time.strftime("%Y-%m-%d", time.gmtime(time.time()))
+
+
 def _token_update_sql(delta: bool) -> str:
     """``UPDATE sessions`` for one usage report: *delta* adds to the stored counters (CLI
     per-call path), otherwise sets them (gateway cumulative path). Cost/route columns
@@ -124,6 +128,7 @@ class SessionUsageMixin:
         """Enqueue a token/cost delta for the background writer (same kwargs as
         :meth:`update_token_counts`). After close() stopped the writer, falls back to the
         synchronous path and may raise."""
+        kwargs["usage_day"] = _utc_usage_day()
         with self._token_queue_cond:
             thread = self._token_writer_thread
             writer_alive = thread is not None and thread.is_alive()
@@ -233,7 +238,11 @@ class SessionUsageMixin:
         for session_id, kwargs in batch:
             key = None
             if not kwargs.get("absolute"):
-                key = (session_id, *(kwargs.get(f) for f in self._TOKEN_DELTA_ROUTE_FIELDS))
+                key = (
+                    session_id,
+                    kwargs.get("usage_day"),
+                    *(kwargs.get(f) for f in self._TOKEN_DELTA_ROUTE_FIELDS),
+                )
             if groups and key is not None and groups[-1][0] == key:
                 merged = groups[-1][2]
                 for f in self._TOKEN_DELTA_SUM_FIELDS:
@@ -293,10 +302,12 @@ class SessionUsageMixin:
         actual_cost_usd: Optional[float]=None, cost_status: Optional[str]=None, cost_source: Optional[str]=None,
         pricing_version: Optional[str]=None, billing_provider: Optional[str]=None, billing_base_url: Optional[str]=None,
         billing_mode: Optional[str]=None, api_call_count: int=0, absolute: bool=False,
+        usage_day: Optional[str]=None,
     ) -> None:
         """Update token counters and backfill model if unset. *absolute*=False increments
         (per-API-call deltas, CLI path); *absolute*=True sets directly (gateway path,
         where the cached agent holds cumulative totals)."""
+        usage_day = usage_day or _utc_usage_day()
         usage = {k: v for k, v in locals().items() if k in _MODEL_USAGE_FIELDS}
         # Ensure the row exists: under concurrent load create_session() may have failed on
         # locking, and the UPDATE would silently affect 0 rows.
@@ -365,10 +376,9 @@ class SessionUsageMixin:
                     for key, value in daily_values.items()
                 }
             if any(daily_values.values()):
-                day = time.strftime("%Y-%m-%d", time.gmtime(time.time()))
                 conn.execute(
                     _DAILY_USAGE_UPSERT_SQL,
-                    (session_id, day, *(daily_values[key] for key in (
+                    (session_id, usage_day, *(daily_values[key] for key in (
                         "api_call_count", "input_tokens", "output_tokens", "cache_read_tokens",
                         "cache_write_tokens", "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
                     ))),

--- a/hermes_state_usage.py
+++ b/hermes_state_usage.py
@@ -70,6 +70,21 @@ _MODEL_USAGE_UPSERT_SQL = """INSERT INTO session_model_usage (
                    cost_source = COALESCE(excluded.cost_source, cost_source),
                    last_seen = excluded.last_seen"""
 
+_DAILY_USAGE_UPSERT_SQL = """INSERT INTO session_daily_usage (
+                   session_id, day, api_call_count, input_tokens, output_tokens,
+                   cache_read_tokens, cache_write_tokens, reasoning_tokens,
+                   estimated_cost_usd, actual_cost_usd
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(session_id, day) DO UPDATE SET
+                   api_call_count = api_call_count + excluded.api_call_count,
+                   input_tokens = input_tokens + excluded.input_tokens,
+                   output_tokens = output_tokens + excluded.output_tokens,
+                   cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
+                   cache_write_tokens = cache_write_tokens + excluded.cache_write_tokens,
+                   reasoning_tokens = reasoning_tokens + excluded.reasoning_tokens,
+                   estimated_cost_usd = estimated_cost_usd + excluded.estimated_cost_usd,
+                   actual_cost_usd = actual_cost_usd + excluded.actual_cost_usd"""
+
 
 # Kwargs forwarded verbatim from update_token_counts / record_auxiliary_usage into
 # _record_model_usage (the per-route attribution row).
@@ -310,7 +325,10 @@ class SessionUsageMixin:
 
         def _do(conn):
             row = conn.execute(
-                "SELECT model, billing_provider, api_call_count FROM sessions WHERE id = ?", (session_id,),
+                """SELECT model, billing_provider, api_call_count, input_tokens, output_tokens,
+                          cache_read_tokens, cache_write_tokens, reasoning_tokens,
+                          estimated_cost_usd, actual_cost_usd
+                   FROM sessions WHERE id = ?""", (session_id,),
             ).fetchone()
             existing = dict(row) if row is not None else {}
             # create_session records the requested route before any API call. If that fails
@@ -327,6 +345,34 @@ class SessionUsageMixin:
                        billing_base_url = ?, billing_mode = ?
                        WHERE id = ?""", (model, billing_provider, billing_base_url, billing_mode, session_id))
             conn.execute(sql, params)
+            daily_values = {
+                "api_call_count": api_call_count,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_read_tokens": cache_read_tokens,
+                "cache_write_tokens": cache_write_tokens,
+                "reasoning_tokens": reasoning_tokens,
+                "estimated_cost_usd": float(estimated_cost_usd or 0.0),
+                "actual_cost_usd": (
+                    existing.get("actual_cost_usd") or 0.0
+                    if absolute and actual_cost_usd is None
+                    else float(actual_cost_usd or 0.0)
+                ),
+            }
+            if absolute:
+                daily_values = {
+                    key: value - (existing.get(key) or 0)
+                    for key, value in daily_values.items()
+                }
+            if any(daily_values.values()):
+                day = time.strftime("%Y-%m-%d", time.gmtime(time.time()))
+                conn.execute(
+                    _DAILY_USAGE_UPSERT_SQL,
+                    (session_id, day, *(daily_values[key] for key in (
+                        "api_call_count", "input_tokens", "output_tokens", "cache_read_tokens",
+                        "cache_write_tokens", "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
+                    ))),
+                )
             if record_model_usage:
                 self._record_model_usage(conn, session_id, **usage)
         self._execute_write(_do)

--- a/tests/agent/test_async_token_accounting.py
+++ b/tests/agent/test_async_token_accounting.py
@@ -571,7 +571,9 @@ class TestCoalesceFieldContract:
             set(db._TOKEN_DELTA_SUM_FIELDS)
             | set(db._TOKEN_DELTA_COST_FIELDS)
             | set(db._TOKEN_DELTA_ROUTE_FIELDS)
-            | {"absolute"}  # control flag: absolute deltas never merge
+            # ``absolute`` disables merging; ``usage_day`` is explicit
+            # coalescing-key metadata.
+            | {"absolute", "usage_day"}
         )
 
         unclassified = params - classified

--- a/tests/agent/test_async_token_accounting.py
+++ b/tests/agent/test_async_token_accounting.py
@@ -53,6 +53,16 @@ def _model_usage(db, session_id):
     return [dict(r) for r in rows]
 
 
+def _daily_usage(db, session_id):
+    with db._lock:
+        rows = db._conn.execute(
+            "SELECT day, input_tokens, api_call_count FROM session_daily_usage"
+            " WHERE session_id = ? ORDER BY day",
+            (session_id,),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
 # =========================================================================
 # Ordering
 # =========================================================================
@@ -114,6 +124,31 @@ class TestOrdering:
 
 
 class TestCoalescing:
+    def test_queue_preserves_activity_day_across_delayed_midnight_flush(self, db, monkeypatch):
+        import hermes_state_usage
+
+        class AliveWriter:
+            @staticmethod
+            def is_alive():
+                return True
+
+        db.create_session("s-midnight", "test")
+        db._token_writer_thread = AliveWriter()
+        try:
+            monkeypatch.setattr(hermes_state_usage.time, "time", lambda: 1767311940.0)
+            db.queue_token_counts("s-midnight", input_tokens=10, api_call_count=1)
+            monkeypatch.setattr(hermes_state_usage.time, "time", lambda: 1767312060.0)
+            db.queue_token_counts("s-midnight", input_tokens=20, api_call_count=1)
+        finally:
+            db._token_writer_thread = None
+        monkeypatch.setattr(hermes_state_usage.time, "time", lambda: 1767398460.0)
+        assert db.flush_token_counts()
+
+        assert _daily_usage(db, "s-midnight") == [
+            {"day": "2026-01-01", "input_tokens": 10, "api_call_count": 1},
+            {"day": "2026-01-02", "input_tokens": 20, "api_call_count": 1},
+        ]
+
     def test_backlog_coalesces_and_sums_match(self, db):
         """When a backlog forms, same-route deltas merge into fewer applies
         while totals stay exact."""

--- a/tests/hermes_cli/test_usage_analytics_daily.py
+++ b/tests/hermes_cli/test_usage_analytics_daily.py
@@ -1,0 +1,53 @@
+import datetime
+
+from hermes_state import SessionDB
+
+
+def _timestamp(day: int) -> float:
+    return datetime.datetime(2026, 1, day, 12, tzinfo=datetime.timezone.utc).timestamp()
+
+
+def test_usage_analytics_buckets_by_activity_day_and_matches_totals(tmp_path, monkeypatch):
+    import hermes_state_usage
+    from hermes_cli.web_routers import analytics
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    try:
+        db.create_session("long-running", "cli")
+        db._write_sql("UPDATE sessions SET started_at = ? WHERE id = ?", (_timestamp(1), "long-running"))
+
+        monkeypatch.setattr(hermes_state_usage.time, "time", lambda: _timestamp(1))
+        db.update_token_counts("long-running", input_tokens=100, output_tokens=10, api_call_count=1)
+        monkeypatch.setattr(hermes_state_usage.time, "time", lambda: _timestamp(10))
+        db.update_token_counts("long-running", input_tokens=200, output_tokens=20, api_call_count=2)
+    finally:
+        db.close()
+
+    monkeypatch.setattr(analytics, "_open_session_db_for_profile", lambda *_args, **_kwargs: SessionDB(db_path))
+    monkeypatch.setattr(analytics.time, "time", lambda: _timestamp(10))
+
+    result = analytics._get_usage_analytics(days=3)
+
+    assert result["daily"] == [{
+        "day": "2026-01-10",
+        "input_tokens": 200,
+        "output_tokens": 20,
+        "cache_read_tokens": 0,
+        "reasoning_tokens": 0,
+        "estimated_cost": 0.0,
+        "actual_cost": 0.0,
+        "sessions": 1,
+        "api_calls": 2,
+    }]
+    daily = result["daily"]
+    assert result["totals"] == {
+        "total_input": sum(row["input_tokens"] for row in daily),
+        "total_output": sum(row["output_tokens"] for row in daily),
+        "total_cache_read": sum(row["cache_read_tokens"] for row in daily),
+        "total_reasoning": sum(row["reasoning_tokens"] for row in daily),
+        "total_estimated_cost": sum(row["estimated_cost"] for row in daily),
+        "total_actual_cost": sum(row["actual_cost"] for row in daily),
+        "total_sessions": 1,
+        "total_api_calls": sum(row["api_calls"] for row in daily),
+    }

--- a/tests/hermes_cli/test_usage_analytics_daily.py
+++ b/tests/hermes_cli/test_usage_analytics_daily.py
@@ -20,7 +20,9 @@ def test_usage_analytics_buckets_by_activity_day_and_matches_totals(tmp_path, mo
         monkeypatch.setattr(hermes_state_usage.time, "time", lambda: _timestamp(1))
         db.update_token_counts("long-running", input_tokens=100, output_tokens=10, api_call_count=1)
         monkeypatch.setattr(hermes_state_usage.time, "time", lambda: _timestamp(10))
-        db.update_token_counts("long-running", input_tokens=200, output_tokens=20, api_call_count=2)
+        db.update_token_counts(
+            "long-running", input_tokens=300, output_tokens=30, api_call_count=3, absolute=True,
+        )
     finally:
         db.close()
 


### PR DESCRIPTION
## What does this PR do?

The usage dashboard now attributes token and cost increments to the UTC day when each API call was recorded. Long-running sessions no longer move later activity back to their start date or disappear from a reporting window merely because they began before it.

### Symptom

A session resumed on a later day showed all lifetime tokens on its start-day bar. If the session started before the selected window, its in-window usage was absent from both the daily chart and the period totals.

### Impact

The desktop Command Center and web dashboard could materially misstate daily token usage, API calls, and cost for long-lived gateway, cron, and interactive sessions.

### Bug Cause

**Trigger:** `hermes_cli/web_routers/analytics.py:83` in `_get_usage_analytics`.

**Causal chain:**
1. `SessionUsageMixin.update_token_counts` accumulates every later API call into lifetime counters on one `sessions` row.
2. The analytics query groups those counters by `date(started_at)` and filters the same creation timestamp against the reporting cutoff.
3. Later activity is assigned to the creation day, while activity from sessions created before the cutoff is omitted.

**Why it is wrong:** A lifetime aggregate has no activity-day grain, so the session creation timestamp cannot identify when its individual increments occurred.

**Working sibling / contrast:** The token accounting path already receives each incremental update at activity time. Recording that delta transactionally preserves the missing day dimension without changing lifetime session counters.

**Ruled out:** UTC versus local calendar boundaries are separate. This change retains the existing UTC day semantics and changes only which event timestamp determines the bucket.

### Fix

Add a `(session_id, day)` daily usage ledger and update it in the same transaction as the lifetime session counters. Absolute counter writes are converted to deltas against the stored row, so both write modes remain consistent. The analytics daily rows and totals now read the same ledger window. Existing aggregate-only history is preserved on its session start day because older databases do not contain enough information for an accurate historical redistribution.

## Related Issue

Closes #107861

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_common.py` - add the daily usage schema and day index.
- `hermes_state_schema.py` - preserve legacy aggregate usage during the schema upgrade.
- `hermes_state_usage.py` - write activity-day deltas for incremental and absolute counter updates.
- `hermes_cli/web_routers/analytics.py` - derive daily rows and period totals from the ledger.
- `tests/hermes_cli/test_usage_analytics_daily.py` - cover cross-day usage, pre-window sessions, and total consistency.

## How to Test

1. Run the focused analytics regression test after opening this PR:

```bash
scripts/run_tests.sh tests/hermes_cli/test_usage_analytics_daily.py
```

2. Run the adjacent accounting and dashboard tests:

```bash
scripts/run_tests.sh tests/agent/test_async_token_accounting.py tests/hermes_cli/test_web_server.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

N/A - backend accounting and API aggregation change covered by automated tests.
