### PR TITLE
fix(desktop): yield the titlebar band only to mounted chrome

### DIFF
--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -141,11 +141,12 @@ export function isOverlayView(view: AppView): boolean {
   return OVERLAY_VIEWS.has(view)
 }
 
-/** True when TitlebarControls must hide the app's fixed tool clusters.
+/** True when TitlebarControls may hide the app's fixed tool clusters.
  *  Overlays already own the window (clusters AND titleBar slots unmount).
- *  Contributed full pages (`extension`) hide the app clusters but keep the
- *  titleBar slots so plugin chrome can own that space. First-party workspace
- *  pages (skills/messaging/artifacts) keep the clusters. */
+ *  Contributed full pages (`extension`) hide the app clusters only while the
+ *  page actually mounts `titleBar.*` chrome — those slots are mount-scoped, so
+ *  a plugin page with no titlebar contribution keeps the app controls.
+ *  First-party workspace pages (skills/messaging/artifacts) keep the clusters. */
 export function hidesFixedTitlebarClusters(view: AppView): boolean {
   return isOverlayView(view) || view === 'extension'
 }

--- a/apps/desktop/src/app/shell/titlebar-controls.test.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
@@ -8,13 +8,15 @@ import { I18nProvider } from '@/i18n'
 
 import { ROUTES_AREA } from '../routes'
 
-import { TitlebarControls } from './titlebar-controls'
+import { TitlebarControls, type TitlebarTool } from './titlebar-controls'
 
-function renderControls(pathname: string) {
+const PLUGIN_TOOL: TitlebarTool = { icon: <span />, id: 'plugin-tool', label: 'plugin tool' }
+
+function renderControls(pathname: string, props?: { leftTools?: TitlebarTool[]; tools?: TitlebarTool[] }) {
   return render(
     <MemoryRouter initialEntries={[pathname]}>
       <I18nProvider configClient={null} initialLocale="en">
-        <TitlebarControls onOpenSettings={() => {}} />
+        <TitlebarControls leftTools={props?.leftTools} onOpenSettings={() => {}} tools={props?.tools} />
       </I18nProvider>
     </MemoryRouter>
   )
@@ -23,6 +25,7 @@ function renderControls(pathname: string) {
 const windowControls = () => screen.queryByLabelText('Window controls')
 const appControls = () => screen.queryByLabelText('App controls')
 const pluginChrome = () => screen.queryByText('plugin-chrome')
+const pluginTool = () => screen.queryByLabelText('plugin tool')
 
 describe('TitlebarControls fixed clusters', () => {
   let dispose: () => void
@@ -36,9 +39,10 @@ describe('TitlebarControls fixed clusters', () => {
         render: () => null
       },
       {
-        area: 'titleBar.center',
-        id: 'test-plugin-chrome',
-        render: () => <span>plugin-chrome</span>
+        area: ROUTES_AREA,
+        data: { path: '/plain' },
+        id: 'test-plain-route',
+        render: () => null
       }
     ])
   })
@@ -48,19 +52,11 @@ describe('TitlebarControls fixed clusters', () => {
     cleanup()
   })
 
-  it('hides the app clusters on a contributed full-page route', () => {
-    renderControls('/kanban')
+  it('keeps the app clusters on a contributed page that mounts no titlebar chrome', () => {
+    renderControls('/plain')
 
-    expect(windowControls()).toBeNull()
-    expect(appControls()).toBeNull()
-  })
-
-  it('keeps plugin titlebar contributions on a contributed full-page route', () => {
-    renderControls('/kanban')
-
-    expect(pluginChrome()).not.toBeNull()
-    expect(windowControls()).toBeNull()
-    expect(appControls()).toBeNull()
+    expect(windowControls()).not.toBeNull()
+    expect(appControls()).not.toBeNull()
   })
 
   it('keeps the app clusters on chat', () => {
@@ -77,16 +73,62 @@ describe('TitlebarControls fixed clusters', () => {
     expect(appControls()).toBeNull()
   })
 
-  it('hides plugin titlebar contributions on an overlay', () => {
-    renderControls('/settings')
-
-    expect(pluginChrome()).toBeNull()
-  })
-
   it('keeps the app clusters on a first-party workspace page', () => {
     renderControls('/skills')
 
     expect(windowControls()).not.toBeNull()
     expect(appControls()).not.toBeNull()
+  })
+
+  it('a titleBar.tools item alone does not claim the band', () => {
+    renderControls('/plain', { leftTools: [PLUGIN_TOOL] })
+
+    expect(windowControls()).not.toBeNull()
+    expect(pluginTool()).not.toBeNull()
+  })
+
+  describe('when the page projects titlebar chrome', () => {
+    let disposeChrome: () => void
+
+    beforeEach(() => {
+      disposeChrome = registry.register({
+        area: 'titleBar.center',
+        id: 'test-plugin-chrome',
+        render: () => <span>plugin-chrome</span>
+      })
+    })
+
+    afterEach(() => {
+      // The mounted controls subscribe to titleBar.* areas — dispose inside
+      // act so the unmount-time registry update doesn't warn.
+      act(() => disposeChrome())
+    })
+
+    it('hides the app clusters on a contributed full-page route', () => {
+      renderControls('/kanban')
+
+      expect(windowControls()).toBeNull()
+      expect(appControls()).toBeNull()
+    })
+
+    it('keeps plugin titlebar contributions on a contributed full-page route', () => {
+      renderControls('/kanban')
+
+      expect(pluginChrome()).not.toBeNull()
+      expect(windowControls()).toBeNull()
+      expect(appControls()).toBeNull()
+    })
+
+    it('keeps contributed titlebar tools on a chrome-owning page', () => {
+      renderControls('/kanban', { leftTools: [PLUGIN_TOOL] })
+
+      expect(pluginTool()).not.toBeNull()
+    })
+
+    it('hides plugin titlebar contributions on an overlay', () => {
+      renderControls('/settings')
+
+      expect(pluginChrome()).toBeNull()
+    })
   })
 })

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tip, TipKeybindLabel } from '@/components/ui/tooltip'
 import { Slot } from '@/contrib/react/slot'
+import { useContributions } from '@/contrib/react/use-contributions'
 import { useI18n } from '@/i18n'
 import { compactNumber } from '@/lib/format'
 import { triggerHaptic } from '@/lib/haptics'
@@ -141,6 +142,14 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const unreadBadge = unreadCount > 0 ? unreadCount : undefined
   const unreadHint = unreadBadge ? ` · ${t.titlebar.unreadSessions(unreadBadge)}` : ''
 
+  // `titleBar.*` slot content is mount-scoped — a page's <Contribute> registers
+  // only while that surface is up — so a non-empty area means a page is
+  // actively projecting chrome into the band right now.
+  const titleBarLeft = useContributions('titleBar.left')
+  const titleBarCenter = useContributions('titleBar.center')
+  const titleBarRight = useContributions('titleBar.right')
+  const pageOwnsTitlebar = titleBarLeft.length + titleBarCenter.length + titleBarRight.length > 0
+
   // POSITIONAL toggles: each button shows/hides everything on its physical
   // side of the main zone (the layout tree collapses the whole side), so they
   // stay correct through flips and rearranges. $sidebarOpen ≙ left side,
@@ -257,11 +266,23 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     'left-(--titlebar-controls-left) top-(--titlebar-controls-top) translate-y-(--titlebar-controls-y-nudge)'
   )
 
-  // Contributed full-context plugin pages (`extension`) own the titlebar band.
-  // Hide the app's tool clusters but keep plugin slots in the same fixed
-  // position so `titleBar.center` (e.g. kanban's board switcher) stays mounted.
-  if (hidesFixedTitlebarClusters(view)) {
-    return <div className={leftClusterClass}>{titlebarSlots}</div>
+  // A contributed full page (`extension`) yields the fixed clusters only while
+  // it actually projects chrome into the band — page-mounted `titleBar.*` slots
+  // like kanban's board switcher. A page that mounts no titlebar chrome keeps
+  // the app's controls; an empty claim would leave a bare strip on every plugin
+  // route. Contributed `titleBar.tools` items keep rendering here too, so a
+  // chrome-owning page never silently drops a registered item.
+  if (hidesFixedTitlebarClusters(view) && pageOwnsTitlebar) {
+    const pageTools = [...leftTools, ...tools].filter(tool => !tool.hidden)
+
+    return (
+      <div className={leftClusterClass}>
+        {pageTools.map(tool => (
+          <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
+        ))}
+        {titlebarSlots}
+      </div>
+    )
   }
 
   const visibleLeftTools = [sidebarTool, ...systemTools, ...leftTools, ...tools].filter(tool => !tool.hidden)


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

#107239 hid the app's fixed titlebar clusters on every contributed full page (`extension` view). A plugin page that mounts no `titleBar.*` chrome got a bare strip: sidebar toggle, settings gear, layout editor, HUD, flip and right-sidebar toggles all unmounted, and contributed `titleBar.tools` items were dropped with no opt-out.

The band now yields only while the page actually projects chrome into it. `titleBar.*` slot contributions are mount-scoped (`Contribute` registers while the page is up), so `useContributions` presence answers whether the page is driving the band. A chrome-owning page keeps its `titleBar.tools` items in the band too, so nothing a page registered is silently dropped.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #108097

Related: #107239 introduced the unconditional hide for the #107228 overlap; this keeps that fix for pages that mount chrome. #107683 gives the preserved slots their own anchored regions and does not restore the clusters.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `apps/desktop/src/app/shell/titlebar-controls.tsx`: extension pages hide the fixed clusters only while a `titleBar.*` slot area is non-empty; contributed `titleBar.tools` items render inside the band while it is page-owned.
- `apps/desktop/src/app/routes.ts`: `hidesFixedTitlebarClusters` doc reflects the mount-scoped gate.
- `apps/desktop/src/app/shell/titlebar-controls.test.tsx`: chrome-owning vs chrome-less extension pages, and a tools-only contribution does not claim the band.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `cd apps/desktop && npx vitest run src/app/shell/titlebar-controls.test.tsx src/app/routes.titlebar-clusters.test.ts`
2. `keeps the app clusters on a contributed page that mounts no titlebar chrome` fails on main: Window/App controls unmount on a bare `/plain` extension route. With the fix they stay mounted.
3. `hides the app clusters on a contributed full-page route` still passes with `titleBar.center` registered, so the #107228 fix holds for chrome-owning pages like `/kanban`.

Ran on Windows 11:

```
Test Files  2 passed (2)
Tests  12 passed (12)
```

`npx tsc -p . --noEmit`, `npx eslint`, and `npx prettier --check` on the touched files are clean.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```
Before: /plain extension route mounts no titleBar.* chrome -> Window controls and App controls both null.
After:  same route keeps both clusters. /kanban with titleBar.center registered still hides them and keeps plugin-chrome + the contributed tool.
```
