### PR TITLE
fix(providers): probe ollama thinking capability before sending reasoning_effort on custom endpoints

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -1,6 +1,7 @@
 """Custom / Ollama (local) provider profile: any endpoint registered as
 provider="custom" (Ollama, vLLM, llama.cpp, GLM-5.2 on ARK, …)."""
 
+import time
 from typing import Any
 from urllib.parse import urlparse
 
@@ -29,6 +30,18 @@ def _looks_like_ollama_endpoint(base_url: str | None) -> bool:
 class CustomProfile(ProviderProfile):
     """Custom/Ollama local provider — think=false and num_ctx support."""
 
+    # (model, base_url) -> (supports_thinking | None when probe failed, monotonic probe time).
+    # A definitive True/False is cached for the process lifetime (a model's capability is
+    # static; the model name is part of the key); a failed probe is retried after the TTL
+    # so a temporarily-down ollama doesn't pin a stale answer. Mirrors ReasoningParamsMixin.
+    # Instance attribute: the registry holds this profile as a process-wide singleton.
+    _THINKING_PROBE_CACHE: dict[tuple[str, str], tuple[bool | None, float]]
+    _THINKING_PROBE_TTL_S = 60.0
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._THINKING_PROBE_CACHE = {}
+
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, ollama_num_ctx: int | None = None, **ctx: Any
     ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -49,9 +62,40 @@ class CustomProfile(ProviderProfile):
                 top_level["reasoning_effort"] = "none"
                 if _looks_like_ollama_endpoint(ctx.get("base_url")):
                     extra_body["think"] = False
-            elif effort:
+            elif effort and not self._endpoint_rejects_thinking(ctx):
                 top_level["reasoning_effort"] = clamp_effort(effort, OPENAI_COMPAT_WIRE_EFFORTS)
         return extra_body, top_level
+
+    def _endpoint_rejects_thinking(self, ctx: dict[str, Any]) -> bool:
+        """True when the target model cannot think, so ``reasoning_effort`` must be omitted.
+
+        Ollama's /v1/chat/completions 400s on ``reasoning_effort`` when the model
+        lacks the ``thinking`` capability (e.g. granite4, ministral-3): "does not
+        support thinking". Probe result cached per (model, base_url) — see
+        ``_THINKING_PROBE_CACHE``.
+        """
+        base_url = ctx.get("base_url") or ""
+        model = ctx.get("model") or ""
+        if not _looks_like_ollama_endpoint(base_url) or not model:
+            return False
+        key = (model, str(base_url).strip().rstrip("/").lower())
+        cached = self._THINKING_PROBE_CACHE.get(key)
+        if cached is not None and (
+            cached[0] is not None or time.monotonic() - cached[1] < self._THINKING_PROBE_TTL_S
+        ):
+            return cached[0] is False
+        try:
+            from hermes_cli.models_local import ollama_model_supports_thinking
+
+            supports = ollama_model_supports_thinking(model, base_url, api_key=ctx.get("api_key"))
+        except Exception:
+            supports = None
+        self._THINKING_PROBE_CACHE[key] = (supports, time.monotonic())
+        if supports is True:
+            return False  # model thinks — effort is safe to send
+        if supports is False:
+            return True  # probed OK, no thinking capability — omit the field
+        return False  # probe failed (server down?): fail open, send effort
 
     def fetch_models(
         self, *, api_key: str | None = None, base_url: str | None = None, timeout: float = 8.0

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -180,3 +180,142 @@ class TestCustomReasoningWithNumCtx:
         assert eb == {"options": {"num_ctx": 8192}}
         assert tl == {}
 
+
+@pytest.fixture
+def clear_thinking_probe_cache(custom_profile):
+    """Isolate the probe cache (held on the registry-singleton profile instance)
+    so tests never see each other's probes."""
+    cache = custom_profile._THINKING_PROBE_CACHE
+    cache.clear()
+    yield cache
+    cache.clear()
+
+
+class TestThinkingCapabilityProbe:
+    """Ollama /v1 400s ("does not support thinking") when ``reasoning_effort`` targets
+    a model without the ``thinking`` capability (#granite4). Before the probe, the
+    profile forwarded any configured effort verbatim, so a global
+    ``agent.reasoning_effort: high`` broke every non-thinking local model.
+    ``ollama_model_supports_thinking`` (native /api/show capabilities) already existed
+    for Ollama Cloud — custom now reuses it for Ollama-shaped localhost endpoints."""
+
+    @pytest.mark.parametrize(
+        "base_url",
+        ["http://localhost:11434/v1", "http://127.0.0.1:11434/v1", "https://ollama.com/v1"],
+    )
+    def test_non_thinking_model_omits_effort(self, custom_profile, clear_thinking_probe_cache,
+                                             monkeypatch, base_url):
+        """Probed OK without ``thinking`` → effort omitted; request cannot 400."""
+        import hermes_cli.models_local as ml
+
+        probes = []
+        monkeypatch.setattr(
+            ml, "ollama_model_supports_thinking",
+            lambda model, base_url_, api_key=None, timeout=5.0: probes.append(model) or False)
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="granite4:3b", base_url=base_url)
+        assert probes == ["granite4:3b"]
+        assert eb == {}
+        assert tl == {}
+
+    def test_thinking_model_sends_effort(self, custom_profile, clear_thinking_probe_cache,
+                                         monkeypatch):
+        """Probed OK with ``thinking`` → effort forwarded verbatim (qwen3, deepseek-r1…)."""
+        import hermes_cli.models_local as ml
+
+        monkeypatch.setattr(
+            ml, "ollama_model_supports_thinking",
+            lambda model, base_url_, api_key=None, timeout=5.0: True)
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="qwen3:8b", base_url="http://localhost:11434/v1")
+        assert eb == {}
+        assert tl == {"reasoning_effort": "high"}
+
+    def test_probe_failure_fails_open(self, custom_profile, clear_thinking_probe_cache,
+                                      monkeypatch):
+        """Unreachable /api/show (server down, ollama removed) → send the effort.
+        A transient probe failure must not silently drop the user's reasoning config;
+        the worst case is the pre-probe behaviour (a 400 from the endpoint itself)."""
+        import hermes_cli.models_local as ml
+
+        monkeypatch.setattr(
+            ml, "ollama_model_supports_thinking",
+            lambda model, base_url_, api_key=None, timeout=5.0: None)
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="granite4:3b", base_url="http://localhost:11434/v1")
+        assert tl == {"reasoning_effort": "high"}
+
+        # ...and a raising probe is equally fail-open, not fatal to kwargs building.
+        def _boom(model, base_url_, api_key=None, timeout=5.0):
+            raise OSError("connection refused")
+
+        clear_thinking_probe_cache.clear()
+        monkeypatch.setattr(ml, "ollama_model_supports_thinking", _boom)
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="granite4:3b", base_url="http://localhost:11434/v1")
+        assert tl == {"reasoning_effort": "high"}
+
+    def test_definitive_probe_cached(self, custom_profile, clear_thinking_probe_cache,
+                                     monkeypatch):
+        """A definitive True/False is cached for the process lifetime — one /api/show
+        per (model, base_url), not one per request build."""
+        import hermes_cli.models_local as ml
+
+        calls = []
+        monkeypatch.setattr(
+            ml, "ollama_model_supports_thinking",
+            lambda model, base_url_, api_key=None, timeout=5.0: calls.append(model) or False)
+        rc = {"enabled": True, "effort": "high"}
+        for _ in range(3):
+            custom_profile.build_api_kwargs_extras(
+                reasoning_config=rc, model="granite4:3b", base_url="http://localhost:11434/v1")
+        assert calls == ["granite4:3b"]
+
+        # A different model is a different cache key → probed separately.
+        custom_profile.build_api_kwargs_extras(
+            reasoning_config=rc, model="ministral-3:8b", base_url="http://localhost:11434/v1")
+        assert calls == ["granite4:3b", "ministral-3:8b"]
+
+    @pytest.mark.parametrize(
+        "base_url",
+        ["https://ark.cn-beijing.volces.com/api/v3", "https://api.groq.com/openai/v1"],
+    )
+    def test_probe_skipped_on_non_ollama_endpoints(self, custom_profile,
+                                                   clear_thinking_probe_cache, monkeypatch,
+                                                   base_url):
+        """GLM/ARK, Groq, llama.cpp, vLLM… keep the verbatim passthrough — no probe,
+        no latency, no behaviour change (#57601 contract)."""
+        import hermes_cli.models_local as ml
+
+        probes = []
+        monkeypatch.setattr(
+            ml, "ollama_model_supports_thinking",
+            lambda model, base_url_, api_key=None, timeout=5.0: probes.append(model) or False)
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2", base_url=base_url)
+        assert probes == []
+        assert tl == {"reasoning_effort": "high"}
+
+    def test_disabled_still_disables_on_thinking_model(self, custom_profile,
+                                                       clear_thinking_probe_cache,
+                                                       monkeypatch):
+        """The explicit disable path (reasoning_effort="none" + think=False) is probed
+        never and always honoured — #14820/#25758 contract unchanged."""
+        import hermes_cli.models_local as ml
+
+        probes = []
+        monkeypatch.setattr(
+            ml, "ollama_model_supports_thinking",
+            lambda model, base_url_, api_key=None, timeout=5.0: probes.append(model) or True)
+        eb, tl = custom_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="qwen3:8b", base_url="http://localhost:11434/v1")
+        assert probes == []
+        assert eb == {"think": False}
+        assert tl == {"reasoning_effort": "none"}
+


### PR DESCRIPTION
## Problem

Ollama's `/v1/chat/completions` rejects top-level `reasoning_effort` with **HTTP 400 `"<model>" does not support thinking`** whenever the target model lacks the `thinking` capability (verified live: `granite4:3b`, `ministral-3:8b`; their `/api/show` capabilities are `[completion, tools]` / `[completion, vision, tools]`).

`CustomProfile` forwarded any configured effort verbatim, so a global `agent.reasoning_effort: high` broke **every non-thinking local model**: three retries, failed turn, and no hint in the UI — the error only surfaced in `errors.log`. The workaround (`agent.reasoning_overrides.<model>: disabled`) must be re-done by hand for every non-thinking model the user ever pulls.

The main conversation path *and* the auxiliary path (session-title generation, which resolves through the same profile) both hit it:

```
ERROR agent.conversation_loop: API call failed after 3 retries.
HTTP 400: "granite4:3b" does not support thinking | provider=custom:ollama-(local) model=granite4:3b
```

## Fix

`CustomProfile` reuses the existing `hermes_cli.models_local.ollama_model_supports_thinking()` probe (native `/api/show` `capabilities` — the same authority `OllamaCloudProfile` and `ReasoningParamsMixin._ollama_supports_thinking_cached()` already rely on) for Ollama-shaped custom endpoints before emitting an effort:

| probe result | behaviour |
|---|---|
| `thinking` in capabilities | effort forwarded verbatim (unchanged for qwen3, deepseek-r1, …) |
| probed OK, no `thinking` | `reasoning_effort` omitted — request cannot 400 |
| probe unreachable / raises | **fail open** — effort sent (worst case is the pre-fix behaviour; a transient probe failure must not silently drop the user's reasoning config) |
| non-Ollama custom endpoint (GLM/ARK, Groq, vLLM, llama.cpp) | no probe, no latency, no behaviour change (`_looks_like_ollama_endpoint` gate; #57601 passthrough contract intact) |

Definitive results are cached per `(model, base_url)` on the profile singleton — one `/api/show` per model per process, not per request build; failed probes retry after a 60 s TTL (mirrors the `_cached_probe` policy in `reasoning_params.py`). The explicit-disable path (`reasoning_effort: none` + `think: false`, #14820/#25758) is untouched and stays probe-free.

## Testing

- 9 new invariant tests in `tests/plugins/model_providers/test_custom_profile.py`: omit-on-non-thinking, verbatim-on-thinking, fail-open on `None`-returning *and* raising probes, definitive caching (+ distinct key per model), no probe on non-Ollama endpoints, disable path still probe-free.
- Full file: **49 passed** (`tests/plugins/model_providers/test_custom_profile.py` + `test_ollama_cloud_profile.py`), existing 40 assertions unchanged and green.
- E2E against a live ollama 0.12.10 on this machine: with `agent.reasoning_effort: high` and *no* overrides, `granite4:3b` now answers a one-shot `hermes chat -q` turn (previously: 3x retry, then HTTP 400 failure).

## Notes for reviewers

- Ollama's native `/api/chat` happily ignores thinking params; this only concerns the OpenAI-compat `/v1` route Hermes uses for custom providers.
- An alternative "catch the 400 and retry without the field" recovery exists in spirit (`_ephemeral_reasoning_off`) but only covers disable-rejected routes; probing before sending is cheaper than a failed turn + retry cycle, and matches how Ollama Cloud is already handled.
