### PR TITLE
feat(skills): add prism-gpu optional skill for per-second GPU rental

### DIFF
--- a/optional-skills/mlops/prism-gpu/SKILL.md
+++ b/optional-skills/mlops/prism-gpu/SKILL.md
@@ -29,6 +29,12 @@ single machine for a bounded window and nothing survives its release.
 
 - A job needs CUDA and the local machine has no NVIDIA card, or has one with too little
   VRAM for the model or kernel under test.
+- Another skill in this tree needs a card the machine does not have. `flash-attention`
+  states it has no CPU path. `slime` starts its container with `--gpus all`. `peft` sizes
+  every example in GPU memory. `nemo-curator` has a CPU install that gives up the speedups
+  it quotes. Lease a box, run that skill's own commands on it, release. Published capacity
+  reports CUDA 12, so a skill that requires CUDA 13 or newer is not served by it: read
+  `gpu.cuda_major` in the offer before planning the run.
 - Several steps depend on each other and need the same box: build, then run, then collect.
 - A result has to be citable by someone who does not trust the caller. Every settled lease
   publishes a receipt whose hash is committed on chain.
@@ -37,8 +43,10 @@ single machine for a bounded window and nothing survives its release.
 - Don't use for a whole interactive session on a GPU shell. The separate `hermes-plugin-prism`
   package (PyPI) makes the agent's own terminal a rented GPU, which is a different shape of
   purchase from the per-job leasing here.
-- Don't use before the job has run once on CPU at reduced size. A crash loop on a rented box
-  bills for the crash loop.
+- Don't use for a multi-GPU example. A lease is one machine with one card, so `--tp_size 4`
+  and an eight-worker cluster have nothing to run on.
+- Don't use before the job has run once at reduced size, on CPU where the code has a CPU
+  path. A crash loop on a rented box bills for the crash loop.
 
 ## Prerequisites
 

--- a/optional-skills/mlops/prism-gpu/SKILL.md
+++ b/optional-skills/mlops/prism-gpu/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: prism-gpu
+description: Rent an NVIDIA GPU by the second from an agent wallet.
+version: 0.1.0
+author: Mika Winter (winterstacks)
+license: MIT
+dependencies: ["prismnetwork>=0.4.0,<0.6"]
+platforms: [linux, macos, windows]
+required_environment_variables:
+  - name: PRISM_AGENT_KEY
+    prompt: Prism agent wallet private key
+    help: A wallet on Robinhood Chain (id 4663) holding USDG for the deposit and a little native ETH for gas. See https://prismnetwork.tech
+    required_for: every SDK call; scripts/pick_gpu.py and scripts/verify_receipt.py read the public feeds without it
+metadata:
+  hermes:
+    tags: [GPU, NVIDIA, CUDA, Compute Rental, USDG, Prism]
+    related_skills: [lambda-labs, modal]
+---
+
+# Prism GPU Skill
+
+Rents a dedicated NVIDIA GPU on Prism Network for a fixed window, runs commands on it
+over SSH, and releases it. Payment settles on-chain in USDG on Robinhood Chain (id 4663)
+from a wallet this agent controls, so there is no account to create and no API key to hold.
+It does not manage clusters, persistent volumes, or long-running services; a lease is a
+single machine for a bounded window and nothing survives its release.
+
+## When to Use
+
+- A job needs CUDA and the local machine has no NVIDIA card, or has one with too little
+  VRAM for the model or kernel under test.
+- Several steps depend on each other and need the same box: build, then run, then collect.
+- A result has to be citable by someone who does not trust the caller. Every settled lease
+  publishes a receipt whose hash is committed on chain.
+- Don't use for a single `nvidia-smi` or a five-second sanity check. Provisioning takes one
+  to four minutes and the deposit books the whole window against the day's budget.
+- Don't use for a whole interactive session on a GPU shell. The separate `hermes-plugin-prism`
+  package (PyPI) makes the agent's own terminal a rented GPU, which is a different shape of
+  purchase from the per-job leasing here.
+- Don't use before the job has run once on CPU at reduced size. A crash loop on a rented box
+  bills for the crash loop.
+
+## Prerequisites
+
+Python 3.10 or newer: every published `prismnetwork` release requires it, and below that pip
+answers "no matching distribution", which reads as a missing package rather than a version
+floor. Check, then install, through the `terminal` tool:
+
+```bash
+python3 --version
+pip install "prismnetwork>=0.4.0,<0.6"
+```
+
+If `python3` is older, run the scripts with a 3.10+ interpreter by name, such as `python3.12`.
+The three SDK-backed scripts refuse on an older one and say why.
+
+`PRISM_AGENT_KEY` holds the private key of the paying wallet. It needs USDG for the deposit
+and a small amount of native ETH for gas, both on Robinhood Chain (id 4663). The wallet is
+the credential: anything holding that key can spend the balance, so keep it out of a rented
+box and out of anything the workload can read.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PRISM_AGENT_KEY` | none | The paying wallet. Every SDK call signs a session with it. |
+| `PRISM_MAX_USDG` | `1` | Ceiling on one lease's deposit. |
+| `PRISM_DAILY_BUDGET_USDG` | `5` | Ceiling on a rolling 24 hours. `0` removes it. |
+| `PRISM_ESCROW` | `0xfD4228eEEfC49e4b76A0CD40af9fdd546220B2FD` | Escrow contract. |
+| `PRISM_LEDGER_PATH` | `~/.prism/spend.json` | Where spend is recorded before money moves. |
+| `PRISM_API_BASE` | `https://prismnetwork.tech` | Control plane for SDK calls. Point it elsewhere and the lease is not Prism's. The public offer and receipt feeds are read from `api.prismnetwork.tech` and do not follow it. |
+| `PRISM_RPC_URL` | `https://rpc.mainnet.chain.robinhood.com` | Robinhood Chain RPC used to sign and confirm. |
+
+`ssh` and `ssh-keygen` from OpenSSH must be on `PATH`; the SDK generates a throwaway key per
+lease and connects with it. macOS and mainstream Linux ship both. On Windows they come from
+the optional OpenSSH Client feature.
+
+## How to Run
+
+Every script below runs through the `terminal` tool from the skill directory, on Python 3.10
+or newer. `python3` on a stock macOS is 3.9 and the SDK-backed scripts refuse on it, so use
+the interpreter the environment installed `prismnetwork` into.
+
+`lease_run_release.py` is the only script that spends. The other four need no wallet:
+`pick_gpu.py` and `verify_receipt.py` read the public feeds, and `budget_check.py` reads
+local limits.
+
+```bash
+python3 scripts/pick_gpu.py --min-vram-gb 24 --duration 900
+python3 scripts/budget_check.py --duration 900 --rate-per-second 222
+python3 scripts/lease_run_release.py "nvidia-smi" --duration 900 --min-vram-gb 24 --dry-run
+python3 scripts/lease_run_release.py "nvidia-smi" --duration 900 --min-vram-gb 24
+python3 scripts/verify_receipt.py --lease 34
+python3 scripts/release_lease.py --list          # and --lease <id> to stop one
+```
+
+`--dry-run` prices the window, checks it against both ceilings and prints the plan without a
+wallet and without signing anything. Run it first on any command that has not been leased
+before.
+
+`--min-vram-gb` takes the number on the card. Nodes publish a little under it, so the floor
+converts at 1000 MiB per GB and `24` selects a card that reports 24564 MiB. Published
+capacity is a handful of machines and it changes, so set the floor from what the job needs
+and let `pick_gpu.py` say whether anything answers it.
+
+To fund the exact offer that was priced instead of whatever is cheapest a minute later,
+carry the node id and rate from `pick_gpu.py` into the lease:
+
+```bash
+python3 scripts/lease_run_release.py "nvidia-smi" --duration 900 \
+    --node <node_id from pick_gpu.py> --rate-per-second <rate_per_second from pick_gpu.py>
+```
+
+## Quick Reference
+
+| Call | Effect |
+|---|---|
+| `PrismAgent(private_key, escrow)` | Client. Both arguments are required; pass `DEFAULT_ESCROW`. |
+| `.authenticate()` | Wallet-signature session. Every other call does it if needed. |
+| `.offers()` | Live capacity. Free and reserves nothing, but signs a session like the rest. |
+| `.balances()` | USDG and gas held by the wallet. |
+| `.quote(image, duration_seconds, min_vram_mib=...)` | Price and machine, no payment. |
+| `.fund_quote(quote)` | Pays that quote. Returns a `Lease`. |
+| `.lease(image, duration_seconds, preferred_node_id=..., max_deposit=...)` | Quote and fund in one call. |
+| `.run(lease, command, timeout=...)` | One command over SSH. Repeatable. |
+| `.release(lease_id)` / `.end_lease(lease)` | Stops the meter. |
+| `.leases()` | Every lease this wallet holds, open ones included. |
+| `.infer(...)` / `.confidential_infer(...)` | Per-generation inference, no GPU to size. |
+| `PrismToolset` | Framework adapter with the budget wired in. |
+
+The wallet-free way to read capacity is the public endpoint
+`https://api.prismnetwork.tech/v1/offers`, which is what `pick_gpu.py` uses.
+
+Full surface in [references/python-sdk.md](references/python-sdk.md). Billing arithmetic and a
+worked settlement in [references/billing.md](references/billing.md).
+
+## Procedure
+
+1. **Read capacity before planning around it.** Run `pick_gpu.py` with the VRAM floor the job
+   actually needs. It reports the chosen offer, why it won, what the others were, and the
+   deposit for the window. Supply is a handful of machines at a time, so treat a plan that
+   assumes a specific card as unfinished until the offer list shows one. Done when a node id
+   and a rate per second are in hand.
+
+2. **Check the deposit against the limits.** Run `budget_check.py --duration N
+   --rate-per-second R` with the rate from step 1. It spends nothing and exits `1` naming the
+   limit that blocks the plan. Done when it prints `fits inside both limits`, or when the
+   window has been shortened until it does.
+
+3. **Pin the image.** The control plane matches on the digest, and the SDK rejects an image
+   without one. Use `image@sha256:...`, never a tag. Omitted, the SDK's default is upstream
+   Ollama at a pinned digest, which carries no training stack. Done when the image string
+   contains `@sha256:`.
+
+4. **Lease, run, release.** Run `lease_run_release.py "<command>" --node <node id>
+   --rate-per-second <rate>` with the pair from step 1, so the machine that gets funded is
+   the machine that was priced and checked. The script reprints the planned deposit, then
+   caps the escrow at that figure and books the same figure against the day, so step 2 and
+   this step cannot disagree. The release sits in a `finally` block, so a failing command
+   still stops the meter, and both output streams are printed because the machine is gone
+   a moment later. Read the exit code as well as the output: `0` ran and released, `4`
+   funded and released but the command never ran, `3` the deposit is in escrow and the
+   lease is still open. Done when the script prints `released`.
+
+5. **Collect the receipt.** Settlement lands shortly after the release and publishes a
+   receipt. Run `verify_receipt.py --lease <id>` with the id from step 4. It recomputes the
+   receipt hash offline, then names the escrow event that commits the same figures on chain,
+   which is what makes the charge checkable independently of anything Prism publishes. Lease
+   ids restart at 1 with every escrow deployment, so the lookup is scoped to the escrow in
+   `PRISM_ESCROW` and refuses to return a same-numbered lease from a retired one. Done when
+   it prints `receipt_hash ... ok` for the escrow the lease was funded on.
+
+For a multi-step job, hold the lease instead: `lease()` once, `run()` repeatedly, then
+`end_lease()` in a `finally` block of your own. Write that driver with `write_file` and run
+it through `terminal` instead of issuing the steps by hand, because an unreleased lease
+keeps billing after the session moves on. If that driver dies mid-flight,
+`scripts/release_lease.py --list` names what the wallet is still paying for and
+`--lease <id>` stops it.
+
+## Pitfalls
+
+- **The deposit is the whole window, not the time used.** Funding a 900-second lease moves
+  900 seconds of USDG into escrow up front. Releasing is what stops the meter. Settlement
+  then charges the seconds between access opening and the release, and returns the rest. A
+  lease nobody releases bills to the end of its window, so budget against the deposit.
+- **A crash after funding leaves a paid machine running.** `PrismError` carries `.broadcast`:
+  `False` before the funding transaction is signed, and the transaction hash after. On a hash,
+  run `scripts/release_lease.py --list` and then `--lease <id>`. `lease_run_release.py` exits
+  `3` only when the lease is still open, and prints those two commands with the funding hash,
+  because a failure inside `lease()` often happens before any lease id comes back. A command
+  that fails on a lease it did release exits `4`, and there is nothing to rescue.
+- **A node id names a slot, and the machine behind it changes.** The same id can publish an
+  RTX 5090 in one poll and an A6000 in the next, at a different rate. `--node` funds that id
+  and the deposit is capped at the rate that was checked, so a machine that has moved is
+  refused rather than funded quietly. Price the window again when that happens.
+- **A rate read from the offer list can move before the lease is funded.** The deposit is
+  capped at the figure that was checked, so a dearer quote is refused before anything is
+  signed. Re-run `pick_gpu.py` and price the window again.
+- **A lease id alone does not name a run.** Ids are numbered per escrow deployment and
+  restart at 1 with each one, so the same number exists on retired escrows with different
+  durations and charges. Cite a `receipt_id`, or a lease id together with its escrow.
+- **Trust class `open` means the host operator can read anything the workload touches.**
+  Treat a rented box as a public machine. Higher classes (`isolated`, `attested`,
+  `confidential`) exist and are far rarer in the offer list; ask for one with
+  `min_trust_class` and expect to find no capacity.
+- **`staker_only` offers are usually the cheapest and usually unrentable.** They are reserved
+  for bonded stakers. `pick_gpu.py` drops them by default and says so under `passed over`.
+- **The spend ledger is shared.** `~/.prism/spend.json` is one file for every Prism client on
+  the machine, and spend is written before the money moves. A crash between funding and the
+  answer still counts against the day, which is the conservative direction.
+- **`max_usdg` only lowers a ceiling.** A value above `PRISM_MAX_USDG` is clamped back down.
+  Raise the environment variable instead of routing around it.
+- **Nothing persists.** Files, caches, and processes die with the lease. Copy results off the
+  box in the same command that produces them.
+
+Error codes and what to do about each are in [references/troubleshooting.md](references/troubleshooting.md).
+
+## Verification
+
+Two checks, neither of which spends anything:
+
+```bash
+python3 scripts/verify_receipt.py --self-test
+python3 scripts/pick_gpu.py --min-vram-gb 24
+```
+
+The first verifies two pinned settlement receipts offline, rejects an edited one, and checks
+that a lease id published on three escrows resolves to the run on the escrow named rather
+than to whichever entry the feed lists first. The second prints a live offer with a node id,
+an hourly rate, and the deposit for the window, or exits `1` naming what each published offer
+failed on. The node id and rate it prints are what step 4 takes.

--- a/optional-skills/mlops/prism-gpu/references/billing.md
+++ b/optional-skills/mlops/prism-gpu/references/billing.md
@@ -1,0 +1,95 @@
+# What a lease costs and when the money moves
+
+USDG is a six-decimal token, so one base unit is 0.000001 USDG. Offers quote
+`rate_per_second` in base units. Every figure below is in those units unless it says USDG.
+
+## The three moments
+
+**Funding.** `lease()` or `fund_quote()` moves `rate_per_second × duration_seconds` into the
+escrow contract in one transaction. That is the whole window, paid before the machine boots.
+It is also the most the lease can ever cost.
+
+**Metering.** The meter starts when access opens, which is after provisioning, and stops at
+the release. Provisioning time is not charged.
+
+**Settlement.** The escrow charges the metered seconds at the quoted rate, pays the node
+operator its share, and returns the remainder to the paying wallet. A receipt is published
+and its hash is committed on chain by a `LeaseFinalized` event.
+
+Unused seconds come back at settlement, and settlement is triggered by the release. There is
+no automatic refund for a lease left open: it bills to the end of its window.
+
+## A settled example
+
+Lease 34, RTX 6000 Ada, quoted at 222 base units per second for a 600-second window.
+
+| Line | Base units | USDG |
+|---|---|---|
+| Deposit at funding (222 × 600) | 133,200 | 0.133200 |
+| Metered runtime, 28 seconds (222 × 28) | 6,216 | 0.006216 |
+| Returned to the wallet | 126,984 | 0.126984 |
+| Paid to the node operator | 5,595 | 0.005595 |
+
+Receipt `8f3e0c1d-391c-8510-9f77-ebc574905ffe`, settled by escrow
+`0xfD4228eEEfC49e4b76A0CD40af9fdd546220B2FD` in transaction
+`0x1de4eba627f8ffc6c0ce3f628b648c5f13d9f2815843d1fc6979a9b731309d88`. Fetch and check it with
+`python3 scripts/verify_receipt.py --lease 34`, which scopes the id to that escrow. Two
+retired escrows also published a lease 34, one of them a 1800-second run charged 0.399600
+USDG, so the number on its own is not a reference to this run.
+
+The lease held 4.7% of what it reserved. Plan against the deposit anyway, because the deposit
+is what the wallet and the day's budget have to clear at the moment of funding.
+
+## Ceilings
+
+Two ceilings bound every lease. A call can lower either for itself and can never raise one.
+
+| Setting | Default | Bounds |
+|---|---|---|
+| `PRISM_MAX_USDG` | 1 | The deposit of any single lease. |
+| `PRISM_DAILY_BUDGET_USDG` | 5 | Everything funded in a rolling 24 hours. `0` removes it. |
+
+A per-call cap above the daily one is refused at startup as the configuration mistake it is.
+
+The ledger at `~/.prism/spend.json` (override with `PRISM_LEDGER_PATH`) records the
+reservation before the transaction is signed, then settles it to the amount the escrow
+actually pulled. A failure that never reached the chain hands the reservation back. A failure
+that may have reached it keeps the reservation, so a bad hour on an RPC endpoint cannot let
+one wallet fund escrow after escrow while the day reports nothing spent.
+
+Every Prism client on the machine draws down the same file.
+
+## Reading the receipt
+
+| Field | Meaning |
+|---|---|
+| `charged_base_units` | Metered seconds at the quoted rate. |
+| `refunded_base_units` | Returned to the paying wallet. Add the two for the deposit. |
+| `provider_paid_base_units` | The node operator's share of the charge. |
+| `runtime_seconds` | Seconds billed. `charged / runtime` reproduces the rate. |
+| `credited_seconds` | Seconds held and **not** charged. Present on interrupted runs only. |
+| `failure_class` | `interrupted`, `provisioning_timeout`, or null on a clean run. |
+| `outcome` | `finalized`, `refunded`, or `disputed`. Only the first two are evidence. |
+| `receipt_hash` | SHA-256 of the canonical payload, committed on chain. |
+
+Canonicalisation is field-declaration order with absent fields dropped and `failure_class`
+kept as an explicit null. Re-serialising with sorted keys produces a different digest and a
+false mismatch. `scripts/verify_receipt.py` implements the rule; reuse it rather than hashing
+the JSON as it arrived.
+
+A `refunded` outcome means the run never produced a charge, most often
+`provisioning_timeout`. Its receipt hash is self-consistency evidence: the `LeaseRefunded`
+event carries a reason hash rather than the receipt hash.
+
+## Public feed
+
+- Index of every settled lease: `https://api.prismnetwork.tech/proof/index.json`
+- One receipt: `https://api.prismnetwork.tech/proof/receipts/<receipt_id>.json`
+- Human view: `https://prismnetwork.tech/proof`
+
+As of 2026-09-10 the feed carries 300 settlements, 226 finalized and 74 refunded, across
+seven card names: `RTX A6000` and `NVIDIA RTX A6000`, `RTX 6000Ada`, `RTX 5880Ada`, `L40S`,
+`H100 PCIe` and `A40`. Nodes publish the model string themselves, so the same card appears
+under more than one spelling and matching on it exactly will miss machines. A card in the
+feed is a card the network has run, which is a weaker claim than a card that can be rented
+today. Only `offers()` says what is rentable now.

--- a/optional-skills/mlops/prism-gpu/references/python-sdk.md
+++ b/optional-skills/mlops/prism-gpu/references/python-sdk.md
@@ -1,0 +1,137 @@
+# prismnetwork 0.4.0 surface
+
+Install through the `terminal` tool: `pip install "prismnetwork>=0.4.0,<0.6"`. Python 3.10 or
+newer; older interpreters get "no matching distribution" rather than a version message.
+
+```python
+from prismnetwork import PrismAgent, PrismError, DEFAULT_ESCROW, DEFAULT_IMAGE
+import os
+
+agent = PrismAgent(os.environ["PRISM_AGENT_KEY"], DEFAULT_ESCROW)
+```
+
+`PrismAgent(private_key, escrow, api_base=..., rpc_url=..., require_host_key=False)`. The
+key is 32 bytes of hex with or without `0x`. `require_host_key=True` refuses any node whose
+grant does not name its SSH host key, which most published capacity does not, so it trades
+supply for the guarantee.
+
+## Reading, which costs nothing
+
+Every call on the agent authenticates first, `offers()` included, so all of these need a
+private key even though none of them spend.
+
+| Call | Returns |
+|---|---|
+| `agent.authenticate()` | Session dict. A wallet signature over a server challenge. |
+| `agent.offers(min_trust="open")` | List of live offers. |
+| `agent.balances()` | `{address, usdg, eth}` in base units and wei. |
+| `agent.leases()` | Every lease this wallet holds. |
+| `agent.access(lease_id)` | SSH endpoint of an open lease. |
+
+An offer carries `node_id`, `gpu.{model, vram_mib, cuda_major}`, `rate_per_second` in USDG
+base units, `trust_class`, `benchmark_score`, `staker_only`, `online`, and `bonded`.
+`scripts/pick_gpu.py` reads the same list without a wallet through the public endpoint
+`https://api.prismnetwork.tech/v1/offers`.
+
+## Paying
+
+```python
+lease = agent.lease(
+    image=DEFAULT_IMAGE,          # must contain @sha256:
+    duration_seconds=900,
+    min_vram_mib=24000,           # MiB, and nodes report under nominal: a 24 GB card
+                                  # publishes 24564, so 24576 matches nothing
+    preferred_node_id=node_id,    # the offer that was priced, not the next one
+    max_deposit=199_800,          # rate_per_second × duration; a dearer quote is refused
+    min_trust_class="open",
+)
+try:
+    print(agent.run(lease, "nvidia-smi", timeout=120))
+finally:
+    agent.end_lease(lease)
+```
+
+`lease()` authenticates, refuses an unfunded wallet, quotes, compares against `max_deposit`,
+and funds. Everything before funding costs nothing and raises with `broadcast=False`.
+
+Split it when a human approves the price: `quote = agent.quote(...)` shows `quote_id`,
+`node_id`, `maximum_escrow`, and `duration_seconds`, then `agent.fund_quote(quote)` pays that
+exact quote. An expired quote is refused rather than silently replaced.
+
+A `Lease` carries `lease_id`, `access`, `key_path`, `funding_hash`, `quote`, and
+`deposit_micros` with `deposit_source` saying whether that figure was read from the funding
+receipt or fell back to the quote's ceiling.
+
+Pass `command=` to `lease()` or `quote()` for a batch lease. The node runs the command and
+reports its output, there is no SSH access to wait for, and the call returns a `BatchLease`
+with `result` instead of `access`.
+
+## Releasing
+
+`agent.end_lease(lease)` releases and removes the local key. `agent.release(lease_id)`
+releases by id, which is what to call after a crash when only the id survives. A refused
+release raises, because the wallet is still paying for the machine.
+`scripts/release_lease.py` is both calls behind `--list` and `--lease <id>`, so a rescue is
+a shell command rather than a driver to write.
+
+## Errors
+
+`PrismError` has `.status`, `.code`, `.body`, and `.broadcast`. Only `.broadcast` says
+whether money moved:
+
+| `.broadcast` | Meaning |
+|---|---|
+| `False` | Nothing was signed onto the wire. The wallet is untouched. |
+| `"0x..."` | The funding transaction hash. The deposit is in escrow. |
+| `None` | Undetermined. Treat it as spent and check `agent.leases()`. |
+
+After a broadcast, `.body` also carries `funding_hash`, `lease_id` when one was assigned, and
+`key_path`. The key stays on disk in that case because it is the only way into a machine the
+wallet is paying for.
+
+## Budget
+
+```python
+from prismnetwork import read_budget, SpendLedger, call_ceiling, record_spend
+
+budget = read_budget()                       # reads PRISM_MAX_USDG, PRISM_DAILY_BUDGET_USDG
+ledger = SpendLedger(budget.ledger_path, budget.daily_micros, budget.max_per_call_micros)
+ceiling = call_ceiling(0.2, budget.max_per_call_micros)   # lowers only, never raises
+deposit = rate_per_second * duration_seconds              # what this lease will actually pull
+lease = record_spend(ledger, "my_tool", min(deposit, ceiling), fund)
+```
+
+Reserve the deposit, not the ceiling. Reserving the ceiling books the full per-lease cap
+against the day until settlement corrects it, which turns a plan that cleared
+`budget_check.py` into a lease the ledger refuses.
+
+`record_spend` writes the reservation, runs `fund`, then settles the entry to what the escrow
+pulled. It hands the reservation back only when the failure proves nothing reached the chain.
+`ledger.status()` and `ledger.remaining()` report the day without spending anything;
+`scripts/budget_check.py` prints both.
+
+## Inference, no GPU to size
+
+`agent.infer(prompt=..., model=..., max_tokens=..., max_usdg=0.05)` buys one generation from
+the open tier and returns `text`, `usage`, `price_usdg`, `tx`, and `receipt_id`. The supplier
+running that GPU can read the prompt and the answer.
+
+`agent.confidential_infer(...)` serves the request from a model inside a GPU TEE, encrypted
+to a key the enclave's attestation quote commits to, established before anything is sent. A
+check that fails raises `ConfidentialError` and no prompt leaves the process. Verifying the
+quote needs the extra `confidential`: `pip install "prismnetwork[confidential]>=0.4.0,<0.6"`.
+
+## Framework adapter
+
+`PrismToolset` exposes `wallet`, `budget_status`, `list_gpus`, `lease_and_run`, `run`, and
+`end_lease` as string-returning tools with the budget already wired in, for LangChain-style
+agents. It registers an `atexit` hook that releases what it opened. A process killed outright
+skips that hook and leaves the lease billing until its window ends, which is why
+`scripts/lease_run_release.py` releases in a `finally` block of its own.
+
+## The terminal backend
+
+`hermes-plugin-prism` on PyPI is a separate package that makes the agent's whole shell a
+rented GPU: one lease per session, released on cleanup or after five idle minutes. Use it
+when the work is a session rather than a job. This skill covers per-job leasing, where the
+lease is opened and closed inside one script.

--- a/optional-skills/mlops/prism-gpu/references/troubleshooting.md
+++ b/optional-skills/mlops/prism-gpu/references/troubleshooting.md
@@ -1,0 +1,108 @@
+# Troubleshooting
+
+## The install
+
+`pip install "prismnetwork>=0.4.0,<0.6"` ending in "Could not find a version that satisfies
+the requirement" is a Python version floor, not a missing package. Every published release
+requires 3.10 or newer. On an older interpreter pip says `(from versions: none)`, and older
+pips print nothing else, so there is no ignored-versions list to look for. Check
+`python3 --version` first: a stock macOS `python3` is 3.9.
+
+## When a lease fails
+
+Read `.broadcast` on the `PrismError` first. It decides whether this is a retry or a rescue.
+
+| `.broadcast` | What happened | What to do |
+|---|---|---|
+| `False` | Nothing was signed. | Fix the cause and retry. Nothing was spent. |
+| `"0x..."` | The deposit is in escrow. | Release the lease before anything else. |
+| `None` | Undetermined. | Treat it as spent: `release_lease.py --list`, then release what is billing. |
+
+## Rescuing a funded lease
+
+Two commands through the `terminal` tool, from the skill directory:
+
+```bash
+python3 scripts/release_lease.py --list         # every lease, and which are still billing
+python3 scripts/release_lease.py --lease 77     # stops the meter; settlement follows
+```
+
+The script calls `agent.leases()` and `agent.release(lease_id)`. `release()` takes the id
+alone, so it works when the `Lease` object and the process that held it are both gone. The
+error's `.body` carries `funding_hash`, `lease_id`, and `key_path` after a broadcast. The
+private key stays on disk deliberately: it is the only way into a machine the wallet is
+paying for.
+
+`scripts/lease_run_release.py` exits `3` only when the lease is still open, and prints both
+commands. A failure on a lease it did manage to release exits `4`: the meter is stopped and
+there is nothing to rescue.
+
+## Codes before any money moves
+
+| Code | Cause | Fix |
+|---|---|---|
+| `wallet_unfunded` | No USDG, or no native ETH for gas. | Fund the wallet on Robinhood Chain (id 4663). Both tokens are required. |
+| `image_must_be_digest_pinned` | The image string has no `@sha256:`. | Resolve the tag to a digest and pass that. |
+| `cost_exceeds_max` | The quote is dearer than `max_deposit`. | Shorten the window, choose a cheaper offer, or raise the ceiling. |
+| `invalid_trust_class` | Not one of `open`, `isolated`, `attested`, `confidential`. | Correct the spelling. |
+| `invalid_command` / `request_too_large` | The batch command is empty or over 8 KiB. | Fetch the payload on the box instead of inlining it. |
+| `control_plane_unreachable` | Network or a control-plane blip. | Retry. Nothing was reserved. |
+| `pre_broadcast_failure` | Anything else before signing. | Read `.body["cause"]`. |
+
+An empty `offers()` list is not an error. It means no machine at that trust class is online.
+Supply is a handful of machines, so widen the VRAM floor, drop to `open`, or wait.
+
+At quote time the control plane says the same thing one step later, as `no_capacity`,
+`no_offer`, or `no_matching_offer`: the constraint matched nothing bookable. Re-read
+`offers()` rather than retrying the same quote.
+
+## Codes after the deposit is in escrow
+
+| Code | Meaning | What to do |
+|---|---|---|
+| `tx_reverted` | The funding transaction failed on chain. | Nothing is leased. Check the USDG allowance and the gas balance. |
+| `confirmation_timeout` | Broadcast, then the RPC stopped answering. | Do not resend. Look the hash up on the explorer, then run `release_lease.py --list`. |
+| `malformed_lease_record` | Funded, but the control plane returned no lease id. | Take the id from `release_lease.py --list` and release it. |
+| `access_timeout` | Funded, and the box never opened access. | Release it. The receipt settles as `provisioning_timeout` and refunds. |
+| `lease_failed_after_funding` | Any other post-funding failure. | Release the lease named in `.body`. |
+
+## Codes while running
+
+| Code | Meaning | What to do |
+|---|---|---|
+| `ssh_access_unavailable` | The node granted gateway access, which has no SSH endpoint. | Use a batch lease (`command=`) for this node, or pick another offer. |
+| `ssh_keygen_failed` | `ssh-keygen` is missing from `PATH`. | Install OpenSSH. On Windows it is an optional feature. |
+| `host_key_unpublished` / `host_key_unavailable` | `require_host_key=True` and the node published none. | Accept the weaker guarantee, or wait for capacity that publishes one. |
+| `host_key_mismatch` | The host key differs from the one pinned earlier. | Stop. Do not release the lease. Report the node id. |
+
+`agent.run()` already retries a connection to a box that is still booting, for up to four
+minutes by default. An exit code of `255` with `Connection refused` that survives that window
+is a real failure rather than a slow boot.
+
+A command that exits non-zero is not an SDK error. `run()` returns `{"code", "stdout",
+"stderr"}` and the caller reads `code`.
+
+## Budget refusals
+
+`BudgetError` never touches the network. It reads as one of:
+
+- the deposit is over `PRISM_MAX_USDG`, so shorten the window or raise the variable;
+- the deposit is over what is left of `PRISM_DAILY_BUDGET_USDG` in the rolling 24 hours;
+- `PRISM_MAX_USDG` is above `PRISM_DAILY_BUDGET_USDG`, which is refused at startup;
+- the ledger file is unreadable, in which case nothing may spend until it is fixed.
+
+`scripts/budget_check.py` prints the numbers behind whichever it is.
+
+## Receipts
+
+A lease that has not settled yet has no receipt, and `verify_receipt.py --lease <id>` says so
+rather than inventing one. Settlement follows the release; give it a minute.
+
+Lease ids are numbered per escrow deployment and restart at 1 with each one, so the published
+feed holds several receipts for most low ids. `--lease` resolves against one escrow only,
+`PRISM_ESCROW` or the live default, and reports the escrows that do hold the id rather than
+returning one of them. Pass `--escrow` to check a lease funded on a retired deployment.
+
+A `receipt_hash MISMATCH` on a receipt fetched from the feed means the payload was edited
+between the feed and the checker. Do not cite it. Re-fetch from
+`https://api.prismnetwork.tech/proof/receipts/<receipt_id>.json` and check again.

--- a/optional-skills/mlops/prism-gpu/scripts/budget_check.py
+++ b/optional-skills/mlops/prism-gpu/scripts/budget_check.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Report the spend limits in force and say whether a planned lease fits inside them.
+
+Usage:
+    budget_check.py [--duration N] [--rate-per-second N] [--max-usdg F] [--json]
+
+Needs no wallet and moves no money. Run it before committing to a long window:
+the whole window is deposited up front, so the deposit is what the day is
+charged against, not the smaller amount settlement ends up taking.
+
+``--rate-per-second`` takes the ``rate_per_second`` field of the offer chosen by
+``pick_gpu.py``. With both it and ``--duration``, the report says whether the
+deposit clears the per-lease cap and today's remainder.
+
+Exit codes, so a caller can branch without parsing the output:
+
+    0   the limits are readable, and any planned deposit fits
+    1   the planned deposit does not fit
+    2   wrong arguments
+    3   the limits or the ledger are unusable, so nothing may spend
+"""
+
+import argparse
+import json
+import sys
+
+if sys.version_info < (3, 10):
+    print("prismnetwork needs Python 3.10 or newer; this interpreter is "
+          f"{sys.version_info.major}.{sys.version_info.minor}. Run these scripts with a "
+          "3.10 or newer python3.", file=sys.stderr)
+    raise SystemExit(2)
+
+from prismnetwork import BudgetError, SpendLedger, call_ceiling, read_budget
+
+MICROS = 1_000_000
+
+FITS = 0
+DOES_NOT_FIT = 1
+UNUSABLE = 3
+
+
+def usdg(micros):
+    return f"{int(micros) / MICROS:.6f} USDG"
+
+
+def verdict(deposit, ceiling, remaining):
+    """Every limit the deposit breaks, in the order a caller can act on them."""
+    problems = []
+    if deposit > ceiling:
+        problems.append(f"deposit {usdg(deposit)} is over the {usdg(ceiling)} per-lease cap; "
+                        "shorten the window, pick a cheaper offer, or raise PRISM_MAX_USDG")
+    if remaining is not None and deposit > remaining:
+        problems.append(f"deposit {usdg(deposit)} is over the {usdg(remaining)} left of today; "
+                        "wait for the rolling 24 hours to clear or raise PRISM_DAILY_BUDGET_USDG")
+    return problems
+
+
+def parse(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--duration", type=int, default=None, help="planned lease window in seconds")
+    parser.add_argument("--rate-per-second", type=int, default=None,
+                        help="the chosen offer's rate_per_second, in USDG base units")
+    parser.add_argument("--max-usdg", type=float, default=None,
+                        help="lower the per-lease ceiling for this plan; it cannot raise it")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    if args.duration is not None and args.duration <= 0:
+        parser.error("--duration must be positive")
+    if args.rate_per_second is not None and args.rate_per_second <= 0:
+        parser.error("--rate-per-second must be positive")
+    if (args.duration is None) != (args.rate_per_second is None):
+        parser.error("--duration and --rate-per-second go together; pass both or neither")
+    if args.max_usdg is not None and args.max_usdg <= 0:
+        # Caught here rather than by call_ceiling, whose failure means the
+        # environment's limits are broken and sends the caller to inspect a
+        # ledger that is fine.
+        parser.error("--max-usdg must be positive; it lowers the per-lease ceiling")
+    return args
+
+
+def main(argv=None):
+    args = parse(sys.argv[1:] if argv is None else argv)
+    try:
+        budget = read_budget()
+        ledger = SpendLedger(budget.ledger_path, budget.daily_micros, budget.max_per_call_micros)
+        ceiling = call_ceiling(args.max_usdg, budget.max_per_call_micros)
+        status = ledger.status()
+        remaining = ledger.remaining()
+    except BudgetError as e:
+        print(f"the spend limits are unusable, so nothing may spend: {e}", file=sys.stderr)
+        return UNUSABLE
+
+    if args.max_usdg is not None and int(args.max_usdg * MICROS) > ceiling:
+        print(f"requested    {args.max_usdg} USDG, clamped to {usdg(ceiling)} by PRISM_MAX_USDG")
+
+    deposit = None
+    problems = []
+    if args.duration is not None:
+        deposit = args.rate_per_second * args.duration
+        problems = verdict(deposit, ceiling, remaining)
+
+    if args.json:
+        print(json.dumps({
+            **status,
+            "ceiling_for_this_plan": usdg(ceiling),
+            "planned_deposit": usdg(deposit) if deposit is not None else None,
+            "fits": not problems if deposit is not None else None,
+            "problems": problems,
+        }, indent=2))
+        return DOES_NOT_FIT if problems else FITS
+
+    print(f"daily budget       {status['daily_budget']}")
+    print(f"spent last 24h     {status['spent_last_24h']}")
+    print(f"remaining today    {status['remaining_today']}")
+    print(f"max per lease      {status['max_per_call']}")
+    print(f"ceiling used here  {usdg(ceiling)}")
+    print(f"ledger             {status['ledger']}")
+    charges = status["charges_last_24h"]
+    print(f"charges last 24h   {'none' if not charges else len(charges)}")
+    for charge in charges:
+        reference = f" ({charge['reference']})" if charge.get("reference") else ""
+        print(f"  {charge['at']} {charge.get('tool', 'prism')} {charge['amount']}{reference}")
+
+    if deposit is None:
+        return FITS
+    print(f"planned deposit    {usdg(deposit)} for {args.duration}s at "
+          f"{args.rate_per_second} base units per second")
+    if problems:
+        for problem in problems:
+            print(f"BLOCKED {problem}", file=sys.stderr)
+        return DOES_NOT_FIT
+    print("verdict            fits inside both limits")
+    return FITS
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/optional-skills/mlops/prism-gpu/scripts/lease_run_release.py
+++ b/optional-skills/mlops/prism-gpu/scripts/lease_run_release.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Rent a GPU, run one command on it, release it, and print what it cost to find out.
+
+Usage:
+    lease_run_release.py "nvidia-smi" [--duration 600] [--min-vram-gb 24]
+                         [--node 0x... --rate-per-second N]
+                         [--image DIGEST_PINNED] [--max-usdg F]
+                         [--min-trust open|isolated|attested|confidential]
+                         [--timeout 120] [--dry-run]
+
+The release sits in a ``finally`` block, because the deposit covers the whole
+window and only the release stops the meter. A command that crashes still gives
+the wallet its unused seconds back; an abandoned lease bills to the end of its
+window. When the release itself cannot be reached, the output names the lease
+and the ``scripts/release_lease.py`` call that stops it.
+
+One machine is priced before anything is signed. Pass ``--node`` and
+``--rate-per-second`` from ``pick_gpu.py`` to fund the exact offer that was
+priced, or let this script read capacity and pick on the same rules. Either way
+the deposit reserved in the ledger, the deposit shown, and the ``max_deposit``
+the escrow is allowed to pull are one figure: ``rate_per_second × duration``.
+The per-lease ceiling only lowers it.
+
+Reads ``PRISM_AGENT_KEY`` from the environment: a funded wallet on Robinhood
+Chain (id 4663), holding USDG for the deposit and native ETH for gas. The spend
+ledger at ``~/.prism/spend.json`` is written before the money moves.
+
+Exit codes, so a caller can branch without parsing the output:
+
+    0   the lease ran and was released, or --dry-run priced it without spending
+    1   the run failed and nothing was spent
+    2   wrong arguments, no capacity, or a deposit the spend limits refuse
+        (nothing has been signed on any of these; --dry-run reaches them all)
+    3   money moved and the lease is still open; the output says how to release it
+    4   the lease was funded and released, but the command did not run
+"""
+
+import argparse
+import json
+import os
+import signal
+import sys
+
+if sys.version_info < (3, 10):
+    print("prismnetwork needs Python 3.10 or newer; this interpreter is "
+          f"{sys.version_info.major}.{sys.version_info.minor}. Run these scripts with a "
+          "3.10 or newer python3.", file=sys.stderr)
+    raise SystemExit(2)
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pick_gpu
+from release_lease import NoWallet, agent_from_env
+
+from prismnetwork import (
+    DEFAULT_IMAGE,
+    BudgetError,
+    PrismError,
+    SpendLedger,
+    call_ceiling,
+    read_budget,
+    record_spend,
+)
+
+MICROS = 1_000_000
+RECEIPTS = "https://api.prismnetwork.tech/proof/index.json"
+# The SDK's own cap for a batch command. The SSH path does not enforce it, but
+# the argument list gives out around the same size.
+COMMAND_LIMIT = 8192
+
+RELEASED = 0
+UNSPENT_FAILURE = 1
+USAGE = 2
+MONEY_AT_RISK = 3
+FUNDED_NOT_RUN = 4
+
+
+def usdg(micros):
+    return f"{int(micros) / MICROS:.6f} USDG"
+
+
+def deposited(lease, planned):
+    """What the escrow pulled, from the funding receipt where the log was
+    readable and from the plan where it was not. The ledger settles against this
+    rather than the quote, which is the other side's document.
+
+    A figure above the plan means the log was misread; ``max_deposit`` is
+    enforced on the way in, so the plan is the safer of the two."""
+    held = getattr(lease, "deposit_micros", None)
+    if isinstance(held, int) and not isinstance(held, bool) and 0 < held <= planned:
+        return held
+    return planned
+
+
+class NoCapacity(Exception):
+    """Nothing published matches the constraints, so there is nothing to price."""
+
+
+def price(args):
+    """Name one machine and its rate before anything is signed.
+
+    A rate is what makes the deposit knowable, and the deposit is what the
+    ledger and the escrow ceiling are both set from. Taking the rate from an
+    offer and then leaving the node open would let funding land on a dearer
+    machine than the one that was checked."""
+    if args.node:
+        return args.node, args.rate_per_second, f"node {args.node} at the rate given"
+    offers = pick_gpu.load(None)
+    if not isinstance(offers, list):
+        raise NoCapacity("capacity answered in an unexpected shape; try again shortly")
+    eligible, rejected = pick_gpu.choose(
+        offers, pick_gpu.floor_mib(args.min_vram_gb), None, args.min_trust, False
+    )
+    if not eligible:
+        missed = "\n".join(f"  {pick_gpu.describe(offer)}: {'; '.join(reasons)}"
+                           for offer, reasons in rejected[:8])
+        raise NoCapacity(
+            f"no offer met the constraints; {len(offers)} were published\n{missed}"
+        )
+    winner = eligible[0]
+    # Anything without a node id or a positive rate was rejected above, so both
+    # of these are present.
+    return winner["node_id"], pick_gpu.rate_micros(winner), pick_gpu.describe(winner)
+
+
+def recovery(lease_id, funding_hash):
+    """What to run to stop a meter this process could not reach.
+
+    Every line is a shell command, because the caller is holding a terminal and
+    a running bill. A failure inside ``lease()`` can leave
+    a funded machine that this script never got an id for, so the instructions
+    have to work from the funding transaction alone."""
+    lines = ["The escrow holds the deposit and the meter is running until the lease is",
+             "released. Stop it through the `terminal` tool, from the skill directory:"]
+    if lease_id is not None:
+        lines.append(f"  python3 scripts/release_lease.py --lease {lease_id}")
+        lines.append(f"  python3 scripts/verify_receipt.py --lease {lease_id}")
+    else:
+        lines.append("  python3 scripts/release_lease.py --list")
+        if funding_hash:
+            lines.append(f"  # the lease funded by {funding_hash} is the one to release")
+        lines.append("  python3 scripts/release_lease.py --lease <id from that list>")
+    return "\n".join(lines)
+
+
+def explain(error, released=False):
+    """A PrismError says which side of the wire it happened on. ``broadcast`` is
+    False before the funding transaction is signed, the transaction hash after,
+    and None where nothing established which. ``released`` overrides all three:
+    once the lease is closed the meter is stopped whatever the failure was, and
+    telling the caller to go hunting for an open lease sends it after a lease
+    that no longer exists."""
+    sent = getattr(error, "broadcast", None)
+    body = getattr(error, "body", None)
+    detail = f": {json.dumps(body)}" if body else ""
+    lease_id = body.get("lease_id") if isinstance(body, dict) else None
+    if released:
+        return (FUNDED_NOT_RUN,
+                f"{fault(error)} on a lease that was funded and then released{detail}\n"
+                "The meter is stopped. Settlement charges the seconds served and returns "
+                "the rest, so the cost is the provisioning, not the window.")
+    if isinstance(sent, str) and sent:
+        return (MONEY_AT_RISK,
+                f"{fault(error)} after the deposit was broadcast in {sent}{detail}\n"
+                + recovery(lease_id, sent))
+    if sent is False:
+        return UNSPENT_FAILURE, f"{fault(error)} before anything was signed{detail}"
+    return (MONEY_AT_RISK,
+            f"{fault(error)}, and nothing established whether the deposit was sent{detail}\n"
+            "Treat it as spent until the wallet's leases say otherwise.\n"
+            + recovery(lease_id, None))
+
+
+def fault(error):
+    """A Prism error carries a code. Anything from below the SDK carries a type."""
+    return getattr(error, "code", None) or type(error).__name__
+
+
+def stop_meter(agent, lease):
+    """Release the lease. Returns the failure that prevented it, or None.
+
+    Catches everything, because a release that fails on a reset connection is
+    still a lease that is billing, and an exception escaping here would skip the
+    report that says so. Returning the failure rather than raising keeps it
+    distinguishable from whatever the command itself did."""
+    try:
+        agent.end_lease(lease)
+        print(f"released     lease {lease.lease_id}; settlement charges the seconds served")
+        return None
+    except Exception as e:
+        print(f"RELEASE FAILED {fault(e)}: the wallet is still paying for lease "
+              f"{lease.lease_id}.", file=sys.stderr)
+        return e
+
+
+def run_lease(agent, ledger, args, node, planned):
+    def fund():
+        lease = agent.lease(
+            image=args.image,
+            duration_seconds=args.duration,
+            min_vram_mib=pick_gpu.floor_mib(args.min_vram_gb),
+            preferred_node_id=node,
+            max_deposit=planned,
+            min_trust_class=args.min_trust,
+        )
+        return {
+            "value": lease,
+            "settled_micros": deposited(lease, planned),
+            "reference": lease.funding_hash,
+        }
+
+    try:
+        lease = record_spend(ledger, "prism_lease_run_release", planned, fund)
+    except BaseException:
+        # Funding blocks for minutes waiting on the receipt and then on access.
+        # An interrupt in that window can land after the deposit is broadcast.
+        print("interrupted while funding; a deposit may already be in escrow.\n"
+              + recovery(None, None), file=sys.stderr)
+        raise
+    failed = None
+    # Everything from here down is inside the try: the meter is running, and a
+    # print to a closed stdout is enough to skip the release if it sits outside.
+    try:
+        print(f"lease        {lease.lease_id} funded in {lease.funding_hash}")
+        print(f"deposit      {usdg(deposited(lease, planned))} for a {args.duration}s window")
+        print(f"access       {lease.access.get('ssh_host')}:{lease.access.get('ssh_port')}")
+        result = agent.run(lease, args.command, timeout=args.timeout)
+        print(f"exit         {result.get('code')}")
+        # Both streams, always. The box is destroyed a few lines below and
+        # nothing on it survives, so a diagnostic dropped here is a diagnostic
+        # that costs another deposit to reproduce.
+        for stream in ("stdout", "stderr"):
+            text = (result.get(stream) or "").rstrip()
+            if text:
+                print(f"--- {stream} ---")
+                print(text)
+    except Exception as e:
+        # Held rather than raised: the release below decides what this costs.
+        failed = e
+    finally:
+        unreleased = stop_meter(agent, lease)
+
+    if unreleased is not None:
+        print(f"the lease was funded but not released: {fault(unreleased)}\n"
+              + recovery(lease.lease_id, lease.funding_hash), file=sys.stderr)
+        return MONEY_AT_RISK
+    print(f"receipt      python3 scripts/verify_receipt.py --lease {lease.lease_id}")
+    print(f"             (published to {RECEIPTS} once settlement lands)")
+    if failed is not None:
+        code, message = explain(failed, released=True)
+        print(f"the command did not run: {message}", file=sys.stderr)
+        return code
+    return RELEASED
+
+
+def parse(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("command", help="shell command to run on the GPU")
+    parser.add_argument("--duration", type=int, default=600, help="lease window in seconds")
+    parser.add_argument("--min-vram-gb", type=float, default=16.0,
+                        help="VRAM floor as the card is labelled; 24 means 24000 MiB")
+    parser.add_argument("--node", default=None,
+                        help="node_id from pick_gpu.py; funds that offer and no other")
+    parser.add_argument("--rate-per-second", type=int, default=None,
+                        help="that offer's rate_per_second, in USDG base units")
+    parser.add_argument("--image", default=DEFAULT_IMAGE,
+                        help="digest-pinned image; the control plane matches on the digest")
+    parser.add_argument("--max-usdg", type=float, default=None,
+                        help="lower the per-call ceiling for this lease; it cannot raise it")
+    parser.add_argument("--min-trust", default="open",
+                        choices=("open", "isolated", "attested", "confidential"))
+    parser.add_argument("--timeout", type=int, default=120, help="seconds to wait for the command")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="print the ceiling and the plan, spend nothing")
+    args = parser.parse_args(argv)
+    if args.duration <= 0 or args.timeout <= 0 or args.min_vram_gb <= 0:
+        parser.error("--duration, --timeout and --min-vram-gb must be positive")
+    if not args.command.strip():
+        parser.error("command must not be empty")
+    if (args.node is None) != (args.rate_per_second is None):
+        parser.error("--node and --rate-per-second go together; a node without its rate "
+                     "leaves the deposit unknown before it is signed")
+    if args.rate_per_second is not None and args.rate_per_second <= 0:
+        parser.error("--rate-per-second must be positive")
+    if args.max_usdg is not None and args.max_usdg <= 0:
+        parser.error("--max-usdg must be positive; it lowers the per-call ceiling")
+    if args.timeout >= args.duration:
+        parser.error(f"--timeout {args.timeout} leaves no room inside a {args.duration}s "
+                     "window. Provisioning and the SSH connect budget run to about four "
+                     "minutes before the command starts, so the window has to be longer "
+                     "than the command is allowed to take.")
+    if "@sha256:" not in args.image:
+        parser.error(f"--image {args.image} carries no digest. The control plane matches on "
+                     "the digest, so a tag is refused after the deposit is planned. Pin it "
+                     "with @sha256:<64 hex>.")
+    if len(args.command.encode("utf-8")) > COMMAND_LIMIT:
+        parser.error(f"the command is over {COMMAND_LIMIT} bytes and would not survive the "
+                     "argument list. Fetch the payload on the box instead of inlining it.")
+    return args
+
+
+def terminate(*_):
+    """SIGTERM's default disposition kills the interpreter without unwinding, so
+    the release in the finally never runs and the window bills out. Turning it
+    into SystemExit unwinds. SIGKILL stays unrecoverable, which is what
+    release_lease.py --list is for."""
+    sys.exit(MONEY_AT_RISK)
+
+
+def main(argv=None):
+    args = parse(sys.argv[1:] if argv is None else argv)
+    try:
+        budget = read_budget()
+        ledger = SpendLedger(budget.ledger_path, budget.daily_micros, budget.max_per_call_micros)
+        ceiling = call_ceiling(args.max_usdg, budget.max_per_call_micros)
+    except BudgetError as e:
+        print(f"the spend limits are unusable, so nothing may spend: {e}", file=sys.stderr)
+        return USAGE
+
+    if args.max_usdg is not None and int(args.max_usdg * MICROS) > ceiling:
+        print(f"requested    {args.max_usdg} USDG, clamped to {usdg(ceiling)} by PRISM_MAX_USDG")
+    print(f"ceiling      {usdg(ceiling)} for this lease")
+    try:
+        left = ledger.remaining()
+    except BudgetError as e:
+        print(f"the spend ledger is unreadable, so nothing may spend: {e}", file=sys.stderr)
+        return USAGE
+    print("remaining    unlimited (daily ceiling removed)" if left is None
+          else f"remaining    {usdg(left)} of today's budget")
+
+    try:
+        node, rate, described = price(args)
+    except NoCapacity as e:
+        print(f"nothing to lease: {e}", file=sys.stderr)
+        return USAGE
+    except (OSError, ValueError) as e:
+        print(f"capacity could not be read, so no deposit can be planned: {e}", file=sys.stderr)
+        return USAGE
+
+    planned = rate * args.duration
+    print(f"machine      {described}")
+    print(f"node         {node}")
+    print(f"deposit      {usdg(planned)} planned for {args.duration}s at {rate} base units/s")
+
+    # Checked here rather than left to the ledger, so the refusal names the
+    # limit and the fix instead of surfacing as a mid-flight budget error.
+    if planned > ceiling:
+        print(f"deposit {usdg(planned)} is over the {usdg(ceiling)} per-lease cap; shorten the "
+              "window, pick a cheaper offer, or raise PRISM_MAX_USDG", file=sys.stderr)
+        return USAGE
+    if left is not None and planned > left:
+        print(f"deposit {usdg(planned)} is over the {usdg(left)} left of today; wait for the "
+              "rolling 24 hours to clear or raise PRISM_DAILY_BUDGET_USDG", file=sys.stderr)
+        return USAGE
+
+    if args.dry_run:
+        print(f"dry run      would lease {pick_gpu.floor_mib(args.min_vram_gb)} MiB or more for "
+              f"{args.duration}s on {args.image} and run: {args.command}")
+        return RELEASED
+
+    signal.signal(signal.SIGTERM, terminate)
+
+    try:
+        agent = agent_from_env()
+    except NoWallet as e:
+        print(str(e), file=sys.stderr)
+        return USAGE
+    except ValueError as e:
+        print(f"PRISM_AGENT_KEY is not usable: {e}", file=sys.stderr)
+        return USAGE
+
+    try:
+        return run_lease(agent, ledger, args, node, planned)
+    except PrismError as e:
+        code, message = explain(e)
+        print(f"the lease did not complete: {message}", file=sys.stderr)
+        return code
+    except BudgetError as e:
+        print(f"refused by the spend limits: {e}", file=sys.stderr)
+        return USAGE
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/optional-skills/mlops/prism-gpu/scripts/pick_gpu.py
+++ b/optional-skills/mlops/prism-gpu/scripts/pick_gpu.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Choose a GPU from Prism's live offer list against a VRAM floor and a price ceiling.
+
+Usage:
+    pick_gpu.py [--min-vram-gb N] [--max-usdg-per-hour F] [--duration N]
+                [--min-trust open|isolated|attested|confidential]
+                [--include-staker-only] [--offers FILE] [--json]
+
+Reads capacity, ranks it, and prints the choice with the reason it won and the
+deposit the window would cost. Offers come from the public HTTP endpoint, so
+this script reads them without a wallet and reserves nothing. Stdlib only.
+
+Nodes publish VRAM in MiB and report a little under the number on the card: a
+24 GB card publishes 24564 MiB, a 32 GB card 32607 MiB. ``--min-vram-gb`` takes
+the label and converts at 1000 MiB per GB, which keeps that headroom, matches
+the SDK's own ``min_vram_mib`` default of 16000, and means asking for 24 GB
+selects a 24 GB card instead of rejecting it. Every figure printed is MiB.
+
+Exit codes, so a caller can branch without parsing the output:
+
+    0   an offer matched; the choice is on stdout
+    1   capacity is online but nothing met the constraints
+    2   wrong arguments
+    3   capacity could not be read
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+OFFERS_URL = "https://api.prismnetwork.tech/v1/offers"
+MICROS = 1_000_000
+# Deliberately decimal. See the module docstring: nodes report under nominal.
+MIB_PER_GB = 1000
+
+# Ascending. An offer satisfies a floor when its own class sits at or above it.
+TRUST_CLASSES = ("open", "isolated", "attested", "confidential")
+
+MATCHED = 0
+NO_MATCH = 1
+UNREACHABLE = 3
+
+
+def fetch(url, timeout=15):
+    request = urllib.request.Request(url, headers={"accept": "application/json"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def load(path, timeout=15):
+    """Every published offer. The endpoint can filter by trust class, but then a
+    constraint that matched nothing comes back as an empty list and the report
+    cannot say what each machine failed on. Filtering happens here instead."""
+    if path:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    return fetch(OFFERS_URL, timeout)
+
+
+def rate_micros(offer):
+    """Base units per second, or None when the offer publishes no usable rate.
+    Zero would sort to the front of a cheapest-first ranking."""
+    try:
+        rate = int(offer.get("rate_per_second"))
+    except (TypeError, ValueError):
+        return None
+    return rate if rate > 0 else None
+
+
+def rate_per_hour(offer):
+    return (rate_micros(offer) or 0) * 3600 / MICROS
+
+
+def vram_mib(offer):
+    gpu = offer.get("gpu")
+    try:
+        return int(gpu.get("vram_mib", 0)) if isinstance(gpu, dict) else 0
+    except (TypeError, ValueError):
+        return 0
+
+
+def floor_mib(min_vram_gb):
+    return int(min_vram_gb * MIB_PER_GB)
+
+
+def rejections(offer, min_vram_mib, max_micros_per_second, min_trust, include_staker_only):
+    """Every reason at once, so the report can name what each machine failed on."""
+    reasons = []
+    if not offer.get("node_id"):
+        reasons.append("no node id to fund")
+    if not offer.get("online", True):
+        reasons.append("offline")
+    have = vram_mib(offer)
+    if have < min_vram_mib:
+        reasons.append(f"{have} MiB VRAM under the {min_vram_mib} MiB floor")
+    rate = rate_micros(offer)
+    if rate is None:
+        reasons.append("no published rate")
+    elif max_micros_per_second is not None and rate > max_micros_per_second:
+        reasons.append(f"{rate * 3600 / MICROS:.4f} USDG/hr over the ceiling")
+    offered = offer.get("trust_class", "open")
+    if offered not in TRUST_CLASSES:
+        reasons.append(f"unrecognised trust class {offered!r}")
+    elif TRUST_CLASSES.index(offered) < TRUST_CLASSES.index(min_trust):
+        reasons.append(f"trust class {offered} below {min_trust}")
+    if offer.get("staker_only") and not include_staker_only:
+        reasons.append("reserved for stakers")
+    return reasons
+
+
+def score(offer):
+    try:
+        return int(offer.get("benchmark_score", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def rank(offer):
+    return (
+        rate_micros(offer) or 0,
+        -score(offer),
+        -vram_mib(offer),
+    )
+
+
+def choose(offers, min_vram_mib, max_micros_per_second, min_trust, include_staker_only):
+    eligible, rejected = [], []
+    for offer in offers:
+        if not isinstance(offer, dict):
+            continue
+        reasons = rejections(offer, min_vram_mib, max_micros_per_second, min_trust, include_staker_only)
+        (rejected if reasons else eligible).append((offer, reasons))
+    eligible.sort(key=lambda pair: rank(pair[0]))
+    return [offer for offer, _ in eligible], rejected
+
+
+def describe(offer):
+    gpu = offer.get("gpu") if isinstance(offer.get("gpu"), dict) else {}
+    return (f"{gpu.get('model', 'GPU')} · {vram_mib(offer)} MiB · "
+            f"{rate_per_hour(offer):.4f} USDG/hr · trust {offer.get('trust_class', 'open')}")
+
+
+def why(winner, runners_up):
+    if not runners_up:
+        return "the only offer that met every constraint"
+    matched = len(runners_up) + 1
+    next_up = runners_up[0]
+    cheaper = rate_per_hour(next_up) - rate_per_hour(winner)
+    if cheaper > 0:
+        return f"cheapest of {matched} matching offers, {cheaper:.4f} USDG/hr under the next one"
+    if score(winner) > score(next_up):
+        return f"tied on price across {matched} offers, highest benchmark score"
+    if vram_mib(winner) > vram_mib(next_up):
+        return f"tied on price and score across {matched} offers, largest card"
+    # Only offers whose whole rank tuple matches are tied. Counting the matching
+    # field instead once reported cards of two different sizes as identical.
+    tied = sum(1 for offer in runners_up if rank(offer) == rank(winner))
+    return (f"tied with {tied} other offer(s) of {matched} on price, score and card size; "
+            "taken in list order")
+
+
+def report(winner, runners_up, rejected, duration):
+    rate = rate_micros(winner)
+    deposit = rate * duration
+    lines = [
+        f"chosen       {describe(winner)}",
+        f"node         {winner.get('node_id')}",
+        f"why          {why(winner, runners_up)}",
+        f"deposit      {deposit / MICROS:.6f} USDG for a {duration}s window "
+        f"({rate} base units per second)",
+        "             The whole window is deposited up front and the release is what",
+        "             stops the meter.",
+    ]
+    if winner.get("staker_only"):
+        lines.append("caution      this node only rents to bonded stakers, so funding it is "
+                     "refused unless this wallet is one")
+    lines.append(f"next         lease_run_release.py \"<command>\" --duration {duration} "
+                 f"--node {winner.get('node_id')} --rate-per-second {rate}")
+    if runners_up:
+        lines.append("runners-up:")
+        lines.extend(f"  {describe(offer)}" for offer in runners_up[:4])
+    if rejected:
+        lines.append("passed over:")
+        lines.extend(f"  {describe(offer)}: {'; '.join(reasons)}" for offer, reasons in rejected[:6])
+    return "\n".join(lines)
+
+
+def as_json(winner, runners_up, rejected, duration, min_vram_mib):
+    return json.dumps({
+        "chosen": winner,
+        "reason": why(winner, runners_up),
+        "duration_seconds": duration,
+        "min_vram_mib": min_vram_mib,
+        "deposit_base_units": rate_micros(winner) * duration,
+        "rate_usdg_per_hour": round(rate_per_hour(winner), 6),
+        "runners_up": runners_up,
+        "passed_over": [{"offer": offer, "reasons": reasons} for offer, reasons in rejected],
+    }, indent=2)
+
+
+def parse(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--min-vram-gb", type=float, default=16.0,
+                        help="VRAM floor as the card is labelled; 24 means 24000 MiB")
+    parser.add_argument("--max-usdg-per-hour", type=float, default=None)
+    parser.add_argument("--duration", type=int, default=600,
+                        help="lease window in seconds, used for the deposit figure")
+    parser.add_argument("--min-trust", choices=TRUST_CLASSES, default="open")
+    parser.add_argument("--include-staker-only", action="store_true",
+                        help="keep offers only bonded stakers can rent")
+    parser.add_argument("--offers", default=None,
+                        help="read a saved offer list instead of the live one")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    if args.min_vram_gb <= 0 or args.duration <= 0:
+        parser.error("--min-vram-gb and --duration must be positive")
+    if args.max_usdg_per_hour is not None and args.max_usdg_per_hour <= 0:
+        parser.error("--max-usdg-per-hour must be positive")
+    return args
+
+
+def main(argv=None):
+    args = parse(sys.argv[1:] if argv is None else argv)
+    try:
+        offers = load(args.offers)
+    except (OSError, urllib.error.URLError, ValueError) as e:
+        print(f"capacity could not be read: {e}", file=sys.stderr)
+        return UNREACHABLE
+    if not isinstance(offers, list):
+        print("capacity answered in an unexpected shape; try again shortly", file=sys.stderr)
+        return UNREACHABLE
+
+    ceiling = None
+    if args.max_usdg_per_hour is not None:
+        ceiling = int(args.max_usdg_per_hour * MICROS / 3600)
+    wanted = floor_mib(args.min_vram_gb)
+    eligible, rejected = choose(offers, wanted, ceiling, args.min_trust, args.include_staker_only)
+    if not offers:
+        print("no capacity is published right now. Supply is a handful of machines and it "
+              "changes; try again shortly.", file=sys.stderr)
+        return NO_MATCH
+    if not eligible:
+        print(f"no offer met the constraints; {len(offers)} were published", file=sys.stderr)
+        for offer, reasons in rejected[:8]:
+            print(f"  {describe(offer)}: {'; '.join(reasons)}", file=sys.stderr)
+        return NO_MATCH
+
+    winner, runners_up = eligible[0], eligible[1:]
+    print(as_json(winner, runners_up, rejected, args.duration, wanted) if args.json
+          else report(winner, runners_up, rejected, args.duration))
+    return MATCHED
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/optional-skills/mlops/prism-gpu/scripts/release_lease.py
+++ b/optional-skills/mlops/prism-gpu/scripts/release_lease.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Release a lease by id, or list the leases this wallet is still paying for.
+
+Usage:
+    release_lease.py --lease <id>
+    release_lease.py --list [--json]
+
+The whole window is deposited when a lease is funded and the release is what
+stops the meter, so a lease outlives the process that opened it and so does its
+bill. This is the way back: ``--list`` names every lease the wallet holds and
+which of them are still billing, ``--lease`` releases one by id. Settlement
+then charges the seconds between access opening and the release and returns the
+rest.
+
+``scripts/lease_run_release.py`` releases in a ``finally`` block and only points
+here when that release could not be reached, or when the failure happened
+before it had a lease object at all.
+
+Reads ``PRISM_AGENT_KEY``: the same wallet that funded the lease. No other
+wallet can release it.
+
+Exit codes, so a caller can branch without parsing the output:
+
+    0   released, or the list printed
+    1   the release was refused; the wallet is still paying for that lease
+    2   wrong arguments, or no usable wallet
+"""
+
+import argparse
+import json
+import os
+import sys
+
+if sys.version_info < (3, 10):
+    print("prismnetwork needs Python 3.10 or newer; this interpreter is "
+          f"{sys.version_info.major}.{sys.version_info.minor}. Run these scripts with a "
+          "3.10 or newer python3.", file=sys.stderr)
+    raise SystemExit(2)
+
+from prismnetwork import DEFAULT_ESCROW, PrismAgent, PrismError
+
+RELEASED = 0
+REFUSED = 1
+USAGE = 2
+
+# The states the control plane treats as finished. Anything else is a machine
+# the wallet is still being charged for.
+SETTLED_STATES = ("closing", "settlement_pending", "finalized", "refunded", "failed")
+
+SUMMARY_FIELDS = ("state", "node_id", "duration_seconds", "started_at", "ends_at",
+                  "deposit_base_units", "image")
+
+
+class NoWallet(Exception):
+    """Raised before anything reaches the network."""
+
+
+def agent_from_env():
+    key = (os.environ.get("PRISM_AGENT_KEY") or "").strip()
+    if not key:
+        raise NoWallet(
+            "PRISM_AGENT_KEY is not set. It holds the private key of a wallet funded with "
+            "USDG and a little native ETH on Robinhood Chain (id 4663). Every call that "
+            "touches a lease signs with it, and only the wallet that funded a lease can "
+            "release it. Reading capacity with pick_gpu.py needs no wallet."
+        )
+    return PrismAgent(
+        key,
+        os.environ.get("PRISM_ESCROW", DEFAULT_ESCROW),
+        api_base=os.environ.get("PRISM_API_BASE", "https://prismnetwork.tech"),
+        rpc_url=os.environ.get("PRISM_RPC_URL", "https://rpc.mainnet.chain.robinhood.com"),
+    )
+
+
+def billing(record):
+    """Whether this record is a machine the wallet is still paying for.
+
+    An entry that is not an object counts as billing. The safe reading of an
+    unrecognisable record is that the meter may still be running."""
+    if not isinstance(record, dict):
+        return True
+    return str(record.get("state", "")) not in SETTLED_STATES
+
+
+def summarise(record):
+    """One line per lease. The control plane may add fields, so unknown ones are
+    counted rather than dropped silently."""
+    if not isinstance(record, dict):
+        return f"  ? BILLING unreadable entry: {record!r}"
+    known = [f"{name}={record[name]}" for name in SUMMARY_FIELDS if record.get(name) is not None]
+    extra = [name for name in record
+             if name not in SUMMARY_FIELDS and name != "lease_id" and record.get(name) is not None]
+    tail = f" (+{len(extra)} more fields; --json prints them)" if extra else ""
+    marker = "BILLING" if billing(record) else "settled"
+    return f"  {record.get('lease_id')} {marker} {' '.join(known)}{tail}"
+
+
+def show(records, as_json):
+    if not isinstance(records, list):
+        # An empty list means no leases. Anything else means the call did not
+        # answer the question, and printing "no leases" for it would be a false
+        # all-clear on a wallet that may well be paying for one.
+        print(f"the lease list came back as {type(records).__name__}, not a list, so "
+              "what this wallet is paying for is unknown. Check the escrow address in "
+              "PRISM_ESCROW and retry.", file=sys.stderr)
+        return REFUSED
+    if as_json:
+        print(json.dumps(records, indent=2))
+        return RELEASED
+    if not records:
+        print("no leases on this escrow for this wallet")
+        return RELEASED
+    open_now = [record for record in records if billing(record)]
+    print(f"{len(records)} lease(s), {len(open_now)} still billing")
+    for record in records:
+        print(summarise(record))
+    if open_now:
+        ids = " ".join(str(record.get("lease_id")) for record in open_now
+                       if isinstance(record, dict))
+        print(f"release each of these: {ids}")
+        first = next((r.get("lease_id") for r in open_now if isinstance(r, dict)), None)
+        if first is not None:
+            print(f"  python3 scripts/release_lease.py --lease {first}")
+    return RELEASED
+
+
+def release(agent, lease_id):
+    result = agent.release(lease_id)
+    print(f"released     lease {lease_id}; the meter is stopped")
+    print("settlement   charges the seconds between access opening and this release, "
+          "and returns the rest")
+    if isinstance(result, dict) and result:
+        print(f"control plane {json.dumps(result)}")
+    print(f"receipt      python3 scripts/verify_receipt.py --lease {lease_id}")
+    return RELEASED
+
+
+def parse(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    what = parser.add_mutually_exclusive_group(required=True)
+    what.add_argument("--lease", default=None, help="id of the lease to release")
+    what.add_argument("--list", action="store_true", dest="list_leases",
+                      help="every lease this wallet holds on this escrow")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    if args.lease is not None and not str(args.lease).strip():
+        parser.error("--lease takes the lease id the failure named")
+    return args
+
+
+def main(argv=None):
+    args = parse(sys.argv[1:] if argv is None else argv)
+    try:
+        agent = agent_from_env()
+    except NoWallet as e:
+        print(str(e), file=sys.stderr)
+        return USAGE
+    except ValueError as e:
+        print(f"PRISM_AGENT_KEY is not usable: {e}", file=sys.stderr)
+        return USAGE
+
+    try:
+        if args.list_leases:
+            return show(agent.leases(), args.json)
+        return release(agent, args.lease)
+    except PrismError as e:
+        detail = f": {json.dumps(e.body)}" if getattr(e, "body", None) else ""
+        if args.list_leases:
+            print(f"the lease list could not be read: {e.code}{detail}", file=sys.stderr)
+            return USAGE
+        if e.code in ("lease_not_found", "not_found"):
+            print(f"no lease {args.lease} for this wallet on this escrow: {e.code}{detail}\n"
+                  "Ids restart at 1 with each escrow deployment, and only the wallet that "
+                  "funded a lease can release it. `--list` shows what this wallet holds; "
+                  "PRISM_ESCROW picks the deployment.", file=sys.stderr)
+            return REFUSED
+        print(f"the release was refused: {e.code}{detail}\n"
+              f"The wallet is still paying for lease {args.lease} until the window ends. "
+              "Retry it.", file=sys.stderr)
+        return REFUSED
+    except Exception as e:
+        # A traceback here would exit 1 by luck rather than by decision. The
+        # meaning is the same either way: nothing was released.
+        what = "the lease list could not be read" if args.list_leases else "the release failed"
+        print(f"{what}: {type(e).__name__}: {e}", file=sys.stderr)
+        return REFUSED
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/optional-skills/mlops/prism-gpu/scripts/verify_receipt.py
+++ b/optional-skills/mlops/prism-gpu/scripts/verify_receipt.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Check a published Prism settlement receipt offline, then say what to match on chain.
+
+Usage:
+    verify_receipt.py <receipt_id | receipt url | path/to/receipt.json>
+    verify_receipt.py --lease <lease_id> [--escrow 0x...]
+    verify_receipt.py --self-test
+
+Recomputes ``receipt_hash`` from the canonical payload and reconciles charged,
+refunded and provider-paid amounts. Everything here is stdlib: no wallet, no
+key, and no dependency on the caller having run the lease. The canonical form
+is field-declaration order with absent fields dropped, so a re-serialisation
+that sorts keys produces a different digest and a false negative.
+
+Lease ids are numbered per escrow deployment and restart at 1 with each one, so
+the same id names a different run on each escrow the feed has published. Lookup
+by lease id is therefore scoped to one escrow, ``PRISM_ESCROW`` or the live
+default, and refuses to guess when the scope still leaves more than one.
+
+Exit codes, so a caller can branch without parsing the output:
+
+    0   verified and the run completed cleanly
+    1   a check failed; this receipt is not evidence
+    2   wrong arguments, or no receipt for that lease on that escrow
+    3   verified, but the run did not complete cleanly (see failure_class)
+    4   the feed could not be reached, so nothing was checked
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections import OrderedDict
+
+FEED = "https://api.prismnetwork.tech/proof/receipts"
+INDEX = "https://api.prismnetwork.tech/proof/index.json"
+EXPLORER = "https://robinhoodchain.blockscout.com/tx"
+# The escrow currently taking deposits. Retired deployments stay in the feed
+# with their own lease numbering, which is why this scopes the lookup.
+DEFAULT_ESCROW = "0xfD4228eEEfC49e4b76A0CD40af9fdd546220B2FD"
+
+OK = 0
+FAILED = 1
+USAGE = 2
+NOT_CLEAN = 3
+UNREACHABLE = 4
+
+# Declaration order. Sorting these produces a different digest.
+RECEIPT_FIELDS = (
+    "receipt_id", "lease_id", "node_id_hash", "gpu_model", "runtime_seconds",
+    "charged_base_units", "refunded_base_units", "provider_paid_base_units",
+    "failure_class", "outcome", "trust_class", "attestation",
+    "credited_seconds", "repro",
+)
+REPRO_FIELDS = (
+    "executor", "token_hash", "spec_hash", "image_digest", "command_hash",
+    "result_hash", "stdout_hash", "stderr_hash", "report_hash", "exit_code",
+    "expected_exit_code", "succeeded", "truncated",
+)
+EMPTY_STREAM = hashlib.sha256(b"").hexdigest()
+
+FAILURE_MEANING = {
+    "interrupted": "the machine stopped answering before the paid window ended",
+    "provisioning_timeout": "the machine never booted",
+}
+
+
+def canonical(receipt):
+    payload = OrderedDict()
+    for field in RECEIPT_FIELDS:
+        # The only optional field that survives as an explicit null. The rest
+        # disappear, which is what keeps older receipts byte-identical.
+        if field == "failure_class":
+            payload[field] = receipt.get("failure_class")
+        elif field == "repro" and "repro" in receipt:
+            payload[field] = OrderedDict(
+                (name, receipt["repro"][name])
+                for name in REPRO_FIELDS
+                if name in receipt["repro"]
+            )
+        elif field in receipt:
+            payload[field] = receipt[field]
+    return json.dumps(payload, separators=(",", ":")).encode()
+
+
+def get(url, timeout=30):
+    request = urllib.request.Request(url, headers={"accept": "application/json"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def is_address(value):
+    text = str(value).strip()
+    return (text.lower().startswith("0x") and len(text) == 42
+            and all(c in "0123456789abcdefABCDEF" for c in text[2:]))
+
+
+def escrow_in_force(explicit=None):
+    """The escrow to scope a lookup to. Whitespace is stripped before the
+    fallbacks, so PRISM_ESCROW=" " falls through to the default rather than
+    matching every entry that omits the field."""
+    named = next((c for c in (explicit, os.environ.get("PRISM_ESCROW")) if c and c.strip()),
+                 DEFAULT_ESCROW)
+    return named.strip().lower()
+
+
+def resolve(index, lease_id, escrow):
+    """Pick the one receipt for ``lease_id`` that ``escrow`` settled.
+
+    Ids repeat across escrow deployments, so matching on the id alone hands
+    back whichever entry the feed happened to list first, which can be a
+    stranger's run of a different length on a retired contract. Anything short
+    of exactly one match on the named escrow raises instead of guessing."""
+    same_id = [r for r in index.get("receipts", []) if str(r.get("lease_id")) == str(lease_id)]
+    if not same_id:
+        raise LookupError(
+            f"no published receipt for lease {lease_id} on any escrow. Settlement lands a "
+            "little after the release; a lease still open has no receipt yet."
+        )
+    matches = [r for r in same_id
+               if str(r.get("escrow_address", "")).strip().lower() == escrow]
+    if not matches:
+        elsewhere = sorted({str(r.get("escrow_address")) for r in same_id})
+        raise LookupError(
+            f"lease {lease_id} has {len(same_id)} published receipt(s), none settled by the "
+            f"escrow at {escrow}. The id is in use on: {', '.join(elsewhere)}. Those are other "
+            "leases that happen to share the number. Set PRISM_ESCROW or pass --escrow to name "
+            "the deployment the lease was funded on."
+        )
+    ids = sorted({str(r["receipt_id"]) for r in matches if r.get("receipt_id")})
+    if not ids:
+        raise LookupError(
+            f"the feed lists lease {lease_id} on escrow {escrow} without a receipt id, so "
+            "there is nothing to fetch. Pass the receipt id."
+        )
+    if len(ids) > 1:
+        raise LookupError(
+            f"lease {lease_id} on escrow {escrow} resolves to {len(ids)} receipts "
+            f"({', '.join(ids)}), so the id does not identify a run. Pass the receipt id."
+        )
+    return ids[0]
+
+
+def load(argument):
+    if argument.startswith(("http://", "https://")):
+        return get(argument)
+    if os.path.exists(argument):
+        with open(argument, encoding="utf-8") as handle:
+            return json.load(handle)
+    if argument.endswith(".json") or os.sep in argument:
+        # It was written as a path. Sending it to the feed turns a typo into a
+        # 404 and blames the network for a file that is simply not there.
+        raise FileNotFoundError(f"no such file: {argument}")
+    return get(f"{FEED}/{argument}.json")
+
+
+# What report() reads without a default. A document short of these is not a
+# receipt, and the feed is a network source, so this is checked before printing.
+REQUIRED = ("receipt_hash", "receipt_id", "charged_base_units",
+            "refunded_base_units", "provider_paid_base_units")
+
+
+def missing_fields(receipt):
+    if not isinstance(receipt, dict):
+        return ["the shape of a receipt"]
+    return [name for name in REQUIRED if receipt.get(name) is None]
+
+
+def report(receipt):
+    """No I/O beyond stdout, so the exit code is the whole verdict."""
+    computed = hashlib.sha256(canonical(receipt)).hexdigest()
+    published = receipt.get("receipt_hash")
+    charged = int(receipt["charged_base_units"])
+    refunded = int(receipt["refunded_base_units"])
+    paid = int(receipt["provider_paid_base_units"])
+    runtime = receipt.get("runtime_seconds")
+    # Seconds held and not charged for. Read as the metered figure it understates
+    # the run and the arithmetic stops reconciling.
+    credited = receipt.get("credited_seconds")
+    failure = receipt.get("failure_class")
+
+    failures = []
+    if computed != published:
+        failures.append(f"receipt_hash mismatch: computed {computed}, published {published}")
+    if paid > charged:
+        failures.append(f"provider paid {paid} of {charged} charged")
+    if receipt.get("outcome") == "disputed":
+        failures.append("receipt is disputed and is not final proof")
+
+    print(f"receipt      {receipt['receipt_id']}")
+    print(f"escrow       {receipt.get('escrow_address')} lease {receipt.get('chain_lease_id')}")
+    print(f"gpu          {receipt.get('gpu_model')}, trust class {receipt.get('trust_class', 'unstated')}")
+    print(f"outcome      {receipt.get('outcome')} ({failure or 'ran clean'})")
+    print(f"metered      {runtime}s, charged {charged} base units ({charged / 1e6:.6f} USDG)")
+    if credited is not None:
+        print(f"credited     {credited}s held and NOT charged")
+    print(f"deposit      {charged + refunded} base units, {refunded} refunded, {paid} to the provider")
+    if "repro" in receipt:
+        repro = receipt["repro"]
+        print(f"image        {repro.get('image_digest')}")
+        print(f"executor     {repro.get('executor')}, exit {repro.get('exit_code')}"
+              f" (expected {repro.get('expected_exit_code')})")
+        for stream in ("stdout_hash", "stderr_hash"):
+            value = repro.get(stream)
+            note = " (empty)" if value == EMPTY_STREAM else ""
+            print(f"{stream:<12} {value}{note}")
+    print(f"receipt_hash {computed} {'ok' if computed == published else 'MISMATCH'}")
+    print(f"settlement   {EXPLORER}/{receipt.get('transaction_hash')}")
+
+    if failures:
+        print()
+        for line in failures:
+            print(f"FAIL {line}")
+        return FAILED
+
+    print()
+    print("Offline checks pass. Still to confirm on Robinhood Chain (id 4663):")
+    if receipt.get("outcome") == "refunded":
+        # LeaseRefunded's third field is reasonHash, so a refund's receipt hash
+        # is self-consistency evidence rather than a value the chain committed.
+        print(f"  the escrow at {receipt.get('escrow_address')} emitted one LeaseRefunded")
+        print(f"  for leaseId {receipt.get('chain_lease_id')} refunding {refunded},")
+        print(f"  carrying the canonical reason hash for {failure}.")
+        print("  The receipt hash above is NOT committed by a refund event.")
+    else:
+        print(f"  the escrow at {receipt.get('escrow_address')} emitted one LeaseFinalized")
+        print(f"  for leaseId {receipt.get('chain_lease_id')} with receiptHash 0x{computed},")
+        print(f"  charged {charged}, providerPaid {paid}, refunded {refunded},")
+        print("  and fee + providerPaid == charged.")
+
+    if failure:
+        print()
+        print(f"CAUTION this run did not complete cleanly: {failure}"
+              f" ({FAILURE_MEANING.get(failure, 'reason not recognised by this checker')}).")
+        if credited is not None:
+            print(f"        {credited}s of the window were held and never billed.")
+        print("        Cite it only with the failure named alongside the claim.")
+        return NOT_CLEAN
+    return OK
+
+
+# Two receipts exactly as the feed published them, one clean and one cut short.
+# Pinned because the classification below is the part that is easy to get
+# backwards: credited_seconds is uncharged time, so a checker that meters it
+# reports 152s on a lease that billed 192.
+PINNED = {
+    "clean": {
+        "receipt_id": "8f3e0c1d-391c-8510-9f77-ebc574905ffe",
+        "lease_id": "34",
+        "node_id_hash": "0xde1fbfc73bdf94761ae16a7f6c98716ea22ece3ce23c1b67d4a7053cb5605dfc",
+        "gpu_model": "RTX 6000Ada",
+        "runtime_seconds": 28,
+        "charged_base_units": 6216,
+        "refunded_base_units": 126984,
+        "provider_paid_base_units": 5595,
+        "failure_class": None,
+        "outcome": "finalized",
+        "trust_class": "open",
+        "escrow_address": "0xfd4228eeefc49e4b76a0cd40af9fdd546220b2fd",
+        "chain_lease_id": "34",
+        "receipt_hash": "2970ee269291020bf03a2d665f6e68accb3a77048dfc0902d0c1d1b5a9a2dbd3",
+        "transaction_hash": "0x1de4eba627f8ffc6c0ce3f628b648c5f13d9f2815843d1fc6979a9b731309d88",
+    },
+    "interrupted": {
+        "receipt_id": "916ea93f-e7fd-8c59-b20d-80c70019d280",
+        "lease_id": "143",
+        "node_id_hash": "0x8126aa45f5829caa2ded18ab38fbe41954f67c5675d70d38278eb6f446077688",
+        "gpu_model": "RTX 5880Ada",
+        "runtime_seconds": 192,
+        "charged_base_units": 42624,
+        "refunded_base_units": 157176,
+        "provider_paid_base_units": 38362,
+        "failure_class": "interrupted",
+        "outcome": "finalized",
+        "trust_class": "open",
+        "credited_seconds": 152,
+        "escrow_address": "0x62c042265991bea17b07229322a01850974626da",
+        "chain_lease_id": "143",
+        "receipt_hash": "93517fa85353029e27db4d1c50721bff751e6c8a894b0e50da37574a61e4ecf5",
+        "transaction_hash": "0xb8de1c478fab41fb3dc4daf6ff4ac9b8c30d3774282a8c91c5aef176d6cd66b5",
+    },
+}
+
+# Three published index entries that all carry lease_id 34, one per escrow the
+# feed has ever settled. Pinned because this collision is the whole reason
+# lookup by lease id is scoped: matching on the number alone returns whichever
+# of these the feed lists first.
+COLLIDING_INDEX = {
+    "receipts": [
+        {"lease_id": "34", "receipt_id": "8f3e0c1d-391c-8510-9f77-ebc574905ffe",
+         "escrow_address": "0xfd4228eeefc49e4b76a0cd40af9fdd546220b2fd",
+         "runtime_seconds": 28, "charged_base_units": 6216},
+        {"lease_id": "34", "receipt_id": "397e9593-7cea-8d9a-9ee3-238ab4b63bb6",
+         "escrow_address": "0x62c042265991bea17b07229322a01850974626da",
+         "runtime_seconds": 1800, "charged_base_units": 399600},
+        {"lease_id": "34", "receipt_id": "b6d76bdf-de6e-8a5f-8972-85065406120f",
+         "escrow_address": "0x71df0ef3bc81022cb3bec0b1a05f52f12bafcded",
+         "runtime_seconds": 120, "charged_base_units": 26640},
+    ]
+}
+
+
+def self_test():
+    """Check the pinned receipts without touching the network.
+
+    Written with explicit comparisons rather than assert, because `python3 -O`
+    strips assert and this is the check SKILL.md points at to back the billing
+    claims. A self-test that passes with its checks removed proves nothing."""
+    failures = []
+    for name, receipt in PINNED.items():
+        computed = hashlib.sha256(canonical(receipt)).hexdigest()
+        if computed != receipt["receipt_hash"]:
+            failures.append(f"{name}: canonicalisation disagrees with the published hash")
+        print(f"--- {name} ---")
+        code = report(receipt)
+        expected = OK if name == "clean" else NOT_CLEAN
+        if code != expected:
+            failures.append(f"{name}: exit {code}, expected {expected}")
+        print()
+
+    interrupted = PINNED["interrupted"]
+    rate = interrupted["charged_base_units"] / interrupted["runtime_seconds"]
+    if rate != 222:
+        failures.append(
+            "the charge divides by runtime_seconds at the quoted rate, so a checker "
+            "that meters credited_seconds is reporting the wrong number"
+        )
+
+    print("--- tampered, expected to be rejected ---")
+    if report(dict(PINNED["clean"], charged_base_units=1)) != FAILED:
+        failures.append("an edited receipt has to fail")
+
+    live = escrow_in_force(DEFAULT_ESCROW)
+    try:
+        resolved = resolve(COLLIDING_INDEX, 34, live)
+    except LookupError as e:
+        resolved = f"LookupError: {e}"
+    if resolved != PINNED["clean"]["receipt_id"]:
+        failures.append(
+            "lease 34 on the live escrow is the 28-second run, not one of the two "
+            f"leases numbered 34 on the retired escrows; got {resolved}"
+        )
+    try:
+        resolve(COLLIDING_INDEX, 34, "0x" + "11" * 20)
+        failures.append("a lease id on an escrow that never settled it must not resolve")
+    except LookupError:
+        pass
+
+    print()
+    if failures:
+        for line in failures:
+            print(f"SELF-TEST FAILED: {line}", file=sys.stderr)
+        return FAILED
+    print(f"{len(PINNED)} pinned receipts verified, tampering rejected, "
+          "colliding lease ids scoped to one escrow")
+    return OK
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("receipt", nargs="?", help="receipt id, receipt URL, or a local .json file")
+    parser.add_argument("--lease", default=None,
+                        help="look the receipt up by lease id, scoped to one escrow")
+    parser.add_argument("--escrow", default=None,
+                        help="escrow the lease was funded on; defaults to PRISM_ESCROW, "
+                             "then to the live escrow")
+    parser.add_argument("--self-test", action="store_true",
+                        help="verify the pinned receipts offline; no network")
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    if args.self_test:
+        if args.receipt or args.lease or args.escrow:
+            parser.error("--self-test runs offline against the pinned receipts and takes "
+                         "nothing else")
+        return self_test()
+    if bool(args.receipt) == bool(args.lease):
+        parser.error("pass a receipt id, or --lease, or --self-test")
+    if args.lease is not None and not str(args.lease).strip().isdigit():
+        parser.error(f"--lease takes the lease number, not {args.lease!r}")
+    if args.escrow is not None and not is_address(args.escrow):
+        parser.error(f"--escrow takes a 20-byte address, not {args.escrow!r}")
+
+    try:
+        target = (resolve(get(INDEX), args.lease, escrow_in_force(args.escrow))
+                  if args.lease else args.receipt)
+        receipt = load(target)
+    except LookupError as e:
+        print(str(e), file=sys.stderr)
+        return USAGE
+    except FileNotFoundError as e:
+        print(str(e), file=sys.stderr)
+        return USAGE
+    except (urllib.error.URLError, OSError) as e:
+        print(f"the feed could not be reached: {e}", file=sys.stderr)
+        return UNREACHABLE
+    except ValueError as e:
+        print(f"the receipt did not parse as JSON: {e}", file=sys.stderr)
+        return USAGE
+    missing = missing_fields(receipt)
+    if missing:
+        print(f"that is not a settlement receipt; it has no {', '.join(missing)}",
+              file=sys.stderr)
+        return USAGE
+    return report(receipt)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skills/test_prism_gpu_skill.py
+++ b/tests/skills/test_prism_gpu_skill.py
@@ -1,0 +1,847 @@
+"""Tests for the prism-gpu optional skill.
+
+Stdlib, pytest and unittest.mock only. Nothing here touches the network, a
+wallet, or the escrow contract: the two SDK-backed scripts are imported against
+a stub ``prismnetwork`` module so their pure logic is exercised without the
+dependency being installed in CI.
+"""
+
+import importlib.util
+import json
+import re
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "mlops" / "prism-gpu"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+SCRIPTS = SKILL_DIR / "scripts"
+
+SECTIONS = [
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+]
+
+
+def load_script(name, stub_sdk=False):
+    """Import a skill script by path, optionally behind a stub SDK."""
+    path = SCRIPTS / name
+    spec = importlib.util.spec_from_file_location(f"prism_gpu_{path.stem}", path)
+    module = importlib.util.module_from_spec(spec)
+    patched = {"prismnetwork": _stub_sdk()} if stub_sdk else {}
+    with mock.patch.dict(sys.modules, patched):
+        spec.loader.exec_module(module)
+    return module
+
+
+class _PrismError(Exception):
+    """The SDK's error, reproduced: ``broadcast`` defaults to None, which is the
+    value the real one raises with when a node grants gateway access."""
+
+    def __init__(self, status, code, body=None, broadcast=None):
+        super().__init__(f"prism {status}: {code}")
+        self.status = status
+        self.code = code
+        self.body = body
+        self.broadcast = broadcast
+
+
+def _stub_sdk():
+    """Just enough of prismnetwork for the scripts' imports to resolve."""
+    stub = types.ModuleType("prismnetwork")
+    stub.DEFAULT_ESCROW = "0xfD4228eEEfC49e4b76A0CD40af9fdd546220B2FD"
+    stub.DEFAULT_IMAGE = "docker.io/ollama/ollama@sha256:" + "a" * 64
+    stub.BudgetError = type("BudgetError", (Exception,), {})
+    stub.PrismError = _PrismError
+    stub.PrismAgent = mock.MagicMock()
+    stub.SpendLedger = mock.MagicMock()
+    stub.call_ceiling = mock.MagicMock()
+    stub.read_budget = mock.MagicMock()
+    stub.record_spend = mock.MagicMock()
+    return stub
+
+
+@pytest.fixture(scope="module")
+def frontmatter():
+    content = SKILL_MD.read_text(encoding="utf-8")
+    assert content.startswith("---"), "frontmatter must start at byte 0"
+    end = re.search(r"\n---\s*\n", content[3:])
+    assert end, "frontmatter must close with a --- line"
+    return yaml.safe_load(content[3:end.start() + 3]), content[end.end() + 3:]
+
+
+def test_description_meets_the_hardline(frontmatter):
+    meta, _ = frontmatter
+    description = meta["description"]
+    assert len(description) <= 60, f"description is {len(description)} chars"
+    assert description.endswith(".")
+    assert description.count(".") == 1, "one sentence"
+    assert "prism-gpu" not in description.lower()
+    assert re.search(r"\bGPU\b", description), "say what it rents"
+
+
+def test_required_frontmatter_fields(frontmatter):
+    meta, _ = frontmatter
+    for field in ("name", "version", "author", "license", "platforms"):
+        assert field in meta, f"missing {field}"
+    assert meta["name"] == "prism-gpu"
+    assert meta["author"] == "Mika Winter (winterstacks)"
+    assert set(meta["platforms"]) <= {"linux", "macos", "windows"}
+    assert meta["metadata"]["hermes"]["tags"]
+
+
+def test_dependency_declares_an_upper_bound(frontmatter):
+    meta, _ = frontmatter
+    for spec in meta["dependencies"]:
+        assert ",<" in spec, f"{spec} needs a next-major ceiling"
+
+
+def test_body_uses_the_modern_section_order(frontmatter):
+    _, body = frontmatter
+    positions = [body.index(section) for section in SECTIONS]
+    assert positions == sorted(positions), "sections are out of order"
+
+
+def test_body_names_no_machine_local_paths(frontmatter):
+    _, body = frontmatter
+    assert "/Users/" not in body
+    assert "/home/" not in body
+
+
+def test_every_referenced_file_exists(frontmatter):
+    _, body = frontmatter
+    for target in re.findall(r"\((references/[\w.-]+)\)", body):
+        assert (SKILL_DIR / target).is_file(), f"{target} is referenced but missing"
+    for script in re.findall(r"scripts/([\w.-]+\.py)", body):
+        assert (SCRIPTS / script).is_file(), f"{script} is referenced but missing"
+
+
+def test_prerequisites_name_the_python_floor(frontmatter):
+    """Every published prismnetwork requires 3.10, and pip's refusal below it
+    reads as a missing package rather than a version floor."""
+    _, body = frontmatter
+    prerequisites = body.split("## Prerequisites")[1].split("## How to Run")[0]
+    assert "3.10" in prerequisites
+
+
+def test_offers_is_not_advertised_as_wallet_free(frontmatter):
+    """`offers()` signs a wallet session like every other SDK call. The public
+    HTTP endpoint is the wallet-free path, and it is the one pick_gpu.py uses."""
+    _, body = frontmatter
+    quick = body.split("## Quick Reference")[1].split("## Procedure")[0]
+    row = next(line for line in quick.splitlines() if line.startswith("| `.offers()`"))
+    assert "signs a session" in row
+    assert "api.prismnetwork.tech/v1/offers" in quick
+
+
+# pick_gpu
+
+OFFERS = [
+    {"node_id": "0xa", "gpu": {"model": "H100 PCIe", "vram_mib": 81920},
+     "rate_per_second": 900, "benchmark_score": 30000, "online": True, "trust_class": "open"},
+    {"node_id": "0xb", "gpu": {"model": "RTX A6000", "vram_mib": 49140},
+     "rate_per_second": 222, "benchmark_score": 12000, "online": True, "trust_class": "open"},
+    {"node_id": "0xc", "gpu": {"model": "RTX 4090", "vram_mib": 24564},
+     "rate_per_second": 177, "benchmark_score": 10000, "online": True, "trust_class": "open",
+     "staker_only": True},
+    {"node_id": "0xd", "gpu": {"model": "L40S", "vram_mib": 46068},
+     "rate_per_second": 222, "benchmark_score": 15000, "online": False, "trust_class": "open"},
+    {"node_id": "0xe", "gpu": {"model": "RTX 6000Ada", "vram_mib": 49140},
+     "rate_per_second": 300, "benchmark_score": 16000, "online": True,
+     "trust_class": "confidential"},
+]
+
+
+@pytest.fixture(scope="module")
+def pick_gpu():
+    return load_script("pick_gpu.py")
+
+
+def test_cheapest_offer_over_the_vram_floor_wins(pick_gpu):
+    eligible, _ = pick_gpu.choose(OFFERS, pick_gpu.floor_mib(40), None, "open", False)
+    assert eligible[0]["node_id"] == "0xb"
+    assert pick_gpu.why(eligible[0], eligible[1:]).startswith("cheapest of 3")
+
+
+def test_a_card_of_the_size_asked_for_is_not_rejected(pick_gpu):
+    """Nodes publish under nominal: a 24 GB card reports 24564 MiB, so a floor
+    converted at 1024 MiB per GiB would reject every card of the size asked for."""
+    assert pick_gpu.floor_mib(24) == 24000
+    eligible, _ = pick_gpu.choose(OFFERS, pick_gpu.floor_mib(24), None, "open", True)
+    assert "0xc" in [offer["node_id"] for offer in eligible], "24564 MiB clears a 24 GB floor"
+    _, rejected = pick_gpu.choose(OFFERS, pick_gpu.floor_mib(32), None, "open", True)
+    reasons = {offer["node_id"]: "; ".join(text) for offer, text in rejected}
+    assert reasons["0xc"] == "24564 MiB VRAM under the 32000 MiB floor"
+
+
+def test_staker_only_and_offline_offers_are_dropped_with_a_reason(pick_gpu):
+    _, rejected = pick_gpu.choose(OFFERS, pick_gpu.floor_mib(16), None, "open", False)
+    reasons = {offer["node_id"]: "; ".join(text) for offer, text in rejected}
+    assert "reserved for stakers" in reasons["0xc"]
+    assert "offline" in reasons["0xd"]
+
+
+def test_staker_only_is_kept_when_asked_for(pick_gpu):
+    eligible, _ = pick_gpu.choose(OFFERS, pick_gpu.floor_mib(16), None, "open", True)
+    assert eligible[0]["node_id"] == "0xc", "the staker offer is the cheapest"
+
+
+def test_a_price_ceiling_excludes_dearer_offers(pick_gpu):
+    ceiling = int(0.70 * 1_000_000 / 3600)          # USDG per hour to base units per second
+    eligible, rejected = pick_gpu.choose(OFFERS, pick_gpu.floor_mib(16), ceiling, "open", False)
+    assert eligible == []
+    assert any("over the ceiling" in reason for _, text in rejected for reason in text)
+
+
+def test_trust_class_floor_is_ordered_not_matched(pick_gpu):
+    eligible, _ = pick_gpu.choose(OFFERS, pick_gpu.floor_mib(16), None, "confidential", False)
+    assert [offer["node_id"] for offer in eligible] == ["0xe"]
+
+
+def test_deposit_is_the_whole_window(pick_gpu):
+    winner = OFFERS[1]
+    payload = pick_gpu.as_json(winner, [], [], 600, pick_gpu.floor_mib(16))
+    assert '"deposit_base_units": 133200' in payload
+
+
+def test_a_24_gb_request_matches_a_24_gb_card_end_to_end(pick_gpu, tmp_path, capsys):
+    feed = tmp_path / "offers.json"
+    feed.write_text(json.dumps([OFFERS[2] | {"staker_only": False}]), encoding="utf-8")
+    assert pick_gpu.main(["--offers", str(feed), "--min-vram-gb", "24"]) == pick_gpu.MATCHED
+    assert "24564 MiB" in capsys.readouterr().out
+
+
+def test_no_match_exits_one(pick_gpu, tmp_path):
+    offers = tmp_path / "offers.json"
+    offers.write_text("[]", encoding="utf-8")
+    assert pick_gpu.main(["--offers", str(offers)]) == pick_gpu.NO_MATCH
+
+
+def test_unreadable_capacity_exits_three(pick_gpu, tmp_path):
+    missing = tmp_path / "absent.json"
+    assert pick_gpu.main(["--offers", str(missing)]) == pick_gpu.UNREACHABLE
+
+
+# verify_receipt
+
+@pytest.fixture(scope="module")
+def verify_receipt():
+    return load_script("verify_receipt.py")
+
+
+def test_pinned_receipts_verify_offline(verify_receipt):
+    assert verify_receipt.self_test() == verify_receipt.OK
+
+
+def test_an_edited_receipt_is_rejected(verify_receipt):
+    tampered = dict(verify_receipt.PINNED["clean"], refunded_base_units=0)
+    assert verify_receipt.report(tampered) == verify_receipt.FAILED
+
+
+def test_an_interrupted_run_is_flagged_rather_than_passed(verify_receipt):
+    assert verify_receipt.report(verify_receipt.PINNED["interrupted"]) == verify_receipt.NOT_CLEAN
+
+
+def test_canonical_form_is_declaration_order(verify_receipt):
+    payload = verify_receipt.canonical(verify_receipt.PINNED["clean"]).decode()
+    assert payload.index('"receipt_id"') < payload.index('"lease_id"') < payload.index('"gpu_model"')
+    assert '"escrow_address"' not in payload, "fields outside the canonical set are dropped"
+    assert '"failure_class":null' in payload, "failure_class survives as an explicit null"
+
+
+def test_a_lease_with_no_receipt_reports_it(verify_receipt, capsys):
+    with mock.patch.object(verify_receipt, "get", return_value={"receipts": []}):
+        assert verify_receipt.main(["--lease", "9999"]) == verify_receipt.USAGE
+
+
+def test_a_lease_id_resolves_to_its_receipt(verify_receipt, capsys):
+    clean = verify_receipt.PINNED["clean"]
+    index = {"receipts": [{"lease_id": "34", "receipt_id": clean["receipt_id"],
+                           "escrow_address": verify_receipt.DEFAULT_ESCROW.lower()}]}
+    with mock.patch.object(verify_receipt, "get", side_effect=[index, clean]):
+        assert verify_receipt.main(["--lease", "34"]) == verify_receipt.OK
+    assert f"receipt      {clean['receipt_id']}" in capsys.readouterr().out
+
+
+def test_a_lease_id_shared_across_escrows_resolves_to_the_named_one(verify_receipt):
+    """Ids restart at 1 with each escrow deployment, so three published receipts
+    carry lease_id 34. Matching on the number alone returns a stranger's run."""
+    live = verify_receipt.escrow_in_force(verify_receipt.DEFAULT_ESCROW)
+    chosen = verify_receipt.resolve(verify_receipt.COLLIDING_INDEX, 34, live)
+    assert chosen == verify_receipt.PINNED["clean"]["receipt_id"]
+    assert chosen != verify_receipt.COLLIDING_INDEX["receipts"][1]["receipt_id"]
+
+
+def test_a_lease_id_on_another_escrow_is_refused_not_substituted(verify_receipt):
+    with pytest.raises(LookupError) as raised:
+        verify_receipt.resolve(verify_receipt.COLLIDING_INDEX, 34, "0x" + "11" * 20)
+    assert "none settled by the escrow" in str(raised.value)
+
+
+def test_two_receipts_on_one_escrow_refuse_to_resolve(verify_receipt):
+    index = {"receipts": [
+        {"lease_id": "5", "receipt_id": "a", "escrow_address": verify_receipt.DEFAULT_ESCROW},
+        {"lease_id": "5", "receipt_id": "b", "escrow_address": verify_receipt.DEFAULT_ESCROW},
+    ]}
+    with pytest.raises(LookupError) as raised:
+        verify_receipt.resolve(index, 5, verify_receipt.escrow_in_force(verify_receipt.DEFAULT_ESCROW))
+    assert "does not identify a run" in str(raised.value)
+
+
+# lease_run_release
+
+@pytest.fixture(scope="module")
+def lease_run_release():
+    return load_script("lease_run_release.py", stub_sdk=True)
+
+
+def test_a_failure_before_broadcast_costs_nothing(lease_run_release):
+    error = mock.Mock(code="wallet_unfunded", body=None, broadcast=False)
+    code, message = lease_run_release.explain(error)
+    assert code == lease_run_release.UNSPENT_FAILURE
+    assert "before anything was signed" in message
+
+
+def test_a_failure_after_broadcast_names_the_transaction(lease_run_release):
+    error = mock.Mock(code="access_timeout", body={"lease_id": 41}, broadcast="0xdead")
+    code, message = lease_run_release.explain(error)
+    assert code == lease_run_release.MONEY_AT_RISK
+    assert "0xdead" in message
+    assert "scripts/release_lease.py --lease 41" in message
+
+
+def test_a_failure_with_no_lease_id_points_at_the_funding_hash(lease_run_release):
+    """``lease()`` can fail after funding and before an id comes back, so telling
+    the caller to release 'the lease named above' names nothing."""
+    error = mock.Mock(code="chain_error", body={"hint": "receipt unreadable"}, broadcast="0xf00")
+    code, message = lease_run_release.explain(error)
+    assert code == lease_run_release.MONEY_AT_RISK
+    assert "scripts/release_lease.py --list" in message
+    assert "0xf00" in message
+    assert "named above" not in message
+
+
+def test_recovery_is_shell_commands_the_skill_actually_ships(lease_run_release):
+    """The heading says to run these through the `terminal` tool, so every line
+    has to be a command and every script named has to exist."""
+    with_id = lease_run_release.recovery(77, "0xabc")
+    assert "scripts/release_lease.py --lease 77" in with_id
+    assert "scripts/verify_receipt.py --lease 77" in with_id
+
+    without_id = lease_run_release.recovery(None, "0xabc")
+    assert "scripts/release_lease.py --list" in without_id
+    assert "0xabc" in without_id, "with no id, the funding hash is the only handle"
+
+    for message in (with_id, without_id):
+        assert message.strip(), "an empty message strands a running meter"
+        assert "agent." not in message, "a shell has no agent binding"
+        for line in message.splitlines():
+            body = line.strip()
+            if body.startswith("python3"):
+                assert (SKILL_DIR / body.split()[1]).is_file(), f"{body} names no shipped script"
+
+
+def test_an_undetermined_failure_is_treated_as_spent(lease_run_release):
+    error = mock.Mock(code="confirmation_timeout", body=None, broadcast=None)
+    code, _ = lease_run_release.explain(error)
+    assert code == lease_run_release.MONEY_AT_RISK
+
+
+def test_a_released_lease_is_never_reported_as_open(lease_run_release):
+    """``broadcast`` is None on the SDK's own ``ssh_access_unavailable``. The
+    release already happened, so the answer is the bill, not a rescue."""
+    error = lease_run_release.PrismError(400, "ssh_access_unavailable",
+                                         {"mode": "gateway", "lease_id": 99})
+    code, message = lease_run_release.explain(error, released=True)
+    assert code == lease_run_release.FUNDED_NOT_RUN
+    assert "The meter is stopped." in message
+    assert "release_lease" not in message
+
+
+def test_the_deposit_is_read_from_the_funding_receipt(lease_run_release):
+    lease = mock.Mock(deposit_micros=133200)
+    assert lease_run_release.deposited(lease, 1_000_000) == 133200
+
+
+def test_an_unreadable_deposit_falls_back_to_the_ceiling(lease_run_release):
+    for held in (None, 0, -1, True, 2_000_000):
+        assert lease_run_release.deposited(mock.Mock(deposit_micros=held), 1_000_000) == 1_000_000
+
+
+def test_no_wallet_is_refused_before_the_network(lease_run_release, monkeypatch):
+    monkeypatch.delenv("PRISM_AGENT_KEY", raising=False)
+    with pytest.raises(lease_run_release.NoWallet):
+        lease_run_release.agent_from_env()
+
+
+def test_an_empty_command_is_rejected(lease_run_release):
+    with pytest.raises(SystemExit):
+        lease_run_release.parse(["   "])
+
+
+def test_a_node_without_its_rate_is_rejected(lease_run_release):
+    with pytest.raises(SystemExit):
+        lease_run_release.parse(["nvidia-smi", "--node", "0xabc"])
+
+
+def test_a_priced_node_is_carried_through_untouched(lease_run_release):
+    args = lease_run_release.parse(["nvidia-smi", "--node", "0xabc", "--rate-per-second", "222"])
+    assert lease_run_release.price(args) == ("0xabc", 222, "node 0xabc at the rate given")
+
+
+def test_pricing_picks_the_cheapest_rentable_offer(lease_run_release):
+    args = lease_run_release.parse(["nvidia-smi", "--min-vram-gb", "16"])
+    with mock.patch.object(lease_run_release.pick_gpu, "load", return_value=OFFERS):
+        node, rate, _ = lease_run_release.price(args)
+    assert (node, rate) == ("0xb", 222), "the staker-only 177 offer is not rentable"
+
+
+def test_no_matching_capacity_raises_before_a_wallet_is_touched(lease_run_release):
+    args = lease_run_release.parse(["nvidia-smi", "--min-vram-gb", "80"])
+    with mock.patch.object(lease_run_release.pick_gpu, "load", return_value=OFFERS[2:]):
+        with pytest.raises(lease_run_release.NoCapacity):
+            lease_run_release.price(args)
+
+
+def test_the_deposit_reserved_is_the_deposit_funded(lease_run_release):
+    """The ledger reservation, the printed deposit and the escrow's ``max_deposit``
+    are one figure, so budget_check.py and this script cannot disagree."""
+    lease = mock.Mock(lease_id=91, funding_hash="0xf00", deposit_micros=199_800)
+    lease.access = {"ssh_host": "10.0.0.1", "ssh_port": 2222}
+    agent = mock.MagicMock()
+    agent.lease.return_value = lease
+    agent.run.return_value = {"code": 0, "stdout": "ok", "stderr": ""}
+    args = lease_run_release.parse(["nvidia-smi", "--duration", "900"])
+    reservations = []
+
+    def reserving(book, tool, micros, run):
+        reservations.append(micros)
+        return run()["value"]
+
+    with mock.patch.object(lease_run_release, "record_spend", side_effect=reserving):
+        assert lease_run_release.run_lease(agent, mock.MagicMock(), args, "0xNODE", 199_800) == \
+            lease_run_release.RELEASED
+
+    assert reservations == [199_800], "the day is booked for the deposit, not the ceiling"
+    kwargs = agent.lease.call_args.kwargs
+    assert kwargs["max_deposit"] == 199_800
+    assert kwargs["preferred_node_id"] == "0xNODE"
+
+
+def test_a_dead_stdout_still_releases_the_lease(lease_run_release):
+    """A closed pipe must not cost a whole window.
+
+    Piping this script into something that exits first (``| head -1``) makes the
+    next print raise BrokenPipeError. The prints that report the funded lease sit
+    inside the try for exactly this reason, so the release still runs.
+    """
+    lease = mock.Mock(lease_id=7, funding_hash="0xdead", deposit_micros=133_200)
+    lease.access = {"ssh_host": "10.0.0.1", "ssh_port": 2222}
+    agent = mock.MagicMock()
+    agent.lease.return_value = lease
+    agent.run.return_value = {"code": 0, "stdout": "ok", "stderr": ""}
+    args = lease_run_release.parse(["nvidia-smi"])
+
+    def broken_pipe(*_a, **_k):
+        raise BrokenPipeError(32, "Broken pipe")
+
+    with mock.patch.object(lease_run_release, "record_spend", lambda book, tool, micros, run: run()["value"]), \
+         mock.patch("builtins.print", side_effect=broken_pipe):
+        with pytest.raises(BrokenPipeError):
+            lease_run_release.run_lease(agent, mock.MagicMock(), args, "0xNODE", 133_200)
+
+    assert agent.end_lease.called, "the lease was funded and the meter was left running"
+
+
+def test_both_streams_survive_the_machine(lease_run_release, capsys):
+    """The box is destroyed in the ``finally`` below, so a crash reason dropped
+    here costs another deposit to see again."""
+    lease = mock.Mock(lease_id=92, funding_hash="0xf01", deposit_micros=133_200)
+    lease.access = {"ssh_host": "10.0.0.1", "ssh_port": 2222}
+    agent = mock.MagicMock()
+    agent.lease.return_value = lease
+    agent.run.return_value = {"code": 1, "stdout": "partial results",
+                              "stderr": "CUDA out of memory"}
+    args = lease_run_release.parse(["train", "--duration", "600"])
+
+    with mock.patch.object(lease_run_release, "record_spend",
+                           side_effect=lambda book, tool, micros, run: run()["value"]):
+        lease_run_release.run_lease(agent, mock.MagicMock(), args, "0xNODE", 133_200)
+
+    printed = capsys.readouterr().out
+    assert "partial results" in printed
+    assert "CUDA out of memory" in printed
+
+
+def funded_lease():
+    lease = mock.Mock(lease_id=99, funding_hash="0xfeed", deposit_micros=133_200)
+    lease.access = {"ssh_host": "10.0.0.1", "ssh_port": 2222}
+    return lease
+
+
+def drive(lease_run_release, agent):
+    args = lease_run_release.parse(["nvidia-smi", "--duration", "600"])
+    with mock.patch.object(lease_run_release, "record_spend",
+                           side_effect=lambda book, tool, micros, run: run()["value"]):
+        return lease_run_release.run_lease(agent, mock.MagicMock(), args, "0xNODE", 133_200)
+
+
+def test_a_run_failure_on_a_released_lease_asks_for_no_rescue(lease_run_release, capsys):
+    """The finally block already released it. Exit 3 would send the agent after a
+    lease that is closed, and a caller branching on 3 would take the rescue path."""
+    agent = mock.MagicMock()
+    agent.lease.return_value = funded_lease()
+    agent.run.side_effect = lease_run_release.PrismError(
+        400, "ssh_access_unavailable", {"mode": "gateway", "lease_id": 99})
+
+    assert drive(lease_run_release, agent) == lease_run_release.FUNDED_NOT_RUN
+
+    printed = capsys.readouterr()
+    assert "released     lease 99" in printed.out
+    assert "release_lease" not in printed.err
+    assert "meter is running" not in printed.err
+
+
+def test_a_release_that_fails_is_the_case_that_needs_the_rescue(lease_run_release, capsys):
+    agent = mock.MagicMock()
+    agent.lease.return_value = funded_lease()
+    agent.run.return_value = {"code": 0, "stdout": "ok", "stderr": ""}
+    agent.end_lease.side_effect = lease_run_release.PrismError(502, "release_refused",
+                                                              {"lease_id": 99})
+
+    assert drive(lease_run_release, agent) == lease_run_release.MONEY_AT_RISK
+    assert "scripts/release_lease.py --lease 99" in capsys.readouterr().err
+
+
+def test_the_vram_floor_reaching_the_paid_call_is_the_one_that_matches(lease_run_release):
+    """The same conversion the offer filter uses goes to the escrow, so a floor
+    that selects a card cannot then be refused by the control plane as no_match."""
+    agent = mock.MagicMock()
+    agent.lease.return_value = funded_lease()
+    agent.run.return_value = {"code": 0, "stdout": "", "stderr": ""}
+    args = lease_run_release.parse(["nvidia-smi", "--min-vram-gb", "24"])
+    with mock.patch.object(lease_run_release, "record_spend",
+                           side_effect=lambda book, tool, micros, run: run()["value"]):
+        lease_run_release.run_lease(agent, mock.MagicMock(), args, "0xNODE", 133_200)
+    assert agent.lease.call_args.kwargs["min_vram_mib"] == 24_000
+
+
+# release_lease
+
+@pytest.fixture(scope="module")
+def release_lease():
+    return load_script("release_lease.py", stub_sdk=True)
+
+
+def test_open_leases_are_marked_as_still_billing(release_lease):
+    assert release_lease.billing({"lease_id": 7, "state": "active"})
+    assert not release_lease.billing({"lease_id": 7, "state": "finalized"})
+    assert not release_lease.billing({"lease_id": 7, "state": "refunded"})
+
+
+def test_the_list_names_what_to_run_next(release_lease, capsys):
+    records = [{"lease_id": 7, "state": "active", "node_id": "0xa"},
+               {"lease_id": 6, "state": "finalized"}]
+    assert release_lease.show(records, False) == release_lease.RELEASED
+    printed = capsys.readouterr().out
+    assert "2 lease(s), 1 still billing" in printed
+    assert "7 BILLING" in printed
+    assert "--lease 7" in printed
+
+
+def test_a_field_the_control_plane_adds_is_counted_not_dropped(release_lease):
+    line = release_lease.summarise({"lease_id": 7, "state": "active", "surprise": "value"})
+    assert "+1 more fields" in line
+
+
+def test_a_release_needs_a_target(release_lease):
+    with pytest.raises(SystemExit):
+        release_lease.parse([])
+    with pytest.raises(SystemExit):
+        release_lease.parse(["--lease", "7", "--list"])
+
+
+def test_no_wallet_cannot_release(release_lease, monkeypatch):
+    monkeypatch.delenv("PRISM_AGENT_KEY", raising=False)
+    with pytest.raises(release_lease.NoWallet):
+        release_lease.agent_from_env()
+
+
+# budget_check
+
+@pytest.fixture(scope="module")
+def budget_check():
+    return load_script("budget_check.py", stub_sdk=True)
+
+
+def test_a_deposit_inside_both_limits_has_no_problems(budget_check):
+    assert budget_check.verdict(133200, 1_000_000, 5_000_000) == []
+
+
+def test_a_deposit_over_the_per_lease_cap_is_blocked(budget_check):
+    problems = budget_check.verdict(7_992_000, 1_000_000, 5_000_000)
+    assert len(problems) == 2, "over the per-lease cap and over the day"
+    assert "per-lease cap" in problems[0]
+    assert "left of today" in problems[1]
+
+
+def test_an_unlimited_day_only_checks_the_per_lease_cap(budget_check):
+    problems = budget_check.verdict(2_000_000, 1_000_000, None)
+    assert len(problems) == 1
+    assert "per-lease cap" in problems[0]
+
+
+def test_duration_and_rate_travel_together(budget_check):
+    with pytest.raises(SystemExit):
+        budget_check.parse(["--duration", "600"])
+
+
+# the guards that only main() reaches
+
+def test_an_unpriced_offer_is_rejected_rather_than_ranked_free(pick_gpu):
+    """``.get("rate_per_second", 0)`` reads a missing rate as free, which sorts it
+    to the front of a ranking that is cheapest-first."""
+    unpriced = dict(OFFERS[0])
+    unpriced.pop("rate_per_second", None)
+    eligible, rejected = pick_gpu.choose(
+        [unpriced] + list(OFFERS[1:2]), pick_gpu.floor_mib(16), None, "open", False)
+    assert [offer["node_id"] for offer in eligible] == [OFFERS[1]["node_id"]]
+    assert any("no published rate" in reason for _, text in rejected for reason in text)
+
+
+def test_a_malformed_offer_list_does_not_crash_the_ranking(pick_gpu):
+    eligible, _ = pick_gpu.choose(
+        [1, "two", None, dict(OFFERS[1])], pick_gpu.floor_mib(16), None, "open", False)
+    assert [offer["node_id"] for offer in eligible] == [OFFERS[1]["node_id"]]
+
+
+def test_a_deposit_over_the_ceiling_never_reaches_a_wallet(lease_run_release, capsys):
+    budget = mock.Mock(ledger_path="/tmp/none.json", daily_micros=None, max_per_call_micros=100)
+    with mock.patch.object(lease_run_release, "read_budget", return_value=budget), \
+         mock.patch.object(lease_run_release, "SpendLedger") as ledger, \
+         mock.patch.object(lease_run_release, "call_ceiling", return_value=100), \
+         mock.patch.object(lease_run_release, "agent_from_env") as wallet:
+        ledger.return_value.remaining.return_value = None
+        code = lease_run_release.main(
+            ["nvidia-smi", "--node", "0xNODE", "--rate-per-second", "222", "--duration", "900"])
+    assert code == lease_run_release.USAGE
+    assert not wallet.called, "no wallet is built for a lease that cannot be afforded"
+    assert "per-lease cap" in capsys.readouterr().err
+
+
+def test_the_planned_deposit_is_the_rate_times_the_window(lease_run_release, capsys):
+    """main() is where the deposit is priced. run_lease only receives the figure."""
+    budget = mock.Mock(ledger_path="/tmp/none.json", daily_micros=None, max_per_call_micros=10**9)
+    with mock.patch.object(lease_run_release, "read_budget", return_value=budget), \
+         mock.patch.object(lease_run_release, "SpendLedger") as ledger, \
+         mock.patch.object(lease_run_release, "call_ceiling", return_value=10**9):
+        ledger.return_value.remaining.return_value = None
+        code = lease_run_release.main(
+            ["nvidia-smi", "--node", "0xNODE", "--rate-per-second", "222",
+             "--duration", "900", "--dry-run"])
+    assert code == lease_run_release.RELEASED
+    assert "0.199800 USDG planned for 900s" in capsys.readouterr().out
+
+
+def test_a_timeout_that_outlives_its_window_is_refused(lease_run_release):
+    with pytest.raises(SystemExit):
+        lease_run_release.parse(["nvidia-smi", "--duration", "300", "--timeout", "300"])
+
+
+def test_a_command_too_large_for_the_argument_list_is_refused(lease_run_release):
+    with pytest.raises(SystemExit):
+        lease_run_release.parse(["x" * (lease_run_release.COMMAND_LIMIT + 1)])
+
+
+def test_a_bad_ceiling_is_a_usage_error_not_a_broken_ledger(budget_check):
+    """Exit 3 sends the caller to inspect the ledger. A negative flag is exit 2."""
+    with pytest.raises(SystemExit) as exit_code:
+        budget_check.parse(["--max-usdg", "-1"])
+    assert exit_code.value.code == 2
+
+
+def test_an_unknown_lease_says_ids_restart_with_each_escrow(release_lease, capsys):
+    agent = mock.MagicMock()
+    agent.release.side_effect = release_lease.PrismError(404, "lease_not_found")
+    with mock.patch.object(release_lease, "agent_from_env", return_value=agent):
+        assert release_lease.main(["--lease", "34"]) == release_lease.REFUSED
+    assert "Ids restart at 1" in capsys.readouterr().err
+
+
+def test_a_lease_list_that_is_not_a_list_is_not_an_all_clear(release_lease, capsys):
+    """"no leases" on an unreadable answer is a false all-clear on a wallet that
+    may still be paying for one."""
+    assert release_lease.show({"leases": []}, False) == release_lease.REFUSED
+    assert "not a list" in capsys.readouterr().err
+
+
+def test_an_unreadable_lease_record_counts_as_billing(release_lease):
+    assert release_lease.billing("not-a-dict") is True
+
+
+def test_a_document_that_is_not_a_receipt_is_refused(verify_receipt, capsys):
+    with mock.patch.object(verify_receipt, "load", return_value={"receipt_hash": "0x1"}):
+        assert verify_receipt.main(["8f3e0c1d"]) == verify_receipt.USAGE
+    assert "not a settlement receipt" in capsys.readouterr().err
+
+
+def test_a_local_receipt_file_is_read_from_disk(verify_receipt, tmp_path, monkeypatch):
+    """The usage line advertises a path. Requiring a slash in it sent
+    ``verify_receipt.py receipt.json`` to the network and reported a 404."""
+    receipt = tmp_path / "receipt.json"
+    receipt.write_text(json.dumps(verify_receipt.PINNED["clean"]), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    with mock.patch.object(verify_receipt, "get", side_effect=AssertionError("went to the network")):
+        assert verify_receipt.load("receipt.json") == verify_receipt.PINNED["clean"]
+
+
+def test_a_blank_escrow_does_not_match_every_receipt(verify_receipt, monkeypatch):
+    monkeypatch.setenv("PRISM_ESCROW", "   ")
+    assert verify_receipt.escrow_in_force() == verify_receipt.DEFAULT_ESCROW.lower()
+
+
+def test_the_self_test_still_checks_under_optimised_python(verify_receipt):
+    """``python3 -O`` strips assert. SKILL.md points at --self-test to back the
+    billing claims, so it has to check something under any interpreter flag."""
+    import subprocess
+    script = SCRIPTS / "verify_receipt.py"
+    source = script.read_text(encoding="utf-8")
+    broken = source.replace('"runtime_seconds": 28,', '"runtime_seconds": 29,', 1)
+    assert broken != source, "the pinned receipt this test edits has moved"
+
+    clean = subprocess.run([sys.executable, "-O", str(script), "--self-test"],
+                           capture_output=True, text=True)
+    assert clean.returncode == 0, clean.stderr
+
+    edited = SCRIPTS.parent / "_self_test_under_o.py"
+    edited.write_text(broken, encoding="utf-8")
+    try:
+        result = subprocess.run([sys.executable, "-O", str(edited), "--self-test"],
+                                capture_output=True, text=True)
+    finally:
+        edited.unlink()
+    assert result.returncode != 0, "an edited pinned receipt passed with asserts stripped"
+    assert "SELF-TEST FAILED" in result.stderr
+    assert verify_receipt.FAILED == 1
+
+
+def test_a_release_that_fails_below_the_sdk_still_reports_the_bill(lease_run_release, capsys):
+    """A reset connection raises OSError, not PrismError. Letting it out of the
+    finally skips the only message that says the meter is still running."""
+    lease = mock.Mock(lease_id=101, funding_hash="0xbeef", deposit_micros=133_200)
+    lease.access = {"ssh_host": "10.0.0.1", "ssh_port": 2222}
+    agent = mock.MagicMock()
+    agent.lease.return_value = lease
+    agent.run.return_value = {"code": 0, "stdout": "ok", "stderr": ""}
+    agent.end_lease.side_effect = ConnectionResetError(54, "Connection reset by peer")
+    args = lease_run_release.parse(["nvidia-smi"])
+
+    with mock.patch.object(lease_run_release, "record_spend",
+                           lambda book, tool, micros, run: run()["value"]):
+        code = lease_run_release.run_lease(agent, mock.MagicMock(), args, "0xNODE", 133_200)
+
+    assert code == lease_run_release.MONEY_AT_RISK
+    printed = capsys.readouterr()
+    assert "RELEASE FAILED ConnectionResetError" in printed.err
+    assert "scripts/release_lease.py --lease 101" in printed.err
+
+
+def test_capacity_is_filtered_here_not_by_the_endpoint(pick_gpu):
+    """Asking the endpoint for one trust class returns a pre-filtered list, and
+    then a constraint that matched nothing reports "0 were published" while six
+    machines are online."""
+    seen = {}
+
+    def record(url, timeout=15):
+        seen["url"] = url
+        return list(OFFERS)
+
+    with mock.patch.object(pick_gpu, "fetch", side_effect=record):
+        pick_gpu.load(None)
+    assert "min_trust" not in seen["url"]
+
+
+def test_an_empty_feed_is_not_reported_as_a_missed_constraint(pick_gpu, tmp_path, capsys):
+    feed = tmp_path / "offers.json"
+    feed.write_text("[]", encoding="utf-8")
+    assert pick_gpu.main(["--offers", str(feed)]) == pick_gpu.NO_MATCH
+    assert "no capacity is published right now" in capsys.readouterr().err
+
+
+def test_a_tie_counts_only_offers_that_are_actually_tied(pick_gpu):
+    """"tied on every criterion" counted the whole matching field, so two cards
+    of different sizes were reported as identical."""
+    same = dict(OFFERS[0])
+    smaller = dict(OFFERS[0], node_id="0xsmall", gpu=dict(OFFERS[0]["gpu"], vram_mib=24564))
+    assert "tied with 1 other offer(s) of 2" in pick_gpu.why(same, [dict(same, node_id="0xb")])
+    assert "largest card" in pick_gpu.why(same, [smaller])
+
+
+def test_a_staker_only_winner_is_flagged_before_the_next_command(pick_gpu, capsys):
+    winner = dict(OFFERS[0], staker_only=True)
+    printed = pick_gpu.report(winner, [], [], 600)
+    assert "only rents to bonded stakers" in printed
+    assert printed.index("caution") < printed.index("next"), "the warning has to precede the command"
+
+
+def test_an_image_without_a_digest_is_refused_before_pricing(lease_run_release):
+    """--dry-run is the pre-flight for the rule SKILL.md states, so it has to
+    make the check the control plane makes."""
+    with pytest.raises(SystemExit):
+        lease_run_release.parse(["nvidia-smi", "--image", "ollama/ollama:latest", "--dry-run"])
+
+
+def test_a_path_that_does_not_exist_is_not_blamed_on_the_network(verify_receipt, capsys):
+    with pytest.raises(FileNotFoundError):
+        verify_receipt.load("/tmp/prism-gpu-no-such-receipt.json")
+    assert verify_receipt.main(["/tmp/prism-gpu-no-such-receipt.json"]) == verify_receipt.USAGE
+    assert "no such file" in capsys.readouterr().err
+
+
+def test_an_unreachable_feed_is_its_own_exit_code(verify_receipt, capsys):
+    """Exit 2 means the arguments were wrong. An outage is not a wrong argument."""
+    with mock.patch.object(verify_receipt, "get",
+                           side_effect=OSError("[Errno 61] Connection refused")):
+        assert verify_receipt.main(["--lease", "34"]) == verify_receipt.UNREACHABLE
+    assert "the feed could not be reached" in capsys.readouterr().err
+
+
+def test_the_self_test_refuses_arguments_it_would_ignore(verify_receipt):
+    with pytest.raises(SystemExit):
+        verify_receipt.main(["--self-test", "--lease", "34"])
+
+
+def test_a_lease_id_that_is_not_a_number_is_caught_before_the_feed(verify_receipt):
+    with pytest.raises(SystemExit):
+        verify_receipt.main(["--lease", "abc"])
+
+
+def test_an_escrow_that_is_not_an_address_is_caught_before_the_feed(verify_receipt):
+    with pytest.raises(SystemExit):
+        verify_receipt.main(["--lease", "34", "--escrow", "potato"])
+    assert verify_receipt.is_address("0x" + "ab" * 20)
+    assert not verify_receipt.is_address("0x" + "ab" * 19)
+
+
+def test_a_ceiling_above_the_environment_says_it_was_clamped(budget_check, capsys):
+    budget = mock.Mock(ledger_path="/tmp/none.json", daily_micros=None, max_per_call_micros=10**6)
+    with mock.patch.object(budget_check, "read_budget", return_value=budget), \
+         mock.patch.object(budget_check, "SpendLedger") as ledger, \
+         mock.patch.object(budget_check, "call_ceiling", return_value=10**6):
+        ledger.return_value.status.return_value = {
+            "daily_budget": "5.000000 USDG", "spent_last_24h": "0.000000 USDG",
+            "remaining_today": "5.000000 USDG", "max_per_call": "1.000000 USDG",
+            "ledger": "/tmp/none.json", "charges_last_24h": [],
+        }
+        ledger.return_value.remaining.return_value = None
+        budget_check.main(["--max-usdg", "50"])
+    assert "clamped to 1.000000 USDG" in capsys.readouterr().out


### PR DESCRIPTION
## What

Adds `optional-skills/mlops/prism-gpu/`: a skill that rents a dedicated NVIDIA GPU on Prism
Network for a bounded window, runs commands on it over SSH, releases it, and verifies the
settlement receipt afterwards.

```
optional-skills/mlops/prism-gpu/
├── SKILL.md
├── scripts/
│   ├── pick_gpu.py                 choose an offer against a VRAM floor and a price ceiling
│   ├── budget_check.py             report the spend limits and whether a planned deposit fits
│   ├── lease_run_release.py        rent, run one command, release in a finally block
│   ├── release_lease.py            list what the wallet is still paying for, release one by id
│   └── verify_receipt.py           recompute a published receipt hash offline
└── references/
    ├── billing.md                  escrow arithmetic, ceilings, receipt fields
    ├── python-sdk.md               prismnetwork 0.4.0 surface
    └── troubleshooting.md          error codes and what each one costs
tests/skills/test_prism_gpu_skill.py
```

The agent pays from a wallet it already holds, in USDG on Robinhood Chain (id 4663). The
wallet is the credential, so there is no account for a human to create first. The other GPU
providers in this tree need an API key that somebody signs up for.

## Why optional-skills/mlops

CONTRIBUTING.md: "If your skill is official and useful but not universally needed (e.g., a
paid service integration, a heavyweight dependency), put it in `optional-skills/`." This is a
paid service integration with a heavyweight dependency (`prismnetwork` pulls `web3` and
`eth-account`), so it does not belong in `skills/`.

`optional-skills/mlops/lambda-labs/` is the precedent: a commercial GPU provider, in this
directory, with SKILL.md plus references. `tensorrt-llm` and `nemo-curator` put
NVIDIA-adjacent skills in the same place. `prism-gpu` sits alongside them and names
`lambda-labs` and `modal` in `related_skills`, so a reader comparing providers finds all
three.

This is a skill, not a plugin: a SKILL.md, five scripts and three reference documents, all
invoked through `terminal`. It adds no directory under `plugins/` and touches no core code.

## Disclosure

I maintain Prism Network, the service this skill talks to. Everything the skill claims is
checkable without taking my word for it:

- live capacity and prices: `https://api.prismnetwork.tech/v1/offers`
- every settled lease: `https://api.prismnetwork.tech/proof/index.json` (300 settlements as
  of 2026-09-10, 226 finalized and 74 refunded)
- the SDK: `prismnetwork` 0.4.0 on PyPI, Apache-2.0
- the escrow contract: `0xfD4228eEEfC49e4b76A0CD40af9fdd546220B2FD` on Robinhood Chain

`scripts/verify_receipt.py --self-test` recomputes two pinned receipt hashes from the
published feed and rejects a tampered one, with no network and no wallet. The billing claims
in SKILL.md are arithmetic, and that is how to run it.

The skill states supply plainly. Prism runs a handful of machines at a time, and the skill
teaches the agent to read `offers()` rather than plan around a card being available. It claims
no partnership with NVIDIA, Nous Research, or Robinhood.

## The billing behaviour

A lease deposits its **whole window** into escrow up front. Releasing the lease is what stops
the meter; settlement then charges the seconds between access opening and the release and
returns the rest. A lease nobody releases bills to the end of its window.

SKILL.md says this in `## Pitfalls`, `scripts/lease_run_release.py` puts the release in a
`finally` block, and `references/billing.md` works through a settled example (lease 34 on the
live escrow: a 600-second window deposited 0.133200 USDG, ran 28 seconds, charged 0.006216,
returned 0.126984). Two spend ceilings bound every lease, `PRISM_MAX_USDG` at 1 and
`PRISM_DAILY_BUDGET_USDG` at 5, recorded in `~/.prism/spend.json` before any money moves.

One figure carries through: the deposit `pick_gpu.py` prices is the figure `budget_check.py`
checks, the figure reserved in the ledger, and the `max_deposit` the escrow is allowed to
pull. `lease_run_release.py` also takes `--node`, so the machine that gets funded is the one
that was priced. A quote that has moved is refused before anything is signed.

A failure after funding splits two ways, and `lease_run_release.py` reports which:
the lease its `finally` block released (exit `4`, the meter is stopped and there is nothing
to chase) and the lease it could not release (exit `3`, printed with the
`release_lease.py --list` and `--lease <id>` commands that stop the meter). Both are scripts
the skill ships, so the state where money is in escrow and the clock is running has a way out
the agent can run.

Lease ids are numbered per escrow deployment and restart at 1 with each one, so the published
feed holds several receipts for most low ids. `verify_receipt.py --lease` resolves against a
single escrow and refuses rather than returning a same-numbered lease from a retired
deployment.

## How to test

None of these spends anything or needs a wallet:

```bash
cd optional-skills/mlops/prism-gpu
python3 scripts/verify_receipt.py --self-test     # offline, no network
python3 scripts/pick_gpu.py --min-vram-gb 24      # reads live capacity, reserves nothing
python3 scripts/lease_run_release.py "nvidia-smi" --duration 900 --dry-run
```

The first verifies two pinned settlement receipts, rejects an edited one, and checks that a
lease id carried by three escrow deployments resolves to the run on the escrow named. The
second prints a live offer with a node id, an hourly rate, and the deposit for the window, or
exits `1` naming what each published offer failed on. Both are stdlib and run on any Python
3.8+; the three scripts that import the SDK need 3.10, which `## Prerequisites` states and
they check at startup. The third prices the window against both spend ceilings and prints
the plan without signing anything, which is the whole spending path a reviewer can exercise
without moving money.

`--min-vram-gb` takes the number on the card and converts at 1000 MiB per GB, because nodes
publish under nominal: a 24 GB card reports 24564 MiB, and the SDK's own `min_vram_mib`
default is 16000 rather than 16384. Asking for 24 selects a 24 GB card.

Unit tests:

```bash
scripts/run_tests.sh tests/skills/test_prism_gpu_skill.py -q
```

82 tests, stdlib plus pytest, `unittest.mock` and `yaml`. No live network. The three
SDK-backed scripts are imported against a stub `prismnetwork` module, so the suite passes in
a hermetic CI environment with the dependency absent. `tests/skills/test_authoring_standards.py`
passes with the skill in the tree.

## Platforms

Developed and tested on macOS 15 with Python 3.12 and 3.14. The scripts use `pathlib`,
`argparse`, `urllib`, and `json` only; there are no POSIX-only primitives, no `/tmp` paths,
and no signals, so `platforms: [linux, macos, windows]` is declared. The one platform-bound
requirement is OpenSSH: the SDK shells out to `ssh-keygen` and `ssh`, which macOS and
mainstream Linux ship and Windows provides as an optional feature. `## Prerequisites` says so.

Not exercised on Linux or Windows.

## What I could not test

The paths that cost money. These run against the live control plane with a throwaway wallet:
authentication, the offer list, the lease list, the unfunded-wallet refusal, which raises with
`broadcast=False` and hands the ledger reservation back, and a refused release. Funding,
provisioning, `run()`, and a successful release are covered by unit tests over the SDK's own
`PrismError` rather than by a real lease, because I did not want to put a spend inside a PR.
Reviewers who want to see one end to end can check any of the 300 receipts in the public feed.

## Related

Searched open and closed issues and PRs for GPU rental, per-second compute, and Prism. Nothing
overlapping. This does not duplicate `lambda-labs` or `modal`: those need an account and an API
key, this one needs a funded wallet and nothing else.

Docs still to regenerate with `python website/scripts/generate-skill-docs.py` before merge, so
the diff carries one per-skill page, one catalog row, and one `website/sidebars.ts` line.
