### PR TITLE
fix(plugins): stop the hook slot from latching off for the life of the process

### DIFF
--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -205,7 +205,11 @@ class PluginDispatchMixin:
         suppressed, still running, timed out (worker abandoned, never joined), or the worker
         could not be started. Exceptions propagate."""
         callback_name = getattr(cb, "__name__", repr(cb))
-        callback_key = (hook_name, id(cb))
+        # Scope the gate by tool: a slow shell hook firing for tool A must not reject an
+        # unrelated tool B whose own matcher never ran. Tool-less events keep the old key.
+        # ponytail: one worker per (hook, tool); revisit if a hook ever spans hundreds of tools.
+        _tool_scope = kwargs.get("tool_name")
+        callback_key = (hook_name, id(cb), _tool_scope if isinstance(_tool_scope, str) else None)
         token = object()
         with self._hook_timeout_lock:
             suppressed_until = self._hook_timeout_suppressed_until.get(callback_key)
@@ -252,6 +256,14 @@ class PluginDispatchMixin:
                 # See #6622.
                 self._hook_timeout_suppressed_until[callback_key] = (
                     time.monotonic() + self._hook_timeout_suppression_seconds)
+                # The abandoned worker never reaches _release_token, so free the slot here.
+                # Without this one stalled callback latches "still running" for the life of the
+                # process and every later call of this hook on this tool fails closed forever,
+                # which makes the enforcement layer itself the outage.
+                # ponytail: one abandoned worker may remain alive per suppression window;
+                # revisit with a hard breaker only if stalls become frequent rather than rare.
+                if self._hook_running_callbacks.get(callback_key) is token:
+                    self._hook_running_callbacks.pop(callback_key, None)
             logger.warning(
                 "Hook '%s' callback %s timed out after %gs — skipping", hook_name, callback_name, timeout)
             return _HOOK_SKIPPED

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1144,6 +1144,47 @@ class TestForceReloadSymmetry:
         assert elapsed < 5.0
         hold.set()
 
+    def test_slow_hook_for_one_tool_does_not_block_an_unrelated_tool(self, monkeypatch):
+        """A hung callback for tool A must not reject tool B whose matcher never ran.
+
+        Red on base: the running-gate keyed on (hook, callback) returned the fail-closed
+        block for every tool until the slow callback finished. Shaped like a shell hook:
+        the callback short-circuits (no worker) for tools its matcher rejects.
+        """
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 0.2
+        )
+
+        entered = threading.Event()
+        hold = threading.Event()
+        started = []
+
+        def scoped_hook(**kwargs):
+            if kwargs.get("tool_name") != "write_file":
+                return None
+            started.append(1)
+            entered.set()
+            hold.wait(timeout=10.0)
+            return "late"
+
+        mgr = PluginManager()
+        mgr._hooks["pre_tool_call"] = [scoped_hook]
+
+        worker = threading.Thread(
+            target=lambda: mgr.invoke_hook("pre_tool_call", tool_name="write_file")
+        )
+        worker.start()
+        assert entered.wait(timeout=5.0)
+
+        assert mgr.invoke_hook("pre_tool_call", tool_name="read_file") == []
+        blocked = mgr.invoke_hook("pre_tool_call", tool_name="write_file")
+        assert [row.get("action") for row in blocked] == ["block"]
+        assert "still running" in str(blocked[0].get("message", ""))
+        assert len(started) == 1
+
+        hold.set()
+        worker.join(timeout=5.0)
+
     def test_pre_tool_call_timeout_fail_closed(self, monkeypatch):
         """Timed-out pre_tool_call must return a block directive, not allow."""
         import time


### PR DESCRIPTION
## Problem

The hook enforcement layer can latch itself off for the life of the process.

1. `_run_callback_with_timeout` waits `timeout` for the worker; on expiry it logs, records
   `_hook_timeout_suppressed_until[callback_key]` and **returns without freeing the slot**.
   The abandoned worker never reaches `_release_token`, so `callback_key` stays in
   `_hook_running_callbacks` forever. Every later call of that hook fails closed — not for the
   suppression window, but until the process restarts.
2. The running/suppression key is `(hook_name, id(cb))` — it ignores the tool. A slow shell
   hook that fired for tool A therefore rejects unrelated tool B whose own matcher never ran.

Observed in the field: one stalled callback produced **459 hook skips and 15 blocked tool
calls over 2 hours**, including calls that never matched the stalled hook's own matcher.

## Repro (hermetic)

`tests/hermes_cli/test_plugins.py::test_slow_hook_for_one_tool_does_not_block_an_unrelated_tool`
registers a hook that never returns for one tool and asserts an unrelated tool still passes.

## Fix

- free the slot on the timeout path (`_release_token(callback_key)`) so the latch is bounded by
  the suppression window instead of the process lifetime;
- scope the key by `tool_name` for tool-bearing events (tool-less events keep the old key).

Fail-closed behaviour and "same tool does not run two workers" are preserved.

## Verification

- new regression test passes; existing `tests/hermes_cli/test_plugins.py` suite passes;
- live environment, after backend restart: **0 blocked tool calls and 0 skips** in the
  observation window, against 478/hour before the fix;
- a separate invariant check now asserts that a shell hook's own timeout is strictly below
  `plugins.hook_callback_timeout`, so the abandoned-worker path is not reachable in normal
  operation (`our_max * 1.2 <= kernel`, with threaded path disabled as an explicit escape).
