### PR TITLE
fix(cron): accept prompt flag after create options

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -571,8 +571,12 @@ def _print_job_details(job_data: Dict[str, Any]) -> None:
 def cron_create(args):
     # The gateway-lifecycle guard lives in cron.jobs.create_job (every creation path); a block
     # surfaces as result["error"].
+    # The flag form exists because argparse cannot bind a trailing value to the
+    # nargs="?" positional once optionals precede it; the positional wins when both
+    # are supplied so existing invocations keep their meaning.
+    prompt = getattr(args, "prompt", None) or getattr(args, "prompt_flag", None)
     result = _cron_api(
-        action="create", schedule=args.schedule, prompt=args.prompt,
+        action="create", schedule=args.schedule, prompt=prompt,
         skill=getattr(args, "skill", None),
         skills=_normalize_skills(getattr(args, "skill", None), getattr(args, "skills", None)),
         no_agent=getattr(args, "no_agent", False) or None,

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -25,6 +25,14 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_create.add_argument("schedule", help="Schedule like '30m', 'every 2h', or '0 9 * * *'")
     cron_create.add_argument(
         "prompt", nargs="?", help="Optional self-contained prompt or task instruction")
+    # Flag form of the same value. argparse cannot match a trailing value to a
+    # nargs="?" positional once optionals are interleaved before it
+    # ("cron create 30m --name x hello world" leaves "hello world" unconsumed),
+    # so a prompt placed after other options needs this spelling.
+    cron_create.add_argument(
+        "--prompt", dest="prompt_flag",
+        help="Same as the positional prompt; use it when the prompt follows "
+             "other options (the positional form cannot bind there).")
     cron_create.add_argument("--name", help="Optional human-friendly job name")
     cron_create.add_argument("--deliver",
         help="Delivery target: origin, local, telegram, discord, signal, "

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -427,6 +427,47 @@ def test_cron_create_failure_returns_nonzero(monkeypatch, capsys):
     assert "Failed to create job: boom" in out
 
 
+def test_cron_create_forwards_prompt_flag(monkeypatch, capsys):
+    """`cron create --prompt X` must reach create_job as the prompt.
+
+    The positional form cannot bind a trailing value after interleaved
+    optionals, so the flag is the supported spelling in that position;
+    dropping it here prevents the command from parsing.
+    """
+    captured = {}
+
+    def fake_api(**kwargs):
+        captured.update(kwargs)
+        return {
+            "success": True,
+            "job_id": "jid",
+            "name": "n",
+            "schedule": "once",
+            "next_run_at": "2026-09-14T09:45:00+08:00",
+            "job": {},
+        }
+
+    monkeypatch.setattr(cron_cli, "_cron_api", fake_api)
+    monkeypatch.setattr(cron_cli, "_warn_if_gateway_not_running", lambda: None)
+
+    args = SimpleNamespace(
+        schedule="2026-09-14T09:45:00+08:00",
+        prompt=None,
+        prompt_flag="send report",
+        name="n",
+        deliver="telegram",
+        repeat=1,
+        skill=["reminder"],
+        skills=None,
+        script=None,
+        workdir=None,
+        no_agent=False,
+    )
+
+    assert cron_cli.cron_create(args) == 0
+    assert captured["prompt"] == "send report"
+
+
 class TestCronRunBackgroundDispatch:
     """`hermes cron run` must not report 'failed' when the run was dispatched
     to the background delegation worker.

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -48,3 +48,27 @@ def test_cron_accept_hooks_flag_on_run_and_tick():
     assert ns.accept_hooks is True
     ns2 = parser.parse_args(["cron", "tick", "--accept-hooks"])
     assert ns2.accept_hooks is True
+
+def test_cron_create_prompt_flag_binds_after_interleaved_options():
+    """A prompt that follows other options must bind via --prompt.
+
+    argparse cannot hand a trailing value to a ``nargs="?"`` positional once
+    optionals are interleaved before it, so ``create 30m --name x hello world``
+    leaves ``hello world`` unconsumed ("unrecognized arguments"). The flag form
+    is the supported spelling when prompt text follows other options.
+    """
+    parser = _build()
+    ns = parser.parse_args(
+        ["cron", "create", "30m", "--name", "nightly", "--prompt", "hello world"]
+    )
+    assert ns.schedule == "30m"
+    assert ns.prompt_flag == "hello world"
+    assert ns.prompt is None
+
+
+def test_cron_create_positional_prompt_still_binds_when_it_leads():
+    # Regression guard for the documented, working positional form.
+    parser = _build()
+    ns = parser.parse_args(["cron", "create", "30m", "hello world"])
+    assert ns.prompt == "hello world"
+    assert ns.prompt_flag is None


### PR DESCRIPTION
## What does this PR do?

Adds an explicit `--prompt` spelling for `hermes cron create` when the prompt follows named options. The existing positional prompt remains supported and takes precedence when both forms are supplied.

This is related to #102983 and the open #103027, but uses a different, additive contract: instead of recovering unknown trailing arguments in the top-level parser, it gives users an unambiguous flag that argparse can bind after interleaved options while preserving strict rejection of unknown arguments.

## Related Issue

Related to #102983 and #103027.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/subcommands/cron.py`: add `--prompt` as an alias for the optional positional prompt.
- `hermes_cli/cron.py`: forward the positional prompt first, then the flag value.
- `tests/hermes_cli/test_cron_parser_builder.py`: cover option-interleaved flag parsing and the existing positional form.
- `tests/hermes_cli/test_cron.py`: verify the flag reaches the create API.

## How to Test

1. Run `hermes cron create 30m --name nightly --prompt "hello world"`.
2. Confirm the job is created with prompt `hello world`.
3. Run `scripts/run_tests.sh tests/hermes_cli/test_cron_parser_builder.py tests/hermes_cli/test_cron.py`.

Local targeted result: 32 passed. A manual create/delete smoke test also passed on macOS.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted tests were run)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Relevant documentation: N/A; CLI help text is updated with the new flag
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow change
- [x] Cross-platform impact considered: argparse behavior is platform-independent
- [x] Tool descriptions/schemas: N/A; no tool schema changed
