### PR TITLE
feat: emit narrow runtime request success evidence

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1352,6 +1352,7 @@ class _LoopState:
     _llm_middleware_trace: Any = None
     api_duration: Any = None
     assistant_message: Any = None
+    dispatched_credential_pool_entry_id: Any = None
 
 
 # _LoopState fields seeded from TurnContext (same name minus the leading underscore).
@@ -1527,6 +1528,7 @@ def _run_conversation_turn(
 
         s.api_start_time, s.retry_count, s.max_retries = time.time(), 0, agent._api_max_retries
         s._retry, s.finish_reason, s.response, s.api_kwargs = TurnRetryState(), "stop", None, None
+        s.dispatched_credential_pool_entry_id = None
         s.api_request_id = agent._current_api_request_id = f"{s.turn_id}:api:{s.api_call_count}"
 
         early_result = _run_api_retry_loop(agent, s)

--- a/agent/turn_api_call.py
+++ b/agent/turn_api_call.py
@@ -38,6 +38,7 @@ class ApiCallVerdict:
     response: Any
     thinking_spinner: Any
     interrupted: Any
+    dispatched_credential_pool_entry_id: Any
 
 
 def _should_stream(agent: Any) -> bool:
@@ -66,11 +67,16 @@ def perform_api_call(
 ) -> ApiCallVerdict:
     """Issue the request (see ``_should_stream`` for the streaming decision)."""
     response = None
+    # Capture the opaque pool reference when this attempt is dispatched. Reading
+    # the mutable agent attribute after the response can misattribute a later
+    # credential recovery or concurrent turn.
+    dispatched_credential_pool_entry_id = None
 
     def _verdict(action: str) -> ApiCallVerdict:
         return ApiCallVerdict(
             action=action, response=response, thinking_spinner=thinking_spinner,
             interrupted=interrupted,
+            dispatched_credential_pool_entry_id=dispatched_credential_pool_entry_id,
         )
 
     def _stop_spinner():
@@ -123,6 +129,8 @@ def perform_api_call(
         if _model_request_active is not None:
             _model_request_active.set()
     try:
+        entry_id = getattr(agent, "_credential_pool_entry_id", None)
+        dispatched_credential_pool_entry_id = entry_id if isinstance(entry_id, str) and entry_id else None
         response = run_llm_execution_middleware(
             api_kwargs, _perform_api_call, original_request=_original_api_kwargs,
             task_id=effective_task_id, turn_id=turn_id, api_request_id=api_request_id,

--- a/agent/turn_response_intake.py
+++ b/agent/turn_response_intake.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 import json
 import logging
 import re
+import time
 from typing import Any, Dict, Optional
 
 from agent.provider_projection import splice_provider_projection
@@ -95,6 +96,27 @@ def _fire_post_api_request_hook(
         pass
 
 
+def _fire_runtime_request_succeeded_hook(
+    agent: Any, *, credential_pool_entry_id: Any, api_request_id: Any,
+) -> None:
+    """Emit narrow success evidence without legacy hook request/response payloads."""
+    if not isinstance(credential_pool_entry_id, str) or not credential_pool_entry_id:
+        return
+    try:
+        from hermes_cli.lifecycle import has_hook, invoke_hook
+        if has_hook("runtime_request_succeeded"):
+            invoke_hook(
+                "runtime_request_succeeded",
+                credential_pool_entry_id=credential_pool_entry_id,
+                occurred_at=time.time(),
+                api_request_id=str(api_request_id or ""),
+                provider=str(agent.provider or ""),
+                model=str(agent.model or ""),
+            )
+    except Exception:
+        pass
+
+
 def _relay_thinking(agent: Any, content: str) -> None:
     """Relay the model's text to the progress callback: subagents send the first line to
     the parent display; any agent with a structured callback gets ``reasoning.available``."""
@@ -115,7 +137,7 @@ def _relay_thinking(agent: Any, content: str) -> None:
 def normalize_model_response(
     agent: Any, *, response: Any, messages: Any, api_messages: Any, conversation_history: Any,
     api_call_count: Any, api_duration: Any, api_start_time: Any, api_request_id: Any,
-    effective_task_id: Any, turn_id: Any,
+    effective_task_id: Any, turn_id: Any, dispatched_credential_pool_entry_id: Any = None,
 ) -> ResponseIntakeVerdict:
     """Normalize ``response`` into ``assistant_message`` (str content, never dict/list) and run
     the post-response hooks and continuation guards, in the original order."""
@@ -139,6 +161,11 @@ def normalize_model_response(
         agent, response, assistant_message, finish_reason, api_messages=api_messages,
         api_call_count=api_call_count, api_duration=api_duration, api_start_time=api_start_time,
         api_request_id=api_request_id, effective_task_id=effective_task_id, turn_id=turn_id,
+    )
+    _fire_runtime_request_succeeded_hook(
+        agent,
+        credential_pool_entry_id=dispatched_credential_pool_entry_id,
+        api_request_id=api_request_id,
     )
 
     content = assistant_message.content

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -151,6 +151,10 @@ _DEFAULT_PAYLOADS = {
         # response, so without this an observer cannot see or price the fan-out.
         "moa_references": None,
     },
+    "runtime_request_succeeded": {
+        "credential_pool_entry_id": "opaque-entry", "occurred_at": 1756000001.234,
+        "api_request_id": "test-turn:api:1", "provider": "openai-codex", "model": "gpt-5",
+    },
     "subagent_stop": {
         "parent_session_id": "parent-sess", "child_role": None,
         "child_summary": "Synthetic summary for hooks test", "child_status": "completed",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -115,6 +115,8 @@ VALID_HOOKS: Set[str] = {
     # {"action": "continue", "message"} (or Claude-Code Stop {"decision": "block", "reason"}) to keep
     # going; anything else finishes. Bounded by agent.max_verify_nudges.
     "pre_verify", "pre_api_request", "post_api_request", "api_request_error",
+    # Safe success-only account evidence; no request/response data is included.
+    "runtime_request_succeeded",
     # transform_api_error_classification: once per failed API call BEFORE
     # agent/error_classifier.classify_api_error(). Kwargs: provider, model, status_code, error_type,
     # error_code, error_message, error_body, error, approx_tokens, context_length, num_messages.

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -41,6 +41,7 @@ logger = logging.getLogger("hermes_cli.plugins")
 _HOOK_TIMEOUT_BOUNDED_HOOKS: Set[str] = {
     "post_tool_call", "transform_terminal_output", "transform_tool_result", "transform_llm_output",
     "pre_llm_call", "post_llm_call", "pre_api_request", "post_api_request", "api_request_error",
+    "runtime_request_succeeded",
     "pre_verify", "on_session_start", "on_session_end",
 }
 

--- a/tests/agent/test_runtime_request_success_evidence.py
+++ b/tests/agent/test_runtime_request_success_evidence.py
@@ -1,0 +1,83 @@
+"""End-to-end success evidence stays bound to the pool entry dispatched for the turn."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent.credential_pool import AUTH_TYPE_OAUTH, CredentialPool, PooledCredential
+
+
+class _Completions:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content="synthetic success", reasoning=None, tool_calls=[]),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+
+
+class _Client:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=_Completions())
+
+
+def test_successful_turn_emits_the_real_synthetic_pool_entry_id(monkeypatch):
+    """Exercise construction, dispatch, response intake, and hook delivery without auth I/O."""
+    from run_agent import AIAgent
+
+    entry = PooledCredential.from_dict("openai-codex", {
+        "id": "synthetic-entry-a",
+        "label": "synthetic",
+        "provider": "openai-codex",
+        "auth_type": AUTH_TYPE_OAUTH,
+        "access_token": "synthetic-token-a",
+        "refresh_token": "synthetic-refresh-a",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+    })
+    pool = CredentialPool(provider="openai-codex", entries=[entry])
+    client = _Client()
+    observed: list[dict] = []
+
+    monkeypatch.setattr("agent.process_bootstrap.OpenAI", lambda **_kwargs: client)
+    monkeypatch.setattr("model_tools.get_tool_definitions", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr("hermes_cli.auth.read_credential_pool", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("auth store read")))
+    monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: name == "runtime_request_succeeded")
+
+    def _capture_success(name, **kwargs):
+        if name == "runtime_request_succeeded":
+            observed.append({"name": name, **kwargs})
+        return []
+
+    monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", _capture_success)
+
+    agent = AIAgent(
+        model="gpt-5",
+        provider="openai-codex",
+        api_mode="chat_completions",
+        api_key="synthetic-token-a",
+        base_url="https://chatgpt.com/backend-api/codex",
+        credential_pool=pool,
+        platform="cli",
+        max_iterations=1,
+        quiet_mode=True,
+        skip_memory=True,
+    )
+
+    result = agent.run_conversation("prove synthetic binding")
+
+    assert result["final_response"].startswith("synthetic success")
+    assert client.chat.completions.calls
+    assert agent._credential_pool_entry_id == "synthetic-entry-a"
+    assert len(observed) == 1
+    assert observed[0]["name"] == "runtime_request_succeeded"
+    assert observed[0]["credential_pool_entry_id"] == "synthetic-entry-a"
+    assert observed[0]["provider"] == "openai-codex"
+    assert observed[0]["model"] == "gpt-5"
+    assert "token" not in observed[0]
+    assert "refresh" not in observed[0]


### PR DESCRIPTION
Adds an opt-in, success-only hook carrying an opaque credential-pool entry ID, timestamp, request ID, provider and model.

Includes isolated full-turn integration coverage using a synthetic CredentialPool and blocks auth-store reads.