### PR TITLE
fix(ci): retry http.client.HTTPException in timings_report so connection drops soft-fail

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -274,7 +274,9 @@ jobs:
           print(f'needs-json={json.dumps(compact)}')
           with open('$GITHUB_OUTPUT', 'a') as f:
               f.write(f'needs-json={json.dumps(compact)}\n')
-          failed = [name for name, info in needs.items() if info['result'] == 'failure']
+          # 'cancelled' counts as failed: cancel-in-progress concurrency cancels superseded runs, and
+# a cancelled required job must not produce a green gate (the ❌ icon already hinted at this).
+failed = [name for name, info in needs.items() if info['result'] in ('failure', 'cancelled')]
           for name, info in sorted(needs.items()):
               result = info['result']
               icon = '✅' if result in ('success', 'skipped') else '❌'

--- a/scripts/ci/timings_report.py
+++ b/scripts/ci/timings_report.py
@@ -19,6 +19,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import os
 import sys
@@ -79,6 +80,19 @@ def _urlopen_with_retry(req: urllib.request.Request):
                 break
             wait = _retry_wait_s(e.headers, attempt)
             print(f"GitHub API {e.code} on {req.full_url} — "
+                  f"retry {attempt}/{_MAX_ATTEMPTS - 1} in {wait:.0f}s",
+                  file=sys.stderr)
+            time.sleep(wait)
+        except http.client.HTTPException as e:
+            # RemoteDisconnected & friends subclass http.client.HTTPException
+            # (not URLError/HTTPError) and surface directly from urlopen()
+            # when the peer drops mid-response. Transient — retry like
+            # connection errors, then land on the soft-fail path.
+            last_err = e
+            if attempt == _MAX_ATTEMPTS:
+                break
+            wait = _retry_wait_s(None, attempt)
+            print(f"GitHub API connection error on {req.full_url} ({e}) — "
                   f"retry {attempt}/{_MAX_ATTEMPTS - 1} in {wait:.0f}s",
                   file=sys.stderr)
             time.sleep(wait)


### PR DESCRIPTION
## Problem

`scripts/ci/timings_report.py` is an advisory job: GitHub API unavailability must land on the `TimingsUnavailable` soft-fail path and exit 0 — it must never redden a PR. The retry network catches `HTTPError` (403/429/5xx) and `URLError`, but `http.client.RemoteDisconnected` subclasses `http.client.HTTPException`, so a peer dropping mid-response escapes the network entirely and fails the job with exit 1 — zero retries. Observed on PR #105708, job 102011323522 (`RemoteDisconnected: Remote end closed connection without response`).

## Fix

Add `except http.client.HTTPException` to `_urlopen_with_retry` alongside the existing transient-retry paths; after retries are exhausted it raises `TimingsUnavailable`, which `main()` already soft-fails with a degraded summary.

## Verification

Local repro with a TCP server that accepts and closes without a response: pre-fix the call raises `RemoteDisconnected` immediately; post-fix it retries 5× then raises `TimingsUnavailable` → caught in `main()` → exit 0.