### PR TITLE
fix(cli): count config.yaml custom model pin as provider_configured

### DIFF
--- a/hermes_cli/free_tier_bootstrap.py
+++ b/hermes_cli/free_tier_bootstrap.py
@@ -96,6 +96,22 @@ def _resolve_inference() -> str:
         return ""
 
 
+def _config_has_explicit_model_pin() -> bool:
+    """Cheap on-disk pin only: a model dict with non-empty provider/base_url/api_key.
+
+    Mirrors the config.yaml branch of ``_has_any_provider_configured`` and nothing
+    else — no registry sweep, gh, or Claude Code. Fail-open on any exception.
+    """
+    try:
+        from hermes_cli.config import load_config
+        model_cfg = load_config().get("model")
+        if not isinstance(model_cfg, dict):
+            return False
+        return any((model_cfg.get(k) or "").strip() for k in ("provider", "base_url", "api_key"))
+    except Exception:
+        return False
+
+
 def run_bootstrap(*, announce: bool = True) -> SetupRecord:
     """Inventory -> ensure identity (gate permitting) -> resolve inference -> record -> broadcast.
 
@@ -127,7 +143,8 @@ def run_bootstrap(*, announce: bool = True) -> SetupRecord:
             logger.info("Nous free tier not set up at boot: %s", exc)
     free_tier = bool(state) and anon_auth.is_guest_state(state) and anon_auth.guest_enabled()
     record = SetupRecord(
-        provider_configured=other or free_tier or (bool(state) and not anon_auth.is_guest_state(state)),
+        provider_configured=other or free_tier or (bool(state) and not anon_auth.is_guest_state(state))
+        or _config_has_explicit_model_pin(),
         inference_provider=_resolve_inference(),
         free_tier=free_tier,
         has_identity=bool(state),

--- a/tests/hermes_cli/test_free_tier_bootstrap_custom_provider.py
+++ b/tests/hermes_cli/test_free_tier_bootstrap_custom_provider.py
@@ -1,0 +1,59 @@
+"""Custom-provider config pin must count as setup without flipping ``other_providers``."""
+
+from __future__ import annotations
+
+from hermes_cli import free_tier_bootstrap as fb
+
+CUSTOM_PIN = {
+    "model": {
+        "provider": "custom:llama.cpp",
+        "base_url": "http://127.0.0.1:8080/v1",
+        "api_key": "local",
+    }
+}
+
+
+def _stub_unresolved_nous(monkeypatch, config):
+    def resolve_provider(requested="auto", skip_free_tier=False, **_kw):
+        return "nous"
+
+    monkeypatch.setattr("hermes_cli.auth.resolve_provider", resolve_provider)
+    monkeypatch.setattr("hermes_cli.anon_auth.current_nous_state", lambda: None)
+    monkeypatch.setattr("hermes_cli.anon_auth.guest_enabled", lambda: False)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+
+
+def test_custom_model_dict_pin_is_provider_configured_without_flipping_other(monkeypatch):
+    _stub_unresolved_nous(monkeypatch, CUSTOM_PIN)
+    fb.reset_for_tests()
+    rec = fb.run_bootstrap(announce=False)
+    assert rec.provider_configured is True
+    assert rec.other_providers is False
+
+
+def test_plain_string_model_stays_unconfigured(monkeypatch):
+    _stub_unresolved_nous(monkeypatch, {"model": "some-default-string"})
+    fb.reset_for_tests()
+    rec = fb.run_bootstrap(announce=False)
+    assert rec.provider_configured is False
+    assert rec.other_providers is False
+
+
+def test_blank_model_dict_is_not_configured(monkeypatch):
+    _stub_unresolved_nous(monkeypatch, {"model": {"provider": "  ", "base_url": "", "api_key": None}})
+    fb.reset_for_tests()
+    rec = fb.run_bootstrap(announce=False)
+    assert rec.provider_configured is False
+    assert rec.other_providers is False
+
+
+def test_load_config_error_does_not_raise_or_flip_other(monkeypatch):
+    def _boom():
+        raise RuntimeError("config unreadable")
+
+    _stub_unresolved_nous(monkeypatch, CUSTOM_PIN)
+    monkeypatch.setattr("hermes_cli.config.load_config", _boom)
+    fb.reset_for_tests()
+    rec = fb.run_bootstrap(announce=False)
+    assert rec.provider_configured is False
+    assert rec.other_providers is False


### PR DESCRIPTION
## What does this PR do?

`setup.status` for the launch profile reads `free_tier_bootstrap.SetupRecord.provider_configured`. That flag was `other or free_tier or (account identity)`. `_inventory_other_providers()` asks `resolve_provider("auto", skip_free_tier=True) != "nous"`. A custom pin such as `custom:llama.cpp` is not in `PROVIDER_REGISTRY`, so the resolver returns `"nous"`, `other` stays False, and with no Nous identity the record is `provider_configured=False`. The Web Dashboard TUI then shows "Setup Required" even though CLI inference works and `_has_any_provider_configured()` already treats a model dict with `provider` / `base_url` / `api_key` as configured.

This PR ORs a **cheap on-disk pin** into `provider_configured` only: `load_config()["model"]` is a dict with a non-empty `provider`, `base_url`, or `api_key`. It does not call the full `_has_any_provider_configured()` (registry sweep / gh / Claude Code). `other_providers` is unchanged, so free-tier mint (`carries_inference=not other`) is not affected.

## Related Issue

Fixes #107918

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔒 Security fix
- [x] ✅ Tests

## Changes Made

- `hermes_cli/free_tier_bootstrap.py`: add `_config_has_explicit_model_pin()` and OR it into `SetupRecord.provider_configured`. Fail-open on `load_config` errors or a non-dict / blank model.
- `tests/hermes_cli/test_free_tier_bootstrap_custom_provider.py` (new): custom pin is configured without flipping `other`; plain-string model, blank dict, and `load_config` exception stay unconfigured.

## How to Test

```
scripts/run_tests.sh tests/hermes_cli/test_free_tier_bootstrap_custom_provider.py -q --tb=short
  -> BEFORE (origin/main 05d705dd69):
     test_custom_model_dict_pin_is_provider_configured_without_flipping_other RED
     AssertionError: assert False is True
     (CONTROL test_plain_string_model_stays_unconfigured already green)
  -> AFTER: 4 passed

scripts/run_tests.sh tests/hermes_cli/test_anon_auth_core.py -k TestBootstrapIsTheOneCreator -q
  -> 4 passed

scripts/run_tests.sh tests/tui_gateway/test_free_tier_rpc.py -q
  -> 4 passed
```

## Related work (not duplicates)

- `_has_any_provider_configured` already counts a config.yaml model dict pin; bootstrap inventory deliberately does not call that function because the full first-run guard can be True on a blank machine (registry / host creds).
- `setup.status` still prefers the bootstrap record for the launch profile; named-profile live probe is unchanged.
- No open competing PR for #107918 at submit time.

## Review follow-up

- Fallback is config-pin only, not `other = other or _has_any_provider_configured()`. Host gh / Claude Code / keyless catalog must not skip Setup Required or block free-tier mint.
- `run_bootstrap` still never raises; pin lookup exceptions fail open to the previous `other/free_tier/account` answer.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run relevant tests locally (see How to Test)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if config keys changed — N/A
- [x] I've considered cross-platform impact — config.yaml parse only
- [x] I've updated tool descriptions/schemas if tool behavior changed — N/A

## Proof Receipt

- Base: `05d705dd695d1084388529124dc2ffe5ce919e89` (`origin/main`)
- Head: `9901e7c545961c68316a424699380c9be0bc21da`
- BEFORE=RED / AFTER=GREEN on the same focused probe
- Self-review P0: 0 (Detection / Fail-open / Forbidden / RED-on-pre-fix / Diff-scope)
- Independent code-review: skipped (2 modules, +77/−1, no auth/crypto/state.db schema / gateway routing change, P0=0)

Made with [Cursor](https://cursor.com)