### PR TITLE
fix(terminal): remote NOPASSWD sudo no longer prompts for a password (#83327, salvage #83357)

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -6,6 +6,7 @@ init_session() failure handling, and the CWD marker contract.
 
 from unittest.mock import MagicMock
 
+import tools.terminal_tool_sudo as terminal_tool_sudo
 from tools.environments.base import BaseEnvironment
 from tools.environments.base_output import _BoundedOutputCollector
 
@@ -21,6 +22,48 @@ class _TestableEnv(BaseEnvironment):
 
     def cleanup(self):
         pass
+
+
+def test_prepare_command_uses_selected_environment_for_nopasswd(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    env = _TestableEnv()
+    monkeypatch.setattr(env, "_sudo_nopasswd_works", lambda: True)
+
+    def _fail_prompt(*_args, **_kwargs):
+        raise AssertionError("interactive sudo prompt should not run for NOPASSWD")
+
+    monkeypatch.setattr(terminal_tool_sudo, "_prompt_for_sudo_password", _fail_prompt)
+
+    transformed, sudo_stdin = env._prepare_command("sudo true")
+
+    assert transformed == "sudo true"
+    assert sudo_stdin is None
+
+
+def test_nopasswd_probe_runs_inside_selected_environment(monkeypatch):
+    env = _TestableEnv()
+    proc = object()
+    run = MagicMock(return_value=proc)
+    wait = MagicMock(return_value={"returncode": 0})
+    monkeypatch.setattr(env, "_run_bash", run)
+    monkeypatch.setattr(env, "_wait_for_process", wait)
+
+    assert env._sudo_nopasswd_works() is True
+    run.assert_called_once_with(
+        "sudo -n true",
+        login=False,
+        timeout=3,
+        stdin_data=None,
+    )
+    wait.assert_called_once_with(proc, timeout=3)
+
+
+def test_nopasswd_probe_fails_closed_on_backend_error(monkeypatch):
+    env = _TestableEnv()
+    monkeypatch.setattr(env, "_run_bash", MagicMock(side_effect=RuntimeError("offline")))
+
+    assert env._sudo_nopasswd_works() is False
 
 
 class TestBoundedOutputCollector:

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -14,6 +14,8 @@ from tools.environments.base_output import _BoundedOutputCollector
 class _TestableEnv(BaseEnvironment):
     """Concrete subclass for testing base class methods."""
 
+    _sudo_nopasswd_probe_supported = True
+
     def __init__(self, cwd="/tmp", timeout=10):
         super().__init__(cwd=cwd, timeout=timeout)
 
@@ -64,6 +66,16 @@ def test_nopasswd_probe_fails_closed_on_backend_error(monkeypatch):
     monkeypatch.setattr(env, "_run_bash", MagicMock(side_effect=RuntimeError("offline")))
 
     assert env._sudo_nopasswd_works() is False
+
+
+def test_nopasswd_probe_skips_backends_without_safe_process_cancel(monkeypatch):
+    env = _TestableEnv()
+    env._sudo_nopasswd_probe_supported = False
+    run = MagicMock(side_effect=AssertionError("probe must not start"))
+    monkeypatch.setattr(env, "_run_bash", run)
+
+    assert env._sudo_nopasswd_works() is False
+    run.assert_not_called()
 
 
 class TestBoundedOutputCollector:

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -6,6 +6,8 @@ init_session() failure handling, and the CWD marker contract.
 
 from unittest.mock import MagicMock
 
+import pytest
+
 import tools.terminal_tool_sudo as terminal_tool_sudo
 from tools.environments.base import BaseEnvironment
 from tools.environments.base_output import _BoundedOutputCollector
@@ -37,45 +39,26 @@ def test_prepare_command_uses_selected_environment_for_nopasswd(monkeypatch):
 
     monkeypatch.setattr(terminal_tool_sudo, "_prompt_for_sudo_password", _fail_prompt)
 
-    transformed, sudo_stdin = env._prepare_command("sudo true")
-
-    assert transformed == "sudo true"
-    assert sudo_stdin is None
+    assert env._prepare_command("sudo true") == ("sudo true", None)
 
 
-def test_nopasswd_probe_runs_inside_selected_environment(monkeypatch):
+@pytest.mark.parametrize(
+    ("supported", "returncode", "expected", "probed"),
+    [(True, 0, True, True), (True, 1, False, True), (False, 0, False, False)],
+)
+def test_nopasswd_probe_runs_sudo_n_inside_backend_only_when_supported(
+    monkeypatch, supported, returncode, expected, probed
+):
     env = _TestableEnv()
-    proc = object()
-    run = MagicMock(return_value=proc)
-    wait = MagicMock(return_value={"returncode": 0})
+    env._sudo_nopasswd_probe_supported = supported
+    run = MagicMock(return_value=object())
     monkeypatch.setattr(env, "_run_bash", run)
-    monkeypatch.setattr(env, "_wait_for_process", wait)
+    monkeypatch.setattr(env, "_wait_for_process", MagicMock(return_value={"returncode": returncode}))
 
-    assert env._sudo_nopasswd_works() is True
-    run.assert_called_once_with(
-        "sudo -n true",
-        login=False,
-        timeout=3,
-        stdin_data=None,
-    )
-    wait.assert_called_once_with(proc, timeout=3)
-
-
-def test_nopasswd_probe_fails_closed_on_backend_error(monkeypatch):
-    env = _TestableEnv()
-    monkeypatch.setattr(env, "_run_bash", MagicMock(side_effect=RuntimeError("offline")))
-
-    assert env._sudo_nopasswd_works() is False
-
-
-def test_nopasswd_probe_skips_backends_without_safe_process_cancel(monkeypatch):
-    env = _TestableEnv()
-    env._sudo_nopasswd_probe_supported = False
-    run = MagicMock(side_effect=AssertionError("probe must not start"))
-    monkeypatch.setattr(env, "_run_bash", run)
-
-    assert env._sudo_nopasswd_works() is False
-    run.assert_not_called()
+    assert env._sudo_nopasswd_works() is expected
+    assert run.called is probed
+    if probed:
+        assert run.call_args.args[0] == "sudo -n true"
 
 
 class TestBoundedOutputCollector:

--- a/tests/tools/test_subagent_sudo_prompt.py
+++ b/tests/tools/test_subagent_sudo_prompt.py
@@ -29,8 +29,6 @@ def _clean_sudo_state(monkeypatch):
     """Isolate sudo-related process/thread state per test."""
     monkeypatch.delenv("SUDO_PASSWORD", raising=False)
     monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
-    # Host sudoers NOPASSWD must not short-circuit the path under test.
-    monkeypatch.setattr(tts, "_sudo_nopasswd_works", lambda: False)
     tts._reset_cached_sudo_passwords()
     tt.set_sudo_password_callback(None)
     yield

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -78,6 +78,39 @@ def test_explicit_empty_sudo_password_tries_empty_without_prompt(monkeypatch):
     assert sudo_stdin == "\n"
 
 
+def test_backend_nopasswd_probe_skips_interactive_prompt(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+    def _fail_prompt(*_args, **_kwargs):
+        raise AssertionError("interactive sudo prompt should not run for NOPASSWD")
+
+    monkeypatch.setattr(terminal_tool_sudo, "_prompt_for_sudo_password", _fail_prompt)
+
+    transformed, sudo_stdin = terminal_tool_sudo._transform_sudo_command(
+        "sudo true",
+        sudo_nopasswd_check=lambda: True,
+    )
+
+    assert transformed == "sudo true"
+    assert sudo_stdin is None
+
+
+def test_configured_password_does_not_run_backend_nopasswd_probe(monkeypatch):
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+
+    def _fail_probe():
+        raise AssertionError("configured passwords must bypass the NOPASSWD probe")
+
+    transformed, sudo_stdin = terminal_tool_sudo._transform_sudo_command(
+        "sudo true",
+        sudo_nopasswd_check=_fail_probe,
+    )
+
+    assert transformed == "sudo -S -p '' true"
+    assert sudo_stdin == "testpass\n"
+
+
 def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project; rm -rf /")
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project$(whoami)")

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -78,37 +78,17 @@ def test_explicit_empty_sudo_password_tries_empty_without_prompt(monkeypatch):
     assert sudo_stdin == "\n"
 
 
-def test_backend_nopasswd_probe_skips_interactive_prompt(monkeypatch):
+def test_headless_sudo_never_runs_backend_nopasswd_probe(monkeypatch):
+    """No prompt can fire without a UI, so the backend round trip must not be paid."""
     monkeypatch.delenv("SUDO_PASSWORD", raising=False)
-    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
-
-    def _fail_prompt(*_args, **_kwargs):
-        raise AssertionError("interactive sudo prompt should not run for NOPASSWD")
-
-    monkeypatch.setattr(terminal_tool_sudo, "_prompt_for_sudo_password", _fail_prompt)
-
-    transformed, sudo_stdin = terminal_tool_sudo._transform_sudo_command(
-        "sudo true",
-        sudo_nopasswd_check=lambda: True,
-    )
-
-    assert transformed == "sudo true"
-    assert sudo_stdin is None
-
-
-def test_configured_password_does_not_run_backend_nopasswd_probe(monkeypatch):
-    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    terminal_tool.set_sudo_password_callback(None)
 
     def _fail_probe():
-        raise AssertionError("configured passwords must bypass the NOPASSWD probe")
+        raise AssertionError("headless sudo must not probe the backend")
 
-    transformed, sudo_stdin = terminal_tool_sudo._transform_sudo_command(
-        "sudo true",
-        sudo_nopasswd_check=_fail_probe,
-    )
-
-    assert transformed == "sudo -S -p '' true"
-    assert sudo_stdin == "testpass\n"
+    assert terminal_tool_sudo._transform_sudo_command("sudo true", sudo_nopasswd_check=_fail_probe) == (
+        "sudo true", None)
 
 
 def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -587,9 +587,27 @@ class BaseEnvironment(ABC):
             pass
 
     def _prepare_command(self, command: str) -> tuple[str, str | None]:
-        """Transform sudo commands if SUDO_PASSWORD is available."""
+        """Prepare sudo using this environment's passwordless-sudo probe."""
         from tools.terminal_tool_sudo import _transform_sudo_command
-        return _transform_sudo_command(command)
+
+        return _transform_sudo_command(
+            command,
+            sudo_nopasswd_check=self._sudo_nopasswd_works,
+        )
+
+    def _sudo_nopasswd_works(self) -> bool:
+        """Probe passwordless sudo inside this execution environment."""
+        try:
+            proc = self._run_bash(
+                "sudo -n true",
+                login=False,
+                timeout=3,
+                stdin_data=None,
+            )
+            result = self._wait_for_process(proc, timeout=3)
+            return result.get("returncode") == 0
+        except Exception:
+            return False
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -154,6 +154,10 @@ class BaseEnvironment(ABC):
     # Snapshot creation timeout (override for slow cold-starts).
     _snapshot_timeout: int = 30
 
+    # Opt in only when a timed-out probe can kill its command without tearing
+    # down the whole backend. SDK adapters cancel by stopping the sandbox.
+    _sudo_nopasswd_probe_supported: bool = False
+
     # Local and Docker override this because they resolve allowlisted values
     # through the active profile scope; other backends keep plain snapshots.
     _profile_scoped_passthrough: bool = False
@@ -597,6 +601,8 @@ class BaseEnvironment(ABC):
 
     def _sudo_nopasswd_works(self) -> bool:
         """Probe passwordless sudo inside this execution environment."""
+        if not self._sudo_nopasswd_probe_supported:
+            return False
         try:
             proc = self._run_bash(
                 "sudo -n true",

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -591,27 +591,20 @@ class BaseEnvironment(ABC):
             pass
 
     def _prepare_command(self, command: str) -> tuple[str, str | None]:
-        """Prepare sudo using this environment's passwordless-sudo probe."""
+        """Rewrite sudo for a piped password, or leave it alone when this backend has NOPASSWD."""
         from tools.terminal_tool_sudo import _transform_sudo_command
+        return _transform_sudo_command(command, sudo_nopasswd_check=self._sudo_nopasswd_works)
 
-        return _transform_sudo_command(
-            command,
-            sudo_nopasswd_check=self._sudo_nopasswd_works,
-        )
+    _SUDO_PROBE_TIMEOUT_S = 3
 
     def _sudo_nopasswd_works(self) -> bool:
-        """Probe passwordless sudo inside this execution environment."""
+        """``sudo -n true`` inside THIS backend (host sudo state must not leak into a sandbox).
+        Fails closed: any error or a timed-out probe means "assume a password is needed"."""
         if not self._sudo_nopasswd_probe_supported:
             return False
         try:
-            proc = self._run_bash(
-                "sudo -n true",
-                login=False,
-                timeout=3,
-                stdin_data=None,
-            )
-            result = self._wait_for_process(proc, timeout=3)
-            return result.get("returncode") == 0
+            proc = self._run_bash("sudo -n true", timeout=self._SUDO_PROBE_TIMEOUT_S)
+            return self._wait_for_process(proc, timeout=self._SUDO_PROBE_TIMEOUT_S).get("returncode") == 0
         except Exception:
             return False
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -486,6 +486,7 @@ class DockerEnvironment(BaseEnvironment):
     size-limited tmpfs). The container is the security boundary — its filesystem stays
     writable so agents can install packages. Persistence bind-mounts /workspace and /root."""
 
+    _sudo_nopasswd_probe_supported = True
     _profile_scoped_passthrough = True
 
     def _additional_profile_scoped_passthrough_names(self) -> tuple[str, ...]:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -687,6 +687,7 @@ class LocalEnvironment(BaseEnvironment):
     the session snapshot preserves env vars across calls; CWD persists via the
     stdout marker."""
 
+    _sudo_nopasswd_probe_supported = True
     _profile_scoped_passthrough = True
     # Commands run on the Hermes host itself — controller-side platform behavior
     # (macOS TCC pruning, etc.) legitimately applies here.

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -138,6 +138,8 @@ class SingularityEnvironment(BaseEnvironment):
     Session snapshot preserves env vars across calls; CWD persists via in-band stdout markers.
     """
 
+    _sudo_nopasswd_probe_supported = True
+
     def __init__(self, image: str, cwd: str = "~", timeout: int = 60, cpu: float = 0,
                  memory: int = 0, disk: int = 0, persistent_filesystem: bool = False,
                  task_id: str = "default"):

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -53,6 +53,7 @@ class SSHEnvironment(BaseEnvironment):
     # Passthrough values are re-forwarded on every command (see _run_bash), so like docker/local
     # they stay out of the remote snapshot under multiplex.
     _profile_scoped_passthrough = True
+    _sudo_nopasswd_probe_supported = True
 
     def __init__(self, host: str, user: str, cwd: str = "~",
                  timeout: int = 60, port: int = 22, key_path: str = "",

--- a/tools/terminal_tool_sudo.py
+++ b/tools/terminal_tool_sudo.py
@@ -13,8 +13,7 @@ import subprocess
 import sys
 import threading
 import time
-from typing import Callable
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
 from utils import env_var_enabled
 
@@ -363,23 +362,6 @@ def _count_real_sudo_invocations(command: str) -> int:
     return _rewrite_real_sudo_invocations(command)[1]
 
 
-def _sudo_nopasswd_works() -> bool:
-    """True when local sudo currently works without prompting. Local backend only — Docker/SSH/
-    Modal must not inherit host sudo state. Re-probes every call (no cache) so an expired sudo
-    timestamp can't make a later command silently block waiting for a password."""
-    from tools.terminal_tool import _tenv
-    if (_tenv("TERMINAL_ENV", "local").strip().lower() or "local") != "local":
-        return False
-    try:
-        probe = subprocess.run(
-            ["sudo", "-n", "true"], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL, timeout=3, check=False,
-        )
-        return probe.returncode == 0
-    except Exception:
-        return False
-
-
 def _rewrite_compound_background(command: str) -> str:
     """Wrap `A && B &` (or `A || B &`) to `A && { B & }` at depth 0. Bash binds `&&` tighter
     than `&`, so `A && B &` backgrounds a subshell that runs B in the foreground and waits for
@@ -447,7 +429,9 @@ def _transform_sudo_command(
     password in the command string themselves. With no password available the command is
     returned unchanged and ``sudo_stdin`` is None, so it fails gracefully with "sudo: a password
     is required". Password sources, in order: configured SUDO_PASSWORD, the session cache, then
-    an interactive prompt (45s timeout, cached on success) when a UI is reachable."""
+    an interactive prompt (45s timeout, cached on success) when a UI is reachable.
+    ``sudo_nopasswd_check`` (supplied by ``BaseEnvironment``) runs ``sudo -n true`` inside the
+    selected backend; a True result skips the prompt and the ``-S`` rewrite entirely."""
     from tools.terminal_tool import _get_sudo_password_callback
     if command is None:
         return None, None
@@ -465,24 +449,19 @@ def _transform_sudo_command(
     has_configured_password = _configured_password is not None
     sudo_password = _configured_password if has_configured_password else _get_cached_sudo_password()
 
-    # sudoers NOPASSWD must not be forced through the prompt or the -S pipe. BaseEnvironment
-    # supplies a probe scoped to the selected backend; direct callers keep the local-host
-    # fallback. Re-probed every call so an expired sudo timestamp cannot silently block.
-    if not has_configured_password and not sudo_password:
-        nopasswd_check = sudo_nopasswd_check or _sudo_nopasswd_works
-        try:
-            if nopasswd_check():
-                return command, None
-        except Exception:
-            pass
-
     # delegate_task children inherit HERMES_INTERACTIVE=1 (and possibly a stale thread-local
     # callback on a recycled worker) but have no user on the other side — always headless;
-    # configured password, session cache and the NOPASSWD probe still apply.
+    # configured password and session cache still apply.
     should_prompt_for_sudo = (
         env_var_enabled("HERMES_INTERACTIVE") or _get_sudo_password_callback() is not None
     ) and not _in_delegated_child_context()
     if not has_configured_password and not sudo_password and should_prompt_for_sudo:
+        # sudoers NOPASSWD must not be forced through the prompt or the -S pipe. The probe is
+        # a round trip on the selected backend (an ssh exec for SSH), so it only runs when a
+        # prompt would otherwise fire: headless callers end up at ``(command, None)`` either
+        # way. Re-probed every call so an expired sudo timestamp cannot silently block.
+        if sudo_nopasswd_check is not None and sudo_nopasswd_check():
+            return command, None
         sudo_password = _prompt_for_sudo_password(timeout_seconds=45)
         if sudo_password:
             _set_cached_sudo_password(sudo_password)

--- a/tools/terminal_tool_sudo.py
+++ b/tools/terminal_tool_sudo.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import threading
 import time
+from typing import Callable
 from collections.abc import Iterator
 
 from utils import env_var_enabled
@@ -434,7 +435,10 @@ def _rewrite_compound_background(command: str) -> str:
     return result
 
 
-def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None]:
+def _transform_sudo_command(
+    command: str | None,
+    sudo_nopasswd_check: Callable[[], bool] | None = None,
+) -> tuple[str | None, str | None]:
     """Rewrite command-position ``sudo`` executables to ``sudo -S -p ''`` when a password is available (shared by every
     execution environment). Returns ``(command, sudo_stdin)``: ``sudo_stdin`` is one password
     line per sudo invocation that the caller must PREPEND to the process stdin (sudo -S consumes
@@ -461,9 +465,16 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     has_configured_password = _configured_password is not None
     sudo_password = _configured_password if has_configured_password else _get_cached_sudo_password()
 
-    # sudoers NOPASSWD hosts must not be forced through the prompt or the -S pipe (local only).
-    if not has_configured_password and not sudo_password and _sudo_nopasswd_works():
-        return command, None
+    # sudoers NOPASSWD must not be forced through the prompt or the -S pipe. BaseEnvironment
+    # supplies a probe scoped to the selected backend; direct callers keep the local-host
+    # fallback. Re-probed every call so an expired sudo timestamp cannot silently block.
+    if not has_configured_password and not sudo_password:
+        nopasswd_check = sudo_nopasswd_check or _sudo_nopasswd_works
+        try:
+            if nopasswd_check():
+                return command, None
+        except Exception:
+            pass
 
     # delegate_task children inherit HERMES_INTERACTIVE=1 (and possibly a stale thread-local
     # callback on a recycled worker) but have no user on the other side — always headless;


### PR DESCRIPTION
Remote SSH (and Docker/Singularity) users with `NOPASSWD` sudo no longer get a Hermes password prompt before their `sudo` command runs.

Salvage of #83357 by @fangliquanflq (both commits cherry-picked, authorship preserved), rebased onto current `main` (the PR predates the #102117 decomposition, so the `_transform_sudo_command` change is ported to its new home `tools/terminal_tool_sudo.py`). Closes #83327.

## Root cause

The only NOPASSWD short-circuit in `_transform_sudo_command` called a host-side `sudo -n true` that was hard-gated to `TERMINAL_ENV=local`, so a remote backend's own sudo policy was never observed and the interactive prompt fired anyway.

## Changes

- `tools/environments/base.py` — `BaseEnvironment._sudo_nopasswd_works()` runs `sudo -n true` through the backend's own `_run_bash` (fail-closed on any error / 3 s timeout) and is passed into `_transform_sudo_command` from `_prepare_command`. Opt-in flag `_sudo_nopasswd_probe_supported`, set on Local / Docker / SSH / Singularity only — SDK sandboxes (Modal, Daytona, Vercel) cancel a timed-out process by terminating the whole sandbox, so they stay on the prompt path. (@fangliquanflq)
- `tools/terminal_tool_sudo.py` — `_transform_sudo_command(command, sudo_nopasswd_check=...)`. Follow-up on top of the contributor's change:
  - the probe runs only when a prompt would otherwise fire (`should_prompt_for_sudo`). Headless callers (gateway, cron, delegated children) reach `(command, None)` either way, so the extra backend round trip — a full ssh exec on the SSH backend — was pure waste on every headless sudo command;
  - the now-callerless host-only `_sudo_nopasswd_works` and its `TERMINAL_ENV` gate are deleted; the dead `try/except` around a callback that already fails closed is gone.
- Tests: 3 behaviour contracts (`_prepare_command` → backend probe → no prompt; parametrized probe rc/unsupported-backend; headless never probes). `test_subagent_sudo_prompt` no longer needs to patch the host probe out.

## Validation

| Check | Result |
|---|---|
| Live E2E, real `LocalEnvironment` + PATH-shim `sudo` where `sudo -n true` exits 0, `TERMINAL_ENV=ssh`, `HERMES_INTERACTIVE=1`, no `SUDO_PASSWORD` | main: prompt fires, command hangs on the prompt (rc 124). branch: no prompt, rc 0. Negative control (probe exits 1): prompt still fires on both. |
| New tests on `origin/main` (production files reverted) | 5 failed (red) |
| New tests on branch | green |
| Mutation: probe moved back above `should_prompt_for_sudo` | headless guard test fails |
| `tests/tools/` environment + terminal + sudo files (12 files) | 184 passed, 5 skipped (backend-conditional) |
| `ruff`, `check_compat_pointers.py`, `check-windows-footguns.py --all` | clean |

Original PR's real-SSH verification (temporary OpenSSH server with a `NOPASSWD` account) is @fangliquanflq's; this salvage reproduces the path locally through the same `BaseEnvironment.execute` → `_prepare_command` → `_run_bash` chain rather than a live remote host.
