### PR TITLE
fix(desktop): keep Bot Mode navigation usable

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
@@ -145,6 +145,7 @@ describe('Sessions/Bots strip — #91223', () => {
     render(<TreeGroup leftEdge node={zoneAt(0)} parentAxis="row" topEdge />)
 
     expect(globalThis.document.querySelector<HTMLElement>('[data-panel-header]')?.style.height).toBe('62px')
+    expect(globalThis.document.querySelector('[data-titlebar-controls-reservation]')).toBeTruthy()
     expect(tabEl('sessions')).toBeTruthy()
     expect(tabEl('hermes-bots:pane')).toBeTruthy()
   })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
@@ -135,6 +135,20 @@ describe('Sessions/Bots strip — #91223', () => {
     expect(tabEl('hermes-bots:pane')).toBeTruthy()
   })
 
+  it('does not offer zone minimization for standing sidebar navigation', () => {
+    render(<LiveTreeGroup parentAxis="row" />)
+
+    expect(globalThis.document.querySelector('button[aria-label="Minimize"]')).toBeNull()
+  })
+
+  it('puts the standing navigation strip below crowded titlebar controls', () => {
+    render(<TreeGroup leftEdge node={zoneAt(0)} parentAxis="row" topEdge />)
+
+    expect(globalThis.document.querySelector<HTMLElement>('[data-panel-header]')?.style.height).toBe('62px')
+    expect(tabEl('sessions')).toBeTruthy()
+    expect(tabEl('hermes-bots:pane')).toBeTruthy()
+  })
+
   it('an explicit never hides the sessions/Bots strip', () => {
     setTreeGroupTabStrip('g-side', 'never')
     expect(tabStripVisibleForGroup(zoneAt(0))).toBe(false)

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -512,10 +512,26 @@ export function TreeGroup({
         >
           {stackedHeader && (
             <div
-              className="w-full shrink-0 [-webkit-app-region:drag]"
-              data-window-drag-handle=""
+              className="flex w-full shrink-0"
               style={{ height: TITLEBAR_HEIGHT }}
-            />
+            >
+              {leftEdge && (
+                <>
+                  <div
+                    className="w-(--titlebar-controls-left,14px) [-webkit-app-region:drag]"
+                    data-window-drag-handle=""
+                  />
+                  <div
+                    className="w-(--titlebar-controls-width,96px) [-webkit-app-region:no-drag]"
+                    data-titlebar-controls-reservation=""
+                  />
+                </>
+              )}
+              <div className="min-w-0 flex-1 [-webkit-app-region:drag]" data-window-drag-handle="" />
+              {rightEdge && (
+                <div className="w-[calc(var(--titlebar-tools-right,0.75rem)+var(--titlebar-tools-width,24px))] [-webkit-app-region:no-drag]" />
+              )}
+            </div>
           )}
           {topEdge && leftEdge && !stackedHeader && (
             <div className="flex shrink-0">

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -387,9 +387,12 @@ export function TreeGroup({
     return chrome.uncloseable || chrome.hideOnly ? undefined : paneId
   }
 
-  // The zone hosting the uncloseable workspace never minimizes — collapsing
-  // MAIN strands the whole app behind a strip.
-  const minimizable = !shown.some(id => paneChrome(paneFor(id)).uncloseable)
+  const standingNavigation = shown.length > 0 && shown.every(id => paneChrome(paneFor(id)).hideOnly)
+  const stackedHeader = Boolean(topEdge) && standingNavigation
+
+  // Main and standing sidebar navigation never minimize: the former strands
+  // the app, while the latter already has the sidebar show/hide control.
+  const minimizable = !shown.some(id => paneChrome(paneFor(id)).uncloseable) && !standingNavigation
 
   // Middle-click / ⌘-click on a tab: one routing for every tab kind, the same
   // one the zone menu's Close and ⌘W use.
@@ -500,11 +503,21 @@ export function TreeGroup({
           bounds, strip refs, focus ownership and split geometry as the body. */}
       {(headerVisible || topEdge) && (
         <div
-          className="flex min-w-0 shrink-0 bg-(--ui-sidebar-surface-background)"
+          className={cn(
+            'flex min-w-0 shrink-0 bg-(--ui-sidebar-surface-background)',
+            stackedHeader && 'flex-col'
+          )}
           data-panel-header=""
-          style={topEdge ? { height: TITLEBAR_HEIGHT } : undefined}
+          style={topEdge ? { height: TITLEBAR_HEIGHT + (stackedHeader ? 28 : 0) } : undefined}
         >
-          {topEdge && leftEdge && (
+          {stackedHeader && (
+            <div
+              className="w-full shrink-0 [-webkit-app-region:drag]"
+              data-window-drag-handle=""
+              style={{ height: TITLEBAR_HEIGHT }}
+            />
+          )}
+          {topEdge && leftEdge && !stackedHeader && (
             <div className="flex shrink-0">
               <div className="w-(--titlebar-controls-left,14px) [-webkit-app-region:drag]" data-window-drag-handle="" />
               <div className="relative w-(--titlebar-controls-width,96px)">
@@ -537,7 +550,7 @@ export function TreeGroup({
                 }}
                 ref={stripRef}
                 style={{ cursor: 'grab', WebkitAppRegion: dragging ? 'no-drag' : undefined } as CSSProperties}
-                titlebar={topEdge}
+                titlebar={topEdge && !stackedHeader}
                 trailing={
                   <>
                     {minimizable && (
@@ -697,7 +710,7 @@ export function TreeGroup({
           ) : (
             <div className="min-w-0 flex-1 [-webkit-app-region:drag]" />
           )}
-          {topEdge && rightEdge && (
+          {topEdge && rightEdge && !stackedHeader && (
             <div className="flex shrink-0">
               <div
                 className="w-6"

--- a/apps/desktop/src/plugins/hermes-bots/chat-empty.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/chat-empty.test.tsx
@@ -1,0 +1,54 @@
+import type * as HermesSdk from '@hermes/plugin-sdk'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, expect, it, vi } from 'vitest'
+
+import { $openBotChat } from './bot-state'
+import { BotChatEmpty } from './chat-empty'
+import { $botMeta, $lastRoster } from './data'
+import type { RosterRow } from './types'
+
+vi.mock('@hermes/plugin-sdk', async importOriginal => {
+  const sdk = await importOriginal<typeof HermesSdk>()
+  const { atom } = await import('nanostores')
+
+  return {
+    ...sdk,
+    host: { ...sdk.host, state: { ...sdk.host.state, focusedStoredSessionId: atom('draft-session') } },
+    useValue: <T,>(store: { get: () => T }) => store.get(),
+    Wordmark: ({ text }: { text: string }) => <div>{text}</div>
+  }
+})
+
+vi.mock('./avatar', () => ({
+  avatarColor: () => '#000',
+  botAppearance: () => ({ color: '#000', image: null, shape: 'blobatar' }),
+  BotFace: () => <div data-testid="bot-face" />
+}))
+vi.mock('./avatar-image', () => ({ isBackfilledFacePng: () => false }))
+vi.mock('./i18n', () => ({ useBots: () => ({ bot: { chatEmpty: 'Say something to get started.' } }) }))
+vi.mock('./labels', () => ({ displayName: (bot: RosterRow) => bot.title || bot.name }))
+vi.mock('./routing', () => ({ botRosterMeta: () => null }))
+
+beforeEach(() => {
+  $lastRoster.set([])
+  $botMeta.set({})
+  $openBotChat.set(null)
+})
+
+it('identifies an empty legacy bot draft from its open claim', () => {
+  $lastRoster.set([
+    {
+      connectionId: 'remote',
+      name: 'seo-ops',
+      remoteSource: true,
+      sourceScoped: true,
+      title: 'Seo Ops'
+    } as RosterRow
+  ])
+  $openBotChat.set({ key: 'remote::seo-ops', openedRegistryId: '' })
+
+  render(<BotChatEmpty sessionId="draft-session" />)
+
+  expect(screen.getByText('Seo Ops')).toBeTruthy()
+  expect(screen.getByText('Say something to get started.')).toBeTruthy()
+})

--- a/apps/desktop/src/plugins/hermes-bots/chat-empty.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/chat-empty.tsx
@@ -11,7 +11,8 @@ import { host, useValue, Wordmark } from '@hermes/plugin-sdk'
 
 import { avatarColor, botAppearance, BotFace } from './avatar'
 import { isBackfilledFacePng } from './avatar-image'
-import { $botMeta, $lastRoster } from './data'
+import { $openBotChat } from './bot-state'
+import { $botMeta, $lastRoster, botRosterKey } from './data'
 import { useBots } from './i18n'
 import { displayName } from './labels'
 import { botRosterMeta } from './routing'
@@ -62,8 +63,13 @@ export function BotChatEmpty({ sessionId }: { sessionId: string }) {
   // is in hand.
   const roster = useValue($lastRoster)
   const allMeta = useValue($botMeta)
+  const open = useValue($openBotChat)
+
   useValue(host.state.focusedStoredSessionId)
-  const bot = botForChat(roster, sessionId)
+
+  const bot =
+    botForChat(roster, sessionId) ??
+    (open?.openedRegistryId === '' ? roster.find(candidate => botRosterKey(candidate) === open.key) ?? null : null)
 
   if (!bot) {
     return null


### PR DESCRIPTION
## What does this PR do?

Fixes two Bot Mode states that can leave Desktop looking blank or broken:

1. A remote/on-demand bot can open through the legacy draft fallback before a canonical Bot Chat session exists. `BotChatEmpty` previously resolved only canonical session IDs, returned `null`, and rendered a blank center pane. It now uses the existing source-qualified `$openBotChat` claim for that draft-only state.
2. The permanent `Sessions | Bots` sidebar navigation shared its narrow top row with native and app titlebar controls. On a crowded macOS titlebar the inactive tab scrolled almost completely out of view, while the zone chevron could collapse both permanent navigation panes into a 28 px track. Standing `hideOnly` navigation now gets a full-width row below the titlebar controls and uses the existing sidebar show/hide control instead of zone minimization.

Canonical Bot Chat identity and ordinary tool-panel minimization are unchanged.

## Related Issue

No exact issue found. Related to the standing-sidebar restore invariant discussed in #91223; distinct from #90458 (click-spam/reminting) and #97527 (canonical tab rebind after backend restart).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/chat-empty.tsx`: resolve the owner of a legacy empty bot draft from the existing source-qualified open claim.
- `apps/desktop/src/plugins/hermes-bots/chat-empty.test.tsx`: cover a remote bot draft without a canonical registry ID.
- `apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx`: give standing sidebar navigation a full-width row and remove its redundant zone-minimize action.
- `apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx`: cover titlebar placement and minimization eligibility while preserving tool-panel behavior.

## How to Test

1. Open Desktop Bot Mode and select a remote/on-demand bot before it has a canonical Bot Chat session. Confirm the bot name and “Say something to get started.” render instead of a blank center pane.
2. With the macOS titlebar crowded by app controls, confirm both `Sessions` and `Bots` remain visible and switch in both directions.
3. Confirm the sidebar navigation has no zone-minimize chevron, while a normal docked tool panel still can minimize and restore.
4. Run:
   - `cd apps/desktop && npm run typecheck`
   - `cd apps/desktop && npx vitest run --project ui src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx src/components/pane-shell/tree/renderer/tree-group.test.tsx src/components/pane-shell/tree/renderer/tab-strip-hide.test.tsx src/plugins/hermes-bots/chat-empty.test.tsx`

Validation performed:

- 19 targeted Desktop UI tests passed.
- Desktop typecheck, ESLint, Prettier, production build, and `hermes desktop --force-build` passed.
- Manually reproduced and verified on macOS 26.6 (Apple silicon) against a remote SSH bot roster.
- `scripts/run_tests.sh` was also attempted. After 3,900+ passing Python tests it hit an unrelated timing-sensitive failure in `tests/agent/test_compression_stall_fallback_78981.py` under parallel load; the isolated file then passed 11/11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6, Apple silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only layout logic; no platform APIs changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The packaged app was rebuilt locally and both regressions were verified in the live Desktop UI.
