### PR TITLE
fix(agent): advance the compression fallback chain when a candidate fails or returns an empty summary

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3225,7 +3225,11 @@ def _is_invalid_aux_response_error(exc: Exception) -> bool:
     if not isinstance(exc, RuntimeError):
         return False
     msg = str(exc).lower()
-    return "auxiliary " in msg and "llm returned invalid response" in msg and "choices[0].message" in msg
+    return (
+        "auxiliary " in msg
+        and "llm returned invalid response" in msg
+        and ("choices[0].message" in msg or "empty content" in msg)
+    )
 
 
 # Tasks on a user-visible critical path (compression blocks resuming an oversized session; vision
@@ -6185,6 +6189,25 @@ def _validate_llm_response(
         model = _field(response, "model")
         if isinstance(model, str) and model.strip():
             context["response_model"] = model
+    # Compression cannot use a response with no text as a summary. Rejecting it here fails the
+    # candidate rather than the route, so the configured fallback chain is tried to exhaustion
+    # before the compressor gives up on the auxiliary route and retries the main chat model — its
+    # existing behaviour when a candidate fails. The emptiness test is the compressor's own helper,
+    # so a summary recovered from reasoning/reasoning_content still counts as text (#11978).
+    if task == "compression":
+        try:
+            message = _field(_field(response, "choices")[0], "message")
+        except (TypeError, IndexError, KeyError):
+            message = None
+        if (
+            message is not None
+            and not extract_content_or_reasoning(response, max_reasoning_chars=8000).strip()
+            and not _field(message, "tool_calls")
+        ):
+            raise RuntimeError(
+                "Auxiliary compression: LLM returned invalid response (empty content). Expected a "
+                "non-empty summary — check provider adapter or custom endpoint compatibility."
+            )
     _complete_relay_auxiliary_call()
     return response
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3991,6 +3991,7 @@ def _context_too_small(
 def _try_configured_fallback_chain(
     task: str, failed_provider: str, reason: str = "error", failed_model: Optional[str] = None, *,
     failed_base_url: str = "", failure_scope: Any = None,
+    excluded_labels: Optional[set[str]] = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
     """Try auxiliary.<task>.fallback_chain entries in order (each needs ``provider``; model/base_url/api_key optional).
     ``failed_model`` scoping per ``_failed_backend_skip`` (sibling models on the same provider still
@@ -4020,6 +4021,8 @@ def _try_configured_fallback_chain(
             continue
         fb_model = fb_model_raw or None
         label = f"fallback_chain[{i}]({fb_provider})"
+        if excluded_labels and label in excluded_labels:
+            continue
         try:
             fb_client, resolved_model = _resolve_fallback_entry(entry)
         except Exception:
@@ -7023,7 +7026,13 @@ def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
     chain, explicit: main-agent-model net). Returns the response or None.
     Capacity errors (payment/quota, connection, exhausted 429, model incompatible, malformed
     response) bypass the explicit-provider gate — the provider cannot serve this request
-    regardless of user intent. Auth errors only fall back in auto mode."""
+    regardless of user intent. Auth errors only fall back in auto mode.
+
+    A configured candidate that fails with a fallback-able error (auth, payment, connection,
+    rate limit, model incompatible/unknown, invalid response) does NOT abort the remaining
+    chain: its label is excluded and the next entry is tried before any main-agent/discovery
+    layer runs, so the same route is never selected twice.
+    """
     task, tag, resolved_provider = route.task, route.tag, route.resolved_provider
     # Respect explicit provider choice for transient errors (auth, request validation, etc.) but allow
     # fallback when the provider clearly cannot serve the request due to capacity: payment/quota exhaustion
@@ -7055,10 +7064,44 @@ def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
         if reason == "payment error" and _custom_health_base_url(resolved_provider, route.base_info)
         else None
     )
-    fb_client, fb_model, fb_label = _try_configured_fallback_chain(
-        task, resolved_provider or "auto", reason=reason, failed_model=_chain_failed_model,
-        failed_base_url=route.base_info, failure_scope=_chain_failure_scope)
-    if fb_client is None and is_auto:
+    # Walk every configured candidate in order: a capacity/model failure on one candidate must
+    # not abort the rest of the configured chain.
+    excluded_labels: set[str] = set()
+    while True:
+        fb_client, fb_model, fb_label = _try_configured_fallback_chain(
+            task, resolved_provider or "auto", reason=reason,
+            failed_model=_chain_failed_model, failed_base_url=route.base_info,
+            failure_scope=_chain_failure_scope, excluded_labels=excluded_labels)
+        if fb_client is None:
+            break
+        _record_route_info(route.route_info, _fallback_provider_from_label(fb_label), fb_model)
+        try:
+            fb_resp = yield _LadderStep("fallback", (fb_client, fb_model, fb_label))
+        except Exception as candidate_err:
+            candidate_can_fallback = (
+                _is_auth_error(candidate_err)
+                or _is_payment_error(candidate_err)
+                or _is_connection_error(candidate_err)
+                or _is_rate_limit_error(candidate_err)
+                or _is_model_incompatible_error(candidate_err)
+                or _is_model_not_found_error(candidate_err)
+                or _is_invalid_aux_response_error(candidate_err)
+            )
+            if not candidate_can_fallback:
+                raise
+            logger.warning(
+                "Auxiliary %s%s: configured fallback %s failed (%s); continuing configured chain",
+                task or "call", tag, fb_label, candidate_err,
+            )
+            excluded_labels.add(fb_label)
+            continue
+        if fb_resp is not None:
+            return fb_resp
+        # Stale/unrefreshable auth returned None after quarantine — try the next entry.
+        excluded_labels.add(fb_label)
+
+    # Configured entries are exhausted — continue with the main-agent/discovery safety layers.
+    if is_auto:
         fb_client, fb_model, fb_label = _try_main_fallback_chain(
             task, resolved_provider or "auto", reason=reason, failed_model=_chain_failed_model,
             failed_base_url=route.base_info, failure_scope=_chain_failure_scope)
@@ -7085,12 +7128,11 @@ def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
                 if fb_client is None:
                     break
     # All fallback layers exhausted — one user-visible warning, then re-raise.
-    logger.warning("Auxiliary %s%s: %s on %s and all fallbacks exhausted "
-                   # All fallback layers exhausted — emit a single user-visible warning so the operator
-                   # knows aux task is about to fail. (#26882) The error itself is re-raised below.
-                   # (#26882)
-                   "(fallback_chain + main agent model). Raising original error.",
-                   task or "call", tag, reason, resolved_provider)
+    logger.warning(
+        "Auxiliary %s%s: %s on %s and all fallbacks exhausted "
+        "(fallback_chain + main agent model). Raising original error.",
+        task or "call", tag, reason, resolved_provider,
+    )
     return None
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4495,6 +4495,132 @@ class TestCompressionFallbackContextFilter:
         assert _task_minimum_context_length(None) is None
 
 
+class TestConfiguredFallbackCandidateFailures:
+    """A failing configured candidate must not abort the remaining chain."""
+
+    def test_sync_chain_continues_after_connection_error(self, monkeypatch):
+        from agent.auxiliary_client import call_llm
+
+        primary = MagicMock(name="primary")
+        first_fallback = MagicMock(name="first_fallback")
+        second_fallback = MagicMock(name="second_fallback")
+        response = _DummyResponse()
+
+        primary.chat.completions.create.side_effect = ConnectionError("primary refused")
+        first_fallback.chat.completions.create.side_effect = ConnectionError("fallback refused")
+        second_fallback.chat.completions.create.return_value = response
+
+        entries = [
+            {"provider": "first", "model": "first-model"},
+            {"provider": "second", "model": "second-model"},
+        ]
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda *args, **kwargs: ("primary", "primary-model", None, None, None),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *args, **kwargs: (primary, "primary-model"),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": entries},
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_fallback_entry",
+            lambda entry: (
+                (first_fallback, "first-model")
+                if entry is entries[0]
+                else (second_fallback, "second-model")
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.get_model_context_length",
+            lambda *args, **kwargs: 1_048_576,
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._transient_retry_count",
+            lambda: 0,
+        )
+
+        result = call_llm(
+            task="compression",
+            messages=[{"role": "user", "content": "summarize"}],
+        )
+
+        assert result is response
+        first_fallback.chat.completions.create.assert_called_once()
+        second_fallback.chat.completions.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_chain_continues_after_connection_error(self, monkeypatch):
+        from agent.auxiliary_client import async_call_llm
+
+        primary = MagicMock(name="primary_async")
+        primary.chat.completions.create = AsyncMock(
+            side_effect=ConnectionError("primary refused")
+        )
+        first_sync = MagicMock(name="first_sync")
+        second_sync = MagicMock(name="second_sync")
+        first_async = MagicMock(name="first_async")
+        second_async = MagicMock(name="second_async")
+        first_async.chat.completions.create = AsyncMock(
+            side_effect=ConnectionError("fallback refused")
+        )
+        response = _DummyResponse()
+        second_async.chat.completions.create = AsyncMock(return_value=response)
+
+        entries = [
+            {"provider": "first", "model": "first-model"},
+            {"provider": "second", "model": "second-model"},
+        ]
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda *args, **kwargs: ("primary", "primary-model", None, None, None),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *args, **kwargs: (primary, "primary-model"),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": entries},
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_fallback_entry",
+            lambda entry: (
+                (first_sync, "first-model")
+                if entry is entries[0]
+                else (second_sync, "second-model")
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._to_async_client",
+            lambda client, model, **kwargs: (
+                (first_async, model) if client is first_sync else (second_async, model)
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.get_model_context_length",
+            lambda *args, **kwargs: 1_048_576,
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._transient_retry_count",
+            lambda: 0,
+        )
+
+        result = await async_call_llm(
+            task="compression",
+            messages=[{"role": "user", "content": "summarize"}],
+        )
+
+        assert result is response
+        first_async.chat.completions.create.assert_awaited_once()
+        second_async.chat.completions.create.assert_awaited_once()
+
+
 class TestCustomEndpointApiKeyInheritance:
     """Issue #9318: when an auxiliary task uses provider=custom with an
     explicit base_url but empty api_key, the custom_key fallback chain must

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -26,6 +26,8 @@ from agent.auxiliary_client import (
     _is_rate_limit_error,
     _is_model_not_found_error,
     _is_model_incompatible_error,
+    _is_invalid_aux_response_error,
+    _validate_llm_response,
     _refresh_nous_recommended_model,
     _normalize_aux_provider,
     _try_payment_fallback,
@@ -4495,8 +4497,107 @@ class TestCompressionFallbackContextFilter:
         assert _task_minimum_context_length(None) is None
 
 
+class TestCompressionEmptyResponseFallback:
+    """An empty compression summary is a route failure, not a successful auxiliary call."""
+
+    def test_compression_empty_content_is_invalid_but_tool_call_is_allowed(self):
+        empty = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="   ", tool_calls=None))]
+        )
+        with pytest.raises(RuntimeError, match="empty content") as exc_info:
+            _validate_llm_response(empty, "compression")
+        assert _is_invalid_aux_response_error(exc_info.value)
+
+        tool_only = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content="", tool_calls=[SimpleNamespace(id="call_1")])
+            )]
+        )
+        assert _validate_llm_response(tool_only, "compression") is tool_only
+
+    def test_other_tasks_keep_accepting_empty_content(self):
+        """Only compression needs a summary; a blank vision answer is not a route failure."""
+        blank = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="", tool_calls=None))]
+        )
+        assert _validate_llm_response(blank, "vision") is blank
+        assert _validate_llm_response(blank, None) is blank
+
+    def test_compression_reasoning_only_summary_is_still_accepted(self):
+        """A summary recovered from reasoning fields must not be rejected as empty (#11978)."""
+        from_reasoning_content = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(
+                content="", reasoning_content="kept reasoning summary", tool_calls=None
+            ))]
+        )
+        from_reasoning = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(
+                content="   ", reasoning="kept reasoning summary", tool_calls=None
+            ))]
+        )
+        assert _validate_llm_response(from_reasoning_content, "compression") is from_reasoning_content
+        assert _validate_llm_response(from_reasoning, "compression") is from_reasoning
+
+
 class TestConfiguredFallbackCandidateFailures:
     """A failing configured candidate must not abort the remaining chain."""
+
+    def test_sync_chain_continues_after_empty_compression_response(self, monkeypatch):
+        from agent.auxiliary_client import call_llm
+
+        primary = MagicMock(name="primary")
+        first_fallback = MagicMock(name="first_fallback")
+        second_fallback = MagicMock(name="second_fallback")
+        response = _DummyResponse()
+
+        primary.chat.completions.create.side_effect = ConnectionError("primary refused")
+        first_fallback.chat.completions.create.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="", tool_calls=None))]
+        )
+        second_fallback.chat.completions.create.return_value = response
+
+        entries = [
+            {"provider": "first", "model": "first-model"},
+            {"provider": "second", "model": "second-model"},
+        ]
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda *args, **kwargs: ("primary", "primary-model", None, None, None),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *args, **kwargs: (primary, "primary-model"),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"fallback_chain": entries},
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_fallback_entry",
+            lambda entry: (
+                (first_fallback, "first-model")
+                if entry is entries[0]
+                else (second_fallback, "second-model")
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.get_model_context_length",
+            lambda *args, **kwargs: 1_048_576,
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._transient_retry_count",
+            lambda: 0,
+        )
+
+        result = call_llm(
+            task="compression",
+            messages=[{"role": "user", "content": "summarize"}],
+        )
+
+        assert result is response
+        first_fallback.chat.completions.create.assert_called_once()
+        second_fallback.chat.completions.create.assert_called_once()
 
     def test_sync_chain_continues_after_connection_error(self, monkeypatch):
         from agent.auxiliary_client import call_llm


### PR DESCRIPTION
## What does this PR do?

Makes a **failing compression candidate advance the configured fallback chain**, and treats an
**empty summary as such a failure**.

Two commits, one logical change — the second is meaningless without the first:

1. `fix: continue auxiliary fallback chains after candidate failure` — walk the remaining
   `auxiliary.<task>.fallback_chain` entries after a candidate fails, instead of abandoning the
   configured chain and dropping straight to the discovery/main-agent-model layers. The chain is
   walked with `excluded_labels` so a candidate that already failed is not retried in the same call.
2. `fix(agent): fail the compression candidate when its summary is empty` — a compression response
   with no usable text (blank `content`, no reasoning fallback, no tool calls: well-formed proxies /
   one-api channels, thinking models whose text never lands in `content`) now raises the canonical
   invalid-response error at the auxiliary boundary. `_is_invalid_aux_response_error()` recognises
   that form, so it is handled like every other candidate failure (connection error, 429, 5xx).

**Why both.** Today an empty summary is only noticed downstream in
`ContextCompressor._generate_summary()`, which then gives up on the auxiliary route and retries the
main chat model — the provider the configured chain exists to route around, and usually the exhausted
one (rate limit / out of credit / context overflow) that made compression run off-provider in the
first place. Validating at the boundary without the chain walk would still skip the remaining
configured candidates, so both are needed for the behaviour to be correct.

Two properties are preserved deliberately:

- **Reasoning fallback still wins (#11978).** The emptiness test is the compressor's own
  `extract_content_or_reasoning()` helper, so a summary carried in `reasoning` /
  `reasoning_content` / `reasoning_details` is not empty and passes untouched — there is a
  regression test for exactly this.
- **End-of-route behaviour is unchanged.** When the chain has no remaining candidates the error
  propagates as it does today, so the main-model fallback + cooldown machinery still runs.

## Related Issue

Fixes #108030

Related: #11978 (the reasoning-field recovery this builds on; its tests still pass), #94448 and
#19003 (user-visible consequences of empty summaries).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`
  - `_ladder_provider_fallback()` — while-loop over `_try_configured_fallback_chain` with an
    `excluded_labels` set: a failed candidate is added to the exclusion set and the chain is walked
    again, instead of the remaining configured entries being skipped. Upstream's two-pass
    stale-credential retry (`_try_payment_fallback` with `reason="stale fallback credential"`) and
    the `main_runtime` propagation are kept as they are.
  - `_try_configured_fallback_chain()` — accepts `excluded_labels` and skips entries already tried in
    this call.
  - `_is_invalid_aux_response_error()` — also recognises the `empty content` form.
  - `_validate_llm_response()` — for `task == "compression"`, a message with no extractable text and
    no tool calls raises the invalid-response error before the relay auxiliary call is completed.
    Other tasks are untouched (a blank `vision` answer is not a route failure).
- `tests/agent/test_auxiliary_client.py`
  - `TestConfiguredFallbackCandidateFailures` — sync + async chain continuation tests (connection
    error, and an empty compression response).
  - `TestCompressionEmptyResponseFallback` — empty compression message raises *and* is classified as
    a route failure; a tool-call-only message is still accepted; `vision`/task-less calls still
    accept empty content; a reasoning-only summary is still accepted (#11978 guard).

## How to Test

```bash
cd ~/.hermes/hermes-agent

# 1. RED — on unmodified main the two new behaviours do not exist
git checkout main -- agent/auxiliary_client.py
venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -q -o addopts= \
  -k "CompressionEmptyResponse or empty_compression or ConfiguredFallbackCandidateFailures"
# → failures (no chain walk, no empty-content failure)

# 2. GREEN — with this PR
git checkout HEAD -- agent/auxiliary_client.py
venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -q -o addopts= \
  -k "CompressionEmptyResponse or empty_compression or ConfiguredFallbackCandidateFailures"
# → 6 passed

# 3. Whole file, and the reasoning-fallback regression path
venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -q -o addopts=                     # 210 passed
venv/bin/python -m pytest tests/agent/test_context_compressor_reasoning_fallback.py -q -o addopts= # 4 passed
```

Reproduction without the harness: point `auxiliary.compression` at a provider whose first chain
candidate returns `content=""` with no reasoning fields and no tool calls, trigger compression on an
oversized session, and watch the chain — before this change the second candidate is never called;
after it is.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and issues (see "Related Issue")
- [x] My PR is focused on one logical change (2 files, 2 commits — see "Why both")
- [x] I've run the affected suites — `tests/agent/test_auxiliary_client.py` in full (210 passed) plus
      the reasoning-fallback regression file (4 passed); wider `tests/agent` results in a follow-up comment
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (Linux), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (behaviour fix, no config/API change)
- [ ] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [ ] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A: in-memory response-shape validation and control
      flow, no filesystem or process handling. `scripts/check-windows-footguns.py --diff` reports no
      new footguns from this diff.
- [ ] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Test evidence in "How to Test". The user-visible effect is a compression that completes on the second
configured candidate instead of failing over to the main model.
