### PR TITLE
feat(models): per-provider hidden_models to keep retired IDs out of the pickers

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -138,10 +138,30 @@ model:
   # Merged onto SDK/provider defaults with the entry's values winning.
   # Header values are treated as secrets and are never logged.
   #
+  # Per-provider model-list controls (same named providers / custom_providers
+  # entries):
+  #
+  # discover_models: false
+  #   Use only the models: you configured and skip the endpoint's /models
+  #   probe. Handy for gateways whose model listing is slow or noisy.
+  #
+  # hidden_models: [old-model-4-pro]
+  #   Keep these IDs out of every model picker (CLI /model, hermes model, TUI,
+  #   desktop, gateway inline keyboards) even when the endpoint's live /models
+  #   listing still offers them — the usual case for a retired alias a vendor
+  #   leaves in its catalog. Deleting the ID from models: is not enough: rows
+  #   are rebuilt from the live probe (see _models_config_is_allowlist), so the
+  #   ID comes straight back. Matching is case-insensitive, the hidden ID need
+  #   not appear in models:, and the model you are currently running stays
+  #   visible on its own row so you can see it and switch away. Explicitly
+  #   typing a hidden ID (/model <id>) still works — the exclusion is
+  #   picker-scoped.
+  #
   # providers:
   #   my-proxy:
   #     base_url: "https://llm.internal.example.com/v1"
   #     key_env: "MY_PROXY_API_KEY"
+  #     hidden_models: ["old-model-4-pro"]
   #     extra_headers:
   #       CF-Access-Client-Id: "xxxx.access"
   #       CF-Access-Client-Secret: "${CF_ACCESS_SECRET}"

--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -637,6 +637,15 @@ class CLIModelSwitchMixin:
                     model_list = provider_model_ids(provider_data["slug"]) or model_list
                 except Exception:
                     pass
+            # Honour ``hidden_models:`` from the provider's config entry. Rows built by
+            # ``model_switch_providers`` are already filtered; this also covers the live
+            # ``provider_model_ids`` fallback above, which would otherwise resurrect a retired
+            # ID the vendor still advertises.
+            hidden_ids = {
+                str(m).strip().lower() for m in (provider_data.get("hidden_models") or [])
+                if str(m).strip()}
+            if hidden_ids:
+                model_list = [m for m in model_list if str(m).strip().lower() not in hidden_ids]
             state.update(
                 stage="model", provider_data=provider_data, model_list=model_list,
                 selected=0, filter="", _filtered_pairs=None)

--- a/hermes_cli/config_providers.py
+++ b/hermes_cli/config_providers.py
@@ -117,7 +117,7 @@ _KNOWN_PROVIDER_KEYS = {
     "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env", "key_cmd",
     "api_mode", "transport", "model", "default_model", "models", "models_discovered",
     "context_length", "rate_limit_delay", "request_timeout_seconds", "stale_timeout_seconds",
-    "discover_models", "extra_body", "extra_headers", "capabilities", "ssl_ca_cert", "ssl_verify"}
+    "discover_models", "hidden_models", "extra_body", "extra_headers", "capabilities", "ssl_ca_cert", "ssl_verify"}
 
 
 def _pick_provider_base_url(entry: Dict[str, Any], provider_key: str) -> str:
@@ -255,6 +255,10 @@ def _normalize_custom_provider_entry(
         ("context_length", lambda v: isinstance(v, int) and v > 0),
         ("rate_limit_delay", lambda v: isinstance(v, (int, float)) and v >= 0),
         ("discover_models", lambda v: isinstance(v, (bool, str))),
+        # Model IDs the user keeps out of the pickers even when the endpoint's live
+        # ``/models`` probe still offers them (a retired alias a vendor leaves in its
+        # catalog). Shape-tolerant — see ``model_switch._hidden_model_ids``.
+        ("hidden_models", lambda v: isinstance(v, (list, tuple, dict, str)) and bool(v)),
     ):
         if ok(entry.get(field)):
             normalized[field] = entry[field]
@@ -284,7 +288,7 @@ def _custom_provider_entry_to_provider_config(
     provider_entry: Dict[str, Any] = {"api": normalized["base_url"]}
     for field in (
         "name", "api_key", "key_env", "key_cmd", "models", "models_discovered", "context_length",
-        "rate_limit_delay", "discover_models", "extra_body", "extra_headers",
+        "rate_limit_delay", "discover_models", "hidden_models", "extra_body", "extra_headers",
         "ssl_ca_cert", "ssl_verify"):
         if field in normalized:
             provider_entry[field] = normalized[field]

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -84,6 +84,32 @@ def _models_config_is_allowlist(value: Any, discovered: bool = False) -> bool:
     return False  # None, dict (per-model metadata), or anything else
 
 
+def _hidden_model_ids(cfg: Any) -> set[str]:
+    """Lowercase model IDs a provider entry excludes from the model pickers.
+
+    Vendors keep retired aliases in their live ``/models`` catalog long after they stop being
+    usable, and every picker row rebuilds its list from that probe (see
+    ``_models_config_is_allowlist``) — so deleting the ID from ``models`` does not hide it, the
+    next probe adds it straight back. ``hidden_models`` is the explicit, probe-proof exclusion::
+
+        custom_providers:
+          - name: deepseek
+            base_url: https://api.deepseek.com
+            hidden_models: [deepseek-v4-pro]
+
+    The hidden ID need not appear in ``models`` — retired IDs are usually gone from config
+    entirely. Shape-tolerant (list, ``{id: ...}`` mapping, or one string) and never raises on
+    malformed config.
+    """
+    if not isinstance(cfg, dict):
+        return set()
+    return {
+        model_id.strip().lower()
+        for model_id in _declared_model_ids(cfg.get("hidden_models"))
+        if model_id.strip()
+    }
+
+
 def _bare_custom_provider_def(current_base_url: str) -> Optional[ProviderDef]:
     """ProviderDef for a direct ``model.provider: custom`` endpoint."""
     base_url = _clean(current_base_url)

--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -1138,11 +1138,13 @@ def list_authenticated_providers(
     _lap_bare_custom_row(b, custom_providers)
     if custom_providers and isinstance(custom_providers, list):
         _lap_custom_provider_rows(b, custom_providers)
-    return _finalize_picker_rows(b.results, user_providers, current_model)
+    return _finalize_picker_rows(b.results, user_providers, current_model, custom_providers)
 
 
-def _finalize_picker_rows(results: list, user_providers, current_model: str) -> list:
-    """Post-passes: drop ``providers.<name>.enabled: false`` rows, inject the current model, sort."""
+def _finalize_picker_rows(results: list, user_providers, current_model: str,
+                          custom_providers: list | None = None) -> list:
+    """Post-passes: drop ``providers.<name>.enabled: false`` rows, strip ``hidden_models`` IDs,
+    inject the current model, sort."""
     # The enabled post-filter covers built-in rows (sections 1-2) that bypass the per-section
     # gate; matched by slug and ``provider_id``.
     try:
@@ -1156,6 +1158,62 @@ def _finalize_picker_rows(results: list, user_providers, current_model: str) -> 
                     r for r in results
                     if str(r.get("provider_id", "")).strip().lower() not in disabled
                     and str(r.get("slug", "")).strip().lower() not in disabled]
+    except Exception:
+        pass
+
+    # Per-provider ``hidden_models``: strip IDs the user excluded from every picker list. Runs
+    # before the current-model injection below so a row never hides the model you are actually
+    # running. Indexed by slug / provider_id and by normalised endpoint URL, which also covers
+    # the bare-``model:`` custom row and built-in rows serving the same endpoint.
+    try:
+        from hermes_cli.model_switch import _hidden_model_ids
+
+        by_key: dict[str, set] = {}
+        by_url: dict[str, set] = {}
+
+        def _index_hidden(key: Any, cfg: Any) -> None:
+            ids = _hidden_model_ids(cfg)
+            if not ids:
+                return
+            name = str(key or "").strip().lower()
+            if name:
+                by_key.setdefault(name, set()).update(ids)
+            if isinstance(cfg, dict):
+                url = _norm_url(cfg.get("base_url") or cfg.get("api") or cfg.get("url") or "")
+                if url:
+                    by_url.setdefault(url, set()).update(ids)
+
+        if isinstance(custom_providers, list):
+            for entry in custom_providers:
+                if isinstance(entry, dict):
+                    _index_hidden(entry.get("name") or entry.get("provider_key") or "", entry)
+        if isinstance(user_providers, dict):
+            for name, cfg in user_providers.items():
+                if isinstance(cfg, dict):
+                    _index_hidden(name, cfg)
+
+        if by_key or by_url:
+            for row in results:
+                hidden: set = set()
+                for key in (str(row.get("slug", "")).strip().lower(),
+                            str(row.get("provider_id", "")).strip().lower()):
+                    if key:
+                        hidden |= by_key.get(key, set())
+                hidden |= by_url.get(_norm_url(row.get("api_url", "")), set())
+                if not hidden:
+                    continue
+                before = list(row.get("models") or [])
+                after = [m for m in before if str(m).strip().lower() not in hidden]
+                if len(after) != len(before):
+                    try:
+                        total = int(row.get("total_models", len(before)))
+                    except (TypeError, ValueError):
+                        total = len(before)
+                    row["models"] = after
+                    row["total_models"] = max(0, total - (len(before) - len(after)))
+                # Exposed so pickers that fall back to a live catalog when ``models`` comes back
+                # empty apply the same exclusion instead of resurrecting the hidden IDs.
+                row["hidden_models"] = sorted(hidden)
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_hidden_models_filter.py
+++ b/tests/hermes_cli/test_hidden_models_filter.py
@@ -1,0 +1,191 @@
+"""Behavior contracts for the per-provider ``hidden_models:`` picker exclusion.
+
+A vendor can keep a retired model alias in its live ``/models`` catalog long after it stops
+being usable. Deleting the ID from ``custom_providers[].models`` does NOT hide it: every picker
+row rebuilds its list from a live probe (see ``_models_config_is_allowlist``), so the next
+``/model`` open adds the ID straight back. ``hidden_models`` is the explicit, probe-proof
+exclusion.
+
+These tests pin the contracts — not a snapshot of any provider's catalog:
+
+- probed IDs named in ``hidden_models`` never reach a picker row;
+- matching is case-insensitive, and works by slug and by endpoint URL;
+- an absent ``hidden_models`` changes nothing;
+- the model you are currently running stays visible even when hidden;
+- the key survives config normalization (the two-place registration the real path needs).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+ENDPOINT = "http://127.0.0.1:9/v1"
+PROBED = ["test-small", "test-retired", "test-large"]
+
+
+def _entry(hidden=None, *, name="TestDS", url=ENDPOINT):
+    entry = {"name": name, "base_url": url, "api_key": "sk-test", "api_mode": "chat_completions"}
+    if hidden is not None:
+        entry["hidden_models"] = hidden
+    return entry
+
+
+def _row(models=None, *, slug="testds", url=ENDPOINT, **extra):
+    row = {
+        "slug": slug,
+        "name": slug,
+        "is_current": False,
+        "is_user_defined": True,
+        "models": list(PROBED if models is None else models),
+        "total_models": len(PROBED if models is None else models),
+        "source": "user-config",
+        "api_url": url,
+    }
+    row.update(extra)
+    return row
+
+
+def _finalize(rows, *, user_providers=None, custom_providers=None, current_model=""):
+    from hermes_cli.model_switch_providers import _finalize_picker_rows
+
+    return _finalize_picker_rows(rows, user_providers or {}, current_model, custom_providers)
+
+
+def _by_slug(rows, slug):
+    """Finalize sorts rows (current first, then by model count) — never index by position."""
+    for row in rows:
+        if row["slug"] == slug:
+            return row
+    raise AssertionError(f"no row for slug {slug!r}: {[r['slug'] for r in rows]}")
+
+
+# ── the exclusion itself ──────────────────────────────────────────────────
+
+
+def test_hidden_model_is_never_offered():
+    """A probed ID listed in ``hidden_models`` is stripped from the row."""
+    rows = _finalize([_row()], custom_providers=[_entry(["test-retired"])])
+
+    assert _by_slug(rows, "testds")["models"] == ["test-small", "test-large"]
+
+
+def test_hidden_count_is_consistent_with_the_visible_list():
+    """``total_models`` must not claim a model the picker cannot show."""
+    row = _by_slug(_finalize([_row()], custom_providers=[_entry(["test-retired"])]), "testds")
+
+    assert row["total_models"] == len(row["models"])
+
+
+def test_hidden_matching_is_case_insensitive():
+    """Config case must not decide whether the exclusion takes effect."""
+    rows = _finalize([_row()], custom_providers=[_entry(["TEST-Retired"])])
+
+    assert "test-retired" not in _by_slug(rows, "testds")["models"]
+
+
+def test_hidden_matches_by_endpoint_url_when_slug_differs():
+    """The bare ``model:`` + ``base_url`` row is slugged ``custom`` — it must still be
+    filtered, because the exclusion is anchored to the endpoint."""
+    rows = _finalize(
+        [_row(slug="custom", url=ENDPOINT)],
+        custom_providers=[_entry(["test-retired"])],
+    )
+
+    assert "test-retired" not in _by_slug(rows, "custom")["models"]
+
+
+def test_hidden_via_providers_dict():
+    """``providers.<name>.hidden_models`` works like the ``custom_providers[]`` shape."""
+    rows = _finalize([_row()], user_providers={"testds": _entry(["test-retired"])})
+
+    assert "test-retired" not in _by_slug(rows, "testds")["models"]
+
+
+def test_absent_hidden_models_leaves_the_probed_list_untouched():
+    """Backward compat: configs without the key behave exactly as before."""
+    row = _by_slug(_finalize([_row()], custom_providers=[_entry()]), "testds")
+
+    assert row["models"] == PROBED
+    assert "hidden_models" not in row
+
+
+def test_unrelated_rows_are_not_touched():
+    """A different endpoint must not inherit another provider's exclusion."""
+    rows = _finalize(
+        [_row(), _row(slug="other", url="http://127.0.0.1:8/v1")],
+        custom_providers=[_entry(["test-retired"])],
+    )
+
+    assert _by_slug(rows, "other")["models"] == PROBED
+    assert "test-retired" not in _by_slug(rows, "testds")["models"]
+
+
+def test_current_model_stays_visible_when_hidden():
+    """Never lie about the active model: if you are running a hidden ID, the current row
+    still shows it (that is how you switch away)."""
+    rows = _finalize(
+        [_row(models=["test-small", "test-large"], is_current=True)],
+        custom_providers=[_entry(["test-retired"])],
+        current_model="test-retired",
+    )
+    row = _by_slug(rows, "testds")
+
+    assert row["is_current"]
+    assert row["models"][0] == "test-retired"
+    assert row["total_models"] == 3
+
+
+# ── config plumbing ───────────────────────────────────────────────────────
+
+
+def test_hidden_models_survives_config_normalization(tmp_path, monkeypatch):
+    """The key must survive ``_normalize_custom_provider_entry`` — the normalizer every real
+    picker passes its rows through. A normalizer that drops the key makes the exclusion a no-op
+    in production while direct-call unit tests still pass."""
+    from hermes_cli.config_providers import (
+        _normalize_custom_provider_entry,
+        providers_dict_to_custom_providers,
+    )
+
+    normalized = _normalize_custom_provider_entry(_entry(["test-retired"]))
+    assert normalized is not None
+    assert normalized.get("hidden_models") == ["test-retired"]
+
+    # Legacy list shape -> providers dict shape keeps it too.
+    converted = providers_dict_to_custom_providers({"testds": _entry(["test-retired"])})
+    assert converted and converted[0].get("hidden_models") == ["test-retired"]
+
+
+def test_hidden_models_is_a_known_provider_key():
+    """The key must be registered, otherwise config load logs 'unknown config keys ignored'
+    and users get a warning for a documented setting."""
+    from hermes_cli.config_providers import _KNOWN_PROVIDER_KEYS
+
+    assert "hidden_models" in _KNOWN_PROVIDER_KEYS
+
+
+def test_list_authenticated_providers_threads_custom_providers_into_finalize():
+    """The exclusion lives in the finalize post-pass, so ``list_authenticated_providers``
+    must hand it the custom providers. Wiring regression guard: dropping the argument would
+    leave the feature silently dead in every UI while finalize's own unit tests still pass."""
+    from hermes_cli import model_switch_providers
+
+    captured: dict = {}
+
+    def _spy(results, user_providers, current_model, custom_providers=None):
+        captured["custom_providers"] = custom_providers
+        return results
+
+    entries = [_entry(["test-retired"])]
+    with patch.object(model_switch_providers, "_finalize_picker_rows", side_effect=_spy), \
+         patch("agent.models_dev.fetch_models_dev", return_value={}), \
+         patch.object(model_switch_providers, "_build_curated_lists", return_value={}):
+        model_switch_providers.list_authenticated_providers(
+            custom_providers=entries, probe_custom_providers=False
+        )
+
+    assert captured.get("custom_providers") == entries
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1336,7 +1336,7 @@ providers:
     transport: anthropic_messages  # for Anthropic-compatible proxies
 ```
 
-Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accepted aliases), `name` (optional display name; defaults to the dict key), `key_env` or inline `api_key` or `key_cmd` (see below), `transport` (`chat_completions` / `anthropic_messages` / `codex_responses`), `default_model`, `models`, `context_length`, `discover_models`, `extra_body`, `extra_headers`, `ssl_ca_cert` / `ssl_verify`, and `enabled: false` to hide an entry without deleting it.
+Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accepted aliases), `name` (optional display name; defaults to the dict key), `key_env` or inline `api_key` or `key_cmd` (see below), `transport` (`chat_completions` / `anthropic_messages` / `codex_responses`), `default_model`, `models`, `context_length`, `discover_models`, `hidden_models` (model IDs to keep out of the pickers even when the endpoint's live `/models` listing still offers them), `extra_body`, `extra_headers`, `ssl_ca_cert` / `ssl_verify`, and `enabled: false` to hide an entry without deleting it.
 
 #### Command-minted credentials (`key_cmd`)
 

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -197,6 +197,19 @@ providers:
 
 With discovery off, the model picker (`hermes model`, `/model`) shows the configured list instead of a live probe.
 
+**`hidden_models`** — a list of model IDs to keep out of every model picker (`/model`, `hermes model`, the TUI/desktop pickers, gateway inline keyboards) even when the endpoint's live `/models` listing still offers them. Use it for a retired alias a vendor leaves in its catalog: deleting the ID from `models` is not enough, because every picker row is rebuilt from a live probe and the ID comes straight back.
+
+```yaml
+providers:
+  my-gateway:
+    api: https://llm.internal.example.com/v1
+    api_key: sk-...
+    hidden_models:
+      - old-model-4-pro   # retired upstream; vendor still lists it
+```
+
+A hidden ID does not have to appear in `models` — retired IDs are usually deleted from config entirely. Matching is case-insensitive. The model you are **currently running** is never hidden from its own provider row, so you can always see what you're on and switch away from it. Typing a hidden ID explicitly (`/model <id>`) still works: the exclusion is picker-scoped.
+
 **`openai_native_compaction`** — set this capability to `true` only for an OpenAI-compatible endpoint that you trust with conversation content. Native compaction sends its payload to that provider's configured `base_url`:
 
 ```yaml


### PR DESCRIPTION
## What does this PR do?

Adds a per-provider **`hidden_models`** list so a user can keep specific model IDs out of the
model pickers even when the endpoint's live `/models` listing still offers them.

The motivating case is a **retired model alias a vendor leaves in its catalog**. Deleting the ID
from `custom_providers[].models` does not hide it: every picker row is rebuilt from a live probe
(`_models_config_is_allowlist` documents that a dict-shaped `models:` is per-model *metadata*,
not an allowlist), so the next `/model` open adds the ID straight back. There was no supported
way to say "never offer this": `discover_models: false` also freezes the rest of the list, and
`enabled: false` hides the whole provider.

```yaml
custom_providers:
  - name: deepseek
    base_url: https://api.deepseek.com
    hidden_models:
      - deepseek-v4-pro
```

Why this shape: the exclusion is anchored to the provider entry (not to the model catalog), so
it works for IDs that are *not* in the config at all — which is the normal case, since retired
IDs get deleted from `models:` — and it survives a live `/models` probe by construction.

Behavior contracts:

- applied in `_finalize_picker_rows`, the single upstream of the CLI `/model` picker,
  `hermes model`, the TUI/desktop payload and the gateway inline keyboards — one place, so no
  picker can drift;
- matched by slug / `provider_id` **and** by normalised endpoint URL, which also covers the bare
  `model:` + `base_url` row (slugged `custom`) and built-in rows serving the same endpoint;
- case-insensitive; the hidden ID need not appear in `models:`;
- **the model you are currently running is never hidden** — it is still injected into its own
  row, so you can see what you are on and switch away; and explicitly typing `/model <id>`
  still works. The exclusion is picker-scoped, not a hard block;
- rows expose `hidden_models` so the CLI's fallback to a live catalog when the curated list comes
  back empty applies the same filter instead of resurrecting the ID.

## Related Issue

Fixes #107984

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/model_switch.py` — new `_hidden_model_ids(cfg)` helper (shape-tolerant via the
  existing `_declared_model_ids`; never raises on malformed config).
- `hermes_cli/model_switch_providers.py` — `_finalize_picker_rows()` gains a `custom_providers`
  parameter plus the exclusion post-pass, placed **after** the `enabled: false` pass and **before**
  the current-model injection; the call site threads the argument through.
- `hermes_cli/config_providers.py` — `hidden_models` registered in `_KNOWN_PROVIDER_KEYS`
  (otherwise config load logs "unknown config keys ignored"), copied through
  `_normalize_custom_provider_entry()`, and carried by
  `_custom_provider_entry_to_provider_config()`.
- `hermes_cli/cli_model_switch_mixin.py` — filters the picker's `provider_model_ids()` fallback,
  which would otherwise resurrect a hidden ID when the curated list is empty.
- `cli-config.yaml.example`, `website/docs/user-guide/configuring-models.md`,
  `website/docs/integrations/providers.md` — documented.
- `tests/hermes_cli/test_hidden_models_filter.py` — 11 tests: the exclusion, case-insensitivity,
  URL matching, `providers:` vs `custom_providers:` shapes, no-op when absent, unrelated rows
  untouched, current-model visibility, key survival through normalization (the
  silent-no-op-in-production trap), and a wiring guard that `list_authenticated_providers`
  threads `custom_providers` into finalize.

## How to Test

1. Add a `hidden_models` entry to any custom provider whose endpoint lists more models than you
   want offered, e.g. `hidden_models: [deepseek-v4-pro]`.
2. Open the picker (`/model`, or `hermes model`) and confirm the ID is no longer offered while
   the provider's other models are.
3. Confirm the running model is still shown on its own row (`/model` while on a hidden ID), and
   that typing `/model deepseek-v4-pro` still switches.
4. `pytest tests/hermes_cli/test_hidden_models_filter.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (git-bash, Python 3.11)

Verification actually performed (not the full suite — check the box above accordingly):

```
tests/hermes_cli/test_hidden_models_filter.py                                11 passed
tests/hermes_cli + tests/gateway files touching the changed modules         169 passed
  (test_list_picker_providers, test_authenticated_providers_exhausted_pool,
   test_model_switch_custom_providers, test_model_catalog, test_anon_picker,
   test_copilot_in_model_list, test_picker_key_cmd_discovery, test_picker_prewarm,
   test_model_picker_persist, test_slack_model_picker, test_model_command_async_offload)
```

Also verified against a real endpoint (no mocks): a provider whose live `/models` returns
`['deepseek-flash', 'deepseek-v4-pro']` yields a picker row of `['deepseek-flash']` once
`deepseek-v4-pro` is listed in `hidden_models`, with `total_models` decremented accordingly.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Real-config / real-probe run (no mocks) after the change:

```
$ python -c "from hermes_cli.config import load_config, get_compatible_custom_providers; \
             from hermes_cli.model_switch_providers import list_authenticated_providers; ..."
规范化后 deepseek 条目键: ['api_key', 'api_mode', 'base_url', 'hidden_models', 'models', 'name']
hidden_models 是否活下来: ['deepseek-v4-pro']
---
  slug: custom:deepseek | url: https://api.deepseek.com
  选择器会展示的模型: ['deepseek-flash']
  total_models: 1
  行上暴露的排除集: ['deepseek-v4-pro']
```

Note for reviewers: the key is deliberately **not** an allowlist (`models:`) and **not** a
provider-level switch — it only narrows what the pickers offer, matching how
`model_catalog.excluded_providers` narrows providers. If you'd rather see this as a hard block
on programmatic resolution too, say so and I'll extend it.
