### PR TITLE
fix(test): raise mock model context window

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -205,7 +205,7 @@ ${modelContextLength ? `  context_length: ${modelContextLength}\n` : ''}provider
     key_env: MOCK_API_KEY
     models:
       mock-model: {}
-    context_length: 4096
+    context_length: 64000
 ${autoTitleDefault}${approvalsDefault}${displaySection}${extraConfig ? `\n${extraConfig.trim()}\n` : ''}`
 
   fs.writeFileSync(configPath, config, 'utf8')
@@ -492,7 +492,7 @@ providers:
     key_env: MOCK_API_KEY
     models:
       mock-model: {}
-    context_length: 4096
+    context_length: 64000
 `,
     'utf8',
   )

--- a/tests/install/e2e-assets/mock-provider.sh
+++ b/tests/install/e2e-assets/mock-provider.sh
@@ -57,7 +57,7 @@ providers:
     key_env: MOCK_API_KEY
     models:
       mock-model: {}
-    context_length: 4096
+    context_length: 64000
 EOF
   printf 'MOCK_API_KEY=e2e-mock-key\n' >> "$HERMES_HOME/.env"
   ok "provider 'mock' configured in $HERMES_HOME (api $url/v1)"


### PR DESCRIPTION
## What does this PR do?

Desktop and install E2E fixtures configure `mock-model` with a 4,096-token context window. Hermes now rejects primary models below 64,000 tokens, so real-session desktop tests fail during fixture setup before exercising the UI.

Raise the shared mock provider context window to the supported minimum of 64,000 tokens. Before this change, `large-session-resume.spec.ts` fails with `agent_init_failed`; after it, the existing resume and background-inference scenarios reach Electron and pass.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Raise the desktop E2E mock provider context window from 4,096 to 64,000 tokens.
- Apply the same supported minimum to the dead-backend fixture and install E2E mock provider so shared test configurations stay consistent.

## How to Test

1. Run `npm run build` from `apps/desktop`.
2. Run `npm run typecheck` from `apps/desktop`.
3. Run `npx playwright test e2e/large-session-resume.spec.ts e2e/hidden-history-messages.spec.ts` with the repository Python environment available.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

- `npm run build`: passed on the final commit based on current `main`.
- `npm run typecheck`: passed.
- `large-session-resume.spec.ts`: 3 passed, 1 platform-conditional skip.
- `hidden-history-messages.spec.ts`: 2 passed.
