### PR TITLE
feat(cron): opt in to following profile inference defaults

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1333,14 +1333,17 @@ class _CronJobConfig:
     model: str
     model_cfg: Any
     cron_default_provider: str
+    follow_profile: bool = False
 
 
-def _snapshot_pin(job: dict, axis: str, current: str, job_id: str) -> str:
+def _snapshot_pin(job: dict, axis: str, current: str, job_id: str, *, follow_profile: bool = False) -> str:
     """The creation snapshot is an unpinned axis's effective pin: return it, logging once when it
     differs from *current* (the live global default); ``""`` for legacy jobs without one, which keep
     following the global default. A global model/provider change must never stop a cron job; a job
     keeps running on what it was created under until the operator pins it or sets a cron.* fleet
     default (#44585)."""
+    if follow_profile:
+        return ""
     snapshot = str(job.get(f"{axis}_snapshot") or "").strip()
     if snapshot and current and snapshot.lower() != current.lower():
         logger.info(
@@ -1354,9 +1357,11 @@ def _snapshot_pin(job: dict, axis: str, current: str, job_id: str) -> str:
 def _load_cron_job_config(job: dict, job_id: str, job_name: str) -> _CronJobConfig:
     """Load config.yaml and resolve the run's model: per-job override > cron.model (fleet default) >
     creation snapshot > HERMES_MODEL > config ``model:``. Re-read every tick (no cache) so
-    ``hermes cron edit --model`` applies next tick."""
+    ``hermes cron edit --model`` applies next tick. With cron.follow_profile enabled,
+    unpinned axes bypass creation snapshots and follow this profile's current defaults."""
     model = job.get("model") or os.getenv("HERMES_MODEL") or ""
     _cron_default_provider = ""
+    follow_profile = False
     _cfg: dict = {}
     _model_cfg: Any = {}
     try:
@@ -1374,6 +1379,7 @@ def _load_cron_job_config(job: dict, job_id: str, job_name: str) -> _CronJobConf
             _cron_cfg_for_model = _cfg.get("cron") or {}
             _cron_default_model = ""
             if isinstance(_cron_cfg_for_model, dict):
+                follow_profile = _cron_cfg_for_model.get("follow_profile") is True
                 _cron_default_model = str(_cron_cfg_for_model.get("model") or "").strip()
                 _cron_default_provider = str(_cron_cfg_for_model.get("model_provider") or "").strip()
             if not job.get("model"):
@@ -1381,7 +1387,9 @@ def _load_cron_job_config(job: dict, job_id: str, job_name: str) -> _CronJobConf
                     model = _cron_default_model
                 else:
                     _, _global_model = resolve_cron_model_drift_defaults(_cfg)
-                    model = _snapshot_pin(job, "model", _global_model, job_id) or _global_model or model
+                    model = _snapshot_pin(
+                        job, "model", _global_model, job_id, follow_profile=follow_profile
+                    ) or _global_model or model
     except Exception as e:
         logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 
@@ -1403,7 +1411,7 @@ def _load_cron_job_config(job: dict, job_id: str, job_name: str) -> _CronJobConf
         _net_cfg = _cfg.get("network", {})
         if isinstance(_net_cfg, dict) and _net_cfg.get("force_ipv4"):
             apply_ipv4_preference(force=True)
-    return _CronJobConfig(_cfg, model, _model_cfg, _cron_default_provider)
+    return _CronJobConfig(_cfg, model, _model_cfg, _cron_default_provider, follow_profile)
 
 
 def _load_prefill_messages(cfg: dict, job_id: str) -> Optional[list]:
@@ -1500,7 +1508,8 @@ def _resolve_job_runtime(job: dict, job_id: str, jc: _CronJobConfig) -> tuple[di
             str(jc.model_cfg.get("provider") or "").strip() if isinstance(jc.model_cfg, dict) else "")
         # None (not the config provider) keeps the legacy no-snapshot path resolving from persisted
         # config exactly as before.
-        requested = _snapshot_pin(job, "provider", global_provider, job_id) or None
+        requested = (global_provider or None) if jc.follow_profile else (
+            _snapshot_pin(job, "provider", global_provider, job_id) or None)
     try:
         # Do NOT pass HERMES_INFERENCE_PROVIDER as `requested`: it would override persisted config
         # and resurrect stale providers for unpinned jobs.

--- a/cron/scheduler_preflight.py
+++ b/cron/scheduler_preflight.py
@@ -95,6 +95,11 @@ def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
     requested = (
         job.get("provider") or str((_cron_cfg or {}).get("model_provider") or "").strip() or None)
     model = job.get("model") or os.getenv("HERMES_MODEL") or ""
+    if _cron_cfg.get("follow_profile") is True:
+        from hermes_cli.config import resolve_cron_model_drift_defaults
+        profile_provider, profile_model = resolve_cron_model_drift_defaults(cfg)
+        requested = requested or profile_provider or None
+        model = job.get("model") or _cron_cfg.get("model") or profile_model
 
     from hermes_cli.auth import AuthError
     try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3013,6 +3013,8 @@ def cron_model_drift_axes(
     # A cron.model / cron.model_provider fleet default covers its axis: that axis never reads the
     # snapshot at fire time, so reporting it would be false.
     fleet = _cron_section(config) or {}
+    if fleet.get("follow_profile") is True:
+        return []
     drifted: List[str] = []
     for axis, fleet_key in (("provider", "model_provider"), ("model", "model")):
         if _model_assignment_text(fleet.get(fleet_key)) or _model_assignment_text(job.get(axis)):

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1618,6 +1618,9 @@ DEFAULT_CONFIG = {
     },
 
     "cron": {
+        # Opt in to following this profile's current defaults for unpinned axes.
+        # Explicit job/fleet overrides still win; stored snapshots remain available for rollback.
+        "follow_profile": False,
         # Let cron-spawned agents use the cronjob toolset (the "cron-librarian" pattern). Off by
         # default: policy-denied in cron context to prevent unattended scheduling loops. Jobs
         # created this way are user-owned in the same flat jobs table. Interactive toolsets

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -42,7 +42,7 @@ def _base_job(**overrides):
 
 
 def _run(job, tmp_path, *, current_provider="openrouter", current_model=None, cron_model=None,
-         cron_model_provider=None):
+         cron_model_provider=None, follow_profile=None):
     """Drive run_job against a temp config.yaml whose ``model.default`` / ``model.provider`` are
     the CURRENT global defaults. Returns ``(success, error, agent_kwargs, resolve_kwargs)`` where
     the last two are the kwargs AIAgent / resolve_runtime_provider were called with (None when
@@ -59,6 +59,8 @@ def _run(job, tmp_path, *, current_provider="openrouter", current_model=None, cr
         cron_lines.append(f"  model: {cron_model}")
     if cron_model_provider is not None:
         cron_lines.append(f"  model_provider: {cron_model_provider}")
+    if follow_profile is not None:
+        cron_lines.append(f"  follow_profile: {str(follow_profile).lower()}")
     if cron_lines:
         config_yaml += "cron:\n" + "\n".join(cron_lines) + "\n"
     (tmp_path / "config.yaml").write_text(config_yaml)
@@ -220,3 +222,43 @@ class TestRuntimeResolutionTargetModel:
         assert success is True, error
         assert resolve_kwargs["target_model"] == "my-pinned-model"
         assert resolve_kwargs["requested"] == "openrouter"
+
+
+class TestFollowProfileDefaults:
+    def test_switch_round_trip_and_opt_out_preserve_job(self, tmp_path):
+        from copy import deepcopy
+        from hermes_cli.config import cron_model_drift_axes
+
+        job = _base_job(provider_snapshot="created-provider", model_snapshot="created-model")
+        before = deepcopy(job)
+        for provider, model in [("provider-a", "model-a"), ("provider-b", "model-b"),
+                                ("provider-a", "model-a")]:
+            success, error, agent, resolved = _run(
+                job, tmp_path, current_provider=provider, current_model=model,
+                follow_profile=True)
+            assert success, error
+            assert (resolved["requested"], resolved["target_model"]) == (provider, model)
+            assert agent["model"] == model
+            assert cron_model_drift_axes(job, current_provider=provider, current_model=model,
+                                         config={"cron": {"follow_profile": True}}) == []
+        assert job == before
+        success, error, agent, resolved = _run(
+            job, tmp_path, current_provider="provider-b", current_model="model-b",
+            follow_profile=False)
+        assert success, error
+        assert (resolved["requested"], agent["model"]) == ("created-provider", "created-model")
+
+    def test_explicit_overrides_still_win_in_follow_profile_mode(self, tmp_path):
+        for job, fleet, expected in [
+            (_base_job(model="role-model"), {}, ("profile-provider", "role-model")),
+            (_base_job(provider="job-provider", model="job-model"), {},
+             ("job-provider", "job-model")),
+            (_base_job(), {"cron_model": "fleet-model", "cron_model_provider": "fleet-provider"},
+             ("fleet-provider", "fleet-model")),
+        ]:
+            job.update(provider_snapshot="old-provider", model_snapshot="old-model")
+            success, error, agent, resolved = _run(
+                job, tmp_path, current_provider="profile-provider", current_model="profile-model",
+                follow_profile=True, **fleet)
+            assert success, error
+            assert (resolved["requested"], agent["model"]) == expected

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -28,6 +28,24 @@ All of this is available to Hermes itself through the `cronjob` tool, so you can
 - **`cron.model` / `cron.model_provider`** — a cron-fleet default: every unpinned job runs on this model, independent of your chat model. Set it once (`hermes config set cron.model <name>`) and switching your chat model with `hermes model` or `/model` never touches your cron fleet.
 - **Global default** — only when neither of the above is set does a job follow `hermes model`. Hermes **snapshots** the provider and model at creation, and that snapshot is the job's effective pin: if you later switch the global default (`hermes model`, `/model`, `hermes config set model.default …`), the job **keeps running on the model and provider it was created under** and logs one INFO line per run noting the difference. A global model change never stops a scheduled job, and an unattended job never silently inherits a switch to a paid provider/model (#44585). To move a job to the new default, pin it (`hermes cron edit <job_id> --provider <provider> --model <model>`) or set `cron.model` to move the whole fleet at once. Jobs created before snapshots existed keep following the live global default.
 
+To make unpinned scheduled jobs automatically follow future provider and model changes **within
+this profile**, opt in once:
+
+```bash
+hermes config set cron.follow_profile true
+```
+
+At the next run, Hermes reads the profile's current defaults instead of the job's creation
+snapshots. This includes existing jobs, without rewriting their schedule, history or snapshots.
+Per-job `model` / `provider` / `base_url` overrides and `cron.model` / `cron.model_provider`
+fleet defaults still take precedence; clear unwanted overrides before relying on inheritance.
+An explicit model-only override keeps that model while its unpinned provider follows the profile;
+choose a model compatible with that provider. Existing configured fallback behavior is unchanged.
+Profiles remain independent, and an already running job keeps its resolved runtime. Turning
+`cron.follow_profile` back to `false` restores creation-snapshot behavior for subsequent runs.
+This opt-in means unattended jobs can inherit a move to a paid provider or model.
+
+
 Whichever provider a job resolves to, its provider-specific request settings (e.g. `request_overrides` such as `extra_body`/`extra_headers` for custom providers) carry into the scheduled run just like an interactive session.
 
 `hermes setup --portal` is the lowest-friction option for unattended runs since OAuth refresh is automatic. See [Nous Portal](/integrations/nous-portal).


### PR DESCRIPTION
Unpinned cron jobs currently stay on their creation provider/model snapshots after the user changes a profile default. Add the explicit opt-in `cron.follow_profile: true` so subsequent runs follow that profile's current provider and model without rewriting jobs.

The default remains snapshot routing. Per-job and fleet overrides retain precedence; snapshots, schedules and history are preserved, and disabling the option restores snapshot routing. Preflight and the affected-jobs summary honor the same mode. Includes configuration and user documentation.

Validation: the two new behavior cases fail on the base and pass with this change; the provider-routing file has 11 passing tests. The cron/config subset has 1,235 passed, 23 skipped and one failing directory-permission test. That same permission failure reproduces on the unmodified base (6 passed, 1 failed). Ruff passes. No model calls or live job changes were used.

Base: 8d79c2ff57bba4b07e5b37ed90387b16541aef53
Change: 87d27ca26a65c3e451407c91488e3dded3c44f41