### PR TITLE
fix(feishu): strip leading @all so a trailing slash command is recogn…

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -966,6 +966,19 @@ def _strip_edge_self_mentions(text: str, mentions: Sequence[FeishuMentionRef]) -
             return remaining
 
 
+def _strip_leading_at_all(text: str) -> str:
+    """Strip a leading @all / @_all (@everyone) trigger from message text.
+
+    Feishu renders @everyone as an ``@_all`` placeholder that ``_normalize_feishu_text``
+    turns into a literal leading ``@all``. That prefix is a routing trigger, not message
+    content, but it hides a trailing slash command: ``"@all /new"`` fails the
+    ``startswith("/")`` check in ``_process_inbound_message``, so the command is folded
+    into conversational text instead of being dispatched. Only a *leading* token is
+    stripped — a mid-message ``@all`` (``"ping @all please"``) stays as content.
+    """
+    return re.sub(r"^@_?all\b\s*", "", text or "")
+
+
 # --- Multiplex isolation for the lark_oapi WebSocket client ---
 #
 # ``lark_oapi.ws.client`` keeps the asyncio loop in a *module-level global* (``loop``), and
@@ -2497,6 +2510,7 @@ class FeishuAdapter(BasePlatformAdapter):
         text, inbound_type, media_urls, media_types, mentions = await self._extract_message_content(message)
         if inbound_type == MessageType.TEXT:
             text = _strip_edge_self_mentions(text, mentions)
+            text = _strip_leading_at_all(text)
             if text.startswith("/"):
                 inbound_type = MessageType.COMMAND
         # Post-strip guard so a pure "@Bot" message (stripped to "") is dropped.

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -979,6 +979,23 @@ def _strip_leading_at_all(text: str) -> str:
     return re.sub(r"^@_?all\b\s*", "", text or "")
 
 
+# Body kept for a message that carried nothing but the @everyone trigger. Feishu sends
+# @everyone as ``@_all`` with no text of its own, so the leading strip above empties a bare
+# ``@_all`` message. It is still a real turn — ``_mentions_self`` admits it on that same
+# ``@_all`` marker — so it gets a placeholder body instead of being dropped by the
+# post-strip guard the way a bodyless "@Bot" ping is.
+_AT_ALL_BODY = "@all"
+
+
+def _bare_at_all_body(raw_content: Any) -> str:
+    """Placeholder body when the message is nothing but @everyone, else ``""``.
+
+    Detection mirrors ``_mentions_self`` so admission and processing agree on what counts as
+    an @everyone trigger.
+    """
+    return _AT_ALL_BODY if isinstance(raw_content, str) and "@_all" in raw_content else ""
+
+
 # --- Multiplex isolation for the lark_oapi WebSocket client ---
 #
 # ``lark_oapi.ws.client`` keeps the asyncio loop in a *module-level global* (``loop``), and
@@ -2513,10 +2530,14 @@ class FeishuAdapter(BasePlatformAdapter):
             text = _strip_leading_at_all(text)
             if text.startswith("/"):
                 inbound_type = MessageType.COMMAND
-        # Post-strip guard so a pure "@Bot" message (stripped to "") is dropped.
+        # Post-strip guard so a pure "@Bot" message (stripped to "") is dropped. A bare
+        # @everyone survives it: the trigger is the whole message, so it gets a placeholder
+        # body rather than being thrown away as empty.
         if inbound_type == MessageType.TEXT and not text and not media_urls:
-            logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
-            return
+            text = _bare_at_all_body(getattr(message, "content", ""))
+            if not text:
+                logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
+                return
         if inbound_type != MessageType.COMMAND:
             hint = _build_mention_hint(mentions)
             if hint:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2380,6 +2380,68 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         self.assertNotIn("[Mentioned:", event.text)
         self.assertTrue(event.text.startswith("/model"))
 
+    def test_bare_at_all_message_reaches_the_agent(self):
+        """A message that is nothing but @everyone (Feishu's "@_all") is a real turn.
+
+        The @_all marker is what got the message past mention gating, so stripping it must
+        not leave an empty body that the post-strip guard throws away.
+        """
+        from gateway.platforms.event import MessageType
+
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "@_all"}),
+            message_type="text",
+            message_id="m4",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="m4",
+            )
+        )
+        self.assertTrue(adapter._dispatch_inbound_event.called)
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.message_type, MessageType.TEXT)
+        self.assertIn("@all", event.text)
+
+    def test_bare_bot_mention_message_is_still_dropped(self):
+        """A bodyless "@Bot" ping stays dropped — the @everyone exemption is not a blanket one."""
+        adapter = self._build_adapter()
+        bot_mention = SimpleNamespace(
+            key="@_user_1",
+            id=SimpleNamespace(open_id="ou_bot", user_id=""),
+            name="Hermes",
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"text": "@_user_1"}),
+            message_type="text",
+            message_id="m5",
+            mentions=[bot_mention],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="m5",
+            )
+        )
+        self.assertFalse(adapter._dispatch_inbound_event.called)
+
 
 class TestFeishuFetchMessageText(unittest.TestCase):
     def _build_adapter(self):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2132,6 +2132,27 @@ class TestFeishuNormalizeText(unittest.TestCase):
         self.assertEqual(_normalize_feishu_text("@_all notice", None), "@all notice")
 
 
+class TestStripLeadingAtAll(unittest.TestCase):
+    """A leading @all/@_all (@everyone) trigger must not hide a trailing slash command."""
+
+    def test_strips_leading_at_all_exposing_slash_command(self):
+        from plugins.platforms.feishu.adapter import _strip_leading_at_all
+
+        self.assertEqual(_strip_leading_at_all("@all /new"), "/new")
+        self.assertEqual(_strip_leading_at_all("@_all /sethome"), "/sethome")
+        self.assertEqual(_strip_leading_at_all("@all\n/reset"), "/reset")
+
+    def test_keeps_mid_message_and_non_all_mentions(self):
+        from plugins.platforms.feishu.adapter import _strip_leading_at_all
+
+        # Mid-message @all is content, not a routing trigger.
+        self.assertEqual(_strip_leading_at_all("ping @all please"), "ping @all please")
+        # A leading non-@all mention is untouched (mention gating handles it).
+        self.assertEqual(_strip_leading_at_all("@Alice /new"), "@Alice /new")
+        # Word boundary: "@allhands" is not the @everyone token.
+        self.assertEqual(_strip_leading_at_all("@allhands on deck"), "@allhands on deck")
+
+
 class TestFeishuPostMentionParsing(unittest.TestCase):
     def test_post_at_tag_renders_via_mentions_map(self):
         """Post <at>.user_id is a placeholder ('@_user_N'); the real display


### PR DESCRIPTION
## What does this PR do?

Feishu renders @everyone as an `@_all` placeholder that `_normalize_feishu_text` normalizes
into a literal leading `@all`. `_process_inbound_message` then ran the `text.startswith("/")`
command check on text that still carried that prefix, so a command behind the @everyone
trigger was never recognized: `@all /new` stayed `"@all /new"`, failed the prefix check, and
was folded into conversational text — handed to the agent instead of being dispatched as the
`/new` command. Same for `/sethome`, `/reset`, and any other slash command.

This PR strips only the leading `@all` / `@_all` token before the command check, restoring
command dispatch for `@all /<command>`. The strip is word-boundary safe, so a mid-message
`@all` (`ping @all please`) stays as content and `@allhands` is not eaten. The logic is
extracted into a pure function `_strip_leading_at_all` so the behaviour is unit-testable.

**Second commit — the strip must not swallow a bare @everyone.** Stripping the leading trigger
empties a message that is *nothing but* `@_all`, and the post-strip guard
(`not text and not media_urls`) then dropped it as an empty text message with a DEBUG-only log.
That is inconsistent with admission: `_mentions_self()` counts `@_all` as a mention, so the
message passed the `require_mention` gate and was then silently thrown away — the trigger that
got it admitted is the whole message, not a prefix to strip. The guard now keeps such a message
with a placeholder body (`@all`) and still drops a bodyless `"@Bot"` ping, which is what the
guard exists for. Same reasoning applies to `@_all` + `@Bot` with no other text, which was also
being dropped.

## Related Issue

No existing issue — the bug surfaced during Feishu group usage testing. Happy to open one
first if maintainers prefer the issue-first flow.

Fixes #N/A

Related: #71317 (Telogen) implements the same leading-`@all` strip. Its
`_strip_edge_all_mentions_for_command()` empties a bare `@_all` the same way, so whichever of
the two lands first needs the guard change in the second commit here — otherwise the bare
@everyone message stays silent.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/feishu/adapter.py`: added `_strip_leading_at_all()` (strips a leading
  `@all`/`@_all` token, word-boundary safe) and call it in `_process_inbound_message` right
  before the `startswith("/")` command check.
- `plugins/platforms/feishu/adapter.py`: added `_bare_at_all_body()` (pure — returns the
  placeholder body when the raw content carries `@_all`, else `""`) and used it in the
  post-strip guard so a bare @everyone message is processed instead of dropped. Detection
  mirrors `_mentions_self()` so admission and processing agree on what an @everyone trigger is.
- `tests/gateway/test_feishu.py`: added `TestStripLeadingAtAll` (2 invariant tests) and, in the
  existing `TestFeishuProcessInboundMessage` pipeline fixture, 2 invariant tests for the
  post-strip guard: a bare `@_all` reaches dispatch, a bodyless `@Bot` still does not.

## How to Test

1. In a Feishu group where @all is the routing trigger and the sender is allowlisted, send
   `@all /new` (also `@all /sethome`, `@all /reset`).
2. Before the fix the message is treated as free text and handed to the agent; after the fix
   it is recognized as the command and dispatched.
3. In the same group, send a bare `@所有人` (`content = {"text":"@_all"}`) with no other text.
   Before the fix nothing happens at INFO level; after the fix it reaches the agent as a turn.
   A bodyless `@Bot` ping (no `@_all`) still produces nothing.
4. Unit level:
   `scripts/run_tests.sh tests/gateway/test_feishu.py -k TestStripLeadingAtAll` → 2 passed;
   `scripts/run_tests.sh tests/gateway/test_feishu.py -k "bare_at_all_message_reaches_the_agent or bare_bot_mention_message_is_still_dropped"`
   → 2 passed (and the `@_all` one fails on the previous commit, see logs).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(feishu): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (none match; see #71317 above for the overlap)
- [x] My PR contains **only** changes related to this fix (no unrelated commits — 2 commits, 2 files)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (docstrings added on the new helpers)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact — N/A (platform-agnostic pure helpers inside the Feishu adapter)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

End-to-end through `adapter._process_inbound_message` (real normalize/strip/guard path, fake
transport; group chat, bot identity `ou_bot`/`Hermes`) — before and after the second commit:

```text
# before (01ad3657)
bare @_all   {"text":"@_all"}              DROPPED (never dispatched)
@_all + @Bot                               DROPPED (never dispatched)
@_all + prose                              dispatched  text='[Mentioned: @all]\n\nhello'
@_all + slash cmd                          dispatched  type=command text='/new'
bare @Bot    {"text":"@_user_1"}           DROPPED (never dispatched)

# after (3661d1b6)
bare @_all   {"text":"@_all"}              dispatched  type=text text='[Mentioned: @all]\n\n@all'
@_all + @Bot                               dispatched  type=text text='[Mentioned: @all]\n\n@all'
@_all + prose                              dispatched  text='[Mentioned: @all]\n\nhello'
@_all + slash cmd                          dispatched  type=command text='/new'
bare @Bot    {"text":"@_user_1"}           DROPPED (never dispatched)
empty text   {"text":""}                   DROPPED (never dispatched)
```

```text
# new tests are red on the base commit, green after (behaviour contract, not a snapshot)
$ git checkout 01ad3657 && scripts/run_tests.sh tests/gateway/test_feishu.py -k "bare_at_all_message_reaches_the_agent or bare_bot_mention_message_is_still_dropped"
FAILED tests/gateway/test_feishu.py::TestFeishuProcessInboundMessage::test_bare_at_all_message_reaches_the_agent
1 failed, 1 passed, 80 deselected

$ scripts/run_tests.sh tests/gateway/test_feishu.py -k "bare_at_all_message_reaches_the_agent or bare_bot_mention_message_is_still_dropped"
=== Summary: 1 files, 2 tests passed, 0 failed ===

$ scripts/run_tests.sh tests/gateway/test_feishu.py
=== Summary: 1 files, 81 tests passed, 1 failed ===

# the single failure is pre-existing and unrelated — it fails 3/3 on pristine upstream main
# (e440bf35) on this machine, with this PR's branch checked out or not:
FAILED tests/gateway/test_feishu.py::TestDedupTTL::test_concurrent_dedup_persists_land_in_order
```

> The full `pytest tests/ -q` suite was not run (only the touched test file), so that box is
> left unchecked on purpose. The one failure in the file is pre-existing, reproduced on base.