### PR TITLE
fix(acp): round-trip named custom provider model ids

### DIFF
--- a/acp_adapter/model_catalog.py
+++ b/acp_adapter/model_catalog.py
@@ -144,12 +144,28 @@ def _choice_provider(model_id: str) -> str:
 
 
 def encode_model_choice(provider: str | None, model: str | None) -> str:
-    """``provider:model`` so ACP clients keep provider context."""
+    """``provider:model`` so ACP clients keep provider context.
+
+    Named custom endpoints must round-trip as ``custom:<name>:<model>``.
+    Inventory slugs are often the bare config key (``aihubmix``); encoding
+    that as ``aihubmix:qwen3.8-flash`` used to come back as an unsplit
+    model id on provider ``custom`` and get sent to the wrong endpoint.
+    """
     raw_model = str(model or "").strip()
     if not raw_model:
         return ""
-    raw_provider = str(provider or "").strip().lower()
-    return f"{raw_provider}:{raw_model}" if raw_provider else raw_model
+    raw_provider = str(provider or "").strip()
+    try:
+        from hermes_cli.models import named_custom_provider_id, parse_model_input
+
+        parsed_provider, parsed_model = parse_model_input(raw_model, raw_provider or "openrouter")
+        durable = named_custom_provider_id(parsed_provider) or parsed_provider
+        if durable:
+            return f"{durable}:{parsed_model}"
+        return parsed_model
+    except Exception:
+        raw_provider_l = raw_provider.lower()
+        return f"{raw_provider_l}:{raw_model}" if raw_provider_l else raw_model
 
 
 @dataclass

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -33,7 +33,7 @@ from acp_adapter.events import (
 from acp_adapter.model_catalog import build_model_state, encode_model_choice
 from acp_adapter.permissions import make_approval_callback
 from acp_adapter.provenance import session_provenance_meta
-from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets
+from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets, persist_identity
 from acp_adapter.tools import build_tool_complete, build_tool_start, coerce_tool_args
 from agent.context_compressor import (COMPRESSED_SUMMARY_METADATA_KEY, ContextCompressor)
 from agent.interrupt_compat import request_hard_interrupt
@@ -291,10 +291,13 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
     def _build_model_state(self, state: SessionState) -> SessionModelState | None:
         """Authenticated providers + models, from the shared Hermes inventory (same substrate
         as ``hermes model``/TUI/dashboard) so the selector isn't just the current curated list."""
-        model = str(state.model or getattr(state.agent, "model", "") or "").strip()
-        provider = getattr(state.agent, "provider", None) or detect_provider() or "openrouter"
+        identity = persist_identity(state)
+        model = str(identity.get("model") or state.model or getattr(state.agent, "model", "") or "").strip()
+        provider = identity.get("provider") or getattr(state.agent, "provider", None) or detect_provider() or "openrouter"
         try:
-            picker = build_model_state(model, provider, str(getattr(state.agent, "base_url", "") or ""))
+            picker = build_model_state(
+                model, provider, str(identity.get("base_url") or getattr(state.agent, "base_url", "") or ""),
+            )
             if picker is not None:
                 return picker
         except Exception:

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -31,7 +31,11 @@ def _plain_str(value: Any) -> Optional[str]:
 
 
 def _named_provider_identity(provider: Any, requested_provider: Any) -> str:
-    """Prefer ``custom:<name>`` over the flattened runtime provider ``custom``."""
+    """Prefer ``custom:<name>`` over the flattened runtime provider ``custom``.
+
+    ``auto`` is a resolution sentinel, not a durable identity — keep the already
+    resolved runtime provider so ACP choice ids stay ``openrouter:...`` (#101946).
+    """
     requested = _plain_str(requested_provider) or ""
     flattened = _plain_str(provider) or ""
     requested_l = requested.lower()
@@ -48,6 +52,8 @@ def _named_provider_identity(provider: Any, requested_provider: Any) -> str:
             return durable
     except Exception:
         pass
+    if requested_l in {"", "auto"}:
+        return flattened
     return requested or flattened
 
 
@@ -114,11 +120,14 @@ def persist_identity(state: "SessionState") -> Dict[str, Optional[str]]:
             else None
         )
 
+    live_requested = requested_provider
     provider, model = _split_prefixed_model(model, provider or requested_provider)
-    requested_provider = (
-        _named_provider_identity(provider, requested_provider) or requested_provider or provider
-    )
-    provider = _named_provider_identity(provider, requested_provider) or provider
+    durable = _named_provider_identity(provider, requested_provider) or provider
+    if (live_requested or "").strip().lower() == "auto":
+        requested_provider = live_requested
+    else:
+        requested_provider = durable or live_requested or provider
+    provider = durable or provider
 
     return {
         "model": model,

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -24,6 +24,111 @@ from typing import Any, Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 
+def _plain_str(value: Any) -> Optional[str]:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _named_provider_identity(provider: Any, requested_provider: Any) -> str:
+    """Prefer ``custom:<name>`` over the flattened runtime provider ``custom``."""
+    requested = _plain_str(requested_provider) or ""
+    flattened = _plain_str(provider) or ""
+    requested_l = requested.lower()
+    flattened_l = flattened.lower()
+    if requested_l.startswith("custom:") and requested_l != "custom:":
+        return requested
+    if flattened_l.startswith("custom:") and flattened_l != "custom:":
+        return flattened
+    try:
+        from hermes_cli.models import named_custom_provider_id
+
+        durable = named_custom_provider_id(requested) or named_custom_provider_id(flattened)
+        if durable:
+            return durable
+    except Exception:
+        pass
+    return requested or flattened
+
+
+def _split_prefixed_model(model: Optional[str], provider: Optional[str]) -> tuple[str, str]:
+    """Split ``aihubmix:qwen3.8-flash`` into ``(custom:aihubmix, qwen3.8-flash)``.
+
+    Unprefixed model ids are returned unchanged with *provider* preserved.
+    """
+    raw_model = _plain_str(model) or ""
+    raw_provider = _plain_str(provider) or ""
+    if not raw_model:
+        return raw_provider, raw_model
+    try:
+        from hermes_cli.models import named_custom_provider_id, parse_model_input
+
+        parsed_provider, parsed_model = parse_model_input(
+            raw_model, raw_provider or "custom"
+        )
+        durable = named_custom_provider_id(parsed_provider) or parsed_provider
+        if parsed_model != raw_model:
+            return durable or parsed_provider, parsed_model
+        if durable:
+            return durable, parsed_model
+        return raw_provider or parsed_provider, parsed_model
+    except Exception:
+        return raw_provider, raw_model
+
+
+def persist_identity(state: "SessionState") -> Dict[str, Optional[str]]:
+    """Return the ACP session identity that should be written to SessionDB.
+
+    Fallback is turn-scoped: a transient aiberm → aihubmix failover must not
+    become the restored primary after the next prompt or ACP process restart.
+    Named custom providers (``custom:aiberm``) are preserved even though the
+    live runtime provider is flattened to ``custom``.
+    """
+    agent = getattr(state, "agent", None)
+    rt = getattr(agent, "_primary_runtime", None) if agent is not None else None
+    if not isinstance(rt, dict):
+        rt = {}
+    fallback_on = getattr(agent, "_fallback_activated", False) is True
+    use_primary = fallback_on and bool(
+        _plain_str(rt.get("model")) or _plain_str(rt.get("provider")) or _plain_str(rt.get("base_url"))
+    )
+
+    if use_primary:
+        model = _plain_str(rt.get("model")) or _plain_str(getattr(state, "model", None))
+        provider = _named_provider_identity(rt.get("provider"), rt.get("requested_provider"))
+        base_url = _plain_str(rt.get("base_url"))
+        api_mode = _plain_str(rt.get("api_mode"))
+        requested_provider = _plain_str(rt.get("requested_provider")) or provider or None
+    else:
+        live_model = getattr(agent, "model", None) if agent is not None else None
+        model = _plain_str(getattr(state, "model", None)) or _plain_str(live_model)
+        provider = _named_provider_identity(
+            getattr(agent, "provider", None) if agent is not None else None,
+            getattr(agent, "requested_provider", None) if agent is not None else None,
+        )
+        base_url = _plain_str(getattr(agent, "base_url", None)) if agent is not None else None
+        api_mode = _plain_str(getattr(agent, "api_mode", None)) if agent is not None else None
+        requested_provider = (
+            _plain_str(getattr(agent, "requested_provider", None)) or provider or None
+            if agent is not None
+            else None
+        )
+
+    provider, model = _split_prefixed_model(model, provider or requested_provider)
+    requested_provider = (
+        _named_provider_identity(provider, requested_provider) or requested_provider or provider
+    )
+    provider = _named_provider_identity(provider, requested_provider) or provider
+
+    return {
+        "model": model,
+        "provider": provider or None,
+        "requested_provider": requested_provider or provider or None,
+        "base_url": base_url,
+        "api_mode": api_mode,
+    }
+
+
 def _translate_acp_cwd(cwd: str) -> str:
     """Translate Windows ACP cwd values (``E:\\Projects``, ``\\\\wsl.localhost\\``) to POSIX form
     when Hermes runs in WSL so agents, tools, and persisted sessions agree; no-op elsewhere."""
@@ -283,11 +388,13 @@ class SessionManager:
         if db is None:
             return
 
-        # Ensure model is a plain string (not a MagicMock or other proxy).
-        model_str = str(state.model) if state.model else None
+        identity = persist_identity(state)
+        model_str = identity.get("model")
+        if model_str:
+            state.model = model_str
         session_meta = {"cwd": state.cwd}
-        for key in ("provider", "base_url", "api_mode"):
-            value = getattr(state.agent, key, None)
+        for key in ("provider", "requested_provider", "base_url", "api_mode"):
+            value = identity.get(key)
             if isinstance(value, str) and value.strip():
                 session_meta[key] = value.strip()
 
@@ -297,7 +404,7 @@ class SessionManager:
                     # Empty editor probes stay ephemeral; copied fork history persists.
                     return
                 db.create_session(session_id=state.session_id, source="acp", model=model_str,
-                                  model_config={"cwd": state.cwd})
+                                  model_config=session_meta)
             else:
                 try:
                     db.update_session_meta(state.session_id, json.dumps(session_meta), model_str)
@@ -355,7 +462,7 @@ class SessionManager:
         try:
             agent = self._make_agent(
                 session_id=session_id, cwd=cwd, model=model, api_mode=meta.get("api_mode") or None,
-                requested_provider=meta.get("provider") or row.get("billing_provider"),
+                requested_provider=meta.get("requested_provider") or meta.get("provider") or row.get("billing_provider"),
                 base_url=meta.get("base_url") or row.get("billing_base_url"))
         except Exception:
             logger.warning("Failed to recreate agent for ACP session %s", session_id, exc_info=True)
@@ -370,7 +477,17 @@ class SessionManager:
     def _make_agent(self, *, session_id: str, cwd: str, model: str | None = None,
                     requested_provider: str | None = None, base_url: str | None = None, api_mode: str | None = None):
         if self._agent_factory is not None:
-            return self._agent_factory()
+            try:
+                return self._agent_factory(
+                    session_id=session_id,
+                    cwd=cwd,
+                    model=model,
+                    requested_provider=requested_provider,
+                    base_url=base_url,
+                    api_mode=api_mode,
+                )
+            except TypeError:
+                return self._agent_factory()
 
         from run_agent import AIAgent
         from hermes_cli.config import load_config
@@ -388,20 +505,50 @@ class SessionManager:
             name for name, cfg in (config.get("mcp_servers") or {}).items()
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
+
+        incoming_model = model or default_model
+        incoming_provider = requested_provider or config_provider
+        if incoming_model:
+            split_provider, split_model = _split_prefixed_model(
+                incoming_model, incoming_provider
+            )
+            incoming_model = split_model or incoming_model
+            if split_provider and (
+                incoming_provider or (model and ":" in str(model))
+            ):
+                incoming_provider = split_provider
+        requested_provider = incoming_provider
+
         kwargs = {
             "platform": "acp", "quiet_mode": True, "session_id": session_id, "session_db": self._get_db(),
             "enabled_toolsets": _expand_acp_enabled_toolsets(["hermes-acp"], mcp_server_names=configured_mcp_servers),
-            "model": model or default_model,
+            "model": incoming_model or default_model,
         }
         try:
-            runtime = resolve_runtime_provider(requested=requested_provider or config_provider)
+            from hermes_cli.fallback_config import get_fallback_chain
+
+            fallback_chain = get_fallback_chain(config)
+            if fallback_chain:
+                kwargs["fallback_model"] = fallback_chain
+        except Exception:
+            logger.debug("ACP session could not load fallback_model", exc_info=True)
+
+        try:
+            runtime = resolve_runtime_provider(
+                requested=requested_provider or config_provider,
+                target_model=kwargs.get("model") or None,
+            )
             kwargs.update({
-                "provider": runtime.get("provider"), "api_mode": api_mode or runtime.get("api_mode"),
+                "provider": runtime.get("provider"),
+                "requested_provider": requested_provider or runtime.get("requested_provider") or runtime.get("provider"),
+                "api_mode": api_mode or runtime.get("api_mode"),
                 "base_url": base_url or runtime.get("base_url"), "api_key": runtime.get("api_key"),
                 "command": runtime.get("command"), "args": list(runtime.get("args") or []),
             })
         except Exception:
             logger.debug("ACP session falling back to default provider resolution", exc_info=True)
+            if requested_provider:
+                kwargs["requested_provider"] = requested_provider
 
         _register_task_cwd(session_id, cwd)
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -707,6 +707,68 @@ def _provider_has_credentials(pid: str) -> bool:
         return False
 
 
+def named_custom_provider_id(name: Optional[str]) -> Optional[str]:
+    """Return the durable ``custom:<key>`` id for a user-configured endpoint.
+
+    Built-in names (``openrouter``, ``deepseek``, bare ``custom``, …) return
+    ``None`` so ``parse_model_input`` keeps treating them as native prefixes.
+    Named ``providers:`` / ``custom_providers:`` keys such as ``aihubmix``
+    become ``custom:aihubmix`` so ACP choice ids round-trip instead of being
+    kept as an unsplit model string.
+    """
+    part = (name or "").strip().lower()
+    if not part:
+        return None
+    if part.startswith("custom:") and part != "custom:":
+        return part
+    if part in _KNOWN_PROVIDER_NAMES:
+        return None
+    try:
+        from hermes_cli.config import get_compatible_custom_providers, load_config
+        from hermes_cli.providers import (
+            custom_provider_slug,
+            resolve_custom_provider,
+            resolve_user_provider,
+        )
+
+        cfg = load_config()
+    except Exception:
+        return None
+    if not isinstance(cfg, dict):
+        return None
+
+    user_providers = cfg.get("providers")
+    if isinstance(user_providers, dict):
+        matched_key = None
+        matched_entry = None
+        for key, entry in user_providers.items():
+            if str(key).strip().lower() == part and isinstance(entry, dict):
+                matched_key = str(key).strip()
+                matched_entry = entry
+                break
+        if matched_key is None:
+            user = resolve_user_provider(part, user_providers)
+            if user is not None:
+                matched_key = str(user.id or part).strip()
+                matched_entry = {"name": user.name}
+        if matched_key:
+            display = ""
+            if isinstance(matched_entry, dict):
+                display = str(matched_entry.get("name") or "").strip()
+            return custom_provider_slug(display or matched_key, matched_key)
+
+    custom = resolve_custom_provider(
+        part,
+        get_compatible_custom_providers(cfg),
+    )
+    if custom is None:
+        return None
+    custom_id = str(custom.id or "").strip()
+    if custom_id.startswith("custom:") and custom_id != "custom:":
+        return custom_id
+    return custom_provider_slug(str(custom.name or custom_id), custom_id)
+
+
 def list_available_providers() -> list[dict[str, str]]:
     """``{id, label, aliases, authenticated}`` for every provider usable with ``provider:model``,
     derived from :data:`CANONICAL_PROVIDERS` (shared with ``hermes model`` and ``/model``)."""
@@ -724,13 +786,22 @@ def list_available_providers() -> list[dict[str, str]]:
 
 def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
     """Parse ``/model`` input into ``(provider, model)``. The colon is a provider delimiter only when
-    the left side is a known provider/alias, so ``anthropic/claude-3.5-sonnet:beta`` stays a model."""
+    the left side is a known provider/alias or a user-configured named endpoint, so
+    ``anthropic/claude-3.5-sonnet:beta`` stays a model while ``aihubmix:qwen3.8-flash``
+    becomes ``("custom:aihubmix", "qwen3.8-flash")``."""
     stripped = raw.strip()
     colon = stripped.find(":")
     if colon > 0:
         provider_part = stripped[:colon].strip().lower()
         model_part = stripped[colon + 1:].strip()
-        if provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES:
+        named_custom = (
+            named_custom_provider_id(provider_part)
+            if provider_part and provider_part not in _KNOWN_PROVIDER_NAMES
+            else None
+        )
+        if provider_part and model_part and (
+            provider_part in _KNOWN_PROVIDER_NAMES or named_custom
+        ):
             if provider_part == "custom":
                 # Longest configured ``custom:<name>`` id that prefixes the input wins.
                 lowered = stripped.lower()
@@ -742,9 +813,14 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
                 if ":" in model_part:
                     custom_name, actual_model = (part.strip() for part in model_part.split(":", 1))
                     if custom_name and actual_model:
+                        durable = named_custom_provider_id(custom_name)
+                        if durable:
+                            return (durable, actual_model)
                         if f"custom:{custom_name.lower()}" in _configured_custom_provider_ids():
                             return (f"custom:{custom_name.lower()}", actual_model)
                         return ("custom", model_part)
+            if named_custom:
+                return (named_custom, model_part)
             return (normalize_provider(provider_part), model_part)
     return (current_provider, stripped)
 

--- a/tests/acp/test_named_provider_catalogs.py
+++ b/tests/acp/test_named_provider_catalogs.py
@@ -275,3 +275,22 @@ class TestModelStateIncludesNamedProviders:
             )
         assert provider == "custom:local-127.0.0.1:11434"
         assert model == "qwen3:1.7b"
+
+    def test_encode_canonicalizes_named_custom_inventory_slug(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "providers": {
+                    "aihubmix": {
+                        "name": "AIHubMix",
+                        "base_url": "https://api.inferera.com/v1",
+                    }
+                }
+            },
+        )
+        from acp_adapter.model_catalog import encode_model_choice
+
+        assert encode_model_choice("aihubmix", "qwen3.8-flash") == "custom:aihubmix:qwen3.8-flash"
+        assert encode_model_choice("custom", "aihubmix:qwen3.8-flash") == "custom:aihubmix:qwen3.8-flash"
+        assert encode_model_choice("custom:aihubmix", "qwen3.8-flash") == "custom:aihubmix:qwen3.8-flash"
+        assert encode_model_choice("openai-codex", "gpt-5.4") == "openai-codex:gpt-5.4"

--- a/tests/acp/test_named_provider_catalogs.py
+++ b/tests/acp/test_named_provider_catalogs.py
@@ -294,3 +294,78 @@ class TestModelStateIncludesNamedProviders:
         assert encode_model_choice("custom", "aihubmix:qwen3.8-flash") == "custom:aihubmix:qwen3.8-flash"
         assert encode_model_choice("custom:aihubmix", "qwen3.8-flash") == "custom:aihubmix:qwen3.8-flash"
         assert encode_model_choice("openai-codex", "gpt-5.4") == "openai-codex:gpt-5.4"
+
+    def test_auto_request_keeps_resolved_provider_id(self):
+        """``auto`` must not leak into ACP choice ids (#101946 / #97233)."""
+        manager = SessionManager(
+            agent_factory=lambda: SimpleNamespace(
+                model="anthropic/claude-sonnet-4.5",
+                provider="openrouter",
+                requested_provider="auto",
+                base_url=None,
+            )
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/tmp")
+
+        with patch(
+            "acp_adapter.model_catalog._named_custom_provider_catalogs",
+            return_value=[],
+        ), patch(
+            "hermes_cli.inventory.build_models_payload",
+            return_value={"providers": []},
+        ):
+            model_state = acp_agent._build_model_state(state)
+
+        assert isinstance(model_state, SessionModelState)
+        assert model_state.current_model_id == "openrouter:anthropic/claude-sonnet-4.5"
+
+    def test_named_provider_inventory_slug_uses_canonical_choice_id(self, monkeypatch):
+        """Bare inventory slugs must not be advertised alongside ``custom:<name>`` (#97233)."""
+        model = "tflow/gpt-5.6-sol"
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "providers": {
+                    "9router": {
+                        "name": "9Router",
+                        "base_url": "https://router.example/v1",
+                    }
+                }
+            },
+        )
+        manager = SessionManager(
+            agent_factory=lambda: SimpleNamespace(
+                model=model,
+                provider="custom",
+                requested_provider="custom:9router",
+                base_url="https://router.example/v1",
+            )
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/tmp")
+        inventory = {
+            "providers": [
+                {
+                    "slug": "9router",
+                    "name": "9Router",
+                    "api_url": "https://router.example/v1",
+                    "models": [{"id": model}],
+                }
+            ]
+        }
+
+        with patch(
+            "hermes_cli.inventory.build_models_payload", return_value=inventory
+        ), patch(
+            "acp_adapter.model_catalog._named_custom_provider_catalogs",
+            return_value=[("custom:9router", "9Router", [(model, "")])],
+        ):
+            model_state = acp_agent._build_model_state(state)
+
+        assert isinstance(model_state, SessionModelState)
+        canonical_id = f"custom:9router:{model}"
+        ids = [item.model_id for item in model_state.available_models]
+        assert ids.count(canonical_id) == 1
+        assert f"9router:{model}" not in ids
+        assert model_state.current_model_id == canonical_id

--- a/tests/acp_adapter/test_persist_identity.py
+++ b/tests/acp_adapter/test_persist_identity.py
@@ -38,6 +38,25 @@ def _state(agent, model="claude-opus-5"):
     )
 
 
+def test_persist_auto_keeps_resolved_provider():
+    ident = persist_identity(_state(_agent(
+        model="anthropic/claude-sonnet-4.5",
+        provider="openrouter",
+        requested_provider="auto",
+        base_url=None,
+        _primary_runtime={
+            "model": "anthropic/claude-sonnet-4.5",
+            "provider": "openrouter",
+            "requested_provider": "auto",
+            "base_url": None,
+            "api_mode": "chat_completions",
+        },
+    ), model="anthropic/claude-sonnet-4.5"))
+    assert ident["model"] == "anthropic/claude-sonnet-4.5"
+    assert ident["provider"] == "openrouter"
+    assert ident["requested_provider"] == "auto"
+
+
 def test_persist_keeps_named_custom_provider():
     ident = persist_identity(_state(_agent()))
     assert ident["model"] == "claude-opus-5"

--- a/tests/acp_adapter/test_persist_identity.py
+++ b/tests/acp_adapter/test_persist_identity.py
@@ -1,0 +1,167 @@
+"""ACP persist identity: named custom providers and turn-scoped fallback."""
+
+from types import SimpleNamespace
+
+from acp_adapter.session import persist_identity, SessionManager, SessionState
+from hermes_state import SessionDB
+
+
+def _agent(**kwargs):
+    defaults = {
+        "model": "claude-opus-5",
+        "provider": "custom",
+        "requested_provider": "custom:aiberm",
+        "base_url": "https://aiberm.com/v1",
+        "api_mode": "chat_completions",
+        "_fallback_activated": False,
+        "_primary_runtime": {
+            "model": "claude-opus-5",
+            "provider": "custom",
+            "requested_provider": "custom:aiberm",
+            "base_url": "https://aiberm.com/v1",
+            "api_mode": "chat_completions",
+        },
+        "_session_db": None,
+        "_session_db_created": False,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _state(agent, model="claude-opus-5"):
+    return SessionState(
+        session_id="s-test",
+        agent=agent,
+        cwd="/tmp",
+        model=model,
+        history=[],
+    )
+
+
+def test_persist_keeps_named_custom_provider():
+    ident = persist_identity(_state(_agent()))
+    assert ident["model"] == "claude-opus-5"
+    assert ident["provider"] == "custom:aiberm"
+    assert ident["requested_provider"] == "custom:aiberm"
+    assert ident["base_url"] == "https://aiberm.com/v1"
+
+
+def test_persist_does_not_write_fallback_identity():
+    agent = _agent(
+        model="glm-5.3",
+        provider="custom",
+        requested_provider="aihubmix",
+        base_url="https://api.inferera.com/v1",
+        _fallback_activated=True,
+    )
+    ident = persist_identity(_state(agent, model="glm-5.3"))
+    assert ident["model"] == "claude-opus-5"
+    assert ident["provider"] == "custom:aiberm"
+    assert ident["requested_provider"] == "custom:aiberm"
+    assert ident["base_url"] == "https://aiberm.com/v1"
+
+
+def test_persist_roundtrip_named_provider_survives_restore(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    captured = {}
+
+    def factory(**kwargs):
+        captured.update(kwargs)
+        return _agent(
+            model=kwargs.get("model") or "claude-opus-5",
+            requested_provider=kwargs.get("requested_provider") or "custom:aiberm",
+            provider=kwargs.get("provider") or "custom",
+            base_url=kwargs.get("base_url") or "https://aiberm.com/v1",
+        )
+
+    manager = SessionManager(agent_factory=factory, db=db)
+    state = manager.create_session(cwd="/tmp")
+    state.model = "claude-opus-5"
+    state.agent = factory(
+        model="claude-opus-5",
+        requested_provider="custom:aiberm",
+        provider="custom",
+        base_url="https://aiberm.com/v1",
+    )
+    state.history.append({"role": "user", "content": "kept content"})
+    manager.save_session(state.session_id)
+
+    row = db.get_session(state.session_id)
+    assert row is not None
+    assert row["model"] == "claude-opus-5"
+    import json
+    meta = json.loads(row["model_config"])
+    assert meta["provider"] == "custom:aiberm"
+    assert meta["requested_provider"] == "custom:aiberm"
+    assert meta["base_url"] == "https://aiberm.com/v1"
+
+    manager._sessions.clear()
+    restored = manager.get_session(state.session_id)
+    assert restored is not None
+    assert captured["model"] == "claude-opus-5"
+    assert captured["requested_provider"] == "custom:aiberm"
+    assert captured["base_url"] == "https://aiberm.com/v1"
+
+
+def test_fallback_save_does_not_replace_primary_in_db(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+
+    def factory(**kwargs):
+        return _agent()
+
+    manager = SessionManager(agent_factory=factory, db=db)
+    state = manager.create_session(cwd="/tmp")
+    state.model = "claude-opus-5"
+    state.agent = _agent()
+    state.history.append({"role": "user", "content": "kept content"})
+    manager.save_session(state.session_id)
+
+    state.agent = _agent(
+        model="qwen3.8-flash",
+        provider="custom",
+        requested_provider="aihubmix",
+        base_url="https://api.inferera.com/v1",
+        _fallback_activated=True,
+    )
+    state.model = "qwen3.8-flash"
+    manager.save_session(state.session_id)
+
+    row = db.get_session(state.session_id)
+    assert row is not None
+    assert row["model"] == "claude-opus-5"
+    import json
+    meta = json.loads(row["model_config"])
+    assert meta["provider"] == "custom:aiberm"
+    assert meta["base_url"] == "https://aiberm.com/v1"
+    assert state.model == "claude-opus-5"
+
+
+def test_persist_splits_unsplit_named_custom_model(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "providers": {
+                "aihubmix": {
+                    "name": "AIHubMix",
+                    "base_url": "https://api.inferera.com/v1",
+                }
+            }
+        },
+    )
+    agent = _agent(
+        model="aihubmix:qwen3.8-flash",
+        provider="custom",
+        requested_provider="custom",
+        base_url="https://api.inferera.com/v1",
+        _primary_runtime={
+            "model": "aihubmix:qwen3.8-flash",
+            "provider": "custom",
+            "requested_provider": "custom",
+            "base_url": "https://api.inferera.com/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    ident = persist_identity(_state(agent, model="aihubmix:qwen3.8-flash"))
+    assert ident["model"] == "qwen3.8-flash"
+    assert ident["provider"] == "custom:aihubmix"
+    assert ident["requested_provider"] == "custom:aihubmix"

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -41,6 +41,56 @@ class TestParseModelInput:
         assert provider == "openrouter"
         assert model == "anthropic/claude-sonnet-4.5"
 
+    def test_known_provider_prefix_still_splits(self):
+        provider, model = parse_model_input("openai-codex:gpt-5.4", "openrouter")
+        assert provider == "openai-codex"
+        assert model == "gpt-5.4"
+
+    def test_named_custom_bare_prefix_splits_to_custom_slug(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "providers": {
+                    "aihubmix": {
+                        "name": "AIHubMix",
+                        "base_url": "https://api.inferera.com/v1",
+                    },
+                    "custom_by-jl": {
+                        "name": "JL",
+                        "base_url": "https://example.jl/v1",
+                    },
+                }
+            },
+        )
+        provider, model = parse_model_input("aihubmix:qwen3.8-flash", "custom")
+        assert provider == "custom:aihubmix"
+        assert model == "qwen3.8-flash"
+        provider, model = parse_model_input("custom_by-jl:deepseek-v4-pro", "openrouter")
+        assert provider == "custom:custom_by-jl"
+        assert model == "deepseek-v4-pro"
+
+    def test_unknown_colon_prefix_stays_in_model_name(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"providers": {}})
+        provider, model = parse_model_input("not-a-provider:weird-model", "openrouter")
+        assert provider == "openrouter"
+        assert model == "not-a-provider:weird-model"
+
+    def test_custom_triple_syntax_unchanged(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "providers": {
+                    "aihubmix": {
+                        "name": "AIHubMix",
+                        "base_url": "https://api.inferera.com/v1",
+                    }
+                }
+            },
+        )
+        provider, model = parse_model_input("custom:aihubmix:qwen3.8-flash", "bedrock")
+        assert provider == "custom:aihubmix"
+        assert model == "qwen3.8-flash"
+
 
 # -- curated_models_for_provider ---------------------------------------------
 


### PR DESCRIPTION
## Summary
- ACP clients (Paseo, Zed, and others) were advertised inventory slugs like `aihubmix:qwen3.8-flash`. `parse_model_input` only treated built-in names as `provider:model` prefixes, so the whole string became the model id on bare `custom` and requests could hit the wrong endpoint.
- Encode durable `custom:<name>:<model>` choice ids, split dirty prefixed ids on persist/restore, keep named custom identity instead of flattened `custom`, and honor `config.yaml` `fallback_model` when building ACP agents.
- Fallback activation stays turn-scoped: persist `_primary_runtime` rather than the fallback identity so a restart does not lock the session onto the backup provider.

## Test plan
- [x] `tests/hermes_cli/test_model_validation.py` — named custom prefixes split; unknown colon prefixes stay in the model name
- [x] `tests/acp/test_named_provider_catalogs.py` — encoder emits `custom:<name>:<model>` and still round-trips that form
- [x] `tests/acp_adapter/test_persist_identity.py` — named provider survives persist/restore; fallback save does not replace primary; unsplit `provider:model` ids are split
- [ ] Manual: in an ACP client, pick a `providers:` endpoint model and confirm the current model id is `custom:<name>:<model>` and the next turn hits that endpoint


Made with [Cursor](https://cursor.com)