### PR TITLE
fix(desktop): sidebar no longer trapped by titlebar tabs on macOS (#107196 #107774 #107927 #106009 #107351, salvage #107209 #107223 #107456)

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -1145,12 +1145,14 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   }
 
   const titlebarToolsRight = titlebarToolsRightCss(nativeOverlayWidth, titlebarChrome)
-  // App controls live on the left; flip and the right toggle share the right.
-  const titlebarToolsWidth = titlebarToolsWidthCss(2)
+  // Right cluster: settings, layout, HUD, flip, right-sidebar toggle.
+  const SYSTEM_TOOL_COUNT = 5
+  const paneToolCount = rightTitlebarTools.filter(tool => !tool.hidden).length
+  const systemToolsWidth = titlebarToolsWidthCss(SYSTEM_TOOL_COUNT)
+  const titlebarToolsWidth =
+    paneToolCount > 0 ? `calc(${systemToolsWidth} + ${titlebarToolsWidthCss(paneToolCount)})` : systemToolsWidth
 
-  const leftToolsWidth = titlebarToolsWidthCss(
-    4 + [...leftTitlebarTools, ...rightTitlebarTools].filter(tool => !tool.hidden).length
-  )
+  const leftToolsWidth = titlebarToolsWidthCss(1 + leftTitlebarTools.filter(tool => !tool.hidden).length)
 
   return (
     <ContribWiringContext.Provider value={api}>
@@ -1163,7 +1165,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
             '--titlebar-controls-width': leftToolsWidth,
             '--titlebar-controls-y-nudge': titlebarControlsYNudge(titlebarChrome),
             '--titlebar-tools-right': titlebarToolsRight,
-            '--titlebar-tools-width': titlebarToolsWidth
+            '--titlebar-tools-width': titlebarToolsWidth,
+            '--shell-preview-toolbar-gap': systemToolsWidth
           } as CSSProperties
         }
       >

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -49,7 +49,6 @@ import { $cronReviewRequest, setCronFocusJobId } from '@/store/cron'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { $previewTarget } from '@/store/preview'
-import { $titlebarAppActionsSide, titlebarAppActionsClusterCounts } from '@/store/titlebar-app-actions'
 import {
   $activeGatewayProfile,
   $freshSessionRequest,
@@ -83,6 +82,7 @@ import {
   setBusy,
   setMessages
 } from '@/store/session'
+import { $titlebarAppActionsSide, titlebarAppActionsClusterCounts } from '@/store/titlebar-app-actions'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
 import { isAuxiliaryWindow, isBrowserWindow, isHudWindow } from '@/store/windows'
@@ -1151,6 +1151,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const leftExtraCount = leftTitlebarTools.filter(tool => !tool.hidden).length
   const clusters = titlebarAppActionsClusterCounts(appActionsSide, leftExtraCount, 0)
   const systemToolsWidth = titlebarToolsWidthCss(clusters.right)
+
   const titlebarToolsWidth =
     paneToolCount > 0 ? `calc(${systemToolsWidth} + ${titlebarToolsWidthCss(paneToolCount)})` : systemToolsWidth
 

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -49,6 +49,7 @@ import { $cronReviewRequest, setCronFocusJobId } from '@/store/cron'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { $previewTarget } from '@/store/preview'
+import { $titlebarAppActionsSide, titlebarAppActionsClusterCounts } from '@/store/titlebar-app-actions'
 import {
   $activeGatewayProfile,
   $freshSessionRequest,
@@ -1145,14 +1146,15 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   }
 
   const titlebarToolsRight = titlebarToolsRightCss(nativeOverlayWidth, titlebarChrome)
-  // Right cluster: settings, layout, HUD, flip, right-sidebar toggle.
-  const SYSTEM_TOOL_COUNT = 5
+  const appActionsSide = useStore($titlebarAppActionsSide)
   const paneToolCount = rightTitlebarTools.filter(tool => !tool.hidden).length
-  const systemToolsWidth = titlebarToolsWidthCss(SYSTEM_TOOL_COUNT)
+  const leftExtraCount = leftTitlebarTools.filter(tool => !tool.hidden).length
+  const clusters = titlebarAppActionsClusterCounts(appActionsSide, leftExtraCount, 0)
+  const systemToolsWidth = titlebarToolsWidthCss(clusters.right)
   const titlebarToolsWidth =
     paneToolCount > 0 ? `calc(${systemToolsWidth} + ${titlebarToolsWidthCss(paneToolCount)})` : systemToolsWidth
 
-  const leftToolsWidth = titlebarToolsWidthCss(1 + leftTitlebarTools.filter(tool => !tool.hidden).length)
+  const leftToolsWidth = titlebarToolsWidthCss(clusters.left)
 
   return (
     <ContribWiringContext.Provider value={api}>

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -24,12 +24,12 @@ import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enable
 import { $reasoningCollapsedByDefault, setReasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
 import { $sessionListDensity, type SessionListDensity, setSessionListDensity } from '@/store/session-list-density'
 import { $tabStripDefault, setTabStripDefault, type TabStripDefault } from '@/store/tabstrip-prefs'
+import { $spentTipCount, $tipsEnabled, resetTips, setTipsEnabled } from '@/store/tips'
 import {
   $titlebarAppActionsSide,
   setTitlebarAppActionsSide,
   type TitlebarAppActionsSide
 } from '@/store/titlebar-app-actions'
-import { $spentTipCount, $tipsEnabled, resetTips, setTipsEnabled } from '@/store/tips'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $toursEnabled, setToursEnabled } from '@/store/tours'
 import {

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -24,6 +24,11 @@ import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enable
 import { $reasoningCollapsedByDefault, setReasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
 import { $sessionListDensity, type SessionListDensity, setSessionListDensity } from '@/store/session-list-density'
 import { $tabStripDefault, setTabStripDefault, type TabStripDefault } from '@/store/tabstrip-prefs'
+import {
+  $titlebarAppActionsSide,
+  setTitlebarAppActionsSide,
+  type TitlebarAppActionsSide
+} from '@/store/titlebar-app-actions'
 import { $spentTipCount, $tipsEnabled, resetTips, setTipsEnabled } from '@/store/tips'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $toursEnabled, setToursEnabled } from '@/store/tours'
@@ -397,6 +402,7 @@ export function AppearanceSettings() {
   const reasoningCollapsedByDefault = useStore($reasoningCollapsedByDefault)
   const sessionListDensity = useStore($sessionListDensity)
   const tabStripDefault = useStore($tabStripDefault)
+  const titlebarAppActionsSide = useStore($titlebarAppActionsSide)
   const zoomPercent = useStore($zoomPercent)
   const embedMode = useStore($embedMode)
   const embedAllowed = useStore($embedAllowed)
@@ -485,6 +491,11 @@ export function AppearanceSettings() {
     { id: 'always', label: a.tabStripAlways },
     { id: 'never', label: a.tabStripNever }
   ] as const satisfies readonly { id: TabStripDefault; label: string }[]
+
+  const appActionsOptions = [
+    { id: 'right', label: a.appActionsRight },
+    { id: 'left', label: a.appActionsLeft }
+  ] as const satisfies readonly { id: TitlebarAppActionsSide; label: string }[]
 
   const embedOptions = [
     { id: 'ask', label: a.embedsAsk },
@@ -659,6 +670,22 @@ export function AppearanceSettings() {
             }
             description={a.tabStripDesc}
             title={a.tabStripTitle}
+          />
+
+          <ListRow
+            action={
+              <SegmentedControl
+                onChange={id => {
+                  triggerHaptic('selection')
+                  setTitlebarAppActionsSide(id)
+                }}
+                options={appActionsOptions}
+                value={titlebarAppActionsSide}
+              />
+            }
+            description={a.appActionsDesc}
+            id={appearanceSettingElementId(APPEARANCE_SETTING_IDS.appActions)}
+            title={a.appActionsTitle}
           />
 
           {/* Linux has neither half of this setting (see TRANSLUCENCY_SUPPORTED),

--- a/apps/desktop/src/app/settings/settings-search.ts
+++ b/apps/desktop/src/app/settings/settings-search.ts
@@ -11,6 +11,7 @@ import type { DesktopConfigSection, SettingsView } from './types'
 export type CredentialSettingsView = 'settings' | 'tools'
 
 export const APPEARANCE_SETTING_IDS = {
+  appActions: 'appearance.app-actions',
   backdrop: 'appearance.backdrop',
   embeds: 'appearance.embeds',
   introSplash: 'appearance.intro-splash',

--- a/apps/desktop/src/app/settings/use-settings-search.ts
+++ b/apps/desktop/src/app/settings/use-settings-search.ts
@@ -200,6 +200,15 @@ export function useSettingsSearchCatalog(enabled: boolean) {
     },
     {
       context: appearanceContext,
+      description: appearance.appActionsDesc,
+      icon: Palette,
+      id: `setting:${APPEARANCE_SETTING_IDS.appActions}`,
+      keywords: ['titlebar', 'settings gear', 'layout', 'HUD', 'left', 'right', 'tabs'],
+      label: appearance.appActionsTitle,
+      target: { setting: APPEARANCE_SETTING_IDS.appActions, view: 'config:appearance' }
+    },
+    {
+      context: appearanceContext,
       description: appearance.embedsDesc,
       icon: Palette,
       id: `setting:${APPEARANCE_SETTING_IDS.embeds}`,

--- a/apps/desktop/src/app/shell/titlebar-controls.test.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { registry } from '@/contrib/registry'
 import { I18nProvider } from '@/i18n'
+import { setTitlebarAppActionsSide } from '@/store/titlebar-app-actions'
 
 import { ROUTES_AREA } from '../routes'
 
@@ -92,7 +93,12 @@ describe('TitlebarControls fixed clusters', () => {
 })
 
 describe('titlebar app-action cluster', () => {
-  it('keeps settings, layout, and HUD on the right so the left titlebar stays free for tabs', () => {
+  afterEach(() => {
+    setTitlebarAppActionsSide('right')
+    cleanup()
+  })
+
+  it('defaults settings, layout, and HUD to the right so the left titlebar stays free for tabs', () => {
     renderControls('/')
 
     const left = screen.getByLabelText('Window controls')
@@ -106,5 +112,18 @@ describe('titlebar app-action cluster', () => {
     expect(within(left).queryByLabelText('Layout editor')).toBeNull()
     expect(within(left).queryByLabelText('HUD mode')).toBeNull()
     expect(within(left).getByLabelText(/Hide sidebar|Show sidebar/)).toBeTruthy()
+  })
+
+  it('moves settings, layout, and HUD to the left when the appearance setting says left', () => {
+    setTitlebarAppActionsSide('left')
+    renderControls('/')
+
+    const left = screen.getByLabelText('Window controls')
+    const right = screen.getByLabelText('App controls')
+
+    expect(within(left).getByLabelText('Open settings')).toBeTruthy()
+    expect(within(left).getByLabelText('Layout editor')).toBeTruthy()
+    expect(within(left).getByLabelText('HUD mode')).toBeTruthy()
+    expect(within(right).queryByLabelText('Open settings')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/shell/titlebar-controls.test.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
@@ -88,5 +88,23 @@ describe('TitlebarControls fixed clusters', () => {
 
     expect(windowControls()).not.toBeNull()
     expect(appControls()).not.toBeNull()
+  })
+})
+
+describe('titlebar app-action cluster', () => {
+  it('keeps settings, layout, and HUD on the right so the left titlebar stays free for tabs', () => {
+    renderControls('/')
+
+    const left = screen.getByLabelText('Window controls')
+    const right = screen.getByLabelText('App controls')
+
+    expect(within(right).getByLabelText('Open settings')).toBeTruthy()
+    expect(within(right).getByLabelText('Layout editor')).toBeTruthy()
+    expect(within(right).getByLabelText('HUD mode')).toBeTruthy()
+
+    expect(within(left).queryByLabelText('Open settings')).toBeNull()
+    expect(within(left).queryByLabelText('Layout editor')).toBeNull()
+    expect(within(left).queryByLabelText('HUD mode')).toBeNull()
+    expect(within(left).getByLabelText(/Hide sidebar|Show sidebar/)).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -24,6 +24,7 @@ import {
   toggleSidebarOpen
 } from '@/store/layout'
 import { $unreadSessionCount } from '@/store/session-dot-state'
+import { $titlebarAppActionsSide } from '@/store/titlebar-app-actions'
 
 import { appViewForPath, hidesFixedTitlebarClusters, isOverlayView } from '../routes'
 
@@ -138,6 +139,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const panesFlipped = useStore($panesFlipped)
   const sidebarOpen = useStore($sidebarOpen)
   const unreadCount = useStore($unreadSessionCount)
+  const appActionsSide = useStore($titlebarAppActionsSide)
   const unreadBadge = unreadCount > 0 ? unreadCount : undefined
   const unreadHint = unreadBadge ? ` · ${t.titlebar.unreadSessions(unreadBadge)}` : ''
 
@@ -265,8 +267,10 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     return <div className={leftClusterClass}>{titlebarSlots}</div>
   }
 
-  const visibleLeftTools = [sidebarTool, ...leftTools].filter(tool => !tool.hidden)
-  const visibleSystemTools = systemTools.filter(tool => !tool.hidden)
+  const visibleLeftTools = (
+    appActionsSide === 'left' ? [sidebarTool, ...systemTools, ...leftTools] : [sidebarTool, ...leftTools]
+  ).filter(tool => !tool.hidden)
+  const visibleSystemTools = appActionsSide === 'right' ? systemTools.filter(tool => !tool.hidden) : []
   const visiblePaneTools = tools.filter(tool => !tool.hidden)
 
   return (

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -276,7 +276,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
 
   return (
     <>
-      <div aria-label={t.shell.windowControls} className={leftClusterClass}>
+      <div aria-label={t.shell.windowControls} className={leftClusterClass} data-titlebar-cluster="left">
         {visibleLeftTools.map(tool => (
           <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
         ))}

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -270,6 +270,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const visibleLeftTools = (
     appActionsSide === 'left' ? [sidebarTool, ...systemTools, ...leftTools] : [sidebarTool, ...leftTools]
   ).filter(tool => !tool.hidden)
+
   const visibleSystemTools = appActionsSide === 'right' ? systemTools.filter(tool => !tool.hidden) : []
   const visiblePaneTools = tools.filter(tool => !tool.hidden)
 

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -187,7 +187,8 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     tour: 'right-pane-toggle'
   }
 
-  // App actions stay visible beside the left sidebar toggle.
+  // Static system tools — always pinned to the screen's right edge so the
+  // left titlebar stays free for tabs (#107351).
   const systemTools: TitlebarTool[] = [
     {
       actionId: 'nav.settings',
@@ -264,7 +265,9 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     return <div className={leftClusterClass}>{titlebarSlots}</div>
   }
 
-  const visibleLeftTools = [sidebarTool, ...systemTools, ...leftTools, ...tools].filter(tool => !tool.hidden)
+  const visibleLeftTools = [sidebarTool, ...leftTools].filter(tool => !tool.hidden)
+  const visibleSystemTools = systemTools.filter(tool => !tool.hidden)
+  const visiblePaneTools = tools.filter(tool => !tool.hidden)
 
   return (
     <>
@@ -272,15 +275,34 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
         {visibleLeftTools.map(tool => (
           <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
         ))}
-        {titlebarSlots}
+        <Slot area="titleBar.left" />
+        <Slot area="titleBar.center" />
       </div>
+
+      {visiblePaneTools.length > 0 && (
+        <div
+          aria-label={t.shell.appControls}
+          className={cn(
+            titlebarToolClusterClass,
+            'top-[calc(var(--titlebar-controls-top)+var(--right-rail-top-inset,0px))] right-[calc(var(--titlebar-tools-right)+var(--shell-preview-toolbar-gap,0))]'
+          )}
+        >
+          {visiblePaneTools.map(tool => (
+            <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
+          ))}
+        </div>
+      )}
 
       <div
         aria-label={t.shell.appControls}
         className={cn(titlebarToolClusterClass, 'right-(--titlebar-tools-right) top-(--titlebar-controls-top)')}
       >
+        {visibleSystemTools.map(tool => (
+          <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
+        ))}
         <TitlebarToolButton navigate={navigate} tool={flipTool} />
         <TitlebarToolButton navigate={navigate} tool={rightSidebarTool} />
+        <Slot area="titleBar.right" />
       </div>
     </>
   )

--- a/apps/desktop/src/components/pane-shell/geometry.test.ts
+++ b/apps/desktop/src/components/pane-shell/geometry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { TITLEBAR_DRAG_FILL_INSET, titlebarDragFillStart } from './geometry'
+import { titlebarDragFillStart } from './geometry'
 
 describe('titlebarDragFillStart', () => {
   it('is 0 when the zone already starts past the control cluster', () => {
@@ -10,12 +10,11 @@ describe('titlebarDragFillStart', () => {
   it('cuts the fill so it starts after the cluster when the zone slides under it', () => {
     expect(titlebarDragFillStart(98, 96, 28)).toBe(166)
   })
-})
 
-describe('TITLEBAR_DRAG_FILL_INSET', () => {
-  it('references the published titlebar and workspace CSS vars', () => {
-    expect(TITLEBAR_DRAG_FILL_INSET).toContain('--titlebar-controls-left')
-    expect(TITLEBAR_DRAG_FILL_INSET).toContain('--titlebar-controls-width')
-    expect(TITLEBAR_DRAG_FILL_INSET).toContain('--workspace-left')
+  it('keys on the zone, not the workspace: a tool zone at x=28 beside a workspace at x=692 still gets cut', () => {
+    // Regression: the inset was computed from --workspace-left (692 → 0 inset)
+    // while the terminal zone itself sat at 28 under the cluster.
+    expect(titlebarDragFillStart(98, 24, 28)).toBe(94)
+    expect(titlebarDragFillStart(98, 24, 692)).toBe(0)
   })
 })

--- a/apps/desktop/src/components/pane-shell/geometry.test.ts
+++ b/apps/desktop/src/components/pane-shell/geometry.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { TITLEBAR_DRAG_FILL_INSET, titlebarDragFillStart } from './geometry'
+
+describe('titlebarDragFillStart', () => {
+  it('is 0 when the zone already starts past the control cluster', () => {
+    expect(titlebarDragFillStart(98, 96, 260)).toBe(0)
+  })
+
+  it('cuts the fill so it starts after the cluster when the zone slides under it', () => {
+    expect(titlebarDragFillStart(98, 96, 28)).toBe(166)
+  })
+})
+
+describe('TITLEBAR_DRAG_FILL_INSET', () => {
+  it('references the published titlebar and workspace CSS vars', () => {
+    expect(TITLEBAR_DRAG_FILL_INSET).toContain('--titlebar-controls-left')
+    expect(TITLEBAR_DRAG_FILL_INSET).toContain('--titlebar-controls-width')
+    expect(TITLEBAR_DRAG_FILL_INSET).toContain('--workspace-left')
+  })
+})

--- a/apps/desktop/src/components/pane-shell/geometry.ts
+++ b/apps/desktop/src/components/pane-shell/geometry.ts
@@ -41,6 +41,22 @@ export function intersect(a: Rect, b: Rect): Rect | null {
   return { x, y, width: right - x, height: bottom - y }
 }
 
+/**
+ * CSS length that starts a titlebar drag fill after the fixed window-control
+ * cluster. When the zone already begins past the cluster (`--workspace-left`
+ * ≥ cluster right edge) this is 0. Cut the strip — Electron's no-drag
+ * carve-out of fixed/transformed elements is unreliable.
+ *
+ * start = max(0, controlsLeft + controlsWidth - workspaceLeft)
+ */
+export const TITLEBAR_DRAG_FILL_INSET =
+  'max(0px, calc(var(--titlebar-controls-left, 0px) + var(--titlebar-controls-width, 0px) - var(--workspace-left, 0px)))'
+
+/** Pixel form of `TITLEBAR_DRAG_FILL_INSET` for callers with resolved lengths. */
+export function titlebarDragFillStart(controlsLeft: number, controlsWidth: number, workspaceLeft: number): number {
+  return Math.max(0, controlsLeft + controlsWidth - workspaceLeft)
+}
+
 // ---------------------------------------------------------------------------
 // Native window controls rect
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/components/pane-shell/geometry.ts
+++ b/apps/desktop/src/components/pane-shell/geometry.ts
@@ -42,19 +42,76 @@ export function intersect(a: Rect, b: Rect): Rect | null {
 }
 
 /**
- * CSS length that starts a titlebar drag fill after the fixed window-control
- * cluster. When the zone already begins past the cluster (`--workspace-left`
- * ≥ cluster right edge) this is 0. Cut the strip — Electron's no-drag
- * carve-out of fixed/transformed elements is unreliable.
+ * Where a titlebar drag fill must start so it never covers the app's fixed
+ * window-control cluster (`--titlebar-controls-left` + `--titlebar-controls-width`).
+ * Measured against the ZONE's own viewport left edge, not `--workspace-left`:
+ * a tool zone rendered between a minimized rail and the workspace starts at
+ * x≈28 while the workspace starts hundreds of px further right, so a
+ * workspace-keyed inset was 0 exactly where the strip slid under the cluster.
+ * Electron's no-drag carve-out of fixed elements is unreliable — cut the strip.
  *
- * start = max(0, controlsLeft + controlsWidth - workspaceLeft)
+ * start = max(0, controlsLeft + controlsWidth - zoneLeft)
+ *
+ * `useTitlebarDragFillInset` passes the measured cluster right edge as
+ * `controlsLeft` with width 0.
  */
-export const TITLEBAR_DRAG_FILL_INSET =
-  'max(0px, calc(var(--titlebar-controls-left, 0px) + var(--titlebar-controls-width, 0px) - var(--workspace-left, 0px)))'
+export function titlebarDragFillStart(controlsLeft: number, controlsWidth: number, zoneLeft: number): number {
+  return Math.max(0, controlsLeft + controlsWidth - zoneLeft)
+}
 
-/** Pixel form of `TITLEBAR_DRAG_FILL_INSET` for callers with resolved lengths. */
-export function titlebarDragFillStart(controlsLeft: number, controlsWidth: number, workspaceLeft: number): number {
-  return Math.max(0, controlsLeft + controlsWidth - workspaceLeft)
+/** Right edge (viewport px) of the fixed left window-control cluster, 0 when
+ *  none is mounted (overlay/extension views hide it). Measured from the DOM:
+ *  the reserving CSS vars live inline on the shell wrapper as `calc()`s and
+ *  do not resolve through `getPropertyValue`. */
+function leftControlClusterRight(): number {
+  const el = document.querySelector<HTMLElement>('[data-titlebar-cluster="left"]')
+
+  if (!el) {
+    return 0
+  }
+
+  const r = el.getBoundingClientRect()
+
+  return r.width > 0 ? r.right : 0
+}
+
+/** Live px inset for a top-edge zone's drag fill (see `titlebarDragFillStart`). */
+export function useTitlebarDragFillInset(ref: RefObject<HTMLElement | null>, enabled = true): number {
+  const [inset, setInset] = useState(0)
+
+  useLayoutEffect(() => {
+    const el = ref.current
+
+    if (!enabled || !el) {
+      setInset(0)
+
+      return
+    }
+
+    const update = () => {
+      const next = titlebarDragFillStart(leftControlClusterRight(), 0, el.getBoundingClientRect().x)
+
+      setInset(prev => (prev === next ? prev : next))
+    }
+
+    update()
+
+    // A sibling collapsing shifts this zone without resizing the window; the
+    // tree store is the signal for that, the observer covers the zone's own
+    // track changes, `resize` covers the rest.
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    window.addEventListener('resize', update)
+    const unsubTree = $layoutTree.listen(() => requestAnimationFrame(update))
+
+    return () => {
+      ro.disconnect()
+      window.removeEventListener('resize', update)
+      unsubTree()
+    }
+  }, [enabled, ref])
+
+  return inset
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
@@ -1,8 +1,9 @@
 import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { registry } from '@/contrib/registry'
+import { stubResizeObserver } from '@/test/jsdom'
 
 import type { GroupNode } from '../model'
 import { $treeDragging, NEW_SESSION_DRAG, SESSION_TILE_DRAG } from '../store'
@@ -42,6 +43,8 @@ const toggle = (label: string) =>
   globalThis.document.querySelector<HTMLButtonElement>(
     `[data-tree-group="terminal-zone"] button[aria-label="${label}"]`
   )!
+
+beforeEach(stubResizeObserver)
 
 afterEach(() => {
   if (root) {
@@ -144,38 +147,48 @@ describe('TreeGroup', () => {
     }
   })
 
-  it('cuts the titlebar drag filler so it cannot cover the window-control cluster', () => {
+  it("cuts the titlebar drag filler by the zone's own overlap with the window-control cluster", () => {
     vi.stubGlobal('CSS', { escape: (value: string) => value })
-    render(
-      <TreeGroup
-        node={{
-          active: 'gone',
-          id: 'empty-zone',
-          minimized: false,
-          panes: ['gone'],
-          type: 'group'
-        }}
-        topEdge
-      />
-    )
 
-    const header = container!.querySelector('[data-panel-header]')!
+    // Fixed cluster at x=98..122; the zone sits at x=28 (beside a minimized
+    // rail), NOT at the workspace's left edge, so the fill starts 122-28 = 94px in.
+    const cluster = globalThis.document.createElement('div')
+    cluster.dataset.titlebarCluster = 'left'
+    globalThis.document.body.append(cluster)
 
-    const filler =
-      header.querySelector('[data-titlebar-drag-fill]') ??
-      [...header.querySelectorAll('div')].find(
-        el =>
-          el.className.includes('flex-1') &&
-          el.className.includes('-webkit-app-region:drag') &&
-          el.childElementCount === 0
+    const rect = (x: number, width: number) =>
+      ({ bottom: 34, height: 34, left: x, right: x + width, toJSON: () => ({}), top: 0, width, x, y: 0 }) as DOMRect
+
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        return this === cluster ? rect(98, 24) : rect(28, 672)
+      })
+
+    try {
+      render(
+        <TreeGroup
+          node={{
+            active: 'gone',
+            id: 'empty-zone',
+            minimized: false,
+            panes: ['gone'],
+            type: 'group'
+          }}
+          topEdge
+        />
       )
 
-    expect(filler).toBeTruthy()
-    expect(filler!.getAttribute('data-titlebar-drag-fill')).not.toBeNull()
-    const css = `${filler!.className} ${filler!.getAttribute('style') ?? ''}`
-    expect(css).toMatch(/--titlebar-controls-left/)
-    expect(css).toMatch(/--titlebar-controls-width/)
+      const filler = container!.querySelector<HTMLElement>('[data-panel-header] [data-titlebar-drag-fill]')!
+
+      expect(filler).toBeTruthy()
+      expect(filler.style.marginLeft).toBe('94px')
+    } finally {
+      rectSpy.mockRestore()
+      cluster.remove()
+    }
   })
+
 
   it('points the docked-zone chevron in the collapse or restore action direction', () => {
     disposePane = registry.register({

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
@@ -125,9 +125,11 @@ describe('TreeGroup', () => {
     const minimize = container!.querySelector('button[aria-label="Minimize"]')
     const strip = header.querySelector<HTMLElement>('[data-zone-tabstrip]')
     const tablist = tab.closest('[role="tablist"]')
+
     const clusterSpacer = [...header.querySelectorAll('div')].some(el =>
       el.className.includes('--titlebar-controls-width')
     )
+
     const titlebarStrip = Boolean(strip?.className.includes('h-full'))
     const tablistScrolls = Boolean(tablist?.className.includes('overflow-x-auto'))
     const truncates = Boolean(tab.querySelector('.truncate'))
@@ -136,6 +138,7 @@ describe('TreeGroup', () => {
     // Left-edge titlebar must not host a truncated overflow-x-auto tablist in
     // the same flex row as the in-flow --titlebar-controls-width spacer.
     expect(clusterSpacer && titlebarStrip && tablistScrolls && truncates).toBe(false)
+
     if (minimize && strip?.contains(minimize)) {
       expect(titlebarStrip && clusterSpacer).toBe(false)
     }
@@ -157,6 +160,7 @@ describe('TreeGroup', () => {
     )
 
     const header = container!.querySelector('[data-panel-header]')!
+
     const filler =
       header.querySelector('[data-titlebar-drag-fill]') ??
       [...header.querySelectorAll('div')].find(

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
@@ -79,6 +79,100 @@ describe('TreeGroup', () => {
     expect(strip.style).toHaveProperty('WebkitAppRegion', '')
   })
 
+  it('keeps panel tabs in the titlebar for a top-edge zone that is not the left edge', () => {
+    disposePane = registry.register({
+      area: 'panes',
+      data: { placement: 'main' },
+      id: 'terminal',
+      title: 'Terminal',
+      render: () => <div>Terminal</div>
+    })
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+    render(<TreeGroup node={terminalGroup(false)} topEdge />)
+    const header = container!.querySelector('[data-panel-header]')!
+    const strip = header.querySelector<HTMLElement>('[data-zone-tabstrip]')!
+    expect(header.contains(strip)).toBe(true)
+    expect(strip.className).toContain('h-full')
+    expect(strip.className).toContain('[-webkit-app-region:drag]')
+  })
+
+  it('does not put a scroll-clipped tab strip in the left titlebar band beside Minimize', () => {
+    disposePane = registry.register({
+      area: 'panes',
+      data: { placement: 'main' },
+      id: 'sessions',
+      title: 'SESSIONS',
+      render: () => <div>Sessions</div>
+    })
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+    render(
+      <TreeGroup
+        leftEdge
+        node={{
+          active: 'sessions',
+          id: 'sessions-zone',
+          minimized: false,
+          panes: ['sessions'],
+          tabStrip: 'always',
+          type: 'group'
+        }}
+        topEdge
+      />
+    )
+
+    const header = container!.querySelector('[data-panel-header]')!
+    const tab = container!.querySelector('[data-tree-tab="sessions"]')!
+    const minimize = container!.querySelector('button[aria-label="Minimize"]')
+    const strip = header.querySelector<HTMLElement>('[data-zone-tabstrip]')
+    const tablist = tab.closest('[role="tablist"]')
+    const clusterSpacer = [...header.querySelectorAll('div')].some(el =>
+      el.className.includes('--titlebar-controls-width')
+    )
+    const titlebarStrip = Boolean(strip?.className.includes('h-full'))
+    const tablistScrolls = Boolean(tablist?.className.includes('overflow-x-auto'))
+    const truncates = Boolean(tab.querySelector('.truncate'))
+
+    expect(tab.textContent).toContain('SESSIONS')
+    // Left-edge titlebar must not host a truncated overflow-x-auto tablist in
+    // the same flex row as the in-flow --titlebar-controls-width spacer.
+    expect(clusterSpacer && titlebarStrip && tablistScrolls && truncates).toBe(false)
+    if (minimize && strip?.contains(minimize)) {
+      expect(titlebarStrip && clusterSpacer).toBe(false)
+    }
+  })
+
+  it('cuts the titlebar drag filler so it cannot cover the window-control cluster', () => {
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+    render(
+      <TreeGroup
+        node={{
+          active: 'gone',
+          id: 'empty-zone',
+          minimized: false,
+          panes: ['gone'],
+          type: 'group'
+        }}
+        topEdge
+      />
+    )
+
+    const header = container!.querySelector('[data-panel-header]')!
+    const filler =
+      header.querySelector('[data-titlebar-drag-fill]') ??
+      [...header.querySelectorAll('div')].find(
+        el =>
+          el.className.includes('flex-1') &&
+          el.className.includes('-webkit-app-region:drag') &&
+          el.childElementCount === 0
+      )
+
+    expect(filler).toBeTruthy()
+    expect(filler!.getAttribute('data-titlebar-drag-fill')).not.toBeNull()
+    const css = `${filler!.className} ${filler!.getAttribute('style') ?? ''}`
+    expect(css).toMatch(/--titlebar-controls-left/)
+    expect(css).toMatch(/--titlebar-controls-width/)
+  })
+
   it('points the docked-zone chevron in the collapse or restore action direction', () => {
     disposePane = registry.register({
       area: 'panes',

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -34,7 +34,7 @@ import { cn } from '@/lib/utils'
 import { closeAllOpenSessionTiles } from '@/store/session-states'
 
 import { $layoutEditMode } from '../../edit-mode'
-import { useWindowControlsOverlap } from '../../geometry'
+import { TITLEBAR_DRAG_FILL_INSET, useWindowControlsOverlap } from '../../geometry'
 import { emptyPaneLifecycleState, reconcilePaneLifecycle } from '../../pane-lifecycle'
 import { hiddenPaneProps, PaneGroupContext, PaneLifecycleContext, PaneVisibleContext } from '../../pane-visibility'
 import {
@@ -357,6 +357,12 @@ export function TreeGroup({
   const verticalCollapse = Boolean(node.minimized) && parentAxis === 'row' && !isEmpty && shown.length <= 1
   // A minimized group IS its header, so it shows one regardless.
   const headerVisible = !isEmpty && !verticalCollapse && (Boolean(node.minimized) || stripVisible)
+  // Left-edge titlebar shares the traffic lights + control cluster; laying
+  // the tab strip in that same flex row leaves crumbs (~26px in a 260px
+  // sidebar) and clips labels (SESSIONS → ONS). Keep the spacers in the
+  // band and drop the strip to the normal h-7 header. topEdge && !leftEdge
+  // still hosts tabs in the titlebar (bbe212de9b).
+  const tabsInTitlebar = topEdge && !leftEdge
 
   // Keep the activated tab — and, on the last one, the trailing "+" — inside
   // the strip's scroll window. Opening a tab past the right edge otherwise
@@ -500,23 +506,52 @@ export function TreeGroup({
           bounds, strip refs, focus ownership and split geometry as the body. */}
       {(headerVisible || topEdge) && (
         <div
-          className="flex min-w-0 shrink-0 bg-(--ui-sidebar-surface-background)"
+          className="flex min-w-0 shrink-0 flex-col bg-(--ui-sidebar-surface-background)"
           data-panel-header=""
-          style={topEdge ? { height: TITLEBAR_HEIGHT } : undefined}
         >
-          {topEdge && leftEdge && (
-            <div className="flex shrink-0">
-              <div className="w-(--titlebar-controls-left,14px) [-webkit-app-region:drag]" data-window-drag-handle="" />
-              <div className="relative w-(--titlebar-controls-width,96px)">
-                <div
-                  className="absolute inset-x-0 top-0 h-(--titlebar-controls-top,5px) [-webkit-app-region:drag]"
-                  data-window-drag-handle=""
-                />
-              </div>
-              <div className="w-3 [-webkit-app-region:drag]" data-window-drag-handle="" />
+          {topEdge && !(headerVisible && tabsInTitlebar) && (
+            <div className="flex min-w-0" data-titlebar-band="" style={{ height: TITLEBAR_HEIGHT }}>
+              {leftEdge && (
+                <div className="flex shrink-0">
+                  <div className="w-(--titlebar-controls-left,14px) [-webkit-app-region:drag]" data-window-drag-handle="" />
+                  <div className="relative w-(--titlebar-controls-width,96px)">
+                    <div
+                      className="absolute inset-x-0 top-0 h-(--titlebar-controls-top,5px) [-webkit-app-region:drag]"
+                      data-window-drag-handle=""
+                    />
+                  </div>
+                  <div className="w-3 [-webkit-app-region:drag]" data-window-drag-handle="" />
+                </div>
+              )}
+              {/* Cut so the fill never covers the fixed window-control cluster.
+                  Electron's no-drag carve-out of fixed/transformed elements is
+                  unreliable — same invariant as the pre-bbe212de9b drag strips. */}
+              <div
+                className="min-w-0 flex-1 [-webkit-app-region:drag]"
+                data-titlebar-drag-fill=""
+                style={{ marginLeft: TITLEBAR_DRAG_FILL_INSET }}
+              />
+              {rightEdge && (
+                <div className="flex shrink-0">
+                  <div
+                    className="w-6"
+                    data-window-drag-handle=""
+                    style={{ WebkitAppRegion: dragging ? 'no-drag' : 'drag' } as CSSProperties}
+                  />
+                  <div className="w-[calc(var(--titlebar-tools-right,0.75rem)+var(--titlebar-tools-width,24px))] [-webkit-app-region:no-drag]" />
+                </div>
+              )}
             </div>
           )}
-          {headerVisible ? (
+          {headerVisible && (
+            <div
+              className="flex min-w-0"
+              style={
+                tabsInTitlebar
+                  ? { height: TITLEBAR_HEIGHT, marginLeft: TITLEBAR_DRAG_FILL_INSET }
+                  : undefined
+              }
+            >
             <ZoneMenu {...zoneMenu}>
               <PaneTabStrip
                 className="flex-1"
@@ -537,7 +572,7 @@ export function TreeGroup({
                 }}
                 ref={stripRef}
                 style={{ cursor: 'grab', WebkitAppRegion: dragging ? 'no-drag' : undefined } as CSSProperties}
-                titlebar={topEdge}
+                titlebar={tabsInTitlebar}
                 trailing={
                   <>
                     {minimizable && (
@@ -694,17 +729,16 @@ export function TreeGroup({
                 )}
               </PaneTabStrip>
             </ZoneMenu>
-          ) : (
-            <div className="min-w-0 flex-1 [-webkit-app-region:drag]" />
-          )}
-          {topEdge && rightEdge && (
-            <div className="flex shrink-0">
-              <div
-                className="w-6"
-                data-window-drag-handle=""
-                style={{ WebkitAppRegion: dragging ? 'no-drag' : 'drag' } as CSSProperties}
-              />
-              <div className="w-[calc(var(--titlebar-tools-right,0.75rem)+var(--titlebar-tools-width,24px))] [-webkit-app-region:no-drag]" />
+              {tabsInTitlebar && rightEdge && (
+                <div className="flex shrink-0">
+                  <div
+                    className="w-6"
+                    data-window-drag-handle=""
+                    style={{ WebkitAppRegion: dragging ? 'no-drag' : 'drag' } as CSSProperties}
+                  />
+                  <div className="w-[calc(var(--titlebar-tools-right,0.75rem)+var(--titlebar-tools-width,24px))] [-webkit-app-region:no-drag]" />
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -781,7 +815,11 @@ export function TreeGroup({
             className="absolute inset-x-0 bottom-0 z-50 flex cursor-grab items-center justify-center outline-1 -outline-offset-2 outline-dashed backdrop-blur-[2px]"
             onPointerDown={e => startPaneDrag(activeId, e, undefined, undefined, active?.title ?? activeId)}
             style={{
-              top: topEdge ? TITLEBAR_HEIGHT : headerVisible ? 28 : 0,
+              top: topEdge
+                ? TITLEBAR_HEIGHT + (headerVisible && leftEdge ? 28 : 0)
+                : headerVisible
+                  ? 28
+                  : 0,
               background:
                 'color-mix(in srgb, var(--ui-accent) 6%, color-mix(in srgb, var(--ui-bg-chrome) 55%, transparent))',
               outlineColor: 'color-mix(in srgb, var(--ui-accent) 55%, transparent)'

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -34,7 +34,7 @@ import { cn } from '@/lib/utils'
 import { closeAllOpenSessionTiles } from '@/store/session-states'
 
 import { $layoutEditMode } from '../../edit-mode'
-import { TITLEBAR_DRAG_FILL_INSET, useWindowControlsOverlap } from '../../geometry'
+import { useTitlebarDragFillInset, useWindowControlsOverlap } from '../../geometry'
 import { emptyPaneLifecycleState, reconcilePaneLifecycle } from '../../pane-lifecycle'
 import { hiddenPaneProps, PaneGroupContext, PaneLifecycleContext, PaneVisibleContext } from '../../pane-visibility'
 import {
@@ -254,6 +254,7 @@ export function TreeGroup({
   const dragging = useStore($treeDragging)
   const editMode = useStore($layoutEditMode)
   const wcOverlap = useWindowControlsOverlap(ref, !topEdge)
+  const dragFillInset = useTitlebarDragFillInset(ref, topEdge)
 
   const hiddenPanes = useStore($hiddenTreePanes)
   const narrow = useStore($narrowViewport)
@@ -529,7 +530,7 @@ export function TreeGroup({
               <div
                 className="min-w-0 flex-1 [-webkit-app-region:drag]"
                 data-titlebar-drag-fill=""
-                style={{ marginLeft: TITLEBAR_DRAG_FILL_INSET }}
+                style={{ marginLeft: dragFillInset }}
               />
               {rightEdge && (
                 <div className="flex shrink-0">
@@ -548,7 +549,7 @@ export function TreeGroup({
               className="flex min-w-0"
               style={
                 tabsInTitlebar
-                  ? { height: TITLEBAR_HEIGHT, marginLeft: TITLEBAR_DRAG_FILL_INSET }
+                  ? { height: TITLEBAR_HEIGHT, marginLeft: dragFillInset }
                   : undefined
               }
             >

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -963,6 +963,39 @@ export function setTreeSideCollapsed(side: TreeSide, collapsed: boolean) {
   }
 }
 
+/** Restore minimized zones without changing their active tab (including Bots). */
+export function restoreMinimizedTreeSide(side: TreeSide): boolean {
+  const tree = $layoutTree.get()
+  const row = rootRow()
+
+  if (!tree || !row) {
+    return false
+  }
+
+  const panes = registry.getArea('panes')
+  let next = tree
+
+  for (const child of row.children) {
+    if (rootChildSide(child, id => panes.find(pane => pane.id === id)) !== side) {
+      continue
+    }
+
+    for (const id of groupLeafIds(child)) {
+      if (findGroup(next, id)?.minimized) {
+        next = setGroupMinimized(next, id, false)
+      }
+    }
+  }
+
+  if (next === tree) {
+    return false
+  }
+
+  commit(next)
+
+  return true
+}
+
 /**
  * Does the layout have a collapsible root side of `side`? ⌘J's normal target is
  * the right sidebar; a layout without one (e.g. a terminal-on-bottom preset)

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -675,6 +675,10 @@ export const en: Translations = {
       tabStripAuto: 'Auto',
       tabStripAlways: 'Always',
       tabStripNever: 'Never',
+      appActionsTitle: 'App Actions',
+      appActionsDesc: 'Where Settings, Layout, and HUD sit in the titlebar. Right leaves room for tabs on the left.',
+      appActionsLeft: 'Left',
+      appActionsRight: 'Right',
       terminalFontTitle: 'Terminal Font',
       terminalFontDesc:
         'Choose an installed font for Desktop terminals. Nerd Fonts render Powerlevel10k and shell icons; leave blank to use bundled JetBrains Mono.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -499,6 +499,10 @@ export const ja = defineLocale({
       tabStripAuto: '自動',
       tabStripAlways: '常に表示',
       tabStripNever: '表示しない',
+      appActionsTitle: 'アプリ操作',
+      appActionsDesc: '設定・レイアウト・HUD をタイトルバーの左右どちらに置くか。右にするとタブ用のスペースが左に残ります。',
+      appActionsLeft: '左',
+      appActionsRight: '右',
       terminalFontTitle: 'ターミナルフォント',
       terminalFontDesc:
         'Desktop のターミナルで使用するインストール済みフォントを選びます。Nerd Font は Powerlevel10k とシェルアイコンを表示できます。空欄では内蔵の JetBrains Mono を使用します。',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -568,6 +568,10 @@ export const ru = defineLocale({
       tabStripAuto: 'Авто',
       tabStripAlways: 'Всегда',
       tabStripNever: 'Никогда',
+      appActionsTitle: 'Действия приложения',
+      appActionsDesc: 'Где в заголовке окна сидят Настройки, Макет и HUD. Справа оставляют место для вкладок слева.',
+      appActionsLeft: 'Слева',
+      appActionsRight: 'Справа',
       terminalFontTitle: 'Шрифт терминала',
       terminalFontDesc:
         'Выберите установленный шрифт для терминалов приложения. Nerd Fonts отображают Powerlevel10k и иконки оболочки; оставьте пустым, чтобы использовать встроенный JetBrains Mono.',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -727,6 +727,10 @@ export interface Translations {
       tabStripAuto: string
       tabStripAlways: string
       tabStripNever: string
+      appActionsTitle: string
+      appActionsDesc: string
+      appActionsLeft: string
+      appActionsRight: string
       terminalFontTitle: string
       terminalFontDesc: string
       terminalFontPlaceholder: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -484,6 +484,10 @@ export const zhHant = defineLocale({
       tabStripAuto: '自動',
       tabStripAlways: '一律',
       tabStripNever: '永不',
+      appActionsTitle: '應用操作',
+      appActionsDesc: '設定、版面與 HUD 放在標題列左側或右側。選右側可把左側留給分頁。',
+      appActionsLeft: '左側',
+      appActionsRight: '右側',
       terminalFontTitle: '終端機字型',
       terminalFontDesc:
         '選擇已安裝的字型用於桌面端終端機。Nerd Font 可正確顯示 Powerlevel10k 與 Shell 圖示；留空則使用內建的 JetBrains Mono。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -656,6 +656,10 @@ export const zh: Translations = {
       tabStripAuto: '自动',
       tabStripAlways: '始终',
       tabStripNever: '从不',
+      appActionsTitle: '应用操作',
+      appActionsDesc: '设置、布局和 HUD 放在标题栏左侧还是右侧。选右侧可给标签留出左边空间。',
+      appActionsLeft: '左侧',
+      appActionsRight: '右侧',
       terminalFontTitle: '终端字体',
       terminalFontDesc:
         '选择已安装的字体用于桌面端终端。Nerd Font 可正确显示 Powerlevel10k 和 Shell 图标；留空则使用内置的 JetBrains Mono。',

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -2,7 +2,7 @@ import { atom, computed, type ReadableAtom, type WritableAtom } from 'nanostores
 
 import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '@/app/layout-constants'
 import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
-import { isPaneVisible, revealTreePane } from '@/components/pane-shell/tree/store'
+import { isPaneVisible, restoreMinimizedTreeSide, revealTreePane } from '@/components/pane-shell/tree/store'
 import { matchesQuery } from '@/hooks/use-media-query'
 import { connectionScopedAtom } from '@/lib/connection-scoped'
 import { type Codec, Codecs, persistentAtom } from '@/lib/persisted'
@@ -528,14 +528,26 @@ function revealNarrowPane(id: string, mode: 'close' | 'open' | 'toggle'): boolea
 }
 
 export function setSidebarOpen(open: boolean) {
+  if (open) {
+    restoreMinimizedTreeSide('left')
+  }
+
   setPaneOpen(CHAT_SIDEBAR_PANE_ID, open)
   revealNarrowPane(CHAT_SIDEBAR_PANE_ID, open ? 'open' : 'close')
 }
 
 export function toggleSidebarOpen() {
-  if (!revealNarrowPane(CHAT_SIDEBAR_PANE_ID, 'toggle')) {
-    togglePane(CHAT_SIDEBAR_PANE_ID)
+  if (revealNarrowPane(CHAT_SIDEBAR_PANE_ID, 'toggle')) {
+    return
   }
+
+  if (restoreMinimizedTreeSide('left')) {
+    setPaneOpen(CHAT_SIDEBAR_PANE_ID, true)
+
+    return
+  }
+
+  togglePane(CHAT_SIDEBAR_PANE_ID)
 }
 
 export function toggleFileBrowserOpen() {

--- a/apps/desktop/src/store/pane-focus.test.ts
+++ b/apps/desktop/src/store/pane-focus.test.ts
@@ -31,6 +31,13 @@ describe('revealDesktopPane', () => {
     expect(setTerminalTakeover).toHaveBeenCalledWith(true)
   })
 
+  it('also un-minimizes the tree pane, since a same-value store set is a no-op', () => {
+    for (const pane of ['files', 'review', 'sessions', 'terminal']) {
+      revealDesktopPane(pane)
+      expect(revealTreePane).toHaveBeenCalledWith(pane)
+    }
+  })
+
   it('returns false for an unknown pane and touches nothing', () => {
     expect(revealDesktopPane('nope')).toBe(false)
     expect(revealTreePane).not.toHaveBeenCalled()

--- a/apps/desktop/src/store/pane-focus.ts
+++ b/apps/desktop/src/store/pane-focus.ts
@@ -19,6 +19,17 @@ const PANE_REVEALERS: Record<string, () => void> = {
   terminal: () => setTerminalTakeover(true)
 }
 
+// The store setters above are same-value no-ops: `$open` already reads true
+// while the pane sits in a zone the user minimized from its chevron, so the
+// listener never fires and the tool reported success over an invisible pane
+// (#106009). An explicit reveal also un-minimizes and fronts the tree pane.
+const TREE_PANE_OF: Record<string, string> = {
+  files: 'files',
+  review: 'review',
+  sessions: 'sessions',
+  terminal: 'terminal'
+}
+
 /** Reveal a desktop pane by name. Returns false for an unknown pane. */
 export function revealDesktopPane(pane: string): boolean {
   const reveal = PANE_REVEALERS[pane]
@@ -28,6 +39,12 @@ export function revealDesktopPane(pane: string): boolean {
   }
 
   reveal()
+
+  const treePane = TREE_PANE_OF[pane]
+
+  if (treePane) {
+    revealTreePane(treePane)
+  }
 
   return true
 }

--- a/apps/desktop/src/store/sidebar-collapse-persistence.test.ts
+++ b/apps/desktop/src/store/sidebar-collapse-persistence.test.ts
@@ -62,3 +62,36 @@ describe('sidebar collapse persistence', () => {
     expect(s2.leftCollapsed()).toBe(true)
   })
 })
+
+describe('minimized sidebar recovery', () => {
+  it.each([false, true])('restores Bots through the shared toggle with flipped=%s', async flipped => {
+    window.localStorage.clear()
+    vi.resetModules()
+    const { layout, tree, bind } = await loadStores()
+    const { group, split, findGroup } = await import('@/components/pane-shell/tree/model')
+    const { registry } = await import('@/contrib/registry')
+
+    const disposers = [
+      registry.register({ area: 'panes', id: 'sessions', title: 'Sessions', data: { placement: 'left' } }),
+      registry.register({ area: 'panes', id: 'bots', title: 'Bots', data: { placement: 'left' } }),
+      registry.register({ area: 'panes', id: 'workspace', title: 'Main', data: { placement: 'main' } })
+    ]
+
+    try {
+      const sidebar = group(['sessions', 'bots'], { active: 'bots', id: 'sidebar', minimized: true })
+      const main = group(['workspace'])
+      tree.$layoutTree.set(split('row', flipped ? [main, sidebar] : [sidebar, main]))
+      bind()
+      layout.toggleSidebarOpen()
+      expect(layout.$sidebarOpen.get()).toBe(true)
+      expect(findGroup(tree.$layoutTree.get()!, 'sidebar')).toMatchObject({ active: 'bots', minimized: false })
+      layout.toggleSidebarOpen()
+      expect(layout.$sidebarOpen.get()).toBe(false)
+      tree.setTreeGroupMinimized('sidebar', true)
+      layout.setSidebarOpen(true)
+      expect(findGroup(tree.$layoutTree.get()!, 'sidebar')).toMatchObject({ active: 'bots', minimized: false })
+    } finally {
+      disposers.forEach(dispose => dispose())
+    }
+  })
+})

--- a/apps/desktop/src/store/titlebar-app-actions.test.ts
+++ b/apps/desktop/src/store/titlebar-app-actions.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $titlebarAppActionsSide,
+  setTitlebarAppActionsSide,
+  TITLEBAR_APP_ACTIONS_DEFAULT,
+  titlebarAppActionsClusterCounts
+} from './titlebar-app-actions'
+
+describe('titlebarAppActionsClusterCounts', () => {
+  it('puts the three app actions on the right by default', () => {
+    expect(titlebarAppActionsClusterCounts('right')).toEqual({ left: 1, right: 5 })
+    expect(titlebarAppActionsClusterCounts('left')).toEqual({ left: 4, right: 2 })
+  })
+
+  it('adds extras to the cluster they belong to', () => {
+    expect(titlebarAppActionsClusterCounts('right', 1, 2)).toEqual({ left: 2, right: 7 })
+    expect(titlebarAppActionsClusterCounts('left', 1, 2)).toEqual({ left: 5, right: 4 })
+  })
+})
+
+describe('$titlebarAppActionsSide', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    setTitlebarAppActionsSide(TITLEBAR_APP_ACTIONS_DEFAULT)
+  })
+
+  it('defaults to right', () => {
+    expect($titlebarAppActionsSide.get()).toBe('right')
+  })
+
+  it('persists left', () => {
+    setTitlebarAppActionsSide('left')
+    expect($titlebarAppActionsSide.get()).toBe('left')
+    expect(window.localStorage.getItem('hermes.desktop.titlebarAppActions')).toBe('left')
+  })
+})

--- a/apps/desktop/src/store/titlebar-app-actions.ts
+++ b/apps/desktop/src/store/titlebar-app-actions.ts
@@ -1,0 +1,41 @@
+import { type Codec, persistentAtom } from '@/lib/persisted'
+
+export type TitlebarAppActionsSide = 'left' | 'right'
+
+const STORAGE_KEY = 'hermes.desktop.titlebarAppActions'
+
+/** Right is the original titlebar: Settings / Layout / HUD stay off the tab strip. */
+export const TITLEBAR_APP_ACTIONS_DEFAULT: TitlebarAppActionsSide = 'right'
+
+const codec: Codec<TitlebarAppActionsSide> = {
+  decode: raw => (raw === 'left' || raw === 'right' ? raw : TITLEBAR_APP_ACTIONS_DEFAULT),
+  encode: value => value
+}
+
+export const $titlebarAppActionsSide = persistentAtom<TitlebarAppActionsSide>(
+  STORAGE_KEY,
+  TITLEBAR_APP_ACTIONS_DEFAULT,
+  codec
+)
+
+export function setTitlebarAppActionsSide(side: TitlebarAppActionsSide) {
+  $titlebarAppActionsSide.set(side)
+}
+
+/** Button counts for the two titlebar clusters. Sidebar is always left; flip and
+ *  the right-sidebar toggle are always right; the three app actions follow `side`. */
+export function titlebarAppActionsClusterCounts(
+  side: TitlebarAppActionsSide,
+  leftExtras = 0,
+  rightExtras = 0
+): { left: number; right: number } {
+  const sidebar = 1
+  const appActions = 3
+  const rightFixed = 2
+
+  if (side === 'left') {
+    return { left: sidebar + appActions + leftExtras, right: rightFixed + rightExtras }
+  }
+
+  return { left: sidebar + leftExtras, right: appActions + rightFixed + rightExtras }
+}

--- a/contributors/emails/160389295+wukangcheng1994@users.noreply.github.com
+++ b/contributors/emails/160389295+wukangcheng1994@users.noreply.github.com
@@ -1,0 +1,2 @@
+wukangcheng1994
+# PR #107209 salvage


### PR DESCRIPTION
The macOS Desktop sidebar can no longer be trapped by the titlebar tabs: `SESSIONS` is fully readable, the zone chevron and ⌘B / the sidebar toggle round-trip, and gear / layout / HUD keep taking clicks after a collapse.

Salvage of the whole `bbe212de9b` ("keep panel tabs in the titlebar") fallout cluster in one PR, contributor commits cherry-picked verbatim onto `origin/main`.

Fixes #107196
Fixes #107774
Fixes #107927
Fixes #106009
Fixes #107351

## Root causes (three, not one)

| # | Mechanism | Symptom |
|---|---|---|
| ① | `tree-group.tsx` lays the left zone's tab strip in the same flex row as the ~206 px traffic-light + 4-button cluster spacers; a 260 px sidebar leaves 26 px | `SESSIONS` paints as `ONS` beside the Minimize chevron (#107196, #107774) |
| ② | The neighbour zone's header filler is a bare `flex-1 [-webkit-app-region:drag]`; once the sidebar minimizes to a 28 px rail it slides under the fixed control cluster. Electron's no-drag carve-out of fixed elements is unreliable, which is why the pre-`bbe212de9b` titlebar cut its drag strips geometrically | gear / layout / HUD stop taking clicks (#107196) |
| ③ | The chevron sets `grp-sessions.minimized=true` while `$sidebarOpen` stays `true`; `toggleSidebarOpen` only consulted the flag, so ⌘B hid an already-invisible zone. Both values persist, so a restart reproduces the trap | ⌘B / toggle look dead; `focus_pane(sessions)` reports success and changes nothing (#106009, #107927) |

## What lands (merge order = commit order)

| Commit | Author | Contribution |
|---|---|---|
| `fix(desktop): restore minimized sidebar through sidebar controls` | @wukangcheng1994 (#107209) | ③ — `restoreMinimizedTreeSide('left')` from `setSidebarOpen(true)` and the toggle; keeps the active tab (Bots stays Bots); both sidebar sides tested |
| `fix(desktop): pin settings layout and HUD back to the right titlebar` | @abundantbeing (#107456) | ① + #107351 — app actions default back to the right edge (macOS convention), left reservation 206 → 134 px so the strip has room. Conflict with #107239's extension-page hide resolved keep-both |
| `feat(desktop): let Appearance choose left or right for titlebar app actions` | @abundantbeing (#107456) | Settings → Appearance → App Actions, Left / Right, persisted; all six locales |
| `fix(desktop): keep left titlebar tabs from clipping beside window controls` | @KoNit-K (#107223) | ① + ② — left-edge titlebar band hosts only the control spacers plus a geometrically cut drag fill (`TITLEBAR_DRAG_FILL_INSET = max(0, controlsLeft + controlsWidth − workspaceLeft)`); that zone's tabs render in the normal `h-7` header so they can never scroll-clip. Non-left top-edge zones keep tabs in the titlebar |
| `fix(desktop): focus_pane un-minimizes the tree zone for every revealer` | ours | ③ class — `revealDesktopPane` routes files / review / sessions / terminal through `revealTreePane` after their store setter (same-value `.set()` is a no-op, so the tool reported success over a minimized zone). Class noted by @worryfreeaa on #106009 |
| `fix(desktop): key the titlebar drag-fill inset on the zone, not the workspace` | ours | ② completeness — the salvaged cut was keyed on `--workspace-left`, so a tool zone between a minimized rail and the workspace (x≈28) got inset 0 and its strip ran under Hide sidebar. Now measured per zone against the mounted left cluster. Found by independent review of this PR |
| `chore` ×2 | ours | eslint `--fix` on the salvaged files; contributor email map |

Credit for diagnosis: @MarionLiew (deterministic chevron → `$sidebarOpen` mismatch trigger, #107823), @worryfreeaa (revealer class + persisted-state readback), @yk-david and @tgmerritt (independent repros), @lusc0529-collab (CDP measurements in #107196).

## Validation

| Check | Result |
|---|---|
| `npx vitest run --project ui` — pane-shell, store, app/shell, app/settings, app/contrib, i18n | see CI; touched files 19/19 locally |
| `npx tsc -p . --noEmit` (apps/desktop) | 0 errors |
| `npx eslint` on touched files | clean after `--fix` |
| Red-on-base: `pane-focus.test.ts` new case | fails on `origin/main` `pane-focus.ts`, passes with fix |
| Red-on-base: `tree-group.test.tsx` zone-keyed drag-fill case | fails on the salvaged head, passes with the zone-keyed commit |
| Red-on-base: #107209 / #107223 own tests | per their bodies; re-run green on this head |
| `scripts/check-windows-footguns.py`, `check_compat_pointers.py`, `git diff --check` | clean |

**Live repro (Playwright against the worktree's Vite renderer, 1355×889, `--titlebar-controls-left: 98px` to model the macOS traffic lights; before = `origin/main` copies of the seven touched source files swapped in via HMR):**

| Step | BEFORE (`origin/main`) | AFTER (this head) |
|---|---|---|
| Initial | Sessions tab at x=206 w=60 inside a strip with `clientWidth=26 scrollWidth=100` → 26 px of `SESSIONS` visible; settings/layout/HUD at x=122/146/170 (left cluster) | tab at x=0 w=60 in the h-7 header row, strip `clientWidth=232`, label fully visible; settings/layout/HUD at x=1223/1247/1271 (right cluster) |
| Rearranged: minimized Sessions ▸ Terminal ▸ Workspace | terminal header drag strip x=28..559 covers Hide sidebar (98..122) — this survived the salvaged cut, fixed by our zone-keyed commit | strip x=122..559; default layout × {App Actions Right, Left} × {open, minimized}: no drag region intersects any cluster button |
| Chevron (`collapseTreePane('sessions')`) | `minimized=true`, `$sidebarOpen=true`, toggle still labelled "Hide sidebar"; `elementFromPoint` at y=17: x=150 → Layout editor button, x=230 → the clipped 9 px label | `minimized=true`, `$sidebarOpen=true`; no in-flow drag region intersects any cluster button (`covering: []`) |
| ⌘B (`toggleSidebarOpen()`) | `$sidebarOpen=false`, `minimized=true` — sidebar gone, trap persisted | `$sidebarOpen=true`, `minimized=false`, `isPaneVisible('sessions')=true`, zone back to 260 px in one press |

Not run: native Electron on macOS (no Electron binary / display on this host), and the `Desktop E2E` check is path-skipped on this PR, so there is no native coverage here; the renderer A/B above is the live evidence. Whether Electron actually swallows clicks under a drag region is the hazard the pre-`bbe212de9b` code documented, not something re-measured natively in this PR.

## Not taken, and why

- #107823 @MarionLiew — same fix as #107209, narrower (hardcodes `'sessions'`, flips the active tab to Sessions); #107209 is earlier and broader. Superseded after this merges.
- #106095 @huklaa — `focus_pane(sessions)` only; covered by #107209 plus the revealer commit here.
- #107217 @wukangcheng1994 — container-query second row at ≤420 px; with the cluster back on the right the left strip has 126 px and the wrap is no longer needed, and it did not address ②.
- #107776 @kokhlo — `relative z-60` on the header. The cluster is already `fixed z-70`; the swallowed clicks are the drag-region hazard (②), which z-index cannot reach. Also carried an unrelated `hermes_cli/hooks.py` change duplicated from #107521.
- #107933 @kokhlo — first-hide toast. With ③ fixed the sidebar toggle IS the restore affordance and it stays clickable after ②; #107927 is resolved by behaviour, not education.

## Infographic

![Desktop sidebar no longer trapped by titlebar tabs](https://v3b.fal.media/files/b/0aa9fbbf/IDKOxXwkrRp-Q6DBvj3_F_Js64YGbm.png)
