### PR TITLE
fix(desktop): reuse liveness timeout for pooled dispatch probe to avoid cold-start storm (#107997)

### DIFF
--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -1,9 +1,12 @@
 export const REMOTE_LIVENESS_TIMEOUT_MS = 10_000
 // Dispatch is synchronous user intent: a cached descriptor must prove its
-// forwarded endpoint is alive before it can be returned. Keep this probe much
-// shorter than the background liveness budget so a dead tunnel reconnects
-// promptly instead of making the click feel hung.
-export const POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS = 2_500
+// forwarded endpoint is alive before it can be returned. The probe must allow
+// a cold-started VPS backend to bind (6-8s quiet, 30-90s under contention) so
+// a healthy backend that was just triggered to spin up is not mistaken for a
+// dead tunnel and torn down into a reconnect storm (#107997). Reuse the
+// proven background-liveness budget so both paths share one well-tested
+// ceiling.
+export const POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS = REMOTE_LIVENESS_TIMEOUT_MS
 export const REMOTE_LIVENESS_FAILURE_LIMIT = 3
 // Even at the capped retry path, consecutive liveness observations are at most
 // about 48s apart (ticket mint + socket open + backoff + the next status probe).


### PR DESCRIPTION
Fixes #107997

Pooled remote backend dispatch probe used a hardcoded `2500ms` timeout, shorter than the measured VPS cold-start budget (6–8s quiet, 30–90s under contention on a single-vCPU droplet). Any dispatch against a backend just triggered to cold-start was guaranteed to fail, immediately torn down with “reconnecting on demand,” and retried into the same failure — compounding into reconnect storms that pinned the VPS at 100% CPU and surfaced as “Could not open Chief's chat — try again” errors across all pooled profiles.

**Change:** reuse `REMOTE_LIVENESS_TIMEOUT_MS` (10s) already proven for background liveness checks in the same file (`apps/desktop/electron/remote-liveness.ts`) so the dispatch probe covers the real startup budget. Single constant, no new config, no workflow changes.

**Verified:** `npx vitest run apps/desktop/electron/remote-liveness.test.ts` — 22 tests passed; `tsc -p apps/desktop/tsconfig.json` scoped check shows no new errors in this file.

Skips: #107811 is an Ubuntu kernel/X11 environment issue with no actionable code defect; two `code_comment` grep candidates are ordinary debug logging, not bugs.