### PR TITLE
fix(cron): support script args and reject malformed script specs

### DIFF
--- a/cron/scheduler_script.py
+++ b/cron/scheduler_script.py
@@ -12,6 +12,7 @@ import contextlib
 import contextvars
 import logging
 import os
+import shlex
 import shutil
 import signal
 import subprocess
@@ -229,7 +230,11 @@ def _drain_script_pipes(proc: subprocess.Popen) -> None:
 
 
 def _windows_cron_bootstrap_argv(
-    python_exe: str, env_overlay: dict[str, str], script_path: str) -> list[str]:
+    python_exe: str,
+    env_overlay: dict[str, str],
+    script_path: str,
+    script_args: Optional[list[str]] = None,
+) -> list[str]:
     """Bootstrap a cron script under the base interpreter with ``.pth`` support. Overlay mode puts
     the venv on ``PYTHONPATH``, but ``.pth`` files are only processed by ``site.addsitedir()``, so
     editable installs would be invisible; bootstrap via addsitedir + ``runpy.run_path`` (keeps
@@ -250,11 +255,29 @@ def _windows_cron_bootstrap_argv(
         "sys.path.insert(0, os.path.dirname(os.path.abspath(script)));"
         "runpy.run_path(script, run_name='__main__')"
     )
-    return [python_exe, "-c", bootstrap, script_path]
+    return [python_exe, "-c", bootstrap, script_path, *(script_args or [])]
 
 
-def _resolve_script_path(script_path: str) -> tuple[Optional[Path], Optional[str]]:
-    """Validate a job script path; ``(path, None)`` or ``(None, error)``. Scripts MUST resolve
+def _split_script_spec(script_spec: str) -> tuple[Optional[str], Optional[list[str]], Optional[str]]:
+    """Parse a cron script specification into ``(path_token, args, error)``.
+
+    The ``script`` field allows shell-style quoting for arguments; token[0] is the script path,
+    remaining tokens are argv passed to the script.
+    """
+    text = str(script_spec)
+    if "\x00" in text:
+        return None, None, f"Blocked: script path contains a NUL byte: {script_spec!r}"
+    try:
+        parts = shlex.split(text, posix=True)
+    except ValueError as exc:
+        return None, None, f"Invalid script specification: {exc}"
+    if not parts:
+        return None, None, "Invalid script specification: empty script value"
+    return parts[0], parts[1:], None
+
+
+def _resolve_script_path(script_spec: str) -> tuple[Optional[Path], Optional[list[str]], Optional[str]]:
+    """Validate a job script spec; ``(path, args, None)`` or ``(None, None, error)``. Scripts MUST resolve
     inside HERMES_HOME/scripts/ (relative, absolute and ``~`` paths are all validated — path
     traversal / absolute-path injection); contract of lifecycle_guard._expand_candidate_path."""
     scripts_dir = _sched._get_hermes_home() / "scripts"
@@ -269,31 +292,34 @@ def _resolve_script_path(script_path: str) -> tuple[Optional[Path], Optional[str
     # cleanly instead of crashing the scheduler. str() first so the guard itself can never raise TypeError
     # on a non-str script_path (e.g. a Path passed by a future caller) — the guard must be crash-proof even
     # though every current call site passes a plain str (#86832 review).
-    if "\x00" in str(script_path):
-        return None, f"Blocked: script path contains a NUL byte: {script_path!r}"
+    script_path, script_args, split_error = _split_script_spec(script_spec)
+    if split_error is not None:
+        return None, None, split_error
+    if script_path is None:
+        return None, None, "Invalid script specification: empty script value"
     try:
         raw = _sched.Path(script_path).expanduser()
     except (ValueError, RuntimeError, OSError):
         # RuntimeError: unexpandable ``~`` (no resolvable HOME).
-        return None, f"Blocked: script path is not a valid filesystem path: {script_path!r}"
+        return None, None, f"Blocked: script path is not a valid filesystem path: {script_path!r}"
     path = raw.resolve() if raw.is_absolute() else (scripts_dir / raw).resolve()
 
     # Traversal / absolute-path / symlink escape guard — MUST stay inside HERMES_HOME/scripts/.
     try:
         path.relative_to(scripts_dir_resolved)
     except ValueError:
-        return None, (
+        return None, None, (
             f"Blocked: script path resolves outside the scripts directory "
             f"({scripts_dir_resolved}): {script_path!r}"
         )
     if not path.exists():
-        return None, f"Script not found: {path}"
+        return None, None, f"Script not found: {path}"
     if not path.is_file():
-        return None, f"Script path is not a file: {path}"
-    return path, None
+        return None, None, f"Script path is not a file: {path}"
+    return path, script_args, None
 
 
-def _script_argv(path: Path) -> tuple[Optional[list[str]], dict[str, str], Optional[str]]:
+def _script_argv(path: Path, script_args: Optional[list[str]] = None) -> tuple[Optional[list[str]], dict[str, str], Optional[str]]:
     """``(argv, env_overlay, error)`` for a validated script. Interpreter by extension — the
     shebang is deliberately NOT honoured (small, auditable surface): ``.sh``/``.bash`` → bash,
     else ``sys.executable`` (Windows uv-venv overlay gets the .pth bootstrap)."""
@@ -306,11 +332,13 @@ def _script_argv(path: Path) -> tuple[Optional[list[str]], dict[str, str], Optio
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
             )
-        return [_bash, str(path)], {}, None
+        return [_bash, str(path), *(script_args or [])], {}, None
     python_exe, env_overlay = _windows_cron_python_invocation(sys.executable)
     if env_overlay:
-        return _windows_cron_bootstrap_argv(python_exe, env_overlay, str(path)), env_overlay, None
-    return [python_exe, str(path)], env_overlay, None
+        return _windows_cron_bootstrap_argv(
+            python_exe, env_overlay, str(path), script_args
+        ), env_overlay, None
+    return [python_exe, str(path), *(script_args or [])], env_overlay, None
 
 
 def _run_job_script(
@@ -327,11 +355,11 @@ def _run_job_script(
     Optional absolute path to use as the script's cwd. When set, the subprocess runs in this directory
     instead of the scripts-dir parent. See #69396.
     """
-    path, err = _resolve_script_path(script_path)
+    path, script_args, err = _resolve_script_path(script_path)
     if path is None:
         return False, err
     script_timeout = _get_script_timeout()
-    argv, env_overlay, err = _script_argv(path)
+    argv, env_overlay, err = _script_argv(path, script_args)
     if argv is None:
         return False, err
 

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -84,6 +84,22 @@ def test_cronjob_tool_create_no_agent_without_script_errors(hermes_env):
     assert "no_agent=True requires a script" in result.get("error", "")
 
 
+def test_cronjob_tool_rejects_malformed_script_spec(hermes_env):
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(
+        cronjob(
+            action="create",
+            schedule="every 5m",
+            prompt="run check",
+            script='probe.py --label "unterminated',
+            deliver="local",
+        )
+    )
+    assert result.get("success") is False
+    assert "Invalid script specification" in result.get("error", "")
+
+
 # ---------------------------------------------------------------------------
 # scheduler.run_job: short-circuit behavior
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -107,6 +107,28 @@ class TestRunJobScript:
         assert success is True
         assert output == "relative works"
 
+    def test_script_with_arguments(self, cron_env):
+        from cron.scheduler_script import _run_job_script
+
+        script = cron_env / "scripts" / "argv_probe.py"
+        script.write_text(
+            "import json\n"
+            "import sys\n"
+            "print(json.dumps(sys.argv[1:]))\n",
+            encoding="utf-8",
+        )
+
+        success, output = _run_job_script('argv_probe.py --hours 168 --label "weekly run"')
+        assert success is True
+        assert json.loads(output) == ["--hours", "168", "--label", "weekly run"]
+
+    def test_script_with_invalid_quoted_spec_fails_cleanly(self, cron_env):
+        from cron.scheduler_script import _run_job_script
+
+        success, output = _run_job_script('argv_probe.py --label "unterminated')
+        assert success is False
+        assert "Invalid script specification" in output
+
 
     def test_script_subprocess_env_sanitized(self, cron_env, monkeypatch):
         """Cron scripts must not inherit Hermes provider env (SECURITY.md §2.3)."""

--- a/tools/cronjob_job_args.py
+++ b/tools/cronjob_job_args.py
@@ -2,6 +2,7 @@
 tools/cronjob_tools.py)."""
 
 import logging
+import shlex
 from typing import Any, Dict, List, Optional, Union
 
 from cron.jobs import effective_job_state
@@ -295,7 +296,14 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
         return None
 
     from hermes_constants import get_hermes_home
-    raw = script.strip()
+    spec = script.strip()
+    try:
+        parts = shlex.split(spec, posix=True)
+    except ValueError as exc:
+        return f"Invalid script specification: {exc}"
+    if not parts:
+        return "Invalid script specification: empty script value"
+    raw = parts[0]
     if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
         return (
             f"Script path must be relative to ~/.hermes/scripts/. "


### PR DESCRIPTION
Summary
- Support shell-style args in cron job script field.
- Parse with shlex.split; resolve/validate only token[0] as script path.
- Pass token[1:] as argv to Python/bash script execution.
- Reject malformed quoted script specs at create/update time.

Why
- Existing behavior accepted arg-bearing script values in jobs but failed at runtime with Script not found, causing silent operational breakage.

Tests
- Added tests in tests/cron/test_cron_script.py:
  - test_script_with_arguments
  - test_script_with_invalid_quoted_spec_fails_cleanly
- Added test in tests/cron/test_cron_no_agent.py:
  - test_cronjob_tool_rejects_malformed_script_spec
- Verified:
  - scripts/run_tests.sh tests/cron/test_cron_script.py tests/cron/test_cron_no_agent.py -q
  - scripts/run_tests.sh tests/cron/ -q (single known pre-existing unrelated failure in test_file_permissions)

Security
- Path traversal/absolute path guards remain enforced post-parse.
- Args are passed as argv list to subprocess; no shell execution introduced.