### PR TITLE
fix(doctor): enforce npm audit timeout on Windows via process-tree kill

### DIFF
--- a/hermes_cli/doctor_tools.py
+++ b/hermes_cli/doctor_tools.py
@@ -364,8 +364,34 @@ def _audit_one(npm_bin: str, npm_dir, label: str, audit_extra: list[str], issues
     import json
     try:
         # Resolved absolute path so Windows can execute npm.cmd (CreateProcessW can't run bare .cmd names).
-        audit_result = subprocess.run([npm_bin, "audit", "--json", *audit_extra], cwd=str(npm_dir),
-                                      capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=30)
+        # NOTE (Windows hang fix): subprocess.run(timeout=...) is NOT a real bound here — when the
+        # timeout fires, run() kills only npm.cmd, but the node.exe grandchildren keep the stdout/stderr
+        # pipe handles open, so the internal communicate() deadlocks until they exit. Observed on a
+        # Windows host with a slow npm registry: a 30s-bounded audit stalled doctor for 300s+ (the
+        # registry query itself needed ~5 minutes). Spawn with Popen and, on timeout, kill the whole
+        # process tree (taskkill /F /T on Windows), then drain with a bounded communicate so the pipe
+        # handles are released and the 30s bound is actually enforced.
+        audit_proc = subprocess.Popen([npm_bin, "audit", "--json", *audit_extra], cwd=str(npm_dir),
+                                      stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                      text=True, encoding='utf-8', errors='replace')
+        try:
+            audit_stdout, audit_stderr = audit_proc.communicate(timeout=30)
+            audit_result = subprocess.CompletedProcess(audit_proc.args, audit_proc.returncode,
+                                                       audit_stdout, audit_stderr)
+        except subprocess.TimeoutExpired:
+            if os.name == "nt":
+                try:
+                    subprocess.run(["taskkill", "/F", "/T", "/PID", str(audit_proc.pid)],
+                                   capture_output=True, timeout=10)
+                except Exception:
+                    audit_proc.kill()
+            else:
+                audit_proc.kill()
+            try:
+                audit_proc.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                pass
+            raise
         audit_data = json.loads(audit_result.stdout) if audit_result.stdout.strip() else {}
         counts = audit_data.get("metadata", {}).get("vulnerabilities", {})
         critical, high, moderate = (counts.get(k, 0) for k in ("critical", "high", "moderate"))


### PR DESCRIPTION
## The bug

`_audit_one` (`hermes_cli/doctor_tools.py`) runs:

```python
subprocess.run([npm_bin, "audit", "--json", *audit_extra], cwd=str(npm_dir),
               capture_output=True, text=True, ..., timeout=30)
```

On Windows, `npm` resolves to `npm.cmd`. When `subprocess.run`'s timeout fires it kills **only the shim** — the `node.exe` grandchildren spawned by npm keep the stdout/stderr pipe handles open, so the internal `communicate()` deadlocks until they exit. The 30-second bound is not enforced.

Observed on a real Windows host with a slow npm registry (the `npm audit --workspace ui-tui` query itself needed ~5 minutes and then errored):

- a nominally 30s-bounded audit stalled for **301.2s** (measured, reproducible);
- `hermes doctor` appeared frozen and tripped every external timeout — health-snapshot automation recorded `rc=124` for all 4 profiles, three runs in a row;
- after patching, the same audit path bounded at **30.4s** and `hermes doctor` completed cleanly end-to-end (exit 0, all checks passed).

## The fix

Spawn with `Popen`; on `TimeoutExpired`, kill the whole process tree (`taskkill /F /T /PID` on Windows, `kill()` elsewhere), then drain with a bounded `communicate(timeout=10)` so the pipe handles are released and the exception propagates as before (the outer `except Exception: pass` still swallows it, preserving current behavior for genuinely unreachable registries).

No behavior change when the audit completes within the bound — the `CompletedProcess` reconstruction keeps the downstream JSON-parsing path byte-identical.

## Scope

- Single site fixed: `_audit_one` is the only `subprocess.run` with a timeout on a `.cmd`-shim executable in the doctor path (sibling call sites were checked — the docker/ssh probes timeout-kill plain executables, not shims, so they don't deadlock).
- Fix verified on the affected Windows 11 host against `npm audit --workspace ui-tui` (the pathological case), three consecutive reproductions.

## Testing

Manual E2E on the affected host (before: 301.2s stall / doctor rc=124; after: 30.4s bound / doctor exit 0). Happy-path unchanged — audits that return in time produce identical output through the same `CompletedProcess` shape.