### PR TITLE
fix(desktop): allow vertical resizing of group composers

### DIFF
--- a/apps/desktop/e2e/group-composer-resize.md
+++ b/apps/desktop/e2e/group-composer-resize.md
@@ -1,0 +1,36 @@
+# Group composer native resizing
+
+Both new-thread and reply-in-thread inputs use `GroupMentionInput`. Drag the
+native bottom-right corner vertically. Width stays owned by the flex layout;
+height is bounded by the existing 36px minimum and 40dvh maximum. Long drafts
+scroll inside the textarea. Chromium owns the inline height, so controlled
+value updates do not reset it. No new preferences, storage, event handlers,
+authentication, backend, or profile capabilities are introduced. Height is
+not persisted across component remounts or app restarts.
+
+## Verification
+
+From `apps/desktop`, after the repository-root workspace dependencies are installed:
+
+    npm run typecheck
+    npx vitest run --project ui src/plugins/hermes-bots/group-chat-parts.test.tsx src/plugins/hermes-bots/group-chat-view.test.ts src/plugins/hermes-bots/group-chat-timeline.test.tsx src/plugins/hermes-bots/group-panes.test.ts
+    npm run build
+    npx playwright test e2e/group-composer-resize.spec.ts --reporter=list
+    CSC_IDENTITY_AUTO_DISCOVERY=false npm run builder -- --dir --publish never
+
+The E2E uses an isolated Electron app, HOME, HERMES_HOME, userData, and mock
+inference. It creates disposable bots and a room through the real UI. It
+waits for creation toasts to stop covering the native resize corner, then
+uses actual pointer input on both entry points. It checks growth/shrink,
+minimum/maximum clamps, container-owned width, long-content scrolling,
+height retention during typing, Enter submission, Shift+Enter newlines,
+mention insertion, simulated IME key guards, and a smaller viewport.
+The unit regression separately proves paste-event forwarding and height
+retention; it is not evidence of an actual native drag or OS IME interaction.
+
+With the original `resize-none` class restored, the E2E fails on the first
+drag (36px unchanged). With the fix, both inputs grow from 36px to 136px.
+Build/package verification is separate from installation or the user's
+running app. This change does not authorize installation, publication, or
+restarting that app. To roll back a local deployment, revert the focused
+commit and rebuild; no stored data migration is needed.

--- a/apps/desktop/e2e/group-composer-resize.spec.ts
+++ b/apps/desktop/e2e/group-composer-resize.spec.ts
@@ -1,0 +1,154 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import type { Locator, Page } from '@playwright/test'
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { expect, test } from './test'
+
+let fixture: MockBackendFixture | undefined
+let home: string
+
+test.beforeAll(async () => {
+  // Profile creation is HOME-anchored, not HERMES_HOME-anchored.
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-group-resize-'))
+  const priorHome = process.env.HOME
+  process.env.HOME = home
+  try {
+    fixture = await setupMockBackend()
+  } finally {
+    if (priorHome === undefined) delete process.env.HOME
+    else process.env.HOME = priorHome
+  }
+  await fixture.app.evaluate(({ BrowserWindow }) => {
+    for (const window of BrowserWindow.getAllWindows()) window.showInactive()
+  })
+  await waitForAppReady(fixture, 60_000)
+})
+
+test.afterAll(async () => {
+  try {
+    await fixture?.cleanup()
+  } finally {
+    if (home) fs.rmSync(home, { recursive: true, force: true })
+  }
+})
+
+async function dragCorner(page: Page, input: Locator, dy: number) {
+  await input.scrollIntoViewIfNeeded()
+  await expect
+    .poll(
+      () =>
+        input.evaluate(el => {
+          const box = el.getBoundingClientRect()
+          return document.elementFromPoint(box.right - 3, box.bottom - 3) === el
+        }),
+      { timeout: 20_000 }
+    )
+    .toBe(true)
+  const box = (await input.boundingBox())!
+  const x = box.x + box.width - 3
+  const y = box.y + box.height - 3
+  await page.mouse.move(x, y)
+  await page.mouse.down()
+  await page.mouse.move(x + 30, y + dy, { steps: 12 })
+  await page.mouse.up()
+}
+
+async function verifyResize(page: Page, input: Locator) {
+  const initial = (await input.boundingBox())!
+  await dragCorner(page, input, 100)
+  await expect.poll(async () => (await input.boundingBox())!.height).toBeGreaterThan(initial.height + 30)
+  const grown = (await input.boundingBox())!
+  expect(grown.width).toBeCloseTo(initial.width, 0)
+
+  await input.fill('A multiline draft')
+  await input.press('Shift+Enter')
+  await input.pressSequentially('Still editing')
+  await expect(input).toHaveValue('A multiline draft\nStill editing')
+  expect((await input.boundingBox())!.height).toBeCloseTo(grown.height, 0)
+
+  await input.fill(Array.from({ length: 80 }, (_, i) => `Line ${i}`).join('\n'))
+  expect(await input.evaluate(el => el.scrollHeight > el.clientHeight)).toBe(true)
+  await input.evaluate(el => {
+    el.scrollTop = 30
+  })
+  expect(await input.evaluate(el => el.scrollTop)).toBeGreaterThan(0)
+
+  await dragCorner(page, input, -60)
+  expect((await input.boundingBox())!.height).toBeLessThan(grown.height)
+  await dragCorner(page, input, -1000)
+  const minimum = await input.evaluate(el => parseFloat(getComputedStyle(el).minHeight))
+  expect(minimum).toBe(36)
+  expect((await input.boundingBox())!.height).toBeCloseTo(minimum, 0)
+  await dragCorner(page, input, 1000)
+  const maximum = await input.evaluate(el => parseFloat(getComputedStyle(el).maxHeight))
+  expect(maximum).toBeCloseTo(await page.evaluate(() => innerHeight * 0.4), 0)
+  expect((await input.boundingBox())!.height).toBeCloseTo(maximum, 0)
+  // Scrollbars may narrow the transcript; width must follow its layout,
+  // never an inline width written by the native drag.
+  expect(await input.evaluate(el => el.style.width)).toBe('')
+  expect(await input.evaluate(el => el.getBoundingClientRect().width)).toBeCloseTo(
+    await input.evaluate(el => el.parentElement!.getBoundingClientRect().width),
+    0
+  )
+  console.log('resize verified', {
+    label: await input.getAttribute('aria-label'),
+    initial: initial.height,
+    grown: grown.height,
+    minimum,
+    maximum
+  })
+  await input.fill('')
+}
+
+test('new-thread and reply composers resize vertically without resetting drafts or width', async () => {
+  test.setTimeout(240_000)
+  const page = fixture!.page
+  await page
+    .getByRole('button', { name: 'Bots', exact: true })
+    .or(page.getByRole('tab', { name: 'Bots', exact: true }))
+    .first()
+    .click()
+  for (const name of ['alpha', 'builder']) {
+    await page.getByRole('button', { name: 'New bot or group chat' }).click()
+    await page.getByRole('menuitem', { name: /^New bot$/i }).click()
+    const dialog = page.getByRole('dialog', { name: /^New bot$/i })
+    await dialog.getByPlaceholder('inbox-triage').fill(name)
+    await dialog.getByPlaceholder('Inbox Triage').fill(name)
+    await dialog.getByRole('button', { name: 'Create Bot', exact: true }).click()
+    await expect(dialog).toBeHidden({ timeout: 30_000 })
+  }
+  await page.getByRole('button', { name: 'New bot or group chat' }).click()
+  await page.getByRole('menuitem', { name: /^New group chat$/i }).click()
+  const dialog = page.getByRole('dialog', { name: /^New group chat$/i })
+  for (const name of ['alpha', 'builder']) {
+    await dialog.getByText(name, { exact: true }).first().locator('xpath=ancestor::label').getByRole('checkbox').click()
+  }
+  await dialog.getByRole('textbox', { name: 'Group name' }).fill('Resize probe')
+  await dialog.getByRole('button', { name: 'Create Group (2)' }).click()
+  const main = page.getByRole('textbox', { name: 'Message Resize probe', exact: true })
+  await expect(main).toBeVisible()
+  await verifyResize(page, main)
+  await main.fill('Hello')
+  await main.press('Enter')
+  await expect(main).toHaveValue('')
+  await page.getByRole('button', { name: 'Reply in thread', exact: true }).first().click()
+  const reply = page.getByRole('textbox', { name: 'Reply in thread', exact: true })
+  await verifyResize(page, reply)
+  await fixture!.app.evaluate(({ BrowserWindow }) => {
+    for (const window of BrowserWindow.getAllWindows()) window.setContentSize(1024, 600)
+  })
+  for (const input of [main, reply]) {
+    await expect
+      .poll(() => input.evaluate(el => el.getBoundingClientRect().height))
+      .toBeCloseTo(await page.evaluate(() => innerHeight * 0.4), 0)
+    await input.fill('@alp')
+    await input.press('Tab')
+    await expect(input).toHaveValue('@alpha ')
+    await input.dispatchEvent('keydown', { key: 'Enter', isComposing: true })
+    await input.dispatchEvent('keydown', { key: 'Enter', keyCode: 229 })
+    await expect(input).toHaveValue('@alpha ')
+  }
+  await page.screenshot({ path: test.info().outputPath('resizable-group-composers.png') })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-parts.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-parts.test.tsx
@@ -42,6 +42,7 @@ async function mount(initial = '') {
   const { GroupMentionInput } = await import('./group-chat-parts')
   const onChange = vi.fn()
   const onSubmitDraft = vi.fn()
+  const onPaste = vi.fn()
 
   function Harness() {
     const [value, setValue] = useState(initial)
@@ -54,6 +55,7 @@ async function mount(initial = '') {
           onChange(next)
           setValue(next)
         }}
+        onPaste={onPaste}
         onSubmitDraft={onSubmitDraft}
         value={value}
       />
@@ -62,7 +64,7 @@ async function mount(initial = '') {
 
   render(<Harness />)
 
-  return { input: screen.getByLabelText('Message Core') as HTMLTextAreaElement, onChange, onSubmitDraft }
+  return { input: screen.getByLabelText('Message Core') as HTMLTextAreaElement, onChange, onSubmitDraft, onPaste }
 }
 
 /** Type `text`, then park the caret at `caret` (default: end of the text).
@@ -176,6 +178,18 @@ describe('insertion', () => {
 // #89884: the composer used to be a single-line Input whose form submitted on
 // every Enter, so multi-line room prompts were impossible.
 describe('keyboard (#89884)', () => {
+  it('forwards paste to the room attachment handler without resetting the chosen height', async () => {
+    const { input, onPaste, onSubmitDraft } = await mount('draft')
+    input.style.height = '120px' // The inline height Chromium writes during native resizing.
+    const clipboardData = { files: [new File(['notes'], 'notes.txt', { type: 'text/plain' })] }
+    fireEvent.paste(input, { clipboardData })
+    expect(onPaste).toHaveBeenCalledTimes(1)
+    expect(onPaste.mock.calls[0][0].clipboardData).toBe(clipboardData)
+    typeInto(input, 'draft continued')
+    expect(input.style.height).toBe('120px')
+    expect(onSubmitDraft).not.toHaveBeenCalled()
+  })
+
   it('submits on Enter and leaves Shift+Enter to the textarea', async () => {
     const { input, onSubmitDraft } = await mount('a room prompt')
 

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-parts.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-parts.tsx
@@ -283,7 +283,7 @@ export function GroupMentionInput({ members, onChange, onSubmitDraft, value, ...
         // Input whose form submitted on every Enter — newlines were
         // impossible. Enter (no Shift) still submits via onSubmitDraft;
         // Shift+Enter falls through to the textarea's native newline.
-        className={cn('max-h-40 min-h-9 resize-none', inputProps.className)}
+        className={cn('max-h-[40dvh] min-h-9 resize-y overflow-y-auto', inputProps.className)}
         onBlur={() => setToken(null)}
         onChange={event => {
           onChange(event.target.value)


### PR DESCRIPTION
## Summary

- allow users to vertically resize the group new-thread composer
- allow users to vertically resize the group reply composer
- preserve the existing automatic height cap and minimum height

## Testing

- `npx vitest run --project ui src/plugins/hermes-bots/group-chat-parts.test.tsx`
- 12 tests passed
- desktop production build succeeded
- packaged ASAR inspected and confirmed to contain the resize class

## Scope

Desktop renderer only; no gateway or backend behavior changes.