### PR TITLE
fix(state): a permanent state.db holder no longer blocks the FTS rebuild forever (#106393, salvage #106559)

### DIFF
--- a/contributors/emails/lucas2brh@users.noreply.github.com
+++ b/contributors/emails/lucas2brh@users.noreply.github.com
@@ -1,0 +1,2 @@
+lucas2brh
+# PR #106559 salvage

--- a/hermes_cli/doctor_state.py
+++ b/hermes_cli/doctor_state.py
@@ -81,7 +81,12 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
     deferral = stats.get("fts_rebuild_deferral")
     if isinstance(deferral, dict):
         pids = deferral.get("holder_pids") or "unknown"
-        if deferral.get("futile"):
+        if deferral.get("proceeding"):
+            lines.append(("warn", f"state.db FTS repair was blocked by the same holder(s) PID(s) {pids} for "
+                          f"{deferral.get('holders_attempts') or '?'} consecutive deferral(s); the rebuild is now "
+                          "attempted under the cross-process lock",
+                          "(see errors.log if it keeps failing; stopping the listed processes is not required)"))
+        elif deferral.get("futile"):
             lines.append(("warn", f"state.db FTS repair is blocked by the same holder(s) PID(s) {pids} for "
                           f"{deferral.get('holders_attempts') or '?'} consecutive deferral(s); waiting is futile",
                           "(stop ONLY the listed process(es) — the gateway keeps running and its own retry "

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -471,12 +471,19 @@ class SessionSchemaMixin:
                 )
                 foreign_holders = self._foreign_state_db_holders()
                 holder_pids = sorted({pid for pid, _path in foreign_holders if pid > 0})
+                if holder_pids != record.get("holder_pids"):  # the reap changed who is blocking
+                    holders_since, holders_attempts = now, 1
         futile = bool(holder_pids) and (
             holders_attempts >= _FTS_HOLDER_FUTILE_ATTEMPTS and now - holders_since >= _FTS_HOLDER_FUTILE_SECONDS
         )
+        # Every holder is an identifiable live process: the flock can serialise the rebuild against
+        # them, so a futile window ends the deferral. A pid <= 0 holder is the "could not prove
+        # quiescence" sentinel the flock cannot speak for, so that case keeps deferring (fail closed).
+        proceeding = futile and all(pid > 0 for pid, _path in foreign_holders)
         diagnostic = {
             "first_seen": first_seen, "last_seen": now, "attempts": attempts, "holder_pids": holder_pids,
-            "holders_since": holders_since, "holders_attempts": holders_attempts, "futile": futile,
+            "holders_since": holders_since, "holders_attempts": holders_attempts,
+            "futile": futile and not proceeding, "proceeding": proceeding,
         }
         cursor.execute(
             "INSERT INTO state_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
@@ -486,20 +493,14 @@ class SessionSchemaMixin:
             self._fts_deferred_holder_pids = None
             return False
         self._fts_deferred_holder_pids = holder_pids
-        if futile and all(pid > 0 for pid, _path in foreign_holders):
-            # A supervised peer never satisfies the orphan reap, so deferring to it forever
-            # means the messages_fts triggers keep failing every canonical INSERT (#106393:
-            # five days, 292 deferrals). Proceed: the rebuild is one BEGIN IMMEDIATE SQL
-            # transaction serialised by the fts_rebuild_admission flock and does no WAL
-            # surgery, so holder absence is not its safety. An uninspectable holder (pid <= 0)
-            # is the "could not prove quiescence" sentinel the flock cannot speak for, so that
-            # case keeps deferring (fail closed).
+        if proceeding or futile:  # _holder_cmdline reads /proc per holder; only these branches log it
+            blocked_by = (holders_attempts, (now - holders_since) / 60.0,
+                          ", ".join(f"pid {pid}: {_holder_cmdline(pid)}" for pid in holder_pids))
+        if proceeding:
             logger.error(
                 "state.db FTS repair has been blocked by the same holder(s) for %d deferrals over %.0f min "
                 "(%s); the holders look permanent, so proceeding with the rebuild under the cross-process "
-                "rebuild lock instead of deferring again.",
-                holders_attempts, (now - holders_since) / 60.0,
-                ", ".join(f"pid {pid}: {_holder_cmdline(pid)}" for pid in holder_pids),
+                "rebuild lock instead of deferring again.", *blocked_by,
             )
             return False
         if futile:
@@ -507,8 +508,7 @@ class SessionSchemaMixin:
                 "state.db FTS repair has been blocked by the same holder(s) for %d deferrals over %.0f min "
                 "(%s); waiting is futile. Stop ONLY the other holder(s) — this process keeps running and its "
                 "own retry admits the rebuild within %.0fs of the holder leaving. `hermes doctor` shows this.",
-                holders_attempts, (now - holders_since) / 60.0,
-                ", ".join(f"pid {pid}: {_holder_cmdline(pid)}" for pid in holder_pids), _FTS_STALE_RETRY_SECONDS,
+                *blocked_by, _FTS_STALE_RETRY_SECONDS,
             )
         elif attempts >= _FTS_HOLDER_ESCALATE_ATTEMPTS and now - first_seen >= _FTS_HOLDER_ESCALATE_SECONDS:
             logger.error(

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -37,6 +37,9 @@ _FTS_HOLDER_ESCALATE_SECONDS = 60.0
 # peer (a supervised service on the same HERMES_HOME), not a transient one worth waiting out (#106393).
 _FTS_HOLDER_FUTILE_ATTEMPTS = 10
 _FTS_HOLDER_FUTILE_SECONDS = 1800.0
+_FTS_SAME_HOLDER_PREFIX = (
+    "state.db FTS repair has been blocked by the same holder(s) for %d deferrals over %.0f min (%s); "
+)
 # retry_deferred_fts_recovery cadence: startup paid the full admission wait once; later
 # retries are non-blocking probes whose spacing doubles up to the cap.
 _FTS_STALE_RETRY_SECONDS = 60.0
@@ -457,10 +460,8 @@ class SessionSchemaMixin:
             first_seen, attempts, holders_since, holders_attempts = now, 1, now, 1
         if first_seen > now or first_seen < 0:
             first_seen = now
-        holder_pids = sorted({pid for pid, _path in foreign_holders if pid > 0})
-        if holder_pids != record.get("holder_pids"):
-            holders_since, holders_attempts = now, 1
-        if attempts >= _FTS_HOLDER_ESCALATE_ATTEMPTS and now - first_seen >= _FTS_HOLDER_ESCALATE_SECONDS:
+        escalated = attempts >= _FTS_HOLDER_ESCALATE_ATTEMPTS and now - first_seen >= _FTS_HOLDER_ESCALATE_SECONDS
+        if escalated:
             reaped = self._reap_inactive_orphan_desktop_holders(
                 foreign_holders, min_age_seconds=_FTS_HOLDER_ESCALATE_SECONDS,
             )
@@ -470,20 +471,23 @@ class SessionSchemaMixin:
                     "state.db FTS rebuild deferrals; checking holders again.", reaped, attempts,
                 )
                 foreign_holders = self._foreign_state_db_holders()
-                holder_pids = sorted({pid for pid, _path in foreign_holders if pid > 0})
-                if holder_pids != record.get("holder_pids"):  # the reap changed who is blocking
-                    holders_since, holders_attempts = now, 1
-        futile = bool(holder_pids) and (
+        # The futile window is measured against the POST-reap holder set: a reap that changes who is
+        # blocking restarts it.
+        holder_pids = sorted({pid for pid, _path in foreign_holders if pid > 0})
+        if holder_pids != record.get("holder_pids"):
+            holders_since, holders_attempts = now, 1
+        window_elapsed = bool(holder_pids) and (
             holders_attempts >= _FTS_HOLDER_FUTILE_ATTEMPTS and now - holders_since >= _FTS_HOLDER_FUTILE_SECONDS
         )
         # Every holder is an identifiable live process: the flock can serialise the rebuild against
-        # them, so a futile window ends the deferral. A pid <= 0 holder is the "could not prove
+        # them, so the window ending admits the rebuild. A pid <= 0 holder is the "could not prove
         # quiescence" sentinel the flock cannot speak for, so that case keeps deferring (fail closed).
-        proceeding = futile and all(pid > 0 for pid, _path in foreign_holders)
+        proceeding = window_elapsed and all(pid > 0 for pid, _path in foreign_holders)
+        futile = window_elapsed and not proceeding
         diagnostic = {
             "first_seen": first_seen, "last_seen": now, "attempts": attempts, "holder_pids": holder_pids,
             "holders_since": holders_since, "holders_attempts": holders_attempts,
-            "futile": futile and not proceeding, "proceeding": proceeding,
+            "futile": futile, "proceeding": proceeding,
         }
         cursor.execute(
             "INSERT INTO state_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
@@ -493,24 +497,23 @@ class SessionSchemaMixin:
             self._fts_deferred_holder_pids = None
             return False
         self._fts_deferred_holder_pids = holder_pids
-        if proceeding or futile:  # _holder_cmdline reads /proc per holder; only these branches log it
-            blocked_by = (holders_attempts, (now - holders_since) / 60.0,
+        if window_elapsed:
+            if proceeding and record.get("proceeding"):
+                return False  # already announced; the rebuild's own logging covers a failed attempt
+            blocked_by = (holders_attempts, (now - holders_since) / 60.0,  # _holder_cmdline reads /proc
                           ", ".join(f"pid {pid}: {_holder_cmdline(pid)}" for pid in holder_pids))
-        if proceeding:
+            if proceeding:
+                logger.error(
+                    _FTS_SAME_HOLDER_PREFIX + "the holders look permanent, so proceeding with the rebuild "
+                    "under the cross-process rebuild lock instead of deferring again.", *blocked_by,
+                )
+                return False
             logger.error(
-                "state.db FTS repair has been blocked by the same holder(s) for %d deferrals over %.0f min "
-                "(%s); the holders look permanent, so proceeding with the rebuild under the cross-process "
-                "rebuild lock instead of deferring again.", *blocked_by,
+                _FTS_SAME_HOLDER_PREFIX + "waiting is futile. Stop ONLY the other holder(s) — this process "
+                "keeps running and its own retry admits the rebuild within %.0fs of the holder leaving. "
+                "`hermes doctor` shows this.", *blocked_by, _FTS_STALE_RETRY_SECONDS,
             )
-            return False
-        if futile:
-            logger.error(
-                "state.db FTS repair has been blocked by the same holder(s) for %d deferrals over %.0f min "
-                "(%s); waiting is futile. Stop ONLY the other holder(s) — this process keeps running and its "
-                "own retry admits the rebuild within %.0fs of the holder leaving. `hermes doctor` shows this.",
-                *blocked_by, _FTS_STALE_RETRY_SECONDS,
-            )
-        elif attempts >= _FTS_HOLDER_ESCALATE_ATTEMPTS and now - first_seen >= _FTS_HOLDER_ESCALATE_SECONDS:
+        elif escalated:
             logger.error(
                 "state.db FTS repair remains blocked after %d deferrals by holder(s) %s. Stop the listed "
                 "processes (this process's own retry then rebuilds), or run `hermes sessions optimize-storage` "

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -432,12 +432,13 @@ class SessionSchemaMixin:
         """Record a deferral diagnostic for the foreign processes holding the DB; True = defer
         (holders remain). After ``_FTS_HOLDER_ESCALATE_ATTEMPTS`` deferrals spanning
         ``_FTS_HOLDER_ESCALATE_SECONDS``, provably inactive orphan Desktop backends are
-        reaped and the holders re-checked. The orphan reap is the only exit, so a supervised
-        peer (never an orphan) blocks forever: once the SAME PID set has blocked
-        ``_FTS_HOLDER_FUTILE_ATTEMPTS`` deferrals over ``_FTS_HOLDER_FUTILE_SECONDS`` the
-        record is marked ``futile`` and the escalation names the holders and the remedy that
-        works from inside a gateway session (stop only the other holder; this process's own
-        retry tick admits the rebuild). A changed holder set restarts that window."""
+        reaped and the holders re-checked. A supervised peer (never an orphan) would otherwise
+        block forever: once the SAME PID set has blocked ``_FTS_HOLDER_FUTILE_ATTEMPTS``
+        deferrals over ``_FTS_HOLDER_FUTILE_SECONDS`` the record is marked ``futile`` and,
+        when every holder is an identifiable live process, the deferral ends (False) so the
+        rebuild proceeds under the admission flock. An uninspectable holder keeps deferring;
+        the escalation then names the holders and the remedy that works from inside a gateway
+        session (stop only the other holder). A changed holder set restarts that window."""
         now = time.time()
         try:
             row = cursor.execute(
@@ -485,6 +486,22 @@ class SessionSchemaMixin:
             self._fts_deferred_holder_pids = None
             return False
         self._fts_deferred_holder_pids = holder_pids
+        if futile and all(pid > 0 for pid, _path in foreign_holders):
+            # A supervised peer never satisfies the orphan reap, so deferring to it forever
+            # means the messages_fts triggers keep failing every canonical INSERT (#106393:
+            # five days, 292 deferrals). Proceed: the rebuild is one BEGIN IMMEDIATE SQL
+            # transaction serialised by the fts_rebuild_admission flock and does no WAL
+            # surgery, so holder absence is not its safety. An uninspectable holder (pid <= 0)
+            # is the "could not prove quiescence" sentinel the flock cannot speak for, so that
+            # case keeps deferring (fail closed).
+            logger.error(
+                "state.db FTS repair has been blocked by the same holder(s) for %d deferrals over %.0f min "
+                "(%s); the holders look permanent, so proceeding with the rebuild under the cross-process "
+                "rebuild lock instead of deferring again.",
+                holders_attempts, (now - holders_since) / 60.0,
+                ", ".join(f"pid {pid}: {_holder_cmdline(pid)}" for pid in holder_pids),
+            )
+            return False
         if futile:
             logger.error(
                 "state.db FTS repair has been blocked by the same holder(s) for %d deferrals over %.0f min "

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -845,12 +845,12 @@ class TestRuntimeFtsRebuild:
             assert reopened._defer_stale_fts_for_holders(cursor, holders) is False
             reopened._conn.commit()
             record = json.loads(_meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY))
-            assert record.get("futile") is True and record["holder_pids"] == [4242]
-            assert "4242" in doctor_blob()
+            assert record.get("proceeding") is True and record["holder_pids"] == [4242]
+            assert "4242" in doctor_blob() and "rebuild is now attempted" in doctor_blob()
         finally:
             reopened.close()
 
-    def _seed_futile_holders(self, db, tmp_path, monkeypatch, holders):
+    def _seed_futile_holders(self, db, tmp_path, monkeypatch, holders, after_reap=None):
         """Stale FTS plus a deferral record already past the futile window for *holders*;
         the rebuild body is stubbed so the assertion is about admission, not SQLite's FTS5 build."""
         db_path = tmp_path / "state.db"
@@ -874,9 +874,13 @@ class TestRuntimeFtsRebuild:
         )
         raw.commit()
         raw.close()
-        monkeypatch.setattr(SessionDB, "_foreign_state_db_holders", lambda self: list(holders))
+        scans = [list(holders), list(after_reap if after_reap is not None else holders)]
         monkeypatch.setattr(
-            SessionDB, "_reap_inactive_orphan_desktop_holders", lambda self, h, *, min_age_seconds: [],
+            SessionDB, "_foreign_state_db_holders", lambda self: list(scans.pop(0) if len(scans) > 1 else scans[0]),
+        )
+        monkeypatch.setattr(
+            SessionDB, "_reap_inactive_orphan_desktop_holders",
+            lambda self, h, *, min_age_seconds: [9] if after_reap is not None else [],
         )
         monkeypatch.setattr(
             hermes_state_schema.time, "time", lambda: 1.0 + 100 * hermes_state_schema._FTS_HOLDER_FUTILE_SECONDS,
@@ -920,6 +924,25 @@ class TestRuntimeFtsRebuild:
             assert rebuilds == []
             assert reopened._fts_stale is True
             assert json.loads(_meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY) or "{}").get("futile") is True
+        finally:
+            reopened.close()
+
+    def test_reap_that_changes_the_holder_set_restarts_the_futile_window(self, db, tmp_path, monkeypatch):
+        """A window accrued against one PID set must not authorise the rebuild against a DIFFERENT
+        set that only appeared after the orphan reap rescan."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db_path, rebuilds = self._seed_futile_holders(
+            db, tmp_path, monkeypatch,
+            [(4242, str(tmp_path / "state.db-wal"))],
+            after_reap=[(5151, str(tmp_path / "state.db-wal"))],
+        )
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert rebuilds == []
+            record = json.loads(_meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY) or "{}")
+            assert record["holder_pids"] == [5151] and record["holders_attempts"] == 1
+            assert not record.get("proceeding")
         finally:
             reopened.close()
 

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -895,21 +895,6 @@ class TestRuntimeFtsRebuild:
         monkeypatch.setattr(SessionDB, "_recover_stale_fts_locked", fake_locked_rebuild)
         return db_path, rebuilds
 
-    def test_futile_live_permanent_holder_admits_the_rebuild(self, db, tmp_path, monkeypatch):
-        """#106393: a supervised peer never leaves and is never reaped; once the SAME live PID set
-        has blocked the futile window the deferral must end so the rebuild runs under the flock."""
-        if not db._fts_enabled:
-            pytest.skip("FTS5 unavailable in this build")
-        db_path, rebuilds = self._seed_futile_holders(
-            db, tmp_path, monkeypatch, [(4242, str(tmp_path / "state.db-wal"))],
-        )
-        reopened = SessionDB(db_path=db_path)
-        try:
-            assert rebuilds == [False]
-            assert reopened._fts_stale is False
-        finally:
-            reopened.close()
-
     def test_futile_uninspectable_holder_keeps_deferring(self, db, tmp_path, monkeypatch):
         """A pid <= 0 holder is the 'could not prove quiescence' sentinel: the rebuild flock cannot
         serialise against it, so even past the futile window the deferral fails closed."""

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -787,13 +787,13 @@ class TestRuntimeFtsRebuild:
         finally:
             reopened.close()
 
-    def test_same_holder_set_across_futile_window_names_holder_and_gateway_safe_remedy(
+    def test_same_holder_set_across_futile_window_ends_the_deferral(
         self, db, tmp_path, monkeypatch, caplog
     ):
-        """#106393: a supervised peer never satisfies the orphan reap, so the generic
-        'remains blocked ... with the gateway stopped' escalation repeats forever. Once the SAME
-        PID set has blocked the futile window, the record is marked futile, the escalation names
-        the holder's cmdline and a remedy runnable from inside the gateway, and doctor says so."""
+        """#106393: a supervised peer never satisfies the orphan reap, so deferring to it repeats
+        forever. Short of the futile window the SAME PID set still defers; once it has blocked the
+        whole window the record is marked futile, doctor names the holder, and the deferral ENDS
+        (False) so the rebuild proceeds under the admission flock instead of waiting again."""
         if not db._fts_enabled:
             pytest.skip("FTS5 unavailable in this build")
         db_path = tmp_path / "state.db"
@@ -841,19 +841,85 @@ class TestRuntimeFtsRebuild:
             assert "futile" not in doctor_blob()
 
             clock[0] += futile_seconds
-            caplog.clear()
-            assert reopened._recover_stale_fts(cursor, legacy=False, timeout_seconds=0.0) is False
+            holders = reopened._foreign_state_db_holders()
+            assert reopened._defer_stale_fts_for_holders(cursor, holders) is False
             reopened._conn.commit()
             record = json.loads(_meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY))
             assert record.get("futile") is True and record["holder_pids"] == [4242]
-            futile_lines = [r for r in caplog.records if "waiting is futile" in r.getMessage()]
-            assert len(futile_lines) == 1 and futile_lines[0].levelno == logging.ERROR
-            msg = futile_lines[0].getMessage()
-            assert "pid 4242: python -m hermes_cli.main serve" in msg
-            assert "Stop ONLY the other holder" in msg and "with the gateway stopped" not in msg
-            blob = doctor_blob()
-            assert "4242" in blob and "waiting is futile" in blob and "stop only" in blob
-            assert "gateway stopped" not in blob
+            assert "4242" in doctor_blob()
+        finally:
+            reopened.close()
+
+    def _seed_futile_holders(self, db, tmp_path, monkeypatch, holders):
+        """Stale FTS plus a deferral record already past the futile window for *holders*;
+        the rebuild body is stubbed so the assertion is about admission, not SQLite's FTS5 build."""
+        db_path = tmp_path / "state.db"
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "seed")
+        _corrupt_fts(db_path)
+        monkeypatch.setattr(
+            db, "rebuild_fts", lambda: (_ for _ in ()).throw(sqlite3.DatabaseError("still corrupt")),
+        )
+        db.append_message("s1", "user", "before restart")
+        db.close()
+        raw = sqlite3.connect(str(db_path))
+        raw.execute(
+            "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (FTS_REBUILD_DEFERRAL_KEY, json.dumps({
+                "first_seen": 1.0, "last_seen": 1.0, "attempts": 500,
+                "holder_pids": sorted({pid for pid, _path in holders if pid > 0}),
+                "holders_since": 1.0, "holders_attempts": 500,
+            })),
+        )
+        raw.commit()
+        raw.close()
+        monkeypatch.setattr(SessionDB, "_foreign_state_db_holders", lambda self: list(holders))
+        monkeypatch.setattr(
+            SessionDB, "_reap_inactive_orphan_desktop_holders", lambda self, h, *, min_age_seconds: [],
+        )
+        monkeypatch.setattr(
+            hermes_state_schema.time, "time", lambda: 1.0 + 100 * hermes_state_schema._FTS_HOLDER_FUTILE_SECONDS,
+        )
+        rebuilds = []
+
+        def fake_locked_rebuild(self, cursor, *, legacy):
+            rebuilds.append(legacy)
+            self._fts_stale = False
+            return True
+
+        monkeypatch.setattr(SessionDB, "_recover_stale_fts_locked", fake_locked_rebuild)
+        return db_path, rebuilds
+
+    def test_futile_live_permanent_holder_admits_the_rebuild(self, db, tmp_path, monkeypatch):
+        """#106393: a supervised peer never leaves and is never reaped; once the SAME live PID set
+        has blocked the futile window the deferral must end so the rebuild runs under the flock."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db_path, rebuilds = self._seed_futile_holders(
+            db, tmp_path, monkeypatch, [(4242, str(tmp_path / "state.db-wal"))],
+        )
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert rebuilds == [False]
+            assert reopened._fts_stale is False
+        finally:
+            reopened.close()
+
+    def test_futile_uninspectable_holder_keeps_deferring(self, db, tmp_path, monkeypatch):
+        """A pid <= 0 holder is the 'could not prove quiescence' sentinel: the rebuild flock cannot
+        serialise against it, so even past the futile window the deferral fails closed."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db_path, rebuilds = self._seed_futile_holders(
+            db, tmp_path, monkeypatch,
+            [(4242, str(tmp_path / "state.db-wal")), (-1, str(tmp_path / "state.db"))],
+        )
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert rebuilds == []
+            assert reopened._fts_stale is True
+            assert json.loads(_meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY) or "{}").get("futile") is True
         finally:
             reopened.close()
 


### PR DESCRIPTION
When the same live process set has blocked the deferred `messages_fts` rebuild for the whole futile window, the deferral now ends and the rebuild proceeds under the cross-process rebuild lock — instead of the triggers failing every canonical INSERT for days (five days / 292 deferrals in the report).

- `hermes_state_schema.py::_defer_stale_fts_for_holders`: `futile` AND every holder is an identifiable live process (pid > 0) → return False (rebuild proceeds; it is one `BEGIN IMMEDIATE` transaction serialised by `fts_rebuild_admission`, no WAL surgery). An uninspectable holder (pid <= 0) keeps deferring — fail closed.
- Follow-ups: the futile window restarts when the orphan reap changes the holder set (a window accrued against one PID set cannot authorise a rebuild against another); the persisted record distinguishes `proceeding` from `futile`, and `hermes doctor` says "rebuild is now attempted" instead of telling the user to kill a process that is no longer the remedy.
- Tests: main's "stays blocked" test flipped; live permanent holder → proceeds; uninspectable holder → still defers; post-reap set change → window restarts. The PR's 645-line test file was not taken.

Validation: `tests/state/test_fts_runtime_rebuild.py` + admission/doctor/repair files: 232 passed (4 pre-existing FTS5-vtable failures on this macOS host, identical on main). New tests red with main's `hermes_state_schema.py`.

Root cause: #106591 marked the record futile and named the holder but still returned "keep deferring".

Credit: fix cherry-picked from #106559 by @lucas2brh (authorship preserved), grafted onto #106591's record shape. Reviewers @andrexibiza / @ehz0ah — the post-reap identity finding is folded.

Closes #106393. Closes #106559.