### PR TITLE
fix(auth): a named profile inherits the global-root Codex credential pool (#34143, salvage #34141)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -742,6 +742,11 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
     _write_private_file_atomic(auth_file, json.dumps(auth_store, indent=2) + "\n", fsync_dir=True)
+    if target_path is not None:
+        # A write-through to the global root must not be masked by the mtime memo: on coarse-mtime
+        # filesystems a read-after-write in the same tick would keep serving the pre-write store.
+        global _global_auth_store_cache
+        _global_auth_store_cache = None
     try:
         auth_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
     except OSError:

--- a/hermes_cli/auth_codex.py
+++ b/hermes_cli/auth_codex.py
@@ -579,18 +579,16 @@ def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
     rate-limited entry does (a redeemed banked reset restores the whole account; a still-exhausted
     entry just re-freezes with fresh metadata on its next 429).
     """
-    from agent.credential_pool import _borrowed_single_use_pool_root
+    from agent.credential_pool import _borrowed_single_use_pool_root, _profile_owns_pool_provider
     from hermes_cli.auth import _auth_store_lock, _load_auth_store, _save_auth_store
-
-    def _clear_in(target: Optional[Path]) -> Optional[int]:
-        """Clear inside *target* (None = active store); None when that store has no codex rows."""
-        cleared = 0
+    cleared = 0
+    try:
+        # Same owner rule as ``persist_pool_entries``: a profile with no Codex rows of its own
+        # borrows the global-root pool, so the cooldown must clear where the rows actually live.
+        target = None if _profile_owns_pool_provider("openai-codex") else _borrowed_single_use_pool_root()
         with _auth_store_lock(target_path=target):
             auth_store = _load_auth_store(target)
-            entries = _pool_entries(auth_store, "openai-codex")
-            if not entries:
-                return None
-            for entry in _codex_pool_dicts(entries):
+            for entry in _codex_pool_dicts(_pool_entries(auth_store, "openai-codex")):
                 if access_token and str(entry.get("access_token") or "") != access_token:
                     continue
                 if _entry_is_rate_limit_exhausted(entry):
@@ -598,19 +596,9 @@ def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
                     cleared += 1
             if cleared:
                 _save_auth_store(auth_store, target_path=target)
-        return cleared
-
-    try:
-        cleared = _clear_in(None)
-        if cleared is None:
-            # No rows of its own: this profile borrows the global-root pool (the same fallback
-            # ``read_credential_pool`` reads through), so the cooldown must clear where the rows live.
-            root = _borrowed_single_use_pool_root()
-            cleared = _clear_in(root) if root is not None else 0
-        return cleared or 0
     except Exception:
         logger.debug("Failed to clear Codex pool quota cooldowns", exc_info=True)
-        return 0
+    return cleared
 
 
 def _codex_pool_dicts(entries: Optional[List[Any]]) -> Iterator[Dict[str, Any]]:

--- a/hermes_cli/auth_codex.py
+++ b/hermes_cli/auth_codex.py
@@ -579,18 +579,17 @@ def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
     rate-limited entry does (a redeemed banked reset restores the whole account; a still-exhausted
     entry just re-freezes with fresh metadata on its next 429).
     """
-    from agent.credential_pool import _borrowed_single_use_pool_root, _profile_owns_pool_provider
+    from agent.credential_pool import _borrowed_single_use_pool_root
     from hermes_cli.auth import _auth_store_lock, _load_auth_store, _save_auth_store
-    cleared = 0
-    try:
-        # A profile borrowing the global-root pool must clear the cooldown where the rows live,
-        # or the restored quota stays frozen behind the root's stale ``last_error_reset_at``.
-        target = None if _profile_owns_pool_provider("openai-codex") else _borrowed_single_use_pool_root()
+
+    def _clear_in(target: Optional[Path]) -> Optional[int]:
+        """Clear inside *target* (None = active store); None when that store has no codex rows."""
+        cleared = 0
         with _auth_store_lock(target_path=target):
             auth_store = _load_auth_store(target)
             entries = _pool_entries(auth_store, "openai-codex")
-            if entries is None:
-                return 0
+            if not entries:
+                return None
             for entry in _codex_pool_dicts(entries):
                 if access_token and str(entry.get("access_token") or "") != access_token:
                     continue
@@ -599,9 +598,19 @@ def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
                     cleared += 1
             if cleared:
                 _save_auth_store(auth_store, target_path=target)
+        return cleared
+
+    try:
+        cleared = _clear_in(None)
+        if cleared is None:
+            # No rows of its own: this profile borrows the global-root pool (the same fallback
+            # ``read_credential_pool`` reads through), so the cooldown must clear where the rows live.
+            root = _borrowed_single_use_pool_root()
+            cleared = _clear_in(root) if root is not None else 0
+        return cleared or 0
     except Exception:
         logger.debug("Failed to clear Codex pool quota cooldowns", exc_info=True)
-    return cleared
+        return 0
 
 
 def _codex_pool_dicts(entries: Optional[List[Any]]) -> Iterator[Dict[str, Any]]:
@@ -610,23 +619,16 @@ def _codex_pool_dicts(entries: Optional[List[Any]]) -> Iterator[Dict[str, Any]]:
             yield entry
 
 
-def _read_codex_pool_entries() -> Optional[List[Any]]:
-    """Locked read of ``credential_pool.openai-codex`` (None when absent).
-
-    Goes through ``read_credential_pool`` so a named profile with an empty local Codex pool
-    inherits the global-root pool, the same per-provider fallback every other pool read uses."""
-    from hermes_cli.auth import _auth_store_lock, read_credential_pool
-    with _auth_store_lock():
-        return read_credential_pool("openai-codex") or None
-
-
 def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
-    """Return metadata for a pool-only Codex credential in quota cooldown."""
-    from hermes_cli.auth import _nonempty_str
+    """Return metadata for a pool-only Codex credential in quota cooldown.
+
+    Reads through ``read_credential_pool`` so a named profile with no Codex rows of its own sees
+    the global-root pool (the per-provider fallback every other pool read uses)."""
+    from hermes_cli.auth import _nonempty_str, read_credential_pool
     from agent.credential_pool import _parse_absolute_timestamp
     try:
         now = time.time()
-        for entry in _codex_pool_dicts(_read_codex_pool_entries()):
+        for entry in _codex_pool_dicts(read_credential_pool("openai-codex")):
             token = entry.get("access_token")
             if not _nonempty_str(token) or not _entry_is_rate_limit_exhausted(entry):
                 continue
@@ -652,11 +654,12 @@ def _pool_entries(auth_store: Dict[str, Any], provider_id: str) -> Optional[List
 def _pool_codex_access_token() -> str:
     """First non-empty pool access_token not in an exhaustion cooldown window, else "".
 
-    Fallback for ``resolve_codex_runtime_credentials`` when the singleton has no creds.
+    Fallback for ``resolve_codex_runtime_credentials`` when the singleton has no creds; reads
+    through ``read_credential_pool`` so a profile inherits the global-root pool (#34143).
     """
-    from hermes_cli.auth import _nonempty_str
+    from hermes_cli.auth import _nonempty_str, read_credential_pool
     try:
-        for entry in _codex_pool_dicts(_read_codex_pool_entries()):
+        for entry in _codex_pool_dicts(read_credential_pool("openai-codex")):
             token, reset_at = entry.get("access_token"), entry.get("last_error_reset_at")
             in_cooldown = isinstance(reset_at, (int, float)) and reset_at > time.time()
             if _nonempty_str(token) and not in_cooldown:

--- a/hermes_cli/auth_codex.py
+++ b/hermes_cli/auth_codex.py
@@ -607,11 +607,13 @@ def _codex_pool_dicts(entries: Optional[List[Any]]) -> Iterator[Dict[str, Any]]:
 
 
 def _read_codex_pool_entries() -> Optional[List[Any]]:
-    """Locked read of ``credential_pool.openai-codex`` from auth.json (None when absent)."""
-    from hermes_cli.auth import _auth_store_lock, _load_auth_store
+    """Locked read of ``credential_pool.openai-codex`` (None when absent).
+
+    Goes through ``read_credential_pool`` so a named profile with an empty local Codex pool
+    inherits the global-root pool, the same per-provider fallback every other pool read uses."""
+    from hermes_cli.auth import _auth_store_lock, read_credential_pool
     with _auth_store_lock():
-        auth_store = _load_auth_store()
-    return _pool_entries(auth_store, "openai-codex")
+        return read_credential_pool("openai-codex") or None
 
 
 def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:

--- a/hermes_cli/auth_codex.py
+++ b/hermes_cli/auth_codex.py
@@ -579,11 +579,15 @@ def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
     rate-limited entry does (a redeemed banked reset restores the whole account; a still-exhausted
     entry just re-freezes with fresh metadata on its next 429).
     """
+    from agent.credential_pool import _borrowed_single_use_pool_root, _profile_owns_pool_provider
     from hermes_cli.auth import _auth_store_lock, _load_auth_store, _save_auth_store
     cleared = 0
     try:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
+        # A profile borrowing the global-root pool must clear the cooldown where the rows live,
+        # or the restored quota stays frozen behind the root's stale ``last_error_reset_at``.
+        target = None if _profile_owns_pool_provider("openai-codex") else _borrowed_single_use_pool_root()
+        with _auth_store_lock(target_path=target):
+            auth_store = _load_auth_store(target)
             entries = _pool_entries(auth_store, "openai-codex")
             if entries is None:
                 return 0
@@ -594,7 +598,7 @@ def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
                     _clear_pool_entry_status(entry)
                     cleared += 1
             if cleared:
-                _save_auth_store(auth_store)
+                _save_auth_store(auth_store, target_path=target)
     except Exception:
         logger.debug("Failed to clear Codex pool quota cooldowns", exc_info=True)
     return cleared

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -153,6 +153,37 @@ def test_provider_auth_state_returns_none_when_neither_has_it(profile_env):
 
 
 
+def test_codex_runtime_uses_global_pool_when_profile_singleton_is_empty(profile_env):
+    """Stale empty profile Codex state must not block the global credential pool."""
+    from hermes_cli.auth import resolve_codex_runtime_credentials
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [{
+            "id": "glob-codex",
+            "label": "global-codex",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "global-codex-access-token",
+            "refresh_token": "global-codex-refresh-token",
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(
+        providers={
+            "openai-codex": {
+                "auth_mode": "chatgpt",
+                "tokens": {"access_token": "", "refresh_token": ""},
+            },
+        },
+        pool={"openai-codex": []},
+    ))
+
+    creds = resolve_codex_runtime_credentials(refresh_if_expiring=False)
+
+    assert creds["source"] == "credential_pool"
+    assert creds["api_key"] == "global-codex-access-token"
+
+
 # ---------------------------------------------------------------------------
 # Classic mode — no fallback path should ever trigger
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -149,10 +149,6 @@ def test_provider_auth_state_returns_none_when_neither_has_it(profile_env):
 # ---------------------------------------------------------------------------
 
 
-
-
-
-
 def test_codex_runtime_uses_global_pool_when_profile_singleton_is_empty(profile_env):
     """Stale empty profile Codex state must not block the global credential pool."""
     from hermes_cli.auth import resolve_codex_runtime_credentials
@@ -182,6 +178,31 @@ def test_codex_runtime_uses_global_pool_when_profile_singleton_is_empty(profile_
 
     assert creds["source"] == "credential_pool"
     assert creds["api_key"] == "global-codex-access-token"
+
+    # Profile rows shadow the root the moment they exist (read_credential_pool precedence).
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [{"id": "prof", "auth_type": "oauth", "priority": 0,
+                          "access_token": "profile-codex-access-token", "refresh_token": "r"}],
+    }))
+    assert resolve_codex_runtime_credentials(refresh_if_expiring=False)["api_key"] == "profile-codex-access-token"
+
+
+def test_codex_cooldown_clear_writes_to_the_store_that_owns_the_borrowed_pool(profile_env):
+    """A restored quota must unfreeze the ROOT row a profile borrows; clearing the (empty)
+    profile store would leave every later resolve stuck on the stale cooldown."""
+    from hermes_cli.auth_codex import clear_codex_pool_quota_cooldowns
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [{"id": "glob", "auth_type": "oauth", "priority": 0,
+                          "access_token": "global-codex-access-token", "refresh_token": "r",
+                          "last_status": "exhausted", "last_error_reason": "rate_limit",
+                          "last_error_reset_at": 4_102_444_800}],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={"openai-codex": []}))
+
+    assert clear_codex_pool_quota_cooldowns() == 1
+    root_rows = json.loads((profile_env["global"] / "auth.json").read_text())["credential_pool"]["openai-codex"]
+    assert root_rows[0].get("last_error_reset_at") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -205,6 +205,28 @@ def test_codex_cooldown_clear_writes_to_the_store_that_owns_the_borrowed_pool(pr
     assert root_rows[0].get("last_error_reset_at") is None
 
 
+def test_codex_cooldown_clear_never_touches_root_when_profile_owns_rows(profile_env):
+    """A profile with its own Codex rows is the owner: the root's cooldown state is not ours to
+    clear, even when none of the profile's rows are exhausted (0 cleared, root byte-identical)."""
+    from hermes_cli.auth_codex import clear_codex_pool_quota_cooldowns
+
+    root_file = profile_env["global"] / "auth.json"
+    _write(root_file, _make_auth_store(pool={
+        "openai-codex": [{"id": "glob", "auth_type": "oauth", "priority": 0,
+                          "access_token": "global-codex-access-token", "refresh_token": "r",
+                          "last_status": "exhausted", "last_error_reason": "rate_limit",
+                          "last_error_reset_at": 4_102_444_800}],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [{"id": "prof", "auth_type": "oauth", "priority": 0,
+                          "access_token": "profile-codex-access-token", "refresh_token": "r"}],
+    }))
+    before = root_file.read_bytes()
+
+    assert clear_codex_pool_quota_cooldowns() == 0
+    assert root_file.read_bytes() == before
+
+
 # ---------------------------------------------------------------------------
 # Classic mode — no fallback path should ever trigger
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -227,6 +227,25 @@ def test_codex_cooldown_clear_never_touches_root_when_profile_owns_rows(profile_
     assert root_file.read_bytes() == before
 
 
+def test_root_write_through_is_visible_to_the_next_fallback_read(profile_env):
+    """``_save_auth_store(target_path=root)`` must invalidate the mtime memo: a same-tick
+    read-after-write (coarse-mtime filesystems) would otherwise keep serving the stale root."""
+    import os
+    from hermes_cli.auth import _save_auth_store, read_credential_pool
+
+    root_file = profile_env["global"] / "auth.json"
+    _write(root_file, _make_auth_store(pool={"openai-codex": [{"id": "glob", "access_token": "old"}]}))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={"openai-codex": []}))
+    assert read_credential_pool("openai-codex")[0]["access_token"] == "old"  # primes the memo
+    stat = root_file.stat()
+
+    _save_auth_store(_make_auth_store(pool={"openai-codex": [{"id": "glob", "access_token": "new"}]}),
+                     target_path=root_file)
+    os.utime(root_file, ns=(stat.st_atime_ns, stat.st_mtime_ns))  # simulate a same-tick write
+
+    assert read_credential_pool("openai-codex")[0]["access_token"] == "new"
+
+
 # ---------------------------------------------------------------------------
 # Classic mode — no fallback path should ever trigger
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
A named profile whose Codex OAuth grant lives only in the global root no longer fails agent init with "No Codex credentials stored".

- `hermes_cli/auth_codex.py::_pool_codex_access_token` / `_codex_pool_rate_limit_status` read through `hermes_cli.auth.read_credential_pool("openai-codex")`, the designed per-provider read-only fallback (profile rows shadow the root the moment they exist). Both consumers — runtime credential resolution and the rate-limit cooldown status — inherit it; the locked private reader `_read_codex_pool_entries` is gone.
- `clear_codex_pool_quota_cooldowns` clears the cooldown in the store that OWNS the rows, using the same rule as `agent/credential_pool.py::persist_pool_entries` (`_profile_owns_pool_provider` → active store, else the borrowed root). Without this a restored quota stayed frozen behind the root's stale cooldown forever. A profile that owns its own rows never has the root touched.
- `hermes_cli/auth.py::_save_auth_store(target_path=...)` now drops the mtime memo of the global-root store, so a root write-through followed by a fallback read in the same mtime tick (coarse-mtime filesystems) cannot serve the pre-write store — the resolve path could otherwise log "quota restored" and still raise `quota_exhausted`.

Tests (`tests/hermes_cli/test_auth_profile_fallback.py`, 4 new): fallback + profile-wins precedence through the resolver; borrowed cooldown clear writes to the root file; owner profile leaves the root byte-identical; root write-through visible to the next fallback read. Each was proven red with its production change reverted.

Validation: 280 codex/auth/pool/xai/profile tests green on this head; live probe with real imports against a temp `HERMES_HOME` (profile + root layout) — main: `codex_auth_missing_access_token`, head: `source=credential_pool` with the root token; precedence, classic mode, no-rows negative, and missing-profile-auth.json cases all as expected, no profile-local copy ever materialized.

Credit: cherry-picked from #34141 by @nekwo (2026-05-28, first submitter), grafted onto the post-decomposition `auth_codex.py`; @Nicolas-Formenton and @mrcobas reproduced on v0.21.1 and mrcobas' branch carried the same resolution.

Closes #34143. Closes #34141.
