### PR TITLE
fix(tui): freeze event replay payloads within byte budget

### DIFF
--- a/tests/test_tui_gateway_event_replay.py
+++ b/tests/test_tui_gateway_event_replay.py
@@ -66,6 +66,36 @@ def test_events_since_returns_only_newer_frames_in_order():
     assert latest_seq("s1") == 5
 
 
+def test_replay_snapshot_is_detached_from_live_event_mutation():
+    frame = _frame("s1", "tool.complete")
+    frame["params"]["payload"] = {"result": "small"}
+    event_replay._stamp_event(frame)
+    retained = replay_stats()["bytes"]
+
+    # The transport/caller still owns the live frame after stamping. Mutating it must not
+    # rewrite or grow an already-admitted replay entry behind the byte-accounting budget.
+    frame["params"]["payload"]["result"] = "x" * 1_000_000
+
+    (replayed,) = events_since("s1", 0)
+    assert replayed["payload"]["result"] == "small"
+    assert replay_stats()["bytes"] == retained
+    assert isinstance(event_replay._replay_buffers["s1"][0][1], bytes)
+
+
+def test_each_replay_read_returns_an_independent_event_graph():
+    frame = _frame("s1", "tool.complete")
+    frame["params"]["payload"] = {"nested": {"value": "original"}}
+    event_replay._stamp_event(frame)
+
+    (first,) = events_since("s1", 0)
+    first["payload"]["nested"]["value"] = "caller-mutated"
+    (second,) = events_since("s1", 0)
+
+    assert second["payload"]["nested"]["value"] == "original"
+    assert first is not second
+    assert first["payload"] is not second["payload"]
+
+
 def test_events_since_returns_client_dispatchable_event_objects():
     """Cross-language contract: the client's replay loop dispatches an element
     only when it has a TOP-LEVEL ``type`` (json-rpc-gateway.ts fetchReplay:

--- a/tui_gateway/event_replay.py
+++ b/tui_gateway/event_replay.py
@@ -5,9 +5,9 @@ Every event frame through :func:`server.write_json` (hence ``_emit``) gets a per
 with its last seen seq and gets everything newer. Invariants: stdio TUI unaffected (``seq`` only on
 event frames; Ink ignores unknown keys); one lock guards counters + buffers, and write_json already
 serializes per-transport writes so stamping cannot reorder frames; memory bound =
-_REPLAY_BUFFER_MAX events AND _REPLAY_BUFFER_BYTES_MAX serialized bytes per session,
-_REPLAY_PROCESS_BYTES_MAX bytes across at most _REPLAY_SESSIONS_MAX sessions, oldest evicted
-FIFO. Evicted or never-retained (oversized) frames leave a truncation watermark so a
+_REPLAY_BUFFER_MAX events AND _REPLAY_BUFFER_BYTES_MAX frozen UTF-8 payload bytes per session,
+_REPLAY_PROCESS_BYTES_MAX frozen UTF-8 payload bytes across at most _REPLAY_SESSIONS_MAX sessions,
+oldest evicted FIFO. Evicted or never-retained (oversized) frames leave a truncation watermark so a
 reconnecting client refetches instead of trusting a replay with holes.
 """
 
@@ -28,13 +28,15 @@ _REPLAY_EPOCH = uuid.uuid4().hex
 _REPLAY_BUFFER_MAX = 512
 _REPLAY_SESSIONS_MAX = 64
 # A ring may legitimately hold many bounded 64 KiB tool results (512 of them ≈ 32 MiB per
-# session, ×64 sessions before any cap); bound the serialized bytes so replay memory cannot
-# scale with payload size without limit.
+# session, ×64 sessions before any cap); bound the frozen serialized payload so replay memory
+# cannot scale with mutable Python object graphs after admission.
 _REPLAY_BUFFER_BYTES_MAX = 4 * 1024 * 1024
 _REPLAY_PROCESS_BYTES_MAX = 64 * 1024 * 1024
 
 _replay_lock = threading.Lock()
-# sid -> deque of (seq, params dict, serialized bytes).
+# sid -> deque of (seq, frozen params JSON bytes without the server-owned seq, retained bytes).
+# Bytes detach the replay ring from the live event object: later caller mutation cannot grow or
+# rewrite an already-accounted cache entry.
 _replay_buffers: "OrderedDict[str, deque]" = OrderedDict()
 _replay_buffer_bytes: dict[str, int] = {}
 _replay_evicted_through: dict[str, int] = {}
@@ -47,8 +49,22 @@ def replay_epoch() -> str:
     return _REPLAY_EPOCH
 
 
+def _freeze_params(params: dict) -> bytes:
+    """Serialize one replay snapshot before the caller can mutate its object graph."""
+    return json.dumps(params, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8", errors="surrogatepass"
+    )
+
+
+def _thaw_params(payload: bytes, seq: int) -> dict:
+    """Rebuild a client event object and restore the server-owned sequence number."""
+    event = json.loads(payload.decode("utf-8", errors="surrogatepass"))
+    event["seq"] = seq
+    return event
+
+
 def _stamp_event(obj: dict) -> None:
-    """Stamp one outgoing event frame (mutates obj in place) and record it."""
+    """Stamp one outgoing event frame (mutates obj in place) and record a frozen snapshot."""
     if obj.get("method") != "event":
         return
     params = obj.get("params")
@@ -58,10 +74,11 @@ def _stamp_event(obj: dict) -> None:
     if not sid:
         # Session-less global events (skin.changed etc.) are re-fetchable via their own RPCs.
         return
-    # Sizing stays OUTSIDE the lock (same rule as transport.write) so one large payload cannot
-    # stall other threads' frames; ``seq`` is not stamped yet, a few bytes off a MiB budget.
-    size = len(json.dumps(params, ensure_ascii=False, separators=(",", ":")).encode(
-        "utf-8", errors="surrogatepass"))
+    # Freeze OUTSIDE the lock (same rule as transport.write) so one large payload cannot stall
+    # other threads' frames. The server-owned seq is restored when replaying, so the snapshot can
+    # be serialized before sequence assignment without retaining the mutable params dict.
+    payload = _freeze_params(params)
+    size = len(payload)
     with _replay_lock:
         global _replay_total_bytes
         seq = _replay_next_seq.get(sid, 0) + 1
@@ -72,14 +89,14 @@ def _stamp_event(obj: dict) -> None:
             buf = _replay_buffers[sid] = deque()
             _replay_buffer_bytes[sid] = 0
             while len(_replay_buffers) > _REPLAY_SESSIONS_MAX:
-                oldest_sid, oldest_buf = _replay_buffers.popitem(last=False)
+                oldest_sid, _oldest_buf = _replay_buffers.popitem(last=False)
                 _replay_total_bytes -= _replay_buffer_bytes.pop(oldest_sid, 0)
                 _replay_next_seq.pop(oldest_sid, None)
                 _replay_evicted_through.pop(oldest_sid, None)
         if size > _REPLAY_BUFFER_BYTES_MAX or size > _REPLAY_PROCESS_BYTES_MAX:
             _replay_evicted_through[sid] = seq
             return
-        buf.append((seq, params, size))
+        buf.append((seq, payload, size))
         _replay_buffer_bytes[sid] += size
         _replay_total_bytes += size
         while len(buf) > _REPLAY_BUFFER_MAX or _replay_buffer_bytes[sid] > _REPLAY_BUFFER_BYTES_MAX:
@@ -93,7 +110,9 @@ def _stamp_event(obj: dict) -> None:
                     evicted_seq, _event, evicted_size = evict_buf.popleft()
                     _replay_buffer_bytes[evict_sid] -= evicted_size
                     _replay_total_bytes -= evicted_size
-                    _replay_evicted_through[evict_sid] = max(_replay_evicted_through.get(evict_sid, 0), evicted_seq)
+                    _replay_evicted_through[evict_sid] = max(
+                        _replay_evicted_through.get(evict_sid, 0), evicted_seq
+                    )
                     break
 
 
@@ -101,11 +120,13 @@ def events_since(sid: str, last_seen: int) -> list[dict]:
     """Recorded EVENT OBJECTS (each frame's ``params`` dict) with seq > last_seen for *sid*.
 
     Returning the full JSON-RPC envelope would make every replayed event fail the
-    client's ``event.type`` gate and be silently dropped.
+    client's ``event.type`` gate and be silently dropped. Decode after releasing the ring lock so a
+    large replay cannot block concurrent event stamping.
     """
     with _replay_lock:
         buf = _replay_buffers.get(sid or "")
-        return [event for seq, event, _size in buf if seq > last_seen] if buf else []
+        snapshots = [(seq, payload) for seq, payload, _size in buf if seq > last_seen] if buf else []
+    return [_thaw_params(payload, seq) for seq, payload in snapshots]
 
 
 def is_truncated(sid: str, last_seen: int) -> bool:
@@ -141,4 +162,5 @@ def replay_stats() -> dict:
             "bytes": _replay_total_bytes,
             "max_per_session": _REPLAY_BUFFER_MAX,
             "max_bytes_per_session": _REPLAY_BUFFER_BYTES_MAX,
-            "max_bytes_process": _REPLAY_PROCESS_BYTES_MAX}
+            "max_bytes_process": _REPLAY_PROCESS_BYTES_MAX,
+        }


### PR DESCRIPTION
## Summary

Fixes #108141.

The TUI/Desktop event replay ring measured UTF-8 JSON bytes but retained the caller-owned mutable `params` dictionary. That allowed an already-admitted entry to grow or change after accounting, bypassing both replay byte limits and snapshot semantics.

This change:

- freezes each replay entry as UTF-8 JSON bytes before admission;
- stores the representation the byte budget actually measures;
- restores the server-owned `seq` when replaying;
- decodes replay snapshots after releasing `_replay_lock`;
- returns a fresh object graph for every replay read;
- adds regressions proving neither the original live event nor a prior replay result can rewrite/grow the retained entry.

## Root cause

Before this PR:

```python
size = len(json.dumps(params, ...).encode(...))
...
buf.append((seq, params, size))
```

The cache retained `params`, not the serialized payload whose size was counted.

A focused base repro admitted a small event as roughly 71 bytes, then mutated its nested payload to one million characters. `replay_stats()["bytes"]` stayed unchanged while `events_since()` returned the mutated 1 MB value.

## Verification

The current exact implementation passes `py_compile` and a focused isolated pytest suite covering:

- mutation of the live frame after admission;
- mutation of one replay result before a second replay read;
- byte-budget eviction and truncation-gap semantics;
- concurrent per-session sequence assignment.

```text
4 passed in 0.08s
```

The branch is one commit directly on upstream `dee30d123defbb61ec53ec17bf7aae281563db49`; only `tui_gateway/event_replay.py` and its focused test are changed. Repository CI remains authoritative for the complete existing replay suite.