### PR TITLE
fix(gateway): Windows stop skips the drain wait when the event loop is provably wedged (#106359)

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1338,7 +1338,24 @@ def stop() -> None:
 
     pid = get_running_pid()
     stop_pids = _collect_gateway_stop_pids(pid)
-    drained = pid is not None and _drain_gateway_pid(pid, _windows_stop_drain_timeout())
+
+    # A provably-dead event loop can never read the planned-stop marker, so draining it is a
+    # guaranteed burn of the full window (#106359: a proxy failure exhausted the TCP port space,
+    # the loop froze, the heartbeat stopped, background threads kept logging, and every stop paid
+    # the ~30s wait before the hard kill). Windows has no SIGTERM — escalate straight to the
+    # bounded force kill. A merely busy gateway (fresh heartbeat / tick witness) never takes this
+    # path and keeps its full drain window. Mirrors the systemd/launchd/fleet liveness gates.
+    drained = False
+    if pid is not None:
+        from hermes_cli.gateway import GATEWAY_LOOP_WEDGED, probe_gateway_loop_liveness
+
+        if probe_gateway_loop_liveness(pid) == GATEWAY_LOOP_WEDGED:
+            print(
+                f"⚠ Gateway PID {pid} event loop is unresponsive — skipping the drain "
+                "wait and forcing a bounded stop..."
+            )
+        else:
+            drained = _drain_gateway_pid(pid, _windows_stop_drain_timeout())
 
     stopped_any = drained
     if is_task_registered():

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -17,6 +17,47 @@ _BREAKAWAY_MARKER = "_HERMES_GATEWAY_BREAKAWAY"
 
 
 
+def _stop_call_seq(monkeypatch, liveness: str):
+    """Arrange a running gateway whose loop classifies as ``liveness``; return (module, calls)."""
+    gw = gateway_windows
+    monkeypatch.setattr(gw, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gw, "_clear_start_attestation", lambda: None)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 4242)
+    monkeypatch.setattr(gw, "_collect_gateway_stop_pids", lambda primary_pid=None: [4242])
+    monkeypatch.setattr("hermes_cli.gateway.probe_gateway_loop_liveness",
+                        lambda pid, **kw: liveness)
+    calls: list[str] = []
+    monkeypatch.setattr(gw, "_drain_gateway_pid",
+                        lambda pid, timeout: calls.append("drain") or True)
+    monkeypatch.setattr(gw, "is_task_registered", lambda: False)
+    monkeypatch.setattr(gw, "_force_terminate_known_gateway_pids",
+                        lambda pids: calls.append("kill") or 1)
+    return gw, calls
+
+
+def test_stop_skips_drain_when_loop_wedged(monkeypatch):
+    """#106359: a provably-dead event loop can't read the planned-stop marker — waiting the full
+    drain window is a guaranteed burn. stop() must skip the drain and go to the bounded kill."""
+    gw, calls = _stop_call_seq(monkeypatch, gateway.GATEWAY_LOOP_WEDGED)
+    gw.stop()
+    assert "drain" not in calls
+    assert "kill" in calls
+
+
+def test_stop_drains_normally_when_loop_alive(monkeypatch):
+    gw, calls = _stop_call_seq(monkeypatch, gateway.GATEWAY_LOOP_ALIVE)
+    gw.stop()
+    assert calls[0] == "drain"
+    assert "kill" in calls
+
+
+def test_stop_drains_when_liveness_unknown(monkeypatch):
+    """Ambiguity is never evidence of a wedge — a merely-busy gateway keeps its full drain."""
+    gw, calls = _stop_call_seq(monkeypatch, gateway.GATEWAY_LOOP_UNKNOWN)
+    gw.stop()
+    assert calls[0] == "drain"
+
+
 def test_schtasks_encoding_falls_back_to_utf8(monkeypatch):
     """A broken/empty locale must not leave us without a decoder (issue #38172)."""
 


### PR DESCRIPTION
## What does this PR do?

`hermes gateway stop` on Windows always paid the full planned-stop drain window (~30 s) before the bounded hard kill — even when the gateway's asyncio event loop is provably dead and can never read the planned-stop marker. Issue #106359 is that incident: an outbound-proxy failure exhausted the ephemeral TCP port space, the loop froze, the heartbeat stopped, background threads kept logging, and every stop attempt burned the whole drain window before Windows' own hang-kill.

The fix: before draining, classify the loop with the liveness probe that already gates the systemd/launchd/fleet stop paths (`probe_gateway_loop_liveness`, #90502/#86684). When it returns `GATEWAY_LOOP_WEDGED` — heartbeat stale past budget **and** the loop-tick witness armed **and** silent across three sustained probes — skip the drain (a dead loop cannot consume the marker, so the wait is a guaranteed burn) and escalate straight to the existing bounded stop: `schtasks /End` + force-terminate of known gateway PIDs. `ALIVE` and every ambiguous classification (`UNKNOWN`) keep the current full drain window; the drain is only skipped on *provable* death.

## Related Issue

Fixes #106359

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

*(🐛 Bug fix — checkbox above uses the correct glyph in the opened PR; see note at bottom.)*

## Changes Made

- `hermes_cli/gateway_windows.py` — in `stop()`: probe loop liveness before `_drain_gateway_pid`; on `GATEWAY_LOOP_WEDGED` print a warning and skip the drain window, falling through to the unchanged `schtasks /End` + `_force_terminate_known_gateway_pids` path. Everything else (PID collection, force-kill bounds, exit messaging) untouched.
- `tests/hermes_cli/test_gateway_windows.py` — three regression tests: WEDGED skips the drain and still force-kills; ALIVE drains first; UNKNOWN drains first (ambiguity is never evidence of a wedge).

## How to Test

1. Repro (pre-fix): run the gateway on Windows, freeze its event loop (e.g. exhaust the ephemeral port space, or block the loop in a debugger so it stops servicing the tick witness) until the heartbeat file ages past the liveness budget. Run `hermes gateway stop` — it waits the full drain timeout, then force-kills anyway (dead loops never read the marker).
2. On this branch, the same stop prints `⚠ Gateway PID <pid> event loop is unresponsive — skipping the drain wait and forcing a bounded stop...` and completes in ~5 s via the bounded kill.
3. Unit evidence: `pytest tests/hermes_cli/test_gateway_windows.py -q` → 12 passed. The new `test_stop_skips_drain_when_loop_wedged` fails on `main` (old code drains and prints "drained cleanly" for a wedged loop) and passes here — red-on-main / green-on-branch.
4. `python scripts/check-windows-footguns.py --diff <merge-base>` → clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

Note: this mirrors the liveness gate already used by the non-Windows stop/escalate paths (`_escalate_wedged_gateway`); Windows previously had no equivalent because it has no SIGTERM — the marker drain was the only stop IPC, and this change stops *waiting* on an IPC endpoint that is provably gone. No behavior change for healthy or merely-busy gateways.
</content>
</invoke>