### PR TITLE
Sessions no longer bind to or read another profile's state.db (#102526, #106761, #105887, #106974; salvage #102534, #106975)

### DIFF
--- a/agent/turn_explainers.py
+++ b/agent/turn_explainers.py
@@ -281,7 +281,7 @@ class TurnExplainersMixin:
 
     @staticmethod
     def _format_turn_completion_explanation(
-        turn_exit_reason: str, persistence_cause: Optional[str] = None
+        turn_exit_reason: str, persistence_cause: Optional[str] = None, db_path=None
     ) -> str:
         """User-facing explanation for an abnormal turn ending, or "" for normal / unknown reasons.
 
@@ -304,11 +304,14 @@ class TurnExplainersMixin:
                 persistence_cause or "unknown", _PERSISTENCE_DEFAULT_EXPLANATION
             )
             if persistence_cause == "corrupt":
-                # Copy-pasteable, so name the real store (profiles / HERMES_HOME do not live under ~/.hermes).
+                # Copy-pasteable, so name the store that actually failed: the agent's own
+                # SessionDB. A multi-profile backend (Desktop serve) hosts sessions whose
+                # state.db is NOT the process default, so the default would send the operator
+                # to inspect/repair the wrong profile's database (#105887).
                 from hermes_constants import get_default_hermes_root
                 from hermes_state import _default_db_path
 
-                body = body.replace("{db_path}", str(_default_db_path()))
+                body = body.replace("{db_path}", str(db_path or _default_db_path()))
                 body = body.replace(
                     "{backups_dir}", str(get_default_hermes_root() / "backups")
                 )

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -375,7 +375,8 @@ def _explain_abnormal_exit(agent, final_response, _turn_exit_reason, preserved_v
         )
         if _is_empty_terminal or _is_partial_fragment or str(_turn_exit_reason) == "partial_stream_recovery":
             _explanation = agent._format_turn_completion_explanation(
-                _turn_exit_reason, getattr(agent, "_last_persistence_error_cause", None)
+                _turn_exit_reason, getattr(agent, "_last_persistence_error_cause", None),
+                db_path=getattr(getattr(agent, "_session_db", None), "db_path", None),
             )
             if _explanation:
                 # Replace the bare sentinel; keep a partial fragment and append why.

--- a/evals/session_search_schema/runner.py
+++ b/evals/session_search_schema/runner.py
@@ -85,21 +85,7 @@ def load_arm(path: Path, name: str, work_db_path: Path):
             return SessionDB(db_path=work_db_path, read_only=True)
         raise ValueError(f"profile '{profile}' does not exist")
 
-    def _fake_locate_session_db(session_id):
-        try:
-            db = SessionDB(db_path=work_db_path, read_only=True)
-            row = db._conn.execute(
-                "SELECT 1 FROM sessions WHERE id = ?", (session_id,)
-            ).fetchone()
-            if row:
-                return db, "work"
-            db.close()
-        except Exception:
-            pass
-        return None, None
-
     mod._resolve_profile_db = _fake_resolve_profile_db
-    mod._locate_session_db = _fake_locate_session_db
     return mod
 
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1184,6 +1184,11 @@ def delete_profile(name: str, yes: bool = False) -> Path:
         _released = _MemoryStore.release_all_under(profile_dir)
         if _released:
             print(f"✓ Released {_released} memory-store connection(s) held by this process")
+    with contextlib.suppress(Exception):
+        from hermes_state_registry import close_all_under as _close_session_dbs_under
+        _closed = _close_session_dbs_under(profile_dir)
+        if _closed:
+            print(f"✓ Released {_closed} session database connection(s) held by this process")
 
     # 3. Remove wrapper script
     if has_wrapper and remove_wrapper_script(canon):

--- a/hermes_state_registry.py
+++ b/hermes_state_registry.py
@@ -22,8 +22,8 @@ Lifecycle rules:
   generation is published while the previous generation is still tearing down.
 - A path can have SEVERAL closes admitted at once (the current generation's final release
   plus a retired generation's drain). The path barrier COUNTS them and is lifted only by
-  the last one to settle, so neither ``acquire`` nor ``close_all`` can escape while any
-  handle for that path is still inside checkpoint/WAL-unlink.
+  the last one to settle, so neither ``acquire`` nor ``close_all`` / ``close_all_under``
+  can escape while any handle for that path is still inside checkpoint/WAL-unlink.
 - Maintenance callers borrow handles with a temporary registry reference instead of
   iterating an unpinned snapshot.
 """
@@ -365,6 +365,10 @@ def close_all_under(directory: str | Path) -> int:
     Profile delete rmtree (and a same-name recreate) fails while this process still holds
     ``state.db``. Same contract as ``MemoryStore.release_all_under``: a live holder is
     expected to fail afterward; a process that holds none is a no-op returning 0.
+
+    A final ``release()`` can drop the generation and admit teardown before the physical
+    close finishes. Wait for those directory-matching barriers even when no generation
+    remains, otherwise rmtree still sees the open handle.
     """
     try:
         root = Path(directory).expanduser().resolve()
@@ -377,12 +381,13 @@ def close_all_under(directory: str | Path) -> int:
             for generation in list(_generations.values()) + list(_retired.values())
             if _path_is_under(generation.path, root)
         ]
-        if not generations:
-            return 0
-        selected_paths = {generation.path for generation in generations}
+        # Collect by directory, not by remaining generations: a last release already
+        # popped the generation and left only ``_tearing_down``.
         active_teardowns = [
-            barrier for path, barrier in _tearing_down.items() if path in selected_paths
+            barrier for path, barrier in _tearing_down.items()
+            if _path_is_under(path, root)
         ]
+        selected_paths = {generation.path for generation in generations}
         for path in selected_paths:
             teardown_barriers[path] = _admit_teardown_locked(path)
         for generation in generations:

--- a/hermes_state_registry.py
+++ b/hermes_state_registry.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple
@@ -308,6 +309,40 @@ def release(db: "SessionDB") -> bool:
     return True
 
 
+def _path_is_under(path: Path, root: Path) -> bool:
+    """True when *path* is *root* or a file inside it (normcase, resolved)."""
+    try:
+        path_key = os.path.normcase(str(path.resolve()))
+        root_key = os.path.normcase(str(root.resolve()))
+    except OSError:
+        path_key = os.path.normcase(str(path))
+        root_key = os.path.normcase(str(root))
+    return path_key == root_key or path_key.startswith(root_key + os.sep)
+
+
+def _teardown_swept_generations(
+    generations: List[_Generation],
+    teardown_barriers: Dict[Path, _TeardownBarrier],
+    active_teardowns: List[_TeardownBarrier],
+) -> int:
+    """Close *generations* outside the registry lock; wait for already-admitted teardowns."""
+    by_path: Dict[Path, List[_Generation]] = {}
+    for generation in generations:
+        by_path.setdefault(generation.path, []).append(generation)
+    for path, path_generations in by_path.items():
+        with _lock:
+            lifecycle_lock = _path_lifecycle_lock_locked(path)
+        try:
+            with lifecycle_lock:
+                for generation in path_generations:
+                    _teardown(generation.db)
+        finally:
+            _finish_teardown(path, teardown_barriers[path])
+    for barrier in active_teardowns:
+        barrier.event.wait()
+    return len(generations)
+
+
 def close_all() -> int:
     """Close every shared SessionDB regardless of refcount; returns the count. For gateway
     shutdown, after all agents and cron jobs finished. Idempotent."""
@@ -321,26 +356,41 @@ def close_all() -> int:
         _retired.clear()
         for generation in generations:
             generation.retired = True
-    # Teardown outside the lock, one path at a time. Holding the lifecycle
-    # mutex across all generations for a path prevents an old retired handle
-    # and the current handle from checkpointing the same sidecars concurrently.
-    by_path: Dict[Path, List[_Generation]] = {}
-    for generation in generations:
-        by_path.setdefault(generation.path, []).append(generation)
-    for path, path_generations in by_path.items():
-        with _lock:
-            lifecycle_lock = _path_lifecycle_lock_locked(path)
-        try:
-            with lifecycle_lock:
-                for generation in path_generations:
-                    _teardown(generation.db)
-        finally:
-            _finish_teardown(path, teardown_barriers[path])
-    # A final release that removed its generation before this sweep took _lock still owns
-    # its physical close; wait for it rather than return over a running teardown.
-    for barrier in active_teardowns:
-        barrier.event.wait()
-    return len(generations)
+    return _teardown_swept_generations(generations, teardown_barriers, active_teardowns)
+
+
+def close_all_under(directory: str | Path) -> int:
+    """Force-close every shared SessionDB whose file lives under *directory*; returns the count.
+
+    Profile delete rmtree (and a same-name recreate) fails while this process still holds
+    ``state.db``. Same contract as ``MemoryStore.release_all_under``: a live holder is
+    expected to fail afterward; a process that holds none is a no-op returning 0.
+    """
+    try:
+        root = Path(directory).expanduser().resolve()
+    except OSError:
+        root = Path(directory).expanduser()
+    teardown_barriers: Dict[Path, _TeardownBarrier] = {}
+    with _lock:
+        generations = [
+            generation
+            for generation in list(_generations.values()) + list(_retired.values())
+            if _path_is_under(generation.path, root)
+        ]
+        if not generations:
+            return 0
+        selected_paths = {generation.path for generation in generations}
+        active_teardowns = [
+            barrier for path, barrier in _tearing_down.items() if path in selected_paths
+        ]
+        for path in selected_paths:
+            teardown_barriers[path] = _admit_teardown_locked(path)
+        for generation in generations:
+            generation.retired = True
+            if _generations.get(generation.path) is generation:
+                _generations.pop(generation.path, None)
+            _retired.pop(id(generation.db), None)
+    return _teardown_swept_generations(generations, teardown_barriers, active_teardowns)
 
 
 def live_shared_session_dbs() -> List["SessionDB"]:

--- a/tests/hermes_cli/test_deleted_profile_tombstone.py
+++ b/tests/hermes_cli/test_deleted_profile_tombstone.py
@@ -106,6 +106,22 @@ class TestDeletedProfileTombstone:
         assert recreated.is_dir()
         assert "worker" in _named_homes(profile_env)
 
+    def test_delete_releases_this_process_session_db(self, profile_env):
+        import hermes_state_registry as registry
+
+        profile_dir = create_profile("worker", no_alias=True, no_skills=True)
+        held = registry.acquire(profile_dir / "state.db")
+        assert held._conn is not None
+        try:
+            _delete("worker")
+            assert held._conn is None
+            recreated = create_profile("worker", no_alias=True, no_skills=True)
+            again = registry.acquire(recreated / "state.db")
+            assert again._conn is not None
+            registry.release(again)
+        finally:
+            registry.close_all()
+
     def test_profile_exists_is_false_for_tombstoned_shell(self, profile_env):
         profile_dir = create_profile("worker", no_alias=True, no_skills=True)
         assert profile_exists("worker") is True

--- a/tests/hermes_state/test_shared_session_db_registry.py
+++ b/tests/hermes_state/test_shared_session_db_registry.py
@@ -671,3 +671,45 @@ class TestCloseAllUnder:
         profile_dir = tmp_path / "profiles" / "empty"
         profile_dir.mkdir(parents=True)
         assert registry.close_all_under(profile_dir) == 0
+
+    def test_waits_for_admitted_teardown_after_generation_is_gone(self, tmp_path, monkeypatch):
+        """Final release admits teardown before close; rmtree still needs that wait."""
+        profile_dir = tmp_path / "profiles" / "work"
+        profile_dir.mkdir(parents=True)
+        db = registry.acquire(profile_dir / "state.db")
+        entered, resume = TestMultiGenerationTeardownBarrier._pause_teardown_of(
+            monkeypatch, db
+        )
+        errors: list[BaseException] = []
+        releaser = TestMultiGenerationTeardownBarrier._release_async(db, errors)
+        try:
+            assert entered.wait(5.0)
+            resolved = (profile_dir / "state.db").resolve()
+            assert registry._generations.get(resolved) is None
+            barrier = registry._tearing_down.get(resolved)
+            assert barrier is not None and not barrier.event.is_set()
+
+            swept: list[int] = []
+            sweep_done = threading.Event()
+
+            def _sweep() -> None:
+                swept.append(registry.close_all_under(profile_dir))
+                sweep_done.set()
+
+            sweeper = threading.Thread(target=_sweep, daemon=True)
+            sweeper.start()
+            assert not sweep_done.wait(0.5), (
+                "close_all_under returned with a close still pending"
+            )
+            assert db._conn is not None
+
+            resume.set()
+            assert sweep_done.wait(10.0)
+            sweeper.join(10.0)
+        finally:
+            resume.set()
+            releaser.join(10.0)
+
+        assert errors == []
+        assert db._conn is None
+        assert swept == [0]

--- a/tests/hermes_state/test_shared_session_db_registry.py
+++ b/tests/hermes_state/test_shared_session_db_registry.py
@@ -644,3 +644,30 @@ class TestMultiGenerationTeardownBarrier:
         fresh = registry.acquire(db_path)
         assert fresh is not db
         assert registry.release(fresh) is True
+
+
+class TestCloseAllUnder:
+    def test_closes_connections_inside_directory_only(self, tmp_path):
+        profile_dir = tmp_path / "profiles" / "work"
+        profile_dir.mkdir(parents=True)
+        inside = registry.acquire(profile_dir / "state.db")
+        outside = registry.acquire(tmp_path / "other" / "state.db")
+        assert inside._conn is not None
+        assert outside._conn is not None
+
+        closed = registry.close_all_under(profile_dir)
+        assert closed == 1
+        assert inside._conn is None
+        assert outside._conn is not None
+        assert registry.close_all_under(profile_dir) == 0
+
+        again = registry.acquire(profile_dir / "state.db")
+        assert again._conn is not None
+        assert again is not inside
+        assert registry.release(again) is True
+        assert registry.release(outside) is True
+
+    def test_noop_when_this_process_holds_nothing(self, tmp_path):
+        profile_dir = tmp_path / "profiles" / "empty"
+        profile_dir.mkdir(parents=True)
+        assert registry.close_all_under(profile_dir) == 0

--- a/tests/run_agent/test_corruption_recovery_guidance.py
+++ b/tests/run_agent/test_corruption_recovery_guidance.py
@@ -63,6 +63,26 @@ def test_gateway_corruption_banner_backups_dir_follows_hermes_home(monkeypatch, 
     assert "~/.hermes/backups" not in sent[0]
 
 
+def test_format_turn_completion_corrupt_names_the_sessions_own_store(monkeypatch, tmp_path):
+    """Recovery commands target the store that failed, not the process default (#105887).
+
+    A Desktop ``serve`` backend launched on the root home hosts named-profile sessions
+    whose SessionDB is ``profiles/<name>/state.db``; guidance built from the process
+    default would tell the operator to inspect/repair the root database.
+    """
+    from run_agent import AIAgent
+
+    root = tmp_path / "root"
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    failing = root / "profiles" / "research" / "state.db"
+
+    explanation = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed", "corrupt", db_path=failing
+    )
+    assert f"--source {failing} --inspect-only" in explanation
+    assert f"--source {root / 'state.db'}" not in explanation
+
+
 def test_format_turn_completion_corrupt_never_names_the_live_db():
     """The 'corrupt' cause must not direct a raw sqlite3 shell at the live DB.
 

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -523,14 +523,14 @@ class TestCrossProfileRead:
         monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: exists)
         monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: home)
 
-    def test_bare_id_locates_across_profiles(self, db, tmp_path, monkeypatch):
-        # The real-world failure: model dropped the owning profile and passed a
-        # bare id. The tool must scan profiles and find it anyway.
+    def test_bare_id_never_reads_another_profiles_store(self, db, tmp_path, monkeypatch):
+        # #106761: profiles are isolated islands. A bare id that misses the caller's
+        # store must NOT be located by scanning every other profile's state.db.
         other_home = tmp_path / "asdf_home"
         other_home.mkdir()
         other = SessionDB(other_home / "state.db")
         other.create_session("s_far", source="cli")
-        other.append_message("s_far", role="user", content="hi")
+        other.append_message("s_far", role="user", content="secret")
         other._conn.commit()
 
         from collections import namedtuple
@@ -539,12 +539,15 @@ class TestCrossProfileRead:
         monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: tmp_path / "default_home")
         monkeypatch.setattr(profiles_mod, "list_profiles", lambda: [Info("asdf", other_home)])
 
-        # `db` (current profile) lacks s_far; no profile passed → scan finds it.
         result = json.loads(session_search(session_id="s_far", db=db))
-        assert result["success"] is True
-        assert result["mode"] == "read"
-        assert result["profile"] == "asdf"
+        assert result["success"] is False
+        assert "messages" not in result and "secret" not in json.dumps(result)
+        assert "profile=" in result["error"]
 
+        # Naming the owning profile is still the sanctioned cross-profile read.
+        self._patch_profiles(monkeypatch, other_home)
+        named = json.loads(session_search(session_id="s_far", profile="asdf", db=db))
+        assert named["success"] is True and named["message_count"] == 1
 
     def test_combined_value_autosplits(self, db, tmp_path, monkeypatch):
         # Agent passed the raw "@session:<profile>/<id>" value as session_id with

--- a/tests/tui_gateway/test_launch_db_home_override_race.py
+++ b/tests/tui_gateway/test_launch_db_home_override_race.py
@@ -1,0 +1,52 @@
+"""Regression for #102526.
+
+The launch backend's lazy ``_get_db()`` handle must bind to the import-time
+launch home, not whatever ``get_hermes_home()`` resolves to at first-touch
+time. The desktop multiplex cron ticker installs per-profile override windows
+at startup; if the first ``session.*`` RPC races into a foreign window, the
+backend permanently serves the wrong profile's state.db.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from tui_gateway import server
+
+
+@pytest.fixture()
+def launch_db_env(monkeypatch, tmp_path):
+    launch_home = tmp_path / "launch"
+    foreign_home = tmp_path / "foreign"
+    launch_home.mkdir()
+    foreign_home.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.setattr(server, "_hermes_home", str(launch_home))
+    monkeypatch.setattr(server, "_db", None)
+    monkeypatch.setattr(server, "_db_error", None)
+
+    captured: list[Path | None] = []
+
+    def _factory(db_path=None, **_kwargs):
+        captured.append(Path(db_path) if db_path is not None else None)
+        return SimpleNamespace(db_path=db_path)
+
+    monkeypatch.setattr("hermes_state.get_shared_session_db", _factory)
+    return launch_home, foreign_home, captured
+
+
+def test_get_db_first_touch_under_foreign_override_uses_launch_path(launch_db_env):
+    launch_home, foreign_home, captured = launch_db_env
+    token = set_hermes_home_override(str(foreign_home))
+    try:
+        db = server._get_db()
+        assert db is not None
+        assert captured == [launch_home / "state.db"]
+        assert server._get_db() is db
+    finally:
+        reset_hermes_home_override(token)

--- a/tests/tui_gateway/test_launch_db_home_override_race.py
+++ b/tests/tui_gateway/test_launch_db_home_override_race.py
@@ -9,11 +9,9 @@ backend permanently serves the wrong profile's state.db.
 
 from __future__ import annotations
 
-from pathlib import Path
-from types import SimpleNamespace
-
 import pytest
 
+import hermes_state_registry as registry
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from tui_gateway import server
 
@@ -29,24 +27,20 @@ def launch_db_env(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_hermes_home", str(launch_home))
     monkeypatch.setattr(server, "_db", None)
     monkeypatch.setattr(server, "_db_error", None)
-
-    captured: list[Path | None] = []
-
-    def _factory(db_path=None, **_kwargs):
-        captured.append(Path(db_path) if db_path is not None else None)
-        return SimpleNamespace(db_path=db_path)
-
-    monkeypatch.setattr("hermes_state.get_shared_session_db", _factory)
-    return launch_home, foreign_home, captured
+    try:
+        yield launch_home, foreign_home
+    finally:
+        registry.close_all()
 
 
 def test_get_db_first_touch_under_foreign_override_uses_launch_path(launch_db_env):
-    launch_home, foreign_home, captured = launch_db_env
+    launch_home, foreign_home = launch_db_env
     token = set_hermes_home_override(str(foreign_home))
     try:
         db = server._get_db()
         assert db is not None
-        assert captured == [launch_home / "state.db"]
+        assert db.db_path.resolve() == (launch_home / "state.db").resolve()
+        assert not (foreign_home / "state.db").exists()
         assert server._get_db() is db
     finally:
         reset_hermes_home_override(token)

--- a/tests/tui_gateway/test_session_resume_db_ownership.py
+++ b/tests/tui_gateway/test_session_resume_db_ownership.py
@@ -116,20 +116,20 @@ def _resume(**params):
     )
 
 
-def test_resume_closes_profile_db_when_session_not_found(profile_dbs):
+def test_resume_closes_profile_db_when_session_not_found(profile_dbs, tmp_path):
     """The 'session not found' early return must not leak the handle.
 
     The stranded-session adoption fallback (#93296 follow-up) may lazily
     construct the SHARED launch handle via ``_get_db()`` while probing the
-    default store for a donor row; that handle carries ``db_path=None`` and
-    is never closed by design (see module docstring). Only the dedicated
-    profile-scoped open (``db_path=<profile>/state.db``) is the caller's to
-    close, so the leak assertion filters to path-scoped opens.
+    default store for a donor row; that handle is never closed by design (see
+    module docstring). Only the dedicated profile-scoped open is the caller's
+    to close, so the leak assertion filters to the profile store path.
     """
+    profile_store = tmp_path / "work" / "state.db"
     resp = _resume(session_id="missing", profile="work")
 
     assert resp["error"]["code"] == 4007
-    scoped = [db for db in profile_dbs if db.db_path is not None]
+    scoped = [db for db in profile_dbs if db.db_path == profile_store]
     assert len(scoped) == 1
     assert scoped[0].closed == 1
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -339,32 +339,6 @@ def _resolve_profile_db(profile: str):
     return SessionDB(db_path=profiles_mod.get_profile_dir(canon) / "state.db", read_only=True)
 
 
-def _locate_session_db(session_id: str):
-    """Scan every profile's ``state.db`` -> ``(db, profile_name)`` or ``(None, None)``.
-    Ids are globally unique, so the first hit is authoritative."""
-    from pathlib import Path
-    try:
-        from hermes_cli import profiles as profiles_mod
-        from hermes_state import SessionDB
-    except Exception:
-        return None, None
-    targets = [("default", profiles_mod.get_profile_dir("default"))] + _quiet(
-        lambda: [(info.name, info.path) for info in profiles_mod.list_profiles()], [],
-        "list_profiles failed during session locate")
-    seen: set = set()
-    for name, home in targets:
-        db_path = Path(home) / "state.db"
-        if str(db_path) in seen or not db_path.exists():
-            continue
-        seen.add(str(db_path))
-        pdb = _quiet(lambda: SessionDB(db_path=db_path, read_only=True), None, "open %s failed", db_path)
-        if pdb and _get_session_meta(pdb, session_id):
-            return pdb, name
-        if pdb:
-            pdb.close()
-    return None, None
-
-
 def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_profile: str = None) -> str:
     """Read shape: whole session, or ``head`` + ``tail`` messages with a scroll pointer."""
     meta = _get_session_meta(db, session_id)
@@ -383,18 +357,19 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
                                "Pass around_message_id (any id above) to scroll the middle.")} if truncated else {}))
 
 
-def _read_with_profile_fallback(db, sid: str, profile: Optional[str]) -> str:
-    """Read shape; on a miss scan every profile (the model may have dropped the owning
-    profile from the link) and tag the result with where it was found."""
+def _read_scoped(db, sid: str, profile: Optional[str]) -> str:
+    """Read shape scoped to ONE store: the caller's profile, or the profile it named.
+
+    A miss is a miss. Profiles are isolated islands, so a bare id never falls through to
+    a scan of every other profile's ``state.db`` — that returned another profile's full
+    transcript to any caller holding the id (#106761). The hint tells the model how to
+    ask properly: ``@session:<profile>/<id>`` or ``profile=``.
+    """
     result = _read_session(db, sid, link_profile=profile)
-    located, owner = (None, None) if json.loads(result).get("success") else _locate_session_db(sid)
-    if located is None:
+    if json.loads(result).get("success") is not False or profile:
         return result
-    try:
-        found = json.loads(_read_session(located, sid, link_profile=owner))
-    finally:
-        located.close()
-    return json.dumps({**found, "profile": owner}, ensure_ascii=False) if found.get("success") else result
+    return tool_error(f"session_id not found in this profile: {sid}. If it belongs to another "
+                      "profile, pass profile=<name> (or the @session:<profile>/<id> link).", success=False)
 
 
 def _list_recent_sessions(db, limit: int, current_session_id: str = None, link_profile: str = None) -> str:
@@ -518,7 +493,7 @@ def _dispatch(query, role_filter, limit, db, current_session_id, session_id,
     if isinstance(session_id, str) and session_id.strip():
         if around_message_id is not None:
             return _scroll(db, session_id.strip(), around_message_id, window, current_session_id)
-        return _read_with_profile_fallback(db, session_id.strip(), profile)
+        return _read_scoped(db, session_id.strip(), profile)
     limit = _clamp_int(limit, 3, 1, 10)
     if not query or not isinstance(query, str) or not query.strip():
         return _list_recent_sessions(db, limit, current_session_id, link_profile=profile)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -385,7 +385,11 @@ def _get_db():
     if _db is None:
         from hermes_state_registry import acquire
         try:
-            _db, _db_error = acquire(), None
+            # Pin to import-time launch home (#102526). A bare acquire() follows
+            # get_hermes_home(), which the desktop multiplex cron ticker temporarily
+            # overrides per profile at startup — first touch inside a foreign window
+            # permanently binds this process-wide handle to the wrong state.db.
+            _db, _db_error = acquire(Path(_hermes_home) / "state.db"), None
         except Exception as exc:
             _db_error = str(exc)
             logger.warning("TUI session store unavailable — continuing without state.db features: %s", exc)


### PR DESCRIPTION
Sessions no longer bind to, read from, or point recovery at another profile's `state.db`: the Desktop launch backend pins its shared handle to its launch home, `session_search` refuses a bare-id read of a foreign profile's store, corruption guidance names the failing session's own database, and profile delete closes this process's shared SessionDB handles before `rmtree`.

## What changed

- **Launch handle races into a foreign profile's override window (#102526, #59566)** — `tui_gateway/server.py::_get_db()` called `acquire()` with no path, so its first touch resolved `get_hermes_home()` under whatever context-local `HERMES_HOME` override the desktop multiplex cron ticker had installed at that instant. The process-lifetime "own store" handle then pointed at another profile's `state.db` forever. Pinned to `Path(_hermes_home) / "state.db"` (import-time launch home). Salvaged from #102534 (@HexLab98); its test's seam was stale on main, so the test now opens a real registry handle and asserts the foreign home stays untouched.
- **`session_search(session_id=<bare id>)` scanned every profile's `state.db` (#106761, refs #87779)** — a miss in the caller's store fell through to `_locate_session_db()`, which opened each profile's DB read-only and returned the first owner's full transcript with no profile named. Profiles are isolated islands; the scan is removed. A miss stays a miss with a hint to pass `profile=` / `@session:<profile>/<id>` (the explicit cross-profile read is unchanged). The existing test that pinned the leak is inverted; the schema eval runner no longer fakes the scan.
- **Corrupt-session recovery guidance targeted the process default DB (#105887)** — the explainer filled `{db_path}` from `_default_db_path()`; a Desktop `serve` backend hosting named-profile sessions told the operator to inspect/repair the root database. The turn finalizer now passes the agent's own `_session_db.db_path`.
- **Profile delete left `state.db` open in-process → WinError 32 (#106974)** — `delete_profile()` released holographic memory-store handles but not shared `hermes_state_registry` SessionDB handles. New `close_all_under(directory)` force-closes every generation under the doomed dir and waits for already-admitted teardown barriers (a final `release()` can drop the generation before the physical close finishes). Salvaged from #106975 (@Sora-bluesky), both commits. Cannot run on Windows here; host-independent invariant tests cover "handle closed, sibling untouched, sweep waits for in-flight close".

## Live repro (real SQLite, temp `HERMES_HOME`, `hermes_state*` purged from `sys.modules`)

| Item | Before (origin/main) | After |
|---|---|---|
| #102526 launch `_get_db()` first-touch under foreign override | bound to `…/foreign/state.db` | bound to `…/launch/state.db`; foreign file never created |
| #106761 bare-id read from `default` of a `victim` session | `success=True profile=victim message_count=1` (full transcript) | `success=False`, error hints `profile=`; named `profile="victim"` read still works |
| #105887 corrupt guidance for a `profiles/research` session | `--source <root>/state.db` | `--source <root>/profiles/research/state.db` |
| #106974 `delete_profile` with a registry handle open | handle stays open (`_conn` not None) | `_conn is None`, same-name recreate acquires a fresh handle |

Regression tests are red with each fix reverted (verified for the launch pin by reverting the one-line change).

## Assessed, not changed here

- **#103467 (Linux Desktop SSH spawn omits `HERMES_HOME`)** — premise does not hold on main: `hermes_cli.main` runs `_apply_profile_override()` at import (before `hermes_state` is imported; verified `hermes_state not in sys.modules` after `import hermes_cli.main`), so `--profile alpha serve --isolated` with no `HERMES_HOME` yields `DEFAULT_DB_PATH=<root>/profiles/alpha/state.db` on both main and the v0.21.0 tag. #103480 (@PRATHAMESH75) adds an env export that is redundant with `--profile`; not salvaged.
- **#102315 (Windows child `--profile default` inherits another profile's home)** — `resolve_profile_env("default")` already strips a profile-shaped `HERMES_HOME` to its root (`57d94dd8dc8`, present at the reporter's SHA); verified `HERMES_HOME=<root>/profiles/work` + `--profile default` → `<root>/state.db`. The reporter's observed `HERMES_HOME=…/profiles/work` in the default child's environment is a spawn-env cosmetic on Windows (case-insensitive key), not a store-binding bug on current main. #102343 (@686f6c61) is a reasonable hygiene change for the env block but not a store fix; left for a Desktop lane.
- **#107528 (stale `active-profile.json`)** — rail switches call `profile.remember` only for local primary-backend activations by design (#79886); the store-binding symptom described is the #102526 class fixed here. The pointer-staleness policy is a Desktop UX call, not touched.
- **#101884 / #102632 (`hermes_state_*` missing from `py-modules`)** — already fixed on main by `283c4f058c5` (`setup.py::_root_py_modules()` derives the list from the tree; `tests/test_packaging_py_modules.py` is the contract test that fails if packaged code imports an unshipped root module). #74506 is superseded.
- #104143 (@HexLab98, in-session rebuild profile store) is already on main as `8da23bdae4f`. #101995 and #94004 target other clusters (live-DB guard roots / default-path plumbing) and are not part of this PR.

Fixes #102526
Fixes #106761
Fixes #105887
Fixes #106974
Refs #59566, #87779, #103467, #102315, #107528, #101884, #102632

Salvaged with authorship: #102534 (@HexLab98), #106975 (@Sora-bluesky).
