### PR TITLE
fix(kanban): keep tasks created parked from auto-promoting

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1366,6 +1366,17 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                if task_status == "blocked":
+                    # Park intent must be an EVENT, not just a status: sticky-block
+                    # detection reads the newest blocked/unblocked event, so a
+                    # status-only park looks unblocked-by-anyone and the next
+                    # dispatcher tick promotes it and spawns workers on work a
+                    # human deliberately deferred.
+                    _append_event(
+                        conn, task_id, "blocked",
+                        {"reason": "created parked (initial_status=blocked)",
+                         "kind": "needs_input", "source_status": task_status},
+                    )
                 # ACK-edge: the originating channel hears a child BLOCK, not just the fan-in.
                 inherit_creator_origin(conn, task_id, creator_task_id, created_at=now)
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -80,6 +80,39 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
 
 
 # ---------------------------------------------------------------------------
+# Tasks created parked (initial_status="blocked") are sticky too
+# ---------------------------------------------------------------------------
+
+
+def test_created_parked_task_is_not_auto_promoted(kanban_home: Path) -> None:
+    """``create_task(initial_status="blocked")`` parks a card for human ops, so
+    it must be as sticky as a worker-initiated block.
+
+    Same failure shape as the worker-block bug, reached by a different door:
+    creation recorded the blocked *status* but emitted no ``blocked`` *event*,
+    and ``_has_sticky_block`` reads events — so the very next tick promoted the
+    card and spawned workers on work a human had explicitly deferred.
+    """
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="parked for human ops", initial_status="blocked")
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        for _ in range(5):
+            promoted = kb.recompute_ready(conn)
+            assert promoted == 0, "parked task must not auto-promote"
+            assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_created_parked_task_can_still_be_unblocked(kanban_home: Path) -> None:
+    """Parking stays reversible — an explicit unblock still releases the card,
+    so the stickiness fix cannot wedge a task permanently."""
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="parked then released", initial_status="blocked")
+        assert kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status in ("ready", "todo")
+
+
+# ---------------------------------------------------------------------------
 # Circuit-breaker blocks still auto-recover (preserve #40c1decb3 intent)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- emit a durable `blocked` event when a task is created with `initial_status="blocked"`
- make parked tasks participate in the existing sticky-block protection
- prevent dispatcher recomputation from silently promoting intentionally parked cards

## Testing

- added a regression to `tests/hermes_cli/test_kanban_blocked_sticky.py`
- full Kanban scope: 344 passed, 0 failed, 9 skipped

## Root cause

Creation set the status to `blocked` but emitted only the creation event. `_has_sticky_block` therefore had no durable blocked event to find.