### PR TITLE
fix(desktop): read the default browser ProgId from UserChoiceLatest before the legacy UserChoice key

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -232,19 +232,43 @@ def _classify_default(value: str, channels, table, match) -> str | None:
     return next((browser for frag, browser in table if match(value, frag)), None)
 
 
-def _detect_default_windows() -> str | None:
+def _windows_default_prog_id() -> str | None:
+    """ProgId of the user's default browser, or None on any read failure.
+
+    Windows 11 25H2+ Settings writes the choice only to ``<scheme>\\UserChoiceLatest``
+    and no longer mirrors it into the legacy ``<scheme>\\UserChoice`` (write-protected
+    by UCPD.sys), so the legacy key can hold a browser the user abandoned — or one
+    already uninstalled. Read the key the OS maintains first; the legacy key stays
+    the source on pre-25H2 builds where UserChoiceLatest does not exist.
+    """
     try:
         import winreg  # type: ignore
-
-        key = winreg.OpenKey(
-            winreg.HKEY_CURRENT_USER,
-            r"Software\Microsoft\Windows\Shell\Associations\UrlAssociations\https\UserChoice")
-        prog_id, _ = winreg.QueryValueEx(key, "ProgId")
-        winreg.CloseKey(key)
-    except Exception:  # non-Windows host (no winreg) or unreadable key
+    except ImportError:  # non-Windows host
         return None
-    return _classify_default(str(prog_id or "").lower(), _WINDOWS_CHANNEL_PROGIDS,
-                             _WINDOWS_PROGID_MAP, str.startswith)
+    for scheme in ("https", "http"):
+        for subkey in ("UserChoiceLatest", "UserChoice"):
+            try:
+                key = winreg.OpenKey(
+                    winreg.HKEY_CURRENT_USER,
+                    r"Software\Microsoft\Windows\Shell\Associations\UrlAssociations"
+                    rf"\{scheme}\{subkey}",
+                )
+                prog_id, _ = winreg.QueryValueEx(key, "ProgId")
+                winreg.CloseKey(key)
+            except OSError:
+                continue
+            if prog_id:
+                return str(prog_id)
+    return None
+
+
+def _detect_default_windows() -> str | None:
+    prog_id = _windows_default_prog_id()
+    if not prog_id:
+        return None
+    return _classify_default(
+        prog_id.lower(), _WINDOWS_CHANNEL_PROGIDS, _WINDOWS_PROGID_MAP, str.startswith
+    )
 
 
 def _run_stdout(argv: list[str]) -> str | None:

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -122,6 +122,22 @@ function Get-UiHtmlPath {
     return $null
 }
 
+function Get-DefaultBrowserProgId {
+    # Windows 11 25H2+ Settings writes the user's browser choice only to
+    # <scheme>\UserChoiceLatest\ProgId and no longer mirrors it into the legacy
+    # <scheme>\UserChoice\ProgId, which UCPD.sys also keeps write-protected.
+    # Read the key the OS actually maintains first; the legacy key remains the
+    # source on pre-25H2 builds where UserChoiceLatest does not exist.
+    param([string]$Scheme)
+    foreach ($subkey in @("UserChoiceLatest", "UserChoice")) {
+        try {
+            $value = (Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\Shell\Associations\UrlAssociations\$scheme\$subkey" -Name ProgId -ErrorAction Stop).ProgId
+            if ($value) { return $value }
+        } catch { continue }
+    }
+    return $null
+}
+
 function Get-DefaultBrowserExe {
     # The OS default browser, read from the UserChoice ProgId that the
     # Windows Settings app writes (https first, http as fallback). Only
@@ -130,9 +146,7 @@ function Get-DefaultBrowserExe {
     # default browser returns $null and degrades to the WinForms card.
     $progId = $null
     foreach ($proto in @("https", "http")) {
-        try {
-            $progId = (Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\Shell\Associations\UrlAssociations\$proto\UserChoice" -Name ProgId -ErrorAction Stop).ProgId
-        } catch { continue }
+        $progId = Get-DefaultBrowserProgId -Scheme $proto
         if ($progId) { break }
     }
     if (-not $progId) { return $null }

--- a/tests/hermes_cli/test_browser_connect_default_chromium.py
+++ b/tests/hermes_cli/test_browser_connect_default_chromium.py
@@ -144,6 +144,81 @@ class TestDetectDefaultLinux:
             assert bc._detect_default_linux() is None
 
 
+class TestWindowsProgId25H2:
+    """25H2 writes only ``UserChoiceLatest``; the legacy key can hold a stale,
+    even uninstalled browser. The reader must prefer the key the OS maintains."""
+
+    class _FakeWinreg:
+        HKEY_CURRENT_USER = 0
+
+        def __init__(self, subkeys: dict[str, str]):
+            self._subkeys = subkeys
+            self.opened: list[str] = []
+
+        def OpenKey(self, _root, path: str):
+            # path = ...\UrlAssociations\<scheme>\<subkey>
+            tail = path.replace("\\", "/").rsplit("/", 2)
+            name = f"{tail[-2]}/{tail[-1]}"
+            self.opened.append(name)
+            if name not in self._subkeys:
+                raise FileNotFoundError(path)
+            return name
+
+        def QueryValueEx(self, key, _name):
+            return self._subkeys[key], 0
+
+        def CloseKey(self, _key):
+            return None
+
+    def _run_with(self, subkeys: dict[str, str]):
+        fake = self._FakeWinreg(subkeys)
+        return patch.dict("sys.modules", {"winreg": fake}), fake
+
+    def test_25h2_prefers_userchoicelatest_over_stale_legacy(self):
+        with_block, fake = self._run_with({
+            "https/UserChoiceLatest": "ChromeHTML",
+            "https/UserChoice": "MSEdgeHTM",
+        })
+        with with_block:
+            assert bc._detect_default_windows() == "chrome"
+        assert fake.opened == ["https/UserChoiceLatest"]
+
+    def test_pre_25h2_falls_back_to_legacy_userchoice(self):
+        with_block, fake = self._run_with({"https/UserChoice": "MSEdgeHTM"})
+        with with_block:
+            assert bc._detect_default_windows() == "edge"
+        assert fake.opened == ["https/UserChoiceLatest", "https/UserChoice"]
+
+    def test_http_scheme_is_the_fallback_when_https_has_no_choice(self):
+        with_block, fake = self._run_with({
+            "https/UserChoice": "",
+            "http/UserChoiceLatest": "ChromeHTML",
+        })
+        with with_block:
+            assert bc._detect_default_windows() == "chrome"
+        assert "http/UserChoiceLatest" in fake.opened
+
+    def test_stale_legacy_with_uninstalled_browser_returns_none(self):
+        with_block, _fake = self._run_with({"https/UserChoice": "MSEdgeHTM"})
+        # Edge uninstalled: no executable will be found downstream, but the
+        # ProgId read itself must succeed -- the classify step decides.
+        with with_block:
+            assert bc._windows_default_prog_id() == "MSEdgeHTM"
+
+    def test_missing_winreg_on_non_windows_hosts_is_none(self):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _no_winreg(name, *args, **kwargs):
+            if name == "winreg":
+                raise ImportError(name)
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=_no_winreg):
+            assert bc._windows_default_prog_id() is None
+
+
 class TestLinuxProfileDir:
     def _env(self, monkeypatch, home):
         monkeypatch.setenv("HOME", str(home))

--- a/tests/test_desktop_update_windows_default_browser.py
+++ b/tests/test_desktop_update_windows_default_browser.py
@@ -1,0 +1,81 @@
+"""Regression tests for the Windows default-browser ProgId resolution.
+
+Windows 11 25H2 (build 26200) writes the user's browser choice only to
+``<scheme>\\UserChoiceLatest\\ProgId`` and no longer mirrors it into the legacy
+``<scheme>\\UserChoice\\ProgId`` (write-protected by UCPD.sys). Readers that look
+only at the legacy key resolve a browser the user abandoned -- and when that
+browser is also uninstalled they resolve nothing at all.
+
+The updater script is not executable on the Linux CI lane, so these tests lock
+the source-level contract for ``windows.ps1``: the ProgId read must consult
+``UserChoiceLatest`` before the legacy ``UserChoice`` for every scheme probed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WINDOWS_UPDATE_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+
+
+def _source() -> str:
+    # windows.ps1 is eol=crlf in .gitattributes; normalize so regex anchors match.
+    return WINDOWS_UPDATE_PS1.read_text(encoding="utf-8").replace("\r\n", "\n")
+
+
+def test_default_browser_progid_reads_userchoicelatest_before_legacy_key() -> None:
+    source = _source()
+    helper = re.search(
+        r"function Get-DefaultBrowserProgId \{(?P<body>.*?)\n\}\n\nfunction Get-DefaultBrowserExe",
+        source,
+        re.DOTALL,
+    )
+    assert helper, (
+        "Expected a Get-DefaultBrowserProgId helper in "
+        "scripts/desktop-update/windows.ps1; the default-browser resolution "
+        "changed -- update this guard."
+    )
+    subkeys = re.findall(r'@?\("([^"]+)",\s*"([^"]+)"\)', helper.group("body"))
+    flat = [name for pair in subkeys for name in pair]
+    assert flat and flat[0] == "UserChoiceLatest" and "UserChoice" in flat, (
+        "The ProgId read must try UserChoiceLatest (the only key 25H2 Settings "
+        "writes) before the legacy UserChoice key; found order: "
+        f"{flat}."
+    )
+
+
+def test_default_browser_exe_resolves_through_the_helper() -> None:
+    source = _source()
+    get_exe = re.search(
+        r"function Get-DefaultBrowserExe \{(?P<body>.*?)\n\}\n\n",
+        source,
+        re.DOTALL,
+    )
+    assert get_exe, "Expected Get-DefaultBrowserExe in the Windows hand-off script."
+    body = get_exe.group("body")
+    assert "Get-DefaultBrowserProgId" in body, (
+        "Get-DefaultBrowserExe must resolve its ProgId through "
+        "Get-DefaultBrowserProgId so every caller gets the 25H2-aware read."
+    )
+    # The https scheme is probed first, http as fallback.
+    schemes = re.findall(r'foreach \(\$proto in @\("(\w+)",\s*"(\w+)"\)\)', body)
+    assert schemes and schemes[0] == ("https", "http"), (
+        f"https must be probed before http; found {schemes}."
+    )
+
+
+def test_no_direct_legacy_only_reads_remain() -> None:
+    source = _source()
+    get_exe = re.search(
+        r"function Get-DefaultBrowserExe \{(?P<body>.*?)\n\}\n\n",
+        source,
+        re.DOTALL,
+    )
+    assert get_exe, "Expected Get-DefaultBrowserExe in the Windows hand-off script."
+    assert "UrlAssociations" not in get_exe.group("body"), (
+        "Get-DefaultBrowserExe must not read UrlAssociations directly; the "
+        "25H2-aware resolution lives in Get-DefaultBrowserProgId."
+    )


### PR DESCRIPTION
## Summary

Windows 11 25H2 (build 26200) writes the user's browser default only to `<scheme>\UserChoiceLatest\ProgId` and no longer mirrors it into the legacy `<scheme>\UserChoice\ProgId` (which UCPD.sys also keeps write-protected). Both Windows default-browser readers in the repo looked only at the legacy key, so on 25H2 they resolve a browser the user abandoned — and when that browser is also uninstalled, they resolve nothing at all.

- **`scripts/desktop-update/windows.ps1`** — `Get-DefaultBrowserExe` read only `UrlAssociations\<scheme>\UserChoice`, so the detached updater shim resolved a stale/uninstalled browser, returned `$null`, and degraded to the WinForms card that never renders while the main thread runs the update (blank "Hermes" ghost window, missing `shim: default-browser app window` log line). The ProgId read is extracted into a `Get-DefaultBrowserProgId` helper that tries `UserChoiceLatest` first (the only key 25H2 Settings writes) and falls back to the legacy `UserChoice` for pre-25H2 builds; `https` stays the primary scheme with `http` as fallback, unchanged.
- **`hermes_cli/browser_connect.py`** — `_detect_default_windows` (the `browser.use_real_profile` resolver) had the same blind spot via `winreg`: it read only `https\UserChoice`. The read moves to `_windows_default_prog_id()` with the same `UserChoiceLatest` → legacy order and the same https-then-http scheme fallback; classification (channels fail closed) is untouched.

## Testing

- `tests/test_desktop_update_windows_default_browser.py` (new): source-level guards in the established `windows.ps1` pattern — the helper exists, tries `UserChoiceLatest` before `UserChoice`, `Get-DefaultBrowserExe` resolves through it, and no direct legacy-only `UrlAssociations` reads remain. The script is not executable on the Linux CI lane, so the contract is locked at source level like the other updater guards.
- `tests/hermes_cli/test_browser_connect_default_chromium.py` — new `TestWindowsProgId25H2` class with a fake `winreg` module: 25H2 prefers `UserChoiceLatest` over a stale legacy value, pre-25H2 falls back to legacy, `http` is the scheme fallback, and a missing `winreg` (non-Windows host) still returns `None`.

```
$ .venv/bin/python -m pytest tests/test_desktop_update_windows_default_browser.py tests/hermes_cli/test_browser_connect_default_chromium.py -q
44 passed in 0.92s
```

Mutation check (order swapped to legacy-first and `UserChoiceLatest` dropped): 2 and 3 tests fail respectively — both guards actually bite.

Fixes #108051


---

**Sibling note (race disclosure):** I claimed #108051 at 08:47Z; #108062 landed at 08:52Z while this PR was being prepared. The two changes are complementary rather than identical — coverage comparison:

| Surface | #108062 | this PR |
|---|---|---|
| `windows.ps1` ProgId resolution | ✅ 3-source chain (UserChoiceLatest → AssocQueryStringW → legacy) | ✅ 2-source chain (UserChoiceLatest → legacy) |
| `browser_connect.py` `_detect_default_windows` (`browser.use_real_profile`) | ❌ | ✅ same blind spot, fixed in the winreg reader |
| fake-winreg unit tests (25H2 / pre-25H2 / http fallback / non-Windows) | ❌ | ✅ |
| source-level `windows.ps1` guard | ✅ (own file) | ✅ (own file) |

Happy to defer to #108062 for `windows.ps1` and rebase this down to the `browser_connect.py` half + tests if the maintainer prefers a single PR per surface — or to re-review theirs with the AssocQueryStringW extension in mind.
