### PR TITLE
fix(desktop): show first-hide toast when zone minimized (#107927)

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -44,6 +44,7 @@ import {
 import { FLOATING_PLACEMENT } from './renderer/floating-rect'
 import { tabStripVisibleForZone } from './renderer/strip-visibility'
 import { rootChildSide } from './renderer/track-model'
+import { maybeShowZoneHideToast } from './zone-hide-toast'
 
 // v2: v1 trees were saved against placeholder panes with index-order zone
 // assignment (chat could land in a corner cell). Retire them wholesale.
@@ -1663,6 +1664,10 @@ export function setTreeGroupMinimized(groupId: string, minimized: boolean) {
 
   if (tree) {
     commit(setGroupMinimized(tree, groupId, minimized))
+
+    if (minimized) {
+      maybeShowZoneHideToast()
+    }
   }
 }
 

--- a/apps/desktop/src/components/pane-shell/tree/zone-hide-toast.ts
+++ b/apps/desktop/src/components/pane-shell/tree/zone-hide-toast.ts
@@ -1,0 +1,27 @@
+import { readKey, writeKey } from '@/lib/storage'
+import { notify } from '@/store/notifications'
+
+const FIRST_HIDE_SEEN_KEY = 'zone-hide-first-time-toast-seen'
+
+/**
+ * Show a one-time educational toast the first time a user minimizes a zone,
+ * telling them how to restore it with ⌘B. Addresses #107927 — zone-level hide
+ * has no visible restore affordance, so discoverability relies on keyboard
+ * knowledge.
+ */
+export function maybeShowZoneHideToast() {
+  const seen = readKey(FIRST_HIDE_SEEN_KEY)
+
+  if (seen === 'true') {
+    return
+  }
+
+  notify({
+    kind: 'info',
+    message: 'Sidebar hidden — press ⌘B to bring it back',
+    durationMs: 8_000,
+    placement: 'default'
+  })
+
+  writeKey(FIRST_HIDE_SEEN_KEY, 'true')
+}


### PR DESCRIPTION
Fixes #107927

**What**: Show a one-time educational toast when a user minimizes a zone for the first time.

**Why**: Zone-level hide has no visible restore affordance. Users who click the zone chevron lose the sidebar with no discoverable way back — recovery requires keyboard knowledge (⌘B), the command palette, or the layout editor. Issue #107927 reported this as the "recovery path too deep" half of the #107196 family.

**How**: A new `maybeShowZoneHideToast()` function checks localStorage on the first minimize and shows an 8s info toast: "Sidebar hidden — press ⌘B to bring it back".

**Alternatives considered**:
- Always-visible restore chip (the #107925 / #107776 thread) — more invasive, requires z-index fix
- Edge handle on the hidden side — harder to discover, more complex
- This toast approach: one-time education, simple implementation, no ongoing UI cost

**Testing**: Manual verification (minimize left zone → toast appears once; second minimize → no toast).

cc @huklaa @cryingpotat0