### PR TITLE
fix(kanban): configure creator delivery wake mode

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1698,6 +1698,10 @@ DEFAULT_CONFIG = {
         # kanban_create is called from a session with a persistent delivery channel. Disable for
         # profiles that prefer explicit kanban_notify-subscribe calls per task.
         "auto_subscribe_on_create": True,
+        # Delivery mode for NEW gateway creator subscriptions. Existing and inherited
+        # subscriptions retain their persisted policy. "wake" suppresses the passive
+        # notifier ping but still resumes the creator session on decision events.
+        "auto_subscribe_delivery_mode": "notify+wake",
         # Run the dispatcher inside the gateway process (~300µs per idle tick). False only if you
         # run it as a separate unit or don't want the gateway spawning workers.
         "dispatch_in_gateway": True,

--- a/tests/gateway/test_kanban_notifier_wake_only_ordering.py
+++ b/tests/gateway/test_kanban_notifier_wake_only_ordering.py
@@ -11,6 +11,7 @@ Residual insight extracted from closed PR #84191 (@MaximCrabbe).
 """
 
 import asyncio
+import json
 
 from gateway.config import Platform
 from gateway.run import GatewayRunner
@@ -40,6 +41,16 @@ class FailingWakeAdapter(RecordingAdapter):
     async def handle_message(self, event):
         self.handled.append(event)
         raise RuntimeError("simulated wake failure")
+
+
+class RecoveringWakeAdapter(RecordingAdapter):
+    """Push adapter which fails one wake, then admits its retry."""
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+        if len(self.handled) == 1:
+            raise RuntimeError("simulated first wake failure")
+        event._gateway_accepted = True
 
 
 async def _run_one_notifier_tick(monkeypatch, runner):
@@ -156,6 +167,47 @@ def test_wake_only_failure_rewinds_and_redelivers(tmp_path, monkeypatch):
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner2))
     assert len(adapter.handled) == 2, "event must be redelivered next tick"
     assert list(runner2._kanban_sub_fail_counts.values()) == [2]
+
+
+def test_creator_wake_mode_recovers_without_passive_ping(tmp_path, monkeypatch):
+    """The creator setting writes wake mode, which retries and recovers as one delivery."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "creator-wake.db"))
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-1")
+    kb.init_db()
+
+    from tools import kanban_tools as kt
+
+    monkeypatch.setattr(kt, "load_config", lambda: {
+        "kanban": {
+            "auto_subscribe_on_create": True,
+            "auto_subscribe_delivery_mode": "wake",
+        },
+    })
+    created = kt._handle_create({"title": "creator wake", "assignee": "worker"})
+    tid = json.loads(created)["task_id"]
+    assert _subs(tid)[0]["delivery_mode"] == "wake"
+
+    conn = kbc.connect()
+    try:
+        kb.complete_task(conn, tid, summary="done")
+    finally:
+        conn.close()
+
+    adapter = RecoveringWakeAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert adapter.sent == []
+    assert len(adapter.handled) == 1
+    assert len(_unseen_terminal_events(tid)) == 1
+
+    retry_runner = _make_runner(adapter)
+    retry_runner._kanban_sub_fail_counts = runner._kanban_sub_fail_counts
+    asyncio.run(_run_one_notifier_tick(monkeypatch, retry_runner))
+    assert adapter.sent == []
+    assert len(adapter.handled) == 2
+    assert _unseen_terminal_events(tid) == []
+    assert retry_runner._kanban_sub_fail_counts == {}
 
 
 def test_notify_wake_failure_retries_without_repeating_ping(tmp_path, monkeypatch):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -9,6 +9,7 @@ Verifies:
 from __future__ import annotations
 
 import json
+import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
 
@@ -931,7 +932,7 @@ def _sub_index(subs):
     return out
 
 
-def test_create_subscribes_gateway_session(monkeypatch, worker_env):
+def test_create_missing_delivery_mode_keeps_notify_wake_compatibility(monkeypatch, worker_env):
     """A gateway session (platform + chat_id set) gets auto-subscribed
     to its own kanban_create result, and the response surfaces the
     ``subscribed`` flag so the orchestrator can react."""
@@ -962,6 +963,104 @@ def test_create_subscribes_gateway_session(monkeypatch, worker_env):
     assert s["user_id_alt"] == "alt-user-9"
     assert s["chat_type"] == "forum"
     assert s["delivery_mode"] == "notify+wake"
+
+
+@pytest.mark.parametrize("delivery_mode", ("notify", "notify+wake", "wake"))
+def test_create_applies_supported_auto_subscribe_delivery_mode(monkeypatch, worker_env, delivery_mode):
+    """Each configured delivery mode is persisted for a new gateway creator row."""
+    from tools import kanban_tools as kt
+
+    monkeypatch.setattr(kt, "load_config", lambda: {
+        "kanban": {
+            "auto_subscribe_on_create": True,
+            "auto_subscribe_delivery_mode": delivery_mode,
+        },
+    })
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "channel-1")
+
+    created = json.loads(kt._handle_create({
+        "title": f"auto-sub {delivery_mode}",
+        "assignee": "peer",
+    }))
+
+    assert created["subscribed"] is True
+    assert _list_subs_for_task(created["task_id"])[0]["delivery_mode"] == delivery_mode
+
+
+def test_create_invalid_delivery_mode_skips_creator_subscription(monkeypatch, worker_env, caplog):
+    """A bad explicit mode must not create a visible fallback notification."""
+    from tools import kanban_tools as kt
+
+    monkeypatch.setattr(kt, "load_config", lambda: {
+        "kanban": {
+            "auto_subscribe_on_create": True,
+            "auto_subscribe_delivery_mode": "interrupt-everyone",
+        },
+    })
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "channel-1")
+
+    with caplog.at_level(logging.WARNING, logger="tools.kanban_tools"):
+        created = json.loads(kt._handle_create({
+            "title": "invalid creator delivery mode",
+            "assignee": "peer",
+        }))
+
+    assert created["ok"] is True
+    assert created["subscribed"] is False
+    assert _list_subs_for_task(created["task_id"]) == []
+    assert "kanban.auto_subscribe_delivery_mode='interrupt-everyone' is invalid" in caplog.text
+
+
+def test_create_reads_delivery_mode_from_profile_config(monkeypatch, worker_env, tmp_path):
+    """The active profile's config, not another profile's settings, chooses the mode."""
+    home = tmp_path / "wake-profile" / ".hermes"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "kanban:\n  auto_subscribe_delivery_mode: wake\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "channel-1")
+
+    from tools import kanban_tools as kt
+    created = json.loads(kt._handle_create({
+        "title": "profile-local delivery mode",
+        "assignee": "peer",
+    }))
+
+    assert created["subscribed"] is True
+    assert _list_subs_for_task(created["task_id"])[0]["delivery_mode"] == "wake"
+
+
+def test_idempotent_create_preserves_existing_creator_subscription_policy(monkeypatch, worker_env):
+    """A create retry must not replace an existing row's mode or cursor."""
+    from tools import kanban_tools as kt
+
+    config = {"kanban": {
+        "auto_subscribe_on_create": True,
+        "auto_subscribe_delivery_mode": "notify",
+    }}
+    monkeypatch.setattr(kt, "load_config", lambda: config)
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "channel-1")
+    args = {
+        "title": "idempotent creator subscription",
+        "assignee": "peer",
+        "idempotency_key": "creator-subscription-retry",
+    }
+
+    first = json.loads(kt._handle_create(args))
+    before = _list_subs_for_task(first["task_id"])[0]
+    config["kanban"]["auto_subscribe_delivery_mode"] = "wake"
+    retry = json.loads(kt._handle_create(args))
+    after = _list_subs_for_task(first["task_id"])[0]
+
+    assert retry["task_id"] == first["task_id"]
+    assert retry["subscribed"] is True
+    assert after["delivery_mode"] == before["delivery_mode"] == "notify"
+    assert after["last_event_id"] == before["last_event_id"]
 
 
 def test_create_subscribes_tui_session_via_session_key(monkeypatch, worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -864,7 +864,7 @@ def _handle_create(args: dict, **kw) -> str:
         return _ok(task_id=new_tid, **landed, subscribed=_maybe_auto_subscribe(conn, new_tid))
 
 
-def _resolve_notify_target() -> Optional[dict[str, Any]]:
+def _resolve_notify_target(delivery_mode: Optional[str] = None) -> Optional[dict[str, Any]]:
     """``kanban_db.add_notify_sub`` kwargs for the calling session, or None (CLI/cron/tests).
     Gateway sessions: ``HERMES_SESSION_PLATFORM``/``CHAT_ID`` ContextVars. TUI/desktop:
     those are cleared but the subprocess inherits ``HERMES_SESSION_KEY`` -> ``platform="tui"``
@@ -905,7 +905,7 @@ def _resolve_notify_target() -> Optional[dict[str, Any]]:
         user_id=env("HERMES_SESSION_USER_ID", "") or None,
         user_id_alt=env("HERMES_SESSION_USER_ID_ALT", "") or None,
         notifier_profile=notifier_profile,
-        delivery_mode="notify+wake" if platform != "tui" else None,
+        delivery_mode=delivery_mode if platform != "tui" else None,
         delivery_metadata=delivery_metadata or None)
 
 
@@ -915,16 +915,26 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
     ``kanban_notify-subscribe``). Gated by ``kanban.auto_subscribe_on_create`` (default
     True). Failures are logged and swallowed: bookkeeping must never fail kanban_create."""
     try:
-        if not cfg_get(load_config(), "kanban", "auto_subscribe_on_create", default=True):
-            return False
+        config = load_config()
     except Exception:
-        pass  # unreadable config keeps the user-friendly default (True)
+        config = None  # unreadable config keeps the user-friendly defaults
+    if not cfg_get(config, "kanban", "auto_subscribe_on_create", default=True):
+        return False
     target = None
     try:
-        target = _resolve_notify_target()
+        delivery_mode = cfg_get(
+            config, "kanban", "auto_subscribe_delivery_mode", default="notify+wake",
+        )
+        target = _resolve_notify_target(delivery_mode)
         if target is None:
             return False  # CLI / cron / test — no persistent channel
         from hermes_cli import kanban_db_notify as _kbn
+        if target["platform"] != "tui" and delivery_mode not in _kbn._NOTIFY_DELIVERY_MODES:
+            logger.warning(
+                "kanban.auto_subscribe_delivery_mode=%r is invalid; skipping creator subscription for %s",
+                delivery_mode, task_id,
+            )
+            return False
         # Inheritance and explicit subscriptions already encode the delivery policy.
         # Auto-subscribe must not turn a passive destination into an agent wake.
         if any(sub["platform"] == target["platform"] and sub["chat_id"] == target["chat_id"]

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -676,7 +676,8 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `auto_decompose_per_tick` | `3` | Cap on decompositions per dispatcher tick. Excess defers to the next tick. |
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
-| `auto_subscribe_on_create` | `true` | When `kanban_create` runs inside a persistent gateway/TUI session, terminal events resume that originating agent with a synthetic status turn. Set to `false` for passive completion or to require explicit `kanban_notify-subscribe` calls. Independent of `auto_decompose`. |
+| `auto_subscribe_on_create` | `true` | When `kanban_create` runs inside a persistent gateway/TUI session, terminal events subscribe the originating session. Set to `false` to require explicit `kanban_notify-subscribe` calls. Independent of `auto_decompose`. |
+| `auto_subscribe_delivery_mode` | `notify+wake` | Delivery mode for a new gateway creator subscription: `notify`, `notify+wake`, or `wake`. It never rewrites an inherited or existing subscription. `wake` suppresses the notifier's passive message, but the resumed agent can still send its own reply. |
 | `done_sub_retention_days` | `30` | Notify subscriptions survive `done` (reopen-safe) and are removed on `archived`. The notifier GC purges subscriptions whose task has been `done` or `blocked` with no new events for this many days, bounding sub-table growth on boards that never archive. `0` disables the sweep. |
 
 And the two auxiliary LLM slots:
@@ -1086,7 +1087,7 @@ Coverage window: desktop notifications ride the live event stream, so they fire 
 
 ## Gateway notifications
 
-When you run `/kanban create …` from the gateway (Telegram, Discord, Slack, etc.), the originating chat is automatically subscribed to the new task. The gateway's background notifier polls `task_events` every few seconds and delivers one message per terminal event (`completed`, `blocked`, `gave_up`, `crashed`, `timed_out`) to that chat. Completed tasks also send the first line of the worker's `--result` so you see the outcome without having to `/kanban show`.
+When you run `/kanban create …` from the gateway (Telegram, Discord, Slack, etc.), the originating chat is automatically subscribed to the new task. The default `kanban.auto_subscribe_delivery_mode: notify+wake` sends one notifier message per terminal event (`completed`, `blocked`, `gave_up`, `crashed`, `timed_out`) and resumes the originating agent. Set the mode to `notify` for a passive message only, or `wake` to resume the agent without the separate notifier message. A `wake` subscription suppresses only that passive message: the resumed agent's normal reply is still delivered. Completed-task messages include the first line of the worker's `--result` so you see the outcome without having to `/kanban show`.
 
 You can manage subscriptions explicitly from the CLI — useful when a script / cron job wants to notify a chat it didn't originate from:
 


### PR DESCRIPTION
## What / why

Adds the profile-local `kanban.auto_subscribe_delivery_mode` setting for newly created gateway-originated Kanban task subscriptions. This lets an orchestrator select `notify`, `notify+wake`, or `wake`; `wake` suppresses the notifier's passive ping while preserving the resumed agent's own reply. The default remains `notify+wake` for compatibility.

Invalid explicit values fail safe: creation succeeds, no creator subscription is added, and the setting is logged rather than silently falling back to a user-visible notification. Existing/inherited subscriptions retain their owner, delivery mode, and cursor.

## Reproduction and test instructions

```bash
scripts/run_tests.sh tests/tools/test_kanban_tools.py tests/gateway/test_kanban_notifier_wake_only_ordering.py
```

The reviewed candidate ran this canonical suite twice: 49 tests passed, 0 failed. Coverage includes missing-setting compatibility, all supported modes, invalid-mode handling, disabled/TUI/channel-less behavior, profile-local resolution, idempotent retry preservation, and wake failure/recovery ordering.

## Tested platforms

Windows 11, using the repository's canonical test runner. Live Discord/Telegram routing and gateway deployment were intentionally not exercised here; they are rollout/QA work.

## Related upstream work

Fresh publication-time sweep found no direct existing issue or PR for configurable creator delivery mode. Related: #40917 introduced auto-subscription on task creation; #101335 and #103750 are active transport-routing work. In particular, #103750 is open and overlaps `tools/kanban_tools.py` and `tests/gateway/test_kanban_notifier_wake_only_ordering.py`; this PR does not incorporate its iMessage-specific routing policy.

## Risk

The configuration applies only to new gateway creator subscriptions. Invalid explicit configuration intentionally skips auto-subscription instead of notifying. Existing/inherited subscriptions are not rewritten. The branch applies cleanly to the current upstream `main` in a local merge simulation.

## Explicit exclusions

No reconciler, cron, relay, or Linear-event-map changes. No new watcher or ledger. No user-visible completion-policy change.
