### PR TITLE
fix(compression): keep pre-compression messages visible after rotation

### DIFF
--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -543,9 +543,13 @@ async def get_session_messages(
         default_page = limit is None
         latest_page = order == "latest" or (order is None and default_page)
         _limit = 500 if default_page else min(limit, 500)
-        return sid, _limit, db.get_messages(
-            sid, limit=_limit, offset=offset, latest=latest_page,
-            include_compacted=include_compacted)
+        if include_compacted:
+            messages = db.get_display_messages(
+                sid, limit=_limit, offset=offset, latest=latest_page)
+        else:
+            messages = db.get_messages(
+                sid, limit=_limit, offset=offset, latest=latest_page)
+        return sid, _limit, messages
 
     result = await asyncio.to_thread(_with_db, profile, _read, read_only=True)
     if result is None:

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -505,7 +505,7 @@ class SessionCompressionMixin:
         seen = {session_id}
         while current:
             parent_id = current.get("parent_session_id")
-            if not parent_id or parent_id in seen or self._is_explicit_fork_child_row(current):
+            if not parent_id or parent_id in seen or self._is_lineage_boundary_child_row(current):
                 break
             parent = _row(parent_id)
             if not parent or parent.get("end_reason") != "compression":
@@ -680,15 +680,7 @@ class SessionCompressionMixin:
 
     def _is_compression_child_row(self, child: Dict[str, Any]) -> bool:
         parent_id = child.get("parent_session_id")
-        if not parent_id or self._is_explicit_fork_child_row(child):
-            return False
-        cfg = child.get("model_config")
-        if isinstance(cfg, str):
-            try:
-                cfg = json.loads(cfg)
-            except json.JSONDecodeError:
-                cfg = None
-        if isinstance(cfg, dict) and cfg.get("_reset_from") == parent_id:
+        if not parent_id or self._is_lineage_boundary_child_row(child):
             return False
         parent = self.get_session(parent_id)
         return bool(parent and parent.get("end_reason") == "compression")
@@ -696,7 +688,7 @@ class SessionCompressionMixin:
     def get_compression_lineage(self, session_id: str) -> List[str]:
         """Return compression ancestors through tip in chronological order."""
         session = self.get_session(session_id)
-        if not session or self._is_explicit_fork_child_row(session):
+        if not session or self._is_lineage_boundary_child_row(session):
             return [session_id] if session else []
         root = session
         ancestors = {root["id"]}

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -691,21 +691,6 @@ class SessionCompressionMixin:
                 break
             root = parent
             ancestors.add(root["id"])
-        lineage = [root["id"]]
-        seen = {root["id"]}
-        current = root
-        while current.get("end_reason") == "compression":
-            rows = self._read_all(
-                """
-                SELECT * FROM sessions
-                WHERE parent_session_id = ?
-                ORDER BY started_at ASC
-                """, (current["id"],))
-            next_child = next((dict(row) for row in rows if self._is_compression_child_row(dict(row))), None)
-            if not next_child or next_child["id"] in seen:
-                break
-            lineage.append(next_child["id"])
-            seen.add(next_child["id"])
-            current = next_child
+        lineage = self.get_compression_chain(root["id"])
         # Later tips are included only when the requested session itself was compacted.
         return lineage if session_id in lineage else [session_id]

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -34,6 +34,9 @@ _CHAIN_STEP_SQL = f"""
                       AND COALESCE(
                             json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from'), ''
                           ) != parent.id
+                      AND COALESCE(
+                            json_extract(COALESCE(child.model_config, '{{}}'), '$._reset_from'), ''
+                          ) != parent.id
                       AND COALESCE(child.source, '') != 'tool'
                     ORDER BY
                       CASE
@@ -101,7 +104,7 @@ class SessionCompressionMixin:
             superseded = conn.execute(
                 "SELECT 1 FROM sessions WHERE parent_session_id = ?"
                 + self._NON_CONTINUATION_CHILD_FILTER_SQL.format(alias="") + " LIMIT 1",
-                (session_id, session_id, session_id)).fetchone()
+                (session_id, session_id, session_id, session_id)).fetchone()
             if superseded is not None:
                 return None
             conn.execute(
@@ -140,7 +143,7 @@ class SessionCompressionMixin:
                 ORDER BY s.started_at ASC
                 LIMIT 2
                 """,
-                (parent_session_id, parent_session_id, parent_session_id),
+                (parent_session_id, parent_session_id, parent_session_id, parent_session_id),
             ).fetchall()
         return self._session_row_dict(rows[0]) if len(rows) == 1 else None
 
@@ -164,7 +167,7 @@ class SessionCompressionMixin:
                 + """
                 LIMIT 1
                 """,
-                (session_id, session_id, session_id),
+                (session_id, session_id, session_id, session_id),
             ).fetchone()
             if child is not None:
                 return False
@@ -678,6 +681,14 @@ class SessionCompressionMixin:
     def _is_compression_child_row(self, child: Dict[str, Any]) -> bool:
         parent_id = child.get("parent_session_id")
         if not parent_id or self._is_explicit_fork_child_row(child):
+            return False
+        cfg = child.get("model_config")
+        if isinstance(cfg, str):
+            try:
+                cfg = json.loads(cfg)
+            except json.JSONDecodeError:
+                cfg = None
+        if isinstance(cfg, dict) and cfg.get("_reset_from") == parent_id:
             return False
         parent = self.get_session(parent_id)
         return bool(parent and parent.get("end_reason") == "compression")

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -28,8 +28,12 @@ _CHAIN_STEP_SQL = f"""
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.id = ?
                       AND parent.end_reason = 'compression'
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
-                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                      AND COALESCE(
+                            json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from'), ''
+                          ) != parent.id
+                      AND COALESCE(
+                            json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from'), ''
+                          ) != parent.id
                       AND COALESCE(child.source, '') != 'tool'
                     ORDER BY
                       CASE

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -1287,6 +1287,31 @@ class SessionMessagesMixin:
         parent_id = session.get("parent_session_id")
         return parent_id in markers if parent_id else any(m is not None for m in markers)
 
+    def _is_lineage_boundary_child_row(self, session: Dict[str, Any]) -> bool:
+        """True for a parent-bound branch, delegate, reset, or tool edge.
+
+        Compression continuations inherit ``model_config`` verbatim, so a marker for an older
+        parent is not a boundary on the current edge. Malformed config does not invent a
+        boundary.
+        """
+        if session.get("source") == "tool":
+            return True
+        cfg = session.get("model_config")
+        if isinstance(cfg, str):
+            try:
+                cfg = json.loads(cfg)
+            except json.JSONDecodeError:
+                return False
+        if not isinstance(cfg, dict):
+            return False
+        parent_id = session.get("parent_session_id")
+        markers = (
+            cfg.get("_branched_from"),
+            cfg.get("_delegate_from"),
+            cfg.get("_reset_from"),
+        )
+        return parent_id in markers if parent_id else any(m is not None for m in markers)
+
     def is_explicit_fork_child(self, session_id: str) -> bool:
         """Read-only :meth:`_is_explicit_fork_child_row`; a missing row is not a fork (prompt_cache_scope keeps
         a declared conversation key from crossing the fork boundary)."""

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -820,7 +820,7 @@ class SessionMessagesMixin:
         the active-only model replay.  ``display_identity`` collapses protected-tail copies
         before LIMIT/OFFSET, and ``display_order`` retains their original chronology.
         """
-        session_ids = self._resume_lineage_ids(session_id)
+        session_ids = self.get_compression_lineage(session_id) or [session_id]
         if len(session_ids) == 1:
             return self.get_messages(
                 session_id, include_compacted=True, limit=limit, offset=offset, latest=latest)

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -811,6 +811,52 @@ class SessionMessagesMixin:
                 rows.reverse()
         return [self._row_to_message_dict(row, warn_context="get_messages", summary_flag=True) for row in rows]
 
+    def get_display_messages(self, session_id: str, *, limit: Optional[int] = None,
+                             offset: int = 0, latest: bool = False) -> List[Dict[str, Any]]:
+        """Page the logical display transcript across a compression lineage.
+
+        Legacy rotating compression stores the visible prefix in ended ancestors and the
+        summary/tail in the live tip.  Display pagination must span both without changing
+        the active-only model replay.  ``display_identity`` collapses protected-tail copies
+        before LIMIT/OFFSET, and ``display_order`` retains their original chronology.
+        """
+        session_ids = self._resume_lineage_ids(session_id)
+        if len(session_ids) == 1:
+            return self.get_messages(
+                session_id, include_compacted=True, limit=limit, offset=offset, latest=latest)
+        if all(self._ensure_display_order(sid) for sid in session_ids):
+            placeholders = _placeholders(session_ids)
+            direction = "DESC" if latest else "ASC"
+            sql = f"""WITH logical AS (
+                    SELECT display_identity, MIN(display_order) AS display_order
+                    FROM messages
+                    WHERE session_id IN ({placeholders}) AND (active = 1 OR compacted = 1)
+                    GROUP BY display_identity
+                ), page AS (
+                    SELECT display_identity, display_order FROM logical
+                    ORDER BY display_order {direction} LIMIT ? OFFSET ?
+                )
+                SELECT chosen.* FROM page
+                JOIN messages AS chosen ON chosen.id = (
+                    SELECT candidate.id FROM messages AS candidate
+                    WHERE candidate.session_id IN ({placeholders})
+                      AND candidate.display_identity = page.display_identity
+                      AND (candidate.active = 1 OR candidate.compacted = 1)
+                    ORDER BY candidate.active DESC, candidate.id DESC LIMIT 1
+                )
+                ORDER BY page.display_order ASC"""
+            rows = self._read_all(
+                sql, [*session_ids, -1 if limit is None else limit, offset, *session_ids])
+        else:
+            # A read-only pre-index store cannot backfill display identities. Preserve the
+            # historical projection exactly, then page the deduped logical rows in memory.
+            rows = self._dedupe_display_generations(self._read_all(
+                f"SELECT * FROM messages WHERE session_id IN ({_placeholders(session_ids)}) "
+                "AND (active = 1 OR compacted = 1) ORDER BY id ASC", session_ids))
+            rows = rows[::-1][offset:][:limit][::-1] if latest else rows[offset:][:limit]
+        return [self._row_to_message_dict(row, warn_context="get_display_messages", summary_flag=True)
+                for row in rows]
+
     def find_pr_url_messages(self, session_ids: List[str]) -> List[Dict[str, Any]]:
         """Tool results containing ``/pull/``: a deliberately loose scan, oldest-first so the caller takes the last."""
         ids = [s for s in session_ids if s]

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -428,6 +428,19 @@ class SessionSessionsMixin:
         " '$._reset_from'), '') != ?\n  AND COALESCE({alias}source, '') != 'tool'\n"
     )
 
+    _LINEAGE_CONTINUATION_EDGE_SQL = """
+                  AND COALESCE(json_extract(
+                        CASE WHEN json_valid({child}.model_config) THEN {child}.model_config ELSE '{{}}' END,
+                        '$._branched_from'), '') != {parent}.id
+                  AND COALESCE(json_extract(
+                        CASE WHEN json_valid({child}.model_config) THEN {child}.model_config ELSE '{{}}' END,
+                        '$._delegate_from'), '') != {parent}.id
+                  AND COALESCE(json_extract(
+                        CASE WHEN json_valid({child}.model_config) THEN {child}.model_config ELSE '{{}}' END,
+                        '$._reset_from'), '') != {parent}.id
+                  AND COALESCE({child}.source, '') != 'tool'
+    """
+
     def end_session(self, session_id: str, end_reason: str) -> None:
         """Mark a session ended; the first end_reason wins (a compression split must keep
         ``'compression'`` even if a stale end_session() lands later); reopen_session() to re-end."""
@@ -808,6 +821,7 @@ class SessionSessionsMixin:
                 JOIN sessions child ON child.id = a.id
                 JOIN sessions parent ON parent.id = child.parent_session_id
                 WHERE parent.end_reason = 'compression'
+                {self._LINEAGE_CONTINUATION_EDGE_SQL.format(child='child', parent='parent')}
               ),
               descendants(id) AS (
                 SELECT ?
@@ -817,6 +831,7 @@ class SessionSessionsMixin:
                 JOIN sessions parent ON parent.id = d.id
                 JOIN sessions child ON child.parent_session_id = parent.id
                 WHERE parent.end_reason = 'compression'
+                {self._LINEAGE_CONTINUATION_EDGE_SQL.format(child='child', parent='parent')}
               ),
               lineage(id) AS (
                 SELECT id FROM ancestors

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -416,14 +416,16 @@ class SessionSessionsMixin:
     # quiet and its unkeyed successor (incident was ~60s; 15 min without spanning conversations).
     _ORPHAN_ADOPTION_MAX_GAP_S = 900.0
 
-    # Children that are NOT compression continuations (branches, delegates, tool sessions). Markers
+    # Children that are NOT compression continuations (branches, delegates, resets, tool sessions). Markers
     # are bound to the queried parent id: continuations inherit model_config verbatim, so
     # presence-matching misclassified them as delegates.
     _NON_CONTINUATION_CHILD_FILTER_SQL = (
         "  AND COALESCE(json_extract(COALESCE({alias}model_config, '{{}}'),"
         " '$._branched_from'), '') != ?\n"
         "  AND COALESCE(json_extract(COALESCE({alias}model_config, '{{}}'),"
-        " '$._delegate_from'), '') != ?\n  AND COALESCE({alias}source, '') != 'tool'\n"
+        " '$._delegate_from'), '') != ?\n"
+        "  AND COALESCE(json_extract(COALESCE({alias}model_config, '{{}}'),"
+        " '$._reset_from'), '') != ?\n  AND COALESCE({alias}source, '') != 'tool'\n"
     )
 
     def end_session(self, session_id: str, end_reason: str) -> None:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2215,6 +2215,37 @@ class TestWebServerEndpoints:
         contents = [m["content"] for m in resp.json()["messages"]]
         assert contents == ["old q", "old a", "summary", "live q", "live a"]
 
+    def test_get_session_messages_pages_across_rotated_compression_lineage(self):
+        """The Desktop display path keeps the parent prefix reachable after rotation."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="rotation-parent", source="telegram")
+            db.append_message("rotation-parent", role="user", content="old q")
+            db.append_message("rotation-parent", role="assistant", content="old a")
+            db.end_session("rotation-parent", "compression")
+            db.create_session(
+                session_id="rotation-child", source="telegram",
+                parent_session_id="rotation-parent")
+            db.append_message("rotation-child", role="user", content="summary")
+            db.append_message("rotation-child", role="assistant", content="recent a")
+        finally:
+            db.close()
+
+        tail = self.client.get(
+            "/api/sessions/rotation-child/messages"
+            "?include_compacted=true&limit=2&order=latest"
+        )
+        prefix = self.client.get(
+            "/api/sessions/rotation-child/messages"
+            "?include_compacted=true&limit=2&offset=2&order=latest"
+        )
+
+        assert tail.status_code == prefix.status_code == 200
+        assert [m["content"] for m in prefix.json()["messages"]] == ["old q", "old a"]
+        assert [m["content"] for m in tail.json()["messages"]] == ["summary", "recent a"]
+
     def test_get_session_messages_projects_and_dedupes_composite_carrier(self):
         from agent.context_compressor import (
             HISTORICAL_TASK_HEADING,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2222,14 +2222,17 @@ class TestWebServerEndpoints:
         db = SessionDB()
         try:
             db.create_session(session_id="rotation-parent", source="telegram")
-            db.append_message("rotation-parent", role="user", content="old q")
-            db.append_message("rotation-parent", role="assistant", content="old a")
+            db.append_message("rotation-parent", role="user", content="old q", timestamp=1.0)
+            db.append_message("rotation-parent", role="assistant", content="old a", timestamp=2.0)
             db.end_session("rotation-parent", "compression")
             db.create_session(
                 session_id="rotation-child", source="telegram",
                 parent_session_id="rotation-parent")
-            db.append_message("rotation-child", role="user", content="summary")
-            db.append_message("rotation-child", role="assistant", content="recent a")
+            db.append_message("rotation-child", role="user", content="summary", timestamp=3.0)
+            # Rotation carries a protected tail into the child. It must not consume a
+            # second pagination slot or move from its original chronological position.
+            db.append_message("rotation-child", role="assistant", content="old a", timestamp=2.0)
+            db.append_message("rotation-child", role="assistant", content="recent a", timestamp=4.0)
         finally:
             db.close()
 

--- a/tests/hermes_state/test_display_projection_parity.py
+++ b/tests/hermes_state/test_display_projection_parity.py
@@ -181,6 +181,25 @@ class TestAncestorPrefix:
 
 
 class TestLogicalDisplayLineage:
+    def test_reset_child_does_not_expose_or_resume_from_compression_parent(self, db):
+        db.create_session("parent", source="desktop")
+        db.append_message("parent", "user", "parent private transcript")
+        db.end_session("parent", "compression")
+        db.create_session(
+            "reset-child",
+            source="desktop",
+            parent_session_id="parent",
+            model_config={"_reset_from": "parent"},
+        )
+        db.append_message("reset-child", "user", "new conversation")
+
+        assert db.find_live_compression_child("parent") is None
+        assert db.resolve_resume_session_id("parent") == "parent"
+        assert db.get_compression_lineage("reset-child") == ["reset-child"]
+        assert _texts(db.get_display_messages("reset-child")) == [
+            ("user", "new conversation"),
+        ]
+
     def test_direct_delegate_excludes_parent_transcript(self, db):
         db.create_session("root", source="telegram")
         db.append_message("root", "user", "root turn")

--- a/tests/hermes_state/test_display_projection_parity.py
+++ b/tests/hermes_state/test_display_projection_parity.py
@@ -180,6 +180,44 @@ class TestAncestorPrefix:
         assert _texts(display) == [("user", "branch turn")]
 
 
+class TestLogicalDisplayLineage:
+    def test_direct_delegate_excludes_parent_transcript(self, db):
+        db.create_session("root", source="telegram")
+        db.append_message("root", "user", "root turn")
+        db.create_session(
+            "delegate",
+            source="delegate",
+            parent_session_id="root",
+            model_config={"_delegate_from": "root"},
+        )
+        db.append_message("delegate", "user", "delegate turn")
+
+        display = db.get_display_messages("delegate")
+
+        assert _texts(display) == [("user", "delegate turn")]
+
+    def test_compressed_branch_continuation_keeps_branch_local_prefix(self, db):
+        db.create_session("root", source="desktop")
+        db.append_message("root", "user", "root turn")
+        db.create_session(
+            "branch",
+            source="desktop",
+            parent_session_id="root",
+            model_config={"_branched_from": "root"},
+        )
+        db.append_message("branch", "user", "branch turn")
+        db.end_session("branch", "compression")
+        db.create_session("branch-tip", source="desktop", parent_session_id="branch")
+        db.append_message("branch-tip", "assistant", "branch-tip turn")
+
+        display = db.get_display_messages("branch-tip")
+
+        assert _texts(display) == [
+            ("user", "branch turn"),
+            ("assistant", "branch-tip turn"),
+        ]
+
+
 class TestResumeGuardBoundsWhatResumeLoads:
     def test_guard_counts_the_rows_the_display_read_materializes(self, db):
         """The guard must not undercount: it bounds an in-memory materialization."""

--- a/tests/hermes_state/test_display_projection_parity.py
+++ b/tests/hermes_state/test_display_projection_parity.py
@@ -217,6 +217,23 @@ class TestLogicalDisplayLineage:
             ("assistant", "branch-tip turn"),
         ]
 
+    def test_live_continuation_ignores_stale_compression_sibling(self, db):
+        db.create_session("parent", source="desktop")
+        db.append_message("parent", "user", "parent prefix")
+        db.end_session("parent", "compression")
+        db.create_session("stale", source="desktop", parent_session_id="parent")
+        db.append_message("stale", "assistant", "stale sibling")
+        db.end_session("stale", "ws_orphan_reap")
+        db.create_session("live", source="desktop", parent_session_id="parent")
+        db.append_message("live", "assistant", "live tip")
+
+        display = db.get_display_messages("live")
+
+        assert _texts(display) == [
+            ("user", "parent prefix"),
+            ("assistant", "live tip"),
+        ]
+
 
 class TestResumeGuardBoundsWhatResumeLoads:
     def test_guard_counts_the_rows_the_display_read_materializes(self, db):

--- a/tests/hermes_state/test_session_archiving.py
+++ b/tests/hermes_state/test_session_archiving.py
@@ -49,3 +49,20 @@ def test_unarchiving_compression_tip_unarchives_projected_root(db):
     assert db.get_session("root")["archived"] == 0
     assert db.get_session("tip")["archived"] == 0
     assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == ["tip"]
+
+
+def test_archiving_respects_parent_bound_reset_but_crosses_inherited_reset(db):
+    _compression_pair(db)
+    db.patch_session_model_config("tip", {"_reset_from": "root"})
+
+    assert db.set_session_archived("tip", True) is True
+
+    assert db.get_session("root")["archived"] == 0
+    assert db.get_session("tip")["archived"] == 1
+    assert db.set_session_archived("tip", False) is True
+    db.patch_session_model_config("tip", {"_reset_from": "older-parent"})
+
+    assert db.set_session_archived("tip", True) is True
+
+    assert db.get_session("root")["archived"] == 1
+    assert db.get_session("tip")["archived"] == 1

--- a/tests/state/test_compression_lineage_guard.py
+++ b/tests/state/test_compression_lineage_guard.py
@@ -158,6 +158,26 @@ def test_compression_lineage_includes_continuation_with_foreign_markers(
     ]
 
 
+def test_compression_lineage_includes_continuation_with_foreign_reset_marker(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db, "reset-descendant")
+    db.create_session(
+        "reset-descendant-tip",
+        source="webui",
+        parent_session_id="reset-descendant",
+        model_config={"_reset_from": "some-original-parent"},
+    )
+
+    assert db.get_compression_lineage("reset-descendant-tip") == [
+        "reset-descendant",
+        "reset-descendant-tip",
+    ]
+    child = db.find_live_compression_child("reset-descendant")
+    assert child is not None
+    assert child["id"] == "reset-descendant-tip"
+
+
 def test_reopen_orphaned_compression_session_fails_closed_with_active_lease(
     db: SessionDB,
 ) -> None:

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -169,6 +169,29 @@ def test_turn_lease_walks_compression_child_that_inherited_fork_markers(tmp_path
     db.release_session_turn_lease("original-parent", original_holder)
 
 
+def test_turn_lease_respects_parent_bound_reset_but_walks_inherited_reset(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("parent", source="test")
+    db.end_session("parent", "compression")
+    db.create_session(
+        "reset-child",
+        source="test",
+        parent_session_id="parent",
+        model_config={"_reset_from": "parent"},
+    )
+    db.create_session("continuation-parent", source="test")
+    db.end_session("continuation-parent", "compression")
+    db.create_session(
+        "continuation",
+        source="test",
+        parent_session_id="continuation-parent",
+        model_config={"_reset_from": "older-parent"},
+    )
+
+    assert db._session_turn_lease_key("reset-child") == "reset-child"
+    assert db._session_turn_lease_key("continuation") == "continuation-parent"
+
+
 def test_turn_lease_write_txn_does_not_trust_fail_open_key_helper(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION
## What does this PR do?

Preserves the complete user-visible transcript when legacy compression rotates a conversation from a parent session to a child. The Desktop transcript endpoint now pages one deduplicated display projection across the compression lineage, while model replay remains scoped to the compressed child context.

### Symptom

After a successful `compression.in_place: false` rotation, the active Desktop conversation starts at the compaction handoff and recent tail. Earlier messages remain stored on the ended parent but cannot be reached through transcript pagination.

### Impact

Users viewing a long messaging conversation can no longer access the pre-compression portion from the active transcript, making preserved history appear deleted.

### Bug Cause

**Trigger:** `hermes_cli/web_routers/sessions.py:546` / `get_session_messages()` with `include_compacted=true` after a compression rotation.

**Causal chain:**
1. Legacy compression closes the current session and publishes a child containing the compacted model context.
2. The session messages endpoint resolves the requested conversation to that child, then calls `SessionDB.get_messages()` for only the child's physical session id.
3. Desktop pagination receives the summary and recent tail but can never page into the parent's still-persisted prefix.

**Why it is wrong:** `include_compacted=true` is the Desktop's display-history path, but it pages one physical segment instead of the logical compression lineage.

**Working sibling / contrast:** TUI resume and warm-session display projections already use the compression lineage while keeping active-only model replay separate.

**Ruled out:** The gateway split-sync warning is not required for this failure. A committed parent-to-child lineage reproduces the missing prefix through the REST display endpoint even when routing already points at the child.

### Fix

Add a bounded `SessionDB.get_display_messages()` projection that pages display-visible rows across the compression lineage. It deduplicates protected-tail copies before applying limit and offset, preserves original chronology, and retains the existing fallback for read-only legacy stores. The REST endpoint uses this projection only for explicit display-history reads.

## Related Issue

Fixes #108132

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_messages.py` - add bounded, deduplicated display pagination and a shared parent-bound lineage boundary predicate.
- `hermes_state_compression.py` - keep transcript lineage and turn-lease resolution on canonical compression continuations without crossing branch, delegate, reset, or tool boundaries.
- `hermes_state_sessions.py` - prevent lineage-wide archive, hidden, pinned, and read-state updates from crossing those boundaries.
- `hermes_cli/web_routers/sessions.py` - route explicit display-history reads through the lineage projection.
- SessionDB and REST tests cover rotated pagination, protected-tail deduplication, reset isolation, inherited marker continuity, and turn-lease scoping.

## How to Test

```bash
scripts/run_tests.sh -j 1 tests/state/test_session_turn_lease.py tests/hermes_state/test_session_archiving.py tests/hermes_cli/test_web_server.py tests/hermes_state/test_display_projection_parity.py tests/state/test_compression_lineage_guard.py tests/hermes_state/test_session_md_export.py
```

Result: 243 passed and 5 skipped on Windows 11. The focused transcript regression fails on `main` and passes on this branch; reset-boundary tests cover independent lineage flags and turn leases while inherited foreign markers remain compression continuations.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on all relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

N/A - covered by the SessionDB-backed REST endpoint regression test.
