### PR TITLE
fix(browser): apply the Chromium sandbox bypass to the real-profile launch

### DIFF
--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -326,6 +326,55 @@ class TestRealProfileCdpLaunch:
         assert "AGENT_BROWSER_IDLE_TIMEOUT_MS" not in captured["env"]
         self._reset()
 
+    def test_launch_adds_sandbox_flags_when_host_needs_them(self, tmp_path):
+        """Root / Docker / AppArmor-userns hosts need --no-sandbox on THIS launch too.
+
+        agent-browser's own launch receives the flags through AGENT_BROWSER_ARGS, but the
+        real-profile launcher builds Chrome's argv directly. Without them Chrome exits rc=1
+        ("Running as root without --no-sandbox is not supported") before writing
+        DevToolsActivePort, and the caller reports "Chrome exited during startup (another
+        instance may hold the profile copy)" — a red herring that hides the real cause.
+        """
+        import tools.browser_tool as bt
+        self._reset()
+        proc = Mock(return_value=None, returncode=0, stdout="", stderr="")
+        captured = {}
+
+        class FakeChrome:
+            def poll(self):
+                return None
+
+        def fake_popen(argv, **kw):
+            captured["chrome_argv"] = argv
+            (tmp_path / "DevToolsActivePort").write_text("41000\n/devtools/browser/x\n")
+            return FakeChrome()
+
+        def launch_argv():
+            captured.clear()
+            with patch.object(bt_cloud, "_use_real_profile", return_value=True), \
+                 patch("hermes_cli.browser_connect.detect_default_chromium", return_value="chrome"), \
+                 patch("hermes_cli.browser_connect.snapshot_real_profile", return_value=(str(tmp_path), None)), \
+                 patch("hermes_cli.browser_connect.chromium_executable", return_value="/usr/bin/chrome"), \
+                 patch.object(bt.subprocess, "Popen", side_effect=fake_popen), \
+                 patch.object(bt_real_profile, "_agent_browser_get_cdp",
+                              side_effect=[None, "http://127.0.0.1:41000"]), \
+                 patch.object(bt_install, "_find_agent_browser", return_value="/usr/bin/agent-browser"), \
+                 patch.object(bt.subprocess, "run", return_value=proc), \
+                 patch.object(bt_cloud, "_is_headed_mode", return_value=False):
+                bt_real_profile._real_profile_cdp()
+            self._reset()
+            return captured["chrome_argv"]
+
+        with patch.object(bt_session, "_needs_chromium_sandbox_bypass", return_value=True):
+            argv = launch_argv()
+        assert "--no-sandbox" in argv
+        assert "--disable-dev-shm-usage" in argv
+
+        with patch.object(bt_session, "_needs_chromium_sandbox_bypass", return_value=False):
+            argv = launch_argv()
+        assert "--no-sandbox" not in argv
+        assert "--disable-dev-shm-usage" not in argv
+
     def test_reuses_only_session_on_our_copy_dir(self, tmp_path):
         """A live session on a DIFFERENT dir (stale/throwaway) is closed, not reused."""
         import tools.browser_tool as bt

--- a/tools/browser_tool_real_profile.py
+++ b/tools/browser_tool_real_profile.py
@@ -163,6 +163,14 @@ def _launch_real_profile_chrome(real_binary: str, copy_dir: str) -> Tuple[Option
     except OSError:
         pass
     chrome_argv = [real_binary, f"--user-data-dir={copy_dir}", *_REAL_PROFILE_CHROME_FLAGS]
+    # Chromium refuses to start as root, and is unreliable inside Docker or on hosts with
+    # apparmor_restrict_unprivileged_userns=1, unless --no-sandbox is passed. agent-browser's own
+    # launch gets those flags through AGENT_BROWSER_ARGS (_session._apply_chromium_sandbox_args),
+    # but this launch builds argv directly, so it must ask the same question here — otherwise
+    # Chrome exits rc=1 before writing DevToolsActivePort and the caller reports the misleading
+    # "Chrome exited during startup (another instance may hold the profile copy)".
+    if _session._needs_chromium_sandbox_bypass():
+        chrome_argv += ["--no-sandbox", "--disable-dev-shm-usage"]
     _has_display = bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
     if not (_cloud._is_headed_mode() and (_has_display or not sys.platform.startswith("linux"))):
         chrome_argv.append("--headless=new")


### PR DESCRIPTION
## What does this PR do?

Fixes real-profile browsing on hosts where Chromium needs the sandbox bypass (running as **root**, inside Docker, or with `apparmor_restrict_unprivileged_userns=1`).

`tools/browser_tool_real_profile.py::_launch_real_profile_chrome` spawns the user's *real* Chromium binary itself (so the OS keychain path stays intact) and builds that argv directly. agent-browser's own launch path gets `--no-sandbox,--disable-dev-shm-usage` injected through `AGENT_BROWSER_ARGS` (`tools/browser_tool_session._apply_chromium_sandbox_args`), but this launcher never asked the same question. On a root host Chrome therefore exits immediately:

```
[ERROR:zygote_host_impl_linux.cc:102] Running as root without --no-sandbox is not supported. See https://crbug.com/638180.
```

and the caller surfaces `browser.use_real_profile is on, but Chrome exited during startup (another instance may hold the profile copy)` — a red herring: no other instance is involved, the browser simply refuses to start, so the toggle looks broken while Chrome's real error never reaches the user.

## Related Issue

Searched the tracker for the user-facing string; no matching issue (this is the report).

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/browser_tool_real_profile.py`: apply the same host detection the agent-browser launch uses (`_session._needs_chromium_sandbox_bypass()`) and append `--no-sandbox`, `--disable-dev-shm-usage` to the real-binary argv when it returns True.
- `tests/tools/test_browser_real_profile.py`: regression test driving the full `_real_profile_cdp()` path twice — with the detection True the captured Chrome argv must contain the flags, with it False it must not.

## How to Test

1. `pytest tests/tools/test_browser_real_profile.py -q` → `83 passed` (82 before this change).
2. RED check: `git stash push -- tools/browser_tool_real_profile.py` and re-run the new test → `AssertionError` (`--no-sandbox` missing); `git stash pop` → green.
3. Live on a root host with `browser.use_real_profile: true`: before, `_launch_real_profile_chrome()` returned the "Chrome exited during startup" error; with the fix it returns a debug port in ~1s on the same profile copy.

## Checklist

- [x] I've read the contributing guide
- [x] My commits follow the conventional commit format
- [x] I've searched for existing PRs — none cover this launcher
- [x] My changes are limited to the bug fix
- [x] Tests pass: `pytest tests/tools/test_browser_real_profile.py -q` (83 passed); the new test fails without the fix
- [x] I've added tests that prove the fix
- [x] Tested on Linux (Ubuntu, Python 3.11.16) — this bug only manifests on sandbox-restricted hosts
- [x] No docs/config/architecture changes needed; behaviour is unchanged on hosts where the bypass isn't required

## Security considerations

This PR adds `--no-sandbox` (plus `--disable-dev-shm-usage`) to the real-profile launch, which is a
security-relevant flag, so it is worth being explicit about the reasoning:

- **It does not introduce a new posture.** `tools/browser_tool_session._apply_chromium_sandbox_args`
  already injects exactly these two flags via `AGENT_BROWSER_ARGS` on the same hosts (root, Docker,
  `apparmor_restrict_unprivileged_userns=1`) for agent-browser's own launch. The real-profile launcher
  was the one path that did not, i.e. the inconsistency is the bug: on those hosts today, the browser
  either runs sandbox-less through agent-browser or does not start at all through this launcher.
- **It is gated on the same detection**, `_session._needs_chromium_sandbox_bypass()` — nothing changes on
  a host where Chromium can sandbox normally (the new test asserts both branches).
- **Why the flag is unavoidable there:** Chromium refuses to run as root (or as any uid on a host with
  unprivileged user namespaces restricted) without it; the alternative is not "sandboxed real-profile
  browsing", it is "real-profile browsing does not work at all". That is precisely the state this PR
  fixes, and why the failure was invisible.
- **What it does not do:** it does not change which profile is loaded, does not weaken the profile-copy
  consent model, and does not touch the keychain path (`--use-mock-keychain` is still deliberately
  absent so the copied cookies decrypt).

**If maintainers prefer the fail-closed direction instead** — i.e. detect the sandbox-restricted host and
return a clear "run the agent as a non-root user, or turn real-profile browsing off" message rather than
degrading the sandbox — that is a reasonable call and I am happy to rework the PR that way. The one thing
that should change regardless is the error text: today it blames "another instance may hold the profile
copy", which sends users hunting for a lock that does not exist while the real cause (Chrome's own
`Running as root without --no-sandbox is not supported`) is discarded to `DEVNULL`.
