### PR TITLE
fix(agent): fail the compression candidate when its summary is empty

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3225,7 +3225,11 @@ def _is_invalid_aux_response_error(exc: Exception) -> bool:
     if not isinstance(exc, RuntimeError):
         return False
     msg = str(exc).lower()
-    return "auxiliary " in msg and "llm returned invalid response" in msg and "choices[0].message" in msg
+    return (
+        "auxiliary " in msg
+        and "llm returned invalid response" in msg
+        and ("choices[0].message" in msg or "empty content" in msg)
+    )
 
 
 # Tasks on a user-visible critical path (compression blocks resuming an oversized session; vision
@@ -6185,6 +6189,25 @@ def _validate_llm_response(
         model = _field(response, "model")
         if isinstance(model, str) and model.strip():
             context["response_model"] = model
+    # Compression cannot use a response with no text as a summary. Rejecting it here fails the
+    # candidate rather than the route, so the configured fallback chain is tried to exhaustion
+    # before the compressor gives up on the auxiliary route and retries the main chat model — its
+    # existing behaviour when a candidate fails. The emptiness test is the compressor's own helper,
+    # so a summary recovered from reasoning/reasoning_content still counts as text (#11978).
+    if task == "compression":
+        try:
+            message = _field(_field(response, "choices")[0], "message")
+        except (TypeError, IndexError, KeyError):
+            message = None
+        if (
+            message is not None
+            and not extract_content_or_reasoning(response, max_reasoning_chars=8000).strip()
+            and not _field(message, "tool_calls")
+        ):
+            raise RuntimeError(
+                "Auxiliary compression: LLM returned invalid response (empty content). Expected a "
+                "non-empty summary — check provider adapter or custom endpoint compatibility."
+            )
     _complete_relay_auxiliary_call()
     return response
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3991,6 +3991,7 @@ def _context_too_small(
 def _try_configured_fallback_chain(
     task: str, failed_provider: str, reason: str = "error", failed_model: Optional[str] = None, *,
     failed_base_url: str = "", failure_scope: Any = None,
+    excluded_labels: Optional[set[str]] = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Try auxiliary.<task>.fallback_chain entries in order (each needs ``provider``; model/base_url/api_key optional).
     ``failed_model`` scoping per ``_failed_backend_skip`` (sibling models on the same provider still
@@ -4020,6 +4021,8 @@ def _try_configured_fallback_chain(
             continue
         fb_model = fb_model_raw or None
         label = f"fallback_chain[{i}]({fb_provider})"
+        if excluded_labels and label in excluded_labels:
+            continue
         try:
             fb_client, resolved_model = _resolve_fallback_entry(entry)
         except Exception:
@@ -7023,7 +7026,13 @@ def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
     chain, explicit: main-agent-model net). Returns the response or None.
     Capacity errors (payment/quota, connection, exhausted 429, model incompatible, malformed
     response) bypass the explicit-provider gate — the provider cannot serve this request
-    regardless of user intent. Auth errors only fall back in auto mode."""
+    regardless of user intent. Auth errors only fall back in auto mode.
+
+    A configured candidate that fails with a fallback-able error (auth, payment, connection,
+    rate limit, model incompatible/unknown, invalid response) does NOT abort the remaining
+    chain: its label is excluded and the next entry is tried before any main-agent/discovery
+    layer runs, so the same route is never selected twice.
+    """
     task, tag, resolved_provider = route.task, route.tag, route.resolved_provider
     # Respect explicit provider choice for transient errors (auth, request validation, etc.) but allow
     # fallback when the provider clearly cannot serve the request due to capacity: payment/quota exhaustion
@@ -7055,10 +7064,44 @@ def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
         if reason == "payment error" and _custom_health_base_url(resolved_provider, route.base_info)
         else None
     )
-    fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-        task, resolved_provider or "auto", reason=reason, failed_model=_chain_failed_model,
-        failed_base_url=route.base_info, failure_scope=_chain_failure_scope)
-    if fb_client is None and is_auto:
+    # Walk every configured candidate in order: a capacity/model failure on one candidate must
+    # not abort the rest of the configured chain.
+    excluded_labels: set[str] = set()
+    while True:
+        fb_client, fb_model, fb_label = _try_configured_fallback_chain(
+            task, resolved_provider or "auto", reason=reason,
+            failed_model=_chain_failed_model, failed_base_url=route.base_info,
+            failure_scope=_chain_failure_scope, excluded_labels=excluded_labels)
+        if fb_client is None:
+            break
+        _record_route_info(route.route_info, _fallback_provider_from_label(fb_label), fb_model)
+        try:
+            fb_resp = yield _LadderStep("fallback", (fb_client, fb_model, fb_label))
+        except Exception as candidate_err:
+            candidate_can_fallback = (
+                _is_auth_error(candidate_err)
+                or _is_payment_error(candidate_err)
+                or _is_connection_error(candidate_err)
+                or _is_rate_limit_error(candidate_err)
+                or _is_model_incompatible_error(candidate_err)
+                or _is_model_not_found_error(candidate_err)
+                or _is_invalid_aux_response_error(candidate_err)
+            )
+            if not candidate_can_fallback:
+                raise
+            logger.warning(
+                "Auxiliary %s%s: configured fallback %s failed (%s); continuing configured chain",
+                task or "call", tag, fb_label, candidate_err,
+            )
+            excluded_labels.add(fb_label)
+            continue
+        if fb_resp is not None:
+            return fb_resp
+        # Stale/unrefreshable auth returned None after quarantine — try the next entry.
+        excluded_labels.add(fb_label)
+
+    # Configured entries are exhausted — continue with the main-agent/discovery safety layers.
+    if is_auto:
         fb_client, fb_model, fb_label = _try_main_fallback_chain(
             task, resolved_provider or "auto", reason=reason, failed_model=_chain_failed_model,
             failed_base_url=route.base_info, failure_scope=_chain_failure_scope)
@@ -7085,12 +7128,11 @@ def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
                 if fb_client is None:
                     break
     # All fallback layers exhausted — one user-visible warning, then re-raise.
-    logger.warning("Auxiliary %s%s: %s on %s and all fallbacks exhausted "
-                   # All fallback layers exhausted — emit a single user-visible warning so the operator
-                   # knows aux task is about to fail. (#26882) The error itself is re-raised below.
-                   # (#26882)
-                   "(fallback_chain + main agent model). Raising original error.",
-                   task or "call", tag, reason, resolved_provider)
+    logger.warning(
+        "Auxiliary %s%s: %s on %s and all fallbacks exhausted "
+        "(fallback_chain + main agent model). Raising original error.",
+        task or "call", tag, reason, resolved_provider,
+    )
     return None
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1496,6 +1496,10 @@ def _run_conversation_turn(
     agent._ephemeral_reasoning_off = False
     agent._auth_pool_refresh_counts = {}
     agent._last_turn_usage = None
+    # Adaptive escalation is temporary and per-turn. Restore the semantic router's original
+    # model parameter, then clear streaks and any scheduled switch. Resolved settings stay cached.
+    from agent.model_switching import reset_model_switching_turn
+    reset_model_switching_turn(agent)
 
     s = _LoopState(
         system_message=system_message, moa_config=moa_config,

--- a/agent/model_switching.py
+++ b/agent/model_switching.py
@@ -1,0 +1,280 @@
+"""Adaptive model switching between tool iterations (opt-in).
+
+The initial model (``model.default: auto``) is chosen by the semantic router. During a long
+tool task the loop can escalate to a harder configured model when a generation keeps failing
+(repeated tool failures — terminal/test exit codes, JSON ``error``/``success: false`` results),
+and descend back to the cheaper model only at a safe boundary (a run of clean rounds with no
+pending failure). The ladder is declared under ``agent.model_switching`` in config.yaml and is
+OFF until ``escalate_to`` is set.
+
+Switches are scheduled only between generations: the decision is made after a tool round has
+fully completed (``observe_tool_round``), and applied at the start of the NEXT iteration with
+nothing in flight (``apply_pending_model_switch``), mirroring ``agent/nous_wire.py``. A
+generation is therefore never switched mid-stream, and the transcript is never mutated.
+
+The adaptive path is intentionally limited to Hermes's configured custom Manifest endpoint. It
+changes only ``agent.model``, which becomes the next request's model parameter. It must not call
+``switch_model``: that full runtime operation invalidates the cached system prompt and persists
+the destination in ``_primary_runtime``. Other provider modes are rejected safely.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, replace
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ESCALATE_AFTER_FAILURES = 3
+DEFAULT_DESCEND_AFTER_SUCCESSES = 2
+DEFAULT_MAX_SWITCHES = 3
+
+_CONFIG_KEY = "agent.model_switching"
+
+
+@dataclass(frozen=True)
+class ModelSwitchingSettings:
+    """The opt-in ladder. ``enabled`` is False until ``escalate_to`` is set."""
+
+    escalate_to: Optional[str] = None
+    descend_to: Optional[str] = None
+    escalate_after_failures: int = DEFAULT_ESCALATE_AFTER_FAILURES
+    descend_after_successes: int = DEFAULT_DESCEND_AFTER_SUCCESSES
+    max_switches: int = DEFAULT_MAX_SWITCHES
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.escalate_to)
+
+
+@dataclass
+class SwitchState:
+    """Per-turn escalation state; reset at the start of every user turn."""
+
+    consecutive_failures: int = 0
+    consecutive_successes: int = 0
+    escalated: bool = False
+    switches: int = 0
+
+
+def _warn_invalid(key: str, raw: Any, default: Any) -> None:
+    logger.warning(
+        "Invalid %s in config.yaml: %r — falling back to default %r.", key, raw, default
+    )
+
+
+def _clean_model_id(raw: Any, key: str) -> Optional[str]:
+    """A model id must be a non-empty string; anything else disables that rung."""
+    if raw is None:
+        return None
+    if not isinstance(raw, str) or not raw.strip():
+        _warn_invalid(key, raw, None)
+        return None
+    return raw.strip()
+
+
+def _resolve_positive_int(raw: Any, *, default: int, key: str) -> int:
+    try:
+        value = int(float(raw))
+    except (TypeError, ValueError):
+        value = -1
+    if value <= 0:
+        _warn_invalid(key, raw, default)
+        return default
+    return value
+
+
+def resolve_model_switching_settings(
+    config: Optional[Dict[str, Any]] = None,
+) -> ModelSwitchingSettings:
+    """Resolve the ``agent.model_switching`` ladder. Invalid values warn and fall back;
+    never raises."""
+    agent_cfg = config.get("agent") if isinstance(config, dict) else None
+    raw_section = agent_cfg.get("model_switching") if isinstance(agent_cfg, dict) else None
+    section: Dict[str, Any] = raw_section if isinstance(raw_section, dict) else {}
+    if raw_section is not None and not isinstance(raw_section, dict):
+        _warn_invalid(_CONFIG_KEY, raw_section, None)
+
+    escalate_to = _clean_model_id(section.get("escalate_to"), f"{_CONFIG_KEY}.escalate_to")
+    descend_to = _clean_model_id(section.get("descend_to"), f"{_CONFIG_KEY}.descend_to")
+    return ModelSwitchingSettings(
+        escalate_to=escalate_to,
+        descend_to=descend_to,
+        escalate_after_failures=_resolve_positive_int(
+            section.get("escalate_after_failures", DEFAULT_ESCALATE_AFTER_FAILURES),
+            default=DEFAULT_ESCALATE_AFTER_FAILURES, key=f"{_CONFIG_KEY}.escalate_after_failures",
+        ),
+        descend_after_successes=_resolve_positive_int(
+            section.get("descend_after_successes", DEFAULT_DESCEND_AFTER_SUCCESSES),
+            default=DEFAULT_DESCEND_AFTER_SUCCESSES, key=f"{_CONFIG_KEY}.descend_after_successes",
+        ),
+        max_switches=_resolve_positive_int(
+            section.get("max_switches", DEFAULT_MAX_SWITCHES),
+            default=DEFAULT_MAX_SWITCHES, key=f"{_CONFIG_KEY}.max_switches",
+        ),
+    )
+
+
+def decide_next_model(
+    settings: ModelSwitchingSettings,
+    state: SwitchState,
+    *,
+    current_model: Optional[str],
+    round_failed: bool,
+) -> Tuple[Optional[str], SwitchState]:
+    """Pure escalation/descent core.
+
+    Returns ``(target_model, new_state)`` where ``target_model`` is the model id to switch
+    to, or ``None`` to hold. The caller must apply the switch only at a generation boundary.
+    """
+    if not settings.enabled:
+        return None, state
+
+    new = replace(state)
+    current = (current_model or "").strip()
+
+    if round_failed:
+        new.consecutive_failures += 1
+        new.consecutive_successes = 0
+    else:
+        new.consecutive_failures = 0
+        new.consecutive_successes += 1
+
+    target: Optional[str] = None
+    if (
+        new.consecutive_failures >= settings.escalate_after_failures
+        and not new.escalated
+        and settings.escalate_to
+        and settings.escalate_to != current
+        and new.switches < settings.max_switches
+    ):
+        target = settings.escalate_to
+        new.escalated = True
+        new.switches += 1
+        new.consecutive_failures = 0
+        new.consecutive_successes = 0
+    elif (
+        new.escalated
+        and settings.descend_to
+        and new.consecutive_successes >= settings.descend_after_successes
+        and settings.descend_to != current
+        and new.switches < settings.max_switches
+    ):
+        target = settings.descend_to
+        new.escalated = False
+        new.switches += 1
+        new.consecutive_successes = 0
+        new.consecutive_failures = 0
+
+    return target, new
+
+
+def _settings_for(agent: Any) -> ModelSwitchingSettings:
+    """Resolve the ladder once per agent and cache it (``None`` sentinel → resolved)."""
+    settings = getattr(agent, "_model_switching_settings", None)
+    if settings is not None:
+        return settings
+    try:
+        from hermes_cli.config import load_config_readonly
+        config = load_config_readonly() or {}
+    except Exception:
+        config = {}
+    settings = resolve_model_switching_settings(config)
+    try:
+        agent._model_switching_settings = settings
+    except Exception:
+        pass
+    return settings
+
+
+def reset_model_switching_turn(agent: Any) -> None:
+    """Restore the semantic router for a new user turn and clear per-turn streaks.
+
+    Escalation is deliberately temporary. Without this restoration, an escalated explicit model
+    would bypass the semantic router on every later user request when ``descend_to`` is omitted.
+    """
+    original = getattr(agent, "_adaptive_model_switch_original_model", None)
+    if original is None:
+        original = getattr(agent, "model", None)
+        agent._adaptive_model_switch_original_model = original
+    else:
+        agent.model = original
+    agent._model_switch_state = None
+    agent._adaptive_model_switch_pending = None
+
+
+def _newest_tool_round(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """The contiguous ``role: "tool"`` tail — exactly the just-executed round's results."""
+    results: List[Dict[str, Any]] = []
+    for msg in reversed(messages or []):
+        if isinstance(msg, dict) and msg.get("role") == "tool":
+            results.append(msg)
+        else:
+            break
+    return results
+
+
+def _round_failed(round_results: List[Dict[str, Any]]) -> bool:
+    """A round failed if ANY of its tool results carries a canonical failure signal."""
+    from agent.display import _detect_tool_failure
+
+    for msg in round_results:
+        name = str(msg.get("name") or msg.get("tool_name") or "")
+        content = msg.get("content")
+        if isinstance(content, list):  # multimodal blocks — treat as non-failure
+            continue
+        is_failure, _ = _detect_tool_failure(name, content)
+        if is_failure:
+            return True
+    return False
+
+
+def observe_tool_round(agent: Any, messages: List[Dict[str, Any]]) -> None:
+    """After a tool round completes, classify its results and schedule a switch if the
+    escalation/descent ladder demands one. Only *schedules* — nothing is applied here."""
+    settings = _settings_for(agent)
+    if not settings.enabled:
+        return
+
+    state = getattr(agent, "_model_switch_state", None)
+    if not isinstance(state, SwitchState):
+        state = SwitchState()
+
+    target, new_state = decide_next_model(
+        settings, state, current_model=getattr(agent, "model", None),
+        round_failed=_round_failed(_newest_tool_round(messages)),
+    )
+    agent._model_switch_state = new_state
+    if target:
+        agent._adaptive_model_switch_pending = target
+
+
+def apply_pending_model_switch(agent: Any) -> bool:
+    """Apply a scheduled model parameter change at an iteration boundary.
+
+    This narrow path is valid only for the custom OpenAI-compatible endpoint, where every
+    candidate is exposed behind one transport. It deliberately leaves the client, cached prompt,
+    compressor and primary runtime untouched.
+    """
+    pending = getattr(agent, "_adaptive_model_switch_pending", None)
+    if not pending:
+        return False
+    agent._adaptive_model_switch_pending = None
+
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    api_mode = str(getattr(agent, "api_mode", "") or "").strip().lower()
+    if provider not in {"custom", "openai-compatible"} or api_mode != "chat_completions":
+        logger.warning(
+            "adaptive model switching requires a custom endpoint in chat_completions mode; "
+            "staying on %s",
+            getattr(agent, "model", None),
+        )
+        return False
+
+    agent.model = pending
+    logger.info(
+        "adaptive model request parameter -> %s (session=%s)",
+        pending, getattr(agent, "session_id", None) or "?",
+    )
+    return True

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -108,6 +108,14 @@ def prepare_iteration(
         from agent.nous_wire import apply_pending_wire_switch
         apply_pending_wire_switch(agent)
 
+    # Adaptive model switching: an escalation/descent scheduled after the previous tool
+    # round lands here, before this iteration's request is built and with nothing in
+    # flight. Only the next request's model parameter changes; transcript and cached
+    # system prompt stay byte-identical.
+    if getattr(agent, "_adaptive_model_switch_pending", None):
+        from agent.model_switching import apply_pending_model_switch
+        apply_pending_model_switch(agent)
+
     # Fire step_callback for gateway hooks (agent:step event).
     if agent.step_callback is not None:
         try:

--- a/agent/turn_tool_round.py
+++ b/agent/turn_tool_round.py
@@ -177,6 +177,11 @@ def run_tool_round(
 
     # Reset per-turn retry counters so one truncation can't poison the turn.
     truncated_tool_call_retries = 0
+    # Adaptive model switching: classify the just-completed tool round at this generation
+    # boundary and schedule an escalation/descent. Only SCHEDULES; the switch is applied at
+    # the start of the next iteration (turn_iteration_prep) with nothing in flight.
+    from agent.model_switching import observe_tool_round
+    observe_tool_round(agent, messages)
     # Defer the paragraph break: _fire_stream_delta() prepends one "\n\n" when real
     # text arrives, so tool iterations don't stack blank lines.
     agent._stream_needs_break = True

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -259,6 +259,27 @@ def _clean_request_string(value: Any) -> Optional[str]:
     return (value.strip() or None) if isinstance(value, str) else None
 
 
+def _parse_search_rewrite_content(value: Any) -> str:
+    """Extract a bounded FTS query from strict JSON or a cheap-model fallback."""
+    if not isinstance(value, str):
+        return ""
+    candidate = value.strip()
+    if candidate.startswith("```"):
+        candidate = re.sub(r"^```(?:json)?\s*", "", candidate, flags=re.IGNORECASE)
+        candidate = re.sub(r"\s*```$", "", candidate).strip()
+    try:
+        decoded = json.loads(candidate)
+    except (TypeError, ValueError):
+        decoded = None
+    if isinstance(decoded, dict) and isinstance(decoded.get("query"), str):
+        candidate = decoded["query"]
+    else:
+        candidate = re.sub(r"^query\s*:\s*", "", candidate, flags=re.IGNORECASE)
+    candidate = re.sub(r"[\r\n\t]+", " ", candidate)
+    candidate = re.sub(r"\s+", " ", candidate).strip()
+    return candidate[:80]
+
+
 def _request_reasoning_config(model_options: Any) -> Optional[Dict[str, Any]]:
     """Translate model_options (structured ``reasoning`` or legacy ``reasoning_effort``) into
     AIAgent reasoning_config; unknown effort values are ignored, never raised."""
@@ -1511,6 +1532,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             ("GET", "/v1/health", self._handle_health),
             ("GET", "/v1/models", self._handle_models),
             ("GET", "/api/model/options", self._handle_model_options),
+            ("POST", "/v1/search/rewrite", self._handle_search_rewrite),
             ("GET", "/v1/capabilities", self._handle_capabilities),
             # Browser-control (gated on browser.extension_control.enabled + API key): POST
             # mints a short-lived ticket, WS consumes it; artifacts are bounded + scope-bound.
@@ -2240,6 +2262,167 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             return _error_response("Failed to list model options.", 500, code="model_options_failed")
 
     @_require_auth
+    async def _handle_search_rewrite(self, request: "web.Request") -> "web.Response":
+        """POST /v1/search/rewrite — turn natural language into a tiny FTS query.
+
+        Unlike ``/v1/chat/completions``, this endpoint does not construct an
+        AIAgent, load memories, expose tools, or create a session. It calls the
+        explicitly selected configured provider with a fixed minimal prompt so
+        mobile search can use an inexpensive model without sending the full
+        Hermes system prompt.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(
+                _openai_error("Invalid JSON body.", code="invalid_json"),
+                status=400,
+            )
+        if not isinstance(body, dict):
+            return web.json_response(
+                _openai_error("Request body must be an object.", code="invalid_request"),
+                status=400,
+            )
+
+        query = _clean_request_string(body.get("query"))
+        provider = _clean_request_string(body.get("provider"))
+        model = _clean_request_string(body.get("model"))
+        for field, value in (("query", query), ("provider", provider), ("model", model)):
+            if not value:
+                return web.json_response(
+                    _openai_error(
+                        f"The '{field}' field is required.",
+                        code=f"missing_{field}",
+                    ),
+                    status=400,
+                )
+        if len(query) > 500:
+            return web.json_response(
+                _openai_error(
+                    "The 'query' field must be 500 characters or fewer.",
+                    code="search_rewrite_query_too_long",
+                ),
+                status=400,
+            )
+        if len(provider) > 100 or len(model) > 300:
+            return web.json_response(
+                _openai_error(
+                    "Provider or model identifier is too long.",
+                    code="search_rewrite_model_invalid",
+                ),
+                status=400,
+            )
+
+        client = None
+        try:
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, resolved_model = resolve_provider_client(
+                provider,
+                model=model,
+                async_mode=True,
+            )
+            if client is None or not resolved_model:
+                return web.json_response(
+                    _openai_error(
+                        "The selected provider/model is not configured on this Hermes host.",
+                        code="search_rewrite_provider_unavailable",
+                    ),
+                    status=400,
+                )
+
+            completion_kwargs: Dict[str, Any] = {
+                "model": resolved_model,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "Rewrite the user's request into a short lexical query for "
+                            "searching their chat message history. Return JSON only: "
+                            '{"query":"..."}. Use 1 to 4 distinctive words or one quoted '
+                            "phrase likely to occur verbatim. Preserve names, project names, "
+                            "places, model names, and technical terms. Do not answer, explain, "
+                            "use markdown, wildcards, or boolean operators. Keep it under 80 "
+                            "characters."
+                        ),
+                    },
+                    {"role": "user", "content": query},
+                ],
+                "temperature": 0,
+                # Reasoning models may spend ~100 hidden tokens before emitting
+                # their tiny JSON answer, so 120 can terminate with content=null.
+                "max_tokens": 400,
+            }
+            if "gpt-oss" in resolved_model.lower():
+                completion_kwargs["extra_body"] = {"reasoning_effort": "low"}
+
+            response = await asyncio.wait_for(
+                client.chat.completions.create(**completion_kwargs),
+                timeout=30,
+            )
+            choices = getattr(response, "choices", None) or []
+            message = getattr(choices[0], "message", None) if choices else None
+            content = getattr(message, "content", "") if message is not None else ""
+            rewritten = _parse_search_rewrite_content(content)
+            if not rewritten:
+                return web.json_response(
+                    _openai_error(
+                        "The selected model returned no usable search query.",
+                        code="search_rewrite_empty",
+                    ),
+                    status=502,
+                )
+
+            usage = getattr(response, "usage", None)
+            input_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
+            output_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
+            total_tokens = int(getattr(usage, "total_tokens", 0) or 0)
+            if not total_tokens:
+                total_tokens = input_tokens + output_tokens
+            return web.json_response(
+                {
+                    "query": rewritten,
+                    "provider": provider,
+                    "model": resolved_model,
+                    "usage": {
+                        "input_tokens": input_tokens,
+                        "output_tokens": output_tokens,
+                        "total_tokens": total_tokens,
+                    },
+                }
+            )
+        except asyncio.TimeoutError:
+            return web.json_response(
+                _openai_error(
+                    "The search rewrite model timed out.",
+                    code="search_rewrite_timeout",
+                ),
+                status=504,
+            )
+        except Exception as exc:
+            logger.exception("[%s] POST /v1/search/rewrite failed", self.name)
+            return web.json_response(
+                _openai_error(
+                    f"Search rewrite failed: {_redact_api_error_text(exc)}",
+                    code="search_rewrite_failed",
+                ),
+                status=502,
+            )
+        finally:
+            close = getattr(client, "close", None)
+            if close is not None:
+                try:
+                    result = close()
+                    if asyncio.iscoroutine(result):
+                        await result
+                except Exception:
+                    logger.debug("Failed to close search rewrite client", exc_info=True)
+
+    @_require_auth
     async def _handle_capabilities(self, request: "web.Request") -> "web.Response":
         """GET /v1/capabilities — the stable, machine-readable API surface for external UIs."""
         return web.json_response({
@@ -2256,6 +2439,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                 "chat_completions": True, "chat_completions_streaming": True,
                 "responses_api": True, "responses_streaming": True, "run_submission": True,
                 "runs_idempotency": _api_runs._idempotency_capabilities(self, store_type=RunIdempotencyStore),
+                "search_rewrite": True,
                 **_STATIC_FEATURE_FLAGS,
                 "cors": bool(self._cors_origins),
                 # Always advertised for feature-detection; enabled follows config.

--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -51,6 +51,15 @@ CREATE TABLE IF NOT EXISTS project_folders (
 CREATE INDEX IF NOT EXISTS idx_project_folders_path
     ON project_folders(path);
 
+CREATE TABLE IF NOT EXISTS project_session_assignments (
+    session_id   TEXT PRIMARY KEY,
+    project_id   TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    assigned_at  INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_session_assignments_project
+    ON project_session_assignments(project_id);
+
 CREATE TABLE IF NOT EXISTS project_meta (
     key    TEXT PRIMARY KEY,
     value  TEXT
@@ -377,6 +386,58 @@ def restore_project(conn: sqlite3.Connection, project_id: str) -> bool:
 def delete_project(conn: sqlite3.Connection, project_id: str) -> bool:
     """Hard-delete a project and its folders (cascade)."""
     return _execute_rowcount(conn, "DELETE FROM projects WHERE id = ?", (project_id,)) > 0
+
+
+# --- Explicit session ownership ----------------------------------------------
+# Conversations are Project members by explicit assignment, independent of their
+# cwd. The session database stays independent from projects.db; a session can
+# disappear through retention without making project metadata invalid. The
+# project side *is* foreign-keyed so deleting a Project clears its bindings
+# atomically (ON DELETE CASCADE).
+
+
+def assign_session(
+    conn: sqlite3.Connection, session_id: str, project_id: Optional[str]
+) -> None:
+    """Bind a conversation to a Project, or clear the binding with ``None``."""
+    sid = str(session_id or "").strip()
+    if not sid:
+        raise ValueError("session_id must not be empty")
+    if project_id is None:
+        conn.execute(
+            "DELETE FROM project_session_assignments WHERE session_id = ?", (sid,)
+        )
+    else:
+        pid = str(project_id).strip()
+        if not pid:
+            raise ValueError("project_id must not be empty")
+        conn.execute(
+            """INSERT INTO project_session_assignments(session_id, project_id, assigned_at)
+               VALUES (?, ?, ?)
+               ON CONFLICT(session_id) DO UPDATE SET
+                   project_id = excluded.project_id,
+                   assigned_at = excluded.assigned_at""",
+            (sid, pid, _now()),
+        )
+    conn.commit()
+
+
+def get_session_project(conn: sqlite3.Connection, session_id: str) -> Optional[str]:
+    row = conn.execute(
+        "SELECT project_id FROM project_session_assignments WHERE session_id = ?",
+        (str(session_id or "").strip(),),
+    ).fetchone()
+    return str(row["project_id"]) if row else None
+
+
+def list_session_assignments(conn: sqlite3.Connection) -> dict[str, str]:
+    """Every explicit session → project binding for one profile."""
+    return {
+        str(row["session_id"]): str(row["project_id"])
+        for row in conn.execute(
+            "SELECT session_id, project_id FROM project_session_assignments"
+        ).fetchall()
+    }
 
 
 # --- Active-project pointer + discovery policy (project_meta KV) --------------

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4495,6 +4495,132 @@ class TestCompressionFallbackContextFilter:
         assert _task_minimum_context_length(None) is None
 
 
+class TestConfiguredFallbackCandidateFailures:
+    """A failing configured candidate must not abort the remaining chain."""
+
+    def test_sync_chain_continues_after_connection_error(self, monkeypatch):
+        from agent.auxiliary_client import call_llm
+
+        primary = MagicMock(name="primary")
+        first_fallback = MagicMock(name="first_fallback")
+        second_fallback = MagicMock(name="second_fallback")
+        response = _DummyResponse()
+
+        primary.chat.completions.create.side_effect = ConnectionError("primary refused")
+        first_fallback.chat.completions.create.side_effect = ConnectionError("fallback refused")
+        second_fallback.chat.completions.create.return_value = response
+
+        entries = [
+            {"provider": "first", "model": "first-model"},
+            {"provider": "second", "model": "second-model"},
+        ]
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda *args, **kwargs: ("primary", "primary-model", None, None, None),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *args, **kwargs: (primary, "primary-model"),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": entries},
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_fallback_entry",
+            lambda entry: (
+                (first_fallback, "first-model")
+                if entry is entries[0]
+                else (second_fallback, "second-model")
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.get_model_context_length",
+            lambda *args, **kwargs: 1_048_576,
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._transient_retry_count",
+            lambda: 0,
+        )
+
+        result = call_llm(
+            task="compression",
+            messages=[{"role": "user", "content": "summarize"}],
+        )
+
+        assert result is response
+        first_fallback.chat.completions.create.assert_called_once()
+        second_fallback.chat.completions.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_chain_continues_after_connection_error(self, monkeypatch):
+        from agent.auxiliary_client import async_call_llm
+
+        primary = MagicMock(name="primary_async")
+        primary.chat.completions.create = AsyncMock(
+            side_effect=ConnectionError("primary refused")
+        )
+        first_sync = MagicMock(name="first_sync")
+        second_sync = MagicMock(name="second_sync")
+        first_async = MagicMock(name="first_async")
+        second_async = MagicMock(name="second_async")
+        first_async.chat.completions.create = AsyncMock(
+            side_effect=ConnectionError("fallback refused")
+        )
+        response = _DummyResponse()
+        second_async.chat.completions.create = AsyncMock(return_value=response)
+
+        entries = [
+            {"provider": "first", "model": "first-model"},
+            {"provider": "second", "model": "second-model"},
+        ]
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda *args, **kwargs: ("primary", "primary-model", None, None, None),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *args, **kwargs: (primary, "primary-model"),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": entries},
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_fallback_entry",
+            lambda entry: (
+                (first_sync, "first-model")
+                if entry is entries[0]
+                else (second_sync, "second-model")
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._to_async_client",
+            lambda client, model, **kwargs: (
+                (first_async, model) if client is first_sync else (second_async, model)
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.get_model_context_length",
+            lambda *args, **kwargs: 1_048_576,
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._transient_retry_count",
+            lambda: 0,
+        )
+
+        result = await async_call_llm(
+            task="compression",
+            messages=[{"role": "user", "content": "summarize"}],
+        )
+
+        assert result is response
+        first_async.chat.completions.create.assert_awaited_once()
+        second_async.chat.completions.create.assert_awaited_once()
+
+
 class TestCustomEndpointApiKeyInheritance:
     """Issue #9318: when an auxiliary task uses provider=custom with an
     explicit base_url but empty api_key, the custom_key fallback chain must

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -26,6 +26,8 @@ from agent.auxiliary_client import (
     _is_rate_limit_error,
     _is_model_not_found_error,
     _is_model_incompatible_error,
+    _is_invalid_aux_response_error,
+    _validate_llm_response,
     _refresh_nous_recommended_model,
     _normalize_aux_provider,
     _try_payment_fallback,
@@ -4495,8 +4497,107 @@ class TestCompressionFallbackContextFilter:
         assert _task_minimum_context_length(None) is None
 
 
+class TestCompressionEmptyResponseFallback:
+    """An empty compression summary is a route failure, not a successful auxiliary call."""
+
+    def test_compression_empty_content_is_invalid_but_tool_call_is_allowed(self):
+        empty = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="   ", tool_calls=None))]
+        )
+        with pytest.raises(RuntimeError, match="empty content") as exc_info:
+            _validate_llm_response(empty, "compression")
+        assert _is_invalid_aux_response_error(exc_info.value)
+
+        tool_only = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content="", tool_calls=[SimpleNamespace(id="call_1")])
+            )]
+        )
+        assert _validate_llm_response(tool_only, "compression") is tool_only
+
+    def test_other_tasks_keep_accepting_empty_content(self):
+        """Only compression needs a summary; a blank vision answer is not a route failure."""
+        blank = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="", tool_calls=None))]
+        )
+        assert _validate_llm_response(blank, "vision") is blank
+        assert _validate_llm_response(blank, None) is blank
+
+    def test_compression_reasoning_only_summary_is_still_accepted(self):
+        """A summary recovered from reasoning fields must not be rejected as empty (#11978)."""
+        from_reasoning_content = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(
+                content="", reasoning_content="kept reasoning summary", tool_calls=None
+            ))]
+        )
+        from_reasoning = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(
+                content="   ", reasoning="kept reasoning summary", tool_calls=None
+            ))]
+        )
+        assert _validate_llm_response(from_reasoning_content, "compression") is from_reasoning_content
+        assert _validate_llm_response(from_reasoning, "compression") is from_reasoning
+
+
 class TestConfiguredFallbackCandidateFailures:
     """A failing configured candidate must not abort the remaining chain."""
+
+    def test_sync_chain_continues_after_empty_compression_response(self, monkeypatch):
+        from agent.auxiliary_client import call_llm
+
+        primary = MagicMock(name="primary")
+        first_fallback = MagicMock(name="first_fallback")
+        second_fallback = MagicMock(name="second_fallback")
+        response = _DummyResponse()
+
+        primary.chat.completions.create.side_effect = ConnectionError("primary refused")
+        first_fallback.chat.completions.create.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="", tool_calls=None))]
+        )
+        second_fallback.chat.completions.create.return_value = response
+
+        entries = [
+            {"provider": "first", "model": "first-model"},
+            {"provider": "second", "model": "second-model"},
+        ]
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda *args, **kwargs: ("primary", "primary-model", None, None, None),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *args, **kwargs: (primary, "primary-model"),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": entries},
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_fallback_entry",
+            lambda entry: (
+                (first_fallback, "first-model")
+                if entry is entries[0]
+                else (second_fallback, "second-model")
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.get_model_context_length",
+            lambda *args, **kwargs: 1_048_576,
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._transient_retry_count",
+            lambda: 0,
+        )
+
+        result = call_llm(
+            task="compression",
+            messages=[{"role": "user", "content": "summarize"}],
+        )
+
+        assert result is response
+        first_fallback.chat.completions.create.assert_called_once()
+        second_fallback.chat.completions.create.assert_called_once()
 
     def test_sync_chain_continues_after_connection_error(self, monkeypatch):
         from agent.auxiliary_client import call_llm

--- a/tests/agent/test_model_switching.py
+++ b/tests/agent/test_model_switching.py
@@ -1,0 +1,314 @@
+"""Unit coverage for ``agent/model_switching.py`` — adaptive model switching between tool
+iterations.
+
+The initial model (``model.default: auto``) is chosen by the semantic router; this module
+decides, purely from per-round signals and an opt-in config ladder, when the loop may
+escalate to a harder configured model or descend back to a cheaper one. Switches are
+scheduled only at generation boundaries (decided after a tool round, applied at the start
+of the next iteration) so a generation is never switched mid-stream and the transcript is
+never mutated — prompt-cache and role-alternation invariants hold.
+
+These are behaviour contracts, not snapshots: they pin the escalation/descent *relations*
+(config → decision) and never freeze model ids or counts that are expected to change.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from agent.model_switching import (
+    ModelSwitchingSettings,
+    SwitchState,
+    apply_pending_model_switch,
+    decide_next_model,
+    observe_tool_round,
+    resolve_model_switching_settings,
+    reset_model_switching_turn,
+)
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+def test_disabled_by_default():
+    for config in (None, {}, {"agent": {}}, {"agent": {"model_switching": {}}}):
+        settings = resolve_model_switching_settings(config)
+        assert settings.enabled is False
+        assert settings.escalate_to is None
+        assert settings.descend_to is None
+
+
+def test_reads_escalate_and_descend_targets():
+    settings = resolve_model_switching_settings(
+        {"agent": {"model_switching": {"escalate_to": "hard-model", "descend_to": "cheap-model"}}}
+    )
+    assert settings.enabled is True
+    assert settings.escalate_to == "hard-model"
+    assert settings.descend_to == "cheap-model"
+
+
+def test_thresholds_coerce_numeric_strings_and_keep_defaults():
+    settings = resolve_model_switching_settings(
+        {"agent": {"model_switching": {"escalate_to": "h", "escalate_after_failures": "4"}}}
+    )
+    assert settings.escalate_after_failures == 4
+    assert settings.descend_after_successes == 2  # untouched default
+    assert settings.max_switches == 3
+
+
+def test_typo_threshold_warns_and_falls_back(caplog):
+    with caplog.at_level(logging.WARNING, logger="agent.model_switching"):
+        settings = resolve_model_switching_settings(
+            {"agent": {"model_switching": {"escalate_to": "h", "escalate_after_failures": "oops"}}}
+        )
+    assert settings.escalate_after_failures == 3
+    assert len(caplog.records) == 1
+
+
+def test_non_positive_threshold_warns_and_falls_back(caplog):
+    with caplog.at_level(logging.WARNING, logger="agent.model_switching"):
+        settings = resolve_model_switching_settings(
+            {"agent": {"model_switching": {"escalate_to": "h", "descend_after_successes": 0}}}
+        )
+    assert settings.descend_after_successes == 2
+    assert len(caplog.records) == 1
+
+
+def test_non_string_escalate_target_disables_and_warns(caplog):
+    with caplog.at_level(logging.WARNING, logger="agent.model_switching"):
+        settings = resolve_model_switching_settings(
+            {"agent": {"model_switching": {"escalate_to": 42}}}
+        )
+    assert settings.enabled is False
+    assert len(caplog.records) >= 1
+
+
+def test_malformed_section_never_raises(caplog):
+    with caplog.at_level(logging.WARNING, logger="agent.model_switching"):
+        result = resolve_model_switching_settings({"agent": "nonsense"})
+    assert result.enabled is False
+    with caplog.at_level(logging.WARNING, logger="agent.model_switching"):
+        result = resolve_model_switching_settings({"agent": {"model_switching": "nonsense"}})
+    assert result.enabled is False
+    assert len(caplog.records) >= 1
+
+
+# ---------------------------------------------------------------------------
+# decide_next_model — the pure escalation/descent core
+# ---------------------------------------------------------------------------
+
+def test_disabled_settings_never_switch():
+    state = SwitchState(consecutive_failures=5, consecutive_successes=5)
+    target, new_state = decide_next_model(
+        ModelSwitchingSettings(), state, current_model="auto", round_failed=True
+    )
+    assert target is None
+    assert new_state == state  # untouched
+
+
+def test_escalates_after_consecutive_failures():
+    settings = ModelSwitchingSettings(escalate_to="hard", escalate_after_failures=3)
+    state = SwitchState()
+    target = None
+    for _ in range(2):
+        target, state = decide_next_model(settings, state, current_model="auto", round_failed=True)
+    assert target is None  # below threshold
+    target, state = decide_next_model(settings, state, current_model="auto", round_failed=True)
+    assert target == "hard"
+    assert state.escalated is True
+
+
+def test_clean_round_resets_failure_streak():
+    settings = ModelSwitchingSettings(escalate_to="hard", escalate_after_failures=3)
+    state = SwitchState()
+    for _ in range(2):
+        _, state = decide_next_model(settings, state, current_model="auto", round_failed=True)
+    _, state = decide_next_model(settings, state, current_model="auto", round_failed=False)
+    # clean round reset the streak; two failures now are below the 3-failure threshold
+    target, state = decide_next_model(settings, state, current_model="auto", round_failed=True)
+    assert target is None
+    target, state = decide_next_model(settings, state, current_model="auto", round_failed=True)
+    assert target is None  # still only 2 consecutive failures
+    target, state = decide_next_model(settings, state, current_model="auto", round_failed=True)
+    assert target == "hard"  # 3rd consecutive failure escalates
+
+
+def test_no_repeat_escalation_when_already_escalated():
+    settings = ModelSwitchingSettings(escalate_to="hard", escalate_after_failures=1)
+    state = SwitchState()
+    target, state = decide_next_model(settings, state, current_model="auto", round_failed=True)
+    assert target == "hard"
+    target, state = decide_next_model(settings, state, current_model="hard", round_failed=True)
+    assert target is None
+
+
+def test_descend_after_clean_successes():
+    settings = ModelSwitchingSettings(
+        escalate_to="hard", descend_to="cheap", escalate_after_failures=1, descend_after_successes=2
+    )
+    state = SwitchState()
+    target, state = decide_next_model(settings, state, current_model="auto", round_failed=True)
+    assert target == "hard"
+    target, state = decide_next_model(settings, state, current_model="hard", round_failed=False)
+    assert target is None
+    target, state = decide_next_model(settings, state, current_model="hard", round_failed=False)
+    assert target == "cheap"
+    assert state.escalated is False
+
+
+def test_descend_requires_prior_escalation():
+    settings = ModelSwitchingSettings(
+        escalate_to="hard", descend_to="cheap", descend_after_successes=1
+    )
+    state = SwitchState()
+    target, _ = decide_next_model(settings, state, current_model="auto", round_failed=False)
+    assert target is None
+
+
+def test_failure_resets_success_streak_blocks_descend():
+    settings = ModelSwitchingSettings(
+        escalate_to="hard", descend_to="cheap", escalate_after_failures=1, descend_after_successes=2
+    )
+    state = SwitchState()
+    _, state = decide_next_model(settings, state, current_model="auto", round_failed=True)  # -> hard
+    _, state = decide_next_model(settings, state, current_model="hard", round_failed=False)  # cs=1
+    _, state = decide_next_model(settings, state, current_model="hard", round_failed=True)   # cs reset
+    # One clean round after the failure is below the 2-clean descend threshold.
+    target, state = decide_next_model(settings, state, current_model="hard", round_failed=False)  # cs=1
+    assert target is None
+    # The second consecutive clean round completes the fresh streak -> descend.
+    target, _ = decide_next_model(settings, state, current_model="hard", round_failed=False)  # cs=2
+    assert target == "cheap"
+
+
+def test_no_op_when_already_on_escalation_target():
+    settings = ModelSwitchingSettings(escalate_to="hard", escalate_after_failures=1)
+    state = SwitchState()
+    target, _ = decide_next_model(settings, state, current_model="hard", round_failed=True)
+    assert target is None
+
+
+def test_max_switches_caps_total_switches():
+    settings = ModelSwitchingSettings(
+        escalate_to="hard", descend_to="cheap",
+        escalate_after_failures=1, descend_after_successes=1, max_switches=1,
+    )
+    state = SwitchState()
+    target, state = decide_next_model(settings, state, current_model="auto", round_failed=True)
+    assert target == "hard"
+    # switches budget exhausted — no descend back
+    target, state = decide_next_model(settings, state, current_model="hard", round_failed=False)
+    assert target is None
+
+
+# ---------------------------------------------------------------------------
+# Loop integration: observe after a tool round, apply at the next iteration
+# ---------------------------------------------------------------------------
+
+def _fake_agent(**overrides):
+    defaults = dict(
+        model="auto", provider="deepseek", api_key="k",
+        base_url="http://127.0.0.1:2100/v1", api_mode="chat_completions",
+        _model_switching_settings=ModelSwitchingSettings(escalate_to="hard", escalate_after_failures=1),
+        _model_switch_state=None, _adaptive_model_switch_pending=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _failing_round():
+    return [
+        {"role": "assistant", "tool_calls": [{"function": {"name": "terminal"}}]},
+        {"role": "tool", "name": "terminal", "tool_call_id": "1",
+         "content": '{"exit_code": 1, "error": "boom"}'},
+    ]
+
+
+def _clean_round():
+    return [
+        {"role": "assistant", "tool_calls": [{"function": {"name": "terminal"}}]},
+        {"role": "tool", "name": "terminal", "tool_call_id": "1",
+         "content": '{"exit_code": 0}'},
+    ]
+
+
+def test_observe_schedules_escalation_after_failure():
+    agent = _fake_agent()
+    observe_tool_round(agent, _failing_round())
+    assert agent._adaptive_model_switch_pending == "hard"
+
+
+def test_observe_clean_round_does_not_schedule():
+    agent = _fake_agent()
+    observe_tool_round(agent, _clean_round())
+    assert agent._adaptive_model_switch_pending is None
+
+
+def test_observe_ignores_when_disabled():
+    agent = _fake_agent(_model_switching_settings=ModelSwitchingSettings())
+    observe_tool_round(agent, _failing_round())
+    assert agent._adaptive_model_switch_pending is None
+    assert agent._model_switch_state is None  # state never advanced
+
+
+def test_turn_reset_restores_original_model_after_descent_disabled():
+    agent = _fake_agent(
+        model="hard",
+        _adaptive_model_switch_original_model="auto",
+        _model_switch_state=SwitchState(escalated=True, switches=1),
+        _adaptive_model_switch_pending="expert",
+    )
+    reset_model_switching_turn(agent)
+    assert agent.model == "auto"
+    assert agent._adaptive_model_switch_original_model == "auto"
+    assert agent._model_switch_state is None
+    assert agent._adaptive_model_switch_pending is None
+
+
+def test_apply_pending_model_switch_changes_only_request_model(monkeypatch):
+    cached_prompt = "byte-stable system prompt"
+    primary_runtime = {"model": "auto", "provider": "custom"}
+    agent = _fake_agent(
+        provider="custom",
+        _adaptive_model_switch_pending="hard",
+        _cached_system_prompt=cached_prompt,
+        _primary_runtime=primary_runtime,
+    )
+
+    def forbidden_switch_model(*args, **kwargs):
+        raise AssertionError("adaptive routing must not invoke the cache-breaking full switch")
+
+    monkeypatch.setattr("agent.agent_runtime_helpers.switch_model", forbidden_switch_model)
+    assert apply_pending_model_switch(agent) is True
+    assert agent.model == "hard"
+    assert agent._cached_system_prompt == cached_prompt
+    assert agent._primary_runtime is primary_runtime
+    assert agent._adaptive_model_switch_pending is None
+
+
+def test_apply_pending_accepts_custom_chat_completions_alias():
+    agent = _fake_agent(
+        provider="openai-compatible",
+        api_mode="chat_completions",
+        _adaptive_model_switch_pending="hard",
+    )
+    assert apply_pending_model_switch(agent) is True
+    assert agent.model == "hard"
+
+
+def test_apply_pending_rejects_non_custom_transport(caplog):
+    agent = _fake_agent(provider="deepseek", _adaptive_model_switch_pending="hard")
+    with caplog.at_level(logging.WARNING, logger="agent.model_switching"):
+        assert apply_pending_model_switch(agent) is False
+    assert agent.model == "auto"
+    assert agent._adaptive_model_switch_pending is None
+    assert "custom endpoint" in caplog.text
+
+
+def test_apply_pending_noop_without_pending():
+    agent = _fake_agent(_adaptive_model_switch_pending=None)
+    assert apply_pending_model_switch(agent) is False
+
+

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -33,6 +33,7 @@ from gateway.platforms.api_server import (
     _IdempotencyCache,
     _derive_chat_session_id,
     _hermes_version,
+    _parse_search_rewrite_content,
     _redact_api_error_text,
     _request_agent_overrides,
     check_api_server_requirements,
@@ -309,6 +310,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/health", adapter._handle_health)
     app.router.add_get("/v1/models", adapter._handle_models)
     app.router.add_get("/api/model/options", adapter._handle_model_options)
+    app.router.add_post("/v1/search/rewrite", adapter._handle_search_rewrite)
     app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
     app.router.add_get("/v1/skills", adapter._handle_skills)
     app.router.add_get("/v1/toolsets", adapter._handle_toolsets)
@@ -761,6 +763,165 @@ class TestHealthDetailedEndpoint:
         with patch("tools.process_registry.process_registry.completion_queue.qsize", return_value=0), \
              patch("tools.async_delegation.active_count", return_value=0):
             assert adapter._readiness_work_counts() == (4, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# /v1/search/rewrite endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestSearchRewriteEndpoint:
+    @pytest.mark.parametrize(
+        ("content", "expected"),
+        [
+            ('```json\n{"query":"RAFT occlusion"}\n```', "RAFT occlusion"),
+            ("query: Hindsight memory", "Hindsight memory"),
+            ('{"query":"  C-MAY   Ethiopia  "}', "C-MAY Ethiopia"),
+        ],
+    )
+    def test_parses_inexpensive_model_output_defensively(self, content, expected):
+        assert _parse_search_rewrite_content(content) == expected
+
+    @pytest.mark.asyncio
+    async def test_requires_api_auth(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post(
+                "/v1/search/rewrite",
+                json={"query": "electric tuk tuk", "provider": "nvidia", "model": "openai/gpt-oss-20b"},
+            )
+        assert response.status == 401
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("payload", "field"),
+        [
+            ({"provider": "nvidia", "model": "openai/gpt-oss-20b"}, "query"),
+            ({"query": "find this", "model": "openai/gpt-oss-20b"}, "provider"),
+            ({"query": "find this", "provider": "nvidia"}, "model"),
+        ],
+    )
+    async def test_rejects_missing_required_fields(self, adapter, payload, field):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post("/v1/search/rewrite", json=payload)
+            body = await response.json()
+        assert response.status == 400
+        assert field in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_runs_a_bare_provider_completion_and_returns_usage(self, adapter):
+        completion = types.SimpleNamespace(
+            choices=[
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(
+                        content='{"query":"tuk-tuk électrique Ethiopie"}'
+                    )
+                )
+            ],
+            usage=types.SimpleNamespace(
+                prompt_tokens=91,
+                completion_tokens=12,
+                total_tokens=103,
+            ),
+        )
+        create = AsyncMock(return_value=completion)
+        client_mock = types.SimpleNamespace(
+            chat=types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=create)
+            )
+        )
+        app = _create_app(adapter)
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(client_mock, "openai/gpt-oss-20b"),
+        ) as resolve:
+            async with TestClient(TestServer(app)) as client:
+                response = await client.post(
+                    "/v1/search/rewrite",
+                    json={
+                        "query": "retrouve le projet de tuk-tuk en Ethiopie",
+                        "provider": "nvidia",
+                        "model": "openai/gpt-oss-20b",
+                    },
+                )
+                body = await response.json()
+
+        assert response.status == 200
+        assert body == {
+            "query": "tuk-tuk électrique Ethiopie",
+            "provider": "nvidia",
+            "model": "openai/gpt-oss-20b",
+            "usage": {
+                "input_tokens": 91,
+                "output_tokens": 12,
+                "total_tokens": 103,
+            },
+        }
+        resolve.assert_called_once_with(
+            "nvidia",
+            model="openai/gpt-oss-20b",
+            async_mode=True,
+        )
+        kwargs = create.call_args.kwargs
+        assert kwargs["model"] == "openai/gpt-oss-20b"
+        assert kwargs["temperature"] == 0
+        assert kwargs["max_tokens"] == 400
+        assert kwargs["extra_body"] == {"reasoning_effort": "low"}
+        assert len(kwargs["messages"]) == 2
+        assert "tools" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_rejects_unavailable_provider_without_fallback(self, adapter):
+        app = _create_app(adapter)
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(None, None),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                response = await client.post(
+                    "/v1/search/rewrite",
+                    json={"query": "find it", "provider": "missing", "model": "cheap-model"},
+                )
+                body = await response.json()
+        assert response.status == 400
+        assert body["error"]["code"] == "search_rewrite_provider_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_redacts_provider_errors(self, adapter):
+        secret = "sk-proj-super-secret-value-1234567890"
+        create = AsyncMock(side_effect=RuntimeError(f"provider rejected {secret}"))
+        client_mock = types.SimpleNamespace(
+            chat=types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=create)
+            )
+        )
+        app = _create_app(adapter)
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(client_mock, "model"),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                response = await client.post(
+                    "/v1/search/rewrite",
+                    json={"query": "find it", "provider": "provider", "model": "model"},
+                )
+                raw_body = await response.text()
+        assert response.status == 502
+        assert secret not in raw_body
+        assert "search_rewrite_failed" in raw_body
+
+    @pytest.mark.asyncio
+    async def test_rejects_overlong_query_before_provider_call(self, adapter):
+        app = _create_app(adapter)
+        with patch("agent.auxiliary_client.resolve_provider_client") as resolve:
+            async with TestClient(TestServer(app)) as client:
+                response = await client.post(
+                    "/v1/search/rewrite",
+                    json={"query": "x" * 501, "provider": "nvidia", "model": "model"},
+                )
+        assert response.status == 400
+        resolve.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tui_gateway/test_gateway_ready_contract.py
+++ b/tests/tui_gateway/test_gateway_ready_contract.py
@@ -1,0 +1,95 @@
+"""The gateway.ready contract both transports must satisfy.
+
+Three client-visible failures traced back to this one payload:
+
+* "Background recovery unavailable - legacy transport" — the ``turn_recovery``
+  capability block was missing, so the Android client fell back to the legacy
+  REST transport.
+* A dropped ``replay_epoch`` — reconnecting clients could not detect a backend
+  restart and reset their per-session seq watermarks.
+* Divergence between the stdio TUI and the WS sidecar, because each transport
+  built its own payload independently.
+
+These are behaviour contracts, not snapshots: they assert how the payload must
+relate to the runtime capability, never that a particular literal is present.
+"""
+
+import tui_gateway.entry as entry
+import tui_gateway.ws as ws
+
+
+def _payloads():
+    return {
+        "stdio": entry.build_gateway_ready_payload({"name": "test"}),
+        "ws": ws.build_gateway_ready_payload(
+            {"name": "test"}, change_events=True, heartbeat=True
+        ),
+    }
+
+
+class TestGatewayReadyPayload:
+    def test_both_transports_share_one_implementation(self):
+        # A second copy of the builder is how the WS sidecar silently drifted.
+        stdio = entry.build_gateway_ready_payload({"name": "test"})
+        via_ws = ws.build_gateway_ready_payload({"name": "test"})
+        assert set(stdio) == set(via_ws)
+
+    def test_every_transport_advertises_turn_recovery(self):
+        for transport, payload in _payloads().items():
+            capability = payload.get("capabilities", {}).get("turn_recovery")
+            assert capability, (
+                f"{transport} dropped turn_recovery; clients degrade to the "
+                "legacy transport"
+            )
+
+    def test_protocol_is_announced_so_clients_do_not_guess(self):
+        for transport, payload in _payloads().items():
+            protocol = payload.get("protocol") or {}
+            assert protocol.get("name") == "hermes-jsonrpc", transport
+            assert protocol.get("major") == 2, transport
+
+    def test_recovery_methods_the_client_calls_are_advertised(self):
+        # The Android client refuses the v2 transport unless each of these is
+        # named; a partial list is what produces "legacy transport".
+        required = {"session.open", "turn.reconcile", "turn.interrupt"}
+        for transport, payload in _payloads().items():
+            methods = set(
+                payload["capabilities"]["turn_recovery"].get("methods", [])
+            )
+            assert required <= methods, f"{transport} is missing {required - methods}"
+
+    def test_advertised_capability_matches_the_runtime(self):
+        from tui_gateway import server
+
+        expected = server._turn_recovery_runtime.ready_payload({})
+        for transport, payload in _payloads().items():
+            assert payload.get("capabilities") == expected.get("capabilities"), (
+                f"{transport} advertises a capability the runtime does not serve"
+            )
+
+    def test_every_transport_carries_replay_epoch(self):
+        for transport, payload in _payloads().items():
+            assert payload.get("replay_epoch"), (
+                f"{transport} dropped replay_epoch; reconnecting clients cannot "
+                "detect a backend restart"
+            )
+
+    def test_replay_epoch_is_stable_within_a_process(self):
+        # Restart detection is meaningless if the value changes per call.
+        first = entry.build_gateway_ready_payload({"name": "test"})
+        second = ws.build_gateway_ready_payload({"name": "test"})
+        assert first["replay_epoch"] == second["replay_epoch"]
+
+    def test_heartbeat_is_opt_in_per_transport(self):
+        # Only the WS sidecar actually sends heartbeats.
+        assert "heartbeat" not in entry.build_gateway_ready_payload({"name": "t"})
+        assert ws.build_gateway_ready_payload({"name": "t"}, heartbeat=True)[
+            "heartbeat"
+        ]
+
+    def test_skin_and_change_events_survive(self):
+        payload = entry.build_gateway_ready_payload(
+            {"name": "custom"}, change_events=True
+        )
+        assert payload["skin"] == {"name": "custom"}
+        assert payload["change_events"] is True

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -657,3 +657,43 @@ def test_equivalent_windows_spellings_derive_one_lane_key():
     b = pt._place_by_heuristic("C:\\work\\notes\\")
     assert a is not None and b is not None
     assert pt._lane_key(a["lane_key"]) == pt._lane_key(b["lane_key"])
+
+
+def test_project_id_for_session_matches_stored_id_directly():
+    """A session assigned by its stored id resolves without a binding map."""
+    assert pt.project_id_for_session("s1", {"s1": "p1"}, {}) == "p1"
+
+
+def test_project_id_for_session_resolves_mobile_id_to_stored():
+    """New Project chats are assigned by their mobile id before session.open
+    creates the mobile->stored binding; the stored-id row must still surface
+    through the alias."""
+    assignments = {"mob-1788027191027-1433e529-73a9-41f1-9fed-9eaf7095e355": "p1"}
+    bindings = {
+        "mob-1788027191027-1433e529-73a9-41f1-9fed-9eaf7095e355": "20260829_181311_bc031d",
+    }
+    assert (
+        pt.project_id_for_session("20260829_181311_bc031d", assignments, bindings)
+        == "p1"
+    )
+
+
+def test_project_id_for_session_mobile_alias_requires_the_binding():
+    """Without the mobile->stored binding there is no way to bridge the ids."""
+    assignments = {"mob-1": "p1"}
+    assert pt.project_id_for_session("stored-1", assignments, {}) is None
+
+
+def test_project_id_for_session_prefers_a_direct_stored_match():
+    """When both ids are assigned, the stored id wins over the mobile alias."""
+    assignments = {"s1": "p1", "mob-1": "p2"}
+    bindings = {"mob-1": "s1"}
+    assert pt.project_id_for_session("s1", assignments, bindings) == "p1"
+
+
+def test_project_id_for_session_unknown_id_returns_none():
+    assert pt.project_id_for_session("nope", {"s1": "p1"}, {}) is None
+
+
+def test_project_id_for_session_blank_id_returns_none():
+    assert pt.project_id_for_session("", {"s1": "p1"}, {}) is None

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -58,6 +58,7 @@ def test_methods_registered():
         "projects.set_primary",
         "projects.archive",
         "projects.set_active",
+        "projects.assign_session",
         "projects.for_cwd",
     ):
         assert m in server._methods
@@ -696,6 +697,86 @@ def _create_session(home: Path, session_id: str, cwd: Path) -> None:
         db.append_message(session_id, "user", f"hello from {session_id}")
     finally:
         db.close()
+
+
+def test_explicit_session_assignment_overrides_cwd_and_can_be_cleared(tmp_path):
+    """Projects are conversation groups, not only filesystem-folder matches."""
+    home = tmp_path / "home"
+    project_folder = tmp_path / "project-repo"
+    unrelated_cwd = tmp_path / "random-chat-cwd"
+    project_folder.mkdir(parents=True)
+    unrelated_cwd.mkdir(parents=True)
+    project = _create_project(home, "Android", project_folder)
+    _create_session(home, "chat-1", unrelated_cwd)
+
+    with _serving_launch_profile(home):
+        before = _call(
+            "projects.project_sessions", {"project_id": project["id"]}
+        )["project"]
+        assert before["sessionCount"] == 0
+
+        assigned = _call(
+            "projects.assign_session",
+            {"project_id": project["id"], "session_id": "chat-1"},
+        )
+        assert assigned == {"session_id": "chat-1", "project_id": project["id"]}
+
+        after = _call(
+            "projects.project_sessions", {"project_id": project["id"]}
+        )["project"]
+        assert after["sessionCount"] == 1
+        nested_sessions = [
+            session
+            for repo in after["repos"]
+            for group in repo["groups"]
+            for session in group["sessions"]
+        ]
+        assert [session["id"] for session in nested_sessions] == ["chat-1"]
+
+        cleared = _call(
+            "projects.assign_session",
+            {"project_id": None, "session_id": "chat-1"},
+        )
+        assert cleared == {"session_id": "chat-1", "project_id": None}
+        final = _call(
+            "projects.project_sessions", {"project_id": project["id"]}
+        )["project"]
+        assert final["sessionCount"] == 0
+
+
+def test_assign_session_rejects_unknown_project_without_losing_prior_binding(tmp_path):
+    home = tmp_path / "home"
+    folder = tmp_path / "repo"
+    folder.mkdir(parents=True)
+    project = _create_project(home, "Keep", folder)
+
+    with _serving_launch_profile(home):
+        _call(
+            "projects.assign_session",
+            {"project_id": project["id"], "session_id": "chat-1"},
+        )
+        response = server._methods["projects.assign_session"](
+            1, {"project_id": "missing", "session_id": "chat-1"}
+        )
+        assert response["error"]["code"] == 5062
+
+        from hermes_cli import projects_db as pdb
+
+        with pdb.connect_closing(home / "projects.db") as conn:
+            assert pdb.get_session_project(conn, "chat-1") == project["id"]
+
+
+def test_assign_session_requires_a_non_empty_session_id(tmp_path):
+    home = tmp_path / "home"
+    folder = tmp_path / "repo"
+    folder.mkdir(parents=True)
+    project = _create_project(home, "Demo", folder)
+
+    with _serving_launch_profile(home):
+        response = server._methods["projects.assign_session"](
+            1, {"project_id": project["id"], "session_id": "  "}
+        )
+        assert response["error"]["code"] == 5063
 
 
 @contextlib.contextmanager

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -969,3 +969,46 @@ def test_projects_without_a_profile_stay_on_the_launch_home(monkeypatch, tmp_pat
     assert not (Path(os.environ["HERMES_HOME"]) / "projects.db").exists()
 
 
+
+def test_assign_session_by_mobile_id_surfaces_in_project_sessions(tmp_path):
+    """New Project chats are committed by their mobile id BEFORE session.open
+    creates the mobile->stored binding, so the tree must resolve the alias or
+    the project reads as empty even though the assignment row exists."""
+    home = tmp_path / "home"
+    folder = tmp_path / "repo"
+    unrelated_cwd = tmp_path / "random-chat-cwd"
+    folder.mkdir(parents=True)
+    unrelated_cwd.mkdir(parents=True)
+    project = _create_project(home, "Android", folder)
+    stored = "20260829_181311_bc031d"
+    mobile = "mob-1788027191027-1433e529-73a9-41f1-9fed-9eaf7095e355"
+    # The chat's cwd deliberately does NOT match the project folder: only the
+    # explicit assignment can place it, which is what Projects are for.
+    _create_session(home, stored, unrelated_cwd)
+
+    with _serving_launch_profile(home):
+        runtime = server._turn_recovery_runtime
+        assert runtime is not None
+        runtime._bindings[mobile] = {
+            "stored_session_id": stored,
+            "binding_version": 1,
+        }
+        try:
+            _call(
+                "projects.assign_session",
+                {"project_id": project["id"], "session_id": mobile},
+            )
+            result = _call(
+                "projects.project_sessions",
+                {"project_id": project["id"]},
+            )["project"]
+            assert result["sessionCount"] == 1
+            nested = [
+                session
+                for repo in result["repos"]
+                for group in repo["groups"]
+                for session in group["sessions"]
+            ]
+            assert [session["id"] for session in nested] == [stored]
+        finally:
+            runtime._bindings.pop(mobile, None)

--- a/tests/tui_gateway/test_turn_recovery_journal.py
+++ b/tests/tui_gateway/test_turn_recovery_journal.py
@@ -1,0 +1,749 @@
+"""Tests for the turn-recovery v2 journal and capability advertisement.
+
+The wire contract these tests pin is defined by the Hermes Android client's
+fail-closed parser (``lib/core/models/gateway_turn_contract.dart``). Every
+assertion here mirrors a rejection branch in that parser: if the server emits a
+capability block or reconcile page that violates one of these invariants, the
+client silently falls back to the legacy transport instead of erroring, so a
+contract regression is invisible in production. That is why these are strict
+invariant assertions and not snapshot comparisons.
+"""
+
+import pytest
+
+from tui_gateway.turn_recovery import (
+    ATTACHMENT_DETACH_METHOD,
+    CAPABILITY_VERSION,
+    CORE_METHODS,
+    EXECUTION_ROUTE,
+    PROMPT_SUBMIT_VERSION,
+    PROTOCOL_MAJOR,
+    PROTOCOL_NAME,
+    TurnJournal,
+    TurnLimits,
+    TurnRecoveryError,
+    build_protocol_frame,
+    build_turn_recovery_capability,
+)
+
+
+class _Clock:
+    """Deterministic monotonic-ish clock; tests advance it explicitly."""
+
+    def __init__(self, now: float = 1000.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock() -> _Clock:
+    return _Clock()
+
+
+@pytest.fixture
+def journal(clock: _Clock) -> TurnJournal:
+    return TurnJournal(clock=clock)
+
+
+def _digest(char: str = "a") -> str:
+    return char * 64
+
+
+# ---------------------------------------------------------------------------
+# Capability advertisement
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityAdvertisement:
+    def test_protocol_frame_matches_client_expectation(self):
+        protocol = build_protocol_frame()
+        assert protocol == {"name": PROTOCOL_NAME, "major": PROTOCOL_MAJOR}
+        assert protocol["name"] == "hermes-jsonrpc"
+        assert protocol["major"] == 2
+
+    def test_capability_declares_exact_versions(self):
+        cap = build_turn_recovery_capability()
+        assert cap["version"] == CAPABILITY_VERSION == 2
+        assert cap["prompt_submit_version"] == PROMPT_SUBMIT_VERSION == 2
+
+    def test_capability_declares_safety_invariants(self):
+        cap = build_turn_recovery_capability()
+        # The client refuses the capability unless both are literally False.
+        assert cap["shadow_only"] is False
+        assert cap["automatic_resubmit"] is False
+        assert cap["execution_route"] == EXECUTION_ROUTE
+        assert cap["mobile_session_id_format"] == "canonical_lowercase_uuid"
+        assert cap["client_turn_id_format"] == "canonical_lowercase_uuid"
+
+    def test_method_sets_are_exact_without_attachments(self):
+        cap = build_turn_recovery_capability(attachments_supported=False)
+        assert set(cap["methods"]) == set(CORE_METHODS)
+        assert set(cap["applies_to"]) == set(CORE_METHODS) | {"prompt.submit@2"}
+        assert ATTACHMENT_DETACH_METHOD not in cap["methods"]
+
+    def test_method_sets_extend_together_with_attachments(self):
+        cap = build_turn_recovery_capability(attachments_supported=True)
+        assert set(cap["methods"]) == set(CORE_METHODS) | {ATTACHMENT_DETACH_METHOD}
+        assert set(cap["applies_to"]) == (
+            set(CORE_METHODS) | {"prompt.submit@2", ATTACHMENT_DETACH_METHOD}
+        )
+
+    def test_method_lists_have_no_duplicates(self):
+        # The client parses these with a strict set builder that rejects
+        # duplicates outright.
+        for attachments in (False, True):
+            cap = build_turn_recovery_capability(attachments_supported=attachments)
+            for key in ("methods", "applies_to"):
+                assert len(cap[key]) == len(set(cap[key])), key
+
+    def test_attachment_limits_present_only_when_supported(self):
+        attachment_keys = (
+            "max_attachments",
+            "max_file_attachment_bytes",
+            "max_image_attachment_bytes",
+            "max_pdf_attachment_bytes",
+            "max_attachment_registry_bytes",
+        )
+        without = build_turn_recovery_capability(attachments_supported=False)
+        for key in attachment_keys:
+            assert key not in without
+        with_attachments = build_turn_recovery_capability(attachments_supported=True)
+        for key in attachment_keys:
+            assert with_attachments[key] > 0
+
+    def test_retention_and_byte_limits_satisfy_client_inequalities(self):
+        cap = build_turn_recovery_capability()
+        assert cap["event_retention_seconds"] > 0
+        assert cap["turn_retention_seconds"] >= cap["event_retention_seconds"]
+        assert cap["max_event_bytes"] > 0
+        assert cap["max_turn_bytes"] > 0
+        assert 0 < cap["terminal_event_reserve_bytes"] <= cap["max_event_bytes"]
+        assert cap["max_prompt_bytes"] > 0
+        assert cap["reconcile_max_events"] > 0
+        assert cap["reconcile_max_page_bytes"] >= cap["max_event_bytes"]
+
+    def test_all_advertised_integers_are_real_ints(self):
+        # The client uses an exact int check that rejects bools and floats.
+        cap = build_turn_recovery_capability(attachments_supported=True)
+        for key, value in cap.items():
+            if key in {"methods", "applies_to"}:
+                continue
+            if isinstance(value, bool) or isinstance(value, str):
+                continue
+            assert isinstance(value, int), key
+
+    def test_capability_reflects_custom_limits(self):
+        limits = TurnLimits(
+            event_retention_seconds=60,
+            turn_retention_seconds=120,
+            max_event_bytes=1024,
+            max_turn_bytes=8192,
+            terminal_event_reserve_bytes=256,
+            max_prompt_bytes=4096,
+            reconcile_max_events=10,
+            reconcile_max_page_bytes=2048,
+        )
+        cap = build_turn_recovery_capability(limits=limits)
+        assert cap["event_retention_seconds"] == 60
+        assert cap["turn_retention_seconds"] == 120
+        assert cap["reconcile_max_events"] == 10
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"event_retention_seconds": 0},
+            {"turn_retention_seconds": 10, "event_retention_seconds": 20},
+            {"terminal_event_reserve_bytes": 4096, "max_event_bytes": 1024},
+            {"reconcile_max_page_bytes": 512, "max_event_bytes": 1024},
+            {"max_prompt_bytes": 0},
+            {"reconcile_max_events": 0},
+        ],
+    )
+    def test_invalid_limits_are_rejected_at_construction(self, kwargs):
+        base = dict(
+            event_retention_seconds=60,
+            turn_retention_seconds=120,
+            max_event_bytes=1024,
+            max_turn_bytes=8192,
+            terminal_event_reserve_bytes=256,
+            max_prompt_bytes=4096,
+            reconcile_max_events=10,
+            reconcile_max_page_bytes=2048,
+        )
+        base.update(kwargs)
+        with pytest.raises(ValueError):
+            TurnLimits(**base)
+
+
+# ---------------------------------------------------------------------------
+# Journal: sequencing
+# ---------------------------------------------------------------------------
+
+
+class TestJournalSequencing:
+    def test_open_turn_starts_at_seq_zero(self, journal: TurnJournal):
+        turn = journal.open_turn(session_id="s1", client_turn_id="c1")
+        assert turn.last_seq == 0
+        assert turn.status == "accepted"
+
+    def test_events_are_numbered_from_one_and_contiguous(self, journal: TurnJournal):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        seqs = [
+            journal.append_event("s1", "c1", "message.start", "m1", {}).seq,
+            journal.append_event(
+                "s1", "c1", "message.delta", "m1", {"text": "a"}
+            ).seq,
+            journal.append_event(
+                "s1", "c1", "message.delta", "m1", {"text": "b"}
+            ).seq,
+        ]
+        assert seqs == [1, 2, 3]
+
+    def test_last_seq_tracks_the_newest_event(self, journal: TurnJournal):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.append_event("s1", "c1", "message.start", "m1", {})
+        journal.append_event("s1", "c1", "message.delta", "m1", {"text": "a"})
+        assert journal.get_turn("s1", "c1").last_seq == 2
+
+    def test_sequences_are_independent_per_turn(self, journal: TurnJournal):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.open_turn(session_id="s1", client_turn_id="c2")
+        journal.append_event("s1", "c1", "message.start", "m1", {})
+        first_of_second = journal.append_event("s1", "c2", "message.start", "m2", {})
+        assert first_of_second.seq == 1
+
+    def test_sequence_never_reused_after_pruning(self, clock: _Clock):
+        limits = TurnLimits(
+            event_retention_seconds=10,
+            turn_retention_seconds=1000,
+            max_event_bytes=1024,
+            max_turn_bytes=65536,
+            terminal_event_reserve_bytes=256,
+            max_prompt_bytes=4096,
+            reconcile_max_events=50,
+            reconcile_max_page_bytes=4096,
+        )
+        journal = TurnJournal(clock=clock, limits=limits)
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.append_event("s1", "c1", "message.start", "m1", {})
+        clock.advance(50)
+        journal.prune()
+        event = journal.append_event("s1", "c1", "message.delta", "m1", {"text": "x"})
+        assert event.seq == 2
+
+
+# ---------------------------------------------------------------------------
+# Journal: idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestJournalIdempotency:
+    def test_reopening_same_client_turn_id_returns_existing_turn(
+        self, journal: TurnJournal
+    ):
+        first = journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.append_event("s1", "c1", "message.start", "m1", {})
+        second = journal.open_turn(session_id="s1", client_turn_id="c1")
+        assert second.turn_id == first.turn_id
+        assert second.created is False
+        assert second.last_seq == 1
+
+    def test_first_open_reports_created_true(self, journal: TurnJournal):
+        assert journal.open_turn(session_id="s1", client_turn_id="c1").created is True
+
+    def test_same_client_turn_id_in_other_session_is_a_distinct_turn(
+        self, journal: TurnJournal
+    ):
+        a = journal.open_turn(session_id="s1", client_turn_id="c1")
+        b = journal.open_turn(session_id="s2", client_turn_id="c1")
+        assert a.turn_id != b.turn_id
+
+    def test_turn_ids_are_unique(self, journal: TurnJournal):
+        ids = {
+            journal.open_turn(session_id="s1", client_turn_id=f"c{i}").turn_id
+            for i in range(25)
+        }
+        assert len(ids) == 25
+
+
+# ---------------------------------------------------------------------------
+# Journal: event payload validation
+# ---------------------------------------------------------------------------
+
+
+class TestEventPayloadValidation:
+    @pytest.mark.parametrize(
+        "event_type,payload",
+        [
+            ("message.start", {}),
+            ("message.delta", {"text": "hello"}),
+            ("message.complete", {"text": "done", "status": "completed"}),
+            ("turn.status", {"status": "running"}),
+        ],
+    )
+    def test_valid_payloads_are_accepted(
+        self, journal: TurnJournal, event_type, payload
+    ):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        assert journal.append_event("s1", "c1", event_type, "m1", payload).seq == 1
+
+    @pytest.mark.parametrize(
+        "event_type,payload",
+        [
+            ("message.start", {"text": "unexpected"}),
+            ("message.delta", {}),
+            ("message.delta", {"text": 1}),
+            ("message.delta", {"text": "a", "extra": "b"}),
+            ("message.complete", {"text": "d"}),
+            # message.complete must carry a terminal status.
+            ("message.complete", {"text": "d", "status": "running"}),
+            ("turn.status", {"status": "not-a-status"}),
+            ("turn.status", {}),
+            ("unknown.type", {}),
+        ],
+    )
+    def test_invalid_payloads_are_rejected(
+        self, journal: TurnJournal, event_type, payload
+    ):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        with pytest.raises(TurnRecoveryError):
+            journal.append_event("s1", "c1", event_type, "m1", payload)
+
+    def test_rejected_event_does_not_consume_a_sequence_number(
+        self, journal: TurnJournal
+    ):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        with pytest.raises(TurnRecoveryError):
+            journal.append_event("s1", "c1", "message.delta", "m1", {})
+        assert journal.append_event("s1", "c1", "message.start", "m1", {}).seq == 1
+
+    def test_append_to_unknown_turn_raises(self, journal: TurnJournal):
+        with pytest.raises(TurnRecoveryError):
+            journal.append_event("s1", "missing", "message.start", "m1", {})
+
+    def test_oversized_event_is_rejected(self, clock: _Clock):
+        limits = TurnLimits(
+            event_retention_seconds=60,
+            turn_retention_seconds=120,
+            max_event_bytes=64,
+            max_turn_bytes=8192,
+            terminal_event_reserve_bytes=32,
+            max_prompt_bytes=4096,
+            reconcile_max_events=10,
+            reconcile_max_page_bytes=2048,
+        )
+        journal = TurnJournal(clock=clock, limits=limits)
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        with pytest.raises(TurnRecoveryError):
+            journal.append_event(
+                "s1", "c1", "message.delta", "m1", {"text": "x" * 500}
+            )
+
+
+# ---------------------------------------------------------------------------
+# Journal: status transitions
+# ---------------------------------------------------------------------------
+
+
+class TestStatusTransitions:
+    def test_status_updates_are_recorded(self, journal: TurnJournal):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.set_status("s1", "c1", "running")
+        assert journal.get_turn("s1", "c1").status == "running"
+
+    def test_terminal_status_is_final(self, journal: TurnJournal):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.set_status("s1", "c1", "completed")
+        with pytest.raises(TurnRecoveryError):
+            journal.set_status("s1", "c1", "running")
+
+    def test_append_after_terminal_status_is_rejected(self, journal: TurnJournal):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.set_status("s1", "c1", "completed")
+        with pytest.raises(TurnRecoveryError):
+            journal.append_event("s1", "c1", "message.delta", "m1", {"text": "x"})
+
+    def test_unknown_status_is_rejected(self, journal: TurnJournal):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        with pytest.raises(TurnRecoveryError):
+            journal.set_status("s1", "c1", "bogus")
+
+    def test_interrupt_marks_turn_interrupted_and_returns_last_seq(
+        self, journal: TurnJournal
+    ):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.append_event("s1", "c1", "message.start", "m1", {})
+        result = journal.interrupt("s1", "c1")
+        assert result.status == "interrupted"
+        # last_seq must be monotonic: the interrupt itself emits turn.status.
+        assert result.last_seq >= 1
+        assert journal.get_turn("s1", "c1").status == "interrupted"
+
+    def test_interrupt_is_idempotent(self, journal: TurnJournal):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        first = journal.interrupt("s1", "c1")
+        second = journal.interrupt("s1", "c1")
+        assert second.status == "interrupted"
+        assert second.last_seq == first.last_seq
+
+
+# ---------------------------------------------------------------------------
+# Reconcile pages
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileEventsMode:
+    def _seed(self, journal: TurnJournal, deltas: int = 3):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.append_event("s1", "c1", "message.start", "m1", {})
+        for index in range(deltas):
+            journal.append_event(
+                "s1", "c1", "message.delta", "m1", {"text": str(index)}
+            )
+
+    def test_full_replay_from_zero(self, journal: TurnJournal):
+        self._seed(journal)
+        page = journal.reconcile("s1", "c1", after_seq=0)
+        assert page["mode"] == "events"
+        assert page["automatic_resubmit"] is False
+        assert [event["seq"] for event in page["events"]] == [1, 2, 3, 4]
+        assert page["next_after_seq"] == 4
+        assert page["last_seq"] == 4
+        assert page["has_more"] is False
+
+    def test_events_start_exactly_after_the_cursor(self, journal: TurnJournal):
+        self._seed(journal)
+        page = journal.reconcile("s1", "c1", after_seq=2)
+        assert [event["seq"] for event in page["events"]] == [3, 4]
+
+    def test_caught_up_cursor_returns_empty_page(self, journal: TurnJournal):
+        self._seed(journal)
+        page = journal.reconcile("s1", "c1", after_seq=4)
+        assert page["events"] == []
+        assert page["next_after_seq"] == 4
+        assert page["has_more"] is False
+
+    def test_pagination_respects_reconcile_max_events(self, clock: _Clock):
+        limits = TurnLimits(
+            event_retention_seconds=600,
+            turn_retention_seconds=1200,
+            max_event_bytes=1024,
+            max_turn_bytes=65536,
+            terminal_event_reserve_bytes=256,
+            max_prompt_bytes=4096,
+            reconcile_max_events=2,
+            reconcile_max_page_bytes=65536,
+        )
+        journal = TurnJournal(clock=clock, limits=limits)
+        self._seed(journal)
+        page = journal.reconcile("s1", "c1", after_seq=0)
+        assert [event["seq"] for event in page["events"]] == [1, 2]
+        assert page["next_after_seq"] == 2
+        assert page["has_more"] is True
+        assert page["last_seq"] == 4
+
+    def test_pagination_respects_page_byte_budget(self, clock: _Clock):
+        limits = TurnLimits(
+            event_retention_seconds=600,
+            turn_retention_seconds=1200,
+            max_event_bytes=4096,
+            max_turn_bytes=1_000_000,
+            terminal_event_reserve_bytes=256,
+            max_prompt_bytes=4096,
+            reconcile_max_events=100,
+            reconcile_max_page_bytes=4096,
+        )
+        journal = TurnJournal(clock=clock, limits=limits)
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        for index in range(10):
+            journal.append_event(
+                "s1", "c1", "message.delta", "m1", {"text": "x" * 1000}
+            )
+        page = journal.reconcile("s1", "c1", after_seq=0)
+        assert 0 < len(page["events"]) < 10
+        assert page["has_more"] is True
+
+    def test_at_least_one_event_is_returned_when_progress_is_possible(
+        self, clock: _Clock
+    ):
+        # Never return an empty page while last_seq > after_seq: the client
+        # treats that exact shape as a protocol violation and gives up.
+        limits = TurnLimits(
+            event_retention_seconds=600,
+            turn_retention_seconds=1200,
+            max_event_bytes=4096,
+            max_turn_bytes=1_000_000,
+            terminal_event_reserve_bytes=256,
+            max_prompt_bytes=4096,
+            reconcile_max_events=100,
+            reconcile_max_page_bytes=4096,
+        )
+        journal = TurnJournal(clock=clock, limits=limits)
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.append_event("s1", "c1", "message.delta", "m1", {"text": "x" * 3000})
+        page = journal.reconcile("s1", "c1", after_seq=0)
+        assert len(page["events"]) == 1
+
+    def test_page_cursor_progresses_to_completion(self, clock: _Clock):
+        limits = TurnLimits(
+            event_retention_seconds=600,
+            turn_retention_seconds=1200,
+            max_event_bytes=1024,
+            max_turn_bytes=1_000_000,
+            terminal_event_reserve_bytes=256,
+            max_prompt_bytes=4096,
+            reconcile_max_events=2,
+            reconcile_max_page_bytes=65536,
+        )
+        journal = TurnJournal(clock=clock, limits=limits)
+        self._seed(journal, deltas=6)
+        cursor = 0
+        collected = []
+        for _ in range(10):
+            page = journal.reconcile("s1", "c1", after_seq=cursor)
+            collected.extend(event["seq"] for event in page["events"])
+            cursor = page["next_after_seq"]
+            if not page["has_more"]:
+                break
+        assert collected == list(range(1, 8))
+
+    def test_has_more_is_exactly_cursor_behind_last_seq(self, journal: TurnJournal):
+        self._seed(journal)
+        for cursor in range(0, 5):
+            page = journal.reconcile("s1", "c1", after_seq=cursor)
+            assert page["has_more"] == (page["next_after_seq"] < page["last_seq"])
+
+    def test_earliest_seq_is_positive(self, journal: TurnJournal):
+        self._seed(journal)
+        assert journal.reconcile("s1", "c1", after_seq=0)["earliest_seq"] >= 1
+
+    def test_negative_cursor_is_rejected(self, journal: TurnJournal):
+        self._seed(journal)
+        with pytest.raises(TurnRecoveryError):
+            journal.reconcile("s1", "c1", after_seq=-1)
+
+    def test_cursor_ahead_of_last_seq_is_rejected(self, journal: TurnJournal):
+        self._seed(journal)
+        with pytest.raises(TurnRecoveryError):
+            journal.reconcile("s1", "c1", after_seq=99)
+
+    def test_unknown_turn_is_rejected(self, journal: TurnJournal):
+        with pytest.raises(TurnRecoveryError):
+            journal.reconcile("s1", "nope", after_seq=0)
+
+
+class TestReconcileSnapshotMode:
+    def _complete_turn(self, journal: TurnJournal):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.append_event("s1", "c1", "message.start", "m1", {})
+        journal.append_event("s1", "c1", "message.delta", "m1", {"text": "hello"})
+        journal.append_event(
+            "s1",
+            "c1",
+            "message.complete",
+            "m1",
+            {"text": "hello", "status": "completed"},
+        )
+        journal.set_status("s1", "c1", "completed")
+
+    def test_pruned_events_fall_back_to_snapshot(self, clock: _Clock):
+        limits = TurnLimits(
+            event_retention_seconds=10,
+            turn_retention_seconds=10_000,
+            max_event_bytes=1024,
+            max_turn_bytes=65536,
+            terminal_event_reserve_bytes=256,
+            max_prompt_bytes=4096,
+            reconcile_max_events=50,
+            reconcile_max_page_bytes=4096,
+        )
+        journal = TurnJournal(clock=clock, limits=limits)
+        self._complete_turn(journal)
+        journal.set_final_message_ref("s1", "c1", 42)
+        journal.set_attachment_manifest_digest("s1", "c1", _digest())
+        clock.advance(100)
+        journal.prune()
+
+        page = journal.reconcile("s1", "c1", after_seq=0)
+        assert page["mode"] == "snapshot"
+        assert page["has_more"] is False
+        assert page["automatic_resubmit"] is False
+        snapshot = page["snapshot"]
+        assert snapshot["status"] == "completed"
+        assert snapshot["assistant"]["complete"] is True
+        assert snapshot["assistant"]["text"] == "hello"
+        assert snapshot["final_message_ref"] == 42
+        assert snapshot["attachment_manifest_digest"] == _digest()
+
+    def test_snapshot_cursors_are_pinned_to_last_seq(self, clock: _Clock):
+        limits = TurnLimits(
+            event_retention_seconds=10,
+            turn_retention_seconds=10_000,
+            max_event_bytes=1024,
+            max_turn_bytes=65536,
+            terminal_event_reserve_bytes=256,
+            max_prompt_bytes=4096,
+            reconcile_max_events=50,
+            reconcile_max_page_bytes=4096,
+        )
+        journal = TurnJournal(clock=clock, limits=limits)
+        self._complete_turn(journal)
+        journal.set_final_message_ref("s1", "c1", 7)
+        journal.set_attachment_manifest_digest("s1", "c1", _digest("b"))
+        clock.advance(100)
+        journal.prune()
+
+        page = journal.reconcile("s1", "c1", after_seq=0)
+        assert page["next_after_seq"] == page["last_seq"]
+        assert page["snapshot"]["last_seq"] == page["last_seq"]
+
+    def test_snapshot_requires_terminal_status(self, clock: _Clock):
+        limits = TurnLimits(
+            event_retention_seconds=10,
+            turn_retention_seconds=10_000,
+            max_event_bytes=1024,
+            max_turn_bytes=65536,
+            terminal_event_reserve_bytes=256,
+            max_prompt_bytes=4096,
+            reconcile_max_events=50,
+            reconcile_max_page_bytes=4096,
+        )
+        journal = TurnJournal(clock=clock, limits=limits)
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.append_event("s1", "c1", "message.start", "m1", {})
+        clock.advance(100)
+        journal.prune()
+        # Still running with its events pruned: no honest answer exists, so the
+        # server must fail loudly instead of fabricating a snapshot.
+        with pytest.raises(TurnRecoveryError):
+            journal.reconcile("s1", "c1", after_seq=0)
+
+    def test_snapshot_digest_defaults_to_empty_manifest_digest(self, clock: _Clock):
+        limits = TurnLimits(
+            event_retention_seconds=10,
+            turn_retention_seconds=10_000,
+            max_event_bytes=1024,
+            max_turn_bytes=65536,
+            terminal_event_reserve_bytes=256,
+            max_prompt_bytes=4096,
+            reconcile_max_events=50,
+            reconcile_max_page_bytes=4096,
+        )
+        journal = TurnJournal(clock=clock, limits=limits)
+        self._complete_turn(journal)
+        journal.set_final_message_ref("s1", "c1", 3)
+        clock.advance(100)
+        journal.prune()
+        digest = journal.reconcile("s1", "c1", after_seq=0)["snapshot"][
+            "attachment_manifest_digest"
+        ]
+        assert len(digest) == 64
+        assert all(char in "0123456789abcdef" for char in digest)
+
+    def test_invalid_digest_is_rejected(self, journal: TurnJournal):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        with pytest.raises(TurnRecoveryError):
+            journal.set_attachment_manifest_digest("s1", "c1", "NOT-HEX")
+
+    def test_invalid_final_message_ref_is_rejected(self, journal: TurnJournal):
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        with pytest.raises(TurnRecoveryError):
+            journal.set_final_message_ref("s1", "c1", 0)
+
+
+# ---------------------------------------------------------------------------
+# Retention
+# ---------------------------------------------------------------------------
+
+
+class TestRetention:
+    def _limits(self) -> TurnLimits:
+        return TurnLimits(
+            event_retention_seconds=10,
+            turn_retention_seconds=100,
+            max_event_bytes=1024,
+            max_turn_bytes=65536,
+            terminal_event_reserve_bytes=256,
+            max_prompt_bytes=4096,
+            reconcile_max_events=50,
+            reconcile_max_page_bytes=4096,
+        )
+
+    def test_fresh_events_survive_pruning(self, clock: _Clock):
+        journal = TurnJournal(clock=clock, limits=self._limits())
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.append_event("s1", "c1", "message.start", "m1", {})
+        clock.advance(5)
+        journal.prune()
+        assert journal.reconcile("s1", "c1", after_seq=0)["events"] != []
+
+    def test_expired_turn_is_dropped_entirely(self, clock: _Clock):
+        journal = TurnJournal(clock=clock, limits=self._limits())
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.append_event("s1", "c1", "message.start", "m1", {})
+        clock.advance(1000)
+        journal.prune()
+        with pytest.raises(TurnRecoveryError):
+            journal.reconcile("s1", "c1", after_seq=0)
+
+    def test_turn_byte_cap_evicts_oldest_events_first(self, clock: _Clock):
+        limits = TurnLimits(
+            event_retention_seconds=10_000,
+            turn_retention_seconds=100_000,
+            max_event_bytes=4096,
+            max_turn_bytes=6000,
+            terminal_event_reserve_bytes=512,
+            max_prompt_bytes=4096,
+            reconcile_max_events=100,
+            reconcile_max_page_bytes=8192,
+        )
+        journal = TurnJournal(clock=clock, limits=limits)
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        for _ in range(10):
+            journal.append_event(
+                "s1", "c1", "message.delta", "m1", {"text": "x" * 1000}
+            )
+        page = journal.reconcile("s1", "c1", after_seq=9)
+        assert page["earliest_seq"] > 1
+        assert page["last_seq"] == 10
+
+    def test_terminal_event_is_admitted_within_its_reserve(self, clock: _Clock):
+        limits = TurnLimits(
+            event_retention_seconds=10_000,
+            turn_retention_seconds=100_000,
+            max_event_bytes=4096,
+            max_turn_bytes=4000,
+            terminal_event_reserve_bytes=2048,
+            max_prompt_bytes=4096,
+            reconcile_max_events=100,
+            reconcile_max_page_bytes=8192,
+        )
+        journal = TurnJournal(clock=clock, limits=limits)
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        for _ in range(20):
+            journal.append_event(
+                "s1", "c1", "message.delta", "m1", {"text": "x" * 500}
+            )
+        event = journal.append_event(
+            "s1",
+            "c1",
+            "message.complete",
+            "m1",
+            {"text": "final", "status": "completed"},
+        )
+        assert event.seq == 21
+        assert journal.get_turn("s1", "c1").last_seq == 21
+
+    def test_prune_is_idempotent(self, clock: _Clock):
+        journal = TurnJournal(clock=clock, limits=self._limits())
+        journal.open_turn(session_id="s1", client_turn_id="c1")
+        journal.append_event("s1", "c1", "message.start", "m1", {})
+        clock.advance(50)
+        journal.prune()
+        journal.prune()
+        assert journal.get_turn("s1", "c1").last_seq == 1

--- a/tests/tui_gateway/test_turn_recovery_runtime.py
+++ b/tests/tui_gateway/test_turn_recovery_runtime.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+import json
+import threading
+import uuid
+from pathlib import Path
+
+import pytest
+
+from tui_gateway.turn_recovery import TurnLimits
+from tui_gateway.turn_recovery_runtime import TurnRecoveryRuntime
+
+
+MOBILE_ID = "11111111-1111-4111-8111-111111111111"
+CLIENT_TURN_ID = "22222222-2222-4222-8222-222222222222"
+
+
+class FakeServer:
+    def __init__(self) -> None:
+        self._methods = {}
+        self._sessions = {}
+        self.calls: list[tuple[str, dict]] = []
+        self.persisted_sessions: list[str] = []
+        self.next_runtime = 1
+        self._methods.update(
+            {
+                "session.create": self._create,
+                "session.resume": self._resume,
+                "prompt.submit": self._submit,
+                "session.interrupt": self._interrupt,
+            }
+        )
+
+    def _ensure_session_db_row(self, session):
+        self.persisted_sessions.append(session["session_key"])
+
+    @staticmethod
+    def _ok(rid, result):
+        return {"jsonrpc": "2.0", "id": rid, "result": result}
+
+    @staticmethod
+    def _err(rid, code, message, *, data=None):
+        error = {"code": code, "message": message}
+        if data is not None:
+            error["data"] = data
+        return {"jsonrpc": "2.0", "id": rid, "error": error}
+
+    def _create(self, rid, params):
+        self.calls.append(("session.create", dict(params)))
+        runtime_id = f"runtime-{self.next_runtime}"
+        stored_id = f"stored-{self.next_runtime}"
+        self.next_runtime += 1
+        self._sessions[runtime_id] = {
+            "session_key": stored_id,
+            "history_lock": threading.Lock(),
+            "transport": object(),
+        }
+        return self._ok(
+            rid,
+            {"session_id": runtime_id, "stored_session_id": stored_id},
+        )
+
+    def _resume(self, rid, params):
+        self.calls.append(("session.resume", dict(params)))
+        stored_id = params["session_id"]
+        runtime_id = f"runtime-{self.next_runtime}"
+        self.next_runtime += 1
+        self._sessions[runtime_id] = {
+            "session_key": stored_id,
+            "history_lock": threading.Lock(),
+            "transport": object(),
+        }
+        return self._ok(
+            rid,
+            {"session_id": runtime_id, "stored_session_id": stored_id},
+        )
+
+    def _submit(self, rid, params):
+        self.calls.append(("prompt.submit", dict(params)))
+        return self._ok(rid, {"status": "streaming"})
+
+    def _interrupt(self, rid, params):
+        self.calls.append(("session.interrupt", dict(params)))
+        return self._ok(rid, {"status": "interrupted"})
+
+
+@pytest.fixture
+def installed(tmp_path: Path):
+    server = FakeServer()
+    runtime = TurnRecoveryRuntime(
+        server,
+        bindings_path=tmp_path / "bindings.json",
+        limits=TurnLimits(),
+    )
+    runtime.install()
+    return server, runtime
+
+
+def _result(response: dict) -> dict:
+    assert "error" not in response, response
+    return response["result"]
+
+
+def _open(server: FakeServer) -> dict:
+    return _result(
+        server._methods["session.open"](
+            "open-1", {"mobile_session_id": MOBILE_ID}
+        )
+    )
+
+
+def _submit_v2(server: FakeServer, runtime_session_id: str) -> dict:
+    return _result(
+        server._methods["prompt.submit"](
+            "submit-1",
+            {
+                "session_id": runtime_session_id,
+                "version": 2,
+                "client_turn_id": CLIENT_TURN_ID,
+                "text": "hello",
+            },
+        )
+    )
+
+
+class TestSessionOpen:
+    def test_creates_binding_with_exact_capability(self, installed):
+        server, _runtime = installed
+
+        result = _open(server)
+
+        assert result["turn_recovery"] is True
+        assert result["automatic_resubmit"] is False
+        assert result["runtime_session_id"] == "runtime-1"
+        assert result["stored_session_id"] == "stored-1"
+        assert result["mobile_session_id"] == MOBILE_ID
+        assert result["binding_version"] == 1
+        assert server.persisted_sessions == ["stored-1"]
+        assert result["capabilities"]["turn_recovery"]["version"] == 2
+        assert result["capabilities"]["turn_recovery"]["methods"] == [
+            "session.open",
+            "turn.reconcile",
+            "turn.interrupt",
+        ]
+        assert server._sessions["runtime-1"]["_turn_recovery_mobile_session_id"] == MOBILE_ID
+
+    def test_reconnect_resumes_same_stored_session_and_increments_version(self, installed):
+        server, _runtime = installed
+        first = _open(server)
+
+        second = _result(
+            server._methods["session.open"](
+                "open-2", {"mobile_session_id": MOBILE_ID}
+            )
+        )
+
+        assert second["stored_session_id"] == first["stored_session_id"]
+        assert second["runtime_session_id"] != first["runtime_session_id"]
+        assert second["binding_version"] == 2
+        assert server.calls[-1] == (
+            "session.resume",
+            {"session_id": first["stored_session_id"], "source": "android"},
+        )
+
+    def test_binding_survives_runtime_reconstruction(self, tmp_path: Path):
+        path = tmp_path / "bindings.json"
+        server1 = FakeServer()
+        runtime1 = TurnRecoveryRuntime(server1, bindings_path=path)
+        runtime1.install()
+        first = _open(server1)
+
+        server2 = FakeServer()
+        runtime2 = TurnRecoveryRuntime(server2, bindings_path=path)
+        runtime2.install()
+        second = _open(server2)
+
+        assert second["stored_session_id"] == first["stored_session_id"]
+        assert second["binding_version"] == 2
+        assert json.loads(path.read_text())[MOBILE_ID] == {
+            "stored_session_id": "stored-1",
+            "binding_version": 2,
+        }
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "11111111-1111-4111-8111-11111111111A",
+            "11111111111141118111111111111111",
+            "not-a-uuid",
+        ],
+    )
+    def test_rejects_noncanonical_mobile_uuid(self, installed, bad):
+        server, _runtime = installed
+        response = server._methods["session.open"](
+            "bad-open", {"mobile_session_id": bad}
+        )
+        assert response["error"]["code"] == -32602
+        assert server.calls == []
+
+    def test_accepts_canonical_persisted_mobile_uuid_from_older_version(self, installed):
+        server, _runtime = installed
+        persisted_v1 = "11111111-1111-1111-8111-111111111111"
+
+        result = _result(
+            server._methods["session.open"](
+                "open-v1", {"mobile_session_id": persisted_v1}
+            )
+        )
+
+        assert result["mobile_session_id"] == persisted_v1
+
+
+class TestPromptSubmitV2:
+    def test_acknowledges_first_submit_and_calls_legacy_handler_once(self, installed):
+        server, _runtime = installed
+        opened = _open(server)
+
+        ack = _submit_v2(server, opened["runtime_session_id"])
+
+        assert ack["accepted"] is True
+        assert ack["automatic_resubmit"] is False
+        assert ack["client_turn_id"] == CLIENT_TURN_ID
+        assert ack["status"] == "accepted"
+        assert ack["last_seq"] == 0
+        assert ack["created"] is True
+        uuid.UUID(ack["turn_id"])
+        assert [name for name, _ in server.calls].count("prompt.submit") == 1
+
+    def test_duplicate_submit_returns_same_turn_without_second_execution(self, installed):
+        server, _runtime = installed
+        opened = _open(server)
+        first = _submit_v2(server, opened["runtime_session_id"])
+
+        second = _submit_v2(server, opened["runtime_session_id"])
+
+        assert second["turn_id"] == first["turn_id"]
+        assert second["created"] is False
+        assert [name for name, _ in server.calls].count("prompt.submit") == 1
+
+    def test_second_distinct_v2_turn_is_rejected_while_first_is_active(self, installed):
+        server, _runtime = installed
+        opened = _open(server)
+        _submit_v2(server, opened["runtime_session_id"])
+        other_client_turn_id = "33333333-3333-4333-8333-333333333333"
+
+        response = server._methods["prompt.submit"](
+            "submit-2",
+            {
+                "session_id": opened["runtime_session_id"],
+                "version": 2,
+                "client_turn_id": other_client_turn_id,
+                "text": "do not queue over the active recovery turn",
+            },
+        )
+
+        assert response["error"]["code"] == 4091
+        assert response["error"]["data"]["reason"] == "turn_active"
+        assert [name for name, _ in server.calls].count("prompt.submit") == 1
+
+    def test_legacy_submit_is_untouched(self, installed):
+        server, _runtime = installed
+        opened = _open(server)
+
+        response = server._methods["prompt.submit"](
+            "legacy", {"session_id": opened["runtime_session_id"], "text": "old"}
+        )
+
+        assert _result(response) == {"status": "streaming"}
+
+    def test_rejects_v2_submit_outside_open_binding(self, installed):
+        server, _runtime = installed
+        response = server._methods["prompt.submit"](
+            "submit",
+            {
+                "session_id": "unknown",
+                "version": 2,
+                "client_turn_id": CLIENT_TURN_ID,
+                "text": "hello",
+            },
+        )
+        assert response["error"]["code"] == -32602
+
+
+class TestRecoveryEventsAndMethods:
+    def test_decorates_live_message_events_with_contiguous_journal_sequence(self, installed):
+        server, runtime = installed
+        opened = _open(server)
+        ack = _submit_v2(server, opened["runtime_session_id"])
+        sid = opened["runtime_session_id"]
+
+        start = runtime.decorate_event("message.start", sid, None)
+        delta = runtime.decorate_event(
+            "message.delta", sid, {"text": "hel", "rendered": "ignored"}
+        )
+        complete = runtime.decorate_event(
+            "message.complete",
+            sid,
+            {"text": "hello", "status": "complete", "usage": {"total": 1}},
+        )
+
+        assert start == {
+            "type": "message.start",
+            "session_id": sid,
+            "turn_id": ack["turn_id"],
+            "seq": 1,
+            "message_id": start["message_id"],
+            "payload": {},
+        }
+        assert delta["seq"] == 2
+        assert delta["payload"] == {"text": "hel"}
+        assert complete["seq"] == 3
+        assert complete["payload"] == {"text": "hello", "status": "completed"}
+
+    def test_reconcile_accepts_turn_id_and_returns_replay(self, installed):
+        server, runtime = installed
+        opened = _open(server)
+        ack = _submit_v2(server, opened["runtime_session_id"])
+        sid = opened["runtime_session_id"]
+        runtime.decorate_event("message.start", sid, None)
+        runtime.decorate_event("message.delta", sid, {"text": "x"})
+
+        page = _result(
+            server._methods["turn.reconcile"](
+                "reconcile",
+                {"session_id": sid, "turn_id": ack["turn_id"], "after_seq": 0},
+            )
+        )
+
+        assert page["mode"] == "events"
+        assert [event["seq"] for event in page["events"]] == [1, 2]
+        assert page["turn_id"] == ack["turn_id"]
+
+    def test_interrupt_stops_legacy_turn_and_closes_recovery_turn(self, installed):
+        server, runtime = installed
+        opened = _open(server)
+        ack = _submit_v2(server, opened["runtime_session_id"])
+        sid = opened["runtime_session_id"]
+        runtime.decorate_event("message.start", sid, None)
+
+        result = _result(
+            server._methods["turn.interrupt"](
+                "interrupt", {"session_id": sid, "turn_id": ack["turn_id"]}
+            )
+        )
+
+        assert result["automatic_resubmit"] is False
+        assert result["client_turn_id"] == CLIENT_TURN_ID
+        assert result["turn_id"] == ack["turn_id"]
+        assert result["status"] == "interrupted"
+        assert result["last_seq"] == 2
+        assert [name for name, _ in server.calls].count("session.interrupt") == 1
+
+    def test_error_event_becomes_terminal_failed_message(self, installed):
+        server, runtime = installed
+        opened = _open(server)
+        _submit_v2(server, opened["runtime_session_id"])
+
+        event = runtime.decorate_event(
+            "error", opened["runtime_session_id"], {"message": "boom"}
+        )
+
+        assert event["type"] == "message.complete"
+        assert event["payload"] == {"text": "Error: boom", "status": "failed"}
+
+
+class TestReadyAdvertisement:
+    def test_ready_payload_contains_protocol_and_capability(self, installed):
+        _server, runtime = installed
+        payload = runtime.ready_payload({"skin": {"name": "x"}, "change_events": True})
+        assert payload["skin"] == {"name": "x"}
+        assert payload["change_events"] is True
+        assert payload["protocol"] == {"name": "hermes-jsonrpc", "major": 2}
+        assert payload["capabilities"]["turn_recovery"]["version"] == 2
+
+
+class TestGatewayIntegration:
+    def test_server_registers_all_recovery_methods(self):
+        from tui_gateway import server
+
+        assert {
+            "session.open",
+            "prompt.submit",
+            "turn.reconcile",
+            "turn.interrupt",
+        } <= set(server._methods)
+        assert server._turn_recovery_runtime.server is server
+
+    def test_server_event_frame_delegates_to_recovery_runtime(self, monkeypatch):
+        from tui_gateway import server
+
+        monkeypatch.setattr(
+            server._turn_recovery_runtime,
+            "decorate_event",
+            lambda event, sid, payload: {
+                "type": event,
+                "session_id": sid,
+                "turn_id": "turn-1",
+                "seq": 7,
+                "message_id": "message-1",
+                "payload": payload or {},
+            },
+        )
+
+        frame = server._event_frame("message.delta", "sid", {"text": "x"})
+
+        assert frame["params"]["turn_id"] == "turn-1"
+        assert frame["params"]["seq"] == 7
+
+    def test_stdio_and_websocket_ready_payloads_use_runtime_capability(self):
+        from tui_gateway import entry, ws
+
+        for payload in (
+            entry.build_gateway_ready_payload({"name": "stdio"}),
+            ws.build_gateway_ready_payload({"name": "websocket"}),
+        ):
+            assert payload["protocol"] == {"name": "hermes-jsonrpc", "major": 2}
+            assert payload["capabilities"]["turn_recovery"]["version"] == 2
+            assert payload["change_events"] is True

--- a/tests/tui_gateway/test_turn_recovery_runtime.py
+++ b/tests/tui_gateway/test_turn_recovery_runtime.py
@@ -22,6 +22,7 @@ class FakeServer:
         self.calls: list[tuple[str, dict]] = []
         self.persisted_sessions: list[str] = []
         self.next_runtime = 1
+        self.resume_tip: str | None = None
         self._methods.update(
             {
                 "session.create": self._create,
@@ -62,7 +63,10 @@ class FakeServer:
 
     def _resume(self, rid, params):
         self.calls.append(("session.resume", dict(params)))
-        stored_id = params["session_id"]
+        # The real gateway's session.resume reports the stored identity as
+        # ``session_key`` and does NOT emit ``stored_session_id``; it may also
+        # follow a compression-continuation chain to a rotated tip.
+        stored_id = self.resume_tip or params["session_id"]
         runtime_id = f"runtime-{self.next_runtime}"
         self.next_runtime += 1
         self._sessions[runtime_id] = {
@@ -72,7 +76,7 @@ class FakeServer:
         }
         return self._ok(
             rid,
-            {"session_id": runtime_id, "stored_session_id": stored_id},
+            {"session_id": runtime_id, "session_key": stored_id},
         )
 
     def _submit(self, rid, params):
@@ -161,6 +165,36 @@ class TestSessionOpen:
             "session.resume",
             {"session_id": first["stored_session_id"], "source": "android"},
         )
+
+    def test_reconnect_rebinds_to_rotated_continuation_tip(self, installed):
+        server, _runtime = installed
+        first = _open(server)
+        server.resume_tip = "stored-rotated-tip"
+
+        second = _result(
+            server._methods["session.open"](
+                "open-rotated", {"mobile_session_id": MOBILE_ID}
+            )
+        )
+
+        assert second["stored_session_id"] == "stored-rotated-tip"
+        assert second["stored_session_id"] != first["stored_session_id"]
+        assert second["binding_version"] == 2
+
+        server.resume_tip = None
+        third = _result(
+            server._methods["session.open"](
+                "open-after-rotation", {"mobile_session_id": MOBILE_ID}
+            )
+        )
+
+        # The rotated tip must be what the next reconnect resumes, otherwise the
+        # phone silently rebinds to the pre-compression parent transcript.
+        assert server.calls[-1] == (
+            "session.resume",
+            {"session_id": "stored-rotated-tip", "source": "android"},
+        )
+        assert third["stored_session_id"] == "stored-rotated-tip"
 
     def test_binding_survives_runtime_reconstruction(self, tmp_path: Path):
         path = tmp_path / "bindings.json"

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -238,6 +238,33 @@ def _write_or_exit(payload: dict, reason: str) -> None:
         sys.exit(0)
 
 
+def build_gateway_ready_payload(
+    skin: dict,
+    *,
+    change_events: bool = True,
+    heartbeat: bool = False,
+) -> dict:
+    """Build the ``gateway.ready`` payload, including turn-recovery capability.
+
+    ``heartbeat`` is advertised only by the WS sidecar (handle_ws), which is the
+    transport that actually sends heartbeats; the stdio TUI leaves it off.
+
+    ``replay_epoch`` is part of the upstream WS replay contract: a reconnecting
+    client compares it to detect a backend restart and reset its per-session
+    seq watermarks. It is emitted here — rather than at each call site — so the
+    turn-recovery capability and the replay contract cannot drift apart again;
+    dropping either one silently degrades a client to legacy transport.
+    """
+    base: dict = {
+        "skin": skin,
+        "change_events": change_events,
+        "replay_epoch": replay_epoch(),
+    }
+    if heartbeat:
+        base["heartbeat"] = True
+    return server._turn_recovery_runtime.ready_payload(base)
+
+
 def main():
     _install_sidecar_publisher()
 
@@ -255,10 +282,12 @@ def main():
     ensure_mcp_discovery_started()
 
     # change_events: clients demote legacy polls; replay_epoch: WS restart detection.
+    # build_gateway_ready_payload emits replay_epoch + the turn-recovery
+    # capability so the two contracts cannot drift apart again.
     _write_or_exit({
         "jsonrpc": "2.0", "method": "event",
-        "params": {"type": "gateway.ready", "payload": {
-            "skin": resolve_skin(), "change_events": True, "replay_epoch": replay_epoch()}}},
+        "params": {"type": "gateway.ready",
+                   "payload": build_gateway_ready_payload(resolve_skin())}},
         "startup write failed (broken stdout pipe before first event)")
 
     # Live-apply skins Hermes activates mid-conversation.

--- a/tui_gateway/methods_projects.py
+++ b/tui_gateway/methods_projects.py
@@ -376,11 +376,21 @@ def _project_tree_inputs(
         # Explicit user ownership wins over cwd/repo inference. Keep the
         # assignment in projects.db (the server-authoritative project store),
         # then project it onto the session rows consumed by the pure tree
-        # builder.
+        # builder. New Project chats may be assigned under their *mobile* id
+        # before session.open binds it to a stored id, so resolve aliases via
+        # the turn-recovery runtime when present.
+        from tui_gateway import project_tree
+        from tui_gateway.turn_recovery_runtime import get_runtime
+
+        runtime = get_runtime()
+        mobile_to_stored = runtime.mobile_to_stored() if runtime is not None else {}
         for session in sessions:
             session_id = str(session.get("id") or "")
-            if session_id in assignments:
-                session["project_id"] = assignments[session_id]
+            project_id = project_tree.project_id_for_session(
+                session_id, assignments, mobile_to_stored
+            )
+            if project_id is not None:
+                session["project_id"] = project_id
         # backfill stays off the hot tree path — grouping uses the live resolver.
         discovered = []
         if include_discovered:

--- a/tui_gateway/methods_projects.py
+++ b/tui_gateway/methods_projects.py
@@ -118,6 +118,25 @@ def _(rid, params, pdb, conn) -> dict:
     return _ok(rid, {"active_id": pdb.get_active_id(conn)})
 
 
+@_projects_method("projects.assign_session")
+def _(rid, params, pdb, conn) -> dict:
+    """Persist explicit conversation ownership, independent of its cwd.
+
+    ``project_id: null`` moves the conversation back to the unassigned/Home
+    bucket. Requiring the target before writing ensures a typo cannot erase a
+    valid prior binding.
+    """
+    session_id = str(params.get("session_id") or "").strip()
+    if not session_id:
+        raise ValueError("session_id must not be empty")
+    raw_project_id = params.get("project_id")
+    project_id = None
+    if raw_project_id is not None:
+        project_id = _require_project(pdb, conn, {"id": raw_project_id}).id
+    pdb.assign_session(conn, session_id, project_id)
+    return _ok(rid, {"session_id": session_id, "project_id": project_id})
+
+
 @_projects_method("projects.for_cwd")
 def _(rid, params, pdb, conn) -> dict:
     cwd = _completion_cwd(
@@ -353,6 +372,15 @@ def _project_tree_inputs(
                 conn, policy_key, preserve_unversioned=_repo_discovery_policy_is_default(policy))
         projects = [p.to_dict() for p in pdb.list_projects(conn)]
         active_id = pdb.get_active_id(conn)
+        assignments = pdb.list_session_assignments(conn)
+        # Explicit user ownership wins over cwd/repo inference. Keep the
+        # assignment in projects.db (the server-authoritative project store),
+        # then project it onto the session rows consumed by the pure tree
+        # builder.
+        for session in sessions:
+            session_id = str(session.get("id") or "")
+            if session_id in assignments:
+                session["project_id"] = assignments[session_id]
         # backfill stays off the hot tree path — grouping uses the live resolver.
         discovered = []
         if include_discovered:

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -301,12 +301,18 @@ class _FolderIndex:
 
     def __init__(self, projects: list[dict]) -> None:
         self._by_path: dict[str, tuple[dict, int]] = {}
+        self._by_id: dict[str, dict] = {
+            str(project["id"]): project for project in projects if project.get("id")
+        }
         for project in projects:
             for folder in project.get("folders") or []:
                 segs = _comparison_segments(folder.get("path") or "")
                 # Deepest folder wins; ties keep the first project (scan order).
                 if segs and len(segs) > self._by_path.get("/".join(segs), (None, -1))[1]:
                     self._by_path["/".join(segs)] = (project, len(segs))
+
+    def by_id(self, project_id: str) -> Optional[dict]:
+        return self._by_id.get(str(project_id or ""))
 
     def match(self, target: str) -> tuple[Optional[dict], int]:
         """Owning project for ``target`` by longest ancestor folder, + its depth."""
@@ -320,6 +326,13 @@ class _FolderIndex:
 
 def _project_for_session(
         session: dict, index: _FolderIndex, resolve: Optional[Resolve]) -> Optional[dict]:
+    # User-assigned ownership is authoritative and intentionally independent
+    # from filesystem location. This is what makes Projects useful for ordinary
+    # chats rather than only coding sessions whose cwd happens to sit in a repo.
+    explicit = index.by_id(str(session.get("project_id") or ""))
+    if explicit is not None:
+        return explicit
+
     cwd = _field(session, "cwd")
     if not cwd:
         return None

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -324,6 +324,31 @@ class _FolderIndex:
         return None, -1
 
 
+def project_id_for_session(
+    session_id: str, assignments: dict[str, str], mobile_to_stored: dict[str, str]
+) -> Optional[str]:
+    """Explicit project assignment for a session row id, resolving mobile aliases.
+
+    ``assignments`` maps an id (as stored by ``projects.assign_session``) to a
+    project id. A session row's id is the durable stored id, but new Project
+    chats are assigned by their *mobile* id before ``session.open`` creates the
+    mobile->stored binding, so the stored-id row would never match the
+    assignment key. ``mobile_to_stored`` maps mobile id -> stored id; reverse it
+    to find the mobile alias of a stored row and look the assignment up under
+    that. A direct stored-id match always wins over the alias.
+    """
+    if not session_id:
+        return None
+    explicit = assignments.get(session_id)
+    if explicit is not None:
+        return explicit
+    stored_to_mobile = {stored: mobile for mobile, stored in mobile_to_stored.items()}
+    mobile = stored_to_mobile.get(session_id)
+    if mobile is not None:
+        return assignments.get(mobile)
+    return None
+
+
 def _project_for_session(
         session: dict, index: _FolderIndex, resolve: Optional[Resolve]) -> Optional[dict]:
     # User-assigned ownership is authoritative and intentionally independent

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -586,7 +586,11 @@ def write_json(obj: dict) -> bool:
 
 
 def _event_frame(event: str, sid: str, payload: dict | None = None) -> dict:
-    params: dict = {"type": event, "session_id": sid, **({"payload": payload} if payload is not None else {})}
+    runtime = globals().get("_turn_recovery_runtime")
+    if runtime is not None:
+        params = runtime.decorate_event(event, sid, payload)
+    else:
+        params: dict = {"type": event, "session_id": sid, **({"payload": payload} if payload is not None else {})}
     return {"jsonrpc": "2.0", "method": "event", "params": params}
 
 
@@ -3231,3 +3235,11 @@ for _m in (
     _methods_session_control, _methods_subagents, _methods_vault, _methods_free_tier):
     _m.register(sys.modules[__name__])
 del _m
+
+# Install only after the split handler modules above registered their legacy
+# methods: turn recovery wraps prompt.submit/session.interrupt and adds the
+# negotiated v2 methods without changing legacy dispatch.
+from tui_gateway.turn_recovery_runtime import install as _install_turn_recovery
+
+_turn_recovery_runtime = _install_turn_recovery(sys.modules[__name__])
+del _install_turn_recovery

--- a/tui_gateway/turn_recovery.py
+++ b/tui_gateway/turn_recovery.py
@@ -1,0 +1,662 @@
+"""Turn-recovery v2 journal and capability advertisement.
+
+Background
+----------
+The Hermes Android client can survive being backgrounded mid-turn: it keeps a
+``client_turn_id``, and on resume it asks the server to replay everything that
+happened while it was away. That handshake only engages when the gateway
+advertises a ``turn_recovery`` capability in its ``gateway.ready`` frame.
+
+The client's parser is deliberately *fail-closed*
+(``lib/core/models/gateway_turn_contract.dart``): if any field is missing,
+mistyped, or internally inconsistent, it silently disables recovery and falls
+back to the legacy transport rather than surfacing an error. That makes a
+malformed advertisement strictly worse than no advertisement at all — the app
+would negotiate a route the server cannot honour, and the failure would be
+invisible. Everything in this module is therefore built to be exact.
+
+Scope
+-----
+This module owns only the in-memory journal and the capability dict. Wiring it
+into ``gateway.ready`` and the JSON-RPC method table is deliberately left to
+later, separately reviewed changes, so that advertising the capability is the
+*last* step — never before the methods behind it actually work.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Deque, Dict, List, Optional, Tuple
+from collections import deque
+
+__all__ = [
+    "ATTACHMENT_DETACH_METHOD",
+    "CAPABILITY_VERSION",
+    "CORE_METHODS",
+    "EXECUTION_ROUTE",
+    "PROMPT_SUBMIT_VERSION",
+    "PROTOCOL_MAJOR",
+    "PROTOCOL_NAME",
+    "TERMINAL_STATUSES",
+    "TURN_STATUSES",
+    "TurnJournal",
+    "TurnLimits",
+    "TurnRecoveryError",
+    "build_protocol_frame",
+    "build_turn_recovery_capability",
+]
+
+# --- Wire constants -------------------------------------------------------
+# These mirror the client's compile-time constants exactly. Changing any of
+# them without a matching client release silently disables recovery.
+
+PROTOCOL_NAME = "hermes-jsonrpc"
+PROTOCOL_MAJOR = 2
+CAPABILITY_VERSION = 2
+PROMPT_SUBMIT_VERSION = 2
+EXECUTION_ROUTE = "single_process_in_process"
+UUID_FORMAT = "canonical_lowercase_uuid"
+
+SESSION_OPEN_METHOD = "session.open"
+RECONCILE_METHOD = "turn.reconcile"
+INTERRUPT_METHOD = "turn.interrupt"
+ATTACHMENT_DETACH_METHOD = "attachment.detach@2"
+PROMPT_SUBMIT_APPLIES_TO = "prompt.submit@2"
+
+CORE_METHODS: Tuple[str, ...] = (
+    SESSION_OPEN_METHOD,
+    RECONCILE_METHOD,
+    INTERRUPT_METHOD,
+)
+
+TURN_STATUSES = frozenset(
+    {"accepted", "running", "waiting_input", "completed", "failed", "interrupted"}
+)
+TERMINAL_STATUSES = frozenset({"completed", "failed", "interrupted"})
+
+_EVENT_TYPES = frozenset(
+    {"message.start", "message.delta", "message.complete", "turn.status"}
+)
+
+_EMPTY_MANIFEST_DIGEST = "0" * 64
+_HEX_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class TurnRecoveryError(Exception):
+    """Raised when a caller violates the turn-recovery contract."""
+
+
+@dataclass(frozen=True)
+class TurnLimits:
+    """Byte/count/retention budgets advertised to the client and enforced here.
+
+    The inequalities below are not stylistic: each one corresponds to a
+    rejection branch in the client's capability parser. Validating them at
+    construction means an operator misconfiguration fails loudly at startup
+    instead of silently disabling recovery on every phone.
+    """
+
+    event_retention_seconds: int = 900
+    turn_retention_seconds: int = 3600
+    max_event_bytes: int = 64 * 1024
+    max_turn_bytes: int = 4 * 1024 * 1024
+    terminal_event_reserve_bytes: int = 32 * 1024
+    max_prompt_bytes: int = 256 * 1024
+    reconcile_max_events: int = 250
+    reconcile_max_page_bytes: int = 512 * 1024
+    max_attachments: int = 8
+    max_file_attachment_bytes: int = 16 * 1024 * 1024
+    max_image_attachment_bytes: int = 16 * 1024 * 1024
+    max_pdf_attachment_bytes: int = 16 * 1024 * 1024
+    max_attachment_registry_bytes: int = 64 * 1024 * 1024
+
+    def __post_init__(self) -> None:
+        positive = (
+            "event_retention_seconds",
+            "turn_retention_seconds",
+            "max_event_bytes",
+            "max_turn_bytes",
+            "terminal_event_reserve_bytes",
+            "max_prompt_bytes",
+            "reconcile_max_events",
+            "reconcile_max_page_bytes",
+            "max_attachments",
+            "max_file_attachment_bytes",
+            "max_image_attachment_bytes",
+            "max_pdf_attachment_bytes",
+            "max_attachment_registry_bytes",
+        )
+        for name in positive:
+            value = getattr(self, name)
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                raise ValueError(f"{name} must be a positive int, got {value!r}")
+
+        if self.turn_retention_seconds < self.event_retention_seconds:
+            raise ValueError(
+                "turn_retention_seconds must be >= event_retention_seconds"
+            )
+        if self.terminal_event_reserve_bytes > self.max_event_bytes:
+            raise ValueError(
+                "terminal_event_reserve_bytes must be <= max_event_bytes"
+            )
+        if self.reconcile_max_page_bytes < self.max_event_bytes:
+            raise ValueError("reconcile_max_page_bytes must be >= max_event_bytes")
+        if self.max_turn_bytes <= self.terminal_event_reserve_bytes:
+            raise ValueError(
+                "max_turn_bytes must exceed terminal_event_reserve_bytes"
+            )
+
+
+def build_protocol_frame() -> Dict[str, Any]:
+    """Return the ``protocol`` block for ``gateway.ready``."""
+
+    return {"name": PROTOCOL_NAME, "major": PROTOCOL_MAJOR}
+
+
+def build_turn_recovery_capability(
+    *,
+    limits: Optional[TurnLimits] = None,
+    attachments_supported: bool = False,
+) -> Dict[str, Any]:
+    """Return the ``capabilities.turn_recovery`` block for ``gateway.ready``.
+
+    ``attachments_supported`` must reflect a route that is genuinely
+    implemented. The client treats the attachment method as all-or-nothing:
+    advertising it without honouring ``attachment.detach@2`` breaks attachment
+    sends rather than degrading them.
+    """
+
+    limits = limits or TurnLimits()
+
+    methods: List[str] = list(CORE_METHODS)
+    applies_to: List[str] = list(CORE_METHODS) + [PROMPT_SUBMIT_APPLIES_TO]
+    if attachments_supported:
+        methods.append(ATTACHMENT_DETACH_METHOD)
+        applies_to.append(ATTACHMENT_DETACH_METHOD)
+
+    capability: Dict[str, Any] = {
+        "version": CAPABILITY_VERSION,
+        "prompt_submit_version": PROMPT_SUBMIT_VERSION,
+        "execution_route": EXECUTION_ROUTE,
+        "mobile_session_id_format": UUID_FORMAT,
+        "client_turn_id_format": UUID_FORMAT,
+        # Recovery replays; it never re-runs a prompt on the user's behalf.
+        "shadow_only": False,
+        "automatic_resubmit": False,
+        "methods": methods,
+        "applies_to": applies_to,
+        "event_retention_seconds": limits.event_retention_seconds,
+        "turn_retention_seconds": limits.turn_retention_seconds,
+        "max_event_bytes": limits.max_event_bytes,
+        "max_turn_bytes": limits.max_turn_bytes,
+        "terminal_event_reserve_bytes": limits.terminal_event_reserve_bytes,
+        "max_prompt_bytes": limits.max_prompt_bytes,
+        "reconcile_max_events": limits.reconcile_max_events,
+        "reconcile_max_page_bytes": limits.reconcile_max_page_bytes,
+    }
+    if attachments_supported:
+        capability.update(
+            {
+                "max_attachments": limits.max_attachments,
+                "max_file_attachment_bytes": limits.max_file_attachment_bytes,
+                "max_image_attachment_bytes": limits.max_image_attachment_bytes,
+                "max_pdf_attachment_bytes": limits.max_pdf_attachment_bytes,
+                "max_attachment_registry_bytes": limits.max_attachment_registry_bytes,
+            }
+        )
+    return capability
+
+
+@dataclass
+class _Event:
+    seq: int
+    turn_id: str
+    message_id: str
+    type: str
+    payload: Dict[str, Any]
+    created_at: float
+    nbytes: int
+
+    def to_wire(self) -> Dict[str, Any]:
+        return {
+            "turn_id": self.turn_id,
+            "seq": self.seq,
+            "message_id": self.message_id,
+            "type": self.type,
+            "payload": dict(self.payload),
+        }
+
+
+@dataclass
+class _Turn:
+    turn_id: str
+    session_id: str
+    client_turn_id: str
+    created_at: float
+    updated_at: float
+    status: str = "accepted"
+    last_seq: int = 0
+    next_seq: int = 1
+    events: Deque[_Event] = field(default_factory=deque)
+    total_bytes: int = 0
+    assistant_message_id: Optional[str] = None
+    assistant_text: str = ""
+    final_message_ref: int = 1
+    attachment_manifest_digest: str = _EMPTY_MANIFEST_DIGEST
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in TERMINAL_STATUSES
+
+    @property
+    def earliest_seq(self) -> int:
+        # With no retained events the window is empty; report the first seq the
+        # client could still receive so ``after_seq >= earliest_seq - 1`` holds.
+        return self.events[0].seq if self.events else self.last_seq + 1
+
+
+@dataclass(frozen=True)
+class TurnHandle:
+    """Result of :meth:`TurnJournal.open_turn`."""
+
+    turn_id: str
+    client_turn_id: str
+    status: str
+    last_seq: int
+    created: bool
+
+
+@dataclass(frozen=True)
+class EventHandle:
+    """Result of :meth:`TurnJournal.append_event`."""
+
+    turn_id: str
+    seq: int
+
+
+@dataclass(frozen=True)
+class InterruptResult:
+    """Result of :meth:`TurnJournal.interrupt`."""
+
+    turn_id: str
+    status: str
+    last_seq: int
+
+
+def _validate_payload(event_type: str, payload: Any) -> None:
+    """Mirror the client's per-type payload validator exactly."""
+
+    if event_type not in _EVENT_TYPES:
+        raise TurnRecoveryError(f"unknown event type {event_type!r}")
+    if not isinstance(payload, dict):
+        raise TurnRecoveryError("event payload must be a mapping")
+
+    if event_type == "message.start":
+        if payload:
+            raise TurnRecoveryError("message.start payload must be empty")
+        return
+
+    if event_type == "message.delta":
+        if set(payload) != {"text"} or not isinstance(payload["text"], str):
+            raise TurnRecoveryError(
+                "message.delta payload must be exactly {'text': str}"
+            )
+        return
+
+    if event_type == "message.complete":
+        if set(payload) != {"text", "status"}:
+            raise TurnRecoveryError(
+                "message.complete payload must be exactly {'text', 'status'}"
+            )
+        if not isinstance(payload["text"], str):
+            raise TurnRecoveryError("message.complete text must be a str")
+        if payload["status"] not in TERMINAL_STATUSES:
+            raise TurnRecoveryError(
+                "message.complete status must be terminal"
+            )
+        return
+
+    # turn.status
+    if set(payload) != {"status"} or payload["status"] not in TURN_STATUSES:
+        raise TurnRecoveryError(
+            "turn.status payload must be exactly {'status': <known status>}"
+        )
+
+
+def _wire_bytes(event: Dict[str, Any]) -> int:
+    return len(json.dumps(event, separators=(",", ":")).encode("utf-8"))
+
+
+class TurnJournal:
+    """In-memory, size- and time-bounded journal of recoverable turns.
+
+    Thread-safe: the gateway appends events from agent worker threads while RPC
+    handlers read from the socket thread.
+    """
+
+    def __init__(
+        self,
+        *,
+        clock: Optional[Callable[[], float]] = None,
+        limits: Optional[TurnLimits] = None,
+    ) -> None:
+        import time
+
+        self._clock = clock or time.monotonic
+        self._limits = limits or TurnLimits()
+        self._lock = threading.RLock()
+        self._turns: Dict[Tuple[str, str], _Turn] = {}
+
+    @property
+    def limits(self) -> TurnLimits:
+        return self._limits
+
+    # -- lookup ------------------------------------------------------------
+
+    def _require(self, session_id: str, client_turn_id: str) -> _Turn:
+        turn = self._turns.get((session_id, client_turn_id))
+        if turn is None:
+            raise TurnRecoveryError(
+                f"unknown turn for session={session_id!r} "
+                f"client_turn_id={client_turn_id!r}"
+            )
+        return turn
+
+    def get_turn(self, session_id: str, client_turn_id: str) -> _Turn:
+        with self._lock:
+            return self._require(session_id, client_turn_id)
+
+    # -- mutation ----------------------------------------------------------
+
+    def open_turn(self, *, session_id: str, client_turn_id: str) -> TurnHandle:
+        """Create a turn, or return the existing one for this client turn id.
+
+        Idempotency is the whole point: a client that resends ``prompt.submit``
+        after a reconnect must land on the same turn instead of running the
+        prompt twice.
+        """
+
+        with self._lock:
+            key = (session_id, client_turn_id)
+            existing = self._turns.get(key)
+            if existing is not None:
+                return TurnHandle(
+                    turn_id=existing.turn_id,
+                    client_turn_id=client_turn_id,
+                    status=existing.status,
+                    last_seq=existing.last_seq,
+                    created=False,
+                )
+            now = self._clock()
+            turn = _Turn(
+                turn_id=str(uuid.uuid4()),
+                session_id=session_id,
+                client_turn_id=client_turn_id,
+                created_at=now,
+                updated_at=now,
+            )
+            self._turns[key] = turn
+            return TurnHandle(
+                turn_id=turn.turn_id,
+                client_turn_id=client_turn_id,
+                status=turn.status,
+                last_seq=turn.last_seq,
+                created=True,
+            )
+
+    def append_event(
+        self,
+        session_id: str,
+        client_turn_id: str,
+        event_type: str,
+        message_id: str,
+        payload: Dict[str, Any],
+    ) -> EventHandle:
+        with self._lock:
+            turn = self._require(session_id, client_turn_id)
+            if turn.is_terminal:
+                raise TurnRecoveryError(
+                    f"turn {turn.turn_id} is terminal ({turn.status}); "
+                    "no further events may be appended"
+                )
+            # Validate before consuming a sequence number so a rejected event
+            # cannot punch a hole in the client's contiguity check.
+            _validate_payload(event_type, payload)
+            if not isinstance(message_id, str) or not message_id:
+                raise TurnRecoveryError("message_id must be a non-empty str")
+
+            seq = turn.next_seq
+            wire = {
+                "turn_id": turn.turn_id,
+                "seq": seq,
+                "message_id": message_id,
+                "type": event_type,
+                "payload": dict(payload),
+            }
+            nbytes = _wire_bytes(wire)
+            if nbytes > self._limits.max_event_bytes:
+                raise TurnRecoveryError(
+                    f"event of {nbytes} bytes exceeds max_event_bytes "
+                    f"({self._limits.max_event_bytes})"
+                )
+
+            is_terminal_event = event_type == "message.complete"
+            self._evict_for(turn, nbytes, is_terminal_event=is_terminal_event)
+
+            now = self._clock()
+            event = _Event(
+                seq=seq,
+                turn_id=turn.turn_id,
+                message_id=message_id,
+                type=event_type,
+                payload=dict(payload),
+                created_at=now,
+                nbytes=nbytes,
+            )
+            turn.events.append(event)
+            turn.total_bytes += nbytes
+            turn.next_seq = seq + 1
+            turn.last_seq = seq
+            turn.updated_at = now
+
+            # Maintain the snapshot projection so a turn stays answerable once
+            # its individual events age out.
+            if event_type in {"message.start", "message.delta", "message.complete"}:
+                if turn.assistant_message_id != message_id:
+                    turn.assistant_message_id = message_id
+                    turn.assistant_text = ""
+                if event_type == "message.delta":
+                    turn.assistant_text += payload["text"]
+                elif event_type == "message.complete":
+                    turn.assistant_text = payload["text"]
+
+            return EventHandle(turn_id=turn.turn_id, seq=seq)
+
+    def _evict_for(
+        self, turn: _Turn, incoming_bytes: int, *, is_terminal_event: bool
+    ) -> None:
+        """Drop oldest events until ``incoming_bytes`` fits the turn budget.
+
+        A slice of ``max_turn_bytes`` is reserved so the terminal event always
+        fits. Without it a chatty turn could evict its own completion frame and
+        leave the client waiting forever on a turn that already finished.
+        """
+
+        budget = self._limits.max_turn_bytes
+        if not is_terminal_event:
+            budget -= self._limits.terminal_event_reserve_bytes
+        while turn.events and turn.total_bytes + incoming_bytes > budget:
+            oldest = turn.events.popleft()
+            turn.total_bytes -= oldest.nbytes
+
+    def set_status(self, session_id: str, client_turn_id: str, status: str) -> None:
+        with self._lock:
+            turn = self._require(session_id, client_turn_id)
+            if status not in TURN_STATUSES:
+                raise TurnRecoveryError(f"unknown turn status {status!r}")
+            if turn.is_terminal and status != turn.status:
+                raise TurnRecoveryError(
+                    f"turn {turn.turn_id} already terminal ({turn.status})"
+                )
+            turn.status = status
+            turn.updated_at = self._clock()
+
+    def set_final_message_ref(
+        self, session_id: str, client_turn_id: str, ref: int
+    ) -> None:
+        with self._lock:
+            turn = self._require(session_id, client_turn_id)
+            if not isinstance(ref, int) or isinstance(ref, bool) or ref <= 0:
+                raise TurnRecoveryError("final_message_ref must be a positive int")
+            turn.final_message_ref = ref
+
+    def set_attachment_manifest_digest(
+        self, session_id: str, client_turn_id: str, digest: str
+    ) -> None:
+        with self._lock:
+            turn = self._require(session_id, client_turn_id)
+            if not isinstance(digest, str) or not _HEX_DIGEST_RE.match(digest):
+                raise TurnRecoveryError(
+                    "attachment_manifest_digest must be 64 lowercase hex chars"
+                )
+            turn.attachment_manifest_digest = digest
+
+    def interrupt(self, session_id: str, client_turn_id: str) -> InterruptResult:
+        """Interrupt a running turn; idempotent once the turn is terminal."""
+
+        with self._lock:
+            turn = self._require(session_id, client_turn_id)
+            if turn.is_terminal:
+                return InterruptResult(
+                    turn_id=turn.turn_id,
+                    status=turn.status,
+                    last_seq=turn.last_seq,
+                )
+            message_id = turn.assistant_message_id or turn.turn_id
+            self.append_event(
+                session_id,
+                client_turn_id,
+                "turn.status",
+                message_id,
+                {"status": "interrupted"},
+            )
+            turn.status = "interrupted"
+            turn.updated_at = self._clock()
+            return InterruptResult(
+                turn_id=turn.turn_id,
+                status=turn.status,
+                last_seq=turn.last_seq,
+            )
+
+    # -- retention ---------------------------------------------------------
+
+    def prune(self) -> None:
+        """Drop expired events and turns. Safe to call repeatedly."""
+
+        with self._lock:
+            now = self._clock()
+            event_cutoff = now - self._limits.event_retention_seconds
+            turn_cutoff = now - self._limits.turn_retention_seconds
+
+            for key in list(self._turns):
+                turn = self._turns[key]
+                if turn.updated_at < turn_cutoff:
+                    del self._turns[key]
+                    continue
+                while turn.events and turn.events[0].created_at < event_cutoff:
+                    oldest = turn.events.popleft()
+                    turn.total_bytes -= oldest.nbytes
+
+    # -- reconcile ---------------------------------------------------------
+
+    def reconcile(
+        self, session_id: str, client_turn_id: str, *, after_seq: int
+    ) -> Dict[str, Any]:
+        """Return one replay page for the client's cursor.
+
+        Two shapes are possible. ``events`` replays the retained tail. When the
+        cursor points at events that have already aged out, the only honest
+        answer for a finished turn is a ``snapshot`` of its final state; for a
+        still-running turn there is no honest answer at all, so we raise rather
+        than fabricate one.
+        """
+
+        with self._lock:
+            turn = self._require(session_id, client_turn_id)
+            if (
+                not isinstance(after_seq, int)
+                or isinstance(after_seq, bool)
+                or after_seq < 0
+            ):
+                raise TurnRecoveryError("after_seq must be a non-negative int")
+            if after_seq > turn.last_seq:
+                raise TurnRecoveryError(
+                    f"after_seq {after_seq} is ahead of last_seq {turn.last_seq}"
+                )
+
+            earliest = turn.earliest_seq
+            if after_seq < earliest - 1:
+                if not turn.is_terminal:
+                    raise TurnRecoveryError(
+                        f"turn {turn.turn_id} lost events before seq {earliest} "
+                        "and is not terminal; cannot reconcile honestly"
+                    )
+                return self._snapshot_page(turn, earliest)
+
+            events: List[Dict[str, Any]] = []
+            page_bytes = 0
+            for event in turn.events:
+                if event.seq <= after_seq:
+                    continue
+                if len(events) >= self._limits.reconcile_max_events:
+                    break
+                if (
+                    events
+                    and page_bytes + event.nbytes
+                    > self._limits.reconcile_max_page_bytes
+                ):
+                    # Always emit at least one event when the cursor is behind:
+                    # an empty page with has_more would stall the client.
+                    break
+                events.append(event.to_wire())
+                page_bytes += event.nbytes
+
+            next_after_seq = events[-1]["seq"] if events else after_seq
+            return {
+                "mode": "events",
+                "turn_id": turn.turn_id,
+                "status": turn.status,
+                "earliest_seq": earliest,
+                "last_seq": turn.last_seq,
+                "next_after_seq": next_after_seq,
+                "has_more": next_after_seq < turn.last_seq,
+                "events": events,
+                "automatic_resubmit": False,
+            }
+
+    def _snapshot_page(self, turn: _Turn, earliest: int) -> Dict[str, Any]:
+        return {
+            "mode": "snapshot",
+            "earliest_seq": earliest,
+            "last_seq": turn.last_seq,
+            "next_after_seq": turn.last_seq,
+            "has_more": False,
+            "automatic_resubmit": False,
+            "snapshot": {
+                "turn_id": turn.turn_id,
+                "client_turn_id": turn.client_turn_id,
+                "status": turn.status,
+                "last_seq": turn.last_seq,
+                "assistant": {
+                    "message_id": turn.assistant_message_id or turn.turn_id,
+                    "text": turn.assistant_text,
+                    "complete": True,
+                },
+                "attachment_manifest_digest": turn.attachment_manifest_digest,
+                "final_message_ref": turn.final_message_ref,
+            },
+        }

--- a/tui_gateway/turn_recovery.py
+++ b/tui_gateway/turn_recovery.py
@@ -17,10 +17,10 @@ invisible. Everything in this module is therefore built to be exact.
 
 Scope
 -----
-This module owns only the in-memory journal and the capability dict. Wiring it
-into ``gateway.ready`` and the JSON-RPC method table is deliberately left to
-later, separately reviewed changes, so that advertising the capability is the
-*last* step — never before the methods behind it actually work.
+This module owns the bounded in-process journal and exact capability dict. The
+separate :mod:`tui_gateway.turn_recovery_runtime` adapter wires those primitives
+into ``gateway.ready`` and the JSON-RPC method table only after every advertised
+method has been installed, so the client never negotiates a partial route.
 """
 
 from __future__ import annotations
@@ -44,6 +44,7 @@ __all__ = [
     "TERMINAL_STATUSES",
     "TURN_STATUSES",
     "TurnJournal",
+    "TurnHandle",
     "TurnLimits",
     "TurnRecoveryError",
     "build_protocol_frame",
@@ -369,6 +370,35 @@ class TurnJournal:
     def get_turn(self, session_id: str, client_turn_id: str) -> _Turn:
         with self._lock:
             return self._require(session_id, client_turn_id)
+
+    def resolve_turn(
+        self,
+        session_id: str,
+        *,
+        client_turn_id: Optional[str] = None,
+        turn_id: Optional[str] = None,
+    ) -> _Turn:
+        """Resolve one turn by either client id or server id, scoped to session."""
+
+        with self._lock:
+            if bool(client_turn_id) == bool(turn_id):
+                raise TurnRecoveryError(
+                    "provide exactly one of client_turn_id or turn_id"
+                )
+            if client_turn_id:
+                return self._require(session_id, client_turn_id)
+            for (candidate_session_id, _), turn in self._turns.items():
+                if candidate_session_id == session_id and turn.turn_id == turn_id:
+                    return turn
+            raise TurnRecoveryError(
+                f"unknown turn for session={session_id!r} turn_id={turn_id!r}"
+            )
+
+    def discard_turn(self, session_id: str, client_turn_id: str) -> None:
+        """Forget a submission that the underlying prompt handler rejected."""
+
+        with self._lock:
+            self._turns.pop((session_id, client_turn_id), None)
 
     # -- mutation ----------------------------------------------------------
 

--- a/tui_gateway/turn_recovery_runtime.py
+++ b/tui_gateway/turn_recovery_runtime.py
@@ -106,6 +106,18 @@ class TurnRecoveryRuntime:
         tmp.write_text(payload, encoding="utf-8")
         os.replace(tmp, self.bindings_path)
 
+    def mobile_to_stored(self) -> dict[str, str]:
+        """Copy of the mobile->stored session binding map.
+
+        Read live under the lock so consumers (the project tree's assignment
+        projection) see bindings injected at runtime, not a startup snapshot.
+        """
+        with self._lock:
+            return {
+                mobile: entry["stored_session_id"]
+                for mobile, entry in self._bindings.items()
+            }
+
     def install(self) -> None:
         if self._original_prompt_submit is not None:
             return

--- a/tui_gateway/turn_recovery_runtime.py
+++ b/tui_gateway/turn_recovery_runtime.py
@@ -157,7 +157,18 @@ class TurnRecoveryRuntime:
                 return response
             result = response.get("result") or {}
             runtime_id = result.get("session_id")
-            stored_id = result.get("stored_session_id")
+            # session.create reports the durable identity as ``stored_session_id``;
+            # session.resume reports it as ``session_key`` (and may point at a
+            # rotated compression-continuation tip rather than the id we asked
+            # for). Accept either spelling, then fall back to the live session
+            # record, so a reconnect can never be rejected as "invalid identity".
+            stored_id = result.get("stored_session_id") or result.get("session_key")
+            if not isinstance(stored_id, str) or not stored_id:
+                live = self.server._sessions.get(runtime_id) if isinstance(runtime_id, str) else None
+                if isinstance(live, dict):
+                    candidate = live.get("session_key")
+                    if isinstance(candidate, str) and candidate:
+                        stored_id = candidate
             if not isinstance(runtime_id, str) or not runtime_id or not isinstance(stored_id, str) or not stored_id:
                 return self.server._err(rid, -32603, "session binding returned an invalid identity")
 

--- a/tui_gateway/turn_recovery_runtime.py
+++ b/tui_gateway/turn_recovery_runtime.py
@@ -1,0 +1,410 @@
+"""Runtime wiring for the Android turn-recovery v2 JSON-RPC contract.
+
+The journal stays isolated in :mod:`tui_gateway.turn_recovery`; this module is
+the narrow adapter around the existing session/prompt handlers. Legacy clients
+continue through the original methods unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+from .turn_recovery import (
+    PROMPT_SUBMIT_VERSION,
+    TurnJournal,
+    TurnLimits,
+    TurnRecoveryError,
+    build_protocol_frame,
+    build_turn_recovery_capability,
+)
+
+
+def _canonical_uuid(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = uuid.UUID(value)
+    except (ValueError, TypeError, AttributeError):
+        return None
+    canonical = str(parsed)
+    if canonical != value:
+        return None
+    return canonical
+
+
+def _canonical_v4_uuid(value: Any) -> Optional[str]:
+    canonical = _canonical_uuid(value)
+    if canonical is None or uuid.UUID(canonical).version != 4:
+        return None
+    return canonical
+
+
+def _default_bindings_path() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = Path(get_hermes_home())
+    except Exception:
+        home = Path.home() / ".hermes"
+    return home / "state" / "turn_recovery_bindings.json"
+
+
+class TurnRecoveryRuntime:
+    """Own bindings, method wrappers, and live-event journal decoration."""
+
+    def __init__(
+        self,
+        server,
+        *,
+        bindings_path: Optional[Path] = None,
+        limits: Optional[TurnLimits] = None,
+    ) -> None:
+        self.server = server
+        self.limits = limits or TurnLimits()
+        self.journal = TurnJournal(limits=self.limits)
+        self.bindings_path = Path(bindings_path or _default_bindings_path())
+        self._lock = threading.RLock()
+        self._bindings = self._load_bindings()
+        self._runtime_to_stored: dict[str, str] = {}
+        self._active: dict[str, dict[str, str]] = {}
+        self._original_prompt_submit = None
+        self._original_session_interrupt = None
+
+    def _load_bindings(self) -> dict[str, dict[str, Any]]:
+        try:
+            raw = json.loads(self.bindings_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        valid: dict[str, dict[str, Any]] = {}
+        for mobile_id, entry in raw.items():
+            if (
+                _canonical_uuid(mobile_id)
+                and isinstance(entry, dict)
+                and isinstance(entry.get("stored_session_id"), str)
+                and entry["stored_session_id"]
+                and isinstance(entry.get("binding_version"), int)
+                and not isinstance(entry["binding_version"], bool)
+                and entry["binding_version"] > 0
+            ):
+                valid[mobile_id] = {
+                    "stored_session_id": entry["stored_session_id"],
+                    "binding_version": entry["binding_version"],
+                }
+        return valid
+
+    def _save_bindings(self) -> None:
+        self.bindings_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.bindings_path.with_suffix(self.bindings_path.suffix + ".tmp")
+        payload = json.dumps(self._bindings, sort_keys=True, indent=2) + "\n"
+        tmp.write_text(payload, encoding="utf-8")
+        os.replace(tmp, self.bindings_path)
+
+    def install(self) -> None:
+        if self._original_prompt_submit is not None:
+            return
+        self._original_prompt_submit = self.server._methods["prompt.submit"]
+        self._original_session_interrupt = self.server._methods["session.interrupt"]
+        self.server._methods["session.open"] = self.session_open
+        self.server._methods["prompt.submit"] = self.prompt_submit
+        self.server._methods["turn.reconcile"] = self.turn_reconcile
+        self.server._methods["turn.interrupt"] = self.turn_interrupt
+
+    def ready_payload(self, base: dict[str, Any]) -> dict[str, Any]:
+        payload = dict(base)
+        payload["protocol"] = build_protocol_frame()
+        capabilities = dict(payload.get("capabilities") or {})
+        capabilities["turn_recovery"] = build_turn_recovery_capability(
+            limits=self.limits,
+            attachments_supported=False,
+        )
+        payload["capabilities"] = capabilities
+        return payload
+
+    def _error(self, rid, message: str, *, reason: str = "invalid_params") -> dict:
+        return self.server._err(rid, -32602, message, data={"reason": reason})
+
+    def session_open(self, rid, params: dict) -> dict:
+        mobile_id = _canonical_uuid(params.get("mobile_session_id"))
+        if mobile_id is None:
+            return self._error(rid, "mobile_session_id must be a canonical lowercase UUID")
+
+        with self._lock:
+            previous = self._bindings.get(mobile_id)
+            if previous is None:
+                response = self.server._methods["session.create"](
+                    rid,
+                    {
+                        "source": "android",
+                        "close_on_disconnect": False,
+                    },
+                )
+            else:
+                response = self.server._methods["session.resume"](
+                    rid,
+                    {
+                        "session_id": previous["stored_session_id"],
+                        "source": "android",
+                    },
+                )
+            if not isinstance(response, dict) or "error" in response:
+                return response
+            result = response.get("result") or {}
+            runtime_id = result.get("session_id")
+            stored_id = result.get("stored_session_id")
+            if not isinstance(runtime_id, str) or not runtime_id or not isinstance(stored_id, str) or not stored_id:
+                return self.server._err(rid, -32603, "session binding returned an invalid identity")
+
+            version = 1 if previous is None else int(previous["binding_version"]) + 1
+            session = self.server._sessions.get(runtime_id)
+            if previous is None and isinstance(session, dict):
+                ensure_persisted = getattr(self.server, "_ensure_session_db_row", None)
+                if callable(ensure_persisted):
+                    try:
+                        ensure_persisted(session)
+                    except Exception as exc:
+                        return self.server._err(
+                            rid,
+                            -32603,
+                            f"failed to persist mobile session binding: {exc}",
+                        )
+            self._bindings[mobile_id] = {
+                "stored_session_id": stored_id,
+                "binding_version": version,
+            }
+            self._save_bindings()
+            self._runtime_to_stored[runtime_id] = stored_id
+            if isinstance(session, dict):
+                session["_turn_recovery_mobile_session_id"] = mobile_id
+
+            return self.server._ok(
+                rid,
+                {
+                    "turn_recovery": True,
+                    "automatic_resubmit": False,
+                    "runtime_session_id": runtime_id,
+                    "stored_session_id": stored_id,
+                    "mobile_session_id": mobile_id,
+                    "binding_version": version,
+                    "capabilities": {
+                        "turn_recovery": build_turn_recovery_capability(
+                            limits=self.limits,
+                            attachments_supported=False,
+                        )
+                    },
+                },
+            )
+
+    @staticmethod
+    def _ack(handle) -> dict[str, Any]:
+        return {
+            "accepted": True,
+            "automatic_resubmit": False,
+            "client_turn_id": handle.client_turn_id,
+            "turn_id": handle.turn_id,
+            "status": handle.status,
+            "last_seq": handle.last_seq,
+            "created": handle.created,
+        }
+
+    def prompt_submit(self, rid, params: dict) -> dict:
+        if params.get("version") != PROMPT_SUBMIT_VERSION:
+            return self._original_prompt_submit(rid, params)
+
+        sid = params.get("session_id")
+        client_turn_id = _canonical_v4_uuid(params.get("client_turn_id"))
+        text = params.get("text")
+        stored_id = self._runtime_to_stored.get(sid) if isinstance(sid, str) else None
+        if stored_id is None or client_turn_id is None:
+            return self._error(rid, "v2 submit requires an open runtime session and canonical client_turn_id")
+        if not isinstance(text, str):
+            return self._error(rid, "text must be a string")
+        if len(text.encode("utf-8")) > self.limits.max_prompt_bytes:
+            return self._error(rid, "prompt exceeds max_prompt_bytes")
+        if params.get("attachments"):
+            return self._error(rid, "v2 attachments are not enabled on this route")
+
+        with self._lock:
+            active = self._active.get(sid)
+        if active is not None and active["client_turn_id"] != client_turn_id:
+            return self.server._err(
+                rid,
+                4091,
+                "another recoverable turn is active for this session",
+                data={"reason": "turn_active"},
+            )
+
+        handle = self.journal.open_turn(
+            session_id=stored_id,
+            client_turn_id=client_turn_id,
+        )
+        if not handle.created:
+            return self.server._ok(rid, self._ack(handle))
+
+        active = {
+            "stored_session_id": stored_id,
+            "client_turn_id": client_turn_id,
+            "turn_id": handle.turn_id,
+            "message_id": str(uuid.uuid4()),
+        }
+        with self._lock:
+            self._active[sid] = active
+        session = self.server._sessions.get(sid)
+        if isinstance(session, dict):
+            session["_turn_recovery_active"] = active
+
+        response = self._original_prompt_submit(rid, params)
+        if not isinstance(response, dict) or "error" in response:
+            self.journal.discard_turn(stored_id, client_turn_id)
+            with self._lock:
+                self._active.pop(sid, None)
+            if isinstance(session, dict):
+                session.pop("_turn_recovery_active", None)
+            return response
+        return self.server._ok(rid, self._ack(handle))
+
+    def _resolve(self, params: dict):
+        sid = params.get("session_id")
+        stored_id = self._runtime_to_stored.get(sid) if isinstance(sid, str) else None
+        if stored_id is None:
+            raise TurnRecoveryError("runtime session has no mobile binding")
+        client_turn_id = params.get("client_turn_id")
+        turn_id = params.get("turn_id")
+        if client_turn_id is not None:
+            client_turn_id = _canonical_v4_uuid(client_turn_id)
+            if client_turn_id is None:
+                raise TurnRecoveryError("client_turn_id must be a canonical UUIDv4")
+        turn = self.journal.resolve_turn(
+            stored_id,
+            client_turn_id=client_turn_id,
+            turn_id=turn_id,
+        )
+        return sid, stored_id, turn
+
+    def turn_reconcile(self, rid, params: dict) -> dict:
+        try:
+            _sid, stored_id, turn = self._resolve(params)
+            page = self.journal.reconcile(
+                stored_id,
+                turn.client_turn_id,
+                after_seq=params.get("after_seq"),
+            )
+            return self.server._ok(rid, page)
+        except TurnRecoveryError as exc:
+            reason = "turn_unknown" if "unknown turn" in str(exc) else "turn_replay_pruned"
+            return self.server._err(rid, 4041, str(exc), data={"reason": reason})
+
+    def turn_interrupt(self, rid, params: dict) -> dict:
+        try:
+            sid, stored_id, turn = self._resolve(params)
+        except TurnRecoveryError as exc:
+            return self.server._err(rid, 4041, str(exc), data={"reason": "turn_unknown"})
+
+        legacy = self._original_session_interrupt(rid, {"session_id": sid})
+        if not isinstance(legacy, dict) or "error" in legacy:
+            return legacy
+        result = self.journal.interrupt(stored_id, turn.client_turn_id)
+        with self._lock:
+            self._active.pop(sid, None)
+        session = self.server._sessions.get(sid)
+        if isinstance(session, dict):
+            session.pop("_turn_recovery_active", None)
+        return self.server._ok(
+            rid,
+            {
+                "automatic_resubmit": False,
+                "client_turn_id": turn.client_turn_id,
+                "turn_id": result.turn_id,
+                "status": result.status,
+                "last_seq": result.last_seq,
+            },
+        )
+
+    def decorate_event(self, event: str, sid: str, payload: Optional[dict]) -> dict:
+        """Return event params, journal-enriched only for an active v2 turn."""
+
+        base: dict[str, Any] = {"type": event, "session_id": sid}
+        if payload is not None:
+            base["payload"] = payload
+        with self._lock:
+            active = self._active.get(sid)
+        if active is None:
+            return base
+
+        event_type = event
+        source = payload if isinstance(payload, dict) else {}
+        if event == "message.start":
+            recovery_payload: dict[str, Any] = {}
+        elif event == "message.delta":
+            recovery_payload = {"text": str(source.get("text") or "")}
+        elif event == "message.complete":
+            status = {
+                "complete": "completed",
+                "completed": "completed",
+                "error": "failed",
+                "failed": "failed",
+                "interrupted": "interrupted",
+            }.get(source.get("status"), "failed")
+            recovery_payload = {"text": str(source.get("text") or ""), "status": status}
+        elif event == "error":
+            event_type = "message.complete"
+            message = str(source.get("message") or "turn failed")
+            recovery_payload = {"text": f"Error: {message}", "status": "failed"}
+        else:
+            return base
+
+        try:
+            handle = self.journal.append_event(
+                active["stored_session_id"],
+                active["client_turn_id"],
+                event_type,
+                active["message_id"],
+                recovery_payload,
+            )
+            if event_type == "message.start":
+                self.journal.set_status(
+                    active["stored_session_id"], active["client_turn_id"], "running"
+                )
+            elif event_type == "message.complete":
+                self.journal.set_status(
+                    active["stored_session_id"],
+                    active["client_turn_id"],
+                    recovery_payload["status"],
+                )
+                with self._lock:
+                    self._active.pop(sid, None)
+                session = self.server._sessions.get(sid)
+                if isinstance(session, dict):
+                    session.pop("_turn_recovery_active", None)
+        except TurnRecoveryError:
+            return base
+
+        return {
+            "type": event_type,
+            "session_id": sid,
+            "turn_id": handle.turn_id,
+            "seq": handle.seq,
+            "message_id": active["message_id"],
+            "payload": recovery_payload,
+        }
+
+
+_runtime: Optional[TurnRecoveryRuntime] = None
+
+
+def install(server) -> TurnRecoveryRuntime:
+    global _runtime
+    if _runtime is None or _runtime.server is not server:
+        _runtime = TurnRecoveryRuntime(server)
+        _runtime.install()
+    return _runtime
+
+
+def get_runtime() -> Optional[TurnRecoveryRuntime]:
+    return _runtime

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -261,6 +261,33 @@ class _SendFailed(Exception):
     """Raised by handle_ws._reply when a reply could not be written: ends the read loop."""
 
 
+def build_gateway_ready_payload(
+    skin: dict,
+    *,
+    change_events: bool = True,
+    heartbeat: bool = False,
+) -> dict:
+    """Delegates to ``tui_gateway.entry`` so both transports emit one payload.
+
+    Defining a second, narrower copy here is what let the WS sidecar drop
+    ``replay_epoch`` (or the turn-recovery capability) independently of the
+    stdio path. One implementation, one contract.
+
+    Imported lazily: ``entry`` pulls in the full CLI/agent stack, and importing
+    it at module scope would make the WS sidecar pay that cost — and risk an
+    import cycle — on every load.
+    """
+    from tui_gateway.entry import (
+        build_gateway_ready_payload as _entry_build_gateway_ready_payload,
+    )
+
+    return _entry_build_gateway_ready_payload(
+        skin,
+        change_events=change_events,
+        heartbeat=heartbeat,
+    )
+
+
 async def handle_ws(ws: Any, *, auth_identity: dict | None = None, subprotocol: str | None = None) -> None:
     """Run one WebSocket session. Wire-compatible with ``tui_gateway.entry``. *auth_identity* is the server-minted
     ``{user_id, provider}`` recorded at WS-upgrade auth, stored as ``WSTransport.auth_identity`` (the only identity
@@ -291,15 +318,24 @@ async def handle_ws(ws: Any, *, auth_identity: dict | None = None, subprotocol: 
         transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer, auth_identity=auth_identity)
         # resolve_skin() is sync I/O + CPU; pooled so the read loop can drain the frontend's initial RPC burst.
         skin_payload = await asyncio.to_thread(server.resolve_skin)
-        # change_events: this backend broadcasts pet/cron/sessions.changed, so clients can demote legacy
-        # polls to backstops. replay_epoch lets reconnecting clients detect a backend restart and reset
-        # their per-session seq watermarks (event_replay).
-        ready_ok = await transport.write_async({
-            "jsonrpc": "2.0", "method": "event",
-            "params": {"type": "gateway.ready", "payload": {
-                "skin": skin_payload, "change_events": True, "heartbeat": True, "replay_epoch": replay_epoch(),
-            }},
-        })
+        # change_events: this backend broadcasts pet/cron/sessions.changed, so clients can demote
+        # legacy polls to backstops; replay_epoch lets reconnecting clients detect a backend
+        # restart and reset their per-session seq watermarks. The builder emits both plus the
+        # turn-recovery capability in one place (entry), so the contracts cannot drift apart.
+        ready_ok = await transport.write_async(
+            {
+                "jsonrpc": "2.0",
+                "method": "event",
+                "params": {
+                    "type": "gateway.ready",
+                    "payload": build_gateway_ready_payload(
+                        skin_payload,
+                        change_events=True,
+                        heartbeat=True,
+                    ),
+                },
+            }
+        )
         if ready_ok:
             # Live-apply skins Hermes activates mid-conversation, and track this peer for session-less
             # global broadcasts write_json can't route.


### PR DESCRIPTION
## What does this PR do?

Fixes a silent fallback-chain stall in auxiliary compression.

An auxiliary compression call returning HTTP 200 with **no usable text** — blank `content`, no
reasoning fallback, no tool calls (well-formed proxies / one-api channels, and thinking models whose
text never lands in `content`) — was accepted at the auxiliary boundary. Nothing raised, so the
recovery ladder treated that candidate as healthy and never advanced to the next entry of
`auxiliary.compression.fallback_chain`. The empty summary was only detected later in
`ContextCompressor._generate_summary()`, which then **gave up on the auxiliary route entirely** and
retried the main chat model — the provider the configured chain exists to route around, and usually
the exhausted one (rate limit / out of credit / context overflow) that made compression run
off-provider in the first place.

The fix validates the summary while the route decision is still open. For `compression` tasks, an
empty message without tool calls raises the canonical invalid-response error, which
`_is_invalid_aux_response_error()` recognises as a candidate failure — so the configured chain is
tried to exhaustion first, exactly like a connection error, a 429 or a 5xx.

Two properties are preserved deliberately:

- **Reasoning fallback still wins (#11978).** The emptiness test is the compressor's own
  `extract_content_or_reasoning()` helper, so a summary carried in `reasoning` /
  `reasoning_content` / `reasoning_details` is *not* empty and passes untouched.
- **The existing end-of-route behaviour is unchanged.** When the chain has no remaining candidates,
  the error propagates exactly as the compressor's own empty-content guard does today, so the
  main-model fallback + cooldown machinery still runs. This PR only stops the chain from being
  skipped.

## Related Issue

Fixes #108030

Related: #11978 (the reasoning-field recovery this builds on), #94448 and #19003 (user-visible
consequences of empty summaries), #88235-adjacent.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`
  - `_is_invalid_aux_response_error()` — also recognises the `empty content` form of the
    invalid-response error, so the existing ladder rung classifies it as a candidate failure.
  - `_validate_llm_response()` — for `task == "compression"`, a message with no extractable text and
    no tool calls raises
    `RuntimeError("Auxiliary compression: LLM returned invalid response (empty content) …")` before
    the relay auxiliary call is completed. Other tasks are untouched: a blank `vision` answer is not
    a route failure.
- `tests/agent/test_auxiliary_client.py`
  - `TestCompressionEmptyResponseFallback` — empty compression message raises *and* is classified as
    a route failure; a tool-call-only message is still accepted; `vision`/task-less calls still
    accept empty content; a reasoning-only summary is still accepted (regression guard for #11978).
  - `TestConfiguredFallbackCandidateFailures.test_sync_chain_continues_after_empty_compression_response`
    — end-to-end: candidate 1 answers with an empty compression message, candidate 2 must be called
    and its response returned.

## How to Test

```bash
cd ~/.hermes/hermes-agent

# 1. RED — fails on unmodified main
git checkout main -- agent/auxiliary_client.py
venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -q -o addopts= \
  -k "CompressionEmptyResponse or empty_compression"
# → 2 failed, 2 passed

# 2. GREEN — with the fix
git checkout HEAD -- agent/auxiliary_client.py
venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -q -o addopts= \
  -k "CompressionEmptyResponse or empty_compression"
# → 4 passed

# 3. No regression in the surrounding file or in the reasoning-fallback path
venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -q -o addopts=          # 210 passed
venv/bin/python -m pytest tests/agent/test_context_compressor_reasoning_fallback.py -q -o addopts=   # 4 passed
scripts/run_tests.sh tests/agent/test_auxiliary_client.py
```

Reproduction without the harness: point `auxiliary.compression` at a provider whose first candidate
returns `content=""` with no reasoning fields and no tool calls, trigger compression on an oversized
session, and watch the configured chain — before this change the second candidate is never called;
after it is.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and issues (see "Related Issue")
- [x] My PR contains **only** changes related to this fix (2 files)
- [x] I've run the affected suites — `tests/agent/test_auxiliary_client.py` in full (210 passed) and
      the reasoning-fallback regression file (4 passed); the wider `tests/agent` suite is running
      separately, results in a follow-up comment
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (Linux), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (behaviour fix, no config/API change)
- [ ] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [ ] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A: in-memory response-shape validation, no filesystem
      or process handling. `scripts/check-windows-footguns.py --diff` reports no new footguns from
      this diff.
- [ ] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

RED/GREEN evidence above (2 failed → 4 passed), with the 206 pre-existing tests in the same file
still green.
