### PR TITLE
fix: display safety refusals without changing recovery policy

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1825,7 +1825,10 @@ def _buffer_fallback_notice(agent, notice: str) -> None:
         agent._pending_fallback_notice = [str(pending), notice] if pending else [notice]
 
 
-def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
+def try_activate_fallback(
+    agent, reason: "FailoverReason | None" = None, *,
+    display_reason: "FailoverReason | None" = None,
+) -> bool:
     """Switch to the next fallback model/provider in the chain; False when exhausted. Swaps client,
     model slug and provider in place so the retry loop continues on the new backend; client
     construction goes through resolve_provider_client (no duplicated provider→key mappings)."""
@@ -1909,7 +1912,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
             notice = (
                 f"⚠️ Model fallback: {old_model} via {old_provider} unavailable "
-                f"({_fallback_reason_text(reason)}); using {fb_model} via {fb_provider}.")
+                f"({_fallback_reason_text(display_reason if display_reason is not None else reason)}); using {fb_model} via {fb_provider}.")
             if cooldown_seconds is not None:
                 remaining = max(0, math.ceil(agent._rate_limited_until - time.monotonic()))
                 notice += f" Primary retry eligible in ~{remaining} s; recovery is not guaranteed."

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -72,6 +72,13 @@ class ClassifiedError:
     should_fallback: bool = False
 
     @property
+    def display_reason(self) -> FailoverReason:
+        """Presentation only; never use this value for recovery decisions."""
+        if "this request was blocked by our safety systems" in self.message.lower():
+            return FailoverReason.content_policy_blocked
+        return self.reason
+
+    @property
     def is_auth(self) -> bool:
         return self.reason in {FailoverReason.auth, FailoverReason.auth_permanent}
 

--- a/agent/turn_api_error.py
+++ b/agent/turn_api_error.py
@@ -307,9 +307,9 @@ def settle_unrecovered_error(
         # Announce the fallback only when a chain exists, else "trying fallback..." lies
         # before a silent abort.
         if agent._has_pending_fallback():
-            _label = _NONRETRYABLE_LABELS.get(classified.reason, f"Non-retryable error (HTTP {status_code})")
+            _label = _NONRETRYABLE_LABELS.get(classified.display_reason, f"Non-retryable error (HTTP {status_code})")
             agent._buffer_status(f"⚠️ {_label} — trying fallback...")
-        if agent._try_activate_fallback():
+        if agent._try_activate_fallback(display_reason=classified.display_reason):
             # Direct ``return _verdict("break")`` is load-bearing: the restart handler
             # re-runs the pre-API preflight against the fallback's context window.
             active_system_prompt = _arm_fallback_restart(agent, api_messages, active_system_prompt, _retry)
@@ -338,7 +338,7 @@ def settle_unrecovered_error(
             return _verdict("continue")
         if agent._has_pending_fallback():
             agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
-        if agent._try_activate_fallback():
+        if agent._try_activate_fallback(display_reason=classified.display_reason):
             # Direct ``return _verdict("break")`` is load-bearing: the restart handler
             # re-runs the pre-API preflight against the fallback's context window.
             active_system_prompt = _arm_fallback_restart(agent, api_messages, active_system_prompt, _retry)

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -688,7 +688,7 @@ def nonretryable_client_error_result(
     # Summarize once: Cloudflare/proxy HTML pages and raw provider bodies must be
     # collapsed here or they leak verbatim via the ``error`` field.
     _nonretryable_summary = agent._summarize_api_error(api_error)
-    _label = _NONRETRYABLE_LABELS.get(classified.reason, f"Non-retryable error (HTTP {status_code})")
+    _label = _NONRETRYABLE_LABELS.get(classified.display_reason, f"Non-retryable error (HTTP {status_code})")
     agent._emit_status(f"❌ {_label}: {_nonretryable_summary}")
     _vlines(
         agent,
@@ -1442,7 +1442,9 @@ def route_classified_error(
         )
         if not pool_may_recover:
             agent._buffer_status(_eager_fallback_status(classified, _is_upstream, _is_transport_failure))
-            if agent._try_activate_fallback(reason=classified.reason):
+            if agent._try_activate_fallback(
+                reason=classified.reason, display_reason=classified.display_reason,
+            ):
                 return _fallback_break()
 
     # A 401/403 surviving credential refresh means a broken credential or endpoint:
@@ -1457,7 +1459,9 @@ def route_classified_error(
             "🔐 Authentication failed and could not be refreshed — "
             "switching to fallback provider..."
         )
-        if agent._try_activate_fallback(reason=classified.reason):
+        if agent._try_activate_fallback(
+            reason=classified.reason, display_reason=classified.display_reason,
+        ):
             return _fallback_break()
 
     # Nous Portal: a genuine account-level 429 is recorded to a shared file so ALL

--- a/tests/agent/test_safety_refusal_display.py
+++ b/tests/agent/test_safety_refusal_display.py
@@ -1,0 +1,71 @@
+"""Safety wording is presentation, not permission to change recovery policy."""
+from dataclasses import asdict
+from unittest.mock import MagicMock, patch
+
+import httpx
+import openai
+import pytest
+
+from agent.error_classifier import FailoverReason, classify_api_error
+from tests.run_agent.test_primary_runtime_restore import _make_agent
+from tests.run_agent.test_provider_fallback import _make_agent as _fallback_agent, _mock_client
+
+
+SAFETY_MESSAGE = (
+    "This request was blocked by our safety systems. "
+    "Reason: Potentially unintended activity."
+)
+
+
+def safety_error(status):
+    error = openai.APIError(
+        SAFETY_MESSAGE, request=httpx.Request("POST", "https://example.test/v1/responses"), body=None,
+    )
+    if status is not None:
+        error.status_code = status
+    return error
+
+
+@pytest.mark.parametrize("status", [None, 400, 403, 429, 500])
+def test_display_reason_does_not_change_recovery(status):
+    error = safety_error(status)
+    classified = classify_api_error(error)
+    before = asdict(classified)
+    assert classified.display_reason == FailoverReason.content_policy_blocked
+    assert asdict(classified) == before
+    control = openai.APIError("ordinary provider failure", request=error.request, body=None)
+    if status is not None:
+        control.status_code = status
+    baseline = classify_api_error(control)
+    for field in ("reason", "retryable", "should_compress", "should_rotate_credential", "should_fallback"):
+        assert getattr(classified, field) == getattr(baseline, field)
+
+
+@pytest.mark.parametrize("status", [None, 400, 403])
+def test_safety_api_error_does_not_enter_transport_recovery(status):
+    agent = _make_agent(provider="custom")
+    agent._vprint = MagicMock()
+    with patch("agent.process_bootstrap.OpenAI", return_value=MagicMock()), patch("time.sleep") as sleep:
+        assert not agent._try_recover_primary_transport(safety_error(status), retry_count=3, max_retries=3)
+    sleep.assert_not_called()
+    agent._vprint.assert_not_called()
+
+
+@pytest.mark.parametrize("status", [None, 400, 403, 429, 500])
+def test_fallback_display_keeps_routing_reason_and_cooldown(status):
+    classified = classify_api_error(safety_error(status))
+    agent = _fallback_agent(fallback_model={"provider": "zai", "model": "glm-5.2"})
+    with (
+        patch("agent.auxiliary_client.resolve_provider_client", return_value=(_mock_client(), "glm-5.2")),
+        patch("agent.fallback_cooldown._arm_rate_limit_cooldown", return_value=None) as cooldown,
+    ):
+        assert agent._try_activate_fallback(reason=classified.reason, display_reason=classified.display_reason)
+    cooldown.assert_called_once_with(agent, classified.reason)
+    assert "content policy blocked" in agent._pending_fallback_notice[-1]
+    assert agent.model == "glm-5.2"
+
+
+def test_ordinary_error_display_unchanged():
+    error = openai.APIError("ordinary provider failure", request=httpx.Request("POST", "https://example.test"), body=None)
+    classified = classify_api_error(error)
+    assert classified.display_reason == classified.reason


### PR DESCRIPTION
## Summary

Provider errors containing `This request was blocked by our safety systems` can be displayed as authentication failures or generic provider errors because their HTTP-derived recovery classification also supplies the user-facing label.

Separate the presentation reason from the existing recovery reason:
- Add a read-only `ClassifiedError.display_reason` for the explicit safety-system wording, retaining the existing classification for other messages.
- Use that presentation reason in non-retryable status labels and fallback notices.
- Keep the original `reason` (including existing omitted/default values) at every routing, retry, credential, cooldown, and fallback decision.

This is **display-only**. It neither enables nor disables fallback after safety errors, changes retry budgets, refreshes credentials differently, nor modifies transport-recovery eligibility. Existing upstream policy remains authoritative. The optional keyword argument to fallback activation is consumed only when formatting its notice.

Adapted onto upstream base `45a6101f36576367359c171cd5820ee76a3d047b` from ANG-Ventures/hermes-agent commit `a22ac726ed5135360a32b66bdc788b9c627e3c6c`. Upstream does not use the fork's transport-recovery path for these API errors, so that fork-specific display hunk is intentionally omitted.

## Verification

Canonical clean-environment, per-file runner:
```sh
scripts/run_tests.sh tests/agent/test_safety_refusal_display.py tests/agent/test_error_classifier.py tests/run_agent/test_provider_fallback.py tests/run_agent/test_primary_runtime_restore.py -q
```
**231 passed, 0 failed across 4 files.** Tests cover absent status and HTTP 400/403/429/500, preserve recovery fields and cooldown inputs, and exercise fallback notice formatting through the real AIAgent helper with provider client creation mocked.

Mutation proof: temporarily returning the original routing reason from `display_reason` (leaving symbols and call sites intact) produces **10 failed, 4 passed** in the new test file. Restoring the implementation gives **14 passed** via the canonical runner.

Additional earlier broad regression run:
```sh
HERMES_HOME=$(mktemp -d) /path/to/venv/bin/python -m pytest tests/agent/test_safety_refusal_display.py tests/agent/test_error_classifier.py tests/run_agent/ -q -o addopts=''
```
**2306 passed, 6 skipped in 321.45s.** This earlier run used a temporary Hermes home but invoked pytest directly, not the canonical per-file runner; the narrower canonical verification above was therefore performed separately.

`git diff --check` passes. No live provider request, deployment, restart, or configuration change was performed; the full repository suite was not run.
