### PR TITLE
fix(website): readable filter pill labels in light mode

### DIFF
--- a/website/src/components/UserStoriesCollage/styles.module.css
+++ b/website/src/components/UserStoriesCollage/styles.module.css
@@ -68,7 +68,10 @@
 }
 .filterActive {
   background: var(--ifm-color-emphasis-900);
-  color: var(--ifm-background-color);
+  /* emphasis-0 keeps labels readable on the near-black pill; --ifm-background-color
+     is only set under [data-theme='dark'] in custom.css, so Infima's light theme
+     resolves it to transparent and the default-active pills look like empty blobs (#91491). */
+  color: var(--ifm-color-emphasis-0);
   border-color: var(--ifm-color-emphasis-900);
 }
 [data-theme='dark'] .filterActive {

--- a/website/src/pages/skills/styles.module.css
+++ b/website/src/pages/skills/styles.module.css
@@ -1036,5 +1036,6 @@
 
 .pickBtn:hover {
   background: var(--ifm-color-primary);
-  color: var(--ifm-background-color, #0b0b0e);
+  /* Same transparent --ifm-background-color failure mode as #91491. */
+  color: var(--ifm-color-emphasis-0, #f7f8fa);
 }


### PR DESCRIPTION
## Summary

- Fixes invisible labels on the default-active filter pills ("All", "All sources") on `/docs/user-stories` in **light mode**, which currently render as solid black blobs (see screenshot in #91491).
- Root cause: `.filterActive` used `color: var(--ifm-background-color)` on a near-black (`--ifm-color-emphasis-900`) background, but Infima's light theme resolves `--ifm-background-color` to `transparent` because `website/src/css/custom.css` only overrides it under `[data-theme='dark']`.
- Switches to `--ifm-color-emphasis-0` for theme-aware contrast; dark mode remains covered by the existing explicit override.
- Applies the same fix to `.pickBtn:hover` on `/docs/skills`, which had the same transparent-text failure mode.

## Related Issue

Fixes #91491

## Test plan

- [ ] Open `/docs/user-stories` in light mode — "All" and "All sources" pills show readable labels (not empty black ovals)
- [ ] Toggle dark mode — active pills still readable
- [ ] On `/docs/skills` in light mode, hover a platform pick button — label stays visible on primary hover background


Made with [Cursor](https://cursor.com)