### PR TITLE
fix(gateway): read TimeoutStopUSec from the scope that loaded the unit

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -219,13 +219,24 @@ def _systemd_timeout_stop_us(unit_name: str) -> Optional[int]:
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                ["systemctl", *flag, "show", unit_name,
+                 "--property=LoadState", "--property=TimeoutStopUSec"],
                 capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=2.0,
             )
         except (subprocess.TimeoutExpired, OSError):
             continue
+        if result.returncode != 0:
+            continue
+        # A manager that does not know the unit still answers about it — with its OWN
+        # defaults — and exits 0: ``LoadState=not-found`` alongside
+        # ``TimeoutStopUSec=1min 30s`` (systemd's DefaultTimeoutStopSec). Accepting that
+        # number reports a phantom budget for a unit that lives in the other scope, so a
+        # system-scope gateway (TimeoutStopUSec=3min 30s) gets warned about being stale.
+        # Only a loaded unit describes itself; otherwise fall through to the next scope.
+        if any(line.strip() == "LoadState=not-found" for line in result.stdout.splitlines()):
+            continue
         # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
-        for line in result.stdout.splitlines() if result.returncode == 0 else ():
+        for line in result.stdout.splitlines():
             if line.startswith("TimeoutStopUSec="):
                 value = line.split("=", 1)[1].strip()
                 timeout_us = int(value) if value.isdigit() else parse_systemd_duration_to_us(value)

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import subprocess
 import time
 from pathlib import Path
 
@@ -146,3 +147,63 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# _systemd_timeout_stop_us — scope resolution
+# ---------------------------------------------------------------------------
+
+class _FakeSystemctl:
+    """Answers per scope; only the user-manager argv carries ``--user``."""
+
+    def __init__(self, user_stdout, system_stdout, user_rc=0, system_rc=0):
+        self._by_scope = {True: (user_rc, user_stdout), False: (system_rc, system_stdout)}
+        self.calls = []
+
+    def __call__(self, argv, **kwargs):
+        is_user = "--user" in argv
+        self.calls.append(list(argv))
+        rc, out = self._by_scope[is_user]
+        return subprocess.CompletedProcess(argv, rc, out, "")
+
+
+class TestSystemdTimeoutStopUs:
+
+    def test_falls_through_when_user_scope_answers_not_found(self, monkeypatch):
+        # systemd answers exit-0 about a unit it does not have — with its own default
+        # (DefaultTimeoutStopSec=1min 30s) — which must not be read as the unit's budget.
+        fake = _FakeSystemctl(
+            user_stdout="LoadState=not-found\nTimeoutStopUSec=1min 30s\n",
+            system_stdout="LoadState=loaded\nTimeoutStopUSec=3min 30s\n",
+        )
+        monkeypatch.setattr(sf.subprocess, "run", fake)
+        assert sf._systemd_timeout_stop_us("hermes-gateway.service") == 210 * 1_000_000
+        assert "--user" in fake.calls[0] and "--user" not in fake.calls[1]
+
+    def test_user_scope_wins_when_the_unit_really_is_loaded_there(self, monkeypatch):
+        fake = _FakeSystemctl(
+            user_stdout="LoadState=loaded\nTimeoutStopUSec=1min 30s\n",
+            system_stdout="LoadState=loaded\nTimeoutStopUSec=3min 30s\n",
+        )
+        monkeypatch.setattr(sf.subprocess, "run", fake)
+        assert sf._systemd_timeout_stop_us("signal-cli.service") == 90 * 1_000_000
+        assert len(fake.calls) == 1
+
+    def test_returns_none_when_no_scope_knows_the_unit(self, monkeypatch):
+        fake = _FakeSystemctl(
+            user_stdout="LoadState=not-found\nTimeoutStopUSec=1min 30s\n",
+            system_stdout="LoadState=not-found\nTimeoutStopUSec=1min 30s\n",
+        )
+        monkeypatch.setattr(sf.subprocess, "run", fake)
+        assert sf._systemd_timeout_stop_us("hermes-gateway.service") is None
+
+    def test_nonzero_exit_is_skipped(self, monkeypatch):
+        fake = _FakeSystemctl(
+            user_stdout="", system_stdout="", user_rc=1, system_rc=0,
+        )
+        monkeypatch.setattr(sf.subprocess, "run", fake)
+        assert sf._systemd_timeout_stop_us("hermes-gateway.service") is None
+
+    def test_unit_meeting_the_expected_budget_is_aligned(self):
+        # drain 180 + cron 30 = 210s expected; a unit at exactly 210 is NOT stale.
+        assert sf.resolve_systemd_timeout_stop_sec(180, 30) == 210


### PR DESCRIPTION
## What does this PR do?

Fixes a false "stale systemd unit" warning that fires on **every gateway startup** for a gateway installed as a **system** service (`/etc/systemd/system/hermes-*.service`).

`_systemd_timeout_stop_us()` queries systemd with `--user` first (correct, since user services are Hermes' usual deployment) and falls back to the system manager. The problem: **systemd answers exit-0 about a unit it does not have**, reporting its own defaults along with `LoadState=not-found`:

```console
$ systemctl --user show hermes-gateway.service --property=LoadState --property=TimeoutStopUSec
TimeoutStopUSec=1min 30s LoadState=not-found      # 90s — the user manager's default
$ systemctl      show hermes-gateway.service --property=LoadState --property=TimeoutStopUSec
TimeoutStopUSec=3min 30s LoadState=loaded         # 210s — the unit's real budget
```

So the check compared a phantom 90s against a real 210s budget (drain 180 + cron drain 30) and reported the unit as stale:

```
WARNING gateway.run: Stale systemd unit detected: hermes-gateway.service has
TimeoutStopSec=90s but drain_timeout=180s cron_drain_timeout=30s (expected >=210s).
```

The unit was never stale. The warning is actively misleading: it sends operators to `hermes gateway install --force`, which cannot fix it (the unit was already correct), and more importantly it can **mask a genuine stale unit** on a different service by training people to ignore the line.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/shutdown_forensics.py` — `_systemd_timeout_stop_us()` now requests `LoadState` alongside `TimeoutStopUSec` and skips any scope reporting `LoadState=not-found`, so the value always comes from the manager that actually loaded the unit. Also treats a non-zero exit as a skip (previously the guard was an awkward inline conditional on the iteration).
- `tests/gateway/test_shutdown_forensics.py` — 5 tests covering scope resolution: fall-through on `not-found`, user-scope still wins when genuinely loaded, `None` when no scope knows the unit, non-zero exit skipped, and the expected-budget calculation.

## How to Test

1. On a host running the gateway as a **system** service, compare the two scopes:
   ```bash
   systemctl --user show hermes-gateway.service --property=LoadState --property=TimeoutStopUSec
   systemctl      show hermes-gateway.service --property=LoadState --property=TimeoutStopUSec
   ```
   The `--user` query returns `LoadState=not-found` with a default `TimeoutStopUSec`.
2. With the fix, resolve the value directly — it now comes from the loaded (system) unit:
   ```bash
   ./venv/bin/python -c "from gateway.shutdown_forensics import _systemd_timeout_stop_us as f; print(f('hermes-gateway.service'))"
   # before: 90000000 (90s, phantom)   after: 210000000 (210s, real)
   ```
3. Restart the gateway and confirm the startup line is gone:
   ```bash
   grep -c "Stale systemd unit" ~/.hermes/logs/gateway.log   # 0 new occurrences after restart
   ```
4. `scripts/run_tests.sh tests/gateway/test_shutdown_forensics.py`

Verified on Ubuntu 22.04 (system-scope gateway at `TimeoutStopUSec=3min 30s`): the warning logged on **every** startup before the fix (3 occurrences in one morning across three restarts) and **0** after, with the resolved value changing 90s → 210s.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04 (systemd 249)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the function's behaviour is documented in its own comment — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the function already returns `None` off-systemd and this only narrows when a value is accepted
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (every startup) and after (zero) on the same host:

```
2026-09-11 08:35:12,798 WARNING gateway.run: Stale systemd unit detected: hermes-gateway.service has TimeoutStopSec=90s but drain_timeout=180s cron_drain_timeout=30s (expected >=210s).
2026-09-11 08:41:19,718 INFO    gateway.run: Starting Hermes Gateway...      <- fixed build: no warning
```
