### PR TITLE
feat(kanban): dispatcher resource gate — dedupe spawn by kind:identifier physical resource

### DIFF
--- a/gateway/kanban_watchers_dispatcher.py
+++ b/gateway/kanban_watchers_dispatcher.py
@@ -300,11 +300,14 @@ def _log_spawn_results(results: Optional[list]) -> bool:
             # Quiet by default: an idle gateway stays silent.
             logger.info(
                 "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
-                "crashed=%d timed_out=%d promoted=%d auto_blocked=%d",
+                "crashed=%d timed_out=%d promoted=%d auto_blocked=%d "
+                "skipped_resource_held=%d",
                 slug, len(res.spawned), res.reclaimed,
                 len(res.crashed) if hasattr(res.crashed, "__len__") else 0,
                 len(res.timed_out) if hasattr(res.timed_out, "__len__") else 0,
                 res.promoted,
                 len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
+                len(res.skipped_resource_held)
+                if hasattr(res.skipped_resource_held, "__len__") else 0,
             )
     return any_spawned

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -359,6 +359,13 @@ def _cmd_create(args: argparse.Namespace) -> int:
     if max_retries is not None and max_retries < 1:
         return _err(f"kanban: --max-retries must be >= 1 (got {max_retries}); "
                     "use 1 to trip on the first failure.", 2)
+    # Normalize (and reject bad tokens) BEFORE the write so an invalid
+    # --resources never creates the card. normalize_resources strips/dedupes.
+    raw_resources = getattr(args, "resources", None)
+    try:
+        resources = kb.normalize_resources(raw_resources.split(",") if raw_resources else None)
+    except ValueError as exc:
+        return _err(f"kanban: --resources: {exc}", 2)
     with kbc.connect_closing() as conn:
         task_id = kb.create_task(
             conn, title=args.title, body=args.body, assignee=args.assignee,
@@ -368,6 +375,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             parents=tuple(args.parent or ()), triage=bool(getattr(args, "triage", False)),
             idempotency_key=getattr(args, "idempotency_key", None),
             max_runtime_seconds=max_runtime, skills=getattr(args, "skills", None) or None,
+            resources=resources,
             max_retries=max_retries, model_override=getattr(args, "model_override", None),
             provider_override=getattr(args, "provider_override", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),
@@ -489,6 +497,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
         latest_summary = kb.latest_summary(conn, args.task_id)
         if not want_json:
             graph = kb.task_graph_context(conn, task.id)
+        # Query inside the with-block: conn is closed by the time diagnostics run.
+        held_resources = kb.running_task_resources(conn)
 
     if want_json:
         _print_json({
@@ -512,6 +522,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
         field("branch", task.branch_name)
     if task.skills:
         field("skills", ", ".join(task.skills))
+    if task.resources:
+        field("resources", ", ".join(task.resources))
     if task.model_override:
         _prov = f" (provider: {task.provider_override})" if task.provider_override else ""
         field("model", f"{task.model_override}{_prov}")
@@ -528,7 +540,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
 
     # Diagnostics up top so CLI users see distress signals before scrolling.
     from hermes_cli import kanban_diagnostics as kd
-    diags = kd.compute_task_diagnostics(task, events, runs, graph=graph)
+    diags = kd.compute_task_diagnostics(task, events, runs, graph=graph,
+                                        held_resources=held_resources)
     if diags:
         print(f"\n  Diagnostics ({len(diags)}):")
         _print_diagnostics(diags, "    ", with_kind=False)
@@ -597,6 +610,25 @@ def _cmd_set_model(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_update(args: argparse.Namespace) -> int:
+    """``hermes kanban update <task_id> --resources …`` — currently the only
+    mutable surface here is the exclusive resource-key set (empty string
+    clears). Applies on the next dispatch."""
+    tokens = [t for t in (p.strip() for p in args.resources.split(",")) if t]
+    try:
+        with kbc.connect_closing() as conn:
+            ok = kb.set_task_resources(conn, args.task_id, tokens)
+    except (ValueError, RuntimeError) as exc:
+        return _err(f"kanban: {exc}", 2)
+    if not ok:
+        return _err(f"no such task: {args.task_id}")
+    if tokens:
+        print(f"Set resources on {args.task_id}: {','.join(tokens)} (applies on next dispatch)")
+    else:
+        print(f"Cleared resources on {args.task_id}")
+    return 0
+
+
 def _cmd_reclaim(args: argparse.Namespace) -> int:
     with kbc.connect_closing() as conn:
         ok = kb.reclaim_task(conn, args.task_id, reason=getattr(args, "reason", None))
@@ -638,6 +670,8 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
     diag_config = kd.config_from_runtime_config(load_config())
 
     with kbc.connect_closing() as conn:
+        # Resources held by running cards: stranded-in-ready exemption input.
+        held_resources = kb.running_task_resources(conn)
         # Either one-task mode or fleet mode.
         if getattr(args, "task", None):
             task = kb.get_task(conn, args.task)
@@ -645,7 +679,8 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
                 return _err(f"no such task: {args.task}")
             diags_by_task = {args.task: kd.compute_task_diagnostics(
                 task, kb.list_events(conn, args.task), kb.list_runs(conn, args.task),
-                graph=kb.task_graph_context(conn, args.task), config=diag_config)}
+                graph=kb.task_graph_context(conn, args.task), config=diag_config,
+                held_resources=held_resources)}
         else:
             # Fleet mode: pull all non-archived tasks + their events/runs.
             rows = list(conn.execute("SELECT * FROM tasks WHERE status != 'archived'").fetchall())
@@ -658,7 +693,8 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
                 for r in rows:
                     tid = r["id"]
                     dl = kd.compute_task_diagnostics(r, ev_by.get(tid, []), run_by.get(tid, []),
-                                                     graph=graph_by.get(tid), config=diag_config)
+                                                     graph=graph_by.get(tid), config=diag_config,
+                                                     held_resources=held_resources)
                     if dl:
                         diags_by_task[tid] = dl
 
@@ -1233,6 +1269,7 @@ _HANDLERS = {
     "init": _cmd_init, "create": _cmd_create, "swarm": _cmd_swarm,
     "list": _cmd_list, "ls": _cmd_list, "show": _cmd_show,
     "assign": _cmd_assign, "set-model": _cmd_set_model,
+    "update": _cmd_update,
     "reclaim": _cmd_reclaim, "reassign": _cmd_reassign,
     "diagnostics": _cmd_diagnostics, "diag": _cmd_diagnostics,
     "link": _cmd_link, "unlink": _cmd_unlink, "claim": _cmd_claim,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -220,7 +220,7 @@ _TICK_ACTIVITY_FIELDS = (
     "spawned", "reclaimed", "promoted", "reconciled_orphans", "crashed", "stale",
     "timed_out", "auto_blocked", "rate_limited", "auto_assigned_default",
     "respawn_guarded", "skipped_per_profile_capped", "skipped_unassigned",
-    "skipped_nonspawnable",
+    "skipped_nonspawnable", "skipped_resource_held",
 )
 
 
@@ -715,12 +715,16 @@ class Task:
     block_kind: Optional[str] = None
     block_recurrences: int = 0               # unblock-loop counter, see BLOCK_RECURRENCE_LIMIT
     completion_contract: Optional[str] = None
+    # Exclusive physical resource keys (parsed from the JSON column); see SCHEMA_SQL.
+    resources: Optional[list[str]] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
         g = lambda col, default=None: _row_get(row, col, default)  # noqa: E731
         parsed = _json_or(g("skills"))
         skills_value = [str(s) for s in parsed if s] if isinstance(parsed, list) else None
+        parsed_res = _json_or(g("resources"))
+        resources_value = [str(r) for r in parsed_res if r] if isinstance(parsed_res, list) else None
         return cls(
             **{col: row[col] for col in _TASK_REQUIRED_COLUMNS},
             **{col: g(col) for col in _TASK_OPTIONAL_COLUMNS},
@@ -730,6 +734,7 @@ class Task:
             consecutive_failures=g("consecutive_failures", g("spawn_failures", 0)),
             last_failure_error=g("last_failure_error", g("last_spawn_error")),
             skills=skills_value,
+            resources=resources_value,
             goal_mode=bool(g("goal_mode")),
             block_recurrences=int(g("block_recurrences") or 0),
         )
@@ -941,7 +946,13 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Exclusive physical resource keys (JSON array of ``kind:identifier``
+    -- tokens, e.g. ``["harmony-device:x1"]``) the task must hold while
+    -- running. The dispatcher treats ``running`` as the lock: a ready card
+    -- whose key is held by any running card is deferred (stays ``ready``).
+    -- NULL or empty array = no exclusive resources.
+    resources            TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1218,6 +1229,85 @@ def _normalize_task_skills(skills: Optional[Iterable[str]]) -> Optional[list[str
     return cleaned
 
 
+# Exclusive resource keys: ``kind:identifier``. The kind namespace is lowercase
+# (``harmony-device``, ``usb``); the identifier is case-sensitive so a real
+# device serial (``6HQ0226318000078``) round-trips exactly — rewriting its case
+# would gate a different physical unit than the operator asked for. Anything
+# else is refused (NOT rewritten).
+_RESOURCE_KIND_RE = re.compile(r"[a-z0-9._/-]+")
+_RESOURCE_ID_RE = re.compile(r"[A-Za-z0-9._:/-]+")
+
+
+def parse_task_resources(raw: Any) -> tuple[str, ...]:
+    """Read-path parse of a ``tasks.resources`` value (JSON column text, or an
+    already-parsed list from ``Task``). Fail-open: None / empty / corrupt JSON /
+    non-list all yield ``()`` so bad DB data never blocks dispatch."""
+    if not raw:
+        return ()
+    parsed = raw if isinstance(raw, list) else _json_or(raw)
+    if not isinstance(parsed, list):
+        return ()
+    return tuple(t for t in (str(item).strip() for item in parsed) if t)
+
+
+def normalize_resources(resources: Optional[Iterable[str]]) -> Optional[list[str]]:
+    """Write-path normalizer for a resource-key list: strip each token, drop
+    empties, dedupe preserving order, and validate each against
+    ``kind:identifier`` — lowercase kind (``[a-z0-9._/-]+``), case-sensitive
+    identifier (``[A-Za-z0-9._:/-]+``, may itself contain ``:``). ``None``
+    passes through; an all-empty result collapses to ``None`` (nothing to
+    hold). Violations raise ``ValueError``."""
+    if resources is None:
+        return None
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for token in resources:
+        if not isinstance(token, str):
+            raise ValueError(
+                f"invalid resources token {token!r}: each resource must be a string "
+                "'kind:identifier' — lowercase kind [a-z0-9._/-]+, case-sensitive "
+                "identifier, e.g. 'harmony-device:DEV1'"
+            )
+        name = token.strip()
+        if not name:
+            continue
+        kind, sep, identifier = name.partition(":")
+        if not sep:
+            raise ValueError(
+                f"invalid resources token {name!r}: resources must be 'kind:identifier' "
+                "with a ':' separator — lowercase kind [a-z0-9._/-]+, case-sensitive "
+                "identifier, e.g. 'harmony-device:DEV1'"
+            )
+        if not kind or not _RESOURCE_KIND_RE.fullmatch(kind):
+            raise ValueError(
+                f"invalid resources token {name!r}: the kind before ':' must be lowercase "
+                f"[a-z0-9._/-]+, got {kind!r}"
+            )
+        if not identifier or not _RESOURCE_ID_RE.fullmatch(identifier):
+            raise ValueError(
+                f"invalid resources token {name!r}: the identifier after ':' must match "
+                f"[A-Za-z0-9._:/-]+ (case-sensitive, e.g. a device serial), got {identifier!r}"
+            )
+        if name in seen:
+            continue
+        seen.add(name)
+        cleaned.append(name)
+    return cleaned or None
+
+
+def running_task_resources(conn: sqlite3.Connection) -> frozenset[str]:
+    """Union of the resource keys held by ``running`` tasks.
+
+    The derived lock behind the dispatcher's resource gate: ``running`` status
+    IS the lock — no lease table, no fencing. Only ``running`` holds; a card in
+    any other state owns nothing.
+    """
+    held: set[str] = set()
+    for row in conn.execute("SELECT resources FROM tasks WHERE status = 'running'"):
+        held.update(parse_task_resources(row["resources"]))
+    return frozenset(held)
+
+
 def create_task(
     conn: sqlite3.Connection, *, title: str, body: Optional[str] = None,
     assignee: Optional[str] = None, created_by: Optional[str] = None,
@@ -1232,6 +1322,7 @@ def create_task(
     project_source_task_id: Optional[str] = None,
     creator_task_id: Optional[str] = None,
     completion_contract: Optional[str] = None,
+    resources: Optional[Iterable[str]] = None,
 ) -> str:
     """Create a task (optionally under ``parents``); returns its id.
 
@@ -1285,6 +1376,7 @@ def create_task(
     )
     parents = tuple(p for p in parents if p)
     skills_list = _normalize_task_skills(skills)
+    resources_list = normalize_resources(resources)
 
     # Idempotency check BEFORE the write txn (no lock held); a concurrent-create
     # race may insert twice, the next lookup stabilises on the newest.
@@ -1331,8 +1423,9 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id, completion_contract
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id, completion_contract,
+                        resources
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id, title.strip(), body, assignee, task_status, priority,
@@ -1342,6 +1435,7 @@ def create_task(
                         json.dumps(skills_list) if skills_list is not None else None,
                         _opt_int(max_retries), model_override, provider_override, reasoning_effort,
                         1 if goal_mode else 0, _opt_int(goal_max_turns), session_id, completion_contract,
+                        json.dumps(resources_list) if resources_list is not None else None,
                     ),
                 )
                 for pid in parents:
@@ -1361,6 +1455,7 @@ def create_task(
                         "branch_name": branch_name,
                         "project_id": project_id,
                         "skills": list(skills_list) if skills_list else None,
+                        "resources": list(resources_list) if resources_list else None,
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
@@ -1567,6 +1662,21 @@ def set_reasoning_effort(conn: sqlite3.Connection, task_id: str, effort: Optiona
         conn, task_id, "UPDATE tasks SET reasoning_effort = ? WHERE id = ?", (effort,),
         "reasoning_effort_set", {"reasoning_effort": effort},
         ("reasoning_effort",), archived_msg="cannot set reasoning effort",
+    )
+
+
+def set_task_resources(
+    conn: sqlite3.Connection, task_id: str, resources: Optional[Iterable[str]],
+) -> bool:
+    """Set (empty list/None clears) the task's exclusive resource keys.
+    Applies on the NEXT dispatch — the currently running holder keeps the
+    resource until it leaves ``running`` — so settable while running."""
+    normalized = normalize_resources(resources)
+    return _set_task_override(
+        conn, task_id, "UPDATE tasks SET resources = ? WHERE id = ?",
+        (json.dumps(normalized) if normalized else None,),
+        "resources_set", {"resources": list(normalized) if normalized else None},
+        ("resources",), archived_msg="cannot set resources",
     )
 
 

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -813,6 +813,8 @@ _LATER_TASK_COLUMNS = (
     # Typed block reason (VALID_BLOCK_KINDS); NULL = generic human blocker.
     ("block_kind", "block_kind TEXT"),
     ("block_recurrences", "block_recurrences INTEGER NOT NULL DEFAULT 0"),
+    # Exclusive resource keys (JSON array); ``running`` status is the lock.
+    ("resources", "resources TEXT"),
 )
 
 _NOTIFY_SUB_COLUMNS = (

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -110,6 +110,10 @@ class DispatchResult:
     """``(task_id, assignee, current_running_count)`` deferred because the
     assignee is at ``kanban.max_in_progress_per_profile``. Picked up on a later
     tick; separate bucket so dashboards show "profile busy" vs "stuck"."""
+    skipped_resource_held: list[tuple[str, str]] = field(default_factory=list)
+    """``(task_id, resource)`` deferred because a running card holds ``resource``.
+    Picked up on a later tick when the holder leaves running; separate bucket so
+    health telemetry tells "waiting on a physical resource" from "stuck"."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -1228,17 +1232,26 @@ def _profile_exists_fn() -> Optional[Callable[[str], bool]]:
 
 def _has_spawnable(conn: sqlite3.Connection, status: str) -> bool:
     rows = conn.execute(
-        "SELECT DISTINCT assignee FROM tasks "
+        "SELECT DISTINCT assignee, resources FROM tasks "
         "WHERE status = ? AND assignee IS NOT NULL AND claim_lock IS NULL",
         (status,),
     ).fetchall()
     if not rows:
         return False
+    # A row whose resources are (even partly) held by a running card can't
+    # spawn this tick, so it must not count as spawnable work.
+    held = _kb.running_task_resources(conn)
+
+    def _resource_clear(row: sqlite3.Row) -> bool:
+        res = _kb.parse_task_resources(row["resources"])
+        return not (res and set(res) & held)
+
     profile_exists = _profile_exists_fn()
     if profile_exists is None:
         # Can't introspect — assume spawnable, preserve legacy behavior.
-        return True
-    return any(profile_exists(row["assignee"]) for row in rows)
+        # The resource filter still applies: a held key blocks regardless.
+        return any(_resource_clear(row) for row in rows)
+    return any(profile_exists(row["assignee"]) and _resource_clear(row) for row in rows)
 
 
 def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
@@ -1501,11 +1514,13 @@ def _dispatch_lane_task(
     spawn_fn,
     per_profile_cap: Optional[int],
     per_profile_running: dict[str, int],
+    held_resources: set[str],
 ) -> bool:
     """Guard, claim, resolve the workspace and spawn one ready/review row.
     Returns True when a spawn slot was consumed (real or ``dry_run``); every
-    skip is recorded on ``result``.
-    """
+    skip is recorded on ``result``. ``held_resources`` is the tick's live
+    resource-hold set (running cards + this tick's spawns); it is mutated as
+    spawns land so later rows in the same tick see the new holds."""
     task_id = row["id"]
     # Non-profile assignees (control-plane lanes that pull via ``claim_task``)
     # would fail ``hermes -p <assignee>`` at startup and loop ready→crash→ready
@@ -1521,6 +1536,15 @@ def _dispatch_lane_task(
         current = per_profile_running.get(assignee, 0)
         if current >= per_profile_cap:
             result.skipped_per_profile_capped.append((task_id, assignee, current))
+            return False
+    # Resource gate: ``running`` status IS the lock (no lease table, no
+    # fencing). A ready card whose key a running card holds stays ready —
+    # "waiting on a physical resource", never a failure, never a block.
+    task_res = _kb.parse_task_resources(row["resources"])
+    if task_res:
+        conflict = sorted(set(task_res) & held_resources)
+        if conflict:
+            result.skipped_resource_held.append((task_id, conflict[0]))
             return False
     guard_reason = check_respawn_guard(conn, task_id, lane=lane)
     if guard_reason is not None:
@@ -1543,9 +1567,15 @@ def _dispatch_lane_task(
         if per_profile_cap is not None and name:
             per_profile_running[name] = per_profile_running.get(name, 0) + 1
 
+    def _hold_resources(res: tuple[str, ...]) -> None:
+        # Rolling update of the tick's held set: later rows this tick must see
+        # the resources this spawn now holds (the 09-10 same-tick fan-out).
+        held_resources.update(res)
+
     if dry_run:
         result.spawned.append((task_id, assignee, ""))
         _count_spawn(assignee)
+        _hold_resources(task_res)
         return True
     claim = _kb.claim_review_task if lane == "review" else _kb.claim_task
     claimed = claim(conn, task_id, ttl_seconds=ttl_seconds)
@@ -1583,6 +1613,7 @@ def _dispatch_lane_task(
         # only on successful completion (complete_task).
         result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
         _count_spawn(claimed.assignee)
+        _hold_resources(task_res)
         return True
     except Exception as exc:
         if _record_task_failure(
@@ -1709,9 +1740,10 @@ def _tick_spawn_budget(
 
 
 def _lane_rows(conn: sqlite3.Connection, status: str) -> list[sqlite3.Row]:
-    """Unclaimed rows of one lane in dispatch order."""
+    """Unclaimed rows of one lane in dispatch order (``resources`` feeds the
+    resource gate)."""
     return conn.execute(
-        "SELECT id, assignee FROM tasks "
+        "SELECT id, assignee, resources FROM tasks "
         f"WHERE status = '{status}' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
@@ -1807,10 +1839,14 @@ def _dispatch_once_locked(
             "GROUP BY assignee"
         ):
             per_profile_running[prow["assignee"]] = int(prow["n"])
+    # Resource gate: one query at tick start for what running cards hold; the
+    # set is rolled forward in-memory as this tick's spawns land.
+    held_resources = set(_kb.running_task_resources(conn))
     lane_kwargs: dict[str, Any] = dict(
         dry_run=dry_run, ttl_seconds=ttl_seconds, board=board,
         failure_limit=failure_limit, spawn_fn=spawn_fn,
         per_profile_cap=per_profile_cap, per_profile_running=per_profile_running,
+        held_resources=held_resources,
     )
     default_assignee = _resolve_default_assignee(default_assignee)
     spawned = 0

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -637,6 +637,16 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     if not assignee.strip():
         return []
 
+    # Held-resource exemption: a card whose key is held by a running card is
+    # queued behind a physical resource, not stranded — the dispatcher defers
+    # it (stays ready) and picks it up when the holder leaves running.
+    # ``or set()`` is load-bearing: ``frozenset() & None`` would TypeError and
+    # the rule loop's except would silently disable the whole rule.
+    from hermes_cli.kanban_db import parse_task_resources
+    task_resources = parse_task_resources(_task_field(task, "resources"))
+    if task_resources and (set(task_resources) & (cfg.get("_held_resources") or set())):
+        return []
+
     # Most recent event that put the task into ready; with none (old task /
     # truncated events) fall back to created_at — over-flagging an ancient
     # task beats missing a stranded one.
@@ -668,9 +678,9 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
         kind="stranded_in_ready", severity=severity,
         title=f"Ready for {age_str} with no worker",
         detail=f"This task has been ready for {age_str} but nothing has claimed it. Common causes: "
-               f"assignee {assignee!r} is misspelled, the profile was deleted, or the external worker "
-               f"pool for this lane is down. Confirm the assignee is correct and that a worker is "
-               f"actually polling for it.",
+               f"assignee {assignee!r} is misspelled, the profile was deleted, the external worker "
+               f"pool for this lane is down, or waiting on a held resource. Confirm the assignee is "
+               f"correct and that a worker is actually polling for it.",
         actions=actions,
         first_seen_at=last_ready_ts, last_seen_at=last_ready_ts, count=1,
         data={"ready_since": last_ready_ts, "age_seconds": int(age_seconds),
@@ -751,14 +761,19 @@ def compute_task_diagnostics(
     now: Optional[int] = None,
     config: Optional[dict] = None,
     graph: Optional[dict] = None,
+    held_resources: Optional[frozenset[str]] = None,
 ) -> list[Diagnostic]:
     """Run every rule for one task; critical first, then error, warning; ties
-    broken by most-recent ``last_seen_at``."""
+    broken by most-recent ``last_seen_at``. ``held_resources`` is the union of
+    resource keys currently held by running cards (``kanban_db.
+    running_task_resources``) so ``stranded_in_ready`` can tell "queued behind
+    a physical resource" from "stuck"."""
     now_ts = int(now if now is not None else time.time())
     config = config or {}
     cfg = {**DEFAULT_CONFIG, **config}
     if graph is not None:
         cfg["_graph"] = graph
+    cfg["_held_resources"] = held_resources or frozenset()
     if not _has_explicit_threshold(config) and "failure_limit" in config:
         cfg["failure_threshold"] = _positive_int(
             config.get("failure_limit"), DEFAULT_CONFIG["failure_threshold"],

--- a/hermes_cli/kanban_ops.py
+++ b/hermes_cli/kanban_ops.py
@@ -104,6 +104,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
             ],
+            "skipped_resource_held": [
+                {"task_id": tid, "resource": key}
+                for (tid, key) in res.skipped_resource_held
+            ],
             "auto_assigned_default": res.auto_assigned_default,
         }, ascii=True)
         return 0
@@ -131,6 +135,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         print(f"Skipped (unassigned): {', '.join(res.skipped_unassigned)}")
     for tid, who, current in res.skipped_per_profile_capped:
         print(f"Deferred ({who} at per-profile cap, {current} running): {tid}")
+    for tid, key in res.skipped_resource_held:
+        print(f"Deferred (resource {key} held by a running card): {tid}")
     if res.skipped_nonspawnable:
         print(
             f"Skipped (non-spawnable assignee — terminal lane, OK): "

--- a/hermes_cli/kanban_output.py
+++ b/hermes_cli/kanban_output.py
@@ -19,7 +19,7 @@ _TASK_DICT_FIELDS = (
     "id", "title", "body", "assignee", "status", "priority", "tenant",
     "workspace_kind", "workspace_path", "branch_name", "project_id",
     "created_by", "created_at", "started_at", "completed_at", "result",
-    "skills", "max_retries", "model_override", "provider_override",
+    "skills", "resources", "max_retries", "model_override", "provider_override",
     "session_id", "workflow_template_id", "current_step_key", "completion_contract", "last_failure_error",
 )
 _SHOW_RUN_FIELDS = (
@@ -75,7 +75,8 @@ def _fmt_task_line(t: kb.Task) -> str:
     icon = _STATUS_ICONS.get(t.status, "?")
     assignee = t.assignee or "(unassigned)"
     tenant = f" [{t.tenant}]" if t.tenant else ""
-    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}"
+    resources = f" [res:{','.join(t.resources)}]" if t.resources else ""
+    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}{resources}  {t.title}"
 
 
 def _obj_dict(obj: Any, fields: tuple[str, ...]) -> dict[str, Any]:
@@ -85,4 +86,5 @@ def _obj_dict(obj: Any, fields: tuple[str, ...]) -> dict[str, Any]:
 def _task_to_dict(t: kb.Task) -> dict[str, Any]:
     d = _obj_dict(t, _TASK_DICT_FIELDS)
     d["skills"] = list(t.skills) if t.skills else []
+    d["resources"] = list(t.resources) if t.resources else []
     return d

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -174,6 +174,11 @@ _SPECS = [
              help="Skill to force-load into the worker (repeatable). The kanban "
                   "lifecycle is already injected automatically. Example: --skill "
                   "translation --skill github-code-review"),
+        _arg("--resources",
+             help="Comma-separated exclusive resource keys the card must hold "
+                  "while running, e.g. 'harmony-device:x1,lab:bench-2'. "
+                  "kind:identifier — lowercase kind, case-sensitive identifier; "
+                  "the dispatcher runs at most one card per key at a time."),
         _arg("--max-retries", type=int, metavar="N",
              help="Per-task override for the consecutive-failure "
                   f"circuit breaker. Trip on the Nth failure — e.g. --max-retries 1 blocks on the "
@@ -241,6 +246,15 @@ _SPECS = [
              help="Provider the model belongs to (worker is spawned with "
                   "--provider <name>). Cleared together with the model."),
     ], help="Set or clear a task's model/provider override (takes effect on the next dispatch)"),
+    _cmd("update", [
+        _TASK_ID,
+        _arg("--resources", required=True,
+             help="Comma-separated exclusive resource keys (kind:identifier — "
+                  "lowercase kind, case-sensitive identifier, e.g. "
+                  "'harmony-device:6HQ0226318000078'); an empty string "
+                  "clears them. The dispatcher runs at most one card per key at "
+                  "a time; changes apply on the next dispatch."),
+    ], help="Update task properties (--resources only)"),
     _cmd("reclaim", [_TASK_ID, _RECLAIM_REASON], help="Release an active worker claim on a running task"),
     _cmd("reassign", [
         _TASK_ID,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -220,11 +220,13 @@ def _compute_task_diagnostics(conn: sqlite3.Connection, task_ids: Optional[list[
     events_by_task = _rows_by_task("task_events")
     runs_by_task = _rows_by_task("task_runs")
     graph_by_task = kanban_db.task_graph_contexts(conn, row_ids)
+    held_resources = kanban_db.running_task_resources(conn)
     out: dict[str, list[dict]] = {}
     for r in rows:
         tid = r["id"]
         diags = kd.compute_task_diagnostics(
-            r, events_by_task[tid], runs_by_task[tid], config=diag_config, graph=graph_by_task.get(tid))
+            r, events_by_task[tid], runs_by_task[tid], config=diag_config,
+            graph=graph_by_task.get(tid), held_resources=held_resources)
         if diags:
             out[tid] = [d.to_dict() for d in diags]
     return out

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1464,6 +1464,25 @@ def _live_system_guard(request, monkeypatch):
         low = cmd_str.lower()
         return any(tok in low for tok in _HERMES_TOKENS)
 
+    def _invokes_hermes_update(cmd) -> bool:
+        # The updater is `update` as the subcommand IMMEDIATELY after the
+        # hermes entrypoint. Matching any later `update` token would also
+        # catch kanban verbs like `hermes kanban update` (AGENTS.md: match
+        # full cmdlines, never argv substrings).
+        tokens = list(cmd) if isinstance(cmd, (list, tuple)) else None
+        if tokens is not None:
+            for i in range(len(tokens) - 1):
+                head = str(tokens[i]).rsplit("/", 1)[-1]
+                if head in ("hermes", "hermes_cli.main") and str(tokens[i + 1]) == "update":
+                    return True
+            # Free-form shell strings (bash -c "..."): the phrase lives
+            # inside one token; block it conservatively.
+            return any(
+                " " in str(tok) and "hermes update" in str(tok).lower()
+                for tok in tokens
+            )
+        return "hermes update" in _cmd_to_string(cmd).lower()
+
     def _is_blocked_systemctl(cmd) -> bool:
         cmd_str = _cmd_to_string(cmd)
         if "systemctl" not in cmd_str:
@@ -1538,16 +1557,7 @@ def _live_system_guard(request, monkeypatch):
         # the update-spawn path must mock subprocess.Popen explicitly.
         cmd_str = _cmd_to_string(cmd)
         low = cmd_str.lower()
-        if "update" in low and (
-            # hermes update / hermes update --gateway / setsid bash -c ... hermes update
-            ("hermes" in low and "update" in low.split())
-            or
-            # python -m hermes_cli.main update --gateway
-            ("hermes_cli" in low and "update" in low.split())
-            or
-            # venv/bin/hermes update  (absolute path variant used in tests)
-            (".venv/bin/hermes" in low and "update" in low)
-        ):
+        if "update" in low and _invokes_hermes_update(cmd):
             raise RuntimeError(
                 f"tests/conftest.py live-system guard: blocked "
                 f"subprocess.{name}({cmd!r}) — this command would run "

--- a/tests/hermes_cli/test_kanban_resource_gate.py
+++ b/tests/hermes_cli/test_kanban_resource_gate.py
@@ -1,0 +1,578 @@
+"""Kanban dispatcher resource gate — ``tasks.resources`` column, derived lock.
+
+A card's ``resources`` are exclusive physical keys (``kind:identifier``, e.g.
+``harmony-device:x1``) that must not be shared by two concurrent workers: the
+09-10 02:31 incident let one tick fan three cards out onto the same HarmonyOS
+device. ``running`` status IS the lock — no lease table, no fencing: a ready
+card whose resource is held by any running card stays ``ready`` (deferred to a
+later tick, ``skipped_resource_held``), never blocked, never failed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sqlite3
+import sys
+import tempfile
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_kanban_home_with_profiles(monkeypatch):
+    """Spin up a fresh HERMES_HOME with kanban DB + alpha/beta profiles."""
+    test_home = tempfile.mkdtemp(prefix="kanban_resource_gate_test_")
+    for prof in ("alpha", "beta", "default"):
+        os.makedirs(os.path.join(test_home, "profiles", prof), exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+    yield kanban_db
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+def _connect(kb):
+    from hermes_cli import kanban_db_connect as kbc
+    return kbc.connect_closing()
+
+
+def _make_board(kb, *task_kwargs_tuple):
+    """Create the default board (idempotent for the fixture's lifetime)."""
+    with _connect(kb) as conn:
+        kb.create_board(slug="default", name="Test")
+
+
+# ---------------------------------------------------------------------------
+# Storage: schema, migration, Task.from_row, parse/normalize helpers
+# ---------------------------------------------------------------------------
+
+
+def test_new_board_has_resources_column(isolated_kanban_home_with_profiles):
+    kb = isolated_kanban_home_with_profiles
+    _make_board(kb)
+    with _connect(kb) as conn:
+        cols = {row["name"]: (row["type"] or "").upper()
+                for row in conn.execute("PRAGMA table_info(tasks)")}
+    assert "resources" in cols
+    assert cols["resources"] == "TEXT"
+
+
+def test_legacy_board_migration_adds_resources(isolated_kanban_home_with_profiles):
+    """A board whose DB predates the column gains it on the next init pass and
+    keeps its rows (additive migration, NULL default)."""
+    kb = isolated_kanban_home_with_profiles
+    _make_board(kb)
+    db_path = kb.kanban_db_path()
+    # Roll the schema back to pre-resources, with one surviving row.
+    raw = sqlite3.connect(str(db_path))
+    raw.execute("ALTER TABLE tasks DROP COLUMN resources")
+    raw.execute(
+        "INSERT INTO tasks (id, title, status, created_at) VALUES ('legacy-1', 'L', 'done', 1000)"
+    )
+    raw.commit()
+    raw.close()
+    # init_db always re-runs the migration pass (connect() caches first init).
+    kb.init_db()
+    with _connect(kb) as conn:
+        cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+        row = conn.execute("SELECT status FROM tasks WHERE id = 'legacy-1'").fetchone()
+    assert "resources" in cols
+    assert row is not None and row["status"] == "done"
+
+
+def test_task_from_row_resources_four_states(isolated_kanban_home_with_profiles):
+    """NULL -> None; '[]' -> []; valid JSON -> list; corrupt JSON -> None."""
+    kb = isolated_kanban_home_with_profiles
+    _make_board(kb)
+    with _connect(kb) as conn:
+        with kb.write_txn(conn):
+            for tid, raw in (("t-null", None), ("t-empty", "[]"),
+                             ("t-one", '["a:b"]'), ("t-bad", "not json")):
+                conn.execute(
+                    "INSERT INTO tasks (id, title, status, created_at, resources) "
+                    "VALUES (?, ?, 'ready', 1000, ?)",
+                    (tid, tid, raw),
+                )
+        assert kb.get_task(conn, "t-null").resources is None
+        assert kb.get_task(conn, "t-empty").resources == []
+        assert kb.get_task(conn, "t-one").resources == ["a:b"]
+        assert kb.get_task(conn, "t-bad").resources is None
+
+
+def test_parse_task_resources_fails_open(isolated_kanban_home_with_profiles):
+    """Bad data on the read path never blocks dispatch and never raises."""
+    kb = isolated_kanban_home_with_profiles
+    assert kb.parse_task_resources(None) == ()
+    assert kb.parse_task_resources("") == ()
+    assert kb.parse_task_resources("not json") == ()
+    assert kb.parse_task_resources('{"a": 1}') == ()  # valid JSON, not a list
+    assert kb.parse_task_resources("[]") == ()
+    assert kb.parse_task_resources('["a:b", "", "c:d"]') == ("a:b", "c:d")
+    assert kb.parse_task_resources(["a:b", 2]) == ("a:b", "2")  # already-parsed list
+
+
+def test_normalize_resources_normalizes(isolated_kanban_home_with_profiles):
+    kb = isolated_kanban_home_with_profiles
+    assert kb.normalize_resources(None) is None
+    assert kb.normalize_resources([]) is None
+    assert kb.normalize_resources(["  "]) is None  # only blanks -> nothing to hold
+    assert kb.normalize_resources([" a:b ", "a:b", ""]) == ["a:b"]  # strip + dedupe, keep order
+    assert kb.normalize_resources(["c:d", "a:b"]) == ["c:d", "a:b"]
+    # Case-preserved identifiers: device serials must round-trip exactly.
+    assert kb.normalize_resources(["harmony-device:DEV1"]) == ["harmony-device:DEV1"]
+    assert kb.normalize_resources(
+        ["harmony-device:6HQ0226318000078"]
+    ) == ["harmony-device:6HQ0226318000078"]
+    assert kb.normalize_resources(["  usb:K1  ", "usb:K1", ""]) == ["usb:K1"]
+    assert kb.normalize_resources(["usb:K1:L2"]) == ["usb:K1:L2"]  # identifier may contain ':'
+
+
+def test_normalize_resources_rejects_instead_of_rewriting(isolated_kanban_home_with_profiles):
+    """Uppercase kind, injection characters, missing ':', empty kind/identifier
+    and non-str are refused (ValueError naming the offending token and the
+    allowed charset) — never silently rewritten into a different identity."""
+    kb = isolated_kanban_home_with_profiles
+    for bad in (["Harmony-Device:X1"], ["usb:K1;rm -rf /"], ["nocolon"],
+                [":K1"], ["usb:"], ["a b"], [123]):
+        with pytest.raises(ValueError) as excinfo:
+            kb.normalize_resources(bad)
+        msg = str(excinfo.value)
+        assert "resources" in msg
+        assert "a-z" in msg  # allowed-charset hint
+
+
+def _running_holder(kb, title: str, resources, assignee: str = "alpha") -> str:
+    """Create a card and claim it — a healthy ``running`` holder with real
+    claim bookkeeping (a hand-made running row with NULL claim fields is a
+    zombie the dispatcher's reconcile pass would requeue before the gate)."""
+    with _connect(kb) as conn:
+        tid = kb.create_task(conn, title=title, assignee=assignee, resources=resources)
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None and claimed.status == "running"
+    return tid
+
+
+def test_running_task_resources_unions_running_only(isolated_kanban_home_with_profiles):
+    """Only ``running`` holds; blocked/review/ready/done never do."""
+    kb = isolated_kanban_home_with_profiles
+    _make_board(kb)
+    _running_holder(kb, "holder-a", ["dev:a", "dev:b"])
+    with _connect(kb) as conn:
+        kb.create_task(conn, title="ready-b", assignee="alpha", resources=["dev:b"])
+        kb.create_task(conn, title="blocked-c", assignee="alpha",
+                       resources=["dev:c"], initial_status="blocked")
+        done_id = kb.create_task(conn, title="done-d", assignee="alpha", resources=["dev:d"])
+        review_id = kb.create_task(conn, title="rev-e", assignee="alpha", resources=["dev:e"])
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (done_id,))
+            conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (review_id,))
+        assert kb.running_task_resources(conn) == frozenset({"dev:a", "dev:b"})
+
+
+# ---------------------------------------------------------------------------
+# create_task / set_task_resources
+# ---------------------------------------------------------------------------
+
+
+def test_create_task_persists_resources(isolated_kanban_home_with_profiles):
+    kb = isolated_kanban_home_with_profiles
+    _make_board(kb)
+    with _connect(kb) as conn:
+        tid = kb.create_task(conn, title="needs device", assignee="alpha",
+                             resources=["a:b", "c:d"])
+        task = kb.get_task(conn, tid)
+        raw = conn.execute("SELECT resources FROM tasks WHERE id = ?", (tid,)).fetchone()
+        events = [e for e in kb.list_events(conn, tid) if e.kind == "created"]
+    assert task.resources == ["a:b", "c:d"]
+    assert json.loads(raw["resources"]) == ["a:b", "c:d"]
+    assert events and events[0].payload.get("resources") == ["a:b", "c:d"]
+
+
+def test_create_task_empty_resources_stores_null(isolated_kanban_home_with_profiles):
+    """Empty list means "no resources" and is stored as NULL, not '[]'."""
+    kb = isolated_kanban_home_with_profiles
+    _make_board(kb)
+    with _connect(kb) as conn:
+        tid = kb.create_task(conn, title="plain", assignee="alpha", resources=[])
+        raw = conn.execute("SELECT resources FROM tasks WHERE id = ?", (tid,)).fetchone()
+        assert raw["resources"] is None
+        assert kb.get_task(conn, tid).resources is None
+
+
+def test_set_task_resources_set_clear_missing_archived(isolated_kanban_home_with_profiles):
+    kb = isolated_kanban_home_with_profiles
+    _make_board(kb)
+    with _connect(kb) as conn:
+        tid = kb.create_task(conn, title="t", assignee="alpha")
+        assert kb.set_task_resources(conn, tid, ["x:y"]) is True
+        assert kb.get_task(conn, tid).resources == ["x:y"]
+        # Clearing with an empty list stores NULL.
+        assert kb.set_task_resources(conn, tid, []) is True
+        assert kb.get_task(conn, tid).resources is None
+        # Unknown task -> False.
+        assert kb.set_task_resources(conn, "t-missing", ["x:y"]) is False
+        # Archived task is refused.
+        arch = kb.create_task(conn, title="arch", assignee="alpha")
+        assert kb.archive_task(conn, arch) is True
+        with pytest.raises(RuntimeError):
+            kb.set_task_resources(conn, arch, ["x:y"])
+        # Invalid token rejected before any write.
+        with pytest.raises(ValueError):
+            kb.set_task_resources(conn, tid, ["BAD KEY"])
+        assert kb.get_task(conn, tid).resources is None
+
+
+# ---------------------------------------------------------------------------
+# The gate in the dispatcher tick
+# ---------------------------------------------------------------------------
+
+
+def _two_cards_same_resource(kb, resource="dev:x"):
+    """Two ready alpha cards needing ``resource``; the first has priority so
+    lane order is deterministic."""
+    with _connect(kb) as conn:
+        first = kb.create_task(conn, title="first", assignee="alpha",
+                               resources=[resource], priority=5)
+        second = kb.create_task(conn, title="second", assignee="alpha",
+                                resources=[resource], priority=1)
+    return first, second
+
+
+def test_same_tick_resource_conflict_deferred(isolated_kanban_home_with_profiles):
+    """Two cards sharing one resource never spawn in the same tick — the exact
+    09-10 cross-contamination shape (dry-run variant)."""
+    kb = isolated_kanban_home_with_profiles
+    first, second = _two_cards_same_resource(kb)
+    from hermes_cli import kanban_db_dispatch as kbd
+    with _connect(kb) as conn:
+        res = kbd.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    assert [s[0] for s in res.spawned] == [first]
+    assert res.skipped_resource_held == [(second, "dev:x")]
+
+
+def test_real_spawn_rolling_hold_blocks_same_tick(isolated_kanban_home_with_profiles):
+    """Non-dry-run: the first card claims (-> running) mid-tick; the second
+    must still be deferred even though the tick-start held-set was empty.
+    Stay-ready contract: no block, no failure, no block_recurrences."""
+    kb = isolated_kanban_home_with_profiles
+    first, second = _two_cards_same_resource(kb)
+    from hermes_cli import kanban_db_dispatch as kbd
+    with _connect(kb) as conn:
+        res = kbd.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    assert [s[0] for s in res.spawned] == [first]
+    assert res.skipped_resource_held == [(second, "dev:x")]
+    with _connect(kb) as conn:
+        row = conn.execute(
+            "SELECT status, consecutive_failures, block_recurrences FROM tasks WHERE id = ?",
+            (second,),
+        ).fetchone()
+    assert row["status"] == "ready"
+    assert row["consecutive_failures"] == 0
+    assert row["block_recurrences"] == 0
+
+
+def test_holder_release_on_next_tick(isolated_kanban_home_with_profiles):
+    """The deferred card is picked up once the holder leaves running."""
+    kb = isolated_kanban_home_with_profiles
+    first, second = _two_cards_same_resource(kb)
+    from hermes_cli import kanban_db_dispatch as kbd
+    with _connect(kb) as conn:
+        res1 = kbd.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    assert res1.skipped_resource_held == [(second, "dev:x")]
+    with _connect(kb) as conn:
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'done', claim_lock = NULL WHERE id = ?", (first,)
+            )
+    with _connect(kb) as conn:
+        res2 = kbd.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    assert [s[0] for s in res2.spawned] == [second]
+    assert res2.skipped_resource_held == []
+
+
+def test_multi_resource_any_intersection_blocks(isolated_kanban_home_with_profiles):
+    """Any single shared key out of several blocks; disjoint keys don't."""
+    kb = isolated_kanban_home_with_profiles
+    from hermes_cli import kanban_db_dispatch as kbd
+    _running_holder(kb, "holder", ["dev:a"])
+    with _connect(kb) as conn:
+        overlap = kb.create_task(conn, title="overlap", assignee="alpha",
+                                 resources=["dev:b", "dev:a"], priority=5)
+        disjoint = kb.create_task(conn, title="disjoint", assignee="alpha",
+                                  resources=["dev:b", "dev:c"], priority=1)
+        res = kbd.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    assert res.skipped_resource_held == [(overlap, "dev:a")]
+    assert [s[0] for s in res.spawned] == [disjoint]
+
+
+def test_no_resources_dispatch_unchanged(isolated_kanban_home_with_profiles):
+    """Cards without resources are untouched by the gate."""
+    kb = isolated_kanban_home_with_profiles
+    with _connect(kb) as conn:
+        a = kb.create_task(conn, title="a", assignee="alpha")
+        b = kb.create_task(conn, title="b", assignee="alpha")
+    from hermes_cli import kanban_db_dispatch as kbd
+    with _connect(kb) as conn:
+        res = kbd.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    assert sorted(s[0] for s in res.spawned) == sorted([a, b])
+    assert res.skipped_resource_held == []
+
+
+def test_per_profile_cap_and_resource_gate_stack(isolated_kanban_home_with_profiles):
+    """Both gates apply: per-profile cap is checked first, the resource gate
+    only sees cards that cleared the cap."""
+    kb = isolated_kanban_home_with_profiles
+    with _connect(kb) as conn:
+        first = kb.create_task(conn, title="first", assignee="alpha",
+                               resources=["dev:x"], priority=5)
+        second = kb.create_task(conn, title="second", assignee="alpha",
+                                resources=["dev:x"], priority=1)
+    from hermes_cli import kanban_db_dispatch as kbd
+    with _connect(kb) as conn:
+        res1 = kbd.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False,
+                                 max_in_progress_per_profile=1)
+    assert [s[0] for s in res1.spawned] == [first]
+    # Cap fires before the resource gate, so the deferral lands in the cap bucket.
+    assert [c[0] for c in res1.skipped_per_profile_capped] == [second]
+    assert res1.skipped_resource_held == []
+    with _connect(kb) as conn:
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'done', claim_lock = NULL WHERE id = ?", (first,)
+            )
+    with _connect(kb) as conn:
+        res2 = kbd.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False,
+                                 max_in_progress_per_profile=1)
+    assert [s[0] for s in res2.spawned] == [second]
+
+
+# ---------------------------------------------------------------------------
+# _has_spawnable resource awareness (health telemetry)
+# ---------------------------------------------------------------------------
+
+
+def test_has_spawnable_ready_resource_aware(isolated_kanban_home_with_profiles):
+    """A ready card whose only key is held by a running card is NOT spawnable
+    ("correctly idle", not "stuck"); with the key free it is."""
+    kb = isolated_kanban_home_with_profiles
+    from hermes_cli import kanban_db_dispatch as kbd
+    _running_holder(kb, "holder", ["dev:x"])
+    with _connect(kb) as conn:
+        blocked_key = kb.create_task(conn, title="needs held key", assignee="alpha",
+                                     resources=["dev:x"])
+        assert kbd.has_spawnable_ready(conn) is False
+        kb.set_task_resources(conn, blocked_key, ["dev:y"])
+        assert kbd.has_spawnable_ready(conn) is True
+
+
+# ---------------------------------------------------------------------------
+# Watcher spawn log
+# ---------------------------------------------------------------------------
+
+
+def test_watcher_log_reports_resource_held(caplog):
+    from gateway import kanban_watchers_dispatcher as kwd
+    from hermes_cli.kanban_db_dispatch import DispatchResult
+
+    res = DispatchResult(
+        spawned=[("t1", "alpha", "/ws")],
+        skipped_resource_held=[("t2", "dev:x"), ("t3", "dev:y")],
+    )
+    with caplog.at_level(logging.INFO):
+        assert kwd._log_spawn_results([("slug", res)]) is True
+    assert "skipped_resource_held=2" in caplog.text
+    # None result rows are tolerated as before.
+    assert kwd._log_spawn_results([("slug", None)]) is False
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics: stranded-in-ready exemption
+# ---------------------------------------------------------------------------
+
+
+def _stranded_task(resources_raw):
+    return {
+        "id": "t-strand", "title": "stranded?", "status": "ready",
+        "assignee": "alpha", "claim_lock": None, "created_at": 1000,
+        "resources": resources_raw,
+    }
+
+
+def _stranded_events(now):
+    return [{"kind": "created", "created_at": now - 7200}]  # ready for 2h
+
+
+def test_stranded_rule_exempt_when_resource_held(isolated_kanban_home_with_profiles):
+    from hermes_cli import kanban_diagnostics as kd
+
+    now = 10_000_000
+    cfg = {"stranded_threshold_seconds": 60}
+    diags = kd.compute_task_diagnostics(
+        _stranded_task('["dev:x"]'), _stranded_events(now), [],
+        now=now, config=cfg, held_resources=frozenset({"dev:x"}),
+    )
+    assert [d.kind for d in diags] == []
+    # Without the held key the same card IS stranded.
+    diags = kd.compute_task_diagnostics(
+        _stranded_task('["dev:x"]'), _stranded_events(now), [],
+        now=now, config=cfg, held_resources=frozenset({"dev:other"}),
+    )
+    assert "stranded_in_ready" in [d.kind for d in diags]
+
+
+def test_stranded_rule_default_held_set_is_empty(isolated_kanban_home_with_profiles):
+    """Callers that don't pass held_resources keep today's behavior (no crash,
+    no wrongful exemption) — the ``&``/``or`` precedence trap."""
+    from hermes_cli import kanban_diagnostics as kd
+
+    now = 10_000_000
+    diags = kd.compute_task_diagnostics(
+        _stranded_task('["dev:x"]'), _stranded_events(now), [],
+        now=now, config={"stranded_threshold_seconds": 60},
+    )
+    assert "stranded_in_ready" in [d.kind for d in diags]
+
+
+def test_stranded_rule_bad_resources_json_does_not_exempt(isolated_kanban_home_with_profiles):
+    """Corrupt resources on the row fail open: the card stays flaggable."""
+    from hermes_cli import kanban_diagnostics as kd
+
+    now = 10_000_000
+    diags = kd.compute_task_diagnostics(
+        _stranded_task("not json"), _stranded_events(now), [],
+        now=now, config={"stranded_threshold_seconds": 60},
+        held_resources=frozenset({"dev:x"}),
+    )
+    assert "stranded_in_ready" in [d.kind for d in diags]
+
+
+def test_stranded_detail_mentions_held_resource(isolated_kanban_home_with_profiles):
+    from hermes_cli import kanban_diagnostics as kd
+
+    now = 10_000_000
+    diags = kd.compute_task_diagnostics(
+        _stranded_task(None), _stranded_events(now), [],
+        now=now, config={"stranded_threshold_seconds": 60},
+    )
+    detail = next(d for d in diags if d.kind == "stranded_in_ready").detail
+    assert "waiting on a held resource" in detail
+
+
+# ---------------------------------------------------------------------------
+# CLI: create --resources, update subcommand, display
+# ---------------------------------------------------------------------------
+
+
+def _parse(*argv):
+    """Build the real ``hermes kanban`` parser (one subparser group, as the CLI
+    wires it) and parse a ``kanban`` argv tail."""
+    from hermes_cli.kanban_parser import build_parser
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    build_parser(parser.add_subparsers(dest="command"))
+    return parser.parse_args(["kanban", *argv])
+
+
+def test_cli_create_with_resources(isolated_kanban_home_with_profiles, capsys):
+    kb = isolated_kanban_home_with_profiles
+    _make_board(kb)
+    from hermes_cli import kanban as kc
+    args = _parse("create", "needs device", "--assignee", "alpha",
+                  "--resources", "a:b, c:d")
+    rc = kc._cmd_create(args)
+    assert rc == 0
+    with _connect(kb) as conn:
+        tasks = kb.list_tasks(conn)
+    assert len(tasks) == 1
+    assert tasks[0].resources == ["a:b", "c:d"]
+
+
+def test_cli_create_rejects_invalid_resource(isolated_kanban_home_with_profiles, capsys):
+    kb = isolated_kanban_home_with_profiles
+    _make_board(kb)
+    from hermes_cli import kanban as kc
+    args = _parse("create", "bad", "--assignee", "alpha",
+                  "--resources", "Harmony-Device:X1")
+    rc = kc._cmd_create(args)
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "resources" in err
+    with _connect(kb) as conn:
+        assert kb.list_tasks(conn) == []  # no card created
+
+
+def test_cli_update_subcommand(isolated_kanban_home_with_profiles, capsys):
+    kb = isolated_kanban_home_with_profiles
+    _make_board(kb)
+    from hermes_cli import kanban as kc
+    with _connect(kb) as conn:
+        tid = kb.create_task(conn, title="t", assignee="alpha")
+    args = _parse("update", tid, "--resources", "x:y,z:w")
+    assert kc._cmd_update(args) == 0
+    with _connect(kb) as conn:
+        assert kb.get_task(conn, tid).resources == ["x:y", "z:w"]
+    # Empty string clears.
+    args = _parse("update", tid, "--resources", "")
+    assert kc._cmd_update(args) == 0
+    with _connect(kb) as conn:
+        assert kb.get_task(conn, tid).resources is None
+    # Unknown task -> non-zero.
+    args = _parse("update", "t-missing", "--resources", "x:y")
+    assert kc._cmd_update(args) != 0
+
+
+def test_cli_show_and_list_display_resources(isolated_kanban_home_with_profiles, capsys):
+    kb = isolated_kanban_home_with_profiles
+    _make_board(kb)
+    from hermes_cli import kanban as kc
+    with _connect(kb) as conn:
+        tid = kb.create_task(conn, title="t", assignee="alpha", resources=["a:b", "c:d"])
+    out = kc.run_slash(f"show {tid}")
+    assert "a:b, c:d" in out
+    out = kc.run_slash("list")
+    assert f"[res:a:b,c:d]" in out
+    assert out.count("[res:") == 1  # compact bracket only when non-empty
+    payload = json.loads(kc.run_slash("list --json"))
+    assert payload[0]["resources"] == ["a:b", "c:d"]
+
+
+# ---------------------------------------------------------------------------
+# Model tool surface
+# ---------------------------------------------------------------------------
+
+
+def test_kanban_create_schema_declares_resources():
+    from tools.kanban_tools_schemas import KANBAN_CREATE_SCHEMA
+    props = KANBAN_CREATE_SCHEMA["parameters"]["properties"]
+    assert props["resources"]["type"] == "array"
+    assert props["resources"]["items"] == {"type": "string"}
+
+
+def test_tool_kanban_create_with_resources(isolated_kanban_home_with_profiles):
+    kb = isolated_kanban_home_with_profiles
+    _make_board(kb)
+    from tools.kanban_tools import _handle_create
+    out = _handle_create({"title": "t", "assignee": "alpha", "resources": ["dev:x"]})
+    payload = json.loads(out)
+    assert payload["ok"] is True
+    with _connect(kb) as conn:
+        assert kb.get_task(conn, payload["task_id"]).resources == ["dev:x"]
+    # A bare string is NOT coerced (unlike skills/parents): deterministic error,
+    # no card — a stringified key would silently gate nothing.
+    out = _handle_create({"title": "t2", "assignee": "alpha", "resources": "usb:K1"})
+    assert "resources" in out
+    assert json.loads(out).get("ok") is not True
+    # Non-str element inside a list is a deterministic error too, no card.
+    out = _handle_create({"title": "t3", "assignee": "alpha", "resources": ["dev:x", 5]})
+    assert "resources" in out
+    # Invalid token -> structured error mentioning resources, no card.
+    out = _handle_create({"title": "t4", "assignee": "alpha", "resources": ["BAD KEY"]})
+    assert "resources" in out
+    with _connect(kb) as conn:
+        assert [t.title for t in kb.list_tasks(conn)] == ["t"]

--- a/tests/hermes_cli/test_kanban_resource_gate_acceptance.py
+++ b/tests/hermes_cli/test_kanban_resource_gate_acceptance.py
@@ -1,0 +1,966 @@
+"""Acceptance tests — kanban dispatcher resource gate (red team, black-box).
+
+Covers the frozen acceptance scenarios 1-10 in the design doc
+(``## 验收场景`` of requirement 20260911-#-kanban-dispatcher-资源闸).
+Written BEFORE the implementation exists; every test is expected red on a
+no-op gate (never intercepts -> 场景1.P1/2.P2/3.P1/5.*/6.P1/7.P2 fail) and
+on a never-releasing gate (over-blocking -> 场景4.P1/6.P2-P3/7.P3 fail).
+
+Black-box public surface only:
+- ``hermes_cli.kanban_db``: parse_task_resources / normalize_resources /
+  running_task_resources / set_task_resources, create_task(resources=...),
+  Task.resources
+- ``hermes_cli.kanban_db_connect.connect_closing``
+- ``hermes_cli.kanban_db_dispatch.dispatch_once`` (DispatchResult.
+  skipped_resource_held: list of (task_id, resource), resource =
+  sorted(intersection)[0]) and ``has_spawnable_ready``
+- ``hermes_cli.kanban_diagnostics.compute_task_diagnostics`` with
+  ``held_resources=``
+- real ``hermes kanban create/update/show/list`` subprocesses
+
+Resource token grammar pinned by the frozen predicates: the kind before the
+first ``:`` must be lowercase; identifiers are case-sensitive (device
+serials like ``6HQ0226318000078`` must survive verbatim). 场景8.P1 / 10.P2
+require ``usb:K1`` and ``harmony-device:6HQ0226318000078`` to be ACCEPTED
+while ``Harmony-Device:X1`` (uppercase kind) and ``usb:K1;rm -rf /``
+(injection chars) are rejected.
+
+Harness follows tests/hermes_cli/test_kanban_per_profile_cap.py (temp
+HERMES_HOME + sys.modules clear + dispatch_once(spawn_fn=_fake_spawn) +
+direct DispatchResult asserts). CLI harness follows
+tests/hermes_cli/test_kanban_cli_exit_status.py (real subprocess,
+``python -m hermes_cli.main``). Nothing writes to the real ``~/.hermes``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[2]
+
+# Frozen scenario literals — used verbatim.
+DEV1 = "harmony-device:DEV1"
+DEV2 = "harmony-device:DEV2"
+K1 = "usb:K1"
+K2 = "usb:K2"
+K3 = "usb:K3"
+K4 = "usb:K4"
+SERIAL = "harmony-device:6HQ0226318000078"
+
+_REWIND_SECONDS = 31 * 60  # "滞留超 30 分钟" via 31-minute back-dating
+
+
+@pytest.fixture()
+def gate_home(tmp_path, monkeypatch):
+    """Fresh HERMES_HOME + kanban DB; hermes modules re-imported so they
+    bind to the redirected home (per_profile_cap harness)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    for prof in ("alpha", "beta", "default"):
+        os.makedirs(os.path.join(str(home), "profiles", prof), exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+    kanban_db.init_db()
+    yield kanban_db
+
+
+# ---------------------------------------------------------------------------
+# Black-box helpers (raw SQL only for status/rewind/inspection — no private
+# implementation functions touched).
+# ---------------------------------------------------------------------------
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+def _mk_ready(conn, kb, title, assignee="alpha", resources=None):
+    """Create a card and force it ready via raw UPDATE so the test does not
+    depend on create_task's default status."""
+    kwargs = {"title": title, "assignee": assignee}
+    if resources is not None:
+        kwargs["resources"] = list(resources)
+    tid = kb.create_task(conn, **kwargs)
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    return tid
+
+
+def _make_running(conn, kb, tid, assignee="alpha"):
+    """Drive a ready card to running via claim (block_kinds precedent)."""
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    claimed = kb.claim_task(conn, tid, claimer=assignee)
+    assert claimed is not None, f"claim_task failed for {tid}"
+    return tid
+
+
+def _leave_running(conn, kb, tid, status="done"):
+    """Take a running card out of running the way
+    test_kanban_per_profile_cap.py does (raw UPDATE of status +
+    claim_lock=NULL). For the 场景5 reclaim arm this models crash reclaim:
+    crash is not a status — the holder leaves running and its claim is
+    released, so the resource it held is free."""
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status = ?, claim_lock = NULL WHERE id = ?",
+            (status, tid),
+        )
+
+
+def _status(conn, tid):
+    return conn.execute(
+        "SELECT status FROM tasks WHERE id = ?", (tid,)
+    ).fetchone()[0]
+
+
+def _dispatch(kbc, kbd, **kwargs):
+    with kbc.connect_closing() as conn:
+        return kbd.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False, **kwargs)
+
+
+def _resource_bucket_ids(res):
+    return [entry[0] for entry in res.skipped_resource_held]
+
+
+def _capped_bucket_ids(res):
+    return [entry[0] for entry in res.skipped_per_profile_capped]
+
+
+def _spawned_ids(res):
+    return [entry[0] for entry in res.spawned]
+
+
+def _in_qs(n):
+    return ",".join("?" * n)
+
+
+def _rewind_31min(conn, kb, tids):
+    """Back-date cards + their events by 31 minutes (场景6 公共前置)."""
+    with kb.write_txn(conn):
+        conn.execute(
+            f"UPDATE tasks SET created_at = created_at - {_REWIND_SECONDS} "
+            f"WHERE id IN ({_in_qs(len(tids))})",
+            tuple(tids),
+        )
+        conn.execute(
+            f"UPDATE task_events SET created_at = created_at - {_REWIND_SECONDS} "
+            f"WHERE task_id IN ({_in_qs(len(tids))})",
+            tuple(tids),
+        )
+
+
+def _compute_diags(conn, kd, tid, **kwargs):
+    """Round-trip a real DB row through the rule engine the way the API
+    layer does (sqlite3.Row in, diagnostics out)."""
+    row = conn.execute("SELECT * FROM tasks WHERE id = ?", (tid,)).fetchone()
+    events = list(conn.execute(
+        "SELECT * FROM task_events WHERE task_id = ? ORDER BY id", (tid,)
+    ))
+    runs = list(conn.execute(
+        "SELECT * FROM task_runs WHERE task_id = ? ORDER BY id", (tid,)
+    ))
+    return kd.compute_task_diagnostics(row, events, runs, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# 场景 1 — held resource blocks the candidate this tick; release on the next
+# ---------------------------------------------------------------------------
+
+
+def test_s1_p1_p2_holder_blocks_then_release(gate_home):
+    """场景1.P1: while running card A holds harmony-device:DEV1, one
+    dispatch() must not release ready card B declaring the same resource —
+    B stays ready, no failure counted, and the result records (B, DEV1) in
+    skipped_resource_held. 场景1.P2: once A leaves running, the next tick
+    dispatches B."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        a = _mk_ready(conn, kb, "A", resources=[DEV1])
+        _make_running(conn, kb, a)
+        b = _mk_ready(conn, kb, "B", resources=[DEV1])
+
+    # 场景1.P1 — holder still running.
+    res1 = _dispatch(kbc, kbd)
+    assert (b, DEV1) in res1.skipped_resource_held
+    with kbc.connect_closing() as conn:
+        assert _status(conn, b) == "ready"
+        assert conn.execute(
+            "SELECT consecutive_failures FROM tasks WHERE id = ?", (b,)
+        ).fetchone()[0] == 0, "resource-gate skip must not count a failure"
+
+    # 场景1.P2 — holder left running, next tick releases B.
+    with kbc.connect_closing() as conn:
+        _leave_running(conn, kb, a)
+    res2 = _dispatch(kbc, kbd)
+    assert b in _spawned_ids(res2)
+    with kbc.connect_closing() as conn:
+        assert _status(conn, b) == "running"
+
+
+# ---------------------------------------------------------------------------
+# 场景 2 — rolling update within one tick: only the first same-resource card
+# spawns
+# ---------------------------------------------------------------------------
+
+
+def test_s2_p1_p2_rolling_update_single_tick(gate_home):
+    """场景2.P1: a SINGLE dispatch() facing 3 ready cards all declaring
+    harmony-device:DEV1 spawns exactly 1 into running, the other 2 stay
+    ready. 场景2.P2: the 2 deferred cards are recorded in
+    skipped_resource_held (tick-internal rolling update — without it the
+    09-10 cross-contamination incident reproduces)."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        ids = [
+            _mk_ready(conn, kb, f"card{i}", resources=[DEV1]) for i in range(3)
+        ]
+
+    res = _dispatch(kbc, kbd)
+
+    with kbc.connect_closing() as conn:
+        statuses = {tid: _status(conn, tid) for tid in ids}
+    running = [t for t, s in statuses.items() if s == "running"]
+    ready = [t for t, s in statuses.items() if s == "ready"]
+    assert len(running) == 1, statuses
+    assert len(ready) == 2, statuses
+    # 场景2.P2
+    assert len(res.skipped_resource_held) == 2
+    assert sorted(_resource_bucket_ids(res)) == sorted(ready)
+    assert all(resource == DEV1 for _, resource in res.skipped_resource_held)
+
+
+# ---------------------------------------------------------------------------
+# 场景 3 — multi-resource card: any intersection blocks, all-free releases
+# ---------------------------------------------------------------------------
+
+
+def test_s3_p1_p2_p3_multi_resource_all_free_required(gate_home):
+    """场景3.P1: while DEV1 (of D's {DEV1, K1}) is held, D is not released.
+    场景3.P2: DEV1 free but K1 held — D still not released. 场景3.P3: once
+    every declared resource is free, D is released."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        e = _mk_ready(conn, kb, "E", resources=[DEV1])
+        _make_running(conn, kb, e)
+        d = _mk_ready(conn, kb, "D", resources=[DEV1, K1])
+
+    # 场景3.P1 — DEV1 held.
+    res1 = _dispatch(kbc, kbd)
+    assert (d, DEV1) in res1.skipped_resource_held
+    with kbc.connect_closing() as conn:
+        assert _status(conn, d) == "ready"
+
+    # 场景3.P2 — DEV1 released, K1 now held by G.
+    with kbc.connect_closing() as conn:
+        _leave_running(conn, kb, e)
+    with kbc.connect_closing() as conn:
+        g = _mk_ready(conn, kb, "G", resources=[K1], assignee="beta")
+        _make_running(conn, kb, g, assignee="beta")
+    res2 = _dispatch(kbc, kbd)
+    assert (d, K1) in res2.skipped_resource_held
+    with kbc.connect_closing() as conn:
+        assert _status(conn, d) == "ready"
+
+    # 场景3.P3 — all declared resources free.
+    with kbc.connect_closing() as conn:
+        _leave_running(conn, kb, g)
+    res3 = _dispatch(kbc, kbd)
+    assert d in _spawned_ids(res3)
+    with kbc.connect_closing() as conn:
+        assert _status(conn, d) == "running"
+
+
+def test_s3_sorted_first_conflict_resource_recorded(gate_home):
+    """Contract: the bucket element is (task_id, sorted(intersection)[0]).
+    With BOTH declared resources held, the recorded resource must be the
+    sorted-first one (harmony-device:DEV1 < usb:K1), deterministically."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        e = _mk_ready(conn, kb, "E", resources=[DEV1])
+        _make_running(conn, kb, e)
+        g = _mk_ready(conn, kb, "G", resources=[K1], assignee="beta")
+        _make_running(conn, kb, g, assignee="beta")
+        d = _mk_ready(conn, kb, "D", resources=[DEV1, K1])
+
+    res = _dispatch(kbc, kbd)
+
+    assert res.skipped_resource_held == [(d, DEV1)]
+    with kbc.connect_closing() as conn:
+        assert _status(conn, d) == "ready"
+
+
+# ---------------------------------------------------------------------------
+# 场景 4 — resource-less cards behave exactly as before (zero regression)
+# ---------------------------------------------------------------------------
+
+
+def test_s4_p1_p2_no_resources_zero_regression(gate_home):
+    """场景4.P1: a ready card H with no declared resources dispatches as
+    usual. 场景4.P2: the dispatcher records no resource-wait skip for it
+    (the only card on the board, so the bucket must be empty)."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        h = _mk_ready(conn, kb, "H")
+
+    res = _dispatch(kbc, kbd)
+
+    assert h in _spawned_ids(res)
+    assert res.skipped_resource_held == []
+    with kbc.connect_closing() as conn:
+        assert _status(conn, h) == "running"
+
+
+# ---------------------------------------------------------------------------
+# 场景 5 — only status 'running' holds resources
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("leave_as", ["blocked", "review", "done", "reclaim"])
+def test_s5_p1_to_p4_only_running_holds(gate_home, leave_as):
+    """场景5.P1/P2/P3/P4: once the holder A leaves running — to blocked, to
+    review, to done, or via reclaim (crash path modelled as the
+    per_profile_cap-style UPDATE; crash is not a status, reclaim releases
+    the claim) — a dispatch() must release ready card B declaring A's
+    resource."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        a = _mk_ready(conn, kb, "A", resources=[DEV1])
+        _make_running(conn, kb, a)
+        b = _mk_ready(conn, kb, "B", resources=[DEV1])
+
+    # AUTO-FIX 留痕 (qa, 2026-09-11): the "blocked" arm originally left the
+    # state via raw UPDATE, but the dispatcher's pre-existing recompute_ready
+    # (#28712) auto-recovers blocked cards with no sticky `kanban_block`
+    # event (kanban_db.py::_has_sticky_block: "direct DB manipulation"
+    # → auto-recover), so A was resurrected to ready and re-spawned before
+    # B. Setup now uses the canonical block API — the asserted contract
+    # ("a blocked card holds nothing") is unchanged; only the state-setup
+    # mechanism is corrected.
+    with kbc.connect_closing() as conn:
+        if leave_as == "blocked":
+            assert kb.block_task(conn, a, kind="transient", reason="s5 operator block")
+        elif leave_as == "reclaim":
+            # Crash path: the worker died; reclaim releases the claim and
+            # drops the card back to ready (not done) — post-reclaim state.
+            _leave_running(conn, kb, a, status="ready")
+        else:
+            _leave_running(conn, kb, a, status=leave_as)
+
+    if leave_as == "reclaim":
+        # AUTO-FIX 留痕 (qa, 2026-09-11): the original arm asserted B spawns
+        # on the very tick after the crash, but the dispatcher's pre-existing
+        # reclaim→ready semantics put A back in the ready lane and lane order
+        # (priority DESC, created_at ASC) legitimately re-spawns A first; the
+        # gate's rolling update then defers B. The crash-path contract under
+        # test is: (1) the held set drops the moment A leaves running ("only
+        # running holds" — a stale held set would also self-block A's own
+        # re-spawn, so this still kills the no-op mutation), and (2) the
+        # re-queued holder re-acquires via the same gate, deferring B with a
+        # bucket record — a healthy wait, not a stuck lock.
+        with kbc.connect_closing() as conn:
+            assert kb.running_task_resources(conn) == frozenset()
+        res = _dispatch(kbc, kbd)
+        assert a in _spawned_ids(res), "crashed card must be re-queueable"
+        assert res.skipped_resource_held == [(b, DEV1)]
+        with kbc.connect_closing() as conn:
+            assert _status(conn, b) == "ready"
+        return
+
+    res = _dispatch(kbc, kbd)
+    assert b in _spawned_ids(res), leave_as
+    with kbc.connect_closing() as conn:
+        assert _status(conn, b) == "running", leave_as
+
+
+# ---------------------------------------------------------------------------
+# 场景 6 — resource wait is not stranded; genuinely stuck cards still are
+# ---------------------------------------------------------------------------
+
+
+def _s6_board(kb, kbc):
+    """A running holding DEV1; B (DEV1), I (no resources), J (DEV2) ready
+    and back-dated 31 minutes."""
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        a = _mk_ready(conn, kb, "A", resources=[DEV1])
+        _make_running(conn, kb, a)
+        b = _mk_ready(conn, kb, "B", resources=[DEV1])
+        i = _mk_ready(conn, kb, "I")
+        j = _mk_ready(conn, kb, "J", resources=[DEV2])
+        _rewind_31min(conn, kb, [b, i, j])
+    return b, i, j
+
+
+def test_s6_p1_resource_wait_exempt_from_stranded(gate_home):
+    """场景6.P1: ready card B's declared resource is held by a running card
+    and B has been ready >30min — the stranded diagnostic must NOT flag B
+    (healthy wait, not stuck)."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_diagnostics as kd
+
+    b, _i, _j = _s6_board(kb, kbc)
+    with kbc.connect_closing() as conn:
+        held = kb.running_task_resources(conn)
+        assert held == frozenset({DEV1})
+        diags = _compute_diags(conn, kd, b, held_resources=held)
+    stranded = [d for d in diags if d.kind == "stranded_in_ready"]
+    assert stranded == []
+
+
+def test_s6_p2_no_resource_ready_stranded(gate_home):
+    """场景6.P2: ready card I declares nothing and has been ready >30min —
+    it must still be flagged stranded."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_diagnostics as kd
+
+    _b, i, _j = _s6_board(kb, kbc)
+    with kbc.connect_closing() as conn:
+        held = kb.running_task_resources(conn)
+        diags = _compute_diags(conn, kd, i, held_resources=held)
+    stranded = [d for d in diags if d.kind == "stranded_in_ready"]
+    assert len(stranded) == 1
+    assert stranded[0].data["age_seconds"] >= 1800
+
+
+def test_s6_p3_free_resource_ready_stranded_and_detail_clause(gate_home):
+    """场景6.P3: ready card J's declared resource (DEV2) is free and J has
+    been ready >30min — J must be flagged stranded, and the detail's common
+    causes must mention the held-resource wait."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_diagnostics as kd
+
+    _b, _i, j = _s6_board(kb, kbc)
+    with kbc.connect_closing() as conn:
+        held = kb.running_task_resources(conn)
+        diags = _compute_diags(conn, kd, j, held_resources=held)
+    stranded = [d for d in diags if d.kind == "stranded_in_ready"]
+    assert len(stranded) == 1
+    assert "waiting on a held resource" in stranded[0].detail
+
+
+# ---------------------------------------------------------------------------
+# 场景 7 — resource gate stacks with the per-profile quota
+# ---------------------------------------------------------------------------
+
+
+def test_s7_p1_quota_gate_wins_bucketing(gate_home):
+    """场景7.P1: per-profile quota full AND C's resources free — C is not
+    released, is bucketed as skipped_per_profile_capped, and NOT as
+    skipped_resource_held (per-profile check runs first)."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        r = _mk_ready(conn, kb, "R", assignee="alpha")
+        _make_running(conn, kb, r, assignee="alpha")  # eats alpha's 1-slot quota, holds nothing
+        c = _mk_ready(conn, kb, "C", resources=[K1], assignee="alpha")
+
+    res = _dispatch(kbc, kbd, max_in_progress_per_profile=1)
+
+    with kbc.connect_closing() as conn:
+        assert _status(conn, c) == "ready"
+    assert c in _capped_bucket_ids(res)
+    assert all(entry[0] != c for entry in res.skipped_resource_held)
+
+
+def test_s7_p2_resource_gate_bucket_when_quota_free(gate_home):
+    """场景7.P2: quota has room (holder is a different profile) but C's
+    resource is held by a running card — C stays ready and is bucketed as
+    skipped_resource_held."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        h = _mk_ready(conn, kb, "H", assignee="beta", resources=[K1])
+        _make_running(conn, kb, h, assignee="beta")
+        c = _mk_ready(conn, kb, "C", resources=[K1], assignee="alpha")
+
+    res = _dispatch(kbc, kbd, max_in_progress_per_profile=1)
+
+    with kbc.connect_closing() as conn:
+        assert _status(conn, c) == "ready"
+    assert (c, K1) in res.skipped_resource_held
+    assert c not in _capped_bucket_ids(res)
+
+
+def test_s7_p3_both_gates_pass_spawns(gate_home):
+    """场景7.P3: quota has room and C's resources are all free — C is
+    released."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        c = _mk_ready(conn, kb, "C", resources=[K1], assignee="alpha")
+
+    res = _dispatch(kbc, kbd, max_in_progress_per_profile=1)
+
+    assert c in _spawned_ids(res)
+    with kbc.connect_closing() as conn:
+        assert _status(conn, c) == "running"
+
+
+# ---------------------------------------------------------------------------
+# Error / helper contracts (hermes_cli.kanban_db public helpers)
+# ---------------------------------------------------------------------------
+
+
+def test_error_contract_fail_open_db_garbage_resources(gate_home):
+    """错误契约 + 红队补充谓词(a): DB hand-edited resources='not json' must
+    fail OPEN on the read path — parse_task_resources returns (), dispatch
+    proceeds treating the card as resource-less (the card is released even
+    though a running holder exists), and nothing raises."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        a = _mk_ready(conn, kb, "A", resources=[K1])
+        _make_running(conn, kb, a)
+        b = _mk_ready(conn, kb, "B", resources=[K1])
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET resources = 'not json' WHERE id = ?", (b,))
+
+    with kbc.connect_closing() as conn:
+        assert kb.parse_task_resources("not json") == ()
+        assert kb.parse_task_resources(None) == ()
+        assert kb.parse_task_resources('["a:b"]') == ("a:b",)
+
+    res = _dispatch(kbc, kbd)
+
+    assert b in _spawned_ids(res)
+    assert res.skipped_resource_held == []
+    with kbc.connect_closing() as conn:
+        assert _status(conn, b) == "running"
+
+
+def test_error_contract_normalize_resources_validation(gate_home):
+    """错误契约 (验收 #8 matrix, write path): uppercase KIND rejected with
+    the original token in the message; injection chars rejected; non-str
+    rejected; whitespace-wrapped tokens stripped + order-preserving dedupe;
+    empty result normalizes to None; case-sensitive identifiers preserved
+    (no silent lowercasing of serials — pinned by 场景8.P1/10.P2)."""
+    kb = gate_home
+
+    assert kb.normalize_resources(None) is None
+    assert kb.normalize_resources([]) is None
+    assert kb.normalize_resources(["", "   "]) is None
+    assert kb.normalize_resources(["  usb:K1  ", "usb:K1", ""]) == [K1]
+    assert kb.normalize_resources(["harmony-device:DEV1"]) == [DEV1]
+
+    with pytest.raises(ValueError) as excinfo:
+        kb.normalize_resources(["Harmony-Device:X1"])
+    assert "Harmony-Device:X1" in str(excinfo.value)
+    # message must hint the legal charset (lowercase)
+    assert "a-z" in str(excinfo.value) or "lowercase" in str(excinfo.value)
+
+    with pytest.raises(ValueError):
+        kb.normalize_resources(["usb:K1;rm -rf /"])
+    with pytest.raises(ValueError):
+        kb.normalize_resources([123])
+
+
+def test_contract_running_task_resources_union_of_running(gate_home):
+    """契约: running_task_resources is the union of parse(resources) over
+    status='running' rows ONLY — blocked/review/done/todo hold nothing."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        a = _mk_ready(conn, kb, "A", resources=[DEV1, K1])
+        _make_running(conn, kb, a)
+        done_t = _mk_ready(conn, kb, "doneT", resources=[DEV2], assignee="beta")
+        _make_running(conn, kb, done_t, assignee="beta")
+        _leave_running(conn, kb, done_t)
+        blocked_t = _mk_ready(conn, kb, "blkT", resources=[K3], assignee="beta")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='blocked' WHERE id=?", (blocked_t,)
+            )
+        _mk_ready(conn, kb, "readyT", resources=[K4], assignee="beta")
+
+        assert kb.running_task_resources(conn) == frozenset({DEV1, K1})
+
+    with kbc.connect_closing() as conn:
+        _leave_running(conn, kb, a)
+        assert kb.running_task_resources(conn) == frozenset()
+
+
+def test_contract_spawn_probe_resource_aware(gate_home):
+    """契约 (闸语义·探针): has_spawnable_ready is False when every ready
+    row conflicts with a held resource (so gateway bad_ticks stuck alarms
+    do not misfire on healthy resource waits), and True once a resource-
+    clean spawnable row exists."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    with kbc.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        a = _mk_ready(conn, kb, "A", resources=[DEV1])
+        _make_running(conn, kb, a)
+        b = _mk_ready(conn, kb, "B", resources=[DEV1])
+
+        with kbc.connect_closing() as inner:
+            assert not kbd.has_spawnable_ready(inner)
+
+        h = _mk_ready(conn, kb, "H")
+        with kbc.connect_closing() as inner:
+            assert kbd.has_spawnable_ready(inner)
+
+        _leave_running(conn, kb, a)
+
+    with kbc.connect_closing() as inner:
+        assert kbd.has_spawnable_ready(inner)
+
+
+# ---------------------------------------------------------------------------
+# 场景 8.P4 / 9.P2 — Python API storage-level predicates
+# ---------------------------------------------------------------------------
+
+
+def test_s8_p4_api_create_persists_equivalent_set(gate_home):
+    """场景8.P4: creating a card via the Python API with the scenario 8
+    resources persists an equivalent set in the DB (JSON array of str)."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+
+    with kbc.connect_closing() as conn:
+        tid = kb.create_task(
+            conn, title="s8p4", assignee="alpha", resources=[SERIAL, K1]
+        )
+        raw = conn.execute(
+            "SELECT resources FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()[0]
+        task = kb.get_task(conn, tid)
+
+    assert raw is not None
+    assert set(json.loads(raw)) == {SERIAL, K1}
+    assert task.resources is not None
+    assert set(task.resources) == {SERIAL, K1}
+
+
+def test_s9_p2_api_set_task_resources_persists(gate_home):
+    """场景9.P2: updating a card's resource declaration via
+    set_task_resources persists the new declaration."""
+    kb = gate_home
+    from hermes_cli import kanban_db_connect as kbc
+
+    with kbc.connect_closing() as conn:
+        tid = _mk_ready(conn, kb, "s9p2", resources=[DEV1])
+        kb.set_task_resources(conn, tid, [K2])
+        raw = conn.execute(
+            "SELECT resources FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()[0]
+        task = kb.get_task(conn, tid)
+
+    assert raw is not None
+    assert K2 in set(json.loads(raw))
+    assert set(task.resources) == {K2}
+
+
+def test_s10_p4_tool_rejects_bad_resource_types(gate_home):
+    """场景10.P4: model-tool kanban_create with a wrongly-typed resources
+    argument returns a deterministic error whose text contains
+    "resources", and creates NO card (count unchanged from baseline)."""
+    from hermes_cli import kanban_db_connect as kbc
+    from tools import kanban_tools as kt
+
+    with kbc.connect_closing() as conn:
+        baseline = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+
+    for bad in ("usb:K1", [K1, 5]):  # not a list; element not a str
+        out = kt._handle_create(
+            {"title": "bad res", "assignee": "peer", "resources": bad}
+        )
+        d = json.loads(out)
+        assert d.get("error"), out
+        assert "resources" in d["error"]
+
+    with kbc.connect_closing() as conn:
+        after = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+    assert after == baseline
+
+
+# ---------------------------------------------------------------------------
+# 场景 8/9/10 — real-process CLI predicates
+# ---------------------------------------------------------------------------
+
+
+class TestKanbanResourceCli:
+    """Real-process CLI scenarios (``[real-process]`` predicates): every
+    observation goes through a ``hermes kanban ...`` subprocess against a
+    temp HERMES_HOME. Harness follows
+    tests/hermes_cli/test_kanban_cli_exit_status.py."""
+
+    @pytest.fixture()
+    def cli_home(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        for mod in list(sys.modules.keys()):
+            if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
+                del sys.modules[mod]
+        from hermes_cli import kanban_db
+        kanban_db.init_db()
+        return home
+
+    def _run(self, home, *args):
+        env = os.environ.copy()
+        env["HERMES_HOME"] = str(home)
+        env["HERMES_KANBAN_HOME"] = str(home)
+        for name in (
+            "HERMES_KANBAN_BOARD",
+            "HERMES_KANBAN_DB",
+            "HERMES_KANBAN_WORKSPACES_ROOT",
+        ):
+            env.pop(name, None)
+        env["PYTHONPATH"] = str(ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+        return subprocess.run(
+            [sys.executable, "-m", "hermes_cli.main", *args],
+            cwd=ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+
+    def _task_rows(self, home):
+        """In-process read of the same DB the subprocesses wrote."""
+        from hermes_cli import kanban_db_connect as kbc
+        with kbc.connect_closing() as conn:
+            return conn.execute(
+                "SELECT id, resources FROM tasks ORDER BY id"
+            ).fetchall()
+
+    def _create(self, home, title, *extra):
+        return self._run(home, "kanban", "create", title, "--json", *extra)
+
+    # -- 场景 8 -----------------------------------------------------------
+
+    def test_s8_p1_create_with_resources_exit_zero(self, cli_home):
+        """场景8.P1: `hermes kanban create --resources
+        "harmony-device:6HQ0226318000078,usb:K1"` exits 0, reports the new
+        card id on stdout, and the card lands in the DB declaring both
+        resources."""
+        home = cli_home
+        proc = self._create(
+            home, "s8 card", "--resources", f"{SERIAL},{K1}"
+        )
+        assert proc.returncode == 0, proc.stderr
+        payload = json.loads(proc.stdout)
+        task_id = payload["id"]
+        assert task_id
+        assert task_id in proc.stdout
+
+        rows = self._task_rows(home)
+        ours = [r for r in rows if r["id"] == task_id]
+        assert len(ours) == 1
+        assert set(json.loads(ours[0]["resources"])) == {SERIAL, K1}
+
+    def test_s8_p2_show_displays_resources(self, cli_home):
+        """场景8.P2: `hermes kanban show <id>` prints the card's declared
+        resources verbatim."""
+        home = cli_home
+        created = self._create(home, "s8 show", "--resources", f"{SERIAL},{K1}")
+        assert created.returncode == 0, created.stderr
+        task_id = json.loads(created.stdout)["id"]
+
+        shown = self._run(home, "kanban", "show", task_id)
+        assert shown.returncode == 0, shown.stderr
+        assert SERIAL in shown.stdout
+        assert K1 in shown.stdout
+
+    def test_s8_p3_list_presents_resources(self, cli_home):
+        """场景8.P3: `hermes kanban list` surfaces resources; `list --json`
+        carries a `resources` key on EVERY card (unset -> [] shaping)."""
+        home = cli_home
+        with_res = self._create(home, "s8 list res", "--resources", f"{SERIAL},{K1}")
+        assert with_res.returncode == 0, with_res.stderr
+        res_id = json.loads(with_res.stdout)["id"]
+        plain = self._create(home, "s8 list plain")
+        assert plain.returncode == 0, plain.stderr
+        plain_id = json.loads(plain.stdout)["id"]
+
+        listing = self._run(home, "kanban", "list")
+        assert listing.returncode == 0, listing.stderr
+        assert SERIAL in listing.stdout
+
+        listing_json = self._run(home, "kanban", "list", "--json")
+        assert listing_json.returncode == 0, listing_json.stderr
+        data = json.loads(listing_json.stdout)
+        tasks = data.get("tasks") if isinstance(data, dict) else data
+        assert tasks, listing_json.stdout
+        by_id = {t["id"]: t for t in tasks}
+        for task in tasks:
+            assert "resources" in task
+        assert set(by_id[res_id]["resources"]) == {SERIAL, K1}
+        assert by_id[plain_id]["resources"] == []
+
+    # -- 场景 9 -----------------------------------------------------------
+
+    def test_s9_p1_update_sets_resources(self, cli_home):
+        """场景9.P1: `hermes kanban update <id> --resources "usb:K2"` exits
+        0 and the follow-up show reflects the new declaration."""
+        home = cli_home
+        created = self._create(home, "s9 card")
+        assert created.returncode == 0, created.stderr
+        task_id = json.loads(created.stdout)["id"]
+
+        upd = self._run(home, "kanban", "update", task_id, "--resources", K2)
+        assert upd.returncode == 0, upd.stderr
+
+        shown = self._run(home, "kanban", "show", task_id)
+        assert shown.returncode == 0, shown.stderr
+        assert K2 in shown.stdout
+
+        rows = [r for r in self._task_rows(home) if r["id"] == task_id]
+        assert len(rows) == 1
+        assert set(json.loads(rows[0]["resources"])) == {K2}
+
+    def test_s9_p3_update_empty_string_clears(self, cli_home):
+        """场景9.P3: `hermes kanban update <id> --resources ""` exits 0 and
+        clears the declaration — the follow-up show mentions neither the
+        old serial nor any harmony-device resource."""
+        home = cli_home
+        created = self._create(home, "s9 clear", "--resources", f"{SERIAL},{K2}")
+        assert created.returncode == 0, created.stderr
+        task_id = json.loads(created.stdout)["id"]
+
+        upd = self._run(home, "kanban", "update", task_id, "--resources", "")
+        assert upd.returncode == 0, upd.stderr
+
+        shown = self._run(home, "kanban", "show", task_id)
+        assert shown.returncode == 0, shown.stderr
+        # AUTO-FIX 留痕 (qa, 2026-09-11): the original bare-substring checks
+        # (`"usb:K2" not in stdout`) also matched the immutable `created`
+        # event payload in show's history section, which legitimately records
+        # the declaration made at creation time. The contract under test is
+        # the CURRENT declaration: the `resources:` field line must be gone.
+        # This still fails for a no-op clear (the field line would remain).
+        import re as _re
+
+        assert not _re.search(r"^\s*resources:", shown.stdout, _re.M), shown.stdout
+        assert not _re.search(r"^\s*resources:.*harmony-device", shown.stdout, _re.M)
+
+        rows = [r for r in self._task_rows(home) if r["id"] == task_id]
+        assert len(rows) == 1
+        raw = rows[0]["resources"]
+        assert raw is None or json.loads(raw) == []
+
+    def test_s9_update_nonexistent_task_nonzero_exit(self, cli_home):
+        """红队补充谓词(b): `kanban update <nonexistent-id> --resources`
+        must exit non-zero."""
+        home = cli_home
+        created = self._create(home, "anchor card")
+        assert created.returncode == 0, created.stderr
+
+        upd = self._run(
+            home, "kanban", "update", "t_absent000", "--resources", K2
+        )
+        assert upd.returncode != 0
+
+    # -- 场景 10 ----------------------------------------------------------
+
+    def test_s10_p1_uppercase_rejected_deterministically(self, cli_home):
+        """场景10.P1: `--resources "Harmony-Device:X1"` is deterministically
+        rejected (two runs, identical non-zero exit, stderr mentions
+        resources) and the raw uppercase form never lands in the DB."""
+        home = cli_home
+        baseline = len(self._task_rows(home))
+
+        r1 = self._create(home, "s10a", "--resources", "Harmony-Device:X1")
+        r2 = self._create(home, "s10b", "--resources", "Harmony-Device:X1")
+        assert r1.returncode != 0
+        assert r2.returncode != 0
+        assert r1.returncode == r2.returncode
+        assert "resources" in r1.stderr.lower()
+        assert "resources" in r2.stderr.lower()
+
+        rows = self._task_rows(home)
+        assert len(rows) == baseline  # no card created
+        assert all(
+            "Harmony-Device:X1" not in (r["resources"] or "") for r in rows
+        )
+
+    def test_s10_p2_whitespace_normalized_accepted(self, cli_home):
+        """场景10.P2: `" usb:K1 , usb:K2 "` is deterministically ACCEPTED
+        (two runs, identical zero exit) and stored as the normalized
+        equivalent set {usb:K1, usb:K2}."""
+        home = cli_home
+        noisy = f" {K1} , {K2} "
+        r1 = self._create(home, "s10c", "--resources", noisy)
+        r2 = self._create(home, "s10d", "--resources", noisy)
+        assert r1.returncode == 0, r1.stderr
+        assert r2.returncode == r1.returncode
+
+        rows = self._task_rows(home)
+        assert len(rows) == 2
+        for row in rows:
+            assert set(json.loads(row["resources"])) == {K1, K2}
+
+    def test_s10_p3_injection_rejected_deterministically(self, cli_home):
+        """场景10.P3: `--resources "usb:K1;rm -rf /"` is deterministically
+        rejected (two runs, identical non-zero exit, stderr mentions
+        resources) and no injection characters ever land in the DB."""
+        home = cli_home
+        baseline = len(self._task_rows(home))
+        evil = "usb:K1;rm -rf /"
+
+        r1 = self._create(home, "s10e", "--resources", evil)
+        r2 = self._create(home, "s10f", "--resources", evil)
+        assert r1.returncode != 0
+        assert r2.returncode != 0
+        assert r1.returncode == r2.returncode
+        assert "resources" in r1.stderr.lower()
+        assert "resources" in r2.stderr.lower()
+
+        rows = self._task_rows(home)
+        assert len(rows) == baseline  # no card created
+        assert all(";" not in (r["resources"] or "") for r in rows)

--- a/tests/test_live_system_guard_self_test.py
+++ b/tests/test_live_system_guard_self_test.py
@@ -334,3 +334,33 @@ def test_bypass_marker_disables_guard():
     # so we get the real os.kill. Calling os.kill(os.getpid(), 0) just
     # checks that the PID exists — harmless.
     os.kill(os.getpid(), 0)  # No exception — guard is OFF.
+
+
+# ──────────────── hermes update interception canary ───────────────
+# The guard must block the SELF-UPDATER (`update` as the subcommand right
+# after the hermes entrypoint) while letting kanban verbs like
+# `hermes kanban update` through — the matcher is entrypoint-adjacency,
+# never argv substrings (AGENTS.md cmdline-matching rule).
+
+
+def test_subprocess_run_hermes_update_blocked():
+    with pytest.raises(RuntimeError, match="live-system guard"):
+        subprocess.run(["hermes", "update"])
+
+
+def test_subprocess_run_hermes_cli_main_update_blocked():
+    with pytest.raises(RuntimeError, match="live-system guard"):
+        subprocess.run(["/some/venv/bin/python", "-m", "hermes_cli.main", "update"])
+
+
+def test_subprocess_run_venv_hermes_update_blocked():
+    with pytest.raises(RuntimeError, match="live-system guard"):
+        subprocess.run([".venv/bin/hermes", "update"])
+
+
+def test_subprocess_run_kanban_update_not_blocked():
+    """`<x>/bin/hermes kanban update` is a kanban verb, not the updater —
+    the guard must NOT raise (the nonexistent path then fails with
+    FileNotFoundError from the real exec, proving the guard stayed out)."""
+    with pytest.raises(FileNotFoundError):
+        subprocess.run(["./nonexistent/bin/hermes", "kanban", "update", "t1"])

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -829,6 +829,14 @@ def _handle_create(args: dict, **kw) -> str:
     triage, skills, goal_mode = (
         _parse_bool_arg(args, "triage"), _coerce_str_list(args.get("skills"), "skills", "skill names"),
         _parse_bool_arg(args, "goal_mode"))
+    # Unlike skills/parents, a bare string is NOT coerced here: resources are
+    # exclusive identities, and a stringified key silently gating nothing is
+    # worse than a loud error. Arrays only; element types stay with
+    # _coerce_str_list/normalize_resources downstream.
+    raw_resources = args.get("resources")
+    _check(raw_resources is None or isinstance(raw_resources, list),
+           "resources must be an array of strings")
+    resources = _coerce_str_list(raw_resources, "resources", "resource keys")
     model_override, provider_override = args.get("model"), args.get("provider")
     _check(model_override or not provider_override, "'provider' requires 'model' to be set as well")
     parents = _coerce_str_list(args.get("parents") or [], "parents", "task ids")
@@ -855,6 +863,7 @@ def _handle_create(args: dict, **kw) -> str:
             creator_task_id=self_tid,
             idempotency_key=args.get("idempotency_key"),
             max_runtime_seconds=_opt_int(args.get("max_runtime_seconds")), skills=skills,
+            resources=resources,
             model_override=model_override, provider_override=provider_override,
             goal_mode=goal_mode, goal_max_turns=_opt_int(args.get("goal_max_turns")),
             completion_contract=args.get("completion_contract"),

--- a/tools/kanban_tools_schemas.py
+++ b/tools/kanban_tools_schemas.py
@@ -447,6 +447,21 @@ KANBAN_CREATE_SCHEMA = _schema(
                 "assignee's profile."
             ),
         },
+        "resources": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Exclusive physical resource keys this task must hold "
+                "while running, each 'kind:identifier' — the kind before "
+                "the first ':' is lowercase ([a-z0-9._/-]), the identifier "
+                "after it is case-sensitive ([A-Za-z0-9._:/-], device "
+                "serials keep their case) — e.g. "
+                "['harmony-device:6HQ0226318000078'] pins the "
+                "task to one device. The dispatcher runs at most one "
+                "card per key: a ready task whose key is held by a "
+                "running card stays ready until the holder finishes."
+            ),
+        },
         "goal_mode": _prop("boolean", (
                 "Run the dispatched worker in a goal loop. When true, "
                 "after each turn an auxiliary judge checks the worker's "


### PR DESCRIPTION
## Motivation

The kanban dispatcher gates spawns on `status` and per-profile caps, but it has no notion of a **physical singleton resource** shared across cards. If two cards both need the same physical device (e.g. one HarmonyOS handset driven via `hdc`), the dispatcher can spawn them in the same tick and the workers cross-contaminate device state. Observed on 2026-09-10: three cards fanned out onto one device in a single tick; all three workers had to be killed to stop the bleeding. The current workaround is a human manually block/unblock-ing cards into a serial chain — ~69% of manual blocks in one week were device mutexes.

## Design: derived lock — `running` status IS the lock

No lease table, no fencing protocol, no background reaper. A card declares `resources` (`kind:identifier` tokens, e.g. `harmony-device:6HQ0226318000078`); the dispatcher computes the union held by `running` cards at tick start, and a ready card whose keys intersect that set is **deferred, not failed**:

- stays `ready` — never `blocked`, never increments failure/loop-breaker counters (sidesteps the block-loop class entirely);
- picked up on a later tick once the holder leaves `running` (existing stale-claim reclaim covers holder death — no new liveness machinery);
- the held set **rolls forward in-memory within a tick**, so the same-tick fan-out that caused the incident is blocked (verified by mutation test B below).

This deliberately occupies the layer neither open upstream attempt covers: #68104 (cross-board leases) was stalled on PID-reuse breaking liveness proofs, and #104135 (worker-side resource block kind) has a post-spawn grab window plus wasted spawn cost. Gating **before** claim at the shared spawn entrypoint (`_dispatch_lane_task`, both ready and review lanes) has no window and zero wasted spawns.

## What changed

- **DB**: `tasks.resources` JSON column + migration; `Task.resources` parse/normalize. Write path validates strictly (lowercase `kind` `[a-z0-9._/-]+`, case-sensitive `identifier` `[A-Za-z0-9._:/-]+` — device serials round-trip exactly; violations raise `ValueError`, nothing is silently rewritten). Read path fails open so corrupt data never wedges dispatch.
- **Dispatch**: pre-claim gate in `_dispatch_lane_task` → new `DispatchResult.skipped_resource_held` bucket; gateway spawn log line reports it.
- **Stuck probe**: `_has_spawnable` is resource-aware — "all ready cards are resource-held" is healthy waiting, not "no work".
- **Diagnostics**: `stranded_in_ready` exempts cards queued behind a held resource (`held_resources` plumbed through the dashboard `plugin_api` caller); detail text mentions the new cause.
- **CLI/tools**: `kanban create --resources`, new `kanban update --resources` subcommand, list/show display, `kanban_create` model-tool schema gains `resources`.
- **Incidental fix**: `tests/conftest.py` live-system guard matched any `update` token, which mis-blocked the new `hermes kanban update` subcommand; it now matches the updater entrypoint-adjacently (`hermes` / `hermes_cli.main` immediately followed by `update`), +4 guard canaries.

## Tests

- 58 new behavior-contract + red-team tests (`tests/hermes_cli/test_kanban_resource_gate.py`, `test_kanban_resource_gate_acceptance.py`); full kanban regression surface (72 files) green.
- **Mutation-checked**: (A) neutralizing the held-intersection check turns 10 tests red; (B) neutralizing the in-tick rolling update turns 5 tests red, including the same-tick fan-out scenario — the gate is not decorative.
- All run via `scripts/run_tests.sh` (CI-parity runner) on current `main`.

## Notes

- Cards without `resources` (NULL/`[]`) see zero behavior change.
- Naming convention for operators: one canonical key per physical unit across the whole pipeline — aliases defeat the mutex.
