### PR TITLE
fix(tui_gateway): composer effort mirroring the global default must not pin

### DIFF
--- a/tests/tui_gateway/test_create_overrides_effort_pin.py
+++ b/tests/tui_gateway/test_create_overrides_effort_pin.py
@@ -1,0 +1,73 @@
+"""Composer effort pins must not shadow per-model config overrides.
+
+Regression shape (2026-09, AssemblyAI gateway): the Desktop composer seeds its effort
+atom from the profile's global ``agent.reasoning_effort`` and ships that value on every
+``session.create``. Treated as a pin, it defeated ``agent.reasoning_overrides`` — a
+model configured in config.yaml to run effort "none" with tools got the global "high"
+on the wire and the provider 500'd. An effort that merely restates the global default
+is not a user choice and must not pin; only a differing value is a real override.
+"""
+import pytest
+
+
+@pytest.fixture
+def overrides():
+    """The bind_module-rebound copy (server globals), as production dispatches it."""
+    import tui_gateway.server as srv
+
+    fn = getattr(srv, "_create_overrides", None)
+    if fn is None:  # direct module call in isolation (no server import side effects)
+        import tui_gateway.methods_session as methods_session
+
+        return methods_session._create_overrides
+    return fn
+
+
+@pytest.fixture
+def cfg_effort(monkeypatch):
+    """Stub server._load_cfg's agent.reasoning_effort (the profile default)."""
+    def _install(global_effort):
+        import tui_gateway.server as srv
+
+        monkeypatch.setattr(srv, "_load_cfg", lambda: {"agent": {"reasoning_effort": global_effort}}, raising=False)
+
+    return _install
+
+
+def test_mirror_of_global_default_is_not_a_pin(overrides, cfg_effort):
+    cfg_effort("high")
+    _, reasoning, _ = overrides({"reasoning_effort": "high"})
+    assert reasoning is None  # config resolution (incl. per-model overrides) decides
+
+
+def test_differing_effort_is_a_real_pin(overrides, cfg_effort):
+    cfg_effort("high")
+    _, reasoning, _ = overrides({"reasoning_effort": "low"})
+    assert reasoning == {"enabled": True, "effort": "low"}
+
+
+def test_none_differs_from_global_effort_is_a_pin(overrides, cfg_effort):
+    cfg_effort("high")
+    _, reasoning, _ = overrides({"reasoning_effort": "none"})
+    assert reasoning == {"enabled": False}
+
+
+def test_case_variant_of_default_is_not_a_pin(overrides, cfg_effort):
+    cfg_effort("high")
+    _, reasoning, _ = overrides({"reasoning_effort": "HIGH"})
+    assert reasoning is None
+
+
+def test_no_global_configured_pin_still_applies(overrides, cfg_effort):
+    cfg_effort("")  # profile has no agent.reasoning_effort
+    _, reasoning, _ = overrides({"reasoning_effort": "medium"})
+    assert reasoning == {"enabled": True, "effort": "medium"}
+
+
+def test_model_override_and_service_tier_untouched(overrides, cfg_effort):
+    cfg_effort("high")
+    model, reasoning, tier = overrides(
+        {"model": "gpt-5.6-sol", "provider": "assemblyai", "reasoning_effort": "high", "fast": True})
+    assert model == {"model": "gpt-5.6-sol", "provider": "assemblyai"}
+    assert reasoning is None
+    assert tier == "priority"

--- a/tests/tui_gateway/test_create_overrides_effort_pin.py
+++ b/tests/tui_gateway/test_create_overrides_effort_pin.py
@@ -64,6 +64,26 @@ def test_no_global_configured_pin_still_applies(overrides, cfg_effort):
     assert reasoning == {"enabled": True, "effort": "medium"}
 
 
+def test_alias_disabled_config_vs_none_payload_is_echo(overrides, cfg_effort):
+    """config 'disabled' and composer 'none' are the same state — echo, not a pin."""
+    cfg_effort("disabled")
+    _, reasoning, _ = overrides({"reasoning_effort": "none"})
+    assert reasoning is None
+
+
+def test_alias_yaml_false_config_vs_none_payload_is_echo(overrides, cfg_effort):
+    """YAML `reasoning_effort: false` loads as Python False; 'none' means the same."""
+    cfg_effort(False)
+    _, reasoning, _ = overrides({"reasoning_effort": "none"})
+    assert reasoning is None
+
+
+def test_whitespace_variant_of_default_is_echo(overrides, cfg_effort):
+    cfg_effort(" medium ")  # parse_reasoning_effort strips
+    _, reasoning, _ = overrides({"reasoning_effort": "medium"})
+    assert reasoning is None
+
+
 def test_model_override_and_service_tier_untouched(overrides, cfg_effort):
     cfg_effort("high")
     model, reasoning, tier = overrides(

--- a/tests/tui_gateway/test_create_overrides_effort_pin.py
+++ b/tests/tui_gateway/test_create_overrides_effort_pin.py
@@ -91,3 +91,29 @@ def test_model_override_and_service_tier_untouched(overrides, cfg_effort):
     assert model == {"model": "gpt-5.6-sol", "provider": "assemblyai"}
     assert reasoning is None
     assert tier == "priority"
+
+
+def _other_profile(tmp_path, effort: str):
+    """A real secondary-profile home (its own config.yaml) — the create TARGETS this profile."""
+    home = tmp_path / "other-profile"
+    home.mkdir()
+    (home / "config.yaml").write_text(f"agent:\n  reasoning_effort: {effort}\n")
+    return home
+
+
+def test_secondary_profile_echo_is_not_a_pin(tmp_path, overrides, cfg_effort):
+    """App-global remote mode: one backend serves several profiles. The shipped value is the TARGET
+    profile's default, so it is an echo even though the LAUNCH profile's default differs."""
+    cfg_effort("high")  # launch profile default
+    other = _other_profile(tmp_path, "low")
+    _, reasoning, _ = overrides({"profile": "other-profile", "reasoning_effort": "low"}, other)
+    assert reasoning is None
+
+
+def test_pick_matching_launch_global_in_another_profile_is_a_pin(tmp_path, overrides, cfg_effort):
+    """The comparison must read the TARGET profile's config: a deliberate pick that differs from the
+    target's default stays a pin even when it happens to equal the launch profile's default."""
+    cfg_effort("high")  # launch profile default — must NOT decide this
+    other = _other_profile(tmp_path, "low")
+    _, reasoning, _ = overrides({"profile": "other-profile", "reasoning_effort": "high"}, other)
+    assert reasoning == {"enabled": True, "effort": "high"}

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -320,11 +320,18 @@ def _create_overrides(params: dict) -> tuple:
         model_override = {"model": create_model, "provider": _str_param(params, "provider") or None}
     reasoning_override = None
     if effort := _str_param(params, "reasoning_effort"):
-        global_effort = str(((_load_cfg() or {}).get("agent") or {}).get("reasoning_effort", "") or "").strip().lower()
-        if effort.strip().lower() != global_effort:
-            with contextlib.suppress(Exception):
-                from hermes_constants import parse_reasoning_effort
-                reasoning_override = parse_reasoning_effort(effort)
+        # A value semantically equal to the CURRENT global default is an echo, not a
+        # choice: drop it so config resolution (incl. agent.reasoning_overrides) applies.
+        # Compare PARSED forms — config.yaml may spell "disabled" as false/"none"/"off".
+        # Known protocol limitation: without a client dirty flag, a user cannot re-pin
+        # the global default over a per-model override from the composer (the echo is
+        # indistinguishable from that choice and is dropped either way).
+        with contextlib.suppress(Exception):
+            from hermes_constants import parse_reasoning_effort
+            parsed = parse_reasoning_effort(effort)
+            global_raw = ((_load_cfg() or {}).get("agent") or {}).get("reasoning_effort")
+            if parsed is not None and parsed != parse_reasoning_effort(global_raw):
+                reasoning_override = parsed
     service_tier_override = None
     if "fast" in params:
         service_tier_override = "priority" if is_truthy_value(params.get("fast")) else ""

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -306,16 +306,25 @@ def _seed_row(record: dict) -> None:
 
 def _create_overrides(params: dict) -> tuple:
     """PER-SESSION (model, reasoning, service_tier) overrides from the composer — never a global config
-    write. ``fast`` presence is the contract: omitted inherits, true pins priority, false pins normal ("")."""
+    write. ``fast`` presence is the contract: omitted inherits, true pins priority, false pins normal ("").
+
+    A reasoning_effort that merely restates the profile's global ``agent.reasoning_effort`` is NOT a
+    user choice — the Desktop composer seeds its effort atom from that default and ships it on every
+    session.create. Shipping it as a pin would shadow ``agent.reasoning_overrides`` per-model config
+    for the whole session (e.g. a gateway model that must run effort "none" with tools). Only an
+    effort that DIFFERS from the global default is a real pin.
+    """
     create_model = _str_param(params, "model")
     model_override = None
     if create_model:
         model_override = {"model": create_model, "provider": _str_param(params, "provider") or None}
     reasoning_override = None
     if effort := _str_param(params, "reasoning_effort"):
-        with contextlib.suppress(Exception):
-            from hermes_constants import parse_reasoning_effort
-            reasoning_override = parse_reasoning_effort(effort)
+        global_effort = str(((_load_cfg() or {}).get("agent") or {}).get("reasoning_effort", "") or "").strip().lower()
+        if effort.strip().lower() != global_effort:
+            with contextlib.suppress(Exception):
+                from hermes_constants import parse_reasoning_effort
+                reasoning_override = parse_reasoning_effort(effort)
     service_tier_override = None
     if "fast" in params:
         service_tier_override = "priority" if is_truthy_value(params.get("fast")) else ""

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -5,6 +5,7 @@ helpers (``_sessions``, ``_ok``, ``_err``, ...) bare; module-level helpers are p
 server.py the same way (tests monkeypatching ``server.X`` still intercept)."""
 
 import contextlib
+from pathlib import Path
 
 from .method_ctx import HandlerRegistry, bind_module
 
@@ -304,15 +305,33 @@ def _seed_row(record: dict) -> None:
         logger.debug("seeded-session title write failed for %s; pending_title stays queued", key, exc_info=True)
 
 
-def _create_overrides(params: dict) -> tuple:
+def _profile_global_effort(profile_home) -> object:
+    """``agent.reasoning_effort`` of the profile a create TARGETS (fail-open → None). ``_load_cfg()``
+    resolves the ACTIVE profile and ``session.create`` is not profile-scoped, so a secondary-profile
+    echo would otherwise be compared against the LAUNCH profile's default — while the fall-through it
+    protects (:func:`_load_reasoning_config`) runs inside ``_profile_build_scope`` and reads the TARGET
+    profile. Same reason as ``_profile_configured_cwd`` (#40334), same config pipeline.
+    """
+    if profile_home is None:  # launch profile: the ambient read IS the target's config
+        return ((_load_cfg() or {}).get("agent") or {}).get("reasoning_effort")
+    with contextlib.suppress(Exception):
+        from hermes_cli.config import read_user_config_raw
+        p = Path(profile_home) / "config.yaml"
+        cfg = _expand_cfg(_apply_managed(read_user_config_raw(p))) if p.exists() else {}
+        return ((cfg or {}).get("agent") or {}).get("reasoning_effort")
+    return None
+
+
+def _create_overrides(params: dict, profile_home=None) -> tuple:
     """PER-SESSION (model, reasoning, service_tier) overrides from the composer — never a global config
     write. ``fast`` presence is the contract: omitted inherits, true pins priority, false pins normal ("").
 
-    A reasoning_effort that merely restates the profile's global ``agent.reasoning_effort`` is NOT a
+    A reasoning_effort that merely restates the global ``agent.reasoning_effort`` is NOT a
     user choice — the Desktop composer seeds its effort atom from that default and ships it on every
     session.create. Shipping it as a pin would shadow ``agent.reasoning_overrides`` per-model config
     for the whole session (e.g. a gateway model that must run effort "none" with tools). Only an
-    effort that DIFFERS from the global default is a real pin.
+    effort that DIFFERS from the global default is a real pin — compared against the TARGET profile's
+    default (``profile_home``), which is the one the fall-through resolves.
     """
     create_model = _str_param(params, "model")
     model_override = None
@@ -329,7 +348,7 @@ def _create_overrides(params: dict) -> tuple:
         with contextlib.suppress(Exception):
             from hermes_constants import parse_reasoning_effort
             parsed = parse_reasoning_effort(effort)
-            global_raw = ((_load_cfg() or {}).get("agent") or {}).get("reasoning_effort")
+            global_raw = _profile_global_effort(profile_home)
             if parsed is not None and parsed != parse_reasoning_effort(global_raw):
                 reasoning_override = parsed
     service_tier_override = None
@@ -352,7 +371,7 @@ def _(rid, params: dict) -> dict:
     _enable_gateway_prompts()
     # ``profile`` (app-global remote mode): stored so the build and every turn re-bind HERMES_HOME.
     profile_home = _profile_home(profile := (params.get("profile") or "").strip() or None)
-    session_model_override, create_reasoning_override, create_service_tier_override = _create_overrides(params)
+    session_model_override, create_reasoning_override, create_service_tier_override = _create_overrides(params, profile_home)
     now = time.time()
     with _sessions_lock:
         _sessions[sid] = {


### PR DESCRIPTION
Closes #107949

## What does this PR do?

`_create_overrides` (the `session.create` override parser) no longer treats a shipped `reasoning_effort` that is **semantically equal to the current global `agent.reasoning_effort`** as a per-session pin. Both sides go through `parse_reasoning_effort`, so canonical forms decide equality — config.yaml may spell thinking-disabled as `false`, `"none"`, or `"disabled"`, and only a *parsed* comparison recognizes the echo. A value that genuinely differs from the global default remains a real pin, unchanged.

## Why

The Desktop composer seeds its effort atom from the profile's global `agent.reasoning_effort` and ships it on every `session.create`. `_make_agent` prefers a composer-provided `reasoning_config_override` over `_load_reasoning_config(model)` — the single chokepoint that resolves `agent.reasoning_overrides` per-model overrides (`hermes_constants.resolve_reasoning_config`: per-model override > global). An echo of the default therefore shadowed per-model config for the whole session.

Verified against a persisted wire dump (September 2026): with `agent.reasoning_effort: high` and `agent.reasoning_overrides: {gpt-5.6-sol: none}`, every new Desktop chat on `gpt-5.6-sol` carried `reasoning_effort: "high"` + 25 tools on the wire — the gateway 400s on that combination (500 when streamed). A CLI one-shot on the same model (no composer pin) resolved the override correctly and worked, isolating the pin as the difference.

## Design notes

- **Parsed-form comparison, not strings.** Config.yaml may spell disabled as `false` (YAML bool), `"none"`, or `"disabled"`; the composer ships `"none"`. Raw string comparison would call that a differing pin and re-shadow the override. `parse_reasoning_effort` normalizes all three to `{"enabled": False}`.
- **Comparison targets the profile the create TARGETS.** `session.create` is not `@_profile_scoped`, so the compare reads a secondary profile's own `config.yaml` (`_profile_global_effort`, same pipeline as `_profile_configured_cwd` / #40334) instead of the launch profile's default; the launch path still reads `_load_cfg()`. Both directions are covered: a secondary-profile echo is dropped, and a deliberate pick that differs from the target's default stays a pin even when it equals the launch profile's.
- **No surface regression.** With the pin dropped, `_make_agent` falls through to `_load_reasoning_config(model)`: models without overrides resolve the same global default as before; models with overrides get their configured value. Session resume is unaffected (`_parse_session_row` hydrates persisted runtime identity, not `session.create` params).
- **Known protocol limitation (documented in-code).** Without a client-side dirty flag, a composer echo is indistinguishable from a user deliberately re-selecting the global default over a per-model override; that one gesture cannot win. The alternative fix layer is renderer dirty-tracking (only ship `reasoning_effort` when the user touched the control) — larger, surface-specific, raised as an open question on the issue.

## Testing

- `tests/tui_gateway/test_create_overrides_effort_pin.py` — 11 invariant tests: mirror-of-default is not a pin (including case and whitespace variants); differing value is a real pin; `none` differs from `high`; alias equivalences (`disabled` config vs `none` payload, YAML `false` vs `none`) are echoes; unset global still allows pins; model/service-tier overrides untouched; secondary-profile echo dropped; pick matching the launch default inside another profile stays a pin. Mutation check: restoring the launch-profile read fails exactly the two profile tests (9 passed, 2 failed) and passes again when restored.
- Full `tests/tui_gateway/` lane via `scripts/run_tests.sh`: 132 files, 1133 passed, 0 failed, 8 skipped. (A worktree-local `.venv` symlink to the incomplete venv makes `test_hud_surface_note.py` report a missing optional `snowballstemmer` dep — environment, not the branch; the same file passes on unpatched `main`.)

## Notes

**Open question for maintainers:** the alternative fix layer is the Desktop client — only include `reasoning_effort` in `session.create` when the user actually modified the control (renderer dirty-tracking), or seed the composer from the model's effective config rather than the global. That's a bigger change across surfaces; this backend-side drop is the minimal, surface-independent fix. Happy to rework at the client layer if preferred.

