### PR TITLE
fix(aux): narrow a rejected json_schema to json_object, and remember the route

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -21,7 +21,7 @@ import threading
 import time
 import uuid
 from types import SimpleNamespace
-from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Tuple, TYPE_CHECKING
 from urllib.parse import urlparse, parse_qs, urlunparse
 
 from agent.codex_headers import (
@@ -3176,6 +3176,62 @@ def _without_structured_output_format(kwargs: dict) -> Optional[dict]:
     return retry_kwargs if changed else None
 
 
+# (base_url, model) pairs that have already rejected a ``json_schema`` request field. A hit lets a
+# later call start at the json_object rung instead of re-paying the 400. Keyed on the endpoint +
+# model because that pair decides the wire shape; provider aliases are excluded on purpose (the
+# same endpoint behind two provider names behaves identically, and an alias mismatch would silently
+# disable the memo). Per-process: auxiliary route resolution is process-stable, so a restart costs
+# one probe. Every observed case was one wasted round trip per *session* — see the DeepSeek repro in
+# tests/agent/test_structured_output_rejection_retry.py.
+_JSON_SCHEMA_REJECTED_ROUTES: Set[Tuple[str, str]] = set()
+
+
+def _structured_output_route_key(model: Optional[str], base_url: Optional[str]) -> Tuple[str, str]:
+    return ((base_url or "").strip().rstrip("/").lower(), (model or "").strip().lower())
+
+
+def _is_json_schema_format(response_format: Any) -> bool:
+    return isinstance(response_format, dict) and response_format.get("type") == "json_schema"
+
+
+def _downgrade_structured_output_format(kwargs: dict) -> Optional[dict]:
+    """Copy *kwargs* with a ``json_schema`` field narrowed to ``json_object`` (top-level and
+    ``extra_body``); None when there is no ``json_schema`` to narrow, so call sites don't retry an
+    unchanged request.
+
+    Dropping the field outright gives up decoder-level JSON enforcement entirely, but providers that
+    refuse schema decoding often still honour plain JSON mode: DeepSeek answers
+    ``This response_format type is unavailable now`` for ``json_schema`` while ``json_object``
+    succeeds. Narrow first, drop only if that also fails.
+    """
+    retry_kwargs = dict(kwargs)
+    changed = False
+    if _is_json_schema_format(retry_kwargs.get("response_format")):
+        retry_kwargs["response_format"] = {"type": "json_object"}
+        changed = True
+    extra_body = retry_kwargs.get("extra_body")
+    if isinstance(extra_body, dict) and _is_json_schema_format(extra_body.get("response_format")):
+        retry_kwargs["extra_body"] = {**extra_body, "response_format": {"type": "json_object"}}
+        changed = True
+    return retry_kwargs if changed else None
+
+
+def _remember_json_schema_rejection(route: "_LadderRoute", kwargs: dict) -> None:
+    """Record that this route rejects ``json_schema``, so later calls narrow up front.
+
+    Only requests that actually carried a ``json_schema`` are recorded: an ``output_config``
+    rejection on the Anthropic wire says nothing about ``json_schema`` support on the OpenAI wire.
+    """
+    if _downgrade_structured_output_format(kwargs) is None:
+        return
+    key = _structured_output_route_key(
+        route.final_model or route.resolved_model, route.base_info or route.resolved_base_url)
+    if key not in _JSON_SCHEMA_REJECTED_ROUTES:
+        _JSON_SCHEMA_REJECTED_ROUTES.add(key)
+        logger.info("Auxiliary %s%s: remembering that %s rejects json_schema; later calls start "
+                    "from json_object", route.task or "call", route.tag, key[1] or key[0])
+
+
 def _is_model_not_found_error(exc: Exception) -> bool:
     """"Requested model doesn't exist" (404 / invalid model) — typically a long-lived process pinned a
     since-dropped model. Excludes billing keywords, which :func:`_is_payment_error` owns."""
@@ -6137,6 +6193,12 @@ def _build_call_kwargs(
             or _endpoint_speaks_anthropic_messages(raw_base) or _is_anthropic_compat_endpoint(provider_norm, raw_base)
         ):
             kwargs["_reasoning_config"] = dict(reasoning_config)
+    # A route that has already rejected json_schema starts at the json_object rung, so the rejected
+    # attempt is not re-paid on every call (see _JSON_SCHEMA_REJECTED_ROUTES).
+    if _JSON_SCHEMA_REJECTED_ROUTES:
+        narrowed = _downgrade_structured_output_format(kwargs)
+        if narrowed is not None and _structured_output_route_key(model, base_url) in _JSON_SCHEMA_REJECTED_ROUTES:
+            kwargs.update(narrowed)
     # OpenCode relay session affinity — same key as the main turn so compression/title/vision
     # calls stay on the conversation's warm backend.
     from agent.opencode_affinity import merge_opencode_session_headers
@@ -6830,6 +6892,13 @@ def _param_rung_accepts(exc: Exception) -> bool:
             or "max_tokens" in str(exc) or "unsupported_parameter" in str(exc))
 
 
+def _structured_output_rung_accepts(exc: Exception) -> bool:
+    """The structured-output rungs chain (json_schema → json_object → no field), so a second
+    rejection must fall through to the next rung rather than re-raise as ``_param_rung_accepts``
+    alone would — otherwise a provider that rejects JSON mode too would never reach the drop rung."""
+    return _param_rung_accepts(exc) or _is_structured_output_rejection(exc)
+
+
 def _credential_rung_accepts(exc: Exception) -> bool:
     return _is_auth_error(exc) or _is_payment_error(exc) or _is_rate_limit_error(exc)
 
@@ -6860,6 +6929,21 @@ def _ladder_parameter_rungs(
             return resp, None, retry_kwargs
         kwargs = retry_kwargs
     if _is_structured_output_rejection(first_err):
+        # Remember the route so the next call starts one rung lower instead of re-paying a 400 that
+        # every session paid again (title generation rejected json_schema once per session).
+        _remember_json_schema_rejection(route, kwargs)
+        # Narrow before dropping: JSON mode often survives even where schema decoding does not, and
+        # a constrained decoder beats asking the model nicely for JSON.
+        narrowed = _downgrade_structured_output_format(kwargs)
+        if narrowed is not None:
+            logger.info("Auxiliary %s%s: provider rejected the structured-output schema; "
+                        "retrying with json_object (JSON mode retained): %s",
+                        task or "call", tag, first_err)
+            resp, first_err = yield from _rung(
+                _LadderStep("call", (client, narrowed)), _structured_output_rung_accepts)
+            if first_err is None:
+                return resp, None, narrowed
+            kwargs = narrowed
         retry_kwargs = _without_structured_output_format(kwargs)
         if retry_kwargs is not None:
             logger.info("Auxiliary %s%s: provider rejected the structured-output "

--- a/tests/agent/test_structured_output_rejection_retry.py
+++ b/tests/agent/test_structured_output_rejection_retry.py
@@ -22,6 +22,7 @@ field, retry once without it. These tests lock in that behaviour for both
 sync and async paths.
 """
 
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
@@ -31,7 +32,50 @@ from agent.auxiliary_client import (
     async_call_llm,
     _is_structured_output_rejection,
     _without_structured_output_format,
+    _downgrade_structured_output_format,
+    _remember_json_schema_rejection,
+    _JSON_SCHEMA_REJECTED_ROUTES,
+    _structured_output_route_key,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_json_schema_memo():
+    """The route memo is module state; a leaked key would silently disable the probe it tests."""
+    _JSON_SCHEMA_REJECTED_ROUTES.clear()
+    yield
+    _JSON_SCHEMA_REJECTED_ROUTES.clear()
+
+
+class TestDowngradeStructuredOutputFormat:
+    """A json_schema field narrows to json_object before the field is given up entirely."""
+
+    def test_narrows_top_level_json_schema(self):
+        kwargs = {"model": "m", "response_format": dict(_TITLE_RESPONSE_FORMAT)}
+        result = _downgrade_structured_output_format(kwargs)
+        assert result is not None
+        assert result["response_format"] == {"type": "json_object"}
+        # Input is not mutated.
+        assert kwargs["response_format"] == _TITLE_RESPONSE_FORMAT
+
+    def test_narrows_extra_body_json_schema_and_keeps_siblings(self):
+        kwargs = {
+            "model": "m",
+            "extra_body": {"response_format": dict(_TITLE_RESPONSE_FORMAT), "metadata": {"u": 1}},
+        }
+        result = _downgrade_structured_output_format(kwargs)
+        assert result is not None
+        assert result["extra_body"]["response_format"] == {"type": "json_object"}
+        assert result["extra_body"]["metadata"] == {"u": 1}
+
+    def test_returns_none_when_already_json_object(self):
+        """Nothing to narrow — the next rung must own this request, not an unchanged retry."""
+        assert _downgrade_structured_output_format(
+            {"model": "m", "extra_body": {"response_format": {"type": "json_object"}}}
+        ) is None
+
+    def test_returns_none_without_a_format_field(self):
+        assert _downgrade_structured_output_format({"model": "m"}) is None
 
 
 _TITLE_RESPONSE_FORMAT = {
@@ -154,7 +198,12 @@ class TestCallLlmStructuredOutputRetry:
         # Strict gateway that rejects the translated Anthropic field
         "HTTP 400: output_config: Extra inputs are not permitted",
     ])
-    def test_retries_once_without_response_format(self, error_message):
+    def test_narrows_json_schema_to_json_object_before_dropping(self, error_message):
+        """A rejected json_schema narrows to json_object — JSON mode is not given up needlessly.
+
+        DeepSeek is the live case: ``This response_format type is unavailable now`` for
+        ``json_schema``, while ``json_object`` is served normally.
+        """
         client = self._setup(RuntimeError(error_message))
 
         with (
@@ -176,12 +225,67 @@ class TestCallLlmStructuredOutputRetry:
         assert client.chat.completions.create.call_count == 2
         first_kwargs = client.chat.completions.create.call_args_list[0].kwargs
         retry_kwargs = client.chat.completions.create.call_args_list[1].kwargs
-        first_eb = first_kwargs.get("extra_body") or {}
-        retry_eb = retry_kwargs.get("extra_body") or {}
-        assert "response_format" in first_eb
-        assert "response_format" not in retry_eb
-        assert "response_format" not in retry_kwargs
+        assert (first_kwargs.get("extra_body") or {})["response_format"] == _TITLE_RESPONSE_FORMAT
+        # The retry keeps a constrained decoder, just not the schema.
+        assert (retry_kwargs.get("extra_body") or {})["response_format"] == {"type": "json_object"}
         assert retry_kwargs["model"] == first_kwargs["model"]
+
+    def test_drops_the_field_when_json_object_is_also_rejected(self):
+        """Providers that reject even JSON mode still get the prompt-compliance retry."""
+        client = MagicMock()
+        client.base_url = "https://api.deepseek.com/v1"
+        client.chat.completions.create.side_effect = [
+            RuntimeError("HTTP 400: This response_format type is unavailable now"),
+            RuntimeError("HTTP 400: This response_format type is unavailable now"),
+            _dummy_response(),
+        ]
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("deepseek", "deepseek-flash", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(client, "deepseek-flash")),
+            patch("agent.auxiliary_client._validate_llm_response",
+                  side_effect=lambda resp, _task, **_kw: resp),
+        ):
+            result = call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=64,
+                extra_body={"response_format": dict(_TITLE_RESPONSE_FORMAT)},
+            )
+
+        assert result == {"ok": True}
+        assert client.chat.completions.create.call_count == 3
+        last_kwargs = client.chat.completions.create.call_args_list[2].kwargs
+        assert "response_format" not in last_kwargs
+        assert "response_format" not in (last_kwargs.get("extra_body") or {})
+
+    def test_json_object_request_goes_straight_to_the_drop_rung(self):
+        """Nothing to narrow on a json_object request: keep the original single retry."""
+        json_object_format = {"type": "json_object"}
+        client = self._setup(RuntimeError("HTTP 400: This response_format type is unavailable now"))
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("openai-codex", "gpt-5.5", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(client, "gpt-5.5")),
+            patch("agent.auxiliary_client._validate_llm_response",
+                  side_effect=lambda resp, _task, **_kw: resp),
+        ):
+            result = call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=64,
+                extra_body={"response_format": dict(json_object_format)},
+            )
+
+        assert result == {"ok": True}
+        assert client.chat.completions.create.call_count == 2
+        retry_kwargs = client.chat.completions.create.call_args_list[1].kwargs
+        assert "response_format" not in retry_kwargs
+        assert "response_format" not in (retry_kwargs.get("extra_body") or {})
 
     def test_unrelated_400_does_not_strip_response_format(self):
         """Unrelated 400s must not silently downgrade the schema contract."""
@@ -273,9 +377,8 @@ class TestAsyncCallLlmStructuredOutputRetry:
         assert client.chat.completions.create.await_count == 2
         first_kwargs = client.chat.completions.create.call_args_list[0].kwargs
         retry_kwargs = client.chat.completions.create.call_args_list[1].kwargs
-        assert "response_format" in (first_kwargs.get("extra_body") or {})
-        assert "response_format" not in (retry_kwargs.get("extra_body") or {})
-        assert "response_format" not in retry_kwargs
+        assert (first_kwargs.get("extra_body") or {})["response_format"] == _TITLE_RESPONSE_FORMAT
+        assert (retry_kwargs.get("extra_body") or {})["response_format"] == {"type": "json_object"}
 
     @pytest.mark.asyncio
     async def test_async_unrelated_400_does_not_retry(self):
@@ -305,3 +408,82 @@ class TestAsyncCallLlmStructuredOutputRetry:
                     },
                 )
         assert client.chat.completions.create.await_count == 1
+
+
+class TestJsonSchemaRouteMemo:
+    """A route that rejects json_schema is not re-probed on every call.
+
+    The live report: every new session's title generation re-paid the same 400 (five sessions,
+    five identical rejections in one ``agent.log``), because the ladder's discovery was thrown away
+    with the request. The memo keeps it, so only the first call on a route narrows reactively.
+    """
+
+    def _call(self, client, model="deepseek-flash", provider="deepseek"):
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=(provider, model, None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(client, model)),
+            patch("agent.auxiliary_client._validate_llm_response",
+                  side_effect=lambda resp, _task, **_kw: resp),
+        ):
+            return call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=64,
+                extra_body={"response_format": dict(_TITLE_RESPONSE_FORMAT)},
+            )
+
+    def _rejecting_client(self, base_url):
+        client = MagicMock()
+        client.base_url = base_url
+        client.chat.completions.create.side_effect = [
+            RuntimeError("HTTP 400: This response_format type is unavailable now"),
+            _dummy_response(),
+        ]
+        return client
+
+    def test_rejection_is_remembered_and_the_next_call_starts_at_json_object(self):
+        first = self._rejecting_client("https://api.deepseek.com/v1")
+        assert self._call(first) == {"ok": True}
+        # Reactive: schema attempt, then the json_object rung.
+        assert first.chat.completions.create.call_count == 2
+        assert _structured_output_route_key("deepseek-flash", "https://api.deepseek.com/v1") \
+            in _JSON_SCHEMA_REJECTED_ROUTES
+
+        second = MagicMock()
+        second.base_url = "https://api.deepseek.com/v1"
+        second.chat.completions.create.side_effect = [_dummy_response()]
+        assert self._call(second) == {"ok": True}
+        # The doomed schema attempt is not paid again.
+        assert second.chat.completions.create.call_count == 1
+        assert (second.chat.completions.create.call_args_list[0].kwargs
+                .get("extra_body") or {})["response_format"] == {"type": "json_object"}
+
+    @pytest.mark.parametrize("other_model,other_base_url", [
+        ("deepseek-flash", "https://other-endpoint.example/v1"),  # different endpoint
+        ("deepseek-v4-pro", "https://api.deepseek.com/v1"),        # different model
+    ])
+    def test_memo_does_not_leak_beyond_the_route_it_was_learned_on(self, other_model, other_base_url):
+        """The memo is scoped to the endpoint+model that rejected the schema, so a new route still
+        gets the schema it might well accept."""
+        assert self._call(self._rejecting_client("https://api.deepseek.com/v1")) == {"ok": True}
+
+        other = self._rejecting_client(other_base_url)
+        assert self._call(other, model=other_model) == {"ok": True}
+        assert other.chat.completions.create.call_count == 2
+        first_kwargs = other.chat.completions.create.call_args_list[0].kwargs
+        assert (first_kwargs.get("extra_body") or {})["response_format"] == _TITLE_RESPONSE_FORMAT
+
+    def test_records_only_requests_that_carried_json_schema(self):
+        """An output_config-only request says nothing about json_schema support."""
+        route = SimpleNamespace(
+            final_model="m", resolved_model=None, base_info="https://x.example/v1",
+            resolved_base_url=None, task="title_generation", tag="",
+        )
+        _remember_json_schema_rejection(
+            route, {"model": "m", "extra_body": {"output_config": {"format": {"type": "json_schema"}}}})
+        assert _JSON_SCHEMA_REJECTED_ROUTES == set()
+
+        _remember_json_schema_rejection(
+            route, {"model": "m", "extra_body": {"response_format": dict(_TITLE_RESPONSE_FORMAT)}})
+        assert _structured_output_route_key("m", "https://x.example/v1") in _JSON_SCHEMA_REJECTED_ROUTES


### PR DESCRIPTION
# fix(aux): narrow a rejected `json_schema` to `json_object`, and remember the route

Refs #82816 — the report that introduced this ladder rung. One of its two endpoints answers
`This response_format type is unavailable now`, which is the case this PR handles more gracefully:
that endpoint serves JSON mode, so the rung can narrow instead of dropping the field.

## What

The auxiliary recovery ladder reacts to a structured-output 400 by dropping `response_format`
entirely (`_without_structured_output_format`), which degrades a schema-enforced call to prompt
compliance — the model is then merely *asked* for JSON. Two changes:

1. **Narrow before dropping.** A rejected `response_format: {"type": "json_schema", ...}` now
   first retries as `{"type": "json_object"}`, which keeps decoder-level JSON enforcement. The
   field is dropped only if JSON mode is rejected too.
2. **Remember the route.** A `(base_url, model)` pair that rejected `json_schema` is memoised, so
   later calls on that route start at the JSON-mode rung instead of re-paying the same 400.

Scope: `agent/auxiliary_client.py` only. No config, no wire-shape or caller changes; every aux
task inherits it.

## Why — the live repro

DeepSeek's API rejects schema decoding but serves JSON mode normally:

```
$ python3 probe_structured_output.py      # response_format shapes against api.deepseek.com
prompt only (no field)   OK   content='{"title": "DeepSeek Throughput Chat"}'
json_object              OK   content='{"title": "DeepSeek Throughput Talk"}'
json_schema strict       HTTP 400  This response_format type is unavailable now
```

So today's fallback throws away a working rung. Worse, the discovery is not retained: one
`agent.log` shows the identical rejection once per *session*, five sessions running:

```
00:37:30  [20260911_003710_0febe5]  Auxiliary title_generation: provider rejected the structured-output format field...
00:40:20  [20260911_004018_c8a75b]  ...
01:01:58  [20260911_010156_3b9b66]  ...
01:26:39  [20260911_012637_01caf4]  ...
04:10:16  [20260911_041014_5b7278]  ...
```

Each line is a rejected request (400 at validation, so no tokens billed) plus a retargeted retry,
paid again by every new session.

## Behaviour, base vs patched

Same fake provider that 400s on `json_schema` and accepts the next request (`/tmp/aux_repro.py`):

| | base | patched |
|---|---|---|
| `response_format` on the retry | `None` (prompt compliance) | `{"type": "json_object"}` |
| calls on a *later* call, same route | 1 — sends `json_schema` again | 1 — sends `json_object`, no doomed attempt |
| `output_config` rejections | unchanged | unchanged (only `json_schema` requests are recorded) |

Unrelated 400s still do not touch the field — the detector is untouched.

## Tests

`tests/agent/test_structured_output_rejection_retry.py`, run with `scripts/run_tests.sh`:

- 34 pass patched; on base the file fails at collection (`cannot import name
  '_downgrade_structured_output_format'`), since both behaviours are new.
- 366 pass across `tests/agent/test_auxiliary_client.py`, `test_actual_auxiliary_routing.py`,
  `test_anthropic_structured_output.py` and this file.

One existing assertion changed deliberately: `test_retries_once_without_response_format`
(now `test_narrows_json_schema_to_json_object_before_dropping`) asserted the retry carried **no**
`response_format`. That is the behaviour this patch alters. The drop rung is still covered — the
new `test_drops_the_field_when_json_object_is_also_rejected` pins it for providers that reject
JSON mode as well.

## Notes for review

- `_structured_output_rung_accepts` exists because `_param_rung_accepts` does not accept a
  structured-output rejection, so a second rejection re-raised and the drop rung was unreachable
  from the new rung. The drop rung keeps its original predicate, so its semantics are unchanged.
- The memo is **per-process**. Aux route resolution is process-stable, which covers the observed
  case (one long-lived backend serving many sessions); a restart pays one probe. Disk persistence
  was left out as a deliberate scope limit — say the word if you'd prefer it durable.
- Keyed on `(base_url, model)`, not provider: the endpoint+model determine the wire shape, and a
  provider-alias mismatch would silently disable the memo.
- `models.dev` reports `structured_output: true` for `deepseek-flash`, which is accurate for JSON
  mode and false for schema decoding. The capability flag is coarser than the wire; that gap is
  exactly why this is handled reactively rather than by precomputed capability.
