### PR TITLE
test(directives): pin brace-in-quoted-value parsing as a known bug

### DIFF
--- a/apps/desktop/src/lib/transcript-directives.test.ts
+++ b/apps/desktop/src/lib/transcript-directives.test.ts
@@ -48,7 +48,40 @@ describe('parseTranscriptDirective', () => {
     expect(parseTranscriptDirective('::preview{file=demo.html}')?.attrs).toEqual({})
   })
 
+  // KNOWN BUG — remove `.fails` when DIRECTIVE_RE stops rejecting braces that
+  // sit inside a quoted value. The body is matched with `[^{}]`, so a follow-up
+  // prompt naming a git stash (`p1="stash@{0}"`) fails to parse and the raw
+  // `::followup{...}` source is rendered as prose in the transcript.
+  // Marked `.fails` so this lands green and starts failing the moment the
+  // behaviour is fixed, rather than red-listing CI in the meantime.
+  it.fails('keeps braces that appear inside quoted values', () => {
+    const source = '::followup{p1="apply stash@{0} onto main" p2="drop stash@{2}"}'
+
+    expect(parseTranscriptDirective(source)).toEqual({
+      name: 'followup',
+      attrs: { p1: 'apply stash@{0} onto main', p2: 'drop stash@{2}' },
+      source
+    })
+  })
+
+  it('rejects braces outside quotes', () => {
+    // Passes today and must keep passing after the fix: loosening the body
+    // must not let an unquoted brace through.
+    expect(parseTranscriptDirective('::preview{file="a.html" {nested}}')).toBeNull()
+    expect(parseTranscriptDirective('::preview{{file="a.html"}')).toBeNull()
+  })
+
   it('bounds pathological input instead of scanning it', () => {
     expect(parseTranscriptDirective(`::x{${'a="b" '.repeat(400)}}`)).toBeNull()
+  })
+
+  it('does not backtrack on brace and quote storms', () => {
+    // Timing only — whether these shapes parse is pre-existing behaviour.
+    const started = performance.now()
+
+    parseTranscriptDirective(`::x{${'"'.repeat(600)}}`)
+    parseTranscriptDirective(`::x{${'a="{'.repeat(200)}}`)
+
+    expect(performance.now() - started).toBeLessThan(250)
   })
 })


### PR DESCRIPTION
Test-only. Splits the failing case out of #107895 so the bug is recorded in the suite independently of the regex change, which needs more review.

## The gap

`DIRECTIVE_RE` matches the directive body with `[^{}]`, which rejects a brace **anywhere** in the paragraph — including inside a quoted value:

```
::followup{p1="apply stash@{0} onto main" p2="drop stash@{2}"}
```

Nothing consumes the parse failure, so the raw directive source renders as prose in the transcript. Hit on a real transcript line naming a git stash.

## What this adds

- `it.fails('keeps braces that appear inside quoted values')` — the bug, executable. `.fails` keeps CI green while the behaviour is still broken.
- `rejects braces outside quotes` — passes today and must keep passing after any fix, so loosening the body cannot let an unquoted brace through.
- `does not backtrack on brace and quote storms` — timing only, no assertion on whether those shapes parse, since that is pre-existing behaviour.

## Why `.fails` rather than a skip

Verified in both directions:

- Against the current regex the case passes as `.fails` — `Tests 12 passed | 1 expected fail (13)`.
- Patching the body to accept quoted braces flips it to a hard failure — `Tests 1 failed | 12 passed` — because the test now passes and `.fails` no longer holds.

So whoever fixes the parser is forced to drop `.fails` in the same change; the marker cannot rot silently the way `it.skip` would.

## Verification

`184` test files / `1758` passed + 1 expected fail across `src/lib` and `src/components/assistant-ui`. `tsc -p tsconfig.json --noEmit` and `eslint` clean. No source file touched.

#107895 carries the actual regex fix and can drop `.fails` when it lands; if this merges first, that PR rebases to a one-word change here.
