### PR TITLE
fix(minimax): register minimax-portal and minimax-global aliases for minimax-oauth (#107928)

### DIFF
--- a/plugins/model-providers/minimax/__init__.py
+++ b/plugins/model-providers/minimax/__init__.py
@@ -49,7 +49,7 @@ minimax_cn = MiniMaxProfile(
 )
 
 minimax_oauth = MiniMaxProfile(
-    name="minimax-oauth", aliases=("minimax_oauth", "minimax-oauth-io"), api_mode="anthropic_messages",
+    name="minimax-oauth", aliases=("minimax_oauth", "minimax-portal", "minimax-global", "minimax-oauth-io"), api_mode="anthropic_messages",
     display_name="MiniMax (OAuth)", description="MiniMax via OAuth browser flow — no API key required",
     signup_url="https://api.minimax.io/",
     env_vars=(),  # OAuth — tokens in auth.json, not env

--- a/tests/plugins/model_providers/test_minimax_profile.py
+++ b/tests/plugins/model_providers/test_minimax_profile.py
@@ -181,3 +181,52 @@ class TestMinimaxM3OpenAIReasoningWireShape:
             "reasoning_split": True,
             "thinking": {"type": "adaptive"},
         }
+
+
+class TestMinimaxOauthAliases:
+    """``minimax-oauth`` provider advertises every alias the docs promise.
+
+    The user-facing guide at ``website/docs/guides/minimax-oauth.md`` lists
+    four ``--provider`` aliases for ``minimax-oauth``:
+
+        - ``minimax-oauth`` (canonical)
+        - ``minimax-portal``
+        - ``minimax-global``
+        - ``minimax_oauth`` (underscore form)
+
+    The provider profile must register each one so ``hermes --provider
+    minimax-portal`` (and the global variant) actually resolve instead of
+    failing with "unknown provider". Pinning the alias set in this test keeps
+    docs and code from drifting back out of sync.
+    """
+
+    DOCUMENTED_OAUTH_ALIASES = ("minimax-oauth", "minimax_oauth", "minimax-portal", "minimax-global")
+
+    def test_minimax_oauth_registers_every_documented_alias(self):
+        import model_tools  # noqa: F401
+        import providers
+
+        profile = providers.get_provider_profile("minimax-oauth")
+        assert profile is not None
+
+        registered = (profile.name, *profile.aliases)
+        for alias in self.DOCUMENTED_OAUTH_ALIASES:
+            assert alias in registered, (
+                f"docs promise '{alias}' as a resolvable provider id for "
+                "minimax-oauth, but the profile only registers "
+                f"{registered!r} — run `hermes --provider {alias}` and it "
+                "fails with 'unknown provider'"
+            )
+
+    def test_each_documented_oauth_alias_resolves_back_to_minimax_oauth(self):
+        import model_tools  # noqa: F401
+        import providers
+
+        for alias in self.DOCUMENTED_OAUTH_ALIASES:
+            resolved = providers.get_provider_profile(alias)
+            assert resolved is not None, f"alias {alias!r} did not resolve"
+            assert resolved.name == "minimax-oauth", (
+                f"alias {alias!r} resolved to {resolved.name!r}, expected "
+                f"'minimax-oauth' (canonical). The alias registry is routing "
+                "to the wrong provider."
+            )


### PR DESCRIPTION
## closes

closes https://github.com/NousResearch/hermes-agent/issues/107928

## what

the `minimax-oauth` provider profile only registers 2 of the 4 aliases its user guide advertises.

we are adding two missing ones, `minimax-portal` and `minimax-global` so that `hermes --provider minimax-portal` and `hermes --provider minimax-global` actually resolves to the oauth profile

## why

the user guide at `website/docs/guides/minimax-oauth.md` lists 4 `--provider` ids for `minimax-oauth`: `minimax-oauth` (canonical), `minimax-portal`, `minimax-global`, and `minimax_oauth` (underscore).

the plugin's `aliases=` tuple only had two of those four

anyone who followed the docs hit "unkown provider"

a new class test, `TestMinimaxOauthAliases`, keeps docs and code in sync going forward, so any future reverts or new doc entries that aren't wired up will show up as a failing test

## tests

- `tests/plugins/model_providers/test_minimax_profile.py::TestMinimaxOauthAliases` — new class, 2 tests
- `test_minimax_oauth_registers_every_documented_alias` — every alias in `DOCUMENTED_OAUTH_ALIASES` is registered in the profile (canonical name or `aliases` tuple)
- `test_each_documented_oauth_alias_resolves_back_to_minimax_oauth` — each alias resolves via `providers.get_provider_profile` to a profile whose `name` is `minimax-oauth`
- Run via `scripts/run_tests.sh tests/plugins/model_providers/test_minimax_profile.py -v` — 16/16 passing (14 pre-existing + 2 new)
- Existing aux-model + M3 reasoning tests still pass (no regression in the profile contract)

## search

checked open + merged PRs for "minimax alias" / "minimax-portal" / "minimax-global" / "provider alias" before opening — no duplicate or in-progress fix for #107928

## platform

tested on Windows 10, Python 3.11. change is pure alias-string registration (no os / fs / network surface), so no cross-platform impact to verify beyond confirming the import path resolves.
