### PR TITLE
fix(serve): the backend exits when its Desktop parent dies instead of living forever (#80204, salvage #106656)

### DIFF
--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -75,7 +75,10 @@ def _process_start_marker(pid: int) -> str:
     marker = result.stdout.strip()
     if result.returncode == 0 and marker:
         return f"ps:{marker}"
-    if result.returncode != 0 and (not marker or "no such process" in result.stderr.lower() or "not found" in result.stderr.lower()):
+    stderr_lower = result.stderr.lower()
+    if (result.returncode == 1 and not marker) or any(
+        msg in stderr_lower for msg in ("no such process", "not found")
+    ):
         raise ProcessLookupError(pid)
     raise OSError(f"ps could not inspect PID {pid}: {result.stderr.strip()}")
 

--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -75,9 +75,8 @@ def _process_start_marker(pid: int) -> str:
     marker = result.stdout.strip()
     if result.returncode == 0 and marker:
         return f"ps:{marker}"
-    # rc==1 with empty output is the portable "no such pid"; "No such process" widens that for ps
-    # builds that say so explicitly. Any other failure stays an OSError so the watchdog degrades to
-    # pid liveness instead of exiting on a healthy backend.
+    # Only known "missing pid" signals become ProcessLookupError; anything else stays OSError so the
+    # watchdog degrades to pid liveness instead of exiting on a healthy backend.
     if (result.returncode == 1 and not marker) or "no such process" in result.stderr.lower():
         raise ProcessLookupError(pid)
     raise OSError(f"ps could not inspect PID {pid}: {result.stderr.strip()}")
@@ -300,8 +299,6 @@ def _is_serve_orphaned(
 
             pid_exists = _pid_exists
         return not bool(pid_exists(int(desktop_pid)))
-    except ProcessLookupError:
-        return True
     except Exception:
         return False
 

--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -75,10 +75,10 @@ def _process_start_marker(pid: int) -> str:
     marker = result.stdout.strip()
     if result.returncode == 0 and marker:
         return f"ps:{marker}"
-    stderr_lower = result.stderr.lower()
-    if (result.returncode == 1 and not marker) or any(
-        msg in stderr_lower for msg in ("no such process", "not found")
-    ):
+    # rc==1 with empty output is the portable "no such pid"; "No such process" widens that for ps
+    # builds that say so explicitly. Any other failure stays an OSError so the watchdog degrades to
+    # pid liveness instead of exiting on a healthy backend.
+    if (result.returncode == 1 and not marker) or "no such process" in result.stderr.lower():
         raise ProcessLookupError(pid)
     raise OSError(f"ps could not inspect PID {pid}: {result.stderr.strip()}")
 

--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -75,7 +75,7 @@ def _process_start_marker(pid: int) -> str:
     marker = result.stdout.strip()
     if result.returncode == 0 and marker:
         return f"ps:{marker}"
-    if result.returncode == 1 and not marker:
+    if result.returncode != 0 and (not marker or "no such process" in result.stderr.lower() or "not found" in result.stderr.lower()):
         raise ProcessLookupError(pid)
     raise OSError(f"ps could not inspect PID {pid}: {result.stderr.strip()}")
 
@@ -278,12 +278,19 @@ def _is_serve_orphaned(
     try:
         if expected_start_marker is not None:
             probe = process_start_marker or _process_start_marker
-            actual_marker = probe(int(desktop_pid))
-            if _parent_start_markers_match(actual_marker, expected_start_marker):
-                return False
-            if _parent_start_marker_mismatch_is_conclusive(actual_marker, expected_start_marker):
+            try:
+                actual_marker = probe(int(desktop_pid))
+            except ProcessLookupError:
                 return True
-            # Inconclusive marker: degrade to PID liveness instead of exiting.
+            except Exception:
+                actual_marker = None
+
+            if actual_marker is not None:
+                if _parent_start_markers_match(actual_marker, expected_start_marker):
+                    return False
+                if _parent_start_marker_mismatch_is_conclusive(actual_marker, expected_start_marker):
+                    return True
+                # Inconclusive marker: degrade to PID liveness instead of exiting.
 
         if pid_exists is None:
             from gateway.status import _pid_exists

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -191,22 +191,19 @@ def test_parent_watchdog_degrades_to_pid_liveness_when_marker_probe_raises_oserr
     assert _is_serve_orphaned(4242, marker, pid_exists=lambda _pid: True,
                               process_start_marker=broken_marker_probe) is False
 
-
-def test_parent_watchdog_detects_dead_parent_on_process_lookup_error():
-    """#80204: ``ProcessLookupError`` from the marker probe means the parent is gone, whatever
-    a (possibly recycled) pid liveness check says."""
     def lookup_error_probe(pid: int) -> str:
         raise ProcessLookupError(pid)
 
-    assert _is_serve_orphaned(4242, "ps:Thu Aug 20 22:33:11 2026", pid_exists=lambda _pid: True,
+    # ProcessLookupError is conclusive on its own, whatever a recycled-pid liveness check says.
+    assert _is_serve_orphaned(4242, marker, pid_exists=lambda _pid: True,
                               process_start_marker=lookup_error_probe) is True
 
 
 @pytest.mark.macos_only
 def test_ps_marker_probe_classifies_missing_process_vs_other_ps_failures(monkeypatch):
-    """The darwin ``ps`` probe raises ``ProcessLookupError`` only for a missing-process message;
-    any other non-zero exit stays a plain ``OSError`` so the watchdog degrades instead of killing
-    a healthy backend."""
+    """The darwin ``ps`` probe raises ``ProcessLookupError`` only for an explicit missing-process
+    message; any other unknown failure stays a plain ``OSError`` so the watchdog degrades instead
+    of killing a healthy backend."""
     import subprocess
 
     from hermes_cli import web_server_lifecycle

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -183,7 +183,7 @@ def test_parent_watchdog_degrades_to_pid_liveness_when_marker_probe_raises_oserr
     """#80204: a probe failure must fall through to ``pid_exists`` instead of pinning the
     watchdog to "not orphaned" forever on a dead Desktop parent."""
     def broken_marker_probe(pid: int) -> str:
-        raise OSError(f"ps could not inspect PID {pid}: ps: {pid}: No such process")
+        raise OSError(f"ps could not inspect PID {pid}: process table temporarily unavailable")
 
     marker = "ps:Thu Aug 20 22:33:11 2026"
     assert _is_serve_orphaned(4242, marker, pid_exists=lambda _pid: False,

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -223,13 +223,14 @@ def test_parent_watchdog_detects_dead_parent_on_process_lookup_error():
 
 
 def test_ps_process_start_marker_raises_process_lookup_error_on_missing_process(monkeypatch):
-    """#80204: _process_start_marker raises ProcessLookupError when ps exits non-zero with no marker."""
+    """#80204: _process_start_marker raises ProcessLookupError when ps exits with known missing-process markers."""
     import subprocess
     import pytest
     from hermes_cli import web_server_lifecycle
 
+    # returncode != 1 but explicit "No such process" in stderr
     def fake_run(*args, **kwargs):
-        return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="ps: 4242: No such process")
+        return subprocess.CompletedProcess(args=args, returncode=2, stdout="", stderr="ps: 4242: No such process")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     monkeypatch.setattr(web_server_lifecycle.sys, "platform", "darwin")
@@ -237,4 +238,57 @@ def test_ps_process_start_marker_raises_process_lookup_error_on_missing_process(
 
     with pytest.raises(ProcessLookupError):
         web_server_lifecycle._process_start_marker(4242)
+
+
+def test_ps_process_start_marker_raises_oserror_on_unrelated_nonzero_failure(monkeypatch):
+    """#80204: unrelated ps failures (e.g. returncode 2 without missing-process message) must raise OSError."""
+    import subprocess
+    import pytest
+    from hermes_cli import web_server_lifecycle
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=2, stdout="", stderr="ps: temporary process table failure")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(web_server_lifecycle.sys, "platform", "darwin")
+    monkeypatch.setattr(web_server_lifecycle.os, "name", "posix")
+
+    with pytest.raises(OSError) as excinfo:
+        web_server_lifecycle._process_start_marker(4242)
+    assert "ps could not inspect PID 4242" in str(excinfo.value)
+    assert not isinstance(excinfo.value, ProcessLookupError)
+
+
+def test_parent_watchdog_does_not_kill_live_parent_on_unrelated_ps_failure(monkeypatch):
+    """#80204: an unrelated nonzero ps error raises OSError, degrading to pid_exists which keeps a live backend alive."""
+    import subprocess
+    from hermes_cli import web_server_lifecycle
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=2, stdout="", stderr="ps: temporary process table failure")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(web_server_lifecycle.sys, "platform", "darwin")
+    monkeypatch.setattr(web_server_lifecycle.os, "name", "posix")
+
+    # Parent is alive: must return False (do not kill healthy backend)
+    assert (
+        web_server_lifecycle._is_serve_orphaned(
+            4242,
+            "ps:Thu Aug 20 22:33:11 2026",
+            pid_exists=lambda _pid: True,
+        )
+        is False
+    )
+
+    # Parent is dead: must return True (reap orphan)
+    assert (
+        web_server_lifecycle._is_serve_orphaned(
+            4242,
+            "ps:Thu Aug 20 22:33:11 2026",
+            pid_exists=lambda _pid: False,
+        )
+        is True
+    )
+
 

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -1,5 +1,7 @@
 """Regression tests for Desktop-owned ``hermes serve`` lifecycle tracking."""
 
+import pytest
+
 from hermes_cli.web_server_lifecycle import (
     _is_serve_orphaned,
     _parent_start_marker_mismatch_is_conclusive,
@@ -177,118 +179,46 @@ class _NoThread:
         raise AssertionError("watchdog thread must not start")
 
 
-def test_parent_watchdog_detects_dead_parent_when_start_marker_probe_raises_oserror():
-    """#80204: when marker probe fails with OSError on a dead parent, watchdog
-    must degrade to PID liveness check and reap the orphan, not return False."""
-    def broken_marker_probe(_pid: int) -> str:
-        raise OSError("ps could not inspect PID 4242: ps: 4242: No such process")
+def test_parent_watchdog_degrades_to_pid_liveness_when_marker_probe_raises_oserror():
+    """#80204: a probe failure must fall through to ``pid_exists`` instead of pinning the
+    watchdog to "not orphaned" forever on a dead Desktop parent."""
+    def broken_marker_probe(pid: int) -> str:
+        raise OSError(f"ps could not inspect PID {pid}: ps: {pid}: No such process")
 
-    # Parent is dead: pid_exists returns False -> must return True (orphaned)
-    assert (
-        _is_serve_orphaned(
-            4242,
-            "ps:Thu Aug 20 22:33:11 2026",
-            pid_exists=lambda _pid: False,
-            process_start_marker=broken_marker_probe,
-        )
-        is True
-    )
-
-    # Parent is still alive: pid_exists returns True -> fail-safe False
-    assert (
-        _is_serve_orphaned(
-            4242,
-            "ps:Thu Aug 20 22:33:11 2026",
-            pid_exists=lambda _pid: True,
-            process_start_marker=broken_marker_probe,
-        )
-        is False
-    )
+    marker = "ps:Thu Aug 20 22:33:11 2026"
+    assert _is_serve_orphaned(4242, marker, pid_exists=lambda _pid: False,
+                              process_start_marker=broken_marker_probe) is True
+    assert _is_serve_orphaned(4242, marker, pid_exists=lambda _pid: True,
+                              process_start_marker=broken_marker_probe) is False
 
 
 def test_parent_watchdog_detects_dead_parent_on_process_lookup_error():
-    """#80204: ProcessLookupError from probe immediately signals parent is gone."""
+    """#80204: ``ProcessLookupError`` from the marker probe means the parent is gone, whatever
+    a (possibly recycled) pid liveness check says."""
     def lookup_error_probe(pid: int) -> str:
         raise ProcessLookupError(pid)
 
-    assert (
-        _is_serve_orphaned(
-            4242,
-            "ps:Thu Aug 20 22:33:11 2026",
-            pid_exists=lambda _pid: True,
-            process_start_marker=lookup_error_probe,
-        )
-        is True
-    )
+    assert _is_serve_orphaned(4242, "ps:Thu Aug 20 22:33:11 2026", pid_exists=lambda _pid: True,
+                              process_start_marker=lookup_error_probe) is True
 
 
-def test_ps_process_start_marker_raises_process_lookup_error_on_missing_process(monkeypatch):
-    """#80204: _process_start_marker raises ProcessLookupError when ps exits with known missing-process markers."""
+@pytest.mark.macos_only
+def test_ps_marker_probe_classifies_missing_process_vs_other_ps_failures(monkeypatch):
+    """The darwin ``ps`` probe raises ``ProcessLookupError`` only for a missing-process message;
+    any other non-zero exit stays a plain ``OSError`` so the watchdog degrades instead of killing
+    a healthy backend."""
     import subprocess
-    import pytest
+
     from hermes_cli import web_server_lifecycle
 
-    # returncode != 1 but explicit "No such process" in stderr
-    def fake_run(*args, **kwargs):
-        return subprocess.CompletedProcess(args=args, returncode=2, stdout="", stderr="ps: 4242: No such process")
+    def fake_run(stderr):
+        return lambda *a, **k: subprocess.CompletedProcess(args=a, returncode=2, stdout="", stderr=stderr)
 
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    monkeypatch.setattr(web_server_lifecycle.sys, "platform", "darwin")
-    monkeypatch.setattr(web_server_lifecycle.os, "name", "posix")
-
+    monkeypatch.setattr(subprocess, "run", fake_run("ps: 4242: No such process"))
     with pytest.raises(ProcessLookupError):
         web_server_lifecycle._process_start_marker(4242)
 
-
-def test_ps_process_start_marker_raises_oserror_on_unrelated_nonzero_failure(monkeypatch):
-    """#80204: unrelated ps failures (e.g. returncode 2 without missing-process message) must raise OSError."""
-    import subprocess
-    import pytest
-    from hermes_cli import web_server_lifecycle
-
-    def fake_run(*args, **kwargs):
-        return subprocess.CompletedProcess(args=args, returncode=2, stdout="", stderr="ps: temporary process table failure")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    monkeypatch.setattr(web_server_lifecycle.sys, "platform", "darwin")
-    monkeypatch.setattr(web_server_lifecycle.os, "name", "posix")
-
+    monkeypatch.setattr(subprocess, "run", fake_run("ps: temporary process table failure"))
     with pytest.raises(OSError) as excinfo:
         web_server_lifecycle._process_start_marker(4242)
-    assert "ps could not inspect PID 4242" in str(excinfo.value)
     assert not isinstance(excinfo.value, ProcessLookupError)
-
-
-def test_parent_watchdog_does_not_kill_live_parent_on_unrelated_ps_failure(monkeypatch):
-    """#80204: an unrelated nonzero ps error raises OSError, degrading to pid_exists which keeps a live backend alive."""
-    import subprocess
-    from hermes_cli import web_server_lifecycle
-
-    def fake_run(*args, **kwargs):
-        return subprocess.CompletedProcess(args=args, returncode=2, stdout="", stderr="ps: temporary process table failure")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-    monkeypatch.setattr(web_server_lifecycle.sys, "platform", "darwin")
-    monkeypatch.setattr(web_server_lifecycle.os, "name", "posix")
-
-    # Parent is alive: must return False (do not kill healthy backend)
-    assert (
-        web_server_lifecycle._is_serve_orphaned(
-            4242,
-            "ps:Thu Aug 20 22:33:11 2026",
-            pid_exists=lambda _pid: True,
-        )
-        is False
-    )
-
-    # Parent is dead: must return True (reap orphan)
-    assert (
-        web_server_lifecycle._is_serve_orphaned(
-            4242,
-            "ps:Thu Aug 20 22:33:11 2026",
-            pid_exists=lambda _pid: False,
-        )
-        is True
-    )
-
-

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -175,3 +175,66 @@ def test_parent_watchdog_warns_when_disarmed_by_unusable_marker(monkeypatch, cap
 class _NoThread:
     def start(self):
         raise AssertionError("watchdog thread must not start")
+
+
+def test_parent_watchdog_detects_dead_parent_when_start_marker_probe_raises_oserror():
+    """#80204: when marker probe fails with OSError on a dead parent, watchdog
+    must degrade to PID liveness check and reap the orphan, not return False."""
+    def broken_marker_probe(_pid: int) -> str:
+        raise OSError("ps could not inspect PID 4242: ps: 4242: No such process")
+
+    # Parent is dead: pid_exists returns False -> must return True (orphaned)
+    assert (
+        _is_serve_orphaned(
+            4242,
+            "ps:Thu Aug 20 22:33:11 2026",
+            pid_exists=lambda _pid: False,
+            process_start_marker=broken_marker_probe,
+        )
+        is True
+    )
+
+    # Parent is still alive: pid_exists returns True -> fail-safe False
+    assert (
+        _is_serve_orphaned(
+            4242,
+            "ps:Thu Aug 20 22:33:11 2026",
+            pid_exists=lambda _pid: True,
+            process_start_marker=broken_marker_probe,
+        )
+        is False
+    )
+
+
+def test_parent_watchdog_detects_dead_parent_on_process_lookup_error():
+    """#80204: ProcessLookupError from probe immediately signals parent is gone."""
+    def lookup_error_probe(pid: int) -> str:
+        raise ProcessLookupError(pid)
+
+    assert (
+        _is_serve_orphaned(
+            4242,
+            "ps:Thu Aug 20 22:33:11 2026",
+            pid_exists=lambda _pid: True,
+            process_start_marker=lookup_error_probe,
+        )
+        is True
+    )
+
+
+def test_ps_process_start_marker_raises_process_lookup_error_on_missing_process(monkeypatch):
+    """#80204: _process_start_marker raises ProcessLookupError when ps exits non-zero with no marker."""
+    import subprocess
+    import pytest
+    from hermes_cli import web_server_lifecycle
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="ps: 4242: No such process")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(web_server_lifecycle.sys, "platform", "darwin")
+    monkeypatch.setattr(web_server_lifecycle.os, "name", "posix")
+
+    with pytest.raises(ProcessLookupError):
+        web_server_lifecycle._process_start_marker(4242)
+


### PR DESCRIPTION
`hermes serve`'s parent-death watchdog now detects an exited Desktop parent: a start-marker probe failure degrades to the PID liveness check instead of being swallowed as "not orphaned".

- `hermes_cli/web_server_lifecycle.py::_is_serve_orphaned`: `ProcessLookupError` from the probe is conclusive (parent gone); any other probe error falls through to `pid_exists`.
- `_process_start_marker`: the `ps` branch raises `ProcessLookupError` on an explicit "No such process" (the portable rc==1/empty-output rule still applies). The original PR's broader "not found" match is dropped — BSD `ps` prints "keyword not found" for an unsupported column, which would have exited a healthy backend.
- Tests: 3 contracts, `@pytest.mark.macos_only` for the darwin `ps` classification instead of monkeypatching `sys.platform`.

Validation: `tests/hermes_cli/test_serve_parent_watchdog.py` 14 passed; degrade + classification tests red with main's file.

Credit: two commits cherry-picked from #106656 by @salch-cred (authorship preserved); follow-ups trim tests and narrow the stderr match.

Closes #80204. Closes #106656.