### PR TITLE
fix(tests): main's banner ssh-fastpath tests no longer hit GitHub on the runner (banner half of #107835)

### DIFF
--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -64,7 +64,7 @@ def test_check_via_local_git_ssh_fastpath_ahead_not_behind(tmp_path):
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
-        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        patch.object(banner, "_github_branch_tip", return_value="a" * 40),
         # merge-base --is-ancestor exits 0: upstream tip IS an ancestor of HEAD
         patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=0)),
     ):
@@ -91,7 +91,7 @@ def test_check_via_local_git_ssh_fastpath_genuinely_behind(tmp_path):
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
-        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        patch.object(banner, "_github_branch_tip", return_value="a" * 40),
         # merge-base --is-ancestor exits 1: not an ancestor -> genuinely behind
         patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=1)),
         patch.object(banner, "_github_compare_behind", return_value=3),
@@ -119,7 +119,7 @@ def test_check_via_local_git_ssh_fastpath_offline_keeps_sentinel(tmp_path):
 
     with (
         patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
-        patch.object(banner, "_upstream_main_sha", return_value="a" * 40),
+        patch.object(banner, "_github_branch_tip", return_value="a" * 40),
         patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=1)),
         patch.object(banner, "_github_compare_behind", return_value=None),
     ):


### PR DESCRIPTION
Main's CI is red on its own push runs (e.g. run 34584085791) on three `tests/hermes_cli/test_banner_git_state.py::test_check_via_local_git_ssh_fastpath_*` tests; this re-seams the tests so they pass without network.

- Root cause: since 338bf9ea9a `_check_via_local_git` reads `_github_branch_tip` directly (`hermes_cli/banner.py:352`); the tests still patched `_upstream_main_sha`, so on the runner the check made a live GitHub call, got `None`, and `behind` stayed `None`.
- Change: the three `patch.object(banner, "_upstream_main_sha", ...)` → `_github_branch_tip` (3 lines, tests only). No production code touched.
- This is the banner half of @teknium1's #107835, commit kept under his authorship; the other half of that PR (`_RESOLVE_TOKEN_CACHE = {}`) already landed via #107822. Opened separately only because six armed auto-merge PRs (#107974 #107975 #107976 #107979 #107981 #108033) are blocked on this red; if #107835 merges first this one is redundant and can be closed.

| condition | before | after |
|---|---|---|
| `pytest tests/hermes_cli/test_banner_git_state.py` with the GitHub API unreachable (`HTTPS_PROXY=http://127.0.0.1:9`) | 3 failed, 3 passed | 6 passed |
| same, network available | 6 passed | 6 passed |
