### PR TITLE
fix(kanban): route Telegram topic notifications past unrelated chats

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1531,6 +1531,26 @@ def _resolve_sequential_dispatch(agent, ref: _ToolCallRef, messages: list) -> _S
     def _execute(next_args: dict) -> Any:
         import model_tools
 
+        tool_origin = None
+        if function_name == "kanban_create":
+            # Persist the triggering user turn before the card side effect so its
+            # stable SessionDB row id can be stored as a direct provenance anchor.
+            with contextlib.suppress(Exception):
+                agent._flush_messages_to_session_db(messages)
+            user_message = next((m for m in reversed(messages)
+                                 if isinstance(m, dict) and m.get("role") == "user"), None)
+            if user_message is not None:
+                prompt = getattr(agent, "_persist_user_message_override", None)
+                if prompt is None:
+                    prompt = user_message.get("content")
+                if isinstance(prompt, list):
+                    prompt = " ".join(str(part.get("text", "")) for part in prompt
+                                      if isinstance(part, dict) and part.get("type") == "text")
+                tool_origin = {
+                    "message_row_id": user_message.get("_row_id"),
+                    "prompt": prompt if isinstance(prompt, str) else str(prompt or ""),
+                }
+
         with model_tools.suppress_post_tool_call_hook():
             return model_tools.handle_function_call(
                 function_name,
@@ -1538,6 +1558,8 @@ def _resolve_sequential_dispatch(agent, ref: _ToolCallRef, messages: list) -> _S
                 effective_task_id,
                 tool_call_id=tool_call_id,
                 session_id=agent.session_id or "",
+                platform=getattr(agent, "platform", "") or "",
+                tool_origin=tool_origin,
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                 enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,

--- a/gateway/kanban_watchers_notifier.py
+++ b/gateway/kanban_watchers_notifier.py
@@ -132,8 +132,16 @@ def _adapter_for_subscription(runner: Any, platform: Any, sub: dict, owner_profi
             from gateway.run import _multiplex_profile_homes
             served = {name for name, _home in _multiplex_profile_homes(config)}
             return primary if profile in served else None
-        if route.matches(platform.value, guild_id=guild or route.guild_id, chat_id=chat,
-                         thread_id=thread, parent_chat_id=parent or (route.chat_id if thread_like else None)):
+        # Only Discord uses a thread/post id as ``chat_id`` and therefore needs
+        # the fail-closed unknown-parent probe. Telegram and Slack keep the
+        # containing chat/channel in ``chat_id``; synthesizing each candidate
+        # route's own chat as their parent made an unrelated DM/channel route
+        # shadow the real Telegram topic route before it could be considered.
+        parent_unknown = platform.value == "discord" and parent is None and thread_like
+        if parent_unknown and route.matches(
+            platform.value, guild_id=guild or route.guild_id, chat_id=chat,
+            thread_id=thread, parent_chat_id=route.chat_id,
+        ):
             return None
     return primary if profile == primary_profile else None
 

--- a/gateway/kanban_watchers_notifier.py
+++ b/gateway/kanban_watchers_notifier.py
@@ -543,8 +543,12 @@ class _KanbanNotification:
         # "no exception == delivered" contract.
         if getattr(_send_res, "success", True) is False:
             raise RuntimeError(f"adapter send() reported failure: {getattr(_send_res, 'error', None) or 'unknown error'}")
-        logger.debug("kanban notifier: delivered %s event for %s to %s/%s on board %s",
-                     ev.kind, self.task_id, self.platform_str, sub["chat_id"], self.board_slug)
+        logger.info(
+            "kanban notifier: delivered %s event %s for %s to %s/%s thread=%s message_id=%s continuations=%s board=%s",
+            ev.kind, ev.id, self.task_id, self.platform_str, sub["chat_id"], sub.get("thread_id") or "-",
+            getattr(_send_res, "message_id", None), getattr(_send_res, "continuation_message_ids", ()) or (),
+            self.board_slug,
+        )
         # Upload artifact paths from the completion payload / legacy result as
         # native files. Only on ``completed`` so retries never spam attachments.
         if ev.kind == "completed":

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -711,6 +711,7 @@ class Task:
     goal_mode: bool = False
     goal_max_turns: Optional[int] = None
     session_id: Optional[str] = None         # originating HERMES_SESSION_ID; NULL from CLI/dashboard
+    origin: Optional[dict] = None            # structured conversation/message provenance (JSON on disk)
     # VALID_BLOCK_KINDS or None (legacy); kept across unblock so a same-kind re-block reads as a loop.
     block_kind: Optional[str] = None
     block_recurrences: int = 0               # unblock-loop counter, see BLOCK_RECURRENCE_LIMIT
@@ -730,6 +731,7 @@ class Task:
             consecutive_failures=g("consecutive_failures", g("spawn_failures", 0)),
             last_failure_error=g("last_failure_error", g("last_spawn_error")),
             skills=skills_value,
+            origin=_json_or(g("origin")) if g("origin") else None,
             goal_mode=bool(g("goal_mode")),
             block_recurrences=int(g("block_recurrences") or 0),
         )
@@ -929,6 +931,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- set the env var. Indexed so per-session list queries stay cheap on
     -- larger boards.
     session_id           TEXT,
+    -- Structured provenance for agent-created cards: profile/session/message
+    -- anchors, route coordinates, a redacted prompt excerpt, and a dashboard
+    -- session link. NULL preserves compatibility for CLI/dashboard/legacy rows.
+    origin               TEXT,
     -- Typed block reason set by ``block_task`` (one of VALID_BLOCK_KINDS, or
     -- NULL for legacy/un-typed blocks). Drives routing: ``dependency`` never
     -- sits in ``blocked`` (goes to ``todo`` for parent-gating); the others go
@@ -1228,7 +1234,8 @@ def create_task(
     max_retries: Optional[int] = None, model_override: Optional[str] = None,
     provider_override: Optional[str] = None, reasoning_effort: Optional[str] = None,
     goal_mode: bool = False, goal_max_turns: Optional[int] = None, initial_status: str = "running",
-    session_id: Optional[str] = None, board: Optional[str] = None, project_id: Optional[str] = None,
+    session_id: Optional[str] = None, origin: Optional[dict] = None,
+    board: Optional[str] = None, project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
     creator_task_id: Optional[str] = None,
     completion_contract: Optional[str] = None,
@@ -1259,6 +1266,8 @@ def create_task(
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
         raise ValueError(f"initial_status must be one of {sorted(VALID_INITIAL_STATUSES)}")
+    if origin is not None and not isinstance(origin, dict):
+        raise ValueError("origin must be an object/dict")
     # A project-scoped board anchors every new task to its project's repo
     # (deterministic worktree + branch) without each surface repeating it.
     # An explicit ``scratch`` (or ``project_id=""``) is a request for no project:
@@ -1331,8 +1340,8 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id, completion_contract
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id, origin, completion_contract
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id, title.strip(), body, assignee, task_status, priority,
@@ -1341,7 +1350,9 @@ def create_task(
                         _opt_int(max_runtime_seconds),
                         json.dumps(skills_list) if skills_list is not None else None,
                         _opt_int(max_retries), model_override, provider_override, reasoning_effort,
-                        1 if goal_mode else 0, _opt_int(goal_max_turns), session_id, completion_contract,
+                        1 if goal_mode else 0, _opt_int(goal_max_turns), session_id,
+                        json.dumps(origin, ensure_ascii=False, sort_keys=True) if origin is not None else None,
+                        completion_contract,
                     ),
                 )
                 for pid in parents:
@@ -3581,6 +3592,7 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     now = int(time.time())
     lines: list[str] = []
     _ctx_header(lines, task)
+    _ctx_origin(lines, task)
     _ctx_attachments(lines, list_attachments(conn, task_id))
     _ctx_prior_attempts(lines, conn, task_id, now)
     _ctx_parent_results(lines, conn, task_id, now)
@@ -3649,6 +3661,34 @@ def _ctx_header(lines: list[str], task: Task) -> None:
         lines.append("## Body")
         lines.append(_ctx_cap(task.body, _CTX_MAX_BODY_BYTES))
         lines.append("")
+
+
+def _ctx_origin(lines: list[str], task: Task) -> None:
+    """Render durable conversation provenance when this card has one."""
+    origin = task.origin
+    if not isinstance(origin, dict) or not origin:
+        return
+    lines.append("## Origin")
+    profile = origin.get("profile") or "(unknown profile)"
+    session_id = origin.get("session_id") or task.session_id
+    session_link = origin.get("session_link")
+    if session_id:
+        label = f"{profile} / {session_id}"
+        lines.append(f"Session: [{label}]({session_link})" if session_link else f"Session: {label}")
+    message_id = origin.get("message_id")
+    row_id = origin.get("message_row_id")
+    if message_id is not None:
+        suffix = f" (session row {row_id})" if row_id is not None else ""
+        lines.append(f"Message: {message_id}{suffix}")
+    elif row_id is not None:
+        lines.append(f"Message: session row {row_id}")
+    route = "/".join(str(v) for v in (
+        origin.get("platform"), origin.get("chat_id"), origin.get("thread_id")) if v)
+    if route:
+        lines.append(f"Route: {route}")
+    if origin.get("prompt_excerpt"):
+        lines.append(f"Prompt: {_ctx_cap(str(origin['prompt_excerpt']))}")
+    lines.append("")
 
 
 def _ctx_attachments(lines: list[str], attachments: list[Attachment]) -> None:

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -810,6 +810,7 @@ _LATER_TASK_COLUMNS = (
     ("goal_max_turns", "goal_max_turns INTEGER"),
     ("completion_contract", "completion_contract TEXT"),
     ("session_id", "session_id TEXT"),
+    ("origin", "origin TEXT"),
     # Typed block reason (VALID_BLOCK_KINDS); NULL = generic human blocker.
     ("block_kind", "block_kind TEXT"),
     ("block_recurrences", "block_recurrences INTEGER NOT NULL DEFAULT 0"),

--- a/hermes_cli/kanban_db_graph.py
+++ b/hermes_cli/kanban_db_graph.py
@@ -16,8 +16,9 @@ def inherit_creator_origin(
 
     conn.execute(
         "UPDATE tasks SET session_id = COALESCE(session_id, "
-        "(SELECT session_id FROM tasks WHERE id = ?)) WHERE id = ?",
-        (creator_task_id, task_id),
+        "(SELECT session_id FROM tasks WHERE id = ?)), origin = COALESCE(origin, "
+        "(SELECT origin FROM tasks WHERE id = ?)) WHERE id = ?",
+        (creator_task_id, creator_task_id, task_id),
     )
     _inherit_notify_subs(conn, task_id, (creator_task_id,), created_at=created_at)
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -802,10 +802,14 @@ def _approval_observability(ids: _CallIds):
 
 
 def _execute_tool(function_name: str, function_args: Dict[str, Any], original_args: Dict[str, Any], ids: _CallIds,
-                  *, user_task: Optional[str], enabled_tools: Optional[List[str]], skip_tool_execution_middleware: bool) -> Any:
+                  *, user_task: Optional[str], enabled_tools: Optional[List[str]], skip_tool_execution_middleware: bool,
+                  platform: Optional[str] = None, tool_origin: Optional[Dict[str, Any]] = None) -> Any:
     """Run the registry handler (through tool-execution middleware unless skipped)
     with the approval observability context bound for the duration."""
     dispatch_kwargs: Dict[str, Any] = {"task_id": ids.task_id, "session_id": ids.session_id}
+    if tool_origin is not None:
+        dispatch_kwargs["platform"] = platform
+        dispatch_kwargs["tool_origin"] = tool_origin
     if function_name == "execute_code":
         # Prefer the caller's list so subagents can't overwrite the parent's
         # tool set via the process-global.
@@ -859,6 +863,7 @@ def handle_function_call(
     skip_pre_tool_call_hook: bool = False, skip_tool_request_middleware: bool = False,
     skip_tool_execution_middleware: bool = False, tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None, disabled_toolsets: Optional[List[str]] = None,
+    platform: Optional[str] = None, tool_origin: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Route a tool call through hooks/middleware to the registry; returns a JSON string.
 
@@ -903,6 +908,7 @@ def handle_function_call(
             skip_pre_tool_call_hook=skip_pre_tool_call_hook, skip_tool_request_middleware=skip_tool_request_middleware,
             skip_tool_execution_middleware=skip_tool_execution_middleware, tool_request_middleware_trace=list(trace),
             enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets,
+            platform=platform, tool_origin=tool_origin,
         )
 
     from tools.tool_gateway.names import is_connector_name, parse_connector_name
@@ -936,7 +942,8 @@ def handle_function_call(
         # duration_ms (monotonic) is exposed to post_tool_call / transform_tool_result.
         start = time.monotonic()
         result = _execute_tool(function_name, function_args, original_args, ids, user_task=user_task,
-                               enabled_tools=enabled_tools, skip_tool_execution_middleware=skip_tool_execution_middleware)
+                               enabled_tools=enabled_tools, skip_tool_execution_middleware=skip_tool_execution_middleware,
+                               platform=platform, tool_origin=tool_origin)
         duration_ms = _elapsed_ms(start)
         _emit(result, duration_ms=duration_ms)
         return _apply_transform_tool_result_hook(function_name, function_args, result, duration_ms, ids)

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3866,6 +3866,36 @@
     );
   }
 
+  function OriginMeta(props) {
+    const origin = props.origin;
+    if (!origin) return null;
+    const sessionLabel = [origin.profile, origin.session_id].filter(Boolean).join(" / ");
+    const safeSessionLink = typeof origin.session_link === "string" && origin.session_link.startsWith("/chat?")
+      ? origin.session_link
+      : null;
+    const sessionValue = safeSessionLink
+      ? h("a", { href: safeSessionLink }, sessionLabel || safeSessionLink)
+      : sessionLabel;
+    const messageValue = origin.message_id || (origin.message_row_id != null
+      ? "session row " + origin.message_row_id
+      : null);
+    const route = [origin.platform, origin.chat_id, origin.thread_id].filter(Boolean).join(" / ");
+    return h(React.Fragment, null,
+      sessionValue ? h(MetaRow, {
+        label: tx(props.i18n, "originSession", "Origin session"), value: sessionValue,
+      }) : null,
+      messageValue ? h(MetaRow, {
+        label: tx(props.i18n, "originMessage", "Origin message"), value: messageValue,
+      }) : null,
+      route ? h(MetaRow, {
+        label: tx(props.i18n, "originRoute", "Origin route"), value: route,
+      }) : null,
+      origin.prompt_excerpt ? h(MetaRow, {
+        label: tx(props.i18n, "originPrompt", "Origin prompt"), value: origin.prompt_excerpt,
+      }) : null,
+    );
+  }
+
   function TaskDetail(props) {
     const { t: i18n } = useI18n();
     const t = props.data.task;
@@ -3913,6 +3943,7 @@
             : "on",
         }) : null,
         t.created_by ? h(MetaRow, { label: tx(i18n, "createdBy", "Created by"), value: t.created_by }) : null,
+        h(OriginMeta, { origin: t.origin, i18n: i18n }),
       ),
       h(StatusActions, {
         task: t,

--- a/tests/gateway/test_kanban_routed_transport.py
+++ b/tests/gateway/test_kanban_routed_transport.py
@@ -99,6 +99,33 @@ def test_exact_routed_profile_delivers_once_on_its_authorized_transport(tmp_path
     assert not unseen(task)
 
 
+def test_telegram_topic_is_not_shadowed_by_an_unrelated_chat_route(tmp_path, monkeypatch):
+    runner = setup_runner(tmp_path, monkeypatch)
+    primary = RecordingAdapter()
+    runner.adapters = {Platform.TELEGRAM: primary}  # type: ignore[assignment]
+    runner.config.profile_routes = parse_profile_routes([
+        dict(platform="telegram", chat_id="-100group", thread_id="3", profile="other"),
+        dict(platform="telegram", chat_id="creator-dm", profile="yuki"),
+        dict(platform="telegram", chat_id="-100group", profile="yuki"),
+    ])
+    with kbc.connect() as conn:
+        task = kb.create_task(conn, title="telegram topic completion", assignee="worker")
+        kbn.add_notify_sub(
+            conn, task_id=task, platform="telegram", chat_id="-100group", thread_id="2",
+            chat_type="group", user_id="creator", notifier_profile="yuki",
+            delivery_mode="notify+wake", delivery_metadata={"chat_type": "group", "thread_id": "2"},
+        )
+        kb.complete_task(conn, task, result="finished")
+
+    rows = collect(runner)
+    assert [row["task"].id for row in rows] == [task]
+    asyncio.run(deliver(runner, rows))
+    assert len(primary.sent) == len(primary.handled) == 1
+    assert primary.sent[0][0] == "-100group"
+    assert primary.sent[0][2]["metadata"]["thread_id"] == "2"
+    assert not collect(runner)
+
+
 def test_route_denials_leave_events_retryable_at_claim_and_send(tmp_path, monkeypatch):
     runner = setup_runner(tmp_path, monkeypatch)
     primary = runner.adapters[Platform.DISCORD]

--- a/tests/hermes_cli/test_kanban_creator_origin.py
+++ b/tests/hermes_cli/test_kanban_creator_origin.py
@@ -11,7 +11,9 @@ def test_creator_origin_survives_without_dependency_parent(tmp_path, monkeypatch
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     kb.init_db()
     with kbc.connect_closing() as conn:
-        owner = kb.create_task(conn, title="owner", session_id="durable", triage=True)
+        origin = {"profile": "daily", "session_id": "durable", "message_row_id": 767}
+        owner = kb.create_task(
+            conn, title="owner", session_id="durable", origin=origin, triage=True)
         kn.add_notify_sub(conn, task_id=owner, platform="telegram", chat_id="chat",
                          delivery_mode="wake", notifier_profile="default")
         if surface == "builtin":
@@ -29,7 +31,10 @@ def test_creator_origin_survives_without_dependency_parent(tmp_path, monkeypatch
             monkeypatch.setenv("HERMES_KANBAN_TASK", owner)
             assert kanban_command(parser.parse_args(["kanban", "create", "child", "--json"])) == 0
             tid = json.loads(capsys.readouterr().out)["id"]
-        assert kb.get_task(conn, tid).session_id == "durable"
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.session_id == "durable"
+        assert task.origin == origin
         subs = kn.list_notify_subs(conn, tid)
         assert len(subs) == 1 and subs[0]["delivery_mode"] == "wake"
         assert not conn.execute("SELECT 1 FROM task_links WHERE child_id = ?", (tid,)).fetchone()

--- a/tests/test_dispatch_session_id.py
+++ b/tests/test_dispatch_session_id.py
@@ -1,6 +1,7 @@
 """Tests that handle_function_call forwards session_id into registry.dispatch."""
 
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -73,3 +74,39 @@ class TestSessionIdForwarding:
                 skip_pre_tool_call_hook=True,
             )
         assert captured.get("task_id") == "task-999"
+
+    def test_conversation_origin_is_forwarded_only_when_supplied(self):
+        captured = {}
+        origin = {"message_row_id": 767, "prompt": "Create a card"}
+        with patch("model_tools.registry", _make_registry(captured)):
+            from model_tools import handle_function_call
+            handle_function_call(
+                "kanban_create", {"title": "traceable"}, session_id="sess-1",
+                platform="telegram", tool_origin=origin, skip_pre_tool_call_hook=True,
+            )
+        assert captured["platform"] == "telegram"
+        assert captured["tool_origin"] == origin
+
+    def test_kanban_dispatch_captures_persisted_triggering_user_row(self):
+        from agent.tool_executor import _resolve_sequential_dispatch, _ToolCallRef
+
+        messages = [{"role": "user", "content": "Create the launch card"}]
+
+        def flush(current_messages):
+            current_messages[0]["_row_id"] = 767
+
+        agent = SimpleNamespace(
+            _context_engine_tool_names=set(), _memory_manager=None, quiet_mode=False,
+            session_id="sess-1", platform="telegram", valid_tool_names=[],
+            _flush_messages_to_session_db=flush, enabled_toolsets=None, disabled_toolsets=None,
+        )
+        ref = _ToolCallRef("kanban_create", {"title": "launch"}, "task-1", "call-1", [])
+        with patch("model_tools.handle_function_call", return_value='{"ok": true}') as execute:
+            _resolve_sequential_dispatch(agent, ref, messages).execute(ref.args)
+
+        assert execute.call_args.kwargs["session_id"] == "sess-1"
+        assert execute.call_args.kwargs["platform"] == "telegram"
+        assert execute.call_args.kwargs["tool_origin"] == {
+            "message_row_id": 767,
+            "prompt": "Create the launch card",
+        }

--- a/tests/tools/test_kanban_provenance.py
+++ b/tests/tools/test_kanban_provenance.py
@@ -59,3 +59,84 @@ def test_tool_subscription_captures_conversation_anchors(tmp_path, monkeypatch):
         metadata = kn.list_notify_subs(conn, result["task_id"])[0]["delivery_metadata"]
         assert metadata["scope_id"] == "guild"
         assert metadata["parent_chat_id"] == "forum"
+
+
+def test_tool_create_persists_and_surfaces_triggering_message_origin(tmp_path, monkeypatch):
+    from hermes_cli import kanban_db as kb, kanban_db_connect as kbc
+    from tools import kanban_tools as kt
+    from gateway.session_context import set_session_vars, clear_session_vars
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_PROFILE", "daily")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    kb.init_db()
+    tokens = set_session_vars(
+        platform="telegram", chat_id="-10042", thread_id="2203",
+        message_id="767", profile="daily", session_id="20260907_191153_242af06a",
+    )
+    try:
+        result = json.loads(kt._handle_create(
+            {"title": "traceable", "assignee": "daily"},
+            session_id="20260907_191153_242af06a",
+            tool_origin={"message_row_id": 767, "prompt": "Prepare the launch checklist\nnow"},
+        ))
+    finally:
+        clear_session_vars(tokens)
+
+    assert result["ok"], result
+    with kbc.connect_closing() as conn:
+        task = kb.get_task(conn, result["task_id"])
+        assert task.origin == {
+            "profile": "daily",
+            "session_id": "20260907_191153_242af06a",
+            "message_id": "767",
+            "message_row_id": 767,
+            "platform": "telegram",
+            "chat_id": "-10042",
+            "thread_id": "2203",
+            "prompt_excerpt": "Prepare the launch checklist now",
+            "session_link": "/chat?resume=20260907_191153_242af06a&profile=daily",
+        }
+        worker_context = kb.build_worker_context(conn, task.id)
+        assert "## Origin" in worker_context
+        assert "Message: 767 (session row 767)" in worker_context
+        assert "](/chat?resume=20260907_191153_242af06a&profile=daily)" in worker_context
+        shown = json.loads(kt._handle_show({"task_id": task.id}))
+        assert shown["task"]["origin"] == task.origin
+
+
+def test_creation_without_session_keeps_origin_absent_on_legacy_board(tmp_path, monkeypatch):
+    import sqlite3
+
+    from hermes_cli import kanban_db as kb, kanban_db_connect as kbc
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "kanban.db"
+    with sqlite3.connect(db_path) as legacy:
+        legacy.executescript("""
+            CREATE TABLE tasks (
+                id TEXT PRIMARY KEY, title TEXT NOT NULL, body TEXT, assignee TEXT,
+                status TEXT NOT NULL, priority INTEGER NOT NULL DEFAULT 0, created_by TEXT,
+                created_at INTEGER NOT NULL, started_at INTEGER, completed_at INTEGER,
+                workspace_kind TEXT NOT NULL DEFAULT 'scratch', workspace_path TEXT,
+                claim_lock TEXT, claim_expires INTEGER
+            );
+        """)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+
+    with kbc.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="plain")
+        task = kb.get_task(conn, task_id)
+        assert task.origin is None
+        assert "## Origin" not in kb.build_worker_context(conn, task_id)
+
+
+def test_dashboard_bundle_renders_origin_session_link_and_message():
+    from pathlib import Path
+
+    bundle = (Path(__file__).resolve().parents[2]
+              / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    assert "function OriginMeta" in bundle
+    assert "origin.session_link" in bundle
+    assert "origin.message_row_id" in bundle

--- a/tests/tools/test_kanban_provenance.py
+++ b/tests/tools/test_kanban_provenance.py
@@ -132,11 +132,46 @@ def test_creation_without_session_keeps_origin_absent_on_legacy_board(tmp_path, 
         assert "## Origin" not in kb.build_worker_context(conn, task_id)
 
 
-def test_dashboard_bundle_renders_origin_session_link_and_message():
-    from pathlib import Path
+def test_origin_redacts_secret_before_persistence_and_display(tmp_path, monkeypatch):
+    from hermes_cli import kanban_db as kb, kanban_db_connect as kbc
+    from tools import kanban_tools as kt
+    from gateway.session_context import set_session_vars, clear_session_vars
 
-    bundle = (Path(__file__).resolve().parents[2]
-              / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
-    assert "function OriginMeta" in bundle
-    assert "origin.session_link" in bundle
-    assert "origin.message_row_id" in bundle
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_PROFILE", "daily")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    kb.init_db()
+    secret = "sk-proj-" + ("a" * 40)
+    tokens = set_session_vars(
+        platform="telegram", chat_id="-10042", message_id="811",
+        profile="daily", session_id="session-with-secret",
+    )
+    try:
+        result = json.loads(kt._handle_create(
+            {"title": "safe origin", "assignee": "daily"},
+            session_id="session-with-secret",
+            tool_origin={
+                "message_row_id": 767,
+                "prompt": f"Prepare the launch checklist using API key {secret} today",
+            },
+        ))
+    finally:
+        clear_session_vars(tokens)
+
+    assert result["ok"], result
+    with kbc.connect_closing() as conn:
+        task = kb.get_task(conn, result["task_id"])
+        assert task is not None
+        assert task.origin is not None
+        shown = json.loads(kt._handle_show({"task_id": task.id}))
+        worker_context = kb.build_worker_context(conn, task.id)
+
+    persisted = json.dumps(task.origin)
+    displayed = json.dumps(shown)
+    for surface in (persisted, displayed, worker_context):
+        assert secret not in surface
+        assert "sk-proj-" not in surface
+        assert "Prepare the launch checklist" in surface
+    assert task.origin["prompt_excerpt"] != (
+        f"Prepare the launch checklist using API key {secret} today"
+    )

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -14,6 +14,7 @@ import os
 import time
 from contextlib import contextmanager
 from typing import Any, Callable, Optional
+from urllib.parse import urlencode
 
 from agent.redact import redact_sensitive_text
 from hermes_cli.goals import judge_goal
@@ -309,7 +310,7 @@ def _opt_int(value: Any, default: Optional[int] = None) -> Optional[int]:
 _TASK_FIELDS = tuple(
     "id title body assignee status tenant priority workspace_kind workspace_path created_by "
     "created_at started_at completed_at result current_run_id model_override "
-    "provider_override completion_contract last_failure_error".split())
+    "provider_override completion_contract last_failure_error session_id origin".split())
 _TASK_SUMMARY_FIELDS = tuple(
     "id title assignee status priority tenant workspace_kind workspace_path project_id created_by "
     "created_at started_at completed_at current_run_id model_override provider_override".split())
@@ -839,7 +840,12 @@ def _handle_create(args: dict, **kw) -> str:
         self_task = kb.get_task(conn, self_tid) if self_tid else None
         # The worker/API runtime may be transient; the owning task's origin is durable.
         session_id = (args.get("session_id") or (self_task.session_id if self_task else None)
+                      or kw.get("session_id")
                       or _current_origin_session_id() or os.environ.get("HERMES_SESSION_ID"))
+        # A worker-created child belongs to the durable creator chain. Never combine a
+        # legacy parent's session id with the worker turn's unrelated prompt metadata.
+        origin = (self_task.origin if self_task else
+                  _conversation_origin(session_id, kw.get("tool_origin"), platform=kw.get("platform")))
         if project_id is None and workspace_kind is None and workspace_path is None:
             if self_task is not None and self_task.project_id:
                 project_id, project_source_task_id = self_task.project_id, self_task.id
@@ -859,9 +865,45 @@ def _handle_create(args: dict, **kw) -> str:
             goal_mode=goal_mode, goal_max_turns=_opt_int(args.get("goal_max_turns")),
             completion_contract=args.get("completion_contract"),
             initial_status=str(args.get("initial_status") or "running"),
-            created_by=os.environ.get("HERMES_PROFILE") or "worker", session_id=session_id)
+            created_by=os.environ.get("HERMES_PROFILE") or "worker",
+            session_id=session_id, origin=origin)
         landed = _fields(kb.get_task(conn, new_tid), _CREATED_FIELDS)
         return _ok(task_id=new_tid, **landed, subscribed=_maybe_auto_subscribe(conn, new_tid))
+
+
+_ORIGIN_PROMPT_CHARS = 240
+
+
+def _conversation_origin(
+    session_id: Optional[str], tool_origin: Any, *, platform: Optional[str] = None,
+) -> Optional[dict[str, Any]]:
+    """Build the privacy-bounded origin persisted on an agent-created card."""
+    if not session_id:
+        return None
+    from gateway.session_context import get_session_env as env
+
+    tool_origin = tool_origin if isinstance(tool_origin, dict) else {}
+    profile = env("HERMES_SESSION_PROFILE", "") or os.environ.get("HERMES_PROFILE") or "default"
+    native_message_id = env("HERMES_SESSION_MESSAGE_ID", "") or None
+    row_id = tool_origin.get("message_row_id")
+    prompt = tool_origin.get("prompt")
+    prompt_excerpt = None
+    if prompt:
+        prompt_excerpt = " ".join(_redact(prompt).split())
+        if len(prompt_excerpt) > _ORIGIN_PROMPT_CHARS:
+            prompt_excerpt = prompt_excerpt[:_ORIGIN_PROMPT_CHARS - 1].rstrip() + "…"
+    origin = {
+        "profile": str(profile),
+        "session_id": str(session_id),
+        "message_id": str(native_message_id or row_id) if native_message_id or row_id is not None else None,
+        "message_row_id": int(row_id) if isinstance(row_id, int) else None,
+        "platform": env("HERMES_SESSION_PLATFORM", "") or platform or None,
+        "chat_id": env("HERMES_SESSION_CHAT_ID", "") or None,
+        "thread_id": env("HERMES_SESSION_THREAD_ID", "") or None,
+        "prompt_excerpt": prompt_excerpt,
+        "session_link": "/chat?" + urlencode({"resume": session_id, "profile": profile}),
+    }
+    return {key: value for key, value in origin.items() if value is not None}
 
 
 def _resolve_notify_target() -> Optional[dict[str, Any]]:

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -113,6 +113,11 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
   below. Single-project users stay on the `default` board and never see the
   word "board" outside this docs section.
 - **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | ready | running | blocked | review | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation).
+  Cards created by an agent during a Hermes conversation also retain a privacy-bounded
+  `origin` record: profile and session, the triggering user-message ID, available
+  platform route coordinates, a redacted 240-character prompt excerpt, and a link back
+  to that session. `kanban_show`, worker context, and the dashboard task drawer expose
+  it. CLI/dashboard-created and legacy cards leave `origin` absent.
 - **Link** — `task_links` row recording a parent → child dependency. The dispatcher promotes `todo → ready` when all parents are `done`.
 - **Comment** — the inter-agent protocol. Agents and humans append comments; when a worker is (re-)spawned it reads the full comment thread as part of its context.
 - **Workspace** — the directory a worker operates in. Three kinds:


### PR DESCRIPTION
## Summary
- limit the fail-closed unknown-parent probe to Discord, where thread chat IDs differ from their parent channel
- prevent unrelated Telegram DM/topic routes from shadowing the matching group route
- add an integration regression covering a Telegram topic behind conflicting topic and DM routes

## Root cause
Telegram keeps the containing group in chat_id and stores the topic separately in thread_id. The notifier treated every threaded subscription like a Discord thread, synthesized each candidate route as a missing parent, and returned fail-closed on an unrelated earlier DM route before reaching the correct group route.

## Test plan
- scripts/run_tests.sh tests/gateway/test_kanban_routed_transport.py tests/gateway/test_kanban_notifier_wake_only_ordering.py tests/gateway/test_kanban_notifier.py tests/tools/test_kanban_tools.py -q
- 59 passed