### PR TITLE
Desktop: clicking a pooled remote profile no longer storms reconnects while the VPS backend cold-starts (#107997, salvage #108009 #97914)

### DIFF
--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   ensureHealthyPooledRemoteBackendForDispatch,
   POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS,
+  POWER_RESUME_REVALIDATION_HOLDOFF_MS,
   REMOTE_LIVENESS_FAILURE_LIMIT,
   REMOTE_LIVENESS_FAILURE_WINDOW_MS,
   REMOTE_LIVENESS_TIMEOUT_MS,
@@ -260,6 +261,36 @@ describe('revalidateRemoteConnection', () => {
 })
 
 describe('ensureHealthyPooledRemoteBackendForDispatch', () => {
+  it('covers quiet-box cold-start and stays below the power-resume holdoff', () => {
+    expect(POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS).toBeGreaterThanOrEqual(REMOTE_LIVENESS_TIMEOUT_MS)
+    expect(POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS).toBeGreaterThanOrEqual(8_000)
+    expect(POWER_RESUME_REVALIDATION_HOLDOFF_MS).toBeGreaterThan(POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS)
+  })
+
+  it('returns a healthy cached descriptor without retiring or reconnecting', async () => {
+    const healthy = { baseUrl: 'http://127.0.0.1:49525', mode: 'remote' }
+    const connectionPromise = Promise.resolve(healthy)
+    const retire = vi.fn()
+    const reconnect = vi.fn()
+    const probe = vi.fn().mockResolvedValue({ ok: true })
+
+    await expect(
+      ensureHealthyPooledRemoteBackendForDispatch({
+        connectionPromise,
+        currentConnectionPromise: () => connectionPromise,
+        probe,
+        reconnect,
+        retire
+      })
+    ).resolves.toBe(healthy)
+
+    expect(probe).toHaveBeenCalledWith(healthy, '/api/status', {
+      timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
+    })
+    expect(retire).not.toHaveBeenCalled()
+    expect(reconnect).not.toHaveBeenCalled()
+  })
+
   it('retires a dead cached descriptor and gives dispatch the replacement', async () => {
     const stale = { baseUrl: 'http://127.0.0.1:49525', mode: 'remote' }
     const replacement = { baseUrl: 'http://127.0.0.1:53968', mode: 'remote' }

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -329,6 +329,36 @@ describe('ensureHealthyPooledRemoteBackendForDispatch', () => {
     expect(retire).toHaveBeenCalledOnce()
     expect(reconnect).toHaveBeenCalledOnce()
   })
+
+  it('falls back to /api/status when /api/health returns 404 on older backends', async () => {
+    const legacy = { baseUrl: 'http://127.0.0.1:49525', mode: 'remote' }
+    const legacyPromise = Promise.resolve(legacy)
+
+    const retire = vi.fn()
+    const reconnect = vi.fn()
+
+    const probe = vi.fn(async (_connection, path) => {
+      if (path === '/api/health') {
+        throw new Error('404: Not Found')
+      }
+    })
+
+    await expect(
+      ensureHealthyPooledRemoteBackendForDispatch({
+        connectionPromise: legacyPromise,
+        currentConnectionPromise: () => legacyPromise,
+        probe,
+        reconnect,
+        retire
+      })
+    ).resolves.toBe(legacy)
+
+    expect(probe).toHaveBeenCalledWith(legacy, '/api/status', {
+      timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
+    })
+    expect(retire).not.toHaveBeenCalled()
+    expect(reconnect).not.toHaveBeenCalled()
+  })
 })
 
 describe('revalidatePooledRemoteBackends', () => {

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -284,7 +284,7 @@ describe('ensureHealthyPooledRemoteBackendForDispatch', () => {
       })
     ).resolves.toBe(healthy)
 
-    expect(probe).toHaveBeenCalledWith(healthy, '/api/status', {
+    expect(probe).toHaveBeenCalledWith(healthy, '/api/health', {
       timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
     })
     expect(retire).not.toHaveBeenCalled()
@@ -323,7 +323,7 @@ describe('ensureHealthyPooledRemoteBackendForDispatch', () => {
       })
     ).resolves.toBe(replacement)
 
-    expect(probe).toHaveBeenCalledWith(stale, '/api/status', {
+    expect(probe).toHaveBeenCalledWith(stale, '/api/health', {
       timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
     })
     expect(retire).toHaveBeenCalledOnce()

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -1,3 +1,5 @@
+import { isMissingHealthEndpointError } from './backend-health'
+
 export const REMOTE_LIVENESS_TIMEOUT_MS = 10_000
 // Dispatch is synchronous user intent: a cached descriptor must prove its
 // forwarded endpoint is alive before it can be returned. Probe cheap
@@ -102,9 +104,22 @@ export async function ensureHealthyPooledRemoteBackendForDispatch<TConnection ex
       return reconnect()
     }
 
-    await probe(connection, '/api/health', {
-      timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
-    })
+    try {
+      await probe(connection, '/api/health', {
+        timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
+      })
+    } catch (healthError) {
+      // A remote that predates /api/health would otherwise 404 every dispatch,
+      // retire the tunnel and reconnect forever; the boot probe falls back the
+      // same way (backend-health.ts).
+      if (!isMissingHealthEndpointError(healthError)) {
+        throw healthError
+      }
+
+      await probe(connection, '/api/status', {
+        timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
+      })
+    }
   } catch (error) {
     if (currentConnectionPromise() === connectionPromise) {
       await retire(error)

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -1,8 +1,10 @@
 export const REMOTE_LIVENESS_TIMEOUT_MS = 10_000
 // Dispatch is synchronous user intent: a cached descriptor must prove its
-// forwarded endpoint is alive before it can be returned. Reuse the background
-// liveness budget so a quiet-box cold-start (~6-8s) can finish instead of
-// failing the probe and kicking off a reconnect storm.
+// forwarded endpoint is alive before it can be returned. Probe cheap
+// /api/health — not /api/status, whose cold payload (gateway probe, topology,
+// state.db session count) on a fresh SSH forward routinely runs seconds — and
+// reuse the background liveness budget so a quiet-box cold-start (~6-8s) can
+// finish instead of failing the probe and kicking off a reconnect storm.
 export const POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS = REMOTE_LIVENESS_TIMEOUT_MS
 export const REMOTE_LIVENESS_FAILURE_LIMIT = 3
 // Even at the capped retry path, consecutive liveness observations are at most
@@ -100,7 +102,7 @@ export async function ensureHealthyPooledRemoteBackendForDispatch<TConnection ex
       return reconnect()
     }
 
-    await probe(connection, '/api/status', {
+    await probe(connection, '/api/health', {
       timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
     })
   } catch (error) {

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -1,9 +1,9 @@
 export const REMOTE_LIVENESS_TIMEOUT_MS = 10_000
 // Dispatch is synchronous user intent: a cached descriptor must prove its
-// forwarded endpoint is alive before it can be returned. Keep this probe much
-// shorter than the background liveness budget so a dead tunnel reconnects
-// promptly instead of making the click feel hung.
-export const POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS = 2_500
+// forwarded endpoint is alive before it can be returned. Reuse the background
+// liveness budget so a quiet-box cold-start (~6-8s) can finish instead of
+// failing the probe and kicking off a reconnect storm.
+export const POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS = REMOTE_LIVENESS_TIMEOUT_MS
 export const REMOTE_LIVENESS_FAILURE_LIMIT = 3
 // Even at the capped retry path, consecutive liveness observations are at most
 // about 48s apart (ticket mint + socket open + backoff + the next status probe).


### PR DESCRIPTION
Clicking a pooled remote (SSH/VPS) profile no longer fails its dispatch probe against a backend that is merely cold-starting, so the probe→retire→reconnect→cold-start storm that pinned single-vCPU VPS boxes at 100% CPU stops.

## Changes

- `apps/desktop/electron/remote-liveness.ts`
  - `POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS` reuses `REMOTE_LIVENESS_TIMEOUT_MS` (10s) instead of a hardcoded 2.5s, so a quiet-box `hermes serve` cold start (~6–8s) can finish before dispatch declares the tunnel dead. (cherry-picked from #108009, @KoNit-K)
  - The dispatch probe hits `/api/health` instead of `/api/status`. `/api/status` (`hermes_cli/web_routers/status.py::get_status`) awaits a gateway health probe, topology collection, a state.db active-session count, a threadpool config load and component health — seconds on a cold forward; `/api/health` returns `{ok, version, auth_required}` with zero I/O. (cherry-picked from #97914, @bennybuoy)
  - On an explicit 404 (backend older than 0.19, before `/api/health` existed) the probe falls back to `/api/status` exactly like the boot readiness probe in `backend-health.ts` already does, so old remotes are not put back into the reconnect storm. (fallback idea + test from #101976, @edosulai)
- `apps/desktop/electron/remote-liveness.test.ts`: three invariants — dispatch budget covers cold start and stays below the power-resume holdoff; a healthy descriptor is returned without retire/reconnect; a 404 on `/api/health` falls back to `/api/status` without retiring.

**Root cause:** the dispatch probe budget (2.5s) was a quarter of the background liveness budget and shorter than the backend's own startup time, and it probed the heaviest public endpoint, so a healthy-but-booting backend was indistinguishable from a dead tunnel.

## Validation

| Check | Result |
|---|---|
| `npx vitest run --project electron electron/remote-liveness.test.ts` | 25 passed |
| Same file with fix neutralized (timeout back to 2_500, fallback disabled) | 2 failed (the new invariants), 23 passed |
| `electron/backend-health.test.ts` + `electron/ssh-connection.test.ts` (siblings) | 94 passed |
| `npx tsc -p tsconfig.electron.json --noEmit` / `npx tsc -p . --noEmit` | clean |
| `npx eslint` on touched files, `git diff --check` | clean |
| Live desktop repro against a VPS | not run (no multi-profile Electron + remote host here) |

Fixes #107997
Supersedes #108009 (cherry-picked, authorship preserved)
Supersedes #97914 (cherry-picked, authorship preserved; timeout raised from its 5s to the 10s liveness budget — 5s does not cover the measured 6–8s cold start)
Supersedes #108016 (same one-line timeout change as #108009, opened 12 minutes later without tests — not absorbed, superseded by #108009's commit)
Partially absorbs #101976 (legacy `/api/status` fallback + its test, co-author credit). Not adopted from it: the per-descriptor "tolerate one timeout" streak (WeakMap + message-sniffing `isDispatchProbeTimeoutError`; with a 10s health probe a timeout is no longer ambiguous, and tolerating it returns a possibly-dead descriptor to a synchronous click) and `ServerAliveInterval/CountMax` on the SSH ControlMaster (a separate keepalive question, not this bug).

**Not changed:** the pool fan-out where one profile click wakes every pooled profile (second half of #107997) — separate seam (`main.ts` / `pool-*.ts`), out of this PR's scope.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9fc40/TuN0wleIaV_wz3olmD_hG_EKIFgrOa.png)
