### PR TITLE
fix(tools): ssh backend file tools resolve ~ against the remote home, not the gateway's (#71201, salvage #71280)

### DIFF
--- a/tests/tools/test_resolve_path.py
+++ b/tests/tools/test_resolve_path.py
@@ -37,3 +37,30 @@ class TestResolvePath:
             terminal_tool.clear_session_cwd(task_id)
 
         assert result == live_dir / "nested" / "file.txt"
+
+    def test_ssh_tilde_not_expanded_on_host(self, monkeypatch):
+        """#71201: on the ssh backend a leading ~ must NOT be expanded against
+        the gateway HOME — it must pass through for remote-side expansion."""
+        from tools import file_tools_paths
+
+        monkeypatch.setattr(
+            file_tools_paths, "_terminal_env_type_for_task",
+            lambda task_id="default": "ssh",
+        )
+
+        assert str(file_tools_paths._resolve_path_for_task("~/notes.txt")) == "~/notes.txt"
+        assert str(file_tools_paths._resolve_path_for_task("~")) == "~"
+        assert str(file_tools_paths._resolve_path_for_task("~user/file.txt")) == "~user/file.txt"
+
+    def test_local_tilde_still_expanded(self, monkeypatch):
+        """On the local backend ~ is still expanded (regression guard)."""
+        from tools import file_tools_paths
+
+        monkeypatch.setattr(
+            file_tools_paths, "_terminal_env_type_for_task",
+            lambda task_id="default": "local",
+        )
+
+        result = file_tools_paths._resolve_path_for_task("~/notes.txt")
+        assert "~" not in str(result)
+        assert result.is_absolute()

--- a/tools/file_tools_paths.py
+++ b/tools/file_tools_paths.py
@@ -171,7 +171,14 @@ def _resolve_base_dir(
 
 def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | PurePosixPath:
     """Resolve *filepath* against the task's absolute base directory
-    (absolute inputs are returned resolved-but-unanchored)."""
+    (absolute inputs are returned resolved-but-unanchored).
+
+    On the ssh backend a leading ``~`` is returned untouched: expanding it here names
+    the GATEWAY's home, but the path runs on the remote, whose ``$HOME`` differs
+    (#71201). ``ShellFileOperations._expand_path`` expands it through the remote shell.
+    """
+    if filepath.startswith("~") and _terminal_env_type_for_task(task_id) == "ssh":
+        return PurePosixPath(filepath)
     container_paths = _uses_container_paths(task_id)
     return _anchor(_host_text(filepath, container_paths),
                    lambda: _resolve_base_dir(task_id, container_paths=container_paths), container_paths)

--- a/tools/file_tools_paths.py
+++ b/tools/file_tools_paths.py
@@ -176,6 +176,7 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
     On the ssh backend a leading ``~`` is returned untouched: expanding it here names
     the GATEWAY's home, but the path runs on the remote, whose ``$HOME`` differs
     (#71201). ``ShellFileOperations._expand_path`` expands it through the remote shell.
+    Container backends are NOT covered here — their ``~`` still expands host-side.
     """
     if filepath.startswith("~") and _terminal_env_type_for_task(task_id) == "ssh":
         return PurePosixPath(filepath)


### PR DESCRIPTION
## Outcome

On the `ssh` terminal backend, `write_file` / `patch` / `read_file` with a `~`-prefixed path now land in the **remote** user's home instead of failing (or silently writing elsewhere) because `~` was expanded against the gateway host's HOME before the path reached the remote.

Fixes #71201. Salvage of #71280 by @pittosporum-seu — their commit is cherry-picked so authorship is preserved; ported from `tools/file_tools.py` to `tools/file_tools_paths.py` (the resolver moved there in the Sep facade split, after the PR was opened) and the tests re-pointed to the same module.

## Changes

- `tools/file_tools_paths.py::_resolve_path_for_task` — a leading `~` on the `ssh` backend returns `PurePosixPath(filepath)` unexpanded; `ShellFileOperations._expand_path` already expands `~` / `~user` through the remote shell (`echo $HOME`). Non-tilde paths and every other backend are untouched.
- `tests/tools/test_resolve_path.py` — 2 invariant tests: ssh tilde forms (`~`, `~/x`, `~user/x`) pass through unchanged; local backend still expands to an absolute path. Proven red on `origin/main`'s resolver, green with the fix.
- Docstring scopes the guard to ssh explicitly (container backends still expand `~` host-side — separate follow-up, see below).

## Validation

Live E2E, macOS gateway (HOME `/Users/<user>`) → Linux ssh remote (HOME `/home/<user>`), real `SSHEnvironment`, temp `HERMES_HOME`:

| | `write_file("~/pr71280-e2e.txt")` | remote `cat` |
|---|---|---|
| `origin/main` 05d705dd69 | `mkdir: cannot create directory '/Users': Permission denied`, `resolved_path: /Users/<user>/pr71280-e2e.txt` | not found |
| this branch | `bytes_written: 14, verified: true` | `tilde fix e2e` |

`read_file("~/…")` on the remote also works post-fix. The issue author independently confirmed the same before/after on a Fedora → libvirt-VM topology on the original PR.

Local: `tests/tools/test_resolve_path.py`, `test_file_tools_cwd_resolution.py`, `test_file_tools_tilde_profile.py` → 19 passed. `ruff`, `check-windows-footguns.py --all`, `check_compat_pointers.py` clean.

Consumer trace of the now-tilde-form resolved path on ssh: every host-side guard (`_check_sensitive_path`, read denylist, mirror guards, checkpoint dir) also evaluates `normpath(_expand_tilde(raw))` or calls `expanduser()` itself, so none weaken. Two behaviour notes:

- `resolved_path` / `files_modified` report the `~/…` form on ssh tilde writes rather than the remote absolute path (the old value was the wrong, gateway-home path). Surfacing the remote-expanded path through `WriteResult` is a follow-up.
- The protected-instruction approval gate now prompts for remote `~/.hermes/*` writes on ssh (it no longer sees them as under the host's `HERMES_HOME`). Those writes previously failed outright, so this is a new path becoming reachable, not a regression.

## Not in scope

Container backends (docker/modal/daytona) still expand `~` host-side in `_host_text`; their `~` is entangled with the sandbox-mirror home design and needs its own live repro. Relative paths on ssh anchoring to the host cwd are #57998's territory.
