### PR TITLE
fix(classifier): route OmniRoute message-only context overflow into compact-and-retry

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -220,6 +220,9 @@ _CONTEXT_OVERFLOW_PATTERNS = (
     # Together/Fireworks-style: "Input length 131393 exceeds the maximum allowed input length of 131040
     # tokens."  No other pattern in this list matches that wording. (port of anomalyco/opencode#37848)
     "maximum allowed input length",
+    # OmniRoute combo admission errors can be re-wrapped without a usable
+    # status_code. Route the message-only form into compact-and-retry.
+    "largest known context limit",
 )
 
 # Last entry: OpenRouter 404 when no endpoint supports tool calling —


### PR DESCRIPTION
## Problem

OmniRoute combo admission errors can be re-wrapped without a usable `status_code`, leaving only the message text available to classify. Those responses carry the wording "largest known context limit", which no existing entry in `_CONTEXT_OVERFLOW_PATTERNS` matches, so the turn fails outright instead of compacting and retrying.

## Change

Adds the "largest known context limit" wording to `_CONTEXT_OVERFLOW_PATTERNS` in `agent/error_classifier.py`, next to the existing Together/Fireworks message-only pattern.

## Notes

Three lines, pattern-list only — no control flow touched. Sits alongside the existing message-only fallbacks that handle providers which drop `status_code` on re-wrap.