### PR TITLE
fix(agent): fail-open when model_dump raises on nested dicts

### DIFF
--- a/agent/anthropic_message_convert.py
+++ b/agent/anthropic_message_convert.py
@@ -212,18 +212,27 @@ def _to_plain_data(value: Any, *, _depth: int = 0, _path: Optional[set] = None) 
         return _to_plain_data(v, _depth=_depth + 1, _path=_path)
 
     _path.add(obj_id)
-    if hasattr(value, "model_dump"):
-        try:
-            # warnings=False: streaming-accumulator blocks trip pydantic's serializer-mismatch
-            # UserWarning, which otherwise leaks to the terminal.
-            dumped = value.model_dump(warnings=False)
-        except TypeError:  # duck-typed model_dump without pydantic's signature
-            dumped = value.model_dump()
-        result = rec(dumped)
-    elif isinstance(value, dict):
+    if isinstance(value, dict):
         result = {k: rec(v) for k, v in value.items()}
     elif isinstance(value, (list, tuple)):
         result = [rec(v) for v in value]
+    elif hasattr(value, "model_dump"):
+        try:
+            try:
+                # warnings=False: streaming-accumulator blocks trip pydantic's serializer-mismatch
+                # UserWarning, which otherwise leaks to the terminal.
+                dumped = value.model_dump(warnings=False)
+            except TypeError:  # duck-typed model_dump without pydantic's signature
+                dumped = value.model_dump()
+        except (AttributeError, RuntimeError):
+            # Nested SDK/dict serializers raise AttributeError or wrap it as
+            # RuntimeError("'dict' object has no attribute 'model_dump'").
+            if hasattr(value, "__dict__"):
+                result = {k: rec(v) for k, v in vars(value).items() if not k.startswith("_")}
+            else:
+                result = value
+        else:
+            result = rec(dumped)
     elif hasattr(value, "__dict__"):
         result = {k: rec(v) for k, v in vars(value).items() if not k.startswith("_")}
     else:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1400,14 +1400,25 @@ def _build_api_kwargs_for_mode(agent, api_messages: list, tools_for_api: list | 
 
 def _model_dump_safe(obj):
     """``model_dump(warnings=False)`` (avoids pydantic serializer UserWarnings on
-    generic-union SDK models), falling back for shims that reject the kwarg."""
+    generic-union SDK models), falling back for shims that reject the kwarg
+    and for dump calls that raise AttributeError/RuntimeError (nested dict)."""
     try:
-        return obj.model_dump(warnings=False)
-    except TypeError:
-        return obj.model_dump()
+        try:
+            return obj.model_dump(warnings=False)
+        except TypeError:
+            return obj.model_dump()
+    except (AttributeError, RuntimeError):
+        if isinstance(obj, dict):
+            return obj
+        raw = getattr(obj, "__dict__", None)
+        if isinstance(raw, dict):
+            return {k: v for k, v in raw.items() if not k.startswith("_")}
+        return obj
 
 
 def _dump_if_model(value):
+    if isinstance(value, dict):
+        return value
     return _model_dump_safe(value) if hasattr(value, "model_dump") else value
 
 

--- a/tests/agent/test_model_dump_dict_runtimeerror.py
+++ b/tests/agent/test_model_dump_dict_runtimeerror.py
@@ -1,0 +1,83 @@
+"""Cron/agent serialization: model_dump raising RuntimeError/AttributeError (#107967).
+
+After Hermes v0.21, agent-mode cron jobs fail with
+``RuntimeError: 'dict' object has no attribute 'model_dump'``. Nested SDK
+serializers (or duck objects) raise that from ``.model_dump()``; helpers that
+only catch ``TypeError`` let it escape and cron wraps it as the job error.
+"""
+
+import pytest
+
+from agent.anthropic_message_convert import _to_plain_data
+from agent.chat_completion_helpers import _dump_if_model, _model_dump_safe
+
+
+class Boom:
+    """Duck object whose model_dump reproduces the nested-dict serializer error."""
+
+    def model_dump(self, **kwargs):
+        raise RuntimeError("'dict' object has no attribute 'model_dump'")
+
+
+class AttrBoom:
+    """Same seam via AttributeError (pydantic/SDK nested-dict path)."""
+
+    def model_dump(self, **kwargs):
+        raise AttributeError("'dict' object has no attribute 'model_dump'")
+
+
+class Duck:
+    def model_dump(self, **kwargs):
+        return {"quack": True, "kwargs": bool(kwargs)}
+
+
+def test_to_plain_data_boom_does_not_raise():
+    result = _to_plain_data(Boom())
+    assert isinstance(result, dict) or result is None or result == {}
+
+
+def test_model_dump_safe_boom_does_not_raise():
+    _model_dump_safe(Boom())
+
+
+def test_dump_if_model_boom_does_not_raise():
+    _dump_if_model(Boom())
+
+
+def test_to_plain_data_attr_boom_does_not_raise():
+    result = _to_plain_data(AttrBoom())
+    assert isinstance(result, dict) or result is None or result == {}
+
+
+def test_model_dump_safe_attr_boom_does_not_raise():
+    _model_dump_safe(AttrBoom())
+
+
+def test_dump_if_model_already_dict_pass_through():
+    payload = {"already": True}
+    assert _dump_if_model(payload) == {"already": True}
+    assert _dump_if_model(payload) is payload
+
+
+def test_to_plain_data_already_dict_pass_through():
+    payload = {"already": True}
+    assert _to_plain_data(payload) == {"already": True}
+
+
+def test_working_duck_model_dump_still_serializes():
+    assert _to_plain_data(Duck())["quack"] is True
+    assert _model_dump_safe(Duck())["quack"] is True
+    assert _dump_if_model(Duck())["quack"] is True
+
+
+def test_real_pydantic_model_still_dumps():
+    pydantic = pytest.importorskip("pydantic")
+
+    class Item(pydantic.BaseModel):
+        name: str
+        count: int = 1
+
+    item = Item(name="cron")
+    assert _to_plain_data(item)["name"] == "cron"
+    assert _model_dump_safe(item)["name"] == "cron"
+    assert _dump_if_model(item)["name"] == "cron"


### PR DESCRIPTION
## What does this PR do?

After the v0.21 upgrade, agent-mode cron jobs fail with `RuntimeError: 'dict' object has no attribute 'model_dump'` and record that string as `last_error`. Cron wraps the agent error, so a dump helper that only caught `TypeError` becomes a hard job failure for every scheduled run.

Serialization helpers now treat a plain `dict` as already-dumped data, and if `.model_dump()` itself raises `AttributeError` or `RuntimeError` (nested SDK/dict serializer), they fall back to `__dict__` / the original value instead of aborting the turn.

Real pydantic models and duck-typed `model_dump()` still serialize as before.

## Related Issue

Fixes #107967

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/anthropic_message_convert.py`: `_to_plain_data` short-circuits dict/list before `hasattr(model_dump)` and catches dump `AttributeError`/`RuntimeError`
- `agent/chat_completion_helpers.py`: `_model_dump_safe` / `_dump_if_model` same fail-open
- `tests/agent/test_model_dump_dict_runtimeerror.py`: RED/GREEN + CONTROL (already-dict, working duck, real pydantic)

## How to Test

```bash
scripts/run_tests.sh \
  tests/agent/test_model_dump_dict_runtimeerror.py \
  tests/agent/test_pydantic_dump_warning_leak.py \
  tests/agent/test_anthropic_adapter.py
```

Proof receipt (worktree from `origin/main` `8d79c2ff57`):

- BEFORE (pre-fix): 5 failed / 4 passed — `Boom`/`AttrBoom` raise `RuntimeError`/`AttributeError: 'dict' object has no attribute 'model_dump'`
- AFTER: 9 passed in the new file; 110 passed across the three focused files
- CONTROL: already-dict pass-through, working duck `model_dump`, real pydantic `BaseModel` still dumps

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(agent):`)
- [x] Searched open PRs for `107967` / `model_dump` — no competing exact PR
- [x] PR contains only this fix
- [x] Focused tests via `scripts/run_tests.sh`
- [x] Tests added for the bug
- [x] Tested on macOS (darwin 24.6)

### Documentation & Housekeeping

- [x] Docs — N/A (no user-facing API/config change)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform: Python-only serialization helpers
- [x] Tool schemas — N/A

## Scope and remaining risk

Independent code-review was not required (2 modules, +116/−13, no auth/crypto/state.db, self-review P0=0).

If a real pydantic dump raises an unrelated `RuntimeError`, that call now falls back to `__dict__` instead of crashing the cron job. That is intentional fail-open for this seam.

Made with [Cursor](https://cursor.com)