### PR TITLE
fix(cron): close Desktop idle-exit admission race

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -87,6 +87,16 @@ def _profile_cron_scope(home):
         reset_hermes_home_override(home_token)
 
 
+def _run_tick_with_dispatch_guard(dispatch_guard, tick, **kwargs):
+    """Run one tick only while its optional admission lease is held."""
+    if dispatch_guard is None:
+        return tick(**kwargs)
+    with dispatch_guard() as admitted:
+        if not admitted:
+            return 0
+        return tick(**kwargs)
+
+
 class CronScheduler(ABC):
     """Decides WHEN a due cron job fires. Only ``name`` + ``start`` are required; keep every other
     hook NON-abstract with a safe default (``test_abc_growth_stays_additive``)."""
@@ -379,7 +389,8 @@ class InProcessCronScheduler(CronScheduler):
 
     def start(
         self, stop_event, *, adapters=None, loop=None, interval=60, can_dispatch=None,
-        profile_homes=None, profile_adapters=None, default_profile=None, profile_gate=None,
+        dispatch_guard=None, profile_homes=None, profile_adapters=None, default_profile=None,
+        profile_gate=None,
     ):
         from cron.scheduler import CronTickYielded
         from cron.scheduler import tick as cron_tick
@@ -396,8 +407,9 @@ class InProcessCronScheduler(CronScheduler):
         if profile_homes:
             self._start_multiplex(
                 stop_event, profile_homes=profile_homes, adapters=adapters, loop=loop,
-                interval=interval, can_dispatch=can_dispatch, profile_adapters=profile_adapters,
-                default_profile=default_profile, profile_gate=profile_gate,
+                interval=interval, can_dispatch=can_dispatch, dispatch_guard=dispatch_guard,
+                profile_adapters=profile_adapters, default_profile=default_profile,
+                profile_gate=profile_gate,
             )
             return
 
@@ -416,7 +428,7 @@ class InProcessCronScheduler(CronScheduler):
                 if can_dispatch is not None and not can_dispatch():
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
-                    cron_tick(
+                    _run_tick_with_dispatch_guard(dispatch_guard, cron_tick,
                         verbose=False, adapters=adapters, loop=loop, sync=False,
                         can_dispatch=can_dispatch,
                     )
@@ -450,7 +462,8 @@ class InProcessCronScheduler(CronScheduler):
 
     def _start_multiplex(
         self, stop_event, *, profile_homes, adapters=None, loop=None, interval=60,
-        can_dispatch=None, profile_adapters=None, default_profile=None, profile_gate=None,
+        can_dispatch=None, dispatch_guard=None, profile_adapters=None, default_profile=None,
+        profile_gate=None,
     ):
         """Tick every profile's store, each scoped via ``_profile_cron_scope``. ``profile_gate(name,
         home)``, when given, is consulted every cycle; a rejected profile is neither ticked nor
@@ -516,9 +529,11 @@ class InProcessCronScheduler(CronScheduler):
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
                     for _pname, home in cycle_homes:
+                        if stop_event.is_set():
+                            break
                         try:
                             with _profile_cron_scope(home):
-                                cron_tick(
+                                _run_tick_with_dispatch_guard(dispatch_guard, cron_tick,
                                     verbose=False, adapters=tick_adapters_for(_pname), loop=loop,
                                     sync=False, can_dispatch=can_dispatch,
                                 )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -74,7 +74,9 @@ from hermes_cli.web_server_lifecycle import (  # noqa: E402
 )
 
 
-def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60) -> None:
+def _start_desktop_cron_ticker(
+    stop_event: "threading.Event", interval: int = 60, *, admission_gate=None,
+) -> None:
     """Tick the cron scheduler from inside the desktop dashboard backend.
 
     The desktop spawns a ``hermes dashboard`` backend, not a gateway, so without
@@ -96,6 +98,9 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
 
     start_kwargs: dict = {"interval": interval}
     if isinstance(provider, InProcessCronScheduler):
+        if admission_gate is not None:
+            start_kwargs["can_dispatch"] = admission_gate.can_dispatch
+            start_kwargs["dispatch_guard"] = admission_gate.dispatch_guard
         try:
             from hermes_cli.profiles import (
                 _check_gateway_running, _served_by_running_multiplexer, profiles_to_serve)
@@ -200,6 +205,9 @@ async def _lifespan(app: "FastAPI"):
     cron_stop: "threading.Event | None" = None
     cron_thread: "threading.Thread | None" = None
     if os.getenv("HERMES_DESKTOP") == "1":
+        from hermes_cli.web_server_idle_exit import CronAdmissionGate
+
+        app.state.cron_admission_gate = CronAdmissionGate()
         # Reap an orphaned gateway from an abnormal previous exit (reparented to
         # launchd, still holding the platform WebSocket) before forking a fresh
         # one that would race the same credential (#77276). Runs
@@ -216,6 +224,7 @@ async def _lifespan(app: "FastAPI"):
         cron_thread = threading.Thread(
             target=_start_desktop_cron_ticker,
             args=(cron_stop,),
+            kwargs={"admission_gate": app.state.cron_admission_gate},
             daemon=True,
             name="desktop-cron-ticker",
         )
@@ -258,6 +267,9 @@ async def _lifespan(app: "FastAPI"):
         _hosted_groups.stop_hosted_room_service(timeout=5.0)
         hosted_room_start_thread.join(timeout=1.0)
         if cron_stop is not None:
+            admission_gate = getattr(app.state, "cron_admission_gate", None)
+            if admission_gate is not None:
+                admission_gate.close()
             cron_stop.set()
         pty_reaper_task.cancel()
         selftest_task.cancel()
@@ -1245,7 +1257,12 @@ def _on_server_started(
             grace = float((load_config().get("dashboard") or {}).get("ssh_isolated_idle_grace_s", DEFAULT_IDLE_GRACE_S))
         except (TypeError, ValueError):
             grace = DEFAULT_IDLE_GRACE_S
-        start_idle_watchdog(server, app.state.ssh_isolated_clients, grace_s=grace)
+        start_idle_watchdog(
+            server,
+            app.state.ssh_isolated_clients,
+            grace_s=grace,
+            admission_gate=getattr(app.state, "cron_admission_gate", None),
+        )
 
     actual_port = _read_bound_port(server, fallback=port)
     app.state.bound_port = actual_port

--- a/hermes_cli/web_server_idle_exit.py
+++ b/hermes_cli/web_server_idle_exit.py
@@ -24,6 +24,7 @@ is the slim redo on the decomposed web server.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import threading
 import time
@@ -64,6 +65,64 @@ class IdleClientTracker:
     def idle_for(self) -> float:
         with self._lock:
             return 0.0 if self._live else self._now() - self._last_client_at
+
+
+class CronAdmissionGate:
+    """Serialize Desktop cron admission with an idle-exit drain decision.
+
+    The gate covers the interval from a ticker deciding to dispatch through the
+    submission of that tick's work. Idle-exit can therefore close admission
+    only after no dispatch is in that interval; existing jobs remain owned by
+    the scheduler and are observed by the normal in-flight probe.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._draining = False
+        self._closed = False
+        self._dispatches = 0
+
+    @property
+    def is_closed(self) -> bool:
+        with self._lock:
+            return self._closed
+
+    def can_dispatch(self) -> bool:
+        with self._lock:
+            return not self._draining and not self._closed
+
+    @contextlib.contextmanager
+    def dispatch_guard(self):
+        with self._lock:
+            admitted = not self._draining and not self._closed
+            if admitted:
+                self._dispatches += 1
+        try:
+            yield admitted
+        finally:
+            if admitted:
+                with self._lock:
+                    self._dispatches -= 1
+
+    def try_begin_drain(self) -> bool:
+        """Close admission iff no ticker dispatch is currently in flight."""
+        with self._lock:
+            if self._closed or self._dispatches:
+                return False
+            self._draining = True
+            return True
+
+    def cancel_drain(self) -> None:
+        """Reopen admission after an aborted idle-exit check, unless permanently closed."""
+        with self._lock:
+            if not self._closed:
+                self._draining = False
+
+    def close(self) -> None:
+        """Permanently and unconditionally close admission for terminal teardown."""
+        with self._lock:
+            self._closed = True
+            self._draining = True
 
 
 def wrap_asgi_with_ws_tracking(app, tracker: IdleClientTracker):
@@ -126,7 +185,8 @@ def should_exit_idle(tracker: IdleClientTracker, grace_s: float,
 
 
 def start_idle_watchdog(server, tracker: IdleClientTracker, *, grace_s: float = DEFAULT_IDLE_GRACE_S,
-                        poll_s: float = 15.0, probe: Callable[[], Optional[bool]] = turn_in_flight) -> threading.Thread:
+                        poll_s: float = 15.0, probe: Callable[[], Optional[bool]] = turn_in_flight,
+                        admission_gate: Optional[CronAdmissionGate] = None) -> threading.Thread:
     """Daemon thread that sets ``server.should_exit`` once :func:`should_exit_idle` holds."""
 
     poll_s = min(poll_s, max(0.5, grace_s / 4))
@@ -134,6 +194,17 @@ def start_idle_watchdog(server, tracker: IdleClientTracker, *, grace_s: float = 
     def _loop() -> None:
         while not getattr(server, "should_exit", False):
             if should_exit_idle(tracker, grace_s, probe):
+                if admission_gate is not None:
+                    if not admission_gate.try_begin_drain():
+                        time.sleep(poll_s)
+                        continue
+                    # Admission is now closed. Re-read both client idleness and
+                    # turn liveness so activity that changed between the first
+                    # probe and the drain decision cannot make shutdown stale.
+                    if tracker.idle_for() < grace_s or probe() is not False:
+                        admission_gate.cancel_drain()
+                        time.sleep(poll_s)
+                        continue
                 _log.warning("SSH-isolated backend idle for %.0fs with no client and no running turn; exiting.",
                              tracker.idle_for())
                 server.should_exit = True

--- a/tests/hermes_cli/test_web_server_idle_exit_drain.py
+++ b/tests/hermes_cli/test_web_server_idle_exit_drain.py
@@ -1,0 +1,341 @@
+"""Contracts for SSH-isolated cron admission during idle-exit drain."""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def test_admission_gate_waits_for_dispatch_before_draining():
+    from hermes_cli.web_server_idle_exit import CronAdmissionGate
+
+    gate = CronAdmissionGate()
+    with gate.dispatch_guard() as admitted:
+        assert admitted is True
+        assert gate.try_begin_drain() is False
+        assert gate.can_dispatch() is True
+
+    assert gate.try_begin_drain() is True
+    assert gate.can_dispatch() is False
+    gate.cancel_drain()
+    assert gate.can_dispatch() is True
+
+
+def test_admission_gate_rejects_new_dispatch_after_drain():
+    from hermes_cli.web_server_idle_exit import CronAdmissionGate
+
+    gate = CronAdmissionGate()
+    assert gate.try_begin_drain() is True
+
+    with gate.dispatch_guard() as admitted:
+        assert admitted is False
+
+
+def test_admission_gate_close_is_terminal_and_irreversible():
+    """Terminal teardown close is unconditional, irreversible, and distinguishable from watchdog drain."""
+    from hermes_cli.web_server_idle_exit import CronAdmissionGate
+
+    gate = CronAdmissionGate()
+    with gate.dispatch_guard() as admitted:
+        assert admitted is True
+        # Close while dispatch reservation is currently active
+        gate.close()
+        assert gate.is_closed is True
+        assert gate.can_dispatch() is False
+
+        # Any new entry is immediately rejected even while older reservation is finishing
+        with gate.dispatch_guard() as second_admitted:
+            assert second_admitted is False
+
+        # Watchdog cancel_drain must NOT reopen admission if closed permanently
+        gate.cancel_drain()
+        assert gate.can_dispatch() is False
+        assert gate.is_closed is True
+
+    # After active reservation exits, admission remains closed and try_begin_drain fails
+    assert gate.can_dispatch() is False
+    assert gate.try_begin_drain() is False
+    gate.cancel_drain()
+    assert gate.can_dispatch() is False
+
+
+def test_admission_gate_close_without_active_reservation():
+    """Terminal teardown with no active reservation closes permanently and ignores cancel_drain."""
+    from hermes_cli.web_server_idle_exit import CronAdmissionGate
+
+    gate = CronAdmissionGate()
+    gate.close()
+    assert gate.is_closed is True
+    assert gate.can_dispatch() is False
+    assert gate.try_begin_drain() is False
+
+    with gate.dispatch_guard() as admitted:
+        assert admitted is False
+
+    gate.cancel_drain()
+    assert gate.can_dispatch() is False
+
+
+def test_desktop_ticker_wires_admission_gate_to_builtin_provider(monkeypatch):
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_cli import web_server
+    from hermes_cli.web_server_idle_exit import CronAdmissionGate
+
+    stop = threading.Event()
+    gate = CronAdmissionGate()
+    received = {}
+
+    def fake_start(_provider, stop_event, **kwargs):
+        received.update(kwargs)
+        stop_event.set()
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: InProcessCronScheduler(),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda **kwargs: [],
+    )
+    monkeypatch.setattr(InProcessCronScheduler, "start", fake_start)
+
+    web_server._start_desktop_cron_ticker(stop, interval=0, admission_gate=gate)
+
+    assert received["can_dispatch"] == gate.can_dispatch
+    assert received["dispatch_guard"] == gate.dispatch_guard
+
+
+def test_inprocess_ticker_holds_admission_guard_around_tick():
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    stop = threading.Event()
+    guard_entered = threading.Event()
+    guard_active = []
+
+    @contextlib.contextmanager
+    def dispatch_guard():
+        guard_active.append(True)
+        guard_entered.set()
+        try:
+            yield True
+        finally:
+            guard_active.pop()
+
+    def fake_tick(*_args, **_kwargs):
+        assert guard_active == [True]
+        stop.set()
+        return 0
+
+    with patch("cron.scheduler.tick", side_effect=fake_tick):
+        thread = threading.Thread(
+            target=InProcessCronScheduler().start,
+            args=(stop,),
+            kwargs={"interval": 0, "dispatch_guard": dispatch_guard},
+            daemon=True,
+        )
+        thread.start()
+        assert guard_entered.wait(timeout=15)
+        thread.join(timeout=15)
+
+    assert not thread.is_alive()
+    assert guard_active == []
+
+
+def test_multiplex_ticker_teardown_closes_admission_and_blocks_second_profile(tmp_path):
+    """Multiplex ticker teardown closes admission during an active profile tick, preventing subsequent profile jobs."""
+    import cron.scheduler as s
+    import cron.scheduler_provider as p
+    from hermes_cli.web_server_idle_exit import CronAdmissionGate
+    from hermes_constants import get_hermes_home
+
+    gate = CronAdmissionGate()
+    stop = threading.Event()
+    entered = threading.Event()
+    release = threading.Event()
+    submitted = threading.Event()
+
+    homes = [("first", tmp_path / "first"), ("second", tmp_path / "second")]
+    for _, h in homes:
+        h.mkdir(parents=True, exist_ok=True)
+
+    errors = []
+
+    def due():
+        if Path(get_hermes_home()).resolve() == homes[0][1].resolve():
+            entered.set()
+            assert release.wait(15)
+            return []
+        return [{
+            "id": "probe-job",
+            "name": "synthetic",
+            "schedule": {"kind": "interval", "minutes": 1},
+        }]
+
+    def worker(job, adapters, loop, verbose):
+        assert stop.is_set()
+        submitted.set()
+        return True
+
+    def run():
+        try:
+            p.InProcessCronScheduler().start(
+                stop,
+                interval=60,
+                profile_homes=homes,
+                can_dispatch=gate.can_dispatch,
+                dispatch_guard=gate.dispatch_guard,
+            )
+        except BaseException as exc:
+            errors.append(repr(exc))
+
+    with ThreadPoolExecutor(max_workers=1) as pool, \
+         patch.object(s, "_get_parallel_pool", return_value=pool), \
+         patch.object(s, "_process_due_job", side_effect=worker), \
+         patch.object(s, "_should_yield_tick_to_fresh_gateway", return_value=None), \
+         patch.object(s, "_maybe_run_worktree_maintenance"), \
+         patch.object(s, "_maybe_reap_dead_owners"), \
+         patch.object(s, "_sweep_mcp_orphans"), \
+         patch.object(s, "get_due_jobs", side_effect=due):
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        try:
+            assert entered.wait(15), errors
+            # Teardown ordering: close gate permanently, then signal stop
+            gate.close()
+            stop.set()
+            release.set()
+            t.join(15)
+        finally:
+            stop.set()
+            release.set()
+            t.join(15)
+
+    assert not t.is_alive() and not errors, errors
+    assert not submitted.is_set(), "new profile job submitted after teardown stop"
+
+
+def test_desktop_lifespan_teardown_closes_admission_gate(monkeypatch, _isolate_hermes_home):
+    """FastAPI lifespan on Desktop initializes CronAdmissionGate and closes it upon shutdown."""
+    from starlette.testclient import TestClient
+    import hermes_cli.web_server as ws
+
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setattr(ws, "_warm_gateway_module", lambda: None)
+    monkeypatch.setattr(ws, "_start_desktop_cron_ticker", lambda *_args, **_kwargs: None)
+    import hermes_cli.gateway as g
+    monkeypatch.setattr(g, "_reap_unsupervised_gateway_orphans", lambda: True)
+
+    client = TestClient(ws.app)
+    with client:
+        gate = ws.app.state.cron_admission_gate
+        assert gate is not None
+        assert gate.is_closed is False
+        assert gate.can_dispatch() is True
+
+    assert gate.is_closed is True
+    assert gate.can_dispatch() is False
+
+
+def test_idle_watchdog_refuses_drain_while_busy():
+    """Watchdog refuses to exit while a ticker dispatch reservation is in flight."""
+    from hermes_cli.web_server_idle_exit import (
+        CronAdmissionGate,
+        IdleClientTracker,
+        start_idle_watchdog,
+    )
+
+    clock = {"value": 0.0}
+    tracker = IdleClientTracker(now=lambda: clock["value"])
+    clock["value"] = 10.0
+    server = SimpleNamespace(should_exit=False)
+    gate = CronAdmissionGate()
+    refused_probe_invoked = threading.Event()
+
+    with gate.dispatch_guard() as admitted:
+        assert admitted is True
+
+        def probe():
+            refused_probe_invoked.set()
+            return False
+
+        watchdog = start_idle_watchdog(
+            server,
+            tracker,
+            grace_s=1.0,
+            poll_s=0.01,
+            probe=probe,
+            admission_gate=gate,
+        )
+        assert refused_probe_invoked.wait(timeout=15)
+        assert server.should_exit is False
+        assert gate.can_dispatch() is True
+
+    # Once the reservation is released, the watchdog can drain and initiate exit
+    watchdog.join(timeout=15)
+    assert server.should_exit is True
+    assert gate.can_dispatch() is False
+
+
+def test_idle_watchdog_can_use_admission_gate_before_exit():
+    from hermes_cli.web_server_idle_exit import (
+        CronAdmissionGate,
+        IdleClientTracker,
+        start_idle_watchdog,
+    )
+
+    clock = {"value": 0.0}
+    tracker = IdleClientTracker(now=lambda: clock["value"])
+    clock["value"] = 10.0
+    server = SimpleNamespace(should_exit=False)
+    gate = CronAdmissionGate()
+
+    start_idle_watchdog(
+        server,
+        tracker,
+        grace_s=1.0,
+        poll_s=0.01,
+        probe=lambda: False,
+        admission_gate=gate,
+    ).join(timeout=15)
+
+    assert server.should_exit is True
+    assert gate.can_dispatch() is False
+
+
+def test_idle_watchdog_reopens_admission_when_liveness_changes():
+    from hermes_cli.web_server_idle_exit import (
+        CronAdmissionGate,
+        IdleClientTracker,
+        start_idle_watchdog,
+    )
+
+    clock = {"value": 0.0}
+    tracker = IdleClientTracker(now=lambda: clock["value"])
+    clock["value"] = 10.0
+    server = SimpleNamespace(should_exit=False)
+    gate = CronAdmissionGate()
+    probes = []
+
+    def probe():
+        probes.append(True)
+        if len(probes) == 2:
+            server.should_exit = True
+            return True
+        return False
+
+    start_idle_watchdog(
+        server,
+        tracker,
+        grace_s=1.0,
+        poll_s=0.01,
+        probe=probe,
+        admission_gate=gate,
+    ).join(timeout=15)
+
+    assert server.should_exit is True
+    assert gate.can_dispatch() is True
+    assert len(probes) == 2


### PR DESCRIPTION
## Summary

This is a complementary follow-up for #107485 and #107503. It closes the admission race at the SSH-isolated Desktop backend boundary: once idle-exit begins draining, the in-process Desktop cron ticker cannot start a new scheduled dispatch, and the watchdog revalidates client idleness and turn liveness before requesting process exit.

This PR does not modify, copy, supersede, or claim ownership of #107503. That PR remains the direct fix for the original blind spot where `turn_in_flight()` did not see in-process cron executions. This change is safe to merge as a follow-up after that liveness fix, or to reconcile with it if both touch the watchdog file.

## Problem observed

- The Desktop backend starts the in-process cron ticker from `hermes_cli/web_server.py:_start_desktop_cron_ticker()`.
- The same SSH-isolated backend runs the idle-exit watchdog.
- The watchdog's decision and cron admission were independent: a probe could report idle, then the ticker could enter `cron.scheduler.tick()` before `server.should_exit` was set.
- With the original cron-blind probe, this was the reported failure in #107485. With the direct liveness fix applied, the remaining check-then-exit window could still admit a scheduled fire concurrently with shutdown.

The regression contract is behavioral: a dispatch already inside the admission boundary prevents drain from starting; after drain begins, a new tick is rejected; if liveness changes during the final recheck, the gate reopens and the backend remains usable.

## Root cause

The existing `can_dispatch` callback only performed a point-in-time boolean read. It was checked before `cron_tick()` and again inside `cron.scheduler.tick()`, but no reservation covered the interval between the read and the actual tick submission. Therefore, idle-exit had no linearization point with scheduled cron admission.

The existing scheduler already exposes an optional `can_dispatch` hook and supports multiplexed profile ticks, but it had no corresponding admission guard. The SSH watchdog could set `server.should_exit` while a ticker was between its liveness check and job submission.

## Impact and scope

Affected:

- Desktop-spawned backends (`HERMES_DESKTOP=1`) that host the built-in in-process cron ticker.
- SSH-isolated backends using the idle-exit watchdog.
- Single-profile and multiplexed Desktop ticker paths.

Not affected:

- External cron providers such as Chronos; no guard is passed to providers that do not support it.
- The `CronScheduler` abstract interface: its required `name` and `start` methods remain unchanged.
- Non-Desktop gateway scheduling, unless its caller explicitly supplies the optional guard.
- Cron persistence, `next_run_at`, catch-up policy, delivery, credentials, prompts, tool schemas, and session prompt caching.

This PR does not independently replace #107503's cron liveness probe. Until #107503 or an equivalent direct probe fix is merged, a cron that is already invisible to `turn_in_flight()` can still be misclassified before this admission gate is reached.

## Solution

- Added `CronAdmissionGate` in `hermes_cli/web_server_idle_exit.py`.
  - `dispatch_guard()` atomically reserves a dispatch under a lock.
  - `try_begin_drain()` closes admission only when no reservation is active.
  - `can_dispatch()` provides the existing boolean hook.
  - `cancel_drain()` restores admission if the final liveness recheck changes.
- Added the optional `dispatch_guard` path to `InProcessCronScheduler.start()` and its multiplex loop.
  - Every built-in tick is executed inside the guard.
  - A rejected dispatch leaves due jobs untouched for the next allowed lifecycle.
  - No new abstract method or provider requirement was introduced.
- Wired one gate through the Desktop backend lifecycle.
  - The Desktop ticker receives both `can_dispatch` and `dispatch_guard`.
  - The SSH idle watchdog closes admission before its final client/turn recheck.
  - If the client or turn state changes, admission is reopened and shutdown is not requested.
  - Normal lifespan teardown also closes admission before signaling the ticker to stop.

The linearization point is the gate lock: either the ticker increments the in-flight dispatch count first, or idle-exit changes the state to draining first. The two operations cannot both observe an open gate without one owning the reservation.

## Alternatives considered

- Directly adding cron to `turn_in_flight()` — implemented by the existing #107503 and intentionally not duplicated here.
- Moving all Desktop scheduling to a long-lived gateway — larger lifecycle/adapter/profile change; does not preserve Desktop-only installations.
- Chronos/external scheduling (#61516) — strongest scale-to-zero architecture, but requires an external service, authenticated callback, and profile-aware deployment.
- Durable execution leases and ledger-based idle probes — useful for cross-process restart recovery, but adds storage I/O and is broader than this admission race.
- Fixed grace-time increases or disabling idle-exit — workarounds that retain unnecessary processes and do not establish ownership.
- Event-only counters — lower polling overhead but do not by themselves provide the drain/admission linearization or durable recovery.
- Catch-up/skip policy changes (#104981, #106255, #77420) — address missed occurrence semantics, not the concurrent shutdown admission bug; remain separate follow-ups.

## Compatibility and residual risks

- No configuration key or public environment variable was added.
- No disk, SQLite, network, SSH, or process scan is added to the idle watchdog hot path.
- Gate transitions are `O(1)` time and `O(1)` memory. Existing scheduler work remains unchanged; each tick adds one short lock/context-manager section.
- The gate covers scheduled built-in ticker dispatches owned by this Desktop backend. It does not change manual run semantics or external-provider ownership.
- A process can still be killed by an external OS failure, deliberate operator restart, or a restart gap with no in-flight run. Existing execution-ledger and at-most-once policies remain unchanged.
- The direct cron-running probe from #107503 remains a prerequisite for the original false-negative case; this PR is deliberately documented as complementary rather than a duplicate replacement.
- The admission gate and the sibling-backend liveness protocol in #107042 both extend the idle-exit lifecycle surface; maintainers may need to reconcile those independent changes during merge.

## Tests and verification

All commands below used the repository-mandated `scripts/run_tests.sh` wrapper with the shared Python interpreter passed through `HERMES_PYTHON`.

| Command | Result |
|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_web_server_idle_exit_drain.py -q` on base before implementation | **RED: 4 failed, 0 passed**; expected missing `CronAdmissionGate` and unsupported `dispatch_guard` behavior |
| Same focused command after implementation | **6 passed, 0 failed** |
| `scripts/run_tests.sh tests/hermes_cli/test_web_server_idle_exit.py tests/hermes_cli/test_web_server.py tests/hermes_cli/test_desktop_cron_ticker_profiles.py tests/cron/test_scheduler_provider.py tests/cron/test_cron_multiplex_desktop_ticker_scope.py tests/cron/test_scheduler_shutdown_guard.py -q` | **245 passed, 0 failed, 4 skipped** |
| `scripts/run_tests.sh tests/cron/test_scheduler.py tests/cron/test_run_one_job.py tests/cron/test_shutdown_interrupt.py tests/cron/test_restart_safe_worker.py tests/cron/test_execution_ledger.py tests/cron/test_misfire_catchup.py -q` | **193 passed, 0 failed, 2 skipped** |
| `scripts/run_tests.sh tests/cron/ -q` | **1187 passed, 11 failed, 35 skipped**; 5 files were flaky on first attempt but passed the runner retry. The 11 failures are Windows/path/lifecycle-budget failures outside this patch. The same four failing files and 11 failures were reproduced on clean `origin/main`. |
| `scripts/check-windows-footguns.py --all` | **Passed; 1530 files scanned** |
| `python -m ruff check hermes_cli/web_server_idle_exit.py hermes_cli/web_server.py cron/scheduler_provider.py tests/hermes_cli/test_web_server_idle_exit_drain.py` | **Passed** |
| `python -m py_compile` on all three production files and the new test | **Passed** |
| `git diff --check` | **Passed** |

The complete `tests/hermes_cli/` directory run exceeded the local 420-second tool limit and is **inconclusive**, not reported as passed or failed. No test process remained afterward.

Graphify was used before editing for `query`, `explain`, and `path` traversal of the cron ticker, idle watchdog, and `get_running_job_ids()` relationships. The post-edit `graphify update . --no-cluster` attempt exceeded the local 420-second limit; no graph index or residual process was left in the isolated worktree.

## Files and documentation

- `hermes_cli/web_server_idle_exit.py` — gate state machine and final idle-exit recheck.
- `cron/scheduler_provider.py` — optional guard around single-profile and multiplexed built-in ticks.
- `hermes_cli/web_server.py` — Desktop gate lifecycle wiring and watchdog integration.
- `tests/hermes_cli/test_web_server_idle_exit_drain.py` — six behavior-contract tests covering admission ordering, rejection after drain, provider wrapping, Desktop wiring, exit, and reopening after liveness changes.

No secrets, credentials, or `.env` contents were read or included.

## Delivery state

- Base: `origin/main` at `05d705dd695d1084388529124dc2ffe5ce919e89`.
- Local head: `4f57d87c0278140abf89d717a240df0e9990a718`.
- Branch: `fix/107485-drain-admission`.
- Intended head repository: `JoaoMarcos44/hermes-agent`.
- This is a complementary follow-up to #107503, not a superseding implementation.
- CI: not yet reported locally; remote CI status must be read after publication.
