### PR TITLE
fix(weixin): keep label-predominant blocks in one bubble

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -80,6 +80,9 @@ _LIVE_ADAPTERS: Dict[str, Any] = {}
 _HEADER_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 _TABLE_RULE_RE = re.compile(r"^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*$")
 _FENCE_RE = re.compile(r"^```([^\n`]*)\s*$")
+# "Label: value" line (label ≤24 chars, no leading space, non-space content after
+# ": ") — the shape of structured confirmations like the /model switch summary.
+_LABEL_LINE_RE = re.compile(r"^\S[^:]{0,23}: \S")
 
 
 def _is_stale_session_ret(ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]") -> bool:
@@ -484,7 +487,15 @@ def _should_split_short_chat_block_for_weixin(block: str) -> bool:
     first = lines[0].strip()
     if _HEADER_RE.match(first) or (len(first) <= 24 and first.endswith((":", "："))):
         return False
-    return all(_looks_like_chatty_line_for_weixin(line) for line in lines)
+    if not all(_looks_like_chatty_line_for_weixin(line) for line in lines):
+        return False
+    # A block whose lines are mostly "Label: value" pairs is structured output
+    # (e.g. the /model switch confirmation), not a short chatty exchange — keep
+    # it in one bubble even when every line is short enough to look chatty.
+    # Majority, not mere presence: a genuine chat may carry a stray
+    # "meeting moved: 3pm" line and must still split (#107946).
+    label_lines = sum(1 for line in lines if _LABEL_LINE_RE.match(line.strip()))
+    return label_lines <= len(lines) // 2
 
 
 def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]:

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -880,3 +880,59 @@ class TestWeixinVoiceGatewayHandoff:
             "the wrong transcript instead of re-transcribing (#27300)."
         )
 
+
+class TestWeixinShortChatSplitLabelGuard:
+    """Regression tests for #107946: a structured "Label: value" block must not
+    be split into separate bubbles by the short-chat heuristic, no matter how
+    short its lines are; genuine short chats — even ones carrying a stray
+    label-looking line — must keep splitting."""
+
+    XIAOMI_CONFIRMATION = "\n".join([
+        "Model switched to `mimo-v2.5-pro`",
+        "Provider: xiaomi",
+        "Context: 200,000 tokens",
+        "Max output: 8,192 tokens",
+        "Capabilities: reasoning, tools, vision",
+        "Saved to session — use /model reset to clear",
+    ])
+
+    def test_structured_confirmation_with_short_lines_not_split(self):
+        # Every line is ≤48 chars and unindented, so all lines look chatty;
+        # four of six are "Label: value" → majority → keep one bubble.
+        assert weixin._should_split_short_chat_block_for_weixin(self.XIAOMI_CONFIRMATION) is False
+
+    def test_structured_confirmation_delivered_as_single_message(self):
+        chunks = weixin._split_text_for_weixin_delivery(self.XIAOMI_CONFIRMATION, max_length=4096)
+        assert chunks == [self.XIAOMI_CONFIRMATION]
+
+    def test_long_capabilities_line_still_not_split(self):
+        # MiniMax form: the 52-char capabilities line fails the chatty gate —
+        # pre-existing behaviour, unaffected by the label guard.
+        block = self.XIAOMI_CONFIRMATION.replace(
+            "Capabilities: reasoning, tools, vision",
+            "Capabilities: reasoning, tools, vision, open weights",
+        )
+        assert weixin._should_split_short_chat_block_for_weixin(block) is False
+
+    def test_pure_short_chat_still_split(self):
+        block = "\n".join(["hey are you there", "just checking", "call me when free"])
+        assert weixin._should_split_short_chat_block_for_weixin(block) is True
+
+    def test_chat_with_stray_label_line_still_split(self):
+        # A genuine chat carrying one "meeting moved: 3pm" line: 1/3 label
+        # lines is not a majority — the exchange must keep splitting.
+        block = "\n".join(["meeting moved: 3pm", "ok sounds good", "see you there"])
+        assert weixin._should_split_short_chat_block_for_weixin(block) is True
+
+    def test_two_line_chat_with_one_label_line_still_split(self):
+        block = "\n".join(["meeting moved: 3pm", "great"])
+        assert weixin._should_split_short_chat_block_for_weixin(block) is True
+
+    def test_all_label_two_line_block_not_split(self):
+        block = "\n".join(["A: 1", "B: 2"])
+        assert weixin._should_split_short_chat_block_for_weixin(block) is False
+
+    def test_non_latin_short_chat_still_split(self):
+        block = "\n".join(["你吃饭了吗", "还没呢", "一起？"])
+        assert weixin._should_split_short_chat_block_for_weixin(block) is True
+


### PR DESCRIPTION
## What does this PR do?

The Weixin short-chat heuristic splits a 2-6 line block into separate bubbles when every line is ≤48 chars, unindented and marker-free. The `/model` switch confirmation is exactly such a block when the model's metadata lines are short — so switching to Xiaomi MiMo delivered six separate bubbles, while switching to MiniMax kept the same confirmation in one message only because its `Capabilities:` line happens to be 52 chars. Structured output segmentation thus depended on the length of an unrelated metadata line (#107946).

This adds a label-predominance guard: when a **majority** of the block's lines read `Label: value` (label ≤24 chars, the same threshold the existing first-line guard uses), the block is structured output and stays in one bubble. Majority rather than mere presence is deliberate: a genuine short chat carrying a stray "meeting moved: 3pm" line (1 of 3) still splits, and non-Latin chats are unaffected.

## Related Issue

Fixes #107946

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/weixin.py`: added `_LABEL_LINE_RE` (`^\S[^:]{0,23}: \S`, next to the other block-shape regexes) and extended `_should_split_short_chat_block_for_weixin()` — after the all-lines-chatty gate passes, a majority of `Label: value` lines now suppresses the split. The 48-char threshold and the genuine-chat splitting behaviour are untouched.
- `tests/gateway/test_weixin.py`: added `TestWeixinShortChatSplitLabelGuard` with 8 regression tests (see How to Test).

## How to Test

1. `pytest tests/gateway/test_weixin.py -q` — observed result: `40 passed` (32 pre-existing + 8 new).
2. Red-green check: with the `weixin.py` change stashed, the three "should NOT split" tests below fail (`3 failed, 37 passed`); restored, all 40 pass — the tests exercise the new guard, not the pre-existing gates.
3. New tests cover: the Xiaomi-shaped 6-line confirmation (4/6 label lines, every line ≤48 chars) is not split and is delivered as a single message via `_split_text_for_weixin_delivery`; the MiniMax-shaped block (52-char capabilities line) remains unsplit (pre-existing behaviour); pure short chat, short chat with one stray label line (1/3), two-line chat with one label line (1/2), and non-Latin short chat all keep splitting; an all-label two-line block is not split.

Observed result: all assertions pass as described.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A