### PR TITLE
fix(update): record a disabled pre-update backup as a skip, not a failure

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -153,6 +153,39 @@ def _record_update_step(step: str, ok: bool, detail: str = "") -> None:
 NETWORK_GIT_TIMEOUT_SECONDS = 300
 
 
+def _record_update_skip(step: str, reason: str) -> None:
+    """Best-effort ``update_receipt.record_skip``; the receipt must never break an update."""
+    with suppress(Exception):
+        from hermes_cli.update_receipt import record_skip
+        record_skip(step, reason)
+
+
+def _record_pre_update_backup_outcome(args, snapshot_id) -> None:
+    """Record the pre-update backup as a skip when it was disabled, else as a step.
+
+    ``snapshot_id`` is None both when the backup was deliberately turned off (config
+    ``updates.pre_update_backup: off``/``false``, or ``--no-backup``) and when a requested backup
+    produced nothing. Recording both as ``ok=false, "disabled or failed"`` made an opt-out
+    indistinguishable from a real failure in the receipt, so a disabled safety net read as a
+    broken one (#94944 is the shipped-opt-out case). A deliberate opt-out is a SKIP WITH its
+    reason; only a requested-but-empty backup is a failed step.
+    """
+    if snapshot_id:
+        _record_update_step("pre_update_backup", True, f"snapshot={snapshot_id}")
+        return
+    try:
+        mode = _resolve_pre_update_backup_mode(args)
+    except Exception:
+        mode = ""
+    if mode == "off":
+        reason = ("disabled by --no-backup" if getattr(args, "no_backup", False)
+                  else "disabled by updates.pre_update_backup (mode: off)")
+        _record_update_skip("pre_update_backup", reason)
+        return
+    _record_update_step("pre_update_backup", False, "no snapshot captured")
+
+
+
 def _git_run(git_cmd, args, cwd=None, *, check=False, network=False):
     """Run git capturing utf-8 text (default cwd: checkout); ``network=True`` disables the
     terminal prompt so an HTTP 401 fails fast instead of hanging, and bounds the wait."""
@@ -1285,11 +1318,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
     _pre_update_plan = _begin_update_receipt_and_plan(args)
 
     # Backup before any git/file mutation; the snapshot id (None if disabled/failed) feeds
-    # the post-update cron-jobs safety net.
+    # the post-update cron-jobs safety net. A deliberate opt-out is recorded as a skip with its
+    # reason, not as a failed step (see _record_pre_update_backup_outcome).
     pre_update_snapshot_id = _m()._run_pre_update_backup(args)
-    _record_update_step(
-        "pre_update_backup", pre_update_snapshot_id is not None,
-        f"snapshot={pre_update_snapshot_id}" if pre_update_snapshot_id else "disabled or failed")
+    _record_pre_update_backup_outcome(args, pre_update_snapshot_id)
 
     _windows_gateway_resume = _m()._pause_windows_gateways_for_update()
     if _windows_gateway_resume:

--- a/tests/hermes_cli/test_update_receipt.py
+++ b/tests/hermes_cli/test_update_receipt.py
@@ -13,11 +13,12 @@ import json
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 import hermes_cli.update_receipt as ur
-from hermes_cli import update_cmd
+from hermes_cli import update_cmd, update_cmd_maint
 
 
 @pytest.fixture()
@@ -401,3 +402,61 @@ class TestCodeIdentity:
         # returned dicts are copies, not the shared cache
         second["sha"] = "mutated"
         assert get_code_identity()["sha"] == first["sha"]
+
+
+class TestPreUpdateBackupStep:
+    """A deliberate pre-update-backup opt-out is a SKIP carrying its reason; only a backup that
+    was requested and captured nothing is a failed step.
+
+    Recording both as ``ok=false, "disabled or failed"`` made a disabled safety net read as a
+    broken one in the receipt — the shipped-opt-out case (#94944) looked like a failure for every
+    update on the affected machine.
+    """
+
+    @staticmethod
+    def _record(monkeypatch, *, args, snapshot_id, updates_cfg) -> dict:
+        """Run the receipt classifier and return the persisted receipt payload."""
+        monkeypatch.setattr(update_cmd_maint, "_load_updates_cfg", lambda: dict(updates_cfg))
+        ur.begin_update_receipt()
+        update_cmd._record_pre_update_backup_outcome(args, snapshot_id)
+        path = _finalize("success")
+        assert path is not None and path.is_file()
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    @pytest.mark.parametrize(
+        "args, updates_cfg, expected_reason",
+        [
+            # The shipped-template case: legacy ``false`` resolves to mode "off" (see #94944).
+            (SimpleNamespace(no_backup=False, backup=False), {"pre_update_backup": False},
+             "updates.pre_update_backup"),
+            # An explicit flag is a different opt-out and must name itself.
+            (SimpleNamespace(no_backup=True, backup=False), {"pre_update_backup": "quick"},
+             "--no-backup"),
+        ],
+    )
+    def test_opt_out_records_a_skip_not_a_failed_step(
+        self, receipt_home, monkeypatch, args, updates_cfg, expected_reason
+    ):
+        payload = self._record(monkeypatch, args=args, snapshot_id=None, updates_cfg=updates_cfg)
+
+        step = "pre_update_backup"
+        assert [entry for entry in payload["steps"] if entry["name"] == step] == []
+        skip = [entry for entry in payload["skips"] if entry["name"] == step]
+        assert len(skip) == 1
+        assert expected_reason in skip[0]["reason"]
+
+    def test_only_an_opt_out_produces_a_skip(self, receipt_home, monkeypatch):
+        """A requested backup never lands in ``skips``: present means captured, absent means failed."""
+        args = SimpleNamespace(no_backup=False, backup=False)
+        updates_cfg = {"pre_update_backup": "quick"}
+
+        captured = self._record(
+            monkeypatch, args=args, snapshot_id="20260911-021847-pre-update", updates_cfg=updates_cfg
+        )
+        assert captured["skips"] == []
+        assert [step["ok"] for step in captured["steps"]] == [True]
+        assert captured["steps"][0]["detail"] == "snapshot=20260911-021847-pre-update"
+
+        empty = self._record(monkeypatch, args=args, snapshot_id=None, updates_cfg=updates_cfg)
+        assert empty["skips"] == []
+        assert [step["ok"] for step in empty["steps"]] == [False]


### PR DESCRIPTION
An opt-out pre-update backup no longer records as a failure.

`cmd_update` classified the step with one predicate, `pre_update_snapshot_id is not None`. `None` covers three different things — config `updates.pre_update_backup: off` (or the legacy `false`), `--no-backup`, and a requested backup that captured nothing — so all three landed as `ok=false, "disabled or failed"`. A receipt whose safety net was switched off read like one whose backup broke, and a real failure carried no reason at all.

Opt-outs now go through `update_receipt.record_skip` with the reason that caused them (`updates.pre_update_backup (mode: off)` or `--no-backup`); only a requested-but-empty backup is a failed step. `skips`/`reason` already existed on the receipt and was always empty, so there is no new surface.

## Changes

- `hermes_cli/update_cmd.py` — `_record_update_skip()` and `_record_pre_update_backup_outcome()` (snapshot → `ok` step; mode `off` → skip naming the trigger; anything else → failed step), replacing the inlined predicate at the `cmd_update` call site.
- `tests/hermes_cli/test_update_receipt.py` — `TestPreUpdateBackupStep`, 3 cases.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_update_receipt.py` | 26 passed |
| update/backup suites (receipt, cmd_update, backup, all_profiles, receipt_endpoint) | 164 passed, 1 skipped |
| `tests/hermes_cli/ tests/gateway/` | 17360 passed, 26 failed, 223 skipped — same 26 on unmodified `origin/main` (A/B in a clean checkout), none touch this path |
| new tests on base | red — no classifier there |

Not hypothetical: `cli-config.yaml.example` still ships `updates.pre_update_backup: false` (#94944), so a fresh install resolves to `off` and never snapshots — every `hermes update` on such a machine recorded `ok=false, "disabled or failed"`, indistinguishable from a broken backup.

Related: #94944 (the template value). No issue covers the receipt conflation.

> Automated posting by agentic team with human oversight.
