### PR TITLE
fix(desktop): give pooled remote dispatch probes the cold-start liveness budget

### DIFF
--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   ensureHealthyPooledRemoteBackendForDispatch,
   POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS,
+  POWER_RESUME_REVALIDATION_HOLDOFF_MS,
   REMOTE_LIVENESS_FAILURE_LIMIT,
   REMOTE_LIVENESS_FAILURE_WINDOW_MS,
   REMOTE_LIVENESS_TIMEOUT_MS,
@@ -260,6 +261,36 @@ describe('revalidateRemoteConnection', () => {
 })
 
 describe('ensureHealthyPooledRemoteBackendForDispatch', () => {
+  it('covers quiet-box cold-start and stays below the power-resume holdoff', () => {
+    expect(POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS).toBeGreaterThanOrEqual(REMOTE_LIVENESS_TIMEOUT_MS)
+    expect(POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS).toBeGreaterThanOrEqual(8_000)
+    expect(POWER_RESUME_REVALIDATION_HOLDOFF_MS).toBeGreaterThan(POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS)
+  })
+
+  it('returns a healthy cached descriptor without retiring or reconnecting', async () => {
+    const healthy = { baseUrl: 'http://127.0.0.1:49525', mode: 'remote' }
+    const connectionPromise = Promise.resolve(healthy)
+    const retire = vi.fn()
+    const reconnect = vi.fn()
+    const probe = vi.fn().mockResolvedValue({ ok: true })
+
+    await expect(
+      ensureHealthyPooledRemoteBackendForDispatch({
+        connectionPromise,
+        currentConnectionPromise: () => connectionPromise,
+        probe,
+        reconnect,
+        retire
+      })
+    ).resolves.toBe(healthy)
+
+    expect(probe).toHaveBeenCalledWith(healthy, '/api/status', {
+      timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
+    })
+    expect(retire).not.toHaveBeenCalled()
+    expect(reconnect).not.toHaveBeenCalled()
+  })
+
   it('retires a dead cached descriptor and gives dispatch the replacement', async () => {
     const stale = { baseUrl: 'http://127.0.0.1:49525', mode: 'remote' }
     const replacement = { baseUrl: 'http://127.0.0.1:53968', mode: 'remote' }

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -1,9 +1,9 @@
 export const REMOTE_LIVENESS_TIMEOUT_MS = 10_000
 // Dispatch is synchronous user intent: a cached descriptor must prove its
-// forwarded endpoint is alive before it can be returned. Keep this probe much
-// shorter than the background liveness budget so a dead tunnel reconnects
-// promptly instead of making the click feel hung.
-export const POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS = 2_500
+// forwarded endpoint is alive before it can be returned. Reuse the background
+// liveness budget so a quiet-box cold-start (~6-8s) can finish instead of
+// failing the probe and kicking off a reconnect storm.
+export const POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS = REMOTE_LIVENESS_TIMEOUT_MS
 export const REMOTE_LIVENESS_FAILURE_LIMIT = 3
 // Even at the capped retry path, consecutive liveness observations are at most
 // about 48s apart (ticket mint + socket open + backoff + the next status probe).


### PR DESCRIPTION
## What does this PR do?

Pooled remote backends health-check a cached descriptor before every dispatch with `POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS = 2_500`. Quiet-box `hermes serve` cold-start is ~6–8s (longer under contention), so a just-triggered backend is guaranteed to miss the probe, get retired, reconnect, and storm.

This reuses the existing background budget `REMOTE_LIVENESS_TIMEOUT_MS` (10s) for that dispatch probe. Dead tunnels still fail the probe and reconnect on demand; a healthy cached descriptor is returned without retire/reconnect. Power-resume holdoff stays at 15s, still strictly above the probe.

## Related Issue

Fixes #107997

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔒 Security fix
- [x] ✅ Tests

## Changes Made

- `apps/desktop/electron/remote-liveness.ts`: `POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS` now aliases `REMOTE_LIVENESS_TIMEOUT_MS` (10_000). Comment updated to match.
- `apps/desktop/electron/remote-liveness.test.ts`: invariant that the dispatch budget covers quiet-box cold-start and stays below `POWER_RESUME_REVALIDATION_HOLDOFF_MS`; CONTROL that a healthy cached descriptor is returned without retire/reconnect. Existing dead-descriptor retire/reconnect test kept.

## How to Test

```
cd apps/desktop
npx vitest run electron/remote-liveness.test.ts
```

Proof receipt (base `dc90a75ab4`):

- BEFORE (pre-fix, same new invariant): 1 failed (`expected 2500 to be greater than or equal to 10000`) / 23 passed
- AFTER: 24 passed (148ms)

## Related work (not duplicates)

- #103375 / #107969 are the local Warm Bot Backends tile-pool analog (`ensureBackend` / `spawnPoolBackend`); this PR does not touch that seam.
- Open PR #100700 (thomasbek3) keeps the SSH scope alive through a dispatch-probe miss and explicitly does **not** change this timeout. Different RCA; the two compose if both merge.
- Pool fan-out (one click waking every pooled profile) is called out in #107997 but left out of scope here.

## Review follow-up

- A dead pooled remote can now stall a click up to 10s instead of 2.5s. That is intentional: 2.5s cannot distinguish dead from cold-starting.
- `POWER_RESUME_REVALIDATION_HOLDOFF_MS` (15_000) was already above 10s, so it was not changed.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) (`fix(desktop): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run relevant tests locally (see How to Test)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS arm64 (focused vitest)

### Documentation & Housekeeping
- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if config keys changed — or N/A
- [x] I've considered cross-platform impact — Electron main-process timeout only; same budget on all desktop OS
- [x] I've updated tool descriptions/schemas if tool behavior changed — or N/A

Self-review P0 = 0 (Detection / Fail-open / Forbidden / RED-on-prefix / Diff-scope). Independent reviewer skipped: 1 module, 39 lines, not auth/crypto/state.db/gateway.

Made with [Cursor](https://cursor.com)