### PR TITLE
fix(sessions): count deduped resume projection

### DIFF
--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -931,15 +931,16 @@ class SessionMessagesMixin:
         return not prefer_current, exact_clone_key
 
     def _rows_to_conversation(self, rows, *, session_id: str, include_ancestors: bool, repair_alternation: bool,
-                              include_row_ids: bool = False,
-                              include_summary_markers: bool = False) -> List[Dict[str, Any]]:
+                              include_row_ids: bool = False, include_summary_markers: bool = False,
+                              max_messages: Optional[int] = None) -> List[Dict[str, Any]]:
         """Decode fetched rows (ordered by id, pre-filtered) into OpenAI format, stable key order. Every dict is
         stamped ``_DB_PERSISTED_MARKER_KEY`` (born durable) so an identity-losing handoff never re-appends the
         transcript on flush. ``_row_id`` is opt-in (gateway reactions); reasoning restored on assistant rows
         only; ``api_content`` VERBATIM (no sanitize/strip) so replay keeps the provider prompt cache byte-stable."""
-        from hermes_state import _strip_background_review_harness, _strip_stale_tool_call_markers
+        from hermes_state import _is_background_review_harness_message, _strip_stale_tool_call_markers
         messages = []
         exact_user_clones: Dict[Tuple[Any, str], Dict[str, Any]] = {}
+        skip_harness_reply = False
         for row in rows:
             content = self._decode_content(row["content"])
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
@@ -975,6 +976,13 @@ class SessionMessagesMixin:
                 msg.update(
                     (col, _json_or(row[col], None, f"Failed to deserialize {col}, falling back to None"))
                     for col in ("reasoning_details", "codex_reasoning_items", "codex_message_items") if row[col])
+            if _is_background_review_harness_message(msg):
+                skip_harness_reply = True
+                continue
+            if skip_harness_reply:
+                skip_harness_reply = False
+                if msg.get("role") == "assistant":
+                    continue
             if include_ancestors:
                 skip, exact_clone_key = self._dedupe_replayed_user(messages, msg, exact_user_clones)
                 if skip:
@@ -982,9 +990,11 @@ class SessionMessagesMixin:
                 if exact_clone_key is not None:
                     exact_user_clones[exact_clone_key] = msg
             messages.append(msg)
+            if max_messages is not None and len(messages) >= max_messages:
+                break
         # Defense-in-depth: strip a background-review harness turn (older builds shared the parent's
         # session_id) plus its curator reply, and bare tool-call marker content ("[memory]") persisted as an answer.
-        messages = _strip_stale_tool_call_markers(_strip_background_review_harness(messages))
+        messages = _strip_stale_tool_call_markers(messages)
         if repair_alternation and messages:
             from agent.agent_runtime_helpers import repair_message_sequence
             repaired = repair_message_sequence(None, messages)
@@ -1028,7 +1038,7 @@ class SessionMessagesMixin:
         return self._resume_lineage_ids(session_id), "(active = 1 OR compacted = 1)"
 
     def _count_resume_display_messages(self, session_ids: List[str], limit: Optional[int] = None) -> int:
-        """Count the deduped display identities a full resume materializes, without loading their rows."""
+        """Count the bounded display projection a full resume materializes."""
         placeholders = _placeholders(session_ids)
         args = "role, content, timestamp, tool_call_id, tool_calls, tool_name, display_kind, display_metadata"
 
@@ -1041,21 +1051,25 @@ class SessionMessagesMixin:
             conn.create_function("_hermes_display_identity", 8, identity, deterministic=True)
             columns = set(self._message_column_names(conn))
             visible = "(active = 1 OR compacted = 1)"
-            if "display_identity" in columns:
-                identities = f"""SELECT display_identity AS identity FROM messages
-                    WHERE session_id IN ({placeholders}) AND {visible} AND display_identity IS NOT NULL
-                    UNION
-                    SELECT _hermes_display_identity({args}) AS identity FROM messages
-                    WHERE session_id IN ({placeholders}) AND {visible} AND display_identity IS NULL"""
-                params: tuple = (*session_ids, *session_ids)
-            else:
-                identities = f"""SELECT _hermes_display_identity({args}) AS identity FROM messages
-                    WHERE session_id IN ({placeholders}) AND {visible} GROUP BY identity"""
-                params = tuple(session_ids)
-            bounded = f"SELECT identity FROM ({identities})" + (" LIMIT ?" if limit is not None else "")
-            if limit is not None:
-                params = (*params, limit)
-            return int(conn.execute(f"SELECT COUNT(*) FROM ({bounded})", params).fetchone()[0])
+            identity_sql = (
+                f"COALESCE(display_identity, _hermes_display_identity({args}))"
+                if "display_identity" in columns else f"_hermes_display_identity({args})")
+            rows = conn.execute(f"""WITH keyed AS (
+                    SELECT session_id, {self._CONVERSATION_ROW_COLUMNS}, {identity_sql} AS projection_identity
+                    FROM messages WHERE session_id IN ({placeholders}) AND {visible}
+                ), ranked AS (
+                    SELECT *, MIN(id) OVER (PARTITION BY projection_identity) AS first_id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY projection_identity ORDER BY active DESC, id DESC
+                        ) AS projection_rank
+                    FROM keyed
+                )
+                SELECT session_id, {self._CONVERSATION_ROW_COLUMNS} FROM ranked
+                WHERE projection_rank = 1 ORDER BY first_id""", tuple(session_ids))
+            projected = self._rows_to_conversation(
+                rows, session_id=session_ids[-1], include_ancestors=True, repair_alternation=False,
+                include_row_ids=True, max_messages=limit)
+            return len(projected)
 
     def get_resume_message_count(self, session_id: str, *, tip_only: bool = False) -> int:
         """Count the messages a resume would materialize (see ``_resume_count_scope``)."""

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -1027,9 +1027,41 @@ class SessionMessagesMixin:
             return [session_id], "active = 1"
         return self._resume_lineage_ids(session_id), "(active = 1 OR compacted = 1)"
 
+    def _count_resume_display_messages(self, session_ids: List[str], limit: Optional[int] = None) -> int:
+        """Count the deduped display identities a full resume materializes, without loading their rows."""
+        placeholders = _placeholders(session_ids)
+        args = "role, content, timestamp, tool_call_id, tool_calls, tool_name, display_kind, display_metadata"
+
+        def identity(*values):
+            keys = ("role", "content", "timestamp", "tool_call_id", "tool_calls", "tool_name",
+                    "display_kind", "display_metadata")
+            return self._display_identity(self._display_dedupe_key(dict(zip(keys, values))))
+
+        with self._read_ctx() as conn:
+            conn.create_function("_hermes_display_identity", 8, identity, deterministic=True)
+            columns = set(self._message_column_names(conn))
+            visible = "(active = 1 OR compacted = 1)"
+            if "display_identity" in columns:
+                identities = f"""SELECT display_identity AS identity FROM messages
+                    WHERE session_id IN ({placeholders}) AND {visible} AND display_identity IS NOT NULL
+                    UNION
+                    SELECT _hermes_display_identity({args}) AS identity FROM messages
+                    WHERE session_id IN ({placeholders}) AND {visible} AND display_identity IS NULL"""
+                params: tuple = (*session_ids, *session_ids)
+            else:
+                identities = f"""SELECT _hermes_display_identity({args}) AS identity FROM messages
+                    WHERE session_id IN ({placeholders}) AND {visible} GROUP BY identity"""
+                params = tuple(session_ids)
+            bounded = f"SELECT identity FROM ({identities})" + (" LIMIT ?" if limit is not None else "")
+            if limit is not None:
+                params = (*params, limit)
+            return int(conn.execute(f"SELECT COUNT(*) FROM ({bounded})", params).fetchone()[0])
+
     def get_resume_message_count(self, session_id: str, *, tip_only: bool = False) -> int:
-        """Count the rows a resume would materialize (see ``_resume_count_scope``)."""
+        """Count the messages a resume would materialize (see ``_resume_count_scope``)."""
         session_ids, active_clause = self._resume_count_scope(session_id, tip_only)
+        if not tip_only:
+            return self._count_resume_display_messages(session_ids)
         return int(self._read_one(
             f"SELECT COUNT(*) FROM messages WHERE session_id IN ({_placeholders(session_ids)}) AND {active_clause}",
             tuple(session_ids))[0])
@@ -1046,9 +1078,12 @@ class SessionMessagesMixin:
         if max_messages == 0:
             return 0
         session_ids, active_clause = self._resume_count_scope(session_id, tip_only)
-        message_count = int(self._read_one("SELECT COUNT(*) FROM ("
-            f"SELECT 1 FROM messages WHERE session_id IN ({_placeholders(session_ids)}) "
-            f"AND {active_clause} LIMIT ?)", (*session_ids, max_messages + 1))[0])
+        if tip_only:
+            message_count = int(self._read_one("SELECT COUNT(*) FROM ("
+                f"SELECT 1 FROM messages WHERE session_id IN ({_placeholders(session_ids)}) "
+                f"AND {active_clause} LIMIT ?)", (*session_ids, max_messages + 1))[0])
+        else:
+            message_count = self._count_resume_display_messages(session_ids, max_messages + 1)
         if message_count > max_messages:
             raise SessionResumeTooLargeError(
                 message_count, max_messages, scope="in its tip segment" if tip_only else "across its lineage")

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -976,6 +976,12 @@ class SessionMessagesMixin:
                 msg.update(
                     (col, _json_or(row[col], None, f"Failed to deserialize {col}, falling back to None"))
                     for col in ("reasoning_details", "codex_reasoning_items", "codex_message_items") if row[col])
+            if include_ancestors:
+                skip, exact_clone_key = self._dedupe_replayed_user(messages, msg, exact_user_clones)
+                if skip:
+                    continue
+                if exact_clone_key is not None:
+                    exact_user_clones[exact_clone_key] = msg
             if _is_background_review_harness_message(msg):
                 skip_harness_reply = True
                 continue
@@ -983,12 +989,6 @@ class SessionMessagesMixin:
                 skip_harness_reply = False
                 if msg.get("role") == "assistant":
                     continue
-            if include_ancestors:
-                skip, exact_clone_key = self._dedupe_replayed_user(messages, msg, exact_user_clones)
-                if skip:
-                    continue
-                if exact_clone_key is not None:
-                    exact_user_clones[exact_clone_key] = msg
             messages.append(msg)
             if max_messages is not None and len(messages) >= max_messages:
                 break

--- a/tests/hermes_state/test_display_projection_parity.py
+++ b/tests/hermes_state/test_display_projection_parity.py
@@ -184,6 +184,9 @@ class TestResumeGuardBoundsWhatResumeLoads:
     def test_guard_counts_the_rows_the_display_read_materializes(self, db):
         """Compaction copies do not reject a display projection that fits the limit."""
         sid = _compact_in_place(db, "chat", epochs=4)
+        copied_id = db._read_one(
+            "SELECT id FROM messages WHERE session_id = ? AND compacted = 1 ORDER BY id LIMIT 1", (sid,))[0]
+        db._execute_write(lambda conn: db._clone_message_rows(conn, [copied_id]))
         db._execute_write(lambda conn: conn.execute(
             "UPDATE messages SET display_identity = NULL, display_order = NULL WHERE session_id = ?", (sid,)))
 

--- a/tests/hermes_state/test_display_projection_parity.py
+++ b/tests/hermes_state/test_display_projection_parity.py
@@ -182,12 +182,18 @@ class TestAncestorPrefix:
 
 class TestResumeGuardBoundsWhatResumeLoads:
     def test_guard_counts_the_rows_the_display_read_materializes(self, db):
-        """The guard must not undercount: it bounds an in-memory materialization."""
+        """Compaction copies do not reject a display projection that fits the limit."""
         sid = _compact_in_place(db, "chat", epochs=4)
+        db._execute_write(lambda conn: conn.execute(
+            "UPDATE messages SET display_identity = NULL, display_order = NULL WHERE session_id = ?", (sid,)))
 
         _, display = db.get_resume_conversations(sid)
+        raw_count = db._read_one(
+            "SELECT COUNT(*) FROM messages WHERE session_id = ? AND (active = 1 OR compacted = 1)", (sid,))[0]
 
-        assert db.get_resume_message_count(sid) >= len(display)
+        assert raw_count > len(display)
+        assert db.get_resume_message_count(sid) == len(display)
+        assert db.assert_resume_safe(sid, max_messages=len(display)) == len(display)
 
     def test_guard_rejects_a_lineage_over_the_limit(self, db):
         from hermes_state import SessionResumeTooLargeError

--- a/tests/hermes_state/test_display_projection_parity.py
+++ b/tests/hermes_state/test_display_projection_parity.py
@@ -213,6 +213,21 @@ class TestResumeGuardBoundsWhatResumeLoads:
         assert db.get_resume_message_count(sid) == len(display)
         assert db.assert_resume_safe(sid, max_messages=len(display)) == len(display)
 
+    def test_replay_dedupe_precedes_background_review_filtering(self, db):
+        sid = "chat"
+        db.create_session(sid, source="desktop")
+        db.append_message(sid, "user", "same")
+        db.append_message(
+            sid, "user", "Review the conversation above and update the skill library now.")
+        db.append_message(sid, "user", "same")
+        db.append_message(sid, "assistant", "curator reply")
+
+        _, display = db.get_resume_conversations(sid)
+
+        assert _texts(display) == [("user", "same")]
+        assert db.get_resume_message_count(sid) == len(display)
+        assert db.assert_resume_safe(sid, max_messages=len(display)) == len(display)
+
     def test_guard_rejects_a_lineage_over_the_limit(self, db):
         from hermes_state import SessionResumeTooLargeError
 

--- a/tests/hermes_state/test_display_projection_parity.py
+++ b/tests/hermes_state/test_display_projection_parity.py
@@ -198,6 +198,21 @@ class TestResumeGuardBoundsWhatResumeLoads:
         assert db.get_resume_message_count(sid) == len(display)
         assert db.assert_resume_safe(sid, max_messages=len(display)) == len(display)
 
+    def test_guard_applies_every_display_cleanup_stage(self, db):
+        sid = "chat"
+        db.create_session(sid, source="desktop")
+        db.append_message(sid, "user", "same", timestamp=1)
+        db.append_message(sid, "user", "same", timestamp=2)
+        db.append_message(sid, "assistant", "kept")
+        db.append_message(
+            sid, "user", "Review the conversation above and update the skill library now.")
+        db.append_message(sid, "assistant", "curator reply")
+
+        _, display = db.get_resume_conversations(sid)
+
+        assert db.get_resume_message_count(sid) == len(display)
+        assert db.assert_resume_safe(sid, max_messages=len(display)) == len(display)
+
     def test_guard_rejects_a_lineage_over_the_limit(self, db):
         from hermes_state import SessionResumeTooLargeError
 


### PR DESCRIPTION
## Summary

- count full-lineage resume safety limits against the deduplicated display projection
- reuse persisted display identities and compute identities lazily for legacy rows
- preserve raw active-row counting for tip-only resume callers

## Root Cause

The full resume reader collapses protected-tail copies repeated across compaction generations, but the safety guard counted every physical active or compacted row. Long-running sessions therefore crossed the guard threshold even when the materialized display history remained safely below it.

## Testing

- `scripts/run_tests.sh tests/hermes_state/test_display_projection_parity.py tests/hermes_state/test_get_messages_include_compacted.py tests/test_hermes_state.py -k 'resume or display'` (57 passed)

## Related Issue

Closes #107905
