### PR TITLE
fix(gateway): notify secondary-profile home channels on shutdown

### DIFF
--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -1016,6 +1016,55 @@ class GatewayShutdownMixin:
                 **({"metadata": metadata} if metadata else {}),
             ):
                 notified.add(dedup_key)
+        # Secondary multiplex profiles run their OWN gateway config (own home directory, own
+        # config.yaml) — ``self.config`` above is the default/root profile's only. Without this,
+        # a secondary profile's home channel never learns the gateway is shutting down, even
+        # though its bot is live in ``self._profile_adapters``. Resolve each profile's config the
+        # same way the handoff watcher does (``_handoff_resolve_scope`` / ``_handoff_watcher``):
+        # scope into that profile's home and reload fresh — never guess with the root config,
+        # which would (at best) look at the wrong platform entry, or (at worst) notify the WRONG
+        # chat under the secondary's bot identity.
+        _profile_adapters = getattr(self, "_profile_adapters", None) or {}
+        if _profile_adapters:
+            from gateway.run import _async_profile_runtime_scope, _handoff_watch_scopes, load_gateway_config
+            for profile_name, profile_home in _handoff_watch_scopes(self):
+                if profile_name is None:
+                    continue  # root/default profile already handled by the loop above
+                profile_adapter_map = _profile_adapters.get(profile_name)
+                if not profile_adapter_map:
+                    continue
+                try:
+                    async with _async_profile_runtime_scope(profile_home):
+                        profile_config = load_gateway_config()
+                except Exception as e:
+                    logger.debug(
+                        "Could not load config for profile %s shutdown home-channel notice: %s",
+                        profile_name, e,
+                    )
+                    continue
+                for platform, adapter in list(profile_adapter_map.items()):
+                    home = profile_config.get_home_channel(platform)
+                    if not home or not home.chat_id:
+                        continue
+                    if not self._notice_allowed(platform, "home channel"):
+                        continue
+                    dedup_key = _notice_target_key(platform.value, home.chat_id, home.thread_id)
+                    if dedup_key in notified:
+                        continue
+                    try:
+                        metadata = self._thread_metadata_for_target(
+                            platform, home.chat_id, home.thread_id, adapter=adapter)
+                    except Exception as e:
+                        logger.debug(
+                            "Failed to send shutdown notification to profile %s home channel %s:%s: %s",
+                            profile_name, platform.value, home.chat_id, e,
+                        )
+                        continue
+                    if await self._send_shutdown_notice(
+                        adapter, str(home.chat_id), msg, "home channel", platform.value,
+                        **({"metadata": metadata} if metadata else {}),
+                    ):
+                        notified.add(dedup_key)
 
     # Agent finalization / resource cleanup
     @staticmethod

--- a/tests/gateway/test_shutdown_secondary_profile_home_channel.py
+++ b/tests/gateway/test_shutdown_secondary_profile_home_channel.py
@@ -1,0 +1,104 @@
+"""Secondary multiplex profiles' HOME CHANNELS must get a shutdown notice too.
+
+``_notify_active_sessions_of_shutdown`` (gateway/run_shutdown.py) already resolves the
+per-SESSION half of shutdown notices through each session's own profile adapter (fixed in
+45a6101f36 — see test_multiplex_notice_egress_profile_adapter.py). But the second,
+unconditional "home channel" broadcast loop in the same function only ever walked
+``self.adapters``/``self.config`` — the DEFAULT profile's adapters and config — and never
+``self._profile_adapters``, so a secondary profile's home channel (its own config.yaml, own
+home directory, own bot) got no notification at all that the gateway was shutting down, even
+though its bot was live and connected.
+
+The fix resolves each secondary profile's OWN config (own home_channel) the same way the
+handoff watcher already does for delivery (``_handoff_resolve_scope`` / ``_handoff_watcher``):
+via ``_handoff_watch_scopes`` + ``_async_profile_runtime_scope`` + a fresh ``load_gateway_config()``
+call, instead of guessing with the root config.
+"""
+
+from types import SimpleNamespace
+from contextlib import asynccontextmanager
+
+import pytest
+
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.run import GatewayRunner
+
+
+class _Adapter:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, chat_id, content=None, metadata=None, **kw):
+        self.sent.append(chat_id)
+        return SimpleNamespace(success=True, message_id="m", error=None)
+
+
+def _config(chat_id):
+    cfg = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="t")})
+    cfg.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM, chat_id=chat_id, name=f"home-{chat_id}",
+    )
+    return cfg
+
+
+def _runner():
+    r = object.__new__(GatewayRunner)
+    r.config = _config("1111")  # default/root profile's home channel
+    r.adapters = {Platform.TELEGRAM: _Adapter()}
+    r._profile_adapters = {"sec": {Platform.TELEGRAM: _Adapter()}}
+    r._primary_profile_name = "default"
+    r.session_store = None
+    r._session_sources = None
+    r._running_agents = {}
+    r._restart_requested = False
+    r._restart_command_source = None
+    r._snapshot_running_agents = lambda: []  # isolate to the home-channel loops, no per-session noise
+    return r
+
+
+@asynccontextmanager
+async def _null_profile_scope(_profile_home):
+    yield
+
+
+@pytest.mark.asyncio
+async def test_secondary_profile_home_channel_gets_shutdown_notice(monkeypatch):
+    import gateway.run as gateway_run
+
+    r = _runner()
+    secondary_config = _config("2222")  # secondary profile's OWN, DIFFERENT home channel
+
+    monkeypatch.setattr(
+        gateway_run, "_handoff_watch_scopes", lambda _runner: [(None, None), ("sec", "/tmp/fake-profile-home")],
+    )
+    monkeypatch.setattr(gateway_run, "load_gateway_config", lambda: secondary_config)
+    monkeypatch.setattr(gateway_run, "_async_profile_runtime_scope", _null_profile_scope)
+
+    await r._notify_active_sessions_of_shutdown()
+
+    # Default/root home channel still gets its notice through the default bot.
+    assert r.adapters[Platform.TELEGRAM].sent == ["1111"]
+    # The secondary profile's OWN home channel gets a notice through ITS OWN bot.
+    assert r._profile_adapters["sec"][Platform.TELEGRAM].sent == ["2222"]
+
+
+@pytest.mark.asyncio
+async def test_secondary_profile_without_config_is_skipped_not_fatal(monkeypatch):
+    """A profile whose config fails to load must not blow up the whole shutdown notice pass."""
+    import gateway.run as gateway_run
+
+    r = _runner()
+
+    def _boom():
+        raise RuntimeError("config.yaml exploded")
+
+    monkeypatch.setattr(
+        gateway_run, "_handoff_watch_scopes", lambda _runner: [(None, None), ("sec", "/tmp/fake-profile-home")],
+    )
+    monkeypatch.setattr(gateway_run, "load_gateway_config", _boom)
+    monkeypatch.setattr(gateway_run, "_async_profile_runtime_scope", _null_profile_scope)
+
+    await r._notify_active_sessions_of_shutdown()  # must not raise
+
+    assert r.adapters[Platform.TELEGRAM].sent == ["1111"]
+    assert r._profile_adapters["sec"][Platform.TELEGRAM].sent == []


### PR DESCRIPTION
## What does this PR do?

`GatewayShutdownMixin._notify_active_sessions_of_shutdown()` (`gateway/run_shutdown.py`) sends two kinds of shutdown notices: one per active chat session, and one "home channel" broadcast per configured platform.

The per-session half already resolves each session's adapter via profile-aware helpers (`_adapter_for_source` / `_authorization_adapter`), fixed same-day in `45a6101f36` ("secondary-profile send_message, notices and /loop wakeups go out via their own bot").

The second, unconditional home-channel broadcast loop right after it was never touched by that fix: it only iterates `self.adapters` and reads `self.config.get_home_channel(platform)` — the **default/root profile's** adapters and config. On a multiplexed gateway (`multiplex_profiles: true`), a secondary profile runs its own `config.yaml` under its own profile home directory (own bot token, own `home_channel`, own everything) — see `_handoff_resolve_scope` / `_handoff_watcher` in `gateway/run_startup.py` / `gateway/run_adapters.py`, which already have to solve exactly this "which profile's config applies" problem for `/handoff` delivery. The shutdown home-channel loop never looked at `self._profile_adapters` at all, so a secondary profile's home channel got **zero notification** that the gateway was shutting down, even though its bot was live and connected.

## Fix

Mirror the pattern the handoff watcher already uses to resolve a secondary profile's own config safely (`_handoff_watch_scopes` to enumerate served profiles + `_async_profile_runtime_scope` to scope into that profile's home + a fresh `load_gateway_config()` call), then send the same shutdown message through that profile's own adapter to that profile's own configured home channel. This is the same "never guess with the root config — it would deliver to the wrong chat, under the wrong bot" invariant `_handoff_resolve_scope` already documents and tests for.

No new mechanism is introduced — `_handoff_watch_scopes`, `_async_profile_runtime_scope`, and `load_gateway_config` are all existing, already-used-elsewhere helpers.

## Scope note

This PR only touches the home-channel broadcast half of `_notify_active_sessions_of_shutdown`. The per-session half was already fixed in `45a6101f36`.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `gateway/run_shutdown.py`: after the existing default-profile home-channel broadcast loop, add a second loop over `self._profile_adapters` that resolves each secondary profile's own config (via `_handoff_watch_scopes` + `_async_profile_runtime_scope` + `load_gateway_config()`) and sends the shutdown notice through that profile's own adapter to that profile's own home channel. A profile whose config fails to load is skipped (logged at debug), never falls back to the root config.
- `tests/gateway/test_shutdown_secondary_profile_home_channel.py` (new): regression test constructing a runner with both a default-profile adapter/home-channel and a secondary-profile adapter/home-channel, asserting both get notified through their own bot; a second test asserts a profile whose config fails to load is skipped without blowing up the rest of the shutdown-notice pass.

## How to Test
```
pytest tests/gateway/test_shutdown_secondary_profile_home_channel.py -v
```
Mutation-verified: reverting only the fix makes `test_secondary_profile_home_channel_gets_shutdown_notice` fail (`assert [] == ['2222']`); restoring the fix makes it pass again. Also ran the full neighboring shutdown/restart/handoff/notification suites (`test_multiplex_notice_egress_profile_adapter.py`, `test_gateway_shutdown.py`, `test_restart_notification.py`, `test_shutdown_cache_cleanup.py`, `test_cron_interrupt_notification.py`, `test_shutdown_executor_quiesce.py`, `test_restart_drain.py`, `test_restart_resume_pending.py`, `test_startup_restart_race.py`, `test_handoff_secondary_profile_adapter.py`) — 114 passed, 2 skipped, nothing broken. A broader sweep of `tests/gateway/` filtered on shutdown/restart/handoff/drain/notif keywords also passed (473 passed; the only failures were in `test_msgraph_webhook.py`, a pre-existing/unrelated environment issue with mocked `aiohttp.web.Response`, not touched by this change).

## Checklist
- [x] Contributing Guide read | Conventional Commits | No duplicate PR found (searched `gh pr list` for "shutdown home channel", "secondary profile shutdown", "notify_active_sessions_of_shutdown", "profile home channel notification"; the closest hits are an unrelated/unmerged PR #60743 exploring a different, rejected approach to per-profile home-channel resolution, and the already-merged sibling commit `45a6101f36` / PR #107655 which only covers the per-session half)
- [x] Single logical fix | Tests added (mutation-verified) | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A (pure Python control flow, no OS dependency)