### PR TITLE
fix(gemini): apply user default_headers to native-Gemini fallback clients (#102788)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2070,7 +2070,13 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         if provider_id == "gemini":
             from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
             if is_native_gemini_base_url(base_url):
-                return GeminiNativeClient(api_key=api_key, base_url=base_url), model
+                # The native client bypasses the OpenAI-wire header path below, so merge the
+                # user's model.default_headers here too — a referer-restricted Google key
+                # otherwise 403s on fallback ("Requests from referer <empty> are blocked", #102788).
+                return GeminiNativeClient(
+                    api_key=api_key, base_url=base_url,
+                    default_headers=_apply_user_default_headers(None),
+                ), model
         if base_url_host_matches(base_url, "api.kimi.com"):
             headers = {"User-Agent": "claude-code/0.1.0"}
         elif base_url_host_matches(base_url, "githubcopilot.com"):
@@ -4831,7 +4837,12 @@ def _resolve_api_key_branch(req: _ResolveRequest, pconfig: Any, resolve_creds: C
     if provider == "gemini":
         from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
         if is_native_gemini_base_url(base_url):
-            client = GeminiNativeClient(api_key=api_key, base_url=base_url)
+            # Native path skips _endpoint_default_headers below; merge the user's
+            # model.default_headers so referer-restricted keys don't 403 (#102788).
+            client = GeminiNativeClient(
+                api_key=api_key, base_url=base_url,
+                default_headers=_apply_user_default_headers(None),
+            )
             logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
             return _route_client(req, client, final_model)
     headers = _endpoint_default_headers(base_url, provider, is_vision=req.is_vision, xai=True)

--- a/tests/agent/test_auxiliary_user_default_headers.py
+++ b/tests/agent/test_auxiliary_user_default_headers.py
@@ -118,3 +118,42 @@ class TestAuxClientHonorsUserDefaultHeaders:
         assert client is not None
         headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
         assert headers.get("User-Agent") == "curl/8.7.1"
+
+
+class TestGeminiNativeHonorsUserDefaultHeaders:
+    """The native Gemini path bypasses the OpenAI-wire header assembly, so it needs
+    its own merge of ``model.default_headers`` — otherwise a referer-restricted Google
+    key 403s ("Requests from referer <empty> are blocked") the moment a fallback routes
+    to it, exactly when the fallback is needed. (#102788)
+    """
+
+    def test_native_gemini_client_gets_user_default_headers(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy_TEST_KEY")
+        _write_config(tmp_path, {
+            "model": {
+                "default": "test-model",
+                "default_headers": {"Referer": "https://example.com/"},
+            },
+        })
+        with patch("agent.gemini_native_adapter.GeminiNativeClient") as mock_client:
+            mock_client.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, _ = resolve_provider_client("gemini", "gemini-3.5-flash")
+
+        assert client is not None
+        assert mock_client.called
+        headers = mock_client.call_args.kwargs.get("default_headers") or {}
+        assert headers.get("Referer") == "https://example.com/"
+
+    def test_native_gemini_client_no_headers_without_config(self, tmp_path, monkeypatch):
+        """No ``model.default_headers`` → nothing injected (None), not an empty-dict change."""
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy_TEST_KEY")
+        _write_config(tmp_path, {"model": {"default": "test-model"}})
+        with patch("agent.gemini_native_adapter.GeminiNativeClient") as mock_client:
+            mock_client.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, _ = resolve_provider_client("gemini", "gemini-3.5-flash")
+
+        assert client is not None
+        assert mock_client.called
+        assert mock_client.call_args.kwargs.get("default_headers") is None


### PR DESCRIPTION
## Problem (#102788)

The primary path merges `model.default_headers` correctly, but the **native-Gemini** construction sites in `agent/auxiliary_client.py` build `GeminiNativeClient(api_key=…, base_url=…)` directly, skipping the OpenAI-wire header assembly that every other provider branch runs through `_apply_user_default_headers`. So with a **referer-restricted Google AI Studio key** (website restrictions), a rate-limit fallback to `gemini` always fails:

```
403 PERMISSION_DENIED: Requests from referer <empty> are blocked
```

— the fallback chain is dead exactly when it is needed.

## Fix

`GeminiNativeClient.__init__` already accepts `default_headers`. This threads the merged user `model.default_headers` through both native sites:

- `_resolve_api_key_provider` (the aux "main" credential scan)
- `resolve_provider_client` (the main router body)

`_apply_user_default_headers(None)` returns `None` when unconfigured, so **there is no behavior change without the setting**. The async wrapper `AsyncGeminiNativeClient` inherits the sync client's headers, so no third site is needed.

> Note on the issue's "three sites": that count was against v0.20.6. `main` has since refactored the router — there are now two direct-construction sites (the async path inherits). Both are fixed.

## Tests

`tests/agent/test_auxiliary_user_default_headers.py`:
- `test_native_gemini_client_gets_user_default_headers` — a configured `Referer` reaches the native client (fails pre-fix: the client took no `default_headers`).
- `test_native_gemini_client_no_headers_without_config` — no config → `default_headers is None`, i.e. no injected change.

Green: 7 in that file; 227 across `test_gemini_provider.py` + `test_auxiliary_client*` with no regressions.

Closes #102788.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
