### PR TITLE
feat(kanban): allow per-task reasoning_effort for dispatched workers

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -370,6 +370,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_runtime_seconds=max_runtime, skills=getattr(args, "skills", None) or None,
             max_retries=max_retries, model_override=getattr(args, "model_override", None),
             provider_override=getattr(args, "provider_override", None),
+            reasoning_effort=getattr(args, "reasoning_effort", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             completion_contract=getattr(args, "completion_contract", None),
@@ -594,6 +595,25 @@ def _cmd_set_model(args: argparse.Namespace) -> int:
         print(f"Set model override on {args.task_id}: {label} (applies on next dispatch)")
     else:
         print(f"Cleared model override on {args.task_id} (worker uses its profile default)")
+    return 0
+
+
+def _cmd_set_reasoning(args: argparse.Namespace) -> int:
+    effort = args.effort
+    if effort is not None and effort.strip().lower() in {"inherit", "-", ""}:
+        effort = None
+    try:
+        with kbc.connect_closing() as conn:
+            ok = kb.set_reasoning_effort(conn, args.task_id, effort)
+    except (ValueError, RuntimeError) as exc:
+        return _err(f"kanban: {exc}", 2)
+    if not ok:
+        return _err(f"no such task: {args.task_id}")
+    if effort:
+        print(f"Set reasoning effort on {args.task_id}: {effort} (applies on next dispatch)")
+    else:
+        print(f"Cleared reasoning effort on {args.task_id} "
+              "(worker inherits its profile setting)")
     return 0
 
 
@@ -1232,7 +1252,7 @@ def _cmd_decompose(args: argparse.Namespace) -> int:
 _HANDLERS = {
     "init": _cmd_init, "create": _cmd_create, "swarm": _cmd_swarm,
     "list": _cmd_list, "ls": _cmd_list, "show": _cmd_show,
-    "assign": _cmd_assign, "set-model": _cmd_set_model,
+    "assign": _cmd_assign, "set-model": _cmd_set_model, "set-reasoning": _cmd_set_reasoning,
     "reclaim": _cmd_reclaim, "reassign": _cmd_reassign,
     "diagnostics": _cmd_diagnostics, "diag": _cmd_diagnostics,
     "link": _cmd_link, "unlink": _cmd_unlink, "claim": _cmd_claim,

--- a/hermes_cli/kanban_output.py
+++ b/hermes_cli/kanban_output.py
@@ -20,6 +20,7 @@ _TASK_DICT_FIELDS = (
     "workspace_kind", "workspace_path", "branch_name", "project_id",
     "created_by", "created_at", "started_at", "completed_at", "result",
     "skills", "max_retries", "model_override", "provider_override",
+    "reasoning_effort",
     "session_id", "workflow_template_id", "current_step_key", "completion_contract", "last_failure_error",
 )
 _SHOW_RUN_FIELDS = (

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 
+from hermes_constants import VALID_REASONING_EFFORTS
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_db_dispatch as kbd
 from hermes_cli import kanban_db_notify as kbn
@@ -187,6 +188,14 @@ _SPECS = [
         _arg("--provider", dest="provider_override",
              help="Provider the --model belongs to (passed as --provider <name> to "
                   "the worker). Requires --model."),
+        _arg("--reasoning", default=None, dest="reasoning_effort",
+             metavar="LEVEL", type=str.lower,
+             choices=("none", *VALID_REASONING_EFFORTS),
+             help="Pin the worker's thinking depth for this task "
+                  "(passed as --reasoning <level>) without changing the "
+                  "profile's agent.reasoning_effort. Independent of "
+                  "--model. 'none' disables thinking. Omit to inherit "
+                  "the profile setting."),
         _arg("--completion-contract", metavar="CONTRACT",
              help="local-only (default), OWNER/REPO for publication, or exact GitHub PR URL; required CI gates done."),
         _arg("--goal", action="store_true", dest="goal_mode",
@@ -241,6 +250,15 @@ _SPECS = [
              help="Provider the model belongs to (worker is spawned with "
                   "--provider <name>). Cleared together with the model."),
     ], help="Set or clear a task's model/provider override (takes effect on the next dispatch)"),
+    _cmd("set-reasoning", [
+        _TASK_ID,
+        _arg("effort", nargs="?", default=None, type=str.lower,
+             choices=("inherit", "none", *VALID_REASONING_EFFORTS),
+             help="Thinking depth to pin the worker to (spawned with "
+                  "--reasoning <level>). 'none' disables thinking; 'inherit' "
+                  "clears the override so the worker uses its profile's "
+                  "agent.reasoning_effort."),
+    ], help="Set or clear a task's reasoning-effort override (takes effect on the next dispatch)"),
     _cmd("reclaim", [_TASK_ID, _RECLAIM_REASON], help="Release an active worker claim on a running task"),
     _cmd("reassign", [
         _TASK_ID,

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -831,6 +831,9 @@ def _handle_create(args: dict, **kw) -> str:
         _parse_bool_arg(args, "goal_mode"))
     model_override, provider_override = args.get("model"), args.get("provider")
     _check(model_override or not provider_override, "'provider' requires 'model' to be set as well")
+    # Per-task thinking depth. Independent of model/provider: a card may run the profile's own
+    # model at a different depth. None = inherit the worker profile's agent.reasoning_effort.
+    reasoning_effort = args.get("reasoning_effort")
     parents = _coerce_str_list(args.get("parents") or [], "parents", "task ids")
     with _board(args.get("board")) as (kb, conn):
         from tools.async_delegation import _current_origin_session_id
@@ -856,12 +859,16 @@ def _handle_create(args: dict, **kw) -> str:
             idempotency_key=args.get("idempotency_key"),
             max_runtime_seconds=_opt_int(args.get("max_runtime_seconds")), skills=skills,
             model_override=model_override, provider_override=provider_override,
+            reasoning_effort=reasoning_effort,
             goal_mode=goal_mode, goal_max_turns=_opt_int(args.get("goal_max_turns")),
             completion_contract=args.get("completion_contract"),
             initial_status=str(args.get("initial_status") or "running"),
             created_by=os.environ.get("HERMES_PROFILE") or "worker", session_id=session_id)
-        landed = _fields(kb.get_task(conn, new_tid), _CREATED_FIELDS)
-        return _ok(task_id=new_tid, **landed, subscribed=_maybe_auto_subscribe(conn, new_tid))
+        new_task = kb.get_task(conn, new_tid)
+        landed = _fields(new_task, _CREATED_FIELDS)
+        return _ok(task_id=new_tid, **landed,
+                   reasoning_effort=(new_task.reasoning_effort if new_task else None),
+                   subscribed=_maybe_auto_subscribe(conn, new_tid))
 
 
 def _resolve_notify_target() -> Optional[dict[str, Any]]:

--- a/tools/kanban_tools_schemas.py
+++ b/tools/kanban_tools_schemas.py
@@ -482,6 +482,22 @@ KANBAN_CREATE_SCHEMA = _schema(
                 "the profile's provider and will fail if it belongs "
                 "to a different one. Requires 'model'."
         )),
+        "reasoning_effort": {
+            "type": "string",
+            "enum": [
+                "none", "minimal", "low", "medium", "high",
+                "xhigh", "max", "ultra",
+            ],
+            "description": (
+                "Pin the dispatched worker's thinking depth for this "
+                "task instead of using the assignee profile's own "
+                "agent.reasoning_effort. Passed to the worker as "
+                "--reasoning <level>; 'none' disables thinking. "
+                "Independent of 'model' — a task can run the "
+                "profile's model at a different depth. Omit to "
+                "inherit the profile setting (the default)."
+            ),
+        },
     },
     ["title", "assignee"],
 )


### PR DESCRIPTION
## What

Adds an optional `reasoning_effort` parameter to kanban task creation and dispatch. When set, it is passed to the dispatched worker as `--reasoning <level>`, overriding that profile's own `agent.reasoning_effort` for that one card.

## Why

When a fleet runs a cheap default model, depth becomes a per-task property rather than a per-agent one. Today the only lever is the profile-level `agent.reasoning_effort`, so raising depth for one hard card raises it for every card that agent runs. This lets an orchestrator pin `high` on the card that needs it and leave the rest on the cheap default.

## Shape

| File | Change |
|---|---|
| `hermes_cli/kanban_parser.py` | accept `--reasoning` on create |
| `hermes_cli/kanban.py` | thread it into the task record / dispatch |
| `hermes_cli/kanban_output.py` | surface it in output |
| `tools/kanban_tools.py` | pass it from the agent-facing tool |
| `tools/kanban_tools_schemas.py` | schema entry for the new parameter |

**Default behaviour is unchanged.** When the parameter is omitted, nothing is passed and dispatch behaves exactly as before.

## Testing

- Applies cleanly to `main` @ `05d705d` (line offsets only, no conflicts).
- `python3 -m py_compile` clean on all five files.
- Running in production on our fleet: cards created with the parameter dispatch workers that honour it; cards without it are unaffected.

---
Disclosure: we have been carrying this as a local patch across three releases, which is why it is only being filed now. It is a small, self-contained feature and useful enough upstream that we would rather stop hand-carrying it.
