### PR TITLE
Desktop: open bot tiles no longer cold-start or pin pooled backends from the background (#103375, salvage #103399)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -16590,6 +16590,32 @@ async function dispatchRegistryApiRequest(
   routeProfile = request?.profile,
   requestProfile = request?.profile
 ) {
+  // Passive tile reconcile must never cold-start a pooled backend (#103375):
+  // fail fast when no warm entry exists instead of spawning a child and
+  // starving the pool. Interactive opens (passive:false) keep the normal spawn.
+  if (request?.passive) {
+    const poolKey = backendScopeKey(registryConnectionId, routeProfile)
+    const entry = backendPool.get(poolKey)
+
+    if (!entry) {
+      throw new Error(`Passive read: no warm backend for "${poolKey}"`)
+    }
+
+    const connection = await entry.connectionPromise
+    const requestPath = pathForRegistryBackendRequest(request.path, requestProfile, connection)
+
+    const response = await fetchJsonForBackend(connection, requestPath, {
+      method: request?.method,
+      body: request?.body,
+      upload: request?.upload,
+      timeoutMs: resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
+    })
+
+    return (request?.method || 'GET').toUpperCase() === 'GET'
+      ? tagRegistrySessionResponse(requestPath, response, registryConnectionId)
+      : response
+  }
+
   // Claim-guarded (#90812): every registry-scoped REST call funnels through
   // here, so it can race a renderer's own WS reconnect dial for the same
   // (connectionId, profile) scope; coalescing avoids bootstrapping a second
@@ -16681,7 +16707,26 @@ async function handleHermesApiRequest(request) {
   let response
 
   try {
-    const connection = await ensureBackend(routeProfile)
+    // Passive reads (tile reconciles) must not spawn pool backends (#103375).
+    // If the target is pooled and has no warm entry, fail fast without
+    // consuming a slot; interactive reads keep the normal ensureBackend path.
+    // Primary route (backendProfile === null) always has a backend (startHermes).
+    const isPassivePooled = Boolean(request?.passive && routeProfile && apiRoute.backendProfile)
+
+    let connection
+
+    if (isPassivePooled) {
+      const key = String(routeProfile).trim()
+      const entry = backendPool.get(key) || backendPool.get(backendScopeKey(null, key))
+
+      if (!entry) {
+        throw new Error(`Passive read: no warm backend for profile "${key}"`)
+      }
+
+      connection = await entry.connectionPromise
+    } else {
+      connection = await ensureBackend(routeProfile)
+    }
     const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
     const url = `${connection.baseUrl}${apiRoute.requestPath}`

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1526,6 +1526,17 @@ function promotePoolEntry(entry: any): void {
   entry.localBackendSpawnRequest?.promote?.('foreground')
 }
 
+// A passive read (background tile reconcile, #103375) may only be served by a
+// backend that already exists: it never cold-starts a pooled child, never
+// takes a slot, and never refreshes lastActiveAt, so an open-but-unviewed tile
+// cannot keep the pool saturated. Callers treat the rejection as "nothing to
+// refresh yet"; primary-routed profiles are always warm and never reach here.
+function assertNotPassiveSpawn(passive: boolean, poolKey: string): void {
+  if (passive) {
+    throw new Error(`Passive read: no warm backend for "${poolKey}"`)
+  }
+}
+
 // Land a spawn failure in desktop.log. A background slot-wait timeout is
 // routine under a saturated pool (the next hydration pass retries), so it is
 // logged as such instead of as a backend-start failure.
@@ -11475,9 +11486,10 @@ function profileRouteOptions(profile, request?) {
 // Resolve a backend connection for the given profile, per the routing table in
 // resolveProfileBackendRoute(). An empty / unknown profile resolves to the
 // primary, so legacy callers are unchanged.
-async function ensureBackend(profile, opts: { spawnPriority?: LocalBackendSpawnPriority } = {}) {
+async function ensureBackend(profile, opts: { passive?: boolean; spawnPriority?: LocalBackendSpawnPriority } = {}) {
   const key = profile && String(profile).trim() ? String(profile).trim() : primaryProfileKey()
   const spawnPriority = spawnPriorityFrom(opts.spawnPriority)
+  const passive = Boolean(opts.passive)
 
   profileDeletionGate.assertCanStart(key)
 
@@ -11508,7 +11520,9 @@ async function ensureBackend(profile, opts: { spawnPriority?: LocalBackendSpawnP
   const existing = backendPool.get(key)
 
   if (existing) {
-    existing.lastActiveAt = Date.now()
+    if (!passive) {
+      existing.lastActiveAt = Date.now()
+    }
 
     if (spawnPriority === 'foreground') {
       promotePoolEntry(existing)
@@ -11520,6 +11534,7 @@ async function ensureBackend(profile, opts: { spawnPriority?: LocalBackendSpawnP
     return connection
   }
 
+  assertNotPassiveSpawn(passive, key)
   evictLruPoolBackends(poolMaxBackends() - 1)
 
   const entry = {
@@ -11564,9 +11579,10 @@ async function ensureRegistryBackend(
   connectionId,
   profile,
   managedUpdateCorrelation = '',
-  opts: { spawnPriority?: LocalBackendSpawnPriority } = {}
+  opts: { passive?: boolean; spawnPriority?: LocalBackendSpawnPriority } = {}
 ) {
   const spawnPriority = spawnPriorityFrom(opts.spawnPriority)
+  const passive = Boolean(opts.passive)
   const registry = readDesktopConnectionsRegistry()
   const id = String(connectionId || '').trim() || registry.primary
   const source = registry.connections.find(c => c.id === id)
@@ -11623,7 +11639,7 @@ async function ensureRegistryBackend(
   const primary = await reuseMatchingPrimarySshBackend({
     connectionId: id,
     effectiveFingerprint: resolveRegistryEffectiveFingerprint,
-    ensurePrimary: () => ensureBackend(profile, { spawnPriority }),
+    ensurePrimary: () => ensureBackend(profile, { passive, spawnPriority }),
     profile,
     registry,
     source
@@ -11644,7 +11660,7 @@ async function ensureRegistryBackend(
   // Desktop window starts two isolated servers whose transient runtime ids
   // are not interchangeable.
   if (id === registry.primary && source.kind !== 'local' && source.kind !== 'ssh') {
-    const primaryDescriptor = await ensureBackend(profile)
+    const primaryDescriptor = await ensureBackend(profile, { passive })
 
     if (registrySourceOwnsPrimaryBackend(registry, id, primaryDescriptor)) {
       return {
@@ -11674,7 +11690,7 @@ async function ensureRegistryBackend(
     })
 
     if (localRoute.delegate) {
-      return ensureBackend(profile, { spawnPriority })
+      return ensureBackend(profile, { passive, spawnPriority })
     }
 
     const stoppingLocal = poolStopper.inFlight(localRoute.poolKey)
@@ -11686,7 +11702,9 @@ async function ensureRegistryBackend(
     const existingLocal = backendPool.get(localRoute.poolKey)
 
     if (existingLocal) {
-      existingLocal.lastActiveAt = Date.now()
+      if (!passive) {
+        existingLocal.lastActiveAt = Date.now()
+      }
 
       if (spawnPriority === 'foreground') {
         promotePoolEntry(existingLocal)
@@ -11695,6 +11713,7 @@ async function ensureRegistryBackend(
       return existingLocal.connectionPromise
     }
 
+    assertNotPassiveSpawn(passive, localRoute.poolKey)
     evictLruPoolBackends(poolMaxBackends() - 1)
 
     const localEntry = {
@@ -11731,7 +11750,10 @@ async function ensureRegistryBackend(
   const existing = backendPool.get(key)
 
   if (existing) {
-    existing.lastActiveAt = Date.now()
+    if (!passive) {
+      existing.lastActiveAt = Date.now()
+    }
+
     const connectionPromise = existing.connectionPromise
 
     // A remote process can die while its local SSH forward stays LISTENing.
@@ -11743,7 +11765,7 @@ async function ensureRegistryBackend(
         connectionPromise,
         currentConnectionPromise: () => backendPool.get(key)?.connectionPromise || null,
         probe: (connection, requestPath, options) => fetchJsonForBackend(connection, requestPath, options),
-        reconnect: () => ensureRegistryBackend(id, profile),
+        reconnect: () => ensureRegistryBackend(id, profile, '', { passive }),
         retire: async (error: any) => {
           // A late failure from an old descriptor must never tear down a newer
           // entry that another caller has already installed.
@@ -11765,6 +11787,7 @@ async function ensureRegistryBackend(
     )
   }
 
+  assertNotPassiveSpawn(passive, key)
   evictLruPoolBackends(poolMaxBackends() - 1)
 
   const entry = {
@@ -16590,39 +16613,17 @@ async function dispatchRegistryApiRequest(
   routeProfile = request?.profile,
   requestProfile = request?.profile
 ) {
-  // Passive tile reconcile must never cold-start a pooled backend (#103375):
-  // fail fast when no warm entry exists instead of spawning a child and
-  // starving the pool. Interactive opens (passive:false) keep the normal spawn.
-  if (request?.passive) {
-    const poolKey = backendScopeKey(registryConnectionId, routeProfile)
-    const entry = backendPool.get(poolKey)
-
-    if (!entry) {
-      throw new Error(`Passive read: no warm backend for "${poolKey}"`)
-    }
-
-    const connection = await entry.connectionPromise
-    const requestPath = pathForRegistryBackendRequest(request.path, requestProfile, connection)
-
-    const response = await fetchJsonForBackend(connection, requestPath, {
-      method: request?.method,
-      body: request?.body,
-      upload: request?.upload,
-      timeoutMs: resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
-    })
-
-    return (request?.method || 'GET').toUpperCase() === 'GET'
-      ? tagRegistrySessionResponse(requestPath, response, registryConnectionId)
-      : response
-  }
-
   // Claim-guarded (#90812): every registry-scoped REST call funnels through
   // here, so it can race a renderer's own WS reconnect dial for the same
   // (connectionId, profile) scope; coalescing avoids bootstrapping a second
-  // SSH tunnel / remote dashboard.
-  const connection: any = await backendDialClaims.run(backendScopeKey(registryConnectionId, routeProfile), () =>
-    ensureRegistryBackend(registryConnectionId, routeProfile)
-  )
+  // SSH tunnel / remote dashboard. A passive read never dials, so it stays
+  // OUT of the claim: an interactive open coalescing onto an in-flight
+  // passive read would otherwise inherit its "no warm backend" rejection.
+  const connection: any = request?.passive
+    ? await ensureRegistryBackend(registryConnectionId, routeProfile, '', { passive: true })
+    : await backendDialClaims.run(backendScopeKey(registryConnectionId, routeProfile), () =>
+        ensureRegistryBackend(registryConnectionId, routeProfile)
+      )
 
   const requestPath = pathForRegistryBackendRequest(request.path, requestProfile, connection)
 
@@ -16707,26 +16708,7 @@ async function handleHermesApiRequest(request) {
   let response
 
   try {
-    // Passive reads (tile reconciles) must not spawn pool backends (#103375).
-    // If the target is pooled and has no warm entry, fail fast without
-    // consuming a slot; interactive reads keep the normal ensureBackend path.
-    // Primary route (backendProfile === null) always has a backend (startHermes).
-    const isPassivePooled = Boolean(request?.passive && routeProfile && apiRoute.backendProfile)
-
-    let connection
-
-    if (isPassivePooled) {
-      const key = String(routeProfile).trim()
-      const entry = backendPool.get(key) || backendPool.get(backendScopeKey(null, key))
-
-      if (!entry) {
-        throw new Error(`Passive read: no warm backend for profile "${key}"`)
-      }
-
-      connection = await entry.connectionPromise
-    } else {
-      connection = await ensureBackend(routeProfile)
-    }
+    const connection = await ensureBackend(routeProfile, { passive: request?.passive })
     const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
     const url = `${connection.baseUrl}${apiRoute.requestPath}`

--- a/apps/desktop/electron/registry-primary-profile-scope.test.ts
+++ b/apps/desktop/electron/registry-primary-profile-scope.test.ts
@@ -30,7 +30,7 @@ describe('primary-remote descriptor reuse keeps profile scope', () => {
 
     // The reuse branch must decorate the ambient primary descriptor with
     // sharedRemote: true, matching the explicit shared-remote connection path.
-    expect(branch).toContain('const primaryDescriptor = await ensureBackend(profile)')
+    expect(branch).toContain('const primaryDescriptor = await ensureBackend(profile, { passive })')
     expect(branch).toContain('registrySourceOwnsPrimaryBackend(registry, id, primaryDescriptor)')
     expect(branch).toContain('sharedRemote: true')
   })

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -396,7 +396,8 @@ export function getSession(id: string, profile?: ProfileScope): Promise<SessionI
 export function getSessionMessages(
   id: string,
   profile?: ProfileScope,
-  page: { limit?: number; offset?: number; order?: 'latest' | 'oldest'; includeCompacted?: boolean } = {}
+  page: { limit?: number; offset?: number; order?: 'latest' | 'oldest'; includeCompacted?: boolean } = {},
+  options: { passive?: boolean } = {}
 ): Promise<SessionMessagesResponse> {
   const query = new URLSearchParams()
 
@@ -426,7 +427,8 @@ export function getSessionMessages(
 
   return hermesApi<SessionMessagesResponse>({
     ...sessionScope,
-    path: `/api/sessions/${encodeURIComponent(id)}/messages${suffix}`
+    path: `/api/sessions/${encodeURIComponent(id)}/messages${suffix}`,
+    ...(options.passive ? { passive: true } : {})
   })
 }
 
@@ -439,15 +441,20 @@ export function getSessionMessages(
  */
 export const LATEST_SESSION_MESSAGES_LIMIT = 120
 
-export function getLatestSessionMessages(id: string, profile?: ProfileScope): Promise<SessionMessagesResponse> {
+export function getLatestSessionMessages(id: string, profile?: ProfileScope, passive = false): Promise<SessionMessagesResponse> {
   // includeCompacted: durable display history must include rows preserved by
   // in-place compaction (active=0, compacted=1); without them the transcript
   // silently ends at the compaction boundary and earlier turns are unreachable.
-  return getSessionMessages(id, profile, {
-    limit: LATEST_SESSION_MESSAGES_LIMIT,
-    order: 'latest',
-    includeCompacted: true
-  }).then(page => {
+  return getSessionMessages(
+    id,
+    profile,
+    {
+      limit: LATEST_SESSION_MESSAGES_LIMIT,
+      order: 'latest',
+      includeCompacted: true
+    },
+    passive ? { passive: true } : {}
+  ).then(page => {
     // Record whether the tail was truncated (page came back full) and where
     // the next older page starts, so "Show earlier" can backfill over REST
     // (app/chat/transcript-backfill). Keyed under both the requested id and

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -441,7 +441,11 @@ export function getSessionMessages(
  */
 export const LATEST_SESSION_MESSAGES_LIMIT = 120
 
-export function getLatestSessionMessages(id: string, profile?: ProfileScope, passive = false): Promise<SessionMessagesResponse> {
+export function getLatestSessionMessages(
+  id: string,
+  profile?: ProfileScope,
+  options: { passive?: boolean } = {}
+): Promise<SessionMessagesResponse> {
   // includeCompacted: durable display history must include rows preserved by
   // in-place compaction (active=0, compacted=1); without them the transcript
   // silently ends at the compaction boundary and earlier turns are unreachable.
@@ -453,7 +457,7 @@ export function getLatestSessionMessages(id: string, profile?: ProfileScope, pas
       order: 'latest',
       includeCompacted: true
     },
-    passive ? { passive: true } : {}
+    options
   ).then(page => {
     // Record whether the tail was truncated (page came back full) and where
     // the next older page starts, so "Show earlier" can backfill over REST

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -276,7 +276,7 @@ describe('active transcript refresh', () => {
 
     // Behavior assertions:
     expect(updaterCallCount).toBeGreaterThan(0)
-    expect(getLatestSessionMessages).toHaveBeenCalledWith(TILE_STORED_ID, undefined)
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(TILE_STORED_ID, undefined, { passive: true })
   })
 
   it('reconciles an idle tile while the main pane is busy', async () => {
@@ -301,7 +301,7 @@ describe('active transcript refresh', () => {
       updateSessionState
     })
 
-    expect(getLatestSessionMessages).toHaveBeenCalledWith(storedId, undefined)
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(storedId, undefined, { passive: true })
     expect(updateSessionState).toHaveBeenCalledTimes(1)
   })
 
@@ -394,15 +394,19 @@ describe('active transcript refresh', () => {
       updateSessionState
     })
 
-    expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-a', {
-      connectionId: 'connection-a',
-      profile: 'target-a'
-    })
-    expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-b', {
-      connectionId: 'connection-b',
-      profile: 'shared-profile'
-    })
-    expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-local', undefined)
+    // Every tile read is passive: it may serve from a warm owner backend but
+    // must never cold-start one (#103375).
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(
+      'stored-a',
+      { connectionId: 'connection-a', profile: 'target-a' },
+      { passive: true }
+    )
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(
+      'stored-b',
+      { connectionId: 'connection-b', profile: 'shared-profile' },
+      { passive: true }
+    )
+    expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-local', undefined, { passive: true })
     expect(updateSessionState).toHaveBeenCalledWith('runtime-a', expect.any(Function), 'stored-a')
     expect(updateSessionState).toHaveBeenCalledWith('runtime-b', expect.any(Function), 'stored-b')
     expect(updateSessionState).toHaveBeenCalledWith('runtime-local', expect.any(Function), 'stored-local')

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -160,7 +160,7 @@ export async function reconcileTileTranscripts({
     const signatureKey = tileTranscriptSignatureKey(tile)
 
     try {
-      const latest = await getLatestSessionMessages(storedSessionId, profileScope)
+      const latest = await getLatestSessionMessages(storedSessionId, profileScope, true)
 
       if (
         requestId !== requestSequenceRef.current ||

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -160,7 +160,9 @@ export async function reconcileTileTranscripts({
     const signatureKey = tileTranscriptSignatureKey(tile)
 
     try {
-      const latest = await getLatestSessionMessages(storedSessionId, profileScope, true)
+      // Passive: a hidden tile's refresh must never cold-start its owner
+      // backend or hold a pool slot (#103375); no warm backend = retry next tick.
+      const latest = await getLatestSessionMessages(storedSessionId, profileScope, { passive: true })
 
       if (
         requestId !== requestSequenceRef.current ||

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -1238,6 +1238,11 @@ export interface HermesApiRequest {
   // through the owning connection, not the local profile pool. Omit / '' to
   // keep the legacy profile-routed path; explicit 'local' forces this device.
   connectionId?: string | null
+  // Passive background read that must never cold-start a pooled backend (#103375).
+  // When true and the target profile has no warm pool entry, the main process
+  // fails fast without spawning a child or consuming a pool slot, so background
+  // tile reconciles cannot starve interactive opens.
+  passive?: boolean
 }
 
 export interface HermesPreviewTarget {

--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -53,6 +53,7 @@ vi.mock('@/store/session-states', () => reconnectStateMocks)
 
 const {
   activeGateway,
+  touchSecondaryGateways,
   closeLegacySecondaryGateways,
   closeSecondaryGateways,
   configureGatewayRegistry,
@@ -530,5 +531,36 @@ describe('reconnect fail-stop on a removed connection', () => {
 
     expect(result).not.toBeNull()
     expect((result as unknown as { connectionState: string }).connectionState).toBe('open')
+  })
+})
+
+describe('touchSecondaryGateways', () => {
+  it('pings only secondaries whose socket is open, so a backend nobody reaches can idle-reap (#103375)', async () => {
+    const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+      descriptorFor(connectionId, profile)
+    )
+    const touchBackend = vi.fn(async () => ({ ok: true }))
+
+    installDesktop({ getConnectionFor, touchBackend })
+
+    await ensureGatewayForAgent('homelab', 'default')
+    await ensureGatewayForAgent('office', 'default')
+    // openSecondary pings once per successful dial; only the keepalive sweep
+    // is under test here.
+    touchBackend.mockClear()
+
+    touchSecondaryGateways()
+    expect(touchBackend).toHaveBeenCalledTimes(2)
+
+    // The office socket drops and sits in reconnect backoff: still wantOpen,
+    // but nothing on this window uses that backend until it reopens.
+    const office = gatewayMocks.instances[1] as unknown as { connectionState: string }
+    office.connectionState = 'closed'
+    touchBackend.mockClear()
+
+    touchSecondaryGateways()
+
+    expect(touchBackend).toHaveBeenCalledTimes(1)
+    expect(touchBackend).not.toHaveBeenCalledWith(expect.stringContaining('office'))
   })
 })

--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -539,6 +539,7 @@ describe('touchSecondaryGateways', () => {
     const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
       descriptorFor(connectionId, profile)
     )
+
     const touchBackend = vi.fn(async () => ({ ok: true }))
 
     installDesktop({ getConnectionFor, touchBackend })
@@ -562,5 +563,162 @@ describe('touchSecondaryGateways', () => {
 
     expect(touchBackend).toHaveBeenCalledTimes(1)
     expect(touchBackend).not.toHaveBeenCalledWith(expect.stringContaining('office'))
+  })
+})
+
+describe('secondary stalled-dial budget', () => {
+  it('parks a scope after repeated stalled dials instead of redialing forever, and a user action re-arms it (#103375)', async () => {
+    vi.useFakeTimers()
+
+    const slotTimeout = () =>
+      new Error('Local backend start for "bot-a" timed out while waiting for a free slot. (background)')
+
+    const getConnectionFor = vi.fn().mockResolvedValueOnce(descriptorFor('homelab', 'bot-a')).mockRejectedValue(slotTimeout())
+
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('homelab', 'bot-a')
+    expect(gatewayMocks.instances).toHaveLength(1)
+
+    const socket = gatewayMocks.instances[0] as unknown as { connectionState: string }
+    socket.connectionState = 'closed'
+
+    // A focus/online nudge starts the automatic loop; every dial loses its
+    // pool-slot wait.
+    reconnectSecondaryGateways()
+    await vi.advanceTimersByTimeAsync(0)
+
+    for (let index = 0; index < 20; index += 1) {
+      await vi.advanceTimersByTimeAsync(20_000)
+    }
+
+    // The nudge dial + a bounded number of stalled redials, then silence.
+    const dialsAfterParking = getConnectionFor.mock.calls.length
+    expect(dialsAfterParking).toBeGreaterThan(1)
+    expect(dialsAfterParking).toBeLessThanOrEqual(4)
+
+    await vi.advanceTimersByTimeAsync(120_000)
+    expect(getConnectionFor.mock.calls.length).toBe(dialsAfterParking)
+
+    // Parked ≠ evicted: an explicit open on the scope dials again.
+    getConnectionFor.mockResolvedValue(descriptorFor('homelab', 'bot-a'))
+    await ensureGatewayForAgent('homelab', 'bot-a')
+    expect(getConnectionFor.mock.calls.length).toBe(dialsAfterParking + 1)
+  })
+
+  it('does not let an interleaved fast failure refill the stall budget', async () => {
+    vi.useFakeTimers()
+
+    const stalled = new Error('Local backend start for "bot-a" timed out while waiting for a free slot. (background)')
+
+    const getConnectionFor = vi
+      .fn()
+      .mockResolvedValueOnce(descriptorFor('homelab', 'bot-a'))
+      .mockRejectedValueOnce(stalled)
+      .mockRejectedValueOnce(new Error('Failed to connect to Hermes gateway'))
+      .mockRejectedValueOnce(stalled)
+      .mockRejectedValueOnce(new Error('Failed to connect to Hermes gateway'))
+      .mockRejectedValue(stalled)
+
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('homelab', 'bot-a')
+    const socket = gatewayMocks.instances[0] as unknown as { connectionState: string }
+    socket.connectionState = 'closed'
+
+    reconnectSecondaryGateways()
+    await vi.advanceTimersByTimeAsync(0)
+
+    for (let index = 0; index < 20; index += 1) {
+      await vi.advanceTimersByTimeAsync(20_000)
+    }
+
+    // 3 stalled dials spread across 5 attempts still park the scope.
+    expect(getConnectionFor.mock.calls.length).toBeLessThanOrEqual(6)
+  })
+
+  it('re-arms a parked scope on the wake/online/focus nudge', async () => {
+    vi.useFakeTimers()
+
+    const getConnectionFor = vi
+      .fn()
+      .mockResolvedValueOnce(descriptorFor('homelab', 'bot-a'))
+      .mockRejectedValue(new Error('Local backend start for "bot-a" timed out while waiting for a free slot.'))
+
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('homelab', 'bot-a')
+    const socket = gatewayMocks.instances[0] as unknown as { connectionState: string }
+    socket.connectionState = 'closed'
+
+    reconnectSecondaryGateways()
+    await vi.advanceTimersByTimeAsync(0)
+
+    for (let index = 0; index < 20; index += 1) {
+      await vi.advanceTimersByTimeAsync(20_000)
+    }
+
+    const parkedDials = getConnectionFor.mock.calls.length
+    getConnectionFor.mockResolvedValue(descriptorFor('homelab', 'bot-a'))
+
+    reconnectSecondaryGateways()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(getConnectionFor.mock.calls.length).toBe(parkedDials + 1)
+  })
+
+  it('keeps the unbounded backoff for fast transport failures (a restarting gateway must come back on its own)', async () => {
+    vi.useFakeTimers()
+
+    const getConnectionFor = vi
+      .fn()
+      .mockResolvedValueOnce(descriptorFor('homelab', 'bot-a'))
+      .mockRejectedValue(new Error('ECONNREFUSED'))
+
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('homelab', 'bot-a')
+    const socket = gatewayMocks.instances[0] as unknown as { connectionState: string }
+    socket.connectionState = 'closed'
+
+    reconnectSecondaryGateways()
+    await vi.advanceTimersByTimeAsync(0)
+
+    for (let index = 0; index < 20; index += 1) {
+      await vi.advanceTimersByTimeAsync(20_000)
+    }
+
+    // Still dialing after ~400s of refusals: never parked.
+    expect(getConnectionFor.mock.calls.length).toBeGreaterThan(10)
+  })
+
+  it('re-arms a parked ACTIVE scope from the explicit recovery path (Reconnect / request retry)', async () => {
+    vi.useFakeTimers()
+
+    const getConnectionFor = vi
+      .fn()
+      .mockResolvedValueOnce(descriptorFor('homelab', 'bot-a'))
+      .mockRejectedValue(new Error('Local backend start for "bot-a" timed out while waiting for a free slot.'))
+
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('homelab', 'bot-a')
+    const socket = gatewayMocks.instances[0] as unknown as { connectionState: string }
+    socket.connectionState = 'closed'
+
+    reconnectSecondaryGateways()
+    await vi.advanceTimersByTimeAsync(0)
+
+    for (let index = 0; index < 20; index += 1) {
+      await vi.advanceTimersByTimeAsync(20_000)
+    }
+
+    const parkedDials = getConnectionFor.mock.calls.length
+    getConnectionFor.mockResolvedValue(descriptorFor('homelab', 'bot-a'))
+
+    const reopened = await ensureActiveGatewayOpen()
+
+    expect(reopened).not.toBeNull()
+    expect(getConnectionFor.mock.calls.length).toBe(parkedDials + 1)
   })
 })

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1665,11 +1665,15 @@ export function openSecondaryCount(): number {
 
 // Keep the idle reaper from killing a backend we still need: ping every live
 // secondary. The active one is pinged separately (touchActiveGatewayBackend).
+// "Live" means the socket is OPEN: a wantOpen entry stuck in its reconnect
+// backoff has no consumer on that backend, and pinging it anyway kept a
+// tile-pinned backend keepalive-fresh forever, so LRU eviction and the idle
+// reaper never freed its pool slot (#103375).
 export function touchSecondaryGateways(): void {
   const desktop = window.hermesDesktop
 
   for (const entry of g.secondaries.values()) {
-    if (entry.wantOpen) {
+    if (entry.wantOpen && isOpen(entry.gateway)) {
       void desktop?.touchBackend?.(entry.scope).catch(() => undefined)
     }
   }

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -4,7 +4,7 @@ import { atom } from 'nanostores'
 import type { HermesConnection } from '@/global'
 import { HermesGateway, setApiRequestConnection } from '@/hermes'
 import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
-import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
+import { isTimeoutError, RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
 import { markNativeNotifyBaseline } from '@/store/notify-baseline'
 import { setConnection, setGatewayState } from '@/store/session'
 import { stampSecondaryProfileOwner } from '@/store/session-event-provenance'
@@ -98,6 +98,9 @@ interface Secondary {
   offState: () => void
   reconnectTimer: ReturnType<typeof setTimeout> | null
   reconnectAttempt: number
+  /** Consecutive automatic dials that stalled (slot wait / dial timeout)
+   *  rather than failing fast; see SECONDARY_STALLED_DIAL_BUDGET. */
+  stalledDials: number
   reconnecting: boolean
   /** A material connection edit is waiting for live owners to drain. */
   pendingConnectionRedial: boolean
@@ -663,6 +666,33 @@ async function openSecondary(entry: Secondary, spawnPriority: SpawnPriority = 'b
   }
 }
 
+// Consecutive STALLED automatic dials (a pool-slot wait or the 20s dial
+// timeout, never a fast transport error) before a secondary parks. A
+// tile-pinned scope stays wantOpen for the tile's lifetime, so an owner
+// backend that keeps losing its slot wait otherwise re-queues a background
+// spawn on every backoff tick forever — the queue/timeout treadmill in
+// #103375. Fast failures (a gateway restarting, ECONNREFUSED) keep the
+// ordinary unbounded backoff: they cost nothing and the socket must come back
+// on its own. Parking keeps the entry; any explicit open of the scope
+// (requestGatewayForAgent, openGatewayForAgent, ensureGatewayForAgent,
+// ensureActiveGatewayOpen) re-arms it with a fresh budget.
+const SECONDARY_STALLED_DIAL_BUDGET = 3
+
+function isStalledDialError(error: unknown): boolean {
+  if (isTimeoutError(error)) {
+    return true
+  }
+
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  return message.includes('timed out while waiting for a free slot')
+}
+
+function rearmSecondary(entry: Secondary): void {
+  entry.wantOpen = true
+  entry.stalledDials = 0
+}
+
 function scheduleReconnect(entry: Secondary): void {
   if (entry.reconnecting || entry.reconnectTimer !== null || !entry.wantOpen) {
     return
@@ -707,7 +737,22 @@ async function reconnectSecondary(entry: Secondary): Promise<void> {
 
       return
     }
-    // Other transport failure → fall through to the backoff below.
+
+    // Only a successful open resets the stall budget (the 'open' state
+    // listener): a treadmill that alternates slot-wait timeouts with a
+    // spawned-but-unresponsive socket must still run out of budget.
+    if (isStalledDialError(error)) {
+      entry.stalledDials += 1
+
+      if (entry.stalledDials >= SECONDARY_STALLED_DIAL_BUDGET) {
+        console.warn(
+          `[gateway] parking scope="${entry.scope}" after ${entry.stalledDials} stalled dials; the next open or wake nudge redials it`
+        )
+        entry.wantOpen = false
+        entry.stalledDials = 0
+      }
+    }
+    // Still wantOpen → fall through to the backoff below.
   } finally {
     entry.reconnecting = false
 
@@ -753,6 +798,7 @@ function createSecondary(profile: string, connectionId: null | string = null): S
     offState: () => {},
     reconnectTimer: null,
     reconnectAttempt: 0,
+    stalledDials: 0,
     reconnecting: false,
     pendingConnectionRedial: false,
     retained: false,
@@ -776,6 +822,7 @@ function createSecondary(profile: string, connectionId: null | string = null): S
 
     if (state === 'open') {
       entry.reconnectAttempt = 0
+      entry.stalledDials = 0
       clearTimer(entry)
     } else if (state === 'closed' || state === 'error') {
       // A dead socket cannot emit the terminal event that normally releases
@@ -864,7 +911,7 @@ async function gatewayForProfile(
     entry.retained = true
   }
 
-  entry.wantOpen = true
+  rearmSecondary(entry)
 
   if (leaseRequest) {
     entry.activeRequests += 1
@@ -989,7 +1036,7 @@ export async function requestGatewayForAgent<T>(
     entry.retained = true
   }
 
-  entry.wantOpen = true
+  rearmSecondary(entry)
   entry.activeRequests += 1
 
   try {
@@ -1108,7 +1155,7 @@ export function retainGatewayForRelay(connectionId: null | string, profile: stri
   }
 
   entry.relayRetainCount += 1
-  entry.wantOpen = true
+  rearmSecondary(entry)
 
   let released = false
 
@@ -1180,7 +1227,7 @@ export async function retainGatewayForAgent(connectionId: null | string, profile
     entry.retained = true
   }
 
-  entry.wantOpen = true
+  rearmSecondary(entry)
   entry.activeRequests += 1
 
   let released = false
@@ -1404,7 +1451,7 @@ export async function openGatewayForAgent(
 
   const entry = g.secondaries.get(scope) ?? createSecondary(profile, connectionId)
   entry.retained = true
-  entry.wantOpen = true
+  rearmSecondary(entry)
 
   if (activationLease) {
     // Stays held after a successful open: the activation that follows releases
@@ -1461,7 +1508,7 @@ export async function ensureGatewayForAgent(
   }
 
   entry.retained = true
-  entry.wantOpen = true
+  rearmSecondary(entry)
   // Lease the entry against the live-work pruner for the whole dial: the
   // switch target is not yet active and has no live sessions, so a prune
   // recompute firing mid-spawn would otherwise dispose it and this
@@ -1539,7 +1586,7 @@ export async function ensureGatewayForProfile(profile: string): Promise<void> {
   }
 
   entry.retained = true
-  entry.wantOpen = true
+  rearmSecondary(entry)
   // Lease the entry against the live-work pruner for the whole dial — the
   // profile-door twin of the agent path's lease above (#89622).
   entry.activationLeaseUntil = Date.now() + ACTIVATION_LEASE_MS
@@ -1596,6 +1643,9 @@ export async function ensureActiveGatewayOpen(): Promise<HermesGateway | null> {
   }
 
   if (!isOpen(entry.gateway)) {
+    // The viewed scope is an explicit recovery target (Reconnect action,
+    // request retry): a parked entry must dial again here, not stay parked.
+    rearmSecondary(entry)
     await reconnectSecondary(entry)
   }
 
@@ -1627,9 +1677,10 @@ const ACTIVE_GATEWAY_OPEN_WAIT_MS = 8_000
 // signals can force sockets that still report open to retire before redialing.
 export function reconnectSecondaryGateways({ forceOpenSockets = false }: { forceOpenSockets?: boolean } = {}): void {
   for (const entry of g.secondaries.values()) {
-    if (!entry.wantOpen) {
-      continue
-    }
+    // A parked entry (stall budget spent) is still pinned by its surface, or
+    // the pruner would have removed it. This nudge is an explicit recovery
+    // signal (online / focus / wake), so it re-arms with a fresh budget.
+    rearmSecondary(entry)
 
     if (isOpen(entry.gateway)) {
       if (!forceOpenSockets) {


### PR DESCRIPTION
Open bot tiles no longer cold-start or pin pooled backends from the background, so interactive bot opens stop timing out on "waiting for a free local slot" (#103375; salvage of #103399 by @kyssta-exe).

Fixes #103375. Supersedes #103399 (cherry-picked to preserve authorship — the original commit carried a `hermes-pr@nousresearch.com` identity that is not the contributor's, so it is re-authored to @kyssta-exe's GitHub noreply).

## What changes

- **Passive read intent** (from #103399): `HermesApiRequest.passive`, `getLatestSessionMessages(id, scope, { passive })`; `reconcileTileTranscripts` reads every tile passively.
- **Passive is decided inside the resolvers, not the dispatchers.** `ensureBackend` / `ensureRegistryBackend` take `{ passive }`: an existing pool entry is served without refreshing `lastActiveAt`; no entry → throw before the eviction/spawn step. The original PR recomputed the pool key in the two REST dispatchers and missed forced-local (`conn:local::<profile>`) and primary-routed profiles, which would have made every bot-tile reconcile throw against a warm backend (silently — the reconcile catch is bare) and regressed background deliveries into open bot chats (#93942).
- **Keepalive sweep touches only open sockets.** `touchSecondaryGateways` pinged every `wantOpen` secondary every 60 s, including ones stuck in reconnect backoff. A tile pins its owner scope `wantOpen` for its lifetime, so an unreachable backend stayed keepalive-fresh forever and neither LRU eviction nor the idle reaper could free its slot.
- **Bounded stalled redials.** `reconnectSecondary` fail-stopped only on removed-connection / deleted-profile errors; a pool-slot wait timeout fell through to an unbounded backoff loop that re-issued a background spawn per tick per tile — the repeating same-order "waiting for a free local slot … timed out … will retry" cycle in the issue's log. After 3 consecutive *stalled* dials (slot-wait timeout or the 20 s dial timeout) the scope parks (`wantOpen=false`); fast failures (a restarting gateway) keep the ordinary unbounded backoff. Only a successful open refills the budget (an interleaved fast failure can't). Every explicit open of the scope — the viewed scope's Reconnect / request retry via `ensureActiveGatewayOpen`, and the online/focus/wake nudge (`reconnectSecondaryGateways`) — re-arms it with a fresh budget.
- Passive reads stay out of `backendDialClaims` in the registry dispatcher: they never dial, and an interactive open coalescing onto an in-flight passive read would otherwise inherit its "no warm backend" rejection.

## Root cause

Tile-pinned owner scopes are `wantOpen` for the tile's lifetime; every automatic path that dials them (reconnect backoff, keepalive touch, REST reads) had spawn/slot-holding side effects with no bound, so N tiles > pool size saturated the pool permanently.

## Validation

| Check | Result |
|---|---|
| `tsc -p tsconfig.electron.json` / `tsc -p .` | clean |
| `eslint` on touched files | 0 errors |
| `use-background-sync.test.ts` (3 failing on #103399) | 34/34 pass (assert passive intent) |
| `backend-dial-claim.test.ts` (1 failing on #103399), `registry-primary-profile-scope.test.ts` | 14/14, 3/3 (both are source-grep tests pinned to exact call text; strings updated) |
| `gateway-connection-lifecycle.test.ts` (+6 invariant tests) | 22/22; each guard test goes red when its guard is removed (touch on closed socket / infinite stall budget / budget refilled by a fast failure / no re-arm on the active scope / no re-arm on the wake nudge); the fast-failure test pins that ECONNREFUSED never parks |
| Full desktop vitest (`--project electron` + `--project ui`) | 2149 + 7498 pass; 2 failures (`managed-ssh-update`, `use-prompt-actions/utils`) reproduce on unmodified `origin/main` — pre-existing |
| `hermes-desktop-app-dev/scripts/main-boot-smoke.sh` on the final branch | main process boots |
| Live multi-profile repro | not run — no 20-profile desktop install available here; mechanism traced against the issue's log |

Not changed: `resumeTile`'s non-passive transcript prefetch — it shares the main-process dial claim with the `session.resume` dial for the same scope, adds no spawn, and a cold tile needs it to paint (`omit_messages` resume).

Also relevant: #103401 (same symptom family), #105264, #105390 (open, priority threading — complementary).
