### PR TITLE
Replacement: capacity failures must not consume Kanban crash strikes

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -63,6 +63,11 @@ _RESPAWN_GUARD_SUCCESS_WINDOW = 3600  # 1 hour
 # ``HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS``.
 DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS = 300  # 5 minutes
 
+# Capacity failures are retried on a deterministic capped ladder.  Counting
+# trailing capacity runs (rather than task failures) keeps this state durable
+# across dispatcher restarts without consuming the crash-strike counter.
+_CAPACITY_BACKOFF_SECONDS = (300, 900, 3600)
+
 # Within this window a GitHub PR URL in a comment blocks re-spawn.
 _RESPAWN_GUARD_PR_WINDOW = 86400  # 24 hours
 
@@ -705,7 +710,7 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     ).fetchall()
     for row in rows:
         outcome = row["outcome"] or ""
-        if outcome == "rate_limited":
+        if outcome in ("rate_limited", "capacity_failure"):
             continue
         if outcome == "crashed" and (
             _kb._json_dict(row["metadata"]).get("protocol_violation")
@@ -745,9 +750,8 @@ class _DeadWorker:
 
     @property
     def run_outcome(self) -> str:
-        # A rate-limited requeue is recorded as ``rate_limited`` so board history
-        # doesn't show a phantom crash for a quota wall.
-        return "rate_limited" if self.rate_limited else "crashed"
+        # Capacity exhaustion is operationally distinct from a task crash.
+        return "capacity_failure" if self.rate_limited else "crashed"
 
 
 def _classify_dead_worker(pid: int, claimer: Optional[str]) -> _DeadWorker:
@@ -771,7 +775,7 @@ def _classify_dead_worker(pid: int, claimer: Optional[str]) -> _DeadWorker:
         return _DeadWorker(
             kind, code,
             f"pid {pid} exited rate-limited (quota wall) — requeued without counting a failure",
-            "rate_limited",
+            "capacity_failure",
             {"pid": pid, "claimer": claimer, "exit_code": code},
             rate_limited=True,
         )
@@ -861,7 +865,8 @@ def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
                 # ``_record_task_failure`` (which stamps this column), yet the
                 # board UI and retry worker need the corrective message.
                 conn.execute(
-                    "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+                    "UPDATE tasks SET last_failure_error = "
+                    "COALESCE(last_failure_error, ?) WHERE id = ?",
                     (dead.error_text[:500], row["id"]),
                 )
             if dead.rate_limited:
@@ -1128,10 +1133,12 @@ def check_respawn_guard(
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
 
     Called per ready/review row before any claim attempt. Priority order:
-    ``"rate_limit_cooldown"`` (latest run ``rate_limited`` within the cooldown;
-    checked BEFORE ``blocker_auth`` because the requeue stamps a quota-flavored
-    ``last_failure_error`` that would otherwise park the task forever — that
-    path never increments ``consecutive_failures``), ``"blocker_auth"``
+    ``"capacity_backoff"`` (latest runs are ``capacity_failure`` within the
+    deterministic 5m/15m/60m ladder) or legacy ``"rate_limit_cooldown"``;
+    checked BEFORE ``blocker_auth`` because the requeue retains quota-flavored
+    ``last_failure_error`` evidence that would otherwise park the task forever.
+    Neither capacity path increments ``consecutive_failures``. Then
+    ``"blocker_auth"``
     (quota/auth pattern; the breaker still trips eventually), then for the
     ready lane only ``"recent_success"`` (completed run within the window, unless
     a re-queue event arrived after it — a deliberate re-run) and ``"active_pr"``
@@ -1148,23 +1155,41 @@ def check_respawn_guard(
 
     now = int(time.time())
 
-    # 1. Rate-limit cooldown — see docstring for why this precedes blocker_auth.
-    #    LATEST run only: a newer crash/completion supersedes the rate-limit run.
-    rl_cooldown = _kb._resolve_rate_limit_cooldown_seconds()
+    # 1. Capacity backoff — see docstring for why this precedes blocker_auth.
+    # Count only the trailing capacity-failure streak.  A genuine run outcome
+    # resets the ladder; legacy ``rate_limited`` rows remain compatible.
     latest_run = conn.execute(
         "SELECT outcome, ended_at FROM task_runs "
         "WHERE task_id = ? AND ended_at IS NOT NULL "
-        "ORDER BY ended_at DESC LIMIT 1",
+        "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    if latest_run is not None and latest_run["outcome"] == "rate_limited":
-        if rl_cooldown <= 0:
-            # Cooldown disabled — respawn immediately, skipping blocker_auth so
-            # the stamped rate-limit text doesn't re-trap the task.
+    if latest_run is not None and latest_run["outcome"] in ("rate_limited", "capacity_failure"):
+        if latest_run["outcome"] == "rate_limited":
+            wait_seconds = _kb._resolve_rate_limit_cooldown_seconds()
+        else:
+            rows = conn.execute(
+                "SELECT outcome FROM task_runs WHERE task_id = ? "
+                "AND ended_at IS NOT NULL ORDER BY id DESC",
+                (task_id,),
+            ).fetchall()
+            streak = 0
+            for run in rows:
+                if run["outcome"] != "capacity_failure":
+                    break
+                streak += 1
+            wait_seconds = _CAPACITY_BACKOFF_SECONDS[
+                min(max(streak, 1), len(_CAPACITY_BACKOFF_SECONDS)) - 1
+            ]
+        if wait_seconds <= 0:
             return None
         ended_at = latest_run["ended_at"]
-        if ended_at is not None and (now - int(ended_at)) < rl_cooldown:
-            return "rate_limit_cooldown"
+        if ended_at is not None and (now - int(ended_at)) < wait_seconds:
+            return (
+                "rate_limit_cooldown"
+                if latest_run["outcome"] == "rate_limited"
+                else "capacity_backoff"
+            )
         # Cooldown elapsed — return early so blocker_auth doesn't catch the
         # stamped rate-limit text; this path intentionally retries forever
         # (spaced by the cooldown) until quota returns or a real run supersedes it.

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -271,7 +271,7 @@ def _exited_status(code: int) -> int:
 def test_rate_limit_exit_requeues_without_counting_failure(
     kanban_home, monkeypatch,
 ):
-    """A rate-limit sentinel exit releases the task to ``ready`` and leaves
+    """A capacity sentinel exit releases the task to ``ready`` and leaves
     ``consecutive_failures`` untouched — the breaker must never trip on a
     transient throttle, even across many quota-wall hits."""
     import hermes_cli.kanban_db as _kb
@@ -327,10 +327,94 @@ def test_rate_limit_exit_requeues_without_counting_failure(
                 "SELECT outcome FROM task_runs WHERE task_id=?", (tid,),
             ).fetchall()
         ]
-        assert "rate_limited" in outcomes
+        assert "capacity_failure" in outcomes
         assert "crashed" not in outcomes
+        event_kinds = [e.kind for e in kb.list_events(conn, tid)]
+        assert "capacity_failure" in event_kinds
+        assert "gave_up" not in event_kinds
 
 
+def test_capacity_failure_storm_uses_5m_15m_60m_backoff(
+    kanban_home, monkeypatch,
+):
+    """Capacity retries back off deterministically without consuming strikes."""
+    import hermes_cli.kanban_db as _kb
+    from hermes_cli import kanban_db_dispatch as _kbd
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    now = 7_000_000
+
+    with kbc.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="capacity storm", assignee="a")
+        evidence = "provider 429: quota exhausted for deployment azure-prod"
+        conn.execute(
+            "UPDATE tasks SET last_failure_error=? WHERE id=?",
+            (evidence, tid),
+        )
+        conn.commit()
+        for attempt, wait in enumerate((300, 900, 3600, 3600), start=1):
+            pid = 71000 + attempt
+            kb.claim_task(conn, tid, claimer=f"{host}:w{attempt}")
+            conn.execute(
+                "UPDATE tasks SET worker_pid=?, started_at=? WHERE id=?",
+                (pid, now, tid),
+            )
+            conn.commit()
+            monkeypatch.setattr(_kb.time, "time", lambda: now)
+            _kbd._record_worker_exit(
+                pid, _exited_status(_kb.KANBAN_RATE_LIMIT_EXIT_CODE)
+            )
+            assert tid not in kbd.detect_crashed_workers(conn)
+
+            task = kb.get_task(conn, tid)
+            assert task.status == "ready"
+            assert task.consecutive_failures == 0
+            assert task.last_failure_error
+            assert task.last_failure_error == evidence
+            run = conn.execute(
+                "SELECT outcome FROM task_runs WHERE task_id=? ORDER BY id DESC LIMIT 1",
+                (tid,),
+            ).fetchone()
+            assert run["outcome"] == "capacity_failure"
+
+            monkeypatch.setattr(_kb.time, "time", lambda: now + wait - 1)
+            assert kbd.check_respawn_guard(conn, tid) == "capacity_backoff"
+            monkeypatch.setattr(_kb.time, "time", lambda: now + wait)
+            assert kbd.check_respawn_guard(conn, tid) is None
+            now += wait
+
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='gave_up'",
+            (tid,),
+        ).fetchone()[0] == 0
+
+
+def test_genuine_non_429_crash_still_consumes_strikes(kanban_home, monkeypatch):
+    import hermes_cli.kanban_db as _kb
+    from hermes_cli import kanban_db_dispatch as _kbd
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    with kbc.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="real crash", assignee="a")
+        for attempt in range(_kb.DEFAULT_FAILURE_LIMIT):
+            pid = 72000 + attempt
+            kb.claim_task(conn, tid, claimer=f"{host}:w{attempt}")
+            conn.execute("UPDATE tasks SET worker_pid=? WHERE id=?", (pid, tid))
+            conn.commit()
+            _kbd._record_worker_exit(pid, _exited_status(1))
+            assert tid in kbd.detect_crashed_workers(conn)
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.consecutive_failures == _kb.DEFAULT_FAILURE_LIMIT
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='gave_up'",
+            (tid,),
+        ).fetchone()[0] == 1
 
 
 def test_respawn_guard_defers_rate_limited_within_cooldown(


### PR DESCRIPTION
What changed
- Record provider 429/quota worker exits as `capacity_failure` rather than crashes.
- Preserve original failure evidence and keep crash strikes unchanged.
- Apply deterministic retry backoff of 5 minutes, 15 minutes, then 60 minutes (capped) to stop per-tick respawn storms.
- Add regression coverage for repeated capacity failures and genuine non-429 crashes.

Verification
- `uv run --with pytest python -m pytest tests/hermes_cli/test_kanban_db.py -q` -> 33 passed, 1 skipped.
- `uv run --with ruff ruff check hermes_cli/kanban_db_dispatch.py tests/hermes_cli/test_kanban_db.py` -> All checks passed.
- `python -m py_compile hermes_cli/kanban_db_dispatch.py tests/hermes_cli/test_kanban_db.py` -> exit 0.
- `git diff --check` -> exit 0.
- Sabotage run with production change reverted: capacity regression failed as expected; genuine crash regression passed.
- Independent pre-commit review: PASS.

Not tested
- Full repository test suite.