### PR TITLE
fix(tests): banner + anon-auth tests no longer depend on live GitHub/portal network (main CI red)

### DIFF
--- a/tests/hermes_cli/test_anon_auth_core.py
+++ b/tests/hermes_cli/test_anon_auth_core.py
@@ -94,7 +94,7 @@ def portal(monkeypatch, tmp_path):
     # resolve_nous_access_token memoises the last token for 5 s across the process; a token minted
     # by an earlier test must not be served to this one.
     from hermes_cli import auth as auth_mod
-    monkeypatch.setattr(auth_mod, "_RESOLVE_TOKEN_CACHE", None)
+    monkeypatch.setattr(auth_mod, "_RESOLVE_TOKEN_CACHE", {})
     return fake
 
 

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -64,7 +64,7 @@ def test_check_via_local_git_ssh_fastpath_ahead_not_behind(tmp_path):
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
-        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        patch.object(banner, "_github_branch_tip", return_value="a" * 40),
         # merge-base --is-ancestor exits 0: upstream tip IS an ancestor of HEAD
         patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=0)),
     ):
@@ -91,7 +91,7 @@ def test_check_via_local_git_ssh_fastpath_genuinely_behind(tmp_path):
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
-        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        patch.object(banner, "_github_branch_tip", return_value="a" * 40),
         # merge-base --is-ancestor exits 1: not an ancestor -> genuinely behind
         patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=1)),
         patch.object(banner, "_github_compare_behind", return_value=3),
@@ -119,7 +119,7 @@ def test_check_via_local_git_ssh_fastpath_offline_keeps_sentinel(tmp_path):
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
-        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        patch.object(banner, "_github_branch_tip", return_value="a" * 40),
         patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=1)),
         patch.object(banner, "_github_compare_behind", return_value=None),
     ):


### PR DESCRIPTION
Two test files went red on main's own push CI (run [34550073898](https://github.com/NousResearch/hermes-agent/actions/runs/34550073898) on `45a6101f3`) and now fail every PR, e.g. #107947. Both are hermeticity gaps in the tests, not product bugs.

## Root causes
- **`test_banner_git_state.py` (3 SSH-fastpath tests):** they patch `banner._upstream_main_sha`, but `_check_via_local_git` resolves a GitHub origin's tip via **`banner._github_branch_tip`** — the patch intercepts nothing and the tests silently rely on a live `api.github.com` call. On runners where that call fails (rate limit / egress), `target_rev` is None and the tests fail with `assert None == 0 / -1`. Fix: patch the seam production reads.
- **`test_anon_auth_core.py` (2 token-path tests):** the `portal` fixture resets the resolve-token memo with `monkeypatch.setattr(auth_mod, "_RESOLVE_TOKEN_CACHE", None)`, but `173105ce6f4` (profile-scoped memo, Sep 10) changed the cache from an `Optional[tuple]` slot to a **dict** keyed by `hermes_home_key()` — `.get()` on None raises `AttributeError` inside `resolve_nous_access_token`. Fix: reset with `{}` (matches `test_resolve_token_memo.py` / `test_nous_portal_staging_allowlist.py`).

## Live repro / A/B (sockets blocked in-process to simulate CI egress failure)
| Tree | Result |
|---|---|
| base (`origin/main`), netblock | **5 failed** — the exact CI failure set |
| fixed, netblock | **40/40 green** |
| fixed, normal network, `scripts/run_tests.sh` (4 files incl. memo + allowlist siblings) | 48 passed, 0 failed |

Test-only change, 5 lines. Unblocks every open PR's `Python tests` job.

## Infographic
![CI hermetic test fix](https://v3b.fal.media/files/b/0aa9f578/I3dDN5pgIp2WEoE8dnN8N_MWOInQyU.png)
