### PR TITLE
fix(kanban): specify/decompose without ?board= use the active board, not default (#107718 K11)

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -101,8 +101,10 @@ def _board_conn(board: Optional[str]) -> Iterator[tuple[Optional[str], sqlite3.C
 
 def _with_board_pinned(board: Optional[str], fn: Callable[[], Any]) -> Any:
     """Run ``fn`` with the board pinned context-locally, not via the process-global
-    ``HERMES_KANBAN_BOARD`` env var (concurrent requests for different boards would cross-write)."""
-    with kanban_db.scoped_current_board(_resolve_board(board) or kanban_db.DEFAULT_BOARD):
+    ``HERMES_KANBAN_BOARD`` env var (concurrent requests for different boards would cross-write).
+    An omitted ``board`` means the active board, as on every other route (#107718 K11) — not
+    ``default``, which sent specify/decompose to a different board than the rest of the UI."""
+    with kanban_db.scoped_current_board(_resolve_board(board) or kanban_db.get_current_board()):
         return fn()
 
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1227,6 +1227,45 @@ def test_specify_happy_path(client, monkeypatch):
     assert "**Goal**" in (detail["body"] or "")
 
 
+def test_specify_without_board_param_uses_the_active_board(client, monkeypatch):
+    """An omitted ``?board=`` means the active board on every route (#107718 K11).
+
+    The auxiliary-LLM endpoints pinned ``default`` instead, so a triage task on the
+    board the user had switched to came back "not found" from specify/decompose
+    while the rest of the dashboard was showing it."""
+    import json as jsonlib
+
+    kb.create_board("alpha")
+    kb.set_current_board("alpha")
+    assert kb.get_current_board() == "alpha"
+
+    # Created without ``?board=`` → lands on the active board, alpha.
+    t = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "one-liner", "triage": True},
+    ).json()["task"]
+    assert client.get(f"/api/plugins/kanban/tasks/{t['id']}").status_code == 200
+    assert client.get(f"/api/plugins/kanban/tasks/{t['id']}?board=default").status_code == 404
+
+    _patch_specifier_response(
+        monkeypatch,
+        content=jsonlib.dumps({"title": "Polished", "body": "**Goal**\nDo the thing."}),
+    )
+
+    r = client.post(
+        f"/api/plugins/kanban/tasks/{t['id']}/specify",
+        json={"author": "ui-tester"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True, body
+    assert body["new_title"] == "Polished"
+
+    # The task on alpha is the one that changed.
+    detail = client.get(f"/api/plugins/kanban/tasks/{t['id']}").json()["task"]
+    assert detail["title"] == "Polished"
+
+
 # ---------------------------------------------------------------------------
 # Final result visibility for Done cards
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Every route in the kanban dashboard plugin treats an omitted `?board=` as **the active board**: `_resolve_board` returns `None` for a missing param (`plugins/kanban/dashboard/plugin_api.py:65-73`), and `_board_conn` → `_conn(board=None)` → `kbc.connect(board=None)` resolves it through `get_current_board()` (context override → `HERMES_KANBAN_BOARD` → `<root>/kanban/current` → `default`; `hermes_cli/kanban_db.py:404`).

The two auxiliary-LLM routes, `POST /tasks/{id}/specify` (line 973) and `POST /tasks/{id}/decompose` (line 1541), go through `_with_board_pinned` (line 102), which did this instead:

```python
with kanban_db.scoped_current_board(_resolve_board(board) or kanban_db.DEFAULT_BOARD):
```

So with no `?board=`, the context override was pinned to `default`, `specify_task` / `decompose_task` opened the `default` DB (`kbc.connect_closing()` inside `hermes_cli/kanban_specify.py:213`), and on any other board the task the dashboard was showing came back `{"ok": false, "reason": "unknown task id"}`. This is item **K11** of the Kanban reliability audit in #107718.

The fix is one line: pin `kanban_db.get_current_board()` for an omitted board, the same resolver the file already uses at lines 333, 1354, 1393, 1424 and 1470. An explicit `?board=` is unchanged.

## Related Issue

Addresses K11 in #107718 (the audit lists 19 items; this PR is scoped to that one, and it does not touch the code regions of the other open K-item PRs, #107723 / #107736 / #107739).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/kanban/dashboard/plugin_api.py`: `_with_board_pinned` resolves an omitted board with `get_current_board()`; docstring says why.
- `tests/plugins/test_kanban_dashboard_plugin.py`: `test_specify_without_board_param_uses_the_active_board` — creates board `alpha`, makes it current, creates a triage task on it (and checks it is *not* on `default`), then specifies it without `?board=`.

## How to Test

1. On `main`, apply only the test: `scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py -k specify_without_board` fails with
   `AssertionError: {'ok': False, 'task_id': 't_…', 'reason': 'unknown task id', 'new_title': None}`.
2. On this branch: the same command passes, and the whole file `scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py` → **39 passed, 0 failed**.
3. Manually: `hermes kanban boards create alpha && hermes kanban boards switch alpha`, create a triage task, open the dashboard and click Specify: the task is found. Before the fix the same click reports "unknown task id".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no open or closed PR touches `_with_board_pinned`; the board-pin PRs #107195 / #107715 / #65246 change `kanban_db.py` / `kanban_decompose.py` only
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the touched test file through `scripts/run_tests.sh`: all passed
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing surface changes; the omitted-param behaviour now matches the documented "active board")
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (no file I/O or process changes)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
