### PR TITLE
fix(agent): re-scope fast-mode params on provider fallback

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1814,6 +1814,30 @@ def _rescope_fallback_extra_body(agent, old_model: str, old_provider: str, old_b
         logger.debug("Failed to resolve extra_body for fallback %s; keeping current: %s", agent.model, _eb_err)
 
 
+def _rescope_fallback_fast_mode(agent) -> None:
+    """Re-resolve the static ``/fast`` param for the NEW route, dropping the old one.
+
+    ``{"speed": "fast"}`` (Anthropic) and ``{"service_tier": "priority"}`` (OpenAI/xAI)
+    are route-specific and pinned at build time. Carrying one onto a fallback that does
+    not accept it raises TypeError inside ``Completions.create()`` before any request is
+    sent, so the turn dies with no response — the failure survives a provider swap that
+    was supposed to rescue it. Bounded auto/cold tiers are layered per request by
+    ``agent.fast_mode`` and are deliberately left alone here.
+    """
+    try:
+        overrides = dict(getattr(agent, "request_overrides", {}) or {})
+        overrides.pop("speed", None)
+        overrides.pop("service_tier", None)
+        if getattr(agent, "service_tier", None) == "priority":
+            from hermes_cli.models import resolve_fast_mode_overrides
+            overrides.update(resolve_fast_mode_overrides(
+                getattr(agent, "model", None), provider=getattr(agent, "provider", None),
+                base_url=getattr(agent, "base_url", None)) or {})
+        agent.request_overrides = overrides
+    except Exception as _fast_err:
+        logger.debug("Failed to re-scope fast-mode overrides for fallback %s: %s", agent.model, _fast_err)
+
+
 def _buffer_fallback_notice(agent, notice: str) -> None:
     """Buffer the switch notice for terminal failure AND retain it as a durable one-shot for
     _emit_pending_fallback_notice (a successful fallback clears retry chatter)."""
@@ -1905,6 +1929,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             _update_fallback_context_compressor(agent)
             _reresolve_fallback_reasoning_config(agent)
             _rescope_fallback_extra_body(agent, old_model, old_provider, old_base_url)
+            _rescope_fallback_fast_mode(agent)
             rewrite_prompt_model_identity(agent, fb_model, fb_provider)
 
             notice = (

--- a/tests/agent/test_fast_mode_fallback_rescope.py
+++ b/tests/agent/test_fast_mode_fallback_rescope.py
@@ -1,0 +1,79 @@
+"""Fast-mode params must be re-scoped to the FALLBACK route, not carried over.
+
+Static ``/fast`` (``service_tier == "priority"``) pins the primary route's fast
+param into ``agent.request_overrides`` at build time: ``{"speed": "fast"}`` on
+native Anthropic, ``{"service_tier": "priority"}`` on OpenAI/xAI. Those are
+route-specific. When the agent falls back to a provider that does not support
+fast mode, a carried-over ``speed`` reaches ``Completions.create()`` as an
+unknown kwarg and the turn dies with TypeError before any request is sent —
+observed live as anthropic/claude-opus-5 -> nous/stepfun, which killed inbound
+``message_agent`` delivery for the whole profile.
+
+``_rescope_fallback_extra_body`` already does this for custom-provider
+extra_body keys; fast params need the same treatment.
+"""
+
+from types import SimpleNamespace
+
+from agent.chat_completion_helpers import _rescope_fallback_fast_mode
+
+
+def _agent(**kw):
+    base = dict(
+        service_tier="priority",
+        model="stepfun/step-3.7-flash:free",
+        provider="nous",
+        base_url="https://inference-api.nousresearch.com/v1/",
+        api_mode="chat_completions",
+        request_overrides={"speed": "fast"},
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_unsupported_fallback_route_drops_stale_fast_param():
+    """anthropic(speed=fast) -> nous: the param the new route rejects is gone."""
+    agent = _agent(request_overrides={"speed": "fast", "extra_body": {"keep": 1}})
+
+    _rescope_fallback_fast_mode(agent)
+
+    assert "speed" not in agent.request_overrides
+    assert "service_tier" not in agent.request_overrides
+    # unrelated overrides survive untouched
+    assert agent.request_overrides["extra_body"] == {"keep": 1}
+
+
+def test_fast_param_is_reshaped_for_the_new_route():
+    """anthropic(speed) -> openai(service_tier): each route gets its OWN param."""
+    agent = _agent(
+        model="gpt-5.4", provider="openai", base_url="https://api.openai.com/v1",
+        request_overrides={"speed": "fast"},
+    )
+
+    _rescope_fallback_fast_mode(agent)
+
+    assert agent.request_overrides == {"service_tier": "priority"}
+
+
+def test_non_fast_sessions_are_not_given_fast_params():
+    """A session that never asked for /fast stays normal across a fallback."""
+    agent = _agent(
+        service_tier=None, model="gpt-5.4", provider="openai",
+        base_url="https://api.openai.com/v1", request_overrides={"extra_body": {"keep": 1}},
+    )
+
+    _rescope_fallback_fast_mode(agent)
+
+    assert agent.request_overrides == {"extra_body": {"keep": 1}}
+
+
+def test_bounded_windows_are_left_to_the_per_request_layer():
+    """auto/cold are layered per request by agent.fast_mode; don't pin them here."""
+    agent = _agent(
+        service_tier="auto", model="claude-opus-5", provider="anthropic",
+        base_url="https://api.anthropic.com", request_overrides={},
+    )
+
+    _rescope_fallback_fast_mode(agent)
+
+    assert agent.request_overrides == {}


### PR DESCRIPTION
## Summary

- re-resolve route-specific fast-mode request parameters after provider fallback
- remove stale overrides (for example Anthropic `speed="fast"`) before switching to a provider that does not support them
- retain only overrides supported by the fallback route

## Testing

- added focused regression coverage in `tests/agent/test_fast_mode_fallback_rescope.py`
- focused fast-mode fallback scope: 6 passed
- live runtime shape verified: Anthropic `{speed: fast}` becomes `{}` on fallback to an unsupported route
- end-to-end Bot Chat delivery succeeded without the prior `unexpected keyword argument speed` error

## Known unrelated upstream failure

The wider `tests/agent -k "fast or fallback"` scope reports one failure in `test_fallback_dynamic_credential.py::test_anthropic_fallback_keeps_callable_without_treating_it_as_oauth_text`. The same test fails identically on clean `origin/main` with this PR absent; it is pre-existing and unrelated to this change.