### PR TITLE
Desktop: hovering the Bots roster no longer spawns a backend per row (#103631, salvage #103634)

### DIFF
--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -11,12 +11,14 @@ import { clearAllSessionStates, publishSessionState } from '@/store/session-stat
 // tests observe the guard's decision through the ONLY side effect that matters
 // — whether openGatewayForProfile was dialed.
 const warmMocks = vi.hoisted(() => ({
+  openGatewayForAgent: vi.fn(async (_connectionId: null | string, _profile: string) => undefined),
   openGatewayForProfile: vi.fn(async (_profile: string) => undefined),
   openSecondaryCount: vi.fn(() => 0)
 }))
 
 vi.mock('@/store/gateway', async importOriginal => ({
   ...((await importOriginal()) as Record<string, unknown>),
+  openGatewayForAgent: warmMocks.openGatewayForAgent,
   openGatewayForProfile: warmMocks.openGatewayForProfile,
   openSecondaryCount: warmMocks.openSecondaryCount
 }))
@@ -47,6 +49,21 @@ describe('host.warmProfile pool-saturation contract', () => {
     host.warmProfile('warm-saturated')
 
     expect(warmMocks.openGatewayForProfile).not.toHaveBeenCalled()
+  })
+
+  it('warmAgent (multi-source rows) honours the same saturation guard', () => {
+    warmMocks.openGatewayForAgent.mockClear()
+    warmMocks.openSecondaryCount.mockReturnValue(3)
+
+    host.warmAgent('conn-vps', 'warm-agent-saturated')
+
+    expect(warmMocks.openGatewayForAgent).not.toHaveBeenCalled()
+
+    warmMocks.openSecondaryCount.mockReturnValue(2)
+
+    host.warmAgent('conn-vps', 'warm-agent-free')
+
+    expect(warmMocks.openGatewayForAgent).toHaveBeenCalledWith('conn-vps', 'warm-agent-free')
   })
 })
 

--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -1,9 +1,54 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { host } from '@/sdk'
 import { setActiveSessionId, setAwaitingResponse, setBusy } from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+
+// The warm path must route through the guarded prewarm resolver, not dial the
+// gateway directly: gateway.ts's openSecondaryCount and pool-limits' cap atom
+// are the two signals prewarmProfileBackend consults, so mocking them lets the
+// tests observe the guard's decision through the ONLY side effect that matters
+// — whether openGatewayForProfile was dialed.
+const warmMocks = vi.hoisted(() => ({
+  openGatewayForProfile: vi.fn(async (_profile: string) => undefined),
+  openSecondaryCount: vi.fn(() => 0)
+}))
+
+vi.mock('@/store/gateway', async importOriginal => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  openGatewayForProfile: warmMocks.openGatewayForProfile,
+  openSecondaryCount: warmMocks.openSecondaryCount
+}))
+
+vi.mock('@/store/pool-limits', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $poolLimits: atom({ idleMs: 600_000, maxBackends: 3 }) }
+})
+
+describe('host.warmProfile pool-saturation contract', () => {
+  beforeEach(() => {
+    warmMocks.openGatewayForProfile.mockClear()
+    warmMocks.openSecondaryCount.mockReturnValue(0)
+  })
+
+  it('dials through the guarded path when a pool slot is free', () => {
+    warmMocks.openSecondaryCount.mockReturnValue(2)
+
+    host.warmProfile('warm-free-slot')
+
+    expect(warmMocks.openGatewayForProfile).toHaveBeenCalledWith('warm-free-slot')
+  })
+
+  it('skips the speculative spawn when every pool slot is occupied', () => {
+    warmMocks.openSecondaryCount.mockReturnValue(3)
+
+    host.warmProfile('warm-saturated')
+
+    expect(warmMocks.openGatewayForProfile).not.toHaveBeenCalled()
+  })
+})
 
 describe('host.state turn flags', () => {
   afterEach(() => {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -67,6 +67,7 @@ import {
   newSessionInAgent,
   newSessionInProfile,
   normalizeProfileKey,
+  prewarmProfileBackend,
   refreshProfiles,
   selectProfile,
   setActiveProfile,
@@ -666,20 +667,25 @@ export const host = {
   },
 
   /** Pre-dial a profile's gateway socket in the background — pool-only, no
-   *  activation, no navigation, no scope change (openGatewayForProfile; it
-   *  already no-ops for shared-remote routes and the primary). Roster UIs
-   *  call this after mount so the FIRST click on an agent doesn't pay the
-   *  whole backend spawn + socket dial latency. Fire-and-forget: failures
-   *  are swallowed — the click path re-runs its own ensure and surfaces
-   *  errors properly. */
+   *  activation, no navigation, no scope change. Delegates to
+   *  prewarmProfileBackend so plugin surfaces get the SAME pool-saturation
+   *  guard, hover dwell, and per-profile throttle as the built-in rail
+   *  (#91545): a pointer sweep across a plugin roster (bot-row's
+   *  onPointerEnter fires with no dwell of its own) previously spawned at
+   *  pointer speed, filled the local backend pool past maxBackends, and left
+   *  the next profile's spawn queued until the 30s slot timeout — observed
+   *  as a profile surface that hangs forever while every other profile
+   *  renders. It already no-ops for shared-remote routes and the primary.
+   *  Fire-and-forget: failures are swallowed — the click path re-runs its
+   *  own ensure and surfaces errors properly. */
   warmProfile: (profile: string): void => {
     const name = (profile ?? '').trim()
 
-    if (!name || name === $activeGatewayProfile.get()) {
+    if (!name) {
       return
     }
 
-    void openGatewayForProfile(name).catch(() => undefined)
+    prewarmProfileBackend(name)
   },
 
   /** Delete a profile THROUGH the desktop's teardown-routed REST path — the

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -821,11 +821,13 @@ export const host = {
   },
 
   /** Pre-dial an agent's socket on ITS source — the (connection, profile)
-   *  analogue of warmProfile. Fire-and-forget, same semantics.
+   *  analogue of warmProfile. Fire-and-forget, same semantics, same guarded
+   *  resolver (prewarmProfileBackend): a pointer sweep across a
+   *  multi-source roster must not spawn past the pool cap either.
    *  `undefined` is accepted alongside `null` because a roster row's
    *  `connectionId` is optional; both mean "no explicit source". */
   warmAgent: (connectionId: null | string | undefined, profile: string): void => {
-    void openGatewayForAgent(connectionId ?? null, (profile ?? '').trim() || 'default').catch(() => undefined)
+    prewarmProfileBackend((profile ?? '').trim() || 'default', connectionId ?? null)
   },
 
   /** Activate an agent's gateway (dialing it if needed) so subsequent

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -1,4 +1,4 @@
-import { LOCAL_CONNECTION_ID } from '@hermes/shared'
+import { LOCAL_CONNECTION_ID, registryBackendScopeKey } from '@hermes/shared'
 import { atom, batch, computed } from 'nanostores'
 
 import type { HermesConnection } from '@/global'
@@ -408,20 +408,30 @@ export const $hydrationSyncProfile = atom<string | null>(null)
 // duplicating it — and a pre-warm for an already-open profile is a no-op.
 // Throttled per profile so drive-by hovers can't spam spawn attempts; failures
 // stay silent here and surface on the real switch, which owns retry/error UX.
+// A `connectionId` scopes the warm to a registry source (the (connection,
+// profile) rows a multi-source roster shows): same guards, keyed by the pool
+// scope key, dialed through openGatewayForAgent. Every speculative warm in
+// the app — rail, session rows, plugin rosters — goes through here so one
+// resolver owns the policy (#91545, #103631).
 const PREWARM_MIN_INTERVAL_MS = 60_000
 
 const prewarmedAt = new Map<string, number>()
 
-export function prewarmProfileBackend(name: string): void {
+export function prewarmProfileBackend(name: string, connectionId: null | string = null): void {
   const key = normalizeProfileKey(name)
+  const connection = (connectionId ?? '').trim() || null
+  const scope = registryBackendScopeKey(connection, key)
 
-  if (key === normalizeProfileKey($activeGatewayProfile.get())) {
+  if (
+    key === normalizeProfileKey($activeGatewayProfile.get()) &&
+    (!connection || connection === activeGatewayConnectionId())
+  ) {
     return
   }
 
   const now = Date.now()
 
-  if (now - (prewarmedAt.get(key) ?? 0) < PREWARM_MIN_INTERVAL_MS) {
+  if (now - (prewarmedAt.get(scope) ?? 0) < PREWARM_MIN_INTERVAL_MS) {
     return
   }
 
@@ -436,8 +446,9 @@ export function prewarmProfileBackend(name: string): void {
     return
   }
 
-  prewarmedAt.set(key, now)
-  openGatewayForProfile(key).catch(() => undefined)
+  prewarmedAt.set(scope, now)
+  const dial = connection ? openGatewayForAgent(connection, key) : openGatewayForProfile(key)
+  dial.catch(() => undefined)
 }
 
 let gatewaySwitch: Promise<void> | null = null


### PR DESCRIPTION
Hovering across the Bots roster no longer spawns a profile backend per row: every plugin-SDK warm now goes through the same guarded prewarm resolver as the built-in profile rail, so a pointer sweep can't fill the local backend pool and starve the next profile's real open (the "4th profile spins forever / timed out waiting for a free slot" symptom).

- `host.warmProfile` delegates to `prewarmProfileBackend` (cherry-picked from #103634, authorship preserved): inherits the active-profile no-op, the 60s per-profile throttle and the pool-saturation skip instead of dialing `openGatewayForProfile` directly.
- `host.warmAgent` (the multi-source roster sibling, also fired from `bot-row.tsx` `onPointerEnter`) had the identical bypass on the registry path (`openGatewayForAgent`). `prewarmProfileBackend` gains an optional `connectionId`; same guards, throttle keyed by the pool scope key, dial routed to `openGatewayForAgent` for scoped sources.
- The real click path (`ensureProfile` / `ensureAgent`, foreground priority) is untouched — only the speculative head start is gated.

**Root cause:** the plugin SDK's warm entry points bypassed the #91545 saturation/throttle guard that the rail's hover prewarm already had, so speculative hover spawns could occupy every pool slot and leave a real spawn queued until the 30s slot timeout.

| Check | Result |
|---|---|
| `npx vitest run --project ui src/sdk/ src/store/profile.test.ts` | 5 files, 100 passed |
| New invariants red on base | `skips the speculative spawn when every pool slot is occupied` fails with `warmProfile` dialing directly; `warmAgent … honours the same saturation guard` fails with `warmAgent` dialing directly |
| `npx tsc -p tsconfig.electron.json --noEmit` / `npx tsc -p . --noEmit` | clean |
| `npx eslint` on touched files | clean |
| Live multi-profile desktop repro | not run (unit-level + line trace only) |

Fixes #103631
Supersedes #103634 (cherry-picked, authorship preserved)
Related: #103401 (hover-spawn half; the "timed out waiting for a free slot" on a real click is the pool-pressure side, tracked separately)

Not changed: the failure UX when a real spawn times out (endless spinner instead of an inline error / raise-cap affordance, problem 2 in #103631) — separate follow-up. `bot-row.tsx` itself is unchanged; the guard lives in the resolver so every caller inherits it.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9fc40/6D_j6-9kaFQevfvwm4t73_Vnc5f8pk.png)
