### PR TITLE
fix(gateway): keep SSH restarts out of Windows Session 0

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -69,6 +69,42 @@ def _assert_windows() -> None:
         raise RuntimeError("gateway_windows is Windows-only")
 
 
+def _process_session_id(pid: int) -> int:
+    """Return the Windows Terminal Services session that owns ``pid``."""
+    _assert_windows()
+    session_id = ctypes.c_ulong()
+    if not ctypes.windll.kernel32.ProcessIdToSessionId(int(pid), ctypes.byref(session_id)):
+        raise ctypes.WinError()
+    return int(session_id.value)
+
+
+def _interactive_session_ids() -> set[int]:
+    """Sessions with an Explorer shell, i.e. an interactive user desktop."""
+    import psutil
+
+    sessions: set[int] = set()
+    for process in psutil.process_iter(("pid", "name")):
+        try:
+            if (process.info.get("name") or "").lower() != "explorer.exe":
+                continue
+            session_id = _process_session_id(int(process.info["pid"]))
+            if session_id > 0:
+                sessions.add(session_id)
+        except (OSError, TypeError, ValueError, psutil.Error):
+            continue
+    return sessions
+
+
+def _session_zero_mismatch() -> tuple[bool, int | None, set[int]]:
+    """Whether this CLI is in Session 0 while an interactive desktop exists."""
+    try:
+        current_session = _process_session_id(os.getpid())
+    except OSError:
+        return False, None, set()
+    interactive_sessions = _interactive_session_ids()
+    return current_session == 0 and bool(interactive_sessions), current_session, interactive_sessions
+
+
 def _hermes_home() -> Path:
     from hermes_cli.config import get_hermes_home
 
@@ -664,6 +700,38 @@ def _spawn_detached(script_path: Path | None = None) -> int:
     return proc.pid
 
 
+def _launch_gateway_for_current_session() -> str:
+    """Launch directly, except when an SSH/service shell would strand it in Session 0.
+
+    A registered Hermes task uses ``InteractiveToken`` and therefore crosses from an OpenSSH
+    service shell into the logged-in desktop session.  Without that task, preserve deliberate
+    Session 0 deployments but make the credential/GUI trade-off explicit instead of silent.
+    """
+    mismatch, current_session, interactive_sessions = _session_zero_mismatch()
+    if mismatch and is_task_registered():
+        task_name = get_task_name()
+        code, out, err = _exec_schtasks(["/Run", "/TN", task_name])
+        if code != 0:
+            detail = (err or out or "unknown error").strip()
+            raise RuntimeError(
+                f"Could not start gateway via interactive Scheduled Task {task_name!r}: {detail}"
+            )
+        sessions = ", ".join(map(str, sorted(interactive_sessions)))
+        return f"Scheduled Task {task_name!r} (interactive Session {sessions})"
+
+    if mismatch:
+        sessions = ", ".join(map(str, sorted(interactive_sessions)))
+        print(
+            f"⚠ This shell is in Windows Session {current_session}, while an interactive desktop "
+            f"exists in Session {sessions}. No Hermes Scheduled Task is registered, so the gateway "
+            "will remain in Session 0; Windows credentials and GUI helpers may be unavailable."
+        )
+        print("  Install an InteractiveToken task with: hermes gateway install")
+
+    pid = _spawn_detached()
+    return f"direct spawn (PID {pid})"
+
+
 def _install_choice_from_env(name: str) -> bool | None:
     raw = os.environ.get(name)
     if raw is None:
@@ -705,8 +773,7 @@ def _start_or_report_running(running_pids: list[int] | None = None) -> None:
     if running_pids:
         _report_already_running(running_pids)
     else:
-        pid = _spawn_detached()
-        _report_gateway_start(f"direct spawn (PID {pid})")
+        _report_gateway_start(_launch_gateway_for_current_session())
 
 
 def _install_startup_fallback(script_path: Path, start_now: bool, detail: str) -> None:
@@ -1210,6 +1277,25 @@ def status(deep: bool = False) -> None:
         print("✗ Gateway service not installed")
 
     print(f"✓ Gateway process running (PID: {', '.join(map(str, pids))})" if pids else "✗ No gateway process detected")
+    if pids:
+        sessions: dict[int, int | None] = {}
+        for pid in pids:
+            try:
+                sessions[pid] = _process_session_id(pid)
+            except OSError:
+                sessions[pid] = None
+        rendered = ", ".join(
+            f"PID {pid} → Session {session_id if session_id is not None else 'unknown'}"
+            for pid, session_id in sessions.items()
+        )
+        print(f"  Windows session: {rendered}")
+        interactive_sessions = _interactive_session_ids()
+        if any(session_id == 0 for session_id in sessions.values()) and interactive_sessions:
+            desktop_sessions = ", ".join(map(str, sorted(interactive_sessions)))
+            print(
+                "⚠ Gateway is running in Session 0 while an interactive desktop exists in "
+                f"Session {desktop_sessions}. Windows credentials and GUI helpers may be unavailable."
+            )
 
     if deep:
         print()
@@ -1244,10 +1330,7 @@ def start() -> None:
             print("  If a UAC prompt opened, approve it, then run: hermes gateway start")
             return
 
-    # Manual starts use the same console-less direct spawn as restart() and install --start-now;
-    # Scheduled Task / Startup entries are only login persistence.
-    pid = _spawn_detached()
-    _report_gateway_start(f"direct spawn (PID {pid})")
+    _report_gateway_start(_launch_gateway_for_current_session())
 
 
 def _drain_gateway_pid(pid: int, drain_timeout: float) -> bool:

--- a/hermes_cli/update_cmd_windows.py
+++ b/hermes_cli/update_cmd_windows.py
@@ -930,13 +930,14 @@ def _cold_start_windows_gateway_after_update() -> bool:
             logger.debug("Skipping Windows gateway cold-start: Desktop owns gateway lifecycle")
             return True
     with _abort_on_error("Could not cold-start Windows gateway after update"):
-        pid = gateway_windows._spawn_detached()
-    if not pid:
-        raise RuntimeError("Windows gateway cold-start did not return a process ID")
+        launch_via = gateway_windows._launch_gateway_for_current_session()
     ready_pids = gateway_windows._wait_for_gateway_ready()
     if not ready_pids:
-        raise RuntimeError(f"Windows gateway cold-start PID {pid} did not become ready")
-    print(f"\n✓ Gateway started via cold-start after update (PID: {', '.join(map(str, ready_pids))})")
+        raise RuntimeError("Windows gateway cold-start did not become ready")
+    print(
+        f"\n✓ Gateway started via cold-start after update using {launch_via} "
+        f"(PID: {', '.join(map(str, ready_pids))})"
+    )
     with suppress(Exception):
         gateway_windows._write_start_attestation(ready_pids, "cold-start after update")
     return True

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -174,6 +174,56 @@ def test_spawn_detached_warns_and_marks_no_breakaway_fallback(
     assert str(tmp_path) not in warnings[0].getMessage()
 
 
+@pytest.mark.windows_only
+def test_launch_gateway_routes_session_zero_through_interactive_task(monkeypatch):
+    calls = []
+    monkeypatch.setattr(gateway_windows, "_session_zero_mismatch", lambda: (True, 0, {1}))
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway")
+    monkeypatch.setattr(
+        gateway_windows,
+        "_exec_schtasks",
+        lambda args: calls.append(args) or (0, "SUCCESS", ""),
+    )
+    monkeypatch.setattr(
+        gateway_windows,
+        "_spawn_detached",
+        lambda: pytest.fail("Session 0 must not directly spawn when an interactive task is available"),
+    )
+
+    via = gateway_windows._launch_gateway_for_current_session()
+
+    assert calls == [["/Run", "/TN", "Hermes_Gateway"]]
+    assert "interactive Session 1" in via
+
+
+@pytest.mark.windows_only
+def test_launch_gateway_warns_before_deliberate_session_zero_spawn(monkeypatch, capsys):
+    monkeypatch.setattr(gateway_windows, "_session_zero_mismatch", lambda: (True, 0, {1}))
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: False)
+    monkeypatch.setattr(gateway_windows, "_spawn_detached", lambda: 4242)
+
+    via = gateway_windows._launch_gateway_for_current_session()
+
+    output = capsys.readouterr().out
+    assert via == "direct spawn (PID 4242)"
+    assert "will remain in Session 0" in output
+    assert "hermes gateway install" in output
+
+    monkeypatch.setattr(gateway_windows, "_print_start_attestation_warning", lambda: None)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway")
+    monkeypatch.setattr(gateway_windows, "is_startup_entry_installed", lambda: False)
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [4242])
+    monkeypatch.setattr(gateway_windows, "_process_session_id", lambda _pid: 0)
+    monkeypatch.setattr(gateway_windows, "_interactive_session_ids", lambda: {1})
+
+    gateway_windows.status()
+
+    status_output = capsys.readouterr().out
+    assert "PID 4242 → Session 0" in status_output
+    assert "Gateway is running in Session 0" in status_output
+
+
 class TestStableWindowsGatewayWorkingDir:
     def test_stable_gateway_working_dir_uses_hermes_home(self, tmp_path, monkeypatch):
         home = tmp_path / ".hermes"

--- a/tests/hermes_cli/test_update_cold_start_gateway_liveness.py
+++ b/tests/hermes_cli/test_update_cold_start_gateway_liveness.py
@@ -30,7 +30,11 @@ def _run_cold_start(monkeypatch, capsys, *, surviving_pids):
         "find_gateway_pids",
         lambda all_profiles=False: [] if all_profiles else surviving_pids,
     )
-    monkeypatch.setattr(gateway_windows, "_spawn_detached", lambda: 4242)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_launch_gateway_for_current_session",
+        lambda: "direct spawn (PID 4242)",
+    )
     # Avoid the real 6s/0.4s poll loop in _report_gateway_start.
     monkeypatch.setattr(
         gateway_windows, "_wait_for_gateway_ready", lambda *a, **k: surviving_pids

--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -176,23 +176,37 @@ hermes gateway install
 
 What happens under the hood:
 
-1. `schtasks /Create /SC ONLOGON /RL LIMITED /TN Hermes_Gateway` — registers a task that runs at your login with standard (non-elevated) permissions. No UAC prompt.
+1. Registers an `InteractiveToken` Scheduled Task named `Hermes_Gateway` that runs at your login with standard (non-elevated) permissions.
 2. If schtasks is blocked by group policy, falls back to writing a small `Hermes_Gateway.vbs` launcher (run hidden via `wscript.exe`) into `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup`. Same effect, slightly cruder. A VBScript is used rather than a `cmd.exe` shortcut because a console allocated at logon can receive a close event that kills the gateway before it finishes starting.
-3. Spawns the gateway **detached via `pythonw.exe`** — not `python.exe`. `pythonw.exe` has no console attached, which immunizes it against `CTRL_C_EVENT` broadcasts from sibling processes (a real issue that used to kill the gateway when you Ctrl+C'd anything in the same process group).
+3. Starts the gateway with a hidden console so command-line children such as Git inherit it without flashing windows.
 
-Flags used when spawning: `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`.
+Flags used for direct spawns: `CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB`.
 
 ### Manage
 
 ```powershell
-hermes gateway status      # Merged view: schtasks + Startup folder + running PID
-hermes gateway start       # Starts the scheduled task now
+hermes gateway status      # Merged view: task/login item + PID + Windows Session ID
+hermes gateway start
 hermes gateway stop        # Graceful SIGTERM equivalent (TerminateProcess via psutil)
 hermes gateway restart
 hermes gateway uninstall   # Removes schtasks entry, Startup shortcut, pid file
 ```
 
 `hermes gateway status` is idempotent — call it a thousand times in a row and it will never accidentally kill the gateway. (Pre-PR #21561 it silently did, via `os.kill(pid, 0)` colliding with `CTRL_C_EVENT` at the C level — see "process management internals" below if you care about the story.)
+
+Windows OpenSSH runs as a service in **Session 0**. If you run `hermes gateway start`,
+`hermes gateway restart`, or an update that cold-starts the gateway from an SSH shell while
+an interactive desktop is logged in, Hermes starts the gateway through the registered
+`InteractiveToken` task so it returns to that desktop session. Without a registered task,
+Hermes preserves the direct Session 0 launch but prints a warning: Credential Manager and GUI
+helpers may be unavailable there. `hermes gateway status` always reports the gateway's Session
+ID and warns when a Session 0 gateway coexists with an interactive desktop.
+
+`InteractiveToken` intentionally ties the task to a logged-in desktop: credentials and GUI
+helpers work, but the gateway stops being available after logout. Configuring Task Scheduler as
+S4U ("run whether user is logged on or not") makes it survive logout by running it in Session 0,
+with the same credential-store and desktop limitations. Use that mode only when those limitations
+are deliberate.
 
 ### Why not a Windows Service?
 


### PR DESCRIPTION
## What does this PR do?

Windows gateway restarts initiated from an OpenSSH shell no longer silently strand the replacement gateway in Session 0. When an interactive desktop and the registered InteractiveToken task are available, Hermes relaunches through that task; otherwise it preserves deliberate Session 0 deployments but warns about unavailable credentials and GUI helpers.

### Symptom

Running `hermes gateway restart` from Windows OpenSSH stops the interactive gateway and directly spawns its replacement in the SSH service's Session 0. `hermes gateway status` previously reported only the PID, so the session change was invisible.

### Impact

A Session 0 gateway can still serve messaging traffic while Windows Credential Manager and desktop GUI helpers fail. A later interactive logon can also start a second task-owned gateway.

### Bug Cause

**Trigger:** `hermes_cli/gateway_windows.py:1330` / `start()` always selected `_spawn_detached()`.

**Causal chain:**
1. Windows OpenSSH launches the CLI from its service process in Session 0.
2. `restart()` stops the existing gateway and `start()` directly spawns a detached child that inherits Session 0.
3. The replacement looks healthy by PID while credential-backed and desktop-bound operations fail.

**Why it is wrong:** Process detachment separates lifetime and console ownership, but it does not move a process between Windows sessions.

**Working sibling / contrast:** The installed Scheduled Task uses `InteractiveToken`, so Task Scheduler launches it in the logged-in user's interactive session.

**Ruled out:** Console flags and Job Object breakaway are not the cause. They affect console visibility and child lifetime, but Windows session inheritance remains unchanged.

### Fix

- Detect the current and Explorer-owned Windows session IDs with `ProcessIdToSessionId`.
- Route manual starts, restarts, install-time starts, and post-update cold starts through the registered Scheduled Task when Session 0 would otherwise replace an interactive gateway.
- Preserve direct Session 0 operation when no interactive task is available, with an explicit warning instead of silently changing semantics.
- Report each gateway PID's Session ID in `hermes gateway status` and warn on a Session 0 / interactive-desktop mismatch.
- Document the InteractiveToken versus S4U trade-off.

## Related Issue


N/A

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Tests

## Changes Made

- `hermes_cli/gateway_windows.py` - add Windows session detection, session-aware launch routing, and status diagnostics.
- `hermes_cli/update_cmd_windows.py` - use the same session-aware launcher for update cold starts.
- `tests/hermes_cli/` - cover task handoff, explicit Session 0 fallback, status reporting, and update liveness.
- `website/docs/user-guide/windows-native.md` - document session behavior and task logon trade-offs.

## How to Test

1. From a Windows OpenSSH shell in Session 0, run `hermes gateway restart` while an interactive desktop is logged in.
2. Run `hermes gateway status` and verify that the replacement gateway reports the interactive Session ID.
3. Run scripts/run_tests.sh against test_gateway_windows.py and test_update_cold_start_gateway_liveness.py.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] Updating `cli-config.yaml.example` is N/A because no config keys changed
- [x] Updating `CONTRIBUTING.md` or `AGENTS.md` is N/A because no contributor workflow changed
- [x] I've considered cross-platform impact; all new runtime behavior is isolated to the Windows backend
- [x] Updating tool descriptions or schemas is N/A
