### PR TITLE
fix(desktop): copy rendered KaTeX as its original LaTeX source

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -8,7 +8,7 @@ import {
   tailBoundedRemend
 } from '@assistant-ui/react-streamdown'
 import type { code as streamdownCode } from '@streamdown/code'
-import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
+import { type ComponentProps, memo, type ClipboardEvent as ReactClipboardEvent, useEffect, useMemo, useState } from 'react'
 
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
@@ -18,6 +18,7 @@ import { ErrorBoundary } from '@/components/error-boundary'
 import { detectArtifact } from '@/lib/artifact-detect'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
+import { selectionTextWithLatex } from '@/lib/latex-copy'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import {
@@ -552,6 +553,29 @@ function MarkdownTextSurface({
   const code = useCodePlugin()
   const plugins = useMemo(() => (code ? { math: mathPlugin, code } : { math: mathPlugin }), [code])
 
+  const copyWithLatex = (event: ReactClipboardEvent<HTMLDivElement>) => {
+    containerProps?.onCopy?.(event)
+
+    if (event.defaultPrevented) {
+      return
+    }
+
+    const selection = window.getSelection()
+
+    if (!selection) {
+      return
+    }
+
+    const copiedText = selectionTextWithLatex(event.currentTarget, selection)
+
+    if (copiedText === null) {
+      return
+    }
+
+    event.preventDefault()
+    event.clipboardData.setData('text/plain', copiedText)
+  }
+
   const components = useMemo(
     () =>
       ({
@@ -683,7 +707,7 @@ function MarkdownTextSurface({
       <StreamdownTextPrimitive
         components={components}
         containerClassName={cn(MARKDOWN_CONTAINER_CLASS_NAME, containerClassName)}
-        containerProps={containerProps}
+        containerProps={{ ...containerProps, onCopy: copyWithLatex }}
         defer={defer}
         lineNumbers={false}
         mode="streaming"

--- a/apps/desktop/src/lib/latex-copy.test.ts
+++ b/apps/desktop/src/lib/latex-copy.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { selectionTextWithLatex } from './latex-copy'
+
+function select(container: HTMLElement, start: Node, end: Node) {
+  const range = document.createRange()
+  range.setStart(start, 0)
+  range.setEnd(end, end.textContent?.length ?? 0)
+  const selection = window.getSelection()!
+  selection.removeAllRanges()
+  selection.addRange(range)
+
+  return selection
+}
+
+describe('selectionTextWithLatex', () => {
+  it('copies inline KaTeX as its original dollar-delimited source', () => {
+    const container = document.createElement('div')
+    container.innerHTML =
+      '<p>Then <span class="katex"><span class="katex-mathml"><math><semantics><annotation encoding="application/x-tex">P(|B^H(1)| &gt; R_1)</annotation></semantics></math></span><span class="katex-html">visual</span></span> follows.</p>'
+    document.body.append(container)
+
+    const paragraph = container.querySelector('p')!
+    const selection = select(container, paragraph.firstChild!, paragraph.lastChild!)
+
+    expect(selectionTextWithLatex(container, selection)).toBe('Then $P(|B^H(1)| > R_1)$ follows.')
+    container.remove()
+  })
+
+  it('copies display KaTeX with double-dollar delimiters', () => {
+    const container = document.createElement('div')
+    container.innerHTML =
+      '<div class="katex-display"><span class="katex"><math><semantics><annotation encoding="application/x-tex">\\frac{\\varepsilon}{2}</annotation></semantics></math></span></div>'
+    document.body.append(container)
+
+    const annotation = container.querySelector('annotation')!.firstChild!
+    const selection = select(container, annotation, annotation)
+
+    expect(selectionTextWithLatex(container, selection)).toBe('$$ \\frac{\\varepsilon}{2} $$')
+    container.remove()
+  })
+
+  // Prose, code and currency have no KaTeX to restore, so the serializer must
+  // decline and leave Chromium's native copy in charge.
+  it('declines selections that contain no rendered math', () => {
+    const container = document.createElement('div')
+    container.innerHTML = '<p>It costs $5 and <code>$HOME</code> is unset.</p>'
+    document.body.append(container)
+
+    const paragraph = container.querySelector('p')!
+    const selection = select(container, paragraph.firstChild!, paragraph.lastChild!)
+
+    expect(selectionTextWithLatex(container, selection)).toBeNull()
+    container.remove()
+  })
+})

--- a/apps/desktop/src/lib/latex-copy.ts
+++ b/apps/desktop/src/lib/latex-copy.ts
@@ -1,0 +1,104 @@
+const BLOCK_TAGS = new Set([
+  'ADDRESS',
+  'BLOCKQUOTE',
+  'DIV',
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6',
+  'LI',
+  'OL',
+  'P',
+  'PRE',
+  'TABLE',
+  'TR',
+  'UL'
+])
+
+function plainText(node: Node): string {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent ?? ''
+  }
+
+  if (!(node instanceof HTMLElement)) {
+    return [...node.childNodes].map(plainText).join('')
+  }
+
+  if (node.tagName === 'BR') {
+    return '\n'
+  }
+
+  const text = [...node.childNodes].map(plainText).join('')
+
+  return BLOCK_TAGS.has(node.tagName) ? `${text}\n` : text
+}
+
+function texSource(element: Element): string | null {
+  return element.querySelector('annotation[encoding="application/x-tex"]')?.textContent?.trim() || null
+}
+
+/**
+ * Return the selected rendered Markdown as plaintext while restoring KaTeX
+ * nodes to their original LaTeX source. A selection ending inside a formula
+ * expands to include that complete formula rather than copying KaTeX's
+ * accessibility text one glyph at a time.
+ */
+export function selectionTextWithLatex(container: HTMLElement, selection: Selection): string | null {
+  if (selection.isCollapsed || selection.rangeCount === 0) {
+    return null
+  }
+
+  const original = selection.getRangeAt(0)
+
+  if (!container.contains(original.commonAncestorContainer)) {
+    return null
+  }
+
+  const range = original.cloneRange()
+
+  const formulas = [...container.querySelectorAll('.katex')].filter(element => {
+    try {
+      return range.intersectsNode(element)
+    } catch {
+      return false
+    }
+  })
+
+  if (formulas.length === 0) {
+    return null
+  }
+
+  const startFormula = formulas.find(element => element.contains(range.startContainer))
+  const endFormula = [...formulas].reverse().find(element => element.contains(range.endContainer))
+
+  if (startFormula) {
+    range.setStartBefore(startFormula.closest('.katex-display') ?? startFormula)
+  }
+
+  if (endFormula) {
+    range.setEndAfter(endFormula.closest('.katex-display') ?? endFormula)
+  }
+
+  const holder = document.createElement('div')
+  holder.append(range.cloneContents())
+
+  for (const display of [...holder.querySelectorAll('.katex-display')]) {
+    const source = texSource(display)
+
+    if (source) {
+      display.replaceWith(document.createTextNode(`$$ ${source} $$`))
+    }
+  }
+
+  for (const inline of [...holder.querySelectorAll('.katex')]) {
+    const source = texSource(inline)
+
+    if (source) {
+      inline.replaceWith(document.createTextNode(`$${source}$`))
+    }
+  }
+
+  return plainText(holder).replace(/\n{3,}/g, '\n\n').trim()
+}

--- a/apps/desktop/src/lib/selection-copy-colors.test.ts
+++ b/apps/desktop/src/lib/selection-copy-colors.test.ts
@@ -288,6 +288,50 @@ describe('installSelectionCopyColorGuard', () => {
     }
   })
 
+  // The guard must DECLINE off-scheme KaTeX selections so the Markdown
+  // surface's canonical `$…$` serializer can own `text/plain`. The fixture
+  // deliberately carries no MathML `<math>` subtree: jsdom throws inside
+  // `getComputedStyle` on MathML elements, and that crash — not the skip —
+  // would otherwise be what stops the guard, hiding a missing skip branch.
+  it('leaves KaTeX selections to the Markdown LaTeX copy handler', () => {
+    const dispose = installSelectionCopyColorGuard(document)
+
+    const host = armSelection(
+      '<p style="color: rgb(230, 237, 243)">before <span class="katex"><span class="katex-html">x²</span></span> after</p>'
+    )
+
+    try {
+      const { event, setData, preventDefault } = makeCopyEvent()
+
+      document.body.dispatchEvent(event)
+
+      expect(preventDefault).not.toHaveBeenCalled()
+      expect(setData).not.toHaveBeenCalled()
+    } finally {
+      dispose()
+      host.remove()
+    }
+  })
+
+  // Guard against over-skipping: prose with no math anywhere must still get
+  // the off-scheme payload rewrite the guard exists to perform.
+  it('still owns the payload for off-scheme selections without math', () => {
+    const dispose = installSelectionCopyColorGuard(document)
+    const host = armSelection('<p style="color: rgb(230, 237, 243)">plain bright prose</p>')
+
+    try {
+      const { event, setData, preventDefault } = makeCopyEvent()
+
+      document.body.dispatchEvent(event)
+
+      expect(preventDefault).toHaveBeenCalled()
+      expect(setData.mock.calls.find(([type]) => type === 'text/plain')?.[1]).toContain('plain bright prose')
+    } finally {
+      dispose()
+      host.remove()
+    }
+  })
+
   it('stops intercepting after disposal', () => {
     const dispose = installSelectionCopyColorGuard(document)
     const host = armSelection('<p style="color: rgb(230, 237, 243)">bright transcript ink</p>')

--- a/apps/desktop/src/lib/selection-copy-colors.ts
+++ b/apps/desktop/src/lib/selection-copy-colors.ts
@@ -155,6 +155,20 @@ function rangeContainsNode(range: Range, node: Node): boolean {
   }
 }
 
+function selectionContainsMath(selection: Selection, doc: Document): boolean {
+  const formulas = doc.querySelectorAll('.katex')
+
+  for (const formula of formulas) {
+    for (let i = 0; i < selection.rangeCount; i++) {
+      if (rangeContainsNode(selection.getRangeAt(i), formula)) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
 /**
  * Mean perceived luma of the ink that paints the current selection, read
  * from the LIVE DOM: the computed color (preferring -webkit-text-fill-color
@@ -295,6 +309,15 @@ export function installSelectionCopyColorGuard(doc: Document = document): () => 
 
     if (selectionStartsInEditable(sel)) {
       trace({ step: 'editable-skip' })
+
+      return
+    }
+
+    // Markdown surfaces own the copy payload for KaTeX selections so the
+    // original `$...$`/`$$...$$` source survives instead of the visual glyphs.
+    // This guard runs during capture, before React's bubbling copy handler.
+    if (selectionContainsMath(sel, doc)) {
+      trace({ step: 'latex-skip' })
 
       return
     }


### PR DESCRIPTION
## Symptom

Selecting a rendered formula in the transcript and pressing Cmd/Ctrl+C puts KaTeX's *visual* layer on the clipboard. KaTeX renders two layers — accessible MathML and visual HTML — and native range serialization concatenates both, so a formula comes back as glyphs split across lines with zero-width spaces wedged between them:

```
Z 
s,t
(n,m)
​
 =Z 
s,s 
m
​
 
(n,m)
​
 +…
```

Pasting that into an editor, a LaTeX document or another chat is unusable, and users reasonably read the symptom as "math rendering is broken" when in fact rendering is fine and only the clipboard payload is wrong.

## Fix

KaTeX already keeps the canonical source in `annotation[encoding="application/x-tex"]`. `selectionTextWithLatex` (new, `src/lib/latex-copy.ts`) walks the selected range and replaces each `.katex` node with `$source$`, or `$$ source $$` when it sits in `.katex-display`. A selection that ends inside a formula expands to the complete expression instead of copying half a glyph run.

Two properties keep the blast radius small:

- It returns `null` when the selection intersects no KaTeX, so prose, code, currency (`$5`, `$HOME`) and components with their own copy handlers keep Chromium's native behavior.
- Only `text/plain` is replaced. MathML stays in the DOM and `text/html` is untouched, so accessibility and rich paste are unaffected.

One non-obvious interaction: `installSelectionCopyColorGuard` in `selection-copy-colors.ts` listens for `copy` during the **capture** phase and calls `preventDefault()` on off-scheme selections, so it would own the payload before the Markdown surface's bubbling handler ever ran. It now declines selections intersecting `.katex` and leaves them to the canonical serializer; every other selection keeps the existing contrast-rewrite behavior.

## Tests

`src/lib/latex-copy.test.ts` (new) covers inline `$…$`, display `$$…$$`, and a negative case asserting the serializer declines prose/code/currency. `selection-copy-colors.test.ts` gains the guard's skip branch plus an anti-over-skip case proving math-free off-scheme selections still get the payload rewrite.

Each test was proven red by reverting only the branch it covers.

One caveat worth flagging for reviewers: the guard fixture deliberately contains **no** `<math>` subtree. jsdom throws inside `getComputedStyle` on MathML elements, so a fixture with full MathML makes the handler crash before it decides — the test then passes whether or not the skip branch exists. The class-only fixture exercises the real branch.

```
npx vitest run --project ui src/lib/latex-copy.test.ts src/lib/selection-copy-colors.test.ts
# 25 passed
```

`tsc -p . --noEmit` and `eslint` on the touched files are clean.

## Verification

Beyond the unit tests, this was packaged and installed locally on macOS (Electron, arm64) and confirmed by a real selection + Cmd+C in the packaged renderer: inline math yields `$…$` and display math `$$ … $$` on the actual system clipboard.