### PR TITLE
refactor(desktop): name the in-memory transcript-tail wipe by what it clears (follow-up to #107993)

### DIFF
--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -460,8 +460,7 @@ export function getLatestSessionMessages(
   // duplicate tail entries and "Show earlier" cannot resolve the loaded tail.
   // Capture before awaiting: the active gateway may change during the read.
   const route = { ...connectionScoped(), ...sessionScoped(profile) }
-  // Owner identity is resolved from the ambient state at REQUEST time; only
-  // the lookup key is normalized — backfill replays `route` verbatim.
+  // Only the lookup key is normalized — backfill replays `route` verbatim.
   const ambientConnectionId = route.connectionId || ambientOwnerConnectionId()
   const ambientProfile = getApiRequestProfile() || 'default'
 

--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -18,7 +18,12 @@ import {
   setSessionsLoading
 } from '@/store/session'
 import { $stalledSessionIds } from '@/store/session-states'
-import { $transcriptTailBySessionId, recordTranscriptTail, transcriptTailState } from '@/store/transcript-tail'
+import {
+  $transcriptTailBySessionId,
+  clearTranscriptTailPaging,
+  recordTranscriptTail,
+  transcriptTailState
+} from '@/store/transcript-tail'
 
 import {
   $gatewaySwitching,
@@ -65,6 +70,7 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     $stalledSessionIds.set([])
     setSessionsLoading(true)
     $gatewaySwitching.set(false)
+    clearTranscriptTailPaging()
   })
 
   it('clears lists and arms loading so sidebar skeletons retrigger', () => {
@@ -99,7 +105,6 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     recordTranscriptTail('recycled-id', page, { connectionId: 'remote-1', profile: 'default' })
     expect(Object.keys($transcriptTailBySessionId.get())).toHaveLength(1)
     expect(transcriptTailState('recycled-id')?.possiblyTruncated).toBe(true)
-    $transcriptTailBySessionId.set({})
   })
 
   it('strands in-flight profile-list fetches so the old backend cannot repaint the rail (#85731)', () => {

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -26,7 +26,7 @@ import {
 import { clearAllSessionControl } from '@/store/session-control'
 import { resetSessionPinMirror } from '@/store/session-pin-sync'
 import { clearAllSessionStates } from '@/store/session-states'
-import { clearAllTranscriptTails } from '@/store/transcript-tail'
+import { clearTranscriptTailPaging } from '@/store/transcript-tail'
 import { clearTranscriptTails } from '@/store/transcript-tail-cache'
 
 // True while a connection switch is mid-flight — a Settings → Gateway apply
@@ -233,7 +233,7 @@ export function wipeSessionListsForGatewaySwitch(): void {
   // owner, so a survivor from the old backend would sit beside the new one and
   // fail the unique-match lookup that shows "Show earlier".
   clearTranscriptTails()
-  clearAllTranscriptTails()
+  clearTranscriptTailPaging()
 
   // Narrowed: account/marketplace/onboarding caches are global, not gateway-
   // scoped, so a mode swap must not refetch them.

--- a/apps/desktop/src/store/transcript-tail.ts
+++ b/apps/desktop/src/store/transcript-tail.ts
@@ -178,9 +178,8 @@ export function transcriptTailState(
   return matches.length === 1 ? matches[0][1] : undefined
 }
 
-/** Forget every tail: the backend behind the window changed and a recycled
- *  stored id must not carry the previous backend's paging state. */
-export function clearAllTranscriptTails(): void {
+/** Drops the LRU order as well as the atom. */
+export function clearTranscriptTailPaging(): void {
   transcriptTailOrder = []
   $transcriptTailBySessionId.set({})
 }


### PR DESCRIPTION
Behaviour-preserving polish from the post-merge simplify pass on #107993 (Desktop "Show earlier" paging keyed by owner).

- `clearAllTranscriptTails` → `clearTranscriptTailPaging`: it sat beside the persisted cache's `clearTranscriptTails` differing by one word that did not say which store each empties. Single caller (`wipeSessionListsForGatewaySwitch`), so the rename is free; the WHY now lives only at that call site.
- `gateway-switch.test.ts`: the new wipe test reset the atom inline as its last statement (skipped on a failing assertion, and it did not reset the LRU order). Reset through the helper in `afterEach` like every other atom in that describe.
- `getLatestSessionMessages`: one duplicated "capture before await" sentence removed.

No runtime behaviour change; +12/−9 across 4 files. Wipe test still fails when the `clearTranscriptTailPaging()` call is removed.
