### PR TITLE
fix(auth): a config.yaml custom/alias provider pin no longer reports "Setup Required" (#107918, salvage #107922)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1396,6 +1396,8 @@ def _config_model_provider() -> Tuple[Any, Optional[str]]:
         model_cfg = (load_config() or {}).get("model")
         provider = model_cfg.get("provider") if isinstance(model_cfg, dict) else None
         provider = provider.strip().lower() if isinstance(provider, str) else ""
+        if provider == "custom" or provider.startswith("custom:"):
+            return model_cfg, "custom"
         return model_cfg, (provider if provider in PROVIDER_REGISTRY else None)
     except Exception as e:
         logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1404,6 +1404,9 @@ def _config_model_provider() -> Tuple[Any, Optional[str]]:
         model_cfg = (load_config() or {}).get("model")
         provider = model_cfg.get("provider") if isinstance(model_cfg, dict) else None
         provider = provider.strip().lower() if isinstance(provider, str) else ""
+        # ``custom:<name>`` folds to ``custom`` HERE only: an explicit ``resolve_provider("custom:x")``
+        # request is answered by _resolve_named_custom_runtime before this rung and a miss must
+        # still error with a hint, whereas a config pin only has to prove "a provider is configured".
         if provider.startswith("custom:"):
             provider = "custom"
         provider = _plugin_aliases().get(provider, provider)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1386,19 +1386,28 @@ def _logged_in_oauth_active_provider(*, skip_free_tier: bool = False) -> Optiona
     return None
 
 
+def _is_ladder_provider(normalized: str) -> bool:
+    """A provider identity ``resolve_provider`` returns as-is: registry entries plus the two
+    identities that live outside the registry (OpenRouter, the custom-endpoint class)."""
+    return normalized in ("openrouter", "custom") or normalized in PROVIDER_REGISTRY
+
+
 def _config_model_provider() -> Tuple[Any, Optional[str]]:
-    """``(model_cfg, provider)`` from config.yaml when ``model.provider`` names a registry provider.
+    """``(model_cfg, provider)`` from config.yaml when ``model.provider`` names something the
+    "auto" ladder can answer with: a registry provider, ``openrouter``, or any spelling that
+    normalises to ``custom`` (``custom:<name>``, ``llamacpp``, ``ollama``, ``vllm`` …).
 
     The normal chat/gateway path resolves config.provider upstream in resolve_requested_provider();
-    this is the safety net for the lone direct caller (main.py resolve_provider("auto"))."""
+    this is rung 2 of ``resolve_provider("auto")`` (main.py, free_tier_bootstrap, status banners)."""
     try:
         from hermes_cli.config import load_config
         model_cfg = (load_config() or {}).get("model")
         provider = model_cfg.get("provider") if isinstance(model_cfg, dict) else None
         provider = provider.strip().lower() if isinstance(provider, str) else ""
-        if provider == "custom" or provider.startswith("custom:"):
-            return model_cfg, "custom"
-        return model_cfg, (provider if provider in PROVIDER_REGISTRY else None)
+        if provider.startswith("custom:"):
+            provider = "custom"
+        provider = _plugin_aliases().get(provider, provider)
+        return model_cfg, (provider if _is_ladder_provider(provider) else None)
     except Exception as e:
         logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)
         return None, None
@@ -1458,7 +1467,7 @@ def resolve_provider(
     normalized = (requested or "auto").strip().lower()
     normalized = _plugin_aliases().get(normalized, normalized)
 
-    if normalized in ("openrouter", "custom") or normalized in PROVIDER_REGISTRY:
+    if _is_ladder_provider(normalized):
         return normalized
     if normalized != "auto":
         hint = _get_config_hint_for_unknown_provider(normalized)

--- a/hermes_cli/free_tier_bootstrap.py
+++ b/hermes_cli/free_tier_bootstrap.py
@@ -96,6 +96,22 @@ def _resolve_inference() -> str:
         return ""
 
 
+def _config_has_explicit_model_pin() -> bool:
+    """Cheap on-disk pin only: a model dict with non-empty provider/base_url/api_key.
+
+    Mirrors the config.yaml branch of ``_has_any_provider_configured`` and nothing
+    else — no registry sweep, gh, or Claude Code. Fail-open on any exception.
+    """
+    try:
+        from hermes_cli.config import load_config
+        model_cfg = load_config().get("model")
+        if not isinstance(model_cfg, dict):
+            return False
+        return any((model_cfg.get(k) or "").strip() for k in ("provider", "base_url", "api_key"))
+    except Exception:
+        return False
+
+
 def run_bootstrap(*, announce: bool = True) -> SetupRecord:
     """Inventory -> ensure identity (gate permitting) -> resolve inference -> record -> broadcast.
 
@@ -127,7 +143,8 @@ def run_bootstrap(*, announce: bool = True) -> SetupRecord:
             logger.info("Nous free tier not set up at boot: %s", exc)
     free_tier = bool(state) and anon_auth.is_guest_state(state) and anon_auth.guest_enabled()
     record = SetupRecord(
-        provider_configured=other or free_tier or (bool(state) and not anon_auth.is_guest_state(state)),
+        provider_configured=other or free_tier or (bool(state) and not anon_auth.is_guest_state(state))
+        or _config_has_explicit_model_pin(),
         inference_provider=_resolve_inference(),
         free_tier=free_tier,
         has_identity=bool(state),

--- a/hermes_cli/free_tier_bootstrap.py
+++ b/hermes_cli/free_tier_bootstrap.py
@@ -96,22 +96,6 @@ def _resolve_inference() -> str:
         return ""
 
 
-def _config_has_explicit_model_pin() -> bool:
-    """Cheap on-disk pin only: a model dict with non-empty provider/base_url/api_key.
-
-    Mirrors the config.yaml branch of ``_has_any_provider_configured`` and nothing
-    else — no registry sweep, gh, or Claude Code. Fail-open on any exception.
-    """
-    try:
-        from hermes_cli.config import load_config
-        model_cfg = load_config().get("model")
-        if not isinstance(model_cfg, dict):
-            return False
-        return any((model_cfg.get(k) or "").strip() for k in ("provider", "base_url", "api_key"))
-    except Exception:
-        return False
-
-
 def run_bootstrap(*, announce: bool = True) -> SetupRecord:
     """Inventory -> ensure identity (gate permitting) -> resolve inference -> record -> broadcast.
 
@@ -143,8 +127,7 @@ def run_bootstrap(*, announce: bool = True) -> SetupRecord:
             logger.info("Nous free tier not set up at boot: %s", exc)
     free_tier = bool(state) and anon_auth.is_guest_state(state) and anon_auth.guest_enabled()
     record = SetupRecord(
-        provider_configured=other or free_tier or (bool(state) and not anon_auth.is_guest_state(state))
-        or _config_has_explicit_model_pin(),
+        provider_configured=other or free_tier or (bool(state) and not anon_auth.is_guest_state(state)),
         inference_provider=_resolve_inference(),
         free_tier=free_tier,
         has_identity=bool(state),

--- a/tests/hermes_cli/test_free_tier_bootstrap_custom_provider.py
+++ b/tests/hermes_cli/test_free_tier_bootstrap_custom_provider.py
@@ -1,7 +1,8 @@
-"""Custom-provider config pin must count as setup without flipping ``other_providers``."""
+"""A config.yaml ``custom``/``custom:<name>`` pin is a configured provider for the boot bootstrap."""
 
 from __future__ import annotations
 
+from hermes_cli import auth as auth_mod
 from hermes_cli import free_tier_bootstrap as fb
 
 CUSTOM_PIN = {
@@ -13,47 +14,23 @@ CUSTOM_PIN = {
 }
 
 
-def _stub_unresolved_nous(monkeypatch, config):
-    def resolve_provider(requested="auto", skip_free_tier=False, **_kw):
-        return "nous"
+def test_custom_pin_resolves_to_custom_on_the_auto_ladder(monkeypatch):
+    """``_config_model_provider`` is rung 2 of ``resolve_provider("auto")``; a ``custom:*`` pin is
+    not in ``PROVIDER_REGISTRY`` but must still answer, or the ladder falls through to env/host
+    credentials and finally ``no_provider_configured`` (#107918)."""
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: CUSTOM_PIN)
+    assert auth_mod._config_model_provider() == (CUSTOM_PIN["model"], "custom")
+    assert auth_mod.resolve_provider("auto", skip_free_tier=True) == "custom"
 
-    monkeypatch.setattr("hermes_cli.auth.resolve_provider", resolve_provider)
+
+def test_custom_pin_counts_as_another_provider_for_the_bootstrap(monkeypatch):
+    """The bootstrap record must be configured AND ``other_providers`` True, so a later free-tier
+    mint does not claim ``active_provider`` over the user's explicit endpoint."""
     monkeypatch.setattr("hermes_cli.anon_auth.current_nous_state", lambda: None)
     monkeypatch.setattr("hermes_cli.anon_auth.guest_enabled", lambda: False)
-    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
-
-
-def test_custom_model_dict_pin_is_provider_configured_without_flipping_other(monkeypatch):
-    _stub_unresolved_nous(monkeypatch, CUSTOM_PIN)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: CUSTOM_PIN)
     fb.reset_for_tests()
     rec = fb.run_bootstrap(announce=False)
     assert rec.provider_configured is True
-    assert rec.other_providers is False
-
-
-def test_plain_string_model_stays_unconfigured(monkeypatch):
-    _stub_unresolved_nous(monkeypatch, {"model": "some-default-string"})
-    fb.reset_for_tests()
-    rec = fb.run_bootstrap(announce=False)
-    assert rec.provider_configured is False
-    assert rec.other_providers is False
-
-
-def test_blank_model_dict_is_not_configured(monkeypatch):
-    _stub_unresolved_nous(monkeypatch, {"model": {"provider": "  ", "base_url": "", "api_key": None}})
-    fb.reset_for_tests()
-    rec = fb.run_bootstrap(announce=False)
-    assert rec.provider_configured is False
-    assert rec.other_providers is False
-
-
-def test_load_config_error_does_not_raise_or_flip_other(monkeypatch):
-    def _boom():
-        raise RuntimeError("config unreadable")
-
-    _stub_unresolved_nous(monkeypatch, CUSTOM_PIN)
-    monkeypatch.setattr("hermes_cli.config.load_config", _boom)
-    fb.reset_for_tests()
-    rec = fb.run_bootstrap(announce=False)
-    assert rec.provider_configured is False
-    assert rec.other_providers is False
+    assert rec.other_providers is True
+    assert rec.inference_provider == "custom"

--- a/tests/hermes_cli/test_free_tier_bootstrap_custom_provider.py
+++ b/tests/hermes_cli/test_free_tier_bootstrap_custom_provider.py
@@ -1,0 +1,59 @@
+"""Custom-provider config pin must count as setup without flipping ``other_providers``."""
+
+from __future__ import annotations
+
+from hermes_cli import free_tier_bootstrap as fb
+
+CUSTOM_PIN = {
+    "model": {
+        "provider": "custom:llama.cpp",
+        "base_url": "http://127.0.0.1:8080/v1",
+        "api_key": "local",
+    }
+}
+
+
+def _stub_unresolved_nous(monkeypatch, config):
+    def resolve_provider(requested="auto", skip_free_tier=False, **_kw):
+        return "nous"
+
+    monkeypatch.setattr("hermes_cli.auth.resolve_provider", resolve_provider)
+    monkeypatch.setattr("hermes_cli.anon_auth.current_nous_state", lambda: None)
+    monkeypatch.setattr("hermes_cli.anon_auth.guest_enabled", lambda: False)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+
+
+def test_custom_model_dict_pin_is_provider_configured_without_flipping_other(monkeypatch):
+    _stub_unresolved_nous(monkeypatch, CUSTOM_PIN)
+    fb.reset_for_tests()
+    rec = fb.run_bootstrap(announce=False)
+    assert rec.provider_configured is True
+    assert rec.other_providers is False
+
+
+def test_plain_string_model_stays_unconfigured(monkeypatch):
+    _stub_unresolved_nous(monkeypatch, {"model": "some-default-string"})
+    fb.reset_for_tests()
+    rec = fb.run_bootstrap(announce=False)
+    assert rec.provider_configured is False
+    assert rec.other_providers is False
+
+
+def test_blank_model_dict_is_not_configured(monkeypatch):
+    _stub_unresolved_nous(monkeypatch, {"model": {"provider": "  ", "base_url": "", "api_key": None}})
+    fb.reset_for_tests()
+    rec = fb.run_bootstrap(announce=False)
+    assert rec.provider_configured is False
+    assert rec.other_providers is False
+
+
+def test_load_config_error_does_not_raise_or_flip_other(monkeypatch):
+    def _boom():
+        raise RuntimeError("config unreadable")
+
+    _stub_unresolved_nous(monkeypatch, CUSTOM_PIN)
+    monkeypatch.setattr("hermes_cli.config.load_config", _boom)
+    fb.reset_for_tests()
+    rec = fb.run_bootstrap(announce=False)
+    assert rec.provider_configured is False
+    assert rec.other_providers is False

--- a/tests/hermes_cli/test_free_tier_bootstrap_custom_provider.py
+++ b/tests/hermes_cli/test_free_tier_bootstrap_custom_provider.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from hermes_cli import auth as auth_mod
 from hermes_cli import free_tier_bootstrap as fb
 
@@ -14,12 +16,14 @@ CUSTOM_PIN = {
 }
 
 
-def test_custom_pin_resolves_to_custom_on_the_auto_ladder(monkeypatch):
-    """``_config_model_provider`` is rung 2 of ``resolve_provider("auto")``; a ``custom:*`` pin is
-    not in ``PROVIDER_REGISTRY`` but must still answer, or the ladder falls through to env/host
-    credentials and finally ``no_provider_configured`` (#107918)."""
-    monkeypatch.setattr("hermes_cli.config.load_config", lambda: CUSTOM_PIN)
-    assert auth_mod._config_model_provider() == (CUSTOM_PIN["model"], "custom")
+@pytest.mark.parametrize("pin", ["custom:llama.cpp", "llamacpp", "ollama"])
+def test_custom_pin_resolves_to_custom_on_the_auto_ladder(monkeypatch, pin):
+    """``_config_model_provider`` is rung 2 of ``resolve_provider("auto")``; a ``custom:*`` pin or
+    a documented alias (``llamacpp``) is not in ``PROVIDER_REGISTRY`` but must still answer, or the
+    ladder falls through to env/host credentials and finally ``no_provider_configured`` (#107918)."""
+    cfg = {"model": {**CUSTOM_PIN["model"], "provider": pin}}
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    assert auth_mod._config_model_provider() == (cfg["model"], "custom")
     assert auth_mod.resolve_provider("auto", skip_free_tier=True) == "custom"
 
 

--- a/tests/hermes_cli/test_free_tier_bootstrap_custom_provider.py
+++ b/tests/hermes_cli/test_free_tier_bootstrap_custom_provider.py
@@ -7,23 +7,18 @@ import pytest
 from hermes_cli import auth as auth_mod
 from hermes_cli import free_tier_bootstrap as fb
 
-CUSTOM_PIN = {
-    "model": {
-        "provider": "custom:llama.cpp",
-        "base_url": "http://127.0.0.1:8080/v1",
-        "api_key": "local",
-    }
-}
+CUSTOM_PIN = {"model": {"provider": "custom:llama.cpp"}}
+# One alias that the ladder documents as a spelling of ``custom`` — derived from the table so the
+# test pins the RELATIONSHIP (an alias of custom answers rung 2), not the table's contents.
+CUSTOM_ALIAS = next(k for k, v in auth_mod._PROVIDER_ALIASES.items() if v == "custom")
 
 
-@pytest.mark.parametrize("pin", ["custom:llama.cpp", "llamacpp", "ollama"])
+@pytest.mark.parametrize("pin", ["custom:llama.cpp", CUSTOM_ALIAS])
 def test_custom_pin_resolves_to_custom_on_the_auto_ladder(monkeypatch, pin):
-    """``_config_model_provider`` is rung 2 of ``resolve_provider("auto")``; a ``custom:*`` pin or
-    a documented alias (``llamacpp``) is not in ``PROVIDER_REGISTRY`` but must still answer, or the
-    ladder falls through to env/host credentials and finally ``no_provider_configured`` (#107918)."""
-    cfg = {"model": {**CUSTOM_PIN["model"], "provider": pin}}
-    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
-    assert auth_mod._config_model_provider() == (cfg["model"], "custom")
+    """``_config_model_provider`` is rung 2 of ``resolve_provider("auto")``; a ``custom:*`` pin or a
+    documented alias is not in ``PROVIDER_REGISTRY`` but must still answer, or the ladder falls
+    through to env/host credentials and finally ``no_provider_configured`` (#107918)."""
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {"provider": pin}})
     assert auth_mod.resolve_provider("auto", skip_free_tier=True) == "custom"
 
 


### PR DESCRIPTION
A `model.provider: custom:llama.cpp` pin (or `llamacpp` / `ollama` / `vllm` / `openrouter`) now answers on the `resolve_provider("auto")` ladder, so the boot bootstrap reports the provider as configured and the Web Dashboard TUI stops showing "Setup Required" for a working local endpoint.

- `hermes_cli/auth.py::_config_model_provider` (rung 2 of the auto ladder) normalises through `_plugin_aliases()` and accepts every identity the explicit-request branch accepts, via one shared `_is_ladder_provider` predicate — so the two rungs cannot drift again.
- Fixing the resolver (not OR-ing a second on-disk check into the bootstrap record) also flips `other_providers=True`, so a later free-tier mint cannot claim `active_provider` over the user's explicit endpoint.
- 2 tests (parametrized ladder answer; bootstrap record).

Validation: before, `resolve_provider("auto", skip_free_tier=True)` with the custom pin → `AuthError(no_provider_configured)`; after → `"custom"`, `other_providers=True`. 12 auth/provider test files green (4 pre-existing failures on main unchanged).

Credit: based on #107922 by @KoNit-K (commit preserved); the follow-up moves the fix to the resolver and trims the tests.

Closes #107918. Closes #107922.