### PR TITLE
Price vendor-prefixed model ids on generic OpenAI-compatible routes

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -400,7 +400,25 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
         return entry
     normalize = _MODEL_NORMALIZERS.get(route.provider)
     normalized = normalize(model) if normalize else model
-    return _OFFICIAL_DOCS_PRICING.get((route.provider, normalized)) if normalized != model else None
+    entry = _OFFICIAL_DOCS_PRICING.get((route.provider, normalized)) if normalized != model else None
+    if entry:
+        return entry
+    # Generic OpenAI-compatible gateways (provider "custom") serve vendor-prefixed ids
+    # ("deepseek/deepseek-v4-flash") and publish no pricing of their own — their /models
+    # payload carries only id/object/created/owned_by. The vendor segment names whose
+    # published snapshot prices the call; without this the session reports unknown cost
+    # for a model that IS in the table under the vendor's own provider key.
+    if "/" in model:
+        vendor, bare = model.split("/", 1)
+        entry = _OFFICIAL_DOCS_PRICING.get((vendor, bare))
+        if entry:
+            return entry
+        vendor_normalize = _MODEL_NORMALIZERS.get(vendor)
+        if vendor_normalize:
+            norm_bare = vendor_normalize(bare)
+            if norm_bare != bare:
+                return _OFFICIAL_DOCS_PRICING.get((vendor, norm_bare))
+    return None
 
 
 def _openrouter_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -191,6 +191,62 @@ def test_deepseek_deprecated_aliases_price_as_flash():
         ), alias
 
 
+def test_custom_gateway_vendor_prefixed_id_uses_vendor_snapshot(monkeypatch):
+    """Invariant: a ``vendor/model`` id routed through a generic OpenAI-compatible
+    gateway (``provider="custom"``) must price from that vendor's bundled snapshot.
+
+    Such gateways publish no pricing — their ``/models`` payload carries only
+    id/object/created/owned_by — so the session reports unknown cost for a model that
+    IS in _OFFICIAL_DOCS_PRICING under the vendor's own provider key. Sessions are
+    priced at run time, so an unknown here is not recovered later.
+    """
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("bundled snapshot should have matched; no /models fetch")
+        ),
+    )
+
+    entry = get_pricing_entry(
+        "deepseek/deepseek-v4-flash",
+        provider="custom",
+        base_url="https://gateway.example.com/v1",
+    )
+
+    assert entry is not None
+    assert entry.source == "official_docs_snapshot"
+    vendor = get_pricing_entry("deepseek-v4-flash", provider="deepseek")
+    assert vendor is not None
+    assert entry.input_cost_per_million == vendor.input_cost_per_million
+    assert entry.output_cost_per_million == vendor.output_cost_per_million
+    assert entry.cache_read_cost_per_million == vendor.cache_read_cost_per_million
+
+
+def test_custom_gateway_unmatched_prefix_stays_unknown(monkeypatch):
+    """Guardrail: the vendor-prefix fallback must never invent pricing.
+
+    A gateway-local alias (``auto``), a flat-fee subscription id, and an opaque
+    ``custom:<uuid>/model`` id have no published per-token rate. They must stay
+    unknown rather than inherit some unrelated vendor's snapshot row.
+    """
+    monkeypatch.setattr(
+        "agent.usage_pricing.fetch_endpoint_model_metadata",
+        lambda *_args, **_kwargs: {},
+    )
+
+    for model in (
+        "auto",
+        "anthropic/claude-opus-4-8-subscription",
+        "custom:724f45a5-0c44-443b-a4ab-ff9a488a5a3d/agnes-1.5-flash",
+    ):
+        assert (
+            get_pricing_entry(
+                model, provider="custom", base_url="https://gateway.example.com/v1"
+            )
+            is None
+        ), model
+
+
 
 
 def test_bedrock_claude_rows_all_carry_cache_pricing():


### PR DESCRIPTION
## Problem

A `provider: custom` route keeps the raw model id, so `_lookup_official_docs_pricing` looks up `("custom", "deepseek/deepseek-v4-flash")`, misses the bundled table, and falls through to the endpoint `/models` API.

Generic OpenAI-compatible gateways publish **no pricing** there — their payload carries only `id/object/created/owned_by`:

```json
{"id": "deepseek/deepseek-v4-flash", "object": "model", "created": 0, "owned_by": "deepseek"}
```

So every session on such a route records `cost_status=unknown` even though the model **is** in `_OFFICIAL_DOCS_PRICING` under the vendor's own provider key. Costs are recorded per run, so the miss is permanent — `hermes insights` reports `Unknown: N session(s) (no pricing data)` and the spend estimate silently excludes that traffic.

Reproduced against the installed 0.21.1 tree (provider `custom`, base_url = a LIteLLM-style gateway):

```
custom    deepseek/deepseek-v4-flash   -> route_prov=custom   route_model=deepseek/deepseek-v4-flash   MISS
custom    deepseek-v4-flash            -> route_prov=custom   route_model=deepseek-v4-flash            MISS
deepseek  deepseek-v4-flash            -> route_prov=deepseek route_model=deepseek-v4-flash            HIT
```

The same model prices correctly once the provider name happens to match a snapshot key — the table is fine, only the lookup is unreachable.

## Fix

In `_lookup_official_docs_pricing`, when no snapshot row matches the route's provider and the id carries a `vendor/model` prefix, retry with the vendor segment as the provider key, reusing the existing per-vendor `_MODEL_NORMALIZERS` entry. ~12 lines, one call site (`get_pricing_entry`), no new surface.

Ids with no matching snapshot still resolve to `None`, so no vendor's rates are borrowed for them:
- `auto` (gateway-local alias — the real model is chosen server-side)
- `anthropic/claude-opus-4-8-subscription` (flat-fee, no per-token rate)
- `custom:<uuid>/agnes-1.5-flash` (opaque provider-managed id)

## Tests

`tests/agent/test_usage_pricing.py`, both behaviour contracts rather than value snapshots:

1. `test_custom_gateway_vendor_prefixed_id_uses_vendor_snapshot` — prices from the vendor snapshot and asserts the `/models` endpoint is **never** consulted (patched to raise, matching the existing `test_bundled_pricing_skips_endpoint_metadata` pattern).
2. `test_custom_gateway_unmatched_prefix_stays_unknown` — the guardrail, so the fallback can't invent pricing.

Verified with `scripts/run_tests.sh`:

- base (fix stashed, tests present): `1 failed, 51 passed` — the new invariant test is the failure
- with fix: `52 passed, 0 failed`

## Notes

- No behaviour change for any route whose provider already matches a snapshot key (`anthropic`/`openai`/`google`/`bedrock`/`fireworks`/`openrouter`/`nous`) — the fallback runs only after those lookups miss.
- Deliberately **not** included: DeepSeek's V4 Pro retirement (Pro ids now route to V4.1-Flash at Flash pricing). That would contradict `test_deepseek_v4_pro_pricing_entry_exists`, which asserts Pro is a premium tier above Flash on every rate — a maintainer call, not a drive-by data edit.
