### PR TITLE
fix: exclude sockets/tmp/pycache from named-profile export

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1525,7 +1525,14 @@ def export_profile(name: str, output_path: str, extra_files: Optional[Dict[str, 
     # copy under a temp dir named after the canonical id: root allow-list for default,
     # credential exclusion for named profiles.
     def _ignore_credentials(directory: str, contents: list) -> set:
-        return _EXPORT_CREDENTIAL_FILES & set(contents)
+        # Credential files, plus universal exclusions (sockets/tmp/pycache) that
+        # shutil.copytree cannot copy anyway (live unix sockets aren't regular files).
+        ignored = set(_EXPORT_CREDENTIAL_FILES & set(contents))
+        ignored.update(
+            entry for entry in contents
+            if entry == "__pycache__" or entry.endswith((".sock", ".tmp"))
+        )
+        return ignored
 
     ignore = _default_export_ignore(profile_dir) if canon == "default" else _ignore_credentials
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/hermes_cli/test_profile_export_credentials.py
+++ b/tests/hermes_cli/test_profile_export_credentials.py
@@ -9,6 +9,7 @@ force-redacted in the staged archive (same pass as sessions --redact).
 The live profile on disk must stay untouched.
 """
 
+import stat
 import tarfile
 
 from hermes_cli.profiles import export_profile
@@ -131,3 +132,57 @@ class TestExportSecretScrub:
         assert _LEAKED_KEY not in archived
         assert _LEAKED_KEY in outside.read_text()
         assert link.is_symlink()
+
+
+class TestExportExcludesLiveSockets:
+
+    def test_named_profile_export_skips_live_unix_socket(self, tmp_path, monkeypatch):
+        """A live gateway unix socket (gateway.sock, state/*.sock) must not make
+        ``shutil.copytree`` blow up with Errno 6 (No such device or address) — regular
+        `open()` on a socket inode always fails; these entries must be filtered out
+        before copytree ever touches them."""
+        import os
+        import socket
+        import tempfile
+
+        profiles_root = tmp_path / "profiles"
+        profile_dir = profiles_root / "sockety"
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "config.yaml").write_text("model: gpt-4\n")
+        (profile_dir / "state").mkdir()
+
+        # AF_UNIX paths are capped at ~108 bytes on Linux, well under a pytest tmp_path.
+        # Bind short-lived sockets under a short /tmp dir, then move the resulting
+        # socket inode into place — rename() has no such length limit.
+        sock_path = profile_dir / "gateway.sock"
+        nested_sock = profile_dir / "state" / "gateway.loop-tick.1234.sock"
+        with tempfile.TemporaryDirectory(dir="/tmp") as short_dir:
+            bind_path = os.path.join(short_dir, "a.sock")
+            server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            server.bind(bind_path)
+            os.rename(bind_path, sock_path)
+
+            nested_bind_path = os.path.join(short_dir, "b.sock")
+            nested_server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            nested_server.bind(nested_bind_path)
+            os.rename(nested_bind_path, nested_sock)
+
+            try:
+                assert stat.S_ISSOCK(sock_path.stat().st_mode)
+                assert stat.S_ISSOCK(nested_sock.stat().st_mode)
+
+                _patch_named_profile(monkeypatch, profiles_root, profile_dir)
+
+                # Must not raise OSError(errno.ENXIO, ...) from copytree opening the socket.
+                result = export_profile("sockety", str(tmp_path / "sockety.tar.gz"))
+
+                with tarfile.open(result, "r:gz") as tf:
+                    names = tf.getnames()
+            finally:
+                nested_server.close()
+                server.close()
+
+        assert any("config.yaml" in n for n in names)
+        assert not any(n.endswith(".sock") for n in names)
+        assert not any("gateway.sock" in n for n in names)
+        assert not any("loop-tick" in n for n in names)


### PR DESCRIPTION
## Bug

`hermes profile export <named-profile> -o out.tar.gz` fails whenever the profile has an active gateway:

```
[Errno 6] No such device or address: '/home/.../profiles/<name>/gateway.sock'
[Errno 6] No such device or address: '/home/.../profiles/<name>/state/gateway.loop-tick.<pid>.sock'
```

## Root cause

`hermes_cli/profiles.py::export_profile()` uses two different `shutil.copytree` ignore
filters depending on profile type:

- **default profile** → `_default_export_ignore()`, which excludes `__pycache__`, `*.sock`,
  `*.tmp` at any depth.
- **named profiles** → `_ignore_credentials()`, which only excludes `auth.json`/`.env`. It
  never filters sockets, so `copytree` tries to `open()` a live gateway unix socket as a
  regular file and dies with `ENXIO`.

Any named profile running an active gateway has these sockets present, so export was broken
for every profile except `default`.

## Fix

Fold the same `__pycache__` / `*.sock` / `*.tmp` exclusions into `_ignore_credentials()`
(wrapping the frozenset intersection in `set()` so `.update()` works — `frozenset & set`
returns a `frozenset`, which has no `.update()`).

## Test

`tests/hermes_cli/test_profile_export_credentials.py::TestExportExcludesLiveSockets` binds
real `AF_UNIX` sockets (bind at a short `/tmp` path, then `os.rename` into the profile dir,
since pytest tmp dirs exceed the ~108-byte `AF_UNIX` path limit) at `gateway.sock` and
`state/gateway.loop-tick.<pid>.sock` inside a fake profile dir, then asserts export succeeds
and the archive excludes both. Verified this test reproduces the exact `Errno 6` from the bug
report against the pre-fix code, and passes after the fix.