### PR TITLE
fix(model-metadata): surface silent context-length downgrades

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1724,6 +1724,62 @@ def _resolve_bedrock_context_length(model: str, base_url: str) -> Optional[int]:
     return ctx
 
 
+def _warn_catalog_context_length(
+    model: str, base_url: str, key: str, value: int, *, custom_endpoint: bool = False,
+) -> None:
+    """A hardcoded catalog match is a built-in *guess*, not a value the endpoint reported.
+
+    ``_longest_key_match`` matches on a substring of the model id, so ``deepseek_v41`` hits
+    ``"deepseek": 128000`` (the ``deepseek-v4-*`` entries are hyphenated and never match the
+    underscore spelling) while the provider may serve 1M — an 8x error that only surfaces as
+    compression firing far more often than before. Logging it at INFO hid the cause and left the
+    user with the symptom, so this is a WARNING.
+    """
+    logger.warning(
+        "Using hardcoded catalog context length %s for model %r (approximate substring match "
+        "on %r%s). This is a built-in guess, not a value the endpoint reported. Set "
+        "model.context_length in config.yaml, or add this model id under the matching "
+        "custom_providers[].models entry, to make the real window apply.",
+        f"{value:,}", model, key, f", custom endpoint {base_url}" if custom_endpoint else "",
+    )
+
+
+def _warn_custom_provider_models_key_missing(
+    model: str, base_url: str, custom_providers: Optional[list], resolved_ctx: Optional[int],
+) -> None:
+    """Warn when a route-matching ``custom_providers`` entry omits this model from its ``models``
+    mapping, so the per-model ``context_length`` sitting right next to it can never apply.
+
+    Observed failure mode: the entry lists sibling models but not the one actually in use, the
+    per-model lookup returns None, and the runtime silently drops to the hardcoded catalog
+    (``"deepseek"`` → 128,000 for ``deepseek_v41`` while the provider serves 1M). Nothing errors
+    — the user only notices that compression now fires at ~96K tokens instead of ~500K.
+    """
+    if not model or not base_url or not custom_providers:
+        return
+    target_url = str(base_url).strip().rstrip("/").lower()
+    target_model = str(model).strip().lower()
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("base_url", "") or "").strip().rstrip("/").lower() != target_url:
+            continue
+        models = entry.get("models")
+        if not isinstance(models, dict) or not models:
+            continue
+        keys = [str(k).strip().lower() for k in models]
+        if target_model in keys:
+            return  # declared — nothing to warn about
+        logger.warning(
+            "custom_providers entry for %s declares models [%s] but has no %r key, so its "
+            "per-model context_length cannot apply — %r resolves to %s tokens from another "
+            "source instead. Add %r under that entry's models: mapping to make it apply.",
+            target_url, ", ".join(sorted(str(k) for k in models)), model, model,
+            f"{resolved_ctx:,}" if resolved_ctx else "the default", model,
+        )
+        return
+
+
 def _resolve_custom_endpoint_context_length(model: str, base_url: str, api_key: str, provider: str) -> int:
     """Steps 2-3 for a truly custom endpoint: /models, local probes, Ollama /api/show, catalog, default."""
     context_length = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
@@ -1749,7 +1805,7 @@ def _resolve_custom_endpoint_context_length(model: str, base_url: str, api_key: 
     # but its model name still matches DEFAULT_CONTEXT_LENGTHS.
     hit = _longest_key_match(DEFAULT_CONTEXT_LENGTHS, model.lower())
     if hit:
-        logger.info("Using hardcoded context length %s for model %r (custom endpoint, catalog match on %r)", f"{hit[1]:,}", model, hit[0])
+        _warn_catalog_context_length(model, base_url, hit[0], hit[1], custom_endpoint=True)
         return hit[1]
     # Same silent-256K bug class as the step-9 fallback — warn here too.
     _warn_context_length_fallback(model, base_url)
@@ -1921,7 +1977,9 @@ def get_model_context_length(
     # 2. Live /models for truly custom endpoints. Known providers skip this: their /models may
     # report a provider-imposed limit (Copilot: 128k) rather than the window.
     if _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url):
-        return _resolve_custom_endpoint_context_length(model, base_url, api_key, provider)
+        _custom_ctx = _resolve_custom_endpoint_context_length(model, base_url, api_key, provider)
+        _warn_custom_provider_models_key_missing(model, base_url, custom_providers, _custom_ctx)
+        return _custom_ctx
     # 4. Anthropic /v1/models API (only for regular API keys, not OAuth)
     if provider == "anthropic" or (base_url and base_url_hostname(base_url) == "api.anthropic.com"):
         ctx = _query_anthropic_context_length(model, base_url or "https://api.anthropic.com", api_key)
@@ -1953,6 +2011,7 @@ def get_model_context_length(
     # 8. Hardcoded defaults: `key in model` only — the reverse would let "claude-sonnet-4" match "claude-sonnet-4-6" and return 1M.
     hit = _longest_key_match(DEFAULT_CONTEXT_LENGTHS, model.lower())
     if hit:
+        _warn_catalog_context_length(model, base_url, hit[0], hit[1])
         return hit[1]
     # 9. Default fallback — warn (deduped) so small-context models don't silently get 256K.
     _warn_context_length_fallback(model, base_url)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -10,6 +10,7 @@ Coverage levels:
   Persistent cache       — save/load, corruption, update, provider isolation
 """
 
+import logging
 import time
 
 import pytest
@@ -1934,3 +1935,128 @@ class TestFallbackWarning:
             if r.levelno == logging.WARNING and "falling back" in r.getMessage()
         ]
         assert len(fallback_warnings) == 0
+
+
+# =========================================================================
+# custom_providers context_length misses must not be silent
+# =========================================================================
+
+class TestCustomProviderContextLengthMissIsLoud:
+    """A route-matching ``custom_providers`` entry that omits the model in use from its
+    ``models`` mapping used to fail silently: the per-model ``context_length`` next door never
+    applied, the runtime dropped to the hardcoded catalog (``"deepseek"`` → 128,000 for
+    ``deepseek_v41`` while the provider served 1M), and the only visible symptom was compression
+    firing at ~96K tokens instead of ~500K. Logging the cause at INFO left the user staring at
+    the symptom.
+    """
+
+    ENTRY_URL = "http://custom.invalid:48080/v1"
+    SIBLINGS = {
+        "ds-v4-flash": {"context_length": 1_048_576},
+        "glm-5_3": {"context_length": 600_000},
+    }
+
+    @staticmethod
+    def _offline(stack):
+        for target, kwargs in (
+            ("agent.model_metadata.get_cached_context_length", {"return_value": None}),
+            ("agent.model_metadata.fetch_model_metadata", {"return_value": {}}),
+            ("agent.model_metadata.fetch_endpoint_model_metadata", {"return_value": {}}),
+            ("agent.model_metadata._query_ollama_api_show", {"return_value": None}),
+            ("agent.models_dev.lookup_models_dev_context", {"return_value": None}),
+        ):
+            stack.enter_context(patch(target, **kwargs))
+
+    def _entry(self, models):
+        return [{
+            "base_url": self.ENTRY_URL,
+            "name": "deepseek_v41",
+            "model": "deepseek_v41",
+            "models": models,
+        }]
+
+    @staticmethod
+    def _warnings(caplog):
+        return " | ".join(r.getMessage() for r in caplog.records)
+
+    def test_missing_model_key_warns_and_falls_back_to_catalog(self, caplog):
+        from contextlib import ExitStack
+
+        with ExitStack() as stack:
+            self._offline(stack)
+            with caplog.at_level(logging.WARNING, logger="agent.model_metadata"):
+                ctx = get_model_context_length(
+                    "deepseek_v41", base_url=self.ENTRY_URL,
+                    provider="custom:deepseek_v41", custom_providers=self._entry(self.SIBLINGS))
+
+        assert ctx == 128_000, "expected the hardcoded catalog substring match"
+        message = self._warnings(caplog)
+        assert "has no 'deepseek_v41' key" in message
+        assert "ds-v4-flash" in message and "glm-5_3" in message  # names the siblings it found
+        assert "128,000" in message
+
+    def test_declared_model_key_wins_and_stays_quiet(self, caplog):
+        from contextlib import ExitStack
+
+        models = dict(self.SIBLINGS, deepseek_v41={"context_length": 1_048_576})
+        with ExitStack() as stack:
+            self._offline(stack)
+            with caplog.at_level(logging.WARNING, logger="agent.model_metadata"):
+                ctx = get_model_context_length(
+                    "deepseek_v41", base_url=self.ENTRY_URL,
+                    provider="custom:deepseek_v41", custom_providers=self._entry(models))
+
+        assert ctx == 1_048_576
+        assert "has no" not in self._warnings(caplog)
+
+    def test_catalog_fallback_is_logged_at_warning_not_info(self, caplog):
+        """The catalog guess can be several times smaller than the served window."""
+        from contextlib import ExitStack
+
+        with ExitStack() as stack:
+            self._offline(stack)
+            with caplog.at_level(logging.WARNING, logger="agent.model_metadata"):
+                ctx = get_model_context_length(
+                    "deepseek_v41", base_url=self.ENTRY_URL, provider="custom:deepseek_v41")
+
+        assert ctx == 128_000
+        assert any(
+            "hardcoded catalog context length" in r.getMessage()
+            for r in caplog.records if r.levelno == logging.WARNING
+        ), "catalog fallback must be a WARNING, not INFO"
+
+    @pytest.mark.parametrize("model, base_url, custom_providers", [
+        ("", "http://x.invalid/v1", [{"base_url": "http://x.invalid/v1", "models": {"a": {}}}]),
+        ("m", "", [{"base_url": "", "models": {"a": {}}}]),
+        ("m", "http://x.invalid/v1", None),
+        ("m", "http://x.invalid/v1", []),
+        ("m", "http://other.invalid/v1", [{"base_url": "http://x.invalid/v1", "models": {"a": {}}}]),
+        ("m", "http://x.invalid/v1", ["not-a-dict"]),
+        ("m", "http://x.invalid/v1", [{"base_url": "http://x.invalid/v1"}]),
+        ("m", "http://x.invalid/v1", [{"base_url": "http://x.invalid/v1", "models": {}}]),
+    ])
+    def test_helper_stays_quiet_on_unrelated_inputs(self, caplog, model, base_url, custom_providers):
+        from agent.model_metadata import _warn_custom_provider_models_key_missing
+
+        with caplog.at_level(logging.WARNING, logger="agent.model_metadata"):
+            _warn_custom_provider_models_key_missing(model, base_url, custom_providers, 128_000)
+
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_step8_catalog_fallback_also_warns(self, caplog):
+        """Step 8 (provider-aware miss) matched the catalog with no log at all."""
+        from contextlib import ExitStack
+
+        from agent.model_metadata import _longest_key_match
+
+        with ExitStack() as stack:
+            self._offline(stack)
+            with caplog.at_level(logging.WARNING, logger="agent.model_metadata"):
+                ctx = get_model_context_length("glm-5_3", base_url="", provider="")
+
+        _hit_key, expected = _longest_key_match(DEFAULT_CONTEXT_LENGTHS, "glm-5_3")
+        assert ctx == expected, "resolved via the hardcoded catalog"
+        assert any(
+            "hardcoded catalog context length" in r.getMessage()
+            for r in caplog.records if r.levelno == logging.WARNING
+        ), "step-8 catalog fallback must warn too"


### PR DESCRIPTION
## Problem

A `custom_providers` entry whose `models:` mapping omits the model actually in use cannot contribute its per-model `context_length` — and nothing says so. Resolution falls through to the hardcoded catalog, which matches on a *substring* of the model id.

Real case (self-hosted OpenAI-compatible endpoint whose `/v1/models` reports no context metadata):

```yaml
custom_providers:
  - base_url: http://...:48080/v1
    model: deepseek_v41
    models:
      ds-v4-flash:  {context_length: 1048576}
      glm-5_3:      {context_length: 600000}
      qwen3_8-27b:  {context_length: 262144}
    name: deepseek_v41      # <- no `deepseek_v41` key in its own models mapping
```

The endpoint serves 1M. The catalog has `"deepseek": 128000` (the `deepseek-v4-*` entries are hyphenated and never match the underscore spelling `deepseek_v41`), so the runtime used **128,000**.

Observable symptom — compression firing far more often than before, with nothing visible explaining why:

```
17:14:16 context compression started: messages=125 tokens=~96,891 model=deepseek_v41
17:20:25 context compression started: messages=114 tokens=~99,346 model=deepseek_v41
17:28:26 context compression started: messages=76  tokens=~98,192 model=deepseek_v41
```

~96K is exactly `128,000 x 0.75` (the small-window threshold floor). The only trace was an INFO line:

```
agent.model_metadata: Using hardcoded context length 128,000 for model 'deepseek_v41' (custom endpoint, catalog match on 'deepseek')
```

## Change

Two warnings. No behaviour change to any resolved value:

1. `_warn_custom_provider_models_key_missing()` — when a route-matching `custom_providers` entry declares sibling models but not this one, WARN and name the entry, the keys it *does* declare, and the value used instead.
2. `_warn_catalog_context_length()` — both catalog fallbacks now warn (step 2b for custom endpoints was INFO; step 8 for every other provider was silent), and state plainly that the number is a built-in guess rather than anything the endpoint reported.

## Why it's safe

- Logging only; no resolution path, return value, or ordering changed.
- Fires at most once per (model, base_url) resolution, and only on paths that already fell through every configured source.
- No new imports, no new public API.

## Tests

New `TestCustomProviderContextLengthMissIsLoud` in `tests/agent/test_model_metadata.py` (offline; every network entry point patched):

- missing model key -> WARN + catalog value; message names the siblings it did find
- declared model key -> declared value, no warning
- catalog fallback (step 2b) logs at WARNING, not INFO
- catalog fallback (step 8) logs at WARNING
- 8 parametrized edge cases stay silent (blank model/base_url, no entries, non-dict entry, other route, empty models)

182 passed across `tests/agent/test_model_metadata.py`, `tests/agent/test_model_metadata_local_ctx.py`, `tests/hermes_cli/test_custom_provider_context_length.py`, `tests/run_agent/test_invalid_context_length_warning.py`.
