### PR TITLE
state.db FTS damage no longer kills turns; doctor/repair/recover handle real incident shapes (#97794, #88587, #100227, #103840, #106667, #102240, #98050, #103647, #96591, #105887; salvage #97843 #88604 #56824 #91413 #102808 #103657 #106890 #103321)

### DIFF
--- a/agent/turn_explainers.py
+++ b/agent/turn_explainers.py
@@ -139,10 +139,10 @@ _PERSISTENCE_CAUSE_EXPLANATIONS: Dict[str, str] = {
         "reported structural corruption (the transcript would "
         "have been lost on restart). Freeing disk space will "
         "not help. Recovery options:\n"
-        "1. Run `hermes doctor --fix`\n"
+        "1. Run `hermes {profile_arg}doctor --fix`\n"
         "2. Stop the gateway, then recover with:\n"
-        "   hermes sessions recover --source {db_path} --inspect-only\n"
-        "   (if it reports recoverable) hermes sessions recover "
+        "   hermes {profile_arg}sessions recover --source {db_path} --inspect-only\n"
+        "   (if it reports recoverable) hermes {profile_arg}sessions recover "
         "--source {db_path} --output recovered-state.db\n"
         "   — recovery snapshots the damaged file first; do NOT "
         "run `sqlite3 ... \".recover\"` against the live "
@@ -157,7 +157,7 @@ _PERSISTENCE_CAUSE_EXPLANATIONS: Dict[str, str] = {
         "the turn was stopped because the session search index (FTS5) "
         "is corrupt and could not be detached, so this message was not "
         "saved. The message store itself is not damaged: do not run "
-        "recovery tools or restore a backup. Run `hermes doctor --fix` "
+        "recovery tools or restore a backup. Run `hermes {profile_arg}doctor --fix` "
         "(or restart Hermes, which repairs the index on open), then "
         "send your message again."
     ),
@@ -328,14 +328,14 @@ class TurnExplainersMixin:
             body = _PERSISTENCE_CAUSE_EXPLANATIONS.get(
                 persistence_cause or "unknown", _PERSISTENCE_DEFAULT_EXPLANATION
             )
-            if persistence_cause == "corrupt":
-                # Copy-pasteable, so name the store that actually failed: the agent's own
-                # SessionDB. A multi-profile backend (Desktop serve) hosts sessions whose
-                # state.db is NOT the process default, so the default would send the operator
-                # to inspect/repair the wrong profile's database (#105887).
-                from hermes_constants import get_default_hermes_root
+            if persistence_cause in ("corrupt", "fts_index"):
+                # Copy-pasteable, so name the store that actually failed and pin the profile:
+                # a multi-profile backend (Desktop serve) hosts sessions whose state.db is NOT
+                # the process default, and a bare `hermes` follows active_profile (#105887).
+                from hermes_constants import get_default_hermes_root, profile_cli_selector
                 from hermes_state import _default_db_path
 
+                body = body.replace("{profile_arg}", profile_cli_selector())
                 body = body.replace("{db_path}", str(db_path or _default_db_path()))
                 body = body.replace(
                     "{backups_dir}", str(get_default_hermes_root() / "backups")

--- a/agent/turn_explainers.py
+++ b/agent/turn_explainers.py
@@ -151,6 +151,16 @@ _PERSISTENCE_CAUSE_EXPLANATIONS: Dict[str, str] = {
         "3. Restore from a backup in {backups_dir}/\n"
         "Then send your message again."
     ),
+    # SQLite scoped the corruption to the FTS index and the derived indexes could not be
+    # detached, so this write did not land; the message store itself is intact (#97794).
+    "fts_index": (
+        "the turn was stopped because the session search index (FTS5) "
+        "is corrupt and could not be detached, so this message was not "
+        "saved. The message store itself is not damaged: do not run "
+        "recovery tools or restore a backup. Run `hermes doctor --fix` "
+        "(or restart Hermes, which repairs the index on open), then "
+        "send your message again."
+    ),
     "disk": (
         "the turn was stopped because session storage could not "
         "be written (the transcript would have been lost on "

--- a/contributors/emails/91889514+jangomango76@users.noreply.github.com
+++ b/contributors/emails/91889514+jangomango76@users.noreply.github.com
@@ -1,0 +1,2 @@
+jangomango76
+# PR #103321 salvage

--- a/contributors/emails/devops@77hub.com
+++ b/contributors/emails/devops@77hub.com
@@ -1,0 +1,2 @@
+TaoMasterCoder
+# PR #102808 salvage (header-damaged state.db in lost_and_found lane; #106667)

--- a/contributors/emails/gunwoo@wustl.edu
+++ b/contributors/emails/gunwoo@wustl.edu
@@ -1,0 +1,2 @@
+leegunwoo98
+# PR #91413 salvage (skip destination-rejected rows in partial recovery; #102240)

--- a/contributors/emails/zsulthan9@gmail.com
+++ b/contributors/emails/zsulthan9@gmail.com
@@ -1,0 +1,2 @@
+SulthanZahran1
+# PR #97843 salvage

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -835,7 +835,8 @@ class GatewayNotificationsMixin:
                 return
         from hermes_constants import get_default_hermes_root
         from hermes_state import _default_db_path, classify_persistence_error, format_session_db_unavailable
-        if classify_persistence_error(error) == "corrupt":
+        cause = classify_persistence_error(error)
+        if cause == "corrupt":
             # Copy-pasteable, so name the real store (profiles / HERMES_HOME do not live under ~/.hermes).
             db_path = _default_db_path()
             backups_dir = get_default_hermes_root() / "backups"
@@ -853,6 +854,15 @@ class GatewayNotificationsMixin:
                 "vulnerable sqlite3 CLI can corrupt it further\n"
                 f"3. Restore from a backup in {backups_dir}/\n"
                 "Run `hermes doctor` for sanitized diagnostics."
+            )
+        elif cause == "fts_index":
+            # Index-scoped corruption: the message tables are not damaged, so the recover /
+            # restore advice above would be destructive on a healthy file (#97794).
+            message = (
+                "⚠️ Session database reported a corruption error confined to the search index "
+                "(FTS5); the message tables are not damaged. Messages may not be persisted until "
+                "it is repaired: run `hermes doctor --fix`, then restart the gateway. Do not run "
+                "recovery tools or restore a backup unless `hermes doctor` confirms damage."
             )
         else:
             message = (

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -833,27 +833,29 @@ class GatewayNotificationsMixin:
             if not error:
                 logger.info("state.db recovered before the home-channel warning went out; not broadcasting")
                 return
-        from hermes_constants import get_default_hermes_root
+        from hermes_constants import get_default_hermes_root, profile_cli_selector
         from hermes_state import _default_db_path, classify_persistence_error, format_session_db_unavailable
         cause = classify_persistence_error(error)
+        # Copy-pasteable, so name the real store and pin the profile: a bare `hermes` follows
+        # active_profile, which may be a different database (#105887).
+        profile_arg = profile_cli_selector()
         if cause == "corrupt":
-            # Copy-pasteable, so name the real store (profiles / HERMES_HOME do not live under ~/.hermes).
             db_path = _default_db_path()
             backups_dir = get_default_hermes_root() / "backups"
             message = (
                 "⚠️ Session database corruption detected. Messages may not be "
                 "persisted. Recovery options:\n"
-                "1. Run `hermes doctor --fix`\n"
+                f"1. Run `hermes {profile_arg}doctor --fix`\n"
                 "2. Stop the gateway, then recover with:\n"
-                f"   hermes sessions recover --source {db_path} "
+                f"   hermes {profile_arg}sessions recover --source {db_path} "
                 "--inspect-only\n"
-                "   (if it reports recoverable) hermes sessions recover "
+                f"   (if it reports recoverable) hermes {profile_arg}sessions recover "
                 f"--source {db_path} --output recovered-state.db\n"
                 "   — recovery snapshots the damaged file first; do NOT run "
                 "`sqlite3 ... \".recover\"` against the live state.db, a "
                 "vulnerable sqlite3 CLI can corrupt it further\n"
                 f"3. Restore from a backup in {backups_dir}/\n"
-                "Run `hermes doctor` for sanitized diagnostics."
+                f"Run `hermes {profile_arg}doctor` for sanitized diagnostics."
             )
         elif cause == "fts_index":
             # Index-scoped corruption: the message tables are not damaged, so the recover /
@@ -861,7 +863,7 @@ class GatewayNotificationsMixin:
             message = (
                 "⚠️ Session database reported a corruption error confined to the search index "
                 "(FTS5); the message tables are not damaged. Messages may not be persisted until "
-                "it is repaired: run `hermes doctor --fix`, then restart the gateway. Do not run "
+                f"it is repaired: run `hermes {profile_arg}doctor --fix`, then restart the gateway. Do not run "
                 "recovery tools or restore a backup unless `hermes doctor` confirms damage."
             )
         else:

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -705,7 +705,7 @@ def _sessions_optimize(_engine: HermesConsoleEngine, args: list[str]) -> None:
 
 
 @_captured
-def _sessions_repair(_engine: HermesConsoleEngine, args: list[str]) -> None:
+def _sessions_repair(_engine: HermesConsoleEngine, args: list[str]) -> int | None:
     ns = _parse(
         "sessions repair", args, (("--check-only",), dict(action="store_true")),
         (("--no-backup",), dict(action="store_true")))
@@ -721,7 +721,7 @@ def _sessions_repair(_engine: HermesConsoleEngine, args: list[str]) -> None:
         return
     print(f"{db_path} does not open cleanly: {reason}")
     if ns.check_only:
-        return
+        return 1  # _capture_output turns a non-zero status into a ConsoleCommandError carrying the printed reason
     report = repair_state_db_schema(db_path, backup=not ns.no_backup)
     if not report.get("repaired"):
         raise ConsoleCommandError(f"Repair failed: {report.get('error')}")

--- a/hermes_cli/doctor_state.py
+++ b/hermes_cli/doctor_state.py
@@ -162,6 +162,8 @@ def _session_count(state_db_path: Path):
 
 
 # Corruption class -> (ok label, not-fixed label, failed issue, fix hint). ``{count}`` = recovered sessions.
+# ``structural`` has no in-place repair: an FTS rebuild cannot fix a canonical b-tree, and the
+# ``.malformed-backup`` the repair path would leave beside state.db is a copy of the same damage (#88587).
 _STATE_DB_REPAIRS = {
     "fts": ("Repaired state.db FTS write health",
             "state.db FTS write-health repair did not recover automatically",
@@ -172,10 +174,21 @@ _STATE_DB_REPAIRS = {
                "state.db schema malformed and auto-repair failed — restore from the backup copy beside state.db",
                "state.db schema malformed — run 'hermes doctor --fix' (or 'hermes sessions repair') to recover hidden sessions"),
 }
+_STATE_DB_STRUCTURAL_ISSUE = (
+    "state.db structural corruption (canonical tables/indexes damaged, not the FTS index) — an FTS rebuild "
+    "cannot repair it. Stop the gateway, then run 'hermes {profile_arg}sessions recover --source {db_path} "
+    "--inspect-only' and, if it reports recoverable, 'hermes {profile_arg}sessions recover --source {db_path} "
+    "--output recovered-state.db'. Do NOT restore a .malformed-backup copy beside state.db: it is a snapshot "
+    "of the same corrupt file."
+)
 
 
 def _repair_state_db(f: Finding, should_fix: bool, state_db_path: Path, kind: str) -> None:
     """Shared --fix path for both state.db corruption classes (FTS write health, malformed schema)."""
+    if kind == "structural":
+        from hermes_constants import profile_cli_selector
+        return f.manual_issues.append(_STATE_DB_STRUCTURAL_ISSUE.format(
+            profile_arg=profile_cli_selector(), db_path=state_db_path))
     ok_label, not_fixed_label, failed_issue, fix_hint = _STATE_DB_REPAIRS[kind]
     if not should_fix:
         return f.issues.append(fix_hint)
@@ -200,11 +213,15 @@ def _state_db_health(f: Finding, should_fix: bool, state_db_path: Path, _DHH: st
         check_ok(f"{_DHH}/state.db exists ({_session_count(state_db_path)} sessions)")
         # COUNT(*) succeeds even when the FTS index is corrupt and every write fails through the triggers;
         # _db_opens_cleanly drives a rolled-back write to surface that.
-        from hermes_state_repair import _db_opens_cleanly
+        from hermes_state_repair import _db_opens_cleanly, state_db_has_structural_damage
         # `_db_opens_cleanly` now drives a rolled-back write so this otherwise-silent corruption class is
         # surfaced (and repaired in place with --fix). See #50502.
         _write_reason = _db_opens_cleanly(state_db_path)
         if _write_reason is not None:
+            if state_db_has_structural_damage(state_db_path):
+                check_warn(f"{_DHH}/state.db has structural corruption (canonical tables/indexes damaged, "
+                           "not the FTS index)", f"({_write_reason})")
+                return _repair_state_db(f, should_fix, state_db_path, "structural")
             check_warn(f"{_DHH}/state.db fails a write-health probe (FTS index may be corrupt)", f"({_write_reason})")
             _repair_state_db(f, should_fix, state_db_path, "fts")
     except Exception as e:

--- a/hermes_cli/session_lost_and_found.py
+++ b/hermes_cli/session_lost_and_found.py
@@ -180,10 +180,41 @@ def _cli_supports_recover(binary: str) -> bool:
         shutil.rmtree(scratch_dir, ignore_errors=True)
 
 
+SQLITE_HEADER_LENGTH = 100
+
+
 def run_cli_lost_and_found_recover(
     source: Path, lf_path: Path, sqlite3_bin: str, *, timeout: float = 3600.0,
 ) -> dict[str, Any]:
-    """Run ``sqlite3 <source> .recover`` streamed into a fresh scratch DB."""
+    """Run ``sqlite3 <source> .recover`` streamed into a fresh scratch DB.
+
+    A file whose page-1 header is garbage (SIGKILL mid-write) is refused outright by the shell
+    (``file is not a database``, rc 26) although the data pages after it survive. ``.recover``
+    walks pages via sqlite_dbpage and only trips on the magic check, so on that refusal the
+    100-byte header of the private snapshot is zeroed and the attempts rerun; a zeroed header
+    makes .recover infer page size and layout from the pages themselves (a spliced donor header
+    would instead report a database size/freelist that contradicts the file). ``source`` is
+    the caller's snapshot copy, never the user's file (#106667).
+    """
+    attempts = _cli_recover_attempts(source, lf_path, sqlite3_bin, timeout=timeout)
+    if attempts[-1]["usable"]:
+        return {"binary": sqlite3_bin, "attempts": attempts}
+    if any("not a database" in a["dump_stderr_tail"] for a in attempts):
+        with source.open("r+b") as handle:
+            handle.write(bytes(SQLITE_HEADER_LENGTH))
+        attempts += _cli_recover_attempts(source, lf_path, sqlite3_bin, timeout=timeout)
+        if attempts[-1]["usable"]:
+            return {"binary": sqlite3_bin, "attempts": attempts, "header_zeroed": True}
+    details = "; ".join(
+        f"[{a['command']}] dump rc={a['dump_returncode']} load rc={a['load_returncode']} "
+        f"{a['dump_stderr_tail'] or a['load_stderr_tail']}".strip()
+        for a in attempts
+    )
+    raise LostAndFoundError(f"sqlite3 .recover did not produce a usable lost_and_found database: {details}")
+
+
+def _cli_recover_attempts(source: Path, lf_path: Path, sqlite3_bin: str, *, timeout: float) -> list[dict[str, Any]]:
+    """``--ignore-freelist`` first (no resurrected deleted rows), plain ``.recover`` for older shells."""
     attempts: list[dict[str, Any]] = []
     for command in (".recover --ignore-freelist", ".recover"):
         if lf_path.exists():
@@ -211,13 +242,8 @@ def run_cli_lost_and_found_recover(
             "usable": _lost_and_found_db_usable(lf_path),
         })
         if attempts[-1]["usable"]:
-            return {"binary": sqlite3_bin, "attempts": attempts}
-    details = "; ".join(
-        f"[{a['command']}] dump rc={a['dump_returncode']} load rc={a['load_returncode']} "
-        f"{a['dump_stderr_tail'] or a['load_stderr_tail']}".strip()
-        for a in attempts
-    )
-    raise LostAndFoundError(f"sqlite3 .recover did not produce a usable lost_and_found database: {details}")
+            break
+    return attempts
 
 
 def _lost_and_found_db_usable(lf_path: Path) -> bool:

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -414,6 +414,22 @@ def _salvage_rowid_bounds(source: sqlite3.Connection, table: str) -> dict[str, A
         result["empty" if not result["errors"] else "unavailable"] = True
         return result
 
+    # An ordered LIMIT 1 walks the table b-tree and dies on a damaged edge leaf, while the
+    # aggregate lets the planner answer from any covering index (every Hermes table has at
+    # least a PRIMARY KEY autoindex). Ask it before falling back to the synthetic domain:
+    # bisecting from INT64_MIN burned the whole query budget on a 4-row table (#98050).
+    missing = [edge for edge in ("low", "high") if rows[edge] is None]
+    if missing:
+        try:
+            aggregate = source.execute(f'SELECT min(rowid), max(rowid) FROM "{table}"').fetchone()
+        except sqlite3.DatabaseError as exc:
+            result["errors"].append(f"aggregate rowid bounds: {exc}")
+        else:
+            for edge, value in zip(("low", "high"), aggregate):
+                if rows[edge] is None and value is not None:
+                    rows[edge] = int(value)
+                    result.setdefault("aggregate_edges", []).append(edge)
+
     # A damaged edge can stop one ordered probe. Keep the readable edge and bound the other side by the
     # SQLite rowid domain, so bisection never assumes user databases hold only positive ids.
     if rows["low"] is None:

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -1040,6 +1040,12 @@ def _recover_via_lost_and_found(
         "BEST-EFFORT page-level salvage: the source table schemas were unreadable, so rows were rebuilt from raw "
         "pages and mapped heuristically. Review every count before trusting this output."
     )
+    if cli_report.get("header_zeroed"):
+        verification["warnings"].append(
+            "header salvage: SQLite refused the source outright (page-1 header damaged, 'file is not a "
+            "database'); the header of the private snapshot copy was zeroed so .recover could walk the "
+            "surviving pages. Rows written only to a -wal after the last checkpoint are not included."
+        )
     verification.update(loss_detected=True, complete=False)
     # Structural checks cannot see a positional mis-mapping: every row still inserts, so integrity/FK/FTS
     # stay green. A systematic timestamp violation is the semantic tell — never report such a salvage as verified.

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -511,8 +511,15 @@ class _RowidRangeSalvage:
         if not self._keep([value]):
             result["excluded_rows"] += 1
             return True
-        with _immediate_transaction(self.destination):
-            self.destination.execute(self.insert_sql, value)
+        try:
+            with _immediate_transaction(self.destination):
+                self.destination.execute(self.insert_sql, value)
+        except sqlite3.IntegrityError as exc:
+            # A phantom row from a damaged page (NULL in a NOT NULL column, FK to nothing) is rejected
+            # by the destination schema; report it as a skipped singleton instead of aborting the table.
+            result["destination_rejected_rows"] += 1
+            self._skip(rowid, rowid, f"destination constraint rejected row: {exc}")
+            return True
         result["copied_rows"] += 1
         result["exact_lookup_recovered"] += 1
         return True
@@ -568,7 +575,8 @@ def _copy_table_salvage(
     """Best-effort rowid-range copy that continues past damaged source pages."""
     result: dict[str, Any] = {
         "mode": "rowid_range_salvage", "source_rows": source_rows, "copied_rows": 0, "excluded_rows": 0,
-        "columns": [], "range_queries": 0, "exact_lookup_recovered": 0, "skipped_rowid_ranges": [],
+        "columns": [], "range_queries": 0, "exact_lookup_recovered": 0, "destination_rejected_rows": 0,
+        "skipped_rowid_ranges": [],
     }
     columns = _compatible_columns(source, destination, table, result)
     if columns is None:

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -97,7 +97,7 @@ def _cmd_repair(args):
         return
     print(f"✗ {db_path} does not open cleanly: {reason}")
     if getattr(args, "check_only", False):
-        return
+        return 1
     print("Repairing (a backup copy is made first)…")
     report = repair_state_db_schema(db_path, backup=not getattr(args, "no_backup", False))
     if report.get("repaired"):

--- a/hermes_cli/web_routers/_common.py
+++ b/hermes_cli/web_routers/_common.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from typing import Any, Callable, Optional
+import sqlite3
+import time
+from typing import Any, Callable, Dict, Optional
 
 from fastapi import HTTPException
 
@@ -76,3 +78,39 @@ def require(value: Optional[str], detail: str) -> str:
     if not stripped:
         raise HTTPException(status_code=400, detail=detail)
     return stripped
+
+
+# Corrupt-store reporting for polled read endpoints. The dashboard polls analytics every few
+# seconds; a persistently malformed state.db once produced ~520K identical tracebacks in 24 h
+# (#96591). One WARNING per store per interval, then debug; the caller gets an explicit status
+# instead of a 500. The file is never quarantined or renamed from here — that is `hermes doctor`'s job.
+_CORRUPT_STORE_WARN_INTERVAL_S = 300.0
+_corrupt_store_warned_at: Dict[str, float] = {}  # {db path: monotonic}
+
+CORRUPT_STORE_DETAIL = {
+    "error": "state_db_corrupt",
+    "message": "state.db corrupt — run `hermes doctor` (then `hermes doctor --fix` or `hermes sessions repair`).",
+}
+
+
+@contextlib.contextmanager
+def corrupt_store_as_status(db_path):
+    """Map a corrupt-image ``sqlite3.DatabaseError`` from a state.db read to a 503 status
+    payload, warning once per store per :data:`_CORRUPT_STORE_WARN_INTERVAL_S`.
+    Busy/locked and every other error propagate unchanged."""
+    from hermes_state_errors import is_malformed_db_error
+
+    try:
+        yield
+    except sqlite3.DatabaseError as exc:
+        if not is_malformed_db_error(exc):
+            raise
+        key, now = str(db_path), time.monotonic()
+        last = _corrupt_store_warned_at.get(key)
+        if last is None or now - last >= _CORRUPT_STORE_WARN_INTERVAL_S:
+            _corrupt_store_warned_at[key] = now
+            log.warning("state.db at %s is corrupt (%s); dashboard reads return a status payload until it is "
+                        "repaired — run `hermes doctor`", db_path, exc)
+        else:
+            log.debug("state.db at %s still corrupt: %s", db_path, exc)
+        raise HTTPException(status_code=503, detail={**CORRUPT_STORE_DETAIL, "path": key}) from exc

--- a/hermes_cli/web_routers/analytics.py
+++ b/hermes_cli/web_routers/analytics.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, HTTPException, Query
 
 from hermes_cli.config import get_config_path, read_raw_config
 from hermes_cli.web_deps import late
+from hermes_cli.web_routers._common import corrupt_store_as_status
 from hermes_cli.web_server_profiles import (
     _approval_mode_of, _aux_task_summary, _aux_usage_rows, _broadcast_gateway_session_info, _is_other_profile, _merge_aux_into_by_model,
 )
@@ -22,6 +23,7 @@ router = APIRouter()
 
 # Late-bound so a test's monkeypatch on the owning module wins at call time.
 _open_session_db_for_profile = late("_open_session_db_for_profile", "hermes_cli.web_server_sessions")
+_session_db_path_for_profile = late("_session_db_path_for_profile", "hermes_cli.web_server_sessions")
 _profile_scope = late("_profile_scope", "hermes_cli.web_server_profiles")
 save_config = late("save_config", "hermes_cli.config")
 
@@ -147,7 +149,8 @@ async def get_usage_analytics(
     values would force expensive full-history SQL and InsightsEngine work, or
     produce empty/inverted time windows. The UI only offers 7/30/90-day
     presets."""
-    return await asyncio.to_thread(_get_usage_analytics, days, profile)
+    with corrupt_store_as_status(_session_db_path_for_profile(profile)):
+        return await asyncio.to_thread(_get_usage_analytics, days, profile)
 
 
 _USAGE_KEYS = (
@@ -305,4 +308,5 @@ async def get_models_analytics(
     profile: Optional[str] = None,
 ):
     """Return model analytics without blocking the serving event loop."""
-    return await asyncio.to_thread(_get_models_analytics, days, profile)
+    with corrupt_store_as_status(_session_db_path_for_profile(profile)):
+        return await asyncio.to_thread(_get_models_analytics, days, profile)

--- a/hermes_cli/web_server_sessions.py
+++ b/hermes_cli/web_server_sessions.py
@@ -180,20 +180,23 @@ def _open_session_db_at_path(db_path: Path, *, read_only: bool):
             return _open_probed()
 
 
-def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):
-    """Open a SessionDB for ``profile`` (None/empty = this process's own state.db).
-
-    Access-mode semantics: see :func:`_open_session_db_at_path`.
-    """
+def _session_db_path_for_profile(profile: Optional[str]) -> Path:
+    """state.db path for ``profile`` (None/empty = this process's own)."""
     from hermes_cli.web_server_cron import _cron_profile_home
     from hermes_state import _default_db_path
 
     if profile:
         _name, home = _cron_profile_home(profile)
-        db_path = Path(home) / "state.db"
-    else:
-        db_path = Path(_default_db_path())
-    return _open_session_db_at_path(db_path, read_only=read_only)
+        return Path(home) / "state.db"
+    return Path(_default_db_path())
+
+
+def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):
+    """Open a SessionDB for ``profile`` (None/empty = this process's own state.db).
+
+    Access-mode semantics: see :func:`_open_session_db_at_path`.
+    """
+    return _open_session_db_at_path(_session_db_path_for_profile(profile), read_only=read_only)
 
 
 # In-process throttle for the opportunistic auto-archive trigger, keyed by

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -771,6 +771,15 @@ def display_hermes_home() -> str:
         return str(home)
 
 
+def profile_cli_selector() -> str:
+    """``-p <name> `` (trailing space) pinning copy-pasteable ``hermes ...`` guidance to the
+    active NAMED profile, else ``""``: a bare ``hermes`` follows the sticky ``active_profile``
+    file, which can name a different database than the one that failed (#105887). A custom
+    home outside the profile tree has no selector (only HERMES_HOME names it)."""
+    name = profile_name_for_home(get_hermes_home())
+    return f"-p {name} " if name and name != "default" else ""
+
+
 def secure_parent_dir(path: Path) -> None:
     """Chmod ``0o700`` on *path*'s parent, refusing ``/`` and top-level dirs (misresolved HERMES_HOME)."""
     parent = path.parent.resolve()

--- a/hermes_state_errors.py
+++ b/hermes_state_errors.py
@@ -3,6 +3,7 @@ Shared by hermes_state and its mixins; string predicates match wrapped RPC
 strings as well as live sqlite3 exceptions."""
 
 import errno
+import re
 import sqlite3
 
 # Malformed schema: ``sqlite_master`` itself is inconsistent (typically a DUPLICATE
@@ -74,8 +75,8 @@ def is_disk_full_error(exc: BaseException | str | None) -> bool:
 
 # Every classify_persistence_error bucket; consumers enumerate this tuple.
 PERSISTENCE_ERROR_CAUSES = (
-    "locked", "compression", "compression_closed", "turn_lease", "corrupt", "replaced",
-    "deleted_wal", "disk", "unknown",
+    "locked", "compression", "compression_closed", "turn_lease", "corrupt", "fts_index",
+    "replaced", "deleted_wal", "disk", "unknown",
 )
 
 
@@ -87,6 +88,38 @@ PERSISTENCE_ERROR_CAUSES = (
 _DB_CORRUPTION_MARKERS = (
     "malformed", "file is not a database", "not a database", "database corruption",
 )
+
+# The module constant exists on Python 3.11+; the numeric value is stable across SQLite releases.
+SQLITE_CORRUPT_VTAB = getattr(sqlite3, "SQLITE_CORRUPT_VTAB", 267)
+
+# Every FTS object hangs off this prefix: the virtual tables and their _data/_idx/_content/
+# _docsize/_config shadow b-trees. FTS5 names the table in its own corruption reports.
+_FTS_OBJECT_RE = re.compile(r"\bmessages_fts\w*")
+
+
+def is_fts_scoped_corruption_error(exc_or_str) -> bool:
+    """Corruption SQLite itself attributes to the FTS index layer: the ONE provenance rule
+    shared by the write-repair gate (``SessionDB._is_fts_write_corruption_error``), the
+    gateway transcript retry and :func:`classify_persistence_error` (#96038, #97794).
+
+    A known result code outranks prose: ``SQLITE_CORRUPT_VTAB`` is FTS-scoped even with
+    the generic malformed-image text older SQLite builds emit, while bare ``SQLITE_CORRUPT``
+    / ``SQLITE_NOTADB`` carry no object scope and any other known code contradicts
+    FTS-looking prose, so both fail closed. Only without a code (Python < 3.11, RPC-wrapped
+    strings) does the text decide, and then only an ``fts5:`` corruption report or a
+    corruption marker that names a ``messages_fts*`` object counts.
+    """
+    if exc_or_str is None:
+        return False
+    code = getattr(exc_or_str, "sqlite_errorcode", None)
+    if code is not None:
+        return code == SQLITE_CORRUPT_VTAB
+    text = (exc_or_str if isinstance(exc_or_str, str) else str(exc_or_str)).lower()
+    if not _FTS_OBJECT_RE.search(text):
+        return False
+    if text.startswith("fts5:") and "corrupt" in text:
+        return True
+    return any(marker in text for marker in _DB_CORRUPTION_MARKERS)
 
 
 class CompressionSessionClosedError(RuntimeError):
@@ -205,8 +238,10 @@ def classify_persistence_error(exc_or_str) -> str:
     matches: "locked" = busy, retry; "disk" = full/read-only/permissions;
     "compression" = a live lease refused the write; "compression_closed" = adopt
     the rotated session id; "turn_lease" = fencing, not storage; "corrupt" =
-    file damage (repair path, not disk space); "replaced" = main-file replacement;
-    "deleted_wal" = a retired sidecar generation requiring capture inspection."""
+    file damage (repair path, not disk space); "fts_index" = SQLite scoped the
+    corruption to the FTS index (the transcript store is not damaged); "replaced" =
+    main-file replacement; "deleted_wal" = a retired sidecar generation requiring
+    capture inspection."""
     if exc_or_str is None:
         return "unknown"
     # Lease refusals contain neither "locked" nor "busy": match by type first,
@@ -216,6 +251,10 @@ def classify_persistence_error(exc_or_str) -> str:
     for exc_type, cause in _PERSISTENCE_CAUSE_BY_TYPE:
         if isinstance(exc_or_str, exc_type):
             return cause
+    # Provenance before prose: an FTS-scoped result code (or, without one, an fts5 report
+    # naming messages_fts*) is index damage, never whole-file corruption (#97794).
+    if is_fts_scoped_corruption_error(exc_or_str):
+        return "fts_index"
     text = str(exc_or_str).lower()
     for markers, cause in _PERSISTENCE_CAUSE_BY_PHRASE:
         if any(marker in text for marker in markers):

--- a/hermes_state_fts.py
+++ b/hermes_state_fts.py
@@ -10,6 +10,7 @@ from typing import Sequence
 
 from hermes_constants import get_hermes_home
 from hermes_state_common import FTS_CJK_STALE_KEY, FTS_STALE_KEY, _FTS_CJK_TRIGGERS, _FTS_TRIGGERS
+from hermes_state_errors import is_fts_scoped_corruption_error
 
 # caplog tests pin the "hermes_state" logger name.
 logger = logging.getLogger("hermes_state")
@@ -341,13 +342,11 @@ class SessionFtsSetupMixin:
 
     @staticmethod
     def _is_fts_write_corruption_error(exc: sqlite3.DatabaseError) -> bool:
-        """Corruption SQLite identifies as FTS-scoped (SQLITE_CORRUPT_VTAB, or an
-        ``fts5:`` message on older builds); a bare malformed image is structural."""
-        error_code = getattr(exc, "sqlite_errorcode", None)
-        if error_code is not None:
-            return error_code == getattr(sqlite3, "SQLITE_CORRUPT_VTAB", 267)
-        msg = str(exc).lower()
-        return msg.startswith("fts5:") and "corrupt structure" in msg
+        """Corruption SQLite identifies as FTS-scoped (SQLITE_CORRUPT_VTAB, or an ``fts5:``
+        report naming ``messages_fts*`` on builds without result codes); a bare malformed
+        image is structural. One rule, shared with ``classify_persistence_error`` and the
+        gateway transcript retry: see :func:`hermes_state_errors.is_fts_scoped_corruption_error`."""
+        return is_fts_scoped_corruption_error(exc)
 
     def _enter_fts_fail_open(self, exc: sqlite3.DatabaseError) -> bool:
         """Detach corrupt FTS indexes so canonical writes can continue. Breadcrumb +

--- a/hermes_state_fts.py
+++ b/hermes_state_fts.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sqlite3
 from pathlib import Path
+from typing import Sequence
 
 from hermes_constants import get_hermes_home
 from hermes_state_common import FTS_CJK_STALE_KEY, FTS_STALE_KEY, _FTS_CJK_TRIGGERS, _FTS_TRIGGERS
@@ -120,6 +121,47 @@ def load_fts5_cjk_extension(conn: sqlite3.Connection) -> bool:
     except Exception:
         logger.warning("fts5_cjk extension load failed (%s)", path, exc_info=True)
         return False
+
+
+# FTS5 shadow tables the virtual-table engine owns. `sqlite3 .recover` re-emits them
+# as ordinary tables but cannot re-emit the CREATE VIRTUAL TABLE row, so every later
+# CREATE VIRTUAL TABLE fails with "fts5: error creating shadow table <name>: table
+# already exists" until the orphans are dropped (#103840).
+_FTS5_SHADOW_SUFFIXES = ("content", "data", "docsize", "idx", "config")
+
+
+def _drop_orphan_fts_shadow_tables(cursor: sqlite3.Cursor, families: Sequence[str]) -> list[str]:
+    """Drop, per family, shadow tables whose virtual table row is absent from sqlite_master.
+
+    Matches exact shadow names only (never a prefix LIKE, so the base family cannot reach
+    ``messages_fts_trigram_*``) and leaves a family alone whenever its vtable is live. The
+    shadows are derived index state; the caller recreates and rebuilds from ``messages``.
+    Returns the families that were repaired.
+    """
+    repaired: list[str] = []
+    for family in families:
+        vtable_live = cursor.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? "
+            "AND sql LIKE 'CREATE VIRTUAL TABLE%'",
+            (family,),
+        ).fetchone()
+        if vtable_live:
+            continue
+        shadows = [f"{family}_{suffix}" for suffix in _FTS5_SHADOW_SUFFIXES]
+        orphans = [row[0] for row in cursor.execute(
+            f"SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ({','.join('?' for _ in shadows)})",
+            shadows,
+        ).fetchall()]
+        if not orphans:
+            continue
+        for name in orphans:
+            cursor.execute(f'DROP TABLE "{name}"')
+        logger.warning(
+            "Dropped orphan FTS5 shadow tables of %s (%s); the index is recreated from messages",
+            family, ", ".join(orphans),
+        )
+        repaired.append(family)
+    return repaired
 
 
 class SessionFtsSetupMixin:

--- a/hermes_state_repair.py
+++ b/hermes_state_repair.py
@@ -391,11 +391,14 @@ def _persistent_repair_attempts_exhausted(db_path: Path) -> bool:
 
 
 def _persistent_repair_exhausted_error(db_path: Path) -> str:
-    """The stable operator-facing diagnostic for an exhausted repair budget."""
+    """The stable operator-facing diagnostic for an exhausted repair budget. The ``hermes`` commands
+    carry the profile selector: a bare ``hermes`` follows ``active_profile`` (#105887)."""
+    from hermes_constants import profile_cli_selector
+    profile_arg = profile_cli_selector()
     return (f"automatic repair has already failed {_MAX_PERSISTENT_REPAIR_ATTEMPTS} times on this exact file — the "
             f"corruption is beyond the schema/FTS repair strategies (likely b-tree page damage). Manual recovery "
-            f"required: restore a backup, or salvage with `hermes sessions recover --source {db_path} "
-            f"--inspect-only`, then (if it reports recoverable) `hermes sessions recover --source {db_path} "
+            f"required: restore a backup, or salvage with `hermes {profile_arg}sessions recover --source {db_path} "
+            f"--inspect-only`, then (if it reports recoverable) `hermes {profile_arg}sessions recover --source {db_path} "
             f"--output recovered-state.db` (recovery snapshots the damaged file first, then runs the page-level "
             f"`.recover` lane on the copy; do NOT point a raw `sqlite3` shell at the live database). "
             f"Delete {_repair_ledger_path(db_path).name} to force another automatic attempt.")

--- a/hermes_state_repair.py
+++ b/hermes_state_repair.py
@@ -788,7 +788,11 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                         # image is malformed") while reads of the FTS5 table itself parse fine.
                         return f"fts5 read probe failed on {fts_table}: {exc}"
             # FTS write probe: drive a row through the messages_fts* triggers in a transaction that is always
-            # rolled back.
+            # rolled back. The trigger INSERT alone only buffers the row in FTS5's in-memory segment; the
+            # ``flush`` command writes that segment to ``<fts>_idx``/``_data`` exactly as a committed append
+            # would, so a stale ``_idx`` row at the next segid (IntegrityError "constraint failed", the #100227
+            # class: integrity_check and MATCH both clean, every real append fails) is hit here rather than
+            # by the user's next message.
             probe_session_id = f"_hermes_fts_health_probe_{time.time_ns()}"
             try:
                 conn.execute("BEGIN IMMEDIATE")
@@ -796,16 +800,24 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                              (probe_session_id, "_health_probe", time.time()))
                 conn.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
                              (probe_session_id, "user", "_fts_health_probe", time.time()))
-                conn.execute("ROLLBACK")
-            except sqlite3.OperationalError as exc:
-                with contextlib.suppress(sqlite3.Error):
-                    conn.execute("ROLLBACK")
+                for fts_table in _FTS_TABLES:
+                    try:
+                        conn.execute(f"INSERT INTO {fts_table}({fts_table}) VALUES('flush')")
+                    except sqlite3.OperationalError as exc:
+                        if not (SessionDB._is_fts5_unavailable_error(exc) or _schema_not_built(exc)):
+                            raise
+            except sqlite3.DatabaseError as exc:
+                # IntegrityError is a DatabaseError sibling of OperationalError, not a child: catching only the
+                # latter let the trigram-segment collision report "healthy".
                 # Missing messages/sessions tables = brand new file mid-init, not corruption. "no such tokenizer":
                 # this process lacks the cjk extension the DB's index needs — capability gap; a tokenizer-less
                 # SessionDB drops the triggers itself.
                 if _schema_not_built(exc) or "no such tokenizer: cjk_unicode61" in str(exc).lower():
                     return None
-                return str(exc)
+                return f"fts5 write probe failed: {exc}"
+            finally:
+                with contextlib.suppress(sqlite3.Error):
+                    conn.execute("ROLLBACK")
             return None
     except sqlite3.DatabaseError as exc:
         return str(exc)

--- a/hermes_state_repair.py
+++ b/hermes_state_repair.py
@@ -12,6 +12,7 @@ import itertools
 import json
 import logging
 import os
+import re
 import shutil
 import sqlite3
 import stat
@@ -682,6 +683,62 @@ def _copy_database_snapshot(source_path: Path, destination_path: Path, *,
 def _schema_not_built(exc: BaseException) -> bool:
     """``no such table/column``: FTS5 / core tables not created yet (brand new file mid-init)."""
     return any(m in str(exc).lower() for m in ("no such table", "no such column"))
+
+
+# Hermes-owned FTS5 objects: the virtual tables and their shadow b-trees. Full-matched, so a
+# user-created lookalike (``archive_fts_data``) is not swept into the rebuildable set.
+_FTS_OBJECT_RE = re.compile(
+    r"messages_fts(_trigram|_cjk)?(_data|_idx|_content|_docsize|_config|_segdir|_segments)?"
+)
+_INTEGRITY_TREE_RE = re.compile(r"\bTree (\d+)\b")
+_INTEGRITY_MISSING_INDEX_RE = re.compile(r"missing from index (\S+)")
+
+
+def integrity_damage_is_structural(integrity_lines, master_rows) -> bool:
+    """True when any damaged object named by ``PRAGMA integrity_check`` output lies outside
+    the FTS shadow set: a ``Tree N`` id mapped through ``sqlite_master.rootpage``, an index in
+    ``row N missing from index X``, or the file's own freelist. Unparseable lines are not
+    counted (the FTS wording stays, which is incomplete rather than wrong). #88587: an FTS
+    rebuild cannot repair a canonical b-tree, and the ``.malformed-backup`` it leaves behind
+    is a snapshot of the same damage."""
+    name_by_rootpage = {int(rp): name for rp, _type, name in master_rows if rp}
+    for line in integrity_lines:
+        text = str(line)
+        if text.startswith("Freelist"):
+            return True
+        tree = _INTEGRITY_TREE_RE.search(text)
+        if tree:
+            name = name_by_rootpage.get(int(tree.group(1)), "")
+            if name and not _FTS_OBJECT_RE.fullmatch(name):
+                return True
+        missing = _INTEGRITY_MISSING_INDEX_RE.search(text)
+        if missing and not _FTS_OBJECT_RE.fullmatch(missing.group(1)):
+            return True
+    return False
+
+
+def state_db_has_structural_damage(db_path: Path) -> bool:
+    """Read-only ``integrity_check`` + ``sqlite_master`` rootpage map on a fresh connection;
+    ``integrity_damage_is_structural`` over the result. A check that RAISES instead of
+    reporting (a torn page under the walk) is structural too: no FTS-only fixture does that
+    while ``messages``/``sessions`` read cleanly, and the FTS rebuild ladder cannot help.
+    Cannot-open / locked stays False so the caller keeps the FTS path."""
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
+    except sqlite3.Error:
+        return False
+    try:
+        master_rows = [tuple(r) for r in conn.execute(
+            "SELECT rootpage, type, name FROM sqlite_master WHERE rootpage > 0").fetchall()]
+        lines = [str(r[0]) for r in conn.execute("PRAGMA integrity_check").fetchall()]
+    except sqlite3.OperationalError:
+        return False
+    except sqlite3.DatabaseError:
+        return True
+    finally:
+        conn.close()
+    return integrity_damage_is_structural(
+        itertools.chain.from_iterable(line.splitlines() for line in lines), master_rows)
 
 
 def _db_opens_cleanly(db_path: Path) -> Optional[str]:

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -26,6 +26,7 @@ from hermes_state_common import (
     LEGACY_FTS_TRIGRAM_SQL, SCHEMA_SQL,
     SCHEMA_VERSION, _FTS_CJK_TRIGGERS, _FTS_TRIGGERS, _ephemeral_child_sql, _sql_json_extract, fts_rebuild_admission,
 )
+from hermes_state_fts import _drop_orphan_fts_shadow_tables
 from hermes_state_holders import _read_proc_argv
 
 # Pre-split logger identity so log filtering/capture is unchanged.
@@ -1129,6 +1130,12 @@ class SessionSchemaMixin:
         OPT-IN v23 boundary: a legacy v22 inline install keeps its inline schema + triggers
         (the v23 DDL would create the trigram source VIEW and leave a mixed state)."""
         legacy_fts = self._db_has_legacy_inline_fts(cursor)
+        # A `.recover`-restored image keeps the shadow tables but not the vtable rows; the DDL
+        # below would fail on the first shadow. Drop only orphaned families, then rebuild the
+        # recreated (empty) index like a missing-trigger repair (#103840).
+        orphan_repaired = _drop_orphan_fts_shadow_tables(
+            cursor, ("messages_fts", "messages_fts_trigram", "messages_fts_cjk"),
+        )
         if not self._fts_stale:
             self._migrate_bounded_tool_fts_triggers(cursor, legacy=legacy_fts)
         if self._fts_stale:
@@ -1142,8 +1149,10 @@ class SessionSchemaMixin:
             # Measure before any DDL. Publishing missing base triggers before rebuild admission lets
             # another process write through an index whose bootstrap/repair has no owner (#105790).
             base_triggers_missing = self._fts_triggers_missing(cursor, _FTS_BASE_TRIGGERS) or getattr(
-                self, "_fts_tool_prefix_migration_requires_rebuild", False)
-            trigram_triggers_missing = self._fts_triggers_missing(cursor, _FTS_TRIGRAM_TRIGGERS)
+                self, "_fts_tool_prefix_migration_requires_rebuild", False) or "messages_fts" in orphan_repaired
+            trigram_triggers_missing = (
+                self._fts_triggers_missing(cursor, _FTS_TRIGRAM_TRIGGERS) or "messages_fts_trigram" in orphan_repaired
+            )
 
             def ensure_and_rebuild() -> None:
                 self._fts_enabled = self._ensure_fts_schema(cursor, "messages_fts", base_sql)

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1216,7 +1216,8 @@ class SessionSearchMixin:
 
         Uses the FTS5 ``'rebuild'`` command, which rewrites the internal b-tree segments from the content
         rows. Unlike ``optimize_fts`` (which merges existing segments), ``rebuild`` discards and recreates
-        the index data entirely. See #50502.
+        the index data entirely — the more destructive of the two, so it is quarantined the same way. See
+        #50502.
         A full structural rebuild must never run concurrently in two processes sharing one state.db — that
         interleaving has structurally corrupted the database in production (PR #93200) — so this admits
         through the cross-process ``fts_rebuild_admission`` authority and FAILS CLOSED: if another process
@@ -1225,6 +1226,8 @@ class SessionSearchMixin:
         path, which retries in-process from the gateway housekeeping tick (``retry_deferred_fts_recovery``)
         and at next startup.
         """
+        self._raise_if_db_corrupt()
+        self._raise_if_db_replaced()
         rebuilt = 0
         with fts_rebuild_admission(self.db_path) as admitted:
             if not admitted:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -530,7 +530,11 @@ class SessionSearchMixin:
                 for row in conn.execute(
                     "SELECT name FROM sqlite_master WHERE type = 'table' "
                     "AND (name LIKE 'messages_fts_%' ESCAPE '\\' "
-                    "OR name LIKE 'messages_fts_trigram_%' ESCAPE '\\')"
+                    "OR name LIKE 'messages_fts_trigram_%' ESCAPE '\\') "
+                    # messages_fts_cjk* is an independent v23+ index, not part of the
+                    # demoted legacy layout: renaming it (or its shadow tables) breaks
+                    # the vtable constructor chain (#103647).
+                    "AND name NOT LIKE 'messages_fts_cjk%'"
                 ).fetchall():
                     conn.execute(f"ALTER TABLE {row[0]} RENAME TO fts_v22_trash_{row[0]}")
             # Claim the backfill BEFORE the empty v23 tables exist so a crash before

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -532,9 +532,11 @@ class SessionSearchMixin:
                     "AND (name LIKE 'messages_fts_%' ESCAPE '\\' "
                     "OR name LIKE 'messages_fts_trigram_%' ESCAPE '\\') "
                     # messages_fts_cjk* is an independent v23+ index, not part of the
-                    # demoted legacy layout: renaming it (or its shadow tables) breaks
-                    # the vtable constructor chain (#103647).
-                    "AND name NOT LIKE 'messages_fts_cjk%'"
+                    # demoted legacy layout: fts5's xRename renames the entire shadow
+                    # family in one step, so sweeping the cjk vtable here aborts the
+                    # loop on the next cjk shadow entry and drags _config — needed by
+                    # the vtable constructor — into the trash family (#103647).
+                    "AND name NOT LIKE 'messages\\_fts\\_cjk%' ESCAPE '\\'"
                 ).fetchall():
                     conn.execute(f"ALTER TABLE {row[0]} RENAME TO fts_v22_trash_{row[0]}")
             # Claim the backfill BEFORE the empty v23 tables exist so a crash before

--- a/tests/hermes_cli/test_doctor_structural_corruption.py
+++ b/tests/hermes_cli/test_doctor_structural_corruption.py
@@ -1,0 +1,93 @@
+"""#88587 — doctor must name STRUCTURAL state.db corruption honestly.
+
+The write-health probe's failure used to be reported as "FTS write corruption" unconditionally,
+routing operators to `--fix` / `sessions repair` (FTS rebuilds that cannot repair canonical-table
+damage) and to the .malformed-backup beside the DB (a snapshot of the same corrupt file). The
+discriminator maps integrity_check damage through sqlite_master.rootpage and keeps the FTS path
+only when every damaged object is a Hermes FTS shadow.
+"""
+
+import contextlib
+import io
+import sqlite3
+
+from hermes_cli.doctor_report import Finding
+from hermes_cli.doctor_state import _state_db_health
+from hermes_state import SessionDB
+from hermes_state_repair import integrity_damage_is_structural, state_db_has_structural_damage
+
+
+def test_integrity_damage_classifier_maps_tree_ids_through_rootpage():
+    """Field mappings from #88587: tree 5 -> sessions and tree 15 -> gateway_routing are
+    structural; a damaged messages_fts shadow tree is not; a lookalike foreign object,
+    a canonical index named in a "missing from index" line, and the freelist are."""
+    fts_only = [
+        "Tree 12 page 9: btreeInitPage() returns error code 11",
+        "row 3 missing from index messages_fts_trigram_idx",
+    ]
+    master = [(12, "table", "messages_fts_data"), (5, "table", "sessions"),
+              (15, "table", "gateway_routing"), (40, "table", "archive_fts_data")]
+    assert integrity_damage_is_structural(fts_only, master) is False
+    assert integrity_damage_is_structural(["Tree 5  page 421385: btreeInitPage() returns error code 11"], master)
+    assert integrity_damage_is_structural(["Tree 15 page 15 cell 0: 2nd reference to page 5453"], master)
+    assert integrity_damage_is_structural(["Tree 40 page 40: btreeInitPage() returns error code 11"], master)
+    assert integrity_damage_is_structural(["row 1 missing from index sqlite_autoindex_delivery_obligations_1"], master)
+    assert integrity_damage_is_structural(["Freelist: invalid page number 167772160"], master)
+    # Unparseable / unknown-tree lines keep the FTS wording (incomplete, never wrong).
+    assert integrity_damage_is_structural(["Tree 999 page 1: garbage", "*** in database main ***"], master) is False
+
+
+def _seed(tmp_path, rows=120):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session("s1", source="cli")
+    for i in range(rows):
+        db.append_message("s1", "user", f"hello {i} alpha beta " + "lorem " * 30)
+    db.close()
+    raw = sqlite3.connect(db_path)
+    raw.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    page_size = raw.execute("PRAGMA page_size").fetchone()[0]
+    root = raw.execute("SELECT rootpage FROM sqlite_master WHERE name='sessions'").fetchone()[0]
+    raw.close()
+    return db_path, page_size, root
+
+
+def _run_doctor(db_path, should_fix):
+    finding = Finding()
+    with contextlib.redirect_stdout(io.StringIO()):
+        _state_db_health(finding, should_fix, db_path, "~/x")
+    return finding
+
+
+def test_doctor_routes_structural_damage_to_recover_not_fts_rebuild(tmp_path, monkeypatch):
+    """Real torn ``sessions`` b-tree: doctor --fix must not run the FTS repair ladder (no
+    .malformed-backup, nothing fixed) and must point at `hermes sessions recover` for THIS
+    database with the profile pinned; a real FTS-only stomp still takes the FTS path."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path, page_size, root = _seed(tmp_path)
+    with open(db_path, "r+b") as f:
+        f.seek((root - 1) * page_size + 8)
+        f.write(b"\xff\xff" * 8)
+    assert state_db_has_structural_damage(db_path) is True
+
+    finding = _run_doctor(db_path, should_fix=True)
+    assert finding.fixed == 0 and finding.issues == []
+    (issue,) = finding.manual_issues
+    assert "structural" in issue and "sessions recover" in issue and str(db_path) in issue
+    assert "FTS write corruption" not in issue and "restore from the backup" not in issue
+    assert not list(tmp_path.glob("state.db.malformed-backup-*"))
+
+    fts_path = tmp_path / "fts" / "state.db"
+    fts_db = SessionDB(db_path=fts_path)
+    fts_db.create_session("s1", source="cli")
+    for i in range(40):
+        fts_db.append_message("s1", "user", f"hello {i} alpha")
+    fts_db.close()
+    raw = sqlite3.connect(fts_path)
+    raw.execute("UPDATE messages_fts_data SET block = X'DEADBEEFDEADBEEFDEADBEEFDEADBEEF'")
+    raw.commit()
+    raw.close()
+    assert state_db_has_structural_damage(fts_path) is False
+    fts_finding = _run_doctor(fts_path, should_fix=False)
+    assert fts_finding.manual_issues == []
+    assert any("FTS" in i for i in fts_finding.issues)

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -834,3 +834,45 @@ def test_lost_and_found_direct_copy_creates_lazy_delivery_ledger(tmp_path: Path)
         lf_conn.close()
         dest.close()
     assert rows == [("ob-1", "pending", None), ("ob-2", "failed", "boom")]
+
+
+
+def test_partial_recovery_skips_phantom_row_rejected_by_destination_schema(
+    tmp_path: Path,
+) -> None:
+    """#102240: a phantom ``sessions`` row with NULL ``started_at`` must be reported as a skipped
+    singleton, not abort the whole ``--allow-partial`` run at the exact-lookup boundary."""
+    source = tmp_path / "phantom-state.db"
+    output = tmp_path / "phantom-recovered.db"
+    _make_source(source)
+
+    # Relax the source's NOT NULL in place (schema text only, the pages stay identical) so the
+    # source can hold a row the destination's canonical schema rejects.
+    with sqlite3.connect(str(source), isolation_level=None) as conn:
+        conn.execute("PRAGMA writable_schema=ON")
+        conn.execute(
+            "UPDATE sqlite_master SET sql = replace(sql, 'started_at REAL NOT NULL', 'started_at REAL') "
+            "WHERE type = 'table' AND name = 'sessions'"
+        )
+        version = conn.execute("PRAGMA schema_version").fetchone()[0]
+        conn.execute(f"PRAGMA schema_version={version + 1}")
+        conn.execute("PRAGMA writable_schema=OFF")
+    with sqlite3.connect(str(source), isolation_level=None) as conn:
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at, title) VALUES ('phantom', 'cli', NULL, 'Phantom')"
+        )
+        assert conn.execute("SELECT count(*) FROM sessions").fetchone()[0] == 4
+
+    report = recover_session_database(source, output, work_dir=tmp_path, chunk_size=16, allow_partial=True)
+
+    copied = report["copy"]["sessions"]
+    assert copied["status"] == "partial"
+    assert copied["copied_rows"] == 3
+    assert copied["destination_rejected_rows"] == 1
+    assert [item["error"] for item in copied["skipped_rowid_ranges"]] == [
+        "destination constraint rejected row: NOT NULL constraint failed: sessions.started_at",
+    ]
+    assert report["verified"] is True
+    with sqlite3.connect(str(output)) as conn:
+        assert conn.execute("SELECT count(*) FROM sessions WHERE id = 'phantom'").fetchone()[0] == 0
+        assert conn.execute("SELECT count(*) FROM messages").fetchone()[0] == 21

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -876,3 +876,42 @@ def test_partial_recovery_skips_phantom_row_rejected_by_destination_schema(
     with sqlite3.connect(str(output)) as conn:
         assert conn.execute("SELECT count(*) FROM sessions WHERE id = 'phantom'").fetchone()[0] == 0
         assert conn.execute("SELECT count(*) FROM messages").fetchone()[0] == 21
+
+
+
+def test_salvage_bounds_damaged_low_edge_from_the_aggregate_not_the_int64_domain(
+    tmp_path: Path,
+) -> None:
+    """#98050: with the leftmost leaf damaged, ``ORDER BY rowid ASC LIMIT 1`` fails while
+    ``min(rowid)`` still answers via the covering index. Bisecting from INT64_MIN burned the
+    whole 10,000-query budget and lost every row; the aggregate must seed the bound instead."""
+    source = tmp_path / "low-edge.db"
+    sessions_root = _make_many_sessions_source(source, session_count=180)
+    page_size, leaf_pages = _btree_leaf_pages(source, sessions_root)
+    assert len(leaf_pages) >= 3
+    first_leaf = leaf_pages[0]
+    data = bytearray(source.read_bytes())
+    header_offset = (first_leaf - 1) * page_size
+    assert data[header_offset] == 0x0D
+    data[header_offset + 3 : header_offset + 5] = b"\xff\xff"
+    source.write_bytes(data)
+
+    conn = sqlite3.connect(str(source))
+    try:
+        with pytest.raises(sqlite3.DatabaseError):
+            conn.execute('SELECT rowid FROM "sessions" ORDER BY rowid ASC LIMIT 1').fetchone()
+        bounds = session_recovery._salvage_rowid_bounds(conn, "sessions")
+        assert bounds["low"] == 1 and bounds["high"] == 180
+        assert bounds["fallback_edges"] == []
+
+        destination = sqlite3.connect(":memory:")
+        destination.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, started_at REAL)")
+        result = session_recovery._copy_table_salvage(
+            conn, destination, "sessions", chunk_size=16, progress_cb=None, source_rows=180,
+        )
+    finally:
+        conn.close()
+    assert result["query_limit_reached"] is False
+    assert result["range_queries"] < 200
+    # Only the rows on the damaged leaf are lost; everything behind it is recovered.
+    assert result["copied_rows"] >= 180 - 60

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -305,6 +305,54 @@ def test_lost_and_found_lane_recovers_schema_unreadable_source(
         recovered_db.close()
 
 
+
+@pytest.mark.skipif(
+    not HAVE_SQLITE3_CLI,
+    reason="sqlite3 CLI not on PATH; .recover is a shell-only feature",
+)
+def test_lost_and_found_lane_recovers_page1_header_damaged_source(tmp_path: Path) -> None:
+    """#106667: a garbage page-1 header makes SQLite (and the shell's .recover) refuse the file
+    with 'file is not a database' although every data page survives. The lane must still
+    salvage the rows, and must do it on its snapshot — the user's file stays byte-identical."""
+    source = tmp_path / "header-damaged.db"
+    output = tmp_path / "header-recovered.db"
+    db = SessionDB(db_path=source)
+    try:
+        for session_number in range(3):
+            session_id = f"hdr-session-{session_number}"
+            db.create_session(session_id, "cli", cwd="/tmp/hdr")
+            for message_number in range(9):
+                db.append_message(session_id, "user", f"payload {session_number} {message_number}")
+    finally:
+        db.close()
+    conn = sqlite3.connect(str(source), isolation_level=None)
+    try:
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        conn.execute("PRAGMA journal_mode=DELETE")
+    finally:
+        conn.close()
+    data = bytearray(source.read_bytes())
+    data[0:100] = bytes(range(1, 101))  # not the magic, not zeroes: the incident shape
+    source.write_bytes(data)
+    damaged_bytes = source.read_bytes()
+
+    with pytest.raises(sqlite3.DatabaseError, match="not a database"):
+        sqlite3.connect(str(source)).execute("SELECT count(*) FROM sqlite_master").fetchone()
+
+    report = recover_session_database(source, output, work_dir=tmp_path, allow_partial=True)
+
+    assert report["mode"] == "lost_and_found_salvage"
+    assert report["sqlite3_cli"]["header_zeroed"] is True
+    assert any("header salvage" in warning for warning in report["verification"]["warnings"])
+    assert source.read_bytes() == damaged_bytes
+    conn = sqlite3.connect(str(output))
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 3
+        assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 27
+    finally:
+        conn.close()
+
+
 # ── mapper unit tests (no sqlite3 CLI required) ─────────────────────────────
 
 

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -157,9 +157,10 @@ def test_exact_lookup_recovers_tail_row_next_to_damaged_high_edge(
 
     copied = report["copy"]["messages"]
     bounds = copied["rowid_bounds"]
-    # Premise check: the high edge probe really failed and fell back.
+    # Premise check: the high edge probe really failed; the bound came from the aggregate
+    # (#98050) or, when that fails too, the synthetic-domain fallback.
     assert any("high rowid" in error for error in bounds["errors"]), bounds
-    assert "high" in bounds["fallback_edges"]
+    assert "high" in bounds["fallback_edges"] or "high" in bounds.get("aggregate_edges", ())
 
     conn = sqlite3.connect(str(output))
     try:

--- a/tests/hermes_cli/test_sessions_repair_check_only_exit.py
+++ b/tests/hermes_cli/test_sessions_repair_check_only_exit.py
@@ -1,0 +1,28 @@
+"""`hermes sessions repair --check-only` must fail (non-zero) when the store is unhealthy.
+
+Automation gates on the exit status; printing the reason and exiting 0 read as "healthy"
+(#63386, PR #103321).
+"""
+import argparse
+from pathlib import Path
+
+import hermes_state
+from hermes_cli import sessions_cmd
+from hermes_state import SessionDB
+
+
+def test_check_only_exit_status_tracks_probe_verdict(tmp_path, monkeypatch):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", db_path)
+    args = argparse.Namespace(check_only=True, no_backup=False)
+
+    assert not sessions_cmd._cmd_repair(args)
+    # Destroy the schema header so the probe fails on its first statement.
+    with open(db_path, "r+b") as f:
+        f.seek(100)
+        f.write(b"\xff" * (4096 - 100))
+    for side in ("-wal", "-shm"):
+        Path(str(db_path) + side).unlink(missing_ok=True)
+    assert sessions_cmd._cmd_repair(args) == 1
+    assert db_path.stat().st_size > 0, "check-only must not touch the file"

--- a/tests/hermes_cli/test_web_analytics_corrupt_store.py
+++ b/tests/hermes_cli/test_web_analytics_corrupt_store.py
@@ -1,0 +1,57 @@
+"""A malformed state.db must not turn dashboard analytics polling into a traceback storm (#96591)."""
+import logging
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli.web_routers import _common, analytics
+from hermes_state import SessionDB
+
+
+def _malformed_state_db(home: Path) -> Path:
+    db_path = home / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session("s1", source="cli", model="m")
+    db.close()
+    for side in ("-wal", "-shm"):
+        Path(str(db_path) + side).unlink(missing_ok=True)
+    with open(db_path, "r+b") as f:
+        f.seek(100)
+        f.write(b"\xff" * (4096 - 100))
+    with pytest.raises(sqlite3.DatabaseError):
+        sqlite3.connect(str(db_path)).execute("SELECT count(*) FROM sqlite_master")
+    return db_path
+
+
+def test_corrupt_store_polls_return_status_and_warn_once_per_interval(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import hermes_state
+    db_path = _malformed_state_db(tmp_path)
+    monkeypatch.setattr(hermes_state, "_default_db_path", lambda: db_path)
+    monkeypatch.setattr(_common, "_corrupt_store_warned_at", {})
+    app = FastAPI()
+    app.include_router(analytics.router)
+    client = TestClient(app)
+
+    with caplog.at_level(logging.DEBUG, logger="hermes_cli.web_server"):
+        first = client.get("/api/analytics/usage?days=7")
+        second = client.get("/api/analytics/usage?days=7")
+        third = client.get("/api/analytics/models?days=7")
+    for resp in (first, second, third):
+        assert resp.status_code == 503
+        assert resp.json()["detail"]["error"] == "state_db_corrupt"
+        assert "hermes doctor" in resp.json()["detail"]["message"]
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warnings) == 1, [r.getMessage() for r in warnings]
+    assert not any(r.exc_info for r in caplog.records), "no tracebacks for a known corrupt store"
+    assert db_path.exists() and db_path.stat().st_size > 0, "dashboard must never quarantine the file"
+
+    # The gate re-arms once the interval has elapsed (aged, not slept).
+    _common._corrupt_store_warned_at[str(db_path)] -= _common._CORRUPT_STORE_WARN_INTERVAL_S + 1
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.web_server"):
+        assert client.get("/api/analytics/usage?days=7").status_code == 503
+    assert sum(r.levelno >= logging.WARNING for r in caplog.records) == 1

--- a/tests/hermes_cli/test_web_analytics_corrupt_store.py
+++ b/tests/hermes_cli/test_web_analytics_corrupt_store.py
@@ -44,7 +44,12 @@ def test_corrupt_store_polls_return_status_and_warn_once_per_interval(tmp_path, 
         assert resp.status_code == 503
         assert resp.json()["detail"]["error"] == "state_db_corrupt"
         assert "hermes doctor" in resp.json()["detail"]["message"]
-    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    # Only the dashboard's own warning counts: hermes_state logs an unrelated
+    # once-per-process SQLite-version advisory on some interpreters (CI's 3.50.4).
+    warnings = [
+        r for r in caplog.records
+        if r.levelno >= logging.WARNING and r.name.startswith("hermes_cli.web_server")
+    ]
     assert len(warnings) == 1, [r.getMessage() for r in warnings]
     assert not any(r.exc_info for r in caplog.records), "no tracebacks for a known corrupt store"
     assert db_path.exists() and db_path.stat().st_size > 0, "dashboard must never quarantine the file"
@@ -54,4 +59,7 @@ def test_corrupt_store_polls_return_status_and_warn_once_per_interval(tmp_path, 
     caplog.clear()
     with caplog.at_level(logging.WARNING, logger="hermes_cli.web_server"):
         assert client.get("/api/analytics/usage?days=7").status_code == 503
-    assert sum(r.levelno >= logging.WARNING for r in caplog.records) == 1
+    assert sum(
+        r.levelno >= logging.WARNING and r.name.startswith("hermes_cli.web_server")
+        for r in caplog.records
+    ) == 1

--- a/tests/hermes_state/test_state_db_corrupt_quarantine.py
+++ b/tests/hermes_state/test_state_db_corrupt_quarantine.py
@@ -307,3 +307,26 @@ class TestVacuumAndMaintenanceRespectQuarantine:
             _clear_flag(db, flag_name)
             db._conn = real_conn
             db.close()
+
+    @pytest.mark.parametrize("flag_name,expected_exc", _QUARANTINE_FLAGS)
+    def test_rebuild_fts_refuses_when_quarantined(self, tmp_path, flag_name, expected_exc):
+        """rebuild_fts() is reachable outside _execute_write's own quarantine check — the gateway's
+        FTS-corruption transcript-retry path (gateway/session_transcript.py::_rebuild_fts_once)
+        calls it directly. Unlike optimize_fts ("merges existing segments"), rebuild_fts "discards
+        and recreates the index data entirely" — strictly more destructive — so it must refuse at
+        least as eagerly."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        real_conn = db._conn
+        try:
+            db.create_session(session_id="s1", source="cli", model="test")
+            db.append_message("s1", role="user", content="hello world")
+            recorder = _RecordingConn(real_conn)
+            db._conn = recorder
+            _force_flag(db, flag_name)
+            with pytest.raises(expected_exc):
+                db.rebuild_fts()
+            assert recorder.recorded == []
+        finally:
+            _clear_flag(db, flag_name)
+            db._conn = real_conn
+            db.close()

--- a/tests/run_agent/test_corruption_recovery_guidance.py
+++ b/tests/run_agent/test_corruption_recovery_guidance.py
@@ -123,3 +123,47 @@ def test_format_turn_completion_locked_still_advises_retry():
     )
     assert "busy" in explanation
     assert "send it again" in explanation
+
+
+def test_corrupt_guidance_pins_the_failing_profile(tmp_path, monkeypatch):
+    """#105887: every `hermes ...` command in the recovery guidance (turn explainer, gateway
+    home-channel notice, exhausted-repair diagnostic) carries the active profile selector and
+    names that profile's state.db. A bare `hermes` follows the sticky ``active_profile`` file,
+    so with another profile active the operator would repair the wrong database."""
+    import asyncio
+
+    import gateway.run as gateway_run
+    from hermes_state import _default_db_path
+    from hermes_state_repair import _persistent_repair_exhausted_error
+    from run_agent import AIAgent
+
+    root = tmp_path / "hermes"
+    home = root / "profiles" / "research"
+    home.mkdir(parents=True)
+    (root / "config.yaml").write_text("")
+    (root / "active_profile").write_text("other\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    explanation = AIAgent._format_turn_completion_explanation("session_persistence_failed", "corrupt")
+    commands = [line.strip() for line in explanation.splitlines() if "hermes " in line]
+    assert commands and all("hermes -p research " in line for line in commands), commands
+    # The conftest pins hermes_state.DEFAULT_DB_PATH, so the store named is whatever the
+    # process resolves — the contract is "the same path the runtime would open".
+    assert f"--source {_default_db_path()} " in explanation
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_db_init_error = "database disk image is malformed"
+    sent = []
+    monkeypatch.setattr(runner, "_home_channel_transports", lambda: [("telegram", {}, "home-chat", object())])
+
+    async def _capture_send(_platform, _home, _transport, message, _log_fmt):
+        sent.append(message)
+
+    monkeypatch.setattr(runner, "_send_home_channel_message", _capture_send)
+    asyncio.run(runner._send_session_db_warning_notifications())
+    notice_commands = [line.strip() for line in sent[0].splitlines() if "hermes " in line]
+    assert notice_commands and all("hermes -p research " in line for line in notice_commands), notice_commands
+    assert f"--source {_default_db_path()} " in sent[0]
+
+    exhausted = _persistent_repair_exhausted_error(home / "state.db")
+    assert "`hermes -p research sessions recover --source" in exhausted

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -173,6 +173,26 @@ def test_explanation_persistence_corrupt_backups_dir_follows_hermes_home(monkeyp
     assert "{backups_dir}" not in out
 
 
+def test_explanation_persistence_fts_index_never_advises_recovery():
+    """#97794: an FTS-scoped failure must never send the user down the recover /
+    restore-backup path on a healthy file, and must not claim the transcript was lost."""
+    out = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed", "fts_index"
+    )
+    lower = out.lower()
+    assert out.strip() != ""
+    assert "sessions recover" not in lower
+    assert ".recover" not in lower
+    # Negative advice ("do not ... restore a backup") is fine; instructions are not.
+    assert "recovery options" not in lower
+    assert "restore from a backup" not in lower and "backups/" not in lower
+    assert "would have been lost" not in lower
+    assert "free" not in lower  # never disk-space advice
+    assert "hermes doctor" in lower
+    assert "search index" in lower and "not damaged" in lower
+    assert "send your message again" in lower  # the handle stays live
+
+
 def test_explanation_persistence_replaced_cause_forbids_inplace_repair():
     out = AIAgent._format_turn_completion_explanation(
         "session_persistence_failed", "replaced"
@@ -350,6 +370,7 @@ def test_persistence_error_causes_tuple_matches_classifier():
         "Session 'abc' is being compressed by another writer",
         "Session turn lease lost; refusing transcript write for 'abc'",
         "database disk image is malformed",
+        'fts5: corrupt structure record for table "messages_fts"',
         "FATAL: state.db was replaced underneath the gateway",
         "FATAL: a live process holds a deleted state.db-wal or state.db-shm inode.",
         "database or disk is full",
@@ -358,6 +379,63 @@ def test_persistence_error_causes_tuple_matches_classifier():
     )
     for probe in probes:
         assert classify_persistence_error(probe) in PERSISTENCE_ERROR_CAUSES
+
+
+def test_classify_persistence_error_fts_provenance_order():
+    """Result code first, prose only without one — the #96038 rule the write-repair gate
+    already enforces, now shared with the classifier so there is one definition of
+    "provably FTS-only" (#97794 review)."""
+    import sqlite3
+
+    from hermes_state import SessionDB, classify_persistence_error
+    from hermes_state_errors import SQLITE_CORRUPT_VTAB, is_fts_scoped_corruption_error
+
+    def _err(text, code=None, cls=sqlite3.DatabaseError):
+        exc = cls(text)
+        if code is not None:
+            exc.sqlite_errorcode = code
+        return exc
+
+    # Tier 1 — a known result code decides. SQLITE_CORRUPT_VTAB is FTS-scoped even with the
+    # generic text older SQLite builds emit; bare SQLITE_CORRUPT / SQLITE_NOTADB are unscoped.
+    vtab = _err("database disk image is malformed", SQLITE_CORRUPT_VTAB)
+    assert classify_persistence_error(vtab) == "fts_index"
+    assert SessionDB._is_fts_write_corruption_error(vtab)  # same verdict as the write gate
+    assert classify_persistence_error(
+        _err("database disk image is malformed", sqlite3.SQLITE_CORRUPT)
+    ) == "corrupt"
+    assert classify_persistence_error(
+        _err("file is not a database", sqlite3.SQLITE_NOTADB)
+    ) == "corrupt"
+    # A contradictory known code outranks FTS-looking prose (the #96038 regression shape).
+    contradictory = _err(
+        'fts5: corrupt structure record for table "messages_fts"',
+        sqlite3.SQLITE_CONSTRAINT_TRIGGER,
+        sqlite3.IntegrityError,
+    )
+    assert not is_fts_scoped_corruption_error(contradictory)
+    assert classify_persistence_error(contradictory) != "fts_index"
+    assert not SessionDB._is_fts_write_corruption_error(contradictory)
+
+    # Tier 2 — no code (Python < 3.11, RPC-wrapped strings): the report must name a
+    # messages_fts* object. Both shapes from #97794's evidence logs qualify.
+    assert classify_persistence_error(
+        _err('fts5: corrupt structure record for table "messages_fts"')
+    ) == "fts_index"
+    assert classify_persistence_error(
+        'fts5: corruption found reading blob 2061584302081 from table "messages_fts"'
+    ) == "fts_index"
+    assert classify_persistence_error(
+        'fts5: corrupt structure record for table "messages_fts_trigram"'
+    ) == "fts_index"
+    assert classify_persistence_error(
+        "malformed inverted index for FTS5 table main.messages_fts"
+    ) == "fts_index"
+    # Generic markers without provenance stay conservative; fts5 text without corruption,
+    # or an FTS name without a corruption marker, is not corruption at all.
+    assert classify_persistence_error("database disk image is malformed") == "corrupt"
+    assert classify_persistence_error('fts5: syntax error near "x"') == "unknown"
+    assert classify_persistence_error("no such table: messages_fts") == "unknown"
 
 
 # --------------------------------------------------------------------------

--- a/tests/state/test_fts_index_fail_open.py
+++ b/tests/state/test_fts_index_fail_open.py
@@ -1,0 +1,133 @@
+"""Regression tests for #97794: an FTS5-index-only failure must not kill the turn, and an
+FTS-scoped error that escapes must not be rendered as whole-file damage.
+
+The write path already fails open on provenance-proven FTS corruption (detach the derived
+indexes, retry the canonical write) and quarantines the handle on unscoped corruption
+(#97940 / #90837). These tests pin the contract at the boundaries the issue was filed
+against — the agent flush whose failure ends the turn, and the cause that drives the
+user-facing guidance:
+
+* the flush succeeds after an FTS-only stomp and the exact user message is durable in
+  ``messages`` (the turn proceeds);
+* an FTS-scoped error that still escapes (detach refused) classifies as ``fts_index`` and
+  never quarantines the handle;
+"""
+
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+def _flush_agent(db, session_id):
+    """Bind the real flush methods onto a stand-in over a live SessionDB."""
+    agent = SimpleNamespace(
+        _session_db=db,
+        _session_db_created=True,
+        _persist_disabled=False,
+        session_id=session_id,
+        _session_persist_lock=None,
+        _flushed_db_message_ids=set(),
+        _flushed_db_message_session_id=None,
+        _last_flushed_db_idx=0,
+        _db_flush_scan_prefix=None,
+        _persist_user_message_idx=None,
+        _persist_user_message_override=None,
+        _persist_user_message_timestamp=None,
+        _pending_cli_user_message=None,
+        _active_session_turn_lease_holder=None,
+        _last_persistence_error_cause=None,
+        _compression_adoption_failed=False,
+    )
+    agent._ensure_db_session = lambda: None
+    agent._flush_messages_to_session_db = (
+        AIAgent._flush_messages_to_session_db.__get__(agent, AIAgent)
+    )
+    agent._flush_messages_to_session_db_unlocked = (
+        AIAgent._flush_messages_to_session_db_unlocked.__get__(agent, AIAgent)
+    )
+    return agent
+
+
+def _seed(db, rows=60):
+    if not db._fts_enabled:
+        pytest.skip("FTS5 unavailable in this build")
+    db.create_session("s1", source="cli")
+    for i in range(rows):
+        db.append_message("s1", "user", f"seed row {i} " + "z" * 200)
+
+
+def _stomp_fts_shadow(db_path):
+    """Overwrite the messages_fts shadow b-tree blocks: FTS5 raises SQLITE_CORRUPT_VTAB on the
+    next MATCH / sync-trigger insert while every canonical row stays intact."""
+    raw = sqlite3.connect(str(db_path))
+    raw.execute("UPDATE messages_fts_data SET block = X'DEADBEEFDEADBEEFDEADBEEFDEADBEEF'")
+    raw.commit()
+    raw.close()
+
+
+def _contents(db_path):
+    raw = sqlite3.connect(str(db_path))
+    try:
+        return [r[0] for r in raw.execute("SELECT content FROM messages ORDER BY id").fetchall()]
+    finally:
+        raw.close()
+
+
+def test_turn_flush_survives_fts_only_corruption(tmp_path):
+    """The turn's transcript write succeeds after an FTS-only stomp: the flush reports
+    success (the turn proceeds, no ``session_persistence_failed``) and the exact user
+    message is durable in ``messages``. The derived indexes are detached, the handle is
+    not quarantined."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        _seed(db)
+        _stomp_fts_shadow(db_path)
+        agent = _flush_agent(db, "s1")
+
+        ok = agent._flush_messages_to_session_db(
+            [{"role": "user", "content": "lands after stomp"}], []
+        )
+
+        assert ok is True
+        assert agent._last_persistence_error_cause is None
+        assert _contents(db_path)[-1] == "lands after stomp"
+        assert db._db_corrupt is False
+        # Builds whose sync trigger walks the stomped structure record detach the derived
+        # indexes; builds that defer the read pass the insert through untouched. Either way
+        # the canonical write landed, which is the contract.
+        assert db._fts_stale in (True, False)
+        assert db.get_session("s1") is not None
+    finally:
+        db.close()
+
+
+def test_escaped_fts_only_error_is_index_scoped_not_quarantined(tmp_path, monkeypatch):
+    """When the detach itself is refused the FTS-scoped error escapes to the agent. It must
+    classify as ``fts_index`` (guidance names the index, not the file) and must not
+    quarantine the handle or touch the derived indexes."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        _seed(db)
+        _stomp_fts_shadow(db_path)
+        monkeypatch.setattr(db, "_enter_fts_fail_open", lambda exc: False)
+        agent = _flush_agent(db, "s1")
+
+        ok = agent._flush_messages_to_session_db(
+            [{"role": "user", "content": "refused detach"}], []
+        )
+        if ok is True:
+            pytest.skip("this SQLite build defers FTS shadow corruption past the insert trigger")
+
+        assert ok is False
+        assert agent._last_persistence_error_cause == "fts_index"
+        assert db._db_corrupt is False
+        assert db._fts_stale is False
+        assert "refused detach" not in _contents(db_path)
+    finally:
+        db.close()

--- a/tests/state/test_fts_orphan_shadow_repair.py
+++ b/tests/state/test_fts_orphan_shadow_repair.py
@@ -1,0 +1,67 @@
+"""#103840: a ``sqlite3 .recover`` restore re-emits FTS5 shadow tables as ordinary tables
+but cannot re-emit the ``CREATE VIRTUAL TABLE`` row. The next SessionDB open then failed
+in ``_ensure_fts_schema`` with "fts5: error creating shadow table messages_fts_data: table
+already exists". Only families whose vtable row is absent may be repaired; a healthy family's
+shadows must survive untouched.
+"""
+
+import sqlite3
+
+from hermes_state import SessionDB
+
+
+def _orphan_family(db_path, family: str) -> None:
+    """Emulate the ``.recover`` residue for one family: vtable row gone, shadows kept."""
+    raw = sqlite3.connect(db_path)
+    raw.isolation_level = None
+    raw.execute("PRAGMA writable_schema=ON")
+    raw.execute(
+        "DELETE FROM sqlite_master WHERE name = ? AND sql LIKE 'CREATE VIRTUAL TABLE%'", (family,),
+    )
+    version = raw.execute("PRAGMA schema_version").fetchone()[0]
+    raw.execute(f"PRAGMA schema_version={version + 1}")
+    raw.execute("PRAGMA writable_schema=OFF")
+    raw.close()
+
+
+def _fts_master_rows(db_path, prefix: str) -> list:
+    raw = sqlite3.connect(db_path)
+    try:
+        return raw.execute(
+            "SELECT rowid, type, name FROM sqlite_master WHERE name LIKE ? ESCAPE '\\' ORDER BY rowid",
+            (prefix.replace("_", "\\_") + "%",),
+        ).fetchall()
+    finally:
+        raw.close()
+
+
+def test_orphaned_base_family_is_repaired_and_healthy_trigram_untouched(tmp_path):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session("s1", source="cli", model="m")
+    for i in range(3):
+        db.append_message("s1", "user", f"recovered orphan {i}")
+    db.close()
+
+    _orphan_family(db_path, "messages_fts")
+    trigram_before = _fts_master_rows(db_path, "messages_fts_trigram")
+    assert trigram_before, "fixture needs a live trigram family"
+    raw = sqlite3.connect(db_path)
+    orphan_shadows = raw.execute(
+        "SELECT count(*) FROM sqlite_master WHERE name IN ('messages_fts_data', 'messages_fts_config')"
+    ).fetchone()[0]
+    raw.close()
+    assert orphan_shadows == 2, "fixture must leave the base shadows behind"
+
+    reopened = SessionDB(db_path=db_path)
+    try:
+        assert reopened._fts_enabled is True
+        with reopened._lock:
+            hits = reopened._conn.execute(
+                "SELECT count(*) FROM messages_fts WHERE messages_fts MATCH 'orphan'"
+            ).fetchone()[0]
+        assert hits == 3, "recreated index must be rebuilt from the canonical messages table"
+    finally:
+        reopened.close()
+    # Same rowids: the healthy family was neither dropped nor recreated.
+    assert _fts_master_rows(db_path, "messages_fts_trigram") == trigram_before

--- a/tests/test_fts_cjk_bigram.py
+++ b/tests/test_fts_cjk_bigram.py
@@ -212,6 +212,85 @@ def test_legacy_v22_optimize_lands_on_cjk(cjk_so, tmp_path, monkeypatch):
         d.close()
 
 
+def test_optimize_demote_leaves_established_cjk_index_intact(cjk_so, tmp_path, monkeypatch):
+    """#103647: a legacy inline-FTS DB that ALSO carries an established (backfilled,
+    trigger-live) messages_fts_cjk index must demote without touching the cjk family.
+    The demote enumeration matches 'messages_fts_%', which sweeps the cjk vtable and
+    its shadow tables into the fts_v22_trash_* renames; renaming them breaks the
+    vtable constructor chain ('vtable constructor failed: messages_fts_cjk') and
+    aborts optimize-storage on every CJK-enabled host before any space is reclaimed."""
+    import time as _time
+
+    from hermes_state_common import SCHEMA_SQL
+    from hermes_state_fts import FTS_CJK_TABLE_SQL, FTS_CJK_TRIGGER_SQL
+
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    db_path = tmp_path / "state.db"
+
+    # Hand-build the coexistence shape: legacy inline FTS + a live cjk index.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.enable_load_extension(True)
+        conn.load_extension(str(cjk_so))
+        conn.executescript(SCHEMA_SQL)
+        conn.executescript("""
+            DROP TABLE IF EXISTS messages_fts;
+            DROP TABLE IF EXISTS messages_fts_trigram;
+            DROP VIEW IF EXISTS messages_fts_trigram_src;
+            CREATE VIRTUAL TABLE messages_fts USING fts5(content);
+            CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
+                INSERT INTO messages_fts(rowid, content) VALUES (new.id, COALESCE(new.content,''));
+            END;
+        """)
+        # Established cjk index: tables + triggers, no backfill markers (complete).
+        conn.executescript(FTS_CJK_TABLE_SQL)
+        conn.executescript(FTS_CJK_TRIGGER_SQL)
+        conn.execute("DELETE FROM schema_version")
+        conn.execute("INSERT INTO schema_version (version) VALUES (10)")
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES ('s1', 'cli', ?)",
+            (_time.time(),),
+        )
+        for role, content in (
+            ("user", "레거시 일본 메시지"),
+            ("assistant", "legacy english reply"),
+        ):
+            conn.execute(
+                "INSERT INTO messages (session_id, timestamp, role, content) "
+                "VALUES ('s1', ?, ?, ?)",
+                (_time.time(), role, content),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    d = SessionDB(db_path=db_path)
+    try:
+        assert d.fts_optimize_available(), "legacy inline layout must be eligible"
+        assert d._fts_cjk_loaded
+        with d._lock:
+            cjk_triggers = d._conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' "
+                "AND name LIKE 'messages_fts_cjk_%'"
+            ).fetchone()[0]
+        assert cjk_triggers == 3, "cjk index is established and trigger-live"
+        result = d.optimize_fts_storage(vacuum=False)
+        assert result["ok"]
+        # The cjk index survives demote untouched: same tables, same service path.
+        assert d._fts_cjk_available
+        assert d.fts_cjk_rebuild_status() is None
+        assert d._describe_search_path("일본") == "fts_cjk"
+        assert d.search_messages("일본", limit=10)
+        with d._lock:
+            trash_cjk = d._conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE name LIKE 'fts_v22_trash_messages_fts_cjk%'"
+            ).fetchone()[0]
+        assert trash_cjk == 0, "no cjk table may be renamed into the trash family"
+    finally:
+        d.close()
+
+
 def test_pure_latin_embedded_in_cjk_recovered_via_cjk_index(db):
     """#54242 residual: a pure-Latin query for a token embedded in CJK text
     (no whitespace) misses on unicode61; with the cjk index available the

--- a/tests/test_state_db_fts_segment_collision_probe.py
+++ b/tests/test_state_db_fts_segment_collision_probe.py
@@ -1,0 +1,76 @@
+"""Segment-dependent FTS5 trigram corruption (#100227).
+
+A stale ``messages_fts_trigram_idx`` row sitting at the segid FTS5 allocates next makes every
+committed append fail with ``IntegrityError: constraint failed`` while ``PRAGMA integrity_check``,
+the FTS5 ``integrity-check`` command and ``MATCH`` all report healthy. The write probe must
+report it (and the repair must heal it) without any mocked detector.
+"""
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_state_repair import _db_opens_cleanly, repair_state_db_schema
+
+
+def _build_db_with_trigram(db_path: Path) -> str:
+    db = SessionDB(db_path=db_path)
+    if not db._trigram_available:
+        db.close()
+        pytest.skip("trigram tokenizer unavailable in this SQLite build")
+    sid = db.create_session(session_id=str(uuid.uuid4()), source="cli")
+    for i in range(60):
+        db.append_message(sid, role="user", content=f"quick brown fox {i} lorem ipsum dolor {i * 7}")
+    db.close()
+    return sid
+
+
+def _plant_stale_trigram_segment(db_path: Path) -> None:
+    """Leave an index row at the next free segid: the shape an aborted segment write leaves behind."""
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    used = {r[0] for r in conn.execute("SELECT segid FROM messages_fts_trigram_idx")}
+    stale = next(s for s in range(1, 1 << 20) if s not in used)
+    conn.execute("INSERT INTO messages_fts_trigram_idx(segid, term, pgno) VALUES (?, X'', 2)", (stale,))
+    conn.close()
+
+
+def _real_append_fails(db_path: Path, sid: str) -> bool:
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    try:
+        conn.execute("INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+                     (sid, "user", "zebra yak xylophone wombat", time.time()))
+        return False
+    except sqlite3.IntegrityError:
+        return True
+    finally:
+        conn.close()
+
+
+def test_write_probe_reports_segment_collision_that_integrity_check_misses(tmp_path):
+    db_path = tmp_path / "state.db"
+    sid = _build_db_with_trigram(db_path)
+    _plant_stale_trigram_segment(db_path)
+
+    assert sqlite3.connect(str(db_path)).execute("PRAGMA integrity_check").fetchall() == [("ok",)]
+    assert _real_append_fails(db_path, sid), "fixture must break real appends"
+
+    reason = _db_opens_cleanly(db_path)
+    assert reason is not None and "constraint failed" in reason
+    # The probe rolls back: it must not have added rows or moved the FTS state.
+    assert sqlite3.connect(str(db_path)).execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
+
+
+def test_repair_heals_segment_collision_and_restores_appends(tmp_path):
+    db_path = tmp_path / "state.db"
+    sid = _build_db_with_trigram(db_path)
+    _plant_stale_trigram_segment(db_path)
+
+    report = repair_state_db_schema(db_path, backup=False)
+    assert report.get("repaired"), report
+    assert _db_opens_cleanly(db_path) is None
+    assert not _real_append_fails(db_path, sid)
+    with SessionDB(db_path=db_path) as db:
+        assert db._conn.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", (sid,)).fetchone()[0] == 61


### PR DESCRIPTION
A damaged FTS5 index no longer kills turns or gets mislabelled as whole-file corruption, and the recovery lane (`hermes doctor`, `sessions repair`, `sessions recover`, `optimize-storage`) now handles the shapes real incident databases actually arrive in: orphan shadow tables after `.recover`, a torn page-1 header, phantom NOT NULL rows, a damaged rowid edge, a CJK index family, and a segment-collision write failure that the health probe used to miss.

## Changes (13 commits, contributor authorship kept)

**Fail-open for FTS, fail-closed for structure**
- `hermes_state_errors.is_fts_scoped_corruption_error` — result-code-first provenance rule: an error raised from the `messages_fts*` shadow tables classifies as new persistence cause `fts_index`, never `corrupt`; bare `SQLITE_CORRUPT`/`SQLITE_NOTADB` stays `corrupt`. Turn explainer and gateway home-channel notice show "search degraded, canonical transcript intact" instead of `.recover`/restore advice. (salvage #97843 @SulthanZahran1, Co-authored-by @Finn763 #97841; #97794)
- `rebuild_fts()` refuses a quarantined corrupt/replaced handle like `vacuum()`/`optimize_fts()` already did. (salvage #106890 @nftpoetrist)
- `hermes doctor` resolves damaged tree ids through `sqlite_master.rootpage`: structural damage is reported as "canonical tables/indexes damaged, not the FTS index" and routes to `hermes sessions recover --inspect-only`; `--fix` no longer writes a 1:1 copy of the damage as a "backup" and tells you to restore it. (salvage #88604 @liuhao1024; #88587)
- Recovery guidance is pinned to the failing profile via `hermes_constants.profile_cli_selector()` (`hermes -p <profile> doctor --fix`, correct `--source` path) in the explainer, gateway notice and repair-exhausted error. (#105887)

**Detection**
- `_db_opens_cleanly` write probe now issues `INSERT INTO <fts>(<fts>) VALUES('flush')` per FTS family inside the rolled-back transaction and catches `sqlite3.DatabaseError` (an `IntegrityError` from a stale `_idx` row at the next segid was slipping past `except OperationalError`). doctor / `sessions repair --check-only` / `repair_state_db_schema` now see and heal the #100227 class.
- `sessions repair --check-only` exits 1 on an unhealthy store. (salvage #103321 @jangomango76, exit-code part only)
- Dashboard `/api/analytics/usage|models` on a malformed state.db: one WARNING per path per ≥300 s, HTTP 503 `{"error":"state_db_corrupt"}` instead of a traceback per poll; busy/locked still propagate; the file is never renamed. (#96591)

**Recovery lane**
- Orphan FTS5 shadow tables (parent virtual-table row absent from `sqlite_master`) are dropped per family on `SessionDB` open, then that family rebuilds under the normal admission gate; a healthy sibling family is never touched. (salvage #56824 @liuhao1024, Co-authored-by @ggoldani #103868; #103840)
- `sessions recover --allow-partial` skips rows the destination schema rejects (`destination_rejected_rows`) instead of aborting. (salvage #91413 @leegunwoo98; #102240)
- `_salvage_rowid_bounds` seeds a damaged edge from `SELECT min(rowid), max(rowid)` (covering PK index) before falling back to the INT64 domain — 40 range queries instead of exhausting the 10,000 budget. (#98050, reported @Ace-Kelly, corroborated @Proff506)
- Header-damaged (`file is not a database`) snapshots: the lost_and_found lane zeroes the 100-byte header on the snapshot copy and reruns `.recover`. (salvage #102808 @TaoMasterCoder, trimmed 302→~40 LOC; #106667). **Mechanism changed vs the PR:** the donor-header splice was verified wrong for direct opens (in-header page count/freelist contradict the file → `malformed`); `.recover` ignores the header, so a zeroed header recovers every row for both 100-byte and whole-page-1 garbage.
- `optimize-storage` legacy demote excludes the `messages_fts_cjk` family from `LIKE 'messages_fts_%'` (xRename cascade into the cjk vtable). (salvage #103657 @liuhao1024, 2 commits; #103647)

## Live repro (real corruption fixtures, no mocked detectors)

| Item | Before (origin/main) | After |
|---|---|---|
| #97794 FTS-scoped error escaping append | `DatabaseError code=267`, `classify → corrupt`, turn fail-closes with `.recover` advice | `cause=fts_index`, canonical `messages` intact, turn continues |
| #88587 torn `sessions` root page | doctor: "FTS write corruption — run doctor --fix"; `--fix` writes `.malformed-backup-*` copy of the damage, fails | doctor: "structural corruption (canonical tables damaged, not the FTS index)" → `sessions recover --inspect-only`; no backup written; DEADBEEF FTS stomp still → `rebuild_fts` |
| #105887 `HERMES_HOME=<root>/profiles/research`, active_profile=other | `1. Run hermes doctor --fix` | `hermes -p research doctor --fix` / `... sessions recover --source <root>/profiles/research/state.db --inspect-only` |
| #106890 `rebuild_fts()` on quarantined handle | 3 param cases DID NOT RAISE | raises like `vacuum()` |
| #100227 stale `messages_fts_trigram_idx` row at next segid | `integrity_check=ok`, `_db_opens_cleanly→None`, check-only "opens cleanly", doctor healthy, real append → `IntegrityError constraint failed` | `_db_opens_cleanly→'fts5 write probe failed: constraint failed'`; check-only ✗ rc 1; doctor ⚠; `repair_state_db_schema` heals, appends work |
| #96591 bytes 100..4096=0xFF, 2 polls | 2×HTTP 500, 2 full tracebacks (164 log lines) | 2×HTTP 503 `state_db_corrupt`, 1 WARNING, 0 tracebacks (12 lines) |
| #103840 vtable row removed, shadows kept | `OperationalError: fts5: error creating shadow table messages_fts_data: table already exists` on open | opens, `fts_enabled=True`, MATCH 5/5, trigram family rowids unchanged |
| #106667 random 100-byte header, sqlite3 3.53.1 | `page-level .recover salvage failed: file is not a database (26)` | `Recovered 60 sessions and 300 messages`, source md5 unchanged |
| #102240 phantom `sessions` row, NULL `started_at` | `IntegrityError: NOT NULL constraint failed: sessions.started_at`, abort | `status=partial copied=3 destination_rejected_rows=1 verified=True` |
| #98050 leftmost `sessions` leaf cell-count `\xff\xff`, 400 rows | `low=-9223372036854775808 copied=0 range_queries=10000 status=failed` | `low=1 high=400 copied=391 range_queries=40 status=partial` |
| #103647 gcc-built `fts5_cjk.so`, `optimize-storage` | `no such table: messages_fts_cjk_data` in `_demote_legacy_fts_to_trash._stage` | optimize ok, cjk searchable, 0 `fts_v22_trash_messages_fts_cjk*` |

## Root cause
Every corruption-shaped error was bucketed as whole-file damage, and the recovery lane assumed an openable file with a consistent schema — so FTS-only damage killed turns while doctor misnamed it, and the tools meant to salvage real incident databases refused the exact files those incidents produce.

## Verified already fixed on main (no change here)
- #96009 / #92401 holder misdetection: `hermes_state_holders` keys on `(st_dev, st_ino)` and parses argv (`06d7b77b1cb`); live harness with a real second-filesystem `state.db` and `grep hermes-agent` / `journalctl -u hermes-agent` / ssh-wrapper argvs → `holders=[]`. #96011 and #92419 are carried in that commit as Co-authored-by.
- #106393 futile-holder diagnostic: `060cd7f9bb5`. #107981's remaining delta (rebuild anyway after futility) proceeds past uninspectable / deleted-WAL holders (its `pid > 0` guard ignores the sentinel prefixes `live_writer_holds_db` fails closed on) — not taken.

## Design calls made in this PR (flagging for review)
- Dropped #97843's `corrupt_unconfirmed` quick_check tier: on 3.53.1 `quick_check` raises rather than reports on a torn shadow b-tree, so the probe could never downgrade the shape it targets, and softening quarantine guidance by probe weakens the fail-close.
- #102808 landed with zero-header instead of donor-header splice (see above).
- Not taken: #106212 (NOT NULL backfill — synthetic-only premise, migration-policy surface), #86062 (+453 LOC on-open integrity probe; base already fail-opens and `sessions repair` heals trigram corruption), #105428 (argv-substring identity inference, fail-open case).

Fixes #97794, #88587, #105887, #100227, #96591, #103840, #106667, #102240, #98050, #103647
Refs #106393, #96009, #92401, #56815, #106212, #86062

## Infographic
![state.db repair](https://v3b.fal.media/files/b/0aa9fbcb/zEy8XIX1HoQW0GIskUSvx_G87BIedY.png)
