### PR TITLE
fix(gateway): surface Windows session id in `gateway status`, warn on Session 0

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1202,7 +1202,12 @@ def _process_session_id(pid: int) -> int | None:
 
 def _active_console_session_id() -> int | None:
     """Session id of the interactive desktop, or None when nobody is logged on
-    (``WTSGetActiveConsoleSessionId`` returns 0xFFFFFFFF in that case)."""
+    (``WTSGetActiveConsoleSessionId`` returns 0xFFFFFFFF in that case).
+
+    ``restype`` must be set explicitly: the function returns a DWORD, but ctypes'
+    default ``c_int`` is signed, so the 0xFFFFFFFF sentinel comes back as -1 and
+    silently fails to match ``_INVALID_SESSION_ID`` (same class of bug as #71218)."""
+    ctypes.windll.kernel32.WTSGetActiveConsoleSessionId.restype = ctypes.c_uint
     session_id = ctypes.windll.kernel32.WTSGetActiveConsoleSessionId()
     return None if session_id == _INVALID_SESSION_ID else session_id
 

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1188,6 +1188,42 @@ def _print_deep_probes() -> None:
     _probe_exit_diag(home / "logs" / "gateway-exit-diag.log")
 
 
+_INVALID_SESSION_ID = 0xFFFFFFFF
+
+
+def _process_session_id(pid: int) -> int | None:
+    """Windows session id that owns `pid`, or None if it can't be queried
+    (process already exited, or we lack query rights)."""
+    session_id = ctypes.c_ulong()
+    if not ctypes.windll.kernel32.ProcessIdToSessionId(ctypes.c_ulong(pid), ctypes.byref(session_id)):
+        return None
+    return session_id.value
+
+
+def _active_console_session_id() -> int | None:
+    """Session id of the interactive desktop, or None when nobody is logged on
+    (``WTSGetActiveConsoleSessionId`` returns 0xFFFFFFFF in that case)."""
+    session_id = ctypes.windll.kernel32.WTSGetActiveConsoleSessionId()
+    return None if session_id == _INVALID_SESSION_ID else session_id
+
+
+def _session_status_lines(sessions: dict[int, int | None], console_session: int | None, task_name: str) -> list[str]:
+    """Session-id lines for ``hermes gateway status``, plus a warning when a gateway PID is
+    stuck in Session 0 while an interactive desktop session exists. A gateway restarted from
+    an SSH shell (itself a Session-0 service) silently inherits Session 0: Credential Manager
+    becomes unreadable there and GUI helpers fail, with no other visible symptom (#108077)."""
+    lines = [
+        f"  Session: PID {pid} -> {sid if sid is not None else 'unknown'}" for pid, sid in sessions.items()
+    ]
+    if console_session not in (None, 0) and any(sid == 0 for sid in sessions.values()):
+        lines.append(
+            "⚠ Gateway is running in Session 0 (services session) while the interactive "
+            f"desktop is Session {console_session}. Credential Manager and GUI helpers will "
+            f"fail from Session 0. Recovery: schtasks /Run /TN {task_name}"
+        )
+    return lines
+
+
 def status(deep: bool = False) -> None:
     """Print a status report for the Windows gateway service."""
     _assert_windows()
@@ -1210,6 +1246,11 @@ def status(deep: bool = False) -> None:
         print("✗ Gateway service not installed")
 
     print(f"✓ Gateway process running (PID: {', '.join(map(str, pids))})" if pids else "✗ No gateway process detected")
+
+    if pids:
+        sessions = {pid: _process_session_id(pid) for pid in pids}
+        for line in _session_status_lines(sessions, _active_console_session_id(), task_name):
+            print(line)
 
     if deep:
         print()

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -30,6 +30,47 @@ def test_schtasks_encoding_falls_back_to_utf8(monkeypatch):
     assert gateway_windows._schtasks_encoding() == "utf-8"
 
 
+# ---------------------------------------------------------------------------
+# _session_status_lines — issue #108077
+#
+# An SSH-initiated gateway restart on Windows silently inherits Session 0
+# (sshd.exe is itself a Session-0 service), which breaks Credential Manager
+# and GUI helpers with no other visible symptom. `hermes gateway status`
+# should surface each PID's session id and warn when one is stuck in
+# Session 0 while an interactive desktop session exists.
+# ---------------------------------------------------------------------------
+
+
+def test_session_status_lines_warns_on_session_zero_gateway():
+    lines = gateway_windows._session_status_lines(
+        sessions={4242: 0}, console_session=1, task_name="Hermes_Gateway"
+    )
+    assert lines[0] == "  Session: PID 4242 -> 0"
+    assert any("Session 0" in line and "schtasks /Run /TN Hermes_Gateway" in line for line in lines)
+
+
+def test_session_status_lines_no_warning_when_gateway_shares_interactive_session():
+    lines = gateway_windows._session_status_lines(
+        sessions={4242: 1}, console_session=1, task_name="Hermes_Gateway"
+    )
+    assert lines == ["  Session: PID 4242 -> 1"]
+    assert not any("⚠" in line for line in lines)
+
+
+def test_session_status_lines_no_warning_without_an_interactive_session():
+    # Nobody logged on (console_session is None) or the console is itself
+    # Session 0 (headless box): a Session-0 gateway is not an accident there.
+    lines = gateway_windows._session_status_lines(
+        sessions={4242: 0}, console_session=None, task_name="Hermes_Gateway"
+    )
+    assert not any("⚠" in line for line in lines)
+
+
+def test_session_status_lines_unresolvable_session_shown_as_unknown():
+    lines = gateway_windows._session_status_lines(
+        sessions={4242: None}, console_session=1, task_name="Hermes_Gateway"
+    )
+    assert lines == ["  Session: PID 4242 -> unknown"]
 
 
 @pytest.mark.windows_only

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -73,6 +73,36 @@ def test_session_status_lines_unresolvable_session_shown_as_unknown():
     assert lines == ["  Session: PID 4242 -> unknown"]
 
 
+def test_active_console_session_id_recognizes_no_interactive_session(monkeypatch):
+    """``WTSGetActiveConsoleSessionId`` returns the DWORD 0xFFFFFFFF when nobody is
+    logged on. ctypes' default restype is the *signed* c_int, so an unbound call
+    would come back as -1 and never match ``_INVALID_SESSION_ID`` (same class of
+    bug as #71218's GetCurrentProcess truncation) — this fakes that signed/unsigned
+    distinction to prove the wrapper binds restype before comparing.
+    """
+
+    import ctypes as ctypes_module
+
+    class FakeWTSGetActiveConsoleSessionId:
+        restype = None
+
+        def __call__(self):
+            value = 0xFFFFFFFF
+            if self.restype is ctypes_module.c_uint:
+                return value
+            return value - 0x100000000  # signed c_int truncation, ctypes' default
+
+    class FakeKernel32:
+        WTSGetActiveConsoleSessionId = FakeWTSGetActiveConsoleSessionId()
+
+    class FakeWindll:
+        kernel32 = FakeKernel32()
+
+    monkeypatch.setattr(gateway_windows.ctypes, "windll", FakeWindll(), raising=False)
+
+    assert gateway_windows._active_console_session_id() is None
+
+
 @pytest.mark.windows_only
 def test_build_gateway_argv_keeps_venv_console_python_for_uv_venv(monkeypatch, tmp_path):
     """No pythonw / base-interpreter detour: the venv console python.exe is


### PR DESCRIPTION
Fixes #108077

## Problem

On Windows, `sshd.exe` (OpenSSH server) is itself a Session-0 service, so a gateway restarted from an SSH shell (`hermes gateway restart` / a `hermes update`-triggered restart) inherits Session 0 instead of the interactive desktop session. This is silent: `hermes gateway status` still reports a running PID and everything *looks* healthy, while Windows Credential Manager becomes unreadable for the interactive user and any GUI helper the agent launches fails from Session 0. The issue reporter burned a full debugging cycle misdiagnosing this as a `git`/credential bug before finding the real root cause.

The issue proposes three independent mitigations; this PR implements the second one, which is purely mechanical (detection/reporting, no design decision required):

> **Detect and report.** Expose the gateway's Windows session id in `hermes gateway status` (not just the PID) and warn when `SessionId == 0` while an interactive session exists.

(Session-aware auto-restart and doc updates are separate, larger design questions left for maintainers/follow-up.)

## Fix

`hermes_cli/gateway_windows.py`:
- `_process_session_id(pid)` — thin `ProcessIdToSessionId` wrapper.
- `_active_console_session_id()` — thin `WTSGetActiveConsoleSessionId` wrapper.
- `_session_status_lines(sessions, console_session, task_name)` — pure function that formats a `Session: PID <pid> -> <session>` line per gateway PID, and appends a `⚠` warning (naming the `schtasks /Run /TN <task>` recovery command) when a gateway PID is in Session 0 while the console has a real interactive session.
- `status()` now calls these and prints the session line(s)/warning right after the existing `✓ Gateway process running (PID: ...)` line.

## Testing

This is Windows-only behavior (`_assert_windows()`), so per this repo's OS-gating convention (`tests/conftest.py`, `AGENTS.md`), the ctypes-calling wrappers that only make sense on real Windows are exercised on native Windows CI only. The decision logic itself (`_session_status_lines`) is a pure function — it takes already-resolved session ids as data, so it's tested directly on Linux, matching the documented pattern for "pure functions that take a platform as data."

Added 5 tests to `tests/hermes_cli/test_gateway_windows.py`:
- warns and includes the recovery command when a gateway PID is in Session 0 and the console has an interactive session
- no warning when the gateway shares the interactive session
- no warning when there's no interactive console session (headless box) — a Session-0 gateway isn't an accident there
- unresolvable session id is shown as `unknown` rather than crashing
- `_active_console_session_id()` correctly recognizes the "nobody logged on" sentinel through the real ctypes wrapper (see below — this is what caught the review bug)

**Update:** an earlier revision of `_active_console_session_id()` didn't set `.restype` on the `WTSGetActiveConsoleSessionId` call, so ctypes fell back to its default *signed* `c_int`. `WTSGetActiveConsoleSessionId` returns a DWORD and signals "nobody logged on" via `0xFFFFFFFF`; without an explicit unsigned restype, that sentinel came back as `-1` and silently failed to match `_INVALID_SESSION_ID`, defeating the whole point of the check on a headless box (same class of bug as the `GetCurrentProcess` truncation fixed for #71218). Fixed by binding `WTSGetActiveConsoleSessionId.restype = ctypes.c_uint` before the call, and added `test_active_console_session_id_recognizes_no_interactive_session`, which fakes the ctypes signed/unsigned distinction to exercise the real wrapper (not just the pure formatter fed fake data) and fails without the restype fix.

Confirmed the tests fail without the fix:
```
$ git checkout HEAD~1 -- hermes_cli/gateway_windows.py
$ python -m pytest tests/hermes_cli/test_gateway_windows.py -k session_status -v
...
FAILED ...test_session_status_lines_warns_on_session_zero_gateway - AttributeError: module 'hermes_cli.gateway_windows' has no attribute '_session_status_lines'
FAILED ...test_session_status_lines_no_warning_when_gateway_shares_interactive_session - AttributeError: ...
FAILED ...test_session_status_lines_no_warning_without_an_interactive_session - AttributeError: ...
FAILED ...test_session_status_lines_unresolvable_session_shown_as_unknown - AttributeError: ...
4 failed, 9 deselected in 0.70s
```

And, separately, confirmed `test_active_console_session_id_recognizes_no_interactive_session` fails without the `restype` fix specifically:
```
$ git checkout HEAD~1 -- hermes_cli/gateway_windows.py   # pre-restype-fix revision
$ python -m pytest tests/hermes_cli/test_gateway_windows.py -k active_console -v
FAILED ...test_active_console_session_id_recognizes_no_interactive_session - assert -1 is None
1 failed, 13 deselected in 0.60s
```

All tests pass with the fix restored:
```
$ python -m pytest tests/hermes_cli/test_gateway_windows.py -v
...
10 passed, 4 skipped in 0.60s   # the 4 skips are windows_only tests, unrelated to this change
```

`ruff check` passes on both changed files with no findings.

## AI assistance disclosure

This PR was written with Claude Code (Anthropic).
