### PR TITLE
fix(cron): avoid self-contention in fire-claim heartbeat

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -86,6 +86,9 @@ _jobs_file_lock = threading.RLock()
 _jobs_lock_state = threading.local()
 _fire_fence_locks: Dict[str, threading.RLock] = {}
 _fire_fence_locks_guard = threading.Lock()
+# Process-wide (not thread-local) view of held fences: a heartbeat runs on its own thread, so a
+# thread-local view cannot see the delivery side effect that is holding the fence.
+_fire_fence_held_keys: Dict[str, int] = {}
 _fire_fence_lock_state = threading.local()
 
 # Upper bound on waiting for the cross-process .jobs.lock. Every cron function funnels through
@@ -329,10 +332,20 @@ def _fire_job_lock(job_id: str):
             logger.error("Cron fire fence unavailable for %s: %s", job_id, exc)
 
         held_locks[lock_key] = acquired
+        if acquired:
+            with _fire_fence_locks_guard:
+                _fire_fence_held_keys[lock_key] = _fire_fence_held_keys.get(lock_key, 0) + 1
         try:
             yield acquired
         finally:
             held_locks.pop(lock_key, None)
+            if acquired:
+                with _fire_fence_locks_guard:
+                    depth = _fire_fence_held_keys.get(lock_key, 1) - 1
+                    if depth > 0:
+                        _fire_fence_held_keys[lock_key] = depth
+                    else:
+                        _fire_fence_held_keys.pop(lock_key, None)
             if lock_fd is not None:
                 if acquired:
                     _release_flock(lock_fd)
@@ -2537,13 +2550,33 @@ def claim_job_for_fire(
     return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
 
 
+def _fire_fence_held_here(job_id: str) -> bool:
+    """True when a thread in THIS process holds *job_id*'s fire fence (e.g. a delivery side effect
+    still in flight). Cheap probe so a heartbeat can avoid blocking on ourselves."""
+    lock_key = f"{_current_cron_store().cron_dir.resolve()}::{job_id}"
+    with _fire_fence_locks_guard:
+        return lock_key in _fire_fence_held_keys
+
+
 def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
     """Refresh an active ``fire_claim`` without extending another owner's lease: an execution may
-    outlive the TTL, and the owner check stops a stale runner from refreshing a recovered claim."""
+    outlive the TTL, and the owner check stops a stale runner from refreshing a recovered claim.
+
+    A fence this process already holds is BUSY, not lost. The side-effect fence spans network
+    delivery, so a delivery that outlives ``_JOBS_LOCK_TIMEOUT_SECONDS`` (any bot-chat turn, a slow
+    platform send) made the heartbeat block on our own held lock, time out, and fail closed — which
+    aborted a live, working run and recorded it as an ownership-loss "shutdown". The fallback renews
+    through the same owner CAS WITHOUT the fire fence: ``fire_claim`` is written under the jobs lock,
+    a takeover needs the fence, and the CAS refuses a changed owner — so the TTL also stays fresh
+    across a delivery longer than ``FIRE_CLAIM_TTL_SECONDS``. A real takeover still reports False."""
     def apply(jobs, _i, job):
         return _refresh_claim(jobs, job.get("fire_claim"), expected_owner)
 
-    return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
+    if not _fire_fence_held_here(job_id):
+        with _fire_job_lock(job_id) as acquired:
+            if acquired:
+                return _with_job(job_id, apply, False)
+    return _with_job(job_id, apply, False)
 
 
 # Completed one-shots are retained in jobs.json (final status stays inspectable) and pruned by

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2580,20 +2580,35 @@ def run_one_job(
                     _running_fire_owners.pop(job["id"], None)
 
 
-_OWNERSHIP_LOST_INTERRUPTED = "Interrupted by shutdown before terminal completion."
+_OWNERSHIP_LOST_INTERRUPTED = (
+    "Interrupted before terminal completion after fire-claim renewal failed "
+    "(no gateway shutdown was recorded)."
+)
 
 
-def _record_fire_ownership_lost(job_id: str, fire_owner: Optional[str], execution_id: str) -> None:
+def _record_fire_ownership_lost(
+    job_id: str, fire_owner: Optional[str], execution_id: str, *,
+    delivery_attempted: bool = False, delivery_error: Optional[str] = None,
+    success: bool = False,
+) -> None:
     """Bookkeeping after fire-claim ownership loss. A transport-level cancel (dashboard drain) is
     not a real loss — we still own the claim, so record the interruption via the owner-fenced
-    terminal write instead of leaving fire_claim/last_status stale; otherwise discard."""
+    terminal write instead of leaving fire_claim/last_status stale; otherwise discard.
+
+    The execution row keeps the TRUTH about the side effect: a delivery that already left the
+    process must not be reported as if it never happened (this path used to blank
+    ``delivery_outcome``, which hides a real delivery behind the interruption)."""
+    delivery_outcome = "failed" if delivery_error else ("delivered" if (delivery_attempted and success) else None)
     if fire_owner is not None and heartbeat_fire_claim(job_id, expected_owner=fire_owner):
         mark_job_run(job_id, False, _OWNERSHIP_LOST_INTERRUPTED, expected_fire_owner=fire_owner)
-        finish_execution(execution_id, success=False, error=_OWNERSHIP_LOST_INTERRUPTED)
+        finish_execution(
+            execution_id, success=False, error=_OWNERSHIP_LOST_INTERRUPTED,
+            delivery_outcome=delivery_outcome)
     else:
         finish_execution(
             execution_id, success=False,
-            error="Fire claim ownership lost; stale result was discarded.")
+            error="Fire claim ownership lost; stale result was discarded.",
+            delivery_outcome=delivery_outcome)
 
 
 def _classify_delivery_outcome(
@@ -2998,7 +3013,10 @@ def _run_one_job_body(
             _teardown_deferred()
 
         if d.side_effect_ownership_lost or _fire_claim_ownership_lost():
-            _record_fire_ownership_lost(job["id"], fire_owner, execution_id)
+            _record_fire_ownership_lost(
+                job["id"], fire_owner, execution_id,
+                delivery_attempted=d.delivery_attempted, delivery_error=d.delivery_error,
+                success=d.success)
             return True
 
         # Empty final_response is a soft failure so last_status is not "ok".

--- a/tests/cron/test_fire_fence_heartbeat_contention.py
+++ b/tests/cron/test_fire_fence_heartbeat_contention.py
@@ -1,0 +1,76 @@
+"""A fire fence this process already holds is BUSY, not lost.
+
+Regression guard for the fleet-wide "Interrupted by shutdown before terminal completion" class:
+the per-job side-effect fence is held across network delivery, so any delivery slower than
+``_JOBS_LOCK_TIMEOUT_SECONDS`` (every bot-chat turn, a slow platform send) made the run's own
+heartbeat block on its own lock, time out, fail closed, and abort a live run as an ownership loss.
+The heartbeat must distinguish "we still own the claim" from "another owner took it".
+"""
+import threading
+import time
+
+import pytest
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME so jobs.json/lock files don't touch the real store."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+def _claimed_job():
+    from cron.jobs import claim_job_for_fire, create_job, get_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="fence-contention")
+    assert claim_job_for_fire(job["id"], return_job=True)
+    return job["id"], get_job(job["id"])["fire_claim"]["by"]
+
+
+def test_heartbeat_survives_a_fence_held_by_this_process(temp_home, monkeypatch):
+    """Delivery side effect in flight (fence held here) must NOT read as a lost claim."""
+    from cron import jobs
+
+    # Keep the red-on-base path fast: without the fix the heartbeat blocks for the fence
+    # timeout before failing closed.
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.5)
+    job_id, owner = _claimed_job()
+
+    holding = threading.Event()
+    release = threading.Event()
+
+    def _hold_fence():
+        with jobs.fire_claim_fence(job_id, expected_owner=owner):
+            holding.set()
+            release.wait(5)
+
+    holder = threading.Thread(target=_hold_fence, daemon=True)
+    holder.start()
+    assert holding.wait(5), "fence holder never acquired the fence"
+
+    started = time.monotonic()
+    try:
+        still_ours = jobs.heartbeat_fire_claim(job_id, expected_owner=owner)
+    finally:
+        release.set()
+        holder.join(5)
+    elapsed = time.monotonic() - started
+
+    assert still_ours is True, "a fence held by this process is busy, not a lost claim"
+    # The fix reads the stored claim instead of queueing behind our own lock.
+    assert elapsed < 0.3, f"heartbeat blocked behind own fence for {elapsed:.2f}s"
+
+
+def test_heartbeat_still_reports_loss_after_a_real_takeover(temp_home):
+    """A claim whose stored owner changed is still lost — the fix must not mask takeovers."""
+    from cron import jobs
+
+    job_id, owner = _claimed_job()
+    with jobs._jobs_lock():
+        records = jobs.load_jobs()
+        for record in records:
+            if record.get("id") == job_id:
+                record["fire_claim"] = {"at": record["fire_claim"]["at"], "by": "other-machine:abc"}
+        jobs.save_jobs(records)
+
+    assert jobs.heartbeat_fire_claim(job_id, expected_owner=owner) is False


### PR DESCRIPTION
Summary
- Fix recurring false ownership-loss cancellations caused by self-contention between delivery-side fire fence lock and heartbeat renewal.
- Add process-wide fence-held depth tracking.
- In heartbeat renewal, when this process already holds the fence (or fence acquisition fails), return owner-read path instead of failing closed.
- Keep delivery outcome persisted when ownership is lost during save/deliver paths.

Why
- Long delivery phases could exceed lock timeout and cause heartbeat renewal to fail on our own lock, triggering erroneous run cancellation.

Tests
- Added tests/cron/test_fire_fence_heartbeat_contention.py (2 invariant tests).
- Verified:
  - scripts/run_tests.sh tests/cron/test_fire_fence_heartbeat_contention.py tests/cron/test_script_claim_heartbeat.py -q

Notes
- Known unrelated existing test issue remains outside this PR scope: tests/cron/test_file_permissions.py::test_ensure_hermes_home_sets_0700.
