### PR TITLE
Desktop: profile switches and Bot opens no longer spawn one backend per profile (#102498, salvage #102512)

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -406,6 +406,30 @@ const ROUTES = [
     expected: { backend: 'primary', descriptorProfile: 'coder', scopePath: true }
   },
   {
+    name: 'a read-only local session request reuses the primary backend',
+    profile: 'coder',
+    opts: {
+      primaryProfile: 'default',
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'GET',
+      requestPath: '/api/sessions/session-1/messages?limit=20'
+    },
+    expected: { backend: 'primary', descriptorProfile: 'coder', scopePath: true }
+  },
+  {
+    name: 'a local session write keeps its pooled backend',
+    profile: 'coder',
+    opts: {
+      primaryProfile: 'default',
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'PATCH',
+      requestPath: '/api/sessions/session-1'
+    },
+    expected: { backend: 'pool', descriptorProfile: null, scopePath: false }
+  },
+  {
     name: 'a profile-management request uses the primary without a query scope',
     profile: 'coder',
     opts: {
@@ -692,6 +716,20 @@ test('resolveProfileApiRequest keeps eligible local REST on the primary backend'
     {
       backendProfile: null,
       requestPath: '/api/config?view=desktop&profile=iris'
+    }
+  )
+})
+
+test('resolveProfileApiRequest scopes read-only session probes without spawning a profile backend', () => {
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/sessions/stored-session?include_compacted=true', {
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'GET'
+    }),
+    {
+      backendProfile: null,
+      requestPath: '/api/sessions/stored-session?include_compacted=true&profile=iris'
     }
   )
 })

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -647,6 +647,14 @@ function localPrimaryRequestScope(opts: ProfileRouteOptions): boolean | null {
     return true
   }
 
+  // Session reads already accept `profile` and open that profile's state.db
+  // read-only. Keep ownership probes and transcript reads on the shared primary
+  // instead of spawning one local backend per profile. Writes remain pooled so
+  // their process-level profile scope and side effects are unchanged.
+  if (method === 'GET' && (pathname === '/api/sessions' || pathname.startsWith('/api/sessions/'))) {
+    return true
+  }
+
   // Every current /api/tools handler accepts `profile`; every /api/profiles
   // handler either aggregates profiles or names its target in the path/body.
   // These are the only whole families safe to route through the primary.

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -255,6 +255,12 @@ Clicking a Connections Bot does **not** hop your window onto that machine — st
 
 See [Connecting Desktop to Many Hermes Instances](./multi-connection-desktop.md) for the full multi-connection guide.
 
+## Warm Bot Backends (how many bots run at once)
+
+Each local Bot runs in its own backend process, and Desktop keeps at most **Settings → Advanced → Warm Bot Backends** of them alive at once (default 3, ~60 MB each). Idle backends are reaped after the idle timeout next to that setting (default 10 minutes); the `Hermes backend for profile "<name>" exited (1)` line in `desktop.log` that follows an idle-reap message is that cleanup, not a crash. A Bot you open while every slot is busy waits up to 30 seconds for a slot, then fails with *timed out waiting for a free local slot*.
+
+Reads of another Bot's chat history and background transcript refreshes do **not** take a slot — only an interactive open or a running turn does. If you drive a large fleet (group chats with many members, or Kanban dispatch across many profiles), raise Warm Bot Backends toward the number of Bots you expect to be active at the same time and give the machine the memory to match. Setting it higher than the profiles you actually use only adds startup work.
+
 ## Turning it off
 
 Bot Mode is a bundled desktop plugin. Flip its **Desktop** switch off in **Capabilities → Plugins → Bots** — the roster, the Routines pane, and the composer middleware unregister live, no restart needed. Your profiles, sessions, and cron jobs are untouched either way; Bot Mode never owns your data, it only renders it.


### PR DESCRIPTION
Switching profiles or opening a stale Bot tile no longer starts one local backend per configured profile: read-only `GET /api/sessions*` requests are served by the already-running primary backend with `?profile=`, so the pool slots stay free for bots that are actually running (#102498, salvage of #102512 by @fangliquanflq).

Closes #102498. Supersedes #102512 (cherry-picked to preserve authorship).

## What changes

- `apps/desktop/electron/connection-config.ts::localPrimaryRequestScope` — `GET /api/sessions` and every subpath (`/{id}`, `/{id}/messages`, `/{id}/latest-descendant`, `/search`) is a profile-scoped local-primary route. Writes (PATCH/DELETE/POST) stay on the per-profile pool so their process-level side effects are unchanged.
- `website/docs/user-guide/bot-mode.md` — new **Warm Bot Backends** section: what the setting bounds, defaults (3 backends, 10 min idle, 30 s slot wait), that the post-reap `exited (1)` line is cleanup not a crash, and which operations take a slot. Requested in the Discord fleet thread.

## Root cause

`resolveStoredSession` (`use-session-actions/utils.ts`) probes a stored session id across every profile when the owner is unknown, one `GET /api/sessions/{id}` per profile. The routing table classified the sessions family as pool-only, so each probe went through `ensureBackend(profile)` → `spawnPoolBackend`. With 9+ profiles one click saturated the pool and every later open hit *timed out waiting for a free local slot*. The Python handlers (`hermes_cli/web_routers/sessions.py::get_session_detail` / `get_session_messages` / `get_sessions`) already accept `profile` and open that profile's state.db read-only, exactly like the sidebar aggregate the primary already serves.

Complements #107969 (dc90a75a), which made background tile reconciles passive: that stopped *reconciles* spawning, this stops *ownership probes* spawning. The registry dispatcher (`dispatchRegistryApiRequest`) is untouched: an explicit `connectionId` pin means a registry-owned backend, and its forced-local path already reuses `ensureBackend` for the delegating route.

## Validation

| Check | Result |
|---|---|
| `vitest --project electron electron/connection-config.test.ts` | 120/120 (2 route-table cases + 1 `resolveProfileApiRequest` case from the salvaged commit) |
| `tsc -p tsconfig.electron.json --noEmit` | clean |
| `eslint` on touched files | 0 errors |
| Cherry-pick onto `origin/main` | clean, `fangliquanflq <fangliquan@qq.com>` authorship preserved |
| Live multi-profile repro | not run here (no 9-profile Windows install); mechanism traced line-level against the reporter's `desktop.log` pattern |

## Related

- #102463 — displaces the stalest running backend to free a slot; closed, it inverts the pool's "never kill a live session for the cap" contract and would surface as failed bot turns for exactly this fleet.
- #105264 (actionable slot timeouts), #102828 (default cap), #103525 (relay timer storms) — open, adjacent, not folded in.

## Infographic

![Session reads stay on the primary](https://v3b.fal.media/files/b/0aa9fa21/m9zdFyYq2c7d39HlsZ2MK_zisX4i98.png)
