### PR TITLE
feat(mcp): CLI enable/disable for MCP servers + machine-readable list --json (salvages #94781)

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -536,13 +536,37 @@ def cmd_mcp_list(args=None):
     """List all configured MCP servers."""
     servers = _get_mcp_servers()
     if not servers:
-        print()
-        _info("No MCP servers configured.")
-        print()
-        _info("Add one with:")
-        _info('  hermes mcp add <name> --url <endpoint>')
-        _info('  hermes mcp add <name> --command <cmd> --args <args...>')
-        print()
+        if getattr(args, "json_output", False):
+            print("[]")
+        else:
+            print()
+            _info("No MCP servers configured.")
+            print()
+            _info("Add one with:")
+            _info('  hermes mcp add <name> --url <endpoint>')
+            _info('  hermes mcp add <name> --command <cmd> --args <args...>')
+            print()
+        return
+
+    if getattr(args, "json_output", False):
+        import json as _mcp_json
+
+        rows = []
+        for name, cfg in servers.items():
+            transport_type = "streamable_http" if "url" in cfg else "stdio"
+            transport_value = cfg.get("url") or cfg.get("command")
+            enabled = cfg.get("enabled", True)
+            if isinstance(enabled, str):
+                enabled = enabled.lower() in {"true", "1", "yes"}
+            rows.append({
+                "name": name,
+                "transport": transport_type,
+                "url": cfg.get("url"),
+                "command": cfg.get("command"),
+                "args": cfg.get("args"),
+                "enabled": enabled,
+            })
+        print(_mcp_json.dumps(rows, indent=2))
         return
 
     print()

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -532,6 +532,50 @@ def cmd_mcp_remove(args):
         pass
 
 
+def _set_mcp_server_enabled(name: str, enabled: bool) -> Optional[bool]:
+    """Flip the ``enabled`` key on a server entry in config.yaml.
+
+    Returns the previous effective enabled state, or None when the server doesn't exist.
+    """
+    config = load_config()
+    servers = config.get("mcp_servers") or {}
+    cfg = servers.get(name)
+    if not isinstance(cfg, dict):
+        return None
+    from tools.mcp_tool_common import _parse_boolish
+    previous = _parse_boolish(cfg.get("enabled", True), default=True)
+    if enabled:
+        # The runtime treats a missing key as enabled; drop it rather than writing `enabled: true`.
+        cfg.pop("enabled", None)
+    else:
+        cfg["enabled"] = False
+    save_config(config)
+    return previous
+
+
+def cmd_mcp_enable(args):
+    """Enable an MCP server without re-entering its config (mirrors `hermes plugins enable`)."""
+    _toggle_mcp_server(args.name, enabled=True)
+
+
+def cmd_mcp_disable(args):
+    """Disable an MCP server while keeping its config (tools drop next session)."""
+    _toggle_mcp_server(args.name, enabled=False)
+
+
+def _toggle_mcp_server(name: str, *, enabled: bool) -> None:
+    servers = _get_mcp_servers()
+    if _lookup_server(name, servers) is None:
+        return
+    verb = "enabled" if enabled else "disabled"
+    previous = _set_mcp_server_enabled(name, enabled)
+    if previous is enabled:
+        _info(f"Server '{name}' is already {verb}.")
+        return
+    _success(f"{verb.capitalize()} '{name}'")
+    _info("Takes effect for new sessions; running sessions keep their current toolset.")
+
+
 def cmd_mcp_list(args=None):
     """List all configured MCP servers."""
     servers = _get_mcp_servers()
@@ -891,8 +935,10 @@ _MCP_USAGE = (
     "hermes mcp add <name> --command <cmd>         Add a stdio server",
     "hermes mcp add <name> --preset <preset>       Add from a known preset",
     "hermes mcp remove <name>                      Remove a server",
-    "hermes mcp list                               List configured servers",
+    "hermes mcp list                               List configured servers (--json for scripting)",
     "hermes mcp test <name>                        Test connection",
+    "hermes mcp enable <name>                      Enable a server (next session)",
+    "hermes mcp disable <name>                     Disable a server, keep its config",
     "hermes mcp configure <name>                   Toggle tools",
     "hermes mcp login <name>                       Re-authenticate OAuth",
     "hermes mcp reauth <name> | --all              Re-auth one or all OAuth servers",
@@ -924,6 +970,7 @@ def mcp_command(args):
         "add": cmd_mcp_add, "remove": cmd_mcp_remove, "rm": cmd_mcp_remove, "list": cmd_mcp_list,
         "ls": cmd_mcp_list, "test": cmd_mcp_test, "configure": cmd_mcp_configure,
         "config": cmd_mcp_configure, "login": cmd_mcp_login, "reauth": cmd_mcp_reauth,
+        "enable": cmd_mcp_enable, "disable": cmd_mcp_disable,
     }.get(action)
     if handler:
         handler(args)

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -55,6 +55,14 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     mcp_test_p = mcp_sub.add_parser("test", help="Test MCP server connection")
     mcp_test_p.add_argument("name", help="Server name to test")
 
+    mcp_enable_p = mcp_sub.add_parser(
+        "enable", help="Enable a configured MCP server (takes effect next session)")
+    mcp_enable_p.add_argument("name", help="Server name to enable")
+
+    mcp_disable_p = mcp_sub.add_parser(
+        "disable", help="Disable a configured MCP server without removing its config")
+    mcp_disable_p.add_argument("name", help="Server name to disable")
+
     mcp_cfg_p = mcp_sub.add_parser("configure", aliases=["config"], help="Toggle tool selection")
     mcp_cfg_p.add_argument("name", help="Server name to configure")
 

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -44,7 +44,13 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")
     mcp_rm_p.add_argument("name", help="Server name to remove")
 
-    mcp_sub.add_parser("list", aliases=["ls"], help="List configured MCP servers")
+    mcp_list_p = mcp_sub.add_parser("list", aliases=["ls"], help="List configured MCP servers")
+    mcp_list_p.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Print servers as a JSON array.",
+    )
 
     mcp_test_p = mcp_sub.add_parser("test", help="Test MCP server connection")
     mcp_test_p.add_argument("name", help="Server name to test")

--- a/tests/hermes_cli/test_mcp_enable_disable.py
+++ b/tests/hermes_cli/test_mcp_enable_disable.py
@@ -1,0 +1,47 @@
+"""`hermes mcp enable/disable <name>` — toggle a server without editing YAML.
+
+Disable writes `enabled: false` to the server's config entry; enable removes the
+key (the runtime treats absence as enabled). Unknown names print the not-found
+hint and leave config untouched.
+"""
+
+import types
+
+import pytest
+import yaml
+
+
+@pytest.fixture()
+def mcp_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text(yaml.safe_dump({
+        "mcp_servers": {"remote": {"url": "https://mcp.example.com/v1"}}}))
+    return home
+
+
+def _config(home):
+    return yaml.safe_load((home / "config.yaml").read_text())
+
+
+def test_disable_then_enable_roundtrip(mcp_home, capsys):
+    from hermes_cli import mcp_config as mod
+
+    mod.cmd_mcp_disable(types.SimpleNamespace(name="remote"))
+    assert _config(mcp_home)["mcp_servers"]["remote"]["enabled"] is False
+
+    mod.cmd_mcp_enable(types.SimpleNamespace(name="remote"))
+    # Enable removes the key entirely — absence means enabled to the runtime.
+    assert "enabled" not in _config(mcp_home)["mcp_servers"]["remote"]
+    out = capsys.readouterr().out
+    assert "Disabled 'remote'" in out and "Enabled 'remote'" in out
+
+
+def test_unknown_server_leaves_config_untouched(mcp_home, capsys):
+    from hermes_cli import mcp_config as mod
+
+    before = _config(mcp_home)
+    mod.cmd_mcp_disable(types.SimpleNamespace(name="nope"))
+    assert _config(mcp_home) == before
+    assert "not found" in capsys.readouterr().out

--- a/tests/hermes_cli/test_mcp_list_json.py
+++ b/tests/hermes_cli/test_mcp_list_json.py
@@ -1,0 +1,64 @@
+"""`hermes mcp list --json` — machine-readable MCP server listing.
+
+With --json, mcp list prints a JSON array of server objects with name,
+transport, url, command, args, and enabled keys. Empty fleet prints [].
+"""
+
+import json
+import types
+
+import pytest
+
+
+@pytest.fixture()
+def tmp_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _run_list(tmp_home, monkeypatch, capsys, *, servers=None):
+    from hermes_cli import mcp_config as mod
+
+    if servers is None:
+        servers = {}
+    monkeypatch.setattr(mod, "_get_mcp_servers", lambda config=None: servers)
+    args = types.SimpleNamespace(json_output=True)
+    mod.cmd_mcp_list(args)
+    return capsys.readouterr().out
+
+
+def test_empty_returns_empty_array(tmp_home, monkeypatch, capsys):
+    out = _run_list(tmp_home, monkeypatch, capsys, servers={})
+    doc = json.loads(out)
+    assert doc == []
+
+
+def test_stdio_server(tmp_home, monkeypatch, capsys):
+    servers = {"myserver": {"command": "npx", "args": ["-y", "mcp-server"]}}
+    out = _run_list(tmp_home, monkeypatch, capsys, servers=servers)
+    doc = json.loads(out)
+    assert len(doc) == 1
+    row = doc[0]
+    assert row["name"] == "myserver"
+    assert row["transport"] == "stdio"
+    assert row["command"] == "npx"
+    assert row["args"] == ["-y", "mcp-server"]
+    assert row["url"] is None
+
+
+def test_http_server(tmp_home, monkeypatch, capsys):
+    servers = {"remote": {"url": "https://mcp.example.com/v1"}}
+    out = _run_list(tmp_home, monkeypatch, capsys, servers=servers)
+    doc = json.loads(out)
+    row = doc[0]
+    assert row["name"] == "remote"
+    assert row["transport"] == "streamable_http"
+    assert row["url"] == "https://mcp.example.com/v1"
+    assert row["command"] is None
+
+
+def test_disabled_server(tmp_home, monkeypatch, capsys):
+    servers = {"off": {"url": "https://x.example.com", "enabled": False}}
+    out = _run_list(tmp_home, monkeypatch, capsys, servers=servers)
+    doc = json.loads(out)
+    assert doc[0]["enabled"] is False

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1462,8 +1462,10 @@ Manage MCP (Model Context Protocol) server configurations and run Hermes as an M
 | `serve [-v\|--verbose]` | Run Hermes as an MCP server — expose conversations to other agents. |
 | `add <name> [--url URL] [--command CMD] [--auth oauth\|header] [--args ...]` | Add a custom MCP server with automatic tool discovery. `--args` passes the remaining argv to the stdio command, so put it last. |
 | `remove <name>` (alias: `rm`) | Remove an MCP server from config. |
-| `list` (alias: `ls`) | List configured MCP servers. |
+| `list [--json]` (alias: `ls`) | List configured MCP servers. `--json` prints a machine-readable array (name, transport, url, command, args, enabled). |
 | `test <name>` | Test connection to an MCP server. |
+| `enable <name>` | Enable a configured server (takes effect for new sessions). |
+| `disable <name>` | Disable a server without removing its config (sets `enabled: false`). |
 | `configure <name>` (alias: `config`) | Toggle tool selection for a server. |
 | `login <name>` | Force re-authentication for an OAuth-based MCP server. |
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -511,6 +511,10 @@ mcp_servers:
 
 If `enabled: false`, Hermes skips the server completely and does not even attempt a connection.
 
+You can flip this from the command line without editing YAML — `hermes mcp disable legacy` /
+`hermes mcp enable legacy`. The change applies to new sessions; running sessions keep their
+current toolset.
+
 ### Whitelist server tools
 
 ```yaml


### PR DESCRIPTION
`hermes mcp enable <name>` / `hermes mcp disable <name>` now toggle a configured MCP server from the CLI, and `hermes mcp list --json` gives scripts a machine-readable server inventory — no more hand-editing `config.yaml` to flip a server off.

## Source
Inspired by **GitHub Copilot CLI v1.0.84-4** ([release notes](https://github.com/github/copilot-cli/releases/tag/v1.0.84-4)), which promoted enable/disable to first-class subcommands (`copilot mcp enable/disable`, `copilot skill enable/disable`) and added `--json` to its list commands. Their mechanism: dedicated per-kind subcommands writing the enabled flag to settings. Our adaptation: same UX on the existing `hermes mcp` dispatcher, keyed to the `enabled` key that `tools/mcp_tool_discovery._enabled` already reads.

**Salvage:** the `--json` half cherry-picks open PR #94781 by @aniruddhaadak80 (authorship preserved, commit `7359d33`); this PR builds the enable/disable commands on top and closes the gap that the runtime honored `enabled: false` but no CLI surface could write it (plugins and catalog picker have toggles; custom `hermes mcp add` servers had none).

## Changes
- `cmd_mcp_enable` / `cmd_mcp_disable` + `_set_mcp_server_enabled` in `hermes_cli/mcp_config.py`; wired into the `mcp_command` handler table
- `enable`/`disable` parser entries in `hermes_cli/subcommands/mcp.py`; `--json` on `list` (from #94781)
- Enable **removes** the `enabled` key (absence == enabled to the runtime) instead of writing `enabled: true`; disable writes `enabled: false`
- Cache-aware: applies to new sessions, and the command says so
- Docs updated in the same PR: `website/docs/reference/cli-commands.md`, `website/docs/user-guide/features/mcp.md`, `_MCP_USAGE`

## Validation
| Check | Result |
|---|---|
| Live E2E (`hermes mcp disable demo` → `list --json` shows `enabled: false` → `enable` → key removed from config.yaml) | pass, real CLI invocation against temp HERMES_HOME |
| `scripts/run_tests.sh tests/hermes_cli/test_mcp_enable_disable.py tests/hermes_cli/test_mcp_list_json.py` | 6 passed |
| Full `tests/hermes_cli/` | only pre-existing failures (`test_anon_auth_core`, `test_update_head_moved_gate`) — fail identically on clean origin/main |
| ruff / windows-footguns / compat pointers / `git diff --check` | clean |

**Live repro:** before — `hermes mcp enable x` prints the catalog picker usage (unknown action falls through); after — toggles the server and confirms.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9f1d6/oQUirAUxA9xiJq-ctcf-R_DxzEeuWI.png)

---
Opened by the weekly Copilot CLI scout cron. **Awaiting review — not merged.**
