### PR TITLE
fix(agent): unmask opaque streaming 5xx with one non-streaming retry

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3140,9 +3140,46 @@ class _StreamingCall(StreamingWaitMonitor):
         else:
             self._maybe_disable_streaming(e)
             logger.exception("Streaming failed before delivery: %s", e)
+            if self._unmask_server_error_with_nonstreaming(e):
+                return False
         # Propagate to the main retry loop (credential rotation, fallback, backoff).
         self.result["error"] = e
         return False
+
+    def _unmask_server_error_with_nonstreaming(self, e: Exception) -> bool:
+        """One non-streaming re-issue when a 5xx killed the stream before any delta.
+
+        Some gateways validate the request only on their non-streaming path and crash
+        opaquely ("500 something went wrong") when streaming — the real 4xx, with its
+        actionable message, never reaches the user through stream retries. One
+        non-streaming probe surfaces it: on success the response is delivered and the
+        session flips to non-streaming (the _adopt_final_response latch); on a probe 4xx
+        that error REPLACES the opaque 5xx. Any other probe failure keeps the original
+        error. True = handled (caller must not overwrite result); False = propagate ``e``.
+        """
+        status = getattr(e, "status_code", None) or getattr(getattr(e, "response", None), "status_code", None)
+        if not isinstance(status, int) or status < 500 or self.deltas_were_sent["yes"]:
+            return False
+        probe_kwargs = {k: v for k, v in self.api_kwargs.items() if k not in ("stream", "stream_options")}
+        try:
+            probe = interruptible_api_call(self.agent, probe_kwargs)
+        except Exception as probe_err:
+            probe_status = getattr(probe_err, "status_code", None) or getattr(
+                getattr(probe_err, "response", None), "status_code", None)
+            if isinstance(probe_status, int) and probe_status < 500:
+                # The provider's REAL validation error beats the opaque 5xx.
+                logger.info("Non-streaming unmask probe surfaced the underlying error: %s", probe_err)
+                self.result["error"] = probe_err
+                return True
+            logger.info("Non-streaming unmask probe failed: %s", probe_err)
+            return False
+        logger.info("Streaming 5xx re-issued non-streaming successfully; switching %s/%s to non-streaming.",
+                    self.agent.provider or "unknown", self.agent.model or "unknown")
+        self._quiet(self.agent._buffer_status,
+                    "⚠  Streaming failed with a provider server error; the non-streaming retry succeeded. "
+                    "Disabling streaming for this session.")
+        self.result["response"] = self._adopt_final_response(probe)
+        return True
 
     def _call_wire(self, stream_attempt_id: int):
         if self.agent.api_mode != "anthropic_messages":

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3162,8 +3162,11 @@ class _StreamingCall(StreamingWaitMonitor):
         it: on success the response is delivered for this turn WITHOUT latching
         non-streaming (a transient gateway 500 must not permanently disable streaming);
         on a probe 4xx that error REPLACES the opaque 5xx; any other probe failure keeps
-        the original error. Interrupts re-raise (the outer handler routes them). True =
-        handled (caller must not overwrite result); False = propagate ``e``.
+        the original error. The successful delivery is bracketed by its own stream
+        start/end pair (the failed attempt already emitted a terminal end), and a response
+        that cannot be replayed restores the saved preference before propagating ``e``.
+        Interrupts re-raise (the outer handler routes them). True = handled (caller must
+        not overwrite result); False = propagate ``e``.
         """
         status = getattr(e, "status_code", None) or getattr(getattr(e, "response", None), "status_code", None)
         if not isinstance(status, int) or status < 500 or self.deltas_were_sent["yes"]:
@@ -3196,8 +3199,19 @@ class _StreamingCall(StreamingWaitMonitor):
         self._quiet(self.agent._buffer_status,
                     "⚠  Streaming failed with a provider server error; the non-streaming retry succeeded.")
         stream_pref = getattr(self.agent, "_disable_streaming", False)
-        self.result["response"] = self._adopt_final_response(probe)
-        self.agent._disable_streaming = stream_pref  # one-turn recovery, not a session latch
+        try:
+            # The failed attempt already emitted its terminal on_stream_end(finished=False),
+            # so the recovered delivery opens and closes its OWN stream pair — consumers must
+            # never see deltas after that error event.
+            adopted = _with_stream_emitters(self.agent, lambda: self._adopt_final_response(probe))
+        except Exception as adopt_err:
+            # A response we cannot replay must not escape into _call()'s except block, and
+            # must not leave streaming latched off for the session.
+            logger.exception("Non-streaming unmask probe response could not be adopted: %s", adopt_err)
+            return False
+        finally:
+            self.agent._disable_streaming = stream_pref  # one-turn recovery, not a session latch
+        self.result["response"] = adopted
         return True
 
     def _call_wire(self, stream_attempt_id: int):

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -56,6 +56,11 @@ _PROVIDER_STREAM_ERROR_TEXT_LIMIT = 4096
 # billing reasons keep their own longer cooldown.
 _FALLBACK_EXHAUSTED_COOLDOWN_S = 5.0
 
+# Streaming 5xx unmask probe: one non-streaming re-issue per this window. Covers the
+# outer retry loop (up to ~3 attempts x backoff, well under 60s) so an outage doesn't
+# double traffic every attempt, while later turns re-arm automatically.
+_STREAM_5XX_PROBE_WINDOW_S = 60.0
+
 
 def _context_thread_target(callback):
     """Bind a no-argument thread target to the caller's ContextVars."""
@@ -3152,17 +3157,29 @@ class _StreamingCall(StreamingWaitMonitor):
         Some gateways validate the request only on their non-streaming path and crash
         opaquely ("500 something went wrong") when streaming — the real 4xx, with its
         actionable message, never reaches the user through stream retries. One
-        non-streaming probe surfaces it: on success the response is delivered and the
-        session flips to non-streaming (the _adopt_final_response latch); on a probe 4xx
-        that error REPLACES the opaque 5xx. Any other probe failure keeps the original
-        error. True = handled (caller must not overwrite result); False = propagate ``e``.
+        non-streaming probe per TURN (latched on the agent: each outer retry builds a
+        fresh _StreamingCall, so an instance flag would re-probe every attempt) surfaces
+        it: on success the response is delivered for this turn WITHOUT latching
+        non-streaming (a transient gateway 500 must not permanently disable streaming);
+        on a probe 4xx that error REPLACES the opaque 5xx; any other probe failure keeps
+        the original error. Interrupts re-raise (the outer handler routes them). True =
+        handled (caller must not overwrite result); False = propagate ``e``.
         """
         status = getattr(e, "status_code", None) or getattr(getattr(e, "response", None), "status_code", None)
         if not isinstance(status, int) or status < 500 or self.deltas_were_sent["yes"]:
             return False
+        if getattr(self.agent, "api_mode", "") not in ("", "chat_completions"):
+            return False  # adoption replays chat-completions shapes only
+        now = time.time()
+        last_probe = getattr(self.agent, "_stream_5xx_probe_ts", 0.0) or 0.0
+        if now - last_probe < _STREAM_5XX_PROBE_WINDOW_S:
+            return False  # one probe per outer-retry cycle; later turns re-arm
+        self.agent._stream_5xx_probe_ts = now
         probe_kwargs = {k: v for k, v in self.api_kwargs.items() if k not in ("stream", "stream_options")}
         try:
             probe = interruptible_api_call(self.agent, probe_kwargs)
+        except (KeyboardInterrupt, InterruptedError):
+            raise  # the outer handler routes user interrupts; never swallow them
         except Exception as probe_err:
             probe_status = getattr(probe_err, "status_code", None) or getattr(
                 getattr(probe_err, "response", None), "status_code", None)
@@ -3173,12 +3190,14 @@ class _StreamingCall(StreamingWaitMonitor):
                 return True
             logger.info("Non-streaming unmask probe failed: %s", probe_err)
             return False
-        logger.info("Streaming 5xx re-issued non-streaming successfully; switching %s/%s to non-streaming.",
+        logger.info("Streaming 5xx re-issued non-streaming successfully for %s/%s "
+                    "(not latched: the 5xx may be transient).",
                     self.agent.provider or "unknown", self.agent.model or "unknown")
         self._quiet(self.agent._buffer_status,
-                    "⚠  Streaming failed with a provider server error; the non-streaming retry succeeded. "
-                    "Disabling streaming for this session.")
+                    "⚠  Streaming failed with a provider server error; the non-streaming retry succeeded.")
+        stream_pref = getattr(self.agent, "_disable_streaming", False)
         self.result["response"] = self._adopt_final_response(probe)
+        self.agent._disable_streaming = stream_pref  # one-turn recovery, not a session latch
         return True
 
     def _call_wire(self, stream_attempt_id: int):

--- a/tests/agent/test_stream_unmask_5xx.py
+++ b/tests/agent/test_stream_unmask_5xx.py
@@ -5,7 +5,17 @@ only on its non-streaming path returns an opaque ``500 something went wrong`` wh
 streaming the SAME request. _handle_stream_error must re-issue once non-streaming on a
 pre-delta 5xx so the actionable 4xx (or a successful response) reaches the user instead
 of three identical opaque 500s.
+
+Gating invariants (from cross-vendor review):
+- never after partial delivery, on non-5xx, or without an HTTP status
+- one probe per 60s window on the AGENT (outer retries build fresh _StreamingCall
+  instances, so an instance flag would re-probe every attempt)
+- chat-completions wire only (adoption replays chat-completions shapes)
+- probe success delivers for the turn WITHOUT latching _disable_streaming
+  (a transient gateway 500 must not permanently disable streaming)
+- user interrupts re-raise; never swallowed
 """
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -13,10 +23,10 @@ import pytest
 from agent import chat_completion_helpers as h
 
 
-def _make_call(api_kwargs, *, deltas_sent=False):
+def _make_call(api_kwargs, *, deltas_sent=False, api_mode="chat_completions"):
     call = h._StreamingCall.__new__(h._StreamingCall)
     call.agent = SimpleNamespace(
-        provider="custom", model="gpt-5.6-sol",
+        provider="custom", model="gpt-5.6-sol", api_mode=api_mode,
         _interrupt_requested=False,
         _is_provider_stream_parse_error=lambda e: False,
         _buffer_status=lambda text: call.buffered.append(text),
@@ -48,20 +58,26 @@ def _run_handle_stream_error(call, e):
     return call._handle_stream_error(e, attempt=2, max_retries=2)
 
 
-def test_stream_5xx_probe_success_delivers_response(monkeypatch):
+def _prime_probe_window(call):
+    """Ensure the agent's probe window is open (no probe yet, or an old one)."""
+    call.agent._stream_5xx_probe_ts = 0.0
+
+
+def test_stream_5xx_probe_success_delivers_response_without_latch(monkeypatch):
     call = _make_call({"model": "m", "stream": True, "stream_options": {"x": 1}, "messages": []})
+    _prime_probe_window(call)
     seen_kwargs = []
 
     def fake_probe(agent, kwargs):
         seen_kwargs.append(kwargs)
-        return "completed-response"
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok", reasoning_content=None))])
 
     monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
     adopt_calls = []
 
     def fake_adopt(r):
         adopt_calls.append(r)
-        call.agent._disable_streaming = True  # mirror the real latch
+        call.agent._disable_streaming = True  # mirror the real latch inside adoption
         return r
 
     monkeypatch.setattr(call, "_adopt_final_response", fake_adopt)
@@ -69,15 +85,17 @@ def test_stream_5xx_probe_success_delivers_response(monkeypatch):
     handled = not _run_handle_stream_error(call, _StreamErr(500))
 
     assert handled
-    assert call.result["response"] == "completed-response"
+    assert call.result["response"] is not None
     assert call.result["error"] is None
     assert seen_kwargs and "stream" not in seen_kwargs[0] and "stream_options" not in seen_kwargs[0]
-    assert call.agent._disable_streaming is True  # latched by _adopt_final_response
+    # One-turn recovery: adoption's internal latch is RESTORED, not kept.
+    assert call.agent._disable_streaming is False
     assert call.buffered and "non-streaming retry succeeded" in call.buffered[0]
 
 
 def test_stream_5xx_unmasked_by_probe_4xx(monkeypatch):
     call = _make_call({"model": "m", "messages": []})
+    _prime_probe_window(call)
     real = _ProbeErr(400)
 
     def fake_probe(agent, kwargs):
@@ -94,6 +112,7 @@ def test_stream_5xx_unmasked_by_probe_4xx(monkeypatch):
 
 def test_stream_5xx_probe_5xx_keeps_original_error(monkeypatch):
     call = _make_call({"model": "m", "messages": []})
+    _prime_probe_window(call)
     original = _StreamErr(500)
 
     def fake_probe(agent, kwargs):
@@ -146,3 +165,59 @@ def test_no_probe_without_status_code(monkeypatch):
     handled = _run_handle_stream_error(call, Exception("connection exploded"))
 
     assert not handled
+
+
+def test_probe_window_blocks_second_probe_within_60s(monkeypatch):
+    call = _make_call({"model": "m", "messages": []})
+    call.agent._stream_5xx_probe_ts = time.time()  # probe just happened (fresh instance = outer retry)
+
+    def fake_probe(agent, kwargs):
+        raise AssertionError("second probe within the window must not run")
+
+    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+
+    handled = _run_handle_stream_error(call, _StreamErr(500))
+
+    assert not handled
+    assert call.result["error"] is not None  # original error propagates
+
+
+def test_probe_window_rearms_after_60s(monkeypatch):
+    call = _make_call({"model": "m", "messages": []})
+    call.agent._stream_5xx_probe_ts = time.time() - 61.0
+
+    def fake_probe(agent, kwargs):
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok", reasoning_content=None))])
+
+    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+    monkeypatch.setattr(call, "_adopt_final_response", lambda r: r)
+
+    handled = not _run_handle_stream_error(call, _StreamErr(500))
+
+    assert handled
+
+
+def test_probe_skipped_for_non_chat_completions_wire(monkeypatch):
+    call = _make_call({"model": "m", "messages": []}, api_mode="anthropic_messages")
+
+    def fake_probe(agent, kwargs):
+        raise AssertionError("probe must not run on the anthropic wire (adoption replays chat shapes)")
+
+    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+
+    handled = _run_handle_stream_error(call, _StreamErr(500))
+
+    assert not handled
+
+
+def test_interrupt_during_probe_reraises(monkeypatch):
+    call = _make_call({"model": "m", "messages": []})
+    _prime_probe_window(call)
+
+    def fake_probe(agent, kwargs):
+        raise InterruptedError("Agent interrupted during API call")
+
+    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+
+    with pytest.raises(InterruptedError):
+        _run_handle_stream_error(call, _StreamErr(500))

--- a/tests/agent/test_stream_unmask_5xx.py
+++ b/tests/agent/test_stream_unmask_5xx.py
@@ -13,6 +13,8 @@ Gating invariants (from cross-vendor review):
 - chat-completions wire only (adoption replays chat-completions shapes)
 - probe success delivers for the turn WITHOUT latching _disable_streaming
   (a transient gateway 500 must not permanently disable streaming)
+- the recovered delivery opens and closes its own stream pair (consumers must never
+  see deltas after the failed attempt's terminal on_stream_end)
 - user interrupts re-raise; never swallowed
 """
 import time
@@ -61,6 +63,24 @@ def _run_handle_stream_error(call, e):
 def _prime_probe_window(call):
     """Ensure the agent's probe window is open (no probe yet, or an old one)."""
     call.agent._stream_5xx_probe_ts = 0.0
+
+
+def _record_probe(monkeypatch, message):
+    """Install a probe that RECORDS every invocation before failing.
+
+    The production code swallows any exception raised by the probe (the 4xx/5xx
+    classification lives in that ``except``), so a raise-only sentinel is invisible:
+    the call still returns "not handled" and a guard-removed build passes. The
+    recorded list is what proves the guard held.
+    """
+    calls = []
+
+    def fake_probe(agent, kwargs):
+        calls.append(kwargs)
+        raise AssertionError(message)
+
+    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+    return calls
 
 
 def test_stream_5xx_probe_success_delivers_response_without_latch(monkeypatch):
@@ -114,79 +134,72 @@ def test_stream_5xx_probe_5xx_keeps_original_error(monkeypatch):
     call = _make_call({"model": "m", "messages": []})
     _prime_probe_window(call)
     original = _StreamErr(500)
+    probe_calls = []
 
-    def fake_probe(agent, kwargs):
+    def raising_probe(agent, kwargs):
+        probe_calls.append(kwargs)
         raise _ProbeErr(503)
 
-    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+    monkeypatch.setattr(h, "interruptible_api_call", raising_probe)
 
     handled = _run_handle_stream_error(call, original)
 
     assert not handled
+    assert len(probe_calls) == 1  # the probe DID run; only its error is discarded
     assert call.result["error"] is original  # probe 5xx is no more informative; keep the first error
 
 
 @pytest.mark.parametrize("status", [400, 429])
 def test_no_probe_for_client_errors(monkeypatch, status):
     call = _make_call({"model": "m", "messages": []})
-
-    def fake_probe(agent, kwargs):
-        raise AssertionError("probe must not run for non-5xx stream errors")
-
-    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+    probe_calls = _record_probe(monkeypatch, "probe must not run for non-5xx stream errors")
 
     handled = _run_handle_stream_error(call, _StreamErr(status))
 
     assert not handled
+    assert probe_calls == []
     assert call.result["response"] is None
 
 
 def test_no_probe_after_partial_delivery(monkeypatch):
     call = _make_call({"model": "m", "messages": []}, deltas_sent=True)
-
-    def fake_probe(agent, kwargs):
-        raise AssertionError("probe must not run after deltas were delivered")
-
-    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+    probe_calls = _record_probe(monkeypatch, "probe must not run after deltas were delivered")
 
     handled = _run_handle_stream_error(call, _StreamErr(500))
 
     assert not handled
+    assert probe_calls == []
 
 
 def test_no_probe_without_status_code(monkeypatch):
     call = _make_call({"model": "m", "messages": []})
-
-    def fake_probe(agent, kwargs):
-        raise AssertionError("probe must not run without a 5xx status")
-
-    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+    probe_calls = _record_probe(monkeypatch, "probe must not run without a 5xx status")
 
     handled = _run_handle_stream_error(call, Exception("connection exploded"))
 
     assert not handled
+    assert probe_calls == []
 
 
 def test_probe_window_blocks_second_probe_within_60s(monkeypatch):
     call = _make_call({"model": "m", "messages": []})
     call.agent._stream_5xx_probe_ts = time.time()  # probe just happened (fresh instance = outer retry)
-
-    def fake_probe(agent, kwargs):
-        raise AssertionError("second probe within the window must not run")
-
-    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+    probe_calls = _record_probe(monkeypatch, "second probe within the window must not run")
 
     handled = _run_handle_stream_error(call, _StreamErr(500))
 
     assert not handled
+    assert probe_calls == []
     assert call.result["error"] is not None  # original error propagates
 
 
 def test_probe_window_rearms_after_60s(monkeypatch):
     call = _make_call({"model": "m", "messages": []})
     call.agent._stream_5xx_probe_ts = time.time() - 61.0
+    seen_kwargs = []
 
     def fake_probe(agent, kwargs):
+        seen_kwargs.append(kwargs)
         return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok", reasoning_content=None))])
 
     monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
@@ -195,19 +208,77 @@ def test_probe_window_rearms_after_60s(monkeypatch):
     handled = not _run_handle_stream_error(call, _StreamErr(500))
 
     assert handled
+    assert len(seen_kwargs) == 1  # the re-armed window actually probed
+    assert call.result["response"] is not None
 
 
 def test_probe_skipped_for_non_chat_completions_wire(monkeypatch):
     call = _make_call({"model": "m", "messages": []}, api_mode="anthropic_messages")
-
-    def fake_probe(agent, kwargs):
-        raise AssertionError("probe must not run on the anthropic wire (adoption replays chat shapes)")
-
-    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+    probe_calls = _record_probe(
+        monkeypatch, "probe must not run on the anthropic wire (adoption replays chat shapes)")
 
     handled = _run_handle_stream_error(call, _StreamErr(500))
 
     assert not handled
+    assert probe_calls == []
+
+
+def test_probe_recovery_brackets_its_own_stream_lifecycle(monkeypatch):
+    """The failed attempt already emitted a terminal on_stream_end — deltas must not
+    follow it, so the recovered delivery opens and closes its own pair."""
+    call = _make_call({"model": "m", "messages": []})
+    _prime_probe_window(call)
+    events = []
+    call.agent._emit_stream_start = lambda: events.append(("start", None, None, None))
+    call.agent._emit_stream_end = lambda *, final_text, finished, error: events.append(
+        ("end", finished, final_text, error))
+
+    def fake_probe(agent, kwargs):
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="recovered", reasoning_content=None))])
+
+    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+
+    def fake_adopt(r):
+        events.append(("delta", "recovered", None, None))
+        call.agent._disable_streaming = True  # adoption's own latch
+        return r
+
+    monkeypatch.setattr(call, "_adopt_final_response", fake_adopt)
+
+    handled = not _run_handle_stream_error(call, _StreamErr(500))
+
+    assert handled
+    assert events[0][0] == "start"
+    assert events[-1] == ("end", True, "recovered", None)  # closed, finished, with the text
+    assert [e[0] for e in events] == ["start", "delta", "end"]
+    assert call.agent._disable_streaming is False
+
+
+def test_adoption_failure_keeps_original_error_and_restores_streaming(monkeypatch):
+    """A probe response we cannot replay must not leak the non-streaming latch and must
+    not escape _handle_stream_error (it runs inside _call()'s except block)."""
+    call = _make_call({"model": "m", "messages": []})
+    _prime_probe_window(call)
+    call.agent._disable_streaming = False
+    original = _StreamErr(500)
+
+    def fake_probe(agent, kwargs):
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok", reasoning_content=None))])
+
+    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+
+    def exploding_adopt(r):
+        call.agent._disable_streaming = True  # latch flipped before the failure
+        raise RuntimeError("adoption exploded")
+
+    monkeypatch.setattr(call, "_adopt_final_response", exploding_adopt)
+
+    handled = _run_handle_stream_error(call, original)
+
+    assert not handled
+    assert call.agent._disable_streaming is False  # no session-wide latch leak
+    assert call.result["response"] is None
+    assert call.result["error"] is original  # the opaque 5xx still reaches the loop
 
 
 def test_interrupt_during_probe_reraises(monkeypatch):

--- a/tests/agent/test_stream_unmask_5xx.py
+++ b/tests/agent/test_stream_unmask_5xx.py
@@ -1,0 +1,148 @@
+"""Streaming 5xx unmasking: the non-streaming probe surfaces the provider's real error.
+
+Regression shape (AssemblyAI LLM Gateway, 2026-09): a gateway that validates requests
+only on its non-streaming path returns an opaque ``500 something went wrong`` when
+streaming the SAME request. _handle_stream_error must re-issue once non-streaming on a
+pre-delta 5xx so the actionable 4xx (or a successful response) reaches the user instead
+of three identical opaque 500s.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from agent import chat_completion_helpers as h
+
+
+def _make_call(api_kwargs, *, deltas_sent=False):
+    call = h._StreamingCall.__new__(h._StreamingCall)
+    call.agent = SimpleNamespace(
+        provider="custom", model="gpt-5.6-sol",
+        _interrupt_requested=False,
+        _is_provider_stream_parse_error=lambda e: False,
+        _buffer_status=lambda text: call.buffered.append(text),
+    )
+    call.buffered = []
+    call.api_kwargs = api_kwargs
+    call.result = {"response": None, "error": None, "partial_tool_names": []}
+    call.deltas_were_sent = {"yes": deltas_sent}
+    call.provider_tool_in_flight = {"yes": False}
+    call._request_cancelled = {"value": False}
+    return call
+
+
+class _StreamErr(Exception):
+    """Stands in for the openai 5xx the stream path raises."""
+
+    def __init__(self, status):
+        super().__init__(f"Error code: {status} - something went wrong")
+        self.status_code = status
+
+
+class _ProbeErr(Exception):
+    def __init__(self, status):
+        super().__init__(f"Error code: {status} - real validation message")
+        self.status_code = status
+
+
+def _run_handle_stream_error(call, e):
+    return call._handle_stream_error(e, attempt=2, max_retries=2)
+
+
+def test_stream_5xx_probe_success_delivers_response(monkeypatch):
+    call = _make_call({"model": "m", "stream": True, "stream_options": {"x": 1}, "messages": []})
+    seen_kwargs = []
+
+    def fake_probe(agent, kwargs):
+        seen_kwargs.append(kwargs)
+        return "completed-response"
+
+    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+    adopt_calls = []
+
+    def fake_adopt(r):
+        adopt_calls.append(r)
+        call.agent._disable_streaming = True  # mirror the real latch
+        return r
+
+    monkeypatch.setattr(call, "_adopt_final_response", fake_adopt)
+
+    handled = not _run_handle_stream_error(call, _StreamErr(500))
+
+    assert handled
+    assert call.result["response"] == "completed-response"
+    assert call.result["error"] is None
+    assert seen_kwargs and "stream" not in seen_kwargs[0] and "stream_options" not in seen_kwargs[0]
+    assert call.agent._disable_streaming is True  # latched by _adopt_final_response
+    assert call.buffered and "non-streaming retry succeeded" in call.buffered[0]
+
+
+def test_stream_5xx_unmasked_by_probe_4xx(monkeypatch):
+    call = _make_call({"model": "m", "messages": []})
+    real = _ProbeErr(400)
+
+    def fake_probe(agent, kwargs):
+        raise real
+
+    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+
+    handled = _run_handle_stream_error(call, _StreamErr(500))
+
+    assert not handled  # loop stops, error propagates
+    assert call.result["error"] is real  # the REAL validation error replaces the opaque 500
+    assert call.result["response"] is None
+
+
+def test_stream_5xx_probe_5xx_keeps_original_error(monkeypatch):
+    call = _make_call({"model": "m", "messages": []})
+    original = _StreamErr(500)
+
+    def fake_probe(agent, kwargs):
+        raise _ProbeErr(503)
+
+    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+
+    handled = _run_handle_stream_error(call, original)
+
+    assert not handled
+    assert call.result["error"] is original  # probe 5xx is no more informative; keep the first error
+
+
+@pytest.mark.parametrize("status", [400, 429])
+def test_no_probe_for_client_errors(monkeypatch, status):
+    call = _make_call({"model": "m", "messages": []})
+
+    def fake_probe(agent, kwargs):
+        raise AssertionError("probe must not run for non-5xx stream errors")
+
+    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+
+    handled = _run_handle_stream_error(call, _StreamErr(status))
+
+    assert not handled
+    assert call.result["response"] is None
+
+
+def test_no_probe_after_partial_delivery(monkeypatch):
+    call = _make_call({"model": "m", "messages": []}, deltas_sent=True)
+
+    def fake_probe(agent, kwargs):
+        raise AssertionError("probe must not run after deltas were delivered")
+
+    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+
+    handled = _run_handle_stream_error(call, _StreamErr(500))
+
+    assert not handled
+
+
+def test_no_probe_without_status_code(monkeypatch):
+    call = _make_call({"model": "m", "messages": []})
+
+    def fake_probe(agent, kwargs):
+        raise AssertionError("probe must not run without a 5xx status")
+
+    monkeypatch.setattr(h, "interruptible_api_call", fake_probe)
+
+    handled = _run_handle_stream_error(call, Exception("connection exploded"))
+
+    assert not handled


### PR DESCRIPTION
Closes #107948

## What does this PR do?

On a streaming failure with an HTTP 5xx status **before any delta is delivered**, re-issue the request once non-streaming before giving up. If the probe succeeds, the response is delivered for that turn and the prior `_disable_streaming` preference is restored (one-turn recovery, not a session latch). If the probe fails with a 4xx, that error — the provider's real, actionable validation message — replaces the opaque 5xx. Any other probe failure keeps the original error, and user interrupts re-raise untouched.

## Why

Some OpenAI-compatible gateways validate requests only on their non-streaming path and crash opaquely when the identical request is streamed. Observed live against AssemblyAI's LLM Gateway (model `gpt-5.6-sol`, September 2026): a request carrying 25 tools + `reasoning_effort: "high"` returns `500 {"message": "something went wrong"}` when streamed and a precise 400 when not ("Function tools with reasoning_effort are not supported for gpt-5.6-sol … set reasoning_effort to 'none'"). Payload size is irrelevant — 30 tokens reproduces it.

Hermes streams first and retries the same streaming shape up to 3×, so users of such gateways see three identical opaque 500s and never learn the actual constraint. The provider's own suggested fix (`/v1/responses`) 404s and its model catalog falsely advertises `tools`, so nothing on the provider side can surface this — only a non-streaming retry reveals it.

## Design notes

- **Pre-delta only.** `deltas_were_sent` guards the probe: after partial delivery, a retry could duplicate streamed text, so the existing no-retry path is unchanged.
- **One probe per 60 s window, latched on the agent.** Each outer retry builds a fresh `_StreamingCall`, so an instance flag would re-probe on every attempt against an already-failing backend (doubling traffic exactly when the backend is unhealthy). The timestamp window covers the retry cycle and re-arms for later turns.
- **Interrupt passthrough.** `except (KeyboardInterrupt, InterruptedError): raise` — the outer handler already routes interrupts through the result channel; the probe must not swallow them.
- **Chat-completions wire only.** `_adopt_final_response` replays chat-completions response shapes; gating on `api_mode` avoids `AttributeError`s on Anthropic/Bedrock-shaped responses.
- **No latch on success.** A transient gateway 500 that the non-streaming retry happens to survive must not permanently disable streaming for the session, so the saved `_disable_streaming` value is restored after adoption — in a `finally`, so a response that cannot be replayed restores it too and keeps the original error.
- **The recovered delivery owns its stream lifecycle.** The failed attempt already emitted its terminal `on_stream_end(finished=False)` before the probe runs, so adoption happens inside its own `_with_stream_emitters` bracket: consumers see a complete start/end pair carrying the adopted text (`finished=True`) instead of deltas after a terminal error event.

## Testing

- `tests/agent/test_stream_unmask_5xx.py` — 13 invariant tests: probe success delivers without latching; 4xx unmask replaces the opaque error; probe 5xx keeps the original error; no probe for 4xx/429/partial-delivery/no-status; window blocks a second probe within 60 s and re-arms after; anthropic wire skipped; interrupt re-raised; the recovered delivery brackets its own stream start/end pair; an unreplayable probe response restores the streaming preference and keeps the original error.
- Each gate is mutation-checked (red counts are per mutation; one test can be reddened by more than one mutation): probe disabled → 6 tests, status/type → 3, latch restore → 3, window → 1, api_mode → 1, emitter wrapper → 1, adoption escape → 1, both partial-delivery guards → 1.
- Full `tests/agent/` lane via `scripts/run_tests.sh`: two failures, both environment-dependent rather than branch-caused — `test_turn_context.py::test_between_turns_refresh_adds_late_tool_when_servers_registered` still fails in the same worktree with the pre-PR `agent/chat_completion_helpers.py` restored (and on the main checkout), and `tests/agent/lsp/test_client_e2e.py::test_client_receives_published_errors` is the conftest live-system guard blocking an `os.kill` outside the test process subtree (passes 5/5 isolated here and at the base SHA; fails in the base-SHA full-lane run too).
- Neighbor streaming files (`test_stream_wait_notice.py`, `test_nonstream_wait_notice.py`, `test_non_stream_stale_timeout.py`, `test_local_stream_timeout.py`): 50 passed.

## Notes

**Open question:** should the probe also cover `anthropic_messages`? The observed failure class is OpenAI-compatible gateways, and adoption currently replays chat-completions shapes only — so the probe is gated to that wire. If Anthropic-mode endpoints exhibit the same validation asymmetry, the adoption path needs an Anthropic-shaped replay first; left as a follow-up.

