### PR TITLE
feat(compression): make Codex auxiliary no-progress timeout configurable per task

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1110,11 +1110,19 @@ class _CodexStreamGuard:
     from ``_aux_stream_total_ceiling`` still terminates a pathological drip.
     """
 
-    def __init__(self, client: Any, total_timeout: Optional[float]):
+    def __init__(
+        self, client: Any, total_timeout: Optional[float],
+        no_progress_timeout: Optional[float] = None,
+    ):
         self._client = client
         self.total_timeout = total_timeout
         self._start = time.monotonic()
-        self.no_progress_timeout = _AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS
+        # Task-scoped override (auxiliary.<task>.no_progress_timeout, #108104); falls back to the
+        # built-in default when unset or not a positive number.
+        if isinstance(no_progress_timeout, (int, float)) and no_progress_timeout > 0:
+            self.no_progress_timeout = float(no_progress_timeout)
+        else:
+            self.no_progress_timeout = _AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS
         # Progress-aware stream deadlines (supersedes the old single absolute kill at ``total_timeout``).
         # Three regimes: 1. First token: the stream must produce its first substantive payload within
         # ``no_progress_timeout`` (60s default) or we fail fast and let the caller's normal retry/fallback
@@ -1463,7 +1471,7 @@ class _CodexCompletionsAdapter:
         # ``response.completed.response.output``, which Codex returns as ``null`` (SDK crash).
         resp_kwargs, model, timeout = self._build_responses_kwargs(kwargs)
         total_timeout = timeout if isinstance(timeout, (int, float)) and timeout > 0 else None
-        guard = _CodexStreamGuard(self._client, total_timeout)
+        guard = _CodexStreamGuard(self._client, total_timeout, no_progress_timeout=kwargs.get("no_progress_timeout"))
         try:
             guard.start()
             from agent.codex_runtime import _bypass_sdk_request_transform, _consume_codex_event_stream
@@ -5794,6 +5802,22 @@ def _compression_fast_lane_controls(
     return max_tokens, body
 
 
+def _get_task_no_progress_timeout(task: str) -> Optional[float]:
+    """``auxiliary.<task>.no_progress_timeout`` from config, or None when unset/invalid
+    (the Codex stream guard then keeps its built-in ``_AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS``
+    default). Lets an operator widen the substantive-progress window independently of the
+    overall request timeout — see #108104."""
+    if not task:
+        return None
+    raw = _get_auxiliary_task_config(task).get("no_progress_timeout")
+    if raw is not None:
+        with contextlib.suppress(ValueError, TypeError):
+            value = float(raw)
+            if value > 0:
+                return value
+    return None
+
+
 def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float:
     """``auxiliary.<task>.timeout`` from config, else *default*."""
     if not task:
@@ -6102,9 +6126,15 @@ def _build_call_kwargs(
     max_tokens: Optional[int] = None, tools: Optional[list] = None, timeout: float = 30.0,
     extra_body: Optional[dict] = None, reasoning_config: Optional[dict] = None,
     base_url: Optional[str] = None, task: Optional[str] = None,
+    no_progress_timeout: Optional[float] = None,
 ) -> dict:
-    """Build kwargs for .chat.completions.create() with model/provider adjustments."""
+    """Build kwargs for .chat.completions.create() with model/provider adjustments.
+    ``no_progress_timeout`` is a Codex-Responses-only extra (consumed by
+    ``_CodexCompletionsAdapter.create``'s ``**kwargs`` catch-all); callers must only pass it
+    when the resolved client is a ``CodexAuxiliaryClient`` — real SDK clients don't accept it."""
     kwargs: Dict[str, Any] = {"model": model, "messages": messages, "timeout": timeout}
+    if no_progress_timeout is not None:
+        kwargs["no_progress_timeout"] = no_progress_timeout
     # Per-model fixed/omitted temperature, then Opus 4.7+ sampling bans: it rejects any
     # non-default temperature/top_p/top_k, so drop silently rather than 400 when the aux model flips.
     fixed_temperature = _fixed_temperature_for_model(model, base_url)
@@ -6758,6 +6788,12 @@ def _prepare_aux_request(
         resolved_api_mode=resolved_api_mode, main_runtime=main_runtime, async_mode=async_mode,
     )
     effective_timeout = _effective_aux_timeout(task, timeout)
+    # Codex-Responses-only: real SDK clients reject an unrecognized ``no_progress_timeout``
+    # kwarg, so only resolve/forward it when the route is actually a Codex stream (#108104).
+    no_progress_timeout = (
+        _get_task_no_progress_timeout(task)
+        if isinstance(client, (CodexAuxiliaryClient, AsyncCodexAuxiliaryClient)) else None
+    )
     request_provider = effective_provider or resolved_provider
     if not async_mode:
         compression_config = _get_auxiliary_task_config("compression") if task == "compression" else {}
@@ -6782,7 +6818,8 @@ def _prepare_aux_request(
     kwargs = _build_call_kwargs(
         request_provider, final_model, messages, temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
-        reasoning_config=reasoning_config, base_url=base_info or resolved_base_url, task=task)
+        reasoning_config=reasoning_config, base_url=base_info or resolved_base_url, task=task,
+        no_progress_timeout=no_progress_timeout)
     if extra_headers:
         kwargs["extra_headers"] = dict(extra_headers)
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -876,6 +876,12 @@ prompt_caching:
 #     provider: "auto"
 #     model: ""
 #     # max_concurrency: 2    # Optional: cap simultaneous compression calls
+#     # no_progress_timeout: 60   # Codex/Responses-only: seconds a stream may go without a
+#                                 # substantive event before it fails fast (default: 60).
+#                                 # Independent of "timeout" above (the overall request
+#                                 # budget) — raising "timeout" alone does not widen this
+#                                 # window. Each substantive event re-arms it; a slow but
+#                                 # progressing reasoning/summary stream is not affected.
 #
 #   # Post-turn memory/skill self-improvement review fork. Runs after a turn
 #   # when the nudge intervals fire; writes skills/memories in a daemon thread.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -699,8 +699,11 @@ DEFAULT_CONFIG = {
         # OpenAI-compatible request fields. Vision: download_timeout = image HTTP download (s).
         "vision": _aux(120, download_timeout=30),
         # web_extract and session_search no longer use an aux LLM; leftover blocks in user config
-        # are ignored. Compression: raise timeout for local models.
-        "compression": _aux(120),
+        # are ignored. Compression: raise timeout for local models. no_progress_timeout
+        # (Codex/Responses streams only): seconds without a substantive event before the stream
+        # fails fast; None = built-in 60s default. Independent of "timeout" (the overall request
+        # budget) — raising "timeout" alone does not widen this window. See #108104.
+        "compression": _aux(120, no_progress_timeout=None),
         "skills_hub": _aux(30),
         "approval": _aux(30),   # classifier — a fast/cheap model is recommended
         # /review reviewer: a full subagent on the async delegation rail, credentials resolved like

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3474,6 +3474,42 @@ class TestCodexAuxiliaryAdapterTimeout:
 
         assert time.monotonic() - started < 0.14
 
+    def test_no_progress_timeout_kwarg_overrides_default_window(self):
+        """#108104: an explicit ``no_progress_timeout`` kwarg (the task-scoped
+        ``auxiliary.<task>.no_progress_timeout`` config value) must set the
+        substantive-progress window itself, not just clamp against the overall
+        request ``timeout`` (the built-in default is 60s; here it's narrowed to
+        0.05s so a stalled-but-alive stream is cut off far sooner than the
+        5s overall timeout would otherwise force)."""
+        class _StallingStream:
+            def __iter__(self):
+                for _ in range(50):
+                    time.sleep(0.02)
+                    yield SimpleNamespace(type="response.in_progress")
+
+            def close(self): pass
+
+        class FakeResponses:
+            def create(self, **kwargs):
+                return _StallingStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses(), close=lambda: None)
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        started = time.monotonic()
+        with pytest.raises(TimeoutError):
+            adapter.create(
+                messages=[{"role": "user", "content": "summarize this"}],
+                timeout=5.0,
+                no_progress_timeout=0.05,
+            )
+        elapsed = time.monotonic() - started
+        assert elapsed < 1.0, (
+            f"no_progress_timeout=0.05 override should cut the stall off in well "
+            f"under 1s, took {elapsed:.2f}s (falling back to the 5s overall timeout "
+            f"instead of honoring the override)"
+        )
+
 
 class TestCodexAuxiliaryAdapterCacheScope:
     """Regression for issue #78941: auxiliary Codex calls (compression,
@@ -4628,6 +4664,61 @@ class TestCustomEndpointApiKeyInheritance:
             )
 
         assert captured.get("api_key") == "no-key-required"
+
+
+class TestNoProgressTimeoutTaskConfigGating:
+    """#108104: ``auxiliary.<task>.no_progress_timeout`` must only reach the request kwargs
+    when the resolved client is a Codex Responses-shim client — forwarding it to a real
+    OpenAI-SDK-shaped client's ``chat.completions.create()`` would raise ``TypeError:
+    unexpected keyword argument 'no_progress_timeout'``."""
+
+    def test_codex_client_receives_configured_no_progress_timeout(self, monkeypatch):
+        completed = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+        real_client = SimpleNamespace(
+            api_key="test-key", base_url="https://chatgpt.com/backend-api/codex/",
+            close=lambda: None,
+        )
+        client = CodexAuxiliaryClient(real_client, "gpt-5.6-sol")
+        direct_create = MagicMock(return_value=completed)
+        monkeypatch.setattr(client.chat.completions, "create", direct_create)
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *args, **kwargs: (client, "gpt-5.6-sol"),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_task_no_progress_timeout",
+            lambda task: 300.0 if task == "compression" else None,
+        )
+
+        call_llm(
+            task="compression", provider="openai-codex", model="gpt-5.6-sol",
+            messages=[{"role": "user", "content": "summarize"}],
+        )
+
+        assert direct_create.call_args.kwargs.get("no_progress_timeout") == 300.0
+
+    def test_non_codex_client_never_receives_the_kwarg(self, monkeypatch):
+        client = MagicMock()
+        client.base_url = "https://api.openai.com/v1"
+        client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("openai", "gpt-4.1", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(client, "gpt-4.1")),
+            patch("agent.auxiliary_client._validate_llm_response",
+                  side_effect=lambda resp, _task, **_kw: resp),
+            patch("agent.auxiliary_client._get_task_no_progress_timeout", return_value=300.0),
+        ):
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert "no_progress_timeout" not in client.chat.completions.create.call_args.kwargs
 
 
 class TestMoaAggregatorStreamingBypass:


### PR DESCRIPTION
## What does this PR do?

Adds a task-scoped `auxiliary.<task>.no_progress_timeout` config option (documented for `auxiliary.compression`) so operators can widen the Codex/Responses auxiliary stream's substantive-progress window independently of `auxiliary.compression.timeout`.

Today `_CodexStreamGuard`'s no-progress window is hardcoded to 60s (`_AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS`) and is only ever narrowed via `min(60, total_timeout)`. Raising `auxiliary.compression.timeout` (e.g. to 600s or 900s) does **not** widen that 60s substantive-progress gap, so a slow-but-live reasoning/summary stream can still abort with `Codex auxiliary Responses stream stalled: no new output for 60.0s`, discarding the in-progress summary and falling back to a deterministic context marker.

This does not remove or weaken the watchdog added in #99660 — a quiet/keepalive-only stream still terminates, and the default behavior (no config set) is unchanged.

## Related Issue

Fixes #108104

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/auxiliary_client.py`:
  - `_CodexStreamGuard.__init__` accepts an optional `no_progress_timeout` override (falls back to the existing `_AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS` default when unset/invalid); still clamped by the overall request timeout, same as before.
  - New `_get_task_no_progress_timeout(task)` reads `auxiliary.<task>.no_progress_timeout` from config.
  - `_prepare_aux_request` resolves this value **only when the resolved client is a Codex Responses-shim client** (`CodexAuxiliaryClient` / `AsyncCodexAuxiliaryClient`) and threads it through `_build_call_kwargs` → `_CodexCompletionsAdapter.create()` → `_CodexStreamGuard`. Real OpenAI-SDK-shaped clients never receive the extra kwarg (they don't accept it).
- `hermes_cli/config_defaults.py`: documents `auxiliary.compression.no_progress_timeout` (default `None` = built-in 60s) in `DEFAULT_CONFIG` so it validates as a known key.
- `cli-config.yaml.example`: documents the new option under the commented `auxiliary.compression` example block.
- `tests/agent/test_auxiliary_client.py`: three new tests (see below).

## How to Test

1. Set `auxiliary.compression.no_progress_timeout: 300` in `config.yaml` with a Codex-routed compression provider and a slow-but-progressing reasoning summary — the stream now has a 300s substantive-progress window instead of 60s, while an actually-dead/keepalive-only stream still fails fast.
2. Automated coverage (see below).

### Test output

```
$ scripts/run_tests.sh tests/agent/test_auxiliary_client.py -q
Discovered 1 test files (~186 tests) under ['tests/agent/test_auxiliary_client.py']; running with -j 8
[100.0% |   186/~186 | ✓207 | ✗  0] ✓ tests/agent/test_auxiliary_client.py (207✓, 11.0s)

=== Summary: 1 files, 207 tests passed, 0 failed (100% complete) in 11.0s (8 workers) ===
```

New tests, verified to FAIL against the pre-fix source (reverted `agent/auxiliary_client.py` / `hermes_cli/config_defaults.py` only, kept the new tests) and PASS after re-applying the fix:

- `TestCodexAuxiliaryAdapterTimeout::test_no_progress_timeout_kwarg_overrides_default_window` — a stalled-but-alive Codex stream with `timeout=5.0, no_progress_timeout=0.05` must abort in well under 1s (the override), not ~5s (the old `min(60, total_timeout)` clamp). Fails on pre-fix code because the extra kwarg was silently ignored, so the guard used the ~5s clamp instead.
- `TestNoProgressTimeoutTaskConfigGating::test_codex_client_receives_configured_no_progress_timeout` — a `CodexAuxiliaryClient` route receives the configured `no_progress_timeout` in its request kwargs. Fails on pre-fix code with `AttributeError: ... has no attribute '_get_task_no_progress_timeout'`.
- `TestNoProgressTimeoutTaskConfigGating::test_non_codex_client_never_receives_the_kwarg` — a generic (non-Codex) client's `chat.completions.create()` never sees `no_progress_timeout`, protecting real SDK clients (which don't accept the kwarg) from a regression. Also fails on pre-fix code (same `AttributeError`, since the seam being tested didn't exist yet).

Pre-fix failure output (excerpt):
```
FAILED tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout::test_no_progress_timeout_kwarg_overrides_default_window
FAILED tests/agent/test_auxiliary_client.py::TestNoProgressTimeoutTaskConfigGating::test_codex_client_receives_configured_no_progress_timeout
FAILED tests/agent/test_auxiliary_client.py::TestNoProgressTimeoutTaskConfigGating::test_non_codex_client_never_receives_the_kwarg
3 failed, 2 passed, 202 deselected in 2.16s
```

Also ran, all passing:
```
$ scripts/run_tests.sh tests/agent/test_auxiliary_compression_timeout_floor.py tests/agent/test_fast_compression_lane.py \
  tests/agent/test_auxiliary_openrouter_max_tokens.py tests/agent/test_aux_affordable_402_retry.py \
  tests/agent/test_auxiliary_concurrency.py tests/agent/test_auxiliary_main_first.py \
  tests/hermes_cli/test_plugin_auxiliary_tasks.py -q
=== Summary: 7 files, 75 tests passed, 0 failed (100% complete) ===

$ scripts/run_tests.sh tests/hermes_cli/test_aux_config.py tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_config.py -q
=== Summary: 3 files, 215 tests passed, 0 failed, 4 skipped (100% complete) ===
```

`ruff check` and `scripts/check-windows-footguns.py` clean on the changed files.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the test suite and all relevant tests pass
- [x] I've added tests for my changes
- [x] Tested on Linux (the CI/dev environment for this change); no platform-specific code touched

### Documentation & Housekeeping

- [x] I've updated `cli-config.yaml.example`
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — N/A (no OS-specific code paths touched)
- [ ] Tool descriptions/schemas — N/A (not a tool)

## Disclosure

This PR was authored with AI assistance (Claude Code / Claude Sonnet 5), including the investigation of the existing `_CodexStreamGuard` watchdog and the test suite. All changes were reviewed against the actual code paths on current `main` before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
