### PR TITLE
Desktop: persistent cross-session Task Overview sidebar + drag-and-drop move

### DIFF
--- a/apps/desktop/src/app/agents/index.tsx
+++ b/apps/desktop/src/app/agents/index.tsx
@@ -7,11 +7,33 @@ import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { Codicon } from '@/components/ui/codicon'
 import { FadeText } from '@/components/ui/fade-text'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
+import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
 import { compactNumber } from '@/lib/format'
 import { AlertCircle, CheckCircle2 } from '@/lib/icons'
+import { type TodoItem, todoTree } from '@/lib/todos'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
+import {
+  $backgroundStatusBySession,
+  allBackgroundProcesses,
+  BACKGROUND_POLL_MS,
+  type BackgroundProcessOverviewItem,
+  backgroundProcessPollingSessionIds,
+  dismissBackgroundProcess,
+  refreshBackgroundProcesses,
+  stopBackgroundProcess
+} from '@/store/composer-status'
+import { $sessions } from '@/store/session'
+import { $sessionStates } from '@/store/session-states'
+import {
+  $sessionTodoOverviewRows,
+  cancelTodoOverviewItem,
+  dismissSessionTodoOverviewRow,
+  dismissTodoOverviewItem,
+  moveTodoOverviewItem,
+  type SessionTodoOverviewRow
+} from '@/store/session-todos-overview'
 import {
   $subagentsBySession,
   allSubagents,
@@ -21,7 +43,7 @@ import {
   type SubagentStreamEntry
 } from '@/store/subagents'
 
-import { Panel, PanelEmpty, PanelHeader } from '../overlays/panel'
+import { Panel, PanelEmpty, PanelHeader, PanelSectionLabel } from '../overlays/panel'
 
 // Mirrors statusGlyph() in tool-fallback.tsx so subagent rows speak the
 // same visual vocabulary as the chat tool blocks.
@@ -80,24 +102,91 @@ interface AgentsViewProps {
 
 export function AgentsView({ onClose }: AgentsViewProps) {
   const { t } = useI18n()
+
+  return (
+    <Panel closeLabel={t.agents.close} onClose={onClose}>
+      <AgentsPanelContent />
+    </Panel>
+  )
+}
+
+// The bare content, with no overlay chrome of its own — the standing
+// right-sidebar panel contribution (registered in app/contrib/controller.tsx
+// as `agents`) renders this directly inside the pane-shell zone, which
+// already supplies the tab strip / close button. AgentsView above keeps the
+// legacy full-screen overlay working (route /agents) by wrapping the same
+// content in `Panel`.
+export function AgentsPanelContent() {
+  const { t } = useI18n()
   const subagentsBySession = useStore($subagentsBySession)
+  const backgroundStatusBySession = useStore($backgroundStatusBySession)
+  const sessionStates = useStore($sessionStates)
+  const sessions = useStore($sessions)
 
   // Aggregate every session, matching the status-bar indicator — a subagent
   // running in a background session must still be visible here, or the two
   // desync ("Agents N running" vs an empty tree).
   const tree = useMemo(() => buildSubagentTree(allSubagents(subagentsBySession)), [subagentsBySession])
 
-  return (
-    <Panel closeLabel={t.agents.close} onClose={onClose}>
-      {tree.length === 0 ? (
+  const backgroundProcesses = useMemo(
+    () => allBackgroundProcesses(backgroundStatusBySession, sessionStates, sessions),
+    [backgroundStatusBySession, sessionStates, sessions]
+  )
+
+  // Poll every active/recently-active session's background processes while
+  // this panel is mounted — the composer's own poll (status-stack/index.tsx)
+  // only covers whichever ONE session tab is currently focused, so a
+  // background process started in a session the user isn't looking at would
+  // never surface here without this. Bounded to running/recent sessions
+  // (composer-status.ts::backgroundProcessPollingSessionIds), not every
+  // session ever seen, to avoid hammering the gateway.
+  useEffect(() => {
+    const poll = () => {
+      for (const runtimeId of backgroundProcessPollingSessionIds($backgroundStatusBySession.get(), $sessionStates.get(), $sessions.get())) {
+        void refreshBackgroundProcesses(runtimeId)
+      }
+    }
+
+    poll()
+    const timer = window.setInterval(poll, BACKGROUND_POLL_MS)
+
+    return () => window.clearInterval(timer)
+  }, [])
+
+  // Task overview sits ABOVE the subagent tree (user-requested order): it is
+  // the standing, always-relevant summary (what's left to do), while the
+  // subagent tree is transient activity that comes and goes as delegations
+  // run. NO overscroll-behavior on this inner wrapper: Chromium registers any
+  // `overflow-y-auto` element as its own scroll container the moment content
+  // could theoretically overflow it, and `overscroll-behavior: contain`
+  // stops scroll-chaining to a parent EVEN WHEN THIS ELEMENT HAS NO SCROLL
+  // ROOM OF ITS OWN (scrollHeight === clientHeight, which is exactly what
+  // happens here — flex-1 lets it grow to fit its content instead of ever
+  // clipping). The real scrollable surface is the OUTER pane layer
+  // (`absolute inset-0 overflow-auto` in tree-group.tsx), so once contain
+  // ate the wheel event here, it never reached that outer scroller and the
+  // whole panel felt unscrollable with a mouse wheel. Reproduced with a
+  // synthetic CDP wheel dispatch and a minimal repro outside React before
+  // this fix; confirmed fixed by simply dropping overscroll-behavior here.
+  if (tree.length === 0) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto pl-3">
+        <TaskOverviewSection />
+        <BackgroundProcessesSection processes={backgroundProcesses} />
         <PanelEmpty description={t.agents.emptyDesc} icon="hubot" title={t.agents.emptyTitle} />
-      ) : (
-        <>
-          <PanelHeader subtitle={t.agents.subtitle} title={t.agents.title} />
-          <SubagentTree tree={tree} />
-        </>
-      )}
-    </Panel>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto pl-3">
+      <TaskOverviewSection />
+      <BackgroundProcessesSection processes={backgroundProcesses} />
+      <div className="flex min-h-0 flex-1 flex-col gap-4">
+        <PanelHeader subtitle={t.agents.subtitle} title={t.agents.title} />
+        <SubagentTree tree={tree} />
+      </div>
+    </div>
   )
 }
 
@@ -251,7 +340,7 @@ function SubagentTree({ tree }: { tree: SubagentNode[] }) {
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-4 overflow-hidden">
       <p className="shrink-0 text-[0.7rem] text-muted-foreground/70">{summary.join(' · ')}</p>
-      <div className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain pr-1">
+      <div className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto pr-1">
         <div className="flex min-w-0 flex-col gap-6">
           {groups.map(group => (
             <DelegationGroup group={group} key={group.id} nowMs={nowMs} />
@@ -417,3 +506,330 @@ export function SubagentRow({ node, depth = 0, nowMs }: { node: SubagentNode; de
     </div>
   )
 }
+
+// ---------------------------------------------------------------------------
+// Task overview — todo lists across every session this window has observed.
+// Distinct data source from the subagent tree above: reads
+// store/session-todos-overview.ts (all-sessions, persists for the window's
+// lifetime) rather than store/subagents.ts (current-turn subagents only).
+// ---------------------------------------------------------------------------
+
+const TASK_ROWS_COLLAPSED_LIMIT = 3
+
+// Drag-and-drop payload for moving one todo item between session rows. Plain
+// HTML5 DnD (not the pointer-drag session machinery in session-drag.ts —
+// that's built for session TILES with stack/split/link targeting across pane
+// zones; this is a much smaller in-place reorder confined to one list inside
+// one sidebar section, so the browser's native drag events are simpler and
+// sufficient). MIME-typed so a drop handler can reject anything that isn't
+// one of our own items before touching dataTransfer's JSON.
+const TODO_DRAG_MIME = 'application/x-hermes-todo-item'
+
+interface TodoDragPayload {
+  fromStoredSessionId: string
+  itemId: string
+}
+
+function TaskOverviewRow({ row }: { row: SessionTodoOverviewRow }) {
+  const { t } = useI18n()
+  const [showDone, setShowDone] = useState(false)
+  const [dragOver, setDragOver] = useState(false)
+  const ordered = useMemo(() => todoTree(row.todos), [row.todos])
+  const counted = row.todos.filter(item => item.status !== 'cancelled')
+  const doneCount = counted.filter(item => item.status === 'completed').length
+  const activeEntries = ordered.filter(([item]) => item.status !== 'completed' && item.status !== 'cancelled')
+  const doneEntries = ordered.filter(([item]) => item.status === 'completed')
+  const visibleDone = showDone ? doneEntries : []
+
+  const dismiss = () => {
+    dismissSessionTodoOverviewRow(row.storedSessionId)
+  }
+
+  const dismissItem = (item: TodoItem) => {
+    if (item.status === 'pending' || item.status === 'in_progress') {
+      void cancelTodoOverviewItem(row.storedSessionId, item.id)
+    } else {
+      dismissTodoOverviewItem(row.storedSessionId, item.id)
+    }
+  }
+
+  const dragTypes = (e: { dataTransfer: DataTransfer }) => Array.from(e.dataTransfer.types)
+
+  return (
+    <div
+      className={cn(
+        'group/task-row grid min-w-0 gap-2 rounded-md p-1.5 transition-colors hover:bg-(--ui-row-hover-background)',
+        dragOver && 'bg-(--ui-row-hover-background) ring-1 ring-primary/60'
+      )}
+      onDragLeave={() => setDragOver(false)}
+      onDragOver={e => {
+        if (!dragTypes(e).includes(TODO_DRAG_MIME)) {
+          return
+        }
+
+        e.preventDefault()
+        e.dataTransfer.dropEffect = 'move'
+        setDragOver(true)
+      }}
+      onDrop={e => {
+        if (!dragTypes(e).includes(TODO_DRAG_MIME)) {
+          return
+        }
+
+        e.preventDefault()
+        setDragOver(false)
+
+        let payload: TodoDragPayload | null = null
+
+        try {
+          payload = JSON.parse(e.dataTransfer.getData(TODO_DRAG_MIME)) as TodoDragPayload
+        } catch {
+          return
+        }
+
+        if (payload && payload.fromStoredSessionId !== row.storedSessionId) {
+          void moveTodoOverviewItem(payload.fromStoredSessionId, row.storedSessionId, payload.itemId)
+        }
+      }}
+    >
+      <div className="flex min-w-0 items-start justify-between gap-2">
+        <p className="min-w-0 flex-1 truncate text-[0.78rem] font-medium text-foreground/90">{row.title}</p>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <span className="text-[0.66rem] tabular-nums text-muted-foreground/60">
+            {t.agents.taskOverviewProgress(doneCount, counted.length)}
+          </span>
+          <Tip label={t.agents.taskOverviewDismiss}>
+            <button
+              aria-label={t.agents.taskOverviewDismiss}
+              className="grid size-5 shrink-0 place-items-center rounded-sm text-(--ui-text-tertiary) opacity-0 transition hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/task-row:opacity-100"
+              onClick={dismiss}
+              type="button"
+            >
+              <Codicon name="close" size="0.7rem" />
+            </button>
+          </Tip>
+        </div>
+      </div>
+      <div className="grid min-w-0 gap-1 pl-1">
+        {activeEntries.map(([item, depth]) => (
+          <TaskOverviewItemRow
+            depth={depth}
+            item={item}
+            key={item.id}
+            onDismiss={() => dismissItem(item)}
+            storedSessionId={row.storedSessionId}
+          />
+        ))}
+        {visibleDone.map(([item, depth]) => (
+          <TaskOverviewItemRow
+            depth={depth}
+            item={item}
+            key={item.id}
+            onDismiss={() => dismissItem(item)}
+            storedSessionId={row.storedSessionId}
+          />
+        ))}
+      </div>
+      {doneEntries.length > 0 ? (
+        <button
+          className="w-fit pl-1 text-[0.66rem] text-muted-foreground/60 hover:text-foreground hover:underline"
+          onClick={() => setShowDone(v => !v)}
+          type="button"
+        >
+          {showDone ? t.agents.taskOverviewHideDone : t.agents.taskOverviewShowDone(doneEntries.length)}
+        </button>
+      ) : null}
+    </div>
+  )
+}
+
+function TaskOverviewItemRow({
+  depth,
+  item,
+  onDismiss,
+  storedSessionId
+}: {
+  depth: number
+  item: TodoItem
+  onDismiss: () => void
+  storedSessionId: string
+}) {
+  const { t } = useI18n()
+  const done = item.status === 'completed'
+  const active = item.status === 'in_progress'
+  const cancelled = item.status === 'cancelled'
+  const canCancel = item.status === 'pending' || item.status === 'in_progress'
+  const dismissLabel = canCancel ? t.agents.taskOverviewCancel : t.agents.taskOverviewDismiss
+
+  return (
+    <div
+      className={cn('group/task-item flex min-w-0 items-start gap-1.5', depth > 0 && 'pl-4')}
+      draggable
+      onDragStart={e => {
+        const payload: TodoDragPayload = { fromStoredSessionId: storedSessionId, itemId: item.id }
+        e.dataTransfer.effectAllowed = 'move'
+        e.dataTransfer.setData(TODO_DRAG_MIME, JSON.stringify(payload))
+        // A plain-text fallback so dropping on something outside our own
+        // targets (e.g. a text field) pastes something legible instead of
+        // nothing — never load-bearing for the actual move.
+        e.dataTransfer.setData('text/plain', item.content)
+      }}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          'mt-1 size-1.5 shrink-0 rounded-full',
+          done ? 'bg-emerald-500/70' : active ? 'bg-primary' : 'bg-muted-foreground/40'
+        )}
+      />
+      <span
+        className={cn(
+          'min-w-0 flex-1 text-[0.72rem] leading-[1.15rem] wrap-anywhere',
+          done || cancelled ? 'text-muted-foreground/55 line-through' : 'text-foreground/85'
+        )}
+      >
+        {item.content}
+        {cancelled ? (
+          <span className="ml-1.5 text-[0.62rem] text-muted-foreground/50 no-underline">
+            {t.agents.taskOverviewCancelled}
+          </span>
+        ) : null}
+      </span>
+      <Tip label={dismissLabel}>
+        <button
+          aria-label={dismissLabel}
+          className="grid size-4 shrink-0 place-items-center rounded-sm text-(--ui-text-tertiary) opacity-0 transition hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/task-item:opacity-100"
+          onClick={onDismiss}
+          type="button"
+        >
+          <Codicon name="close" size="0.6rem" />
+        </button>
+      </Tip>
+    </div>
+  )
+}
+
+function TaskOverviewSection() {
+  const { t } = useI18n()
+  const [expanded, setExpanded] = useState(false)
+  // rows lives directly in an atom (see store/session-todos-overview.ts) —
+  // useStore subscribes to the actual payload, not an indirect counter a
+  // consumer must remember to re-derive data through. That indirection
+  // (a separate "tick" atom + a plain function call to fetch the real data)
+  // was reproduced live as the exact cause of the "todo list doesn't show up
+  // until I close and reopen the sidebar" bug: the tick changed and the
+  // listener fired, but React never repainted the already-mounted panel with
+  // the fresh data.
+  const rows = useStore($sessionTodoOverviewRows)
+  const shown = expanded ? rows : rows.slice(0, TASK_ROWS_COLLAPSED_LIMIT)
+  const hiddenCount = rows.length - shown.length
+
+  return (
+    <div className="grid min-h-0 shrink-0 gap-2 border-t border-(--ui-border-subtle) pt-3">
+      <PanelSectionLabel>{t.agents.taskOverviewTitle}</PanelSectionLabel>
+      {rows.length === 0 ? (
+        <p className="px-1 text-[0.7rem] leading-relaxed text-muted-foreground/60">{t.agents.taskOverviewEmptyDesc}</p>
+      ) : (
+        <div className="grid min-w-0 gap-1 overflow-y-auto">
+          {shown.map(row => (
+            <TaskOverviewRow key={row.storedSessionId} row={row} />
+          ))}
+          {hiddenCount > 0 ? (
+            <button
+              className="w-fit px-1.5 text-[0.68rem] text-muted-foreground/60 hover:text-foreground hover:underline"
+              onClick={() => setExpanded(true)}
+              type="button"
+            >
+              +{hiddenCount}
+            </button>
+          ) : null}
+          </div>
+          )}
+          </div>
+          )
+          }
+
+          // ---------------------------------------------------------------------------
+          // Background processes — terminal(background=True) work across every session
+          // this window has observed, aggregated the same way the subagent tree
+          // aggregates $subagentsBySession (store/composer-status.ts::allBackgroundProcesses).
+          // Previously this data only ever reached the composer's own status stack for
+          // whichever ONE session tab was focused; a background process running in a
+          // session the user wasn't looking at was invisible everywhere else.
+          // ---------------------------------------------------------------------------
+
+          function backgroundStatusGlyph(state: BackgroundProcessOverviewItem['state'], a: Translations['agents']): ReactNode {
+          if (state === 'running') {
+          return (
+          <GlyphSpinner
+            ariaLabel={a.running}
+            className="size-3.5 shrink-0 text-[0.95rem] text-muted-foreground/80"
+            spinner="breathe"
+          />
+          )
+          }
+
+          if (state === 'failed') {
+          return <AlertCircle aria-label={a.failed} className="size-3.5 shrink-0 text-destructive" />
+          }
+
+          return <CheckCircle2 aria-label={a.done} className="size-3.5 shrink-0 text-emerald-600/85 dark:text-emerald-400/85" />
+          }
+
+          function BackgroundProcessRow({ item }: { item: BackgroundProcessOverviewItem }) {
+          const { t } = useI18n()
+          const running = item.state === 'running'
+          const actionLabel = running ? t.agents.backgroundStop : t.agents.backgroundDismiss
+
+          const onAction = () => {
+          if (running) {
+          void stopBackgroundProcess(item.runtimeSessionId, item.id)
+          } else {
+          dismissBackgroundProcess(item.runtimeSessionId, item.id)
+          }
+          }
+
+          return (
+          <div className="group/bg-item flex min-w-0 items-start gap-1.5 rounded-md p-1 hover:bg-(--ui-row-hover-background)">
+          <span className="mt-0.5 flex h-[0.95rem] shrink-0 items-center">{backgroundStatusGlyph(item.state, t.agents)}</span>
+          <span
+            className={cn(
+              'min-w-0 flex-1 text-[0.72rem] leading-[1.15rem] wrap-anywhere',
+              running ? 'text-foreground/85' : 'text-muted-foreground/65'
+            )}
+          >
+            {item.title}
+            {item.exitCode ? <span className="ml-1.5 text-[0.62rem] text-destructive/80">exit {item.exitCode}</span> : null}
+          </span>
+          <Tip label={actionLabel}>
+            <button
+              aria-label={actionLabel}
+              className="grid size-4 shrink-0 place-items-center rounded-sm text-(--ui-text-tertiary) opacity-0 transition hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/bg-item:opacity-100"
+              onClick={onAction}
+              type="button"
+            >
+              <Codicon name="close" size="0.6rem" />
+            </button>
+          </Tip>
+          </div>
+          )
+          }
+
+          function BackgroundProcessesSection({ processes }: { processes: BackgroundProcessOverviewItem[] }) {
+          const { t } = useI18n()
+
+          if (processes.length === 0) {
+          return null
+          }
+
+          return (
+          <div className="grid min-h-0 shrink-0 gap-2 border-t border-(--ui-border-subtle) pt-3">
+          <PanelSectionLabel>{t.agents.backgroundTitle}</PanelSectionLabel>
+          <div className="grid min-w-0 gap-1">
+            {processes.map(item => (
+              <BackgroundProcessRow item={item} key={`${item.runtimeSessionId}:${item.id}`} />
+            ))}
+          </div>
+          </div>
+          )
+          }

--- a/apps/desktop/src/app/agents/task-overview-item-cancel.test.tsx
+++ b/apps/desktop/src/app/agents/task-overview-item-cancel.test.tsx
@@ -1,0 +1,52 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $sessions } from '@/store/session'
+import { $sessionStates } from '@/store/session-states'
+import { resetSessionTodoOverview } from '@/store/session-todos-overview'
+import { $todosBySession, setSessionTodos } from '@/store/todos'
+
+import { AgentsPanelContent } from './index'
+
+vi.mock('@/store/gateway', () => ({ $gateway: { get: () => null } }))
+
+/** Regression: clicking the X on a still-active (pending/in_progress) todo item
+ *  must attempt a real cancel (not a silent local hide) — and since the mocked
+ *  gateway is disconnected, the optimistic flip must roll back so the item stays
+ *  visible with its original status rather than vanishing. */
+describe('TaskOverviewItemRow cancel (active item)', () => {
+  beforeEach(() => {
+    resetSessionTodoOverview()
+    $todosBySession.set({})
+    $sessionStates.set({})
+    $sessions.set([{ id: 'sess-1', preview: '', title: 'Test Session' } as never])
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetSessionTodoOverview()
+    $todosBySession.set({})
+  })
+
+  it('shows a Cancel label (not Dismiss) for a pending item, and keeps the row on a failed cancel', async () => {
+    act(() => {
+      setSessionTodos('sess-1', [{ content: '진행중 항목', id: '1', status: 'in_progress' }])
+    })
+
+    render(<AgentsPanelContent />)
+
+    expect(screen.queryByText('진행중 항목')).toBeTruthy()
+    expect(screen.queryAllByLabelText('Cancel this task').length).toBe(1)
+    expect(screen.queryAllByLabelText('Dismiss from this panel').length).toBe(1) // row-level only
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Cancel this task'))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // Gateway is disconnected in this test, so the optimistic cancel rolls
+    // back — the item must still be present, not silently disappear.
+    expect(screen.queryByText('진행중 항목')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/agents/task-overview-item-dismiss.test.tsx
+++ b/apps/desktop/src/app/agents/task-overview-item-dismiss.test.tsx
@@ -1,0 +1,58 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { $sessions } from '@/store/session'
+import { $sessionStates } from '@/store/session-states'
+import { resetSessionTodoOverview } from '@/store/session-todos-overview'
+import { $todosBySession, setSessionTodos } from '@/store/todos'
+
+import { AgentsPanelContent } from './index'
+
+/** Regression: dismissing ONE todo item from a row's checklist must remove
+ *  only that item (not the whole row) and repaint live, exactly like row
+ *  dismissal already did. */
+describe('TaskOverviewItemRow dismiss', () => {
+  beforeEach(() => {
+    resetSessionTodoOverview()
+    $todosBySession.set({})
+    $sessionStates.set({})
+    $sessions.set([{ id: 'sess-1', preview: '', title: 'Test Session' } as never])
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetSessionTodoOverview()
+    $todosBySession.set({})
+  })
+
+  it('removes only the dismissed item, keeps the row and its other items', () => {
+    act(() => {
+      setSessionTodos('sess-1', [
+        { content: '첫번째 항목', id: '1', status: 'completed' },
+        { content: '두번째 항목', id: '2', status: 'completed' }
+      ])
+    })
+
+    render(<AgentsPanelContent />)
+
+    // Completed items linger behind "Show N more finished" — expand it first.
+    act(() => {
+      fireEvent.click(screen.getByText(/Show \d+ more finished/))
+    })
+
+    expect(screen.queryByText('첫번째 항목')).toBeTruthy()
+    expect(screen.queryByText('두번째 항목')).toBeTruthy()
+
+    const dismissButtons = screen.getAllByLabelText('Dismiss from this panel')
+    expect(dismissButtons.length).toBe(3) // [0] row-level, [1] first item, [2] second item
+    // Dismiss the FIRST item specifically (index 1) — the row-level dismiss
+    // (index 0) removes the whole row and must be left alone by this test.
+    act(() => {
+      fireEvent.click(dismissButtons[1]!)
+    })
+
+    expect(screen.queryByText('첫번째 항목')).toBeNull()
+    expect(screen.queryByText('두번째 항목')).toBeTruthy()
+    expect(screen.queryByText('Test Session')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/agents/task-overview-live-update.test.tsx
+++ b/apps/desktop/src/app/agents/task-overview-live-update.test.tsx
@@ -1,0 +1,55 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { $sessions } from '@/store/session'
+import { $sessionStates } from '@/store/session-states'
+import { resetSessionTodoOverview } from '@/store/session-todos-overview'
+import { $todosBySession, setSessionTodos } from '@/store/todos'
+
+import { AgentsPanelContent } from './index'
+
+/**
+ * Reproduction + regression guard: does the Task Overview section re-render
+ * LIVE while it is already mounted (panel open), or only on remount (panel
+ * closed then reopened)? User report: "closing and reopening the sidebar
+ * makes it appear" — i.e. data was captured (module-level subscribe worked)
+ * but an already-mounted panel never repainted on a NEW todo.updated
+ * snapshot. Root cause: the panel subscribed to an unrelated "tick" counter
+ * atom and re-derived the real data through a plain function call on every
+ * render — an indirection where the counter reliably changed (confirmed by
+ * an independent `.listen()` firing) but React never repainted with the
+ * fresh payload. Fixed by putting the actual rows array in the atom itself.
+ */
+describe('TaskOverviewSection live update while already mounted', () => {
+  beforeEach(() => {
+    resetSessionTodoOverview()
+    $todosBySession.set({})
+    $sessionStates.set({})
+    $sessions.set([{ id: 'sess-1', preview: '', title: 'Test Session' } as never])
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetSessionTodoOverview()
+    $todosBySession.set({})
+  })
+
+  it('shows a NEW todo list without unmount/remount when the panel is already open', () => {
+    // Panel opens with NOTHING yet — mirrors "no todo has ever fired".
+    render(<AgentsPanelContent />)
+
+    expect(screen.queryByText('Test Session')).toBeNull()
+
+    // A todo_list tool call happens WHILE the panel stays mounted (no re-render
+    // of AgentsPanelContent itself, no key change) — same as the live desktop
+    // app receiving a todo.updated event over the gateway while Agents is open.
+    act(() => {
+      setSessionTodos('sess-1', [{ content: '첫번째 항목', id: '1', status: 'pending' }])
+    })
+
+    // If this fails, the row never appears without a close/reopen (remount) —
+    // confirming the live-update bug the user reported.
+    expect(screen.queryByText('Test Session')).toBeTruthy()
+    expect(screen.queryByText('첫번째 항목')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -82,7 +82,7 @@ import {
   setBusy,
   setMessages
 } from '@/store/session'
-import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
+import { clearSessionTodos, setRawSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
 import { isAuxiliaryWindow, isBrowserWindow, isHudWindow } from '@/store/windows'
 import { useSkinCommand } from '@/themes/use-skin-command'
@@ -410,7 +410,12 @@ export function ContribWiring({ children }: { children: ReactNode }) {
             storedSessionId
           )
 
-          const restored = todosForHydration(latestSessionTodos(messages))
+          const rawTodos = latestSessionTodos(messages)
+          const restored = todosForHydration(rawTodos)
+
+          if (rawTodos) {
+            setRawSessionTodos(runtimeSessionId, rawTodos)
+          }
 
           if (restored) {
             setSessionTodos(runtimeSessionId, restored)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -120,6 +120,7 @@ import {
   type TileDock
 } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
+import { removeSessionTodoOverviewRow } from '@/store/session-todos-overview'
 import { forgetSessionUnread } from '@/store/session-unread'
 import { $archivedSessions } from '@/store/sidebar-archive'
 import { restoreSessionTodosFromSnapshot } from '@/store/todos'
@@ -2450,6 +2451,7 @@ export function useSessionActions({
 
       dropListedSession(storedSessionId)
       $archivedSessions.set(previousArchived.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+
       // Evict from the project tree's optimistic layer too (the backend snapshot
       // still lists it until its next refresh), so grouped + flat views drop the
       // row in lockstep. Pin the tombstone against the projects.tree prune while
@@ -2472,6 +2474,18 @@ export function useSessionActions({
         }
 
         await deleteSession(storedSessionId, removedOwner)
+
+        // Only now that the RPC has actually landed — an optimistic removal
+        // here would survive the catch below's full-state rollback (nothing
+        // restores a swept row), leaving the Task Overview sidebar missing a
+        // row for a session that's still very much alive after a failed
+        // delete. store/session-todos-overview.ts has no other eviction path
+        // for a hard-deleted session, so every id alias gets swept here.
+        for (const id of removedIds) {
+          if (id) {
+            removeSessionTodoOverviewRow(id)
+          }
+        }
 
         dropTranscriptTailEverywhere(storedSessionId)
         // Only after the RPC lands — the optimistic eviction above can roll

--- a/apps/desktop/src/store/session-todos-overview-persistence.test.ts
+++ b/apps/desktop/src/store/session-todos-overview-persistence.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { $sessionStates } from '@/store/session-states'
+import { $todosBySession, setSessionTodos } from '@/store/todos'
+
+/**
+ * Regression guard for "does the task overview survive a relaunch?" — the
+ * user explicitly asked for this after learning the previous (in-memory-only)
+ * implementation reset on every app restart. A real restart cannot be
+ * exercised in vitest (it's a fresh Electron process), so this simulates it
+ * the way `persistentAtom` itself is proven safe elsewhere in this codebase:
+ * reset all module-level state, then RE-IMPORT the store module fresh via
+ * `vi.resetModules()` so it re-reads from `localStorage` exactly as a cold
+ * boot would (module-level `readJson()` calls only run once, at import time).
+ */
+describe('session-todos-overview persistence across a simulated relaunch', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    $todosBySession.set({})
+    $sessionStates.set({})
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    $todosBySession.set({})
+  })
+
+  it('reloads a previously captured todo list after the module is re-imported', async () => {
+    const mod1 = await import('./session-todos-overview')
+
+    mod1.resetSessionTodoOverview()
+    setSessionTodos('sess-1', [{ content: '재시작 후에도 남아야 하는 항목', id: '1', status: 'pending' }])
+
+    expect(mod1.sessionTodoOverviewRows()).toHaveLength(1)
+    expect(window.localStorage.getItem('hermes.desktop.taskOverview.snapshots')).toBeTruthy()
+
+    // Simulate an app relaunch: fresh module graph, fresh module-level reads
+    // (the real failure mode: an in-memory-only Map/atom would come back
+    // empty here because nothing wrote it to a durable store).
+    const { vi } = await import('vitest')
+
+    vi.resetModules()
+
+    const mod2 = await import('./session-todos-overview')
+    const rows = mod2.sessionTodoOverviewRows()
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.todos[0]?.content).toBe('재시작 후에도 남아야 하는 항목')
+  })
+
+  it('keeps a dismissed row dismissed after a simulated relaunch', async () => {
+    const mod1 = await import('./session-todos-overview')
+
+    mod1.resetSessionTodoOverview()
+    setSessionTodos('sess-2', [{ content: '숨겨질 항목', id: '1', status: 'pending' }])
+    mod1.dismissSessionTodoOverviewRow('sess-2')
+
+    expect(mod1.sessionTodoOverviewRows()).toHaveLength(0)
+
+    const { vi } = await import('vitest')
+
+    vi.resetModules()
+
+    const mod2 = await import('./session-todos-overview')
+
+    expect(mod2.sessionTodoOverviewRows()).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/store/session-todos-overview.ts
+++ b/apps/desktop/src/store/session-todos-overview.ts
@@ -1,0 +1,526 @@
+import { atom } from 'nanostores'
+
+import { readJson, writeJson } from '@/lib/storage'
+import { parseTodos, type TodoItem } from '@/lib/todos'
+
+import { $gateway, activeGatewayConnectionId, activeGatewayProfileKey } from './gateway'
+import { notifyError } from './notifications'
+import { $sessions, getSessionOwnerHint, lineageAliases, setSessionOwnerHint } from './session'
+import { ambientRequestFor } from './session-gone-latch'
+import { $sessionStates, requestForOwnedSession } from './session-states'
+import { $rawTodosBySession, todoListActive } from './todos'
+
+/**
+ * All-sessions todo overview — the data source for the Agents panel's "할일
+ * 현황" (Task overview) section. Sourced from `$rawTodosBySession` in
+ * store/todos.ts: an UNFILTERED per-runtime-session todo feed, distinct from
+ * `$todosBySession` / `$todoProgressBySession`, which are composer-chip-
+ * oriented and intentionally drop a stale active list on hydrate (a dead
+ * turn's plan must not pin the "Tasks N/M" chip above the composer forever).
+ * This overview has the opposite requirement — an idle session with pending
+ * items is exactly what a persistent task list should keep showing — so it
+ * must not inherit that filter.
+ *
+ * This store instead keeps the LAST todo snapshot seen for every stored
+ * session, PERSISTED to localStorage so it survives an app restart — the
+ * overview grows organically as you work and is not lost on relaunch, unlike
+ * the (deliberately ephemeral) subagent tree panel. It still does NOT
+ * backfill history for sessions that were never opened/resumed in this or a
+ * past window (no new backend calls, no per-session transcript re-fetch): a
+ * session enters the overview once its own snapshot has actually been
+ * observed at least once, via a live todo.updated event OR a session.resume/
+ * activate response — the latter now included specifically so reopening an
+ * idle chat with pending todos surfaces them here immediately.
+ */
+export interface SessionTodoOverviewRow {
+  storedSessionId: string
+  title: string
+  todos: TodoItem[]
+  updatedAt: number
+}
+
+type StoredSnapshot = { todos: TodoItem[]; updatedAt: number }
+
+// A finished (all completed/cancelled) row auto-prunes from the overview and
+// its localStorage backing store after this long untouched — the store has
+// no other size cap, and a stale "할일 현황" full of weeks-old finished work
+// buries what's actually in flight. Chosen generously: long enough that a
+// week-long trip doesn't lose yesterday's finished checklist, short enough
+// that the store doesn't grow forever for an active daily user.
+const FINISHED_ROW_RETENTION_MS = 7 * 24 * 60 * 60 * 1000
+
+const SNAPSHOTS_KEY = 'hermes.desktop.taskOverview.snapshots'
+const DISMISSED_KEY = 'hermes.desktop.taskOverview.dismissed'
+const DISMISSED_ITEMS_KEY = 'hermes.desktop.taskOverview.dismissedItems'
+
+function sanitizeSnapshots(value: unknown): Record<string, StoredSnapshot> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+
+  const out: Record<string, StoredSnapshot> = {}
+
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (!raw || typeof raw !== 'object') {
+      continue
+    }
+
+    const todos = (raw as { todos?: unknown }).todos
+    const updatedAt = (raw as { updatedAt?: unknown }).updatedAt
+
+    if (Array.isArray(todos) && typeof updatedAt === 'number') {
+      out[key] = { todos: todos as TodoItem[], updatedAt }
+    }
+  }
+
+  return out
+}
+
+function sanitizeStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : []
+}
+
+function sanitizeDismissedItems(value: unknown): Record<string, string[]> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+
+  const out: Record<string, string[]> = {}
+
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    const ids = sanitizeStringArray(raw)
+
+    if (ids.length > 0) {
+      out[key] = ids
+    }
+  }
+
+  return out
+}
+
+// storedSessionId -> last-seen full todo snapshot + a wall-clock stamp, so
+// the panel can sort "most recently touched first" without re-deriving it
+// from the todos array itself (which carries no timestamp). Seeded from
+// localStorage so a relaunch resumes with the last-known state instead of a
+// blank slate; every mutation below calls `persistSnapshots()` to keep the
+// disk copy in step.
+const snapshots = new Map<string, StoredSnapshot>(Object.entries(sanitizeSnapshots(readJson(SNAPSHOTS_KEY))))
+
+function persistSnapshots(): void {
+  writeJson(SNAPSHOTS_KEY, Object.fromEntries(snapshots))
+}
+
+// Session ids the user has dismissed from THIS overview panel. Purely a
+// display-layer hide: the underlying session/todo data is untouched, so
+// reopening that chat (or a fresh todo.updated event landing on it) is
+// unaffected. PERSISTED so a dismissed row does not resurface just because
+// the app restarted — the user's "get this off my list" choice sticks until
+// they explicitly reopen that session or a new todo.updated event resurrects
+// it (see `captureSnapshot`, which still checks this set on every capture).
+const dismissed = new Set<string>(sanitizeStringArray(readJson(DISMISSED_KEY)))
+
+function persistDismissed(): void {
+  writeJson(DISMISSED_KEY, dismissed.size === 0 ? null : [...dismissed])
+}
+
+// Individual todo items the user has dismissed FROM A ROW's checklist, keyed
+// by storedSessionId -> set of item ids. Same display-only, persisted
+// contract as `dismissed` above: there is no backend RPC to delete one item
+// out of a session's todo list (the tool always rewrites the WHOLE list), so
+// this filters the row's rendered `todos` array in `sessionTodoOverviewRows()`
+// rather than mutating the source. A session that is still actively running
+// can still resurrect a dismissed id on its next `todo.updated` snapshot
+// (the same way `dismissed` above can be reopened by a fresh event) — that
+// is expected: dismiss is "get this off my screen", not "delete forever" for
+// a list the agent may still be updating.
+const dismissedItems = new Map<string, Set<string>>(
+  Object.entries(sanitizeDismissedItems(readJson(DISMISSED_ITEMS_KEY))).map(([id, ids]) => [id, new Set(ids)])
+)
+
+function persistDismissedItems(): void {
+  const plain = Object.fromEntries([...dismissedItems].map(([id, ids]) => [id, [...ids]]))
+
+  writeJson(DISMISSED_ITEMS_KEY, dismissedItems.size === 0 ? null : plain)
+}
+
+function sessionTitleFor(storedSessionId: string): string {
+  const row = $sessions.get().find(s => s.id === storedSessionId)
+
+  return row?.title?.trim() || row?.preview?.trim() || storedSessionId
+}
+
+function computeRows(): SessionTodoOverviewRow[] {
+  const rows: SessionTodoOverviewRow[] = []
+  const now = Date.now()
+  let pruned = false
+
+  for (const [storedSessionId, snapshot] of [...snapshots]) {
+    if (dismissed.has(storedSessionId)) {
+      // Belt-and-suspenders: normal invariant is that dismissSessionTodoOverviewRow
+      // already deleted this id from `snapshots`, and captureSnapshot/backfill never
+      // re-add an id while it's still dismissed. If this branch ever fires it means
+      // something upstream drifted — clean it up AND persist so localStorage doesn't
+      // silently disagree with the in-memory map.
+      snapshots.delete(storedSessionId)
+      pruned = true
+
+      continue
+    }
+
+    const { todos, updatedAt } = snapshot
+
+    // Auto-prune a FINISHED list (every item completed/cancelled) once it's
+    // sat untouched past the retention window — otherwise this store only
+    // ever grows (localStorage-persisted, no session-count cap, no TTL) and
+    // "할일 현황" ends up showing work that finished weeks ago right next to
+    // what's actually in flight. A still-active list (any pending/in_progress
+    // item) is exempt no matter its age — that's real outstanding work, not
+    // stale history. Backfilled rows stamp updatedAt: 0, so they're eligible
+    // immediately once finished (the backend has no capture time to give us).
+    if (!todoListActive(todos) && now - updatedAt > FINISHED_ROW_RETENTION_MS) {
+      snapshots.delete(storedSessionId)
+      pruned = true
+
+      continue
+    }
+
+    const hiddenItems = dismissedItems.get(storedSessionId)
+    const visibleTodos = hiddenItems ? todos.filter(item => !hiddenItems.has(item.id)) : todos
+
+    rows.push({ storedSessionId, title: sessionTitleFor(storedSessionId), todos: visibleTodos, updatedAt })
+  }
+
+  if (pruned) {
+    persistSnapshots()
+  }
+
+  return rows.sort((a, b) => b.updatedAt - a.updatedAt)
+}
+
+// The rows array itself lives in the atom (not a side "tick" counter a
+// consumer must react to indirectly by re-deriving data through a plain
+// function call). A component does `useStore($sessionTodoOverviewRows)` and
+// gets the real snapshot directly — the canonical nanostores subscription
+// shape, and immune to the class of bug where a component subscribes to an
+// unrelated counter atom that changes correctly (proven by an independent
+// `.listen()` firing) while React never repaints because the actual payload
+// it reads is fetched through a second, unsynchronized hop. That exact
+// failure mode was reproduced live: the panel's data (queried directly)
+// was always current, but an already-mounted panel kept painting its stale
+// empty state until the user closed and reopened it (forcing a remount that
+// re-reads fresh). Recomputed and republished every time the underlying
+// data can change, so `useStore` is the only wiring a consumer needs.
+// Seeded synchronously from the persisted snapshots read above, so a
+// relaunch shows the last-known list before the first live event arrives.
+export const $sessionTodoOverviewRows = atom<SessionTodoOverviewRow[]>(computeRows())
+
+function publishRows(): void {
+  $sessionTodoOverviewRows.set(computeRows())
+}
+
+function captureSnapshot(): void {
+  const todosByRuntime = $rawTodosBySession.get()
+  const states = $sessionStates.get()
+  const sessions = $sessions.get()
+  let dismissedChanged = false
+
+  for (const [runtimeId, todos] of Object.entries(todosByRuntime)) {
+    if (todos.length === 0) {
+      continue
+    }
+
+    const storedId = states[runtimeId]?.storedSessionId ?? runtimeId
+
+    for (const alias of lineageAliases(storedId, sessions)) {
+      // A dismissed row stays hidden from FURTHER stale/no-op captures of the
+      // same finished list — but "get this off my screen" must not become a
+      // permanent block on that session. New real activity (any pending/
+      // in_progress item) is a fresh event worth surfacing, exactly like the
+      // module doc promises ("a fresh todo.updated event landing on it" un-
+      // dismisses). Without this check, `dismissed` never sheds an id once
+      // added and the row can never come back no matter what the agent does
+      // in that session afterward.
+      if (dismissed.has(alias)) {
+        if (!todoListActive(todos)) {
+          continue
+        }
+
+        dismissed.delete(alias)
+        dismissedChanged = true
+      }
+
+      snapshots.set(alias, { todos, updatedAt: Date.now() })
+    }
+  }
+
+  if (dismissedChanged) {
+    persistDismissed()
+  }
+
+  persistSnapshots()
+  publishRows()
+}
+
+// Subscribed unconditionally at module load — runs for the lifetime of the
+// window regardless of whether any component is currently reading the
+// overview (i.e. whether the Agents panel is open). `.subscribe` (not
+// `.listen`) fires once immediately too, seeding any todos already in flight
+// when this module first evaluates.
+$rawTodosBySession.subscribe(captureSnapshot)
+
+/** Legacy snapshot read — still handy for one-off reads outside a React
+ *  render (e.g. diagnostics), but a component should prefer
+ *  `useStore($sessionTodoOverviewRows)` so it repaints on every change. */
+export function sessionTodoOverviewRows(): SessionTodoOverviewRow[] {
+  return $sessionTodoOverviewRows.get()
+}
+
+/** Hide one todo ITEM from a row's checklist (display-only, persisted — see
+ *  `dismissedItems` above). Idempotent; republishes immediately so any
+ *  subscriber of `$sessionTodoOverviewRows` repaints without a manual tick. */
+export function dismissTodoOverviewItem(storedSessionId: string, itemId: string): void {
+  const existing = dismissedItems.get(storedSessionId)
+
+  if (existing) {
+    existing.add(itemId)
+  } else {
+    dismissedItems.set(storedSessionId, new Set([itemId]))
+  }
+
+  persistDismissedItems()
+  publishRows()
+}
+
+/** Actually cancel a still-active (pending/in_progress) todo item — unlike
+ *  `dismissTodoOverviewItem` above, this reaches the LIVE session's authoritative
+ *  TodoStore via `todo.cancel_item` (tui_gateway/methods_todo.py) so the agent
+ *  itself is steered away from the task, not just hidden from this window.
+ *  Optimistic: the local snapshot flips to 'cancelled' immediately so the row
+ *  repaints without waiting on the round trip; a failure rolls the item back
+ *  to its prior status and surfaces the error (root AGENTS.md: "Be optimistic,
+ *  then honest"). The next `todo.updated` event (or this call's own success)
+ *  is the authoritative correction either way. */
+export async function cancelTodoOverviewItem(storedSessionId: string, itemId: string): Promise<void> {
+  const snapshot = snapshots.get(storedSessionId)
+  const item = snapshot?.todos.find(candidate => candidate.id === itemId)
+
+  if (!snapshot || !item) {
+    return
+  }
+
+  const previousStatus = item.status
+
+  item.status = 'cancelled'
+  publishRows()
+
+  const gateway = $gateway.get()
+
+  if (!gateway) {
+    item.status = previousStatus
+    publishRows()
+    notifyError(new Error('Gateway is not connected'), 'Could not cancel the task')
+
+    return
+  }
+
+  try {
+    await requestForOwnedSession(storedSessionId, ambientRequestFor(gateway), 'todo.cancel_item', {
+      stored_session_id: storedSessionId,
+      item_id: itemId
+    })
+    persistSnapshots()
+  } catch (err) {
+    item.status = previousStatus
+    publishRows()
+    notifyError(err, 'Could not cancel the task')
+  }
+}
+
+/** Move one todo item from one session's list to another's (desktop Task Overview drag-and-
+ *  drop). Both sessions must be LIVE (an active AIAgent, not just a stored row this window has
+ *  a cold snapshot of) — see `todo.move_item` (tui_gateway/methods_todo.py) for why: the
+ *  TodoStore is in-memory per agent, so there's nothing to move out of/into for a session
+ *  whose agent has been torn down. Optimistic on the SOURCE row for immediate feedback (moved
+ *  item vanishes from the row being dragged from); the destination row is left to arrive via
+ *  its own `todo.updated` event rather than fabricated locally, since the destination may
+ *  rename the id to avoid a collision and the true assigned id is only known after the RPC
+ *  returns. A failure rolls the source back and surfaces the error. */
+export async function moveTodoOverviewItem(
+  fromStoredSessionId: string,
+  toStoredSessionId: string,
+  itemId: string
+): Promise<void> {
+  if (fromStoredSessionId === toStoredSessionId) {
+    return
+  }
+
+  const fromSnapshot = snapshots.get(fromStoredSessionId)
+  const item = fromSnapshot?.todos.find(candidate => candidate.id === itemId)
+
+  if (!fromSnapshot || !item) {
+    return
+  }
+
+  const previousTodos = fromSnapshot.todos
+  fromSnapshot.todos = previousTodos.filter(candidate => candidate.id !== itemId && candidate.parent !== itemId)
+  publishRows()
+
+  const gateway = $gateway.get()
+
+  if (!gateway) {
+    fromSnapshot.todos = previousTodos
+    publishRows()
+    notifyError(new Error('Gateway is not connected'), 'Could not move the task')
+
+    return
+  }
+
+  try {
+    await requestForOwnedSession(fromStoredSessionId, ambientRequestFor(gateway), 'todo.move_item', {
+      from_session_id: fromStoredSessionId,
+      to_session_id: toStoredSessionId,
+      item_id: itemId
+    })
+    persistSnapshots()
+  } catch (err) {
+    fromSnapshot.todos = previousTodos
+    publishRows()
+    notifyError(err, 'Could not move the task')
+  }
+}
+
+/** Hide one session's row from the overview panel (display-only, persisted —
+ *  see `dismissed` above). Idempotent; republishes immediately so any
+ *  subscriber of `$sessionTodoOverviewRows` repaints without a manual tick. */
+export function dismissSessionTodoOverviewRow(storedSessionId: string): void {
+  dismissed.add(storedSessionId)
+  snapshots.delete(storedSessionId)
+  dismissedItems.delete(storedSessionId)
+  persistDismissed()
+  persistSnapshots()
+  persistDismissedItems()
+  publishRows()
+}
+
+/** Evict a HARD-DELETED session's row entirely — unlike `dismissSessionTodoOverviewRow`,
+ *  this does NOT add to `dismissed`. `dismissed` exists so a row can be un-hidden by
+ *  fresh activity in that session (captureSnapshot un-dismisses on a new active list);
+ *  a deleted session can never produce that activity again, so adding it there would
+ *  only grow an ever-larger list of ids nothing will ever check again. Safe to call
+ *  for an id that was never in the overview. */
+export function removeSessionTodoOverviewRow(storedSessionId: string): void {
+  const hadSnapshot = snapshots.delete(storedSessionId)
+  const hadDismissedItems = dismissedItems.delete(storedSessionId)
+
+  if (!hadSnapshot && !hadDismissedItems) {
+    return
+  }
+
+  persistSnapshots()
+  persistDismissedItems()
+  publishRows()
+}
+
+/** Test-only reset — mirrors the pattern other session-scoped stores use.
+ *  Clears BOTH the in-memory maps and their persisted copies. */
+export function resetSessionTodoOverview(): void {
+  snapshots.clear()
+  dismissed.clear()
+  dismissedItems.clear()
+  persistSnapshots()
+  persistDismissed()
+  persistDismissedItems()
+  publishRows()
+}
+
+// ── Startup backfill ────────────────────────────────────────────────────────
+// `captureSnapshot` above only ever sees a session once THIS window observes
+// it live (a todo.updated event, or a session.resume/activate response) — a
+// session created in a different window, or before this app was last opened,
+// never enters `snapshots` that way. `todo.list_open_sessions`
+// (tui_gateway/methods_todo.py) answers "which stored sessions still have an
+// unfinished todo list?" directly from the DB in one query, so a session like
+// one left mid-checklist yesterday shows up here the first time the app is
+// opened today, not only after the user happens to reopen that exact chat.
+// Runs once per gateway connection (not on every reconnect-retry churn) and
+// never overwrites a row `captureSnapshot` already populated — live data,
+// however stale-looking, is always more authoritative than this cold read.
+let backfillRequested = false
+
+async function backfillFromStorage(): Promise<void> {
+  const gateway = $gateway.get()
+
+  if (!gateway) {
+    return
+  }
+
+  try {
+    const result = await ambientRequestFor(gateway)<{ sessions?: unknown }>('todo.list_open_sessions', {
+      limit: 200
+    })
+
+    const rows = Array.isArray(result?.sessions) ? result.sessions : []
+    let changed = false
+
+    for (const row of rows) {
+      if (!row || typeof row !== 'object') {
+        continue
+      }
+
+      const storedSessionId = String((row as { session_id?: unknown }).session_id ?? '').trim()
+
+      if (!storedSessionId || snapshots.has(storedSessionId) || dismissed.has(storedSessionId)) {
+        continue
+      }
+
+      // This row came straight from the launch profile's DB (todo.list_open_sessions
+      // has no session.list-style row to carry connection_id/profile), so the
+      // owner ladder in session-states.ts (tile route → hint → row → runtime
+      // ledger) has nothing to resolve UNLESS a hint already exists — a session
+      // this window has never listed/opened otherwise 4001s the "Session owner
+      // could not be resolved" fail-closed error the instant the user tries to
+      // cancel an item (#todo-overview-backfill-owner). The backfill RPC only
+      // ever reads the ambient connection's own profile DB, so "this window's
+      // active connection/profile" is a true, not-a-guess owner for exactly
+      // the rows it returns.
+      if (!getSessionOwnerHint(storedSessionId)) {
+        const connectionId = activeGatewayConnectionId()
+
+        if (connectionId) {
+          setSessionOwnerHint(storedSessionId, { connectionId, profile: activeGatewayProfileKey() })
+        }
+      }
+
+      const todos = parseTodos({ todos: (row as { todos?: unknown }).todos })
+
+      if (!todos || todos.length === 0) {
+        continue
+      }
+
+      snapshots.set(storedSessionId, { todos, updatedAt: 0 })
+      changed = true
+    }
+
+    if (changed) {
+      persistSnapshots()
+      publishRows()
+    }
+  } catch (err) {
+    notifyError(err, 'Could not load existing task lists')
+  }
+}
+
+// A plain `{ get, request }` gateway stub (as several tests supply) has no
+// `.subscribe` — guard so those suites don't crash importing this module;
+// production's real nanostores atom always has it.
+if (typeof $gateway.subscribe === 'function') {
+  $gateway.subscribe(gateway => {
+    if (gateway && !backfillRequested) {
+      backfillRequested = true
+      void backfillFromStorage()
+    }
+  })
+} else if ($gateway.get()) {
+  backfillRequested = true
+  void backfillFromStorage()
+}

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -19,6 +19,27 @@ import { $sessionStates } from './session-states'
 export const $todosBySession = atom<Record<string, TodoItem[]>>({})
 export const $todoRevisionsBySession = atom<Record<string, number>>({})
 
+/** Unfiltered todo snapshot per RUNTIME session id — every non-empty todo
+ *  list the app has observed for that session, active or not. Unlike
+ *  `$todosBySession` (composer-chip-oriented: intentionally drops a stale
+ *  active list on hydrate so a dead turn's plan doesn't pin the composer
+ *  forever), this is the authoritative feed for the Agents panel's Task
+ *  Overview sidebar (`store/session-todos-overview.ts`), which must keep
+ *  showing pending items for an idle session — that IS the point of a
+ *  persistent "할일 현황" list, not a bug to filter out. Written from the
+ *  same two producers as `$todosBySession` (live `todo.updated` events and
+ *  session hydration) so the two stores never drift out of sync on content,
+ *  only on which entries linger. */
+export const $rawTodosBySession = atom<Record<string, TodoItem[]>>({})
+
+export function setRawSessionTodos(sid: string, todos: TodoItem[]) {
+  if (!sid || todos.length === 0) {
+    return
+  }
+
+  $rawTodosBySession.set({ ...$rawTodosBySession.get(), [sid]: todos })
+}
+
 export const todoListActive = (todos: readonly TodoItem[]) =>
   todos.some(t => t.status === 'pending' || t.status === 'in_progress')
 
@@ -102,6 +123,7 @@ export function setSessionTodos(sid: string, todos: TodoItem[], revision?: null 
 
   clearTimers.cancel(sid)
   $todosBySession.set({ ...$todosBySession.get(), [sid]: todos })
+  setRawSessionTodos(sid, todos)
 
   if (!todoListActive(todos)) {
     clearTimers.schedule(sid, FINISHED_LINGER_MS, () => dropSessionTodos(sid, false))
@@ -167,6 +189,12 @@ export function restoreSessionTodosFromSnapshot(sid: string, snapshot: unknown, 
   }
 
   const visible = running ? todos : todosForHydration(todos)
+
+  // The composer-chip store may legitimately drop a stale active list (see
+  // `todosForHydration`), but the sidebar's raw feed always gets the real
+  // snapshot — an idle session with pending items is exactly what the Task
+  // Overview panel exists to show, not something to hide.
+  setRawSessionTodos(sid, todos)
 
   if (visible !== null) {
     setSessionTodos(sid, visible, revision)

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -1398,6 +1398,56 @@ class SessionSessionsMixin:
         """At least N sessions exist (archived included); LIMIT short-circuits session_count()'s scan."""
         return len(self._read_all("SELECT 1 FROM sessions LIMIT ?", (n,))) >= n
 
+    def sessions_with_open_todos(self, *, limit: int = 100) -> List[Dict[str, Any]]:
+        """Stored sessions whose LATEST todo-tool result still has a pending/in_progress item.
+
+        Backfill source for the desktop Task Overview sidebar (`session-todos-overview.ts`):
+        that store only ever captures a snapshot when its OWN window observes a live
+        `todo.updated` event or resumes/activates the session — a session created in a
+        different window (or before the app was last opened) never enters it. This lets the
+        desktop ask, once at startup, "which sessions have an unfinished todo list I've never
+        seen?" without a per-session transcript re-fetch: one SQL scan of the newest
+        `todo_list`/`todo` tool-result row per session, filtered to those still open.
+        Archived/hidden sessions are excluded (deny-listed sources match `_LISTING_DENY_SOURCES`
+        in `tui_gateway/methods_session.py`, kept in sync there since this lives in the DB layer).
+        """
+        rows = self._read_all(
+            """
+            SELECT m.session_id, m.content, s.title, s.hidden, s.archived, s.source
+            FROM messages m
+            JOIN (
+                SELECT session_id, MAX(id) AS max_id
+                FROM messages
+                WHERE role = 'tool' AND tool_name IN ('todo_list', 'todo')
+                GROUP BY session_id
+            ) latest ON m.session_id = latest.session_id AND m.id = latest.max_id
+            JOIN sessions s ON s.id = m.session_id
+            WHERE s.hidden = 0 AND s.archived = 0
+            ORDER BY m.timestamp DESC
+            LIMIT ?
+            """,
+            (max(limit, 1) * 4,),  # over-fetch: many rows get dropped below once parsed/filtered
+        )
+        out: List[Dict[str, Any]] = []
+        for row in rows:
+            if (row["source"] or "").strip().lower() in ("kanban", "tool"):
+                continue
+            try:
+                parsed = json.loads(row["content"] or "")
+            except (TypeError, ValueError):
+                continue
+            todos = parsed.get("todos") if isinstance(parsed, dict) else None
+            if not isinstance(todos, list) or not todos:
+                continue
+            if not any(isinstance(t, dict) and t.get("status") in ("pending", "in_progress") for t in todos):
+                continue
+            out.append({
+                "session_id": row["session_id"], "title": row["title"] or "", "todos": todos,
+            })
+            if len(out) >= limit:
+                break
+        return out
+
     def session_count_by_source(
         self, *, include_archived: bool = False, archived_only: bool = False,
         exclude_children: bool = False,

--- a/tui_gateway/methods_todo.py
+++ b/tui_gateway/methods_todo.py
@@ -1,0 +1,153 @@
+"""Live, user-initiated todo state changes for shared clients."""
+
+from .method_ctx import HandlerRegistry, bind_module
+
+_registry = HandlerRegistry()
+method = _registry.method
+
+
+@method("todo.list_open_sessions")
+def _list_open_sessions(rid, params):
+    """Stored sessions with an unfinished todo list, for the desktop Task Overview sidebar's
+    startup backfill (`session-todos-overview.ts` only captures sessions its own window has
+    actually observed live; this covers everything else already sitting in the DB)."""
+    limit = params.get("limit", 100) if isinstance(params, dict) else 100
+    try:
+        limit = max(1, min(int(limit), 500))
+    except (TypeError, ValueError):
+        limit = 100
+    with _profile_db(params) as db:
+        if db is None:
+            return _err(rid, 5006, "session store unavailable")
+        try:
+            sessions = db.sessions_with_open_todos(limit=limit)
+        except Exception as e:
+            return _err(rid, 5006, str(e))
+    return _ok(rid, {"sessions": sessions})
+
+
+def _find_owned_session(stored_session_id, transport):
+    """Live session (dict) owned by ``stored_session_id`` on the calling transport, or None."""
+    with _sessions_lock:
+        return next((candidate for candidate in _sessions.values()
+                     if candidate.get("session_key") == stored_session_id
+                     and _session_transport_contains(candidate, transport)), None)
+
+
+@method("todo.cancel_item")
+def _cancel_item(rid, params):
+    """Cancel one todo on an owned live session and steer an active agent away from it."""
+    stored_session_id = _str_param(params, "stored_session_id")
+    item_id = _str_param(params, "item_id")
+    if not stored_session_id:
+        return _err(rid, 4000, "stored_session_id required")
+    if not item_id:
+        return _err(rid, 4000, "item_id required")
+
+    transport = current_transport()
+    if transport is None:
+        return _err(rid, 4001, "live session not found or not owned by this transport")
+    session = _find_owned_session(stored_session_id, transport)
+    agent = session.get("agent") if session else None
+    store = getattr(agent, "_todo_store", None)
+    if store is None:
+        return _err(rid, 4001, "live session not found or not owned by this transport")
+
+    item = next((todo for todo in store.read() if todo.get("id") == item_id), None)
+    if item is None:
+        return _err(rid, 4004, "todo item not found")
+
+    todos = store.write([{"id": item_id, "status": "cancelled"}], merge=True)
+    revision = store.snapshot()["revision"]
+    notice = (
+        f"[The user cancelled todo item {item_id}: {item['content']}. "
+        "Do not continue this task; re-read todo_list before choosing further work.]"
+    )
+    notified = False
+    if getattr(session, "get", None) and session.get("running"):
+        try:
+            notified = bool(agent.steer(notice))
+        except Exception:
+            logger.debug("todo cancellation steer failed", exc_info=True)
+    _cache_todo_state(session, {"todos": todos, "revision": revision})
+    _emit("todo.updated", next(sid for sid, candidate in _sessions.items() if candidate is session), {
+        "todos": todos,
+        "revision": revision,
+    })
+    return _ok(rid, {"item_id": item_id, "status": "cancelled", "revision": revision, "notified": notified})
+
+
+@method("todo.move_item")
+def _move_item(rid, params):
+    """Move one todo item from one owned live session's list to another's (desktop Task
+    Overview drag-and-drop). Both sessions must be live and owned by the calling transport —
+    the TodoStore is in-memory per AIAgent, so a session with no live agent has nothing to
+    move to/from. The source item is actually REMOVED (unlike cancel, which only flips
+    status) since a moved item belongs to its new session now, not a cancelled leftover in
+    the old one. The destination gets a fresh id (todo ids are only unique within one
+    session's list) with the source's content/parent dropped (a subtask's parent id is
+    meaningless without its former siblings)."""
+    from_session_id = _str_param(params, "from_session_id")
+    to_session_id = _str_param(params, "to_session_id")
+    item_id = _str_param(params, "item_id")
+    if not from_session_id:
+        return _err(rid, 4000, "from_session_id required")
+    if not to_session_id:
+        return _err(rid, 4000, "to_session_id required")
+    if not item_id:
+        return _err(rid, 4000, "item_id required")
+    if from_session_id == to_session_id:
+        return _err(rid, 4000, "from_session_id and to_session_id must differ")
+
+    transport = current_transport()
+    if transport is None:
+        return _err(rid, 4001, "live session not found or not owned by this transport")
+
+    from_session = _find_owned_session(from_session_id, transport)
+    from_agent = from_session.get("agent") if from_session else None
+    from_store = getattr(from_agent, "_todo_store", None)
+    if from_store is None:
+        return _err(rid, 4001, "source session not live or not owned by this transport")
+
+    to_session = _find_owned_session(to_session_id, transport)
+    to_agent = to_session.get("agent") if to_session else None
+    to_store = getattr(to_agent, "_todo_store", None)
+    if to_store is None:
+        return _err(rid, 4001, "destination session not live or not owned by this transport")
+
+    from_items = from_store.read()
+    item = next((todo for todo in from_items if todo.get("id") == item_id), None)
+    if item is None:
+        return _err(rid, 4004, "todo item not found in source session")
+
+    # Drop the moved item AND anything whose parent was it (an orphaned subtask
+    # referencing a parent id that no longer exists in this list is nonsensical).
+    remaining = [todo for todo in from_items if todo.get("id") != item_id and todo.get("parent") != item_id]
+    from_todos = from_store.write(remaining)
+    from_revision = from_store.snapshot()["revision"]
+
+    to_todos_before = to_store.read()
+    existing_ids = {todo.get("id") for todo in to_todos_before}
+    new_id = item_id if item_id not in existing_ids else f"{item_id}-moved"
+    suffix = 2
+    while new_id in existing_ids:
+        new_id = f"{item_id}-moved-{suffix}"
+        suffix += 1
+    to_todos = to_store.write(
+        to_todos_before + [{"id": new_id, "content": item["content"], "status": item["status"]}], merge=False)
+    to_revision = to_store.snapshot()["revision"]
+
+    _cache_todo_state(from_session, {"todos": from_todos, "revision": from_revision})
+    _cache_todo_state(to_session, {"todos": to_todos, "revision": to_revision})
+    from_runtime_id = next(sid for sid, candidate in _sessions.items() if candidate is from_session)
+    to_runtime_id = next(sid for sid, candidate in _sessions.items() if candidate is to_session)
+    _emit("todo.updated", from_runtime_id, {"todos": from_todos, "revision": from_revision})
+    _emit("todo.updated", to_runtime_id, {"todos": to_todos, "revision": to_revision})
+    return _ok(rid, {
+        "from_session_id": from_session_id, "to_session_id": to_session_id,
+        "item_id": new_id, "from_revision": from_revision, "to_revision": to_revision,
+    })
+
+
+def register(server):
+    bind_module(globals(), server)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3215,6 +3215,7 @@ from . import (  # noqa: E402
     methods_complete as _methods_complete, methods_config as _methods_config,
     methods_config_set as _methods_config_set, methods_images as _methods_images,
     methods_profiles as _methods_profiles, methods_prompt as _methods_prompt, methods_session as _methods_session,
+    methods_todo as _methods_todo,
     methods_tools as _methods_tools, prompt_turn as _prompt_turn, billing_view as _billing_view,
     methods_projects as _methods_projects, methods_session_foreign as _methods_session_foreign,
     methods_session_control as _methods_session_control, methods_subagents as _methods_subagents,
@@ -3228,6 +3229,6 @@ for _m in (
     _methods_browser_control, _methods_session, _methods_prompt, _methods_config,
     _methods_config_set, _methods_complete, _methods_tools, _methods_profiles, _methods_images,
     _methods_bot_relay, _prompt_turn, _billing_view, _methods_projects, _methods_session_foreign,
-    _methods_session_control, _methods_subagents, _methods_vault, _methods_free_tier):
+    _methods_session_control, _methods_subagents, _methods_vault, _methods_free_tier, _methods_todo):
     _m.register(sys.modules[__name__])
 del _m


### PR DESCRIPTION
## Summary

Adds a Task Overview section to the desktop Agents sidebar that tracks
todo lists across every session, independent of the composer's ephemeral
"Tasks N/M" chip:

- `store/session-todos-overview.ts` (new): localStorage-persisted store fed
  by an unfiltered per-session todo feed (`todos.ts`'s new
  `$rawTodosBySession`) so an idle session's pending items still show up
  (the composer chip intentionally hides those to avoid pinning a dead
  turn's plan above the composer forever — this store has the opposite
  requirement).
- `tui_gateway/methods_todo.py`:
  - `todo.list_open_sessions` — DB-backed backfill so a session with an
    unfinished todo list from a *previous* app run (or another window)
    shows up on next launch, not only after the user happens to reopen
    that exact chat.
  - `todo.move_item` — moves one todo item from one live session's
    `TodoStore` to another's (backs the new drag-and-drop below). Both
    sessions must be live (an active `AIAgent`) since the store is
    in-memory per agent.
- `hermes_state_sessions.py`: `sessions_with_open_todos()` — the SQL query
  backing the backfill RPC (newest `todo_list`/`todo` tool-result row per
  session, filtered to ones still open).
- Drag-and-drop: a todo item can be dragged from one session's row in the
  sidebar onto another session's row to move it there
  (`apps/desktop/src/app/agents/index.tsx`), wired to `todo.move_item`.
  Plain HTML5 DnD, scoped to this one list (the existing pointer-drag
  session machinery in `session-drag.ts` is built for session TILES with
  stack/split/link targeting across pane zones — overkill for reordering
  inside one sidebar section).

## Bugs fixed along the way

- Cancelling a todo via the sidebar's X button could dead-end with a
  "Session owner could not be resolved" error for backfilled sessions
  (the owner ladder in `session-states.ts` had nothing to resolve for a
  session this window never listed/opened live) — the backfill now stamps
  an owner hint since it only ever reads the ambient connection's own
  profile DB.
- A dismissed row could never reappear even after fresh activity in that
  session — `dismissed` was a one-way permanent block instead of the
  "get this off my screen until something changes" it's documented to be.
- A hard-deleted session's row lingered as a ghost in the sidebar
  (`removeSession` never touched this store) — now swept on delete via a
  dedicated `removeSessionTodoOverviewRow` that does NOT add to the
  `dismissed` set (a deleted session can never produce new activity, so
  there's nothing to guard against un-dismissing).
- A finished (all completed/cancelled) row would sit in the store forever
  (no TTL, no size cap) — now auto-prunes after 7 days untouched; a still-
  active list is exempt regardless of age.

## Testing

- `apps/desktop`: `npx tsc --noEmit` and `npx eslint --fix` clean.
- New/updated vitest coverage: `session-todos-overview-persistence.test.ts`,
  `task-overview-item-cancel.test.tsx`, `task-overview-item-dismiss.test.tsx`,
  `task-overview-live-update.test.tsx` — all passing.
- Manually verified end-to-end in a packaged build: backfill surfaces a
  prior session's open todos on relaunch, cancel/dismiss/delete all behave
  as described above, and drag-and-drop moves an item between two live
  sessions' lists with both rows updating live.