### PR TITLE
fix(desktop/radio): preserve stream on external pause for Fluid Voice resume

### DIFF
--- a/apps/desktop/src/contrib/radio-plugin.test.ts
+++ b/apps/desktop/src/contrib/radio-plugin.test.ts
@@ -82,4 +82,35 @@ describe('bundled Radio plugin', () => {
     expect(player().status.get()).toBe('paused')
     expect(document.querySelector('audio')).toBeNull()
   })
+
+  it('survives external pause without destroying the stream or blocking resume', async () => {
+    $pluginDecisions.set({ accent: false, kanban: false, 'hermes-bots': false })
+    discoverBundledPlugins()
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue()
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {})
+    vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {})
+    vi.stubGlobal('AudioContext', undefined)
+    await setPluginEnabled('radio', true)
+    const radio = player()
+    await radio.play()
+    const media = document.querySelector('audio')!
+    media.dispatchEvent(new Event('playing'))
+    expect(radio.status.get()).toBe('live')
+    const originalSrc = media.getAttribute('src')
+
+    // External controller (Fluid Voice, Whisper Flow, media keys) pauses the element.
+    Object.defineProperty(media, 'paused', { value: true, configurable: true })
+    Object.defineProperty(media, 'ended', { value: false, configurable: true })
+    media.dispatchEvent(new Event('pause'))
+
+    // Status should reflect pause, but the element and its src must survive.
+    expect(radio.status.get()).toBe('paused')
+    expect(document.querySelector('audio')).toBe(media)
+    expect(media.getAttribute('src')).toBe(originalSrc)
+
+    // Resume is then possible.
+    Object.defineProperty(media, 'paused', { value: false })
+    media.dispatchEvent(new Event('playing'))
+    expect(radio.status.get()).toBe('live')
+  })
 })

--- a/apps/desktop/src/plugins/radio/plugin.js
+++ b/apps/desktop/src/plugins/radio/plugin.js
@@ -232,7 +232,7 @@ function createPlayer(ctx) {
     // Browser/media controls can pause the element outside our buttons.
     // Reflect that state instead of showing a frozen trace as live playback.
     element.addEventListener('pause', () => {
-      if (current() && element.paused && !element.ended) stop()
+      if (current() && element.paused && !element.ended) status.set('paused')
     })
     element.addEventListener('waiting', () => {
       if (current()) { status.set('connecting'); clearTimeout(timeout); timeout = setTimeout(fail, 15000) }


### PR DESCRIPTION
Closes #108113.

Browser and external media controls (macOS Fluid Voice, Whisper Flow, media keys) pause the `HTMLAudioElement` outside the plugin's own buttons. The old external-pause handler tore down the stream unconditionally: it cleared `src`, invoked `load()`, removed the element, and advanced the generation token. That prevented resume by the controller that issued the pause.

**Root cause:** the plugin's own Pause control already increments the generation first, so its resulting media `pause` event is safely ignored by `current()`. Therefore the external-event branch can be non-destructive.

**Fix:** replace `stop()` with `status.set('paused')` in the external `pause` listener (`apps/desktop/src/plugins/radio/plugin.js`, L235). The following `playing` event already transitions the state back to `live`.

**Acceptance coverage:** added a focused lifecycle test that fires an external pause, verifies status becomes `paused` and the element and its `src` survive, then dispatches `playing` and verifies status returns to `live`.