### PR TITLE
fix: update errors name the real cause; hermes update can't hang on a stalled fetch; shallow grafts pruned

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3257,7 +3257,7 @@ async function checkUpdatesViaApi({ slug, branch, currentSha }) {
   try {
     targetSha = String(await fetchGitHubApi(branchTipApiUrl(slug, branch), 'application/vnd.github.sha')).trim()
   } catch (error) {
-    return { error: 'fetch-failed', message: `GitHub API: ${error?.message || error}` }
+    return { error: 'fetch-failed', message: describeUpdateCheckFailure(error) }
   }
 
   if (!/^[0-9a-f]{40}$/i.test(targetSha)) {
@@ -3315,6 +3315,45 @@ async function checkUpdatesViaLsRemote({ updateRoot, branch, currentSha }) {
   return { behind: null, updateAvailable: true, targetSha, commits: [] }
 }
 
+// One line a user can act on (or paste into a bug report) instead of the
+// generic "couldn't reach the update server": which host, which failure.
+// #105855 was a run of GitHub outages that read as a Hermes bug because the
+// UI hid the cause.
+function describeUpdateCheckFailure(error) {
+  const status = error?.statusCode
+  const code = error?.code
+
+  if (status === 403 || status === 429) {
+    return `GitHub API rate limit reached (HTTP ${status}) — try again in an hour.`
+  }
+
+  if (typeof status === 'number' && status >= 500) {
+    return `GitHub is having trouble (HTTP ${status} from api.github.com) — check githubstatus.com and try again later.`
+  }
+
+  if (typeof status === 'number') {
+    return `api.github.com answered HTTP ${status}.`
+  }
+
+  if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') {
+    return 'DNS lookup for api.github.com failed — check your connection or proxy.'
+  }
+
+  if (code === 'ETIMEDOUT' || error?.message === 'timeout') {
+    return 'api.github.com did not answer within 10 seconds.'
+  }
+
+  if (code === 'ECONNREFUSED' || code === 'ECONNRESET' || code === 'EHOSTUNREACH' || code === 'ENETUNREACH') {
+    return `Connection to api.github.com failed (${code}) — a firewall or proxy may be blocking it.`
+  }
+
+  if (typeof code === 'string' && /CERT|SSL|TLS/i.test(code)) {
+    return `TLS handshake with api.github.com failed (${code}) — a proxy may be intercepting HTTPS.`
+  }
+
+  return `api.github.com: ${error?.message || String(error)}`
+}
+
 function fetchGitHubApi(url, accept = 'application/vnd.github+json') {
   return new Promise((resolve, reject) => {
     const req = https.get(
@@ -3335,7 +3374,7 @@ function fetchGitHubApi(url, accept = 'application/vnd.github+json') {
           const body = Buffer.concat(chunks).toString('utf8')
 
           if ((res.statusCode || 500) >= 400) {
-            reject(new Error(`HTTP ${res.statusCode}`))
+            reject(Object.assign(new Error(`HTTP ${res.statusCode}`), { statusCode: res.statusCode }))
 
             return
           }

--- a/apps/desktop/src/app/settings/about-settings.tsx
+++ b/apps/desktop/src/app/settings/about-settings.tsx
@@ -83,7 +83,7 @@ export function AboutSettings() {
     statusLine = status?.message ?? a.cantUpdate
     statusTone = 'error'
   } else if (status?.error) {
-    statusLine = a.cantReach
+    statusLine = status.message ? `${a.cantReach} ${status.message}` : a.cantReach
     statusTone = 'error'
   } else if (applying) {
     statusLine = a.installing

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -215,6 +215,7 @@ function IdleView({
           </Button>
         }
         body={u.connectionRetry}
+        detail={status.message}
         icon={<ErrorIcon />}
         title={u.checkFailedTitle}
       />
@@ -557,11 +558,15 @@ function ErrorView({ message, onDismiss, onRetry }: { message: string; onDismiss
 function CenteredStatus({
   action,
   body,
+  detail,
   icon,
   title
 }: {
   action?: React.ReactNode
   body?: string
+  /** Diagnostic line from the main process (HTTP status, DNS, TLS…), shown
+   *  verbatim so a bug report carries the real cause. */
+  detail?: string
   icon: React.ReactNode
   title: string
 }) {
@@ -572,6 +577,11 @@ function CenteredStatus({
 
         <DialogTitle className="text-center text-lg">{title}</DialogTitle>
         {body && <DialogDescription className="text-center text-sm">{body}</DialogDescription>}
+        {detail && (
+          <p className="max-w-sm break-words rounded-md bg-muted/40 px-2 py-1 font-mono text-xs text-muted-foreground">
+            {detail}
+          </p>
+        )}
       </div>
 
       {action && <div className="flex justify-center">{action}</div>}

--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -126,3 +126,68 @@ def is_ancestor_of_head(repo_root: Path, rev: str) -> bool:
         logger.debug("merge-base --is-ancestor probe failed for %s", rev, exc_info=True)
         return False
 # ---- END PLUGIN-COMPAT ----
+
+
+def _git_stdout_lines(repo_root: Path, args: List[str]) -> List[str]:
+    """Run a read-only git query in ``repo_root``; [] on any failure."""
+    try:
+        result = subprocess.run(
+            ["git", *args], cwd=str(repo_root),
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode != 0:
+            return []
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    except Exception:
+        logger.debug("git query failed: %s", args, exc_info=True)
+        return []
+
+
+def prune_stale_shallow_grafts(repo_root: Path) -> int:
+    """Drop ``.git/shallow`` graft lines no live ref still points at (#105951).
+
+    Every ``git fetch --depth 1`` appends the fetched tip to ``.git/shallow`` as a new
+    graft and never removes the previous one, so a long-lived shallow installer checkout
+    accumulates one graft per update check (57 observed in the wild). The stale grafts
+    break ``merge-base`` and push ``hermes update`` into the orphan-divergence reset path
+    on every run. Keep only the boundaries that still protect referenced tips (HEAD,
+    FETCH_HEAD, and every ref tip): the dropped commits are already unreachable and their
+    objects are left for ``git gc``. Returns the number of graft lines removed; never
+    raises, and restores the original file if the trimmed set breaks history walking.
+    """
+    try:
+        shallow_rel = _git_stdout_lines(repo_root, ["rev-parse", "--git-path", "shallow"])
+        if not shallow_rel:
+            return 0
+        shallow_path = Path(shallow_rel[0])
+        if not shallow_path.is_absolute():
+            shallow_path = Path(repo_root) / shallow_path
+        if not shallow_path.is_file():
+            return 0
+        lines = [line for line in shallow_path.read_text(encoding="utf-8").splitlines() if line]
+        if not lines:
+            return 0
+        keep = set(lines) & {
+            *(_git_stdout_lines(repo_root, ["rev-parse", "HEAD"]) or []),
+            *(_git_stdout_lines(repo_root, ["rev-parse", "--verify", "--quiet", "FETCH_HEAD"]) or []),
+            *_git_stdout_lines(repo_root, ["for-each-ref", "--format=%(objectname)"]),
+        }
+        if len(keep) == len(lines):
+            return 0
+        original = shallow_path.read_text(encoding="utf-8")
+        tmp_path = shallow_path.with_name(shallow_path.name + ".hermes-prune")
+        tmp_path.write_text("\n".join(sorted(keep)) + "\n", encoding="utf-8")
+        os.replace(tmp_path, shallow_path)
+        # Fail-safe: if any reachable walk now crosses a boundary we wrongly removed,
+        # put the grafts back — a growing file beats a broken repo.
+        still_walks = _git_stdout_lines(repo_root, ["rev-list", "--count", "HEAD"]) and \
+            _git_stdout_lines(repo_root, ["rev-list", "--count", "--all"])
+        if not still_walks:
+            shallow_path.write_text(original, encoding="utf-8")
+            logger.debug("shallow prune self-check failed; grafts restored")
+            return 0
+        logger.info("Pruned %d stale shallow graft(s) in %s", len(lines) - len(keep), repo_root)
+        return len(lines) - len(keep)
+    except Exception:
+        logger.debug("shallow graft prune failed for %s", repo_root, exc_info=True)
+        return 0

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -147,13 +147,30 @@ def _record_update_step(step: str, ok: bool, detail: str = "") -> None:
         record_step(step, ok, detail)
 
 
+# A fetch whose transport dead-stalls (HTTP/2 to GitHub on some networks, a black-holed proxy)
+# otherwise leaves `hermes update` on "Fetching updates..." forever (#93759, #95777). Five
+# minutes is generous for a scoped single-branch fetch and still ends in a real error.
+NETWORK_GIT_TIMEOUT_SECONDS = 300
+
+
 def _git_run(git_cmd, args, cwd=None, *, check=False, network=False):
     """Run git capturing utf-8 text (default cwd: checkout); ``network=True`` disables the
-    terminal prompt so an HTTP 401 fails fast instead of hanging."""
-    return subprocess.run(
-        git_cmd + args, cwd=_m().PROJECT_ROOT if cwd is None else cwd, capture_output=True,
-        text=True, encoding="utf-8", errors="replace", check=check,
-        **(_no_prompt_git_kwargs() if network else {}))
+    terminal prompt so an HTTP 401 fails fast instead of hanging, and bounds the wait."""
+    try:
+        return subprocess.run(
+            git_cmd + args, cwd=_m().PROJECT_ROOT if cwd is None else cwd, capture_output=True,
+            text=True, encoding="utf-8", errors="replace", check=check,
+            **({"timeout": NETWORK_GIT_TIMEOUT_SECONDS, **_no_prompt_git_kwargs()} if network else {}))
+    except subprocess.TimeoutExpired as exc:
+        # subprocess.run already killed the child; the checkout stays consistent because
+        # fetch writes to tmp_pack_* and only renames on success. Report as a failed run
+        # so every caller's existing stderr path prints one clear line.
+        result = subprocess.CompletedProcess(
+            exc.cmd, 124, stdout="",
+            stderr=f"git {args[0]} timed out after {NETWORK_GIT_TIMEOUT_SECONDS}s with no response from the remote")
+        if check:
+            raise subprocess.CalledProcessError(124, exc.cmd, output="", stderr=result.stderr) from exc
+        return result
 
 
 def _capture_head_sha(git_cmd, cwd) -> str | None:
@@ -1321,6 +1338,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
         swept = clear_stale_tmp_packs(_m().PROJECT_ROOT)
         if swept:
             print("  (removed %d aborted-fetch pack temp file(s))" % len(swept))
+        # Shallow installer checkouts collect one `.git/shallow` graft per past depth-1 fetch
+        # (#105951); stale grafts break merge-base and push this run into the divergence path.
+        from hermes_cli.gitlock import prune_stale_shallow_grafts
+        pruned = prune_stale_shallow_grafts(_m().PROJECT_ROOT)
+        if pruned:
+            print(f"  (pruned {pruned} stale shallow graft(s) left by past depth-1 checks)")
 
         # Surface autostashes left by earlier updates (--keep-stash, failed restores).
         # Surface autostash entries left behind by earlier updates (#63717 problem 6) — parked --keep-stash

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -514,6 +514,15 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         _print_fetch_failure(fetch_result.stderr)
         sys.exit(1)
 
+    if is_shallow:
+        # The depth-1 fetch above leaves the previous tip behind as a ``.git/shallow`` graft
+        # (git never removes old grafts); prune the stale ones so the file stops growing and
+        # merge-base / the orphan-divergence heuristic keep working (#105951).
+        from hermes_cli.gitlock import prune_stale_shallow_grafts
+        pruned = prune_stale_shallow_grafts(_m().PROJECT_ROOT)
+        if pruned:
+            print(f"  (pruned {pruned} stale shallow graft(s) left by past depth-1 checks)")
+
     # rev-list on a bogus ref exits 128 and (check=True) would traceback; verify first.
     verify_result = _git_run(git_cmd, ["rev-parse", "--verify", "--quiet", compare_branch])
     if verify_result.returncode != 0:

--- a/tests/hermes_cli/test_shallow_graft_prune.py
+++ b/tests/hermes_cli/test_shallow_graft_prune.py
@@ -1,0 +1,127 @@
+"""Stale shallow-graft pruning after depth-1 update checks (#105951).
+
+Every ``git fetch --depth 1`` appends the fetched tip to ``.git/shallow`` as a
+new graft and never removes the previous one, so a long-lived shallow installer
+checkout accumulates one line per update check (57 observed in the wild). The
+stale grafts break ``merge-base`` and push ``hermes update`` into the
+orphan-divergence reset path. ``prune_stale_shallow_grafts()`` drops grafts no
+live ref points at; ``hermes update --check`` calls it after its successful
+depth-1 fetch, clearing the grafts accumulated by past checks (the passive
+banner check no longer git-fetches since #107648).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from hermes_cli.gitlock import prune_stale_shallow_grafts
+
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=str(repo), capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def _shallow_lines(repo: Path) -> list:
+    return [
+        line for line in (repo / ".git" / "shallow").read_text().splitlines() if line
+    ]
+
+
+def _mk_shallow_scenario(tmp_path: Path) -> Path:
+    """Depth-1 clone whose origin advanced twice: shallow carries 3 grafts."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    _git(origin, "config", "user.email", "t@example.com")
+    _git(origin, "config", "user.name", "t")
+    for i in range(3):
+        _git(origin, "commit", "--allow-empty", "-q", "-m", f"c{i}")
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(clone)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for i in range(3, 5):
+        _git(origin, "commit", "--allow-empty", "-q", "-m", f"c{i}")
+        _git(clone, "fetch", "-q", "--depth", "1", "origin", "main")
+    return clone
+
+
+def test_prunes_orphaned_grafts_keeps_referenced_boundaries(tmp_path):
+    clone = _mk_shallow_scenario(tmp_path)
+    assert len(_shallow_lines(clone)) == 3  # HEAD graft + two fetched tips
+
+    head_sha = _git(clone, "rev-parse", "HEAD")
+    tip_sha = _git(clone, "rev-parse", "origin/main")
+
+    removed = prune_stale_shallow_grafts(clone)
+
+    assert removed == 1  # the middle, now-unreferenced tip
+    assert set(_shallow_lines(clone)) == {head_sha, tip_sha}
+    # Boundaries that survive must still walk cleanly.
+    assert _git(clone, "rev-list", "--count", "HEAD") == "1"
+    assert _git(clone, "rev-list", "--count", "origin/main") == "1"
+
+
+def test_prune_is_idempotent_and_noop_without_grafts(tmp_path):
+    clone = _mk_shallow_scenario(tmp_path)
+    assert prune_stale_shallow_grafts(clone) == 1
+    assert prune_stale_shallow_grafts(clone) == 0  # nothing left to drop
+
+    empty_dir = tmp_path / "not-a-repo"
+    empty_dir.mkdir()
+    assert prune_stale_shallow_grafts(empty_dir) == 0  # not a git repo: no-op
+
+    git_no_shallow = tmp_path / "full-clone"
+    git_no_shallow.mkdir()
+    (git_no_shallow / ".git").mkdir()
+    assert prune_stale_shallow_grafts(git_no_shallow) == 0  # no shallow file: no-op
+
+
+def test_update_check_prunes_and_reports_count(tmp_path, monkeypatch, capsys):
+    """`hermes update --check` prunes grafts after its depth-1 fetch and reports the prune."""
+    import hermes_cli.update_cmd as update_cmd
+
+    fake_root = SimpleNamespace(PROJECT_ROOT=tmp_path)
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_root)
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.update_contract.evaluate_update_admission", lambda root: None
+    )
+    monkeypatch.setattr(update_cmd, "_is_shallow_checkout", lambda git_cmd: True)
+    monkeypatch.setattr(update_cmd, "_tip_shas", lambda git_cmd, branch: (SHA_A, SHA_B))
+
+    def fake_git_run(git_cmd, args, **kwargs):
+        joined = " ".join(args)
+        if "get-url" in joined and "upstream" in joined:
+            return MagicMock(returncode=1, stdout="", stderr="")  # no upstream remote
+        if "fetch" in joined:
+            return MagicMock(returncode=0, stdout="", stderr="")  # depth-1 fetch lands
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(update_cmd, "_git_run", fake_git_run)
+    monkeypatch.setattr(update_cmd, "_base_git_cmd", lambda: ["git"])
+    monkeypatch.setattr("hermes_cli.banner._github_compare_behind", lambda *a, **k: 0)
+    prune_calls = []
+    monkeypatch.setattr(
+        "hermes_cli.gitlock.prune_stale_shallow_grafts",
+        lambda repo: prune_calls.append(repo) or 2,
+    )
+
+    update_cmd._cmd_update_check("main")
+
+    out = capsys.readouterr().out
+    assert prune_calls == [tmp_path]
+    assert "pruned 2 stale shallow graft(s)" in out

--- a/tests/hermes_cli/test_update_fetch_timeout.py
+++ b/tests/hermes_cli/test_update_fetch_timeout.py
@@ -1,0 +1,43 @@
+"""A dead-stalled network fetch ends `hermes update` with an error, never a hang (#93759, #95777).
+
+`_git_run(network=True)` bounds the wait; a `TimeoutExpired` becomes a failed
+CompletedProcess whose stderr names the stall, so every caller's existing
+fetch-failure path prints one clear line. Local git (network=False) is unbounded.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import hermes_cli.update_cmd as update_cmd
+
+
+def _timeout(cmd, **kwargs):
+    if "timeout" in kwargs:
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+    return MagicMock(returncode=0, stdout="ok", stderr="")
+
+
+def test_network_fetch_stall_becomes_a_failed_run_with_a_named_cause(monkeypatch):
+    monkeypatch.setattr(update_cmd, "_m", lambda: MagicMock(PROJECT_ROOT="/repo"))
+    with patch.object(update_cmd.subprocess, "run", side_effect=_timeout) as run:
+        result = update_cmd._git_run(["git"], ["fetch", "origin", "main"], network=True)
+
+    assert result.returncode != 0
+    assert "timed out" in result.stderr and "fetch" in result.stderr
+    assert run.call_args.kwargs["timeout"] == update_cmd.NETWORK_GIT_TIMEOUT_SECONDS
+    # The no-prompt guard still rides along with the bound.
+    assert run.call_args.kwargs["env"]["GIT_TERMINAL_PROMPT"] == "0"
+
+
+def test_local_git_stays_unbounded_and_check_true_raises(monkeypatch):
+    monkeypatch.setattr(update_cmd, "_m", lambda: MagicMock(PROJECT_ROOT="/repo"))
+    with patch.object(update_cmd.subprocess, "run", side_effect=_timeout) as run:
+        assert update_cmd._git_run(["git"], ["rev-parse", "HEAD"]).returncode == 0
+        assert "timeout" not in run.call_args.kwargs
+
+        try:
+            update_cmd._git_run(["git"], ["fetch", "origin", "main"], network=True, check=True)
+        except subprocess.CalledProcessError as exc:
+            assert exc.returncode == 124
+        else:
+            raise AssertionError("check=True must raise on a timed-out fetch")


### PR DESCRIPTION
Update failures now tell the user what actually went wrong, `hermes update` can no longer hang on a stalled fetch, and shallow installer checkouts heal their accumulated `.git/shallow` grafts. Follow-up to #107648, which removed `git fetch` from passive checks; this resolves the residue that landing left behind.

Resolves #105855, resolves #105951. Salvages #105963 (@liuhao1024, cherry-picked with authorship) and the intent of #93759 (@fangliquanflq).

## Changes

**Desktop: actionable update-check errors (#105855)**
- The generic "We couldn't reach the update server." hid GitHub's recent outages behind a line that read as a Hermes bug. `main.ts::describeUpdateCheckFailure` classifies the failure into one sentence: 403/429 → rate limit, 5xx → "GitHub is having trouble (HTTP 503) — check githubstatus.com", ENOTFOUND → DNS, ECONNREFUSED/RESET → firewall/proxy, TLS cert codes → intercepting proxy, timeout → "did not answer within 10 seconds".
- The overlay renders that line (monospace, under the title) and About appends it to the status line, so a bug report carries the cause.

**CLI: shallow graft prune (#105951, salvage #105963)**
- `gitlock.prune_stale_shallow_grafts()` drops `.git/shallow` lines no live ref points at, with a walk self-check that restores the file if pruning was wrong. Called from `hermes update --check` (contributor's change) and now also from the apply path's existing lock/tmp_pack cleanup, so installs already carrying 57 grafts heal on their next update.

**CLI: bounded network git (#93759 / #95777 intent)**
- `update_cmd._git_run(network=True)` carries a 300s timeout. A dead-stalled fetch becomes a failed run whose stderr names the stall; every caller's existing `_print_fetch_failure` path prints it. Local git stays unbounded. ~25 LOC instead of #93759's process-group teardown machinery — `subprocess.run` already kills the child on timeout, and fetch writes only `tmp_pack_*` until success, which `clear_stale_tmp_packs` already sweeps.

## Validation

| Check | Result |
|---|---|
| Live Electron IPC `hermes:updates:check` with `https.get` faulted per case (503 / 429 / ENOTFOUND / ECONNREFUSED / SELF_SIGNED_CERT_IN_CHAIN / timeout) | Each returns `error: fetch-failed` with the matching sentence, e.g. `GitHub is having trouble (HTTP 503 from api.github.com) — check githubstatus.com and try again later.` |
| `tests/hermes_cli/test_update_fetch_timeout.py` (2 invariants) | red on origin/main (0/2), green here |
| `tests/hermes_cli/test_shallow_graft_prune.py` (real depth-1 clone with 3 grafts) | 3/3, prune removes exactly the orphaned middle graft, idempotent |
| `tests/hermes_cli/` | 9412 passed; sole red `test_update_head_moved_gate::test_update_success_when_head_moves` fails identically on origin/main (pre-existing) |
| Desktop `vitest src/store src/app` | 289 files / 2830 tests pass; `tsc` clean on both tsconfigs |

## Infographic

![update failures name the cause](https://v3b.fal.media/files/b/0aa9f98c/NyrJB_rvixdBp-9jnxPDK_xoFoSMaJ.png)
