### PR TITLE
feat(desktop): edit Kanban priority in task drawer

### DIFF
--- a/apps/desktop/src/plugins/kanban/drawer.test.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.test.tsx
@@ -23,6 +23,7 @@ const legacyDetail: Omit<KanbanTaskDetail, 'attachments'> = {
 }
 
 let detail: object
+let patchError: Error | null
 let client: QueryClient
 let disposeApi: () => void
 let disposeLocales: () => void
@@ -35,6 +36,17 @@ const rest = vi.fn(async (path: string, options?: PluginRestOptions): Promise<un
   }
 
   if (path === '/tasks/t_example') {
+    if (options?.method === 'PATCH') {
+      if (patchError) {
+        throw patchError
+      }
+
+      const current = detail as KanbanTaskDetail
+      detail = { ...current, task: { ...current.task, ...(options.body as Partial<KanbanTaskDetail['task']>) } }
+
+      return { ok: true }
+    }
+
     return detail
   }
 
@@ -54,6 +66,7 @@ const rest = vi.fn(async (path: string, options?: PluginRestOptions): Promise<un
 })
 
 beforeEach(() => {
+  patchError = null
   client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   disposeLocales = registerPluginLocales('kanban', KANBAN_LOCALES)
   disposeApi = bindApi(
@@ -71,13 +84,88 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-function openDrawer() {
+function openDrawer(onClose = vi.fn()) {
   return render(
     <QueryClientProvider client={client}>
-      <TaskDrawer columns={['todo', 'ready', 'done']} id="t_example" onClose={vi.fn()} onOpen={vi.fn()} />
+      <TaskDrawer columns={['todo', 'ready', 'done']} id="t_example" onClose={onClose} onOpen={vi.fn()} />
     </QueryClientProvider>
   )
 }
+
+function priorityPatchCalls() {
+  return rest.mock.calls.filter(([path, options]) => path === '/tasks/t_example' && options?.method === 'PATCH')
+}
+
+describe('task priority editing', () => {
+  beforeEach(() => {
+    detail = { ...legacyDetail, task: { ...legacyDetail.task, priority: 2 }, attachments: [] }
+  })
+
+  it('saves a changed integer directly from the priority field on blur', async () => {
+    openDrawer()
+    const input = await screen.findByRole('spinbutton', { name: en.metaPriority })
+
+    fireEvent.change(input, { target: { value: '7' } })
+    fireEvent.blur(input)
+
+    await waitFor(() =>
+      expect(rest).toHaveBeenCalledWith('/tasks/t_example', {
+        method: 'PATCH',
+        body: { priority: 7 }
+      })
+    )
+    await waitFor(() => expect((input as HTMLInputElement).value).toBe('7'))
+  })
+
+  it('saves a changed integer on Enter', async () => {
+    openDrawer()
+    const input = await screen.findByRole('spinbutton', { name: en.metaPriority })
+
+    input.focus()
+    fireEvent.change(input, { target: { value: '8' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(priorityPatchCalls()).toHaveLength(1))
+    expect(priorityPatchCalls()[0][1]?.body).toEqual({ priority: 8 })
+  })
+
+  it('restores the saved value on Escape without closing the drawer', async () => {
+    const onClose = vi.fn()
+    openDrawer(onClose)
+    const input = await screen.findByRole('spinbutton', { name: en.metaPriority })
+
+    input.focus()
+    fireEvent.change(input, { target: { value: '9' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect((input as HTMLInputElement).value).toBe('2')
+    expect(priorityPatchCalls()).toHaveLength(0)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it.each(['', '2.5'])('restores the saved value instead of writing invalid input %j', async value => {
+    openDrawer()
+    const input = await screen.findByRole('spinbutton', { name: en.metaPriority })
+
+    fireEvent.change(input, { target: { value } })
+    fireEvent.blur(input)
+
+    expect((input as HTMLInputElement).value).toBe('2')
+    expect(priorityPatchCalls()).toHaveLength(0)
+  })
+
+  it('restores the saved value when the write fails', async () => {
+    patchError = new Error('priority write failed')
+    openDrawer()
+    const input = await screen.findByRole('spinbutton', { name: en.metaPriority })
+
+    fireEvent.change(input, { target: { value: '7' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(priorityPatchCalls()).toHaveLength(1))
+    await waitFor(() => expect((input as HTMLInputElement).value).toBe('2'))
+  })
+})
 
 describe('task attachment compatibility', () => {
   it.each([{}, { attachments: null }])(
@@ -87,6 +175,7 @@ describe('task attachment compatibility', () => {
       openDrawer()
 
       expect(await screen.findByRole('heading', { name: legacyDetail.task.title })).toBeTruthy()
+      expect((screen.getByRole('spinbutton', { name: en.metaPriority }) as HTMLInputElement).value).toBe('0')
       expect(screen.getByText(legacyDetail.task.body!)).toBeTruthy()
       expect(screen.getByText(legacyDetail.comments[0].body)).toBeTruthy()
       expect(screen.queryByRole('button', { name: en.uploadAttachment })).toBeNull()

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuTrigger,
   ErrorState,
   host,
+  Input,
   Loader,
   LogView,
   Textarea,
@@ -175,6 +176,77 @@ function MetaRow({ children, label }: { children: ReactNode; label: string }) {
       <span className="text-(--ui-text-quaternary)">{label}</span>
       <span className="min-w-0 truncate text-(--ui-text-secondary)">{children}</span>
     </>
+  )
+}
+
+function PriorityField({
+  label,
+  onSave,
+  priority
+}: {
+  label: string
+  onSave: (priority: number) => Promise<unknown>
+  priority: number
+}) {
+  const [draft, setDraft] = useState(String(priority))
+  const [pending, setPending] = useState(false)
+  const focused = useRef(false)
+
+  useEffect(() => {
+    if (!focused.current && !pending) {
+      setDraft(String(priority))
+    }
+  }, [pending, priority])
+
+  const reset = () => setDraft(String(priority))
+
+  const save = async () => {
+    focused.current = false
+    const next = Number(draft)
+
+    if (!draft.trim() || !Number.isInteger(next) || next === priority) {
+      reset()
+
+      return
+    }
+
+    setPending(true)
+
+    try {
+      await onSave(next)
+    } catch (err) {
+      reset()
+      host.notify({ kind: 'error', message: errText(err) })
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <Input
+      aria-label={label}
+      className="w-20"
+      disabled={pending}
+      onBlur={() => void save()}
+      onChange={event => setDraft(event.target.value)}
+      onFocus={() => {
+        focused.current = true
+      }}
+      onKeyDown={event => {
+        if (event.key === 'Enter') {
+          event.preventDefault()
+          event.currentTarget.blur()
+        } else if (event.key === 'Escape') {
+          event.preventDefault()
+          event.stopPropagation()
+          reset()
+        }
+      }}
+      size="sm"
+      step={1}
+      type="number"
+      value={draft}
+    />
   )
 }
 
@@ -588,6 +660,14 @@ export function TaskDrawer({
     void qc.invalidateQueries({ queryKey: ['kanban', 'board', slug] })
   }
 
+  const savePriority = async (priority: number) => {
+    await patchTask(id!, { priority })
+    await Promise.all([
+      qc.invalidateQueries({ queryKey: taskKey(slug, id!) }),
+      qc.invalidateQueries({ queryKey: ['kanban', 'board', slug] })
+    ])
+  }
+
   // Optimistic status change against the task cache; rolls back + toasts on a
   // rejected transition (the backend enforces the workflow).
   const moveMut = useMutation({
@@ -763,7 +843,9 @@ export function TaskDrawer({
                   onReassign={profile => void mutate(() => reassignTask(task.id, profile))()}
                 />
               </MetaRow>
-              {typeof task.priority === 'number' && <MetaRow label={k.metaPriority}>{task.priority}</MetaRow>}
+              <MetaRow label={k.metaPriority}>
+                <PriorityField label={k.metaPriority} onSave={savePriority} priority={task.priority ?? 0} />
+              </MetaRow>
               {task.tenant && <MetaRow label={k.metaTenant}>{task.tenant}</MetaRow>}
               {task.workspace_path && (
                 <MetaRow label={k.workspace}>


### PR DESCRIPTION
## What does this PR do?

Makes an existing Kanban task's priority editable directly in the native desktop task drawer. The control uses the drawer's existing task PATCH path, so reprioritizing a card does not require a secondary CLI or dashboard workflow.

The input saves on blur or Enter, restores the saved value on Escape, rejects empty and fractional values, and rolls back to the authoritative task value if the update fails.

## Related Issue

Related to #84915

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/kanban/drawer.tsx`: replace the read-only priority value with an always-visible numeric input backed by the existing task patch action.
- `apps/desktop/src/plugins/kanban/drawer.test.tsx`: cover successful edits, Enter/blur behavior, Escape restoration, invalid values, and failed-update rollback.

## How to Test

1. Open the native desktop Kanban and select an existing card.
2. Change the value in the Priority field, then press Enter or move focus away.
3. Reopen the card and confirm the value persisted. Press Escape during a subsequent edit and confirm the prior value is restored.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; this is a desktop-only TypeScript change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the existing field is now editable
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Verification:

- `npm run typecheck` — passed
- ESLint on both changed files — passed
- `vitest` focused drawer suite — 9/9 passed
- Packaged desktop app — manually verified on macOS; priority edit and persistence work as intended
- Full desktop `npm test` — 9,668 passed, 6 skipped, and 1 unrelated existing test failed on macOS. `electron/managed-ssh-update.test.ts` hardcodes `/bin/true`; macOS provides `/usr/bin/true`. The file is unchanged by this PR, and the repository's JavaScript CI runs on Ubuntu where `/bin/true` exists.
