### PR TITLE
fix(kanban): auto-decompose tick runs with no profile secret scope under multiplex, so it never decomposes

### DIFF
--- a/gateway/kanban_watchers_dispatcher.py
+++ b/gateway/kanban_watchers_dispatcher.py
@@ -247,29 +247,36 @@ class _KanbanDispatcher:
             return 0
         attempted = 0
         successes = 0
-        for slug in self._board_slugs():
-            if attempted >= auto_decompose_per_tick:
-                break
-            # Pin the board via env for the call: the decomposer connects
-            # with no board kwarg (same pattern as the dashboard specify endpoint).
-            prev_env = os.environ.get("HERMES_KANBAN_BOARD")
-            try:
-                os.environ["HERMES_KANBAN_BOARD"] = slug
+        # This tick runs via _to_thread_process_service in a FRESH context, so no
+        # per-turn profile scope is installed. With gateway.multiplex_profiles on,
+        # agent.secret_scope.get_secret() fails closed without a scope and every
+        # decompose attempt dies with UnscopedSecretError before the aux LLM call.
+        # Scope the aux-LLM credential reads to the gateway's default profile —
+        # the same home load_gateway_config_for_runner() uses for the runner.
+        with _default_profile_secret_scope():
+            for slug in self._board_slugs():
+                if attempted >= auto_decompose_per_tick:
+                    break
+                # Pin the board via env for the call: the decomposer connects
+                # with no board kwarg (same pattern as the dashboard specify endpoint).
+                prev_env = os.environ.get("HERMES_KANBAN_BOARD")
                 try:
-                    triage_ids = _decomp.list_triage_ids()
-                except Exception as exc:
-                    logger.debug("kanban auto-decompose: list_triage_ids failed on board %s (%s)", slug, exc)
-                    triage_ids = []
-                for tid in triage_ids:
-                    if attempted >= auto_decompose_per_tick:
-                        break
-                    attempted += 1
-                    successes += self._decompose_one(_decomp, slug, tid)
-            finally:
-                if prev_env is None:
-                    os.environ.pop("HERMES_KANBAN_BOARD", None)
-                else:
-                    os.environ["HERMES_KANBAN_BOARD"] = prev_env
+                    os.environ["HERMES_KANBAN_BOARD"] = slug
+                    try:
+                        triage_ids = _decomp.list_triage_ids()
+                    except Exception as exc:
+                        logger.debug("kanban auto-decompose: list_triage_ids failed on board %s (%s)", slug, exc)
+                        triage_ids = []
+                    for tid in triage_ids:
+                        if attempted >= auto_decompose_per_tick:
+                            break
+                        attempted += 1
+                        successes += self._decompose_one(_decomp, slug, tid)
+                finally:
+                    if prev_env is None:
+                        os.environ.pop("HERMES_KANBAN_BOARD", None)
+                    else:
+                        os.environ["HERMES_KANBAN_BOARD"] = prev_env
         return successes
 
     @staticmethod
@@ -289,6 +296,42 @@ class _KanbanDispatcher:
         else:
             logger.info("kanban auto-decompose [%s]: %s → single task (no fanout)", slug, tid)
         return 1
+
+
+@contextlib.contextmanager
+def _default_profile_secret_scope():
+    """Install the gateway default profile's secret scope when multiplexing is on
+    and no scope is active (background ticks run in a fresh context). No-op
+    otherwise, so single-profile gateways keep reading os.environ as before.
+    """
+    try:
+        from pathlib import Path
+
+        from agent.secret_scope import (
+            build_profile_secret_scope,
+            current_secret_scope,
+            is_multiplex_active,
+            reset_secret_scope,
+            set_secret_scope,
+        )
+        from hermes_constants import get_hermes_home
+    except Exception:  # pragma: no cover
+        yield
+        return
+    if not is_multiplex_active() or current_secret_scope() is not None:
+        yield
+        return
+    try:
+        secrets = build_profile_secret_scope(Path(get_hermes_home()))
+    except Exception:
+        logger.debug("kanban auto-decompose: could not build default profile secret scope", exc_info=True)
+        yield
+        return
+    token = set_secret_scope(secrets)
+    try:
+        yield
+    finally:
+        reset_secret_scope(token)
 
 
 def _log_spawn_results(results: Optional[list]) -> bool:


### PR DESCRIPTION
fix(kanban): auto-decompose tick runs with no profile secret scope under multiplex, so it never decomposes

## What does this PR do?

With `gateway.multiplex_profiles: true`, `agent.secret_scope.get_secret()` fails closed whenever no profile secret scope is installed (by design: a background read must never leak another profile's credential). The kanban auto-decompose tick is scheduled through `_to_thread_process_service`, which deliberately runs in a fresh context with no per-turn scope, so the decomposer's Anthropic credential read raises `UnscopedSecretError` on every tick before the auxiliary LLM is called. Every triage card stays in triage forever, and the only trace is an INFO line in `agent.log`:

```
INFO hermes_cli.kanban_decompose: decompose: API call failed for t_xxxxxxxx (get_secret('ANTHROPIC_TOKEN') called with no profile secret scope active while multiplexing is on. ...)
```

The fix wraps `auto_decompose_tick` in a small `_default_profile_secret_scope()` context manager: when multiplexing is active and no scope is installed, it builds the gateway default profile's secret scope (the same home `load_gateway_config_for_runner()` uses to load the runner) for the duration of the tick and resets it afterwards. It is a no-op for single-profile gateways and whenever a scope is already active, so nothing changes outside the multiplexed path.

## Related Issue

No existing issue found (`gh search issues/prs "decompose multiplex"`, `"auto-decompose secret scope"`). Related but different: #65581 (false dispatcher-stuck warnings), #55446 (`default_assignee` needs restart).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/kanban_watchers_dispatcher.py`
  - new module-level `_default_profile_secret_scope()` context manager (multiplex-aware, never raises; falls through to a bare `yield` if the scope cannot be built)
  - `auto_decompose_tick` body runs inside it

## How to Test

1. On a multiplexed gateway (two or more profiles, `gateway.multiplex_profiles: true`, `kanban.auto_decompose: true`), create a triage card: `hermes kanban --board <slug> create "Do X" --triage`.
2. Before this patch: `grep "decompose: API call failed" ~/.hermes/logs/agent.log` grows by one line per tick and the card never leaves triage.
3. After this patch: the card is decomposed on the next tick (`kanban auto-decompose [<slug>]: t_… → N children` at INFO) and no `UnscopedSecretError` lines appear.
4. Unit level: `python -m pytest -q tests/gateway/test_kanban_auto_decompose_live.py tests/gateway/test_kanban_watchers_mixin.py` → 3 passed on this branch (rebased on current `main`).
5. Functional check used during development: with `set_multiplex_active(True)` and a stubbed `hermes_cli.kanban_decompose`, `auto_decompose_tick(3)` now sees `current_secret_scope() is not None` inside `decompose_task`, `resolve_anthropic_token()` resolves, and the scope is reset after the tick.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (ran the two dispatcher suites listed above; full-suite run pending on a Linux box)
- [ ] I've added tests for my changes (existing `test_kanban_auto_decompose_live.py` covers the tick; a dedicated multiplex-scope test can be added on request)
- [x] I've tested on my platform: Windows 11, Hermes 0.21.1 multiplexed gateway serving 10 profiles

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing config change)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered (pure Python, contextvar-based; no platform-specific code)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Before (one line per 60 s tick, per triage card):

```
2026-09-10 23:39:00,647 INFO hermes_cli.kanban_decompose: decompose: API call failed for t_d7048f60 (get_secret('ANTHROPIC_TOKEN') called with no profile secret scope active while multiplexing is on. This credential read must run inside a set_secret_scope(...) block ...)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
