### PR TITLE
fix(tests): skip POSIX-only and symlink tests on Windows CI

### DIFF
--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -224,6 +224,7 @@ def test_atomic_replace_broken_symlink_creates_target(tmp_path: Path) -> None:
 
 
 
+@pytest.mark.require_symlinks
 def test_atomic_replace_copy_fallback_preserves_symlink(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -506,6 +507,7 @@ def test_in_place_rewrite_never_exposes_a_truncated_file(
     assert observed == [5000]
 
 
+@pytest.mark.require_symlinks
 def test_symlinked_target_survives_a_contended_rename(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fast_replace_retries: None
 ) -> None:

--- a/tests/test_hermes_bootstrap.py
+++ b/tests/test_hermes_bootstrap.py
@@ -120,6 +120,7 @@ class TestUserOptOut:
 
 
 
+@pytest.mark.linux_only
 class TestPosixNoOp:
     """POSIX: zero behavior change.  We don't touch LANG, LC_*, or any
     stdio.  The goal is that Linux/macOS behave identically before and
@@ -336,6 +337,7 @@ class TestHardenImportPath:
 class TestSuppressPlatformVerConsole:
     """suppress_platform_ver_console: stub applied on Windows, no-op on POSIX."""
 
+    @pytest.mark.linux_only
     def test_noop_on_posix(self):
         import platform
         hb = _fresh_import()

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -33,6 +33,7 @@ from hermes_constants import (
 class TestGetDefaultHermesRoot:
     """Tests for get_default_hermes_root() — Docker/custom deployment awareness."""
 
+    @pytest.mark.linux_only
     def test_no_hermes_home_returns_native(self, tmp_path, monkeypatch):
         """When HERMES_HOME is not set, returns ~/.hermes."""
         monkeypatch.delenv("HERMES_HOME", raising=False)
@@ -759,7 +760,10 @@ class TestGetHermesDir:
         """
         self._set_home(tmp_path, monkeypatch)
         legacy = tmp_path / "pairing"
-        legacy.symlink_to(tmp_path / "does-not-exist")
+        try:
+            legacy.symlink_to(tmp_path / "does-not-exist")
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"Symlink not supported on this platform/permission: {exc}")
         new = tmp_path / "platforms" / "pairing"
         new.mkdir(parents=True)
         (new / "discord-approved.json").write_text("[]")
@@ -773,7 +777,10 @@ class TestGetHermesDir:
         real.mkdir()
         (real / "cached.png").write_bytes(b"x")
         legacy = tmp_path / "image_cache"
-        legacy.symlink_to(real)
+        try:
+            legacy.symlink_to(real)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"Symlink not supported on this platform/permission: {exc}")
         result = get_hermes_dir("cache/images", "image_cache")
         assert result == legacy
 


### PR DESCRIPTION
Five tests were silently failing on the Windows CI job because they either required a Linux/macOS runtime or created symlinks (which the default Windows user cannot do without Developer Mode).

Mark them with the project's existing linux_only / require_symlinks markers so CI on Windows skips them cleanly instead of reporting red:

* TestPosixNoOp, test_noop_on_posix, test_no_hermes_home_returns_native -> @pytest.mark.linux_only (the asserts only make sense on POSIX where '~/.hermes' is the natural HERMES_HOME fallback).
* test_atomic_replace_copy_fallback_preserves_symlink, test_symlinked_target_survives_a_contended_rename -> @pytest.mark.require_symlinks (matches the pattern already used by sibling tests in the same file).

For the two symlink tests in test_hermes_constants.py that weren't covered by require_symlinks, wrap the symlink_to() call in a try/except(OSError, NotImplementedError) -> pytest.skip() so a host without symlink privilege still skips instead of erroring out.

No production code touched. Verified locally on win32 Python 3.11.9: 88 passed, 25 skipped, 0 failed across the three files (down from 7 failed, 88 passed).

## What does this PR do?

Five test cases were hard-coded to assert POSIX-only behavior (`~/.hermes`, `os.environ` untouched) or to call `Path.symlink_to()` — both of which fail on a vanilla Windows CI runner. The project's `pytest` setup already defines `linux_only` and `require_symlinks` markers via `tests/conftest.py`, but three of these tests pre-date (or were overlooked when) those markers landed. This PR routes the failing cases through the existing marker mechanism so they skip cleanly on Windows instead of red'ing the job, and uses a `try/except + pytest.skip()` fallback for the two `symlink_to()` calls that aren't already covered by a marker (the conftest's `_check_symlink_support` only gates tests that opted in via `@pytest.mark.require_symlinks`).

## Related Issue

None — discovered while reading the codebase and running the test suite on Windows.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/test_hermes_bootstrap.py`: `@pytest.mark.linux_only` on `TestPosixNoOp` class and on `TestSuppressPlatformVerConsole.test_noop_on_posix`.
- `tests/test_hermes_constants.py`: `@pytest.mark.linux_only` on `TestGetDefaultHermesRoot.test_no_hermes_home_returns_native`; wrapped the `symlink_to()` calls in `test_dangling_legacy_symlink_returns_new` and `test_symlink_to_populated_dir_returns_legacy` with `try/except(OSError, NotImplementedError) -> pytest.skip()`.
- `tests/test_atomic_replace_symlinks.py`: `@pytest.mark.require_symlinks` on `test_atomic_replace_copy_fallback_preserves_symlink` and `test_symlinked_target_survives_a_contended_rename` (matches the four sibling tests in the same file that already use the marker).

## How to Test

1. Activate a Python 3.11 venv and `uv pip install -e ".[all,dev]"` (or the lighter `.[dev]` extra) from the repo root.
2. From the repo root on Windows:
   ```
   pytest tests/test_hermes_bootstrap.py tests/test_hermes_constants.py tests/test_atomic_replace_symlinks.py
   ```
3. Expect 88 passed, 25 skipped, 0 failed (the 5 originally failing tests now report as `skipped` because the host isn't Linux or doesn't permit symlinks).
4. To confirm the markers still gate correctly on their supported platforms, run the same command inside WSL/Linux — the `linux_only` / `require_symlinks` tests should run and pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A: no new tests added; this PR only adjusts the *selection* of tests that already exist.
- [x] I've tested on my platform: Windows 11, Python 3.11.9

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this *is* a cross-platform fix
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Local pytest output (Windows 11, Python 3.11.9, `pytest <three files>`):

```
collected 113 items

tests\test_hermes_bootstrap.py ....s............s.                       [ 16%]
tests\test_hermes_constants.py s........ssssss.......................... [ 53%]
..ssss..ss..................                                             [ 77%]
tests\test_atomic_replace_symlinks.py s..ssssssss.........s....          [100%]

======================= 88 passed, 25 skipped in 4.38s =======================
```

Before this change, the same command produced **7 failed, 88 passed**; the 7 now-skipped tests are the ones this PR routes through the markers.