### PR TITLE
test: catch shadowed class definitions and remove the two already in the tree

### DIFF
--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -101,11 +101,6 @@ def codex_auth_dir(tmp_path, monkeypatch):
     return codex_dir
 
 
-class TestAuxiliaryMaxTokensParam:
-    pass
-
-
-
 class TestResolveTaskProviderModel:
     @pytest.mark.parametrize(
         "provider",

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -182,27 +182,6 @@ async def test_non_streaming_media_failure_notifies_user(tmp_path, monkeypatch):
     assert adapter.notices == ["⚠️ Couldn't deliver the video attachment."]
 
 
-class _DiscordMediaFailureAdapter(BasePlatformAdapter):
-    """Minimal adapter to exercise non-streaming MEDIA failure notification."""
-
-    def __init__(self):
-        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.DISCORD)
-        self.notices: list[str] = []
-
-    async def connect(self, *, is_reconnect: bool = False):
-        return True
-
-    async def disconnect(self):
-        pass
-
-    async def send(self, chat_id, content=None, **kwargs):
-        self.notices.append(content or "")
-        return SendResult(success=True, message_id="notice")
-
-    async def get_chat_info(self, chat_id):
-        return {"id": chat_id, "type": "dm"}
-
-
 @pytest.mark.asyncio
 async def test_queued_followup_delivery_strips_media_tag_from_text_and_sends_image(
     tmp_path, monkeypatch,

--- a/tests/test_no_shadowed_test_definitions.py
+++ b/tests/test_no_shadowed_test_definitions.py
@@ -18,6 +18,16 @@ Both had already happened here:
   surviving one omitted the recorded 400 ``invalid root_id`` state, so the
   case the name describes was never exercised.
 
+Classes shadow the same way, and the guard originally only looked at
+functions. Two had slipped through:
+
+* ``tests/agent/test_auxiliary_client.py`` carried an empty
+  ``class TestAuxiliaryMaxTokensParam: pass`` stub 4,000 lines above the real
+  class of that name. The real one happened to be defined last, so nothing was
+  lost; had a test been added to the stub it would have vanished silently.
+* ``tests/gateway/test_tts_media_routing.py`` defined the
+  ``_DiscordMediaFailureAdapter`` helper twice, byte for byte.
+
 This guard is cheap and catches the whole class at collection time.
 """
 
@@ -48,11 +58,14 @@ def _decorator_names(node: ast.AST) -> list[str]:
     return out
 
 
+_DEFINITIONS = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+
+
 def _duplicates_in(body, scope: str, rel: str) -> list[str]:
     seen: dict[str, int] = {}
     problems: list[str] = []
     for node in body:
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        if not isinstance(node, _DEFINITIONS):
             continue
         if node.name in _ALLOWED_REPEATS:
             continue
@@ -64,8 +77,9 @@ def _duplicates_in(body, scope: str, rel: str) -> list[str]:
             seen[node.name] = node.lineno
             continue
         if node.name in seen:
+            suffix = "" if isinstance(node, ast.ClassDef) else "()"
             problems.append(
-                f"{rel}:{node.lineno} {scope}.{node.name}() shadows the "
+                f"{rel}:{node.lineno} {scope}.{node.name}{suffix} shadows the "
                 f"definition at line {seen[node.name]}"
             )
         seen[node.name] = node.lineno
@@ -103,6 +117,39 @@ def test_guard_detects_a_known_duplicate_shape():
     )
     tree = ast.parse(src)
     assert _duplicates_in(tree.body, "<module>", "fake.py")
+
+
+def test_guard_detects_a_duplicate_class():
+    """A repeated class name deletes the earlier class, tests and all."""
+    src = (
+        "class TestThing:\n    def test_a(self):\n        pass\n\n"
+        "class TestThing:\n    pass\n"
+    )
+    tree = ast.parse(src)
+    problems = _duplicates_in(tree.body, "<module>", "fake.py")
+    assert problems == ["fake.py:5 <module>.TestThing shadows the definition at line 1"]
+
+
+def test_guard_detects_a_duplicate_nested_class():
+    src = (
+        "class TestOuter:\n"
+        "    class Inner:\n        pass\n"
+        "    class Inner:\n        pass\n"
+    )
+    tree = ast.parse(src)
+    cls = tree.body[0]
+    assert _duplicates_in(cls.body, "TestOuter", "fake.py") == [
+        "fake.py:4 TestOuter.Inner shadows the definition at line 2"
+    ]
+
+
+def test_guard_does_not_confuse_a_class_with_a_function_of_the_same_name():
+    """Same name, different kinds, is still a shadow: the later one wins."""
+    src = "def helper():\n    pass\n\nclass helper:\n    pass\n"
+    tree = ast.parse(src)
+    assert _duplicates_in(tree.body, "<module>", "fake.py") == [
+        "fake.py:4 <module>.helper shadows the definition at line 1"
+    ]
 
 
 @pytest.mark.parametrize("decorator", ["@property", "@x.setter", "@functools.singledispatch"])


### PR DESCRIPTION
## What does this PR do?

`tests/test_no_shadowed_test_definitions.py` (added in #75272) fails at collection time when a test module defines the same name twice in one scope: Python keeps only the last definition, so the earlier one disappears with no error and no skip. The guard only looked at functions. Classes shadow the same way, and once the guard also walks `ast.ClassDef` it lists two live cases on `main`:

```
tests/agent/test_auxiliary_client.py:4319 <module>.TestAuxiliaryMaxTokensParam shadows the definition at line 104
tests/gateway/test_tts_media_routing.py:185 <module>._DiscordMediaFailureAdapter shadows the definition at line 141
```

- `tests/agent/test_auxiliary_client.py:104` is an empty `class TestAuxiliaryMaxTokensParam: pass` stub 4,000 lines above the real class of that name. The real one happens to be defined last, so nothing is lost today; a test added to the stub would vanish silently. The stub is removed.
- `tests/gateway/test_tts_media_routing.py:185` is a byte-for-byte copy of the helper adapter defined at line 141 (checked with `diff`). The copy is removed.

The guard change is small: `_duplicates_in` accepts `ClassDef` alongside the two function node types, under the same decorator exemptions, and the message drops the `()` for a class. Three new guard tests pin the class cases: a duplicate at module level, a duplicate nested in a class, and a class that shadows a function of the same name (still a shadow: the later definition wins).

## Related Issue

No tracked issue; follow-up to #75272, which added the guard.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/test_no_shadowed_test_definitions.py`: classes count as definitions; three new guard tests; the module docstring records the two cases.
- `tests/agent/test_auxiliary_client.py`: remove the empty `TestAuxiliaryMaxTokensParam` stub at line 104.
- `tests/gateway/test_tts_media_routing.py`: remove the duplicate `_DiscordMediaFailureAdapter` at line 185.

## How to Test

1. Copy this branch's `tests/test_no_shadowed_test_definitions.py` onto a clean `main` checkout and run `scripts/run_tests.sh tests/test_no_shadowed_test_definitions.py`: the guard fails listing exactly the two lines above.
2. On this branch: `scripts/run_tests.sh tests/test_no_shadowed_test_definitions.py tests/gateway/test_tts_media_routing.py tests/agent/test_auxiliary_client.py` → **222 passed, 0 failed** (219 on `main`; the three extra are the new guard tests, and neither removed class carried a test).
3. `ruff check` on the three files: clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the three touched files through `scripts/run_tests.sh`: 222 passed
- [x] I've added tests for my changes (three guard tests)
- [x] I've tested on my platform: macOS 26, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (the guard's own docstring is updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure-Python test code, `ast` only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
