### PR TITLE
fix(gateway): keep standalone BlueBubbles sends port-free

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -113,9 +113,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     MAX_MESSAGE_LENGTH = MAX_TEXT_LENGTH
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
 
-    def __init__(self, config: PlatformConfig):
+    def __init__(self, config: PlatformConfig, *, receive_webhooks: bool = True):
         super().__init__(config, Platform.BLUEBUBBLES)
         extra = config.extra or {}
+        self.receive_webhooks = receive_webhooks
         self.server_url = _normalize_server_url(_setting(extra, "server_url", "BLUEBUBBLES_SERVER_URL"))
         self.password = extra.get("password") or _get_scoped_secret("BLUEBUBBLES_PASSWORD", "")
         self.webhook_host = _setting(extra, "webhook_host", "BLUEBUBBLES_WEBHOOK_HOST", DEFAULT_WEBHOOK_HOST)
@@ -216,6 +217,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             logger.error("[bluebubbles] cannot reach server at %s: %s", self.server_url, exc)
             await self._close_client()
             return False
+        if not self.receive_webhooks:
+            self._mark_connected()
+            return True
         # client_max_size makes aiohttp enforce the cap on every read path, incl. chunked requests
         # with no Content-Length.
         # Explicit body cap: BlueBubbles webhook events are small JSON (or form-encoded) payloads.
@@ -244,7 +248,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             self.client = None
 
     async def disconnect(self) -> None:
-        await self._unregister_webhook()
+        if self.receive_webhooks:
+            await self._unregister_webhook()
         await self._close_client()
         if self._runner:
             await self._runner.cleanup()

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -74,6 +74,27 @@ class TestBlueBubblesHelpers:
         adapter = _make_adapter(monkeypatch, server_url="http://localhost:1234/")
         assert adapter.server_url == "http://localhost:1234"
 
+    @pytest.mark.asyncio
+    async def test_send_only_connection_skips_webhook_lifecycle(self, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        from gateway.platforms.bluebubbles import BlueBubblesAdapter
+
+        adapter = BlueBubblesAdapter(
+            PlatformConfig(extra={"server_url": "http://localhost:1234", "password": "secret"}),
+            receive_webhooks=False,
+        )
+        monkeypatch.setattr(adapter, "_api_get", AsyncMock(side_effect=[{}, {"data": {}}]))
+        unregister = AsyncMock()
+        monkeypatch.setattr(adapter, "_unregister_webhook", unregister)
+
+        assert await adapter.connect() is True
+        assert adapter.is_connected is True
+        assert adapter._runner is None
+
+        await adapter.disconnect()
+        unregister.assert_not_awaited()
+
 
 class _FakeBlueBubblesRequest:
     def __init__(self, payload, password="secret"):

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -35,6 +35,7 @@ from tools.send_message_tool import (
     send_message_tool,
 )
 from tools.send_message_targets import _parse_target_ref
+from tools.send_message_senders import _send_bluebubbles
 # Discord helpers moved to the plugin in #24325.  Import from the new path
 # and provide a thin ``_send_discord(token, ...)`` shim that mirrors the
 # pre-migration signature so the existing test bodies keep working.
@@ -66,6 +67,33 @@ async def _send_discord(
         thread_id=thread_id,
         media_files=media_files,
     )
+
+
+def test_bluebubbles_standalone_sender_uses_send_only_adapter(monkeypatch):
+    from gateway.platforms import bluebubbles
+    from gateway.platforms.base import SendResult
+
+    captured = {}
+
+    class FakeAdapter:
+        def __init__(self, config, *, receive_webhooks=True):
+            captured["receive_webhooks"] = receive_webhooks
+
+        async def connect(self):
+            return True
+
+        async def send(self, chat_id, message):
+            return SendResult(success=True, message_id="m1")
+
+        async def disconnect(self):
+            captured["disconnected"] = True
+
+    monkeypatch.setattr(bluebubbles, "BlueBubblesAdapter", FakeAdapter)
+
+    result = asyncio.run(_send_bluebubbles({}, "chat", "hello"))
+
+    assert result["success"] is True
+    assert captured == {"receive_webhooks": False, "disconnected": True}
 
 
 class _StreamingAiohttpContent:

--- a/tools/send_message_senders.py
+++ b/tools/send_message_senders.py
@@ -570,7 +570,7 @@ async def _send_bluebubbles(extra, chat_id, message):
         return err
     try:
         from gateway.config import PlatformConfig
-        adapter = bb.BlueBubblesAdapter(PlatformConfig(extra=extra))
+        adapter = bb.BlueBubblesAdapter(PlatformConfig(extra=extra), receive_webhooks=False)
         if not await adapter.connect():
             return _error("BlueBubbles: failed to connect to server")
         try:


### PR DESCRIPTION
## Summary

- add an explicit send-only BlueBubbles adapter mode that skips the inbound webhook lifecycle
- use send-only mode for standalone cron and `send_message` deliveries
- preserve normal gateway webhook startup and its bind-error behavior

## Testing

- `scripts/run_tests.sh tests/gateway/test_bluebubbles.py tests/tools/test_send_message_tool.py` (72 passed)

## Related Issue

N/A
