### PR TITLE
fix(directives): keep braces inside quoted attribute values

### DIFF
--- a/apps/desktop/src/lib/transcript-directives.test.ts
+++ b/apps/desktop/src/lib/transcript-directives.test.ts
@@ -48,7 +48,36 @@ describe('parseTranscriptDirective', () => {
     expect(parseTranscriptDirective('::preview{file=demo.html}')?.attrs).toEqual({})
   })
 
+  it('keeps braces that appear inside quoted values', () => {
+    // Real failure: a follow-up prompt naming a git stash was printed as raw
+    // source because `@{0}` put a brace inside the attribute value.
+    const source = '::followup{p1="apply stash@{0} onto main" p2="drop stash@{2}"}'
+
+    expect(parseTranscriptDirective(source)).toEqual({
+      name: 'followup',
+      attrs: { p1: 'apply stash@{0} onto main', p2: 'drop stash@{2}' },
+      source
+    })
+  })
+
+  it('still rejects braces outside quotes, so nesting cannot be smuggled in', () => {
+    expect(parseTranscriptDirective('::preview{file="a.html" {nested}}')).toBeNull()
+    expect(parseTranscriptDirective('::preview{{file="a.html"}')).toBeNull()
+  })
+
   it('bounds pathological input instead of scanning it', () => {
     expect(parseTranscriptDirective(`::x{${'a="b" '.repeat(400)}}`)).toBeNull()
+  })
+
+  it('does not backtrack on unbalanced quotes', () => {
+    // The value alternation must not turn a quote storm into exponential work.
+    // Only timing is asserted — whether these shapes parse is pre-existing
+    // behaviour this change deliberately leaves alone.
+    const started = performance.now()
+
+    parseTranscriptDirective(`::x{${'"'.repeat(600)}}`)
+    parseTranscriptDirective(`::x{${'a="{'.repeat(200)}}`)
+
+    expect(performance.now() - started).toBeLessThan(250)
   })
 })

--- a/apps/desktop/src/lib/transcript-directives.ts
+++ b/apps/desktop/src/lib/transcript-directives.ts
@@ -45,8 +45,13 @@ export interface ParsedTranscriptDirective {
 }
 
 // The whole paragraph, nothing else on the line: `::name` or `::name{...}`.
-// Length caps bound the attr scan on adversarial input.
-const DIRECTIVE_RE = /^::([a-z][a-z0-9-]{0,63})(?:\{([^{}]{0,1024})\})?$/
+// The body is a run of quoted strings and plain characters, so a brace inside
+// a quoted value (`p1="stash@{0}"`) is content while a brace outside one still
+// fails the match. The alternation branches start with distinct characters, so
+// there is nothing ambiguous to backtrack over. Note the repetition counts
+// alternation groups rather than characters, so the real bound on body length
+// is the 1200-char guard in parseTranscriptDirective below.
+const DIRECTIVE_RE = /^::([a-z][a-z0-9-]{0,63})(?:\{((?:"[^"]*"|'[^']*'|[^{}"']){0,1024})\})?$/
 
 // `key="value"` pairs; single quotes accepted for model sloppiness.
 const ATTR_RE = /([a-z][\w-]{0,63})=(?:"([^"]*)"|'([^']*)')/gi


### PR DESCRIPTION
## The bug

`parseTranscriptDirective` matched the directive body with `[^{}]`, which rejects a brace **anywhere** in the paragraph — including inside a quoted value. A follow-up prompt that names a git stash fails to parse:

```
::followup{p1="apply stash@{0} onto main" p2="drop stash@{2}"}
```

Nothing consumes the parse failure, so the raw directive source is rendered as prose and the user sees the markup in the transcript. Reproduced on a real transcript line pulled from `state.db`; the same line parses into three prompts after this change.

## The fix

Match the body as a run of quoted strings and plain characters:

```js
/^::([a-z][a-z0-9-]{0,63})(?:\{((?:"[^"]*"|'[^']*'|[^{}"']){0,1024})\})?$/
```

A brace is content when it sits inside quotes and still a parse failure when it does not, so `::preview{file="a.html" {nested}}` keeps rejecting. `ATTR_RE` is unchanged — it already stops at the closing quote, so the values come out intact.

## Scope note

The repetition now counts alternation groups rather than characters, so it no longer caps the body at 1024 chars — a quoted run can reach ~1104. The effective bound is the pre-existing 1200-char guard in `parseTranscriptDirective`, and the comment now says so rather than implying the regex does it.

I deliberately did **not** change what happens to unbalanced-quote shapes like `::x{"""…}`; that behaviour predates this change and tightening it belongs in its own PR. The added timing test asserts only timing for those inputs, not their parse result.

## Verification

- New test `keeps braces that appear inside quoted values` fails on `main` (`expected null to deeply equal { name: 'followup' … }`) and passes here — written before the regex change.
- `still rejects braces outside quotes` guards the nesting case the old character class covered.
- Hostile-input probe — quote storms, `a="{`×200, nested braces, 2.4 KB of pairs — worst case **0.09 ms**, no backtracking blowup.
- `199` test files / `1952` tests pass across `src/lib`, `src/components/assistant-ui`, `src/app/contrib`, `src/sdk`.
- `tsc -p tsconfig.json --noEmit` and `eslint` clean.
