### PR TITLE
fix(dashboard): startup schema reconcile no longer opens state.db as a second writable owner (#107688, salvage #107691 + #107701)

### DIFF
--- a/contributors/emails/luc@provencher.family
+++ b/contributors/emails/luc@provencher.family
@@ -1,0 +1,2 @@
+Rroven
+# PR #107701 test co-author

--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -168,17 +168,22 @@ def _resolve_restart_drain_timeout() -> float:
 
 
 def _eager_reconcile_own_session_db() -> None:
-    """One writable open of this process's own state.db at startup.
+    """Read-only open of this process's own state.db at startup.
 
-    ``SessionDB.__init__`` runs ``_init_schema`` → ``_reconcile_columns`` with
-    open-time lock patience. Never raises: an unfixable store still gets the
-    per-poll read-probe heal in :func:`_open_session_db_at_path`.
+    When the gateway shares ``state.db``, a writable open here creates the
+    documented concurrent-FTS-rebuild corruption vector (PR #93200, issues
+    #89293 / #90950). ``_open_session_db_at_path(..., read_only=True)``
+    preserves startup bootstrap and schema heal via ONE writable open but
+    avoids a second writable ``SessionDB`` owner. Never raises: an unfixable
+    store still gets the per-poll read-probe heal inside
+    :func:`_open_session_db_at_path`.
     """
     try:
         from hermes_state import _default_db_path
-        from hermes_state_registry import acquire, release_or_close
+        from hermes_cli.web_server_sessions import _open_session_db_at_path
+        from hermes_state_registry import release_or_close
 
-        db = acquire(Path(_default_db_path()))
+        db = _open_session_db_at_path(Path(_default_db_path()), read_only=True)
         release_or_close(db)
     except Exception as exc:
         _log.warning(

--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -168,12 +168,11 @@ def _resolve_restart_drain_timeout() -> float:
 
 
 def _eager_reconcile_own_session_db() -> None:
-    """Heal a stale schema in this process's own state.db at startup, without becoming a second
-    writable owner. The gateway already owns the store; ``read_only=True`` takes the dashboard's
-    normal read path, which bootstraps a missing store or heals a stale schema through ONE writable
-    open only when its read probe fails, and otherwise never opens writable (a writable open ran
-    the full schema init plus a close-time checkpoint beside the gateway's own writer). Never
-    raises: an unfixable store still gets the per-poll read-probe heal.
+    """Heal a stale schema in this process's own state.db at startup — read-only, so the dashboard
+    never becomes a second writable owner beside the gateway (a writable open ran full schema init
+    plus a close-time checkpoint against its writer). Access-mode semantics: see
+    :func:`hermes_cli.web_server_sessions._open_session_db_at_path`. Never raises: an unfixable
+    store still gets the per-poll read-probe heal.
     """
     try:
         from hermes_cli.web_server_sessions import _open_session_db_for_profile

--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -168,23 +168,18 @@ def _resolve_restart_drain_timeout() -> float:
 
 
 def _eager_reconcile_own_session_db() -> None:
-    """Read-only open of this process's own state.db at startup.
-
-    When the gateway shares ``state.db``, a writable open here creates the
-    documented concurrent-FTS-rebuild corruption vector (PR #93200, issues
-    #89293 / #90950). ``_open_session_db_at_path(..., read_only=True)``
-    preserves startup bootstrap and schema heal via ONE writable open but
-    avoids a second writable ``SessionDB`` owner. Never raises: an unfixable
-    store still gets the per-poll read-probe heal inside
-    :func:`_open_session_db_at_path`.
+    """Heal a stale schema in this process's own state.db at startup, without becoming a second
+    writable owner. The gateway already owns the store; ``read_only=True`` takes the dashboard's
+    normal read path, which bootstraps a missing store or heals a stale schema through ONE writable
+    open only when its read probe fails, and otherwise never opens writable (a writable open ran
+    the full schema init plus a close-time checkpoint beside the gateway's own writer). Never
+    raises: an unfixable store still gets the per-poll read-probe heal.
     """
     try:
-        from hermes_state import _default_db_path
-        from hermes_cli.web_server_sessions import _open_session_db_at_path
+        from hermes_cli.web_server_sessions import _open_session_db_for_profile
         from hermes_state_registry import release_or_close
 
-        db = _open_session_db_at_path(Path(_default_db_path()), read_only=True)
-        release_or_close(db)
+        release_or_close(_open_session_db_for_profile(None, read_only=True))
     except Exception as exc:
         _log.warning(
             "startup schema reconcile of state.db failed (%s); session "

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -581,6 +581,42 @@ class TestWebServerEndpoints:
         # Must swallow — reads fall back to the per-poll probe heal.
         _web_server_lifecycle._eager_reconcile_own_session_db()
 
+    def test_startup_eager_reconcile_opens_read_only(self, monkeypatch):
+        """A healthy store must NOT get a gratuitous second writable SessionDB open.
+
+        Regression for the concurrent-FTS-rebuild corruption vector: the
+        dashboard's startup reconcile used to call the unconditional writable
+        ``acquire()``, making it a second writable SessionDB owner on a
+        `state.db` shared with the gateway (hermes_state_common.py documents two
+        concurrent rebuilds corrupt state.db in production). The reconcile now
+        routes through the read-only ``_open_session_db_at_path`` so a healthy
+        store is opened read-only (the read path still heals a stale schema via
+        one writable open when the probe fails).
+        """
+        from pathlib import Path
+
+        import hermes_state
+        import hermes_cli.web_server_sessions as _web_server_sessions
+
+        calls = []
+        closed = []
+
+        def fake_open(db_path: Path, *, read_only: bool):
+            calls.append((str(db_path), read_only))
+            return SimpleNamespace(close=lambda: closed.append(True))
+
+        monkeypatch.setattr(hermes_state, "_default_db_path", lambda: "/tmp/fake-state.db")
+        monkeypatch.setattr(
+            _web_server_sessions, "_open_session_db_at_path", fake_open,
+        )
+
+        _web_server_lifecycle._eager_reconcile_own_session_db()
+
+        assert calls == [("/tmp/fake-state.db", True)], (
+            "eager reconcile must open state.db read-only on a healthy store"
+        )
+        assert closed == [True], "the startup handle must be released, not leaked"
+
     def test_heal_gives_up_when_reconcile_cannot_fix_the_store(self, monkeypatch):
         """A probe failure reconciliation can't cure must not retry forever.
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -583,7 +583,7 @@ class TestWebServerEndpoints:
 
     def test_startup_eager_reconcile_opens_read_only(self, monkeypatch):
         """A healthy store gets a read-only open (no second writable owner) and the handle is
-        released; the read path still heals a stale schema through its own single writable open."""
+        released. The stale-schema heal is covered by test_startup_eager_reconcile_heals_stale_store."""
         from pathlib import Path
 
         import hermes_state

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -582,17 +582,8 @@ class TestWebServerEndpoints:
         _web_server_lifecycle._eager_reconcile_own_session_db()
 
     def test_startup_eager_reconcile_opens_read_only(self, monkeypatch):
-        """A healthy store must NOT get a gratuitous second writable SessionDB open.
-
-        Regression for the concurrent-FTS-rebuild corruption vector: the
-        dashboard's startup reconcile used to call the unconditional writable
-        ``acquire()``, making it a second writable SessionDB owner on a
-        `state.db` shared with the gateway (hermes_state_common.py documents two
-        concurrent rebuilds corrupt state.db in production). The reconcile now
-        routes through the read-only ``_open_session_db_at_path`` so a healthy
-        store is opened read-only (the read path still heals a stale schema via
-        one writable open when the probe fails).
-        """
+        """A healthy store gets a read-only open (no second writable owner) and the handle is
+        released; the read path still heals a stale schema through its own single writable open."""
         from pathlib import Path
 
         import hermes_state


### PR DESCRIPTION
The dashboard's startup schema reconcile of this process's own `state.db` now opens read-only, so a store the gateway already owns never gets a second writable `SessionDB` owner.

- `hermes_cli/web_server_lifecycle.py::_eager_reconcile_own_session_db` routes through `_open_session_db_for_profile(None, read_only=True)` (the path every dashboard router uses) instead of the writable registry `acquire()`; the read path still bootstraps a missing store or heals a stale schema through ONE writable open when its read probe fails.
- Handle is released with `release_or_close`; one test asserts the read-only open and the close.

Validation: `tests/hermes_cli/test_web_server.py` 188 passed; the new test goes red with main's `web_server_lifecycle.py`.

Root cause: an unconditional writable `acquire()` ran the full schema init plus a close-time WAL checkpoint beside the gateway's writer on every dashboard start.

Credit: fix cherry-picked from #107691 by @kokhlo (first submitter); regression test from #107701 by @Rroven (Co-authored). Both authorships preserved in git history. Refs #107688 (reviewer note: the FTS-corruption mechanism claimed in the original PR is already fenced by rebuild admission; this lands as hardening, so `Refs` not `Closes`).

Closes #107691, closes #107701.