### PR TITLE
fix(identity): enforce 0600 on spawn ledger writes

### DIFF
--- a/hermes_cli/process_identity.py
+++ b/hermes_cli/process_identity.py
@@ -20,6 +20,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Optional
 
+from utils import atomic_json_write
+
 logger = logging.getLogger(__name__)
 
 SPAWN_ENV_VAR = "HERMES_SPAWN"
@@ -265,9 +267,7 @@ def _append_entry(entry: LedgerEntry) -> bool:
         pruned.append(asdict(entry))
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            tmp = path.with_suffix(path.suffix + f".tmp{os.getpid()}")
-            tmp.write_text(json.dumps(pruned, indent=2), encoding="utf-8")
-            os.replace(tmp, path)
+            atomic_json_write(path, pruned, mode=0o600)
             return True
         except OSError:
             logger.debug("spawn ledger write failed", exc_info=True)

--- a/tests/hermes_cli/test_process_identity.py
+++ b/tests/hermes_cli/test_process_identity.py
@@ -15,6 +15,8 @@ Runs on any host: psutil interactions go through a fake module.
 from __future__ import annotations
 
 import json
+import os
+import stat
 import sys
 import types
 from pathlib import Path
@@ -130,6 +132,18 @@ def test_register_self_writes_and_prunes_dead(tmp_path):
     me = next(e for e in entries if e["pid"] == 999)
     assert me["purpose"] == "serve"
     assert me["create_time"] == pytest.approx(50.0, abs=0.01)
+
+
+def test_register_self_writes_ledger_with_0600(tmp_path):
+    ledger = tmp_path / "spawn-ledger.json"
+    fake = _fake_psutil({999: 50.0})
+    with patch.dict(sys.modules, {"psutil": fake}), \
+         patch.object(pi, "_ledger_path", return_value=ledger), \
+         patch.object(pi.os, "getpid", return_value=999):
+        assert pi.register_self("serve", project_root=Path("/x/install")) is True
+
+    mode = stat.S_IMODE(os.stat(ledger).st_mode)
+    assert mode == 0o600
 
 
 def test_register_self_inherits_spawn_tag_lineage(tmp_path):


### PR DESCRIPTION
Summary
- Fix spawn-ledger permission drift by writing ledger updates with explicit mode 0600.
- Replace umask-dependent tmp+replace path with atomic_json_write(..., mode=0o600).
- Add regression test proving register_self writes spawn-ledger.json as 0600.

Why
- spawn-ledger.json is regenerated frequently; default umask produced 0644 and repeatedly violated permission policy.

Tests
- scripts/run_tests.sh tests/hermes_cli/test_process_identity.py tests/hermes_cli/test_mcp_helper_ledger.py -q

Security
- Sensitive process metadata ledger now lands with least-privilege perms regardless of host umask.
