### PR TITLE
feat(mcp): add Agent Guild endpoint preflight catalog entry

### DIFF
--- a/optional-mcps/agentguild/README.md
+++ b/optional-mcps/agentguild/README.md
@@ -1,0 +1,39 @@
+# Agent Guild
+
+Use Agent Guild when deciding whether to try a public remote agent or MCP
+provider and you want a fresh endpoint observation before delegation.
+
+Install with `hermes mcp install agentguild`, retain the two preselected
+tools, and start a new Hermes session. Both work without an account or key:
+
+- `guild_preflight(url=...)`: inspect an explicitly chosen public endpoint.
+- `guild_paid_operations()`: read current prices and entrypoints for paid
+  operations. The price lookup itself is free.
+
+If this entry is not yet in your installed catalog, merge the following
+server entry into the existing `mcp_servers` block in your Hermes config:
+
+```yaml
+mcp_servers:
+  agentguild:
+    url: https://agent-guild-5d5r.onrender.com/mcp
+    tools:
+      include:
+        - guild_preflight
+        - guild_paid_operations
+```
+
+For example, ask Hermes: “Use Agent Guild to inspect this public provider URL
+before I delegate. Summarize the observations and unknowns without invoking
+the provider's tools.” Supply the actual public URL separately.
+
+Preflight sends that URL to Agent Guild. Do not provide internal URLs or
+URLs containing credentials. Its unsigned observations are not proof of
+the provider's identity, authorization, task quality, or safety. This is
+an ordinary tool integration; it does not intercept other tool calls.
+
+Review tool selection with `hermes mcp configure agentguild`. The service
+also exposes paid tools, which are not preselected. Paid operations require
+separate authorization and payment; `GET /check` is not a free lookup.
+
+Source and documentation: [Agent Guild](https://github.com/AgentTanuki/agent-guild).

--- a/optional-mcps/agentguild/manifest.yaml
+++ b/optional-mcps/agentguild/manifest.yaml
@@ -1,0 +1,40 @@
+manifest_version: 1
+
+name: agentguild
+description: Observe a public agent endpoint before delegation and inspect current trust-operation prices.
+source: https://github.com/AgentTanuki/agent-guild
+
+transport:
+  type: http
+  url: https://agent-guild-5d5r.onrender.com/mcp
+
+auth:
+  type: none
+
+tools:
+  default_enabled:
+    - guild_preflight
+    - guild_paid_operations
+
+suggest:
+  keywords:
+    - agent guild
+    - agentguild
+  hosts:
+    - agent-guild-5d5r.onrender.com
+
+post_install: |
+  Start a new Hermes session. Two free tools are preselected; no account,
+  API key, local server, or payment is needed for them.
+
+  guild_preflight(url=...) asks Agent Guild to inspect a public endpoint
+  you choose. The URL is sent to Agent Guild. Do not supply internal URLs
+  or URLs containing credentials. Report observations and unknowns; an
+  unsigned endpoint observation is not proof of identity, authorization,
+  task quality, or safety. This does not intercept other tool calls.
+
+  guild_paid_operations() reads current prices and callable entrypoints
+  for additional paid operations; this lookup itself is free. Calling
+  paid operations is separate. GET /check is not a free lookup.
+
+  Run `hermes mcp configure agentguild` to review the enabled tools.


### PR DESCRIPTION
## What does this PR do?

Hermes users considering a public remote provider can obtain a fresh endpoint observation through Agent Guild before delegation. This adds a URL-only catalog entry and a short usage guide. Only `guild_preflight` and `guild_paid_operations` are preselected; both are free without an account or key. The latter reads current prices, without purchasing anything.

The guide explains that the chosen URL is sent to Agent Guild and that observations do not prove identity, authorization, task quality, or safety. This is an ordinary MCP tool integration, not a runtime guard. I maintain Agent Guild; acceptance into the catalog remains the maintainers' decision.

## Related Issue

No linked issue. The MCP documentation explicitly invites catalog PRs under `optional-mcps/`. Exact AgentTanuki, agentguild and canonical-origin searches found no existing issue or PR.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `optional-mcps/agentguild/manifest.yaml`: HTTP transport, no credentials or bootstrap, two free defaults, brand-specific suggestions and focused setup notes.
- `optional-mcps/agentguild/README.md`: use case, direct configuration, URL disclosure and observation/payment boundaries.

## How to Test

1. Run the catalog parser against the entry and inspect the resulting URL-only server configuration.
2. Install the entry in an isolated Hermes profile. Confirm that the two free tools are preselected and that retaining them writes `tools.include`.
3. Start a fresh session and call `guild_paid_operations` without credentials to verify the free price lookup. Any endpoint preflight should use an explicitly chosen public test endpoint.

Completed on macOS with Python 3.12:

- `scripts/run_tests.sh -j 1 --file-timeout 90 --file-retries 0 tests/hermes_cli/test_mcp_catalog.py -q`: 35 passed, including validation of the new manifest alongside the existing catalog.
- Two additional local cases through the same wrapper installed the actual candidate and read its saved configuration through real Hermes imports in temporary profiles. Successful discovery used a retained current 43-tool response; failed discovery used `None`. Both preserved the two free defaults and created no credential file. No provider was invoked.
- Nine supporting isolated catalog checks covered interactive defaults, preserved user choices and the existing empty-discovery boundary.
- September 11 first-party `initialize` and `tools/list` returned HTTP200 and confirmed both tool names/input schemas. No tool invocation or payment was needed for this check.

The full repository suite, model-driven session, and provider execution are not claimed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing PRs to make sure this is not a duplicate.
- [x] The proposed change contains only related catalog/usage files.
- [ ] I've run `pytest tests/ -q` and all tests pass.
- [ ] I've added upstream tests for my changes.
- [x] I've tested catalog installation on macOS using isolated temporary profiles.

### Documentation & Housekeeping

- [x] Relevant usage documentation is included.
- [x] Config keys, architecture, tool behavior and schemas are unchanged; corresponding examples/guides are N/A.
- [x] This declarative HTTP entry adds no platform-specific process or filesystem behavior.

## Screenshots / Logs

Focused validation is described above. Catalog defaults are preselection hints, not a payment policy; explicit user choices and existing selections retain their normal Hermes behavior.
