### PR TITLE
fix(desktop): older session history stays reachable across scope spellings and backends (salvage #107839)

### DIFF
--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -86,6 +86,25 @@ export function connectionScoped(): { connectionId?: string } {
   return _apiConnectionId ? { connectionId: _apiConnectionId } : {}
 }
 
+// Whether the window's primary connection is the local pool. Pushed from
+// store/session's setConnection (same no-store-import contract as _apiProfile)
+// so api/ helpers can name the backend an UNTAGGED request lands on without
+// importing the heavy session store — which would close a module cycle
+// through @/hermes.
+let _apiLocalMode = false
+
+export function setApiRequestLocalMode(local: boolean): void {
+  _apiLocalMode = local
+}
+
+/** The connection an ambient (untagged) request is served by: the registry
+ *  tag when one is active, else `'local'` for the local pool. Identity only —
+ *  never send this as a request pin (an explicit `'local'` bypasses Electron's
+ *  legacy per-profile remote overrides). */
+export function ambientOwnerConnectionId(): string | undefined {
+  return _apiConnectionId ?? (_apiLocalMode ? 'local' : undefined)
+}
+
 /** Send a REST request to the renderer's active registry source. Request-level
  *  routing may override the active source for an explicitly-owned resource.
  *

--- a/apps/desktop/src/api/session-transcript-paging.test.ts
+++ b/apps/desktop/src/api/session-transcript-paging.test.ts
@@ -6,11 +6,10 @@ import {
   transcriptBackfillAvailable
 } from '@/app/chat/transcript-backfill'
 import { toChatMessages } from '@/lib/chat-messages'
-import { $connection } from '@/store/session'
 import { $transcriptTailBySessionId, transcriptTailState } from '@/store/transcript-tail'
 import type { SessionMessagesResponse } from '@/types/hermes'
 
-import { setApiRequestConnection, setApiRequestProfile } from './client'
+import { setApiRequestConnection, setApiRequestLocalMode, setApiRequestProfile } from './client'
 import { getLatestSessionMessages, LATEST_SESSION_MESSAGES_LIMIT } from './sessions'
 
 // Zero timestamps use the conversion-time clock for IDs; keep fixtures stable.
@@ -31,11 +30,11 @@ describe('session transcript pagination ownership', () => {
     $transcriptTailBySessionId.set({})
     Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: { api } })
     setApiRequestProfile('default')
-    $connection.set({ mode: 'local' } as NonNullable<ReturnType<typeof $connection.get>>)
+    setApiRequestLocalMode(true)
   })
 
   afterEach(() => {
-    $connection.set(null)
+    setApiRequestLocalMode(false)
     setApiRequestConnection(null)
     setApiRequestProfile(null)
     Reflect.deleteProperty(window, 'hermesDesktop')

--- a/apps/desktop/src/api/session-transcript-paging.test.ts
+++ b/apps/desktop/src/api/session-transcript-paging.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  backfillOlderTranscriptPage,
+  mergeOlderTranscriptPage,
+  transcriptBackfillAvailable
+} from '@/app/chat/transcript-backfill'
+import { toChatMessages } from '@/lib/chat-messages'
+import { $connection } from '@/store/session'
+import { $transcriptTailBySessionId, transcriptTailState } from '@/store/transcript-tail'
+import type { SessionMessagesResponse } from '@/types/hermes'
+
+import { setApiRequestConnection, setApiRequestProfile } from './client'
+import { getLatestSessionMessages, LATEST_SESSION_MESSAGES_LIMIT } from './sessions'
+
+const row = (id: number) => ({ id, role: 'user' as const, content: `message ${id}`, timestamp: id })
+
+const page = (messages: ReturnType<typeof row>[], offset = 0): SessionMessagesResponse => ({
+  session_id: 'stored-session',
+  profile: 'default',
+  messages,
+  pagination: { limit: LATEST_SESSION_MESSAGES_LIMIT, offset, order: 'latest', returned: messages.length }
+})
+
+describe('session transcript pagination ownership', () => {
+  const api = vi.fn()
+
+  beforeEach(() => {
+    api.mockReset()
+    $transcriptTailBySessionId.set({})
+    Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: { api } })
+    setApiRequestProfile('default')
+    $connection.set({ mode: 'local' } as NonNullable<ReturnType<typeof $connection.get>>)
+  })
+
+  afterEach(() => {
+    $connection.set(null)
+    setApiRequestConnection(null)
+    setApiRequestProfile(null)
+    Reflect.deleteProperty(window, 'hermesDesktop')
+  })
+
+  it.each(['local', null])(
+    'keeps older history reachable across scope spellings on connection %s',
+    async connectionId => {
+      setApiRequestConnection(connectionId)
+      const owner = { connectionId: 'local', profile: 'default' }
+      const older = Array.from({ length: 79 }, (_, index) => row(index + 1))
+      const tail = Array.from({ length: LATEST_SESSION_MESSAGES_LIMIT }, (_, index) => row(older.length + index + 1))
+      api.mockResolvedValue(page(tail))
+
+      // Resume, post-turn hydration, and background refresh use different scope
+      // spellings, but all three requests go to the same owning backend.
+      for (const scope of [owner, 'default', undefined]) {
+        await getLatestSessionMessages('stored-session', scope)
+      }
+
+      expect(Object.keys($transcriptTailBySessionId.get())).toHaveLength(1)
+      expect(transcriptBackfillAvailable('stored-session', owner)).toBe(true)
+      expect(transcriptBackfillAvailable('stored-session')).toBe(true)
+
+      let messages = toChatMessages(tail)
+      api.mockResolvedValueOnce(page(older, tail.length))
+      expect(
+        await backfillOlderTranscriptPage({
+          storedSessionId: 'stored-session',
+          profile: owner,
+          isCurrent: () => true,
+          applyOlderPage: earlier => {
+            messages = mergeOlderTranscriptPage(messages, earlier)
+          }
+        })
+      ).toBe(true)
+
+      // Resolve the owner for lookup, but replay the exact ambient read route.
+      expect(api).toHaveBeenLastCalledWith({
+        ...(connectionId ? { connectionId } : {}),
+        path: `/api/sessions/stored-session/messages?limit=${LATEST_SESSION_MESSAGES_LIMIT}&offset=${tail.length}&order=latest&include_compacted=true`
+      })
+      expect(messages.map(message => message.rowId)).toEqual([...older, ...tail].map(message => message.id))
+      expect(transcriptBackfillAvailable('stored-session', owner)).toBe(false)
+    }
+  )
+
+  it('preserves legacy named-profile routing while the foreground is local', async () => {
+    setApiRequestConnection(null)
+    const profile = 'remote-alias'
+    const owner = { connectionId: 'local', profile }
+    const tail = Array.from({ length: LATEST_SESSION_MESSAGES_LIMIT }, (_, index) => row(index + 2))
+    api.mockResolvedValueOnce({ ...page(tail), profile: 'work' })
+
+    await getLatestSessionMessages('stored-session', profile)
+
+    // An explicit local pin would bypass Electron's per-profile remote override.
+    expect.soft(api).toHaveBeenLastCalledWith({
+      profile,
+      path: `/api/sessions/stored-session/messages?profile=${profile}&limit=${LATEST_SESSION_MESSAGES_LIMIT}&order=latest&include_compacted=true`
+    })
+    expect(transcriptBackfillAvailable('stored-session', owner)).toBe(true)
+
+    const applyOlderPage = vi.fn()
+    api.mockResolvedValueOnce({ ...page([row(1)], tail.length), profile: 'work' })
+    expect(
+      await backfillOlderTranscriptPage({
+        storedSessionId: 'stored-session',
+        profile: owner,
+        isCurrent: () => true,
+        applyOlderPage
+      })
+    ).toBe(true)
+
+    expect(api).toHaveBeenLastCalledWith({
+      profile,
+      path: `/api/sessions/stored-session/messages?profile=${profile}&limit=${LATEST_SESSION_MESSAGES_LIMIT}&offset=${tail.length}&order=latest&include_compacted=true`
+    })
+    expect(applyOlderPage).toHaveBeenCalledWith(toChatMessages([row(1)]))
+    expect(transcriptTailState('stored-session', owner)).toMatchObject({
+      nextOffset: tail.length + 1,
+      possiblyTruncated: false,
+      profile: { profile }
+    })
+  })
+
+  it.each(['work', null])(
+    'isolates an ambient %s profile across explicit reads and gateway switches',
+    async servingProfile => {
+      setApiRequestConnection('source-a')
+      const tail = page(Array.from({ length: LATEST_SESSION_MESSAGES_LIMIT }, (_, index) => row(index + 1)))
+      let resolve!: (value: SessionMessagesResponse) => void
+      api.mockReturnValueOnce(
+        new Promise<SessionMessagesResponse>(done => {
+          resolve = done
+        })
+      )
+      const pending = getLatestSessionMessages('stored-session')
+      api.mockResolvedValueOnce(page([row(1)]))
+      await getLatestSessionMessages('stored-session', { connectionId: 'source-a', profile: 'default' })
+
+      setApiRequestConnection('source-b')
+      api.mockResolvedValueOnce(page([row(1)]))
+      await getLatestSessionMessages('stored-session', { connectionId: 'source-b', profile: 'default' })
+      resolve({ ...tail, profile: servingProfile })
+      await pending
+
+      const ownerA = { connectionId: 'source-a', profile: servingProfile || undefined }
+      const ownerB = { connectionId: 'source-b', profile: 'default' }
+      expect(transcriptTailState('stored-session', ownerA)).toMatchObject({
+        possiblyTruncated: true,
+        profile: { connectionId: 'source-a' }
+      })
+      expect(transcriptTailState('stored-session', { connectionId: 'source-a', profile: 'default' })).toMatchObject({
+        possiblyTruncated: false
+      })
+      expect(transcriptTailState('stored-session', ownerB)).toMatchObject({ possiblyTruncated: false, profile: ownerB })
+      expect(transcriptTailState('stored-session')).toBeUndefined()
+
+      const defaultA = transcriptTailState('stored-session', { connectionId: 'source-a', profile: 'default' })
+      const defaultB = transcriptTailState('stored-session', ownerB)
+      const applyOlderPage = vi.fn()
+      api.mockResolvedValueOnce({ ...page([row(0)], tail.messages.length), profile: servingProfile })
+      expect(
+        await backfillOlderTranscriptPage({
+          storedSessionId: 'stored-session',
+          profile: ownerA,
+          isCurrent: () => true,
+          applyOlderPage
+        })
+      ).toBe(true)
+
+      // Serving-profile metadata selects the cache entry, not the request route.
+      expect(api).toHaveBeenLastCalledWith({
+        connectionId: 'source-a',
+        path: `/api/sessions/stored-session/messages?limit=${LATEST_SESSION_MESSAGES_LIMIT}&offset=${tail.messages.length}&order=latest&include_compacted=true`
+      })
+      expect(applyOlderPage).toHaveBeenCalledWith(toChatMessages([row(0)]))
+      expect(transcriptTailState('stored-session', ownerA)).toEqual({
+        nextOffset: tail.messages.length + 1,
+        possiblyTruncated: false,
+        profile: { connectionId: 'source-a' }
+      })
+      expect(transcriptTailState('stored-session', { connectionId: 'source-a', profile: 'default' })).toBe(defaultA)
+      expect(transcriptTailState('stored-session', ownerB)).toBe(defaultB)
+    }
+  )
+})

--- a/apps/desktop/src/api/session-transcript-paging.test.ts
+++ b/apps/desktop/src/api/session-transcript-paging.test.ts
@@ -82,6 +82,23 @@ describe('session transcript pagination ownership', () => {
     }
   )
 
+  it('coalesces spellings against a backend that predates the profile field', async () => {
+    setApiRequestConnection(null)
+    const owner = { connectionId: 'local', profile: 'default' }
+    const tail = Array.from({ length: LATEST_SESSION_MESSAGES_LIMIT }, (_, index) => row(index + 1))
+    const { profile: _omitted, ...legacyPage } = page(tail)
+    api.mockResolvedValue(legacyPage)
+
+    for (const scope of [owner, 'default', undefined]) {
+      await getLatestSessionMessages('stored-session', scope)
+    }
+
+    // The legacy response cannot name its profile; the ambient profile stands in.
+    expect(Object.keys($transcriptTailBySessionId.get())).toHaveLength(1)
+    expect(transcriptBackfillAvailable('stored-session', owner)).toBe(true)
+    expect(transcriptBackfillAvailable('stored-session')).toBe(true)
+  })
+
   it('preserves legacy named-profile routing while the foreground is local', async () => {
     setApiRequestConnection(null)
     const profile = 'remote-alias'

--- a/apps/desktop/src/api/session-transcript-paging.test.ts
+++ b/apps/desktop/src/api/session-transcript-paging.test.ts
@@ -138,65 +138,63 @@ describe('session transcript pagination ownership', () => {
     })
   })
 
-  it.each(['work', null])(
-    'isolates an ambient %s profile across explicit reads and gateway switches',
-    async servingProfile => {
-      setApiRequestConnection('source-a')
-      const tail = page(Array.from({ length: LATEST_SESSION_MESSAGES_LIMIT }, (_, index) => row(index + 1)))
-      let resolve!: (value: SessionMessagesResponse) => void
-      api.mockReturnValueOnce(
-        new Promise<SessionMessagesResponse>(done => {
-          resolve = done
-        })
-      )
-      const pending = getLatestSessionMessages('stored-session')
-      api.mockResolvedValueOnce(page([row(1)]))
-      await getLatestSessionMessages('stored-session', { connectionId: 'source-a', profile: 'default' })
-
-      setApiRequestConnection('source-b')
-      api.mockResolvedValueOnce(page([row(1)]))
-      await getLatestSessionMessages('stored-session', { connectionId: 'source-b', profile: 'default' })
-      resolve({ ...tail, profile: servingProfile })
-      await pending
-
-      const ownerA = { connectionId: 'source-a', profile: servingProfile || undefined }
-      const ownerB = { connectionId: 'source-b', profile: 'default' }
-      expect(transcriptTailState('stored-session', ownerA)).toMatchObject({
-        possiblyTruncated: true,
-        profile: { connectionId: 'source-a' }
+  it('isolates an ambient named profile across explicit reads and gateway switches', async () => {
+    const servingProfile = 'work'
+    setApiRequestConnection('source-a')
+    const tail = page(Array.from({ length: LATEST_SESSION_MESSAGES_LIMIT }, (_, index) => row(index + 1)))
+    let resolve!: (value: SessionMessagesResponse) => void
+    api.mockReturnValueOnce(
+      new Promise<SessionMessagesResponse>(done => {
+        resolve = done
       })
-      expect(transcriptTailState('stored-session', { connectionId: 'source-a', profile: 'default' })).toMatchObject({
-        possiblyTruncated: false
-      })
-      expect(transcriptTailState('stored-session', ownerB)).toMatchObject({ possiblyTruncated: false, profile: ownerB })
-      expect(transcriptTailState('stored-session')).toBeUndefined()
+    )
+    const pending = getLatestSessionMessages('stored-session')
+    api.mockResolvedValueOnce(page([row(1)]))
+    await getLatestSessionMessages('stored-session', { connectionId: 'source-a', profile: 'default' })
 
-      const defaultA = transcriptTailState('stored-session', { connectionId: 'source-a', profile: 'default' })
-      const defaultB = transcriptTailState('stored-session', ownerB)
-      const applyOlderPage = vi.fn()
-      api.mockResolvedValueOnce({ ...page([row(0)], tail.messages.length), profile: servingProfile })
-      expect(
-        await backfillOlderTranscriptPage({
-          storedSessionId: 'stored-session',
-          profile: ownerA,
-          isCurrent: () => true,
-          applyOlderPage
-        })
-      ).toBe(true)
+    setApiRequestConnection('source-b')
+    api.mockResolvedValueOnce(page([row(1)]))
+    await getLatestSessionMessages('stored-session', { connectionId: 'source-b', profile: 'default' })
+    resolve({ ...tail, profile: servingProfile })
+    await pending
 
-      // Serving-profile metadata selects the cache entry, not the request route.
-      expect(api).toHaveBeenLastCalledWith({
-        connectionId: 'source-a',
-        path: `/api/sessions/stored-session/messages?limit=${LATEST_SESSION_MESSAGES_LIMIT}&offset=${tail.messages.length}&order=latest&include_compacted=true`
+    const ownerA = { connectionId: 'source-a', profile: servingProfile }
+    const ownerB = { connectionId: 'source-b', profile: 'default' }
+    expect(transcriptTailState('stored-session', ownerA)).toMatchObject({
+      possiblyTruncated: true,
+      profile: { connectionId: 'source-a' }
+    })
+    expect(transcriptTailState('stored-session', { connectionId: 'source-a', profile: 'default' })).toMatchObject({
+      possiblyTruncated: false
+    })
+    expect(transcriptTailState('stored-session', ownerB)).toMatchObject({ possiblyTruncated: false, profile: ownerB })
+    expect(transcriptTailState('stored-session')).toBeUndefined()
+
+    const defaultA = transcriptTailState('stored-session', { connectionId: 'source-a', profile: 'default' })
+    const defaultB = transcriptTailState('stored-session', ownerB)
+    const applyOlderPage = vi.fn()
+    api.mockResolvedValueOnce({ ...page([row(0)], tail.messages.length), profile: servingProfile })
+    expect(
+      await backfillOlderTranscriptPage({
+        storedSessionId: 'stored-session',
+        profile: ownerA,
+        isCurrent: () => true,
+        applyOlderPage
       })
-      expect(applyOlderPage).toHaveBeenCalledWith(toChatMessages([row(0)]))
-      expect(transcriptTailState('stored-session', ownerA)).toEqual({
-        nextOffset: tail.messages.length + 1,
-        possiblyTruncated: false,
-        profile: { connectionId: 'source-a' }
-      })
-      expect(transcriptTailState('stored-session', { connectionId: 'source-a', profile: 'default' })).toBe(defaultA)
-      expect(transcriptTailState('stored-session', ownerB)).toBe(defaultB)
-    }
-  )
+    ).toBe(true)
+
+    // Serving-profile metadata selects the cache entry, not the request route.
+    expect(api).toHaveBeenLastCalledWith({
+      connectionId: 'source-a',
+      path: `/api/sessions/stored-session/messages?limit=${LATEST_SESSION_MESSAGES_LIMIT}&offset=${tail.messages.length}&order=latest&include_compacted=true`
+    })
+    expect(applyOlderPage).toHaveBeenCalledWith(toChatMessages([row(0)]))
+    expect(transcriptTailState('stored-session', ownerA)).toEqual({
+      nextOffset: tail.messages.length + 1,
+      possiblyTruncated: false,
+      profile: { connectionId: 'source-a' }
+    })
+    expect(transcriptTailState('stored-session', { connectionId: 'source-a', profile: 'default' })).toBe(defaultA)
+    expect(transcriptTailState('stored-session', ownerB)).toBe(defaultB)
+  })
 })

--- a/apps/desktop/src/api/session-transcript-paging.test.ts
+++ b/apps/desktop/src/api/session-transcript-paging.test.ts
@@ -13,7 +13,8 @@ import type { SessionMessagesResponse } from '@/types/hermes'
 import { setApiRequestConnection, setApiRequestProfile } from './client'
 import { getLatestSessionMessages, LATEST_SESSION_MESSAGES_LIMIT } from './sessions'
 
-const row = (id: number) => ({ id, role: 'user' as const, content: `message ${id}`, timestamp: id })
+// Zero timestamps use the conversion-time clock for IDs; keep fixtures stable.
+const row = (id: number) => ({ id, role: 'user' as const, content: `message ${id}`, timestamp: 1_000 + id })
 
 const page = (messages: ReturnType<typeof row>[], offset = 0): SessionMessagesResponse => ({
   session_id: 'stored-session',

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -460,8 +460,10 @@ export function getLatestSessionMessages(
   // duplicate tail entries and "Show earlier" cannot resolve the loaded tail.
   // Capture before awaiting: the active gateway may change during the read.
   const route = { ...connectionScoped(), ...sessionScoped(profile) }
-  // Normalize only the lookup key; backfill must replay the original route.
-  const owner = { ...route, connectionId: route.connectionId || ambientOwnerConnectionId() }
+  // Owner identity is resolved from the ambient state at REQUEST time; only
+  // the lookup key is normalized — backfill replays `route` verbatim.
+  const ambientConnectionId = route.connectionId || ambientOwnerConnectionId()
+  const ambientProfile = getApiRequestProfile() || 'default'
 
   // includeCompacted: durable display history must include rows preserved by
   // in-place compaction (active=0, compacted=1); without them the transcript
@@ -480,15 +482,18 @@ export function getLatestSessionMessages(
     // the next older page starts, so "Show earlier" can backfill over REST
     // (app/chat/transcript-backfill). Keyed under both the requested id and
     // the resolved id — callers hold either.
-    // A backend that predates the `profile` field cannot name itself; an
-    // untagged read there lands on the ambient profile (`'default'` when
-    // none is active). `null` is a custom HERMES_HOME and stays distinct.
-    const servedProfile = page.profile === undefined ? getApiRequestProfile() || 'default' : page.profile
-    const resolvedOwner = { ...owner, profile: owner.profile || servedProfile }
-    recordTranscriptTail(id, page, route, resolvedOwner)
+    // A backend that predates the `profile` field cannot name itself; its
+    // untagged read landed on the ambient profile.
+    const owner = {
+      ...route,
+      connectionId: ambientConnectionId,
+      profile: route.profile || page.profile || ambientProfile
+    }
+
+    recordTranscriptTail(id, page, route, owner)
 
     if (page.session_id && page.session_id !== id) {
-      recordTranscriptTail(page.session_id, page, route, resolvedOwner)
+      recordTranscriptTail(page.session_id, page, route, owner)
     }
 
     return page

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -15,6 +15,7 @@ import {
   capabilityScoped,
   connectionScoped,
   getApiRequestConnection,
+  getApiRequestProfile,
   hermesApi,
   type ProfileScope,
   profileScoped
@@ -479,7 +480,11 @@ export function getLatestSessionMessages(
     // the next older page starts, so "Show earlier" can backfill over REST
     // (app/chat/transcript-backfill). Keyed under both the requested id and
     // the resolved id — callers hold either.
-    const resolvedOwnerScope = { ...ownerScope, profile: ownerScope.profile || page.profile || undefined }
+    // A backend that predates the `profile` field cannot name itself; an
+    // untagged read there lands on the ambient profile (`'default'` when
+    // none is active). `null` is a custom HERMES_HOME and stays distinct.
+    const servedProfile = page.profile === undefined ? getApiRequestProfile() || 'default' : page.profile
+    const resolvedOwnerScope = { ...ownerScope, profile: ownerScope.profile || servedProfile }
     recordTranscriptTail(id, page, tailScope, resolvedOwnerScope)
 
     if (page.session_id && page.session_id !== id) {

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -459,9 +459,9 @@ export function getLatestSessionMessages(
   // (ambient, profile string, or explicit pin). Otherwise refreshes create
   // duplicate tail entries and "Show earlier" cannot resolve the loaded tail.
   // Capture before awaiting: the active gateway may change during the read.
-  const tailScope = { ...connectionScoped(), ...sessionScoped(profile) }
+  const route = { ...connectionScoped(), ...sessionScoped(profile) }
   // Normalize only the lookup key; backfill must replay the original route.
-  const ownerScope = { ...tailScope, connectionId: tailScope.connectionId || ambientOwnerConnectionId() }
+  const owner = { ...route, connectionId: route.connectionId || ambientOwnerConnectionId() }
 
   // includeCompacted: durable display history must include rows preserved by
   // in-place compaction (active=0, compacted=1); without them the transcript
@@ -484,11 +484,11 @@ export function getLatestSessionMessages(
     // untagged read there lands on the ambient profile (`'default'` when
     // none is active). `null` is a custom HERMES_HOME and stays distinct.
     const servedProfile = page.profile === undefined ? getApiRequestProfile() || 'default' : page.profile
-    const resolvedOwnerScope = { ...ownerScope, profile: ownerScope.profile || servedProfile }
-    recordTranscriptTail(id, page, tailScope, resolvedOwnerScope)
+    const resolvedOwner = { ...owner, profile: owner.profile || servedProfile }
+    recordTranscriptTail(id, page, route, resolvedOwner)
 
     if (page.session_id && page.session_id !== id) {
-      recordTranscriptTail(page.session_id, page, tailScope, resolvedOwnerScope)
+      recordTranscriptTail(page.session_id, page, route, resolvedOwner)
     }
 
     return page

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -1,6 +1,7 @@
 import { isMissingRestEndpoint } from '@/lib/gateway-rpc'
 import { maybeBackfillLegacySessionOwners } from '@/lib/legacy-session-owner-backfill'
 import { stampRowsWithOwningConnection } from '@/lib/session-owner-stamp'
+import { $connection } from '@/store/session'
 import { recordTranscriptTail } from '@/store/transcript-tail'
 import type {
   PaginatedSessions,
@@ -10,7 +11,14 @@ import type {
   SessionSearchResponse
 } from '@/types/hermes'
 
-import { capabilityScoped, getApiRequestConnection, hermesApi, type ProfileScope, profileScoped } from './client'
+import {
+  capabilityScoped,
+  connectionScoped,
+  getApiRequestConnection,
+  hermesApi,
+  type ProfileScope,
+  profileScoped
+} from './client'
 
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
 
@@ -446,6 +454,19 @@ export function getLatestSessionMessages(
   profile?: ProfileScope,
   options: { passive?: boolean } = {}
 ): Promise<SessionMessagesResponse> {
+  // Key pagination by the effective request owner, not the caller's spelling
+  // (ambient, profile string, or explicit pin). Otherwise refreshes create
+  // duplicate tail entries and "Show earlier" cannot resolve the loaded tail.
+  // Capture before awaiting: the active gateway may change during the read.
+  const tailScope = { ...connectionScoped(), ...sessionScoped(profile) }
+  const ownerScope = { ...tailScope }
+
+  // Normalize only the lookup key: a local request pin would bypass Electron's
+  // legacy per-profile remote overrides. Backfill must retain the original route.
+  if (!ownerScope.connectionId && $connection.get()?.mode === 'local') {
+    ownerScope.connectionId = 'local'
+  }
+
   // includeCompacted: durable display history must include rows preserved by
   // in-place compaction (active=0, compacted=1); without them the transcript
   // silently ends at the compaction boundary and earlier turns are unreachable.
@@ -463,10 +484,11 @@ export function getLatestSessionMessages(
     // the next older page starts, so "Show earlier" can backfill over REST
     // (app/chat/transcript-backfill). Keyed under both the requested id and
     // the resolved id — callers hold either.
-    recordTranscriptTail(id, page, profile)
+    const resolvedOwnerScope = { ...ownerScope, profile: ownerScope.profile || page.profile || undefined }
+    recordTranscriptTail(id, page, tailScope, resolvedOwnerScope)
 
     if (page.session_id && page.session_id !== id) {
-      recordTranscriptTail(page.session_id, page, profile)
+      recordTranscriptTail(page.session_id, page, tailScope, resolvedOwnerScope)
     }
 
     return page

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -1,7 +1,6 @@
 import { isMissingRestEndpoint } from '@/lib/gateway-rpc'
 import { maybeBackfillLegacySessionOwners } from '@/lib/legacy-session-owner-backfill'
 import { stampRowsWithOwningConnection } from '@/lib/session-owner-stamp'
-import { $connection } from '@/store/session'
 import { recordTranscriptTail } from '@/store/transcript-tail'
 import type {
   PaginatedSessions,
@@ -12,6 +11,7 @@ import type {
 } from '@/types/hermes'
 
 import {
+  ambientOwnerConnectionId,
   capabilityScoped,
   connectionScoped,
   getApiRequestConnection,
@@ -459,13 +459,8 @@ export function getLatestSessionMessages(
   // duplicate tail entries and "Show earlier" cannot resolve the loaded tail.
   // Capture before awaiting: the active gateway may change during the read.
   const tailScope = { ...connectionScoped(), ...sessionScoped(profile) }
-  const ownerScope = { ...tailScope }
-
-  // Normalize only the lookup key: a local request pin would bypass Electron's
-  // legacy per-profile remote overrides. Backfill must retain the original route.
-  if (!ownerScope.connectionId && $connection.get()?.mode === 'local') {
-    ownerScope.connectionId = 'local'
-  }
+  // Normalize only the lookup key; backfill must replay the original route.
+  const ownerScope = { ...tailScope, connectionId: tailScope.connectionId || ambientOwnerConnectionId() }
 
   // includeCompacted: durable display history must include rows preserved by
   // in-place compaction (active=0, compacted=1); without them the transcript

--- a/apps/desktop/src/pairing-scope.test.ts
+++ b/apps/desktop/src/pairing-scope.test.ts
@@ -4,14 +4,19 @@
 // `profileScoped()` at the top level would approve into the default
 // profile's whitelist while the operator was managing another one — a grant
 // the running gateway for that profile never consults.
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const api = vi.fn().mockResolvedValue({ ok: true })
 
-vi.stubGlobal('window', { hermesDesktop: { api } })
-
 describe('pairing requests carry the active profile', () => {
-  beforeEach(() => api.mockClear())
+  beforeEach(() => {
+    api.mockClear()
+    Object.defineProperty(window, 'hermesDesktop', { configurable: true, value: { api } })
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'hermesDesktop')
+  })
 
   it('scopes approve and revoke by body, and the listing by query', async () => {
     const mod = await import('@/hermes')

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -18,6 +18,7 @@ import {
   setSessionsLoading
 } from '@/store/session'
 import { $stalledSessionIds } from '@/store/session-states'
+import { $transcriptTailBySessionId, recordTranscriptTail, transcriptTailState } from '@/store/transcript-tail'
 
 import {
   $gatewaySwitching,
@@ -77,6 +78,28 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     expect($sessionsLoading.get()).toBe(true)
     expect($sessionsLimit.get()).toBe(SIDEBAR_SESSIONS_PAGE_SIZE)
     expect($freshDraftReady.get()).toBe(true)
+  })
+
+  it("forgets the previous backend's in-memory paging state", () => {
+    const page = {
+      messages: Array.from({ length: 120 }, (_, index) => ({
+        id: index,
+        role: 'user' as const,
+        content: '',
+        timestamp: 1
+      })),
+      pagination: { limit: 120, offset: 0, order: 'latest' as const, returned: 120 }
+    }
+
+    recordTranscriptTail('recycled-id', page, { connectionId: 'local', profile: 'default' })
+
+    wipeSessionListsForGatewaySwitch()
+
+    // A same-id session on the next backend must resolve its own tail alone.
+    recordTranscriptTail('recycled-id', page, { connectionId: 'remote-1', profile: 'default' })
+    expect(Object.keys($transcriptTailBySessionId.get())).toHaveLength(1)
+    expect(transcriptTailState('recycled-id')?.possiblyTruncated).toBe(true)
+    $transcriptTailBySessionId.set({})
   })
 
   it('strands in-flight profile-list fetches so the old backend cannot repaint the rail (#85731)', () => {

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -26,6 +26,7 @@ import {
 import { clearAllSessionControl } from '@/store/session-control'
 import { resetSessionPinMirror } from '@/store/session-pin-sync'
 import { clearAllSessionStates } from '@/store/session-states'
+import { clearAllTranscriptTails } from '@/store/transcript-tail'
 import { clearTranscriptTails } from '@/store/transcript-tail-cache'
 
 // True while a connection switch is mid-flight — a Settings → Gateway apply
@@ -227,8 +228,12 @@ export function wipeSessionListsForGatewaySwitch(): void {
 
   // Cached transcript tails belong to the PREVIOUS backend's sessions; a
   // different backend can recycle stored ids, and painting another machine's
-  // conversation under a same-named id is worse than a loader. Wipe them.
+  // conversation under a same-named id is worse than a loader. Wipe both the
+  // persisted cache and the in-memory paging entries — the latter are keyed by
+  // owner, so a survivor from the old backend would sit beside the new one and
+  // fail the unique-match lookup that shows "Show earlier".
   clearTranscriptTails()
+  clearAllTranscriptTails()
 
   // Narrowed: account/marketplace/onboarding caches are global, not gateway-
   // scoped, so a mode swap must not refetch them.

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -1178,6 +1178,8 @@ export const setConnection = (next: Updater<HermesConnection | null>) => {
   rescopeConnectionScopedStores($connection.get())
   syncCronModelImpactConnection($connection.get())
 
+  // Null descriptor = reconnect blip; keep the last resolved mode (same
+  // contract as rescopeConnectionScopedStores above).
   const mode = $connection.get()?.mode
 
   if (mode) {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -1,6 +1,7 @@
 import type { ConnectionState } from '@hermes/shared'
 import { atom, computed } from 'nanostores'
 
+import { setApiRequestLocalMode } from '@/api/client'
 import { lastVisibleMessageIsUser } from '@/app/chat/thread-loading'
 import type { ContextSuggestion } from '@/app/types'
 import type { HermesConnection } from '@/global'
@@ -1176,6 +1177,13 @@ export const setConnection = (next: Updater<HermesConnection | null>) => {
   // keeps the current scope.
   rescopeConnectionScopedStores($connection.get())
   syncCronModelImpactConnection($connection.get())
+
+  const mode = $connection.get()?.mode
+
+  if (mode) {
+    setApiRequestLocalMode(mode === 'local')
+  }
+
   rescopeComposerSelection(composerScopeForConnection($connection.get()))
 }
 

--- a/apps/desktop/src/store/transcript-tail-cache.ts
+++ b/apps/desktop/src/store/transcript-tail-cache.ts
@@ -23,8 +23,10 @@ import { withUniqueToolCallIdsWithinMessage } from '@/lib/chat-messages'
 //     profile switches in the same window: an unscoped key let profile A's
 //     tail be painted against profile B's backend, which then retried a
 //     session id that does not exist there ("session not found") on every
-//     wake. The scope mirrors the in-memory twin's transcriptTailKey
-//     (transcript-tail.ts). Entries persisted before scoping shipped (v1,
+//     wake. The scope is the REQUEST scope the resume path passes (always a
+//     named profile); the in-memory twin (transcript-tail.ts) keys by the
+//     resolved owner instead and the two are never cross-read. Entries
+//     persisted before scoping shipped (v1,
 //     bare-id keys) carry no owner and are unreachable by construction —
 //     they are swept once per window so a stale tail can never paint again.
 

--- a/apps/desktop/src/store/transcript-tail.ts
+++ b/apps/desktop/src/store/transcript-tail.ts
@@ -53,7 +53,8 @@ function normalizedScope(profile?: TranscriptProfileScope): { connectionId: stri
 
   return {
     connectionId: String(profile.connectionId || '').trim(),
-    profile: String(profile.profile || '').trim() || 'default'
+    // An omitted profile targets the serving process, not necessarily default.
+    profile: String(profile.profile || '').trim()
   }
 }
 
@@ -115,12 +116,19 @@ function setTranscriptTailEntry(key: string, state: TranscriptTailState): void {
 }
 
 /** Record the outcome of a tail hydration (`getLatestSessionMessages`). */
-export function recordTranscriptTail(storedSessionId: string, page: TailPage, profile?: TranscriptProfileScope): void {
+export function recordTranscriptTail(
+  storedSessionId: string,
+  page: TailPage,
+  profile?: TranscriptProfileScope,
+  ownerScope: TranscriptProfileScope | undefined = profile
+): void {
   if (!storedSessionId) {
     return
   }
 
-  const key = transcriptTailKey(storedSessionId, profile)
+  // Keep request routing separate from the resolved owner used for lookup:
+  // backfill must replay an ambient read even when the server names its profile.
+  const key = transcriptTailKey(storedSessionId, ownerScope)
   setTranscriptTailEntry(key, tailStateFromPage(page, profile))
 }
 

--- a/apps/desktop/src/store/transcript-tail.ts
+++ b/apps/desktop/src/store/transcript-tail.ts
@@ -23,8 +23,10 @@ export interface TranscriptTailState {
   /** The last hydration page was exactly the page limit, so older rows
    *  likely exist beyond what the in-memory store holds. */
   possiblyTruncated: boolean
-  /** Owning profile captured at hydration time, so a later backfill routes
-   *  its REST read to the same backend that served the tail. */
+  /** The request route captured at hydration time, replayed verbatim by a
+   *  later backfill so it reaches the backend that served the tail. The
+   *  resolved OWNER is the map key, not this field: an ambient read must stay
+   *  ambient even once the server has named its profile. */
   profile?: TranscriptProfileScope
 }
 
@@ -43,6 +45,8 @@ let transcriptTailOrder: string[] = []
 type TailPage = Pick<SessionMessagesResponse, 'messages' | 'pagination'>
 
 function normalizedScope(profile?: TranscriptProfileScope): { connectionId: string; profile: string } | null {
+  // A bare string is the legacy "named profile" spelling: it always names a
+  // profile, so empty means the default one.
   if (typeof profile === 'string') {
     return { connectionId: '', profile: profile.trim() || 'default' }
   }
@@ -115,21 +119,20 @@ function setTranscriptTailEntry(key: string, state: TranscriptTailState): void {
   $transcriptTailBySessionId.set(next)
 }
 
-/** Record the outcome of a tail hydration (`getLatestSessionMessages`). */
+/** Record the outcome of a tail hydration (`getLatestSessionMessages`).
+ *  `route` is what the request was sent with; `owner` is the resolved backend
+ *  the entry is keyed under (defaults to the route when they coincide). */
 export function recordTranscriptTail(
   storedSessionId: string,
   page: TailPage,
-  profile?: TranscriptProfileScope,
-  ownerScope: TranscriptProfileScope | undefined = profile
+  route?: TranscriptProfileScope,
+  owner: TranscriptProfileScope | undefined = route
 ): void {
   if (!storedSessionId) {
     return
   }
 
-  // Keep request routing separate from the resolved owner used for lookup:
-  // backfill must replay an ambient read even when the server names its profile.
-  const key = transcriptTailKey(storedSessionId, ownerScope)
-  setTranscriptTailEntry(key, tailStateFromPage(page, profile))
+  setTranscriptTailEntry(transcriptTailKey(storedSessionId, owner), tailStateFromPage(page, route))
 }
 
 /** Advance the bookkeeping after one older backfill page landed. */

--- a/apps/desktop/src/store/transcript-tail.ts
+++ b/apps/desktop/src/store/transcript-tail.ts
@@ -178,6 +178,13 @@ export function transcriptTailState(
   return matches.length === 1 ? matches[0][1] : undefined
 }
 
+/** Forget every tail: the backend behind the window changed and a recycled
+ *  stored id must not carry the previous backend's paging state. */
+export function clearAllTranscriptTails(): void {
+  transcriptTailOrder = []
+  $transcriptTailBySessionId.set({})
+}
+
 export function clearTranscriptTail(storedSessionId: string, profile?: TranscriptProfileScope): void {
   const current = $transcriptTailBySessionId.get()
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -699,6 +699,8 @@ export interface SessionMessage {
 }
 
 export interface SessionMessagesResponse {
+  /** Serving profile for unscoped reads; null for a custom HERMES_HOME. */
+  profile?: null | string
   messages: SessionMessage[]
   pagination?: {
     limit: number

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -699,8 +699,9 @@ export interface SessionMessage {
 }
 
 export interface SessionMessagesResponse {
-  /** Serving profile for unscoped reads; null for a custom HERMES_HOME. */
-  profile?: null | string
+  /** Profile the page was read from (the serving process's own when the
+   *  request named none). Absent on backends that predate the field. */
+  profile?: string
   messages: SessionMessage[]
   pagination?: {
     limit: number

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -551,14 +551,12 @@ async def get_session_messages(
     if result is None:
         raise HTTPException(status_code=404, detail=_NOT_FOUND)
     sid, _limit, messages = result
-    from hermes_cli.profiles import get_active_profile_name
-
-    serving_profile = _serving_profile(profile) if profile else get_active_profile_name()
     projected_messages = _project_for_display(messages)
     return {
         "session_id": sid,
-        # Unscoped reads use this process's DB, which may be a named profile.
-        "profile": None if serving_profile == "custom" else serving_profile,
+        # The same stamp list rows carry, so the Desktop keys a page under the
+        # owner it already routes the session by.
+        "profile": _serving_profile(profile),
         "messages": projected_messages,
         "pagination": {
             "limit": _limit, "offset": offset,

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -551,9 +551,14 @@ async def get_session_messages(
     if result is None:
         raise HTTPException(status_code=404, detail=_NOT_FOUND)
     sid, _limit, messages = result
+    from hermes_cli.profiles import get_active_profile_name
+
+    serving_profile = _serving_profile(profile) if profile else get_active_profile_name()
     projected_messages = _project_for_display(messages)
     return {
         "session_id": sid,
+        # Unscoped reads use this process's DB, which may be a named profile.
+        "profile": None if serving_profile == "custom" else serving_profile,
         "messages": projected_messages,
         "pagination": {
             "limit": _limit, "offset": offset,

--- a/tests/hermes_cli/test_session_message_page_owner.py
+++ b/tests/hermes_cli/test_session_message_page_owner.py
@@ -39,7 +39,7 @@ def test_message_pages_identify_the_serving_profile(tmp_path, monkeypatch, servi
         older = client.get(f"/api/sessions/same-id/messages?{query}&offset=120").json()
         default = client.get(f"/api/sessions/same-id/messages?{query}&profile=default").json()
 
-    assert tail["profile"] == older["profile"] == serving_profile
+    assert tail["profile"] == older["profile"] == (serving_profile or "default")
     assert default["profile"] == "default"
     assert len(tail["messages"]) == 120
     assert len(older["messages"]) == 79

--- a/tests/hermes_cli/test_session_message_page_owner.py
+++ b/tests/hermes_cli/test_session_message_page_owner.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.parametrize("serving_profile", ["work", None])
+def test_message_pages_identify_the_serving_profile(tmp_path, monkeypatch, serving_profile):
+    from hermes_state import SessionDB
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    work_home = default_home / "profiles" / "work" if serving_profile else default_home / "custom-home"
+    default_home.mkdir(parents=True)
+    work_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(work_home))
+    # conftest redirects this legacy override independently of HERMES_HOME.
+    monkeypatch.setattr("hermes_state.DEFAULT_DB_PATH", work_home / "state.db")
+
+    for home, count in ((default_home, 1), (work_home, 199)):
+        db = SessionDB(db_path=home / "state.db")
+        try:
+            db.create_session(session_id="same-id", source="desktop")
+            db.append_messages_batch("same-id", [
+                {"role": "user", "content": f"message-{index}"}
+                for index in range(count)
+            ])
+        finally:
+            db.close()
+
+    from hermes_cli.web_routers.sessions import manage_router
+
+    app = FastAPI()
+    app.include_router(manage_router)
+    with TestClient(app) as client:
+        query = "limit=120&order=latest&include_compacted=true"
+        tail = client.get(f"/api/sessions/same-id/messages?{query}").json()
+        older = client.get(f"/api/sessions/same-id/messages?{query}&offset=120").json()
+        default = client.get(f"/api/sessions/same-id/messages?{query}&profile=default").json()
+
+    assert tail["profile"] == older["profile"] == serving_profile
+    assert default["profile"] == "default"
+    assert len(tail["messages"]) == 120
+    assert len(older["messages"]) == 79
+    assert len(default["messages"]) == 1
+    assert [row["content"] for row in older["messages"] + tail["messages"]] == [
+        f"message-{index}" for index in range(199)
+    ]


### PR DESCRIPTION
Desktop chat no longer loses "Show earlier" for sessions whose stored history is longer than the 120-row initial page — a reported session kept 199 rows in storage but exposed only the last 120.

Salvage of #107839 by @rewbs, cherry-picked to preserve authorship, rebased onto current `main`, plus follow-ups.

## Root cause

The transcript-tail bookkeeping (`apps/desktop/src/store/transcript-tail.ts`) that tells the chat an older page exists was keyed by the caller's *spelling* of the scope. Resume, post-turn hydration and background refresh read the same session as an ambient call, a profile string, and an explicit `{connectionId, profile}` pin — three keys for one backend. The unique-match lookup then saw more than one entry, returned nothing, and the action stayed hidden.

## Changes

- **@rewbs (#107839):** key the tail entry by the resolved owner (connection normalised to `'local'` when ambient-local; profile from the request or from a new `profile` field on `GET /api/sessions/{id}/messages`), while the stored route replays the original request on backfill. Frontend regression cases for mixed spellings, gateway switches mid-read and same-id sessions on different backends; a DB-backed HTTP test that reconstructs 199 rows as a 120-row tail plus 79 older rows.
- **Follow-ups (this PR):**
  - `api/sessions.ts` imported `$connection` from `@/store/session`, closing a module cycle (`api/sessions → store/session → session-unread-remote → @/hermes → api/sessions`) that `api/client.ts` documents a push-seam to avoid. The local/remote fact is now published through that seam (`setApiRequestLocalMode` from `setConnection`; `ambientOwnerConnectionId()` for the owner key).
  - Backends that predate the `profile` field left the owner's profile empty while the resume path recorded `'default'` — still two entries per backend. An absent field now falls back to the ambient request profile, captured at request time so a profile switch mid-read cannot re-key the page.
  - The backend returned `null` for a custom `HERMES_HOME`, while list rows for the same backend are stamped `"default"` — two identities for one backend, and a lookup miss for the Desktop's own sandboxed/`HERMES_HOME`-overridden installs. The messages endpoint now returns the same `_serving_profile()` stamp the rows carry.
  - A connection/mode re-home wiped the persisted tail cache but not the in-memory atom; with owner keys, a survivor from the previous backend would sit beside the new one and fail the unique-match lookup. The wipe now clears both.
  - `recordTranscriptTail(id, page, route, owner)` names what each scope is for; `TranscriptTailState.profile` doc corrected (it is the route, the owner is the key); stale "mirrors transcriptTailKey" comment in `transcript-tail-cache.ts` fixed.

No session data migration, deletion, or change to page size.

## Validation

| Check | Result |
|---|---|
| `session-transcript-paging.test.ts` (6 cases) | pass; all 6 fail with `sessions.ts` + `transcript-tail.ts` reverted to `main` |
| `test_session_message_page_owner.py` (2 cases) | pass; both fail (`KeyError: 'profile'`) with `sessions.py` reverted to `main` |
| `gateway-switch.test.ts` new case | pass; fails when the in-memory wipe is removed |
| Live: real `manage_router` via TestClient, `HERMES_HOME=…/profiles/work`, 199 rows | tail `profile: work` 120 rows, `offset=120` 79 rows, contiguous `message-0..198`; `?profile=default` reaches the other DB |
| vitest `src/{api,store,app/chat,app/contrib,app/session,lib}` | 1 pre-existing failure on `main` (en-IN locale grouping in `use-prompt-actions/utils.test.ts`), unrelated |
| `tsc -p . --noEmit`, `eslint` on touched files, `ruff`, `check-windows-footguns --all`, `check_compat_pointers`, `git diff --check` | clean |

Closes #107839 (supersedes; authorship preserved via cherry-pick).
