### PR TITLE
fix(dashboard): use token-based subcommand detection in orphan-serve reaper

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from hermes_cli.update_cmd_windows import _hermes_holder_subcommand
+
 # Cmdline substrings identifying the long-lived server (``serve`` = the headless name Desktop
 # spawns; reaped on update for the same reason).
 _DASHBOARD_PATTERNS = tuple(
@@ -491,10 +493,15 @@ def _is_desktop_local_serve_cmdline(command: str) -> bool:
 
     Long-lived headless serves (``--host <tailscale-ip> --port 9119``) must never match —
     those are operator-managed remote backends that legitimately run with ppid 1.
+
+    Token-based subcommand detection via ``_hermes_holder_subcommand`` avoids the
+    substring pitfall where ``"serve"`` matches ``preserve``, ``server``,
+    ``observer``, ``reserved`` in argv paths or flags (see #107631, #90778).
     """
-    cmd = command.lower()
-    if "serve" not in cmd or ("hermes" not in cmd and "hermes_cli" not in cmd):
+    subcmd = _hermes_holder_subcommand(command)
+    if subcmd != "serve":
         return False
+    cmd = command.lower()
     has_loopback = any(tok in cmd for tok in (
         "--host 127.0.0.1", "--host=127.0.0.1", "--host localhost", "--host=localhost"))
     return has_loopback and ("--port 0" in cmd or "--port=0" in cmd)

--- a/tests/hermes_cli/test_orphan_desktop_serve_reap.py
+++ b/tests/hermes_cli/test_orphan_desktop_serve_reap.py
@@ -42,6 +42,27 @@ def test_desktop_local_serve_shape_spares_fixed_port_and_non_serve():
     )
 
 
+def test_desktop_local_serve_shape_rejects_argv_substring_matches():
+    """Regression: 'serve' as a substring of other words must not match (#107631)."""
+    # --preserve-cache contains "serve" in "preserve"
+    assert not _is_desktop_local_serve_cmdline(
+        "python -m hermes_cli.main kanban --preserve-cache --host 127.0.0.1 --port 0"
+    )
+    # Path containing "server"
+    assert not _is_desktop_local_serve_cmdline(
+        "/home/u/hermes-server/venv/bin/python -m hermes_cli.main dashboard "
+        "--host 127.0.0.1 --port 0"
+    )
+    # Subcommand is "dashboard", not "serve"
+    assert not _is_desktop_local_serve_cmdline(
+        "hermes dashboard --host 127.0.0.1 --port 0"
+    )
+    # Subcommand is "observer" (hypothetical), not "serve"
+    assert not _is_desktop_local_serve_cmdline(
+        "hermes observer --host 127.0.0.1 --port 0"
+    )
+
+
 def test_reap_only_kills_ppid1_local_serves():
     scanned = [
         (111, "hermes serve --host 127.0.0.1 --port 0"),  # orphan local


### PR DESCRIPTION
## Summary

The orphan-serve reaper in `_is_desktop_local_serve_cmdline` used a raw substring check (`"serve" not in cmd`) to identify processes, which matched false positives like `--preserve-cache`, paths containing `server`, `observer`, or `reserved`. Matched PIDs are SIGTERM'd then SIGKILL'd, so this could kill live user processes.

Replace the substring heuristic with the existing `_hermes_holder_subcommand` parser from `update_cmd_windows.py`, which tokenizes argv and returns the actual subcommand. The function now checks `subcmd != "serve"` instead of `"serve" not in cmd`.

The `--host` and `--port` substring checks remain safe because they are flag-value pairs that don't appear as substrings of other words.

## Test cases added

- `--preserve-cache` argv (contains "serve" in "preserve") → must not match
- Path containing `server` directory → must not match
- Subcommand is `dashboard` → must not match
- Subcommand is `observer` → must not match

All 12 tests in `test_orphan_desktop_serve_reap.py` pass.

## Reproduction

```python
from hermes_cli.dashboard_procs import _is_desktop_local_serve_cmdline
_is_desktop_local_serve_cmdline(
    "python -m hermes_cli.main kanban --preserve-cache --host 127.0.0.1 --port 0"
)
# Before fix: True (kills the process)
# After fix: False (process survives)
```

Fixes #107631 (sibling consumer of #90778, same bug class as #91869).
