### PR TITLE
Desktop: a rotated remote session token asks for a new token instead of connecting forever (#100530, supersedes #100629)

### DIFF
--- a/apps/desktop/electron/backend-health.test.ts
+++ b/apps/desktop/electron/backend-health.test.ts
@@ -12,6 +12,8 @@ import {
   isServerSideHttpError,
   makeNousCloudBackendDownError,
   makeUnsignedOauthError,
+  REMOTE_TOKEN_REJECTED_MESSAGE,
+  REMOTE_TOKEN_VERIFY_PATH,
   waitForHermesReady
 } from './backend-health'
 
@@ -541,4 +543,58 @@ test('makeNousCloudBackendDownError preserves legacy string-prefix compatibility
   assert.ok(result)
   assert.equal((result as any).isCloudBackendDown, true)
   assert.equal((result as any).statusCode, 503)
+})
+
+test('FIX #100530: a remote token connection proves its credential against a gated route after readiness', async () => {
+  // /api/health is public, so a rotated session token sails through readiness;
+  // the verify hop is the only place a token 401 can be observed before the WS
+  // upgrade (which browsers report as an anonymous handshake error).
+  const calls: string[] = []
+
+  const error = await waitForHermesReady('http://gateway.example', {
+    token: 'stale',
+    fetchPublicJson: async () => ({ ok: true }),
+    probeHealth: async url => {
+      calls.push(url)
+
+      return { ok: true }
+    },
+    probeIsCredentialed: true,
+    fetchJson: async url => {
+      calls.push(url)
+      throw new Error('401: {"detail":"Unauthorized"}')
+    },
+    verifyCredentialPath: REMOTE_TOKEN_VERIFY_PATH,
+    credentialRejectedMessage: REMOTE_TOKEN_REJECTED_MESSAGE,
+    sleep: async () => {},
+    timeoutMs: 100,
+    pollMs: 1
+  }).then(
+    () => null,
+    (err: unknown) => err
+  )
+
+  assert.deepEqual(calls, ['http://gateway.example/api/health', `http://gateway.example${REMOTE_TOKEN_VERIFY_PATH}`])
+  assert.equal(isReauthRequiredError(error), true, 'a rejected token latches like an expired OAuth session')
+  assert.equal((error as Error).message, REMOTE_TOKEN_REJECTED_MESSAGE)
+})
+
+test('FIX #100530: the credential verify hop ignores everything but a confirmed 401/403', async () => {
+  // Older backends 404 the verify route; a 5xx is the backend's problem, not
+  // the credential's. Both must leave a ready backend ready.
+  for (const failure of ['404: {"detail":"Not Found"}', '503: unavailable', 'read ECONNRESET']) {
+    await waitForHermesReady('http://gateway.example', {
+      token: 'fine',
+      fetchPublicJson: async () => ({ ok: true }),
+      probeHealth: async () => ({ ok: true }),
+      probeIsCredentialed: true,
+      fetchJson: async () => {
+        throw new Error(failure)
+      },
+      verifyCredentialPath: REMOTE_TOKEN_VERIFY_PATH,
+      sleep: async () => {},
+      timeoutMs: 100,
+      pollMs: 1
+    })
+  }
 })

--- a/apps/desktop/electron/backend-health.ts
+++ b/apps/desktop/electron/backend-health.ts
@@ -33,10 +33,29 @@ export interface HermesReadyOptions {
    * two very different meanings of a 401 (see `waitForHermesReady`).
    */
   probeIsCredentialed?: boolean
+  /**
+   * A GATED route to hit once with `fetchJson` after the backend answers
+   * ready. `/api/health` and `/api/status` are public, so a credential the
+   * gateway no longer accepts (the loopback session token rotates on every
+   * dashboard restart) sails through readiness and only fails at the WS
+   * upgrade — which browsers report as an anonymous handshake error, so the
+   * renderer redials forever (#100530). A 401/403 here is the confirmed
+   * rejection; any other failure (404 on an older backend, 5xx) is ignored.
+   */
+  verifyCredentialPath?: string
+  /** Message for the reauth error thrown when `verifyCredentialPath` is rejected. */
+  credentialRejectedMessage?: string
 }
 
 export const REMOTE_SESSION_EXPIRED_MESSAGE =
   'Your remote gateway session has expired. Open Settings → Gateway and click "Sign in" again.'
+
+// Cheapest session-token-gated GET that every backend since mid-2026 serves:
+// a DB count, no bodies, no config. Public routes cannot prove a credential.
+export const REMOTE_TOKEN_VERIFY_PATH = '/api/sessions/empty/count'
+
+export const REMOTE_TOKEN_REJECTED_MESSAGE =
+  "This connection's session token was rejected. Open Settings → Gateway and paste a new session token."
 
 export const REMOTE_UNSIGNED_OAUTH_MESSAGE =
   'Remote Hermes gateway uses OAuth, but you are not signed in. ' +
@@ -192,8 +211,8 @@ export function isGatedMissingHealthError(error: unknown): boolean {
 }
 
 /** Tag a terminal reauth failure the main process latches and the overlay keys on. */
-export function makeReauthRequiredError(detail?: string): Error {
-  const error = new Error(REMOTE_SESSION_EXPIRED_MESSAGE) as any
+export function makeReauthRequiredError(detail?: string, message = REMOTE_SESSION_EXPIRED_MESSAGE): Error {
+  const error = new Error(message) as any
   error.needsOauthLogin = true
   error.isReauthRequired = true
 
@@ -228,6 +247,19 @@ function supersededError() {
   error.kind = 'superseded'
 
   return error
+}
+
+async function verifyCredential(url: string, options: HermesReadyOptions, timeoutMs: number): Promise<void> {
+  try {
+    await options.fetchJson(url, options.token, { timeoutMs })
+  } catch (error) {
+    if (isAuthRejectionError(error)) {
+      throw makeReauthRequiredError(
+        error instanceof Error ? error.message : String(error),
+        options.credentialRejectedMessage
+      )
+    }
+  }
 }
 
 export async function waitForHermesReady(baseUrl: string, options: HermesReadyOptions): Promise<void> {
@@ -270,8 +302,6 @@ export async function waitForHermesReady(baseUrl: string, options: HermesReadyOp
       } else {
         await probeHealth(`${base}/api/health`, { timeoutMs: healthProbeTimeoutMs })
       }
-
-      return
     } catch (error) {
       lastError = error
 
@@ -298,7 +328,17 @@ export async function waitForHermesReady(baseUrl: string, options: HermesReadyOp
       }
 
       await sleep(pollMs)
+
+      continue
     }
+
+    // Outside the retry loop's catch on purpose: a confirmed rejection here
+    // is terminal, not another transient miss to poll past.
+    if (options.verifyCredentialPath) {
+      await verifyCredential(`${base}${options.verifyCredentialPath}`, options, healthProbeTimeoutMs)
+    }
+
+    return
   }
 
   const detail = lastError instanceof Error ? lastError.message : 'timeout'

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -49,9 +49,12 @@ import { createBackendConnectionState } from './backend-connection-state'
 import { BackendDialClaims } from './backend-dial-claim'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
 import {
+  type HermesReadyOptions,
   isReauthRequiredError,
   makeNousCloudBackendDownError,
   makeUnsignedOauthError,
+  REMOTE_TOKEN_REJECTED_MESSAGE,
+  REMOTE_TOKEN_VERIFY_PATH,
   waitForHermesReady
 } from './backend-health'
 import { backendCommandMatches, createBackendOwnership, createBackendShutdownCoordinator } from './backend-ownership'
@@ -6519,7 +6522,7 @@ async function buildReadinessHealthProbe(baseUrl, authMode, token) {
   return { probeHealth: fetchPublicJson, probeIsCredentialed: false }
 }
 
-async function waitForHermes(baseUrl, token, signal?, authMode?, headers = {}) {
+async function waitForHermes(baseUrl, token, signal?, authMode?, headers = {}, verify: Partial<HermesReadyOptions> = {}) {
   const { probeHealth, probeIsCredentialed } = await buildReadinessHealthProbe(baseUrl, authMode, token)
 
   return waitForHermesReady(baseUrl, {
@@ -6530,8 +6533,25 @@ async function waitForHermes(baseUrl, token, signal?, authMode?, headers = {}) {
       ? (url, _token, options = {}) => probeHealth(url, requestOptionsWithHeaders(options, headers))
       : fetchJson,
     probeHealth: (url, options = {}) => probeHealth(url, requestOptionsWithHeaders(options, headers)),
-    probeIsCredentialed
+    probeIsCredentialed,
+    ...(probeIsCredentialed ? verify : {})
   })
+}
+
+// A remote gateway (URL / registry / SSH tunnel) token must be PROVEN against a
+// gated route once the backend answers ready: `/api/health` and `/api/status`
+// are public, the loopback session token rotates on every dashboard restart,
+// and the WS upgrade's rejection reaches the renderer as an anonymous handshake
+// error — without this the renderer redials the stale token forever (#100530).
+// OAuth connections prove theirs at the WS-ticket mint; local children mint
+// their own token and never rotate it underneath a running app.
+async function waitForRemoteHermes(remote: { baseUrl: string; token?: string; authMode?: string; headers?: Record<string, string> }) {
+  const verify =
+    remote.authMode === 'token'
+      ? { verifyCredentialPath: REMOTE_TOKEN_VERIFY_PATH, credentialRejectedMessage: REMOTE_TOKEN_REJECTED_MESSAGE }
+      : {}
+
+  return waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode, remote.headers, verify)
 }
 
 function getWindowButtonPosition(win = mainWindow) {
@@ -11939,7 +11959,7 @@ async function connectRegistryBackend(
     source.headers
   )
 
-  await waitForHermes(connection.baseUrl, connection.token, undefined, connection.authMode, connection.headers)
+  await waitForRemoteHermes(connection)
   poolEntry.remoteBaseUrl = connection.baseUrl
 
   return {
@@ -12606,7 +12626,7 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   profileDeletionGate.assertCanStart(profile)
 
   if (remote) {
-    await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode, remote.headers)
+    await waitForRemoteHermes(remote)
 
     // Recorded on the entry so revalidation can probe this descriptor without
     // awaiting connectionPromise, which may still be pending for a sibling.
@@ -13024,7 +13044,7 @@ async function startHermes() {
       }
 
       await advanceBootProgress('backend.remote', `Connecting to remote Hermes backend at ${remote.baseUrl}`, 24)
-      await waitForHermes(remote.baseUrl, remote.token, undefined, remote.authMode, remote.headers)
+      await waitForRemoteHermes(remote)
 
       // Second async boundary: the health probe itself can outlive the
       // attempt. A late success here must not publish a stale descriptor.

--- a/apps/desktop/src/components/boot-failure-reauth.test.ts
+++ b/apps/desktop/src/components/boot-failure-reauth.test.ts
@@ -191,3 +191,14 @@ describe('signInLabel', () => {
     expect(signInLabel(null)).toBe('Sign in with your identity provider')
   })
 })
+
+describe('token rejection (#100530)', () => {
+  it('a rejected session token is auth-shaped: it escalates post-boot instead of staying in the reconnect loop', () => {
+    const message = "This connection's session token was rejected. Open Settings → Gateway and paste a new session token."
+
+    expect(isRemoteReauthError(message)).toBe(true)
+    expect(shouldApplyPostBootProgressError(message)).toBe(true)
+    // …but it is NOT an OAuth sign-in: the token overlay keeps Gateway settings / Retry / Use local.
+    expect(isRemoteReauthFailure(config({ remoteAuthMode: 'token', remoteOauthConnected: false }), message)).toBe(false)
+  })
+})

--- a/apps/desktop/src/components/boot-failure-reauth.ts
+++ b/apps/desktop/src/components/boot-failure-reauth.ts
@@ -56,6 +56,7 @@ export function isRemoteReauthError(error: string | null | undefined): boolean {
     text.includes('remote gateway session has expired') ||
     text.includes('gateway sign-in required') ||
     text.includes('needs oauth login') ||
+    text.includes('session token was rejected') ||
     (text.includes('oauth') && (text.includes('not signed in') || text.includes('sign in')))
   )
 }


### PR DESCRIPTION
A remote token-mode gateway whose session token rotated (every dashboard restart / upgrade) now boots into the recovery overlay saying "session token was rejected — paste a new one", instead of spinning on "connecting" forever.

Fixes #100530. Supersedes #100629 by @686f6c61 (credit for the diagnosis and the token-mode `resolveGatewayWsUrl` finding — see the PR comment for why its mechanism could not work).

Stacked on #107990 (the OAuth reauth latch) — the same `isReauthRequired` latch + non-retryable boot progress is what holds the overlay stable here. Only the top commit is new; it will rebase to a 1-commit diff once that lands.

## Root cause

The desktop's readiness probes hit `/api/health` and `/api/status`, both in `PUBLIC_API_PATHS`, so a stale session token passes readiness. The only place it fails is the `/api/ws` upgrade, which the gateway rejects *pre-accept* (`ws.close(code=4401)` → uvicorn emits an HTTP 403 handshake). Browsers surface that as an anonymous `error` + close 1006 — no status, no close code — so the renderer's reconnect loop classified it as transport and redialled the same stale URL indefinitely.

## Change

`backend-health.ts::waitForHermesReady` gains an optional `verifyCredentialPath`: after the backend answers ready, hit it ONCE with the connection's credentials. A 401/403 throws `makeReauthRequiredError(REMOTE_TOKEN_REJECTED_MESSAGE)` — the same tag `startHermes` already latches for OAuth — and the renderer's existing `isRemoteReauthError` now recognises the message so a post-boot rotation escalates to the overlay too. 404 (older backend) / 5xx / transport leave readiness untouched.

`main.ts::waitForHermes` enables it only for REMOTE token connections (`/api/sessions/empty/count`, the cheapest gated GET). OAuth connections already prove their credential at the WS-ticket mint; local children mint their own token and never rotate it under a running app.

## Validation

| Check | Result |
|---|---|
| Live probe vs a real `hermes serve` (token mode) | `/api/health`, `/api/status` → 200 with a stale token; `/api/sessions/empty/count` → 401; WS upgrade → HTTP 403, no close code |
| E2E vs a real `hermes serve` | stale token, without verify → READY (the bug); with verify → `isReauthRequired` + the paste-token message; good token → READY both ways |
| Mutation | verify hop removed → the new test goes red |
| `vitest --project electron` | 2161 passed; 3 failures in untouched files (`git-review-ops`, `managed-ssh-update`, `remote-lifecycle`) reproduce independently of this diff |
| `main-boot-smoke.sh` | OK: main process booted |

Review follow-up: the readiness loop no longer needs a `ready` flag (the catch `continue`s); `verifyCredential` takes the resolved probe timeout; the three remote call sites go through `waitForRemoteHermes(remote)` instead of a 6th positional options bag.
