### PR TITLE
fix(desktop): stop a stale hand-off root failing a healthy update

### DIFF
--- a/hermes_cli/desktop_update_verify.py
+++ b/hermes_cli/desktop_update_verify.py
@@ -74,15 +74,34 @@ def checkout_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+def _root_to_verify(project_root: Path | None) -> Path:
+    """The root the receipt may describe: a caller's root is a hint, not a contract.
+
+    The hand-off script is read before the pull, so an update that ships a fix to
+    the caller side cannot apply it to its own run: a pre-fix ``windows.ps1`` still
+    passes ``Path.cwd()``, which is HERMES_HOME and never holds a packaged Desktop
+    app. Honour a caller-supplied root only while it actually carries one, and fall
+    back to the checkout this module was imported from -- the tree the update just
+    wrote. A supplied root that does carry a packaged app is still verified as
+    given, so real damage there stays fail-closed.
+    """
+    if project_root is None:
+        return checkout_root()
+    if _desktop_packaged_executable(project_root / "apps" / "desktop") is not None:
+        return project_root
+    return checkout_root()
+
+
 def verify_windows_desktop_update(project_root: Path | None = None) -> None:
     """Raise when a zero-exit updater left an incomplete or stale packaged app.
 
     The root defaults to the imported checkout, never the caller's cwd: the hand-off
     is spawned from HERMES_HOME by the pre-update Desktop, and a cwd-derived root
-    reported a healthy install as "Desktop executable is missing" (Sep 2026).
+    reported a healthy install as "Desktop executable is missing" (Sep 2026). A
+    caller-supplied root with no packaged app falls back to that same checkout, so a
+    stale in-flight hand-off cannot fail a healthy install either.
     """
-    if project_root is None:
-        project_root = checkout_root()
+    project_root = _root_to_verify(project_root)
     desktop = project_root / "apps" / "desktop"
     executable = _desktop_packaged_executable(desktop)
     if executable is None:

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -794,7 +794,9 @@ trap 'on_signal TERM' TERM
 # Truthful completion: `hermes update` calls a GUI build failure non-fatal
 # (exit 0). For a Desktop-driven update that would relaunch the OLD build
 # and call it success -- retry the build once, propagate honestly.
-if [ "$CODE" -eq 0 ] && printf '%s' "$OUT" | grep -q "Desktop build failed"; then
+# Both shapes: "Desktop build failed" (dependency stage) and the packaged-app
+# stage's "Desktop GUI build failed", which the narrow literal never matched.
+if [ "$CODE" -eq 0 ] && printf '%s' "$OUT" | grep -qE "Desktop( GUI)? build failed"; then
   log "desktop build failed inside hermes update; retrying build"
   publish_stage "Rebuilding Desktop"
   "${UPDATE_INVOKE[@]}" desktop --force-build --build-only >> "$LOG" 2>&1 || {

--- a/scripts/desktop-update/retry-policy.ps1
+++ b/scripts/desktop-update/retry-policy.ps1
@@ -14,3 +14,15 @@ function Test-HermesUpdateShouldRetry {
     $deferredInstallMarker = Join-Path $InstallRoot ".update-incomplete"
     return Test-Path -LiteralPath $deferredInstallMarker
 }
+
+function Test-HermesDesktopBuildFailed {
+    param([string]$Output)
+
+    # `hermes update` treats a Desktop build failure as non-fatal and prints it in
+    # two shapes: "Desktop build failed" from the dependency stage and
+    # "Desktop GUI build failed" from the packaged-app stage. The hand-off matched
+    # only the first, so the packaged-app class -- the one a missing desktop
+    # workspace produces -- never triggered the single rebuild retry (#107685).
+    if ([string]::IsNullOrEmpty($Output)) { return $false }
+    return $Output -match "Desktop( GUI)? build failed"
+}

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -1633,8 +1633,18 @@ try {
     # a one-line warning, exits 0). For a Desktop-DRIVEN update that warning
     # is fatal: we would relaunch the old exe and call it success. Detect it,
     # retry the build once, and propagate honestly.
+    #
+    # The detector lives in the companion policy file, which is dot-sourced from
+    # the checkout AFTER the pull: an in-flight script cannot see a fix to its own
+    # matching rules, but it can read them from the tree the update just wrote.
     $desktopBuildFailed = $false
-    if ($res.Code -eq 0 -and $res.Output -match "Desktop build failed") {
+    if (Get-Command Test-HermesDesktopBuildFailed -ErrorAction SilentlyContinue) {
+        $buildFailureReported = Test-HermesDesktopBuildFailed -Output $res.Output
+    } else {
+        Write-HandoffLog "desktop build-failure policy is unavailable after checkout swap; using the inline match"
+        $buildFailureReported = [bool]($res.Output -match "Desktop( GUI)? build failed")
+    }
+    if ($res.Code -eq 0 -and $buildFailureReported) {
         Write-HandoffLog "hermes update reported a desktop build failure (non-fatal there, fatal here); retrying build"
         Publish-UiProgress "Rebuilding Desktop"
         $rebuild = Invoke-HermesStep $pythonExe @("-m", "hermes_cli.main", "desktop", "--force-build", "--build-only") "rebuild"
@@ -1648,7 +1658,7 @@ try {
         $verify = Invoke-HermesStep $pythonExe @("-c", $verifyCode) "verify"
         if ($verify.Code -ne 0) {
             $finalCode = 8
-            $finalMsg = "The updated Hermes runtime or Desktop build failed verification. Repair the installation and review antivirus quarantine before retrying."
+            $finalMsg = "The updated Hermes runtime or Desktop build could not be verified. The update was applied and nothing was removed - run hermes doctor in a terminal to check the install."
             Write-HandoffLog $finalMsg
             exit $finalCode
         }

--- a/tests/hermes_cli/test_desktop_update_verify.py
+++ b/tests/hermes_cli/test_desktop_update_verify.py
@@ -63,3 +63,45 @@ def test_default_root_is_the_imported_checkout_not_cwd(tmp_path, monkeypatch):
     assert seen['desktop'] == verify.checkout_root() / 'apps' / 'desktop'
     assert (verify.checkout_root() / 'hermes_cli' / 'desktop_update_verify.py').is_file()
     assert verify.checkout_root() != tmp_path
+
+
+def _app_only_under(root):
+    """A packaged-app lookup that finds an app under *root* and nowhere else."""
+    from pathlib import Path
+
+    desktop = (root / 'apps' / 'desktop').resolve()
+
+    def lookup(candidate):
+        return desktop / 'release/fixture/Hermes.exe' if Path(candidate).resolve() == desktop else None
+
+    return lookup
+
+
+def test_caller_root_without_a_packaged_app_falls_back_to_the_checkout(bundle, tmp_path, monkeypatch):
+    # A hand-off script read before the pull still passes HERMES_HOME, which never
+    # holds a packaged app. The healthy checkout it just wrote must be verified instead.
+    checkout, _, _ = bundle
+    monkeypatch.setattr(verify, '_desktop_packaged_executable', _app_only_under(checkout))
+    monkeypatch.setattr(verify, 'checkout_root', lambda: checkout)
+    verify.verify_windows_desktop_update(tmp_path / 'hermes_home')
+
+
+def test_no_packaged_app_under_either_root_still_fails(tmp_path, monkeypatch):
+    monkeypatch.setattr(verify, '_desktop_packaged_executable', lambda _: None)
+    monkeypatch.setattr(verify, 'checkout_root', lambda: tmp_path / 'checkout')
+    with pytest.raises(RuntimeError, match='executable is missing'):
+        verify.verify_windows_desktop_update(tmp_path / 'hermes_home')
+
+
+def test_caller_root_that_has_a_packaged_app_is_verified_as_given(bundle, tmp_path, monkeypatch):
+    # Fail-closed: the fallback is for a root with nothing to read, never a way to
+    # launder a damaged build past the receipt by switching to a healthy tree.
+    checkout, _, _ = bundle
+    supplied = tmp_path / 'supplied'
+    resources = supplied / 'apps/desktop/release/fixture/resources'
+    resources.mkdir(parents=True)
+    (resources / 'app.asar').write_bytes(b'not an asar')
+    monkeypatch.setattr(verify, '_desktop_packaged_executable', _app_only_under(supplied))
+    monkeypatch.setattr(verify, 'checkout_root', lambda: checkout)
+    with pytest.raises(RuntimeError, match='archive or main entry is invalid'):
+        verify.verify_windows_desktop_update(supplied)

--- a/tests/test_desktop_update_build_failure_retry.py
+++ b/tests/test_desktop_update_build_failure_retry.py
@@ -1,0 +1,83 @@
+"""The hand-off must recognise every Desktop build-failure message (#107685).
+
+``hermes update`` calls a Desktop build failure non-fatal and exits 0, so the
+Desktop-driven hand-off re-reads its output to decide whether to spend its one
+rebuild retry. It matched the literal "Desktop build failed" only, which the
+packaged-app stage's "Desktop GUI build failed" never contains -- so the retry
+could not fire for the failure class that actually needs it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DESKTOP_UPDATE = REPO_ROOT / "scripts" / "desktop-update"
+RETRY_POLICY = DESKTOP_UPDATE / "retry-policy.ps1"
+WINDOWS_PS1 = DESKTOP_UPDATE / "windows.ps1"
+POSIX_SH = DESKTOP_UPDATE / "posix.sh"
+
+
+@pytest.mark.windows_only
+def test_policy_matches_both_build_failure_shapes() -> None:
+    policy = str(RETRY_POLICY).replace("'", "''")
+    command = f"""
+        . '{policy}'
+        $gui = [char]0x2717 + ' Desktop GUI build failed'
+        $deps = '  ' + [char]0x26A0 + ' Desktop build failed (run hermes desktop to retry)'
+        @{{
+            gui = [bool](Test-HermesDesktopBuildFailed -Output $gui)
+            deps = [bool](Test-HermesDesktopBuildFailed -Output $deps)
+            clean = [bool](Test-HermesDesktopBuildFailed -Output 'Desktop packaged app ready')
+            empty = [bool](Test-HermesDesktopBuildFailed -Output '')
+        }} | ConvertTo-Json -Compress
+    """
+    result = subprocess.run(
+        ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command],
+        text=True,
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout
+    assert json.loads(result.stdout) == {"gui": True, "deps": True, "clean": False, "empty": False}
+
+
+def test_windows_handoff_reads_the_detector_from_the_updated_checkout() -> None:
+    text = WINDOWS_PS1.read_text(encoding="utf-8")
+
+    # The in-flight script cannot fix its own matching rules, but the companion
+    # policy is dot-sourced from the checkout the update just wrote.
+    assert "Test-HermesDesktopBuildFailed -Output $res.Output" in text
+    assert 'Desktop( GUI)? build failed' in text
+    assert '-match "Desktop build failed"' not in text
+
+
+def test_posix_handoff_matches_the_gui_build_failure() -> None:
+    text = POSIX_SH.read_text(encoding="utf-8")
+
+    assert 'grep -qE "Desktop( GUI)? build failed"' in text
+    assert 'grep -q "Desktop build failed"' not in text
+
+
+def test_verification_failure_does_not_advise_repair_or_antivirus() -> None:
+    messages = [
+        line
+        for line in WINDOWS_PS1.read_text(encoding="utf-8").splitlines()
+        if "$finalMsg" in line and "verif" in line.lower()
+    ]
+
+    assert messages
+    for line in messages:
+        # "Repair the installation and review antivirus quarantine" is destructive
+        # advice for a condition that means "the receipt could not read the app".
+        assert "antivirus" not in line.lower()
+        assert "repair the installation" not in line.lower()


### PR DESCRIPTION
## What does this PR do?

A Desktop-driven update on Windows can finish successfully and still tell the user it failed.

The hand-off script is launched, and read, *before* the pull, so an update that changes the caller side of the verify boundary cannot apply that change to its own run: a pre-pull `windows.ps1` still calls `verify_windows_desktop_update(Path.cwd())`, and cwd is `HERMES_HOME`, which never holds a packaged Desktop app. The receipt raises "The updated Desktop executable is missing", the hand-off exits 8, and a healthy install that already relaunched fine gets "Repair the installation and review antivirus quarantine before retrying."

Three changes, one per follow-up in the issue:

1. **The receipt tolerates a stale caller root.** A caller-supplied root is now a hint, not a contract: it is honoured only while it actually carries a packaged app, otherwise the receipt falls back to the checkout this module was imported from — the tree the update just wrote. A supplied root that *does* carry an app is still verified as given, so a damaged build there stays fail-closed, and a root with nothing to read under either path still raises the original error.

2. **The build-failure detector moved to the companion policy file**, which the hand-off dot-sources from `$PSScriptRoot` *after* the pull. That is the one place where a fix landed by the running update can reach the run that carries it, and it is where the retry rules already live. The inline fallback stays for a checkout swapped out from under an older script.

   That detector also fixes the matching bug noted in the issue: `hermes update` prints the packaged-app failure as `Desktop GUI build failed`, which the literal `"Desktop build failed"` match never matched, so the single rebuild retry could not fire for the class that needs it — a pack starting without its desktop workspace deps. The widened `Desktop( GUI)? build failed` pattern is the one suggested on the issue thread. `posix.sh` had the same narrow grep, so it gets the same widened pattern.

3. **The verification message no longer prescribes a repair.** "Repair the installation and review antivirus quarantine" is destructive advice for a condition that really means "the receipt could not read the packaged app", and a user who follows it can lose a working install. It now says the update was applied, nothing was removed, and points at `hermes doctor`.

## Related Issue

Fixes #107685

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/desktop_update_verify.py`: added `_root_to_verify()`; a caller root with no packaged app falls back to `checkout_root()`.
- `scripts/desktop-update/retry-policy.ps1`: added `Test-HermesDesktopBuildFailed`, matching `Desktop( GUI)? build failed`.
- `scripts/desktop-update/windows.ps1`: use that detector when the post-pull policy file provides it, inline widened match otherwise; softened the verification-failure message.
- `scripts/desktop-update/posix.sh`: widened the same grep.
- `tests/hermes_cli/test_desktop_update_verify.py`: stale caller root falls back; both roots empty still fails; a caller root that has an app is verified as given.
- `tests/test_desktop_update_build_failure_retry.py`: the detector matches both failure shapes and neither a clean run nor empty output; both hand-off scripts carry the widened pattern; the verification message advises neither a repair nor antivirus.

## How to Test

1. `pytest tests/hermes_cli/test_desktop_update_verify.py tests/test_desktop_update_build_failure_retry.py -q`
2. Revert the four source files and rerun: the fallback test and the four script-contract tests go red.
3. For the matching bug on its own, in PowerShell: `([char]0x2717 + ' Desktop GUI build failed') -match 'Desktop build failed'` is `False`, which is why the retry never fired.

I also ran the neighbouring desktop/update suites (`test_desktop_update_windows_retry_policy.py`, `test_desktop_update_windows_cwd.py`, `test_update_handoff_desktop_rebuild.py`, `test_update_desktop_stale_warning.py`, `test_desktop_exe_integrity.py`) and `ruff check` on the changed Python files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the tests covering the files I touched (listed above) and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the changed behaviour) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — the receipt change is host-independent; `posix.sh` gets the same detection fix as `windows.ps1`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
