### PR TITLE
feat(desktop): configurable session-source exclusions for sidebar recents + search

### DIFF
--- a/apps/desktop/src/api/sessions.test.ts
+++ b/apps/desktop/src/api/sessions.test.ts
@@ -11,7 +11,7 @@ vi.mock('./client', () => ({
 
 const client = await import('./client')
 
-const { deleteSession, setSessionArchived, setSessionPinnedRemote, setSessionUnreadRemote, listSidebarSessions } =
+const { deleteSession, searchSessions, setSessionArchived, setSessionPinnedRemote, setSessionUnreadRemote, listSidebarSessions } =
   await import('./sessions')
 
 const hermesApi = vi.mocked(client.hermesApi)
@@ -172,5 +172,29 @@ describe('listSidebarSessions remote ownership', () => {
     })
 
     expect(result.recents.sessions[0]).toMatchObject({ connection_id: 'prometheus', id: 'remote-session' })
+  })
+})
+
+// Search must honor the same source exclusions the sidebar recents slice uses
+// (`sessions.exclude_sources`): the backend has always accepted
+// `exclude_sources`, but search sent only `q`, so a term that lives inside an
+// A2A dispatch would surface a row the sidebar itself hides.
+describe('searchSessions source exclusions', () => {
+  it('sends only the query when no exclusions are configured', async () => {
+    hermesApi.mockResolvedValue({ results: [] } as never)
+
+    await searchSessions('baozun')
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({ path: '/api/sessions/search?q=baozun' })
+  })
+
+  it('passes the configured exclusions so a hidden row stays hidden in search', async () => {
+    hermesApi.mockResolvedValue({ results: [] } as never)
+
+    await searchSessions('baozun', ['a2a', 'cron'])
+
+    expect((hermesApi.mock.calls[0][0] as { path: string }).path).toBe(
+      '/api/sessions/search?q=baozun&exclude_sources=a2a%2Ccron'
+    )
   })
 })

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -370,9 +370,20 @@ export function setSessionUnreadRemote(id: string, unread: boolean, profile?: st
   })
 }
 
-export function searchSessions(query: string): Promise<SessionSearchResponse> {
+// Session search accepts the same source exclusions the sidebar recents slice
+// uses (`sessions.exclude_sources`), so a term that only appears inside an
+// excluded source — A2A dispatches by default — doesn't surface a row the list
+// itself hides. The backend has honored `exclude_sources` all along; before
+// this, search sent only `q` and every exclusion was silently ignored.
+export function searchSessions(query: string, excludeSources: string[] = []): Promise<SessionSearchResponse> {
+  const params = new URLSearchParams({ q: query })
+
+  if (excludeSources.length) {
+    params.set('exclude_sources', excludeSources.join(','))
+  }
+
   return hermesApi<SessionSearchResponse>({
-    path: `/api/sessions/search?q=${encodeURIComponent(query)}`
+    path: `/api/sessions/search?${params.toString()}`
   })
 }
 

--- a/apps/desktop/src/app/chat/sidebar/chat-sidebar.integration.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chat-sidebar.integration.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, cleanup, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -24,25 +25,31 @@ const sessionRows = [
   makeSessionInfo({ id: 'tile-two', last_active: 2, profile: 'default', started_at: 1, title: 'Tile two' })
 ]
 
+// The sidebar reads the shared config record (sessions.exclude_sources, the
+// extra sources its recents list and search must hide) through React Query, so
+// every render needs a QueryClientProvider — a fresh client per render, or a
+// cached config from one test leaks into the next.
 const renderSidebar = (pathname: string, currentView: AppView) =>
   render(
-    <MemoryRouter initialEntries={[pathname]}>
-      <SidebarProvider>
-        <ChatSidebar
-          currentView={currentView}
-          onArchiveSession={noop}
-          onBranchSession={noop}
-          onDeleteSession={noop}
-          onLoadMoreSessions={noop}
-          onManageCronJob={noop}
-          onNavigate={noop}
-          onNewSessionInWorkspace={noop}
-          onNewSessionSplit={noop}
-          onResumeSession={noop}
-          onTriggerCronJob={noopAsync}
-        />
-      </SidebarProvider>
-    </MemoryRouter>
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MemoryRouter initialEntries={[pathname]}>
+        <SidebarProvider>
+          <ChatSidebar
+            currentView={currentView}
+            onArchiveSession={noop}
+            onBranchSession={noop}
+            onDeleteSession={noop}
+            onLoadMoreSessions={noop}
+            onManageCronJob={noop}
+            onNavigate={noop}
+            onNewSessionInWorkspace={noop}
+            onNewSessionSplit={noop}
+            onResumeSession={noop}
+            onTriggerCronJob={noopAsync}
+          />
+        </SidebarProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
   )
 
 const currentButtons = () =>

--- a/apps/desktop/src/app/chat/sidebar/gateway-groups.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/gateway-groups.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, expect, it, vi } from 'vitest'
@@ -15,25 +16,30 @@ import { ChatSidebar } from './index'
 const noop = () => {}
 const resume = vi.fn()
 
+// The sidebar reads the shared config record (sessions.exclude_sources, the
+// extra sources its recents list and search must hide) through React Query, so
+// every mount needs a QueryClientProvider.
 const mount = () =>
   render(
-    <MemoryRouter>
-      <SidebarProvider>
-        <ChatSidebar
-          currentView="chat"
-          onArchiveSession={noop}
-          onBranchSession={noop}
-          onDeleteSession={noop}
-          onLoadMoreSessions={noop}
-          onManageCronJob={noop}
-          onNavigate={noop}
-          onNewSessionInWorkspace={noop}
-          onNewSessionSplit={noop}
-          onResumeSession={resume}
-          onTriggerCronJob={async () => {}}
-        />
-      </SidebarProvider>
-    </MemoryRouter>
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MemoryRouter>
+        <SidebarProvider>
+          <ChatSidebar
+            currentView="chat"
+            onArchiveSession={noop}
+            onBranchSession={noop}
+            onDeleteSession={noop}
+            onLoadMoreSessions={noop}
+            onManageCronJob={noop}
+            onNavigate={noop}
+            onNewSessionInWorkspace={noop}
+            onNewSessionSplit={noop}
+            onResumeSession={resume}
+            onTriggerCronJob={async () => {}}
+          />
+        </SidebarProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
   )
 
 afterEach(cleanup)

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -5,6 +5,7 @@ import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router'
 
+import { useHermesConfigRecord } from '@/app/hooks/use-config-record'
 import { PlatformAvatar } from '@/app/messaging/platform-icon'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
@@ -27,7 +28,7 @@ import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/he
 import { useI18n } from '@/i18n'
 import { comboTokens } from '@/lib/keybinds/combo'
 import { sessionMatchesSearch } from '@/lib/session-search'
-import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
+import { configuredExcludeSources, normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
 import { $activeConnectionId } from '@/store/connections'
 import { $cronJobs } from '@/store/cron'
@@ -642,6 +643,16 @@ export function ChatSidebar({
     [isPinnedSession, filtersNarrow, sessionMatchesFilters]
   )
 
+  // Search honors the same source exclusions as the recents slice
+  // (`sessions.exclude_sources`, `a2a` by default): a hit inside an excluded
+  // source must not resurface a row the list itself hides.
+  const { data: searchConfigRecord } = useHermesConfigRecord()
+
+  const searchExcludeSources = useMemo(
+    () => configuredExcludeSources(searchConfigRecord),
+    [searchConfigRecord]
+  )
+
   // Full-text search across *all* sessions (not just the loaded page) so 699
   // sessions stay findable. Debounced; loaded sessions are matched instantly
   // client-side and merged ahead of the server hits.
@@ -658,7 +669,7 @@ export function ChatSidebar({
     setSearchPending(true)
 
     const id = window.setTimeout(() => {
-      void searchSessions(trimmedQuery)
+      void searchSessions(trimmedQuery, searchExcludeSources)
         .then(res => {
           if (!cancelled) {
             setServerMatches(res.results)
@@ -676,7 +687,7 @@ export function ChatSidebar({
       cancelled = true
       window.clearTimeout(id)
     }
-  }, [trimmedQuery])
+  }, [trimmedQuery, searchExcludeSources])
 
   const searchResults = useMemo(() => {
     if (!trimmedQuery) {

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -103,8 +103,19 @@ vi.mock('@/store/session-removal', async importActual => ({
   $removedSessionIds: { get: () => removed.ids }
 }))
 
+// The recents exclusion list is the built-in machine sources plus whatever
+// `sessions.exclude_sources` adds. Stub the shared config record so these tests
+// can drive the config side without a React Query client (the real hook reads
+// GET /api/config through useHermesConfigRecord).
+const configRecord = vi.hoisted(() => ({ value: undefined as unknown }))
+
+vi.mock('@/app/hooks/use-config-record', () => ({
+  useHermesConfigRecord: () => ({ data: configRecord.value })
+}))
+
 beforeEach(() => {
   gatewayScope.epoch = 0
+  configRecord.value = undefined
   getCronJobs.mockReset()
   getCronJobs.mockResolvedValue([])
   listSidebarSessions.mockReset()
@@ -868,5 +879,54 @@ describe('messaging profile scope', () => {
 
     expect(listAllProfileSessions).not.toHaveBeenCalled()
     expect($messagingPlatformTotals.get()).toEqual({ 'work:signal': 12 })
+  })
+})
+
+// `sessions.exclude_sources` reaches the recents fetch as an addition to the
+// built-in exclusions: default config hides `a2a`, an absent key or an explicit
+// `[]` leaves the built-in list exactly as it was.
+describe('recents source exclusions', () => {
+  const recentsExcludeCall = (): string[] =>
+    (listSidebarSessions.mock.calls[0][0] as { recentsExclude: string[] }).recentsExclude
+
+  it('hides the built-in machine sources plus the configured ones', async () => {
+    configRecord.value = { sessions: { exclude_sources: ['a2a'] } }
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect(recentsExcludeCall()).toContain('a2a')
+    expect(recentsExcludeCall()).toContain('cron')
+  })
+
+  it('falls back to the built-in list when the config key is absent', async () => {
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect(recentsExcludeCall()).toContain('cron')
+    expect(recentsExcludeCall()).not.toContain('a2a')
+  })
+
+  it('lets an explicit empty list keep only the built-in exclusions', async () => {
+    configRecord.value = { sessions: { exclude_sources: [] } }
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect(recentsExcludeCall()).toContain('cron')
+    expect(recentsExcludeCall()).not.toContain('a2a')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -1,10 +1,13 @@
-import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 
+import { useHermesConfigRecord } from '@/app/hooks/use-config-record'
 import { listAllProfileSessions, listSidebarSessions, type SessionInfo } from '@/hermes'
 import { sameCronSignature } from '@/lib/session-signatures'
 import {
+  configuredExcludeSources,
   isMessagingSource,
   LOCAL_SESSION_SOURCE_IDS,
+  mergeExcludedSources,
   MESSAGING_SESSION_SOURCE_IDS,
   normalizeSessionSource
 } from '@/lib/session-source'
@@ -116,6 +119,18 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   const loadMoreMessagingRequestRef = useRef<Record<string, number>>({})
   const refreshMessagingSessionsRequestRef = useRef(0)
   const refreshSessionsRequestRef = useRef(0)
+
+  // The recents slice hides the built-in machine sources (SIDEBAR_EXCLUDED_SOURCES)
+  // plus whatever `sessions.exclude_sources` adds — `a2a` by default, so A2A peer
+  // dispatches don't crowd out interactive chats. Reading the shared config record
+  // makes the extra exclusions user-configurable without a code change; the
+  // built-in entries can never be configured away.
+  const { data: configRecord } = useHermesConfigRecord()
+
+  const recentsExclude = useMemo(
+    () => mergeExcludedSources(SIDEBAR_EXCLUDED_SOURCES, configuredExcludeSources(configRecord)),
+    [configRecord]
+  )
 
   useLayoutEffect(() => {
     profileScopeRef.current = profileScope
@@ -279,7 +294,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         const result = await listSidebarSessions({
           recentsProfile: sessionProfile,
           recentsLimit: limit,
-          recentsExclude: SIDEBAR_EXCLUDED_SOURCES,
+          recentsExclude,
           cronLimit: CRON_SECTION_LIMIT,
           messagingLimit: MESSAGING_SECTION_LIMIT,
           messagingExclude: MESSAGING_EXCLUDED_SOURCES
@@ -384,7 +399,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         void refreshCronJobs()
       }
     },
-    [profileScope, refreshCronJobs]
+    [profileScope, recentsExclude, refreshCronJobs]
   )
 
   const loadMoreSessions = useCallback(async () => {

--- a/apps/desktop/src/lib/session-source.test.ts
+++ b/apps/desktop/src/lib/session-source.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { isMessagingSource, MESSAGING_SESSION_SOURCE_IDS, sessionSourceSearchTerms } from './session-source'
+import {
+  configuredExcludeSources,
+  isMessagingSource,
+  mergeExcludedSources,
+  MESSAGING_SESSION_SOURCE_IDS,
+  sessionSourceSearchTerms
+} from './session-source'
 
 // Regression guard for #46761 / PR #47395: Photon (iMessage) must keep its own
 // sidebar section. refreshMessagingSessions() filters rows through
@@ -31,5 +37,33 @@ describe('photon messaging source registration', () => {
     expect(isMessagingSource('cli')).toBe(false)
     expect(isMessagingSource(null)).toBe(false)
     expect(isMessagingSource(undefined)).toBe(false)
+  })
+})
+
+// `sessions.exclude_sources` is read out of the raw config record
+// (`Record<string, unknown>`), merged on top of the built-in exclusions. These
+// pin the two properties the sidebar depends on: the built-in entries can never
+// be configured away, and a malformed/absent key degrades to "nothing extra
+// excluded" instead of throwing inside the render path.
+describe('configured source exclusions', () => {
+  it('reads and normalizes the configured list', () => {
+    expect(configuredExcludeSources({ sessions: { exclude_sources: ['A2A', ' cron '] } })).toEqual(['a2a', 'cron'])
+  })
+
+  it('degrades to an empty list for absent / malformed values', () => {
+    expect(configuredExcludeSources(undefined)).toEqual([])
+    expect(configuredExcludeSources({})).toEqual([])
+    expect(configuredExcludeSources({ sessions: {} })).toEqual([])
+    expect(configuredExcludeSources({ sessions: { exclude_sources: 'a2a' } })).toEqual([])
+    expect(configuredExcludeSources({ sessions: { exclude_sources: [1, null, ''] } })).toEqual([])
+  })
+
+  it('merges configured sources on top of the built-in ones, deduped', () => {
+    expect(mergeExcludedSources(['cron', 'kanban'], ['a2a', 'cron'])).toEqual(['cron', 'kanban', 'a2a'])
+  })
+
+  it('returns the built-in array identity when nothing is configured', () => {
+    const builtIn = ['cron', 'kanban']
+    expect(mergeExcludedSources(builtIn, [])).toBe(builtIn)
   })
 })

--- a/apps/desktop/src/lib/session-source.ts
+++ b/apps/desktop/src/lib/session-source.ts
@@ -128,3 +128,37 @@ export function sessionSourceSearchTerms(source: null | string | undefined): str
 
   return [id, label ?? '', ...(SOURCE_ALIASES[id] ?? [])].filter(Boolean)
 }
+
+/**
+ * Read `sessions.exclude_sources` out of the raw config record. The record is
+ * `Record<string, unknown>` (it is whatever config.yaml holds), so a missing
+ * key, a non-array value, and non-string entries all degrade to "nothing extra
+ * excluded" rather than throwing inside the sidebar render path. Entries are
+ * normalized the same way session sources are, so `A2A` and `a2a` both match.
+ */
+export function configuredExcludeSources(record: unknown): string[] {
+  const sessions = (record as { sessions?: { exclude_sources?: unknown } } | null | undefined)?.sessions
+  const raw = sessions?.exclude_sources
+
+  if (!Array.isArray(raw)) {
+    return []
+  }
+
+  const ids = raw.map(value => normalizeSessionSource(typeof value === 'string' ? value : null))
+
+  return Array.from(new Set(ids.filter((id): id is string => id != null)))
+}
+
+/**
+ * Merge configured exclusions on top of a built-in source list: the built-in
+ * entries always stay excluded, the configured ones are additive and deduped.
+ * Returns the built-in array identity when nothing is configured, so callers
+ * (the sidebar recents fetch) don't re-fetch on an unchanged list.
+ */
+export function mergeExcludedSources(builtIn: string[], configured: string[]): string[] {
+  if (!configured.length) {
+    return builtIn
+  }
+
+  return Array.from(new Set([...builtIn, ...configured]))
+}

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2048,6 +2048,14 @@ DEFAULT_CONFIG = {
         # index matches instead of LIKE scans. True = use when present (inert otherwise); False =
         # never load/serve it. Bridged to HERMES_CJK_FTS.
         "cjk_fts": True,
+        # Session sources to hide from the Desktop sidebar's "recent sessions"
+        # slice and its session search (Cmd+Shift+F). Merged on top of the
+        # built-in exclusions (cron / kanban / subagent / tool / messaging
+        # platforms), never replacing them. Default hides A2A peer dispatches:
+        # they are machine-to-machine, so on any host that runs A2A peers they
+        # crowd out interactive chats. An empty list restores the built-in
+        # behavior only.
+        "exclude_sources": ["a2a"],
         # Slow session-search threshold (ms): searches at/above it log one INFO line with the
         # routing path (fts_cjk / fts5 / trigram / like_scan). 0 logs every search. Bridged to
         # HERMES_SEARCH_SLOW_MS.


### PR DESCRIPTION
## What does this PR do?

The Desktop sidebar's "recent sessions" slice and the Cmd+Shift+F session search mix in A2A sessions (`source='a2a'`). The built-in `SIDEBAR_EXCLUDED_SOURCES` already drops `cron`, `kanban`, `subagent`, `tool` and the messaging platforms — A2A is the one machine source missing from that list, and there was no way to exclude it without editing the constant.

A2A conversations are machine-to-machine dispatches, not interactive chats: on a host that runs A2A peers they crowd out the recents page (measured on one always-on worker: A2A alone was 35% of the last 500 sessions, A2A + cron 66%). This adds a configurable exclusion list so the sidebar and session search stay shaped around interactive chats without forking the constant.

Design: one config key, read through the existing Desktop config record, merged **on top of** the built-in constant rather than replacing it. Additive, user-controllable, zero backend work.

## Related Issue

Fixes #108003

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config_defaults.py` — new `sessions.exclude_sources` (default `["a2a"]`; `[]` restores today's behavior, absent key → built-in list only).
- `apps/desktop/src/lib/session-source.ts` — `configuredExcludeSources()` reads + normalizes the key out of the raw config record; `mergeExcludedSources()` merges it on top of a built-in list (deduped; returns the built-in array identity when nothing is configured).
- `apps/desktop/src/app/session/hooks/use-session-list-actions.ts` — the recents fetch passes the merged list as `recents_exclude` (was the constant).
- `apps/desktop/src/api/sessions.ts` — `searchSessions(query, excludeSources)` now sends `exclude_sources`; previously only `q` was sent, so session search ignored every exclusion.
- `apps/desktop/src/app/chat/sidebar/index.tsx` — passes the configured list into `searchSessions`.
- Tests: `session-source.test.ts`, `use-session-list-actions.test.tsx`, `api/sessions.test.ts` (9 new cases), plus a `QueryClientProvider` wrapper in the two sidebar tests that mount `ChatSidebar` (it now reads the config record).

**Zero backend changes** — `GET /api/profiles/sessions/sidebar` (`recents_exclude`, `hermes_cli/web_routers/profiles.py:419`) and `GET /api/sessions/search` (`exclude_sources`, `hermes_cli/web_routers/sessions.py:257`) already accept and honor both.

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/lib/session-source.test.ts src/api/sessions.test.ts src/app/session/hooks/use-session-list-actions.test.tsx`
   → **Test Files 3 passed (3) · Tests 53 passed (53)** — 9 new cases: config read + normalization, malformed/absent fallback, merge + dedupe, built-in identity preserved, recents fetch carries the merged list (and falls back without the key / with `[]`), search sends `exclude_sources`, search omits it when empty.
2. `cd apps/desktop && npm run typecheck` → clean (`tsc -p .` / `tsconfig.electron` / `tsconfig.e2e`).
3. `cd apps/desktop && npx eslint src/lib/session-source.ts src/lib/session-source.test.ts src/api/sessions.ts src/api/sessions.test.ts src/app/session/hooks/use-session-list-actions.ts src/app/session/hooks/use-session-list-actions.test.tsx src/app/chat/sidebar/index.tsx src/app/chat/sidebar/chat-sidebar.integration.test.tsx src/app/chat/sidebar/gateway-groups.test.tsx` → clean.
4. `python -m pytest tests/hermes_cli/test_config.py -q` → **121 passed, 4 skipped** (the new key is a config default; no existing assertion enumerates `sessions.*`).
5. Full UI suite: **785 of 786 files pass** — `src/store/voice-prefs.test.ts` fails 2 cases, and it reproduces identically on a pristine `origin/main` checkout (2 failed | 5 passed) without this branch, so it is a pre-existing upstream failure unrelated to this change.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(config):`, `feat(desktop):`)
- [x] I searched for existing PRs — this supersedes the closed #84322, which bundled unrelated agent / dashboard-auth / TUI changes; this PR carries only the sidebar + search feature
- [x] My PR contains **only** changes related to this issue (no unrelated commits)
- [ ] I've run `pytest tests/ -q` — not run in full: this change adds a config default only, so I ran `tests/hermes_cli/test_config.py` (121 passed, 4 skipped). Happy to run the full suite on request.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5 — unit tests, typecheck and lint on this branch; the Desktop-app manual check is listed under Screenshots / Logs and is still to be attached.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: no docs page enumerates `sessions.*` keys (checked `docs/` for the existing `auto_prune` reference: none)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: that file has no `sessions:` section today
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A: renderer-side filtering only, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Command output for steps 1-5 above is the code-level evidence. Backend side, verified live against a real `state.db` (43 A2A sessions) through the same access path the two endpoints use (`_open_session_db_for_profile` → `list_sessions_rich` / `search_messages`):

```
sidebar recents (same call as /api/profiles/sessions/sidebar?recents_exclude=...)
  without exclusions: 20 rows {'tui': 5, 'cli': 3, 'cron': 12}
  with exclusions   : 20 rows {'tui': 12, 'cli': 6, 'todo-launch-84673e37': 1, 'todo-launch-55cee1b1': 1}
session search (same call as /api/sessions/search?q=A2A)
  without exclude_sources : 100 hits {'cli': 51, 'tui': 45, 'a2a': 2, 'cron': 2}
  with exclude_sources=a2a: 100 hits {'cli': 53, 'tui': 45, 'cron': 2}
```

So the exclusions really do change which rows surface: once the machine sources are dropped the page refills with interactive sessions. On this host the A2A rows are older than its cron/tui traffic, so its recents page is not A2A-dominated — the 35% / 66% figures in the description come from a busier always-on A2A worker.

The Desktop-app manual check is still to be attached: on a host with A2A traffic, the recents list before/after (with and without `[A2A]` rows) and a Cmd+Shift+F search for a term that only exists inside an A2A session (no result after the change, hit after setting `sessions.exclude_sources: []`).

## Follow-up

- A `Filter → Sources` submenu that edits `sessions.exclude_sources` from the UI is intentionally not in this PR (it adds a config write path + i18n); will open it separately.
- Related, not overlapping: #68123 fixes excluded rows re-entering local recents through the keep-semantics path in the same file; this PR only changes where the exclusion list comes from. Happy to rebase if #68123 lands first.
