### PR TITLE
Desktop: Bot Mode no longer dials or spawns a backend per bot on every roster tick (#99336, #102913)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/profile-ops.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/profile-ops.test.ts
@@ -12,11 +12,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $botMeta } from './data'
-import { duplicateBot } from './profile-ops'
+import { duplicateBot, pullServerAvatars } from './profile-ops'
 import type { RosterRow } from './types'
 
-const { ensureBotMetadataMock, hostMock, storageMock } = vi.hoisted(() => ({
+const { ensureBotMetadataMock, faceOnlyMock, hostMock, storageMock } = vi.hoisted(() => ({
   ensureBotMetadataMock: vi.fn(),
+  faceOnlyMock: vi.fn((_data: string) => false),
   hostMock: {
     request: vi.fn(),
     requestProfile: vi.fn(),
@@ -39,13 +40,14 @@ vi.mock('@hermes/plugin-sdk', async () => {
 })
 
 vi.mock('./shared', () => ({ getPluginCtx: () => ({ storage: storageMock }), ID: 'hermes-bots' }))
-vi.mock('./avatar-image', () => ({ isBackfilledFacePng: () => false }))
+vi.mock('./avatar-image', () => ({ isBackfilledFacePng: (data: string) => faceOnlyMock(data) }))
 vi.mock('./canonical-chat', () => ({ ensureBotMetadata: ensureBotMetadataMock }))
 
 const calls: Array<{ method: string; params: Record<string, unknown> }> = []
 
 beforeEach(() => {
   vi.clearAllMocks()
+  faceOnlyMock.mockReturnValue(false)
   calls.length = 0
   $botMeta.set({})
   storageMock.set.mockResolvedValue(undefined)
@@ -151,5 +153,58 @@ describe('duplicating a bot', () => {
     hostMock.requestProfile.mockResolvedValue({ ok: true })
 
     expect(await duplicateBot(bot, [bot, elsewhere])).toBe('ops-2')
+  })
+})
+
+describe('roster avatar sync rides the active socket (#99336, #102913)', () => {
+  // The roster paints every 5s and hands pullServerAvatars its ACTIVE-source
+  // rows, which the multi-source merge marks sourceScoped. Dialing each row's
+  // own backend for a profile-directory file was a fresh WebSocket per bot per
+  // tick, and a pool spawn for every bot with no running backend.
+  const scopedRows = (...names: string[]) =>
+    names.map(
+      name =>
+        ({
+          connectionId: 'local',
+          connectionKind: 'local',
+          has_avatar: true,
+          name,
+          route: { connectionId: 'local', mode: 'local', profile: name, targetProfile: name },
+          sourceScoped: true
+        }) as RosterRow
+    )
+
+  const answerAssets = (reply: Record<string, unknown>) =>
+    hostMock.request.mockImplementation(async (method: string, params: Record<string, unknown>) => {
+      calls.push({ method, params: structuredClone(params ?? {}) })
+
+      return reply
+    })
+
+  it('reads every active-source avatar through the active gateway, never a per-bot route', async () => {
+    answerAssets({ found: false })
+
+    pullServerAvatars(scopedRows('secretary', 'ux-designer'))
+    await vi.waitFor(() => expect(calls.filter(call => call.method === 'profiles.get_asset')).toHaveLength(2))
+
+    expect(hostMock.requestProfile).not.toHaveBeenCalled()
+  })
+
+  it('does not re-fetch a face-only raster on the next roster tick', async () => {
+    faceOnlyMock.mockReturnValue(true)
+    answerAssets({ data: 'data:image/png;base64,AAAA', found: true })
+
+    pullServerAvatars(scopedRows('secretary'))
+    await vi.waitFor(() => expect(calls.filter(call => call.method === 'profiles.get_asset')).toHaveLength(1))
+
+    // Let the first fetch fully settle (its in-flight guard clears in a
+    // finally) so the second tick is decided by memory, not by that guard.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    pullServerAvatars(scopedRows('secretary'))
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(calls.filter(call => call.method === 'profiles.get_asset')).toHaveLength(1)
+    // The raster is a notice-only copy of the live face — never parked on the roster.
+    expect($botMeta.get()['local::secretary']?.image).toBeUndefined()
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/profile-ops.ts
+++ b/apps/desktop/src/plugins/hermes-bots/profile-ops.ts
@@ -39,6 +39,23 @@ import type { RosterRow } from './types'
 
 const avatarFetchInflight = new Set<string>()
 const avatarPushInflight = new Set<string>()
+// Rows whose server avatar is only the plugin's own face raster: nothing to
+// paint, so the roster must not re-fetch it on every tick.
+const avatarFaceOnly = new Set<string>()
+
+/** Avatar sync RPC for a row of the ACTIVE source's roster (#99336, #102913).
+ *
+ *  Assets are profile-directory files, which every backend on that host can
+ *  read for any of its profiles — the gateway that just answered
+ *  profiles.list included. Routing them through requestForBot dialed each
+ *  bot's OWN backend instead: every source-scoped row (which, after the
+ *  multi-source merge, is every row) paid a fresh WebSocket per roster tick
+ *  and, for a bot with no running backend, a pool spawn just to read a PNG —
+ *  a spawn re-queued every ~30s against a full pool. Ride the active socket
+ *  like the roster query itself; the roster passes active-source rows only. */
+function requestAvatarAsset<T>(method: string, params: Record<string, unknown>): Promise<T> {
+  return host.request<T>(method, params)
+}
 
 /** Backfill: local meta has art the server lacks -> profiles.set_asset.
  *  Server-side avatars power the inter-agent notice pfp (core #85855) and
@@ -56,17 +73,11 @@ function pushLocalAvatars(roster: RosterRow[]) {
     if (image && typeof image === 'string' && image.startsWith('data:')) {
       avatarPushInflight.add(key)
 
-      const request = bot.sourceScoped
-        ? requestForBot(bot, 'profiles.set_asset', {
-            name: bot.name,
-            asset: 'avatar',
-            data: image
-          })
-        : host.request('profiles.set_asset', {
-            name: bot.name,
-            asset: 'avatar',
-            data: image
-          })
+      const request = requestAvatarAsset('profiles.set_asset', {
+        name: bot.name,
+        asset: 'avatar',
+        data: image
+      })
 
       Promise.resolve(request)
         .then(() =>
@@ -92,18 +103,11 @@ function pushLocalAvatars(roster: RosterRow[]) {
     rasterizeSvgToPng(svg, 160)
       .then(png =>
         png
-          ? (bot.sourceScoped
-              ? requestForBot(bot, 'profiles.set_asset', {
-                  name: bot.name,
-                  asset: 'avatar',
-                  data: png
-                })
-              : host.request('profiles.set_asset', {
-                  name: bot.name,
-                  asset: 'avatar',
-                  data: png
-                })
-            ).then(() =>
+          ? requestAvatarAsset('profiles.set_asset', {
+              name: bot.name,
+              asset: 'avatar',
+              data: png
+            }).then(() =>
               queryClient.invalidateQueries({
                 queryKey: ['hermes-bots', 'roster']
               })
@@ -165,7 +169,7 @@ export function pullServerAvatars(roster: RosterRow[]) {
   for (const bot of roster) {
     const key = botMetaKey(bot)
 
-    if (!bot.has_avatar || avatarFetchInflight.has(key)) {
+    if (!bot.has_avatar || avatarFetchInflight.has(key) || avatarFaceOnly.has(key)) {
       continue
     }
 
@@ -175,25 +179,24 @@ export function pullServerAvatars(roster: RosterRow[]) {
 
     avatarFetchInflight.add(key)
 
-    const assetRequest = bot.sourceScoped
-      ? requestForBot(bot, 'profiles.get_asset', {
-          name: bot.name,
-          asset: 'avatar'
-        })
-      : host.request('profiles.get_asset', {
-          name: bot.name,
-          asset: 'avatar'
-        })
+    const assetRequest = requestAvatarAsset<ProfilesGetAssetResult>('profiles.get_asset', {
+      name: bot.name,
+      asset: 'avatar'
+    })
 
-    Promise.resolve(assetRequest as Promise<ProfilesGetAssetResult>)
+    assetRequest
       .then(res => {
         if (res?.found && res.data) {
           const current = $botMeta.get()
           const mine = current[key] || {}
 
           // A 160px raster of the vector face is only for inter-agent
-          // notices. Do not park it on the roster or the live face dies.
+          // notices. Do not park it on the roster or the live face dies —
+          // and remember the answer, or the empty image slot re-fetches the
+          // same raster on every roster tick.
           if (isBackfilledFacePng(res.data) && mine.imageKind !== 'photo' && !mine.pet) {
+            avatarFaceOnly.add(key)
+
             return
           }
 
@@ -432,6 +435,7 @@ export async function deleteBot(bot: RosterRow) {
   forgetSessionUnread([bot.canonical_session?.id, bot.canonical_session?.resolved_id], bot.name)
   rosterWatermarks.delete(botSelectionKey(bot))
   avatarFetchInflight.delete(botMetaKey(bot))
+  avatarFaceOnly.delete(botMetaKey(bot))
   avatarPushInflight.delete(botMetaKey(bot))
 
   if ($selectedBot.get() === botSelectionKey(bot)) {


### PR DESCRIPTION
Bot Mode no longer dials a fresh WebSocket to every background profile every ~5 seconds, and no longer re-queues a backend spawn per idle bot every ~30 seconds against a full local pool — the avatar sync behind both reports now reads over the socket that already answered the roster.

## What was happening

- `useRoster` repaints every 5s and hands `pullServerAvatars` the active-source rows. Since the multi-source merge (ed20a6f01af) every such row is `sourceScoped`, so the avatar sync picked `requestForBot` and dialed each bot's **own** backend to read a profile-directory PNG (`profile-ops.ts:182-190` on main).
- Warm background profile: one WebSocket per bot per tick, one JSON-RPC message, disposed at refcount 0 — the `ws accepted / ws closed messages=1` pair every ~5.2s in #99336's `gui.log`, stopping the moment that profile becomes foreground (primary route → no dial).
- Idle bot on a full pool: `requestGatewayForProfile → sharedPrimaryRoute → hermes:connection → ensureBackend` queues a spawn that waits out `POOL_SLOT_WAIT_MS` (30s) and is re-queued by the next paint — #102913's per-bot `waiting for a free local slot … timed out` cadence, gone when the plugin is disabled.
- Self-sustaining: the plugin's own 160px face raster is deliberately not parked in `$botMeta`, so the empty image slot re-fetched it every tick.

**Root cause:** avatar RPCs for active-source rows were routed to each bot's own backend although the asset is a profile-directory file any backend on that host serves.

## Fix

- The three avatar RPCs (`profiles.get_asset`, the two `profiles.set_asset` backfills) ride `host.request` — the active gateway — like the roster query itself.
- Face-only answers are remembered per row (cleared on delete) so a row is fetched once, not once per tick.
- Two invariant tests in `profile-ops.test.ts` (both red on `origin/main`; the second also red with only the memo neutralized).

## Why not the two salvage PRs

- **#103525 (relay cooldown):** `relayConnections()` dedupes to one route per registered connection and both loops return below two connections (`relay.ts:186-200, 260, 339`). A 7-bot single-connection desktop never issues a relay RPC; with 2+ connections the relay polls one profile per connection, not per bot. The cooldown never executes in the reported topology, so it is not cherry-picked. `#107969`'s passive-read primitive does not apply either: it is a REST option and there is no REST route for profile assets — and once assets ride the active socket there is nothing left to cool down.
- **#99367 (roster socket retention):** `useRoster`'s `profiles.list` already goes through `requestForBot({ name })`, whose row is not `sourceScoped`, so it uses the active socket (`routing.ts:205-223`); retaining a per-profile secondary keeps a socket open that the poll never used, and keeps dormant backends warm — the opposite of the issue's "not kept warm by the poll alone" expectation. Its reviewer also noted the local path was unchanged. Not cherry-picked.

## Validation

| Check | Result |
|---|---|
| `npx vitest run --project ui src/plugins/hermes-bots src/store/gateway-relay-retention.test.ts src/sdk/profile-routing.test.ts` | 65 files, 644 tests passed |
| New tests on `origin/main` source | 2 failed (per-bot `requestProfile` dial / re-fetch on second tick) |
| `npx tsc -p . --noEmit` / `npx tsc -p tsconfig.electron.json --noEmit` | clean |
| `npx eslint` on touched files, `git diff --check` | clean |
| Live multi-profile desktop repro | not run (no Electron here); verified at the unit + line-trace layer |

Fixes #102913
Fixes #99336
Supersedes #103525 (relay cooldown — premise does not hold on main; see above)
Supersedes #99367 (roster socket retention — premise does not hold on main; see above)

Not changed: `relay.ts`, `data.ts`, `sdk/index.ts`, `store/gateway.ts`, `electron/*`.
