### PR TITLE
fix(doctor): flag and repair undocumented updates.pre_update_backup values

### DIFF
--- a/hermes_cli/doctor_config.py
+++ b/hermes_cli/doctor_config.py
@@ -363,9 +363,13 @@ def _drift_max_iterations_ghost(f: Finding, should_fix: bool, config_path) -> No
         f.manual_issues.append(f"Manually delete the HERMES_MAX_ITERATIONS line from {_DHH}/.env — config.yaml agent.max_turns is authoritative.")
 
 
-# Only the literal legacy tokens count: YAML 1.1 also folds unquoted ``off``/``on``/``yes``/``no``
-# into bools, and ``off`` is a documented mode string that must never be reported as legacy.
-_PRE_UPDATE_BACKUP_BOOL_RE = re.compile(r"^\s*pre_update_backup\s*:\s*(true|false)\s*(?:#.*)?$", re.MULTILINE)
+# Every spelling PyYAML folds into a bool ("true"/"false"/"yes"/"no"/"on", any case) is a legacy
+# write — except "off", which is a documented mode string that must never be reported as legacy
+# drift, or doctor would rewrite a deliberate opt-out on every run. "y"/"n" are not folded by
+# PyYAML (they resolve as strings), so they are not listed; `isinstance(value, bool)` below is
+# the second half of the gate.
+_PRE_UPDATE_BACKUP_BOOL_RE = re.compile(r"^\s*pre_update_backup\s*:\s*(true|false|yes|no|on)\s*(?:#.*)?$",
+                                       re.MULTILINE | re.IGNORECASE)
 
 
 def _drift_pre_update_backup_legacy_bool(f: Finding, should_fix: bool, config_path) -> None:
@@ -385,8 +389,8 @@ def _drift_pre_update_backup_legacy_bool(f: Finding, should_fix: bool, config_pa
     updates_cfg = raw_config.get("updates")
     if not isinstance(updates_cfg, dict) or not isinstance(updates_cfg.get("pre_update_backup"), bool):
         return
-    # YAML folds an unquoted ``off``/``on`` into a bool as well, so the parsed value alone cannot
-    # tell the legacy boolean from the documented ``off`` string — accept only the literal token,
+    # YAML folds unquoted ``off`` into a bool as well, so the parsed value alone cannot tell the
+    # legacy boolean from the documented ``off`` string — accept only the folded spellings above,
     # or doctor would "fix" a deliberate `off` into a quoted 'off' on every run.
     if not _PRE_UPDATE_BACKUP_BOOL_RE.search(config_path.read_text(encoding="utf-8")):
         return

--- a/hermes_cli/doctor_config.py
+++ b/hermes_cli/doctor_config.py
@@ -363,23 +363,62 @@ def _drift_max_iterations_ghost(f: Finding, should_fix: bool, config_path) -> No
         f.manual_issues.append(f"Manually delete the HERMES_MAX_ITERATIONS line from {_DHH}/.env — config.yaml agent.max_turns is authoritative.")
 
 
+# The three mode strings are the whole documented surface: any other value that still resolves to a
+# mode is a legacy write (the installer seeded a boolean; `hermes config set` writes the raw string
+# for this string-typed key; a blank value stringifies to "none" in the resolver).
+_DOCUMENTED_PRE_UPDATE_BACKUP_MODES = ("quick", "off", "full")
+
 # Every spelling PyYAML folds into a bool ("true"/"false"/"yes"/"no"/"on", any case) is a legacy
 # write — except "off", which is a documented mode string that must never be reported as legacy
 # drift, or doctor would rewrite a deliberate opt-out on every run. "y"/"n" are not folded by
-# PyYAML (they resolve as strings), so they are not listed; `isinstance(value, bool)` below is
-# the second half of the gate.
+# PyYAML (they resolve as strings), so they are not listed; the `isinstance(value, bool)` branch in
+# `_pre_update_backup_legacy_form` is the other half of the gate.
 _PRE_UPDATE_BACKUP_BOOL_RE = re.compile(r"^\s*pre_update_backup\s*:\s*(true|false|yes|no|on)\s*(?:#.*)?$",
                                        re.MULTILINE | re.IGNORECASE)
 
 
-def _drift_pre_update_backup_legacy_bool(f: Finding, should_fix: bool, config_path) -> None:
-    """``updates.pre_update_backup`` written as a legacy boolean instead of a mode string.
+def _pre_update_backup_legacy_form(value, config_text: str):
+    """``(kind, written_form, mode)`` when *value* is a form the docs do not describe, else ``None``.
 
-    The installer/setup wizard used to seed ``false`` (meaning "off"), which switches the
-    pre-update state snapshot off — the #48200 wipe safety net — with nothing on the receipt to
-    distinguish "you opted out" from "the backup broke". ``true`` means "full": a zip of the whole
-    home on every update. Both are rewritten to the equivalent mode string, so the behaviour does
-    not change but the value becomes auditable and the docs' surface.
+    ``kind`` is ``"bool"``, ``"alias"`` or ``"empty"``. The value is read from the raw file, so the
+    documented mode strings are the whole supported surface: every other form that still resolves to
+    a mode is a legacy write whose effect is only discoverable by reading the alias mapping in
+    ``update_cmd_maint`` — which is imported rather than duplicated, so the two cannot drift apart.
+    """
+    from hermes_cli.update_cmd_maint import _BACKUP_MODE_ALIASES
+
+    if isinstance(value, bool):
+        # YAML folds unquoted ``off`` into a bool as well, so the parsed value alone cannot tell the
+        # legacy boolean from the documented ``off`` string — require a folded spelling that is not
+        # ``off`` to appear in the file, or doctor would "fix" a deliberate `off` on every run.
+        if not _PRE_UPDATE_BACKUP_BOOL_RE.search(config_text):
+            return None
+        return "bool", str(value).lower(), ("full" if value else "off")
+    if value is None:
+        # A blank value (`pre_update_backup:`) is not "unset": the resolver stringifies it to
+        # "none", which the alias map sends to "off" — no snapshot, and nothing says so.
+        return "empty", "empty", "off"
+    if isinstance(value, str):
+        token = value.strip().lower()
+        if token in _DOCUMENTED_PRE_UPDATE_BACKUP_MODES:
+            return None
+        # An unknown string falls back to "quick" with a runtime warning (backups stay ON), so only
+        # the aliases the resolver actually accepts are legacy writes here.
+        mode = _BACKUP_MODE_ALIASES.get(token)
+        return ("alias", repr(value), mode) if mode else None
+    return None
+
+
+def _drift_pre_update_backup_legacy_form(f: Finding, should_fix: bool, config_path) -> None:
+    """``updates.pre_update_backup`` written in a form the docs do not describe.
+
+    The installer/setup wizard seeded ``false`` (meaning "off"), which switches the pre-update state
+    snapshot off — the #48200 wipe safety net — with nothing on the receipt to distinguish "you
+    opted out" from "the backup broke". ``true`` means "full": a zip of the whole home on every
+    update. ``hermes config set updates.pre_update_backup false`` writes the *string* ``'false'``
+    (this key's default is a string, so the value is written verbatim) and the resolver's alias map
+    turns that into "off" as well. All of them are rewritten to the equivalent mode string, so the
+    behaviour does not change but the value becomes auditable and lands on the docs' surface.
     """
     from hermes_cli.config import atomic_config_write, read_user_config_raw
 
@@ -387,27 +426,33 @@ def _drift_pre_update_backup_legacy_bool(f: Finding, should_fix: bool, config_pa
         return
     raw_config = read_user_config_raw(config_path)
     updates_cfg = raw_config.get("updates")
-    if not isinstance(updates_cfg, dict) or not isinstance(updates_cfg.get("pre_update_backup"), bool):
+    if not isinstance(updates_cfg, dict) or "pre_update_backup" not in updates_cfg:
         return
-    # YAML folds unquoted ``off`` into a bool as well, so the parsed value alone cannot tell the
-    # legacy boolean from the documented ``off`` string — accept only the folded spellings above,
-    # or doctor would "fix" a deliberate `off` into a quoted 'off' on every run.
-    if not _PRE_UPDATE_BACKUP_BOOL_RE.search(config_path.read_text(encoding="utf-8")):
+    legacy = _pre_update_backup_legacy_form(updates_cfg["pre_update_backup"],
+                                            config_path.read_text(encoding="utf-8"))
+    if legacy is None:
         return
-    value = updates_cfg["pre_update_backup"]
-    mode = "full" if value else "off"
-    check_warn(f"updates.pre_update_backup is the legacy boolean {str(value).lower()} (equivalent to '{mode}')",
+    kind, written_form, mode = legacy
+    described = {
+        "bool": f"the legacy boolean {written_form}",
+        "alias": f"the legacy alias {written_form}",
+        "empty": "empty",
+    }[kind]
+    check_warn(f"updates.pre_update_backup is {described} (equivalent to '{mode}')",
                "(supported values: quick (default), off, full)")
+    if kind == "empty":
+        check_info("A blank value is not 'unset': it resolves to 'off'. Use 'quick' for the default "
+                   "snapshot, or 'off' to opt out deliberately")
     if mode == "off":
         check_info("As 'off', `hermes update` takes no pre-update snapshot: state lost to a failed "
                    "update cannot be recovered")
     if not should_fix:
-        f.issues.append(f"Legacy boolean updates.pre_update_backup ({str(value).lower()}) — "
+        f.issues.append(f"Legacy updates.pre_update_backup value ({written_form}) — "
                         "run 'hermes doctor --fix' to write the mode string")
         return
     updates_cfg["pre_update_backup"] = mode
     atomic_config_write(config_path, raw_config)
-    check_ok(f"Rewrote updates.pre_update_backup: {str(value).lower()} -> '{mode}'")
+    check_ok(f"Rewrote updates.pre_update_backup: {written_form} -> '{mode}'")
     f.fixed += 1
 
 
@@ -436,14 +481,14 @@ def _drift_structure(f: Finding, should_fix: bool, config_path) -> None:
 
 
 _CONFIG_DRIFT_STEPS = (
-    _drift_config_version, _drift_stale_root_keys, _drift_pre_update_backup_legacy_bool,
+    _drift_config_version, _drift_stale_root_keys, _drift_pre_update_backup_legacy_form,
     _drift_max_iterations_ghost, _drift_deprecations, _drift_structure,
 )
 
 
 @doctor_check()
 def _check_config_drift(should_fix: bool, f: Finding) -> None:
-    """Config version, stale root keys, legacy pre-update backup boolean, HERMES_MAX_ITERATIONS ghost, deprecations, structure.
+    """Config version, stale root keys, legacy pre-update backup form, HERMES_MAX_ITERATIONS ghost, deprecations, structure.
 
     Each step is independent and best-effort: a failure in one never hides the next.
     """

--- a/hermes_cli/doctor_config.py
+++ b/hermes_cli/doctor_config.py
@@ -4,7 +4,6 @@ Split out of ``hermes_cli/doctor.py``."""
 from __future__ import annotations
 
 import os
-import re
 import shutil
 from hermes_cli.doctor_report import (
     Finding, _fail_and_issue, _section, check_bool, check_fail, check_info, check_ok, check_warn, doctor_check,
@@ -368,16 +367,35 @@ def _drift_max_iterations_ghost(f: Finding, should_fix: bool, config_path) -> No
 # for this string-typed key; a blank value stringifies to "none" in the resolver).
 _DOCUMENTED_PRE_UPDATE_BACKUP_MODES = ("quick", "off", "full")
 
-# Every spelling PyYAML folds into a bool ("true"/"false"/"yes"/"no"/"on", any case) is a legacy
-# write — except "off", which is a documented mode string that must never be reported as legacy
-# drift, or doctor would rewrite a deliberate opt-out on every run. "y"/"n" are not folded by
-# PyYAML (they resolve as strings), so they are not listed; the `isinstance(value, bool)` branch in
-# `_pre_update_backup_legacy_form` is the other half of the gate.
-_PRE_UPDATE_BACKUP_BOOL_RE = re.compile(r"^\s*pre_update_backup\s*:\s*(true|false|yes|no|on)\s*(?:#.*)?$",
-                                       re.MULTILINE | re.IGNORECASE)
+
+def _pre_update_backup_scalar_node(config_text: str):
+    """The YAML node for ``updates.pre_update_backup`` as written, or ``None``.
+
+    The parsed value cannot tell the documented ``off`` from the legacy boolean — YAML folds both to
+    ``False`` — so the check needs the scalar *as written*. That has to be the node at the key's own
+    path: a text search over the file is satisfied by any matching line (another section, a block
+    scalar, a duplicate key) while missing the forms a real value takes (flow style, a quoted key, an
+    anchored alias). The walk mirrors PyYAML's loader, duplicates included, so the last ``updates:``
+    block wins exactly like the loaded config does.
+    """
+    import yaml
+
+    try:
+        root = yaml.compose(config_text)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(root, yaml.MappingNode):
+        return None
+    node = None
+    for key_node, value_node in root.value:
+        if getattr(key_node, "value", None) == "updates" and isinstance(value_node, yaml.MappingNode):
+            for inner_key, inner_value in value_node.value:
+                if getattr(inner_key, "value", None) == "pre_update_backup":
+                    node = inner_value
+    return node
 
 
-def _pre_update_backup_legacy_form(value, config_text: str):
+def _pre_update_backup_legacy_form(value, scalar_node):
     """``(kind, written_form, mode)`` when *value* is a form the docs do not describe, else ``None``.
 
     ``kind`` is ``"bool"``, ``"alias"`` or ``"empty"``. The value is read from the raw file, so the
@@ -388,12 +406,15 @@ def _pre_update_backup_legacy_form(value, config_text: str):
     from hermes_cli.update_cmd_maint import _BACKUP_MODE_ALIASES
 
     if isinstance(value, bool):
-        # YAML folds unquoted ``off`` into a bool as well, so the parsed value alone cannot tell the
-        # legacy boolean from the documented ``off`` string — require a folded spelling that is not
-        # ``off`` to appear in the file, or doctor would "fix" a deliberate `off` on every run.
-        if not _PRE_UPDATE_BACKUP_BOOL_RE.search(config_text):
+        # ``off`` is documented and YAML folds it to False as well, so the parsed value cannot tell
+        # it from the legacy boolean: the scalar's own spelling can. A documented mode spelling
+        # (case-insensitively) is never drift, or doctor would rewrite a deliberate opt-out on every
+        # run. No readable scalar (alias to a non-scalar, or a file doctor cannot parse twice) is
+        # left alone rather than guessed at.
+        token = (getattr(scalar_node, "value", None) or "").strip()
+        if not token or token.lower() in _DOCUMENTED_PRE_UPDATE_BACKUP_MODES:
             return None
-        return "bool", str(value).lower(), ("full" if value else "off")
+        return "bool", token.lower(), ("full" if value else "off")
     if value is None:
         # A blank value (`pre_update_backup:`) is not "unset": the resolver stringifies it to
         # "none", which the alias map sends to "off" — no snapshot, and nothing says so.
@@ -428,8 +449,9 @@ def _drift_pre_update_backup_legacy_form(f: Finding, should_fix: bool, config_pa
     updates_cfg = raw_config.get("updates")
     if not isinstance(updates_cfg, dict) or "pre_update_backup" not in updates_cfg:
         return
-    legacy = _pre_update_backup_legacy_form(updates_cfg["pre_update_backup"],
-                                            config_path.read_text(encoding="utf-8"))
+    legacy = _pre_update_backup_legacy_form(
+        updates_cfg["pre_update_backup"],
+        _pre_update_backup_scalar_node(config_path.read_text(encoding="utf-8")))
     if legacy is None:
         return
     kind, written_form, mode = legacy

--- a/hermes_cli/doctor_config.py
+++ b/hermes_cli/doctor_config.py
@@ -4,6 +4,7 @@ Split out of ``hermes_cli/doctor.py``."""
 from __future__ import annotations
 
 import os
+import re
 import shutil
 from hermes_cli.doctor_report import (
     Finding, _fail_and_issue, _section, check_bool, check_fail, check_info, check_ok, check_warn, doctor_check,
@@ -362,6 +363,50 @@ def _drift_max_iterations_ghost(f: Finding, should_fix: bool, config_path) -> No
         f.manual_issues.append(f"Manually delete the HERMES_MAX_ITERATIONS line from {_DHH}/.env — config.yaml agent.max_turns is authoritative.")
 
 
+# Only the literal legacy tokens count: YAML 1.1 also folds unquoted ``off``/``on``/``yes``/``no``
+# into bools, and ``off`` is a documented mode string that must never be reported as legacy.
+_PRE_UPDATE_BACKUP_BOOL_RE = re.compile(r"^\s*pre_update_backup\s*:\s*(true|false)\s*(?:#.*)?$", re.MULTILINE)
+
+
+def _drift_pre_update_backup_legacy_bool(f: Finding, should_fix: bool, config_path) -> None:
+    """``updates.pre_update_backup`` written as a legacy boolean instead of a mode string.
+
+    The installer/setup wizard used to seed ``false`` (meaning "off"), which switches the
+    pre-update state snapshot off — the #48200 wipe safety net — with nothing on the receipt to
+    distinguish "you opted out" from "the backup broke". ``true`` means "full": a zip of the whole
+    home on every update. Both are rewritten to the equivalent mode string, so the behaviour does
+    not change but the value becomes auditable and the docs' surface.
+    """
+    from hermes_cli.config import atomic_config_write, read_user_config_raw
+
+    if config_path is None:
+        return
+    raw_config = read_user_config_raw(config_path)
+    updates_cfg = raw_config.get("updates")
+    if not isinstance(updates_cfg, dict) or not isinstance(updates_cfg.get("pre_update_backup"), bool):
+        return
+    # YAML folds an unquoted ``off``/``on`` into a bool as well, so the parsed value alone cannot
+    # tell the legacy boolean from the documented ``off`` string — accept only the literal token,
+    # or doctor would "fix" a deliberate `off` into a quoted 'off' on every run.
+    if not _PRE_UPDATE_BACKUP_BOOL_RE.search(config_path.read_text(encoding="utf-8")):
+        return
+    value = updates_cfg["pre_update_backup"]
+    mode = "full" if value else "off"
+    check_warn(f"updates.pre_update_backup is the legacy boolean {str(value).lower()} (equivalent to '{mode}')",
+               "(supported values: quick (default), off, full)")
+    if mode == "off":
+        check_info("As 'off', `hermes update` takes no pre-update snapshot: state lost to a failed "
+                   "update cannot be recovered")
+    if not should_fix:
+        f.issues.append(f"Legacy boolean updates.pre_update_backup ({str(value).lower()}) — "
+                        "run 'hermes doctor --fix' to write the mode string")
+        return
+    updates_cfg["pre_update_backup"] = mode
+    atomic_config_write(config_path, raw_config)
+    check_ok(f"Rewrote updates.pre_update_backup: {str(value).lower()} -> '{mode}'")
+    f.fixed += 1
+
+
 def _drift_deprecations(f: Finding, should_fix: bool, config_path) -> None:
     """Warn-only deprecation sweep over the raw file + on-disk .env (process env would false-positive)."""
     from hermes_cli.config import load_env, read_user_config_raw
@@ -387,13 +432,14 @@ def _drift_structure(f: Finding, should_fix: bool, config_path) -> None:
 
 
 _CONFIG_DRIFT_STEPS = (
-    _drift_config_version, _drift_stale_root_keys, _drift_max_iterations_ghost, _drift_deprecations, _drift_structure,
+    _drift_config_version, _drift_stale_root_keys, _drift_pre_update_backup_legacy_bool,
+    _drift_max_iterations_ghost, _drift_deprecations, _drift_structure,
 )
 
 
 @doctor_check()
 def _check_config_drift(should_fix: bool, f: Finding) -> None:
-    """Config version, stale root keys, HERMES_MAX_ITERATIONS ghost, deprecations, structure.
+    """Config version, stale root keys, legacy pre-update backup boolean, HERMES_MAX_ITERATIONS ghost, deprecations, structure.
 
     Each step is independent and best-effort: a failure in one never hides the next.
     """

--- a/tests/hermes_cli/test_doctor_legacy_pre_update_backup.py
+++ b/tests/hermes_cli/test_doctor_legacy_pre_update_backup.py
@@ -67,6 +67,51 @@ def test_legacy_false_is_flagged_by_doctor_and_fixed_to_off(tmp_path, monkeypatc
 
 @pytest.mark.parametrize(
     "written,expected_mode",
+    # PyYAML folds this whole set to booleans in any case (verified against PyYAML 6.0.3):
+    # true/false/yes/no/on. Only ``off`` is excluded — it is a documented mode string.
+    [("True", "full"), ("TRUE", "full"), ("False", "off"), ("FALSE", "off"),
+     ("yes", "full"), ("Yes", "full"), ("YES", "full"),
+     ("no", "off"), ("No", "off"), ("NO", "off"),
+     ("on", "full"), ("On", "full"), ("ON", "full")],
+)
+def test_every_folded_bool_spelling_is_reported(tmp_path, written, expected_mode):
+    """A capitalised or word-spelled boolean is the same invisible write as ``false``/``true``.
+
+    The token guard was lowercase-only, so ``pre_update_backup: True`` parsed as a bool, matched
+    nothing, and was never flagged or fixed — the drift this check exists to surface.
+    """
+    cfg = _write_config(tmp_path, f"pre_update_backup: {written}")
+    f = Finding()
+
+    from hermes_cli.doctor_config import _drift_pre_update_backup_legacy_bool
+
+    _drift_pre_update_backup_legacy_bool(f, should_fix=True, config_path=cfg)
+
+    assert f.fixed == 1
+    assert _written_value(cfg) == expected_mode
+    assert _resolved_mode(tmp_path) == expected_mode
+
+
+@pytest.mark.parametrize("written", ["off", "Off", "OFF", "y", "n"])
+def test_documented_off_and_non_bool_spellings_are_never_reported(tmp_path, written):
+    """``off`` in any case is the documented mode — never drift, never rewritten.
+
+    ``y``/``n`` are in the YAML 1.1 spec's bool set but PyYAML does not fold them (they parse as
+    strings), so they must not be reported either.
+    """
+    cfg = _write_config(tmp_path, f"pre_update_backup: {written}")
+    f = Finding()
+
+    from hermes_cli.doctor_config import _drift_pre_update_backup_legacy_bool
+
+    _drift_pre_update_backup_legacy_bool(f, should_fix=True, config_path=cfg)
+
+    assert f.issues == [] and f.fixed == 0
+    assert f"pre_update_backup: {written}" in cfg.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "written,expected_mode",
     # Mode strings are the supported surface: never reported, never rewritten.
     [("quick", None), ("off", None), ("full", None),
      # The other legacy form: ``true`` is an alias for a full zip on every update.

--- a/tests/hermes_cli/test_doctor_legacy_pre_update_backup.py
+++ b/tests/hermes_cli/test_doctor_legacy_pre_update_backup.py
@@ -1,8 +1,10 @@
-"""``hermes doctor`` must flag the legacy boolean form of ``updates.pre_update_backup``.
+"""``hermes doctor`` must flag every form of ``updates.pre_update_backup`` the docs do not describe.
 
 Installers and the setup wizard seeded ``false`` (meaning "off"), so a machine could run for months
 with the pre-update state snapshot — the #48200 wipe safety net — switched off, while the update
-receipt reported a backup step either way. ``false``/``true`` are not the supported surface; only
+receipt reported a backup step either way. ``hermes config set updates.pre_update_backup false``
+writes the *string* ``'false'``, which the updater's alias map also resolves to "off". A blank value
+resolves to "off" too. None of ``false``/``true``/``'false'``/blank are the supported surface; only
 ``quick``, ``off`` and ``full`` are. Rewriting keeps the meaning and makes the setting auditable.
 """
 
@@ -44,6 +46,14 @@ def _resolved_mode(home: Path) -> str:
     return proc.stdout.strip()
 
 
+def _drift(cfg: Path, should_fix: bool) -> Finding:
+    from hermes_cli.doctor_config import _drift_pre_update_backup_legacy_form
+
+    f = Finding()
+    _drift_pre_update_backup_legacy_form(f, should_fix, cfg)
+    return f
+
+
 def test_legacy_false_is_flagged_by_doctor_and_fixed_to_off(tmp_path, monkeypatch):
     """``false`` disables the snapshot: doctor reports it, --fix writes the mode string."""
     cfg = _write_config(tmp_path, "pre_update_backup: false")
@@ -55,9 +65,7 @@ def test_legacy_false_is_flagged_by_doctor_and_fixed_to_off(tmp_path, monkeypatc
     reported = _check_config_drift(False)
     assert any("pre_update_backup" in issue for issue in reported.issues)
 
-    from hermes_cli.doctor_config import _drift_pre_update_backup_legacy_bool
-    f = Finding()
-    _drift_pre_update_backup_legacy_bool(f, True, cfg)
+    f = _drift(cfg, True)
     assert f.fixed == 1
     assert _written_value(cfg) == "off"  # documented mode string, not a bool
     # Semantics preserved: the rewrite makes an existing "off" legible, it does not silently
@@ -81,33 +89,106 @@ def test_every_folded_bool_spelling_is_reported(tmp_path, written, expected_mode
     nothing, and was never flagged or fixed — the drift this check exists to surface.
     """
     cfg = _write_config(tmp_path, f"pre_update_backup: {written}")
-    f = Finding()
-
-    from hermes_cli.doctor_config import _drift_pre_update_backup_legacy_bool
-
-    _drift_pre_update_backup_legacy_bool(f, should_fix=True, config_path=cfg)
+    f = _drift(cfg, True)
 
     assert f.fixed == 1
     assert _written_value(cfg) == expected_mode
     assert _resolved_mode(tmp_path) == expected_mode
 
 
-@pytest.mark.parametrize("written", ["off", "Off", "OFF", "y", "n"])
-def test_documented_off_and_non_bool_spellings_are_never_reported(tmp_path, written):
-    """``off`` in any case is the documented mode — never drift, never rewritten.
+def test_config_set_string_alias_is_reported_and_fixed(tmp_path):
+    """``hermes config set updates.pre_update_backup false`` writes the *string* ``'false'``.
 
-    ``y``/``n`` are in the YAML 1.1 spec's bool set but PyYAML does not fold them (they parse as
-    strings), so they must not be reported either.
+    The key's default is the string ``"quick"``, so ``_coerce_config_set_value`` returns the typed
+    value verbatim and the file gets a quoted scalar. ``_resolve_pre_update_backup_mode`` maps it to
+    "off" through the alias table — the same silent opt-out as the boolean, and invisible to a
+    check gated on ``isinstance(value, bool)``.
     """
+    cfg = _write_config(tmp_path, "pre_update_backup: 'false'")
+    assert _written_value(cfg) == "false"  # string, not a bool
+    assert _resolved_mode(tmp_path) == "off"  # the harm: no snapshot
+
+    f = _drift(cfg, False)
+    assert [i for i in f.issues if "pre_update_backup" in i], "the string alias was not reported"
+
+    f = _drift(cfg, True)
+    assert f.fixed == 1
+    assert _written_value(cfg) == "off"
+    assert _resolved_mode(tmp_path) == "off"
+
+
+@pytest.mark.parametrize(
+    "written,expected_mode",
+    # Every alias the updater's `_BACKUP_MODE_ALIASES` accepts that is not a documented mode string.
+    [("'true'", "full"), ("'True'", "full"), ("'none'", "off"), ("'disabled'", "off"),
+     ("'zip'", "full"), ("'FALSE'", "off")],
+)
+def test_alias_strings_are_reported_and_fixed(tmp_path, written, expected_mode):
+    """The alias family resolves to a mode but is not the documented surface."""
     cfg = _write_config(tmp_path, f"pre_update_backup: {written}")
-    f = Finding()
+    f = _drift(cfg, True)
 
-    from hermes_cli.doctor_config import _drift_pre_update_backup_legacy_bool
+    assert f.fixed == 1
+    assert _written_value(cfg) == expected_mode
+    assert _resolved_mode(tmp_path) == expected_mode
 
-    _drift_pre_update_backup_legacy_bool(f, should_fix=True, config_path=cfg)
+
+@pytest.mark.parametrize("written", ["", "null", "~"])
+def test_blank_value_is_reported_and_fixed_to_off(tmp_path, written):
+    """A blank value is not "unset": the resolver stringifies it to "none" → "off".
+
+    ``updates.pre_update_backup:`` (nothing after the colon) is an easy YAML mistake that silently
+    disables the snapshot, so doctor names it rather than leaving it to the alias mapping.
+    """
+    body = "pre_update_backup:" if not written else f"pre_update_backup: {written}"
+    cfg = _write_config(tmp_path, body)
+    assert _written_value(cfg) is None
+    assert _resolved_mode(tmp_path) == "off"
+
+    f = _drift(cfg, True)
+    assert f.fixed == 1
+    assert _written_value(cfg) == "off"
+    assert _resolved_mode(tmp_path) == "off"  # meaning preserved
+
+
+@pytest.mark.parametrize("written", ["'off'", "'quick'", "'full'", "'OFF'", "'QUICK'"])
+def test_documented_mode_strings_are_never_reported(tmp_path, written):
+    """Quoting or capitalising a documented mode is not drift — the resolver lowercases it anyway."""
+    cfg = _write_config(tmp_path, f"pre_update_backup: {written}")
+    f = _drift(cfg, True)
+
+    assert f.fixed == 0
+    assert f"pre_update_backup: {written}" in cfg.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("written", ["off", "Off", "OFF", "y", "n",
+                                     "'no'", "'yes'", "'banana'", "1", "0.0"])
+def test_documented_off_non_bool_and_unknown_values_are_never_reported(tmp_path, written):
+    """``off`` in any case is the documented mode; ``y``/``n`` are not folded by PyYAML (they parse
+    as strings); and an unknown value falls back to ``quick`` with a runtime warning, so it leaves
+    backups ON — none of them are silent opt-outs for doctor to rewrite."""
+    cfg = _write_config(tmp_path, f"pre_update_backup: {written}")
+    f = _drift(cfg, True)
 
     assert f.issues == [] and f.fixed == 0
     assert f"pre_update_backup: {written}" in cfg.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("written", ["false", "true", "True", "'false'", "'zip'", "", "null"])
+def test_reporting_is_idempotent_after_one_fix(tmp_path, written):
+    """One ``--fix`` must settle the value: a second pass reports and rewrites nothing.
+
+    The gate is deliberately token-based so a documented ``off`` is never rewritten on every run;
+    this pins that no other form re-triggers either.
+    """
+    body = "pre_update_backup:" if not written else f"pre_update_backup: {written}"
+    cfg = _write_config(tmp_path, body)
+
+    assert _drift(cfg, True).fixed == 1
+    after_fix = cfg.read_text(encoding="utf-8")
+    second = _drift(cfg, True)
+    assert second.issues == [] and second.fixed == 0
+    assert cfg.read_text(encoding="utf-8") == after_fix
 
 
 @pytest.mark.parametrize(
@@ -121,11 +202,7 @@ def test_only_the_literal_boolean_form_is_reported(tmp_path, written, expected_m
     """``off`` must survive untouched — YAML parses it as ``False`` too, so a value-only check
     would report a deliberate opt-out as legacy drift."""
     cfg = _write_config(tmp_path, f"pre_update_backup: {written}")
-    f = Finding()
-
-    from hermes_cli.doctor_config import _drift_pre_update_backup_legacy_bool
-
-    _drift_pre_update_backup_legacy_bool(f, should_fix=True, config_path=cfg)
+    f = _drift(cfg, True)
 
     if expected_mode is None:
         assert f.issues == [] and f.fixed == 0

--- a/tests/hermes_cli/test_doctor_legacy_pre_update_backup.py
+++ b/tests/hermes_cli/test_doctor_legacy_pre_update_backup.py
@@ -192,6 +192,59 @@ def test_reporting_is_idempotent_after_one_fix(tmp_path, written):
 
 
 @pytest.mark.parametrize(
+    "label,body",
+    [
+        # A text search over the file is satisfied by any matching line while the *effective* value
+        # at updates.pre_update_backup is a documented mode — doctor would warn and rewrite a config
+        # that was already correct.
+        ("other section decoy + off",
+         "other:\n  pre_update_backup: false\nupdates:\n  pre_update_backup: off\n"),
+        ("block scalar decoy + off",
+         "updates:\n  pre_update_backup: off\nnote: |\n  pre_update_backup: false\n"),
+        # Duplicate key: PyYAML keeps the last, so the effective token is the documented ``off``.
+        ("duplicate keys, last is off",
+         "updates:\n  pre_update_backup: false\nupdates:\n  pre_update_backup: off\n"),
+    ],
+)
+def test_decoys_elsewhere_in_the_file_are_not_reported(tmp_path, label, body):
+    """The gate reads the scalar at ``updates.pre_update_backup``'s own node, not the file text."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(body, encoding="utf-8")
+
+    f = _drift(cfg, False)
+    assert f.issues == [], f"{label}: reported a documented value as legacy"
+    assert _drift(cfg, True).fixed == 0
+    assert cfg.read_text(encoding="utf-8") == body
+
+
+@pytest.mark.parametrize(
+    "label,body",
+    [
+        # The value really is a legacy boolean; the old file-wide regex could not see these shapes.
+        ("flow style", "updates: {pre_update_backup: false}\n"),
+        ("double-quoted key", 'updates:\n  "pre_update_backup": false\n'),
+        ("single-quoted key", "updates:\n  'pre_update_backup': false\n"),
+        ("anchored value", "b: &pb false\nupdates:\n  pre_update_backup: *pb\n"),
+        # Duplicate key: the last one wins, and it is the legacy boolean.
+        ("duplicate keys, last is false",
+         "updates:\n  pre_update_backup: quick\nupdates:\n  pre_update_backup: false\n"),
+    ],
+)
+def test_forms_a_text_search_misses_are_still_reported(tmp_path, label, body):
+    """Every shape that resolves ``updates.pre_update_backup`` to a legacy boolean is reported."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(body, encoding="utf-8")
+    assert _resolved_mode(tmp_path) == "off", label  # the harm is real for each shape
+
+    f = _drift(cfg, False)
+    assert [i for i in f.issues if "pre_update_backup" in i], f"{label}: not reported"
+
+    assert _drift(cfg, True).fixed == 1
+    assert _written_value(cfg) == "off"
+    assert _resolved_mode(tmp_path) == "off"  # meaning preserved
+
+
+@pytest.mark.parametrize(
     "written,expected_mode",
     # Mode strings are the supported surface: never reported, never rewritten.
     [("quick", None), ("off", None), ("full", None),

--- a/tests/hermes_cli/test_doctor_legacy_pre_update_backup.py
+++ b/tests/hermes_cli/test_doctor_legacy_pre_update_backup.py
@@ -1,0 +1,91 @@
+"""``hermes doctor`` must flag the legacy boolean form of ``updates.pre_update_backup``.
+
+Installers and the setup wizard seeded ``false`` (meaning "off"), so a machine could run for months
+with the pre-update state snapshot — the #48200 wipe safety net — switched off, while the update
+receipt reported a backup step either way. ``false``/``true`` are not the supported surface; only
+``quick``, ``off`` and ``full`` are. Rewriting keeps the meaning and makes the setting auditable.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from hermes_cli.doctor_report import Finding
+
+
+def _write_config(root: Path, updates_body: str) -> Path:
+    cfg = root / "config.yaml"
+    cfg.write_text(f"updates:\n  {updates_body}\n", encoding="utf-8")
+    return cfg
+
+
+def _written_value(cfg: Path):
+    return yaml.safe_load(cfg.read_text(encoding="utf-8"))["updates"]["pre_update_backup"]
+
+
+def _resolved_mode(home: Path) -> str:
+    """The updater's own answer for that home.
+
+    In a subprocess on purpose: ``load_config`` caches per process, so reading a config written a
+    moment ago from inside this one can return a stale answer and prove nothing.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c",
+         "from types import SimpleNamespace;"
+         "from hermes_cli.update_cmd_maint import _resolve_pre_update_backup_mode as r;"
+         "print(r(SimpleNamespace()))"],
+        env={**os.environ, "HERMES_HOME": str(home)}, capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip()
+
+
+def test_legacy_false_is_flagged_by_doctor_and_fixed_to_off(tmp_path, monkeypatch):
+    """``false`` disables the snapshot: doctor reports it, --fix writes the mode string."""
+    cfg = _write_config(tmp_path, "pre_update_backup: false")
+    monkeypatch.setattr("hermes_cli.doctor.HERMES_HOME", tmp_path)
+
+    from hermes_cli.doctor_config import _check_config_drift
+
+    # Through the registered check, as `hermes doctor` runs it.
+    reported = _check_config_drift(False)
+    assert any("pre_update_backup" in issue for issue in reported.issues)
+
+    from hermes_cli.doctor_config import _drift_pre_update_backup_legacy_bool
+    f = Finding()
+    _drift_pre_update_backup_legacy_bool(f, True, cfg)
+    assert f.fixed == 1
+    assert _written_value(cfg) == "off"  # documented mode string, not a bool
+    # Semantics preserved: the rewrite makes an existing "off" legible, it does not silently
+    # switch backups on behind the user's back.
+    assert _resolved_mode(tmp_path) == "off"
+
+
+@pytest.mark.parametrize(
+    "written,expected_mode",
+    # Mode strings are the supported surface: never reported, never rewritten.
+    [("quick", None), ("off", None), ("full", None),
+     # The other legacy form: ``true`` is an alias for a full zip on every update.
+     ("true", "full")],
+)
+def test_only_the_literal_boolean_form_is_reported(tmp_path, written, expected_mode):
+    """``off`` must survive untouched — YAML parses it as ``False`` too, so a value-only check
+    would report a deliberate opt-out as legacy drift."""
+    cfg = _write_config(tmp_path, f"pre_update_backup: {written}")
+    f = Finding()
+
+    from hermes_cli.doctor_config import _drift_pre_update_backup_legacy_bool
+
+    _drift_pre_update_backup_legacy_bool(f, should_fix=True, config_path=cfg)
+
+    if expected_mode is None:
+        assert f.issues == [] and f.fixed == 0
+        assert f"pre_update_backup: {written}" in cfg.read_text(encoding="utf-8")
+        return
+    assert f.fixed == 1
+    assert _written_value(cfg) == expected_mode
+    assert _resolved_mode(tmp_path) == expected_mode


### PR DESCRIPTION
## What does this PR do?

`hermes doctor` reports `updates.pre_update_backup` values the docs do not describe, and `--fix`
rewrites each to the mode it already resolves to.

Covered forms, all of which resolve to a real mode with nothing saying so:

- boolean spellings — `false` (`False`/`yes`/`no`/`on`, any case) → `off`; `true` → `full`
- the strings `hermes config set` writes — `'false'`/`'none'`/`'disabled'` → `off`; `'true'`/`'zip'` → `full`
- a blank value (`pre_update_backup:`) → `off`

`off` means no pre-update state snapshot — the #48200 safety net — while the update receipt still
reports a backup step. On the machine I was diagnosing, `find ~/.hermes -type d -name state-snapshots`
was empty after a month of updates.

The check reads the scalar at `updates.pre_update_backup`'s own YAML node: the parsed value cannot
tell the documented `off` (YAML folds it to `False` too) from the legacy `false`, and a text search
would also be satisfied by a decoy line elsewhere while missing flow style, quoted keys, anchors and
duplicate `updates:` blocks. Documented mode strings, and unknown values (the resolver warns and
keeps `quick`), are left alone.

## Related Issue

Related: #94944 (the template value that makes `off` the fresh-install default); the #94954 review
thread called the doctor side follow-up.

Fixes # — no issue covers it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor_config.py` — `_pre_update_backup_scalar_node()` +
  `_pre_update_backup_legacy_form()`, registered as `_drift_pre_update_backup_legacy_form`; the alias
  table is imported from `update_cmd_maint` rather than duplicated.
- `tests/hermes_cli/test_doctor_legacy_pre_update_backup.py` — 11 tests, 58 cases.

## How to Test

```bash
hermes config set updates.pre_update_backup false       # writes the string 'false'
hermes doctor        # ⚠ ... is the legacy alias 'false' (equivalent to 'off')
hermes doctor --fix  # ✓ Rewrote updates.pre_update_backup: 'false' -> 'off'
```

Automated:

```bash
scripts/run_tests.sh tests/hermes_cli/test_doctor_legacy_pre_update_backup.py   # 58 passed
# plus test_doctor.py, test_doctor_live.py, test_doctor_journal_modes.py,
# test_doctor_command_install.py, test_doctor_dedicated_provider_skip.py,
# test_config_loader_e2e.py, test_config_read_guard.py, test_backup.py

# 219 passed, 1 skipped
```

Red on base: the registered `_check_config_drift(False)` reports nothing for any of these forms
(`assert False`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Searched for existing PRs — not a duplicate
- [x] Only changes related to this fix (2 files, four commits)
- [ ] `pytest tests/ -q` — I ran `scripts/run_tests.sh` on the doctor/config/backup files above; CI is the authority
- [x] Tests added
- [x] Tested on my platform: macOS 15.7.9 (darwin)

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing surface change beyond receipt content)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure Python, no platform-specific path
- [x] Tool descriptions/schemas — N/A

> Automated posting by agentic team with human oversight.
