### PR TITLE
state.db: one corrupt row (bad timestamp / malformed marker JSON / oversized IN-list) no longer kills sessions list, export, insights or prune (#102399 #102352 #99959 #94691 #106060; salvage #106071 #101726 #94701 #102679 #100658)

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
 from agent.usage_pricing import CanonicalUsage, estimate_usage_cost, format_cost_label, format_duration_compact, has_known_pricing
+from hermes_cli.timefmt import coerce_epoch
 
 _TOKEN_KEYS = ("input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens")
 _SKILL_TOOLS = {"skill_view", "skill_manage"}
@@ -71,7 +72,7 @@ def _hour12(hr: int) -> str:
 
 
 def _day(ts: Any) -> str:
-    return datetime.fromtimestamp(ts).strftime("%b %d") if ts else "?"
+    return datetime.fromtimestamp(ts).strftime("%b %d") if ts and (ts := coerce_epoch(ts)) else "?"
 
 
 def _scoped(before: str, after: str = "", *, src: str = " AND s.source = ?") -> tuple[str, str]:
@@ -206,7 +207,13 @@ class InsightsEngine:
     # ------------------------------------------------------------------ SQL
 
     def _get_sessions(self, cutoff: float, source: str = None) -> List[Dict]:
-        return [dict(row) for row in self._query("_GET_SESSIONS", cutoff, source)]
+        # Coerce the two epoch columns once at load: one corrupt/TEXT cell must degrade to "unknown"
+        # for that session, never abort the whole report (#99959).
+        rows = [dict(row) for row in self._query("_GET_SESSIONS", cutoff, source)]
+        for row in rows:
+            for col in ("started_at", "ended_at"):
+                row[col] = coerce_epoch(row.get(col), session_id=row.get("id"), field=col)
+        return rows
 
     def _get_tool_usage(self, cutoff: float, source: str = None) -> List[Dict]:
         """Tool call counts from two sources: ``tool_name`` on 'tool' rows (set
@@ -479,9 +486,9 @@ class InsightsEngine:
             "  ╚══════════════════════════════════════════════════════════╝",
             "",
         ]
-        if o.get("date_range_start") and o.get("date_range_end"):
-            start_str = datetime.fromtimestamp(o["date_range_start"]).strftime("%b %d, %Y")
-            end_str = datetime.fromtimestamp(o["date_range_end"]).strftime("%b %d, %Y")
+        if (start := coerce_epoch(o.get("date_range_start"))) is not None and (end := coerce_epoch(o.get("date_range_end"))) is not None:
+            start_str = datetime.fromtimestamp(start).strftime("%b %d, %Y")
+            end_str = datetime.fromtimestamp(end).strftime("%b %d, %Y")
             lines += [f"  Period: {start_str} — {end_str}", ""]
         lines += self._section("📋 Overview") + [
             f"  Sessions:          {o['total_sessions']:<12}  Messages:        {o['total_messages']:,}",

--- a/hermes_cli/cli_session_mixin.py
+++ b/hermes_cli/cli_session_mixin.py
@@ -364,7 +364,7 @@ class CLISessionMixin:
         for idx, session in enumerate(sessions, start=1):
             title = session.get("title") or "—"
             preview = (session.get("preview") or "")[:38]
-            last_active = _relative_time(session.get("last_active"))
+            last_active = _relative_time(session.get("last_active"), session_id=session.get("id"))
             _cli_visible_print(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
         _cli_visible_print()
         _cli_visible_print("  Use /resume <number>, /resume <session id>, or /resume <session title> to continue.")

--- a/hermes_cli/session_export.py
+++ b/hermes_cli/session_export.py
@@ -12,6 +12,8 @@ from html import escape as html_escape
 import json
 from typing import Any, Dict, Iterable, Iterator, List, Literal, Optional, Tuple
 
+from hermes_cli.timefmt import coerce_epoch
+
 
 ExportFormat = Literal["jsonl", "markdown"]
 ExportOnly = Literal["user-prompts"]
@@ -91,7 +93,7 @@ def iter_user_prompt_records(sessions: Iterable[Dict[str, Any]]) -> Iterator[Dic
             record: Dict[str, Any] = {
                 "session_id": session_id,
                 "index": index,
-                "created_at": _format_timestamp(message.get("timestamp")),
+                "created_at": _format_timestamp(message.get("timestamp"), session_id),
                 "role": "user",
                 "text": _message_text(message.get("content")),
             }
@@ -123,7 +125,7 @@ def _append_session_messages(lines: List[str], session: Dict[str, Any], *, headi
         return
     for message in visible_messages:
         role = str(message.get("role") or "unknown")
-        timestamp = _format_timestamp(message.get("timestamp"))
+        timestamp = _format_timestamp(message.get("timestamp"), _session_id(session))
         suffix = f" - {timestamp}" if timestamp else ""
         text = _message_text(message.get("content"))
         if role == "tool":
@@ -157,15 +159,15 @@ def _content_part_text(part: Any) -> str:
     return json.dumps(part, ensure_ascii=False, sort_keys=True)
 
 
-def _format_timestamp(value: Any) -> Optional[str]:
+def _format_timestamp(value: Any, session_id: Optional[str] = None) -> Optional[str]:
     if value is None:
         return None
-    if isinstance(value, (int, float)):
-        dt = datetime.fromtimestamp(float(value), tz=timezone.utc)
-    elif isinstance(value, datetime):
+    if isinstance(value, datetime):
         dt = (value if value.tzinfo else value.replace(tzinfo=timezone.utc)).astimezone(timezone.utc)
+    elif (ts := coerce_epoch(value, session_id=session_id)) is None:
+        return str(value)  # corrupt cell: odd-looking date, not an aborted export
     else:
-        return str(value)
+        dt = datetime.fromtimestamp(ts, tz=timezone.utc)
     return dt.isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
@@ -176,7 +178,7 @@ def _session_metadata_lines(session: Dict[str, Any]) -> List[str]:
             lines.append(f"- {label}: `{session[key]}`")
     if title := session.get("title"):
         lines.append(f"- Title: {' '.join(str(title).splitlines()).strip()}")
-    if started := _format_timestamp(session.get("started_at")):
+    if started := _format_timestamp(session.get("started_at"), _session_id(session)):
         lines.append(f"- Started: {started}")
     if (message_count := session.get("message_count")) is not None:
         lines.append(f"- Messages: {message_count}")

--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -5,6 +5,8 @@ import secrets
 from typing import Any, Dict, List
 from urllib.parse import quote
 
+from hermes_cli.timefmt import coerce_epoch
+
 # --- Icons (Lucide-style SVGs) ---
 ICON_USER = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-user"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>'
 ICON_BOT = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-bot"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>'
@@ -650,8 +652,9 @@ def _escape_html(text: Any) -> str:
     )
 
 
-def _format_timestamp(ts: float) -> str:
-    return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S") if ts else "N/A"
+def _format_timestamp(ts: Any) -> str:
+    # A corrupt cell renders as N/A; never raw text (a TEXT timestamp would otherwise reach an HTML sink).
+    return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S") if ts and (ts := coerce_epoch(ts)) else "N/A"
 
 
 _ROLE_ICONS = {"user": ICON_USER, "assistant": ICON_BOT, "system": ICON_SHIELD}

--- a/hermes_cli/session_export_md.py
+++ b/hermes_cli/session_export_md.py
@@ -14,6 +14,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from hermes_cli.timefmt import coerce_epoch
+
 EXPORTER_VERSION = "hermes sessions export (md/qmd) v1"
 _SHA_LINE_RE = re.compile(r"- SHA256 of exported body: `([0-9a-f]{64})`")
 _SHA_PLACEHOLDER = "__SHA256_PLACEHOLDER__"
@@ -23,10 +25,8 @@ _VERIFICATION_HEADING = "## Export verification"
 def _iso_timestamp(value: Any) -> str:
     if value is None or value == "":
         return ""
-    try:
-        ts = float(value)
-    except (TypeError, ValueError):
-        return str(value)
+    if (ts := coerce_epoch(value)) is None:
+        return str(value)  # corrupt cell: odd-looking date, not an aborted export
     return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
 
 

--- a/hermes_cli/session_filters.py
+++ b/hermes_cli/session_filters.py
@@ -7,6 +7,8 @@ import time
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
+from hermes_cli.timefmt import coerce_epoch
+
 _DURATION_RE = re.compile(
     r"^(\d+(?:\.\d+)?)\s*"
     r"(s|sec|secs|second|seconds|"
@@ -51,8 +53,8 @@ def parse_point_in_time(value: str, flag: str) -> float:
 
 
 def format_epoch(ts: Optional[float]) -> str:
-    """Render an epoch timestamp as a short local-time string."""
-    return "-" if ts is None else datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M")
+    """Render an epoch timestamp as a short local-time string; ``-`` when unset or corrupt."""
+    return "-" if (ts := coerce_epoch(ts)) is None else datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M")
 
 
 # (filter key, argparse attr, CLI flag, description template) for the four epoch bounds.

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -273,7 +273,7 @@ def _cmd_list(db, args):
         return ((os.path.basename(key.rstrip("/\\")) or key) if key else "—")[:16]
     _title = lambda s, n: (s.get("title") or "—")[:n]  # noqa: E731
     _preview = lambda s, n: s.get("preview", "")[:n]  # noqa: E731
-    _ago = lambda s: _relative_time(s.get("last_active"))  # noqa: E731
+    _ago = lambda s: _relative_time(s.get("last_active"), session_id=s["id"])  # noqa: E731
     layouts = {  # (has_ws, has_titles): header, rule width, row formatter
         (True, True): (f"{'Title':<28} {'Workspace':<18} {'Last Active':<13} {'ID'}", 110,
                        lambda s: f"{_title(s, 26):<28} {_ws(s):<18} {_ago(s):<13} {s['id']}"),
@@ -727,7 +727,7 @@ def _cmd_pinned(db, args):
     print(f"{'Title':<32} {'Last Active':<13} {'Src':<9} {'ID'}\n" + "─" * 100)
     for s in pinned_rows:
         title = (s.get("title") or s.get("preview", "") or "—")[:30]
-        print(f"{title:<32} {_relative_time(s.get('last_active')):<13} {(s.get('source') or '-'):<9} {s['id']}")
+        print(f"{title:<32} {_relative_time(s.get('last_active'), session_id=s['id']):<13} {(s.get('source') or '-'):<9} {s['id']}")
 
 
 def _cmd_retitle_skills(db, args):

--- a/hermes_cli/sessions_cmd_browse.py
+++ b/hermes_cli/sessions_cmd_browse.py
@@ -58,7 +58,7 @@ def _format_row(s: dict, max_x: int) -> str:
     name = ((s.get("title") or "").strip() or (s.get("preview") or "").strip())[:name_width] or sid
     return (
         f"{name:<{name_width}}  {_session_status_tag(s.get('_status')):<5}  "
-        f"{_msgs_str(s):>5}  {_relative_time(s.get('last_active')):<10}  "
+        f"{_msgs_str(s):>5}  {_relative_time(s.get('last_active'), session_id=s['id']):<10}  "
         f"{s.get('source', '')[:6]:<5} {sid}"
     )
 
@@ -218,7 +218,7 @@ def _fallback_picker(sessions: list) -> Optional[str]:
     for i, s in enumerate(sessions):
         print(
             f"  {i + 1:>3}. {_clip(_label(s), 50):<50}  {_session_status_tag(s.get('_status')):<5}  "
-            f"{_msgs_str(s):>5}  {_relative_time(s.get('last_active')):<10}  {s.get('source', '')[:6]}"
+            f"{_msgs_str(s):>5}  {_relative_time(s.get('last_active'), session_id=s['id']):<10}  {s.get('source', '')[:6]}"
         )
     while True:
         try:

--- a/hermes_cli/timefmt.py
+++ b/hermes_cli/timefmt.py
@@ -2,13 +2,47 @@
 
 from __future__ import annotations
 
+import logging
+import math
 import time as _time
 from datetime import datetime
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Epoch-seconds window a stored timestamp must fall in to be trusted: 1970 .. ~2103 (inside 32-bit
+# ``time_t`` so ``fromtimestamp`` accepts it on every platform). SQLite dynamic typing lets a TEXT
+# cell, ``inf``/``nan`` or a garbage double (``8.4e252`` salvaged from a damaged page) sit in a REAL
+# column; ``datetime.fromtimestamp`` then raises and one bad row killed the whole listing, export
+# or report (#102399, #102352, #99959).
+EPOCH_MIN = 0.0
+EPOCH_MAX = 4_200_000_000.0
 
 
-def relative_time(ts) -> str:
-    """Format a timestamp as relative time (e.g., '2h ago', 'yesterday')."""
-    if not ts:
+def coerce_epoch(value: Any, *, session_id: Optional[str] = None, field: str = "timestamp") -> Optional[float]:
+    """A stored timestamp cell as float epoch seconds, or ``None`` when it cannot be trusted.
+
+    Numbers, numeric strings and ``datetime`` are accepted; anything else, non-finite values and
+    values outside ``EPOCH_MIN..EPOCH_MAX`` return ``None`` after a WARNING naming the session so
+    the corrupt row can be found. ``None``/``""`` mean "unset" and stay silent. Every reader that
+    renders a row timestamp goes through here (a bad row degrades to one ``?`` cell, never a dead
+    command) and every writer uses it to refuse persisting a new bad row.
+    """
+    if value is None or value == "":
+        return None
+    try:
+        ts = float(value.timestamp()) if isinstance(value, datetime) else float(value)
+    except (TypeError, ValueError):
+        ts = math.nan
+    if not (EPOCH_MIN <= ts <= EPOCH_MAX):  # also False for nan
+        logger.warning("Ignoring corrupt %s %r%s", field, value, f" on session {session_id}" if session_id else "")
+        return None
+    return ts
+
+
+def relative_time(ts, *, session_id: Optional[str] = None) -> str:
+    """Format a timestamp as relative time (e.g., '2h ago', 'yesterday'); ``?`` when unset or corrupt."""
+    if not ts or (ts := coerce_epoch(ts, session_id=session_id, field="last_active")) is None:
         return "?"
     delta = _time.time() - ts
     if delta < 60:

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -502,7 +502,16 @@ CREATE TABLE IF NOT EXISTS async_delegations (
     owner_started_at INTEGER,
     task_json TEXT,
     delivery_claim TEXT,
-    delivery_claimed_at REAL
+    delivery_claimed_at REAL,
+    -- Mirrors the delegation tool's own CREATE TABLE (tools/async_delegation.py
+    -- _initialize_schema). Keeping the canonical fresh-install shape identical
+    -- to the tool's avoids a silent schema drift: the tool's lazy
+    -- ALTER TABLE ADD COLUMN used to be the only source of this column, so two
+    -- databases at the same schema_version had different
+    -- async_delegations shapes depending on whether the delegation tool had
+    -- ever run, breaking rebuild/replay pipelines that reconstruct state.db
+    -- from the canonical schema (#94691).
+    origin_session_id TEXT NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -763,7 +763,7 @@ FTS_TRIGRAM_EXCLUDED_SOURCES = ("cron", "subagent")
 FTS_TRIGRAM_SESSION_SQL = (
     "source NOT IN ("
     + ", ".join(f"'{src}'" for src in FTS_TRIGRAM_EXCLUDED_SOURCES)
-    + ") AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL"
+    + f") AND {_sql_json_extract('model_config', '$._delegate_from')} IS NULL"
 )
 
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -38,6 +38,16 @@ def _sql_literal(text: str) -> str:
     return "'" + text.replace("'", "''") + "'"
 
 
+def _sql_json_extract(expression: str, path: str) -> str:
+    """Build a non-throwing JSON marker lookup for a JSON TEXT column."""
+
+    safe_json = (
+        f"(CASE WHEN json_valid({expression}) "
+        f"THEN {expression} ELSE json_object() END)"
+    )
+    return f"json_extract({safe_json}, {_sql_literal(path)})"
+
+
 def _sql_ltrim_whitespace(expression: str) -> str:
     return f"LTRIM({expression}, {_SQL_WHITESPACE})"
 
@@ -112,7 +122,7 @@ _PREVIEW_RAW_SUBQUERY_SQL = (f"COALESCE((SELECT {_PREVIEW_RAW_SELECT} FROM messa
 # ── Session lineage predicates ({a} = sessions alias) ───────────────────────
 
 # /branch child (kept visible, never cascade-deleted): stable marker OR legacy end_reason heuristic.
-_BRANCH_CHILD_SQL = ("json_extract(COALESCE({a}.model_config, '{{}}'), '$._branched_from') IS NOT NULL"
+_BRANCH_CHILD_SQL = (f"{_sql_json_extract('{a}.model_config', '$._branched_from')} IS NOT NULL"
     " OR EXISTS (SELECT 1 FROM sessions p            WHERE p.id = {a}.parent_session_id"
     "            AND p.end_reason = 'branched'            AND {a}.started_at >= p.ended_at)")
 _COMPRESSION_CHILD_SQL = ("EXISTS (SELECT 1 FROM sessions p        WHERE p.id = {a}.parent_session_id"
@@ -166,7 +176,7 @@ def _legacy_reset_child_sql(alias: str, reasons_sql: str) -> str:
 
 # A reset starts a separate user-visible conversation though rows keep parent_session_id for lineage.
 # Stable marker, or the same-key fallback for pre-marker rows (exact key keeps subagent children out).
-_RESET_CHILD_SQL = ("json_extract(COALESCE({a}.model_config, '{{}}'), '$._reset_from') IS NOT NULL"
+_RESET_CHILD_SQL = (f"{_sql_json_extract('{a}.model_config', '$._reset_from')} IS NOT NULL"
     " OR " + _legacy_reset_child_sql("{a}", _RESET_END_REASONS_SQL))
 
 # Picker-visible rows: roots + branch/reset children (not subagent runs or compression continuations).

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -756,22 +756,20 @@ END;
 # ``parent_session_id`` but NOT the marker, so they stay trigram-indexed.
 FTS_TRIGRAM_EXCLUDED_SOURCES = ("cron", "subagent")
 
-# Predicate over a ``sessions`` row (unqualified column names) selecting
-# sessions whose rows belong in the trigram index. Shared by the view, the
-# sync triggers, and the deferred-backfill INSERT ... SELECTs so they can
-# never disagree about the index boundary.
-FTS_TRIGRAM_SESSION_SQL = (
-    "source NOT IN ("
-    + ", ".join(f"'{src}'" for src in FTS_TRIGRAM_EXCLUDED_SOURCES)
-    + f") AND {_sql_json_extract('model_config', '$._delegate_from')} IS NULL"
-)
-
-
-def fts_trigram_session_sql(alias: str) -> str:
-    """``FTS_TRIGRAM_SESSION_SQL`` with every column qualified by ``alias``."""
-    return FTS_TRIGRAM_SESSION_SQL.replace("source ", f"{alias}.source ").replace(
-        "COALESCE(model_config", f"COALESCE({alias}.model_config"
+def fts_trigram_session_sql(alias: str = "") -> str:
+    """Predicate over a ``sessions`` row selecting sessions whose rows belong in
+    the trigram index; ``alias`` qualifies every column for joins. Shared by the
+    view, the sync triggers, and the deferred-backfill INSERT ... SELECTs so they
+    can never disagree about the index boundary."""
+    q = f"{alias}." if alias else ""
+    return (
+        f"{q}source NOT IN ("
+        + ", ".join(f"'{src}'" for src in FTS_TRIGRAM_EXCLUDED_SOURCES)
+        + f") AND {_sql_json_extract(q + 'model_config', '$._delegate_from')} IS NULL"
     )
+
+
+FTS_TRIGRAM_SESSION_SQL = fts_trigram_session_sql()
 
 
 FTS_TRIGRAM_SQL = f"""

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -279,6 +279,19 @@ def _placeholders(items) -> str:
     return ",".join("?" for _ in range(items if isinstance(items, int) else len(items)))
 
 
+# Ids per ``IN (?,...)`` list: SQLite caps bound parameters at SQLITE_MAX_VARIABLE_NUMBER (999 on builds
+# < 3.32, 32766 after); a bulk prune of a cron-heavy store bound tens of thousands of ids into one list and
+# died with "too many SQL variables". Every IN-list over session ids goes through ``_id_chunks``.
+_SQL_IN_CHUNK = 900
+
+
+def _id_chunks(ids, size: int = _SQL_IN_CHUNK):
+    """Yield *ids* (any iterable) as lists of at most *size* elements."""
+    ids = list(ids)
+    for start in range(0, len(ids), size):
+        yield ids[start:start + size]
+
+
 _FTS_TRIGGERS = ("messages_fts_insert", "messages_fts_delete", "messages_fts_update",
                  "messages_fts_trigram_insert", "messages_fts_trigram_delete", "messages_fts_trigram_update")
 

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -12,7 +12,8 @@ import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_state_common import (
-    _BOUNDARY_END_REASONS, _COMPRESSION_LOCK_ROW_SQL as _LOCK_ROW_SQL, _ENDED_ROW_SQL, _ended_by_compression, _sql_session_last_active, is_automatic_end_reason)
+    _BOUNDARY_END_REASONS, _COMPRESSION_LOCK_ROW_SQL as _LOCK_ROW_SQL, _ENDED_ROW_SQL, _ended_by_compression,
+    _sql_json_extract, _sql_session_last_active, is_automatic_end_reason)
 
 # Log-record parity with the origin module (caplog tests pin "hermes_state").
 logger = logging.getLogger("hermes_state")
@@ -28,8 +29,8 @@ _CHAIN_STEP_SQL = f"""
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.id = ?
                       AND parent.end_reason = 'compression'
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                      AND {_sql_json_extract('child.model_config', '$._branched_from')} IS NULL
+                      AND {_sql_json_extract('child.model_config', '$._delegate_from')} IS NULL
                       AND COALESCE(child.source, '') != 'tool'
                     ORDER BY
                       CASE

--- a/hermes_state_gateway.py
+++ b/hermes_state_gateway.py
@@ -12,14 +12,15 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from hermes_state_common import _RECOVERABLE_END_REASONS_SQL, _RESET_END_REASONS_SQL, _sql_session_last_active
+from hermes_state_common import (
+    _RECOVERABLE_END_REASONS_SQL, _RESET_END_REASONS_SQL, _sql_json_extract, _sql_session_last_active)
 
 # Log-record parity with the origin module (caplog tests pin "hermes_state").
 logger = logging.getLogger("hermes_state")
 
 # Recursive CTE naming a session plus its compression ancestors (rows a
 # resume must keep on one routing peer); branch/delegate/tool rows stop it.
-_COMPRESSION_LINEAGE_CTE = """
+_COMPRESSION_LINEAGE_CTE = f"""
                     WITH RECURSIVE compression_lineage(id) AS (
                         SELECT ?
                         UNION
@@ -28,14 +29,8 @@ _COMPRESSION_LINEAGE_CTE = """
                         JOIN sessions child ON child.id = lineage.id
                         JOIN sessions parent ON parent.id = child.parent_session_id
                         WHERE parent.end_reason = 'compression'
-                          AND json_extract(
-                              COALESCE(child.model_config, '{}'),
-                              '$._branched_from'
-                          ) IS NULL
-                          AND json_extract(
-                              COALESCE(child.model_config, '{}'),
-                              '$._delegate_from'
-                          ) IS NULL
+                          AND {_sql_json_extract('child.model_config', '$._branched_from')} IS NULL
+                          AND {_sql_json_extract('child.model_config', '$._delegate_from')} IS NULL
                           AND COALESCE(child.source, '') != 'tool'
                     )
                 """
@@ -108,10 +103,8 @@ _ORPHANS_SQL = f"""
                   AND EXISTS (SELECT 1 FROM messages m
                                WHERE m.session_id = o.id)
                   AND COALESCE(o.source, '') != 'tool'
-                  AND json_extract(COALESCE(o.model_config, '{{}}'),
-                                   '$._branched_from') IS NULL
-                  AND json_extract(COALESCE(o.model_config, '{{}}'),
-                                   '$._delegate_from') IS NULL
+                  AND {_sql_json_extract('o.model_config', '$._branched_from')} IS NULL
+                  AND {_sql_json_extract('o.model_config', '$._delegate_from')} IS NULL
                 ORDER BY o.started_at ASC
                 """
 _ORPHAN_LINEAGE_DONOR_SQL = f"""

--- a/hermes_state_maintenance.py
+++ b/hermes_state_maintenance.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_state_common import (
-    AUTO_VACUUM_MIN_FREELIST_RATIO, _placeholders, _sql_session_last_active, escape_like as _escape_like
+    AUTO_VACUUM_MIN_FREELIST_RATIO, _id_chunks, _placeholders, _sql_session_last_active, escape_like as _escape_like
 )
 
 # caplog tests pin the "hermes_state" logger name.
@@ -95,8 +95,9 @@ class SessionMaintenanceMixin:
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id
                   )
             """, (cutoff,)).fetchall()]
+            for chunk in _id_chunks(ids):
+                conn.execute(f"DELETE FROM sessions WHERE id IN ({_placeholders(chunk)})", chunk)
             if ids:
-                conn.execute(f"DELETE FROM sessions WHERE id IN ({_placeholders(ids)})", ids)
                 self._delete_unreferenced_system_prompts(conn)
             return ids
         removed_ids = self._execute_write(_do) or []
@@ -282,12 +283,13 @@ class SessionMaintenanceMixin:
                                 if self._write_guards_reject(conn, sid, allow_closed_compression_parent=True)}
             if not session_ids:
                 return 0
-            conn.execute(f"UPDATE sessions SET parent_session_id = NULL "
-                         f"WHERE parent_session_id IN ({_placeholders(session_ids)})", list(session_ids))
-            for sid in session_ids:
-                conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
-                conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
-                removed_ids.append(sid)
+            # Batched: a cron-heavy store prunes tens of thousands of ids in one call.
+            for chunk in _id_chunks(session_ids):
+                ph = _placeholders(chunk)
+                conn.execute(f"UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id IN ({ph})", chunk)
+                conn.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", chunk)
+                conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", chunk)
+                removed_ids.extend(chunk)
             self._delete_unreferenced_system_prompts(conn)
             return len(session_ids)
         count = self._execute_write(_do)

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -14,7 +14,7 @@ from agent.memory_manager import sanitize_context
 from agent.message_sanitization import _sanitize_surrogates
 from hermes_state_common import (
     _COMPRESSION_LOCK_ROW_SQL, _ENDED_ROW_SQL, _RESET_END_REASONS, _RESET_END_REASONS_SQL, _ended_by_compression,
-    _legacy_reset_child_sql, _placeholders)
+    _legacy_reset_child_sql, _placeholders, _sql_json_extract)
 
 logger = logging.getLogger("hermes_state")  # caplog tests pin the origin module's name
 
@@ -868,9 +868,9 @@ class SessionMessagesMixin:
                         best = current
                     child_row = conn.execute(
                         "SELECT id FROM sessions AS child WHERE child.parent_session_id = ? "
-                        "  AND json_extract(COALESCE(child.model_config, '{}'), '$._branched_from') IS NULL "
-                        "  AND json_extract(COALESCE(child.model_config, '{}'), '$._delegate_from') IS NULL "
-                        "  AND json_extract(COALESCE(child.model_config, '{}'), '$._reset_from') IS NULL "
+                        f"  AND {_sql_json_extract('child.model_config', '$._branched_from')} IS NULL "
+                        f"  AND {_sql_json_extract('child.model_config', '$._delegate_from')} IS NULL "
+                        f"  AND {_sql_json_extract('child.model_config', '$._reset_from')} IS NULL "
                         f"  AND NOT {_legacy_reset_child_sql('child', _RESET_END_REASONS_SQL)} "
                         "  AND COALESCE(child.source, '') != 'tool' "
                         "ORDER BY child.started_at DESC, child.id DESC LIMIT 1", (current,)).fetchone()

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from agent.context_compressor import _DB_PERSISTED_MARKER as _DB_PERSISTED_MARKER_KEY, split_user_originated_turn
 from agent.memory_manager import sanitize_context
 from agent.message_sanitization import _sanitize_surrogates
+from hermes_cli.timefmt import coerce_epoch
 from hermes_state_common import (
     _COMPRESSION_LOCK_ROW_SQL, _ENDED_ROW_SQL, _RESET_END_REASONS, _RESET_END_REASONS_SQL, _ended_by_compression,
     _legacy_reset_child_sql, _placeholders, _sql_json_extract)
@@ -54,18 +55,15 @@ def _json_or(raw: Any, fallback: Any, warning: str) -> Any:
 
 
 def _coerce_timestamp(value: Any, default: float) -> float:
-    """Explicit message timestamp (datetime or number) or *default* when invalid."""
-    if value is None:
+    """Explicit message timestamp (datetime or number) or *default* when invalid or outside the sane
+    epoch window — the write-side twin of the readers' ``coerce_epoch``: a bad row is never persisted."""
+    result = coerce_epoch(value, field="message timestamp")
+    if result is None:
         return default
-    try:
-        result = float(value.timestamp()) if hasattr(value, "timestamp") else float(value)
-        # SQLite reads both signed zero spellings back as 0.0. Hash the value
-        # in that stored form so -0.0 and 0.0 retain the historical SQL/Python
-        # identity equality.
-        return 0.0 if result == 0.0 else result
-    except (TypeError, ValueError):
-        logger.debug("Ignoring invalid explicit message timestamp: %r", value)
-        return default
+    # SQLite reads both signed zero spellings back as 0.0. Hash the value
+    # in that stored form so -0.0 and 0.0 retain the historical SQL/Python
+    # identity equality.
+    return 0.0 if result == 0.0 else result
 
 
 def _parse_tool_calls(tool_calls: Any) -> Any:

--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.skill_commands import SKILL_SCAFFOLD_SQL_LIKE
 from utils import safe_json_loads
+from hermes_cli.timefmt import coerce_epoch
 from hermes_state_common import SCHEMA_SQL, _PREVIEW_RAW_SUBQUERY_SQL, _shape_preview, _sql_session_last_active
 
 # Pre-split logger identity so log filtering/capture is unchanged.
@@ -465,7 +466,7 @@ class SessionPortabilityMixin:
 
     def _import_session_row(self, conn, raw: Dict[str, Any], messages: List[Dict[str, Any]], session_id: str) -> None:
         """INSERT one normalized session + its messages; counts fixed up after."""
-        started_at = self._coerce_or(raw.get("started_at"), float, None)
+        started_at = coerce_epoch(raw.get("started_at"), session_id=session_id, field="started_at")
         params = {
             "id": session_id, "source": str(raw.get("source") or "import"),
             "system_prompt_hash": self._store_system_prompt(conn, raw.get("system_prompt")),

--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -258,7 +258,22 @@ class SessionPortabilityMixin:
 
     def export_all(self, source: str = None) -> List[Dict[str, Any]]:
         """Export all sessions (with messages) as dicts, e.g. for JSONL backup."""
-        return [self._with_messages(s) for s in self.search_sessions(source=source, limit=100000)]
+        sessions = self.search_sessions(source=source, limit=100000)
+        messages_by_session = {session["id"]: [] for session in sessions}
+        session_ids = list(messages_by_session)
+        # Stay below SQLite's legacy 999-variable limit while replacing the per-session N+1 reads.
+        for start in range(0, len(session_ids), 900):
+            chunk = session_ids[start:start + 900]
+            rows = self._read_all(
+                f"SELECT * FROM messages WHERE session_id IN ({','.join('?' for _ in chunk)}) "
+                "AND active = 1 ORDER BY session_id, id",
+                chunk,
+            )
+            for row in rows:
+                messages_by_session[row["session_id"]].append(
+                    self._row_to_message_dict(row, warn_context="get_messages", summary_flag=True)
+                )
+        return [{**session, "messages": messages_by_session[session["id"]]} for session in sessions]
 
     def adopt_session_lineage_from(self, donor_db: Any, session_id: str, *, retire_donor: bool = True) -> Dict[str, Any]:
         """Adopt *session_id*'s full compression lineage from *donor_db* (stranded-bot-session

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -1197,3 +1197,25 @@ class SessionSchemaMixin:
                     1 if entry.get("expiry_finalized") or entry.get("memory_flushed") else 0, str(session_id),
                 ),
             )
+
+
+def reconcile_state_schema(conn: sqlite3.Connection) -> None:
+    """Bring a raw ``state.db`` connection to the canonical SCHEMA_SQL shape.
+
+    Single durable-shape authority for callers that open ``state.db``
+    outside SessionDB. The async-delegation tool used to carry its own
+    CREATE TABLE and ALTER column list for ``async_delegations``; it drifted
+    from SCHEMA_SQL (same-name columns with different nullability/defaults
+    depending on which authority touched the database first, #94691). This
+    helper instead replays the canonical DDL (every statement is
+    IF NOT EXISTS/idempotent) and reuses SessionDB's declarative column
+    reconciliation, so out-of-band openers can never grow a second
+    hand-maintained shape for the same durable tables.
+    """
+    conn.executescript(SCHEMA_SQL)
+    # _reconcile_columns only touches the staticmethod _parse_schema_columns,
+    # so a bare instance works; reusing it keeps one reconciliation
+    # implementation (one authority) instead of a near-copy on raw
+    # connections.
+    shim = object.__new__(SessionSchemaMixin)
+    shim._reconcile_columns(conn.cursor())

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -24,7 +24,7 @@ from hermes_state_common import (
     DEFERRED_INDEX_SQL, FTS_CJK_STALE_KEY, FTS_REBUILD_DEFERRAL_KEY, FTS_STALE_KEY, FTS_SQL,
     FTS_STORAGE_VERSION, FTS_TOOL_FULL_CONTENT_HIGH_WATER_KEY, FTS_TRIGRAM_SQL, LEGACY_FTS_SQL,
     LEGACY_FTS_TRIGRAM_SQL, SCHEMA_SQL,
-    SCHEMA_VERSION, _FTS_CJK_TRIGGERS, _FTS_TRIGGERS, _ephemeral_child_sql, fts_rebuild_admission,
+    SCHEMA_VERSION, _FTS_CJK_TRIGGERS, _FTS_TRIGGERS, _ephemeral_child_sql, _sql_json_extract, fts_rebuild_admission,
 )
 from hermes_state_holders import _read_proc_argv
 
@@ -939,14 +939,14 @@ class SessionSchemaMixin:
                     "UPDATE sessions SET model_config = json_set("
                     "COALESCE(model_config, '{}'), '$._delegate_from', parent_session_id) "
                     f"WHERE parent_session_id IS NOT NULL "
-                    "AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL "
+                    f"AND {_sql_json_extract('model_config', '$._delegate_from')} IS NULL "
                     f"AND {_ephemeral_child_sql('sessions')}"
                 )
                 cursor.execute(
                     "UPDATE sessions SET model_config = json_set("
                     "COALESCE(model_config, '{}'), '$._delegate_from', '__orphaned__') WHERE parent_session_id IS NULL "
-                    "AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL "
-                    "AND json_extract(COALESCE(model_config, '{}'), '$._branched_from') IS NULL "
+                    f"AND {_sql_json_extract('model_config', '$._delegate_from')} IS NULL "
+                    f"AND {_sql_json_extract('model_config', '$._branched_from')} IS NULL "
                     "AND title IS NULL AND message_count <= 25 AND EXISTS (SELECT 1 FROM messages m "
                     "            WHERE m.session_id = sessions.id AND m.role = 'tool') "
                     "AND NOT EXISTS (SELECT 1 FROM sessions ch "

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -454,8 +454,7 @@ class SessionSessionsMixin:
             conn.execute(
                 "UPDATE sessions AS child SET model_config = json_set("
                 "COALESCE(child.model_config, '{}'), '$._reset_from', child.parent_session_id) "
-                "WHERE child.parent_session_id = ? AND json_extract(COALESCE(child.model_config, '{}'), "
-                "                 '$._reset_from') IS NULL "
+                f"WHERE child.parent_session_id = ? AND {_sql_json_extract('child.model_config', '$._reset_from')} IS NULL "
                 f"AND {_legacy_reset_child_sql('child', _session_ids_placeholders(_RESET_END_REASONS))}",
                 (session_id, *_RESET_END_REASONS),
             )

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -16,7 +16,7 @@ from agent.session_activity import (
 from hermes_state_common import (
     _LISTABLE_CHILD_SQL, _PREVIEW_ELIGIBLE_SQL, _PREVIEW_RAW_SELECT, _RECOVERABLE_END_REASONS,
     _RECOVERABLE_END_REASONS_SQL, _RESET_END_REASONS, _legacy_reset_child_sql, _shape_preview,
-    _sql_session_last_active, _sql_session_last_active_by_id, escape_like as _escape_like,
+    _sql_json_extract, _sql_session_last_active, _sql_session_last_active_by_id, escape_like as _escape_like,
     _placeholders as _session_ids_placeholders,
 )
 
@@ -31,7 +31,7 @@ def workspace_key(row: Dict[str, Any]) -> Optional[str]:
 
 
 def _delegate_from_json(col: str = "model_config") -> str:
-    return f"json_extract(COALESCE({col}, '{{}}'), '$._delegate_from')"
+    return _sql_json_extract(col, "$._delegate_from")
 
 
 # _merge_model_config_json's "no such row" result — distinct from the legal None
@@ -420,10 +420,9 @@ class SessionSessionsMixin:
     # are bound to the queried parent id: continuations inherit model_config verbatim, so
     # presence-matching misclassified them as delegates.
     _NON_CONTINUATION_CHILD_FILTER_SQL = (
-        "  AND COALESCE(json_extract(COALESCE({alias}model_config, '{{}}'),"
-        " '$._branched_from'), '') != ?\n"
-        "  AND COALESCE(json_extract(COALESCE({alias}model_config, '{{}}'),"
-        " '$._delegate_from'), '') != ?\n  AND COALESCE({alias}source, '') != 'tool'\n"
+        f"  AND COALESCE({_sql_json_extract('{alias}model_config', '$._branched_from')}, '') != ?\n"
+        f"  AND COALESCE({_sql_json_extract('{alias}model_config', '$._delegate_from')}, '') != ?\n"
+        "  AND COALESCE({alias}source, '') != 'tool'\n"
     )
 
     def end_session(self, session_id: str, end_reason: str) -> None:
@@ -1231,8 +1230,8 @@ class SessionSessionsMixin:
                     JOIN sessions parent ON parent.id = c.cur_id
                     JOIN sessions child ON child.parent_session_id = c.cur_id
                     WHERE parent.end_reason = 'compression'
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                      AND {_sql_json_extract('child.model_config', '$._branched_from')} IS NULL
+                      AND {_sql_json_extract('child.model_config', '$._delegate_from')} IS NULL
                       AND COALESCE(child.source, '') != 'tool'
                 ),
                 chain_max AS (

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -1573,16 +1573,14 @@ class SessionSessionsMixin:
             ).fetchall()}
             if not session_ids:
                 return 0
-            conn.execute(
-                "UPDATE sessions SET parent_session_id = NULL "
-                f"WHERE parent_session_id IN ({_session_ids_placeholders(session_ids)})", list(session_ids),
-            )
-            for sid in session_ids:
+            for chunk in _id_chunks(session_ids):
+                ph = _session_ids_placeholders(chunk)
+                conn.execute(f"UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id IN ({ph})", chunk)
                 # DELETE FROM messages: a row inserted between the SELECT and here
                 # would otherwise dangle (clean FK state).
-                conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
-                conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
-                removed_ids.append(sid)
+                conn.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", chunk)
+                conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", chunk)
+                removed_ids.extend(chunk)
             self._delete_unreferenced_system_prompts(conn)
             return len(session_ids)
         count = self._execute_write(_do)

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -17,7 +17,7 @@ from hermes_state_common import (
     _LISTABLE_CHILD_SQL, _PREVIEW_ELIGIBLE_SQL, _PREVIEW_RAW_SELECT, _RECOVERABLE_END_REASONS,
     _RECOVERABLE_END_REASONS_SQL, _RESET_END_REASONS, _legacy_reset_child_sql, _shape_preview,
     _sql_json_extract, _sql_session_last_active, _sql_session_last_active_by_id, escape_like as _escape_like,
-    _placeholders as _session_ids_placeholders,
+    _SQL_IN_CHUNK, _id_chunks, _placeholders as _session_ids_placeholders,
 )
 
 # caplog tests pin the "hermes_state" logger name.
@@ -141,24 +141,29 @@ def _collect_delegate_child_ids(conn, parent_ids: List[str]) -> List[str]:
     found: set[str] = set(seeds)
     frontier = list(seeds)
     while frontier:
-        ph = _session_ids_placeholders(frontier)
-        cursor = conn.execute(
-            f"SELECT id FROM sessions WHERE {df} IN ({ph}) "
-            f"OR (parent_session_id IN ({ph}) AND {df} IS NOT NULL)", frontier + frontier,
-        )
-        frontier = [row["id"] for row in cursor.fetchall() if row["id"] not in found]
-        found.update(frontier)
+        next_frontier: List[str] = []
+        for chunk in _id_chunks(frontier, _SQL_IN_CHUNK // 2):  # each id is bound twice below
+            ph = _session_ids_placeholders(chunk)
+            cursor = conn.execute(
+                f"SELECT id FROM sessions WHERE {df} IN ({ph}) "
+                f"OR (parent_session_id IN ({ph}) AND {df} IS NOT NULL)", chunk + chunk,
+            )
+            for row in cursor.fetchall():
+                if row["id"] not in found:
+                    found.add(row["id"])
+                    next_frontier.append(row["id"])
+        frontier = next_frontier
     return [sid for sid in found if sid not in seeds]
 
 
 def _delete_delegate_children(conn, parent_ids: List[str]) -> List[str]:
     ids = _collect_delegate_child_ids(conn, parent_ids)
-    if ids:
-        ph = _session_ids_placeholders(ids)
-        conn.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", ids)
+    for chunk in _id_chunks(ids):
+        ph = _session_ids_placeholders(chunk)
+        conn.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", chunk)
         # FK safety: orphan any untagged stragglers pointing at a doomed row.
-        conn.execute(f"UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id IN ({ph})", ids)
-        conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", ids)
+        conn.execute(f"UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id IN ({ph})", chunk)
+        conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", chunk)
     return ids
 
 
@@ -1524,19 +1529,19 @@ class SessionSessionsMixin:
             return 0
         removed_ids: list[str] = []
         def _do(conn):
-            existing = [row["id"] for row in conn.execute(
-                f"SELECT id FROM sessions WHERE id IN ({_session_ids_placeholders(unique_ids)})",
-                unique_ids,
+            existing = [row["id"] for chunk in _id_chunks(unique_ids) for row in conn.execute(
+                f"SELECT id FROM sessions WHERE id IN ({_session_ids_placeholders(chunk)})", chunk,
             ).fetchall()]
             if not existing:
                 return 0
-            ph = _session_ids_placeholders(existing)
             removed_ids.extend(_delete_delegate_children(conn, existing))
-            conn.execute(  # orphan children whose parent is in the kill list (FK)
-                f"UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id IN ({ph})", existing,
-            )
-            conn.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", existing)
-            conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", existing)
+            for chunk in _id_chunks(existing):
+                ph = _session_ids_placeholders(chunk)
+                conn.execute(  # orphan children whose parent is in the kill list (FK)
+                    f"UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id IN ({ph})", chunk,
+                )
+                conn.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", chunk)
+                conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", chunk)
             self._delete_unreferenced_system_prompts(conn)
             removed_ids.extend(existing)
             return len(existing)

--- a/tests/hermes_state/test_corrupt_row_robustness.py
+++ b/tests/hermes_state/test_corrupt_row_robustness.py
@@ -1,0 +1,92 @@
+"""One corrupt timestamp row must degrade to one '?' cell, never kill a whole listing/export/report.
+
+Real SQLite fixtures: SQLite dynamic typing lets a TEXT cell or a garbage double sit in a REAL
+timestamp column (#102399, #102352, #99959). Never monkeypatch the coercion helper.
+"""
+
+import argparse
+import logging
+import sqlite3
+
+import pytest
+
+from agent.insights import InsightsEngine
+from hermes_cli.session_export import iter_user_prompt_records
+from hermes_cli.session_export_html import generate_multi_session_html_export
+from hermes_cli.session_export_md import _iso_timestamp
+from hermes_cli.sessions_cmd import _cmd_list
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def corrupt_db(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    for sid in ("good", "bad-text", "bad-huge"):
+        db.create_session(sid, "cli")
+        db.append_message(sid, "user", f"hello from {sid}")
+
+    def _corrupt(conn):
+        conn.execute("UPDATE sessions SET started_at='not-a-timestamp', last_activity_at='not-a-timestamp' "
+                     "WHERE id='bad-text'")
+        conn.execute("UPDATE messages SET timestamp='not-a-timestamp' WHERE session_id='bad-text'")
+        conn.execute("UPDATE sessions SET started_at=8.4e252 WHERE id='bad-huge'")
+        conn.execute("UPDATE messages SET timestamp=1e30 WHERE session_id='bad-huge'")
+
+    db._execute_write(_corrupt)
+    yield db
+    db.close()
+
+
+def test_list_export_and_insights_survive_corrupt_timestamp_rows(corrupt_db, capsys, caplog):
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.timefmt"):
+        _cmd_list(corrupt_db, argparse.Namespace(limit=20, source=None, all=False, workspace=None))
+        listing = capsys.readouterr().out
+        exported = corrupt_db.export_all()
+        records = list(iter_user_prompt_records(exported))
+        html = generate_multi_session_html_export(exported)
+        md_stamps = [_iso_timestamp(s["started_at"]) for s in exported]
+        report = InsightsEngine(corrupt_db).generate(days=365_000)
+
+    # Every session is still present on every surface; the bad cells degrade, the good one renders.
+    assert all(sid in listing for sid in ("good", "bad-text", "bad-huge")) and "?" in listing
+    assert {r["session_id"] for r in records} == {"good", "bad-text", "bad-huge"}
+    assert "not-a-timestamp" not in html and html.count("N/A") >= 2
+    assert md_stamps.count("not-a-timestamp") == 1 and any(stamp.endswith("Z") for stamp in md_stamps)
+    assert report["overview"]["total_sessions"] == 3
+    # The warning names the session so the corrupt row can be found.
+    assert any("bad-huge" in rec.getMessage() for rec in caplog.records)
+
+
+def test_writers_never_persist_an_out_of_window_timestamp(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s", "cli")
+        db.append_message("s", "user", "a", timestamp=8.4e252)
+        db.append_messages_batch("s", [{"role": "assistant", "content": "b", "timestamp": "not-a-timestamp"}])
+        stored = [row["timestamp"] for row in db.get_messages("s")]
+    finally:
+        db.close()
+    assert len(stored) == 2 and all(isinstance(ts, float) and 0 < ts < 4.2e9 for ts in stored)
+
+
+def test_bulk_delete_and_prune_stay_below_sqlite_variable_limit(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        old = 1_600_000_000.0
+        ids = [f"cron_job_{i}" for i in range(1200)]
+
+        def seed(conn):
+            conn.executemany("INSERT INTO sessions (id, source, started_at, ended_at, message_count) "
+                             "VALUES (?, 'cron', ?, ?, 1)", [(sid, old, old) for sid in ids])
+            conn.executemany("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, 'user', 'x', ?)",
+                             [(sid, old) for sid in ids])
+
+        db._execute_write(seed)
+        db._conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 999)  # the legacy ceiling, deterministic
+        assert db.prune_sessions(older_than_days=14, source="cron") == 1200
+        db._execute_write(seed)
+        db._conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 999)
+        assert db.delete_sessions(ids) == 1200
+        assert db._read_one("SELECT COUNT(*) FROM messages WHERE session_id NOT IN (SELECT id FROM sessions)")[0] == 0
+    finally:
+        db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1835,6 +1835,81 @@ class TestSchemaInit:
                 )
 
 
+class TestAsyncDelegationsSchemaAgreement:
+    """SCHEMA_SQL and the delegation tool's own DDL must declare the same
+    shape (#94691).
+
+    The delegation tool carries its own CREATE TABLE for async_delegations
+    (plus a lazy ALTER for pre-existing tables). When its column list drifts
+    ahead of the canonical SCHEMA_SQL, two databases at the same
+    schema_version end up with different async_delegations shapes depending
+    only on whether the delegation tool ever ran — breaking rebuild/replay
+    pipelines that reconstruct state.db from the canonical schema.
+    """
+
+    def _async_delegations_columns(self, conn):
+        import sqlite3
+
+        rows = conn.execute(
+            "PRAGMA table_info(async_delegations)"
+        ).fetchall()
+        return {row[1] for row in rows}
+
+    def test_fresh_db_and_tool_schema_agree(self, tmp_path):
+        import sqlite3
+
+        from tools.async_delegation import _initialize_schema
+
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        db.close()
+
+        conn = sqlite3.connect(db_path)
+        try:
+            canonical_cols = self._async_delegations_columns(conn)
+            # The drift column from the tool's DDL is present from the
+            # canonical fresh-install shape (#94691).
+            assert "origin_session_id" in canonical_cols
+            _initialize_schema(conn)
+            conn.commit()
+            after_cols = self._async_delegations_columns(conn)
+        finally:
+            conn.close()
+
+        # Running the tool's schema initializer over a canonical database
+        # must not change the table's shape — the two authorities agree.
+        assert after_cols == canonical_cols
+
+    def test_reconcile_backfills_drift_column_on_pre_tool_db(self, tmp_path):
+        """A database created before the column existed (canonical schema
+        without it, delegation tool never run) gets it backfilled by the
+        declarative reconciliation on the next writable open."""
+        import sqlite3
+
+        from hermes_state_common import SCHEMA_SQL
+
+        db_path = tmp_path / "legacy-state.db"
+        legacy_sql = SCHEMA_SQL.replace(
+            "    origin_session_id TEXT NOT NULL DEFAULT ''\n", ""
+        ).replace(
+            "    delivery_claimed_at REAL,\n",
+            "    delivery_claimed_at REAL\n",
+        )
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.executescript(legacy_sql)
+            assert "origin_session_id" not in self._async_delegations_columns(conn)
+        finally:
+            conn.close()
+
+        db = SessionDB(db_path=db_path)
+        try:
+            cols = self._async_delegations_columns(db._conn)
+            assert "origin_session_id" in cols
+        finally:
+            db.close()
+
+
 class TestReconcileColumnsErrorHandling:
     """_reconcile_columns must not bury migration failures (#79531/#80037).
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2365,6 +2365,59 @@ class TestListSessionsRich:
         assert len(sessions) == 1
         assert "Help me refactor the auth module" in sessions[0]["preview"]
 
+    @pytest.mark.parametrize(
+        "unsafe_model_config",
+        ["{not-json", "[]", '"scalar"', "5", "null"],
+    )
+    def test_unsafe_model_config_does_not_break_session_surfaces(
+        self, db, unsafe_model_config
+    ):
+        db.create_session("root", "telegram")
+        db.append_message("root", "user", "root message")
+        db.create_session("compression-parent", "telegram")
+        db.end_session("compression-parent", "compression")
+        db.create_session(
+            "compression-child",
+            "telegram",
+            parent_session_id="compression-parent",
+        )
+        db.append_message("compression-child", "user", "child message")
+        db.create_session("routing-orphan", "telegram")
+        db.append_message("routing-orphan", "user", "orphan message")
+        db._conn.execute(
+            "UPDATE sessions SET model_config = ? "
+            "WHERE id IN (?, ?, ?)",
+            (unsafe_model_config, "root", "compression-child", "routing-orphan"),
+        )
+        db._conn.commit()
+
+        listed = db.list_sessions_rich(source="telegram")
+        ordered = db.list_sessions_rich(
+            source="telegram", order_by_last_active=True
+        )
+
+        assert "root" in {row["id"] for row in listed}
+        assert "root" in {row["id"] for row in ordered}
+        assert db.session_count(source="telegram", exclude_children=True) == 3
+        assert db.session_count_by_source(exclude_children=True)["telegram"] == 3
+        assert db.get_compression_chain("compression-parent") == [
+            "compression-parent",
+            "compression-child",
+        ]
+        db.record_gateway_session_peer(
+            "compression-child",
+            source="telegram",
+            session_key="agent:main:telegram:dm:recovered",
+            include_compression_ancestors=True,
+        )
+        assert db.get_session("compression-parent")["session_key"] == (
+            "agent:main:telegram:dm:recovered"
+        )
+        assert any(
+            row["orphan_id"] == "routing-orphan"
+            for row in db.find_orphaned_gateway_sessions()
+        )
+
 
 
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1836,26 +1836,84 @@ class TestSchemaInit:
 
 
 class TestAsyncDelegationsSchemaAgreement:
-    """SCHEMA_SQL and the delegation tool's own DDL must declare the same
-    shape (#94691).
+    """One durable-shape authority for async_delegations (#94691).
 
-    The delegation tool carries its own CREATE TABLE for async_delegations
-    (plus a lazy ALTER for pre-existing tables). When its column list drifts
-    ahead of the canonical SCHEMA_SQL, two databases at the same
-    schema_version end up with different async_delegations shapes depending
-    only on whether the delegation tool ever ran — breaking rebuild/replay
-    pipelines that reconstruct state.db from the canonical schema.
+    The delegation tool used to carry its own CREATE TABLE + ALTER column
+    list; it drifted from SCHEMA_SQL (a same-name column with a different
+    shape depending on which authority touched the database first). The
+    tool's initializer now routes through the canonical reconciler, so
+    every opening order must land on the same canonical shape — compared
+    over FULL PRAGMA table_info metadata (type, notnull, dflt_value, pk),
+    not just column names, and with the canonical index set pinned.
     """
 
-    def _async_delegations_columns(self, conn):
+    def _table_info(self, conn):
+        return {
+            row[1]: (row[2], row[3], row[4], row[5])
+            for row in conn.execute(
+                "PRAGMA table_info(async_delegations)"
+            ).fetchall()
+        }
+
+    def _canonical_shape(self):
+        ref = __import__("sqlite3").connect(":memory:")
+        try:
+            from hermes_state_common import SCHEMA_SQL
+
+            ref.executescript(SCHEMA_SQL)
+            return self._table_info(ref), {
+                row[0]
+                for row in ref.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='async_delegations' AND sql IS NOT NULL"
+                ).fetchall()
+            }
+        finally:
+            ref.close()
+
+    def _legacy_db(self, db_path):
+        """A database created before origin_session_id existed, carrying a
+        pre-existing delegation row that must survive every opening order."""
         import sqlite3
 
-        rows = conn.execute(
-            "PRAGMA table_info(async_delegations)"
-        ).fetchall()
-        return {row[1] for row in rows}
+        from hermes_state_common import SCHEMA_SQL
 
-    def test_fresh_db_and_tool_schema_agree(self, tmp_path):
+        legacy_sql = SCHEMA_SQL.replace(
+            "    origin_session_id TEXT NOT NULL DEFAULT ''\n", ""
+        ).replace(
+            "    delivery_claimed_at REAL,\n",
+            "    delivery_claimed_at REAL\n",
+        )
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.executescript(legacy_sql)
+            conn.execute(
+                "INSERT INTO async_delegations (delegation_id, origin_session, origin_ui_session_id, state, dispatched_at, updated_at) VALUES ('legacy-1', 'sess-a', '', 'completed', 1.0, 1.0)"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _assert_canonical(self, conn):
+        expected_cols, expected_indexes = self._canonical_shape()
+        live_cols = self._table_info(conn)
+        assert live_cols == expected_cols
+        live_indexes = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='async_delegations' AND sql IS NOT NULL"
+            ).fetchall()
+        }
+        assert live_indexes == expected_indexes
+        row = conn.execute(
+            "SELECT delegation_id, IFNULL(origin_session_id, '<null>') FROM async_delegations WHERE delegation_id='legacy-1'"
+        ).fetchone()
+        if row is not None:
+            # The legacy row survived and the canonical '' default
+            # backfilled the added column (SQLite ADD COLUMN ... DEFAULT
+            # populates existing rows with the default).
+            assert row[1] == ""
+
+    def test_fresh_session_db_then_tool(self, tmp_path):
         import sqlite3
 
         from tools.async_delegation import _initialize_schema
@@ -1866,46 +1924,42 @@ class TestAsyncDelegationsSchemaAgreement:
 
         conn = sqlite3.connect(db_path)
         try:
-            canonical_cols = self._async_delegations_columns(conn)
-            # The drift column from the tool's DDL is present from the
-            # canonical fresh-install shape (#94691).
-            assert "origin_session_id" in canonical_cols
+            shape_before = self._table_info(conn)
             _initialize_schema(conn)
             conn.commit()
-            after_cols = self._async_delegations_columns(conn)
+            assert self._table_info(conn) == shape_before
+            self._assert_canonical(conn)
         finally:
             conn.close()
 
-        # Running the tool's schema initializer over a canonical database
-        # must not change the table's shape — the two authorities agree.
-        assert after_cols == canonical_cols
+    def test_legacy_store_then_session_db(self, tmp_path):
+        db_path = tmp_path / "legacy-state.db"
+        self._legacy_db(db_path)
 
-    def test_reconcile_backfills_drift_column_on_pre_tool_db(self, tmp_path):
-        """A database created before the column existed (canonical schema
-        without it, delegation tool never run) gets it backfilled by the
-        declarative reconciliation on the next writable open."""
+        db = SessionDB(db_path=db_path)
+        try:
+            self._assert_canonical(db._conn)
+        finally:
+            db.close()
+
+    def test_legacy_store_then_tool_then_session_db(self, tmp_path):
         import sqlite3
 
-        from hermes_state_common import SCHEMA_SQL
+        from tools.async_delegation import _initialize_schema
 
-        db_path = tmp_path / "legacy-state.db"
-        legacy_sql = SCHEMA_SQL.replace(
-            "    origin_session_id TEXT NOT NULL DEFAULT ''\n", ""
-        ).replace(
-            "    delivery_claimed_at REAL,\n",
-            "    delivery_claimed_at REAL\n",
-        )
+        db_path = tmp_path / "legacy-tool-state.db"
+        self._legacy_db(db_path)
+
         conn = sqlite3.connect(db_path)
         try:
-            conn.executescript(legacy_sql)
-            assert "origin_session_id" not in self._async_delegations_columns(conn)
+            _initialize_schema(conn)
+            conn.commit()
         finally:
             conn.close()
 
         db = SessionDB(db_path=db_path)
         try:
-            cols = self._async_delegations_columns(db._conn)
-            assert "origin_session_id" in cols
+            self._assert_canonical(db._conn)
         finally:
             db.close()
 

--- a/tests/test_session_export_batch.py
+++ b/tests/test_session_export_batch.py
@@ -1,0 +1,41 @@
+from hermes_state import SessionDB
+
+
+def test_export_all_batches_message_reads_without_changing_export_rows(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        for index, source in enumerate(("cli", "telegram", "cli", "cli")):
+            session_id = f"session-{index}"
+            db.create_session(session_id=session_id, source=source)
+            db.append_messages_batch(
+                session_id,
+                [
+                    {"role": "user", "content": f"question {index}"},
+                    {
+                        "role": "assistant",
+                        "content": f"answer {index}",
+                        "tool_calls": [{"id": f"call-{index}", "type": "function"}],
+                    },
+                ],
+            )
+
+        sessions = db.search_sessions(source="cli", limit=100000)
+        expected = [
+            {**session, "messages": db.get_messages(session["id"])}
+            for session in sessions
+        ]
+
+        original_read_all = db._read_all
+        read_calls = 0
+
+        def counted_read_all(*args, **kwargs):
+            nonlocal read_calls
+            read_calls += 1
+            return original_read_all(*args, **kwargs)
+
+        monkeypatch.setattr(db, "_read_all", counted_read_all)
+
+        assert db.export_all(source="cli") == expected
+        assert read_calls <= 2
+    finally:
+        db.close()

--- a/tests/tools/test_async_delegation_fd_leak.py
+++ b/tests/tools/test_async_delegation_fd_leak.py
@@ -79,6 +79,16 @@ def test_ledger_operations_close_every_connection(monkeypatch, tmp_path):
     assert set(opened) == set(closed)
 
 
+def _fail_large_schema_replay(self, script):
+    # The schema initializer replays the full canonical schema as one
+    # large multi-statement script (single durable-shape authority,
+    # #94691). Simulate the DDL failure on that path so the
+    # connect-close-on-init-failure contract stays pinned.
+    if len(script) > 1000:
+        raise sqlite3.OperationalError("simulated schema init failure")
+    return self._real.executescript(script)
+
+
 def test_schema_init_failure_still_closes_connection(monkeypatch, tmp_path):
     """A PRAGMA/DDL failure after connect() must still close the connection."""
     _point_ledger(monkeypatch, tmp_path)
@@ -97,6 +107,8 @@ def test_schema_init_failure_still_closes_connection(monkeypatch, tmp_path):
         return _FailingSchemaConnection(conn, closed)
 
     monkeypatch.setattr(ad.sqlite3, "connect", tracking_connect)
+
+    _FailingSchemaConnection.executescript = _fail_large_schema_replay
 
     with pytest.raises(sqlite3.OperationalError):
         with ad._transaction():

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -96,37 +96,18 @@ def _connect() -> sqlite3.Connection:
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:
     from hermes_state_repair import apply_durability_barriers
+    from hermes_state_schema import reconcile_state_schema
     # Preserve the journal mode SessionDB configured on state.db: forcing WAL from
     # every short-lived connection collides with live transcript/FTS writers.
     apply_durability_barriers(conn)
-    conn.execute("""CREATE TABLE IF NOT EXISTS async_delegations (
-            delegation_id TEXT PRIMARY KEY,
-            origin_session TEXT NOT NULL,
-            origin_ui_session_id TEXT NOT NULL DEFAULT '',
-            parent_session_id TEXT,
-            state TEXT NOT NULL,
-            dispatched_at REAL NOT NULL,
-            completed_at REAL,
-            updated_at REAL NOT NULL,
-            event_json TEXT,
-            result_json TEXT,
-            delivery_state TEXT NOT NULL DEFAULT 'pending',
-            delivery_attempts INTEGER NOT NULL DEFAULT 0,
-            delivered_at REAL,
-            owner_pid INTEGER,
-            owner_started_at INTEGER,
-            task_json TEXT,
-            delivery_claim TEXT,
-            delivery_claimed_at REAL,
-            origin_session_id TEXT NOT NULL DEFAULT ''
-        )""")
-    columns = {row[1] for row in conn.execute("PRAGMA table_info(async_delegations)")}
-    # origin_session_id: raw api_server session id of the ORIGINATING request
-    # (wake target); without it restart-recovered completions are unroutable there.
-    for name, sql_type in (("owner_pid", "INTEGER"), ("owner_started_at", "INTEGER"), ("task_json", "TEXT"),
-                           ("delivery_claim", "TEXT"), ("delivery_claimed_at", "REAL"), ("origin_session_id", "TEXT")):
-        if name not in columns:
-            conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
+    # Single durable-shape authority: the canonical SCHEMA_SQL drives both
+    # table creation and column backfill (reconcile_state_schema replays the
+    # canonical DDL and reuses SessionDB's declarative reconciliation). This
+    # module previously carried its own CREATE TABLE + ALTER column list,
+    # which drifted from SCHEMA_SQL — same-name columns with different
+    # nullability/defaults depending on which authority touched the database
+    # first (#94691).
+    reconcile_state_schema(conn)
 
 
 @contextmanager


### PR DESCRIPTION
One corrupt `state.db` row — a TEXT/garbage timestamp, malformed `model_config` JSON, or a bulk delete past SQLite's bound-variable ceiling — no longer kills `hermes sessions list/browse`, session export (JSONL/MD/QMD/HTML), `hermes insights`, `sessions prune`, or bulk delete; plus `async_delegations` gets one schema authority and `export_all` drops its N+1 query.

## What changed

- **One timestamp coercion helper** — `hermes_cli.timefmt.coerce_epoch()`: a stored cell → float epoch seconds inside a sane window (1970..~2103, inside 32-bit `time_t`) or `None` after a **WARNING naming the session id**. Every reader routes through it: `relative_time` (list/browse/resume picker), `format_epoch` (prune/candidates), the three exporters' timestamp formatters, insights `_get_sessions`/`_day`/period range. A bad row renders as `?` / `N/A` / raw text for that one cell; the command completes.
- **Write-side guard** — `hermes_state_messages._coerce_timestamp` (`append_message`, `append_messages_batch`, import) and the import path's `started_at` use the same window: an out-of-window timestamp falls back to `now()` instead of being persisted. Hermes cannot write a new bad row.
- **Malformed marker JSON** (salvage #101726, @efe-arv): `_sql_json_extract()` guards every `model_config` marker read with `json_valid`; widened in a follow-up commit to the 4 remaining raw sites (trigram FTS view/triggers, v16 delegate-tagging migration, `reopen_session`). Zero raw `json_extract(COALESCE(model_config …))` reads remain in `hermes_state_*.py`.
- **`async_delegations` schema drift** (salvage #94701, @liuhao1024, 3 commits): `origin_session_id TEXT NOT NULL DEFAULT ''` declared in canonical `SCHEMA_SQL`; `tools/async_delegation.py` drops its private `CREATE TABLE` + `ALTER` list and calls `reconcile_state_schema()` (replays `SCHEMA_SQL` + `_reconcile_columns`). Column additions are declarative (no `SCHEMA_VERSION` bump needed — see `_reconcile_columns` docstring); the durability-barrier call main added is kept.
- **`export_all` N+1** (salvage #106071, @Xipong): messages hydrated in 900-id `IN` chunks, same row decoder, original order.
- **`too many SQL variables`** (hand-ported #102679 @mssteuer + #100658 @Mi55ed under `--author`; both PRs targeted the pre-decomposition `hermes_state.py` god file): `_id_chunks`/`_SQL_IN_CHUNK` (900) in `hermes_state_common`; every session-id `IN` list in `delete_sessions`, delegate cascade, `prune_sessions`, `delete_empty_sessions`, `prune_empty_ghost_sessions` is chunked. Same transaction, same cascade/orphan contract. Mi55ed's one-pass transcript-directory sweep was not ported (out of scope).

## Live repro (real SQLite, temp `HERMES_HOME`, `UPDATE … SET started_at='not-a-timestamp'` / `8.4e252`, `messages.timestamp=1e30`; 1200 ids under `setlimit(SQLITE_LIMIT_VARIABLE_NUMBER, 999)`)

| Surface | Before (origin/main) | After |
|---|---|---|
| `sessions list` | `TypeError: unsupported operand type(s) for -: 'float' and 'str'` | 5 lines, bad rows show `?` |
| export JSONL (`iter_user_prompt_records`) | `OverflowError: timestamp out of range for platform time_t` | 3 records |
| export MD/QMD `_iso_timestamp` | `OverflowError` | raw text for the bad cell, `…Z` for good |
| export HTML | `TypeError: 'str' object cannot be interpreted as an integer` | renders, `N/A` cells, no raw TEXT reaches a sink |
| `insights generate` | `TypeError: '<' not supported between 'float' and 'str'` | `sessions=3` + `WARNING … started_at 8.4e+252 on session bad-huge` |
| `delete_sessions(1200)` | `OperationalError: too many SQL variables` | 1200 |
| `prune_sessions(--older-than 14)` | `OperationalError: too many SQL variables` | 1200, 0 orphaned messages |

## `fromtimestamp(` over row values — audit (hermes_cli/, hermes_state_*.py, agent/insights.py)

| Site | Before | Now |
|---|---|---|
| `hermes_cli/timefmt.py::relative_time` | raw `ts` | via `coerce_epoch` |
| `hermes_cli/session_export.py::_format_timestamp` | `float(value)` raw | via `coerce_epoch` |
| `hermes_cli/session_export_md.py::_iso_timestamp` | `float(value)` raw (TEXT guarded, overflow not) | via `coerce_epoch` |
| `hermes_cli/session_export_html.py::_format_timestamp` | raw | via `coerce_epoch` |
| `hermes_cli/session_filters.py::format_epoch` | raw | via `coerce_epoch` |
| `agent/insights.py` `_day`, `_compute_activity_patterns`, period range | raw | via `coerce_epoch` (rows coerced once in `_get_sessions`) |
| `hermes_cli/cli_session_mixin.py::_timestamp_or` | already try/except-guarded | unchanged |
| `hermes_state_*.py` | 0 hits | — |
| other `hermes_cli/*` hits (`logs.py` mtime, auth/oauth `expires_at`) | not row values | out of scope |

## Root cause

SQLite dynamic typing lets a TEXT cell, `inf`/`nan`, a garbage double or malformed JSON sit in a typed column, and every reader trusted the cell (`fromtimestamp(ts)`, `json_extract(...)`) inside the row loop — so one bad row raised out of the whole command; bulk deletes bound the entire id set into a single `IN` list.

## Tests

- `tests/hermes_state/test_corrupt_row_robustness.py` — 3 invariants, all red on `origin/main`, green here (real corruption fixtures, no monkeypatched detector).
- Salvaged: `tests/test_session_export_batch.py`, `TestAsyncDelegationsSchemaAgreement` (3), `test_unsafe_model_config_does_not_break_session_surfaces`, fd-leak injection extension.
- `scripts/run_tests.sh tests/hermes_state/ tests/hermes_cli/test_session_{browse,export,export_html,export_html_escape,export_md,filters}.py tests/hermes_cli/test_prune_spares_pinned.py tests/tools/test_async_delegation*.py tests/agent/test_insights.py tests/test_session_export_batch.py` → **436 passed, 8 skipped**.
- `scripts/run_tests.sh tests/test_hermes_state.py` → **271 passed, 1 failed** — `TestFTS5Search::test_search_projection_skips_context_enrichment_queries` fails identically on clean `origin/main` (`assert 0 == 1`; pre-existing, disclosed in #106071 too).
- ruff, `check-windows-footguns --all`, `check_compat_pointers`, `git diff --check`, `audit_pr_attribution` all clean.

## Assessed, not covered

- **#97455** (`kanban show` crashes on ISO strings in INTEGER columns): different DB (`kanban.db`), different helper (`int(row[...])` in `from_row`, `_to_epoch` already exists for `task_age`). Every writer in current `kanban_db.py` uses `int(time.time())`; I could not find an ISO-writing path on main — the reporter was on v0.20.5. Not touched here; needs its own read-side `_to_epoch` in `Run.from_row` if the corruption is still reachable. `Refs #97455`.
- **#87928** (prune leaves orphaned messages): premise does not hold on main — `delete_session`, `delete_sessions`, `prune_sessions`, `delete_empty_sessions` and the delegate cascade all `DELETE FROM messages` in the same txn (also true at v2026.8.3/8.13). `prune_empty_ghost_sessions`/`delete_session_if_empty` only delete rows proven to have no messages. Repro here shows 0 orphans after 2400 deletes. No orphan-GC sweep exists for rows orphaned by *older* builds or external tooling — that is a separate maintenance feature. Close candidate (cannot reproduce on main).
- **#102374** (stale native-compaction checkpoints retained), **#57153** (system_prompt duplication → #60852 content-addressed store): retention-policy / schema-change design calls, not touched.

Fixes #102399
Fixes #102352
Fixes #99959
Fixes #94691
Fixes #106060
Refs #97455
Refs #87928

Salvaged with authorship: #106071 (@Xipong), #101726 (@efe-arv), #94701 (@liuhao1024), #102679 (@mssteuer, hand-port under `--author`), #100658 (@Mi55ed, hand-port under `--author`). #91543 (@liuhao1024, SQL-side `last_active` epoch window) read but not taken: it guards only the `MAX()` aggregation for the desktop pane; the Python-side helper here covers every CLI/export/insights reader and the write side. Thanks to @kokhlo for the insights site-by-site analysis.
