### PR TITLE
fix(gateway): make cross-platform session indexes resumable

### DIFF
--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -109,6 +109,11 @@ def _strip_resume_name(parts: list[str]) -> str:
     return name
 
 
+def _normalize_resume_options(parts: list[str]) -> list[str]:
+    """Accept mobile autocorrect's single Unicode dash for ``--all`` without rewriting titles."""
+    return ["--all" if part.lower() in {"—all", "–all"} else part for part in parts]
+
+
 class GatewaySessionCommandsMixin:
     """Session-transcript slash commands (/new, /resume, /sessions, /branch, /title, /save, /undo, /retry, /topic, /compress)."""
 
@@ -832,7 +837,7 @@ class GatewaySessionCommandsMixin:
         """Titled sessions visible to the caller (origin-scoped unless admin ``--all``)."""
         widen = allow_all and self._resume_caller_is_admin(source)
         sessions = await self._session_db.list_sessions_rich(
-            source=source.platform.value if source.platform else None,
+            source=None if widen else (source.platform.value if source.platform else None),
             session_key=None if widen else session_key, limit=10)
         titled = [s for s in sessions if s.get("title")][:10]
         return [s for s in titled if await self._resume_row_visible(source, s, allow_all)]
@@ -886,7 +891,7 @@ class GatewaySessionCommandsMixin:
         source = await asyncio.to_thread(self._normalize_source_for_session_key, event.source)
         session_key = self._session_key_for_source(source)
         try:
-            parts = shlex.split(event.get_command_args().strip())
+            parts = _normalize_resume_options(shlex.split(event.get_command_args().strip()))
         except ValueError as exc:
             return t("gateway.resume.parse_error", error=exc)
         allow_all = "--all" in parts

--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -111,7 +111,8 @@ def _strip_resume_name(parts: list[str]) -> str:
 
 def _normalize_resume_options(parts: list[str]) -> list[str]:
     """Accept mobile autocorrect's single Unicode dash for ``--all`` without rewriting titles."""
-    return ["--all" if part.lower() in {"—all", "–all"} else part for part in parts]
+    # MessageEvent has already mapped an en dash to a single ASCII hyphen.
+    return ["--all" if part.lower() in {"—all", "–all", "-all"} else part for part in parts]
 
 
 class GatewaySessionCommandsMixin:

--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -834,14 +834,32 @@ class GatewaySessionCommandsMixin:
 
     # -------------------------------------------------------------- /resume, /sessions
 
+    async def _session_listing_rows(
+        self, source, session_key: str, *, include_all: bool,
+        include_unnamed: bool = False, search_query: str | None = None,
+    ) -> tuple[list[dict], bool]:
+        """Build the shared row projection consumed by ``/sessions`` and numeric ``/resume``."""
+        from hermes_cli.session_listing import query_session_listing
+
+        cross_origin = include_all and self._resume_caller_is_admin(source)
+        current_entry = await self.async_session_store.get_or_create_session(source)
+        query_limit = 50 if search_query else 10
+        rows = await asyncio.to_thread(
+            query_session_listing, getattr(self._session_db, "_db", self._session_db),
+            source=source.platform.value if source.platform else None,
+            session_key=None if cross_origin else session_key,
+            current_session_id=current_entry.session_id, include_current_session=True,
+            include_all_sources=cross_origin, include_unnamed=include_unnamed,
+            search_query=search_query, limit=query_limit, exclude_sources=["tool"])
+        if not cross_origin:
+            rows = [row for row in rows if await self._resume_row_visible(source, row, allow_all=False)]
+        return rows[:10], cross_origin
+
     async def _list_titled_sessions(self, source, session_key: str, allow_all: bool) -> list[dict]:
         """Titled sessions visible to the caller (origin-scoped unless admin ``--all``)."""
-        widen = allow_all and self._resume_caller_is_admin(source)
-        sessions = await self._session_db.list_sessions_rich(
-            source=None if widen else (source.platform.value if source.platform else None),
-            session_key=None if widen else session_key, limit=10)
-        titled = [s for s in sessions if s.get("title")][:10]
-        return [s for s in titled if await self._resume_row_visible(source, s, allow_all)]
+        rows, _cross_origin = await self._session_listing_rows(
+            source, session_key, include_all=allow_all)
+        return rows
 
     async def _resolve_resume_target(self, source, session_key: str, name: str, allow_all: bool):
         """``(target_id, name)`` for a numbered choice, session id or title; else the error reply."""
@@ -975,8 +993,7 @@ class GatewaySessionCommandsMixin:
         """Handle /sessions — list previous sessions for gateway chats."""
         if not self._session_db:
             return self._session_db_unavailable_reply()
-        from hermes_cli.session_listing import (
-            format_gateway_session_listing, parse_session_listing_args, query_session_listing)
+        from hermes_cli.session_listing import format_gateway_session_listing, parse_session_listing_args
         try:
             include_all, include_unnamed, target, search_query = parse_session_listing_args(
                 event.get_command_args().strip())
@@ -990,23 +1007,12 @@ class GatewaySessionCommandsMixin:
         session_key = self._session_key_for_source(source)
         # `/sessions all` is admin-only like `/resume --all` (else any caller could enumerate other
         # origins' ids/titles/previews); a non-admin gets explicit feedback, not a silent narrowing.
-        cross_origin = include_all and self._resume_caller_is_admin(source)
         scope_notice = None
+        rows, cross_origin = await self._session_listing_rows(
+            source, session_key, include_all=include_all,
+            include_unnamed=include_unnamed, search_query=search_query)
         if include_all and not cross_origin:
             scope_notice = "_Note: `all` (cross-chat listing) requires a configured admin; showing this chat's sessions only._"
-        current_entry = await self.async_session_store.get_or_create_session(source)
-        rows = await asyncio.to_thread(
-            query_session_listing, getattr(self._session_db, "_db", self._session_db),
-            source=source.platform.value if source.platform else None,
-            session_key=None if cross_origin else session_key,
-            current_session_id=current_entry.session_id, include_current_session=True,
-            include_all_sources=cross_origin, include_unnamed=include_unnamed,
-            search_query=search_query,
-            # Search filters in SQL: over-fetch so origin-invisible matches don't consume the page.
-            limit=50 if search_query else 10, exclude_sources=["tool"])
-        if not cross_origin:
-            rows = [row for row in rows if await self._resume_row_visible(source, row, allow_all=False)]
-        rows = rows[:10]
         if search_query:
             title = f"Sessions matching “{search_query}”"
         else:

--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -864,6 +864,8 @@ class GatewaySessionCommandsMixin:
     async def _resolve_resume_target(self, source, session_key: str, name: str, allow_all: bool):
         """``(target_id, name)`` for a numbered choice, session id or title; else the error reply."""
         if name.isdigit():
+            from hermes_cli.session_listing import session_listing_display_parts
+
             try:
                 titled = await self._list_titled_sessions(source, session_key, allow_all)
             except Exception as e:
@@ -873,7 +875,8 @@ class GatewaySessionCommandsMixin:
             if index < 1 or index > len(titled):
                 return t("gateway.resume.out_of_range", index=index)
             target = titled[index - 1]
-            target_id, name = target.get("id"), target.get("title") or name
+            display_name, current_part = session_listing_display_parts(target)
+            target_id, name = target.get("id"), f"{display_name}{current_part}"
         else:  # session id first, then title
             session = await self._session_db.get_session(name)
             target_id = session["id"] if session else await self._session_db.resolve_session_by_title(name)
@@ -966,6 +969,8 @@ class GatewaySessionCommandsMixin:
     def _resume_listing_reply(self, source, titled: list[dict], allow_all: bool) -> str:
         """Numbered /resume list; a non-admin ``--all`` falls back to same-origin scoping and says so
         (sibling of the /sessions notice)."""
+        from hermes_cli.session_listing import session_listing_display_parts
+
         scope_note = None
         if allow_all and not self._resume_caller_is_admin(source):
             scope_note = t("gateway.resume.all_requires_admin")
@@ -976,14 +981,17 @@ class GatewaySessionCommandsMixin:
             return f"{base}\n{scope_note}" if scope_note else base
         lines = [t("gateway.resume.list_header")]
         for idx, s in enumerate(titled[:10], start=1):
-            title = s["title"]
+            title, current_part = session_listing_display_parts(s)
             if source.platform == Platform.MATRIX and allow_all:
                 origin = self._gateway_session_origin_for_id(str(s.get("id") or ""))
                 if origin:
                     title = f"{title} — {origin.chat_name or origin.chat_id}"
             preview = s.get("preview", "")[:40]
             preview_part = t("gateway.resume.list_preview_suffix", preview=preview) if preview else ""
-            lines.append(t("gateway.resume.list_item_numbered", index=idx, title=title, preview_part=preview_part))
+            lines.append(t(
+                "gateway.resume.list_item_numbered", index=idx,
+                title=f"{title}{current_part}", preview_part=preview_part,
+            ))
         if scope_note:
             lines.append(scope_note)
         lines.append(t("gateway.resume.list_footer_numbered"))

--- a/hermes_cli/session_listing.py
+++ b/hermes_cli/session_listing.py
@@ -22,7 +22,8 @@ def parse_session_listing_args(raw_args: str) -> tuple[bool, bool, str, str | No
     target_parts: list[str] = []
     for i, part in enumerate(parts):
         lower = part.strip().lower()
-        if lower in {"—all", "–all"}:
+        # Gateway MessageEvent maps an en dash to a single ASCII hyphen first.
+        if lower in {"—all", "–all", "-all"}:
             lower = "--all"
         if not target_parts:
             if lower in _LIST_WORDS:

--- a/hermes_cli/session_listing.py
+++ b/hermes_cli/session_listing.py
@@ -22,6 +22,8 @@ def parse_session_listing_args(raw_args: str) -> tuple[bool, bool, str, str | No
     target_parts: list[str] = []
     for i, part in enumerate(parts):
         lower = part.strip().lower()
+        if lower in {"—all", "–all"}:
+            lower = "--all"
         if not target_parts:
             if lower in _LIST_WORDS:
                 continue

--- a/hermes_cli/session_listing.py
+++ b/hermes_cli/session_listing.py
@@ -9,6 +9,13 @@ _LIST_WORDS = {"list", "ls", "browse"}
 _SEARCH_WORDS = {"search", "find"}
 
 
+def session_listing_display_parts(row: dict[str, Any]) -> tuple[str, str]:
+    """Return the display name and current-session suffix shared by listing consumers."""
+    name = str(row.get("title") or "—")
+    current_part = " (current)" if row.get("is_current_session") else ""
+    return name, current_part
+
+
 def parse_session_listing_args(raw_args: str) -> tuple[bool, bool, str, str | None]:
     """Parse `/sessions`-style args into ``(include_all_sources, include_unnamed, target, search_query)``.
 
@@ -101,13 +108,13 @@ def format_gateway_session_listing(
         ])
     lines = [f"📋 **{title}**", ""]
     for idx, row in enumerate(rows, start=1):
-        current_part = " (current)" if row.get("is_current_session") else ""
+        display_name, current_part = session_listing_display_parts(row)
         preview = str(row.get("preview") or "")[:40]
         source = str(row.get("source") or "")
         source_part = f" `{source}`" if include_source and source else ""
         preview_part = f" — _{preview}_" if preview else ""
         lines.append(
-            f"{idx}. **{row.get('title') or '—'}**{current_part}{source_part}"
+            f"{idx}. **{display_name}**{current_part}{source_part}"
             f" — `{row.get('id') or ''}`{preview_part}"
         )
     return "\n".join([

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -326,6 +326,38 @@ class TestHandleResumeCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_admin_all_resolves_cross_platform_sessions_listing_number(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(text="/sessions all")
+        lane_key = _session_key_for_event(event)
+        db.create_session(
+            "tg_named", "telegram", session_key=lane_key,
+            user_id="12345", chat_id="67890",
+        )
+        db.set_session_title("tg_named", "Telegram Work")
+        db.create_session(
+            "discord_named", "discord", session_key="agent:main:discord:dm:other",
+            user_id="other-user", chat_id="other",
+        )
+        db.set_session_title("discord_named", "Discord Work")
+
+        runner = _make_runner(session_db=db, event=event)
+        runner._resume_caller_is_admin = lambda _source: True
+        listing = await runner._handle_sessions_command(event)
+        discord_line = next(line for line in listing.splitlines() if "`discord_named`" in line)
+        discord_index = int(discord_line.split(".", 1)[0])
+
+        result = await runner._handle_resume_command(
+            _make_event(text=f"/resume --all {discord_index}")
+        )
+
+        assert "Resumed" in result
+        assert runner.session_store.switch_session.call_args.args[1] == "discord_named"
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_numeric_resume_fallback_uses_exact_lane_candidates(self, tmp_path):
         from hermes_state import SessionDB
 
@@ -655,6 +687,30 @@ class TestHandleSessionsCommand:
 
         assert "Telegram Work" in result
         assert "Discord Work" in result
+        db.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("dash", ["—", "–"])
+    async def test_unicode_dash_all_widens_resume_and_sessions(self, tmp_path, dash):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(
+            "discord_named", "discord", session_key="agent:main:discord:dm:other",
+            user_id="other-user", chat_id="other",
+        )
+        db.set_session_title("discord_named", "Discord Work")
+        event = _make_event(text=f"/sessions {dash}all")
+        runner = _make_runner(session_db=db, event=event)
+        runner._resume_caller_is_admin = lambda _source: True
+
+        sessions_result = await runner._handle_sessions_command(event)
+        resume_result = await runner._handle_resume_command(
+            _make_event(text=f"/resume {dash}all")
+        )
+
+        assert "Discord Work" in sessions_result
+        assert "Discord Work" in resume_result
         db.close()
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -371,7 +371,7 @@ class TestHandleResumeCommand:
         from hermes_state import SessionDB
 
         db = SessionDB(db_path=tmp_path / "state.db")
-        event = _make_event(text="/resume 2")
+        event = _make_event(text="/sessions")
         lane_key = _session_key_for_event(event)
         db.create_session(
             "lane_older", "telegram", session_key=lane_key,
@@ -399,11 +399,34 @@ class TestHandleResumeCommand:
         runner = _make_runner(
             session_db=db, current_session_id="current_session_001", event=event
         )
-        result = await runner._handle_resume_command(event)
+        sessions_listing = await runner._handle_sessions_command(event)
+        resume_listing = await runner._handle_resume_command(_make_event(text="/resume"))
+        older_line = next(
+            line for line in sessions_listing.splitlines() if "`lane_older`" in line
+        )
+        current_line = next(
+            line for line in sessions_listing.splitlines() if "`current_session_001`" in line
+        )
+        older_index = int(older_line.split(".", 1)[0])
+        current_index = int(current_line.split(".", 1)[0])
+
+        assert f"{current_index}. **— (current)**" in resume_listing
+        assert f"{older_index}. **Lane Older**" in resume_listing
+        assert "None" not in resume_listing
+
+        result = await runner._handle_resume_command(
+            _make_event(text=f"/resume {older_index}")
+        )
 
         assert "Resumed" in result
         runner.session_store.switch_session.assert_called_once()
         assert runner.session_store.switch_session.call_args[0][1] == "lane_older"
+
+        already_current = await runner._handle_resume_command(
+            _make_event(text=f"/resume {current_index}")
+        )
+        assert "Already on session **— (current)**" in already_current
+        assert f"session **{current_index}**" not in already_current
         db.close()
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -342,6 +342,15 @@ class TestHandleResumeCommand:
             user_id="other-user", chat_id="other",
         )
         db.set_session_title("discord_named", "Discord Work")
+        for i in range(10):
+            db.create_session(
+                f"newer_unnamed_{i}", "telegram",
+                session_key=f"agent:main:telegram:dm:newer-{i}",
+                user_id=f"newer-user-{i}", chat_id=f"newer-{i}",
+            )
+        db.create_session(
+            "newer_tool", "tool", session_key="agent:main:tool:job:newer",
+        )
 
         runner = _make_runner(session_db=db, event=event)
         runner._resume_caller_is_admin = lambda _source: True


### PR DESCRIPTION
## What does this PR do?

This fixes gateway admins being unable to resume cross-platform sessions by the numbers shown in `/sessions all`. The numbered `/resume --all` candidate query now widens both the session-key and platform-source filters, matching the existing global session listing. It also accepts mobile-autocorrect em/en dash forms of the `--all` option without rewriting session titles.

### Symptom

`/sessions all` can show desktop and messaging sessions in one numbered list, but `/resume --all <number>` resolves that number against only the caller's platform. It can therefore resume the wrong session or report that a displayed index is out of range. Mobile-autocorrect em/en dash forms of the `all` option also fail to enable global scope.

### Impact

Gateway administrators cannot reliably use the displayed cross-platform session indexes to resume sessions. The failure affects configured admins using cross-origin session management; non-admin session isolation is unchanged.

### Bug Cause

**Trigger:** `gateway/slash_commands_session.py` / `_list_titled_sessions()` when an administrator supplies `--all`.

**Causal chain:**
1. `/sessions all` asks `query_session_listing()` for all sources and displays a cross-platform numbered list.
2. `/resume --all <number>` clears the session-key filter but still passes the caller platform as the source filter.
3. The same number is resolved against a narrower platform-only list, producing the wrong target or an out-of-range response.

**Why it is wrong:** The two sibling commands assign different candidate sets to the same numbered resume workflow.

**Working sibling / contrast:** `query_session_listing(include_all_sources=True)` already removes the source filter for `/sessions all`.

**Ruled out:** Authorization is not the cause. Both commands recognize the configured administrator; the mismatch occurs after authorization while constructing the database query filters.

### Fix

- Remove the source filter together with the session-key filter for administrator `/resume --all` queries.
- Normalize exact Unicode-dash `all` option tokens on both session command paths while preserving dashes inside titles.
- Add regression coverage that resolves the cross-platform index rendered by `/sessions all` and covers both Unicode dash variants.

## Related Issue

Fixes #107911

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands_session.py` - align global resume scope and normalize Unicode-dash resume options.
- `hermes_cli/session_listing.py` - recognize Unicode-dash `all` listing options.
- `tests/gateway/test_resume_command.py` - cover cross-platform index parity and Unicode-dash handling.

## How to Test

1. Configure a gateway administrator and create titled sessions on two platforms.
2. Run `/sessions all`, then `/resume --all <number>` using the number of the other platform's session.
3. Run the targeted automated tests after PR creation (47 passed):

```bash
scripts/run_tests.sh tests/gateway/test_resume_command.py tests/hermes_cli/test_session_listing.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test entry and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A
- [x] Configuration example update: N/A
- [x] Architecture/workflow documentation update: N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

N/A
