### PR TITLE
fix(cli): bound .git/shallow graft growth after depth-1 update checks

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -514,6 +514,14 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         _print_fetch_failure(fetch_result.stderr)
         sys.exit(1)
 
+    if is_shallow:
+        # Each depth-1 fetch appends the fetched tip to .git/shallow and never removes
+        # the tip it replaced, so an installer checkout grows the graft list by one line
+        # per check (#105951). Bound it: drop grafts no live ref points at anymore.
+        pruned = _prune_stale_shallow_grafts(git_cmd)
+        if pruned:
+            print(f"  (pruned {pruned} stale shallow graft(s) left by earlier depth-1 fetches)")
+
     # rev-list on a bogus ref exits 128 and (check=True) would traceback; verify first.
     verify_result = _git_run(git_cmd, ["rev-parse", "--verify", "--quiet", compare_branch])
     if verify_result.returncode != 0:
@@ -546,6 +554,56 @@ def _base_git_cmd() -> list[str]:
 
 def _is_shallow_checkout(git_cmd) -> bool:
     return _git_run(git_cmd, ["rev-parse", "--is-shallow-repository"]).stdout.strip() == "true"
+
+
+def _prune_stale_shallow_grafts(git_cmd, cwd=None) -> int:
+    """Bound ``.git/shallow`` growth on shallow checkouts (#105951); returns lines removed.
+
+    Every ``fetch --depth 1`` appends the fetched tip to ``.git/shallow`` as a graft and
+    never removes the tip it replaced, so an installer checkout accumulates one graft line
+    per update check. Keep only the boundaries that still protect referenced tips (HEAD,
+    FETCH_HEAD, and every ref tip); the dropped commits are already unreachable. Never
+    raises, and restores the original file when the post-trim walk self-check fails — a
+    growing file beats a broken repo.
+    """
+    def _lines(args: list[str]) -> list[str]:
+        result = _git_run(git_cmd, args, cwd=cwd)
+        if result.returncode != 0:
+            return []
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    try:
+        shallow_rel = _lines(["rev-parse", "--git-path", "shallow"])
+        if not shallow_rel:
+            return 0
+        shallow_path = Path(shallow_rel[0])
+        if not shallow_path.is_absolute():
+            shallow_path = Path(cwd) if cwd is not None else _m().PROJECT_ROOT
+            shallow_path = shallow_path / shallow_rel[0]
+        if not shallow_path.is_file():
+            return 0
+        lines = [ln for ln in shallow_path.read_text(encoding="utf-8").splitlines() if ln]
+        if not lines:
+            return 0
+        keep = set(lines) & {
+            *_lines(["rev-parse", "HEAD"]),
+            *_lines(["rev-parse", "--verify", "--quiet", "FETCH_HEAD"]),
+            *_lines(["for-each-ref", "--format=%(objectname)"]),
+        }
+        if len(keep) == len(lines):
+            return 0
+        original = shallow_path.read_text(encoding="utf-8")
+        tmp_path = shallow_path.with_name(shallow_path.name + ".hermes-prune")
+        tmp_path.write_text("\n".join(sorted(keep)) + "\n", encoding="utf-8")
+        os.replace(tmp_path, shallow_path)
+        if not (_lines(["rev-list", "--count", "HEAD"]) and _lines(["rev-list", "--count", "--all"])):
+            shallow_path.write_text(original, encoding="utf-8")
+            logger.debug("shallow graft prune self-check failed; grafts restored")
+            return 0
+        return len(lines) - len(keep)
+    except Exception:
+        logger.debug("shallow graft prune failed", exc_info=True)
+        return 0
 
 
 def _tip_shas(git_cmd, target_ref: str) -> tuple[str, str]:

--- a/tests/hermes_cli/test_shallow_graft_prune.py
+++ b/tests/hermes_cli/test_shallow_graft_prune.py
@@ -1,0 +1,122 @@
+"""Bounding .git/shallow growth after depth-1 update checks (#105951).
+
+Every ``git fetch --depth 1`` appends the fetched tip to ``.git/shallow`` as a new
+graft and never removes the tip it replaced, so a long-lived shallow installer
+checkout accumulates one graft line per update check (57 observed in the wild).
+``_prune_stale_shallow_grafts()`` drops grafts no live ref points at;
+``hermes update --check`` calls it after its successful depth-1 fetch, bounding the
+graft list instead of letting it grow (the passive banner check no longer
+git-fetches since #107648).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from hermes_cli.update_cmd import _prune_stale_shallow_grafts
+
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=str(repo), capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def _shallow_lines(repo: Path) -> list:
+    return [
+        line for line in (repo / ".git" / "shallow").read_text().splitlines() if line
+    ]
+
+
+def _mk_shallow_scenario(tmp_path: Path) -> Path:
+    """Depth-1 clone whose origin advanced twice: shallow carries 3 grafts."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    _git(origin, "config", "user.email", "t@example.com")
+    _git(origin, "config", "user.name", "t")
+    for i in range(3):
+        _git(origin, "commit", "--allow-empty", "-q", "-m", f"c{i}")
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(clone)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for i in range(3, 5):
+        _git(origin, "commit", "--allow-empty", "-q", "-m", f"c{i}")
+        _git(clone, "fetch", "-q", "--depth", "1", "origin", "main")
+    return clone
+
+
+def test_prunes_replaced_tip_keeps_referenced_boundaries(tmp_path):
+    clone = _mk_shallow_scenario(tmp_path)
+    assert len(_shallow_lines(clone)) == 3  # HEAD graft + two fetched tips
+
+    head_sha = _git(clone, "rev-parse", "HEAD")
+    tip_sha = _git(clone, "rev-parse", "origin/main")
+
+    removed = _prune_stale_shallow_grafts(["git"], cwd=str(clone))
+
+    assert removed == 1  # the middle, now-unreferenced tip
+    assert set(_shallow_lines(clone)) == {head_sha, tip_sha}
+    # Boundaries that survive must still walk cleanly.
+    assert _git(clone, "rev-list", "--count", "HEAD") == "1"
+    assert _git(clone, "rev-list", "--count", "origin/main") == "1"
+
+
+def test_prune_is_idempotent_and_noop_outside_shallow_checkouts(tmp_path):
+    clone = _mk_shallow_scenario(tmp_path)
+    assert _prune_stale_shallow_grafts(["git"], cwd=str(clone)) == 1
+    assert (
+        _prune_stale_shallow_grafts(["git"], cwd=str(clone)) == 0
+    )  # nothing left to drop
+
+    not_a_repo = tmp_path / "not-a-repo"
+    not_a_repo.mkdir()
+    assert _prune_stale_shallow_grafts(["git"], cwd=str(not_a_repo)) == 0  # no-op
+
+
+def test_update_check_bounds_grafts_after_fetch(tmp_path, monkeypatch, capsys):
+    """`hermes update --check` prunes grafts after its depth-1 fetch and reports the prune."""
+    import hermes_cli.update_cmd as update_cmd
+
+    fake_root = SimpleNamespace(PROJECT_ROOT=tmp_path)
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_root)
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.update_contract.evaluate_update_admission", lambda root: None
+    )
+    monkeypatch.setattr(update_cmd, "_is_shallow_checkout", lambda git_cmd: True)
+    monkeypatch.setattr(update_cmd, "_tip_shas", lambda git_cmd, branch: (SHA_A, SHA_B))
+
+    def fake_git_run(git_cmd, args, **kwargs):
+        joined = " ".join(args)
+        if "get-url" in joined and "upstream" in joined:
+            return MagicMock(returncode=1, stdout="", stderr="")  # no upstream remote
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(update_cmd, "_git_run", fake_git_run)
+    monkeypatch.setattr(update_cmd, "_base_git_cmd", lambda: ["git"])
+    monkeypatch.setattr("hermes_cli.banner._github_compare_behind", lambda *a, **k: 0)
+    prune_calls = []
+    monkeypatch.setattr(
+        update_cmd,
+        "_prune_stale_shallow_grafts",
+        lambda git_cmd, cwd=None: prune_calls.append(git_cmd) or 2,
+    )
+
+    update_cmd._cmd_update_check("main")
+
+    out = capsys.readouterr().out
+    assert prune_calls == [["git"]]
+    assert "pruned 2 stale shallow graft(s)" in out


### PR DESCRIPTION
## What does this PR do?

Every `hermes update --check` on a shallow (installer) checkout runs `git fetch --depth 1`, which appends the fetched tip to `.git/shallow` as a graft and never removes the tip it replaced — so the graft list grows by one line per check (#105951 observed 57 entries in the wild, breaking `merge-base` and pushing `hermes update` into the orphan-divergence reset path). This PR bounds that growth: after a successful shallow fetch, `--check` drops graft lines that no live ref (HEAD, FETCH_HEAD, every ref tip) points at anymore. The dropped commits are already unreachable; surviving boundaries keep walking cleanly, and a post-trim walk self-check restores the original file if the trim ever breaks history walking — a growing file beats a broken repo.

This is the focused follow-up to #105963 suggested by @teknium1: only the `update_cmd.py` bounding on current main, no general prune pass. The high-frequency graft generator (the passive banner check's `git fetch --depth 1`) was already removed in #107648, which moved passive checks to the GitHub REST API; what is left is the `--check` fetch, which this change keeps from accumulating grafts.

## Related Issue

Fixes #105951

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py`: added `_prune_stale_shallow_grafts()`, which trims `.git/shallow` to the boundaries still referenced by HEAD / FETCH_HEAD / ref tips (never raises, restores the file if the post-trim walk check fails)
- `hermes_cli/update_cmd.py`: `_cmd_update_check()` calls it after a successful `fetch --depth 1` on shallow checkouts and reports the number of stale grafts pruned
- `tests/hermes_cli/test_shallow_graft_prune.py`: real-git scenario test (depth-1 clone + two fetches → stale middle tip pruned, referenced boundaries kept and still walkable), idempotence/no-op test, and a mocked `_cmd_update_check` integration test asserting the prune runs after the shallow fetch and is reported

## How to Test

1. `pytest tests/hermes_cli/test_shallow_graft_prune.py -q` — 3 passed (Observed result: 3 passed on this branch)
2. `pytest tests/hermes_cli/test_shallow_graft_prune.py tests/hermes_cli/test_update_check.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_behind_count_recovery.py tests/hermes_cli/test_update_apply_shallow_count.py tests/hermes_cli/test_banner_git_state.py tests/hermes_cli/test_passive_update_opt_out.py -q` — 84 passed (Observed result: 84 passed, no regressions)
3. `ruff check hermes_cli/update_cmd.py tests/hermes_cli/test_shallow_graft_prune.py` — All checks passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64); the shallow-graft scenario tests drive real `git` clones and fetches, covering the git-side mechanics cross-platform

### Documentation & Housekeeping

- [x] N/A (no config keys, no architecture/workflow change; the new helper carries a full docstring)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the prune runs via the existing `_git_run` helper (inherits the Windows appendAtomically config) and never touches platform-specific state
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A
