### PR TITLE
fix(desktop): local-graph fallback when the update compare API 404s a patched checkout

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -384,7 +384,7 @@ import {
   windowOpacityFor,
   windowOpacityOptions
 } from './translucency'
-import { branchTipApiUrl, cacheIsFresh, compareApiUrl, githubRepoSlug, parseCompare } from './update-api-check'
+import { branchTipApiUrl, cacheIsFresh, compareApiUrl, githubRepoSlug, listLocalCommits, parseCompare, resolveBehindLocally } from './update-api-check'
 import { waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
@@ -3183,7 +3183,7 @@ async function checkUpdates({ force = false }: { force?: boolean } = {}) {
   const slug = githubRepoSlug(originUrl)
 
   const status = slug
-    ? await checkUpdatesViaApi({ slug, branch, currentSha })
+    ? await checkUpdatesViaApi({ slug, branch, currentSha, updateRoot, git })
     : await checkUpdatesViaLsRemote({ updateRoot, branch, currentSha })
 
   const result = {
@@ -3225,7 +3225,7 @@ function writeUpdateCheckCache(entry) {
 // then the compare endpoint only when the tips differ — it yields the exact
 // behind count plus the commit list the overlay renders, replacing both
 // `rev-list --count` and `git log HEAD..origin/<branch>`.
-async function checkUpdatesViaApi({ slug, branch, currentSha }) {
+async function checkUpdatesViaApi({ slug, branch, currentSha, updateRoot, git }) {
   let targetSha
 
   try {
@@ -3244,15 +3244,40 @@ async function checkUpdatesViaApi({ slug, branch, currentSha }) {
 
   // Compare failure (rate-limited, local-only HEAD 404) keeps the honest
   // "update available, count unknown" — never a fabricated number.
+  let compareError = null
   const compared = await fetchGitHubApi(compareApiUrl(slug, currentSha, targetSha))
     .then(parseCompare)
-    .catch(() => null)
+    .catch(error => {
+      compareError = error
+
+      return null
+    })
 
   // ahead_by === 0 with differing tips: the remote tip is reachable from our
   // HEAD — a local commit sitting AHEAD, not behind. Flagging that as an update
   // nudges the user into wiping their work.
   if (compared?.behind === 0) {
     return { behind: 0, updateAvailable: false, targetSha, commits: [] }
+  }
+
+  // A local-only HEAD (a patched checkout's merge/rebase commits exist nowhere
+  // upstream) makes the compare endpoint 404 FOREVER — the fallback below then
+  // holds a permanent "update available" no update can ever clear, since every
+  // update re-creates the local-only HEAD. When the already-fetched tip is in
+  // the local object database, answer from the local graph instead — the same
+  // ancestry guard the ls-remote path already applies and the backend's
+  // banner._tips_behind uses. Only a tip we can't see at all stays "unknown".
+  if (compared === null && compareError && updateRoot) {
+    const local = await resolveBehindLocally(git, updateRoot, currentSha, targetSha)
+
+    if (local !== null) {
+      return {
+        behind: local,
+        updateAvailable: local > 0,
+        targetSha,
+        commits: local > 0 ? await listLocalCommits(git, updateRoot, currentSha, targetSha) : []
+      }
+    }
   }
 
   return {

--- a/apps/desktop/electron/update-api-check.test.ts
+++ b/apps/desktop/electron/update-api-check.test.ts
@@ -17,7 +17,9 @@ import {
   branchTipApiUrl,
   cacheIsFresh,
   githubRepoSlug,
+  listLocalCommits,
   parseCompare,
+  resolveBehindLocally,
   UPDATE_CHECK_FAILURE_TTL_MS,
   UPDATE_CHECK_TTL_MS
 } from './update-api-check'
@@ -78,4 +80,72 @@ test('compare payload maps to the behind count and a newest-first commit list; m
     branchTipApiUrl('nousresearch/hermes-agent', 'bb/gui'),
     'https://api.github.com/repos/nousresearch/hermes-agent/commits/bb%2Fgui'
   )
+})
+
+/**
+ * Fake runGit keyed on the subcommand. Records every call so tests can pin
+ * that a stale tip short-circuits before any graph walk.
+ */
+function fakeGit(responses: Record<string, { code: number; stdout?: string }>) {
+  const calls: string[][] = []
+
+  return {
+    calls,
+    runGit: async (args: string[]) => {
+      calls.push(args)
+      const canned = responses[args[0]] ?? { code: 0 }
+
+      return { code: canned.code, stdout: canned.stdout ?? '', stderr: '' }
+    }
+  }
+}
+
+test('resolveBehindLocally: unreachable tip is unknown, reachable tip is ahead, otherwise the real gap', async () => {
+  // A tip missing from the object database (truly stale checkout) stays unknown.
+  const stale = fakeGit({ 'cat-file': { code: 1 } })
+  assert.equal(await resolveBehindLocally(stale.runGit, '/repo', SHA_A, SHA_B), null)
+  assert.deepEqual(stale.calls.map(args => args[0]), ['cat-file'])
+
+  // The remote tip reachable from HEAD is a local commit AHEAD, not an update.
+  const ahead = fakeGit({})
+  assert.equal(await resolveBehindLocally(ahead.runGit, '/repo', SHA_A, SHA_B), 0)
+  assert.deepEqual(ahead.calls.map(args => args[0]), ['cat-file', 'merge-base'])
+
+  // Otherwise the honest local count of HEAD..tip (merge-base must fail first).
+  const behind = fakeGit({ 'merge-base': { code: 1 }, 'rev-list': { code: 0, stdout: '3\n' } })
+  assert.equal(await resolveBehindLocally(behind.runGit, '/repo', SHA_A, SHA_B), 3)
+  assert.deepEqual(behind.calls.map(args => args[0]), ['cat-file', 'merge-base', 'rev-list'])
+
+  // A git failure mid-walk is never silently read as zero.
+  const broken = fakeGit({ 'merge-base': { code: 1 }, 'rev-list': { code: 128 } })
+  assert.equal(await resolveBehindLocally(broken.runGit, '/repo', SHA_A, SHA_B), null)
+})
+
+test('listLocalCommits renders the local gap newest-first in the parseCompare shape', async () => {
+  const OLDEST = '1'.repeat(40)
+  const NEWEST = '2'.repeat(40)
+  const gitLog = fakeGit({
+    log: {
+      code: 0,
+      stdout: [
+        [OLDEST, 'Old Hand', '2026-09-10T00:00:00+00:00', 'fix: older'].join('\x1f'),
+        [NEWEST, 'New Face', '2026-09-11T00:00:00+00:00', 'feat: newer'].join('\x1f'),
+        ''
+      ].join('\n')
+    }
+  })
+
+  const commits = await listLocalCommits(gitLog.runGit, '/repo', SHA_A, SHA_B)
+  assert.deepEqual(
+    commits.map(c => [c.sha, c.summary, c.author]),
+    [
+      [NEWEST, 'feat: newer', 'New Face'],
+      [OLDEST, 'fix: older', 'Old Hand']
+    ]
+  )
+  assert.equal(commits[0].at, Date.parse('2026-09-11T00:00:00+00:00'))
+
+  // A failed log renders as "no listed commits", never a fabricated list.
+  const failed = fakeGit({ log: { code: 128 } })
+  assert.deepEqual(await listLocalCommits(failed.runGit, '/repo', SHA_A, SHA_B), [])
 })

--- a/apps/desktop/electron/update-api-check.ts
+++ b/apps/desktop/electron/update-api-check.ts
@@ -109,3 +109,75 @@ export function parseCompare(payload: unknown): { behind: number; commits: Compa
 
   return { behind: ahead, commits }
 }
+
+/** A git command runner — main.ts injects its runGit; tests inject a fake. */
+export type GitRunner = (args: string[], options?: { cwd?: string }) => Promise<{
+  code: number
+  stdout: string
+  stderr: string
+}>
+
+/**
+ * Answer "how far behind is HEAD?" from the LOCAL object database when the
+ * compare endpoint can't — its 404 on a local-only HEAD (a patched checkout's
+ * merge/rebase commits exist nowhere upstream) or a rate limit. Mirrors the
+ * ls-remote path's ancestry guard and the backend's banner._tips_behind: a
+ * tip reachable from HEAD is a local commit AHEAD, not an update; anything
+ * else counts HEAD..tip. Returns null when the tip isn't in the local
+ * database (a truly stale checkout) so callers keep the honest
+ * "update available, count unknown" state instead of a fabricated number.
+ */
+export async function resolveBehindLocally(
+  runGit: GitRunner,
+  cwd: string,
+  currentSha: string,
+  targetSha: string
+): Promise<number | null> {
+  const known = await runGit(['cat-file', '-e', `${targetSha}^{commit}`], { cwd })
+
+  if (known.code !== 0) {
+    return null
+  }
+
+  if ((await runGit(['merge-base', '--is-ancestor', targetSha, currentSha], { cwd })).code === 0) {
+    return 0
+  }
+
+  const count = await runGit(['rev-list', '--count', `${currentSha}..${targetSha}`], { cwd })
+  const parsed = Number.parseInt(count.stdout.trim(), 10)
+
+  return count.code === 0 && Number.isInteger(parsed) && parsed >= 0 ? parsed : null
+}
+
+/**
+ * Newest-first commit list for resolveBehindLocally's count, in the same
+ * CompareCommit shape as parseCompare so the overlay's "what's changed" list
+ * renders the local answer too.
+ */
+export async function listLocalCommits(
+  runGit: GitRunner,
+  cwd: string,
+  currentSha: string,
+  targetSha: string
+): Promise<CompareCommit[]> {
+  const log = await runGit(
+    ['log', '--reverse', '--date=iso-strict', '--pretty=%H%x1f%an%x1f%ad%x1f%s', `${currentSha}..${targetSha}`],
+    { cwd }
+  )
+
+  if (log.code !== 0) {
+    return []
+  }
+
+  return log.stdout
+    .split('\n')
+    .map(line => line.split('\x1f'))
+    .filter(parts => parts.length === 4 && parts[0])
+    .map(([sha, author, date, summary]) => ({
+      sha,
+      author,
+      summary,
+      at: Number.isFinite(Date.parse(date)) ? Date.parse(date) : 0
+    }))
+    .reverse()
+}


### PR DESCRIPTION
## What does this PR do?

On a desktop install whose checkout carries local commits on top of the tracked branch (the local-patches shape: patch commits plus a merge of `main`), the passive update check reports a permanent **"(update)"** badge that no update can ever clear:

1. `checkUpdatesViaApi` fetches the upstream tip — fine.
2. The local HEAD never equals that tip (it has local-only commits on top), so it calls the compare endpoint.
3. The compare endpoint **404s forever**, because a local-only HEAD does not exist upstream.
4. The `catch` maps every failure to `{ behind: null, updateAvailable: true }` — "update available, count unknown".

Every `hermes update` re-creates a local-only HEAD, so step 3–4 repeat forever. The user is nudged into an update loop that can never satisfy the badge — the exact failure mode the codebase already guards against elsewhere: `hermes_cli/banner.py` ("misreporting an ahead checkout nudges the user into `hermes update`, which can wipe carried work") and `checkUpdatesViaLsRemote` in this very file, which already runs a `merge-base --is-ancestor` guard for the same situation on non-GitHub origins. The API path is the one path missing the guard.

This PR applies the same ancestry logic to the API path. When the compare call fails **and** the already-fetched tip is present in the local object database, the answer comes from the local graph — tip reachable from HEAD → ahead, not an update (`behind: 0`); otherwise the real `HEAD..tip` count and a newest-first commit list in `parseCompare`'s shape, so the overlay's "what's changed" renders on this path too. Only a tip the checkout cannot see at all (truly stale, or an unreachable `git`) keeps the existing honest "count unknown" state.

## Related Issue

No tracking issue found (searched open/closed PRs and issues). Closest prior is #88422 — a different root cause (shallow-clone fetch) with an overlapping symptom in the same subsystem, closed after its premise was refined by #94680; this 404 path is independent of clone depth.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/update-api-check.ts` — add `resolveBehindLocally()` (object-database presence check → ancestry guard → `rev-list --count`; `null` when the tip is unknown locally) and `listLocalCommits()` (newest-first, `CompareCommit`-shaped). Both are pure and take the git runner as a parameter, matching the module's injection pattern.
- `apps/desktop/electron/main.ts` — `checkUpdatesViaApi` now receives `updateRoot` and the local `git` runner it already had in scope at the call site; on compare failure it consults the local graph before falling back to "count unknown". No other behavior changes: a successful compare and the ahead-by-0 guard are untouched.
- `apps/desktop/electron/update-api-check.test.ts` — invariant tests with a fake git runner: stale tip stays unknown (and short-circuits before any graph walk), reachable tip is ahead (`0`), real gap counted, mid-walk git failure never read as zero, commit list renders newest-first and never fabricates on failure.

## How to Test

1. `npx vitest run electron/update-api-check.test.ts` — 4 tests pass; the new tests are red on `main` (they import helpers that only exist here).
2. Reproduce on `main`: on any checkout carrying local commits on top of the tracked branch, force a desktop update check — the badge shows "(update)" with no count immediately after a successful update and never clears. Trace: `checkUpdatesViaApi` → compare endpoint 404 → `updateAvailable: true, behind: null`. Same checkout on this branch: badge clears (tip reachable → ahead); when upstream moves ahead it shows `(+N)` with the commit list.
3. `npx tsc --build tsconfig.electron.json` — clean.

Tested on macOS 15.7.4 (arm64). Full desktop vitest suite: 9645 passed; the only failures (`managed-ssh-update`, `windows-system-ca`, `scripts/*`) are environment-dependent (local keychain, spawning the real updater, ESM loader) and fail identically on unmodified `origin/main` — verified by running those files against a base checkout in the same tree.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (JS-only change; `npx vitest run` per the desktop suite)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior documented in docstrings; no user-facing docs describe the badge's failure modes)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — git CLI calls only, same mechanism the ls-remote path already uses on all platforms
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
