### PR TITLE
ci: fail all-checks-pass gate on cancelled required jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -274,7 +274,9 @@ jobs:
           print(f'needs-json={json.dumps(compact)}')
           with open('$GITHUB_OUTPUT', 'a') as f:
               f.write(f'needs-json={json.dumps(compact)}\n')
-          failed = [name for name, info in needs.items() if info['result'] == 'failure']
+          # 'cancelled' counts as failed: cancel-in-progress concurrency cancels superseded runs, and
+# a cancelled required job must not produce a green gate (the ❌ icon already hinted at this).
+failed = [name for name, info in needs.items() if info['result'] in ('failure', 'cancelled')]
           for name, info in sorted(needs.items()):
               result = info['result']
               icon = '✅' if result in ('success', 'skipped') else '❌'


### PR DESCRIPTION
## Problem

`all-checks-pass` in `ci.yaml` is the PR merge gate, but its embedded evaluator only treats `result == 'failure'` as failed. This workflow uses `concurrency: {group: ci-<ref>, cancel-in-progress: true}`, so pushing a second commit cancels the in-flight run — a **cancelled** required job leaves the gate **green** while the same job is printed with a ❌ icon two lines earlier.

## Fix

Treat `cancelled` the same as `failure` in the gate evaluator. `skipped` stays a pass because path-gated lanes legitimately skip.

## Verification

- Simulated the embedded evaluator with a needs payload containing `cancelled`: old code exits 0 (fake green), new code exits 1 with the error annotation.
- Path-gated `skipped` results still pass.