### PR TITLE
fix(bot-mode): resume same-connection relay delivery over persistent socket

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/relay.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.test.ts
@@ -335,9 +335,9 @@ describe('relay-route socket retention (#93594)', () => {
     expect(pins.filter(pin => pin.released)).toHaveLength(releasedCount)
   })
 
-  it('unpins everything when the peer set drops below two connections', async () => {
-    // Retention follows the relay-ELIGIBLE set: with nothing to relay,
-    // nothing stays pinned.
+  it('keeps retention for the remaining connection when routes drop to one', async () => {
+    // Same-connection relay still needs one pinned socket, so only removed
+    // connections are released.
     const pins = trackRetention()
 
     respondWith(() => ({ envelopes: [] }))
@@ -351,7 +351,10 @@ describe('relay-route socket retention (#93594)', () => {
     hostMock.profileRoutes = vi.fn(async () => [route('a')])
     await pushAndSettle()
 
-    expect(pins.every(pin => pin.released)).toBe(true)
+    expect(pins[0].route.connectionId).toBe('a')
+    expect(pins[1].route.connectionId).toBe('b')
+    expect(pins[0].released).toBe(false)
+    expect(pins[1].released).toBe(true)
 
     stopBotRelay()
   })
@@ -370,8 +373,8 @@ describe('relay-route socket retention (#93594)', () => {
   })
 })
 
-describe('the roster loop pushes the OTHER connections’ agents', () => {
-  it('gives each gateway a union roster that excludes its own agents', async () => {
+describe('the roster loop pushes the full union + self marker', () => {
+  it('gives each gateway the full union and its own self_connection_id', async () => {
     const calls = respondWith(call => {
       if (call.method === 'profiles.list') {
         return { profiles: [{ name: call.connectionId === 'a' ? 'default' : 'ops' }] }
@@ -388,13 +391,21 @@ describe('the roster loop pushes the OTHER connections’ agents', () => {
     const syncs = calls.filter(call => call.method === 'bot_relay.roster.sync')
 
     expect(syncs.map(call => call.connectionId)).toEqual(['a', 'b'])
-    expect(syncs[0].params.agents).toEqual([
-      expect.objectContaining({ connection_id: 'b', handle: 'ops', profile: 'ops' })
-    ])
-    // The primary profile is published by its callable alias, never "default".
-    expect(syncs[1].params.agents).toEqual([
-      expect.objectContaining({ connection_id: 'a', handle: 'hermes', profile: 'default' })
-    ])
+    expect(syncs[0].params.self_connection_id).toBe('a')
+    expect(syncs[1].params.self_connection_id).toBe('b')
+    // full union includes both rows on both connections
+    expect(syncs[0].params.agents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ connection_id: 'a', handle: 'hermes', profile: 'default' }),
+        expect.objectContaining({ connection_id: 'b', handle: 'ops', profile: 'ops' })
+      ])
+    )
+    expect(syncs[1].params.agents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ connection_id: 'a', handle: 'hermes', profile: 'default' }),
+        expect.objectContaining({ connection_id: 'b', handle: 'ops', profile: 'ops' })
+      ])
+    )
 
     stopBotRelay()
   })
@@ -429,7 +440,12 @@ describe('the roster loop pushes the OTHER connections’ agents', () => {
 
     const pushedToA = calls.find(call => call.method === 'bot_relay.roster.sync' && call.connectionId === 'a')
 
-    expect(pushedToA?.params.agents).toEqual([expect.objectContaining({ profile: 'ops' })])
+    expect(pushedToA?.params.agents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ connection_id: 'a', profile: 'default' }),
+        expect.objectContaining({ connection_id: 'b', profile: 'ops' })
+      ])
+    )
 
     stopBotRelay()
   })
@@ -451,21 +467,34 @@ describe('the roster loop pushes the OTHER connections’ agents', () => {
 
     const pushedToA = calls.find(call => call.method === 'bot_relay.roster.sync' && call.connectionId === 'a')
 
-    expect(pushedToA?.params.agents).toEqual([expect.objectContaining({ profile: 'c' })])
+    expect(pushedToA?.params.agents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ connection_id: 'a', profile: 'a' }),
+        expect.objectContaining({ connection_id: 'c', profile: 'c' })
+      ])
+    )
 
     stopBotRelay()
   })
 
-  it('stays quiet with a single connection — there is no peer to relay to', async () => {
+  it('still syncs a single connection so same-connection relay can engage', async () => {
     hostMock.profileRoutes = vi.fn(async () => [route('a')])
 
-    const calls = respondWith(() => ({}))
+    const calls = respondWith(call =>
+      call.method === 'profiles.list' ? { profiles: [{ name: 'default' }] } : {}
+    )
     const { startBotRelay, stopBotRelay } = await loadRelay()
 
     startBotRelay()
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(calls).toHaveLength(0)
+    const syncs = calls.filter(call => call.method === 'bot_relay.roster.sync')
+    expect(syncs).toHaveLength(1)
+    expect(syncs[0].connectionId).toBe('a')
+    expect(syncs[0].params.self_connection_id).toBe('a')
+    expect(syncs[0].params.agents).toEqual([
+      expect.objectContaining({ connection_id: 'a', handle: 'hermes', profile: 'default' })
+    ])
 
     stopBotRelay()
   })

--- a/apps/desktop/src/plugins/hermes-bots/relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.ts
@@ -243,7 +243,7 @@ async function relayAgentsOn(connection: RelayConnection): Promise<RelayAgentRow
 const RELAY_AGENTS_CACHE_MAX = 32
 const relayAgentsCache = new LruCache<string, RelayAgentRow[]>(RELAY_AGENTS_CACHE_MAX)
 
-/** Push every gateway the union roster of agents on the OTHER connections. */
+/** Push every gateway the union roster of agents plus its self-connection id. */
 async function syncRelayRosters() {
   if (relay.disposed || relay.rosterBusy) {
     return
@@ -254,7 +254,7 @@ async function syncRelayRosters() {
   try {
     const connections = await relayConnections()
 
-    if (connections.length < 2) {
+    if (connections.length < 1) {
       return
     }
 
@@ -286,19 +286,18 @@ async function syncRelayRosters() {
       }
     }
 
+    const union: RelayAgentRow[] = []
+
+    for (const agents of agentsByConnection.values()) {
+      union.push(...agents)
+    }
+
     await Promise.all(
       connections.map(async connection => {
-        const others: RelayAgentRow[] = []
-
-        for (const [id, agents] of agentsByConnection) {
-          if (id !== connection.id) {
-            others.push(...agents)
-          }
-        }
-
         try {
           await host.requestProfile(connection.route, 'bot_relay.roster.sync', {
-            agents: others
+            agents: union,
+            self_connection_id: connection.id
           })
         } catch {
           // Older backend without the relay RPCs — skip this connection.
@@ -332,11 +331,11 @@ async function drainRelayOutboxes() {
   try {
     const connections = await relayConnections()
 
-    // Retention follows the relay-eligible set: with fewer than two
-    // connections there is nothing to relay, so nothing stays pinned.
-    syncRelayRetention(connections.length >= 2 ? connections : [])
+    // Retention follows the relay-eligible set: at least one connection is
+    // enough for same-connection relay deliveries.
+    syncRelayRetention(connections.length >= 1 ? connections : [])
 
-    if (connections.length < 2) {
+    if (connections.length < 1) {
       return
     }
 

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from tools import bot_mode_dm, bot_mode_probe
+from tools import bot_mode_dm, bot_mode_probe, bot_relay
 
 
 @pytest.fixture(autouse=True)
@@ -269,6 +269,42 @@ def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     content = Path(dm_file).read_text(encoding="utf-8")
     assert content.startswith("Message from 🤖 hermes (@hermes): ")
     assert '$(and this is not shell)' in content
+
+
+def test_same_connection_local_target_prefers_relay_queue(tmp_path, monkeypatch):
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home(tmp_path, teammates=("researcher",))
+    # Desktop pushes full union + self marker once relay engages.
+    bot_relay.write_remote_roster(
+        home,
+        [
+            {"profile": "default", "handle": "hermes", "connection_id": "local-1"},
+            {
+                "profile": "researcher",
+                "handle": "researcher",
+                "connection_id": "local-1",
+                "connection_label": "Local Gateway",
+            },
+            {"profile": "ops", "handle": "ops", "connection_id": "cloud-1"},
+        ],
+        self_connection_id="local-1",
+    )
+    agent = _FakeAgent(home, title="Bot Chat")
+
+    out = json.loads(bot_mode_dm.message_agent_tool(target="researcher", message="ping", agent=agent))
+    assert out["status"] == "sent"
+    assert out["to"] == "@researcher on Local Gateway"
+
+    # same-connection relay path: no local `--run-delivery query-file`
+    # subprocess command should be spawned.
+    assert len(calls) == 1
+    assert "--run-delivery" not in calls[0]["command"]
+
+    pending = bot_relay.claim_pending_envelopes(home)
+    assert len(pending) == 1
+    assert pending[0]["target_connection"] == "local-1"
+    assert pending[0]["target_profile"] == "researcher"
+    assert pending[0]["id"] in calls[0]["command"]
 
 
 def test_peer_delivery_command_pins_registry_profile_for_secondary_bots(

--- a/tests/tools/test_bot_relay.py
+++ b/tests/tools/test_bot_relay.py
@@ -67,6 +67,22 @@ def test_roster_roundtrip_and_validation(root):
     assert back[0]["title"] == "Moxie"
 
 
+def test_read_remote_roster_filters_self_connection_rows(root):
+    rows = [
+        {"profile": "default", "handle": "hermes", "connection_id": "local-1"},
+        {"profile": "researcher", "handle": "researcher", "connection_id": "local-1"},
+        {"profile": "ops", "handle": "ops", "connection_id": "cloud-1"},
+    ]
+    bot_relay.write_remote_roster(root, rows, self_connection_id="local-1")
+
+    payload = bot_relay.read_relay_roster(root)
+    assert payload["self_connection_id"] == "local-1"
+    assert {r["profile"] for r in payload["agents"]} == {"default", "researcher", "ops"}
+
+    remote = bot_relay.read_remote_roster(root)
+    assert [r["profile"] for r in remote] == ["ops"]
+
+
 def test_roster_read_missing_and_corrupt(root):
     assert bot_relay.read_remote_roster(root) == []
     base = bot_relay.relay_root(root)

--- a/tests/tui_gateway/test_bot_relay_methods.py
+++ b/tests/tui_gateway/test_bot_relay_methods.py
@@ -37,6 +37,7 @@ def test_roster_sync_persists_and_counts(home):
         srv._methods["bot_relay.roster.sync"](
             1,
             {
+                "self_connection_id": "local-1",
                 "agents": [
                     {"profile": "scout", "handle": "scout", "connection_id": "cloud-1"},
                     {"profile": "", "connection_id": "cloud-1"},  # dropped
@@ -45,6 +46,8 @@ def test_roster_sync_persists_and_counts(home):
         )
     )
     assert out["count"] == 1
+    payload = bot_relay.read_relay_roster(home)
+    assert payload["self_connection_id"] == "local-1"
     assert [r["profile"] for r in bot_relay.read_remote_roster(home)] == ["scout"]
 
 

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -245,8 +245,77 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
         return _roster_err(f"No teammate named '{raw_target}' on this install, on a connected "
                            "machine, or on a registered peer. Pick a name from the roster "
                            "(roles are listed in your system prompt).")
+    # Prefer same-connection relay when available: this reuses the existing
+    # gateway socket instead of spawning a fresh local `hermes -p <target> chat`
+    # cold start for each DM. Falls back to local subprocess when the relay
+    # roster does not expose this gateway's self-connection marker yet.
+    relayed_local = _try_same_connection_relay_delivery(
+        root,
+        resolved,
+        body,
+        me,
+        _handle(me),
+        task_id=task_id,
+        agent=agent,
+    )
+    if relayed_local is not None:
+        return relayed_local
+
     return _start_delivery(["hermes", "-p", resolved, *BOT_CHAT_TURN_ARGS], content, f"@{_handle(resolved)}",
                            stdin_file=False, profile_home=roster_homes[resolved], **delivery)
+
+
+def _try_same_connection_relay_delivery(
+    root: Path,
+    resolved_profile: str,
+    body: str,
+    me: str,
+    sender_handle: str,
+    *,
+    task_id: Optional[str],
+    agent: Any,
+) -> Optional[str]:
+    """Queue same-machine teammate DM through the Desktop relay when available.
+
+    Returns None when the relay roster lacks this gateway's `self_connection_id`
+    marker or does not list the target profile on that same connection.
+    """
+    try:
+        from tools.bot_relay import EnvelopeRefusedError, enqueue_envelope, read_relay_roster, waiter_command
+
+        payload = read_relay_roster(root)
+        self_id = str(payload.get("self_connection_id") or "").strip()
+        rows = payload.get("agents") if isinstance(payload.get("agents"), list) else []
+        if not self_id or not rows:
+            return None
+
+        match = next(
+            (
+                row for row in rows
+                if str(row.get("connection_id") or "") == self_id
+                and str(row.get("profile") or "") == resolved_profile
+            ),
+            None,
+        )
+        if not isinstance(match, dict):
+            return None
+
+        try:
+            envelope = enqueue_envelope(
+                root,
+                target=match,
+                message=f"Message from 🤖 {sender_handle} (@{sender_handle}): {body}",
+                sender_profile=me,
+                sender_handle=sender_handle,
+            )
+        except EnvelopeRefusedError as exc:
+            return json.dumps({"error": str(exc), "reason": exc.reason})
+
+        label = f"@{match['handle']} on {match.get('connection_label') or match['connection_id']}"
+        return _spawn_delivery(waiter_command(root, envelope), label, task_id=task_id, agent=agent)
+    except Exception:
+        logger.debug("same-connection relay delivery attempt failed", exc_info=True)
+        return None
 
 
 def _try_relay_delivery(root: Path, raw_target: str, content: str, me: str, *,

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -130,29 +130,68 @@ def _normalize_roster_row(row: Any) -> Optional[dict]:
     return out
 
 
-def write_remote_roster(root: Path | str, rows: Any) -> int:
-    """Atomically persist the Desktop-pushed remote roster. Returns count."""
-    base = _ensure_dirs(root)
+def _clean_roster_rows(rows: Any) -> list[dict]:
+    """Validate/dedupe roster rows from the Desktop payload."""
     by_key: dict[tuple[str, str], dict] = {}
     for norm in filter(None, map(_normalize_roster_row, rows if isinstance(rows, list) else [])):
         by_key.setdefault((norm["connection_id"], norm["profile"]), norm)
-    cleaned = [by_key[k] for k in sorted(by_key)]
-    _atomic_write_json(base / ROSTER_FILE, {"updated_at": int(time.time()), "agents": cleaned},
-                       prefix=".roster-", sort_keys=True)
+    return [by_key[k] for k in sorted(by_key)]
+
+
+def write_remote_roster(root: Path | str, rows: Any, *, self_connection_id: str | None = None) -> int:
+    """Atomically persist the Desktop-pushed relay roster. Returns count.
+
+    ``self_connection_id`` marks which rows belong to THIS gateway so callers
+    can read either the full union (for same-connection relay) or only OTHER
+    connections (legacy helper).
+    """
+    base = _ensure_dirs(root)
+    cleaned = _clean_roster_rows(rows)
+    self_id = str(self_connection_id or "").strip()
+    if self_id and not _HANDLE_RE.match(self_id):
+        self_id = ""
+    _atomic_write_json(
+        base / ROSTER_FILE,
+        {"updated_at": int(time.time()), "self_connection_id": self_id, "agents": cleaned},
+        prefix=".roster-",
+        sort_keys=True,
+    )
     return len(cleaned)
 
 
-def read_remote_roster(root: Path | str) -> list[dict]:
-    """The current remote roster (possibly empty). Never raises."""
+def read_relay_roster(root: Path | str) -> dict:
+    """Raw relay payload: ``{updated_at, self_connection_id, agents}``.
+
+    Backward compatible with older payloads that persisted a raw list.
+    Never raises.
+    """
+    out = {"updated_at": 0, "self_connection_id": "", "agents": []}
     try:
         data = json.loads((relay_root(root) / ROSTER_FILE).read_text(encoding="utf-8"))
-        agents = data.get("agents") if isinstance(data, dict) else None
-        return [r for r in map(_normalize_roster_row, agents) if r] if isinstance(agents, list) else []
+        if isinstance(data, dict):
+            out["updated_at"] = int(data.get("updated_at") or 0)
+            self_id = str(data.get("self_connection_id") or "").strip()
+            out["self_connection_id"] = self_id if _HANDLE_RE.match(self_id) else ""
+            out["agents"] = _clean_roster_rows(data.get("agents"))
+            return out
+        out["agents"] = _clean_roster_rows(data)
+        return out
     except FileNotFoundError:
-        return []
+        return out
     except Exception:
         logger.debug("bot_relay roster read failed", exc_info=True)
-        return []
+        return out
+
+
+def read_remote_roster(root: Path | str) -> list[dict]:
+    """Rows for OTHER connections only (legacy helper). Never raises."""
+    payload = read_relay_roster(root)
+    raw_rows = payload.get("agents")
+    rows = [r for r in map(_normalize_roster_row, raw_rows if isinstance(raw_rows, list) else []) if r]
+    self_id = str(payload.get("self_connection_id") or "").strip()
+    if not self_id:
+        return rows
+    return [r for r in rows if str(r.get("connection_id") or "") != self_id]
 
 
 def resolve_remote_target(raw_target: str, roster: list[dict]) -> Any:
@@ -192,7 +231,8 @@ def _target_liveness(root: Path | str, target: dict) -> Optional[bool]:
             age = time.time() - (relay_root(root) / ROSTER_FILE).stat().st_mtime
         except OSError:
             return None
-        roster = read_remote_roster(root) if age <= ROSTER_FRESH_SECONDS else []
+        payload = read_relay_roster(root) if age <= ROSTER_FRESH_SECONDS else {}
+        roster = payload.get("agents") if isinstance(payload.get("agents"), list) else []
         if not roster:
             return None
         key = (str(target.get("connection_id") or ""), str(target.get("profile") or ""))

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -42,7 +42,13 @@ def _(rid, params: dict, _root=_relay_root) -> dict:
     (``agents`` rows ``{profile, handle, connection_id, ...}``; invalid rows are dropped)."""
     try:
         from tools.bot_relay import write_remote_roster
-        return _ok(rid, {"count": write_remote_roster(_root(), params.get("agents"))})
+        return _ok(rid, {
+            "count": write_remote_roster(
+                _root(),
+                params.get("agents"),
+                self_connection_id=str(params.get("self_connection_id") or ""),
+            )
+        })
     except Exception as e:
         return _err(rid, 5090, str(e))
 


### PR DESCRIPTION
## Summary
Resumes JP-approved psocket delivery path for **same-machine bot-to-bot DMs** while keeping subprocess fallback intact.

### 1) Relay engagement hard-gate fix
- Publish `self_connection_id` on `bot_relay.roster.sync` payloads.
- Push full union roster (not others-only) so same-connection targets are addressable.
- Keep `read_remote_roster()` backward-compatible by filtering self rows when `self_connection_id` exists.
- Allow single-connection roster sync/drain loops so same-connection relay can engage even with one connected gateway.

### 2) Transport switch (additive)
- `tools/bot_mode_dm.py` now tries `_try_same_connection_relay_delivery(...)` for local teammate targets.
- If relay marker/row is missing, it **falls back** to existing `--run-delivery query-file` subprocess path unchanged.

## Safety
- Fallback retained by design (incremental rollout-safe).
- Existing cross-connection behavior preserved.
- No credential or personal-data files touched.

## Tests
- `scripts/run_tests.sh tests/tools/test_bot_relay.py tests/tools/test_bot_mode_dm.py tests/tui_gateway/test_bot_relay_methods.py -q`
- `npm test -- src/plugins/hermes-bots/relay.test.ts`

## Evidence (hard gate)
- Rebuilt desktop package (`npm run pack`), runtime asset now contains `self_connection_id` token:
  `apps/desktop/release/mac-arm64/Hermes.app/Contents/Resources/app.asar.unpacked/dist/assets/index-CvRlVBa4.js`
- Manual RPC harness evidence file:
  `/var/folders/88/nfbzr5k57ts0k9qn9ft00_z00000gn/T/psocket-proof-45wq3_bd/psocket-evidence.json`
  - roster sync persists `self_connection_id: local-1`
  - one envelope drained via `bot_relay.outbox.drain` (`drained_envelopes=1`)
  - delivered via `bot_relay.deliver` and acknowledged via `bot_relay.reply`
  - sender command switched from `--run-delivery ... hermes -p <target> chat` (before) to relay waiter command (after), proving no local subprocess fallback on relay-engaged path.
