### PR TITLE
feat(gateway): relay MCP OAuth callbacks from messaging chats

### DIFF
--- a/gateway/control_socket.py
+++ b/gateway/control_socket.py
@@ -124,7 +124,8 @@ class GatewayControlServer:
     because its control socket couldn't bind; consumers fall back to the scan layer."""
 
     def __init__(self, home: Optional[Path] = None, *,
-                 verb_handlers: Optional[dict[str, Callable[[], dict[str, Any]]]] = None) -> None:
+                 verb_handlers: Optional[dict[str, Callable[[], dict[str, Any]]]] = None,
+                 request_handlers: Optional[dict[str, Callable[[dict], dict]]] = None) -> None:
         if home is None:
             from gateway.status import _get_process_hermes_home
             home = _get_process_hermes_home()
@@ -135,6 +136,7 @@ class GatewayControlServer:
         self._pointer_file: Optional[Path] = None
         self._handlers: dict[str, Callable[[], dict[str, Any]]] = {
             "identify": build_identify_payload, "status": build_status_payload, **(verb_handlers or {})}
+        self._request_handlers = request_handlers or {}
 
     async def start(self) -> bool:
         """Bind and start serving. Returns True on success, False otherwise."""
@@ -206,9 +208,20 @@ class GatewayControlServer:
                 raise ValueError("request must be a JSON object")
             request_id, verb = request.get("id"), request.get("verb")
             handler = self._handlers.get(verb) if isinstance(verb, str) else None
-            if handler is None:
+            request_handler = self._request_handlers.get(verb) if isinstance(verb, str) else None
+            if request_handler is not None:
+                params = request.get("params", {})
+                if not isinstance(params, dict):
+                    raise ValueError("params must be an object")
+                try:
+                    result = request_handler(params)
+                    response = {"ok": True, "protocol": CONTROL_PROTOCOL_VERSION, "result": result}
+                except Exception:
+                    response = {"ok": False, "error": "Control request rejected", "protocol": CONTROL_PROTOCOL_VERSION}
+            elif handler is None:
                 response: dict[str, Any] = {"ok": False, "error": f"unknown verb: {verb!r}",
-                                            "protocol": CONTROL_PROTOCOL_VERSION, "supported_verbs": sorted(self._handlers)}
+                                            "protocol": CONTROL_PROTOCOL_VERSION,
+                                            "supported_verbs": sorted(self._handlers.keys() | self._request_handlers.keys())}
             else:
                 response = {"ok": True, "protocol": CONTROL_PROTOCOL_VERSION, "result": handler()}
         except Exception as exc:
@@ -264,11 +277,13 @@ class _PipeControlProtocol(asyncio.Protocol):
                 self._transport.close()
 
 
-def query_gateway_control(home: Path, verb: str, *, timeout: float = _DEFAULT_CLIENT_TIMEOUT) -> Optional[dict[str, Any]]:
+def query_gateway_control(home: Path, verb: str, *, timeout: float = _DEFAULT_CLIENT_TIMEOUT,
+                          params: Optional[dict] = None) -> Optional[dict[str, Any]]:
     """Ask the gateway serving ``home`` a control verb; returns its ``result`` payload. Any failure (no/stale
     socket, timeout, malformed answer, ``ok: false``) returns None so callers fall back to the scan layer.
     Never raises."""
-    request = json.dumps({"verb": verb, "id": 1, "protocol": CONTROL_PROTOCOL_VERSION}).encode("utf-8") + b"\n"
+    request = json.dumps({"verb": verb, "id": 1, "protocol": CONTROL_PROTOCOL_VERSION,
+                          **({"params": params} if params is not None else {})}).encode("utf-8") + b"\n"
     query = _query_windows_pipe if _IS_WINDOWS else _query_unix_socket
     try:
         raw = query(Path(home), request, timeout)

--- a/gateway/mcp_oauth.py
+++ b/gateway/mcp_oauth.py
@@ -1,0 +1,314 @@
+"""Off-turn MCP browser callbacks. The SDK owns OAuth; the gateway owns identity.
+
+Pending secrets live only in memory. Restart requires a new attempt. Tokens are
+staged until token exchange succeeds and the attempt is still live.
+"""
+from __future__ import annotations
+
+import asyncio
+import copy
+import re
+import secrets
+import threading
+import time
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+
+def principal(source, home):
+    return (str(Path(home).resolve()), source.profile, source.platform.value,
+            source.scope_id, source.chat_id, source.thread_id, source.user_id)
+
+
+def callback_candidate(text):
+    # Deliberately broader than acceptance: malformed/orphan callbacks are also
+    # secrets, and must never become a model turn. No URL fetching occurs here.
+    from tools.mcp_oauth_redact import contains_oauth_parameters
+    return isinstance(text, str) and (contains_oauth_parameters(text) or bool(re.search(
+        r"(?i)https?://(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?/[^\s]*callback", text)))
+
+
+def callback_url(text):
+    """Remove only lossless chat autolink envelopes; never extract a URL from prose."""
+    if text.startswith("<") and text.endswith(">"):
+        inner = text[1:-1]
+        target, separator, label = inner.partition("|")
+        if not separator or label == target:
+            return target.replace("&amp;", "&")
+    return text
+
+
+def _query(url):
+    if (not isinstance(url, str) or len(url) > 16384 or
+            re.search(r"[\s\x00-\x1f\x7f]|%(?![0-9a-fA-F]{2})", url)):
+        raise ValueError("Invalid OAuth URL")
+    parsed = urlsplit(url)
+    if parsed.fragment or parsed.username or parsed.password:
+        raise ValueError("Invalid OAuth URL")
+    values = parse_qs(parsed.query, keep_blank_values=True, strict_parsing=True,
+                      encoding="utf-8", errors="strict", max_num_fields=32)
+    if any(len(v) != 1 for v in values.values()):
+        raise ValueError("Invalid OAuth URL")
+    for key in ("code", "state"):
+        if key in values and (not values[key][0].isascii() or
+                              re.search(r"[\x00-\x20\x7f]", values[key][0])):
+            raise ValueError("Invalid OAuth URL")
+    return parsed, {k: v[0] for k, v in values.items()}
+
+
+class MessagingOAuthFlow(DashboardOAuthFlow):
+    def __init__(self, source, home, server, redirect_uri):
+        super().__init__(secrets.token_hex(16), server, source.profile, home, redirect_uri)
+        self.source = copy.copy(source)
+        self.owner = principal(source, home)
+        self.deadline = time.monotonic() + 300
+        self._lock = threading.RLock()
+        self.credentials_committed = False
+
+    def __repr__(self):
+        return f"MessagingOAuthFlow(status={self.status!r})"
+
+    def check_live(self):
+        if self.status in {"error", "approved"}:
+            raise RuntimeError("OAuth attempt ended")
+        if time.monotonic() >= self.deadline:
+            raise TimeoutError("OAuth attempt expired")
+
+    async def publish_authorization_url(self, url):
+        parsed, values = _query(url)
+        if (parsed.scheme != "https" or not parsed.hostname or
+                values.get("redirect_uri") != self.redirect_uri or not values.get("state")):
+            raise ValueError("Invalid authorization URL")
+        def publish():
+            with self._lock:
+                self.check_live()
+                if self.expected_state is not None:
+                    raise RuntimeError("OAuth attempt already published its authorization URL")
+                asyncio.run(super(MessagingOAuthFlow, self).publish_authorization_url(url))
+        await asyncio.to_thread(publish)
+
+    def deliver_url(self, source, home, url):
+        try:
+            parsed, values = _query(url)
+            expected = urlsplit(self.redirect_uri)
+            if (principal(source, home) != self.owner or
+                    (parsed.scheme, parsed.netloc, parsed.path) !=
+                    (expected.scheme, expected.netloc, expected.path) or
+                    bool(values.get("code")) == bool(values.get("error")) or
+                    ("code" in values and "error" in values)):
+                return False
+            with self._lock:
+                self.check_live()
+                # Never propagate provider-controlled error_description/error text.
+                self.deliver_callback(code=values.get("code"), state=values.get("state"),
+                                      error="Authorization declined" if values.get("error") else None)
+            return True
+        except (ValueError, RuntimeError, TimeoutError, UnicodeError):
+            return False
+
+    async def wait_for_callback(self, timeout=300):
+        def check():
+            with self._lock:
+                self.check_live()
+        await asyncio.to_thread(check)
+        result = await super().wait_for_callback(min(timeout, max(0, self.deadline - time.monotonic())))
+        await asyncio.to_thread(check)
+        return result
+
+    def cancel(self):
+        with self._lock:
+            if not self.credentials_committed:
+                self.mark_error("OAuth attempt cancelled")
+
+    def mark_error(self, error):
+        # Exception strings may contain callback URLs, codes or provider bodies.
+        super().mark_error("OAuth connection failed or cancelled. Start a new login.")
+
+
+async def intercept_callback(runner, event):
+    from tools.mcp_oauth_redact import redact_oauth_log
+    # Later messages can quote platform history containing an earlier callback.
+    # Scrub those context fields even when this message is ordinary conversation.
+    for field in ("channel_context", "reply_to_text"):
+        value = getattr(event, field, None)
+        if isinstance(value, str):
+            setattr(event, field, redact_oauth_log(value))
+    if not callback_candidate(event.text):
+        return False
+    raw = callback_url(event.text)
+    event.text = "[OAuth callback redacted]"
+    event.raw_message = None
+    event.metadata = {}
+    if event.internal or not event.allow_gateway_control or event.source.is_bot:
+        return True
+    relay = getattr(runner, "_mcp_oauth_relay", None) if runner is not None else None
+    if isinstance(relay, MessagingOAuthRelay):
+        await relay.deliver(event.source, raw)
+    return True
+
+
+class MessagingOAuthRelay:
+    def __init__(self, runner):
+        self.runner = runner
+        self.loop = asyncio.get_running_loop()
+        self.attempts = {}
+        self.tasks = set()
+        self.closed = False
+
+    def request(self, params):
+        """Local control socket entry. Resolve origin from the gateway, never a
+        caller-supplied chat destination. The OS-user-owned socket is trusted like
+        the existing terminal/config surface; it is not a remote auth endpoint.
+        """
+        from gateway.run import _profile_runtime_scope
+        from gateway.slash_access import policy_for_source
+        from hermes_cli.mcp_config import _get_mcp_servers
+        from hermes_cli.mcp_security import validate_mcp_server_entry
+        required = ("session_id", "user_id", "home", "server")
+        if any(not isinstance(params.get(k), str) or not params[k] for k in required):
+            raise ValueError("Missing OAuth origin")
+        entry = self.runner.session_store.lookup_by_session_id(params["session_id"])
+        source = entry.origin if entry else None
+        if (source is None or source.user_id != params["user_id"] or
+                not self.runner._is_user_authorized_for_source(source)):
+            raise ValueError("Invalid OAuth origin")
+        policy = policy_for_source(self.runner.config, source)
+        if policy.enabled and not policy.is_admin(source.user_id):
+            raise ValueError("MCP configuration is restricted")
+        home = self.runner._resolve_profile_home_for_source(source)
+        if Path(home).resolve() != Path(params["home"]).resolve():
+            raise ValueError("Invalid OAuth profile")
+        server = params["server"]
+        if not re.fullmatch(r"[A-Za-z0-9_-]{1,128}", server):
+            raise ValueError("Invalid MCP server name")
+        action = params.get("action", "start")
+        if action not in {"start", "cancel"}:
+            raise ValueError("Invalid OAuth operation")
+        with _profile_runtime_scope(home):
+            cfg = _get_mcp_servers().get(server)
+        if params.get("url"):
+            if cfg is not None:
+                raise ValueError("MCP server already configured")
+            cfg = {"url": params["url"], "auth": "oauth"}
+        if action == "start" and (not isinstance(cfg, dict) or cfg.get("auth") != "oauth"
+                                  or not cfg.get("url") or validate_mcp_server_entry(server, cfg)):
+            raise ValueError("Configure an OAuth MCP server first")
+
+        async def execute():
+            try:
+                if action == "cancel":
+                    attempt = self.attempts.get((str(Path(home).resolve()), server))
+                    if attempt is not None and attempt.owner == principal(source, home):
+                        await asyncio.to_thread(attempt.cancel)
+                else:
+                    self.start(source, home, server, cfg)
+            except Exception:
+                try:
+                    await self.notify(source, "OAuth login could not start. Check the server configuration or cancel its active login.")
+                except Exception:
+                    pass
+        def schedule():
+            task = asyncio.create_task(execute())
+            self.tasks.add(task)
+            task.add_done_callback(self.tasks.discard)
+        self.loop.call_soon_threadsafe(schedule)
+        return {"status": "queued"}
+
+    def start(self, source, home, server, cfg):
+        from tools.mcp_oauth import HermesTokenStorage, _cached_redirect
+        from gateway.slash_commands_login import _LOGIN_BLOCKED_PLATFORMS
+        if self.closed:
+            raise RuntimeError("Gateway OAuth relay is stopping")
+        if (not source.user_id or not source.chat_id or source.is_bot or
+                source.platform.value in _LOGIN_BLOCKED_PLATFORMS):
+            raise ValueError("OAuth requires an identified sender")
+        home = str(Path(home).resolve())
+        # Credentials are profile/server scoped, not per sender. Serialize even
+        # different principals sharing that credential slot to prevent overwrites.
+        key = (home, server)
+        if key in self.attempts:
+            raise RuntimeError("An OAuth login is already active for this server")
+        oauth = cfg.get("oauth") or {}
+        cached, _ = _cached_redirect(HermesTokenStorage(server, hermes_home=home))
+        port = int(oauth.get("redirect_port") or 8765)
+        if not 1 <= port <= 65535:
+            raise ValueError("Invalid OAuth redirect port")
+        redirect = oauth.get("redirect_uri") or cached or f"http://127.0.0.1:{port}/callback"
+        parsed = urlsplit(redirect)
+        if (parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}
+                or parsed.query or parsed.fragment or parsed.username or parsed.password):
+            raise ValueError("Messaging OAuth requires a loopback redirect")
+        attempt = MessagingOAuthFlow(source, home, server, redirect)
+        self.attempts[key] = attempt
+        task = asyncio.create_task(self._run(attempt, cfg, key))
+        self.tasks.add(task)
+        task.add_done_callback(self.tasks.discard)
+        return attempt
+
+    async def _run(self, attempt, cfg, key):
+        from gateway.mcp_oauth_worker import probe_and_commit
+        worker = asyncio.create_task(asyncio.to_thread(probe_and_commit, attempt, cfg))
+        try:
+            url = await attempt.wait_for_authorization_url(30)
+            await self.notify(attempt.source, "Open this authorization URL, then paste the exact loopback callback URL here, even if the browser cannot load it. Expires in five minutes.\n" + url)
+            await asyncio.shield(worker)
+            if attempt.status != "approved":
+                raise RuntimeError("OAuth failed")
+            await self.notify(attempt.source, "MCP connected. Start a new session to use the discovered tools.")
+        except asyncio.CancelledError:
+            await asyncio.to_thread(attempt.cancel)
+            raise
+        except Exception:
+            await asyncio.to_thread(attempt.cancel)
+            if attempt.status == "approved":
+                return  # A delivery failure does not turn a completed login into failure.
+            try:
+                message = ("OAuth credentials saved, but MCP discovery failed. Try /reload-mcp." if attempt.credentials_committed else
+                           "OAuth connection failed, expired, or was cancelled. Start a new login.")
+                await self.notify(attempt.source, message)
+            except Exception:
+                pass
+        finally:
+            # The worker sees the cancelled flow and cannot commit staged tokens.
+            # Keep ownership until it unwinds, including cancellation during I/O.
+            try:
+                await asyncio.shield(worker)
+            except (Exception, asyncio.CancelledError):
+                pass
+            if self.attempts.get(key) is attempt:
+                self.attempts.pop(key, None)
+
+    async def notify(self, source, text):
+        adapter = self.runner._adapter_for_source(source)
+        if adapter is None:
+            raise RuntimeError("Messaging transport unavailable")
+        metadata = dict(self.runner._thread_metadata_for_source(source) or {})
+        metadata["_interim_send"] = True
+        result = await adapter.send(source.chat_id, text, metadata=metadata)
+        if not result or not result.success:
+            raise RuntimeError("Messaging delivery failed")
+
+    async def deliver(self, source, url):
+        accepted = False
+        try:
+            if not self.runner._is_user_authorized_for_source(source):
+                return
+            home = self.runner._resolve_profile_home_for_source(source)
+            for attempt in tuple(self.attempts.values()):
+                if await asyncio.to_thread(attempt.deliver_url, source, home, url):
+                    accepted = True
+                    break
+            await self.notify(source, "OAuth callback accepted; connecting." if accepted else
+                              "OAuth callback rejected. Use the exact URL in the originating chat during an active login.")
+        except Exception:
+            # Transport exceptions may embed the original payload. Never log them.
+            return
+
+    async def close(self):
+        self.closed = True
+        await asyncio.gather(*(asyncio.to_thread(attempt.cancel)
+                               for attempt in tuple(self.attempts.values())))
+        for task in self.tasks:
+            task.cancel()

--- a/gateway/mcp_oauth_worker.py
+++ b/gateway/mcp_oauth_worker.py
@@ -1,0 +1,85 @@
+"""Reuse Hermes' SDK probe; isolate uncommitted credentials from live profiles."""
+import asyncio
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+def probe_and_commit(flow, cfg):
+    from gateway.run import _profile_runtime_scope
+    from hermes_cli.mcp_config import _probe_single_server, _get_mcp_servers, _save_mcp_server, _resolve_mcp_server_config
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    from tools.mcp_dashboard_oauth import dashboard_oauth_flow
+    from tools.mcp_oauth import HermesTokenStorage, force_interactive_oauth, suppress_interactive_oauth
+    from tools.mcp_oauth_manager import get_manager
+    from tools.mcp_tool_discovery import discover_mcp_tools, _clear_connect_failure
+    from tools.mcp_tool_loop import reconnect_mcp_server, _wait_for_server_session_ready
+    from tools import mcp_tool
+
+    home = Path(flow.owner[0])
+    try:
+        with _profile_runtime_scope(home):
+            original_cfg = _get_mcp_servers().get(flow.server_name)
+            if original_cfg is not None and original_cfg != cfg:
+                raise RuntimeError("MCP configuration changed before login started")
+            target = HermesTokenStorage(flow.server_name, hermes_home=home)
+            original_tokens = target.snapshot()
+            resolved = _resolve_mcp_server_config(cfg)
+            with TemporaryDirectory(prefix="mcp-oauth-") as staging:
+                staged = HermesTokenStorage(flow.server_name, hermes_home=staging)
+                client = asyncio.run(target.get_client_info())
+                if client is not None:
+                    asyncio.run(staged.set_client_info(client))
+                token = set_hermes_home_override(staging)
+                try:
+                    with force_interactive_oauth(), dashboard_oauth_flow(flow):
+                        _probe_single_server(flow.server_name, resolved, connect_timeout=300)
+                    tokens = asyncio.run(staged.get_tokens())
+                    client = asyncio.run(staged.get_client_info())
+                    metadata = staged.load_oauth_metadata()
+                    if tokens is None or client is None:
+                        raise RuntimeError("OAuth did not produce credentials")
+                finally:
+                    get_manager().remove(flow.server_name, hermes_home=staging)
+                    reset_hermes_home_override(token)
+                with flow._lock:
+                    flow.check_live()
+                    with mcp_tool._lock:
+                        scope = mcp_tool._mcp_registry_scope()
+                        if (flow.server_name in mcp_tool._servers and
+                                (mcp_tool._server_scope_keys.get(flow.server_name) != scope or
+                                 mcp_tool._server_tool_scopes.get(flow.server_name, set()) - {scope})):
+                            raise RuntimeError("MCP server name is already used by another profile")
+                    if (_get_mcp_servers().get(flow.server_name) != original_cfg or
+                            target.snapshot() != original_tokens):
+                        raise RuntimeError("MCP configuration or credentials changed during login")
+                    # Token is the commit marker. Cancellation after this commit
+                    # does not revoke an already completed authorization.
+                    try:
+                        asyncio.run(target.set_client_info(client))
+                        if metadata is not None:
+                            target.save_oauth_metadata(metadata)
+                        asyncio.run(target.set_tokens(tokens))
+                        if original_cfg != cfg and not _save_mcp_server(flow.server_name, cfg):
+                            raise RuntimeError("Could not save MCP configuration")
+                    except Exception:
+                        target.restore(original_tokens)
+                        raise
+                    flow.credentials_committed = True
+            # Discovery updates the registry; never mutate a cached agent's tools
+            # or system prompt. Existing sessions adopt them at a fresh session.
+            with suppress_interactive_oauth():
+                with mcp_tool._lock:
+                    _clear_connect_failure(flow.server_name)
+                    old_server = mcp_tool._servers.get(flow.server_name)
+                    old_session = old_server.session if old_server else None
+                reconnect_mcp_server(flow.server_name)
+                discover_mcp_tools(allowed_mcp_names=[flow.server_name])
+                with mcp_tool._lock:
+                    server = mcp_tool._servers.get(flow.server_name)
+                if server is None or not _wait_for_server_session_ready(server, old_session=old_session):
+                    raise RuntimeError("Credentials saved but MCP discovery failed")
+            flow.mark_approved()
+    except Exception:
+        flow.mark_error("OAuth failed")
+    finally:
+        flow.mark_worker_done()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3505,6 +3505,9 @@ class BasePlatformAdapter(ABC):
         """Process an incoming message; returns quickly by spawning a background
         task so new messages (and interrupts) can arrive while an agent runs."""
         event._gateway_accepted = False
+        from gateway.mcp_oauth import intercept_callback
+        if await intercept_callback(getattr(self, "gateway_runner", None), event):
+            return
         if not self._message_handler:
             return
         if event.allow_gateway_control:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5060,8 +5060,11 @@ async def _start_gateway_start_control_socket(runner):
                 "pausing": accepted, "already_stopping": not accepted,
                 "pid": os.getpid(), "drain_timeout": _drain}
 
+        from gateway.mcp_oauth import MessagingOAuthRelay
+        runner._mcp_oauth_relay = MessagingOAuthRelay(runner)
         _control_server = GatewayControlServer(
-            verb_handlers={"pause-for-update": _pause_for_update_handler})
+            verb_handlers={"pause-for-update": _pause_for_update_handler},
+            request_handlers={"mcp-oauth": runner._mcp_oauth_relay.request})
         if not await _control_server.start():
             _control_server = None
         else:

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -115,6 +115,9 @@ class GatewayInboundMixin:
         """Ingress gates for ``_handle_message``; None when dropped, else ``(event, source, is_internal)``
         (the ``pre_gateway_dispatch`` hook may have rewritten ``event``)."""
         from gateway.run import _is_slack_ignored_channel
+        from gateway.mcp_oauth import intercept_callback
+        if await intercept_callback(self, event):
+            return None
         source = event.source
         # getattr(self, ...) throughout: bare test runners build GatewayRunner via object.__new__.
         _config = getattr(self, "config", None)

--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -1561,6 +1561,12 @@ class GatewayShutdownMixin:
         logger.info("Stopping gateway%s...", " for restart" if self._restart_requested else "")
         ctx.started_at = time.monotonic()
         self._running = False
+        relay = getattr(self, "_mcp_oauth_relay", None)
+        if relay is not None:
+            try:
+                await relay.close()
+            except Exception:
+                logger.warning("MCP OAuth shutdown failed")
         self._clear_plugin_message_injector()
         self._draining = True
         # getattr-guards: shutdown-path test doubles may lack the room worker / systemd watchdog.

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -708,6 +708,14 @@ def _reauth_oauth_server(name: str, server_config: dict, *, flow: str | None = N
 
 def cmd_mcp_login(args):
     """Run an explicit browser or device authorization for an OAuth-based MCP server."""
+    if getattr(args, "gateway", False):
+        if getattr(args, "flow", None) not in (None, "browser"):
+            raise ValueError("Messaging OAuth uses the browser authorization-code flow")
+        from hermes_cli.mcp_gateway_oauth import gateway_oauth_login
+        gateway_oauth_login(args)
+        return
+    if getattr(args, "cancel", False) or getattr(args, "url", None):
+        raise ValueError("--url and --cancel require --gateway")
     cfg = _lookup_server(args.name, _get_mcp_servers())
     if cfg is not None:
         _reauth_oauth_server(args.name, cfg, flow=getattr(args, "flow", None))

--- a/hermes_cli/mcp_gateway_oauth.py
+++ b/hermes_cli/mcp_gateway_oauth.py
@@ -1,0 +1,28 @@
+"""Start an off-turn OAuth operation on the gateway serving this terminal turn."""
+from pathlib import Path
+
+
+def gateway_oauth_login(args):
+    from gateway.control_socket import query_gateway_control
+    from gateway.session_context import get_session_env
+    from hermes_constants import get_hermes_home
+
+    session = get_session_env("HERMES_SESSION_ID")
+    user = get_session_env("HERMES_SESSION_USER_ID")
+    if not session or not user:
+        raise RuntimeError("Messaging OAuth requires a gateway-originated terminal session")
+    home = get_hermes_home()
+    params = {"session_id": session, "user_id": user, "home": str(home), "server": args.name,
+              "action": "cancel" if getattr(args, "cancel", False) else "start"}
+    if getattr(args, "url", None):
+        params["url"] = args.url
+    # Multiplex gateways own the default profile's socket, while credentials live
+    # under the routed profile. The server independently validates that mapping.
+    from hermes_cli.profiles import _get_default_hermes_home
+    homes = dict.fromkeys((Path(home), _get_default_hermes_home()))
+    for socket_home in homes:
+        result = query_gateway_control(socket_home, "mcp-oauth", params=params)
+        if result is not None:
+            print("OAuth operation queued. Authorization and completion will arrive in the originating chat.")
+            return
+    raise RuntimeError("The originating gateway is unavailable or rejected this OAuth operation")

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -55,6 +55,9 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     mcp_login_p = mcp_sub.add_parser(
         "login", help="Force re-authentication for an OAuth-based MCP server")
     mcp_login_p.add_argument("name", help="Server name to re-authenticate")
+    mcp_login_p.add_argument("--gateway", action="store_true", help="Authorize through the originating messaging chat")
+    mcp_login_p.add_argument("--url", help="Register a new OAuth MCP URL through the messaging gateway")
+    mcp_login_p.add_argument("--cancel", action="store_true", help="Cancel this chat's pending gateway OAuth login")
     mcp_login_p.add_argument(
         "--flow", choices=["browser", "device"], default=None,
         help="OAuth flow (overrides oauth.flow): browser PKCE or RFC 8628 device code")

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -115,9 +115,22 @@ def _install_session_record_factory() -> None:
     current_factory = logging.getLogRecordFactory()
     if getattr(current_factory, "_hermes_session_injector", False):
         return
+    from tools.mcp_oauth_redact import redact_oauth_log
 
     def _session_record_factory(*args, **kwargs):
         record = current_factory(*args, **kwargs)
+        message = record.getMessage()
+        redacted = redact_oauth_log(message)
+        if redacted != message:
+            record.msg, record.args = redacted, ()
+        if record.exc_info:
+            import traceback
+            exception = "".join(traceback.format_exception(*record.exc_info))
+            redacted_exception = redact_oauth_log(exception)
+            if redacted_exception != exception:
+                # Retain benign exception metadata for filters; a secret-bearing
+                # traceback must not remain available to third-party handlers.
+                record.exc_text, record.exc_info = redacted_exception, None
         sid = getattr(_session_context, "session_id", None)
         record.session_tag = f" [{sid}]" if sid else ""  # type: ignore[attr-defined]
         # QueueListener formats on its own thread, after the profile-scoped

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3420,7 +3420,8 @@ class SlackAdapter(BasePlatformAdapter):
         key = self._workspace_thread_key(team_id, channel_id, thread_ts)
         if not key or key in self._titled_assistant_threads:
             return
-        title = re.sub(r"\s+", " ", title_source).strip()
+        from tools.mcp_oauth_redact import redact_oauth_log
+        title = re.sub(r"\s+", " ", redact_oauth_log(title_source)).strip()
         if not title or title.startswith("/"):
             return
         title = title[:77].rstrip() + "..." if len(title) > 80 else title

--- a/tests/gateway/test_mcp_oauth_relay.py
+++ b/tests/gateway/test_mcp_oauth_relay.py
@@ -1,0 +1,308 @@
+"""The pasted redirect is control traffic, never a conversation turn."""
+import asyncio
+from dataclasses import replace
+from urllib.parse import urlencode
+
+import pytest
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+def source(**changes):
+    return replace(SessionSource(platform=Platform.TELEGRAM, chat_id="chat", user_id="alice"), **changes)
+
+
+def test_oauth_parameters_are_redacted_before_log_handlers(caplog):
+    import logging
+    import hermes_logging
+    with caplog.at_level(logging.WARNING):
+        logging.getLogger("transport").warning("inbound %s", "http://localhost/callback?code=PRIVATECODE&state=PRIVATESTATE")
+        logging.getLogger("transport").warning("inbound %s", "http://localhost/callback?%63ode=PRIVATECODE&amp;%73tate=PRIVATESTATE")
+        logging.getLogger("transport").warning("inbound %s", "code=PRIVATECODE&state=PRIVATESTATE")
+        logging.getLogger("transport").warning("inbound %s", "https://invalid.example/%23code=PRIVATECODE%26state=PRIVATESTATE")
+    assert "PRIVATECODE" not in caplog.text
+    assert "PRIVATESTATE" not in caplog.text
+
+
+def test_control_socket_forwards_structured_request_without_exposing_payload(tmp_path):
+    import json
+    from gateway.control_socket import GatewayControlServer
+    received = []
+    server = GatewayControlServer(tmp_path, request_handlers={
+        "mcp-oauth": lambda data: received.append(data) or {"status": "started"}})
+    result = json.loads(server.handle_request_line(json.dumps({
+        "verb": "mcp-oauth", "params": {"server": "reports", "session_id": "s"}}).encode()))
+    assert result["result"] == {"status": "started"}
+    assert received == [{"server": "reports", "session_id": "s"}]
+    rejected = json.loads(server.handle_request_line(b'{"verb":"unknown"}'))
+    assert "mcp-oauth" in rejected["supported_verbs"]
+
+
+def flow(tmp_path):
+    from gateway.mcp_oauth import MessagingOAuthFlow
+    return MessagingOAuthFlow(source(), str(tmp_path), "reports", "http://127.0.0.1:8765/callback")
+
+
+async def publish(attempt):
+    await attempt.publish_authorization_url("https://idp.example/authorize?" + urlencode({
+        "state": "secret-state", "redirect_uri": attempt.redirect_uri,
+    }))
+
+
+@pytest.mark.asyncio
+async def test_exact_callback_reaches_same_attempt_once(tmp_path):
+    attempt = flow(tmp_path)
+    await publish(attempt)
+    url = attempt.redirect_uri + "?code=secret-code&state=secret-state"
+    assert attempt.deliver_url(source(), str(tmp_path), url)
+    assert not attempt.deliver_url(source(), str(tmp_path), url)
+    assert await attempt.wait_for_callback() == ("secret-code", "secret-state")
+    assert "secret" not in repr(attempt)
+
+
+@pytest.mark.asyncio
+async def test_transport_link_envelopes_preserve_exact_callback(tmp_path):
+    from gateway.mcp_oauth import callback_url
+    valid = "http://127.0.0.1:8765/callback?code=secret-code&state=secret-state"
+    assert callback_url("<" + valid + ">") == valid
+    assert callback_url("<" + valid + "|" + valid + ">") == valid
+    assert callback_url("<" + valid + "|different>") != valid
+
+
+@pytest.mark.asyncio
+async def test_rejects_foreign_principals_and_malformed_redirects(tmp_path):
+    attempt = flow(tmp_path)
+    await publish(attempt)
+    valid = attempt.redirect_uri + "?code=secret-code&state=secret-state"
+    for other in (source(user_id="mallory"), source(chat_id="other"),
+                  source(profile="other"), source(thread_id="other"), source(scope_id="other")):
+        assert not attempt.deliver_url(other, str(tmp_path), valid)
+    assert not attempt.deliver_url(source(), str(tmp_path / "other"), valid)
+    for bad in (valid.replace("secret-state", "wrong"), valid + "&state=secret-state",
+                valid + "#fragment", valid.replace("127.0.0.1", "evil.example"),
+                valid.replace("8765", "9999"), valid.replace("/callback", "/elsewhere"),
+                "prefix " + valid, valid + "&code=other", valid + "&error=denied",
+                valid.replace("secret-code", "%ZZ"), valid.replace("secret-code", "%0a"),
+                valid.replace("secret-state", "%C3%A9"), valid.replace("secret-code", "")):
+        assert not attempt.deliver_url(source(), str(tmp_path), bad)
+    assert attempt.deliver_url(source(), str(tmp_path), valid)
+
+
+@pytest.mark.asyncio
+async def test_expiry_and_cancellation_reject_late_callback(tmp_path):
+    attempt = flow(tmp_path)
+    await publish(attempt)
+    attempt.deadline = 0
+    assert not attempt.deliver_url(source(), str(tmp_path), attempt.redirect_uri + "?code=c&state=secret-state")
+    with pytest.raises((TimeoutError, RuntimeError)):
+        await attempt.wait_for_callback()
+    attempt = flow(tmp_path)
+    await publish(attempt)
+    attempt.cancel()
+    assert not attempt.deliver_url(source(), str(tmp_path), attempt.redirect_uri + "?code=c&state=secret-state")
+    with pytest.raises(RuntimeError):
+        await attempt.wait_for_callback()
+
+
+@pytest.mark.asyncio
+async def test_base_ingress_drops_orphan_callback_before_busy_queue(tmp_path):
+    from unittest.mock import AsyncMock
+    from gateway.platforms.base import BasePlatformAdapter, MessageEvent
+    # Exercise the shared ingress with a minimal adapter, including an active agent.
+    class Adapter(BasePlatformAdapter):
+        async def connect(self): return True
+        async def disconnect(self): pass
+        async def send(self, *args, **kwargs): pass
+        async def get_chat_info(self, chat_id): return {}
+    from gateway.config import PlatformConfig
+    adapter = Adapter(PlatformConfig(), Platform.TELEGRAM)
+    adapter._message_handler = AsyncMock()
+    adapter._start_session_processing = lambda *args: pytest.fail("callback became a turn")
+    event = MessageEvent(text="http://127.0.0.1:8765/callback?code=SECRET&state=STATE", source=source())
+    await adapter.handle_message(event)
+    assert event.text == "[OAuth callback redacted]"
+    adapter._message_handler.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("finish", ["success", "cancel", "restart", "expiry"])
+async def test_relay_runs_real_oauth_exchange_and_discovery(tmp_path, monkeypatch, finish):
+    import base64
+    import hashlib
+    import json
+    import threading
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+    from urllib.parse import parse_qs, urlsplit
+    from gateway.mcp_oauth import MessagingOAuthRelay
+    from tools.mcp_oauth import HermesTokenStorage
+    from hermes_cli.mcp_config import _save_mcp_server, _get_mcp_servers
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    observed = {}
+    token_entered = threading.Event()
+    token_release = threading.Event()
+
+    class Provider(BaseHTTPRequestHandler):
+        def log_message(self, *args): pass
+        def reply(self, value, status=200, **headers):
+            body = json.dumps(value).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            for key, value in headers.items(): self.send_header(key, value)
+            self.end_headers()
+            self.wfile.write(body)
+        def do_GET(self):
+            if "oauth-protected-resource" in self.path:
+                self.reply({"resource": endpoint, "authorization_servers": [issuer]})
+            elif "well-known" in self.path:
+                self.reply({"issuer": issuer, "authorization_endpoint": "https://idp.example/authorize",
+                            "token_endpoint": issuer + "/token", "registration_endpoint": issuer + "/register",
+                            "response_types_supported": ["code"], "code_challenge_methods_supported": ["S256"],
+                            "grant_types_supported": ["authorization_code", "refresh_token"]})
+            else: self.reply({}, 405)
+        def do_DELETE(self): self.reply({})
+        def do_POST(self):
+            body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            if self.path == "/register":
+                registration = json.loads(body)
+                observed["registration"] = registration
+                self.reply({**registration, "client_id": "hermes-test"}, 201)
+            elif self.path == "/token":
+                observed["token"] = parse_qs(body.decode())
+                token_entered.set()
+                assert token_release.wait(15)
+                self.reply({"access_token": "private-token", "token_type": "Bearer", "expires_in": 3600})
+            elif self.headers.get("Authorization") != "Bearer private-token":
+                self.reply({}, 401, **{"WWW-Authenticate": 'Bearer resource_metadata="' + issuer + '/.well-known/oauth-protected-resource"'})
+            else:
+                req = json.loads(body)
+                if "id" not in req: self.reply({}, 202); return
+                result = ({"protocolVersion": "2025-06-18", "capabilities": {"tools": {}},
+                           "serverInfo": {"name": "fixture", "version": "1"}} if req["method"] == "initialize"
+                          else {"tools": [{"name": "hello", "description": "Hello", "inputSchema": {"type": "object"}}]})
+                self.reply({"jsonrpc": "2.0", "id": req["id"], "result": result})
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Provider)
+    issuer = f"http://127.0.0.1:{server.server_port}"
+    endpoint = issuer + "/mcp"
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    from gateway.platforms.base import BasePlatformAdapter
+    from gateway.config import PlatformConfig
+    class Adapter(BasePlatformAdapter):
+        async def connect(self): return True
+        async def disconnect(self): pass
+        async def send(self, *args, **kwargs): pass
+        async def get_chat_info(self, chat_id): return {}
+    adapter = Adapter(PlatformConfig(), Platform.TELEGRAM)
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=True))
+    adapter._message_handler = AsyncMock()
+    runner = SimpleNamespace(_adapter_for_source=lambda src: adapter,
+                             _thread_metadata_for_source=lambda src: {},
+                             _is_user_authorized_for_source=lambda src: True,
+                             _resolve_profile_home_for_source=lambda src: tmp_path)
+    from gateway.config import GatewayConfig
+    from gateway.session import SessionStore
+    runner.config = GatewayConfig()
+    runner.session_store = SessionStore(tmp_path / "sessions", runner.config)
+    entry = runner.session_store.get_or_create_session(source())
+    adapter.gateway_runner = runner
+    relay = MessagingOAuthRelay(runner)
+    runner._mcp_oauth_relay = relay
+    cfg = {"url": endpoint, "auth": "oauth"}
+    from tools.mcp_tool_discovery import _note_connect_failure
+    _note_connect_failure("reports", RuntimeError("OAuth required"))
+    if finish != "success":
+        assert _save_mcp_server("reports", cfg)
+        from mcp.shared.auth import OAuthToken
+        await HermesTokenStorage("reports").set_tokens(OAuthToken(access_token="old-token", token_type="Bearer"))
+    from gateway.control_socket import GatewayControlServer
+    control = GatewayControlServer(tmp_path, request_handlers={"mcp-oauth": relay.request})
+    assert await control.start()
+    try:
+        from gateway.control_socket import query_gateway_control
+        params = {"session_id": entry.session_id, "user_id": "alice", "home": str(tmp_path), "server": "reports"}
+        for key, value in (("session_id", "foreign-session"), ("user_id", "mallory"), ("home", str(tmp_path / "foreign"))):
+            assert await asyncio.to_thread(query_gateway_control, tmp_path, "mcp-oauth", params={**params, key: value}) is None
+        assert not relay.attempts
+        from gateway.session_context import set_session_vars
+        from hermes_cli.mcp_gateway_oauth import gateway_oauth_login
+        set_session_vars(platform="telegram", user_id="alice", session_id=entry.session_id)
+        if finish == "success":
+            import os
+            import subprocess
+            import sys
+            result = await asyncio.to_thread(subprocess.run,
+                [sys.executable, "-m", "hermes_cli.main", "mcp", "login", "reports", "--gateway", "--url", endpoint],
+                env={**os.environ, "HERMES_HOME": str(tmp_path), "HERMES_SESSION_ID": entry.session_id,
+                     "HERMES_SESSION_USER_ID": "alice"}, capture_output=True, text=True, timeout=20)
+            assert result.returncode == 0, result.stderr
+            assert "queued" in result.stdout
+        else:
+            await asyncio.to_thread(gateway_oauth_login, SimpleNamespace(name="reports"))
+        await asyncio.sleep(0)
+        attempt = relay.attempts[(str(tmp_path), "reports")]
+        with pytest.raises(RuntimeError): relay.start(source(), tmp_path, "reports", cfg)
+        authorization_url = await attempt.wait_for_authorization_url(15)
+        query = parse_qs(urlsplit(authorization_url).query)
+        assert query["code_challenge_method"] == ["S256"]
+        assert query["resource"] == [endpoint]
+        callback = query["redirect_uri"][0] + "?" + urlencode({"code": "private-code", "state": query["state"][0]})
+        from gateway.platforms.base import MessageEvent
+        from gateway.mcp_oauth import intercept_callback
+        event = MessageEvent(text=callback, source=source())
+        adapter._active_sessions[adapter._event_session_key(event)] = object()
+        await adapter.handle_message(event)
+        assert event.text == "[OAuth callback redacted]"
+        adapter._message_handler.assert_not_called()
+        assert not adapter._pending_messages
+        assert await asyncio.to_thread(token_entered.wait, 10)
+        if finish == "cancel": attempt.cancel()
+        if finish == "restart": await relay.close()
+        if finish == "expiry": attempt.deadline = 0
+        token_release.set()
+        if finish == "restart":
+            await asyncio.gather(*tuple(relay.tasks), return_exceptions=True)
+            for _ in range(200):
+                if attempt.worker_done: break
+                await asyncio.sleep(0.05)
+            assert attempt.worker_done
+        else:
+            await asyncio.wait_for(asyncio.gather(*tuple(relay.tasks)), 30)
+        if finish != "success":
+            assert (await HermesTokenStorage("reports").get_tokens()).access_token == "old-token"
+            assert attempt.status == "error"
+            restarted = MessagingOAuthRelay(runner)
+            runner._mcp_oauth_relay = restarted
+            assert await intercept_callback(runner, MessageEvent(text=callback, source=source()))
+            assert "private-code" not in str(adapter.send.call_args_list)
+            return
+        assert attempt.status == "approved", attempt.error
+        token = observed["token"]
+        challenge = base64.urlsafe_b64encode(hashlib.sha256(token["code_verifier"][0].encode()).digest()).rstrip(b"=").decode()
+        assert query["code_challenge"] == [challenge]
+        assert token["redirect_uri"] == query["redirect_uri"]
+        assert token["resource"] == [endpoint]
+        assert token["code"] == ["private-code"]
+        assert query["redirect_uri"][0] in observed["registration"]["redirect_uris"]
+        assert (await HermesTokenStorage("reports").get_tokens()).access_token == "private-token"
+        from tools import mcp_tool
+        assert mcp_tool._servers["reports"].session is not None
+        assert _get_mcp_servers()["reports"] == cfg
+        notices = [call.args[1] for call in adapter.send.call_args_list]
+        assert all(call.kwargs["metadata"]["_interim_send"] for call in adapter.send.call_args_list)
+        assert any(authorization_url in text for text in notices)
+        assert any("connected" in text for text in notices)
+        assert all("private-code" not in text for text in notices)
+        assert await intercept_callback(runner, MessageEvent(text=callback, source=source()))
+    finally:
+        token_release.set()
+        await relay.close()
+        await control.stop()
+        from tools.mcp_tool_lifecycle import shutdown_mcp_servers
+        await asyncio.to_thread(shutdown_mcp_servers)
+        server.shutdown()
+        server.server_close()

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3368,6 +3368,15 @@ class TestAssistantThreadLifecycle:
         msg_event = assistant_adapter.handle_message.call_args[0][0]
         assert msg_event.metadata["slack_team_id"] == "T_TEAM"
 
+    @pytest.mark.asyncio
+    async def test_callback_is_not_copied_to_assistant_thread_title(self, assistant_adapter):
+        assistant_adapter._app.client.assistant_threads_setTitle = AsyncMock()
+        await assistant_adapter._set_assistant_thread_title(
+            "D123", "171.111", "http://localhost/callback?code=PRIVATE&state=SECRET", team_id="T_TEAM")
+        calls = assistant_adapter._app.client.assistant_threads_setTitle.call_args_list
+        assert "PRIVATE" not in str(calls)
+        assert "SECRET" not in str(calls)
+
 
 # ---------------------------------------------------------------------------
 # TestUserNameResolution

--- a/tools/mcp_oauth_redact.py
+++ b/tools/mcp_oauth_redact.py
@@ -1,0 +1,15 @@
+"""OAuth query credentials must be scrubbed before any log handler sees them."""
+import re
+
+_KEYS = "|".join("".join(f"(?:{char}|%{ord(char):02x})" for char in key)
+                 for key in ("code", "state", "error", "error_description"))
+_PARAM = re.compile(r"(?i)((?:^|&amp;|[?&#\s\"']|%3f|%26|%23)(?:" + _KEYS + r")(?:=|%3d))([^\s&#\"'<>]*)")
+_CANDIDATE = re.compile(r"(?i)(?:^|&amp;|[?&#]|%3f|%26|%23)(?:" + _KEYS + r")(?:=|%3d)")
+
+
+def contains_oauth_parameters(text):
+    return bool(_CANDIDATE.search(text))
+
+
+def redact_oauth_log(text):
+    return _PARAM.sub(r"\1[REDACTED]", text)

--- a/website/docs/guides/oauth-over-ssh.md
+++ b/website/docs/guides/oauth-over-ssh.md
@@ -44,6 +44,70 @@ If your provider isn't in the table, you don't need a tunnel.
 
 ## MCP Servers
 
+### Connect from a messaging chat
+
+Ask the agent in Slack, Telegram, or another gateway chat to run:
+
+```bash
+hermes mcp login reports --gateway --url https://mcp.example.com/mcp
+# For a server already configured in this profile:
+hermes mcp login reports --gateway
+```
+
+The command returns immediately. The gateway owns the attempt independently of
+the agent turn and sends an authorization link to the originating chat/thread.
+Open it, sign in, and approve. If the browser cannot load the loopback redirect,
+copy the **entire URL from the address bar** and paste it into the same chat/thread
+as the same user. No SSH tunnel, public callback service, or new model tool is needed.
+The gateway consumes the callback before normal message queues or agent processing.
+It sends success/failure directly; callback codes never enter the conversation.
+
+The SDK still performs protected-resource/authorization-server discovery, dynamic
+client registration, PKCE S256, resource binding, and token exchange. This follows
+the [MCP 2025-06-18 authorization flow](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)
+and changes only the transport of the browser callback. Existing client registrations
+and configured loopback redirect URIs are preserved. HTTPS/public callback URIs and
+device-code flows should use their existing CLI/dashboard paths.
+Adapters without individual sender identities cannot start a login. Multiplexed
+profiles must use distinct server names when their live MCP connections differ;
+the relay refuses to replace a connection owned by another profile.
+
+New server configuration is saved through Hermes' config API after authentication;
+tokens stay in the originating profile. Discovery reloads the MCP registry. **Start
+a new session to use new tools**; the relay does not rebuild active agents, rewrite
+their system prompts, or inject synthetic conversation messages.
+
+An attempt expires five minutes after it starts. Duplicate attempts for the same
+profile/server are refused (including another user sharing that credential slot).
+Wrong users, chats, threads, workspaces, profiles, states, redirect URIs, duplicate
+query parameters, and replayed callbacks are rejected. Only complete callback URLs
+are accepted, with lossless chat autolink formatting allowed. Codes/states are
+redacted from Hermes logs; the authorization link itself necessarily carries state
+when delivered to the user. Chat-provider retention of the user's pasted message is
+outside Hermes' control.
+
+To cancel, ask the agent to run:
+
+```bash
+hermes mcp login reports --gateway --cancel
+```
+
+Cancellation/expiry before credential commit discards staged credentials and leaves
+existing tokens intact. Cancellation after a successful commit does not revoke the
+completed authorization. Gateway shutdown cancels pending attempts; after restart,
+old callbacks are rejected and a new login is required. Pending codes/state are never
+persisted. A failed notification is not delivered through an LLM fallback.
+
+The terminal must run on the gateway host with its inherited session context and
+access to the existing local gateway control socket. The gateway resolves the
+destination from its own session store and validates the user and profile; CLI
+arguments cannot select another chat. This socket trusts the local OS account, as
+the existing terminal/config surface does. Shared installations should configure
+`allow_admin_from` / `group_allow_admin_from`: MCP credentials are shared within a
+profile, and the relay honors those existing administration policies.
+
+### Connect from a desktop or terminal
+
 **Desktop Skills → MCP:** the native app receives the callback on your computer
 and relays it to the selected connection and profile, so this flow does not need
 an SSH callback tunnel or `dashboard.public_url`. Tokens stay on the owning


### PR DESCRIPTION
## What does this PR do?

An agent in a messaging gateway can run `hermes mcp login reports --gateway --url https://mcp.example.com/mcp`. The CLI queues a gateway-owned operation and exits; the gateway sends the authorization link to the originating chat. The same user pastes the exact loopback callback URL into that chat/thread, even if the browser could not load it. The gateway consumes it off-turn, completes the existing SDK flow, saves profile credentials/config, reloads MCP discovery, and sends the outcome.

This reuses the dashboard OAuth callback bridge, SDK discovery/DCR/PKCE/token exchange, config/token storage APIs, and local control socket. No provider-specific integration, model tool, dependency, public callback endpoint, or behavioral config knob is introduced. Active agent tool snapshots and conversation prompts are not rebuilt.

## Related Issue

Tracks [ENG-1871](https://linear.app/emmabyaw/issue/ENG-1871/hermes-generic-messaging-gateway-mcp-oauth-callback-relay).

Related: #79449 adds a broader opt-in per-user credential architecture, including chat consent. This contribution retains the existing profile/server credential layout and focuses on an explicit gateway-owned CLI operation, strict paste ingress, and the cancellation/commit boundary. No code was copied from that PR.

## Type of Change

- [x] New feature
- [x] Security fix
- [x] Documentation and behavioral tests

## Changes Made

- Bind each attempt to the authenticated originating user, platform/workspace, chat/thread, profile home, server, redirect URI, and exact SDK state. Serialize the profile/server credential slot, including competing users.
- Consume callback-shaped inputs before adapter busy queues, gateway hooks, agent interruption, and transcript processing. Reject malformed, foreign, expired, and replayed callbacks; redact query credentials from logs, quoted history, and Slack thread titles.
- Retain pending code/state only in memory, expire after five minutes, and invalidate pending attempts on shutdown/restart. Token exchange uses isolated staging storage; cancellation before commit preserves existing credentials.
- Preserve SDK PKCE S256, DCR, redirect registration, and resource parameters. Clear previous discovery backoff after successful authorization and verify the live connection before reporting success.
- Add `--gateway`, `--url`, and `--cancel` to `hermes mcp login`, and document remote-host usage.

Complexity ledger: additive gateway transport/state handling and tests; zero dependencies, core model tools, provider branches, or new config settings. Existing OAuth protocol implementation remains shared.

## How to Test

The first RED run had four relay failures and four passing dashboard controls. It reproduced an orphan callback becoming a normal turn on the base branch. Subsequent RED regressions covered real discovery remaining in backoff, log redaction, and callback exposure through a Slack thread title.

```bash
scripts/run_tests.sh tests/gateway/ tests/tools/test_mcp*.py tests/hermes_cli/test_mcp*.py tests/test_hermes_logging.py -j 4 -q
scripts/run_tests.sh tests/gateway/test_mcp_oauth_relay.py tests/gateway/test_slack.py tests/test_hermes_logging.py tests/gateway/test_control_socket.py tests/gateway/test_control_socket_pause.py tests/hermes_cli/test_mcp_config.py -j 4 -q
```

Broad suite passed twice, including the final implementation: **8,932 passed, 0 failed, 47 skipped** (885 files). Focused run: **333 passed, 0 failed, 2 skipped**. After the final two review fixes, `scripts/run_tests.sh tests/gateway/test_mcp_oauth_relay.py tests/gateway/test_control_socket.py tests/test_hermes_logging.py -j 2 -q` passed **54 tests, 0 failed, 2 skipped**. The interim-message regression plus relay E2E passed **19 tests** via `scripts/run_tests.sh tests/gateway/test_mcp_oauth_relay.py tests/gateway/test_stream_final_contract.py -j 2 -q`. Ruff and `git diff --check` passed.

The network E2E uses a real local OAuth/MCP HTTP server, the real SDK, a temporary `HERMES_HOME`, persisted session routing, a real gateway control socket, a CLI subprocess, and the shared adapter ingress while a session is busy. It verifies DCR registration, authorization/token resource parameters, the S256 challenge/verifier relationship, callback code exchange, config/token persistence, and live discovery. Token-exchange barriers exercise cancellation, expiry, and gateway restart while preserving prior credentials. Transport delivery is a fake adapter transport; no real Slack/Telegram accounts or vendor credentials are used.

## Review and operational notes

Two independent CodeRabbit CLI reviews covered all 16 changed files. All seven first-pass findings and both second-pass findings were addressed: broader credential redaction (including encoded fragments), nonblocking flow locks, safe shutdown, truthful post-commit discovery status, preservation of benign logging metadata, and complete control-socket verb reporting. Sensitive exception metadata is deliberately removed before log handlers; there is no fail-open redaction fallback. Final targeted redactor re-review completed with **zero findings**.

- Tested on Linux. OS-marked skips are reported; no live Windows/macOS or real messaging-provider smoke is claimed.
- Existing profile-shared credentials remain shared. Existing administrator allowlists govern who may start login. Adapters without individual sender identity cannot start it.
- The terminal must reach the gateway's existing local control socket. Multiplex profiles must use distinct names for different simultaneously live MCP connections; replacing another profile's connection is refused.
- New tools are available to fresh sessions. After credential commit, a discovery failure is reported separately; cancellation does not revoke an already committed grant.
- The pasted message is retained by the chat provider under its own policies. Hermes consumes it off-turn and redacts credentials from its own logs/context. The authorization link delivered to the user necessarily contains state.
- No upstream merge is requested or authorized by this contribution's execution task.

## Checklist

- [x] Read the contributing and area development guides.
- [x] Searched existing work; related PR noted above.
- [x] Changes are scoped to the messaging OAuth relay.
- [x] Behavioral RED/GREEN tests and real network E2E included.
- [x] Used `scripts/run_tests.sh`; no bare pytest invocation.
- [x] Updated remote OAuth documentation.
- [x] No dependencies, tool schemas, or config defaults changed.

```text
Accountable-Owner: Harsha Vankayalapati
Accountable-Linear-ID: 142fef82-4d45-4070-99be-c5debe565ac6
Accountable-GitHub: harshmoney123
Execution-Actor: codex
Linear-Issue: ENG-1871
Automation-Run: codex-hermes-oauth-relay-20260911
```
