### PR TITLE
fix(cron): report hard guardrail stops as failures

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1761,23 +1761,36 @@ def _run_agent_with_watchdog(
 
 
 def _final_response_from_result(result: dict, job_id: str, job_name: str, AIAgent) -> str:
-    """Deliverable final response from a ``run_conversation`` result. Raises RuntimeError on
-    `failed=True`/`completed=False`: the error text may sit in `final_response` and would otherwise
-    be delivered as the reply with the job marked ok."""
+    """Return a deliverable response, rejecting agent and guardrail failures.
+
+    ``run_conversation`` can synthesize a final response when a hard tool-loop guardrail stops
+    the turn. That text explains the failure; it is not successful job output.
+    """
     # If the agent itself reported failure (e.g. all retries exhausted on API errors, model abort, mid-run
     # interrupt), do not silently mark the job as successful. run_agent populates
     # `failed=True`/`completed=False` on these paths and may put the error into `final_response`, which
     # would otherwise be delivered as if it were the agent's reply and the job's `last_status` set to "ok".
+    # A hard tool guardrail is another abnormal terminal even though the generic agent result remains
+    # completed=True/failed=False for interactive surfaces. Cron must route its synthesized explanation
+    # through the failure-delivery lane instead of recording completed/delivered.
     # Raise so the except handler below builds the proper failure tuple. (issue #17855)
     turn_exit_reason = str(result.get("turn_exit_reason") or "")
     final_response_text = (result.get("final_response") or "").strip()
+    guardrail = result.get("guardrail")
+    guardrail_halt = turn_exit_reason == "guardrail_halt" or (
+        isinstance(guardrail, dict) and guardrail.get("action") == "halt"
+    )
     max_iteration_summary = (
         result.get("failed") is not True
         and result.get("completed") is False
         and turn_exit_reason.startswith("max_iterations_reached(")
         and bool(final_response_text)
     )
-    if result.get("failed") is True or (result.get("completed") is False and not max_iteration_summary):
+    if (
+        guardrail_halt
+        or result.get("failed") is True
+        or (result.get("completed") is False and not max_iteration_summary)
+    ):
         raise RuntimeError(result.get("error") or final_response_text or "agent reported failure")
     if max_iteration_summary:
         logger.warning(

--- a/tests/cron/test_scheduler_completion_verification.py
+++ b/tests/cron/test_scheduler_completion_verification.py
@@ -143,6 +143,27 @@ def test_run_with_final_assistant_reply_books_complete(monkeypatch, tmp_path):
     assert reasons == ["cron_complete"]
 
 
+def test_guardrail_halt_is_a_failed_cron_run():
+    """A synthesized hard-stop message is a failure notice, not successful job output."""
+    result = {
+        "completed": True,
+        "failed": False,
+        "final_response": "I stopped retrying patch after repeated failures.",
+        "turn_exit_reason": "guardrail_halt",
+        "guardrail": {
+            "action": "halt",
+            "code": "same_tool_failure_halt",
+            "tool_name": "patch",
+            "count": 8,
+        },
+    }
+
+    with pytest.raises(RuntimeError, match="stopped retrying patch"):
+        cron_scheduler._final_response_from_result(
+            result, "guardrail-job", "Guardrail job", _FakeCronAgent
+        )
+
+
 def test_classification_probe_failure_keeps_historical_reason(monkeypatch, tmp_path):
     """Best-effort metadata: a failing classifier must not mislabel a run."""
     _RecordingSessionDB.next_lifecycle = RuntimeError("db busy")


### PR DESCRIPTION
## Summary
- classify hard tool-loop guardrail stops as failed cron runs
- route the synthesized guardrail explanation through the failure delivery lane
- prevent completed/delivered from masking an incomplete cron task

## Verification
- regression reproduced red on baseline
- `tests/cron/test_scheduler_completion_verification.py`: 4 passed
- full `tests/cron/`: 1,214 passed, 20 skipped
- independent exact-tree review approved `d742b2ed1630b21b7616009cce411b4b6389ef76`
