### PR TITLE
fix(weixin): keep structured /model confirmations as single bubble (#107946)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -482,7 +482,16 @@ def _should_split_short_chat_block_for_weixin(block: str) -> bool:
     if not 2 <= len(lines) <= 6:
         return False
     first = lines[0].strip()
-    if _HEADER_RE.match(first) or (len(first) <= 24 and first.endswith((":", "："))):
+    if _HEADER_RE.match(first) or (len(first) <= 24 and first.endswith(( ":", "："))):
+        return False
+    # Structured confirmations (e.g. `/model` switch) render as several
+    # ``Label: value`` lines and are short enough to look chatty
+    # (provider-dependent: ``Capabilities: reasoning, tools, open weights``
+    # is 42 chars vs 52 chars with vision). Keep the heuristic for genuine
+    # chat but suppress label-predominant blocks so the confirmation stays a
+    # single bubble (#107946).
+    label_lines = sum(1 for line in lines if re.match(r"^\S[^:]{0,23}: \S", line.strip()))
+    if label_lines >= 3:
         return False
     return all(_looks_like_chatty_line_for_weixin(line) for line in lines)
 


### PR DESCRIPTION
Fixes #107946

Weixin short-chat heuristic split any 2–6 line block where every line was ≤48 chars and unindented. The gateway `/model` confirmation is six unindented lines; Xiaomi MiMo (Capabilities: `reasoning, tools, open weights` = 42 chars) was split into six bubbles while MiniMax (52 chars with `vision`) was not.

Suppress label-predominant blocks (≥3 lines matching `^\\S[^:]{0,23}: \\S`) so structured confirmations stay a single message while genuine chat—including chat containing a single `label: value` line and non-Latin chat—keeps splitting.

Tested via `python -c` repro (xiaomi/minimax both False, chat probes remain True) and `pytest tests/gateway/test_weixin.py` (32 passed).