### PR TITLE
fix(gateway): classify Slack dead-target errors (channel_not_found, is_archived)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1603,7 +1603,17 @@ SEND_ERROR_KINDS = frozenset(
 
 # ``not_found`` substrings by blast radius: chat-level = target dead; thread/topic/message-level
 # leaves the parent chat reachable.
-_CHAT_LEVEL_NOT_FOUND_SUBSTRINGS = ("chat not found",)
+#
+# ``channel_not_found`` (Slack) is unambiguously chat-level: unlike Discord, a Slack thread is a
+# message field (``thread_ts``) inside its parent channel, not a separately-addressable object, so
+# this code can never mean "just the thread is gone" — it always means the channel/DM itself does
+# not exist. A Discord-side "Unknown Channel" (10003) equivalent is deliberately NOT added here:
+# Discord threads ARE their own channel ids, so the identical error text also fires when only a
+# THREAD was deleted and the parent channel is still very much alive — adding it here would risk
+# permanently blacklisting a live channel over one dead thread (self-healing can't recover it: the
+# dead-target check short-circuits every future send before it is attempted). See classify_send_error's
+# module docs / the PR that added this comment for the full reasoning.
+_CHAT_LEVEL_NOT_FOUND_SUBSTRINGS = ("chat not found", "channel_not_found")
 _SUBCHAT_NOT_FOUND_SUBSTRINGS = (
     "message to edit not found", "message to reply not found", "thread not found", "topic_deleted",
     "message_id_invalid")
@@ -1631,7 +1641,11 @@ _SEND_ERROR_CLASSIFIERS: Tuple[Tuple[str, Callable[[str], bool]], ...] = (
         or ("bad request" in b and "entit" in b))),
     ("forbidden", lambda b: _any_in(
         b, "forbidden", "bot was blocked", "blocked by the user", "user is deactivated",
-        "not enough rights", "have no rights", "not a member")),
+        "not enough rights", "have no rights", "not a member",
+        # Slack: the channel exists but is archived, so posting to it is permanently blocked
+        # until someone unarchives it -- same "bot cannot reach this chat" shape as the other
+        # forbidden markers above, not a target-doesn't-exist (not_found) condition.
+        "is_archived")),
     ("not_found", lambda b: _any_in(b, *_CHAT_LEVEL_NOT_FOUND_SUBSTRINGS, *_SUBCHAT_NOT_FOUND_SUBSTRINGS)),
     ("rate_limited", lambda b: _any_in(b, "flood", "too many requests", "retry after", "rate limit")),
     ("transient", lambda b: _any_in(b, *_RETRYABLE_ERROR_PATTERNS, "connecttimeout")))

--- a/tests/gateway/test_dead_targets.py
+++ b/tests/gateway/test_dead_targets.py
@@ -89,6 +89,35 @@ async def test_forbidden_marks_target_dead_then_short_circuits(isolate):
 
 
 @pytest.mark.asyncio
+async def test_slack_channel_not_found_marks_target_dead_then_short_circuits(isolate):
+    """Scoped follow-up: classify_send_error's table was Telegram-only, so a permanently-dead
+    Slack channel (deleted / bot never invited) was misclassified 'unknown' and retried forever
+    instead of being short-circuited like the Telegram Forbidden case above."""
+    adapter_calls_message = "SlackApiError: The server responded with: {'ok': False, 'error': 'channel_not_found'}"
+
+    class SlackDeadChannelAdapter:
+        def __init__(self):
+            self.calls = []
+
+        async def send(self, chat_id, content, metadata=None):
+            self.calls.append(chat_id)
+            raise RuntimeError(adapter_calls_message)
+
+    slack_adapter = SlackDeadChannelAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.SLACK: slack_adapter})
+    target = DeliveryTarget.parse("slack:C123")
+
+    res1 = await router.deliver("hi", [target])
+    assert res1["slack:C123"]["success"] is False
+    assert router.dead_targets.is_dead("slack", "C123") is True
+    assert slack_adapter.calls == ["C123"]
+
+    res2 = await router.deliver("hi again", [target])
+    assert res2["slack:C123"]["skipped"] == "dead_target"
+    assert slack_adapter.calls == ["C123"]  # short-circuited: adapter not called again
+
+
+@pytest.mark.asyncio
 async def test_shared_registry_is_used_when_injected(isolate):
     shared = DeadTargetRegistry()
     shared.mark_dead("telegram", "500", "pre-existing")

--- a/tests/gateway/test_send_error_classification.py
+++ b/tests/gateway/test_send_error_classification.py
@@ -37,10 +37,72 @@ class _FakeBadRequest(Exception):
         ("ConnectTimeout", "transient"),
         ("some entirely novel provider message", "unknown"),
         ("", "unknown"),
+        # Slack permanently-dead-target signatures (#82791-adjacent scope: classify_send_error was
+        # Telegram-only; these are the well-documented, unambiguous Slack Web API error codes for a
+        # channel/DM that no longer exists or can never receive messages again).
+        ("The server responded with: {'ok': False, 'error': 'channel_not_found'}", "not_found"),
+        ("The server responded with: {'ok': False, 'error': 'is_archived'}", "forbidden"),
+        # Slack rate-limit errors must NOT be swept into a dead-target classification (neither
+        # "forbidden" nor "not_found" -- both are in gateway/dead_targets.py's _DEAD_ERROR_KINDS).
+        ("SlackApiError: 429 Too Many Requests, Retry-After: 30", "rate_limited"),
+        # account_inactive means the BOT'S OWN token/account was deactivated -- every future send
+        # (to any chat) would fail the same way, so it is deliberately NOT treated as evidence that
+        # this one target is dead (see gateway/platforms/base.py's _SEND_ERROR_CLASSIFIERS comment).
+        ("The server responded with: {'ok': False, 'error': 'account_inactive'}", "unknown"),
     ],
 )
 def test_classify_send_error_text(text, expected):
     assert classify_send_error(None, text) == expected
+
+
+class TestSlackDeadTargetClassification:
+    """Scoped follow-up to the Telegram-only classify_send_error table: Discord's 403/50007
+    ("Cannot send messages to this user") already matched the pre-existing generic "forbidden"
+    substring and needed no change. Discord's 10003 ("Unknown Channel") is deliberately NOT
+    added: Discord threads are their own channel ids, so the identical error text also fires when
+    only a thread (not the parent channel) was deleted, and the dead-target short-circuit in
+    gateway/delivery.py would then permanently blacklist a live channel with no way to self-heal.
+    """
+
+    def test_channel_not_found_is_chat_level_not_found(self):
+        from gateway.platforms.base import is_chat_level_not_found
+
+        # Unlike Discord, a Slack thread is a message field (thread_ts) inside its parent
+        # channel, not a separate addressable object -- channel_not_found can only mean the
+        # channel/DM itself is gone, never "just this thread".
+        assert is_chat_level_not_found(
+            error_text="The server responded with: {'ok': False, 'error': 'channel_not_found'}"
+        ) is True
+
+    def test_discord_forbidden_blocked_dm_already_classified_dead(self):
+        """Documents existing behavior (no code change needed): Discord's Forbidden/50007 text
+        already contains the generic "forbidden" substring."""
+        assert classify_send_error(
+            None, "403 Forbidden (error code: 50007): Cannot send messages to this user"
+        ) == "forbidden"
+
+    def test_discord_unknown_channel_deliberately_not_classified_dead(self):
+        """Documents the deliberate exclusion: ambiguous between a dead channel and a dead
+        thread inside a live channel, so it must stay 'unknown' (never dead-target-marked)."""
+        assert classify_send_error(
+            None, "404 Not Found (error code: 10003): Unknown Channel"
+        ) == "unknown"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "SlackApiError: 429 Too Many Requests, Retry-After: 30",
+            "The server responded with: {'ok': False, 'error': 'ratelimited'}",
+            "httpx.ReadTimeout: connection timed out",
+        ],
+    )
+    def test_slack_transient_errors_are_never_dead_target_kinds(self, text):
+        """A clearly-transient Slack failure (rate limit, timeout) must never fall into
+        gateway/dead_targets.py's DEAD_ERROR_KINDS ('forbidden'/'not_found'), or a temporary
+        429/timeout would wrongly and permanently blacklist a perfectly-alive target."""
+        from gateway.dead_targets import _DEAD_ERROR_KINDS
+
+        assert classify_send_error(None, text) not in _DEAD_ERROR_KINDS
 
 
 def test_every_classification_is_in_the_vocabulary():


### PR DESCRIPTION
## What does this PR do?

`classify_send_error()` (`gateway/platforms/base.py`) maps a send exception/error string to a platform-neutral kind (`too_long`, `bad_format`, `forbidden`, `not_found`, `rate_limited`, `transient`, `unknown`). `gateway/delivery.py`'s `DeliveryManager.deliver()` calls it generically for every platform, and `gateway/dead_targets.py` short-circuits future sends to any target whose classification lands in `{"forbidden", "not_found"}` (a chat-level `not_found`, specifically — see `is_chat_level_not_found`).

The `_SEND_ERROR_CLASSIFIERS` table's substrings, though, are all Telegram Bot API phrasing (`"bot was blocked"`, `"chat not found"`, `"flood"`, ...). A permanently-dead target on another platform falls through to `"unknown"`, which is *not* in `_DEAD_ERROR_KINDS`, so it gets retried on every cron tick forever instead of being short-circuited like a dead Telegram target already is.

## Scope note

This PR deliberately does **not** attempt every platform in the registry — only the clearest, most unambiguous, well-documented "permanently dead target" signatures were added, and only after checking what this codebase's own Discord/Slack adapter code actually produces (not from memory):

- **Slack `channel_not_found`** → `not_found` (chat-level). Added. Unlike Discord, a Slack thread is a message field (`thread_ts`) inside its parent channel, not a separately-addressable object — this code can only ever mean the channel/DM itself is gone.
- **Slack `is_archived`** → `forbidden`. Added. The channel exists but can never receive messages again until someone unarchives it — same "bot cannot reach this chat" shape as the other `forbidden` markers.
- **Slack `account_inactive`** → intentionally **not** added. It means the bot's own token/account was deactivated — every future send (to any target) would fail identically, so it is not evidence that any *one* target is dead, and would poison the dead-target registry with an unrelated chat_id.
- **Discord `Forbidden`/`50007`** ("Cannot send messages to this user") → already correctly classified as `forbidden` today, **no change needed** (verified empirically: `discord.py`'s `HTTPException.__str__` embeds the literal word "Forbidden", which the existing generic `forbidden` substring already matches).
- **Discord `NotFound`/`10003`** ("Unknown Channel") → intentionally **not** added, despite being an obvious-looking candidate. Discord threads are their own channel ids, so the identical error text also fires when only a *thread* was deleted and the parent channel is still completely alive. `gateway/delivery.py` marks `target.chat_id` (the parent channel) dead, and the dead-target check short-circuits *every* future send to it before attempting it — with no way to self-heal short of a successful send, which would never happen once short-circuited. Adding this would trade "occasionally retried forever" for "occasionally permanently blacklists a live channel," which is worse. Left as a follow-up for someone who wants to plumb thread-vs-channel context through to the classifier (it isn't available from the error text alone).
- Every other platform in the registry is out of scope for this PR.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `gateway/platforms/base.py`: added `"channel_not_found"` to `_CHAT_LEVEL_NOT_FOUND_SUBSTRINGS` and `"is_archived"` to the `forbidden` classifier's substring list, each with an inline comment explaining the reasoning (including why the Discord counterparts were deliberately excluded).
- `tests/gateway/test_send_error_classification.py`: parametrized cases for the two new Slack classifications plus a documentation test locking in that Discord's `50007` already worked and that `10003` and Slack's `account_inactive` deliberately stay `"unknown"`; a parametrized test asserting clearly-transient Slack errors (429, timeout) never land in `dead_targets.py`'s `_DEAD_ERROR_KINDS`.
- `tests/gateway/test_dead_targets.py`: an end-to-end `DeliveryRouter.deliver()` test (mirroring the existing Telegram-forbidden test right above it) proving a Slack `channel_not_found` failure now marks the target dead and short-circuits the next delivery attempt.

## How to Test
```
pytest tests/gateway/test_send_error_classification.py tests/gateway/test_dead_targets.py -v
```
Mutation-verified: reverting only the `gateway/platforms/base.py` diff makes 4 of the new assertions fail (`channel_not_found` → `unknown` instead of `not_found`; `is_archived` → `unknown` instead of `forbidden`; the chat-level check and the end-to-end dead-target test both flip); restoring the diff makes them pass again. Also ran the neighboring platform-base/dead-target/delivery/discord/slack suites — 1426 passed. A handful of unrelated failures (`test_wake_delivery.py`, `test_api_delegation_delivery_contract.py` — missing `aiohttp` in this dev venv; `test_discord_send.py`/`test_send_multiple_images.py` — a pre-existing cross-file test-isolation issue) were confirmed to occur identically with this diff reverted, so they predate and are unrelated to this change.

## Checklist
- [x] Contributing Guide read | Conventional Commits | No duplicate PR found (fresh `gh pr list` search across "classify_send_error", "dead target discord slack", "classify send error slack", "discord dead target", "slack channel_not_found", "is_archived dead", "discord forbidden classify", "unknown channel classify" — the closest hits are platform-*different* dead-target classifiers, e.g. #74145 Photon and #62682 Telegram PEER_ID_INVALID, both by another contributor, neither touching Discord/Slack); also re-confirmed via `gh pr diff 82791` that the open, unrelated PR #82791 (Discord-404 job-degradation flag in `cron/jobs.py`/`cron/scheduler.py`) still does not touch `gateway/platforms/base.py` or `gateway/dead_targets.py`.
- [x] Single logical fix | Tests added (mutation-verified) | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A (pure string-classification logic, no OS dependency)