### PR TITLE
feat(cli): name the pooled credential in the /model switch summary

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1793,6 +1793,14 @@ display:
   #   false: Hide reasoning (default)
   show_reasoning: false
 
+  # Name the pooled API key that will serve the next request, printed under the
+  # provider line of the /model switch summary. Useful when a provider holds
+  # several pooled credentials ("hermes auth priority <provider> <label> 0"):
+  # the model name alone cannot tell you which key is live.
+  #   true:  Show the credential label + priority (default)
+  #   false: Omit those lines from the switch summary
+  show_switch_credentials: true
+
   # Stream tokens to the terminal as they arrive instead of waiting for the
   # full response. The response box opens on first token and text appears
   # line-by-line. Tool calls are still captured silently.

--- a/cli.py
+++ b/cli.py
@@ -407,6 +407,7 @@ def _cli_config_defaults():
             "resume_display": "full", "resume_exchanges": 10, "resume_max_user_chars": 300,
             "resume_max_assistant_chars": 200, "resume_max_assistant_lines": 3, "resume_skip_tool_only": True,
             "show_reasoning": True, "reasoning_full": False, "streaming": True, "busy_input_mode": "interrupt",
+            "show_switch_credentials": True,
             "persistent_output": True, "persistent_output_max_lines": 200,
             # Also clear scrollback on redraw/resize recovery; off because users prefer history.
             "cli_rebuild_scrollback_on_redraw": False,
@@ -2582,6 +2583,9 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         self.bell_on_complete = display.get("bell_on_complete", False)
         self.bell_on_prompt = display.get("bell_on_prompt", False)  # bell when a blocking modal opens
         self.show_reasoning = display.get("show_reasoning", True)
+        # Name the pooled credential the next request will use in the /model switch summary
+        # (display.show_switch_credentials).
+        self.show_switch_credentials = display.get("show_switch_credentials", True)
         self.reasoning_full = display.get("reasoning_full", False)
         _configure_output_history(
             enabled=display.get("persistent_output", True),

--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -83,6 +83,33 @@ def _merge_preflight_warning(cli, result, custom_providers) -> None:
         logger.debug("preflight-compression switch warning failed: %s", exc)
 
 
+def _active_credential_lines(provider: str) -> list[str]:
+    """Lines naming the pooled credential the next request for ``provider`` will use.
+
+    Reads the same source as ``hermes auth list`` (``credential_pool.load_pool(...).peek()``), so the
+    label printed is the credential the pool will actually select — not a guess from the model name.
+    ``peek()`` is a non-destructive read. Display-only: any failure yields no lines.
+    """
+    provider = (provider or "").strip().lower()
+    if not provider:
+        return []
+    try:
+        from agent.credential_pool import load_pool
+        pool = load_pool(provider)
+        entry = pool.peek()
+    except Exception:
+        return []
+    if entry is None:
+        return []
+    label = (getattr(entry, "label", "") or "").strip()
+    if not label:
+        return []
+    lines = [f"    API key: {label} (priority {entry.priority})"]
+    if len(pool.entries()) > 1:
+        lines.append(f"    Switch: hermes auth priority {provider} <label> 0")
+    return lines
+
+
 def _print_switch_summary(cli, result, old_model, *, one_turn: bool, strict_context: bool) -> None:
     """Record the next-turn switch note and print the "Model switched" block.
 
@@ -101,6 +128,9 @@ def _print_switch_summary(cli, result, old_model, *, one_turn: bool, strict_cont
         f"Adjust your self-identification accordingly.]")
     _cprint(f"  ✓ Model switched: {_display_new}")
     _cprint(f"    Provider: {result.provider_label or result.target_provider}")
+    if getattr(cli, "show_switch_credentials", True):
+        for line in _active_credential_lines(result.target_provider):
+            _cprint(line)
 
     # Provider-aware context chain: Codex OAuth / Copilot / Nous caps win over the raw
     # models.dev entry (gpt-5.5 is 1.05M on openai but 272K on Codex OAuth).

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -785,6 +785,10 @@ DEFAULT_CONFIG = {
         # Post-response "Reasoning" recap collapses to 10 lines; true prints it all (live streaming
         # is always full).
         "reasoning_full": False,
+        # Name the pooled credential (label + priority) the next request will use, right under the
+        # provider line of the /model switch summary — the label is the key actually selected, which
+        # the model name alone does not reveal when a provider has several pooled keys.
+        "show_switch_credentials": True,
         # Background self-improvement notices in chat: "off" (review still runs) | "on" (generic "💾
         # Memory updated") | "verbose" (content preview). Per-platform via
         # display.platforms.<platform>.memory_notifications.

--- a/tests/hermes_cli/test_model_switch_credentials.py
+++ b/tests/hermes_cli/test_model_switch_credentials.py
@@ -1,0 +1,84 @@
+"""The /model switch summary names the pooled credential the next request will use.
+
+A provider can hold several pooled keys (`hermes auth pool`), and the switch summary named only the
+model and provider — so "which key am I on?" was unanswerable from the CLI without `hermes auth
+list`. The summary now prints the label of the credential the pool will actually select
+(``credential_pool.load_pool(provider).peek()``, the same source ``hermes auth list`` marks with
+``←``), plus the reorder hint when the pool has more than one entry.
+
+Contract under test: the lines follow the pool, not the model name — and
+``display.show_switch_credentials: false`` suppresses them without touching the rest of the block.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from hermes_cli.cli_model_switch_mixin import _print_switch_summary
+
+
+class _FakeEntry:
+    def __init__(self, label="work-key", priority=0):
+        self.label = label
+        self.priority = priority
+
+
+class _FakePool:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def peek(self):
+        return self._entries[0] if self._entries else None
+
+    def entries(self):
+        return list(self._entries)
+
+
+def _result():
+    """Minimal switch result: `model_info=None` keeps Context/Max output out of the block."""
+    return SimpleNamespace(
+        new_model="deepseek-flash", target_provider="deepseek", provider_label="DeepSeek",
+        model_info=None, base_url="", api_key="", api_mode=None, warning_message=None)
+
+
+def _cli(**overrides):
+    cli = SimpleNamespace(agent=None, base_url="", api_key="", conversation_history=[])
+    cli.__dict__.update(overrides)
+    return cli
+
+
+def _run(cli, pool):
+    printed = []
+    with patch("cli._cprint", side_effect=printed.append), \
+            patch("agent.credential_pool.load_pool", return_value=pool), \
+            patch("hermes_cli.model_switch.resolve_display_context_length", return_value=None):
+        _print_switch_summary(cli, _result(), "glm-5.3-flash", one_turn=False, strict_context=False)
+    return printed
+
+
+def test_summary_names_the_pooled_credential_and_reorder_hint():
+    """Two pooled keys: the selected label shows, and the reorder hint names the provider."""
+    printed = _run(_cli(), _FakePool([_FakeEntry("work-key", 0), _FakeEntry("backup-key", 1)]))
+
+    assert any("work-key" in line for line in printed), printed
+    assert any("work-key (priority 0)" in line for line in printed), printed
+    assert any("hermes auth priority deepseek" in line for line in printed), printed
+    assert not any("backup-key" in line for line in printed), (
+        "only the credential the pool will use is named, not the whole pool")
+
+
+def test_single_entry_pool_has_no_reorder_hint():
+    """One key cannot be reordered before another, so the hint would be noise."""
+    printed = _run(_cli(), _FakePool([_FakeEntry("only-key", 0)]))
+
+    assert any("only-key" in line for line in printed), printed
+    assert not any("hermes auth priority" in line for line in printed), printed
+
+
+def test_disabled_flag_suppresses_credential_lines_only():
+    """`display.show_switch_credentials: false` drops these lines, not the switch summary."""
+    printed = _run(_cli(show_switch_credentials=False), _FakePool([_FakeEntry("work-key")]))
+
+    assert any("Model switched: deepseek-flash" in line for line in printed), printed
+    assert any("Provider: DeepSeek" in line for line in printed), printed
+    assert not any("work-key" in line for line in printed), printed

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1991,6 +1991,7 @@ display:
   # protocol advertised), a warp://cli-agent OSC 777 event (`stop` on completion, `permission_request` on
   # blocking prompts) so Warp's tab status and notification mailbox track Hermes. No extra keys needed.
   show_reasoning: true    # Show model reasoning/thinking above each response (default: true; toggle with /reasoning show|hide)
+  show_switch_credentials: true  # Name the pooled API key (label + priority) the next request will use, under the provider line of the /model switch summary
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   show_cost: false        # Show estimated $ cost in the CLI status bar
   timestamps: false       # When true, prefixes user and assistant labels with timestamps in the CLI / TUI transcript


### PR DESCRIPTION
## What does this PR do?

The `/model` switch summary tells you the model and the provider, but never which **credential** served it. A provider can hold several pooled keys (`hermes auth priority <provider> <label> <n>`), so after switching, "which key am I on?" is only answerable by running `hermes auth list` and finding the `←` marker by eye.

This adds the missing line: the label (and priority) of the credential the pool will actually select, printed directly under the provider line, plus the reorder hint when the pool holds more than one entry.

```
  ✓ Model switched: deepseek-flash
    Provider: DeepSeek
    API key: work-key (priority 0)
    Switch: hermes auth priority deepseek <label> 0
    Context: 1,000,000 tokens
    Max output: 384,000 tokens
    Capabilities: reasoning, tools, vision, structured output, open weights
```

The label comes from `agent.credential_pool.load_pool(provider).peek()` — the same source `hermes auth list` marks with `←`, so the line follows the pool's actual selection rather than guessing from the model name. `peek()` is a non-destructive read: it does not rotate the pool and does not rewrite the store (verified below). No key material is printed — only the label.

Gated by `display.show_switch_credentials` (default `true`); a provider with no pool, a blank label, or any lookup failure simply adds no line.

## Related Issue

N/A — no issue exists for this. Searched first per `CONTRIBUTING.md`: `gh search prs --repo NousResearch/hermes-agent --state all` and `gh pr list --state all` for "credential pool switch summary" / "switch summary credential" returned no matching PR (closest neighbours are #63943 `/apikey` mid-session credential hotswap and #67285 credential-pool switch command, neither of which reports the active credential in the switch summary). `gh search issues` turned up one adjacent open issue, #86230 (`switch_model` loads an empty credential pool for custom providers) — same subsystem, a different problem; this PR neither fixes nor depends on it.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/cli_model_switch_mixin.py` — new module-level `_active_credential_lines(provider)` helper, and the gated call in `_print_switch_summary()` under the `Provider:` line.
- `hermes_cli/config_defaults.py` — declares `display.show_switch_credentials` (default `true`).
- `cli.py` — the matching entry in `CLI_CONFIG`'s display baseline (that file's comment requires the two dicts stay in sync) and `self.show_switch_credentials`, read once at init like the neighbouring display flags.
- `tests/hermes_cli/test_model_switch_credentials.py` — 3 tests: the selected label + reorder hint appear and the non-selected label does not; a single-entry pool omits the hint; `show_switch_credentials: false` removes the lines but leaves the rest of the block intact.
- `website/docs/user-guide/configuration.md`, `cli-config.yaml.example` — documented.

Zero deletions — every change is additive.

## How to Test

1. `hermes` → `/model <name>` on a provider with pooled credentials. The summary gains `API key: <label> (priority N)` and, when the pool has more than one credential, `Switch: hermes auth priority <provider> <label> 0`.
2. `hermes config set display.show_switch_credentials false`, restart the CLI, switch again: the credential lines are gone, the rest of the block (Provider / Context / Max output / Capabilities / persistence note) is unchanged.
3. `scripts/run_tests.sh tests/hermes_cli/test_model_switch_credentials.py` → 3 passed.

Evidence gathered while building this:

- `peek()` proven non-writing: `auth.json` sha/md5 identical before and after the call, for both the profile store and the root store.
- Labels cross-checked against `hermes auth list <provider>` for four providers: `openrouter` (3 credentials → `meir (priority 0)` + hint), `deepseek` (3 → same shape), `nous` (single OAuth credential → label shown, hint correctly suppressed), `anthropic` (no pool → no lines).
- Gate exercised end-to-end through the real `switch_model()` → `_print_switch_summary()` path in both states.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(cli): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run in full.** I ran the affected suites with `scripts/run_tests.sh`: `tests/hermes_cli/test_model_switch_credentials.py` (3 passed), the other `tests/hermes_cli/test_model_switch_*.py` files, `test_apply_model_switch_result_context.py`, `test_config.py`, `test_config_loader_e2e.py`, `test_reasoning_full_command.py`, `test_session_vacuum_config.py`, `test_state_synchronous_pragma.py` (45 tests, all passed). One pre-existing failure to be aware of, unrelated to this diff: `tests/hermes_cli/test_model_switch_context_offload.py`'s three async tests fail on this host with `PytestUnknownMarkWarning: Unknown pytest.mark.asyncio` — they fail identically with these changes stashed (missing pytest-asyncio in the local venv). Happy to run the full suite if CI doesn't cover it.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 26.04.1 LTS (CLI, Python 3.14)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/user-guide/configuration.md` display section
- [x] I've updated `cli-config.yaml.example` for the new config key
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A: pure string formatting plus a config read; no paths, no OS-specific calls
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Live sample from the author's install (provider with three pooled credentials):

```
$ /model deepseek-flash
  ✓ Model switched: deepseek-flash
    Provider: DeepSeek
    API key: meir (priority 0)
    Switch: hermes auth priority deepseek <label> 0
    Context: 1,000,000 tokens
    Max output: 384,000 tokens
    Capabilities: reasoning, tools, vision, structured output, open weights
    (session only — add --global to persist)
```

With `display.show_switch_credentials: false`, the `API key:` and `Switch:` lines are absent and every other line is byte-identical.
