### PR TITLE
fix(classifier): classify kimi reasoning_details invalid type as thinking_signature

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -564,9 +564,13 @@ def _provider_special_cases(c: _Ctx) -> Optional[Verdict]:
     # ``codex_reasoning_items`` — a genuine block with nothing to strip behaves as before.
     if _is_codex_masked_replay_rejection(c):
         return _v(_R.invalid_encrypted_content, **_ABORT_FALLBACK)
-    # Anthropic thinking-block 400s (signature mismatch after transcript
-    # mutation). Not gated on provider — OpenRouter proxies Anthropic errors.
-    if status == 400 and "thinking" in msg and any(p in msg for p in _THINKING_MUTATION_WORDS):
+    # Anthropic / Kimi thinking-block 400s (signature mismatch after transcript
+    # mutation, or Kimi invalid reasoning_details type). Not gated on provider.
+    thinking_hit = (
+        ("thinking" in msg and any(p in msg for p in _THINKING_MUTATION_WORDS))
+        or ("reasoning_details" in msg and "invalid type" in msg)
+    )
+    if status == 400 and thinking_hit:
         return _v(_R.thinking_signature)
     # Anthropic long-context tier gate (429 "extra usage" + "long context").
     if status == 429 and "extra usage" in msg and "long context" in msg:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -745,7 +745,50 @@ class TestClassifyApiError:
 
 
 
-    # ── Provider-specific: Anthropic thinking signature ──
+    # ── Provider-specific: Anthropic / Kimi thinking signature ──
+
+    def test_anthropic_thinking_signature(self):
+        e = MockAPIError(
+            "thinking block has invalid signature",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="anthropic")
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_anthropic_thinking_blocks_cannot_be_modified(self):
+        e = MockAPIError(
+            "messages.73.content.10: `thinking` or `redacted_thinking` blocks "
+            "in the latest assistant message cannot be modified. These blocks "
+            "must remain as they were in the original response.",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="anthropic")
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_kimi_reasoning_details_invalid_type_classified_as_thinking_signature(self):
+        """Kimi coding endpoint returns HTTP 400 when replaying reasoning blocks:
+        'the reasoning_details at position 1 entry 0 has an invalid type'.
+        This must be classified as thinking_signature so the conversation loop
+        can strip reasoning_details and retry."""
+        e = MockAPIError(
+            "the reasoning_details at position 1 entry 0 has an invalid type",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="custom:kimi-coding")
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+        assert result.should_compress is False
+
+    def test_400_reasoning_details_without_invalid_type_not_classified(self):
+        e = MockAPIError(
+            "the reasoning_details field is missing",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="custom:kimi-coding")
+        assert result.reason != FailoverReason.thinking_signature
+
 
 
 


### PR DESCRIPTION
Fixes #108071

## What changed and why

When using Kimi coding endpoints (`custom:kimi-coding`, `k3`), replaying reasoning blocks across multi-turn sessions fails with HTTP 400: `"the reasoning_details at position N entry M has an invalid type"`. The error was previously missed by `agent/error_classifier.py` and classified as a non-retryable generic client error, causing the session to hard abort without self-healing.

### Two-Stage Diagnosis:
- **Stage 1 (Surface symptom):** When replaying conversation history containing Kimi reasoning details, the upstream endpoint rejects the request with HTTP 400 mentioning `reasoning_details` and `invalid type`.
- **Stage 2 (Deeper mechanism):** The error classifier's `thinking_signature` recovery rule strictly checked for `"thinking"` in `msg` alongside signature mutation phrases. Because Kimi uses `reasoning_details` without the literal keyword `thinking`, the error fell through the classifier. Even though `conversation_loop.py` already includes self-healing logic to strip `reasoning_details` from `api_messages` upon receiving `FailoverReason.thinking_signature`, that recovery branch was never reached, permanently bricking the active session.

## Fix

- `agent/error_classifier.py`: Updated `_provider_special_cases` thinking-signature pattern matching to match `status == 400` when `reasoning_details` and `invalid type` are both present in the error message, routing it to `FailoverReason.thinking_signature`.
- `tests/agent/test_error_classifier.py`: Added regression test `test_kimi_reasoning_details_invalid_type_classified_as_thinking_signature` and boundary check `test_400_reasoning_details_without_invalid_type_not_classified`.

## What this does NOT change

- Does not modify canonical conversation messages in storage; only enables the existing transient stripping of `reasoning_details` in `conversation_loop.py` during retry.
- Does not affect other 400 bad request errors or provider-specific classifiers.

## How to test

Run the error classifier test suite:

```bash
pytest tests/agent/test_error_classifier.py -k "thinking"
```

## Platforms tested

Linux (pure Python change, no OS-specific calls).
