### PR TITLE
Connectors reach installs with a saved toolset list (connections toolset auto-enable)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -435,7 +435,9 @@ def enabled_mcp_server_names(config: dict) -> Set[str]:
 #: toolset on a checklist, an unchecking user's config is byte-identical to one saved before it existed and this
 #: rule would turn the opt-out back on (stuck checkbox). ``check_fn``-gated toolsets cost nothing here; never
 #: probe a remote service from this path — it runs on every CLI start, gateway session and cron tick.
-_RECENTLY_SHIPPED_TOOLSETS: frozenset = frozenset()
+#: ``connections`` shipped in #106842 (unreleased at v2026.9.7); empty this set in the release after the
+#: one that ships it, as 76e306c458 did for ``bfl``.
+_RECENTLY_SHIPPED_TOOLSETS: frozenset = frozenset({"connections"})
 
 
 def _enable_recently_shipped_toolsets(enabled_toolsets: Set[str], config: dict, platform: str) -> None:


### PR DESCRIPTION
Installs that saved their toolset list before 2026-09-10 now get the `manage_connections` tool. Until this change, those installs never saw it, even when signed in to a paid Nous org.

## The problem

`hermes tools` (and the desktop Toolsets UI) writes an explicit `platform_toolsets.<platform>` list to `config.yaml`. Nothing ever adds to that list. A toolset that ships after the save is read as "the user declined it" and stays off.

`connections` (the toolset that carries `manage_connections`, #106842) shipped on 2026-09-10 and is not in any release tag yet. Every install with a saved list from before that date has the tool stripped from its schema. The Nous entitlement check runs after the toolset list and never gets a vote.

Fresh installs and users on the `[hermes-cli]` composite were never affected. That is why the onboarding rehearsal did not show it.

```mermaid
flowchart LR
    A[config.yaml<br/>platform_toolsets.cli<br/>saved before 2026-09-10] --> B[_get_platform_tools]
    B --> C{connections<br/>in saved list?}
    C -- no --> D[toolset off]
    D --> E[manage_connections<br/>absent from schema]
    E --> F[entitlement check<br/>never runs]
```

<!-- before-and-after:start -->
| Before (hermes chat -q, same prompt, same saved toolset list) | After (hermes chat -q, same prompt, same saved toolset list) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/a9ce5356-55bb-4a8b-b378-05de3ac3d7b2) | ![After](https://github.com/user-attachments/assets/87377151-8dfa-45b2-a476-b5466d7914ef) |

<!-- before-and-after:end -->

## What the user experiences

| | Before | After |
|---|---|---|
| Saved `platform_toolsets` list from before 2026-09-10, signed in to a paid org | `manage_connections` absent. Agent says the tool does not exist. | Tool present. `status` returns the connector list. |
| Same install, user unchecked Connections in `hermes tools` | absent | absent (decline is recorded in `known_builtin_toolsets` and still wins) |
| Same install, `agent.disabled_toolsets: [connections]` | absent | absent |
| Fresh install, or `[hermes-cli]` composite | present | present (no change) |
| Signed out, or free tier with no tool pool | absent | absent (`check_fn` gate, no change) |

## What changes

One line in `hermes_cli/tools_config.py`:

```python
_RECENTLY_SHIPPED_TOOLSETS: frozenset = frozenset({"connections"})
```

`_enable_recently_shipped_toolsets` already exists for this case. It turns a named toolset on for any platform whose saved list predates it, and honours a recorded decline. Same shape as `bfl` in 97c6a183af (added) and 76e306c458 (emptied one release later).

No migration step. The set is read at toolset-resolution time, so it applies on the next process start with no config write and no `hermes update` run.

## Follow-up required

Empty `_RECENTLY_SHIPPED_TOOLSETS` in the release after the one that ships this. Once a released build has put Connections on the checklist, a user who unchecks it writes a config identical to one saved before the toolset existed, and leaving the entry in would turn their opt-out back on. Tracked in the comment above the constant.

## Tests

`tests/hermes_cli/test_tools_config.py` already carries five invariant tests behind `@_requires_recently_shipped` (they skip when the set is empty). This change un-skips them.

| Tree | Result |
|---|---|
| base (`origin/main` 8c74118c4a) | 52 passed, 6 skipped |
| this branch | 58 passed, 0 skipped |

Also run: `tests/tools/test_connections_tool.py`, `tests/tools/test_connector_bridge_wiring.py` (59 passed), `tests/test_tui_gateway_server.py` (652 passed, 1 pre-existing failure in `test_model_options_preserves_canonical_custom_row_after_agent_init` that fails identically on base).

## Live repro

Temp `HERMES_HOME`, real `auth.json` from a paid org, `config.yaml` with `platform_toolsets.cli: [file, terminal, web]` and `known_builtin_toolsets.cli` without `connections`. Same prompt to `hermes chat -q` on both trees.

| Tree | Tool the agent called | Reply |
|---|---|---|
| base 8c74118c4a | `tool_search` (no match) | `TOOL NOT AVAILABLE: manage_connections` |
| this branch | `manage_connections {"action": "status"}` | `CONNECTED: googlecalendar, slack, linear, ...` |

Third home with `connections` listed in `known_builtin_toolsets.cli` (a recorded decline): toolset stays off on this branch.
