### PR TITLE
fix(tui-gateway): expose cli.exec stdout and stderr as separate fields

### DIFF
--- a/tests/tui_gateway/test_cli_exec_streams.py
+++ b/tests/tui_gateway/test_cli_exec_streams.py
@@ -1,0 +1,41 @@
+"""Focused tests for cli.exec structured stdout/stderr payload fields."""
+
+from types import SimpleNamespace
+
+import tui_gateway.methods_tools as m
+
+
+def _proc(stdout, stderr, returncode=0):
+    return SimpleNamespace(stdout=stdout, stderr=stderr, returncode=returncode)
+
+
+def test_structured_streams_split_both():
+    payload = m._cli_exec_output(_proc("out\n", "warn\n"))
+    assert payload["output"] == "out\n\nwarn"
+    assert payload["stdout"] == "out\n"
+    assert payload["stderr"] == "warn\n"
+
+
+def test_empty_and_none_streams_yield_placeholders():
+    for stdout, stderr in (("", ""), (None, None)):
+        payload = m._cli_exec_output(_proc(stdout, stderr))
+        assert payload["output"] == "(no output)"
+        assert payload["stdout"] == ""
+        assert payload["stderr"] == ""
+
+
+def test_bounds_and_default_limit_identity():
+    limited = m._cli_exec_output(_proc("abcdefghijk", "1234567890"), limit=8)
+    assert limited["stdout"] == "abcdefgh"
+    assert limited["stderr"] == "12345678"
+    assert limited["output"] == "abcdefgh"
+
+    payload = m._cli_exec_output(_proc("a" * 60_000, "b" * 60_000))
+    assert len(payload["stdout"]) == 48_000
+    assert len(payload["stderr"]) == 48_000
+    assert payload["output"] == "a" * 48_000
+
+
+def test_payload_key_set_is_exact():
+    payload = m._cli_exec_output(_proc("out", "warn"))
+    assert set(payload) == {"output", "stdout", "stderr"}

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -181,6 +181,15 @@ def _joined_output(r) -> str:
     return "\n".join(p for p in (r.stdout or "", r.stderr or "") if p).strip()
 
 
+def _cli_exec_output(r, limit: int = 48_000) -> dict[str, str]:
+    """Structured cli.exec streams; ``output`` matches the legacy joined bound."""
+    return {
+        "output": (_joined_output(r) or "(no output)")[:limit],
+        "stdout": (r.stdout or "")[:limit],
+        "stderr": (r.stderr or "")[:limit],
+    }
+
+
 def _toolset_rows(params: dict, *, with_tools: bool) -> list[dict]:
     toolsets = _tools_mod("toolsets")
     session = _sessions.get(params.get("session_id", ""))
@@ -442,7 +451,7 @@ def _(rid, params: dict) -> dict:
     return _captured_exec(
         rid, [sys.executable, "-m", "hermes_cli.main", *argv], min(int(params.get("timeout", 240)), 600),
         on_result=lambda r: _ok(rid, {
-            "blocked": False, "code": r.returncode, "output": (_joined_output(r) or "(no output)")[:48_000]}),
+            "blocked": False, "code": r.returncode, **_cli_exec_output(r)}),
         timeout_err=(5016, "cli.exec: timeout"), fail_code=5017,
         env=hermes_subprocess_env(inherit_credentials=True))
 


### PR DESCRIPTION
## What does this PR do?

`cli.exec` returns a single `output` string: stdout and stderr joined with a newline. A machine
consumer that parses stdout as structured data therefore breaks as soon as anything writes to
stderr — a command emitting valid JSON on stdout plus a few warning lines on stderr yields an
`output` that cannot be parsed, even though the command exited 0.

This adds `stdout` and `stderr` as separate fields. `output` is unchanged and remains
byte-identical at its default bound, so existing callers are unaffected.

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/methods_tools.py`: new pure helper `_cli_exec_output(r, limit=48_000)` returning
  `output` (unchanged semantics), `stdout`, and `stderr`; the existing non-blocked `cli.exec`
  branch builds its payload from it.
- `tests/tui_gateway/test_cli_exec_streams.py`: focused tests for split streams, empty/`None`
  streams, per-field bounds incl. default-limit `output` identity, and the exact key set.

The blocked branch is untouched and still returns `blocked`, `hint`, `code`, `output`.

## How to Test

1. `scripts/run_tests.sh tests/tui_gateway/test_cli_exec_streams.py` → 4 passed.
2. Drive the registered handler (`server._methods["cli.exec"]`) with a real subprocess:
   `argv ["--help"]` → `code 0`, non-empty `stdout`; an unknown subcommand → non-zero `code`,
   non-empty `stderr`; `argv []` → the unchanged blocked payload.

## Exposure and interaction with open work

- The new fields are additive and each independently bounded at 48,000 characters. Combined they
  can surface up to ~96,000 characters, and `stderr` can carry bytes that the combined `output`
  currently drops once stdout fills that budget. This is a widening, not merely a re-split.
- No redaction is applied to this payload on the base. Open PR #45794 adds redaction to this RPC's
  output and should cover the new fields when it lands.
- Neighbouring handler code is under active change (#45794, #78036, #60423), so a conflict is
  possible; this change touches neither env nor credential handling.
- Tested on Windows 11.
