### PR TITLE
fix(gateway): do not warn about a session db lock that already cleared

### DIFF
--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -825,7 +825,29 @@ class GatewayNotificationsMixin:
             return
         from hermes_constants import get_default_hermes_root
         from hermes_state import _default_db_path, classify_persistence_error, format_session_db_unavailable
-        if classify_persistence_error(error) == "corrupt":
+        # A startup lock can clear while the messaging adapters are still connecting, and a
+        # borrowed handle can be re-acquired once its owner releases it. Probe off the event loop
+        # before broadcasting, so the user is warned only about a failure that is still active —
+        # a banner about a lock that already cleared teaches users to ignore the next one (#88235).
+        cause = classify_persistence_error(error)
+        if cause == "locked" or "sqlite handle unavailable" in error.lower():
+            for attempt in range(15):
+                try:
+                    recovered = await asyncio.to_thread(self._open_session_db_for_active_scope)
+                except Exception:
+                    logger.debug("state.db recovery probe before warning failed", exc_info=True)
+                    recovered = None
+                if recovered is not None:
+                    self._session_db_init_error = None
+                    logger.info("state.db recovered before the failure warning was broadcast")
+                    return
+                if attempt + 1 < 15:
+                    await asyncio.sleep(1.0)
+            error = getattr(self, "_session_db_init_error", None)
+            if not error:
+                return
+            cause = classify_persistence_error(error)
+        if cause == "corrupt":
             # Copy-pasteable, so name the real store (profiles / HERMES_HOME do not live under ~/.hermes).
             db_path = _default_db_path()
             backups_dir = get_default_hermes_root() / "backups"

--- a/tests/run_agent/test_corruption_recovery_guidance.py
+++ b/tests/run_agent/test_corruption_recovery_guidance.py
@@ -13,9 +13,97 @@ The fix adds:
    message to all home channels after the gateway connects
 3. Improved "corrupt" cause wording in _format_turn_completion_explanation
    with the full recovery path (hermes doctor, sqlite3 .recover, backups)
+4. _send_session_db_warning_notifications() re-probes the active store (15 x 1s,
+   off the event loop) before broadcasting, so a startup lock that clears while the
+   messaging adapters connect never produces a warning about a failure that is
+   already gone
 """
 
 from pytest import fixture
+
+
+def test_session_db_warning_rechecks_recovery_before_notifying():
+    """A startup lock that has already cleared must not produce a stale user warning."""
+    import asyncio
+
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_db_init_error = "OperationalError: database is locked"
+    probes = []
+
+    def recover(*, raise_on_error=False):
+        probes.append(raise_on_error)
+        runner._session_db_init_error = None
+        return object()
+
+    async def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("a cleared lock must not be broadcast as a live failure")
+
+    runner._open_session_db_for_active_scope = recover
+    runner._send_home_channel_message = fail_if_called
+
+    asyncio.run(runner._send_session_db_warning_notifications())
+
+    assert probes == [False]
+    assert runner._session_db_init_error is None
+
+
+def test_session_db_warning_waits_for_transient_lock_recovery(monkeypatch):
+    """A lock hidden behind the shared-store wrapper gets a recovery grace period."""
+    import asyncio
+
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_db_init_error = "SessionStore SQLite handle unavailable"
+    outcomes = iter((None, None, object()))
+
+    def recover(*, raise_on_error=False):
+        outcome = next(outcomes)
+        if outcome is not None:
+            runner._session_db_init_error = None
+        return outcome
+
+    async def no_sleep(_seconds):
+        return None
+
+    runner._open_session_db_for_active_scope = recover
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    asyncio.run(runner._send_session_db_warning_notifications())
+
+    assert runner._session_db_init_error is None
+
+
+def test_session_db_warning_broadcasts_when_the_lock_persists(monkeypatch):
+    """A lock that never clears still warns the user — the probe must not swallow real failures."""
+    import asyncio
+
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_db_init_error = "OperationalError: database is locked"
+    runner._open_session_db_for_active_scope = lambda *, raise_on_error=False: None
+    sent = []
+
+    monkeypatch.setattr(
+        runner, "_home_channel_transports", lambda: [("telegram", {}, "home-chat", object())]
+    )
+
+    async def capture_send(_platform, _home, _transport, message, _log_fmt):
+        sent.append(message)
+
+    async def no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(runner, "_send_home_channel_message", capture_send)
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    asyncio.run(runner._send_session_db_warning_notifications())
+
+    assert sent, "a lock that survived the grace period must still be broadcast"
+    assert "locked" in sent[0].lower() or "may not be persisted" in sent[0]
 
 
 def test_format_turn_completion_corrupt_includes_recovery_options():


### PR DESCRIPTION
## What does this PR do?

Stops the gateway from broadcasting a "Session database unavailable — messages may not be persisted"
banner for a lock that has already cleared.

`_send_session_db_warning_notifications()` (#88235) broadcasts the banner from the error recorded at
gateway startup. A startup lock routinely clears while the messaging adapters are still connecting,
and a borrowed store handle becomes available again once its owner releases it — so the user is told
their sessions are not being persisted while the store is healthy. A warning that is wrong once gets
ignored the next time it is right, which defeats the purpose of the banner.

The fix re-probes the active scope's store before broadcasting, **for lock and borrowed-handle
causes only** (15 × 1s, off the event loop). A corrupt or otherwise unusable store still warns
immediately, and a lock that survives the grace period is still reported — the probe can only
suppress a failure that healed, never silence a real one.

## Related Issue

Fixes #108031

Related: #88235 (closed) added the broadcast; this is the follow-up so it does not report a failure
that already healed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run_notifications.py` — `_send_session_db_warning_notifications()`: classify the cause
  once; for `locked` (or a `sqlite handle unavailable` borrowed-handle failure) probe
  `_open_session_db_for_active_scope` in a thread up to 15 times with a 1s pause, returning early and
  clearing `_session_db_init_error` when the store answers; re-read the error afterwards and reuse the
  classification for the existing corrupt/other branches.
- `tests/run_agent/test_corruption_recovery_guidance.py` — three regression tests: a cleared lock
  must not broadcast (and must not call the sender), a borrowed-handle failure gets the grace period
  before it clears, and a lock that survives the grace period is still broadcast (guards against the
  probe silencing a real failure).

## How to Test

```bash
cd ~/.hermes/hermes-agent

# 1. RED — fails on unmodified main
git stash push gateway/run_notifications.py
venv/bin/python -m pytest tests/run_agent/test_corruption_recovery_guidance.py -q -o addopts= \
  -k "session_db_warning"
# → 2 failed, 1 passed

# 2. GREEN
git stash pop
venv/bin/python -m pytest tests/run_agent/test_corruption_recovery_guidance.py -q -o addopts=
# → 8 passed

# 3. Full file + neighbouring suite
scripts/run_tests.sh tests/run_agent/test_corruption_recovery_guidance.py \
                      tests/hermes_cli/test_sqlite3_cli_salvage_gate.py
# → 40 passed
```

Manual reproduction: start the gateway while another process holds a write lock on `state.db` for a
second or two (a concurrent `hermes sessions …`, or a slow NFS/SMB lock release). Before this change
the home channels get the banner even though the store opened a moment later; after it, the banner
only appears if the store is still unavailable when the gateway has finished connecting.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and issues
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected suites: `scripts/run_tests.sh tests/run_agent` — see below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (Linux), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (behaviour fix)
- [ ] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [ ] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the probe runs through `asyncio.to_thread` and path
      handling is unchanged; `scripts/check-windows-footguns.py` reports no footguns in this diff.
- [ ] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

RED/GREEN evidence is in "How to Test" (2 failed → 8 passed). The banner text itself is unchanged.
