### PR TITLE
fix(copilot): refresh enterprise tokens after 403

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3470,11 +3470,15 @@ def _creds_have_api_key(creds: Dict[str, Any]) -> bool:
 
 
 def _refresh_copilot_credentials() -> bool:
-    from hermes_cli.copilot_auth import _jwt_cache, _token_fingerprint, exchange_copilot_token, resolve_copilot_token
+    from hermes_cli.copilot_auth import (
+        evict_cached_exchanged_token,
+        exchange_copilot_token,
+        resolve_copilot_token,
+    )
     raw_token, _source = resolve_copilot_token()
     if not str(raw_token or "").strip():
         return False
-    _jwt_cache.pop(_token_fingerprint(raw_token), None)
+    evict_cached_exchanged_token(raw_token)
     exchange_copilot_token(raw_token)
     return True
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3115,10 +3115,14 @@ def _transient_retry_count() -> int:
         return _DEFAULT_TRANSIENT_RETRIES
 
 
-def _is_auth_error(exc: Exception) -> bool:
-    """Auth failures that should trigger provider-specific refresh."""
+def _is_auth_error(exc: Exception, provider: Optional[str] = None) -> bool:
+    """Auth failures that should trigger provider-specific refresh.
+
+    Copilot Enterprise reports an expired exchanged token as a generic 403,
+    while the public Copilot endpoint reports the same condition as 401.
+    """
     status = getattr(exc, "status_code", None)
-    if status == 401:
+    if status == 401 or (status == 403 and _normalize_aux_provider(provider) == "copilot"):
         return True
     err_lower = str(exc).lower()
     if "error code: 401" in err_lower or "authenticationerror" in type(exc).__name__.lower():
@@ -3297,7 +3301,7 @@ _POOL_PROVIDER_BY_HOST = (
     ("githubcopilot.com", "copilot"), ("api.kimi.com", "kimi-coding"), ("api.x.ai", "xai-oauth"),
 )
 _AUTH_REFRESH_PROVIDER_BY_HOST = (
-    ("api.githubcopilot.com", "copilot"), ("chatgpt.com", "openai-codex"),
+    ("githubcopilot.com", "copilot"), ("chatgpt.com", "openai-codex"),
     ("api.anthropic.com", "anthropic"), ("inference-api.nousresearch.com", "nous"),
 )
 
@@ -6952,7 +6956,7 @@ def _ladder_credential_rungs(
     Returns ``(response, None)`` or ``(None, first_err)`` to fall through."""
     client, task, tag, resolved_provider = route.client, route.task, route.tag, route.resolved_provider
     auth_refresh_provider = _auth_refresh_provider_for_route(resolved_provider, route.base_info)
-    if (_is_auth_error(first_err) and auth_refresh_provider not in {"auto", "", None}
+    if (_is_auth_error(first_err, auth_refresh_provider) and auth_refresh_provider not in {"auto", "", None}
             and not client_is_nous):
         refresh_kwargs = ({"failed_api_key": getattr(client, "api_key", "")}
                           if auth_refresh_provider == "anthropic" else {})

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -312,12 +312,15 @@ def _print_anthropic_401_diagnostics(agent: Any, key: Any) -> None:
 def _refresh_credentials_after_401(
     agent: Any, api_error: Exception, _retry: TurnRetryState, status_code: Optional[int]
 ) -> bool:
-    """Per-provider one-shot credential refresh on 401 (codex/xai, vertex, nous, copilot,
-    anthropic), printing user-facing diagnostics when the nous/anthropic refresh fails.
-    Returns True when a refresh succeeded and the call should be retried."""
+    """Per-provider one-shot credential refresh on 401, plus Copilot Enterprise's 403.
+
+    Prints user-facing diagnostics when the Nous/Anthropic refresh fails and returns
+    True when a refresh succeeded and the call should be retried.
+    """
     from agent.conversation_loop import _is_copilot_provider
 
-    if status_code != 401:
+    copilot_auth_failure = status_code == 403 and _is_copilot_provider(agent)
+    if status_code != 401 and not copilot_auth_failure:
         return False
     if (
         agent.api_mode == "codex_responses"
@@ -347,7 +350,7 @@ def _refresh_credentials_after_401(
     if _is_copilot_provider(agent) and not _retry.copilot_auth_retry_attempted:
         _retry.copilot_auth_retry_attempted = True
         if agent._try_refresh_copilot_client_credentials():
-            agent._buffer_vprint("🔐 Copilot credentials refreshed after 401. Retrying request...")
+            agent._buffer_vprint("🔐 Copilot credentials refreshed after auth failure. Retrying request...")
             return True
     if (
         agent.api_mode == "anthropic_messages"

--- a/tests/agent/test_turn_recovery_copilot.py
+++ b/tests/agent/test_turn_recovery_copilot.py
@@ -1,0 +1,102 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+from agent.auxiliary_client import call_llm
+from agent.turn_recovery import _refresh_credentials_after_401
+from agent.turn_retry_state import TurnRetryState
+
+
+def test_copilot_enterprise_403_refreshes_credentials_and_retries():
+    agent = SimpleNamespace(
+        provider="copilot",
+        api_mode="codex_responses",
+        base_url="https://api.enterprise.githubcopilot.com",
+        _try_refresh_copilot_client_credentials=Mock(return_value=True),
+        _buffer_vprint=Mock(),
+    )
+    retry = TurnRetryState()
+
+    recovered = _refresh_credentials_after_401(
+        agent,
+        RuntimeError("HTTP 403: forbidden"),
+        retry,
+        status_code=403,
+    )
+
+    assert recovered is True
+    assert retry.copilot_auth_retry_attempted is True
+    agent._try_refresh_copilot_client_credentials.assert_called_once_with()
+    agent._buffer_vprint.assert_called_once_with(
+        "🔐 Copilot credentials refreshed after auth failure. Retrying request..."
+    )
+
+    assert _refresh_credentials_after_401(
+        agent,
+        RuntimeError("HTTP 403: forbidden"),
+        retry,
+        status_code=403,
+    ) is False
+    agent._try_refresh_copilot_client_credentials.assert_called_once_with()
+
+
+class _AuxAuth403(Exception):
+    status_code = 403
+
+
+class _DummyResponse:
+    def __init__(self, content):
+        self.choices = [SimpleNamespace(message=SimpleNamespace(content=content))]
+        self.usage = None
+
+
+def test_auto_routed_enterprise_copilot_403_refreshes_and_retries():
+    stale_client = MagicMock()
+    stale_client.base_url = "https://api.enterprise.githubcopilot.com"
+    stale_client.chat.completions.create.side_effect = _AuxAuth403("HTTP 403: forbidden")
+
+    fresh_client = MagicMock()
+    fresh_client.base_url = "https://api.enterprise.githubcopilot.com"
+    fresh_client.chat.completions.create.return_value = _DummyResponse("fresh-auto-copilot")
+
+    with (
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ),
+        patch(
+            "agent.auxiliary_client._get_cached_client",
+            side_effect=[(stale_client, "gpt-5.6-sol"), (fresh_client, "gpt-5.6-sol")],
+        ) as get_client,
+        patch("agent.auxiliary_client._refresh_provider_credentials", return_value=True) as refresh,
+        patch("agent.auxiliary_client._evict_cached_clients") as evict,
+    ):
+        response = call_llm(
+            task="title_generation",
+            messages=[{"role": "user", "content": "hi"}],
+            main_runtime={"provider": "copilot", "model": "gpt-5.6-sol"},
+        )
+
+    assert response.choices[0].message.content == "fresh-auto-copilot"
+    refresh.assert_called_once_with("copilot")
+    evict.assert_called_once_with("auto")
+    assert get_client.call_args_list[0].args[0] == "auto"
+    assert get_client.call_args_list[1].args[0] == "copilot"
+    assert stale_client.chat.completions.create.call_count == 1
+    assert fresh_client.chat.completions.create.call_count == 1
+
+
+def test_non_copilot_403_is_not_treated_as_refreshable_auth_failure():
+    agent = SimpleNamespace(
+        provider="openrouter",
+        api_mode="chat_completions",
+        base_url="https://openrouter.ai/api/v1",
+    )
+
+    recovered = _refresh_credentials_after_401(
+        agent,
+        RuntimeError("HTTP 403: forbidden"),
+        TurnRetryState(),
+        status_code=403,
+    )
+
+    assert recovered is False

--- a/tests/agent/test_turn_recovery_copilot.py
+++ b/tests/agent/test_turn_recovery_copilot.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import _refresh_copilot_credentials, call_llm
 from agent.turn_recovery import _refresh_credentials_after_401
 from agent.turn_retry_state import TurnRetryState
 
@@ -83,6 +83,47 @@ def test_auto_routed_enterprise_copilot_403_refreshes_and_retries():
     assert get_client.call_args_list[1].args[0] == "copilot"
     assert stale_client.chat.completions.create.call_count == 1
     assert fresh_client.chat.completions.create.call_count == 1
+
+
+def test_auxiliary_copilot_refresh_evicts_rejected_persisted_token(tmp_path, monkeypatch):
+    import json
+    import time
+    import urllib.request
+
+    import hermes_cli.copilot_auth as copilot_auth
+
+    raw_token = "gho_raw"
+    fingerprint = copilot_auth._token_fingerprint(raw_token)
+    disk_path = tmp_path / copilot_auth._JWT_DISK_FILENAME
+    monkeypatch.setattr(copilot_auth, "_jwt_disk_path", lambda: disk_path)
+    monkeypatch.setattr(copilot_auth, "_jwt_cache", {})
+    monkeypatch.setattr(copilot_auth, "_exchange_failure_cache", {})
+    monkeypatch.setattr(
+        copilot_auth,
+        "resolve_copilot_token",
+        lambda: (raw_token, "test"),
+    )
+    copilot_auth._save_jwt_to_disk(
+        fingerprint,
+        "rejected-but-time-fresh",
+        time.time() + 1800,
+        "https://api.enterprise.githubcopilot.com",
+    )
+
+    fresh_token = "tid=fresh;exp=999;sku=copilot_enterprise"
+    response = MagicMock()
+    response.read.return_value = json.dumps(
+        {"token": fresh_token, "expires_at": time.time() + 1800}
+    ).encode()
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    urlopen = MagicMock(return_value=response)
+    monkeypatch.setattr(urllib.request, "urlopen", urlopen)
+
+    assert _refresh_copilot_credentials() is True
+    urlopen.assert_called_once()
+    assert copilot_auth._jwt_cache[fingerprint][0] == fresh_token
+    assert json.loads(disk_path.read_text())[fingerprint]["api_token"] == fresh_token
 
 
 def test_non_copilot_403_is_not_treated_as_refreshable_auth_failure():


### PR DESCRIPTION
1|## Summary
2|
3|- refresh Copilot credentials once when an account-specific endpoint returns HTTP 403
4|- recognize validated `*.githubcopilot.com` hosts during auxiliary auto-route recovery
5|- preserve existing behavior for non-Copilot 403 responses
6|- add main-agent and auxiliary regression coverage
7|
8|## Problem
9|
10|Copilot Enterprise can report an expired exchanged API token as `HTTP 403: forbidden`. Hermes only entered its Copilot refresh path for HTTP 401, so a long-lived gateway marked the underlying credential exhausted and stopped responding until its exchanged-token cache was cleared and the gateway restarted.
11|
12|Auxiliary auto-routing had the same gap: the route resolver recognized only `api.githubcopilot.com`, and generic 403 responses were not considered refreshable authentication errors.
13|
14|## Approach
15|
16|- Allow status 403 through the main-agent refresh gate only when the active provider is Copilot.
17|- Make auxiliary authentication classification provider-aware, treating a generic 403 as refreshable only for a concrete Copilot route.
18|- Match Copilot account endpoints through the existing validated `githubcopilot.com` host suffix.
19|- Keep the existing one-shot retry guard and use provider-neutral recovery messaging.
20|
21|## Verification
22|
23|- Both regression tests were proven red before their implementations, including the persisted rejected-token path reported in review.
24|- `scripts/run_tests.sh tests/agent/test_turn_recovery_copilot.py -q` — 4 passed.
25|- Four-file related sweep on current `main` — 286 passed; the pre-existing wall-clock assertion in `TestCodexAuxiliaryAdapterTimeout` fails identically on current `main` on this host.
26|- `scripts/run_tests.sh tests/agent/test_auxiliary_client.py -k 'not enforces_total_timeout_while_stream_keeps_emitting_events' -q` — 203 passed with that unrelated baseline failure excluded.
27|- `git diff --check` — clean.
28|- Independent code review found no security concerns or logic errors.
29|
30|## Scope
31|
32|This does not change generic 403 handling for other providers and does not alter credential-pool policy. It complements #81131, which covers auxiliary 401 refresh and the host-suffix gap but not Copilot Enterprise's generic 403 response or the main-agent recovery path.
33|
34|Fixes #108022
35|