### PR TITLE
Desktop: Bot Mode no longer spawns or dials a backend per profile on launch and every roster tick (#102978, #99336, #102913)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/profile-ops.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/profile-ops.test.ts
@@ -153,3 +153,60 @@ describe('duplicating a bot', () => {
     expect(await duplicateBot(bot, [bot, elsewhere])).toBe('ops-2')
   })
 })
+
+/**
+ * Roster avatar sync must stay on the ACTIVE gateway (#102978). Every row of
+ * a local-primary roster is source-scoped, so routing `profiles.get_asset` /
+ * `set_asset` per row through the (connectionId, profile) secondary dialed a
+ * pooled backend for every registered profile on the first paint after
+ * launch — 60 profiles against 3 slots, a queue that never drained. The
+ * active gateway's `profiles.list` already read those directories; the asset
+ * RPCs are the same reads, addressed by the row's backend name.
+ */
+describe('roster avatar sync (#102978)', () => {
+  it('fetches has_avatar art through the active gateway, never a per-row secondary dial', async () => {
+    const { pullServerAvatars } = await import('./profile-ops')
+    hostMock.request.mockResolvedValue({ found: false })
+
+    const roster = ['alpha', 'beta', 'gamma'].map(
+      name =>
+        ({
+          connectionId: 'local',
+          connectionKind: 'local',
+          has_avatar: true,
+          name,
+          route: { connectionId: 'local', mode: 'local', profile: name, targetProfile: name },
+          sourceScoped: true
+        }) as RosterRow
+    )
+
+    pullServerAvatars(roster)
+    await Promise.resolve()
+
+    expect(hostMock.requestProfile).not.toHaveBeenCalled()
+    expect(hostMock.request.mock.calls.map(([method, params]) => [method, params.name])).toEqual([
+      ['profiles.get_asset', 'alpha'],
+      ['profiles.get_asset', 'beta'],
+      ['profiles.get_asset', 'gamma']
+    ])
+  })
+
+  it('addresses an aliased row by its backend profile name', async () => {
+    const { pullServerAvatars } = await import('./profile-ops')
+    hostMock.request.mockResolvedValue({ found: false })
+
+    pullServerAvatars([
+      {
+        connectionId: 'local',
+        has_avatar: true,
+        name: 'mara',
+        route: { connectionId: 'local', mode: 'local', profile: 'mara', targetProfile: 'default' },
+        sourceScoped: true
+      } as RosterRow
+    ])
+    await Promise.resolve()
+
+    expect(hostMock.requestProfile).not.toHaveBeenCalled()
+    expect(hostMock.request).toHaveBeenCalledWith('profiles.get_asset', { asset: 'avatar', name: 'default' })
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/profile-ops.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/profile-ops.test.ts
@@ -15,8 +15,9 @@ import { $botMeta } from './data'
 import { duplicateBot } from './profile-ops'
 import type { RosterRow } from './types'
 
-const { ensureBotMetadataMock, hostMock, storageMock } = vi.hoisted(() => ({
+const { ensureBotMetadataMock, faceOnlyMock, hostMock, storageMock } = vi.hoisted(() => ({
   ensureBotMetadataMock: vi.fn(),
+  faceOnlyMock: vi.fn((_data: string) => false),
   hostMock: {
     request: vi.fn(),
     requestProfile: vi.fn(),
@@ -39,13 +40,14 @@ vi.mock('@hermes/plugin-sdk', async () => {
 })
 
 vi.mock('./shared', () => ({ getPluginCtx: () => ({ storage: storageMock }), ID: 'hermes-bots' }))
-vi.mock('./avatar-image', () => ({ isBackfilledFacePng: () => false }))
+vi.mock('./avatar-image', () => ({ isBackfilledFacePng: (data: string) => faceOnlyMock(data) }))
 vi.mock('./canonical-chat', () => ({ ensureBotMetadata: ensureBotMetadataMock }))
 
 const calls: Array<{ method: string; params: Record<string, unknown> }> = []
 
 beforeEach(() => {
   vi.clearAllMocks()
+  faceOnlyMock.mockReturnValue(false)
   calls.length = 0
   $botMeta.set({})
   storageMock.set.mockResolvedValue(undefined)
@@ -208,5 +210,31 @@ describe('roster avatar sync (#102978)', () => {
 
     expect(hostMock.requestProfile).not.toHaveBeenCalled()
     expect(hostMock.request).toHaveBeenCalledWith('profiles.get_asset', { asset: 'avatar', name: 'default' })
+  })
+
+  it('does not re-fetch a face-only raster on the next roster tick (#99336)', async () => {
+    const { pullServerAvatars } = await import('./profile-ops')
+    faceOnlyMock.mockReturnValue(true)
+    hostMock.request.mockResolvedValue({ data: 'data:image/png;base64,AAAA', found: true })
+
+    const row = {
+      connectionId: 'local',
+      has_avatar: true,
+      name: 'secretary',
+      route: { connectionId: 'local', mode: 'local', profile: 'secretary', targetProfile: 'secretary' },
+      sourceScoped: true
+    } as RosterRow
+
+    pullServerAvatars([row])
+    await vi.waitFor(() => expect(hostMock.request).toHaveBeenCalledTimes(1))
+    // Let the first fetch settle (its in-flight guard clears in a finally) so
+    // the second tick is decided by the memo, not by that guard.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    pullServerAvatars([row])
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(hostMock.request).toHaveBeenCalledTimes(1)
+    // The raster is a notice-only copy of the live face, never parked on the roster.
+    expect($botMeta.get()['local::secretary']?.image).toBeUndefined()
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/profile-ops.ts
+++ b/apps/desktop/src/plugins/hermes-bots/profile-ops.ts
@@ -40,6 +40,21 @@ import type { RosterRow } from './types'
 const avatarFetchInflight = new Set<string>()
 const avatarPushInflight = new Set<string>()
 
+/** Asset RPC for a row of the ACTIVE source's roster (#102978). These rows
+ *  came back from the active gateway's own `profiles.list`, which reads every
+ *  local profile's directory — `profiles.get_asset` / `set_asset` are the
+ *  same directory reads, so the active gateway answers them with the row's
+ *  backend name. Routing them through requestForBot instead dials the row's
+ *  own (connectionId, profile) secondary, and on a local-primary desktop
+ *  every roster row is source-scoped: the first roster paint after launch
+ *  queued one pooled backend spawn per registered profile (60 profiles, 3
+ *  slots → a queue that never drained). */
+function requestAssetOnActiveSource<T>(bot: RosterRow, method: string, params: Record<string, unknown>) {
+  const route = botConnectionRoute(bot)
+
+  return host.request<T>(method, { ...params, name: route ? route.targetProfile || route.profile : bot.name })
+}
+
 /** Backfill: local meta has art the server lacks -> profiles.set_asset.
  *  Server-side avatars power the inter-agent notice pfp (core #85855) and
  *  cross-machine roster art, so local-only images are a bug, not a state. */
@@ -56,17 +71,11 @@ function pushLocalAvatars(roster: RosterRow[]) {
     if (image && typeof image === 'string' && image.startsWith('data:')) {
       avatarPushInflight.add(key)
 
-      const request = bot.sourceScoped
-        ? requestForBot(bot, 'profiles.set_asset', {
-            name: bot.name,
-            asset: 'avatar',
-            data: image
-          })
-        : host.request('profiles.set_asset', {
-            name: bot.name,
-            asset: 'avatar',
-            data: image
-          })
+      const request = requestAssetOnActiveSource(bot, 'profiles.set_asset', {
+        name: bot.name,
+        asset: 'avatar',
+        data: image
+      })
 
       Promise.resolve(request)
         .then(() =>
@@ -92,18 +101,11 @@ function pushLocalAvatars(roster: RosterRow[]) {
     rasterizeSvgToPng(svg, 160)
       .then(png =>
         png
-          ? (bot.sourceScoped
-              ? requestForBot(bot, 'profiles.set_asset', {
-                  name: bot.name,
-                  asset: 'avatar',
-                  data: png
-                })
-              : host.request('profiles.set_asset', {
-                  name: bot.name,
-                  asset: 'avatar',
-                  data: png
-                })
-            ).then(() =>
+          ? requestAssetOnActiveSource(bot, 'profiles.set_asset', {
+              name: bot.name,
+              asset: 'avatar',
+              data: png
+            }).then(() =>
               queryClient.invalidateQueries({
                 queryKey: ['hermes-bots', 'roster']
               })
@@ -175,17 +177,12 @@ export function pullServerAvatars(roster: RosterRow[]) {
 
     avatarFetchInflight.add(key)
 
-    const assetRequest = bot.sourceScoped
-      ? requestForBot(bot, 'profiles.get_asset', {
-          name: bot.name,
-          asset: 'avatar'
-        })
-      : host.request('profiles.get_asset', {
-          name: bot.name,
-          asset: 'avatar'
-        })
+    const assetRequest = requestAssetOnActiveSource<ProfilesGetAssetResult>(bot, 'profiles.get_asset', {
+      name: bot.name,
+      asset: 'avatar'
+    })
 
-    Promise.resolve(assetRequest as Promise<ProfilesGetAssetResult>)
+    assetRequest
       .then(res => {
         if (res?.found && res.data) {
           const current = $botMeta.get()

--- a/apps/desktop/src/plugins/hermes-bots/profile-ops.ts
+++ b/apps/desktop/src/plugins/hermes-bots/profile-ops.ts
@@ -39,8 +39,11 @@ import type { RosterRow } from './types'
 
 const avatarFetchInflight = new Set<string>()
 const avatarPushInflight = new Set<string>()
+// Rows whose server avatar is only the plugin's own face raster: nothing to
+// paint, so the roster must not re-fetch it on every tick.
+const avatarFaceOnly = new Set<string>()
 
-/** Asset RPC for a row of the ACTIVE source's roster (#102978). These rows
+/** Asset RPC for a row of the ACTIVE source's roster (#102978, #99336, #102913). These rows
  *  came back from the active gateway's own `profiles.list`, which reads every
  *  local profile's directory — `profiles.get_asset` / `set_asset` are the
  *  same directory reads, so the active gateway answers them with the row's
@@ -167,7 +170,7 @@ export function pullServerAvatars(roster: RosterRow[]) {
   for (const bot of roster) {
     const key = botMetaKey(bot)
 
-    if (!bot.has_avatar || avatarFetchInflight.has(key)) {
+    if (!bot.has_avatar || avatarFetchInflight.has(key) || avatarFaceOnly.has(key)) {
       continue
     }
 
@@ -189,8 +192,12 @@ export function pullServerAvatars(roster: RosterRow[]) {
           const mine = current[key] || {}
 
           // A 160px raster of the vector face is only for inter-agent
-          // notices. Do not park it on the roster or the live face dies.
+          // notices. Do not park it on the roster or the live face dies —
+          // and remember the answer, or the empty image slot re-fetches the
+          // same raster on every roster tick.
           if (isBackfilledFacePng(res.data) && mine.imageKind !== 'photo' && !mine.pet) {
+            avatarFaceOnly.add(key)
+
             return
           }
 
@@ -429,6 +436,7 @@ export async function deleteBot(bot: RosterRow) {
   forgetSessionUnread([bot.canonical_session?.id, bot.canonical_session?.resolved_id], bot.name)
   rosterWatermarks.delete(botSelectionKey(bot))
   avatarFetchInflight.delete(botMetaKey(bot))
+  avatarFaceOnly.delete(botMetaKey(bot))
   avatarPushInflight.delete(botMetaKey(bot))
 
   if ($selectedBot.get() === botSelectionKey(bot)) {


### PR DESCRIPTION
Opening Bot Mode on a desktop with dozens of registered profiles no longer queues one pooled backend spawn per profile at launch: roster avatar sync (`profiles.get_asset` / `set_asset`) now asks the already-open active gateway for every local row instead of dialing each row's own secondary socket (#102978), and the same per-row dial was the every-5-seconds WebSocket churn and 30-second re-spawn loop reported against the roster poll and relay timers (#99336, #102913).

Fixes #102978. Fixes #99336. Fixes #102913.

Lane B (#108135, folded in here as commit 527d026e) and Lane D (#108134) traced three issues to the same site independently; consolidated so one PR lands the fix. Candidate PRs #103525 and #99367 are not cherry-picked (below).

## What changes

- Also (527d026e): a face-only avatar answer (`isBackfilledFacePng`) is memoized per row, so the empty image slot stops re-fetching the same raster every roster tick — this was the steady-state churn after launch.

- `apps/desktop/src/plugins/hermes-bots/profile-ops.ts` — `pullServerAvatars` / `pushLocalAvatars` route asset RPCs through `host.request` on the active socket, addressed by the row's backend profile name (`route.targetProfile`, so managed aliases still resolve). One helper `requestAssetOnActiveSource` replaces three `bot.sourceScoped ? requestForBot(...) : host.request(...)` ladders.
- `profile-ops.test.ts` — 2 invariant tests (red on `origin/main`, green here): a 3-row source-scoped roster produces zero `requestProfile` dials and three active-gateway `get_asset` calls; an aliased row is addressed by its backend name.

## Root cause

On a local-primary desktop `host.agents()` annotates every roster row `sourceScoped: true` with a `conn:local::<profile>` route, so the first roster paint's per-row `profiles.get_asset` went through `requestForBot → host.requestProfile → requestGatewayForAgent`, which opens a `(local, profile)` secondary and spawns that profile's pooled backend — ~60 background spawns against 3 slots, i.e. the 56-deep queue in the report. The active gateway's own `profiles.list` had already read those profile directories; the asset RPCs are the same directory reads.

## Premise check against main

- #107969 (dc90a75a) bounds how long each queued dial keeps retrying (stall budget → parked); it does not remove the launch-time trigger, so the storm still fires once per boot and re-arms on every roster refetch that finds new `has_avatar` rows.
- #108069 (ad6fdd4f) routes `GET /api/sessions*` to the primary; the avatar path is JSON-RPC over a secondary socket, untouched by it.
- Candidate #103522 adds an 8-strike fail-stop for "Timed out connecting" errors in `reconnectSecondary` — a strictly weaker duplicate of the 3-strike stall budget already on main (its `isPoolConnectTimeout` matches the same two messages as `isStalledDialError`). Nothing left to salvage; its approach also evicts the entry instead of parking it, so a later open would not rearm. Not cherry-picked.
- Candidate #103525 (#102913) adds a starvation cooldown map to `relay.ts`, but `relayConnections()` dedupes to one route per registered connection and both relay loops return below 2 connections — on the reported single-connection desktop the relay never issues an RPC, so the cooldown never executes. Not cherry-picked.
- Candidate #99367 (#99336) retains a per-profile secondary socket for the roster poll, but `useRoster`'s `profiles.list` already rides the active socket; the per-profile dial was the avatar path, and retaining it keeps dormant backends warm (the opposite of the issue's ask). Not cherry-picked.

## Validation

| Check | Result |
|---|---|
| `vitest --project ui src/plugins/hermes-bots/profile-ops.test.ts` on `origin/main` source | 2 failed (`requestProfile` called 3× / 1×) |
| same, with fix | 9/9 (memo test red when `avatarFaceOnly.add` is neutralized) |
| `vitest --project ui src/plugins/hermes-bots` | 63 files, 588/588 |
| `vitest --project ui src/store/gateway-connection-lifecycle.test.ts src/store/gateway*` | 14 files, 110/110 |
| `tsc -p . --noEmit` / `tsc -p tsconfig.electron.json --noEmit` | clean / clean |
| `eslint` on touched files | 0 |
| Live 60-profile desktop repro | not run (no multi-profile Electron here); mechanism traced line-level: `roster-pane-lifecycle.ts::usePublishRosterSnapshot → pullServerAvatars(activeSourceRoster) → requestForBot → host.requestProfile → requestGatewayForAgent → createSecondary → openSecondary → hermes:connection:for → ensureRegistryBackend → spawnPoolBackend` |

## Not changed

- The 99% CPU climb of long-lived `hermes serve` processes (symptom 2 in #102978) is a Python-side finding, reported separately to the maintainer; not addressed here.
- `hermes_cli/web_server.py::_start_desktop_cron_ticker` ticks every profile's cron store in-process (`profile_homes`); it does not spawn backends and is not the launch storm.
- `apps/desktop/src/store/gateway.ts` untouched.

Fixes #102978
Supersedes #103522 (redundant with dc90a75a on main; nothing to cherry-pick)

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9fc40/wkjb6VoKFH8dlVGfXjkiE_riUbwDOy.png)
