### PR TITLE
fix(gateway): a failed turn's request can no longer ride into the next message and execute later (#107070, salvage #107088)

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1708,9 +1708,10 @@ class GatewayTurnMixin:
                     )
                 else:
                     await store.append_to_transcript(sid, _user_row, skip_db=agent_persisted)
-                await store.append_to_transcript(
-                    sid, self._hmwa_failed_turn_boundary_row(self._hmwa_failed_turn_notice(agent_result), ts),
-                )
+                    # The boundary belongs to the user row it closes; a deduped retry already has one.
+                    await store.append_to_transcript(
+                        sid, self._hmwa_failed_turn_boundary_row(self._hmwa_failed_turn_notice(agent_result), ts),
+                    )
             else:
                 # Only the NEW messages: history_offset (what the agent saw), not len(history), which
                 # counts session_meta entries stripped before the agent saw them.

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1843,10 +1843,11 @@ class GatewayTurnMixin:
         elif status_code in {400, 500}:
             # 400/500 on a large session: context overflow / payload too large.
             if len(prepared.history) > 50:
-                return self._hmwa_add_failed_turn_notice(
+                # Overflow is a deterministic request rejection, not an indeterminate-effect
+                # failure (#107567): keep the reply to the /compact / /reset guidance only.
+                return (
                     "⚠️ Session too large for the model's context window.\nUse /compact to "
-                    "compress the conversation, or /reset to start fresh.",
-                    self._PARTIAL_FAILED_TURN_NOTICE,
+                    "compress the conversation, or /reset to start fresh."
                 )
             elif status_code == 400:
                 status_hint = " The request was rejected by the API."

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1527,9 +1527,8 @@ class GatewayTurnMixin:
         "before resending."
     )
 
-    def _hmwa_add_failed_turn_notice(self, response, notice=None):
+    def _hmwa_add_failed_turn_notice(self, response, notice):
         """Make failed-turn delivery explicit without replacing the provider-specific guidance."""
-        notice = notice or self._FAILED_TURN_NOTICE
         response = str(response or "").strip()
         if notice in response:
             return response
@@ -1537,9 +1536,12 @@ class GatewayTurnMixin:
 
     def _hmwa_failed_turn_notice(self, agent_result):
         """Choose retry guidance without assuming completed tool effects can be repeated safely."""
-        messages = agent_result.get("messages", []) or []
-        history_offset = agent_result.get("history_offset", 0)
-        turn_messages = messages[history_offset:]
+        from gateway.media_repair import _current_turn_messages
+        # Compression during the failed turn can move the slice boundary; the shared helper falls
+        # back to the last user row so tool evidence is not silently dropped.
+        turn_messages = _current_turn_messages(
+            agent_result.get("messages", []) or [], agent_result.get("history_offset", 0),
+        )
         if any(
             message.get("role") == "tool"
             or (message.get("role") == "assistant" and message.get("tool_calls"))
@@ -1547,6 +1549,13 @@ class GatewayTurnMixin:
         ):
             return self._PARTIAL_FAILED_TURN_NOTICE
         return self._FAILED_TURN_NOTICE
+
+    @staticmethod
+    def _hmwa_failed_turn_boundary_row(notice, ts):
+        """Gateway-owned assistant row closing a failed turn: a user-only tail lets alternation repair
+        merge this request into an unrelated future message and replay stale side effects. Carries
+        only the stable safety statement, never raw provider details."""
+        return {"role": "assistant", "content": notice, "timestamp": ts}
 
     def _hmwa_classify_turn_failure(self, agent_result, history, session_entry):
         """Classify a finished turn for transcript persistence. Returns
@@ -1654,7 +1663,6 @@ class GatewayTurnMixin:
     async def _hmwa_persist_turn_transcript(
         self, *, event, source, session_entry, session_key, agent_result, agent_messages,
         prepared, response, agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure,
-        failed_turn_notice,
     ):
         """Persist this turn to the transcript (session_meta on first turn, closed failed turn on
         transient failure, nothing on context overflow), update last_prompt_tokens, and re-baseline the
@@ -1700,13 +1708,8 @@ class GatewayTurnMixin:
                     )
                 else:
                     await store.append_to_transcript(sid, _user_row, skip_db=agent_persisted)
-                # Close the failed turn with a durable assistant boundary. Leaving a user-only tail
-                # lets alternation repair merge this request into an unrelated future message and
-                # can replay stale side effects. Persist only the stable safety statement, not raw
-                # provider details; this row is gateway-owned and was not written by the agent.
                 await store.append_to_transcript(
-                    sid,
-                    {"role": "assistant", "content": failed_turn_notice, "timestamp": ts},
+                    sid, self._hmwa_failed_turn_boundary_row(self._hmwa_failed_turn_notice(agent_result), ts),
                 )
             else:
                 # Only the NEW messages: history_offset (what the agent saw), not len(history), which
@@ -1814,11 +1817,7 @@ class GatewayTurnMixin:
                     )
                 await self.async_session_store.append_to_transcript(
                     session_entry.session_id,
-                    {
-                        "role": "assistant",
-                        "content": self._PARTIAL_FAILED_TURN_NOTICE,
-                        "timestamp": time.time(),
-                    },
+                    self._hmwa_failed_turn_boundary_row(self._PARTIAL_FAILED_TURN_NOTICE, time.time()),
                 )
         except Exception:
             logger.debug("Failed to persist inbound user message after agent exception", exc_info=True)
@@ -2058,9 +2057,8 @@ class GatewayTurnMixin:
             agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure = (
                 self._hmwa_classify_turn_failure(agent_result, history, session_entry)
             )
-            failed_turn_notice = self._hmwa_failed_turn_notice(agent_result)
             if agent_failed_early and not is_context_overflow_failure:
-                response = self._hmwa_add_failed_turn_notice(response, failed_turn_notice)
+                response = self._hmwa_add_failed_turn_notice(response, self._hmwa_failed_turn_notice(agent_result))
             response, session_entry = await self._hmwa_compression_exhaustion_reset(
                 agent_result, response, session_entry, session_key, source,
             )
@@ -2070,7 +2068,6 @@ class GatewayTurnMixin:
                 response=response, agent_failed_early=agent_failed_early,
                 hidden_reasoning_incomplete=hidden_reasoning_incomplete,
                 is_context_overflow_failure=is_context_overflow_failure,
-                failed_turn_notice=failed_turn_notice,
             )
             return await self._hmwa_deliver_turn_response(
                 event, source, session_entry, session_key, run_generation,

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1530,8 +1530,6 @@ class GatewayTurnMixin:
     def _hmwa_add_failed_turn_notice(self, response, notice):
         """Make failed-turn delivery explicit without replacing the provider-specific guidance."""
         response = str(response or "").strip()
-        if notice in response:
-            return response
         return f"{response}\n\n{notice}" if response else notice
 
     def _hmwa_failed_turn_notice(self, agent_result):
@@ -1549,13 +1547,6 @@ class GatewayTurnMixin:
         ):
             return self._PARTIAL_FAILED_TURN_NOTICE
         return self._FAILED_TURN_NOTICE
-
-    @staticmethod
-    def _hmwa_failed_turn_boundary_row(notice, ts):
-        """Gateway-owned assistant row closing a failed turn: a user-only tail lets alternation repair
-        merge this request into an unrelated future message and replay stale side effects. Carries
-        only the stable safety statement, never raw provider details."""
-        return {"role": "assistant", "content": notice, "timestamp": ts}
 
     def _hmwa_classify_turn_failure(self, agent_result, history, session_entry):
         """Classify a finished turn for transcript persistence. Returns
@@ -1663,10 +1654,12 @@ class GatewayTurnMixin:
     async def _hmwa_persist_turn_transcript(
         self, *, event, source, session_entry, session_key, agent_result, agent_messages,
         prepared, response, agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure,
+        failed_turn_notice=None,
     ):
         """Persist this turn to the transcript (session_meta on first turn, closed failed turn on
         transient failure, nothing on context overflow), update last_prompt_tokens, and re-baseline the
-        cached agent's message count."""
+        cached agent's message count. *failed_turn_notice* is the SAME string the user was shown; it
+        closes the failed turn as a gateway-owned assistant row."""
         from gateway.run import _resolve_gateway_model
         ts = time.time()  # Unix epoch float — consistent with DB storage
         store = self.async_session_store
@@ -1708,10 +1701,13 @@ class GatewayTurnMixin:
                     )
                 else:
                     await store.append_to_transcript(sid, _user_row, skip_db=agent_persisted)
-                    # The boundary belongs to the user row it closes; a deduped retry already has one.
-                    await store.append_to_transcript(
-                        sid, self._hmwa_failed_turn_boundary_row(self._hmwa_failed_turn_notice(agent_result), ts),
-                    )
+                    # Gateway-owned assistant row closing the failed turn: a user-only tail lets
+                    # alternation repair merge this request into an unrelated future message and replay
+                    # stale side effects. Belongs to the user row it closes — a deduped retry has one.
+                    await store.append_to_transcript(sid, {
+                        "role": "assistant", "timestamp": ts,
+                        "content": failed_turn_notice or self._hmwa_failed_turn_notice(agent_result),
+                    })
             else:
                 # Only the NEW messages: history_offset (what the agent saw), not len(history), which
                 # counts session_meta entries stripped before the agent saw them.
@@ -1816,10 +1812,10 @@ class GatewayTurnMixin:
                     await self.async_session_store.append_to_transcript(
                         session_entry.session_id, self._hmwa_user_transcript_entry(event, prepared, time.time()),
                     )
-                await self.async_session_store.append_to_transcript(
-                    session_entry.session_id,
-                    self._hmwa_failed_turn_boundary_row(self._PARTIAL_FAILED_TURN_NOTICE, time.time()),
-                )
+                # Same boundary row as the persist path: tool effects are unknown after an exception.
+                await self.async_session_store.append_to_transcript(session_entry.session_id, {
+                    "role": "assistant", "content": self._PARTIAL_FAILED_TURN_NOTICE, "timestamp": time.time(),
+                })
         except Exception:
             logger.debug("Failed to persist inbound user message after agent exception", exc_info=True)
         # Never expose raw exception types/messages to end users (info-leakage risk).
@@ -2058,8 +2054,11 @@ class GatewayTurnMixin:
             agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure = (
                 self._hmwa_classify_turn_failure(agent_result, history, session_entry)
             )
-            if agent_failed_early and not is_context_overflow_failure:
-                response = self._hmwa_add_failed_turn_notice(response, self._hmwa_failed_turn_notice(agent_result))
+            failed_turn_notice = None
+            if (agent_failed_early or hidden_reasoning_incomplete) and not is_context_overflow_failure:
+                failed_turn_notice = self._hmwa_failed_turn_notice(agent_result)
+            if agent_failed_early and failed_turn_notice:
+                response = self._hmwa_add_failed_turn_notice(response, failed_turn_notice)
             response, session_entry = await self._hmwa_compression_exhaustion_reset(
                 agent_result, response, session_entry, session_key, source,
             )
@@ -2068,7 +2067,7 @@ class GatewayTurnMixin:
                 agent_result=agent_result, agent_messages=agent_messages, prepared=prepared,
                 response=response, agent_failed_early=agent_failed_early,
                 hidden_reasoning_incomplete=hidden_reasoning_incomplete,
-                is_context_overflow_failure=is_context_overflow_failure,
+                is_context_overflow_failure=is_context_overflow_failure, failed_turn_notice=failed_turn_notice,
             )
             return await self._hmwa_deliver_turn_response(
                 event, source, session_entry, session_key, run_generation,

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1522,13 +1522,31 @@ class GatewayTurnMixin:
     _FAILED_TURN_NOTICE = (
         "Your request was not processed. Send it again if you still want me to carry it out."
     )
+    _PARTIAL_FAILED_TURN_NOTICE = (
+        "This turn did not complete. Some actions may already have run; verify their effects "
+        "before resending."
+    )
 
-    def _hmwa_add_failed_turn_notice(self, response):
+    def _hmwa_add_failed_turn_notice(self, response, notice=None):
         """Make failed-turn delivery explicit without replacing the provider-specific guidance."""
+        notice = notice or self._FAILED_TURN_NOTICE
         response = str(response or "").strip()
-        if self._FAILED_TURN_NOTICE in response:
+        if notice in response:
             return response
-        return f"{response}\n\n{self._FAILED_TURN_NOTICE}" if response else self._FAILED_TURN_NOTICE
+        return f"{response}\n\n{notice}" if response else notice
+
+    def _hmwa_failed_turn_notice(self, agent_result):
+        """Choose retry guidance without assuming completed tool effects can be repeated safely."""
+        messages = agent_result.get("messages", []) or []
+        history_offset = agent_result.get("history_offset", 0)
+        turn_messages = messages[history_offset:]
+        if any(
+            message.get("role") == "tool"
+            or (message.get("role") == "assistant" and message.get("tool_calls"))
+            for message in turn_messages
+        ):
+            return self._PARTIAL_FAILED_TURN_NOTICE
+        return self._FAILED_TURN_NOTICE
 
     def _hmwa_classify_turn_failure(self, agent_result, history, session_entry):
         """Classify a finished turn for transcript persistence. Returns
@@ -1636,6 +1654,7 @@ class GatewayTurnMixin:
     async def _hmwa_persist_turn_transcript(
         self, *, event, source, session_entry, session_key, agent_result, agent_messages,
         prepared, response, agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure,
+        failed_turn_notice,
     ):
         """Persist this turn to the transcript (session_meta on first turn, closed failed turn on
         transient failure, nothing on context overflow), update last_prompt_tokens, and re-baseline the
@@ -1687,7 +1706,7 @@ class GatewayTurnMixin:
                 # provider details; this row is gateway-owned and was not written by the agent.
                 await store.append_to_transcript(
                     sid,
-                    {"role": "assistant", "content": self._FAILED_TURN_NOTICE, "timestamp": ts},
+                    {"role": "assistant", "content": failed_turn_notice, "timestamp": ts},
                 )
             else:
                 # Only the NEW messages: history_offset (what the agent saw), not len(history), which
@@ -1797,7 +1816,7 @@ class GatewayTurnMixin:
                     session_entry.session_id,
                     {
                         "role": "assistant",
-                        "content": self._FAILED_TURN_NOTICE,
+                        "content": self._PARTIAL_FAILED_TURN_NOTICE,
                         "timestamp": time.time(),
                     },
                 )
@@ -1826,13 +1845,15 @@ class GatewayTurnMixin:
             if len(prepared.history) > 50:
                 return self._hmwa_add_failed_turn_notice(
                     "⚠️ Session too large for the model's context window.\nUse /compact to "
-                    "compress the conversation, or /reset to start fresh."
+                    "compress the conversation, or /reset to start fresh.",
+                    self._PARTIAL_FAILED_TURN_NOTICE,
                 )
             elif status_code == 400:
                 status_hint = " The request was rejected by the API."
         return self._hmwa_add_failed_turn_notice(
             f"Sorry, I encountered an unexpected error.{status_hint}\n"
-            "Try again or use /reset to start a fresh session."
+            "Use /reset to start a fresh session if needed.",
+            self._PARTIAL_FAILED_TURN_NOTICE,
         )
 
     def _hmwa_discard_stale_result(self, source, _quick_key, run_generation):
@@ -2036,8 +2057,9 @@ class GatewayTurnMixin:
             agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure = (
                 self._hmwa_classify_turn_failure(agent_result, history, session_entry)
             )
+            failed_turn_notice = self._hmwa_failed_turn_notice(agent_result)
             if agent_failed_early and not is_context_overflow_failure:
-                response = self._hmwa_add_failed_turn_notice(response)
+                response = self._hmwa_add_failed_turn_notice(response, failed_turn_notice)
             response, session_entry = await self._hmwa_compression_exhaustion_reset(
                 agent_result, response, session_entry, session_key, source,
             )
@@ -2047,6 +2069,7 @@ class GatewayTurnMixin:
                 response=response, agent_failed_early=agent_failed_early,
                 hidden_reasoning_incomplete=hidden_reasoning_incomplete,
                 is_context_overflow_failure=is_context_overflow_failure,
+                failed_turn_notice=failed_turn_notice,
             )
             return await self._hmwa_deliver_turn_response(
                 event, source, session_entry, session_key, run_generation,

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1853,7 +1853,7 @@ class GatewayTurnMixin:
                 status_hint = " The request was rejected by the API."
         return self._hmwa_add_failed_turn_notice(
             f"Sorry, I encountered an unexpected error.{status_hint}\n"
-            "Use /reset to start a fresh session if needed.",
+            "Try again or use /reset to start a fresh session.",
             self._PARTIAL_FAILED_TURN_NOTICE,
         )
 

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1519,6 +1519,17 @@ class GatewayTurnMixin:
         except Exception as e:
             logger.debug("Watch queue drain error: %s", e)
 
+    _FAILED_TURN_NOTICE = (
+        "Your request was not processed. Send it again if you still want me to carry it out."
+    )
+
+    def _hmwa_add_failed_turn_notice(self, response):
+        """Make failed-turn delivery explicit without replacing the provider-specific guidance."""
+        response = str(response or "").strip()
+        if self._FAILED_TURN_NOTICE in response:
+            return response
+        return f"{response}\n\n{self._FAILED_TURN_NOTICE}" if response else self._FAILED_TURN_NOTICE
+
     def _hmwa_classify_turn_failure(self, agent_result, history, session_entry):
         """Classify a finished turn for transcript persistence. Returns
         ``(agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure)``.
@@ -1602,11 +1613,10 @@ class GatewayTurnMixin:
     @staticmethod
     def _hmwa_user_transcript_entry(event, prepared, ts):
         """Transcript row for the inbound user turn (clean text + event time when captured)."""
-        # Transient failure (429/timeout/5xx): persist only the user message so the next message can load a
-        # transcript that reflects what was said. Skip the assistant error text since it's a
-        # gateway-generated hint, not model output. Hidden- reasoning-only incomplete turns follow the same
-        # persistence rule so peer-agent channels don't ingest them as completed assistant turns. (#7100,
-        # #51628)
+        # Transient failure (429/timeout/5xx): persist the user message so the next message can load a
+        # transcript that reflects what was said. The caller pairs it with a stable assistant safety
+        # boundary rather than the provider error text. Hidden-reasoning-only incomplete turns follow the
+        # same persistence rule so peer-agent channels don't ingest provider details. (#7100, #51628)
         _user_entry = {
             "role": "user",
             "content": (
@@ -1627,8 +1637,8 @@ class GatewayTurnMixin:
         self, *, event, source, session_entry, session_key, agent_result, agent_messages,
         prepared, response, agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure,
     ):
-        """Persist this turn to the transcript (session_meta on first turn, user-only on transient
-        failure, nothing on context overflow), update last_prompt_tokens, and re-baseline the
+        """Persist this turn to the transcript (session_meta on first turn, closed failed turn on
+        transient failure, nothing on context overflow), update last_prompt_tokens, and re-baseline the
         cached agent's message count."""
         from gateway.run import _resolve_gateway_model
         ts = time.time()  # Unix epoch float — consistent with DB storage
@@ -1661,8 +1671,8 @@ class GatewayTurnMixin:
                     "timestamp": ts,
                 })
             if agent_failed_early or hidden_reasoning_incomplete:
-                # Transient failure / hidden-reasoning incomplete: persist only the user message (the
-                # assistant error text is a gateway hint, not model output). Dedupe on platform
+                # Transient failure / hidden-reasoning incomplete: persist the user message without
+                # the provider error text (a gateway hint, not model output). Dedupe on platform
                 # message_id (Telegram retries after transient failures).
                 if event.message_id and await store.has_platform_message_id(sid, str(event.message_id)):
                     logger.info(
@@ -1671,6 +1681,14 @@ class GatewayTurnMixin:
                     )
                 else:
                     await store.append_to_transcript(sid, _user_row, skip_db=agent_persisted)
+                # Close the failed turn with a durable assistant boundary. Leaving a user-only tail
+                # lets alternation repair merge this request into an unrelated future message and
+                # can replay stale side effects. Persist only the stable safety statement, not raw
+                # provider details; this row is gateway-owned and was not written by the agent.
+                await store.append_to_transcript(
+                    sid,
+                    {"role": "assistant", "content": self._FAILED_TURN_NOTICE, "timestamp": ts},
+                )
             else:
                 # Only the NEW messages: history_offset (what the agent saw), not len(history), which
                 # counts session_meta entries stripped before the agent saw them.
@@ -1775,6 +1793,14 @@ class GatewayTurnMixin:
                     await self.async_session_store.append_to_transcript(
                         session_entry.session_id, self._hmwa_user_transcript_entry(event, prepared, time.time()),
                     )
+                await self.async_session_store.append_to_transcript(
+                    session_entry.session_id,
+                    {
+                        "role": "assistant",
+                        "content": self._FAILED_TURN_NOTICE,
+                        "timestamp": time.time(),
+                    },
+                )
         except Exception:
             logger.debug("Failed to persist inbound user message after agent exception", exc_info=True)
         # Never expose raw exception types/messages to end users (info-leakage risk).
@@ -1798,13 +1824,13 @@ class GatewayTurnMixin:
         elif status_code in {400, 500}:
             # 400/500 on a large session: context overflow / payload too large.
             if len(prepared.history) > 50:
-                return (
+                return self._hmwa_add_failed_turn_notice(
                     "⚠️ Session too large for the model's context window.\nUse /compact to "
                     "compress the conversation, or /reset to start fresh."
                 )
             elif status_code == 400:
                 status_hint = " The request was rejected by the API."
-        return (
+        return self._hmwa_add_failed_turn_notice(
             f"Sorry, I encountered an unexpected error.{status_hint}\n"
             "Try again or use /reset to start a fresh session."
         )
@@ -2010,6 +2036,8 @@ class GatewayTurnMixin:
             agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure = (
                 self._hmwa_classify_turn_failure(agent_result, history, session_entry)
             )
+            if agent_failed_early and not is_context_overflow_failure:
+                response = self._hmwa_add_failed_turn_notice(response)
             response, session_entry = await self._hmwa_compression_exhaustion_reset(
                 agent_result, response, session_entry, session_key, source,
             )

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1548,6 +1548,19 @@ class GatewayTurnMixin:
             return self._PARTIAL_FAILED_TURN_NOTICE
         return self._FAILED_TURN_NOTICE
 
+    async def _hmwa_close_failed_turn(self, session_id, notice):
+        """Append the gateway-owned assistant boundary iff the durable tail is an open user row.
+
+        The tail, not "did the gateway write the user row", is the key: on the primary path the
+        agent's turn-start flush already persisted the row (so the platform-id dedupe skips the
+        gateway write), and a platform redelivery of an already-closed turn must not stack a
+        second assistant row."""
+        if await self.async_session_store.transcript_tail_role(session_id) != "user":
+            return
+        await self.async_session_store.append_to_transcript(session_id, {
+            "role": "assistant", "content": notice, "timestamp": time.time(),
+        })
+
     def _hmwa_classify_turn_failure(self, agent_result, history, session_entry):
         """Classify a finished turn for transcript persistence. Returns
         ``(agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure)``.
@@ -1654,12 +1667,10 @@ class GatewayTurnMixin:
     async def _hmwa_persist_turn_transcript(
         self, *, event, source, session_entry, session_key, agent_result, agent_messages,
         prepared, response, agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure,
-        failed_turn_notice=None,
     ):
         """Persist this turn to the transcript (session_meta on first turn, closed failed turn on
         transient failure, nothing on context overflow), update last_prompt_tokens, and re-baseline the
-        cached agent's message count. *failed_turn_notice* is the SAME string the user was shown; it
-        closes the failed turn as a gateway-owned assistant row."""
+        cached agent's message count."""
         from gateway.run import _resolve_gateway_model
         ts = time.time()  # Unix epoch float — consistent with DB storage
         store = self.async_session_store
@@ -1701,13 +1712,9 @@ class GatewayTurnMixin:
                     )
                 else:
                     await store.append_to_transcript(sid, _user_row, skip_db=agent_persisted)
-                    # Gateway-owned assistant row closing the failed turn: a user-only tail lets
-                    # alternation repair merge this request into an unrelated future message and replay
-                    # stale side effects. Belongs to the user row it closes — a deduped retry has one.
-                    await store.append_to_transcript(sid, {
-                        "role": "assistant", "timestamp": ts,
-                        "content": failed_turn_notice or self._hmwa_failed_turn_notice(agent_result),
-                    })
+                # Close the failed turn: a user-only tail lets alternation repair merge this request
+                # into an unrelated future message and replay stale side effects (#107070).
+                await self._hmwa_close_failed_turn(sid, self._hmwa_failed_turn_notice(agent_result))
             else:
                 # Only the NEW messages: history_offset (what the agent saw), not len(history), which
                 # counts session_meta entries stripped before the agent saw them.
@@ -1798,10 +1805,18 @@ class GatewayTurnMixin:
 
     async def _hmwa_agent_error_reply(self, e, event, source, session_entry, session_key, prepared):
         """``except Exception`` body of the agent turn: stop typing, log, persist the inbound user
-        turn once, and build the sanitized user-facing error reply."""
+        turn once and close it, and build the sanitized user-facing error reply."""
         # Retain Slack thread/workspace routing so a failed turn cannot leave its status visible.
         await self._hmwa_stop_typing_for_turn(event, source)
         logger.exception("Agent error in session %s", session_key)
+        status_code = getattr(e, "status_code", None)
+        if status_code in {400, 500} and len(prepared.history) > 50:
+            # Context overflow / payload too large: a deterministic rejection (#107567), and the same
+            # no-grow rule as the persist path (#1630) — nothing is written into an oversized session.
+            return (
+                "⚠️ Session too large for the model's context window.\nUse /compact to "
+                "compress the conversation, or /reset to start fresh."
+            )
         # Replay can coalesce inputs; only this input's durable marker establishes ownership.
         try:
             if prepared.message_text is not None and session_entry is not None:
@@ -1812,14 +1827,11 @@ class GatewayTurnMixin:
                     await self.async_session_store.append_to_transcript(
                         session_entry.session_id, self._hmwa_user_transcript_entry(event, prepared, time.time()),
                     )
-                # Same boundary row as the persist path: tool effects are unknown after an exception.
-                await self.async_session_store.append_to_transcript(session_entry.session_id, {
-                    "role": "assistant", "content": self._PARTIAL_FAILED_TURN_NOTICE, "timestamp": time.time(),
-                })
+                # Tool effects are unknown after an exception.
+                await self._hmwa_close_failed_turn(session_entry.session_id, self._PARTIAL_FAILED_TURN_NOTICE)
         except Exception:
             logger.debug("Failed to persist inbound user message after agent exception", exc_info=True)
         # Never expose raw exception types/messages to end users (info-leakage risk).
-        status_code = getattr(e, "status_code", None)
         status_hint = self._STATUS_HINTS.get(status_code, "")
         if status_code == 429:
             # Plan usage limit (resets on a schedule) vs a transient rate limit
@@ -1836,17 +1848,8 @@ class GatewayTurnMixin:
                 status_hint = f" Your plan's usage limit has been reached. It resets in ~{math.ceil(_resets_in / 3600)}h."
             else:
                 status_hint = " Your plan's usage limit has been reached. Please wait until it resets."
-        elif status_code in {400, 500}:
-            # 400/500 on a large session: context overflow / payload too large.
-            if len(prepared.history) > 50:
-                # Overflow is a deterministic request rejection, not an indeterminate-effect
-                # failure (#107567): keep the reply to the /compact / /reset guidance only.
-                return (
-                    "⚠️ Session too large for the model's context window.\nUse /compact to "
-                    "compress the conversation, or /reset to start fresh."
-                )
-            elif status_code == 400:
-                status_hint = " The request was rejected by the API."
+        elif status_code == 400:
+            status_hint = " The request was rejected by the API."
         return self._hmwa_add_failed_turn_notice(
             f"Sorry, I encountered an unexpected error.{status_hint}\n"
             "Try again or use /reset to start a fresh session.",
@@ -2054,11 +2057,8 @@ class GatewayTurnMixin:
             agent_failed_early, hidden_reasoning_incomplete, is_context_overflow_failure = (
                 self._hmwa_classify_turn_failure(agent_result, history, session_entry)
             )
-            failed_turn_notice = None
-            if (agent_failed_early or hidden_reasoning_incomplete) and not is_context_overflow_failure:
-                failed_turn_notice = self._hmwa_failed_turn_notice(agent_result)
-            if agent_failed_early and failed_turn_notice:
-                response = self._hmwa_add_failed_turn_notice(response, failed_turn_notice)
+            if agent_failed_early and not is_context_overflow_failure:
+                response = self._hmwa_add_failed_turn_notice(response, self._hmwa_failed_turn_notice(agent_result))
             response, session_entry = await self._hmwa_compression_exhaustion_reset(
                 agent_result, response, session_entry, session_key, source,
             )
@@ -2067,7 +2067,7 @@ class GatewayTurnMixin:
                 agent_result=agent_result, agent_messages=agent_messages, prepared=prepared,
                 response=response, agent_failed_early=agent_failed_early,
                 hidden_reasoning_incomplete=hidden_reasoning_incomplete,
-                is_context_overflow_failure=is_context_overflow_failure, failed_turn_notice=failed_turn_notice,
+                is_context_overflow_failure=is_context_overflow_failure,
             )
             return await self._hmwa_deliver_turn_response(
                 event, source, session_entry, session_key, run_generation,

--- a/gateway/session_transcript.py
+++ b/gateway/session_transcript.py
@@ -419,6 +419,19 @@ class SessionTranscriptMixin:
             logger.debug("has_platform_message_id lookup failed", exc_info=True)
             return False
 
+    def transcript_tail_role(self, session_id: str) -> Optional[str]:
+        """Role of the newest live conversation row on the route ``load_transcript`` reads (``None``
+        when empty, no DB, or the read fails — the boundary write would fail the same way)."""
+        session_id = self._compression_tip_for_session_id(self._follow_reroutes(session_id))
+        db = self._db_for_session_id(session_id)
+        if not db:
+            return None
+        try:
+            return db.latest_conversation_role(session_id)
+        except Exception:
+            logger.debug("transcript tail lookup failed for %s", session_id, exc_info=True)
+            return None
+
     def rewrite_transcript(
         self, session_id: str, messages: List[Dict[str, Any]], active_only: bool = False,
         reject_active_turn_lease: bool = False) -> bool:

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -458,6 +458,15 @@ class SessionMessagesMixin:
             (session_id, role, int(offset)))
         return row[0] if row else None
 
+    def latest_conversation_role(self, session_id: str) -> Optional[str]:
+        """Role of the newest active user/assistant/tool row, or ``None``. ``session_meta`` /
+        ``system`` rows are transcript bookkeeping stripped before the model sees history, so
+        they must not hide an open user tail from the failed-turn boundary check."""
+        row = self._read_one(
+            "SELECT role FROM messages WHERE session_id = ? AND active = 1 "
+            "AND role NOT IN ('session_meta', 'system') ORDER BY id DESC LIMIT 1", (session_id,))
+        return row[0] if row else None
+
     def get_message_role(self, session_id: str, row_id: int) -> Optional[str]:
         """Role of the active message at *row_id* in *session_id*, or ``None``."""
         if not session_id:

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -152,7 +152,7 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
     )
-    assert "not processed" in response
+    assert runner._FAILED_TURN_NOTICE in response
 
     transcript_rows = [
         call.args[1]
@@ -160,7 +160,7 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
         if len(call.args) >= 2 and call.args[1].get("role") in {"user", "assistant"}
     ]
     assert [row["role"] for row in transcript_rows] == ["user", "assistant"]
-    assert "not processed" in transcript_rows[-1]["content"]
+    assert transcript_rows[-1]["content"] == runner._FAILED_TURN_NOTICE
 
     # The next unrelated input remains its own turn instead of alternation repair
     # merging the failed mutating request into it.

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -137,7 +137,7 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
     runner._run_agent = AsyncMock(
         return_value={
             "failed": True,
-            "final_response": None,
+            "final_response": "API call failed after 3 retries: 429 Too Many Requests",
             "error": "429 Too Many Requests — rate limit exceeded",
             "messages": [],
             "history_offset": 0,
@@ -145,13 +145,30 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
         }
     )
 
-    await runner._handle_message_with_agent(
+    response = await runner._handle_message_with_agent(
         _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
     )
 
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
     )
+    assert "not processed" in response
+
+    transcript_rows = [
+        call.args[1]
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2 and call.args[1].get("role") in {"user", "assistant"}
+    ]
+    assert [row["role"] for row in transcript_rows] == ["user", "assistant"]
+    assert "not processed" in transcript_rows[-1]["content"]
+
+    # The next unrelated input remains its own turn instead of alternation repair
+    # merging the failed mutating request into it.
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    replay = [*transcript_rows, {"role": "user", "content": "unrelated question"}]
+    assert repair_message_sequence(None, replay) == 0
+    assert replay[-1]["content"] == "unrelated question"
 
 
 # ── Test 2: agent_failed_early with no _session_db → skip_db not True ─

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -171,6 +171,51 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
     assert replay[-1]["content"] == "unrelated question"
 
 
+@pytest.mark.asyncio
+async def test_failed_turn_with_tool_activity_does_not_recommend_blind_retry(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._run_agent = AsyncMock(
+        return_value={
+            "failed": True,
+            "final_response": "API call failed after 3 retries: 500 Internal Server Error",
+            "error": "500 Internal Server Error",
+            "messages": [
+                {"role": "user", "content": "reset the password"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "function": {"name": "reset_password", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "Password reset"},
+            ],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    response = await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assistant_rows = [
+        call.args[1]
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2 and call.args[1].get("role") == "assistant"
+    ]
+    assert len(assistant_rows) == 1
+    assert assistant_rows[0]["content"] == runner._PARTIAL_FAILED_TURN_NOTICE
+    assert runner._PARTIAL_FAILED_TURN_NOTICE in response
+    assert "not processed" not in response
+    assert "Send it again" not in response
+
+
 # ── Test 2: agent_failed_early with no _session_db → skip_db not True ─
 
 

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -171,6 +171,32 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
     assert replay[-1]["content"] == "unrelated question"
 
 
+
+@pytest.mark.asyncio
+async def test_deduped_retry_of_failed_turn_adds_no_second_boundary(monkeypatch, tmp_path):
+    """A platform retry of the same failed message (dedupe skips the user row) must not stack a
+    second boundary behind the first — that would be two consecutive assistant rows."""
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner.session_store.has_platform_message_id.return_value = True
+    runner._run_agent = AsyncMock(
+        return_value={
+            "failed": True,
+            "final_response": "API call failed after 3 retries: 429 Too Many Requests",
+            "error": "429 Too Many Requests — rate limit exceeded",
+            "messages": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(_event(), _source(), "agent:main:telegram:group:-1001:12345", 1)
+
+    assert [
+        call.args[1]["role"] for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2 and call.args[1].get("role") in {"user", "assistant"}
+    ] == []
+
+
 @pytest.mark.asyncio
 async def test_failed_turn_with_tool_activity_does_not_recommend_blind_retry(
     monkeypatch, tmp_path

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -69,6 +69,8 @@ def _bootstrap(monkeypatch, tmp_path):
     # Mock has_platform_message_id to return False so the dedupe guard
     # (#47237) in gateway/run.py does not skip the append_to_transcript call.
     runner.session_store.has_platform_message_id.return_value = False
+    # The durable tail after the user row landed (gateway write or agent flush) is that user row.
+    runner.session_store.transcript_tail_role.return_value = "user"
     runner.session_store.update_session = MagicMock()
 
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
@@ -173,11 +175,20 @@ async def test_agent_failed_early_skip_db_when_agent_has_session_db(
 
 
 @pytest.mark.asyncio
-async def test_deduped_retry_of_failed_turn_adds_no_second_boundary(monkeypatch, tmp_path):
-    """A platform retry of the same failed message (dedupe skips the user row) must not stack a
-    second boundary behind the first — that would be two consecutive assistant rows."""
+@pytest.mark.parametrize(
+    "tail_role, expected_roles",
+    [("user", ["assistant"]), ("assistant", [])],
+    ids=["agent-flushed-user-row-still-closed", "redelivery-of-closed-turn-adds-nothing"],
+)
+async def test_boundary_keyed_on_durable_tail_when_user_row_is_deduped(
+    monkeypatch, tmp_path, tail_role, expected_roles
+):
+    """The platform-id dedupe skips the gateway's user write in two production shapes: the agent's
+    own turn-start flush already persisted THIS turn's row (tail = user → boundary must still land),
+    and a platform redelivery of an already-closed turn (tail = boundary → nothing may stack)."""
     runner = _bootstrap(monkeypatch, tmp_path)
     runner.session_store.has_platform_message_id.return_value = True
+    runner.session_store.transcript_tail_role.return_value = tail_role
     runner._run_agent = AsyncMock(
         return_value={
             "failed": True,
@@ -191,10 +202,12 @@ async def test_deduped_retry_of_failed_turn_adds_no_second_boundary(monkeypatch,
 
     await runner._handle_message_with_agent(_event(), _source(), "agent:main:telegram:group:-1001:12345", 1)
 
-    assert [
-        call.args[1]["role"] for call in runner.session_store.append_to_transcript.call_args_list
+    rows = [
+        call.args[1] for call in runner.session_store.append_to_transcript.call_args_list
         if len(call.args) >= 2 and call.args[1].get("role") in {"user", "assistant"}
-    ] == []
+    ]
+    assert [row["role"] for row in rows] == expected_roles
+    assert all(row["content"] == runner._FAILED_TURN_NOTICE for row in rows)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_failure_writer_ownership.py
+++ b/tests/gateway/test_failure_writer_ownership.py
@@ -93,23 +93,69 @@ def test_failure_owner_follows_only_live_lineage_markers(tmp_path):
             store._transcript_reroutes.clear()
             assert store.has_input_owner(sid, owner) is owned, location
             before = db.message_count()
+            open_tail = store.transcript_tail_role(sid) == "user"
             reply = await runner._hmwa_agent_error_reply(
                 RuntimeError("controlled post-compaction failure"),
                 MessageEvent(text="same", source=source, message_id=pid),
                 source, entry, entry.session_key, prepared,
             )
-            # Exception fallback adds the missing user only when unowned, then always
-            # closes the failed turn with a durable assistant safety boundary.
-            assert db.message_count() == before + (not owned) + 1, location
+            # Exception fallback adds the missing user only when unowned, and a boundary iff that
+            # leaves an open user tail on the live route — never anything else.
+            assert db.message_count() == before + (not owned) + ((not owned) or open_tail), location
             assert store.has_input_owner(sid, owner), location
-            live_messages = db.get_messages(child)
-            assert live_messages[-1]["role"] == "assistant"
-            assert live_messages[-1]["content"] == runner._PARTIAL_FAILED_TURN_NOTICE
             assert runner._PARTIAL_FAILED_TURN_NOTICE in reply
+            live_messages = db.get_messages(child)
+            assert not live_messages or live_messages[-1]["role"] != "user", location
+            assert sum(m["role"] == "assistant" for m in live_messages) <= 1, location
             if not owned:
+                assert live_messages[-1]["content"] == runner._PARTIAL_FAILED_TURN_NOTICE
                 persisted_user = live_messages[-2]
                 assert persisted_user["content"] == prepared.persist_user_message
                 assert persisted_user["display_metadata"]["gateway_input_owner"] == owner
+            # A repeated delivery of the same closed turn adds no second boundary.
+            closed = db.message_count()
+            await runner._hmwa_agent_error_reply(
+                RuntimeError("redelivered"), MessageEvent(text="same", source=source, message_id=pid),
+                source, entry, entry.session_key, prepared,
+            )
+            assert db.message_count() == closed, location
+        db.close()
+
+    asyncio.run(check())
+
+
+def test_context_overflow_exception_persists_nothing(tmp_path):
+    """Exception-path overflow (400/500 on a long session) must not write the user row or a
+    boundary — the same no-grow rule as the persist path (#1630)."""
+    import asyncio
+    from gateway.config import GatewayConfig, Platform
+    from gateway.platforms.event import MessageEvent
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource, SessionStore
+
+    async def check():
+        store = SessionStore(tmp_path / "sessions", GatewayConfig())
+        runner = object.__new__(GatewayRunner)
+        runner.session_store = store
+
+        async def stop_typing(event, source):
+            return None
+
+        runner._hmwa_stop_typing_for_turn = stop_typing
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="overflow", user_id="u")
+        entry = store.get_or_create_session(source)
+        db = store._db_for_session_id(entry.session_id)
+        prepared = runner._PreparedTurn(
+            [{"role": "user", "content": "x"}] * 51, "", "x", "x", None, None, entry.session_id, "owner-overflow",
+        )
+        err = RuntimeError("payload too large")
+        err.status_code = 400
+        before = db.message_count()
+        reply = await runner._hmwa_agent_error_reply(
+            err, MessageEvent(text="x", source=source, message_id="m-overflow"), source, entry, entry.session_key, prepared,
+        )
+        assert db.message_count() == before
+        assert reply.startswith("⚠️ Session too large for the model's context window.")
         db.close()
 
     asyncio.run(check())
@@ -142,3 +188,47 @@ def test_context_overflow_error_reply_carries_no_partial_effect_notice():
     assert reply.startswith("⚠️ Session too large for the model's context window.")
     assert reply.endswith("or /reset to start fresh.")
     assert runner._PARTIAL_FAILED_TURN_NOTICE not in reply
+
+
+def test_fresh_session_agent_flushed_failed_turn_is_closed(tmp_path):
+    """First turn of a new session, agent-persisted runtime: the agent's turn-start flush wrote the
+    user row (platform id stamped) before the gateway appends ``session_meta``. The boundary must
+    still land — ``session_meta`` is stripped before the model sees history, so an open user row
+    behind it is exactly the #107070 replay shape."""
+    import asyncio
+    from gateway.config import GatewayConfig, Platform
+    from gateway.platforms.event import MessageEvent
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource, SessionStore
+
+    async def check():
+        store = SessionStore(tmp_path / "sessions", GatewayConfig())
+        runner = object.__new__(GatewayRunner)
+        runner.session_store = store
+        runner._session_db = object()  # agent_persisted defaults True
+
+        async def noop(*args, **kwargs):
+            return None
+
+        runner._refresh_agent_cache_message_count = noop
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="fresh", user_id="u")
+        entry = store.get_or_create_session(source)
+        sid = entry.session_id
+        db = store._db_for_session_id(sid)
+        db.append_message(sid, "user", "reset the password", platform_message_id="m-1")
+        failed = {"failed": True, "final_response": "429", "error": "429", "messages": [],
+                  "history_offset": 0, "last_prompt_tokens": 0}
+        for _ in range(2):  # second pass = platform redelivery of the same failed message
+            await runner._hmwa_persist_turn_transcript(
+                event=MessageEvent(text="reset the password", source=source, message_id="m-1"),
+                source=source, session_entry=entry, session_key=entry.session_key, agent_result=failed,
+                agent_messages=[], prepared=runner._PreparedTurn([], "", "reset the password", None, None, None, sid, "o"),
+                response="x", agent_failed_early=True, hidden_reasoning_incomplete=False,
+                is_context_overflow_failure=False,
+            )
+        roles = [m["role"] for m in db.get_messages(sid) if m["role"] != "session_meta"]
+        assert roles == ["user", "assistant"]
+        assert store.transcript_tail_role(sid) == "assistant"
+        db.close()
+
+    asyncio.run(check())

--- a/tests/gateway/test_failure_writer_ownership.py
+++ b/tests/gateway/test_failure_writer_ownership.py
@@ -104,10 +104,8 @@ def test_failure_owner_follows_only_live_lineage_markers(tmp_path):
             assert store.has_input_owner(sid, owner), location
             live_messages = db.get_messages(child)
             assert live_messages[-1]["role"] == "assistant"
-            assert "Some actions may already have run" in live_messages[-1]["content"]
-            assert "not processed" not in live_messages[-1]["content"]
-            assert "Some actions may already have run" in reply
-            assert "not processed" not in reply
+            assert live_messages[-1]["content"] == runner._PARTIAL_FAILED_TURN_NOTICE
+            assert runner._PARTIAL_FAILED_TURN_NOTICE in reply
             if not owned:
                 persisted_user = live_messages[-2]
                 assert persisted_user["content"] == prepared.persist_user_message

--- a/tests/gateway/test_failure_writer_ownership.py
+++ b/tests/gateway/test_failure_writer_ownership.py
@@ -93,7 +93,7 @@ def test_failure_owner_follows_only_live_lineage_markers(tmp_path):
             store._transcript_reroutes.clear()
             assert store.has_input_owner(sid, owner) is owned, location
             before = db.message_count()
-            await runner._hmwa_agent_error_reply(
+            reply = await runner._hmwa_agent_error_reply(
                 RuntimeError("controlled post-compaction failure"),
                 MessageEvent(text="same", source=source, message_id=pid),
                 source, entry, entry.session_key, prepared,
@@ -104,7 +104,10 @@ def test_failure_owner_follows_only_live_lineage_markers(tmp_path):
             assert store.has_input_owner(sid, owner), location
             live_messages = db.get_messages(child)
             assert live_messages[-1]["role"] == "assistant"
-            assert "not processed" in live_messages[-1]["content"]
+            assert "Some actions may already have run" in live_messages[-1]["content"]
+            assert "not processed" not in live_messages[-1]["content"]
+            assert "Some actions may already have run" in reply
+            assert "not processed" not in reply
             if not owned:
                 persisted_user = live_messages[-2]
                 assert persisted_user["content"] == prepared.persist_user_message

--- a/tests/gateway/test_failure_writer_ownership.py
+++ b/tests/gateway/test_failure_writer_ownership.py
@@ -115,3 +115,32 @@ def test_failure_owner_follows_only_live_lineage_markers(tmp_path):
         db.close()
 
     asyncio.run(check())
+
+
+def test_context_overflow_error_reply_carries_no_partial_effect_notice():
+    """Overflow is a deterministic rejection (#107567); the reply must stay the /compact
+    guidance alone rather than inherit the indeterminate "actions may have run" warning."""
+    import asyncio
+    from gateway.config import Platform
+    from gateway.platforms.event import MessageEvent
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    runner = object.__new__(GatewayRunner)
+
+    async def stop_typing(event, source):
+        return None
+
+    runner._hmwa_stop_typing_for_turn = stop_typing
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="c", user_id="u")
+    prepared = runner._PreparedTurn([{"role": "user", "content": "x"}] * 51, "", None, None, None, None)
+    err = RuntimeError("payload too large")
+    err.status_code = 400
+
+    reply = asyncio.run(runner._hmwa_agent_error_reply(
+        err, MessageEvent(text="x", source=source), source, None, "k", prepared,
+    ))
+
+    assert reply.startswith("⚠️ Session too large for the model's context window.")
+    assert reply.endswith("or /reset to start fresh.")
+    assert runner._PARTIAL_FAILED_TURN_NOTICE not in reply

--- a/tests/gateway/test_failure_writer_ownership.py
+++ b/tests/gateway/test_failure_writer_ownership.py
@@ -98,12 +98,17 @@ def test_failure_owner_follows_only_live_lineage_markers(tmp_path):
                 MessageEvent(text="same", source=source, message_id=pid),
                 source, entry, entry.session_key, prepared,
             )
-            assert db.message_count() == before + (not owned), location
+            # Exception fallback adds the missing user only when unowned, then always
+            # closes the failed turn with a durable assistant safety boundary.
+            assert db.message_count() == before + (not owned) + 1, location
             assert store.has_input_owner(sid, owner), location
+            live_messages = db.get_messages(child)
+            assert live_messages[-1]["role"] == "assistant"
+            assert "not processed" in live_messages[-1]["content"]
             if not owned:
-                latest = db.get_messages(child)[-1]
-                assert latest["content"] == prepared.persist_user_message
-                assert latest["display_metadata"]["gateway_input_owner"] == owner
+                persisted_user = live_messages[-2]
+                assert persisted_user["content"] == prepared.persist_user_message
+                assert persisted_user["display_metadata"]["gateway_input_owner"] == owner
         db.close()
 
     asyncio.run(check())

--- a/tests/gateway/test_incomplete_gateway_turns.py
+++ b/tests/gateway/test_incomplete_gateway_turns.py
@@ -123,7 +123,7 @@ def _make_event() -> MessageEvent:
 
 
 @pytest.mark.asyncio
-async def test_incomplete_codex_turn_stays_out_of_slack_transcript(monkeypatch, tmp_path):
+async def test_incomplete_codex_turn_closes_transcript_without_slack_delivery(monkeypatch, tmp_path):
     adapter = CaptureSlackAdapter()
     runner = _make_runner(adapter)
 
@@ -148,8 +148,11 @@ async def test_incomplete_codex_turn_stays_out_of_slack_transcript(monkeypatch, 
         call.args[1]["role"]
         for call in runner.session_store.append_to_transcript.call_args_list
     ]
-    assert transcript_roles == ["session_meta", "user"]
+    assert transcript_roles == ["session_meta", "user", "assistant"]
     assert runner.session_store.append_to_transcript.call_args_list[1].args[1]["content"] == "hello"
+    boundary = runner.session_store.append_to_transcript.call_args_list[2].args[1]["content"]
+    assert "not processed" in boundary
+    assert "remained incomplete" not in boundary
     assert adapter.processing_hooks == [
         ("start", "m-1"),
         ("complete", "m-1", ProcessingOutcome.SUCCESS),

--- a/tests/gateway/test_incomplete_gateway_turns.py
+++ b/tests/gateway/test_incomplete_gateway_turns.py
@@ -98,6 +98,7 @@ def _make_runner(adapter: CaptureSlackAdapter) -> gateway_run.GatewayRunner:
     # (#47237). A bare MagicMock returns a truthy mock, which would wrongly
     # mark the user turn as a duplicate and skip persisting it.
     runner.session_store.has_platform_message_id = MagicMock(return_value=False)
+    runner.session_store.transcript_tail_role = MagicMock(return_value="user")
     runner._running_agents = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}

--- a/tests/gateway/test_incomplete_gateway_turns.py
+++ b/tests/gateway/test_incomplete_gateway_turns.py
@@ -151,8 +151,7 @@ async def test_incomplete_codex_turn_closes_transcript_without_slack_delivery(mo
     assert transcript_roles == ["session_meta", "user", "assistant"]
     assert runner.session_store.append_to_transcript.call_args_list[1].args[1]["content"] == "hello"
     boundary = runner.session_store.append_to_transcript.call_args_list[2].args[1]["content"]
-    assert "not processed" in boundary
-    assert "remained incomplete" not in boundary
+    assert boundary == runner._FAILED_TURN_NOTICE
     assert adapter.processing_hooks == [
         ("start", "m-1"),
         ("complete", "m-1", ProcessingOutcome.SUCCESS),


### PR DESCRIPTION
A transient failure (or hidden-reasoning-incomplete turn) now closes the transcript with a gateway-owned assistant boundary row, so alternation repair can never merge the stale request into the user's next instruction and replay it.

- `gateway/run_turn.py::_hmwa_persist_turn_transcript` appends the boundary directly after the persisted user row; `_hmwa_failed_turn_notice` picks "not processed — send it again" (no tool evidence in the turn) vs "some actions may already have run — verify before retrying" (tool calls / tool rows present). The exception fallback path gets the partial-effect notice.
- Follow-ups: the context-overflow ("Session too large") reply keeps its exact text with no notice (#107567 tightened that verdict); an unrelated wording change is reverted; the tool-evidence slice goes through `media_repair._current_turn_messages` so mid-turn compression cannot hide tool evidence; one shared boundary-row builder; a deduped platform retry (Telegram redelivery) adds no second boundary, so two assistant rows never stack.
- Boundary keyed on the durable conversation tail (`SessionDB.latest_conversation_role` → `SessionStore.transcript_tail_role`, same route `load_transcript` reads, `session_meta` excluded), not on whether the gateway wrote the user row: the agent's turn-start flush already persists that row with the platform id, so the dedupe previously skipped the boundary on the primary path; a redelivery of a closed turn stacks nothing; the exception fallback classifies overflow before any write.
- Tests: no-tool → "not processed"; tool evidence → partial; `repair_message_sequence` leaves the next request untouched; overflow reply unchanged; deduped retry; real-store: agent-flushed row closed (incl. fresh session), exception redelivery idempotent per lineage location, exception overflow persists nothing.

Validation: 10 gateway test files, 77 passed; 81 transcript/session/failure files, 562 passed; each new guard red with its production change reverted; `evals/gateway_failure_ownership/probe.py` (real `AIAgent` + fixture provider) 20/20.

Credit: two commits cherry-picked from #107088 by @fangliquanflq (first submitter; authorship preserved), conflict with #107567 resolved to main. #107108 (@KoNit-K) proposed a later TTL variant of the same fix.

Closes #107070. Closes #107088.

