### PR TITLE
Replacement: Kanban notifier dedupe and crash digest

### DIFF
--- a/gateway/kanban_watchers_notifier.py
+++ b/gateway/kanban_watchers_notifier.py
@@ -8,6 +8,7 @@ per-subscription delivery (``_KanbanNotification``) live here.
 from __future__ import annotations
 
 import re
+import time
 from functools import partial
 from pathlib import Path
 import weakref
@@ -50,6 +51,8 @@ _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked", "revie
 # every 5 seconds forever. A genuinely dead chat still drops, just ~60s later — a fine trade for an
 # unattended gate where a false drop means silent work pileup.
 MAX_SEND_FAILURES = 12
+_FAILURE_DEDUPE_SECONDS = 30 * 60
+_FAILURE_KINDS = frozenset({"crashed", "gave_up"})
 
 _LOCAL_PATH_RE = re.compile(r"(?<![\w:/])(?:/(?:Users|home|private|tmp|var|etc|workspace)/[^\s,;]+|" r"[A-Za-z]:\\[^\s,;]+)")
 
@@ -406,10 +409,21 @@ class _KanbanNotification:
         self.adapter: Any = None
         self.is_push_adapter = True
         self.wake_kinds: set = set()
+        self.failure_dedupe: dict[tuple, dict[str, Any]] = getattr(
+            runner, "_kanban_failure_dedupe", {},
+        )
+        runner._kanban_failure_dedupe = self.failure_dedupe
+        self.events: list[Any] = []
+        self.event_suffixes: dict[int, str] = {}
+        self._dedupe_before: Optional[dict[str, Any]] = None
 
     # -- cursor / subscription ops (blocking, run in a fresh-context thread) --
 
     async def rewind(self) -> None:
+        if self._dedupe_before is None:
+            self.failure_dedupe.pop(self.sub_key, None)
+        else:
+            self.failure_dedupe[self.sub_key] = self._dedupe_before
         await _to_thread_process_service(
             self.runner._kanban_rewind, self.sub, self.d["cursor"], self.d.get("old_cursor", 0), self.board_slug,
         )
@@ -441,6 +455,45 @@ class _KanbanNotification:
 
     # -- formatting --
 
+    @staticmethod
+    def _failure_error(ev: Any) -> str:
+        payload = getattr(ev, "payload", None) or {}
+        return _safe_review_reason(payload.get("error") or payload.get("reason") or "unknown error", 200)
+
+    @staticmethod
+    def _digest(state: dict[str, Any]) -> str:
+        count = int(state.get("suppressed", 0))
+        if not count:
+            return ""
+        return f"\nCrash storm digest: {count} suppressed; latest error: {state.get('latest_error') or 'unknown error'}"
+
+    def prepare_events(self) -> None:
+        """Suppress repeated task failures while preserving recovery and expiry digests."""
+        now = time.monotonic()
+        state = self.failure_dedupe.get(self.sub_key)
+        self._dedupe_before = dict(state) if state is not None else None
+        for ev in self.d["events"]:
+            if ev.kind in _FAILURE_KINDS:
+                if state is not None and now - state["last_emitted"] < _FAILURE_DEDUPE_SECONDS:
+                    state["suppressed"] += 1
+                    state["latest_error"] = self._failure_error(ev)
+                    continue
+                suffix = self._digest(state) if state is not None else ""
+                state = {"last_emitted": now, "suppressed": 0, "latest_error": self._failure_error(ev)}
+                self.failure_dedupe[self.sub_key] = state
+                if suffix:
+                    self.event_suffixes[ev.id] = suffix
+                self.events.append(ev)
+                continue
+
+            if state is not None:
+                suffix = self._digest(state)
+                if suffix:
+                    self.event_suffixes[ev.id] = suffix
+                self.failure_dedupe.pop(self.sub_key, None)
+                state = None
+            self.events.append(ev)
+
     def format_event(self, ev: Any) -> Optional[str]:
         """Render one event; accumulates wake handoff/review detail. None → silent kind."""
         formatter = _EVENT_FORMATTERS.get(ev.kind)
@@ -451,12 +504,12 @@ class _KanbanNotification:
             self.wake_handoff = handoff
         if review_detail is not None:
             self.wake_review_detail = review_detail
-        return msg
+        return msg + self.event_suffixes.get(ev.id, "")
 
     def build_wake_text(self) -> None:
         """Set ``wake_kinds`` / ``session_key`` / ``synth`` for the wake paths."""
         task, sub = self.task, self.sub
-        self.wake_kinds = {ev.kind for ev in self.d["events"] if ev.kind in _WAKE_KINDS} if self.wake_agent else set()
+        self.wake_kinds = {ev.kind for ev in self.events if ev.kind in _WAKE_KINDS} if self.wake_agent else set()
         if not self.wake_kinds:
             return
         if self.is_push_adapter:
@@ -550,7 +603,7 @@ class _KanbanNotification:
 
     async def _send_pings(self) -> bool:
         """Send every text ping; False when a send failed (claim already rewound/dropped)."""
-        for ev in self.d["events"]:
+        for ev in self.events:
             msg = self.format_event(ev)
             if msg is None:
                 continue
@@ -600,6 +653,8 @@ class _KanbanNotification:
         self.adapter = adapter
         from gateway.wake import adapter_supports_push
         self.is_push_adapter = adapter_supports_push(adapter)
+
+        self.prepare_events()
 
         if not await self._send_pings():
             return

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -295,66 +295,110 @@ class ReportedFailureAdapter:
         return SendResult(success=False, error="Not connected")
 
 
-def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
-    """A retry cycle (crashed → reclaimed → crashed) notifies the user twice.
+def _append_failure_event(tid, kind="crashed", error=None):
+    conn = kbc.connect()
+    try:
+        kb._append_event(conn, tid, kind=kind, payload={"error": error} if error else None)
+    finally:
+        conn.close()
 
-    Before #21398 the notifier auto-unsubscribed on any terminal event kind
-    (gave_up / crashed / timed_out), so the second crash in a respawn cycle
-    silently dropped — the subscription was already gone. This test pins the
-    new contract: subscription survives non-final terminal events; the
-    cursor handles dedup.
 
-    Two crashes ten seconds apart on the same task — both should land on
-    the adapter.
-    """
-    db_path = tmp_path / "redeliver-cycle.db"
+def _tick_again(monkeypatch, runner):
+    runner._running = True
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+
+def test_notifier_suppresses_repeated_crash_wakes_for_thirty_minutes(tmp_path, monkeypatch):
+    db_path = tmp_path / "crash-storm.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
     kb.init_db()
+    now = [100.0]
+    monkeypatch.setattr("gateway.kanban_watchers_notifier.time.monotonic", lambda: now[0])
 
     conn = kbc.connect()
     try:
-        tid = kb.create_task(conn, title="cycle test", assignee="worker")
-        kbn.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
-        # First crash — fired by the dispatcher when the worker PID dies.
-        kb._append_event(conn, tid, kind="crashed")
+        tid = kb.create_task(conn, title="cycle test", assignee="worker", session_id="origin")
+        kbn.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="chat-1", delivery_mode="notify+wake",
+        )
     finally:
         conn.close()
 
     adapter = RecordingAdapter()
     runner = _make_runner(adapter)
-    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    for error in ("first", "second", "latest"):
+        _append_failure_event(tid, error=error)
+        _tick_again(monkeypatch, runner)
+        now[0] += 10
 
-    # First crash delivered.
     assert len(adapter.sent) == 1
+    assert len(adapter.handled) == 1
     assert "crashed" in adapter.sent[0]["text"].lower()
+    assert _unseen_terminal_events(tid) == []
 
-    # Subscription survives — the cursor advanced past event #1, but the
-    # row is still there.
+
+def test_notifier_emits_crash_digest_after_suppression_window(tmp_path, monkeypatch):
+    db_path = tmp_path / "crash-digest.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    now = [100.0]
+    monkeypatch.setattr("gateway.kanban_watchers_notifier.time.monotonic", lambda: now[0])
+
     conn = kbc.connect()
     try:
-        subs = kbn.list_notify_subs(conn, tid)
-        assert len(subs) == 1, (
-            "Subscription must survive a crashed event so a respawn-cycle "
-            "second crash also notifies the user (issue #21398)."
-        )
-
-        # Second crash — same task, same dispatcher (or a respawn). Append
-        # another event to simulate the dispatcher firing crashed a second
-        # time during retry.
-        kb._append_event(conn, tid, kind="crashed")
+        tid = kb.create_task(conn, title="cycle test", assignee="worker")
+        kbn.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
     finally:
         conn.close()
 
-    # New tick: the second event has a fresh id past the cursor advance,
-    # so it gets claimed and delivered.
+    adapter = RecordingAdapter()
     runner = _make_runner(adapter)
-    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    for error in ("first", "middle", "latest failure"):
+        _append_failure_event(tid, kind="gave_up", error=error)
+        _tick_again(monkeypatch, runner)
+        now[0] += 10
 
-    assert len(adapter.sent) == 2, (
-        f"Second crashed event should also notify; got {len(adapter.sent)} "
-        f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
-    )
-    assert "crashed" in adapter.sent[1]["text"].lower()
+    now[0] = 1901.0
+    _append_failure_event(tid, kind="crashed", error="new window")
+    _tick_again(monkeypatch, runner)
+
+    assert len(adapter.sent) == 2
+    digest = adapter.sent[-1]["text"].lower()
+    assert "2 suppressed" in digest
+    assert "latest failure" in digest
+
+
+def test_notifier_delivers_completion_during_crash_suppression(tmp_path, monkeypatch):
+    db_path = tmp_path / "crash-recovery.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    monkeypatch.setattr("gateway.kanban_watchers_notifier.time.monotonic", lambda: 100.0)
+
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="recovers", assignee="worker", session_id="origin")
+        kbn.add_notify_sub(
+            conn, task_id=tid, platform="telegram", chat_id="chat-1", delivery_mode="notify+wake",
+        )
+        kb._append_event(conn, tid, kind="crashed", payload={"error": "boom"})
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    _tick_again(monkeypatch, runner)
+    _append_failure_event(tid, error="still broken")
+    _tick_again(monkeypatch, runner)
+    conn = kbc.connect()
+    try:
+        kb.complete_task(conn, tid, summary="recovered")
+    finally:
+        conn.close()
+    _tick_again(monkeypatch, runner)
+
+    assert len(adapter.sent) == 2
+    assert len(adapter.handled) == 2
+    assert "done" in adapter.sent[-1]["text"].lower()
 
 
 def test_notifier_subscription_survives_done_reopen_until_archive(


### PR DESCRIPTION
What changed:
- deduplicate crashed/gave_up notification and wake delivery per task/subscription for 30 minutes
- retain suppressed count and latest error, emitting them on the next failure window or terminal recovery
- preserve cursor advancement and restore dedupe state if delivery is rewound
- add regressions for repeated crashes, suppression expiry/digest, and completion recovery

Verified:
- uv run --extra dev pytest tests/gateway/test_kanban_notifier*.py -q (23 passed)
- uv run --extra dev ruff check gateway/kanban_watchers_notifier.py tests/gateway/test_kanban_notifier.py (All checks passed)
- git diff --check (clean)
- sabotage run against HEAD implementation: 3 new tests failed

Not tested:
- live messaging adapters and multi-process gateway restart behavior