### PR TITLE
fix(goals): stop /goal over-continuation on exploratory + scope-narrow goals (salvage of #34343)

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -109,6 +109,91 @@ CONTINUATION_PROMPT_GATE_FAILED_TEMPLATE = (
     "gate itself is wrong or cannot pass, say so clearly and stop."
 )
 
+# ---------------------------------------------------------------------
+# Exploratory-goal heuristic (#34196)
+# ---------------------------------------------------------------------
+_EXPLORATORY_KEYWORDS: Tuple[str, ...] = (
+    "review",
+    "reflect",
+    "reflection",
+    "suggest",
+    "suggestions",
+    "explore",
+    "brainstorm",
+    "propose options",
+    "propose some",
+    "analyze",
+    "analysis",
+    "compare",
+    "comparison",
+    "summarize",
+    "summary",
+    "think about",
+    "think through",
+    "consider",
+    "recommend",
+    "recommendation",
+    "observe",
+    "reflect on ways",
+    "ways you can help",
+    "ways to help",
+    "what could",
+    "what would you suggest",
+    "investigate",
+    "audit",
+    "evaluate",
+)
+
+_ILLUSTRATIVE_MARKERS: Tuple[str, ...] = (
+    "for example",
+    "e.g.",
+    "such as",
+    "examples include",
+    "examples:",
+    "maybe",
+    "you could",
+    "could be",
+    "or maybe",
+    "or perhaps",
+    "like writing",
+    "like preparing",
+    "like creating",
+)
+
+
+def _classify_goal_shape(goal: str) -> str:
+    """Classify a goal as 'exploratory', 'illustrative', or 'concrete'."""
+    if not goal:
+        return "concrete"
+    text = goal.lower()
+    is_exploratory = any(kw in text for kw in _EXPLORATORY_KEYWORDS)
+    is_illustrative = any(marker in text for marker in _ILLUSTRATIVE_MARKERS)
+    if is_exploratory:
+        return "exploratory"
+    if is_illustrative:
+        return "illustrative"
+    return "concrete"
+
+
+_GOAL_SHAPE_HINTS: Dict[str, str] = {
+    "exploratory": (
+        "\n\nNote: This goal is EXPLORATORY (review/reflect/suggest/analyze). "
+        "A substantive synthesis or recommendation list IS the deliverable. "
+        "Do not require the agent to manufacture additional artifacts that "
+        "the goal only mentioned as examples. Mark DONE when the response "
+        "meaningfully addresses the stated scope."
+    ),
+    "illustrative": (
+        "\n\nNote: This goal lists possible actions with 'for example' / "
+        "'maybe' / 'you could' markers. Treat those as illustrative "
+        "possibilities, NOT as required deliverables. The agent satisfies "
+        "the goal by addressing the core request — it does not need to "
+        "produce every listed example."
+    ),
+    "concrete": "",
+}
+
+
 JUDGE_SYSTEM_PROMPT = (
     "You are a strict judge evaluating whether an autonomous agent has "
     "achieved a user's stated goal. You receive the goal text, the agent's "
@@ -153,6 +238,23 @@ JUDGE_SYSTEM_PROMPT = (
     "finishes.\n\n"
     "CONTINUE — not done, and there is a concrete next step the agent can "
     "take right now. This is the default when in doubt.\n\n"
+    "- The goal is EXPLORATORY (asks to review, reflect, suggest, explore, "
+    "brainstorm, propose options, analyze, or compare) AND the response "
+    "provides a substantive synthesis / analysis / recommendation that "
+    "addresses the stated scope. For exploratory goals a high-quality "
+    "synthesis IS the deliverable — do NOT keep continuing just to "
+    "manufacture artifacts the goal merely listed as examples of help.\n\n"
+    "Guardrails when judging CONTINUE:\n"
+    "- Do NOT infer 'incomplete' from a file being untracked, unstaged, "
+    "or uncommitted unless the goal explicitly required staging, "
+    "committing, pushing, or a clean working tree.\n"
+    "- Do NOT require a magic phrase like 'goal complete'. A clear final "
+    "answer with the requested content satisfies the goal.\n"
+    "- Treat goal items phrased as 'for example' / 'maybe' / 'you could' "
+    "as illustrative possibilities, NOT required deliverables.\n"
+    "- When the goal scope is narrow (one file, one section, one specific "
+    "change) and the response confirms that exact scope is done, return "
+    "DONE — do not expand scope to neighboring sections.\n\n"
     "Reply ONLY with a single JSON object on one line. Shapes:\n"
     '{"verdict": "done", "reason": "<one sentence>"}\n'
     '{"verdict": "blocked", "reason": "<one sentence>"}\n'
@@ -906,16 +1008,23 @@ def judge_goal(
         + (JUDGE_DELEGATIONS_BLOCK_TEMPLATE.format(count=active_delegations) if active_delegations > 0 else ""),
         current_time=datetime.now(tz=timezone.utc).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z"),
     )
+    goal_shape = _classify_goal_shape(goal)
+    shape_hint = _GOAL_SHAPE_HINTS.get(goal_shape, "")
     if contract is not None and not contract.is_empty():
         contract_block = contract.render_block()
         if clean_subgoals:
             contract_block = f"{contract_block}\n{_render_extra_criteria(clean_subgoals)}"
         prompt = JUDGE_USER_PROMPT_WITH_CONTRACT_TEMPLATE.format(contract_block=_truncate(contract_block, 2500), **common)
+        # Contract is the authoritative definition of done — the shape hint
+        # (a heuristic) deliberately does not override it.
     elif clean_subgoals:
         subgoals_block = "\n".join(f"- {i}. {text}" for i, text in enumerate(clean_subgoals, start=1))
         prompt = JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE.format(subgoals_block=_truncate(subgoals_block, 2000), **common)
+        # With-subgoals template enforces strict evidence per criterion;
+        # don't dilute that with exploratory/illustrative hints.
     else:
         prompt = JUDGE_USER_PROMPT_TEMPLATE.format(**common)
+        prompt = prompt + shape_hint
 
     try:
         raw = _call_goal_judge_llm(call_llm, JUDGE_SYSTEM_PROMPT, prompt, timeout)
@@ -1688,6 +1797,6 @@ __all__ = [
     "CONTINUATION_PROMPT_WITH_CONTRACT_TEMPLATE", "JUDGE_USER_PROMPT_TEMPLATE",
     "JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE", "JUDGE_USER_PROMPT_WITH_CONTRACT_TEMPLATE",
     "DRAFT_CONTRACT_SYSTEM_PROMPT", "KANBAN_GOAL_CONTINUATION_TEMPLATE", "KANBAN_GOAL_FINALIZE_TEMPLATE",
-    "DEFAULT_MAX_TURNS", "load_goal", "save_goal", "clear_goal", "migrate_goal_to_session", "judge_goal",
+    "JUDGE_SYSTEM_PROMPT", "DEFAULT_MAX_TURNS", "_classify_goal_shape", "_GOAL_SHAPE_HINTS", "_EXPLORATORY_KEYWORDS", "_ILLUSTRATIVE_MARKERS", "load_goal", "save_goal", "clear_goal", "migrate_goal_to_session", "judge_goal",
     "run_kanban_goal_loop",
 ]

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -873,3 +873,90 @@ class TestBlockedVerdict:
         assert mgr.state is not None
         assert mgr.state.status == "paused"
         assert "unachievable" in (mgr.state.paused_reason or "").lower()
+
+
+class TestClassifyGoalShape:
+    def test_exploratory_review(self):
+        from hermes_cli.goals import _classify_goal_shape
+        assert _classify_goal_shape("Please review the architecture") == "exploratory"
+
+    def test_illustrative_for_example(self):
+        from hermes_cli.goals import _classify_goal_shape
+        assert _classify_goal_shape("Help me plan, for example writing a README") == "illustrative"
+
+    def test_concrete_default(self):
+        from hermes_cli.goals import _classify_goal_shape
+        assert _classify_goal_shape("Add a --verbose flag to the CLI") == "concrete"
+
+    def test_empty_is_concrete(self):
+        from hermes_cli.goals import _classify_goal_shape
+        assert _classify_goal_shape("") == "concrete"
+
+
+class TestJudgeSystemPromptGuardrails:
+    def test_mentions_exploratory(self):
+        from hermes_cli.goals import JUDGE_SYSTEM_PROMPT
+        assert "EXPLORATORY" in JUDGE_SYSTEM_PROMPT
+
+    def test_mentions_untracked(self):
+        from hermes_cli.goals import JUDGE_SYSTEM_PROMPT
+        assert "untracked" in JUDGE_SYSTEM_PROMPT
+
+    def test_mentions_magic_phrase(self):
+        from hermes_cli.goals import JUDGE_SYSTEM_PROMPT
+        assert "magic phrase" in JUDGE_SYSTEM_PROMPT
+
+    def test_mentions_illustrative(self):
+        from hermes_cli.goals import JUDGE_SYSTEM_PROMPT
+        assert "illustrative" in JUDGE_SYSTEM_PROMPT
+
+
+class TestJudgePromptIncludesGoalShapeHint:
+    def test_exploratory_gets_hint(self, hermes_home):
+        from unittest.mock import patch
+        from hermes_cli import goals
+
+        captured = {}
+
+        def fake_llm(call_llm, system_prompt, user_prompt, timeout):
+            captured["user"] = user_prompt
+            return '{"verdict": "done", "reason": "ok"}'
+
+        with patch("hermes_cli.goals._call_goal_judge_llm", side_effect=fake_llm), patch(
+            "agent.auxiliary_client.call_llm", return_value=None
+        ):
+            goals.judge_goal("review the logs", "Here is a synthesis of the logs.")
+        assert "EXPLORATORY" in captured["user"]
+
+    def test_concrete_no_hint(self, hermes_home):
+        from unittest.mock import patch
+        from hermes_cli import goals
+
+        captured = {}
+
+        def fake_llm(call_llm, system_prompt, user_prompt, timeout):
+            captured["user"] = user_prompt
+            return '{"verdict": "continue", "reason": "ok"}'
+
+        with patch("hermes_cli.goals._call_goal_judge_llm", side_effect=fake_llm), patch(
+            "agent.auxiliary_client.call_llm", return_value=None
+        ):
+            goals.judge_goal("Add a --verbose flag to the CLI", "I added it.")
+        assert "EXPLORATORY" not in captured["user"]
+        assert "for example" not in captured["user"]
+
+    def test_subgoals_skip_hint(self, hermes_home):
+        from unittest.mock import patch
+        from hermes_cli import goals
+
+        captured = {}
+
+        def fake_llm(call_llm, system_prompt, user_prompt, timeout):
+            captured["user"] = user_prompt
+            return '{"verdict": "continue", "reason": "ok"}'
+
+        with patch("hermes_cli.goals._call_goal_judge_llm", side_effect=fake_llm), patch(
+            "agent.auxiliary_client.call_llm", return_value=None
+        ):
+            goals.judge_goal("review the logs", "synthesis", subgoals=["must cite file X"])
+        assert "EXPLORATORY" not in captured["user"]


### PR DESCRIPTION
Salvage of #34343 by @Bartok9, rebuilt cleanly on current `main`.

## Problem
`/goal` judge over-continues exploratory (review/reflect/suggest) goals and infers incompleteness from untracked files (#34196, #34197).

## Fix
- `_classify_goal_shape` + shape hints on the default judge user prompt
- Guardrails in `JUDGE_SYSTEM_PROMPT` (exploratory DONE, no magic phrase, untracked not incomplete, illustrative examples not required)
- Contract/subgoals templates skip the heuristic

## Verification
`python3 -m pytest tests/hermes_cli/test_goals.py -q` — 51 passed
`python3 -m py_compile hermes_cli/goals.py tests/hermes_cli/test_goals.py`

Closes the salvage of #34343. Issue #34196 already closed; #34197 still open (lifecycle race is separate).