### PR TITLE
fix(slack): recover missed thread updates on plain replies

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4019,7 +4019,7 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def _hydrate_thread_context(
         self, *, channel_id: str, event_thread_ts, ts: str, user_id: str, team_id: str,
-        is_thread_reply: bool, is_mentioned: bool, is_dm: bool,
+        is_thread_reply: bool, is_mentioned: bool, is_dm: bool, latest_ts: str = "",
     ) -> Tuple[Optional[str], List[str], List[str]]:
         """``(channel_context, root_media_urls, root_media_types)`` for a thread reply. No session:
         full thread + root images once, set watermark. Active sessions fetch a paginated delta on
@@ -4100,6 +4100,7 @@ class SlackAdapter(BasePlatformAdapter):
                             channel_id=channel_id,
                             thread_ts=event_thread_ts,
                             current_ts=ts,
+                            latest_ts=latest_ts,
                             team_id=team_id,
                         )
                     )
@@ -4415,7 +4416,7 @@ class SlackAdapter(BasePlatformAdapter):
         ) = await self._hydrate_thread_context(
             channel_id=channel_id, event_thread_ts=event_thread_ts, ts=ts, user_id=user_id,
             team_id=team_id, is_thread_reply=is_thread_reply, is_mentioned=is_mentioned,
-            is_dm=is_dm)
+            is_dm=is_dm, latest_ts=str(event.get("_slack_changed_event_ts") or ts))
         # Thread-root media is delivered ahead of the trigger message's own files.
         media_urls, media_types, text = await self._collect_inbound_media(
             event, channel_id, team_id, text, thread_root_media_urls, thread_root_media_types)
@@ -5557,6 +5558,7 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def _fetch_complete_thread_context(
         self, *, channel_id: str, thread_ts: str, current_ts: str, team_id: str,
+        latest_ts: str = "",
     ) -> Tuple[str, bool]:
         """Fetch a complete bounded snapshot for restart/edit recovery.
 
@@ -5573,7 +5575,7 @@ class SlackAdapter(BasePlatformAdapter):
                     100,
                     team_id,
                     cursor=cursor,
-                    latest=current_ts,
+                    latest=latest_ts or current_ts,
                     inclusive=False,
                 )
             except Exception as exc:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -919,7 +919,7 @@ class SlackAdapter(BasePlatformAdapter):
         # ts of messages already routed to the agent, so later edits don't re-trigger a reply.
         self._processed_message_ts: Dict[str, float] = {}
         # Workspace-scoped companion used when filtering recovered thread deltas.
-        self._processed_message_markers: set[Tuple[str, str]] = set()
+        self._processed_message_markers: set[Tuple[str, str, str]] = set()
         # approval / clarify message_ts (or (team_id, ts)) → resolved; blocks double-clicks.
         # Bounded: never-clicked prompts would otherwise leak forever.
         self._approval_resolved: Dict[Any, bool] = {}
@@ -952,6 +952,7 @@ class SlackAdapter(BasePlatformAdapter):
         # mark only their thread for another delta check.
         self._thread_rehydration_checked: set = set()
         self._pending_thread_updates: Dict[str, str] = {}
+        self._pending_edited_thread_messages: Dict[Tuple[str, str, str, str], dict] = {}
         # Message IDs with reaction lifecycle (bounded: an exception between add and finalize would
         # leak entries).
         self._reacting_message_ids: set = set()
@@ -3275,16 +3276,29 @@ class SlackAdapter(BasePlatformAdapter):
             "context_channel_id": context_channel_id or cached.get("context_channel_id", ""),
             "team_id": team_id, "user_id": user_id}
 
-    def _remember_processed_message_ts(self, ts: str, *, team_id: str = "") -> None:
+    def _processed_message_marker(
+        self, team_id: str, user_id: str, ts: str
+    ) -> Tuple[str, str, str]:
+        store_cfg = getattr(getattr(self, "_session_store", None), "config", None)
+        session_user = user_id if getattr(store_cfg, "thread_sessions_per_user", False) else ""
+        return team_id, session_user, ts
+
+    def _remember_processed_message_ts(
+        self, ts: str, *, team_id: str = "", user_id: str = ""
+    ) -> None:
         """Claim a message ts for the ``message_changed`` guard: on entry (suppresses mid-flight
         unfurls) and after construction (refreshes LRU recency). Bounded."""
         if not ts:
             return
         self._processed_message_ts[ts] = time.time()
         if team_id:
-            self._processed_message_markers.add(self._workspace_message_marker(team_id, ts))
+            self._processed_message_markers.add(
+                self._processed_message_marker(team_id, user_id, ts)
+            )
             self._evict_oldest_by_ts(
-                self._processed_message_markers, self._PROCESSED_MESSAGE_TS_MAX
+                self._processed_message_markers,
+                self._PROCESSED_MESSAGE_TS_MAX,
+                lambda marker: marker[-1],
             )
         if len(self._processed_message_ts) > self._PROCESSED_MESSAGE_TS_MAX:
             newest = sorted(self._processed_message_ts.items(), key=lambda item: item[1])
@@ -4070,6 +4084,7 @@ class SlackAdapter(BasePlatformAdapter):
                         thread_ts=event_thread_ts,
                         current_ts=ts,
                         team_id=team_id,
+                        user_id=user_id,
                         after_ts=watermark_ts,
                     )
                     recovery_complete = watermark_to_set == ts
@@ -4329,7 +4344,9 @@ class SlackAdapter(BasePlatformAdapter):
         # original block a later "@bot" edit from summoning the bot.
         _claim_ts = str(event.get("ts") or "")
         if _claim_ts:
-            self._remember_processed_message_ts(_claim_ts, team_id=team_id)
+            self._remember_processed_message_ts(
+                _claim_ts, team_id=team_id, user_id=user_id
+            )
         if is_mentioned:
             text, original_text, command_probe_text, is_command_text = self._apply_bot_mention(
                 text, original_text, command_probe_text, is_command_text, bot_uid, thread_ts,
@@ -4361,7 +4378,7 @@ class SlackAdapter(BasePlatformAdapter):
                 f"[Slack app context: user is viewing channel {context_channel_id}]\n\n"
                 f"{msg_event.text}")
         if ts:
-            self._remember_processed_message_ts(ts, team_id=team_id)
+            self._remember_processed_message_ts(ts, team_id=team_id, user_id=user_id)
         await self.handle_message(msg_event)
 
     async def _build_message_event(
@@ -5490,7 +5507,8 @@ class SlackAdapter(BasePlatformAdapter):
         return next((m for m in messages if m.get("ts", "") == thread_ts), None)
 
     async def _fetch_thread_delta(
-        self, *, channel_id: str, thread_ts: str, current_ts: str, team_id: str, after_ts: str,
+        self, *, channel_id: str, thread_ts: str, current_ts: str, team_id: str,
+        user_id: str, after_ts: str,
     ) -> Tuple[str, str]:
         """Return a bounded delta and the latest timestamp that was safely recovered."""
         messages: List[dict] = []
@@ -5505,7 +5523,9 @@ class SlackAdapter(BasePlatformAdapter):
                     msg.get("user") == bot_uid
                     or self._workspace_message_marker(team_id, str(msg.get("ts") or ""))
                     in self._bot_message_ts
-                    or self._workspace_message_marker(team_id, str(msg.get("ts") or ""))
+                    or self._processed_message_marker(
+                        team_id, user_id, str(msg.get("ts") or "")
+                    )
                     in self._processed_message_markers
                 )
             ]
@@ -5541,6 +5561,15 @@ class SlackAdapter(BasePlatformAdapter):
             metadata = result.get("response_metadata") or {}
             cursor = str(metadata.get("next_cursor") or "")
             if not cursor:
+                messages.extend(
+                    self._pending_edited_messages_for_delta(
+                        channel_id=channel_id,
+                        thread_ts=thread_ts,
+                        team_id=team_id,
+                        after_ts=after_ts,
+                        current_ts=current_ts,
+                    )
+                )
                 return await _format_recovered(), current_ts
         recovered_ts = max(
             (str(msg.get("ts") or "") for msg in messages if msg.get("ts")),
@@ -5597,7 +5626,8 @@ class SlackAdapter(BasePlatformAdapter):
                 continue
             is_parent = msg_ts == thread_ts
             # Skip already-consumed messages; parent still flows through for parent_text capture.
-            skip_for_delta = bool(after_ts and msg_ts and msg_ts <= after_ts)
+            delta_ts = str(msg.get("_slack_changed_event_ts") or msg_ts)
+            skip_for_delta = bool(after_ts and delta_ts and delta_ts <= after_ts)
             if skip_for_delta and not is_parent:
                 continue
             msg_text = self._render_message_text(msg, bot_uid=bot_uid)
@@ -5885,9 +5915,10 @@ class SlackAdapter(BasePlatformAdapter):
         """Remember a dropped external app/bot post so the next human turn recovers its delta."""
         channel_id = str(event.get("channel") or "")
         thread_ts = str(event.get("thread_ts") or "")
-        update_ts = str(event.get("ts") or "")
+        message_ts = str(event.get("ts") or "")
+        update_ts = str(event.get("_slack_changed_event_ts") or message_ts)
         team_id = team_id or str(event.get("team") or event.get("team_id") or "")
-        if not channel_id or not thread_ts or not update_ts or thread_ts == update_ts:
+        if not channel_id or not thread_ts or not update_ts or thread_ts == message_ts:
             return
         key = self._pending_thread_update_key(channel_id, thread_ts, team_id)
         previous = self._pending_thread_updates.get(key, "")
@@ -5902,6 +5933,37 @@ class SlackAdapter(BasePlatformAdapter):
             self._PENDING_THREAD_UPDATES_MAX,
             lambda entry: self._pending_thread_updates.get(entry, ""),
         )
+        if event.get("_slack_changed_event_ts") and message_ts:
+            edit_key = (team_id, channel_id, thread_ts, message_ts)
+            self._pending_edited_thread_messages[edit_key] = dict(event)
+            self._evict_oldest_by_ts(
+                self._pending_edited_thread_messages,
+                self._PENDING_THREAD_UPDATES_MAX,
+                lambda entry: self._pending_edited_thread_messages[entry].get(
+                    "_slack_changed_event_ts", ""
+                ),
+            )
+
+    def _pending_edited_messages_for_delta(
+        self, *, channel_id: str, thread_ts: str, team_id: str,
+        after_ts: str, current_ts: str,
+    ) -> List[dict]:
+        """Edited app posts whose edit event, not original message, falls in this delta."""
+        recovered = []
+        for (edit_team, edit_channel, edit_thread, _), message in (
+            self._pending_edited_thread_messages.items()
+        ):
+            if (edit_team, edit_channel, edit_thread) != (team_id, channel_id, thread_ts):
+                continue
+            changed_ts = str(message.get("_slack_changed_event_ts") or "")
+            if (
+                self._slack_timestamp_sort_key(changed_ts)
+                > self._slack_timestamp_sort_key(after_ts)
+                and self._slack_timestamp_sort_key(changed_ts)
+                <= self._slack_timestamp_sort_key(current_ts)
+            ):
+                recovered.append(dict(message))
+        return recovered
 
     def _thread_watermark_io(
         self, method: str, channel_id: str, thread_ts: str, user_id: str, team_id: str, *args: Any

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -918,6 +918,8 @@ class SlackAdapter(BasePlatformAdapter):
         self._dedup = MessageDeduplicator(ttl_seconds=_slack_dedup_ttl_seconds())
         # ts of messages already routed to the agent, so later edits don't re-trigger a reply.
         self._processed_message_ts: Dict[str, float] = {}
+        # Workspace-scoped companion used when filtering recovered thread deltas.
+        self._processed_message_markers: set[Tuple[str, str]] = set()
         # approval / clarify message_ts (or (team_id, ts)) → resolved; blocks double-clicks.
         # Bounded: never-clicked prompts would otherwise leak forever.
         self._approval_resolved: Dict[Any, bool] = {}
@@ -3273,12 +3275,17 @@ class SlackAdapter(BasePlatformAdapter):
             "context_channel_id": context_channel_id or cached.get("context_channel_id", ""),
             "team_id": team_id, "user_id": user_id}
 
-    def _remember_processed_message_ts(self, ts: str) -> None:
+    def _remember_processed_message_ts(self, ts: str, *, team_id: str = "") -> None:
         """Claim a message ts for the ``message_changed`` guard: on entry (suppresses mid-flight
         unfurls) and after construction (refreshes LRU recency). Bounded."""
         if not ts:
             return
         self._processed_message_ts[ts] = time.time()
+        if team_id:
+            self._processed_message_markers.add(self._workspace_message_marker(team_id, ts))
+            self._evict_oldest_by_ts(
+                self._processed_message_markers, self._PROCESSED_MESSAGE_TS_MAX
+            )
         if len(self._processed_message_ts) > self._PROCESSED_MESSAGE_TS_MAX:
             newest = sorted(self._processed_message_ts.items(), key=lambda item: item[1])
             self._processed_message_ts = dict(newest[-self._PROCESSED_MESSAGE_TS_MAX :])
@@ -4033,7 +4040,8 @@ class SlackAdapter(BasePlatformAdapter):
 
         watermark_args = dict(
             channel_id=channel_id, thread_ts=event_thread_ts, user_id=user_id, team_id=team_id)
-        advance_watermark = True
+        watermark_to_set = ts
+        recovery_complete = True
         if not has_active_thread_session:
             await _fetch()
             (
@@ -4055,19 +4063,23 @@ class SlackAdapter(BasePlatformAdapter):
                     > self._slack_timestamp_sort_key(watermark_ts)
                 )
             )
-            if needs_delta and watermark_ts:
-                channel_context, advance_watermark = await self._fetch_thread_delta(
-                    channel_id=channel_id,
-                    thread_ts=event_thread_ts,
-                    current_ts=ts,
-                    team_id=team_id,
-                    after_ts=watermark_ts,
-                )
-            if advance_watermark:
+            if needs_delta:
+                if watermark_ts:
+                    channel_context, watermark_to_set = await self._fetch_thread_delta(
+                        channel_id=channel_id,
+                        thread_ts=event_thread_ts,
+                        current_ts=ts,
+                        team_id=team_id,
+                        after_ts=watermark_ts,
+                    )
+                    recovery_complete = watermark_to_set == ts
+                else:
+                    await _fetch(force_refresh=True)
+            if recovery_complete:
                 self._mark_thread_rehydration_checked(
                     channel_id, event_thread_ts, user_id, team_id)
-        if advance_watermark:
-            self._set_thread_watermark(watermark_ts=ts, **watermark_args)
+        if watermark_to_set:
+            self._set_thread_watermark(watermark_ts=watermark_to_set, **watermark_args)
         return channel_context, thread_root_media_urls, thread_root_media_types
 
     @staticmethod
@@ -4206,7 +4218,12 @@ class SlackAdapter(BasePlatformAdapter):
         if not sender_is_bot_user:
             return False
         allow_bots = self._slack_allow_bots()
-        return allow_bots == "none" or (allow_bots == "mentions" and not is_mentioned)
+        should_drop = allow_bots == "none" or (
+            allow_bots == "mentions" and not is_mentioned
+        )
+        if should_drop:
+            self._remember_pending_thread_update(event, team_id=team_id)
+        return should_drop
 
     def _apply_bot_mention(
         self, text: str, original_text: str, command_probe_text: str, is_command_text: bool,
@@ -4312,7 +4329,7 @@ class SlackAdapter(BasePlatformAdapter):
         # original block a later "@bot" edit from summoning the bot.
         _claim_ts = str(event.get("ts") or "")
         if _claim_ts:
-            self._remember_processed_message_ts(_claim_ts)
+            self._remember_processed_message_ts(_claim_ts, team_id=team_id)
         if is_mentioned:
             text, original_text, command_probe_text, is_command_text = self._apply_bot_mention(
                 text, original_text, command_probe_text, is_command_text, bot_uid, thread_ts,
@@ -4344,7 +4361,7 @@ class SlackAdapter(BasePlatformAdapter):
                 f"[Slack app context: user is viewing channel {context_channel_id}]\n\n"
                 f"{msg_event.text}")
         if ts:
-            self._remember_processed_message_ts(ts)
+            self._remember_processed_message_ts(ts, team_id=team_id)
         await self.handle_message(msg_event)
 
     async def _build_message_event(
@@ -5474,10 +5491,35 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def _fetch_thread_delta(
         self, *, channel_id: str, thread_ts: str, current_ts: str, team_id: str, after_ts: str,
-    ) -> Tuple[str, bool]:
-        """Return the complete bounded delta and whether it is safe to advance the watermark."""
+    ) -> Tuple[str, str]:
+        """Return a bounded delta and the latest timestamp that was safely recovered."""
         messages: List[dict] = []
         cursor = ""
+
+        async def _format_recovered() -> str:
+            bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
+            unseen = [
+                msg
+                for msg in messages
+                if not (
+                    msg.get("user") == bot_uid
+                    or self._workspace_message_marker(team_id, str(msg.get("ts") or ""))
+                    in self._bot_message_ts
+                    or self._workspace_message_marker(team_id, str(msg.get("ts") or ""))
+                    in self._processed_message_markers
+                )
+            ]
+            return (
+                await self._format_thread_context(
+                    unseen,
+                    thread_ts=thread_ts,
+                    current_ts=current_ts,
+                    team_id=team_id,
+                    channel_id=channel_id,
+                    after_ts=after_ts,
+                )
+            )[0]
+
         for _page in range(10):
             try:
                 result = await self._conversations_replies_with_backoff(
@@ -5492,38 +5534,24 @@ class SlackAdapter(BasePlatformAdapter):
                 )
             except Exception as exc:
                 logger.warning("[Slack] Failed to fetch thread delta: %s", exc)
-                return "", False
+                return "", ""
             if result is None:
-                return "", False
+                return "", ""
             messages.extend(result.get("messages", []))
             metadata = result.get("response_metadata") or {}
             cursor = str(metadata.get("next_cursor") or "")
             if not cursor:
-                bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
-                unseen = [
-                    msg
-                    for msg in messages
-                    if not (
-                        msg.get("user") == bot_uid
-                        or self._workspace_message_marker(team_id, str(msg.get("ts") or ""))
-                        in self._bot_message_ts
-                        or str(msg.get("ts") or "") in self._processed_message_ts
-                    )
-                ]
-                return (
-                    await self._format_thread_context(
-                        unseen,
-                        thread_ts=thread_ts,
-                        current_ts=current_ts,
-                        team_id=team_id,
-                        channel_id=channel_id,
-                        after_ts=after_ts,
-                    )
-                )[0], True
-        logger.warning(
-            "[Slack] Thread delta exceeded 10 pages; watermark retained for a later retry"
+                return await _format_recovered(), current_ts
+        recovered_ts = max(
+            (str(msg.get("ts") or "") for msg in messages if msg.get("ts")),
+            key=self._slack_timestamp_sort_key,
+            default="",
         )
-        return "", False
+        logger.warning(
+            "[Slack] Thread delta exceeded 10 pages; advancing through %s for a later retry",
+            recovered_ts,
+        )
+        return await _format_recovered(), recovered_ts
 
     async def _conversations_replies_with_backoff(
         self, channel_id: str, thread_ts: str, limit: int, team_id: str, **query: Any) -> Any:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4164,15 +4164,41 @@ class SlackAdapter(BasePlatformAdapter):
         turn from a mid-flight unfurl); if THIS call newly claimed it and raises, release the claim
         so a retry/edit can re-drive it. Pre-existing claims stay."""
         _ts = str((event or {}).get("ts") or "")
+        _marker_event = event or {}
+        if _marker_event.get("subtype") == "message_changed" and isinstance(
+            _marker_event.get("message"), dict
+        ):
+            _marker_event = _marker_event["message"]
+            _ts = str(_marker_event.get("ts") or _ts)
+        _team_id = self._event_team_id(_marker_event, payload) or self._event_team_id(
+            event or {}, payload
+        )
+        _user_id = str(_marker_event.get("user") or "")
+        _marker = (
+            self._processed_message_marker(_team_id, _user_id, _ts)
+            if _team_id and _ts
+            else None
+        )
         # getattr: bare test doubles (object.__new__) may lack the map.
         _claims = getattr(self, "_processed_message_ts", None)
+        _markers = getattr(self, "_processed_message_markers", None)
         _was_claimed = bool(_ts) and _claims is not None and _ts in _claims
+        _was_marker_claimed = bool(
+            _marker is not None and _markers is not None and _marker in _markers
+        )
         try:
             return await self._handle_slack_message_impl(event, payload)
         except BaseException:
             _claims = getattr(self, "_processed_message_ts", None)
             if _ts and not _was_claimed and _claims is not None and _ts in _claims:
                 _claims.pop(_ts, None)
+                _markers = getattr(self, "_processed_message_markers", None)
+                if (
+                    _marker is not None
+                    and not _was_marker_claimed
+                    and _markers is not None
+                ):
+                    _markers.discard(_marker)
                 logger.warning(
                     "[%s] handler failed after claiming ts=%s; claim released "
                     "so a retry or edit can re-drive the turn", self.name, _ts)
@@ -5542,7 +5568,13 @@ class SlackAdapter(BasePlatformAdapter):
         for _page in range(10):
             try:
                 result = await self._conversations_replies_with_backoff(
-                    channel_id, thread_ts, 100, team_id, cursor=cursor
+                    channel_id,
+                    thread_ts,
+                    100,
+                    team_id,
+                    cursor=cursor,
+                    latest=current_ts,
+                    inclusive=False,
                 )
             except Exception as exc:
                 logger.warning("[Slack] Failed to fetch complete thread context: %s", exc)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -953,6 +953,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._thread_rehydration_checked: set = set()
         self._pending_thread_updates: Dict[str, str] = {}
         self._pending_thread_full_refresh: Dict[str, str] = {}
+        self._recovered_pending_updates: set[Tuple[str, str]] = set()
         # Message IDs with reaction lifecycle (bounded: an exception between add and finalize would
         # leak entries).
         self._reacting_message_ids: set = set()
@@ -4070,23 +4071,40 @@ class SlackAdapter(BasePlatformAdapter):
             pending_ts = self._pending_thread_updates.get(pending_key, "")
             restart_check = rehydration_key not in self._thread_rehydration_checked
             full_refresh_ts = self._pending_thread_full_refresh.get(pending_key, "")
-            needs_full_refresh = restart_check or (
-                full_refresh_ts
-                and self._slack_timestamp_sort_key(full_refresh_ts)
-                > self._slack_timestamp_sort_key(watermark_ts)
+            pending_marker = (rehydration_key, pending_ts)
+            pending_unresolved = bool(
+                pending_ts and pending_marker not in self._recovered_pending_updates
             )
-            needs_delta = (
-                is_mentioned
-                or restart_check
+            pending_behind_watermark = bool(
+                pending_unresolved
+                and self._slack_timestamp_sort_key(pending_ts)
+                <= self._slack_timestamp_sort_key(watermark_ts)
+            )
+            needs_full_refresh = (
+                restart_check
+                or pending_behind_watermark
                 or (
-                    pending_ts
-                    and self._slack_timestamp_sort_key(pending_ts)
-                    > self._slack_timestamp_sort_key(watermark_ts)
+                    pending_unresolved
+                    and full_refresh_ts == pending_ts
                 )
             )
-            if needs_delta:
+            needs_recovery = (
+                is_mentioned
+                or restart_check
+                or pending_unresolved
+            )
+            if needs_recovery:
                 if needs_full_refresh or not watermark_ts:
-                    await _fetch(force_refresh=True)
+                    full_context, recovery_complete = (
+                        await self._fetch_complete_thread_context(
+                            channel_id=channel_id,
+                            thread_ts=event_thread_ts,
+                            current_ts=ts,
+                            team_id=team_id,
+                        )
+                    )
+                    channel_context = full_context or None
+                    watermark_to_set = ts if recovery_complete else ""
                 else:
                     channel_context, watermark_to_set = await self._fetch_thread_delta(
                         channel_id=channel_id,
@@ -4100,6 +4118,13 @@ class SlackAdapter(BasePlatformAdapter):
             if recovery_complete:
                 self._mark_thread_rehydration_checked(
                     channel_id, event_thread_ts, user_id, team_id)
+                if pending_unresolved:
+                    self._recovered_pending_updates.add(pending_marker)
+                    self._evict_oldest_by_ts(
+                        self._recovered_pending_updates,
+                        self._PENDING_THREAD_UPDATES_MAX,
+                        lambda marker: marker[-1],
+                    )
         if watermark_to_set:
             self._set_thread_watermark(watermark_ts=watermark_to_set, **watermark_args)
         return channel_context, thread_root_media_urls, thread_root_media_types
@@ -5503,6 +5528,48 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.warning("[Slack] Failed to fetch thread context: %s", e)
             return ""
+
+    async def _fetch_complete_thread_context(
+        self, *, channel_id: str, thread_ts: str, current_ts: str, team_id: str,
+    ) -> Tuple[str, bool]:
+        """Fetch a complete bounded snapshot for restart/edit recovery.
+
+        A failure or a thread beyond the ten-page safety bound is explicitly incomplete, so the
+        caller retains its old watermark and retries on a later human turn.
+        """
+        messages: List[dict] = []
+        cursor = ""
+        for _page in range(10):
+            try:
+                result = await self._conversations_replies_with_backoff(
+                    channel_id, thread_ts, 100, team_id, cursor=cursor
+                )
+            except Exception as exc:
+                logger.warning("[Slack] Failed to fetch complete thread context: %s", exc)
+                return "", False
+            if result is None:
+                return "", False
+            page_messages = result.get("messages", [])
+            if not isinstance(page_messages, list):
+                return "", False
+            messages.extend(page_messages)
+            metadata = result.get("response_metadata") or {}
+            cursor = str(metadata.get("next_cursor") or "")
+            if not cursor:
+                content = (
+                    await self._format_thread_context(
+                        messages,
+                        thread_ts=thread_ts,
+                        current_ts=current_ts,
+                        team_id=team_id,
+                        channel_id=channel_id,
+                    )
+                )[0]
+                return content, True
+        logger.warning(
+            "[Slack] Complete thread refresh exceeded 10 pages; watermark retained"
+        )
+        return "", False
 
     @staticmethod
     def _thread_cache_key(channel_id: str, thread_ts: str, team_id: str) -> str:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -952,7 +952,7 @@ class SlackAdapter(BasePlatformAdapter):
         # mark only their thread for another delta check.
         self._thread_rehydration_checked: set = set()
         self._pending_thread_updates: Dict[str, str] = {}
-        self._pending_edited_thread_messages: Dict[Tuple[str, str, str, str], dict] = {}
+        self._pending_thread_full_refresh: Dict[str, str] = {}
         # Message IDs with reaction lifecycle (bounded: an exception between add and finalize would
         # leak entries).
         self._reacting_message_ids: set = set()
@@ -4068,9 +4068,16 @@ class SlackAdapter(BasePlatformAdapter):
             pending_key = self._pending_thread_update_key(channel_id, event_thread_ts, team_id)
             watermark_ts = self._get_thread_watermark(**watermark_args)
             pending_ts = self._pending_thread_updates.get(pending_key, "")
+            restart_check = rehydration_key not in self._thread_rehydration_checked
+            full_refresh_ts = self._pending_thread_full_refresh.get(pending_key, "")
+            needs_full_refresh = restart_check or (
+                full_refresh_ts
+                and self._slack_timestamp_sort_key(full_refresh_ts)
+                > self._slack_timestamp_sort_key(watermark_ts)
+            )
             needs_delta = (
                 is_mentioned
-                or rehydration_key not in self._thread_rehydration_checked
+                or restart_check
                 or (
                     pending_ts
                     and self._slack_timestamp_sort_key(pending_ts)
@@ -4078,7 +4085,9 @@ class SlackAdapter(BasePlatformAdapter):
                 )
             )
             if needs_delta:
-                if watermark_ts:
+                if needs_full_refresh or not watermark_ts:
+                    await _fetch(force_refresh=True)
+                else:
                     channel_context, watermark_to_set = await self._fetch_thread_delta(
                         channel_id=channel_id,
                         thread_ts=event_thread_ts,
@@ -4088,8 +4097,6 @@ class SlackAdapter(BasePlatformAdapter):
                         after_ts=watermark_ts,
                     )
                     recovery_complete = watermark_to_set == ts
-                else:
-                    await _fetch(force_refresh=True)
             if recovery_complete:
                 self._mark_thread_rehydration_checked(
                     channel_id, event_thread_ts, user_id, team_id)
@@ -5561,15 +5568,6 @@ class SlackAdapter(BasePlatformAdapter):
             metadata = result.get("response_metadata") or {}
             cursor = str(metadata.get("next_cursor") or "")
             if not cursor:
-                messages.extend(
-                    self._pending_edited_messages_for_delta(
-                        channel_id=channel_id,
-                        thread_ts=thread_ts,
-                        team_id=team_id,
-                        after_ts=after_ts,
-                        current_ts=current_ts,
-                    )
-                )
                 return await _format_recovered(), current_ts
         recovered_ts = max(
             (str(msg.get("ts") or "") for msg in messages if msg.get("ts")),
@@ -5626,8 +5624,7 @@ class SlackAdapter(BasePlatformAdapter):
                 continue
             is_parent = msg_ts == thread_ts
             # Skip already-consumed messages; parent still flows through for parent_text capture.
-            delta_ts = str(msg.get("_slack_changed_event_ts") or msg_ts)
-            skip_for_delta = bool(after_ts and delta_ts and delta_ts <= after_ts)
+            skip_for_delta = bool(after_ts and msg_ts and msg_ts <= after_ts)
             if skip_for_delta and not is_parent:
                 continue
             msg_text = self._render_message_text(msg, bot_uid=bot_uid)
@@ -5933,37 +5930,13 @@ class SlackAdapter(BasePlatformAdapter):
             self._PENDING_THREAD_UPDATES_MAX,
             lambda entry: self._pending_thread_updates.get(entry, ""),
         )
-        if event.get("_slack_changed_event_ts") and message_ts:
-            edit_key = (team_id, channel_id, thread_ts, message_ts)
-            self._pending_edited_thread_messages[edit_key] = dict(event)
+        if event.get("_slack_changed_event_ts"):
+            self._pending_thread_full_refresh[key] = update_ts
             self._evict_oldest_by_ts(
-                self._pending_edited_thread_messages,
+                self._pending_thread_full_refresh,
                 self._PENDING_THREAD_UPDATES_MAX,
-                lambda entry: self._pending_edited_thread_messages[entry].get(
-                    "_slack_changed_event_ts", ""
-                ),
+                lambda entry: self._pending_thread_full_refresh.get(entry, ""),
             )
-
-    def _pending_edited_messages_for_delta(
-        self, *, channel_id: str, thread_ts: str, team_id: str,
-        after_ts: str, current_ts: str,
-    ) -> List[dict]:
-        """Edited app posts whose edit event, not original message, falls in this delta."""
-        recovered = []
-        for (edit_team, edit_channel, edit_thread, _), message in (
-            self._pending_edited_thread_messages.items()
-        ):
-            if (edit_team, edit_channel, edit_thread) != (team_id, channel_id, thread_ts):
-                continue
-            changed_ts = str(message.get("_slack_changed_event_ts") or "")
-            if (
-                self._slack_timestamp_sort_key(changed_ts)
-                > self._slack_timestamp_sort_key(after_ts)
-                and self._slack_timestamp_sort_key(changed_ts)
-                <= self._slack_timestamp_sort_key(current_ts)
-            ):
-                recovered.append(dict(message))
-        return recovered
 
     def _thread_watermark_io(
         self, method: str, channel_id: str, thread_ts: str, user_id: str, team_id: str, *args: Any

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4119,7 +4119,7 @@ class SlackAdapter(BasePlatformAdapter):
                     "so a retry or edit can re-drive the turn", self.name, _ts)
             raise
 
-    async def _drop_bot_sender(self, event: dict) -> bool:
+    async def _drop_bot_sender(self, event: dict, *, team_id: str = "") -> bool:
         """allow_bots gate: ``none`` drops all bot posts (default), ``mentions`` those not
         @mentioning us, ``all`` accepts — own posts always drop (echo loops). Unlabeled events
         without ``client_msg_id`` are probed via users.info (humans carry it, stray bots don't)."""
@@ -4142,12 +4142,12 @@ class SlackAdapter(BasePlatformAdapter):
                     "[Slack] Dropping bot message under allow_bots=mentions: "
                     "no <@%s> mention in flat text or blocks", self._bot_user_id)
                 should_drop = True
-        team_id = str(event.get("team") or event.get("team_id") or "")
+        team_id = team_id or str(event.get("team") or event.get("team_id") or "")
         bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
         is_self = bool(msg_user and bot_uid and msg_user == bot_uid)
         should_drop = should_drop or is_self
         if should_drop and not is_self:
-            self._remember_pending_thread_update(event)
+            self._remember_pending_thread_update(event, team_id=team_id)
         return should_drop
 
     async def _prefilter_inbound(
@@ -4184,7 +4184,7 @@ class SlackAdapter(BasePlatformAdapter):
         if self._is_ignored_channel(channel_id):
             logger.info("[Slack] Ignoring message in configured ignored channel %s", channel_id)
             return None
-        if await self._drop_bot_sender(event):
+        if await self._drop_bot_sender(event, team_id=dedup_team_id):
             return None
         # Edits were normalized above so an @mention added by edit can wake the bot once.
         if event.get("subtype") == "message_deleted":
@@ -5853,12 +5853,12 @@ class SlackAdapter(BasePlatformAdapter):
     def _pending_thread_update_key(channel_id: str, thread_ts: str, team_id: str = "") -> str:
         return f"{team_id}:{channel_id}:{thread_ts}"
 
-    def _remember_pending_thread_update(self, event: dict) -> None:
+    def _remember_pending_thread_update(self, event: dict, *, team_id: str = "") -> None:
         """Remember a dropped external app/bot post so the next human turn recovers its delta."""
         channel_id = str(event.get("channel") or "")
         thread_ts = str(event.get("thread_ts") or "")
         update_ts = str(event.get("ts") or "")
-        team_id = str(event.get("team") or event.get("team_id") or "")
+        team_id = team_id or str(event.get("team") or event.get("team_id") or "")
         if not channel_id or not thread_ts or not update_ts or thread_ts == update_ts:
             return
         key = self._pending_thread_update_key(channel_id, thread_ts, team_id)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -869,7 +869,8 @@ class SlackAdapter(BasePlatformAdapter):
     # Bounded-cache caps (instance assignment in tests overrides per adapter).
     _USER_NAME_CACHE_MAX = _CHANNEL_NAME_CACHE_MAX = _DM_CONVERSATION_CACHE_MAX = 5000
     _PROCESSED_MESSAGE_TS_MAX = _BOT_TS_MAX = _MENTIONED_THREADS_MAX = 5000
-    _ASSISTANT_THREADS_MAX = _AGENT_VIEW_CONTEXTS_MAX = 5000
+    _ASSISTANT_THREADS_MAX = _AGENT_VIEW_CONTEXTS_MAX = _THREAD_REHYDRATION_CHECKED_MAX = 5000
+    _PENDING_THREAD_UPDATES_MAX = 5000
     _REACTING_MESSAGE_IDS_MAX = _TITLED_ASSISTANT_THREADS_MAX = 5000
     _CHANNEL_TEAM_MAX = 10000
     _APPROVAL_RESOLVED_MAX = _CLARIFY_RESOLVED_MAX = _ACTIVE_STATUS_THREADS_MAX = 1000
@@ -944,8 +945,13 @@ class SlackAdapter(BasePlatformAdapter):
         # long retry loops used to spam threads with dozens of out-of-order status messages.
         self._status_message_ids: Dict[Tuple[str, str, str], str] = {}
         self._thread_context_cache: Dict[str, _ThreadContextCache] = {}
-        # Message IDs with reaction lifecycle (bounded: an exception between add and finalize
-        # would leak entries).
+        # Persistent sessions survive gateway restarts, so the first ordinary reply in each
+        # thread performs one bounded delta check. While running, dropped app/peer-bot events
+        # mark only their thread for another delta check.
+        self._thread_rehydration_checked: set = set()
+        self._pending_thread_updates: Dict[str, str] = {}
+        # Message IDs with reaction lifecycle (bounded: an exception between add and finalize would
+        # leak entries).
         self._reacting_message_ids: set = set()
         # Active Assistant statuses by (team_id, channel_id, thread_ts) so cleanup
         # can't clear an overlapping Slack Connect workspace; evicted oldest-thread-first.
@@ -3994,10 +4000,9 @@ class SlackAdapter(BasePlatformAdapter):
         is_thread_reply: bool, is_mentioned: bool, is_dm: bool,
     ) -> Tuple[Optional[str], List[str], List[str]]:
         """``(channel_context, root_media_urls, root_media_types)`` for a thread reply. No session:
-        full thread + root images once, set watermark. Active sessions fetch the delta past the
-        watermark for every routed reply, including plain-language wakes, because app and peer-bot
-        messages may not have become agent turns. Context goes into the NEW turn only (prompt
-        caching)."""
+        full thread + root images once, set watermark. Active sessions fetch a paginated delta on
+        explicit mentions, once after restart, or after a dropped app/peer-bot event marks the
+        thread as pending. Context goes into the NEW turn only (prompt caching)."""
         # - Active thread + explicit @mention: refresh with only the delta since the last hydrate/refresh
         #   (#23918), bypassing the TTL cache. The delta is injected as part of the NEW turn (via
         #   ``channel_context``) — prior conversation history is never rewritten, so prompt caching is
@@ -4028,6 +4033,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         watermark_args = dict(
             channel_id=channel_id, thread_ts=event_thread_ts, user_id=user_id, team_id=team_id)
+        advance_watermark = True
         if not has_active_thread_session:
             await _fetch()
             (
@@ -4035,14 +4041,33 @@ class SlackAdapter(BasePlatformAdapter):
             ) = await self._collect_thread_root_images(
                 channel_id=channel_id, thread_ts=event_thread_ts, team_id=team_id)
         else:
-            # A routed human reply can follow app/peer-bot messages that were deliberately not
-            # admitted as turns. Always recover the bounded delta before advancing the watermark;
-            # otherwise the next turn silently loses completion or incident evidence. This also
-            # covers the restart gap (#63530 / #33215) without a once-per-process shortcut.
+            rehydration_key = self._thread_rehydration_key(
+                channel_id, event_thread_ts, user_id, team_id)
+            pending_key = self._pending_thread_update_key(channel_id, event_thread_ts, team_id)
             watermark_ts = self._get_thread_watermark(**watermark_args)
-            if watermark_ts:
-                await _fetch(after_ts=watermark_ts, force_refresh=True)
-        self._set_thread_watermark(watermark_ts=ts, **watermark_args)
+            pending_ts = self._pending_thread_updates.get(pending_key, "")
+            needs_delta = (
+                is_mentioned
+                or rehydration_key not in self._thread_rehydration_checked
+                or (
+                    pending_ts
+                    and self._slack_timestamp_sort_key(pending_ts)
+                    > self._slack_timestamp_sort_key(watermark_ts)
+                )
+            )
+            if needs_delta and watermark_ts:
+                channel_context, advance_watermark = await self._fetch_thread_delta(
+                    channel_id=channel_id,
+                    thread_ts=event_thread_ts,
+                    current_ts=ts,
+                    team_id=team_id,
+                    after_ts=watermark_ts,
+                )
+            if advance_watermark:
+                self._mark_thread_rehydration_checked(
+                    channel_id, event_thread_ts, user_id, team_id)
+        if advance_watermark:
+            self._set_thread_watermark(watermark_ts=ts, **watermark_args)
         return channel_context, thread_root_media_urls, thread_root_media_types
 
     @staticmethod
@@ -4107,8 +4132,7 @@ class SlackAdapter(BasePlatformAdapter):
         if not sender_is_bot:
             return False
         allow_bots = self._slack_allow_bots()
-        if allow_bots == "none":
-            return True
+        should_drop = allow_bots == "none"
         if allow_bots == "mentions":
             # Mentions may live only in Block Kit, not the flat text.
             # See #52387.
@@ -4117,8 +4141,14 @@ class SlackAdapter(BasePlatformAdapter):
                 logger.debug(
                     "[Slack] Dropping bot message under allow_bots=mentions: "
                     "no <@%s> mention in flat text or blocks", self._bot_user_id)
-                return True
-        return bool(msg_user and self._bot_user_id and msg_user == self._bot_user_id)
+                should_drop = True
+        team_id = str(event.get("team") or event.get("team_id") or "")
+        bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
+        is_self = bool(msg_user and bot_uid and msg_user == bot_uid)
+        should_drop = should_drop or is_self
+        if should_drop and not is_self:
+            self._remember_pending_thread_update(event)
+        return should_drop
 
     async def _prefilter_inbound(
         self, event: dict, payload: Optional[dict]) -> Optional[Tuple[dict, str, str]]:
@@ -5442,14 +5472,70 @@ class SlackAdapter(BasePlatformAdapter):
         """First message whose ``ts`` is the thread root, else None."""
         return next((m for m in messages if m.get("ts", "") == thread_ts), None)
 
+    async def _fetch_thread_delta(
+        self, *, channel_id: str, thread_ts: str, current_ts: str, team_id: str, after_ts: str,
+    ) -> Tuple[str, bool]:
+        """Return the complete bounded delta and whether it is safe to advance the watermark."""
+        messages: List[dict] = []
+        cursor = ""
+        for _page in range(10):
+            try:
+                result = await self._conversations_replies_with_backoff(
+                    channel_id,
+                    thread_ts,
+                    100,
+                    team_id,
+                    oldest=after_ts,
+                    latest=current_ts,
+                    inclusive=False,
+                    cursor=cursor,
+                )
+            except Exception as exc:
+                logger.warning("[Slack] Failed to fetch thread delta: %s", exc)
+                return "", False
+            if result is None:
+                return "", False
+            messages.extend(result.get("messages", []))
+            metadata = result.get("response_metadata") or {}
+            cursor = str(metadata.get("next_cursor") or "")
+            if not cursor:
+                bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
+                unseen = [
+                    msg
+                    for msg in messages
+                    if not (
+                        msg.get("user") == bot_uid
+                        or self._workspace_message_marker(team_id, str(msg.get("ts") or ""))
+                        in self._bot_message_ts
+                        or str(msg.get("ts") or "") in self._processed_message_ts
+                    )
+                ]
+                return (
+                    await self._format_thread_context(
+                        unseen,
+                        thread_ts=thread_ts,
+                        current_ts=current_ts,
+                        team_id=team_id,
+                        channel_id=channel_id,
+                        after_ts=after_ts,
+                    )
+                )[0], True
+        logger.warning(
+            "[Slack] Thread delta exceeded 10 pages; watermark retained for a later retry"
+        )
+        return "", False
+
     async def _conversations_replies_with_backoff(
-        self, channel_id: str, thread_ts: str, limit: int, team_id: str) -> Any:
+        self, channel_id: str, thread_ts: str, limit: int, team_id: str, **query: Any) -> Any:
         """``conversations.replies`` with 1s/2s backoff on Tier-3 rate limits (429)."""
         client = self._get_client(channel_id, team_id=team_id)
         for attempt in range(3):
             try:
-                return await client.conversations_replies(
-                    channel=channel_id, ts=thread_ts, limit=limit, inclusive=True)
+                params = dict(channel=channel_id, ts=thread_ts, limit=limit, inclusive=True)
+                params.update(query)
+                if not params.get("cursor"):
+                    params.pop("cursor", None)
+                return await client.conversations_replies(**params)
             except Exception as exc:
                 err_str = str(exc).lower()
                 is_rate_limit = (
@@ -5746,6 +5832,49 @@ class SlackAdapter(BasePlatformAdapter):
             platform=Platform.SLACK, chat_id=channel_id, chat_type=chat_type, user_id=user_id,
             thread_id=thread_ts, scope_id=team_id or None)
 
+    def _thread_rehydration_key(
+        self, channel_id: str, thread_ts: str, user_id: str, team_id: str = "") -> str:
+        """Per-process key for the restart delta check; per-user when sessions are per-user."""
+        key = f"{team_id}:{channel_id}:{thread_ts}"
+        store_cfg = getattr(getattr(self, "_session_store", None), "config", None)
+        return f"{key}:{user_id}" if getattr(store_cfg, "thread_sessions_per_user", False) else key
+
+    def _mark_thread_rehydration_checked(
+        self, channel_id: str, thread_ts: str, user_id: str, team_id: str = "") -> None:
+        self._thread_rehydration_checked.add(
+            self._thread_rehydration_key(channel_id, thread_ts, user_id, team_id))
+        self._evict_oldest_by_ts(
+            self._thread_rehydration_checked,
+            self._THREAD_REHYDRATION_CHECKED_MAX,
+            lambda entry: entry.split(":")[2] if entry.count(":") >= 2 else "",
+        )
+
+    @staticmethod
+    def _pending_thread_update_key(channel_id: str, thread_ts: str, team_id: str = "") -> str:
+        return f"{team_id}:{channel_id}:{thread_ts}"
+
+    def _remember_pending_thread_update(self, event: dict) -> None:
+        """Remember a dropped external app/bot post so the next human turn recovers its delta."""
+        channel_id = str(event.get("channel") or "")
+        thread_ts = str(event.get("thread_ts") or "")
+        update_ts = str(event.get("ts") or "")
+        team_id = str(event.get("team") or event.get("team_id") or "")
+        if not channel_id or not thread_ts or not update_ts or thread_ts == update_ts:
+            return
+        key = self._pending_thread_update_key(channel_id, thread_ts, team_id)
+        previous = self._pending_thread_updates.get(key, "")
+        if (
+            not previous
+            or self._slack_timestamp_sort_key(update_ts)
+            > self._slack_timestamp_sort_key(previous)
+        ):
+            self._pending_thread_updates[key] = update_ts
+        self._evict_oldest_by_ts(
+            self._pending_thread_updates,
+            self._PENDING_THREAD_UPDATES_MAX,
+            lambda entry: self._pending_thread_updates.get(entry, ""),
+        )
+
     def _thread_watermark_io(
         self, method: str, channel_id: str, thread_ts: str, user_id: str, team_id: str, *args: Any
     ) -> Any:
@@ -5765,8 +5894,9 @@ class SlackAdapter(BasePlatformAdapter):
         self, channel_id: str, thread_ts: str, user_id: str, team_id: str = "") -> str:
         """Return the last Slack thread ts this session consumed (persisted)."""
         try:
-            return str(self._thread_watermark_io(
+            value = str(self._thread_watermark_io(
                 "get_session_metadata", channel_id, thread_ts, user_id, team_id, "") or "")
+            return value if re.fullmatch(r"\d+\.\d+", value) else ""
         except Exception:
             return ""
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4055,6 +4055,9 @@ class SlackAdapter(BasePlatformAdapter):
 
         watermark_args = dict(
             channel_id=channel_id, thread_ts=event_thread_ts, user_id=user_id, team_id=team_id)
+        complete_through_ts = (
+            latest_ts if re.fullmatch(r"\d+\.\d+", latest_ts) else ts
+        )
         watermark_to_set = ts
         recovery_complete = True
         if not has_active_thread_session:
@@ -4100,12 +4103,12 @@ class SlackAdapter(BasePlatformAdapter):
                             channel_id=channel_id,
                             thread_ts=event_thread_ts,
                             current_ts=ts,
-                            latest_ts=latest_ts,
+                            latest_ts=complete_through_ts,
                             team_id=team_id,
                         )
                     )
                     channel_context = full_context or None
-                    watermark_to_set = ts if recovery_complete else ""
+                    watermark_to_set = complete_through_ts if recovery_complete else ""
                 else:
                     channel_context, watermark_to_set = await self._fetch_thread_delta(
                         channel_id=channel_id,

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -869,7 +869,7 @@ class SlackAdapter(BasePlatformAdapter):
     # Bounded-cache caps (instance assignment in tests overrides per adapter).
     _USER_NAME_CACHE_MAX = _CHANNEL_NAME_CACHE_MAX = _DM_CONVERSATION_CACHE_MAX = 5000
     _PROCESSED_MESSAGE_TS_MAX = _BOT_TS_MAX = _MENTIONED_THREADS_MAX = 5000
-    _ASSISTANT_THREADS_MAX = _AGENT_VIEW_CONTEXTS_MAX = _THREAD_REHYDRATION_CHECKED_MAX = 5000
+    _ASSISTANT_THREADS_MAX = _AGENT_VIEW_CONTEXTS_MAX = 5000
     _REACTING_MESSAGE_IDS_MAX = _TITLED_ASSISTANT_THREADS_MAX = 5000
     _CHANNEL_TEAM_MAX = 10000
     _APPROVAL_RESOLVED_MAX = _CLARIFY_RESOLVED_MAX = _ACTIVE_STATUS_THREADS_MAX = 1000
@@ -944,12 +944,8 @@ class SlackAdapter(BasePlatformAdapter):
         # long retry loops used to spam threads with dozens of out-of-order status messages.
         self._status_message_ids: Dict[Tuple[str, str, str], str] = {}
         self._thread_context_cache: Dict[str, _ThreadContextCache] = {}
-        # Threads already rehydration-checked this process (first reply after a restart injects
-        # missed messages exactly once); message IDs with reaction lifecycle (bounded: an exception
-        # between add and finalize would leak entries).
-        # Persistent sessions survive gateway restarts, but messages that arrived while the gateway was DOWN
-        # never reached the session. Keys follow the thread session-key scoping. See #63530.
-        self._thread_rehydration_checked: set = set()
+        # Message IDs with reaction lifecycle (bounded: an exception between add and finalize
+        # would leak entries).
         self._reacting_message_ids: set = set()
         # Active Assistant statuses by (team_id, channel_id, thread_ts) so cleanup
         # can't clear an overlapping Slack Connect workspace; evicted oldest-thread-first.
@@ -3998,9 +3994,10 @@ class SlackAdapter(BasePlatformAdapter):
         is_thread_reply: bool, is_mentioned: bool, is_dm: bool,
     ) -> Tuple[Optional[str], List[str], List[str]]:
         """``(channel_context, root_media_urls, root_media_types)`` for a thread reply. No session:
-        full thread + root images once, set watermark. Session + @mention: delta past watermark
-        (cache bypassed). Session, first plain reply this process: restart rehydration; later
-        replies only advance the watermark. Context goes into the NEW turn only (prompt caching)."""
+        full thread + root images once, set watermark. Active sessions fetch the delta past the
+        watermark for every routed reply, including plain-language wakes, because app and peer-bot
+        messages may not have become agent turns. Context goes into the NEW turn only (prompt
+        caching)."""
         # - Active thread + explicit @mention: refresh with only the delta since the last hydrate/refresh
         #   (#23918), bypassing the TTL cache. The delta is injected as part of the NEW turn (via
         #   ``channel_context``) — prior conversation history is never rewritten, so prompt caching is
@@ -4037,25 +4034,15 @@ class SlackAdapter(BasePlatformAdapter):
                 thread_root_media_urls, thread_root_media_types,
             ) = await self._collect_thread_root_images(
                 channel_id=channel_id, thread_ts=event_thread_ts, team_id=team_id)
-        elif is_mentioned:
-            await _fetch(after_ts=self._get_thread_watermark(**watermark_args), force_refresh=True)
         else:
-            # Restart rehydration (#63530 restart gap / #33215): persistent sessions survive gateway
-            # restarts, but thread replies posted while the gateway was down never reached the session. On
-            # the FIRST ordinary reply per thread in this process, fetch the delta past the persisted
-            # watermark and inject anything missed as part of this new turn. Checked at most once per thread
-            # per process; a non-empty watermark plus an empty delta costs one cached conversations.replies
-            # call.
-            rehydration_key = self._thread_rehydration_key(
-                channel_id, event_thread_ts, user_id, team_id)
-            if rehydration_key in self._thread_rehydration_checked:
-                self._set_thread_watermark(watermark_ts=ts, **watermark_args)
-                return channel_context, thread_root_media_urls, thread_root_media_types
+            # A routed human reply can follow app/peer-bot messages that were deliberately not
+            # admitted as turns. Always recover the bounded delta before advancing the watermark;
+            # otherwise the next turn silently loses completion or incident evidence. This also
+            # covers the restart gap (#63530 / #33215) without a once-per-process shortcut.
             watermark_ts = self._get_thread_watermark(**watermark_args)
             if watermark_ts:
                 await _fetch(after_ts=watermark_ts, force_refresh=True)
         self._set_thread_watermark(watermark_ts=ts, **watermark_args)
-        self._mark_thread_rehydration_checked(channel_id, event_thread_ts, user_id, team_id)
         return channel_context, thread_root_media_urls, thread_root_media_types
 
     @staticmethod
@@ -5758,25 +5745,6 @@ class SlackAdapter(BasePlatformAdapter):
         return SessionSource(
             platform=Platform.SLACK, chat_id=channel_id, chat_type=chat_type, user_id=user_id,
             thread_id=thread_ts, scope_id=team_id or None)
-
-    def _thread_rehydration_key(
-        self, channel_id: str, thread_ts: str, user_id: str, team_id: str = "") -> str:
-        """Per-process key for the once-per-thread rehydration check; per-user when
-        ``thread_sessions_per_user`` is on, like the session key."""
-        key = f"{team_id}:{channel_id}:{thread_ts}"
-        store_cfg = getattr(getattr(self, "_session_store", None), "config", None)
-        return f"{key}:{user_id}" if getattr(store_cfg, "thread_sessions_per_user", False) else key
-
-    def _mark_thread_rehydration_checked(
-        self, channel_id: str, thread_ts: str, user_id: str, team_id: str = "") -> None:
-        """Record that this thread's restart-rehydration check has run."""
-        self._thread_rehydration_checked.add(
-            self._thread_rehydration_key(channel_id, thread_ts, user_id, team_id))
-        # Evict oldest thread_ts first, never in set order: dropping an ACTIVE
-        # thread's key would re-run rehydration and re-inject the missed delta.
-        self._evict_oldest_by_ts(
-            self._thread_rehydration_checked, self._THREAD_REHYDRATION_CHECKED_MAX,
-            lambda e: e.split(":")[2] if e.count(":") >= 2 else "")
 
     def _thread_watermark_io(
         self, method: str, channel_id: str, thread_ts: str, user_id: str, team_id: str, *args: Any

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3147,8 +3147,7 @@ class TestThreadReplyHandling:
             "ts": "123.456",
             "thread_ts": "123.000",
             "channel_type": "channel",
-            "team": "T_TEAM",
-        })
+        }, {"team_id": "T_TEAM"})
 
         adapter_with_session_store._app.client.conversations_replies.assert_awaited_once()
         msg_event = adapter_with_session_store.handle_message.call_args[0][0]
@@ -3194,8 +3193,7 @@ class TestThreadReplyHandling:
             "ts": "123.200",
             "thread_ts": "123.000",
             "channel_type": "channel",
-            "team": "T_TEAM",
-        })
+        }, {"team_id": "T_TEAM"})
         adapter_with_session_store._app.client.conversations_replies = AsyncMock(
             return_value={
                 "messages": [

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3160,6 +3160,37 @@ class TestThreadReplyHandling:
         assert metadata["slack_thread_watermark:C123:123.000"] == "123.456"
 
     @pytest.mark.asyncio
+    async def test_active_mention_without_watermark_fetches_full_thread(
+        self, adapter_with_session_store
+    ):
+        adapter_with_session_store._has_active_session_for_thread = MagicMock(return_value=True)
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(
+            return_value={
+                "messages": [
+                    {"ts": "123.000", "user": "U_PARENT", "text": "Original report"},
+                    {"ts": "123.200", "user": "U_APP", "text": "Missed update"},
+                    {"ts": "123.456", "user": "U_USER", "text": "<@U_BOT> verify"},
+                ]
+            }
+        )
+
+        await adapter_with_session_store._handle_slack_message({
+            "text": "<@U_BOT> verify",
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        })
+
+        adapter_with_session_store._app.client.conversations_replies.assert_awaited_once()
+        assert (
+            "Missed update"
+            in adapter_with_session_store.handle_message.call_args[0][0].channel_context
+        )
+
+    @pytest.mark.asyncio
     async def test_active_thread_plain_wake_recovers_intermediate_app_message(
         self, adapter_with_session_store, mock_session_store
     ):
@@ -3309,6 +3340,9 @@ class TestThreadReplyHandling:
             ]
         )
         adapter_with_session_store._user_name_cache = {("T_TEAM", "U_APP"): "Release app"}
+        adapter_with_session_store._remember_processed_message_ts(
+            "123.200", team_id="T_OTHER"
+        )
 
         await adapter_with_session_store._handle_slack_message({
             "text": "verify now",
@@ -3326,6 +3360,73 @@ class TestThreadReplyHandling:
         assert "part one" in msg_event.channel_context
         assert "part two" in msg_event.channel_context
         assert metadata["slack_thread_watermark:C123:123.000"] == "123.456"
+
+    @pytest.mark.asyncio
+    async def test_oversized_delta_advances_to_last_fetched_page(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        adapter_with_session_store._has_active_session_for_thread = MagicMock(return_value=True)
+        metadata = {"slack_thread_watermark:C123:123.000": "123.100"}
+        mock_session_store.get_session_metadata = MagicMock(
+            side_effect=lambda sk, k, d=None: metadata.get(k, d)
+        )
+        mock_session_store.set_session_metadata = MagicMock(
+            side_effect=lambda sk, k, v: metadata.__setitem__(k, v) or True
+        )
+        adapter_with_session_store._pending_thread_updates[
+            "T_TEAM:C123:123.000"
+        ] = "123.900"
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(
+            side_effect=[
+                {
+                    "messages": [
+                        {
+                            "ts": f"123.{200 + page:03d}",
+                            "user": "U_APP",
+                            "text": f"page {page}",
+                        }
+                    ],
+                    "response_metadata": {"next_cursor": f"page-{page + 1}"},
+                }
+                for page in range(10)
+            ]
+        )
+
+        await adapter_with_session_store._handle_slack_message({
+            "text": "verify now",
+            "user": "U_USER",
+            "client_msg_id": "human-message",
+            "channel": "C123",
+            "ts": "124.000",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        })
+
+        assert metadata["slack_thread_watermark:C123:123.000"] == "123.209"
+        assert "page 9" in adapter_with_session_store.handle_message.call_args[0][0].channel_context
+
+    @pytest.mark.asyncio
+    async def test_unlabelled_peer_bot_drop_marks_thread_pending(self, adapter_with_session_store):
+        adapter_with_session_store._app.client.users_info = AsyncMock(
+            return_value={"user": {"is_bot": True, "profile": {"display_name": "Peer bot"}}}
+        )
+
+        await adapter_with_session_store._handle_slack_message({
+            "text": "completion from peer bot",
+            "user": "U_PEER",
+            "client_msg_id": "bot-shaped-client-id",
+            "channel": "C123",
+            "ts": "123.300",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        })
+
+        assert adapter_with_session_store._pending_thread_updates[
+            "T_TEAM:C123:123.000"
+        ] == "123.300"
+        adapter_with_session_store.handle_message.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_failed_pending_delta_retains_watermark_for_retry(

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3528,8 +3528,18 @@ class TestThreadReplyHandling:
 
     @pytest.mark.asyncio
     async def test_edit_refresh_uses_edit_time_but_excludes_edited_trigger(
-        self, adapter_with_session_store
+        self, adapter_with_session_store, mock_session_store
     ):
+        adapter_with_session_store._has_active_session_for_thread = MagicMock(
+            return_value=True
+        )
+        metadata = {"slack_thread_watermark:C123:123.000": "123.100"}
+        mock_session_store.get_session_metadata = MagicMock(
+            side_effect=lambda sk, k, d=None: metadata.get(k, d)
+        )
+        mock_session_store.set_session_metadata = MagicMock(
+            side_effect=lambda sk, k, v: metadata.__setitem__(k, v) or True
+        )
         adapter_with_session_store._app.client.conversations_replies = AsyncMock(
             return_value={
                 "messages": [
@@ -3540,19 +3550,23 @@ class TestThreadReplyHandling:
             }
         )
 
-        context, complete = await adapter_with_session_store._fetch_complete_thread_context(
+        context, _, _ = await adapter_with_session_store._hydrate_thread_context(
             channel_id="C123",
-            thread_ts="123.000",
-            current_ts="123.200",
+            event_thread_ts="123.000",
+            ts="123.200",
+            user_id="U_APP",
             latest_ts="123.500",
             team_id="T_TEAM",
+            is_thread_reply=True,
+            is_mentioned=False,
+            is_dm=False,
         )
 
-        assert complete is True
         assert "intermediate reply" in context
         assert "edited trigger" not in context
         call = adapter_with_session_store._app.client.conversations_replies.await_args.kwargs
         assert call["latest"] == "123.500"
+        assert metadata["slack_thread_watermark:C123:123.000"] == "123.500"
 
     @pytest.mark.asyncio
     async def test_failed_handler_releases_session_scoped_processed_marker(

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3160,6 +3160,69 @@ class TestThreadReplyHandling:
         # Watermark advanced to the trigger ts.
         assert metadata["slack_thread_watermark:C123:123.000"] == "123.456"
 
+    @pytest.mark.asyncio
+    async def test_active_thread_plain_wake_recovers_intermediate_app_message(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        """A routed plain reply must recover messages that were not routed as
+        turns, even after this process already hydrated the active thread.
+
+        External apps commonly post a completion update between Milo's reply
+        and a human's plain-language wake. Advancing the watermark without a
+        fresh conversations.replies read silently hides that evidence.
+        """
+        mock_session_store._entries = {"any": MagicMock()}
+        adapter_with_session_store._has_active_session_for_thread = MagicMock(
+            return_value=True
+        )
+        metadata = {"slack_thread_watermark:C123:123.000": "123.100"}
+        mock_session_store.get_session_metadata = MagicMock(
+            side_effect=lambda sk, k, d=None: metadata.get(k, d)
+        )
+        mock_session_store.set_session_metadata = MagicMock(
+            side_effect=lambda sk, k, v: metadata.__setitem__(k, v) or True
+        )
+        adapter_with_session_store._mark_thread_rehydration_checked(
+            "C123", "123.000", "U_USER", "T_TEAM"
+        )
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(
+            return_value={
+                "messages": [
+                    {"ts": "123.000", "user": "U_PARENT", "text": "Original report"},
+                    {"ts": "123.100", "user": "U_USER", "text": "Old context"},
+                    {
+                        "ts": "123.200",
+                        "user": "U_APP",
+                        "bot_id": "B_APP",
+                        "subtype": "bot_message",
+                        "text": "Issue resolved; PR merged and deployment succeeded",
+                    },
+                    {"ts": "123.456", "user": "U_USER", "text": "Milo, please verify"},
+                ]
+            }
+        )
+        adapter_with_session_store._user_name_cache = {
+            ("T_TEAM", "U_PARENT"): "Reporter",
+            ("T_TEAM", "U_USER"): "User",
+            ("T_TEAM", "U_APP"): "Release app",
+        }
+
+        await adapter_with_session_store._handle_slack_message({
+            "text": "Milo, please verify",
+            "user": "U_USER",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        })
+
+        adapter_with_session_store._app.client.conversations_replies.assert_awaited_once()
+        msg_event = adapter_with_session_store.handle_message.call_args[0][0]
+        assert "Issue resolved; PR merged and deployment succeeded" in msg_event.channel_context
+        assert "Old context" not in msg_event.channel_context
+        assert metadata["slack_thread_watermark:C123:123.000"] == "123.456"
+
 
 # ---------------------------------------------------------------------------
 # TestAssistantThreadLifecycle

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3362,6 +3362,104 @@ class TestThreadReplyHandling:
         assert metadata["slack_thread_watermark:C123:123.000"] == "123.456"
 
     @pytest.mark.asyncio
+    async def test_processed_delta_markers_follow_per_user_session_scope(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        mock_session_store.config.thread_sessions_per_user = True
+        adapter_with_session_store._remember_processed_message_ts(
+            "123.200", team_id="T_TEAM", user_id="U_FIRST"
+        )
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(
+            return_value={
+                "messages": [
+                    {"ts": "123.200", "user": "U_FIRST", "text": "first user's update"},
+                ]
+            }
+        )
+
+        second_context, _ = await adapter_with_session_store._fetch_thread_delta(
+            channel_id="C123",
+            thread_ts="123.000",
+            current_ts="123.456",
+            team_id="T_TEAM",
+            user_id="U_SECOND",
+            after_ts="123.100",
+        )
+        first_context, _ = await adapter_with_session_store._fetch_thread_delta(
+            channel_id="C123",
+            thread_ts="123.000",
+            current_ts="123.456",
+            team_id="T_TEAM",
+            user_id="U_FIRST",
+            after_ts="123.100",
+        )
+
+        assert "first user's update" in second_context
+        assert "first user's update" not in first_context
+
+    @pytest.mark.asyncio
+    async def test_pending_app_edit_uses_edit_timestamp_for_recovery(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        adapter_with_session_store._has_active_session_for_thread = MagicMock(return_value=True)
+        metadata = {"slack_thread_watermark:C123:123.000": "123.300"}
+        mock_session_store.get_session_metadata = MagicMock(
+            side_effect=lambda sk, k, d=None: metadata.get(k, d)
+        )
+        mock_session_store.set_session_metadata = MagicMock(
+            side_effect=lambda sk, k, v: metadata.__setitem__(k, v) or True
+        )
+        adapter_with_session_store._mark_thread_rehydration_checked(
+            "C123", "123.000", "U_USER", "T_TEAM"
+        )
+
+        await adapter_with_session_store._handle_slack_message({
+            "subtype": "message_changed",
+            "channel": "C123",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+            "event_ts": "123.400",
+            "message": {
+                "text": "Deployment succeeded",
+                "user": "U_APP",
+                "bot_id": "B_APP",
+                "subtype": "bot_message",
+                "channel": "C123",
+                "ts": "123.200",
+                "thread_ts": "123.000",
+                "edited": {"user": "U_APP", "ts": "123.400"},
+            },
+        })
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(
+            return_value={
+                "messages": [
+                    {
+                        "ts": "123.200",
+                        "user": "U_APP",
+                        "bot_id": "B_APP",
+                        "text": "Deployment succeeded",
+                    },
+                    {"ts": "123.500", "user": "U_USER", "text": "verify"},
+                ]
+            }
+        )
+
+        await adapter_with_session_store._handle_slack_message({
+            "text": "verify",
+            "user": "U_USER",
+            "client_msg_id": "human-message",
+            "channel": "C123",
+            "ts": "123.500",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        })
+
+        context = adapter_with_session_store.handle_message.call_args[0][0].channel_context
+        assert "Deployment succeeded" in context
+        assert metadata["slack_thread_watermark:C123:123.000"] == "123.500"
+
+    @pytest.mark.asyncio
     async def test_oversized_delta_advances_to_last_fetched_page(
         self, adapter_with_session_store, mock_session_store
     ):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3507,6 +3507,70 @@ class TestThreadReplyHandling:
         assert not adapter_with_session_store._thread_rehydration_checked
 
     @pytest.mark.asyncio
+    async def test_complete_restart_refresh_is_bounded_before_triggering_reply(
+        self, adapter_with_session_store
+    ):
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(
+            return_value={"messages": [], "response_metadata": {"next_cursor": ""}}
+        )
+
+        _, complete = await adapter_with_session_store._fetch_complete_thread_context(
+            channel_id="C123",
+            thread_ts="123.000",
+            current_ts="123.500",
+            team_id="T_TEAM",
+        )
+
+        assert complete is True
+        call = adapter_with_session_store._app.client.conversations_replies.await_args.kwargs
+        assert call["latest"] == "123.500"
+        assert call["inclusive"] is False
+
+    @pytest.mark.asyncio
+    async def test_failed_handler_releases_session_scoped_processed_marker(
+        self, adapter_with_session_store
+    ):
+        adapter_with_session_store.handle_message = AsyncMock(
+            side_effect=RuntimeError("agent delivery failed")
+        )
+        failed_event = {
+            "text": "please verify",
+            "user": "U_USER",
+            "client_msg_id": "human-message",
+            "_hermes_force_process": True,
+            "channel": "C123",
+            "ts": "123.200",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        }
+
+        with pytest.raises(RuntimeError, match="agent delivery failed"):
+            await adapter_with_session_store._handle_slack_message(failed_event)
+
+        marker = adapter_with_session_store._processed_message_marker(
+            "T_TEAM", "U_USER", "123.200"
+        )
+        assert marker not in adapter_with_session_store._processed_message_markers
+
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(
+            return_value={
+                "messages": [
+                    {"ts": "123.200", "user": "U_USER", "text": "please verify"},
+                ],
+                "response_metadata": {"next_cursor": ""},
+            }
+        )
+        context, _ = await adapter_with_session_store._fetch_thread_delta(
+            channel_id="C123",
+            thread_ts="123.000",
+            current_ts="123.500",
+            team_id="T_TEAM",
+            user_id="U_USER",
+            after_ts="123.100",
+        )
+        assert "please verify" in context
+
+    @pytest.mark.asyncio
     async def test_out_of_order_pending_bot_event_forces_full_recovery(
         self, adapter_with_session_store, mock_session_store
     ):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3182,11 +3182,30 @@ class TestThreadReplyHandling:
         mock_session_store.set_session_metadata = MagicMock(
             side_effect=lambda sk, k, v: metadata.__setitem__(k, v) or True
         )
+        adapter_with_session_store._mark_thread_rehydration_checked(
+            "C123", "123.000", "U_USER", "T_TEAM"
+        )
+        await adapter_with_session_store._handle_slack_message({
+            "text": "Issue resolved; PR merged and deployment succeeded",
+            "user": "U_APP",
+            "bot_id": "B_APP",
+            "subtype": "bot_message",
+            "channel": "C123",
+            "ts": "123.200",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        })
         adapter_with_session_store._app.client.conversations_replies = AsyncMock(
             return_value={
                 "messages": [
-                    {"ts": "123.000", "user": "U_PARENT", "text": "Original report"},
-                    {"ts": "123.100", "user": "U_USER", "text": "Old context"},
+                    {
+                        "ts": "123.150",
+                        "user": "U_BOT",
+                        "bot_id": "B_SELF",
+                        "subtype": "bot_message",
+                        "text": "My already-persisted answer",
+                    },
                     {
                         "ts": "123.200",
                         "user": "U_APP",
@@ -3217,8 +3236,135 @@ class TestThreadReplyHandling:
         adapter_with_session_store._app.client.conversations_replies.assert_awaited_once()
         msg_event = adapter_with_session_store.handle_message.call_args[0][0]
         assert "Issue resolved; PR merged and deployment succeeded" in msg_event.channel_context
+        assert "My already-persisted answer" not in msg_event.channel_context
         assert "Old context" not in msg_event.channel_context
         assert metadata["slack_thread_watermark:C123:123.000"] == "123.456"
+
+    @pytest.mark.asyncio
+    async def test_active_plain_reply_without_pending_update_uses_no_history_api(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        mock_session_store._entries = {"any": MagicMock()}
+        adapter_with_session_store._has_active_session_for_thread = MagicMock(return_value=True)
+        metadata = {"slack_thread_watermark:C123:123.000": "123.100"}
+        mock_session_store.get_session_metadata = MagicMock(
+            side_effect=lambda sk, k, d=None: metadata.get(k, d)
+        )
+        mock_session_store.set_session_metadata = MagicMock(
+            side_effect=lambda sk, k, v: metadata.__setitem__(k, v) or True
+        )
+        adapter_with_session_store._mark_thread_rehydration_checked(
+            "C123", "123.000", "U_USER", "T_TEAM"
+        )
+
+        await adapter_with_session_store._handle_slack_message({
+            "text": "ordinary follow-up",
+            "user": "U_USER",
+            "client_msg_id": "human-message",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        })
+
+        adapter_with_session_store._app.client.conversations_replies.assert_not_awaited()
+        assert metadata["slack_thread_watermark:C123:123.000"] == "123.456"
+
+    @pytest.mark.asyncio
+    async def test_pending_thread_delta_paginates_before_advancing_watermark(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        mock_session_store._entries = {"any": MagicMock()}
+        adapter_with_session_store._has_active_session_for_thread = MagicMock(return_value=True)
+        metadata = {"slack_thread_watermark:C123:123.000": "123.100"}
+        mock_session_store.get_session_metadata = MagicMock(
+            side_effect=lambda sk, k, d=None: metadata.get(k, d)
+        )
+        mock_session_store.set_session_metadata = MagicMock(
+            side_effect=lambda sk, k, v: metadata.__setitem__(k, v) or True
+        )
+        adapter_with_session_store._mark_thread_rehydration_checked(
+            "C123", "123.000", "U_USER", "T_TEAM"
+        )
+        await adapter_with_session_store._handle_slack_message({
+            "text": "deployment update",
+            "user": "U_APP",
+            "bot_id": "B_APP",
+            "subtype": "bot_message",
+            "channel": "C123",
+            "ts": "123.300",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        })
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(
+            side_effect=[
+                {
+                    "messages": [{"ts": "123.200", "user": "U_APP", "text": "part one"}],
+                    "response_metadata": {"next_cursor": "page-2"},
+                },
+                {
+                    "messages": [{"ts": "123.300", "user": "U_APP", "text": "part two"}],
+                    "response_metadata": {"next_cursor": ""},
+                },
+            ]
+        )
+        adapter_with_session_store._user_name_cache = {("T_TEAM", "U_APP"): "Release app"}
+
+        await adapter_with_session_store._handle_slack_message({
+            "text": "verify now",
+            "user": "U_USER",
+            "client_msg_id": "human-message",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        })
+
+        assert adapter_with_session_store._app.client.conversations_replies.await_count == 2
+        msg_event = adapter_with_session_store.handle_message.call_args[0][0]
+        assert "part one" in msg_event.channel_context
+        assert "part two" in msg_event.channel_context
+        assert metadata["slack_thread_watermark:C123:123.000"] == "123.456"
+
+    @pytest.mark.asyncio
+    async def test_failed_pending_delta_retains_watermark_for_retry(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        mock_session_store._entries = {"any": MagicMock()}
+        adapter_with_session_store._has_active_session_for_thread = MagicMock(return_value=True)
+        metadata = {"slack_thread_watermark:C123:123.000": "123.100"}
+        mock_session_store.get_session_metadata = MagicMock(
+            side_effect=lambda sk, k, d=None: metadata.get(k, d)
+        )
+        mock_session_store.set_session_metadata = MagicMock(
+            side_effect=lambda sk, k, v: metadata.__setitem__(k, v) or True
+        )
+        adapter_with_session_store._mark_thread_rehydration_checked(
+            "C123", "123.000", "U_USER", "T_TEAM"
+        )
+        adapter_with_session_store._pending_thread_updates[
+            "T_TEAM:C123:123.000"
+        ] = "123.200"
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(
+            side_effect=RuntimeError("history unavailable")
+        )
+
+        await adapter_with_session_store._handle_slack_message({
+            "text": "verify now",
+            "user": "U_USER",
+            "client_msg_id": "human-message",
+            "channel": "C123",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        })
+
+        adapter_with_session_store.handle_message.assert_awaited_once()
+        assert metadata["slack_thread_watermark:C123:123.000"] == "123.100"
 
 
 # ---------------------------------------------------------------------------
@@ -4564,6 +4710,34 @@ class TestTrackingStructureBounds:
         # Newest entry survives; oldest was evicted.
         assert ("T1", "U49") in adapter._user_name_cache
         assert ("T1", "U0") not in adapter._user_name_cache
+
+    def test_rehydration_checked_evicts_oldest_thread_first(self, adapter):
+        adapter._THREAD_REHYDRATION_CHECKED_MAX = 4
+        for ts in [
+            "1000.000002",
+            "999.999999",
+            "1000.000004",
+            "1000.000001",
+            "1000.000003",
+        ]:
+            adapter._mark_thread_rehydration_checked("C1", ts, "U1", "T1")
+        assert adapter._thread_rehydration_checked == {
+            "T1:C1:1000.000003",
+            "T1:C1:1000.000004",
+        }
+
+    def test_pending_thread_updates_evict_oldest_update_first(self, adapter):
+        adapter._PENDING_THREAD_UPDATES_MAX = 4
+        for i in range(5):
+            adapter._remember_pending_thread_update({
+                "channel": "C1",
+                "thread_ts": f"1000.00000{i}",
+                "ts": f"2000.00000{i}",
+                "team": "T1",
+            })
+        assert len(adapter._pending_thread_updates) <= 4
+        assert "T1:C1:1000.000004" in adapter._pending_thread_updates
+        assert "T1:C1:1000.000000" not in adapter._pending_thread_updates
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3182,9 +3182,6 @@ class TestThreadReplyHandling:
         mock_session_store.set_session_metadata = MagicMock(
             side_effect=lambda sk, k, v: metadata.__setitem__(k, v) or True
         )
-        adapter_with_session_store._mark_thread_rehydration_checked(
-            "C123", "123.000", "U_USER", "T_TEAM"
-        )
         adapter_with_session_store._app.client.conversations_replies = AsyncMock(
             return_value={
                 "messages": [
@@ -4567,24 +4564,6 @@ class TestTrackingStructureBounds:
         # Newest entry survives; oldest was evicted.
         assert ("T1", "U49") in adapter._user_name_cache
         assert ("T1", "U0") not in adapter._user_name_cache
-
-
-    def test_rehydration_checked_evicts_oldest_thread_first(self, adapter):
-        """Regression shape for #51019: the ACTIVE (newest) thread key must
-        survive eviction pressure so its rehydration check does not re-run."""
-        adapter._THREAD_REHYDRATION_CHECKED_MAX = 4
-        for ts in [
-            "1000.000002",
-            "999.999999",
-            "1000.000004",
-            "1000.000001",
-            "1000.000003",
-        ]:
-            adapter._mark_thread_rehydration_checked("C1", ts, "U1", "T1")
-        assert adapter._thread_rehydration_checked == {
-            "T1:C1:1000.000003",
-            "T1:C1:1000.000004",
-        }
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3527,6 +3527,34 @@ class TestThreadReplyHandling:
         assert call["inclusive"] is False
 
     @pytest.mark.asyncio
+    async def test_edit_refresh_uses_edit_time_but_excludes_edited_trigger(
+        self, adapter_with_session_store
+    ):
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(
+            return_value={
+                "messages": [
+                    {"ts": "123.200", "user": "U_APP", "text": "edited trigger"},
+                    {"ts": "123.300", "user": "U_USER", "text": "intermediate reply"},
+                ],
+                "response_metadata": {"next_cursor": ""},
+            }
+        )
+
+        context, complete = await adapter_with_session_store._fetch_complete_thread_context(
+            channel_id="C123",
+            thread_ts="123.000",
+            current_ts="123.200",
+            latest_ts="123.500",
+            team_id="T_TEAM",
+        )
+
+        assert complete is True
+        assert "intermediate reply" in context
+        assert "edited trigger" not in context
+        call = adapter_with_session_store._app.client.conversations_replies.await_args.kwargs
+        assert call["latest"] == "123.500"
+
+    @pytest.mark.asyncio
     async def test_failed_handler_releases_session_scoped_processed_marker(
         self, adapter_with_session_store
     ):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3438,17 +3438,26 @@ class TestThreadReplyHandling:
         adapter_with_session_store._pending_thread_full_refresh.clear()
         adapter_with_session_store._thread_rehydration_checked.clear()
         adapter_with_session_store._app.client.conversations_replies = AsyncMock(
-            return_value={
-                "messages": [
-                    {
-                        "ts": "123.200",
-                        "user": "U_APP",
-                        "bot_id": "B_APP",
-                        "text": "Deployment succeeded",
-                    },
-                    {"ts": "123.500", "user": "U_USER", "text": "verify"},
-                ]
-            }
+            side_effect=[
+                {
+                    "messages": [
+                        {"ts": "123.000", "user": "U_PARENT", "text": "Original report"},
+                    ],
+                    "response_metadata": {"next_cursor": "page-2"},
+                },
+                {
+                    "messages": [
+                        {
+                            "ts": "123.200",
+                            "user": "U_APP",
+                            "bot_id": "B_APP",
+                            "text": "Deployment succeeded",
+                        },
+                        {"ts": "123.500", "user": "U_USER", "text": "verify"},
+                    ],
+                    "response_metadata": {"next_cursor": ""},
+                },
+            ]
         )
 
         await adapter_with_session_store._handle_slack_message({
@@ -3464,7 +3473,93 @@ class TestThreadReplyHandling:
 
         context = adapter_with_session_store.handle_message.call_args[0][0].channel_context
         assert "Deployment succeeded" in context
+        assert adapter_with_session_store._app.client.conversations_replies.await_count == 2
         assert metadata["slack_thread_watermark:C123:123.000"] == "123.500"
+
+    @pytest.mark.asyncio
+    async def test_failed_restart_refresh_retains_watermark_for_retry(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        adapter_with_session_store._has_active_session_for_thread = MagicMock(return_value=True)
+        metadata = {"slack_thread_watermark:C123:123.000": "123.300"}
+        mock_session_store.get_session_metadata = MagicMock(
+            side_effect=lambda sk, k, d=None: metadata.get(k, d)
+        )
+        mock_session_store.set_session_metadata = MagicMock(
+            side_effect=lambda sk, k, v: metadata.__setitem__(k, v) or True
+        )
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(
+            side_effect=RuntimeError("temporary Slack failure")
+        )
+
+        await adapter_with_session_store._handle_slack_message({
+            "text": "verify",
+            "user": "U_USER",
+            "client_msg_id": "human-message",
+            "channel": "C123",
+            "ts": "123.500",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        })
+
+        assert metadata["slack_thread_watermark:C123:123.000"] == "123.300"
+        assert not adapter_with_session_store._thread_rehydration_checked
+
+    @pytest.mark.asyncio
+    async def test_out_of_order_pending_bot_event_forces_full_recovery(
+        self, adapter_with_session_store, mock_session_store
+    ):
+        adapter_with_session_store._has_active_session_for_thread = MagicMock(return_value=True)
+        metadata = {"slack_thread_watermark:C123:123.000": "123.500"}
+        mock_session_store.get_session_metadata = MagicMock(
+            side_effect=lambda sk, k, d=None: metadata.get(k, d)
+        )
+        mock_session_store.set_session_metadata = MagicMock(
+            side_effect=lambda sk, k, v: metadata.__setitem__(k, v) or True
+        )
+        adapter_with_session_store._mark_thread_rehydration_checked(
+            "C123", "123.000", "U_USER", "T_TEAM"
+        )
+        await adapter_with_session_store._handle_slack_message({
+            "text": "Late-delivered deployment success",
+            "user": "U_APP",
+            "bot_id": "B_APP",
+            "subtype": "bot_message",
+            "channel": "C123",
+            "ts": "123.400",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        })
+        adapter_with_session_store._app.client.conversations_replies = AsyncMock(
+            return_value={
+                "messages": [
+                    {
+                        "ts": "123.400",
+                        "user": "U_APP",
+                        "bot_id": "B_APP",
+                        "text": "Late-delivered deployment success",
+                    },
+                    {"ts": "123.600", "user": "U_USER", "text": "verify"},
+                ]
+            }
+        )
+
+        await adapter_with_session_store._handle_slack_message({
+            "text": "verify",
+            "user": "U_USER",
+            "client_msg_id": "human-message",
+            "channel": "C123",
+            "ts": "123.600",
+            "thread_ts": "123.000",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+        })
+
+        context = adapter_with_session_store.handle_message.call_args[0][0].channel_context
+        assert "Late-delivered deployment success" in context
+        assert metadata["slack_thread_watermark:C123:123.000"] == "123.600"
 
     @pytest.mark.asyncio
     async def test_oversized_delta_advances_to_last_fetched_page(

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3139,6 +3139,9 @@ class TestThreadReplyHandling:
             ("T_TEAM", "U_USER"): "User",
             ("T_TEAM", "U_OTHER"): "Other",
         }
+        adapter_with_session_store._mark_thread_rehydration_checked(
+            "C123", "123.000", "U_USER", "T_TEAM"
+        )
 
         await adapter_with_session_store._handle_slack_message({
             "text": "<@U_BOT> what changed?",
@@ -3430,6 +3433,10 @@ class TestThreadReplyHandling:
                 "edited": {"user": "U_APP", "ts": "123.400"},
             },
         })
+        # A restart loses all in-memory edit flags but must still recover the
+        # current edited thread from Slack on its first session wake.
+        adapter_with_session_store._pending_thread_full_refresh.clear()
+        adapter_with_session_store._thread_rehydration_checked.clear()
         adapter_with_session_store._app.client.conversations_replies = AsyncMock(
             return_value={
                 "messages": [
@@ -3474,6 +3481,9 @@ class TestThreadReplyHandling:
         adapter_with_session_store._pending_thread_updates[
             "T_TEAM:C123:123.000"
         ] = "123.900"
+        adapter_with_session_store._mark_thread_rehydration_checked(
+            "C123", "123.000", "U_USER", "T_TEAM"
+        )
         adapter_with_session_store._app.client.conversations_replies = AsyncMock(
             side_effect=[
                 {


### PR DESCRIPTION
## What does this PR do?

Slack now records when a dropped external app or peer-bot message lands in an active thread. The next routed human reply recovers that missed evidence before advancing the persisted watermark. In-place app edits, such as a deployment status changing from running to succeeded, trigger a complete paginated current-thread refresh; the first reply after a gateway restart does the same so those edits remain recoverable after memory is cleared. The watermark advances only after that refresh is exhaustive and successful.

Ordinary active-thread replies with no pending external update make no Slack history request. New-message deltas are paginated and resumable, exclude only messages already delivered to the same session, and keep workspace and per-user session boundaries intact.

## Related Issue

No linked issue; reproduced from a live dropped-completion-message incident.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Mark only threads containing dropped external app/peer-bot messages for recovery.
- Use complete paginated current-thread refresh for restart recovery and edited app messages.
- Keep unresolved recovery pending across API failures, oversized threads, and out-of-order app events.
- Bound full refreshes at the triggering event time so concurrent later replies are not delivered twice, while an edit to an older message still retains intervening thread replies.
- Release both deduplication markers when message handling fails so Slack can safely retry the turn.
- Paginate new-message deltas and advance only through the last safely recovered page.
- Retain the previous watermark when delta recovery fails.
- Exclude self-authored and already-routed messages using workspace and session-aware markers.
- Preserve outer-payload workspace identity for dropped bot messages.

## How to Test

1. The original regression fails on the pre-fix base because the plain wake never reads the intermediate app message.
2. Focused cases cover dropped completion posts, in-place status edits and their event-time cutoff, gateway restart, complete refresh failure, concurrent later replies, failed message handling, out-of-order app events, pagination, safe partial progress, failure retry, no-extra-read behavior, duplicate exclusion, workspace isolation, and per-user session isolation.
3. `scripts/run_tests.sh tests/gateway/test_slack.py` passes: 249 passed, 1 skipped.

## Checklist

### Code

- [x] I have read the Contributing Guide and repository guidance.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs and found no duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] I ran the complete repository test suite; the affected Slack adapter file is green.
- [x] I added behavioral regression tests.
- [x] Tested on macOS.

### Documentation & Housekeeping

- [x] Documentation and docstrings updated where relevant.
- [x] Config example N/A; no config keys changed.
- [x] CONTRIBUTING or AGENTS update N/A; no architecture contract changed.
- [x] Cross-platform impact considered; logic is platform-API based.
- [x] Tool descriptions or schemas N/A.

## Screenshots / Logs

Affected Slack adapter suite: 249 passed, 1 skipped.
