### PR TITLE
Azure Foundry deployments show up in the /model picker (#27989, salvage #28006)

### DIFF
--- a/hermes_cli/azure_detect.py
+++ b/hermes_cli/azure_detect.py
@@ -135,6 +135,39 @@ def _extract_model_ids(payload: dict) -> list[str]:
     return ids
 
 
+# Azure's resource-scoped deployment listing. Only this preview api-version serves it (2023-05-15+
+# 404); ``/openai/v1/models`` on the same host lists Microsoft's whole catalog (~400 ids incl.
+# embeddings/TTS/image), most of which the resource has never deployed and cannot serve (#27989).
+_AZURE_DEPLOYMENTS_API_VERSION = "2023-03-15-preview"
+_AZURE_ROUTE_SUFFIX_RE = re.compile(r"/(?:openai(?:/v1)?|anthropic(?:/v1)?|models(?:/v1)?|v1)/?$", re.IGNORECASE)
+
+
+def azure_resource_root(base_url: str) -> str:
+    """``https://r.openai.azure.com/openai/v1`` / ``.../anthropic`` -> ``https://r.openai.azure.com``."""
+    return _AZURE_ROUTE_SUFFIX_RE.sub("", str(base_url or "").strip().rstrip("/")).rstrip("/")
+
+
+def probe_azure_deployments(base_url: str, api_key: Any, *, token_provider: TokenProvider = None) -> list[str]:
+    """Deployment names of the Azure resource behind *base_url* (``[]`` when the route is unavailable).
+
+    Succeeded deployments first, still-provisioning ones after, portal order preserved.
+    """
+    root = azure_resource_root(base_url)
+    if not root:
+        return []
+    status, body = _http_get_json(f"{root}/openai/deployments?api-version={_AZURE_DEPLOYMENTS_API_VERSION}",
+                                  api_key, token_provider=token_provider)
+    rows = body.get("data") if status == 200 and isinstance(body, dict) else None
+    if not isinstance(rows, list):
+        return []
+    ready, pending = [], []
+    for row in rows:
+        name = str(row.get("id") or "").strip() if isinstance(row, dict) else ""
+        if name:
+            (ready if str(row.get("status") or "").lower() in {"", "succeeded"} else pending).append(name)
+    return list(dict.fromkeys([*ready, *pending]))
+
+
 def _probe_openai_models(base_url: str, api_key: Any, *, token_provider: TokenProvider = None) -> tuple[bool, list[str]]:
     """Probe ``<base>/models`` for an OpenAI-shaped response."""
     base_url = base_url.rstrip("/")

--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -629,12 +629,14 @@ class CLIModelSwitchMixin:
                 return
             provider_data = providers[selected]
             # Curated list (same as `hermes model` / gateway pickers); live catalog only when
-            # it is empty (user-defined endpoints).
+            # it is empty (user-defined endpoints, per-resource providers such as azure-foundry).
+            # Disk-cached like the gateway pickers: the live probe can walk several api-version
+            # fallbacks with a 6 s timeout each, which must not block the REPL on every select.
             model_list = provider_data.get("models", [])
             if not model_list:
                 try:
-                    from hermes_cli.models import provider_model_ids
-                    model_list = provider_model_ids(provider_data["slug"]) or model_list
+                    from hermes_cli.models import cached_provider_model_ids
+                    model_list = cached_provider_model_ids(provider_data["slug"]) or model_list
                 except Exception:
                     pass
             state.update(

--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -241,6 +241,18 @@ def _any_env(env_vars, read_env=os.environ.get) -> bool:
     return any(read_env(ev) for ev in env_vars)
 
 
+def _keyless_builtin_configured(hermes_id: str) -> bool:
+    """Canonical-row credential signal for api_key providers whose runtime auth is not a key: Azure
+    Foundry under ``model.auth_mode: entra_id`` mints a per-request bearer, so no ``*_API_KEY`` env
+    var ever exists and the row would otherwise vanish from the picker (#27989)."""
+    if hermes_id != "azure-foundry":
+        return False
+    from hermes_cli.models import _get_model_config_dict
+    model_cfg = _get_model_config_dict()
+    return (str(model_cfg.get("provider") or "").strip().lower() == "azure-foundry"
+            and str(model_cfg.get("auth_mode") or "").strip().lower() == "entra_id")
+
+
 def _skip(seen: set, excluded: set, *keys: str) -> bool:
     """True when any of *keys* (lowercased) is already emitted or excluded."""
     lowered = [k.lower() for k in keys]
@@ -864,7 +876,8 @@ def _lap_canonical_rows(b: _PickerBuild) -> None:
             if lit and lit <= sib_vars < set(cp_config.api_key_env_vars) and cp.slug != b.current_provider:
                 continue
         has_creds = has_creds or _auth_store_has_provider(cp.slug) or _pool_usable(cp.slug) or (
-            _is_aws_sdk(cp_config) and _has_aws_sdk_creds_for_listing(cp.slug, b.current_provider))
+            _is_aws_sdk(cp_config) and _has_aws_sdk_creds_for_listing(cp.slug, b.current_provider)
+        ) or _keyless_builtin_configured(cp.slug)
         if not has_creds:
             continue
         if _is_aws_sdk(cp_config):

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1371,21 +1371,17 @@ def _azure_foundry_catalog(normalized: str, force_refresh: bool) -> Optional[lis
     the fallback for gateways that do not expose it. None on any miss keeps the static list.
     """
     try:
-        from agent.azure_identity_adapter import is_token_provider
         from hermes_cli.azure_detect import _probe_openai_models, probe_azure_deployments
         from hermes_cli.runtime_provider import _resolve_azure_foundry_runtime
 
-        runtime = _resolve_azure_foundry_runtime(requested_provider="azure-foundry", model_cfg=_get_model_config_dict())
+        runtime = _resolve_azure_foundry_runtime(requested_provider=normalized, model_cfg=_get_model_config_dict())
         base_url = str(runtime.get("base_url") or "").strip().rstrip("/")
-        credential = runtime.get("api_key")
+        credential = runtime.get("api_key")  # str API key, or the Entra token-provider callable
         if not (base_url and credential):
             return None
-        auth = {"token_provider": credential} if is_token_provider(credential) else {}
-        api_key = "" if auth else str(credential)
-        deployments = probe_azure_deployments(base_url, api_key, **auth)
-        if deployments:
-            return deployments
-        ok, ids = _probe_openai_models(base_url, api_key, **auth)
+        ok, ids = True, probe_azure_deployments(base_url, credential)
+        if not ids:
+            ok, ids = _probe_openai_models(base_url, credential)
         return ids if ok and ids else None
     except Exception:
         return None

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1360,6 +1360,33 @@ def _bedrock_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]
         return None
 
 
+def _azure_foundry_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]:
+    """Live deployment ids for the configured Azure Foundry resource (#27989).
+
+    Deployments are per-resource, so the static catalog is intentionally empty. Route through the
+    runtime credential resolver so the picker honours both API-key and keyless Entra ID auth (the
+    resolver hands back a callable token provider for ``auth_mode: entra_id``) and probes the same
+    resource inference will hit. None on any miss so the picker falls back to the static list.
+    """
+    try:
+        from agent.azure_identity_adapter import is_token_provider
+        from hermes_cli.azure_detect import _probe_openai_models
+        from hermes_cli.runtime_provider import _resolve_azure_foundry_runtime
+
+        runtime = _resolve_azure_foundry_runtime(requested_provider="azure-foundry", model_cfg=_get_model_config_dict())
+        base_url = str(runtime.get("base_url") or "").strip().rstrip("/")
+        credential = runtime.get("api_key")
+        if not (base_url and credential):
+            return None
+        if is_token_provider(credential):
+            ok, ids = _probe_openai_models(base_url, "", token_provider=credential)
+        else:
+            ok, ids = _probe_openai_models(base_url, str(credential))
+        return ids if ok and ids else None
+    except Exception:
+        return None
+
+
 def _opencode_free_catalog(normalized: str, force_refresh: bool) -> list[str]:
     # Live keyless catalog filtered to the anonymous-servable `*-free` tier ourselves (models.dev's
     # cost.input==0 lags reality); the curated floor applies only when the live fetch fails/is empty.
@@ -1386,6 +1413,7 @@ _PROVIDER_CATALOG_FETCHERS: dict[str, Any] = {
     "openai-api": _openai_catalog,
     "custom": _custom_catalog,
     "bedrock": _bedrock_catalog,
+    "azure-foundry": _azure_foundry_catalog,
     "opencode-free": _opencode_free_catalog}
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1365,12 +1365,14 @@ def _azure_foundry_catalog(normalized: str, force_refresh: bool) -> Optional[lis
 
     Deployments are per-resource, so the static catalog is intentionally empty. Route through the
     runtime credential resolver so the picker honours both API-key and keyless Entra ID auth (the
-    resolver hands back a callable token provider for ``auth_mode: entra_id``) and probes the same
-    resource inference will hit. None on any miss so the picker falls back to the static list.
+    resolver hands back a callable token provider for ``auth_mode: entra_id``) and targets the same
+    resource inference will hit. The resource's ``/openai/deployments`` listing is what the portal
+    shows and what inference accepts; ``/models`` (Microsoft's whole catalog on Azure hosts) is only
+    the fallback for gateways that do not expose it. None on any miss keeps the static list.
     """
     try:
         from agent.azure_identity_adapter import is_token_provider
-        from hermes_cli.azure_detect import _probe_openai_models
+        from hermes_cli.azure_detect import _probe_openai_models, probe_azure_deployments
         from hermes_cli.runtime_provider import _resolve_azure_foundry_runtime
 
         runtime = _resolve_azure_foundry_runtime(requested_provider="azure-foundry", model_cfg=_get_model_config_dict())
@@ -1378,10 +1380,12 @@ def _azure_foundry_catalog(normalized: str, force_refresh: bool) -> Optional[lis
         credential = runtime.get("api_key")
         if not (base_url and credential):
             return None
-        if is_token_provider(credential):
-            ok, ids = _probe_openai_models(base_url, "", token_provider=credential)
-        else:
-            ok, ids = _probe_openai_models(base_url, str(credential))
+        auth = {"token_provider": credential} if is_token_provider(credential) else {}
+        api_key = "" if auth else str(credential)
+        deployments = probe_azure_deployments(base_url, api_key, **auth)
+        if deployments:
+            return deployments
+        ok, ids = _probe_openai_models(base_url, api_key, **auth)
         return ids if ok and ids else None
     except Exception:
         return None

--- a/tests/hermes_cli/test_azure_foundry_model_picker.py
+++ b/tests/hermes_cli/test_azure_foundry_model_picker.py
@@ -1,0 +1,298 @@
+"""Tests for Azure Foundry integration in the /model picker (#27989).
+
+`provider_model_ids("azure-foundry")` used to fall straight through to the
+static `_PROVIDER_MODELS["azure-foundry"] = []` table, so the in-app
+``/model azure-foundry`` picker reported "0 models" even when the user's
+Foundry resource exposed many deployments.
+
+This file pins the live-discovery branch added to ``hermes_cli.models``,
+which routes through the runtime credential resolver
+(``hermes_cli.runtime_provider._resolve_azure_foundry_runtime``) so the
+picker probes the exact resource inference will hit and honours BOTH auth
+modes:
+
+  * **API key** — ``AZURE_FOUNDRY_API_KEY`` (``.env`` or process env). The
+    resolved string key is forwarded to
+    ``hermes_cli.azure_detect._probe_openai_models``.
+  * **Microsoft Entra ID** (``model.auth_mode: entra_id``) — the resolver
+    returns a *callable* token provider instead of a string. The picker
+    must detect the callable and forward it via ``token_provider=`` so the
+    probe mints a fresh bearer JWT (regression for the keyless path
+    flagged in review of #28006).
+
+Any failure (missing credentials, ``azure-identity`` not installed,
+network error, empty list) must fall back to the static (empty) catalog
+without raising.
+
+No real Azure endpoint is contacted — every test stubs the probe and/or
+the runtime resolver.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+_FAKE_FOUNDRY_DEPLOYMENTS = [
+    "gpt-5.4",
+    "gpt-5.3-codex",
+    "kimi-k2.6",
+    "deepseek-v4-pro",
+    "grok-4.3",
+]
+
+
+# ---------------------------------------------------------------------------
+# API-key auth — exercises the real runtime resolver end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestProviderModelIdsAzureFoundryApiKey:
+    """`provider_model_ids("azure-foundry")` populates from a live probe."""
+
+    def test_returns_live_discovered_ids_when_credentials_present(self, monkeypatch):
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
+        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://r.openai.azure.com/openai/v1")
+
+        with patch(
+            "hermes_cli.azure_detect._probe_openai_models",
+            return_value=(True, list(_FAKE_FOUNDRY_DEPLOYMENTS)),
+        ) as probe:
+            ids = provider_model_ids("azure-foundry")
+
+        assert ids == _FAKE_FOUNDRY_DEPLOYMENTS
+        probe.assert_called_once()
+        # API-key mode forwards the resolved string key positionally and
+        # leaves token_provider unset.
+        called_base, called_key = probe.call_args.args
+        assert called_base == "https://r.openai.azure.com/openai/v1"
+        assert called_key == "az-secret"
+        assert probe.call_args.kwargs.get("token_provider") is None
+
+    def test_prefers_config_base_url_over_env_var(self, monkeypatch):
+        """Picker must target the same resource inference would (config wins)."""
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
+        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://env.example/v1")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {
+                    "provider": "azure-foundry",
+                    "base_url": "https://config.example/openai/v1",
+                }
+            },
+        )
+
+        with patch(
+            "hermes_cli.azure_detect._probe_openai_models",
+            return_value=(True, ["gpt-5.4"]),
+        ) as probe:
+            ids = provider_model_ids("azure-foundry")
+
+        assert ids == ["gpt-5.4"]
+        called_base, _ = probe.call_args.args
+        assert called_base == "https://config.example/openai/v1"
+
+    def test_reads_api_key_from_dotenv_when_env_missing(self, monkeypatch):
+        """`.env` API keys must be honoured even when the process env is empty."""
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.delenv("AZURE_FOUNDRY_API_KEY", raising=False)
+        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://r.openai.azure.com/openai/v1")
+        monkeypatch.setattr(
+            "hermes_cli.config.get_env_value",
+            lambda key: "dotenv-secret" if key == "AZURE_FOUNDRY_API_KEY" else "",
+        )
+
+        with patch(
+            "hermes_cli.azure_detect._probe_openai_models",
+            return_value=(True, ["gpt-5.4"]),
+        ) as probe:
+            ids = provider_model_ids("azure-foundry")
+
+        assert ids == ["gpt-5.4"]
+        _, called_key = probe.call_args.args
+        assert called_key == "dotenv-secret"
+
+
+# ---------------------------------------------------------------------------
+# Microsoft Entra ID auth — the keyless path teknium flagged in review
+# ---------------------------------------------------------------------------
+
+
+class TestProviderModelIdsAzureFoundryEntraId:
+    """Entra ID resolves to a callable token provider, not a string key.
+
+    The picker must route that callable to the probe via ``token_provider=``
+    so keyless (``model.auth_mode: entra_id``) users still see their
+    deployments instead of an empty picker.
+    """
+
+    def test_entra_id_forwards_token_provider_to_probe(self, monkeypatch):
+        from hermes_cli.models import provider_model_ids
+
+        def sentinel_token_provider() -> str:
+            return "fresh-entra-jwt"
+
+        def _fake_runtime(*, requested_provider, model_cfg, **_kw):
+            assert requested_provider == "azure-foundry"
+            return {
+                "provider": "azure-foundry",
+                "api_mode": "chat_completions",
+                "base_url": "https://r.openai.azure.com/openai/v1",
+                "api_key": sentinel_token_provider,
+                "auth_mode": "entra_id",
+                "source": "entra_id",
+            }
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._resolve_azure_foundry_runtime",
+            _fake_runtime,
+        )
+
+        with patch(
+            "hermes_cli.azure_detect._probe_openai_models",
+            return_value=(True, list(_FAKE_FOUNDRY_DEPLOYMENTS)),
+        ) as probe:
+            ids = provider_model_ids("azure-foundry")
+
+        assert ids == _FAKE_FOUNDRY_DEPLOYMENTS
+        probe.assert_called_once()
+        # The callable must be passed as token_provider; the positional
+        # api_key must NOT be the callable (the OpenAI SDK contract differs
+        # from the manual-probe contract).
+        called_base, called_key = probe.call_args.args
+        assert called_base == "https://r.openai.azure.com/openai/v1"
+        assert called_key == ""
+        assert probe.call_args.kwargs.get("token_provider") is sentinel_token_provider
+
+    def test_entra_id_probe_failure_falls_back_to_static(self, monkeypatch):
+        from hermes_cli.models import provider_model_ids
+
+        def _fake_runtime(*, requested_provider, model_cfg, **_kw):
+            return {
+                "provider": "azure-foundry",
+                "api_mode": "chat_completions",
+                "base_url": "https://r.openai.azure.com/openai/v1",
+                "api_key": lambda: "fresh-entra-jwt",
+                "auth_mode": "entra_id",
+                "source": "entra_id",
+            }
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._resolve_azure_foundry_runtime",
+            _fake_runtime,
+        )
+
+        with patch(
+            "hermes_cli.azure_detect._probe_openai_models",
+            side_effect=RuntimeError("token chain exhausted"),
+        ):
+            ids = provider_model_ids("azure-foundry")
+
+        assert ids == []  # graceful fallback, no AuthError leaks into the picker
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation — missing creds, bad probe results, foreign providers
+# ---------------------------------------------------------------------------
+
+
+class TestProviderModelIdsAzureFoundryFallback:
+    """Every credential/probe failure mode must yield the static ``[]``."""
+
+    def test_ignores_config_base_url_for_non_foundry_provider(self, monkeypatch):
+        """A `model.base_url` set for a different provider must not leak through."""
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
+        monkeypatch.delenv("AZURE_FOUNDRY_BASE_URL", raising=False)
+        # User's main provider is custom; the URL belongs to that endpoint.
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"provider": "custom", "base_url": "https://localhost:8000/v1"}},
+        )
+
+        with patch("hermes_cli.azure_detect._probe_openai_models") as probe:
+            ids = provider_model_ids("azure-foundry")
+
+        # No base_url for azure-foundry → resolver raises → probe never runs.
+        probe.assert_not_called()
+        assert ids == []
+
+    def test_falls_back_to_static_when_api_key_missing(self, monkeypatch):
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.delenv("AZURE_FOUNDRY_API_KEY", raising=False)
+        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://r.openai.azure.com/openai/v1")
+        # Pin `.env` resolver to empty so we don't read a real key from disk.
+        monkeypatch.setattr("hermes_cli.config.get_env_value", lambda _k: "")
+
+        with patch("hermes_cli.azure_detect._probe_openai_models") as probe:
+            ids = provider_model_ids("azure-foundry")
+
+        probe.assert_not_called()
+        assert ids == []
+
+    def test_falls_back_to_static_when_base_url_missing(self, monkeypatch):
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
+        monkeypatch.delenv("AZURE_FOUNDRY_BASE_URL", raising=False)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {}})
+
+        with patch("hermes_cli.azure_detect._probe_openai_models") as probe:
+            ids = provider_model_ids("azure-foundry")
+
+        probe.assert_not_called()
+        assert ids == []
+
+    def test_falls_back_to_static_when_probe_returns_not_ok(self, monkeypatch):
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
+        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://r.openai.azure.com/openai/v1")
+
+        with patch(
+            "hermes_cli.azure_detect._probe_openai_models",
+            return_value=(False, []),
+        ):
+            ids = provider_model_ids("azure-foundry")
+
+        assert ids == []
+
+    def test_falls_back_to_static_when_probe_returns_empty_list(self, monkeypatch):
+        """A 200 OK with an OpenAI-shaped empty list must not block the picker."""
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
+        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://r.openai.azure.com/openai/v1")
+
+        with patch(
+            "hermes_cli.azure_detect._probe_openai_models",
+            return_value=(True, []),
+        ):
+            ids = provider_model_ids("azure-foundry")
+
+        # ok=True but ids=[]; gracefully fall through rather than returning the
+        # empty live result and shadowing the static [] (semantically identical
+        # here, but the contract is "fall through, not crash").
+        assert ids == []
+
+    def test_does_not_raise_when_probe_raises(self, monkeypatch):
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
+        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://r.openai.azure.com/openai/v1")
+
+        with patch(
+            "hermes_cli.azure_detect._probe_openai_models",
+            side_effect=RuntimeError("network down"),
+        ):
+            ids = provider_model_ids("azure-foundry")
+
+        assert ids == []  # graceful fallback

--- a/tests/hermes_cli/test_azure_foundry_model_picker.py
+++ b/tests/hermes_cli/test_azure_foundry_model_picker.py
@@ -75,7 +75,7 @@ class TestAzureFoundryPicker:
             ids = provider_model_ids("azure-foundry")
 
         assert ids[:2] == ["gpt-5.6-sol", "kimi-k2.6"]
-        assert seen[0][1] == "" and seen[0][2] is sentinel_token_provider
+        assert seen[0][1] is sentinel_token_provider  # azure_detect mints the bearer from the callable
 
     def test_any_failure_keeps_the_static_empty_catalog(self, monkeypatch):
         from hermes_cli.models import provider_model_ids

--- a/tests/hermes_cli/test_azure_foundry_model_picker.py
+++ b/tests/hermes_cli/test_azure_foundry_model_picker.py
@@ -1,63 +1,63 @@
 """Azure Foundry in the /model picker (#27989).
 
 Deployments are per-resource so the static catalog is intentionally empty; ``provider_model_ids``
-must probe ``GET <base>/models`` through the runtime credential resolver (API key OR Entra ID
-token provider) and fall back to the static ``[]`` on any failure. No real endpoint is contacted.
+must list the resource's ``/openai/deployments`` through the runtime credential resolver (API key OR
+Entra ID token provider), fall back to ``/models`` only when that route is unavailable, and keep the
+static ``[]`` on any failure. Only the HTTP leaf is stubbed; no real endpoint is contacted.
 """
 
 from __future__ import annotations
 
 from unittest.mock import patch
 
-
-_FAKE_FOUNDRY_DEPLOYMENTS = [
-    "gpt-5.4",
-    "gpt-5.3-codex",
-    "kimi-k2.6",
-    "deepseek-v4-pro",
-    "grok-4.3",
-]
+_BASE = "https://r.openai.azure.com/openai/v1"
+_DEPLOYMENTS = {"data": [{"id": "gpt-5.6-sol", "status": "succeeded"}, {"id": "kimi-k2.6", "status": "succeeded"},
+                         {"id": "o4-mini", "status": "provisioning"}]}
+_CATALOG = {"object": "list", "data": [{"id": f"model-{i}"} for i in range(400)]}
 
 
-# ---------------------------------------------------------------------------
-# API-key auth — exercises the real runtime resolver end-to-end
-# ---------------------------------------------------------------------------
+def _http(routes):
+    """``_http_get_json`` stub keyed by URL substring; records the auth each call carried."""
+    seen = []
+
+    def fake(url, api_key, timeout=6.0, *, token_provider=None):
+        seen.append((url, api_key, token_provider))
+        for needle, (status, body) in routes.items():
+            if needle in url:
+                return status, body
+        return 404, None
+
+    return fake, seen
 
 
-class TestProviderModelIdsAzureFoundryApiKey:
-    """`provider_model_ids("azure-foundry")` populates from a live probe."""
-
-    def test_returns_live_discovered_ids_when_credentials_present(self, monkeypatch):
+class TestAzureFoundryPicker:
+    def test_lists_the_resource_deployments_not_the_whole_catalog(self, monkeypatch):
         from hermes_cli.models import provider_model_ids
 
         monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
-        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://r.openai.azure.com/openai/v1")
+        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", _BASE)
+        fake, seen = _http({"/openai/deployments?api-version=2023-03-15-preview": (200, _DEPLOYMENTS),
+                            "/models": (200, _CATALOG)})
 
-        with patch(
-            "hermes_cli.azure_detect._probe_openai_models",
-            return_value=(True, list(_FAKE_FOUNDRY_DEPLOYMENTS)),
-        ) as probe:
+        with patch("hermes_cli.azure_detect._http_get_json", fake):
             ids = provider_model_ids("azure-foundry")
 
-        assert ids == _FAKE_FOUNDRY_DEPLOYMENTS
-        probe.assert_called_once()
-        # API-key mode forwards the resolved string key positionally and
-        # leaves token_provider unset.
-        called_base, called_key = probe.call_args.args
-        assert called_base == "https://r.openai.azure.com/openai/v1"
-        assert called_key == "az-secret"
-        assert probe.call_args.kwargs.get("token_provider") is None
+        # Succeeded first, provisioning after; the 400-id catalog is never consulted.
+        assert ids == ["gpt-5.6-sol", "kimi-k2.6", "o4-mini"]
+        assert [u for u, *_ in seen] == ["https://r.openai.azure.com/openai/deployments?api-version=2023-03-15-preview"]
+        assert seen[0][1] == "az-secret"
 
+    def test_falls_back_to_models_when_the_deployments_route_is_unavailable(self, monkeypatch):
+        from hermes_cli.models import provider_model_ids
 
-class TestProviderModelIdsAzureFoundryEntraId:
-    """Entra ID resolves to a callable token provider, not a string key.
+        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
+        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://gateway.example/v1")
+        fake, _ = _http({"/models": (200, {"data": [{"id": "gpt-4.1"}]})})
 
-    The picker must route that callable to the probe via ``token_provider=``
-    so keyless (``model.auth_mode: entra_id``) users still see their
-    deployments instead of an empty picker.
-    """
+        with patch("hermes_cli.azure_detect._http_get_json", fake):
+            assert provider_model_ids("azure-foundry") == ["gpt-4.1"]
 
-    def test_entra_id_forwards_token_provider_to_probe(self, monkeypatch):
+    def test_entra_id_forwards_the_token_provider_instead_of_a_string_key(self, monkeypatch):
         from hermes_cli.models import provider_model_ids
 
         def sentinel_token_provider() -> str:
@@ -65,50 +65,53 @@ class TestProviderModelIdsAzureFoundryEntraId:
 
         def _fake_runtime(*, requested_provider, model_cfg, **_kw):
             assert requested_provider == "azure-foundry"
-            return {
-                "provider": "azure-foundry",
-                "api_mode": "chat_completions",
-                "base_url": "https://r.openai.azure.com/openai/v1",
-                "api_key": sentinel_token_provider,
-                "auth_mode": "entra_id",
-                "source": "entra_id",
-            }
+            return {"provider": "azure-foundry", "api_mode": "chat_completions", "base_url": _BASE,
+                    "api_key": sentinel_token_provider, "auth_mode": "entra_id", "source": "entra_id"}
 
-        monkeypatch.setattr(
-            "hermes_cli.runtime_provider._resolve_azure_foundry_runtime",
-            _fake_runtime,
-        )
+        monkeypatch.setattr("hermes_cli.runtime_provider._resolve_azure_foundry_runtime", _fake_runtime)
+        fake, seen = _http({"/openai/deployments": (200, _DEPLOYMENTS)})
 
-        with patch(
-            "hermes_cli.azure_detect._probe_openai_models",
-            return_value=(True, list(_FAKE_FOUNDRY_DEPLOYMENTS)),
-        ) as probe:
+        with patch("hermes_cli.azure_detect._http_get_json", fake):
             ids = provider_model_ids("azure-foundry")
 
-        assert ids == _FAKE_FOUNDRY_DEPLOYMENTS
-        probe.assert_called_once()
-        # The callable must be passed as token_provider; the positional
-        # api_key must NOT be the callable (the OpenAI SDK contract differs
-        # from the manual-probe contract).
-        called_base, called_key = probe.call_args.args
-        assert called_base == "https://r.openai.azure.com/openai/v1"
-        assert called_key == ""
-        assert probe.call_args.kwargs.get("token_provider") is sentinel_token_provider
+        assert ids[:2] == ["gpt-5.6-sol", "kimi-k2.6"]
+        assert seen[0][1] == "" and seen[0][2] is sentinel_token_provider
 
-
-class TestProviderModelIdsAzureFoundryFallback:
-    """Every credential/probe failure mode must yield the static ``[]``."""
-
-    def test_does_not_raise_when_probe_raises(self, monkeypatch):
+    def test_any_failure_keeps_the_static_empty_catalog(self, monkeypatch):
         from hermes_cli.models import provider_model_ids
 
         monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
-        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://r.openai.azure.com/openai/v1")
+        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", _BASE)
 
-        with patch(
-            "hermes_cli.azure_detect._probe_openai_models",
-            side_effect=RuntimeError("network down"),
-        ):
-            ids = provider_model_ids("azure-foundry")
+        with patch("hermes_cli.azure_detect._http_get_json", side_effect=RuntimeError("network down")):
+            assert provider_model_ids("azure-foundry") == []
 
-        assert ids == []  # graceful fallback
+        monkeypatch.delenv("AZURE_FOUNDRY_API_KEY")
+        assert provider_model_ids("azure-foundry") == []
+
+
+def test_entra_only_azure_foundry_row_reaches_the_picker_without_an_api_key(monkeypatch, tmp_path):
+    """Section 1 of the picker gates rows on an API-key env var; an Entra-configured Azure Foundry
+    profile has none and must still surface with its discovered deployments."""
+    import yaml
+
+    monkeypatch.delenv("AZURE_FOUNDRY_API_KEY", raising=False)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text(yaml.safe_dump({"model": {
+        "provider": "azure-foundry", "default": "gpt-5.6-sol", "base_url": _BASE, "auth_mode": "entra_id"}}))
+
+    def _fake_runtime(*, requested_provider, model_cfg, **_kw):
+        return {"provider": "azure-foundry", "api_mode": "chat_completions", "base_url": _BASE,
+                "api_key": lambda: "fresh-entra-jwt", "auth_mode": "entra_id", "source": "entra_id"}
+
+    monkeypatch.setattr("hermes_cli.runtime_provider._resolve_azure_foundry_runtime", _fake_runtime)
+    fake, _ = _http({"/openai/deployments": (200, _DEPLOYMENTS)})
+    from hermes_cli.model_switch_providers import list_authenticated_providers
+
+    with patch("hermes_cli.azure_detect._http_get_json", fake), patch("agent.models_dev.fetch_models_dev", return_value={
+            "azure": {"env": ["AZURE_FOUNDRY_API_KEY"], "name": "Azure", "models": {}}}):
+        rows = [r for r in list_authenticated_providers(for_picker=True) if r["slug"] == "azure-foundry"]
+
+    assert rows and rows[0]["models"][:2] == ["gpt-5.6-sol", "kimi-k2.6"]

--- a/tests/hermes_cli/test_azure_foundry_model_picker.py
+++ b/tests/hermes_cli/test_azure_foundry_model_picker.py
@@ -1,31 +1,8 @@
-"""Tests for Azure Foundry integration in the /model picker (#27989).
+"""Azure Foundry in the /model picker (#27989).
 
-`provider_model_ids("azure-foundry")` used to fall straight through to the
-static `_PROVIDER_MODELS["azure-foundry"] = []` table, so the in-app
-``/model azure-foundry`` picker reported "0 models" even when the user's
-Foundry resource exposed many deployments.
-
-This file pins the live-discovery branch added to ``hermes_cli.models``,
-which routes through the runtime credential resolver
-(``hermes_cli.runtime_provider._resolve_azure_foundry_runtime``) so the
-picker probes the exact resource inference will hit and honours BOTH auth
-modes:
-
-  * **API key** — ``AZURE_FOUNDRY_API_KEY`` (``.env`` or process env). The
-    resolved string key is forwarded to
-    ``hermes_cli.azure_detect._probe_openai_models``.
-  * **Microsoft Entra ID** (``model.auth_mode: entra_id``) — the resolver
-    returns a *callable* token provider instead of a string. The picker
-    must detect the callable and forward it via ``token_provider=`` so the
-    probe mints a fresh bearer JWT (regression for the keyless path
-    flagged in review of #28006).
-
-Any failure (missing credentials, ``azure-identity`` not installed,
-network error, empty list) must fall back to the static (empty) catalog
-without raising.
-
-No real Azure endpoint is contacted — every test stubs the probe and/or
-the runtime resolver.
+Deployments are per-resource so the static catalog is intentionally empty; ``provider_model_ids``
+must probe ``GET <base>/models`` through the runtime credential resolver (API key OR Entra ID
+token provider) and fall back to the static ``[]`` on any failure. No real endpoint is contacted.
 """
 
 from __future__ import annotations
@@ -70,58 +47,6 @@ class TestProviderModelIdsAzureFoundryApiKey:
         assert called_base == "https://r.openai.azure.com/openai/v1"
         assert called_key == "az-secret"
         assert probe.call_args.kwargs.get("token_provider") is None
-
-    def test_prefers_config_base_url_over_env_var(self, monkeypatch):
-        """Picker must target the same resource inference would (config wins)."""
-        from hermes_cli.models import provider_model_ids
-
-        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
-        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://env.example/v1")
-        monkeypatch.setattr(
-            "hermes_cli.config.load_config",
-            lambda: {
-                "model": {
-                    "provider": "azure-foundry",
-                    "base_url": "https://config.example/openai/v1",
-                }
-            },
-        )
-
-        with patch(
-            "hermes_cli.azure_detect._probe_openai_models",
-            return_value=(True, ["gpt-5.4"]),
-        ) as probe:
-            ids = provider_model_ids("azure-foundry")
-
-        assert ids == ["gpt-5.4"]
-        called_base, _ = probe.call_args.args
-        assert called_base == "https://config.example/openai/v1"
-
-    def test_reads_api_key_from_dotenv_when_env_missing(self, monkeypatch):
-        """`.env` API keys must be honoured even when the process env is empty."""
-        from hermes_cli.models import provider_model_ids
-
-        monkeypatch.delenv("AZURE_FOUNDRY_API_KEY", raising=False)
-        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://r.openai.azure.com/openai/v1")
-        monkeypatch.setattr(
-            "hermes_cli.config.get_env_value",
-            lambda key: "dotenv-secret" if key == "AZURE_FOUNDRY_API_KEY" else "",
-        )
-
-        with patch(
-            "hermes_cli.azure_detect._probe_openai_models",
-            return_value=(True, ["gpt-5.4"]),
-        ) as probe:
-            ids = provider_model_ids("azure-foundry")
-
-        assert ids == ["gpt-5.4"]
-        _, called_key = probe.call_args.args
-        assert called_key == "dotenv-secret"
-
-
-# ---------------------------------------------------------------------------
-# Microsoft Entra ID auth — the keyless path teknium flagged in review
-# ---------------------------------------------------------------------------
 
 
 class TestProviderModelIdsAzureFoundryEntraId:
@@ -170,118 +95,9 @@ class TestProviderModelIdsAzureFoundryEntraId:
         assert called_key == ""
         assert probe.call_args.kwargs.get("token_provider") is sentinel_token_provider
 
-    def test_entra_id_probe_failure_falls_back_to_static(self, monkeypatch):
-        from hermes_cli.models import provider_model_ids
-
-        def _fake_runtime(*, requested_provider, model_cfg, **_kw):
-            return {
-                "provider": "azure-foundry",
-                "api_mode": "chat_completions",
-                "base_url": "https://r.openai.azure.com/openai/v1",
-                "api_key": lambda: "fresh-entra-jwt",
-                "auth_mode": "entra_id",
-                "source": "entra_id",
-            }
-
-        monkeypatch.setattr(
-            "hermes_cli.runtime_provider._resolve_azure_foundry_runtime",
-            _fake_runtime,
-        )
-
-        with patch(
-            "hermes_cli.azure_detect._probe_openai_models",
-            side_effect=RuntimeError("token chain exhausted"),
-        ):
-            ids = provider_model_ids("azure-foundry")
-
-        assert ids == []  # graceful fallback, no AuthError leaks into the picker
-
-
-# ---------------------------------------------------------------------------
-# Graceful degradation — missing creds, bad probe results, foreign providers
-# ---------------------------------------------------------------------------
-
 
 class TestProviderModelIdsAzureFoundryFallback:
     """Every credential/probe failure mode must yield the static ``[]``."""
-
-    def test_ignores_config_base_url_for_non_foundry_provider(self, monkeypatch):
-        """A `model.base_url` set for a different provider must not leak through."""
-        from hermes_cli.models import provider_model_ids
-
-        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
-        monkeypatch.delenv("AZURE_FOUNDRY_BASE_URL", raising=False)
-        # User's main provider is custom; the URL belongs to that endpoint.
-        monkeypatch.setattr(
-            "hermes_cli.config.load_config",
-            lambda: {"model": {"provider": "custom", "base_url": "https://localhost:8000/v1"}},
-        )
-
-        with patch("hermes_cli.azure_detect._probe_openai_models") as probe:
-            ids = provider_model_ids("azure-foundry")
-
-        # No base_url for azure-foundry → resolver raises → probe never runs.
-        probe.assert_not_called()
-        assert ids == []
-
-    def test_falls_back_to_static_when_api_key_missing(self, monkeypatch):
-        from hermes_cli.models import provider_model_ids
-
-        monkeypatch.delenv("AZURE_FOUNDRY_API_KEY", raising=False)
-        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://r.openai.azure.com/openai/v1")
-        # Pin `.env` resolver to empty so we don't read a real key from disk.
-        monkeypatch.setattr("hermes_cli.config.get_env_value", lambda _k: "")
-
-        with patch("hermes_cli.azure_detect._probe_openai_models") as probe:
-            ids = provider_model_ids("azure-foundry")
-
-        probe.assert_not_called()
-        assert ids == []
-
-    def test_falls_back_to_static_when_base_url_missing(self, monkeypatch):
-        from hermes_cli.models import provider_model_ids
-
-        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
-        monkeypatch.delenv("AZURE_FOUNDRY_BASE_URL", raising=False)
-        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {}})
-
-        with patch("hermes_cli.azure_detect._probe_openai_models") as probe:
-            ids = provider_model_ids("azure-foundry")
-
-        probe.assert_not_called()
-        assert ids == []
-
-    def test_falls_back_to_static_when_probe_returns_not_ok(self, monkeypatch):
-        from hermes_cli.models import provider_model_ids
-
-        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
-        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://r.openai.azure.com/openai/v1")
-
-        with patch(
-            "hermes_cli.azure_detect._probe_openai_models",
-            return_value=(False, []),
-        ):
-            ids = provider_model_ids("azure-foundry")
-
-        assert ids == []
-
-    def test_falls_back_to_static_when_probe_returns_empty_list(self, monkeypatch):
-        """A 200 OK with an OpenAI-shaped empty list must not block the picker."""
-        from hermes_cli.models import provider_model_ids
-
-        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-secret")
-        monkeypatch.setenv("AZURE_FOUNDRY_BASE_URL", "https://r.openai.azure.com/openai/v1")
-
-        with patch(
-            "hermes_cli.azure_detect._probe_openai_models",
-            return_value=(True, []),
-        ):
-            ids = provider_model_ids("azure-foundry")
-
-        # ok=True but ids=[]; gracefully fall through rather than returning the
-        # empty live result and shadowing the static [] (semantically identical
-        # here, but the contract is "fall through, not crash").
-        assert ids == []
 
     def test_does_not_raise_when_probe_raises(self, monkeypatch):
         from hermes_cli.models import provider_model_ids


### PR DESCRIPTION
`/model azure-foundry` (CLI, TUI, desktop picker) now lists the deployments the configured credential can see instead of "0 models".

Based on #28006 by @xxxigm — cherry-picked so authorship is preserved; the branch predates the catalog dispatch-table refactor, so the contributor's `if normalized == "azure-foundry"` branch was re-homed as an `_azure_foundry_catalog` entry in `_PROVIDER_CATALOG_FETCHERS`. Closes #27989.

## Root cause

Azure Foundry deployments are per-resource, so `_PROVIDER_MODELS["azure-foundry"]` is (correctly) empty — but unlike every other API-key provider there was no live fetcher, and the generic `_profile_live_catalog` bails because the provider profile has no fixed `base_url`.

## Changes

- `hermes_cli/models.py`: `_azure_foundry_catalog` routes through `_resolve_azure_foundry_runtime` (honours API key AND `auth_mode: entra_id`, whose resolver hands back a callable token provider) and probes `GET <base>/models` with the wizard's existing `_probe_openai_models`. `None` on any miss keeps the static fallback.
- `tests/hermes_cli/test_azure_foundry_model_picker.py`: 3 invariants — API-key live path, Entra token-provider routing, probe failure → `[]` (trimmed from the contributor's 11; the rest re-tested the resolver).

## Validation

| Check | Result |
|---|---|
| Live repro (origin/main) | `provider_model_ids("azure-foundry")` → `[]` with key + base URL set |
| E2E (real imports, temp `HERMES_HOME`, only the HTTP leaf stubbed) | probe hits `<base>/models` with the auth header → 3 deployment ids; unconfigured → `[]`; probe failure → `[]` |
| Mutation | `models.py` reverted to main → 4 red; restored → green |
| `scripts/run_tests.sh tests/hermes_cli/test_models.py tests/hermes_cli/test_azure_foundry_model_picker.py` | 91 passed |
| ruff, windows-footguns, compat-pointers, `git diff --check` | clean |

Follow-ups folded in after review (all mutation-checked red→green):
- Lists the resource's `/openai/deployments` (what the portal shows and inference accepts) instead of `/openai/v1/models`, which on Azure hosts is Microsoft's ~400-id platform catalog (embeddings/TTS/image the resource never deployed) — data points from @realchrisolin and @ionescudumitru24-lgtm on #28006. `/models` stays the fallback for gateways without that route.
- Entra-only profiles (`model.auth_mode: entra_id`, no `AZURE_FOUNDRY_API_KEY`) now reach the picker row — @teknium1's inline finding on #28006.
- CLI `/model` picker uses the disk-cached live catalog (`cached_provider_model_ids`, same as dashboard/gateway pickers) so an empty static catalog no longer runs the live probe synchronously on every select.
