### PR TITLE
fix(desktop): recover trapped sidebars and keep titlebar controls clickable

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -206,7 +206,11 @@ Sizes: `default`, `xs`, `overlay` (titlebar glyph counts).
 
 Top-edge panels extend into the native titlebar band. Their tab strips remain
 inside their own zones so tab drops, focus, and split boundaries use the same
-geometry. Lower panels keep local headers. Empty header space moves the window;
+geometry. Panels without room beside the measured window controls place their
+tabs on a full-width row below the controls. Minimized row groups use vertical
+restore rails, including groups with multiple tabs. Sidebar buttons and shortcuts
+restore minimized or fully hidden side groups without changing the selected tab.
+Lower panels keep local headers. Empty header space moves the window;
 tabs and actions remain no-drag, with native-control space reserved from the
 existing traffic-light and Window Controls Overlay measurements.
 

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -268,7 +268,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
 
   return (
     <>
-      <div aria-label={t.shell.windowControls} className={leftClusterClass}>
+      <div aria-label={t.shell.windowControls} className={leftClusterClass} data-titlebar-cluster="left">
         {visibleLeftTools.map(tool => (
           <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
         ))}
@@ -278,6 +278,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
       <div
         aria-label={t.shell.appControls}
         className={cn(titlebarToolClusterClass, 'right-(--titlebar-tools-right) top-(--titlebar-controls-top)')}
+        data-titlebar-cluster="right"
       >
         <TitlebarToolButton navigate={navigate} tool={flipTool} />
         <TitlebarToolButton navigate={navigate} tool={rightSidebarTool} />

--- a/apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
@@ -200,7 +200,7 @@ describe('docked tool tile — collapsing keeps the restore chip', () => {
   })
 })
 
-describe('a stacked tool zone collapsed in a row keeps the horizontal strip', () => {
+describe('a stacked tool zone collapsed in a row keeps a vertical restore rail', () => {
   beforeEach(() => {
     registerPane('workspace', { placement: 'main', uncloseable: true }, 'Chat')
     registerPane('terminal', { placement: 'bottom' }, 'Terminal')
@@ -223,6 +223,7 @@ describe('a stacked tool zone collapsed in a row keeps the horizontal strip', ()
 
     expect(tabEl('terminal')).toBeTruthy()
     expect(tabEl('logs')).toBeTruthy()
-    expect(globalThis.document.querySelector('[data-zone-tabstrip="g-tools"]')).toBeTruthy()
+    expect(tabEl('terminal')?.getAttribute('data-vertical')).toBe('true')
+    expect(tabEl('logs')?.getAttribute('data-vertical')).toBe('true')
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/panel-titlebar.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/panel-titlebar.ts
@@ -1,0 +1,62 @@
+import { type RefObject, useCallback, useLayoutEffect, useState } from 'react'
+
+import { useResizeObserver } from '@/hooks/use-resize-observer'
+
+/** Reserve actual chrome intersections, including after a neighbor becomes a rail. */
+export function usePanelTitlebar(ref: RefObject<HTMLElement | null>, enabled: boolean, minimized: boolean) {
+  const [belowControls, setBelowControls] = useState(true)
+
+  const measure = useCallback(() => {
+    const element = ref.current
+
+    if (!enabled || !element) {
+      return
+    }
+
+    const rect = element.getBoundingClientRect()
+
+    if (!rect.width) {
+      return
+    }
+
+    const leftControls = document.querySelector<HTMLElement>('[data-titlebar-cluster="left"]')?.getBoundingClientRect()
+
+    const rightControls = document
+      .querySelector<HTMLElement>('[data-titlebar-cluster="right"]')
+      ?.getBoundingClientRect()
+
+    // Empty chrome during a route overlay retains the last safe reservation.
+    if (!leftControls || !rightControls) {
+      return
+    }
+
+    const left = Math.min(rect.width, Math.max(0, leftControls.right + 12 - rect.left))
+    const right = Math.min(rect.width - left, Math.max(0, rect.right - rightControls.left + 24))
+    element.style.setProperty('--panel-titlebar-left', `${left}px`)
+    element.style.setProperty('--panel-titlebar-right', `${right}px`)
+    setBelowControls(minimized || rect.width - left - right < 120)
+  }, [enabled, minimized, ref])
+
+  useResizeObserver(measure, ref)
+  useLayoutEffect(() => {
+    if (!enabled) {
+      return
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+
+    for (const element of document.querySelectorAll('[data-titlebar-cluster], [data-tree-group]')) {
+      observer.observe(element)
+    }
+
+    window.addEventListener('resize', measure)
+
+    return () => {
+      observer.disconnect()
+      window.removeEventListener('resize', measure)
+    }
+  }, [enabled, measure])
+
+  return enabled && belowControls
+}

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
@@ -66,6 +66,14 @@ describe('TreeGroup', () => {
       render: () => <div>Terminal</div>
     })
     vi.stubGlobal('CSS', { escape: (value: string) => value })
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    )
     render(<TreeGroup leftEdge node={terminalGroup(false)} rightEdge topEdge />)
     const zone = container!.querySelector('[data-tree-group]')!
     const strip = zone.querySelector<HTMLElement>('[data-zone-tabstrip]')!

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -84,6 +84,7 @@ import {
 } from '../tab-selection'
 
 import { startPaneDrag } from './drag-session'
+import { usePanelTitlebar } from './panel-titlebar'
 import { tabStripVisibleForZone } from './strip-visibility'
 import { useActiveTabVisible } from './tab-strip-scroll'
 import { paneChrome } from './track-model'
@@ -222,9 +223,7 @@ export function TreeGroup({
   node,
   parentAxis,
   railSide = 'left',
-  topEdge = false,
-  leftEdge = false,
-  rightEdge = false
+  topEdge = false
 }: {
   node: GroupNode
   parentAxis?: 'column' | 'row'
@@ -239,6 +238,8 @@ export function TreeGroup({
   // The scrolling tab list inside the header (the strip also holds the
   // minimize chevron, which must not scroll away).
   const tabsRef = useRef<HTMLDivElement>(null)
+  const tabsBelowControls = usePanelTitlebar(ref, topEdge, Boolean(node.minimized))
+  const tabsInTitlebar = topEdge && !tabsBelowControls
   // The chip under the last right-click — the pane the zone menu's Split
   // actions carry into the new zone (header background = the active pane).
   // STATE, not a ref: the menu items (incl. Close's visibility) are JSX
@@ -350,11 +351,9 @@ export function TreeGroup({
   // (tabs reading top-to-bottom). In a column (stacked zones) the horizontal
   // header IS the collapsed form, exactly as before.
   //
-  // EXCEPTION: when the zone has ≥2 shown panes, keep the horizontal tab bar
-  // even when minimized — the user can still switch (and restore) without
-  // expanding first. The vertical rail is only for a lone pane, where it
-  // still renders that pane's tab as the restore handle.
-  const verticalCollapse = Boolean(node.minimized) && parentAxis === 'row' && !isEmpty && shown.length <= 1
+  // Every minimized row group becomes a vertical restore rail. A horizontal
+  // multi-tab strip cannot fit in the collapsed 28px track.
+  const verticalCollapse = Boolean(node.minimized) && parentAxis === 'row' && !isEmpty
   // A minimized group IS its header, so it shows one regardless.
   const headerVisible = !isEmpty && !verticalCollapse && (Boolean(node.minimized) || stripVisible)
 
@@ -440,7 +439,13 @@ export function TreeGroup({
         setMenuPane((e.target as HTMLElement).closest('[data-tree-tab]')?.getAttribute('data-tree-tab') ?? undefined)
       }}
       ref={ref}
-      style={wcOverlap ? { paddingTop: wcOverlap.y + wcOverlap.height } : undefined}
+      style={
+        wcOverlap
+          ? { paddingTop: wcOverlap.y + wcOverlap.height }
+          : topEdge && verticalCollapse
+            ? { paddingTop: TITLEBAR_HEIGHT }
+            : undefined
+      }
     >
       {wcOverlap && (
         <div
@@ -498,34 +503,25 @@ export function TreeGroup({
 
       {/* Keep the header INSIDE its zone: titlebar drops use the same panel
           bounds, strip refs, focus ownership and split geometry as the body. */}
-      {(headerVisible || topEdge) && (
+      {(headerVisible || (topEdge && !verticalCollapse)) && (
         <div
-          className="flex min-w-0 shrink-0 bg-(--ui-sidebar-surface-background)"
+          className="relative flex min-w-0 shrink-0 bg-(--ui-sidebar-surface-background)"
           data-panel-header=""
-          style={topEdge ? { height: TITLEBAR_HEIGHT } : undefined}
+          style={topEdge ? { height: TITLEBAR_HEIGHT + (tabsBelowControls && headerVisible ? 28 : 0) } : undefined}
         >
-          {topEdge && leftEdge && (
-            <div className="flex shrink-0">
-              <div className="w-(--titlebar-controls-left,14px) [-webkit-app-region:drag]" data-window-drag-handle="" />
-              <div className="relative w-(--titlebar-controls-width,96px)">
-                <div
-                  className="absolute inset-x-0 top-0 h-(--titlebar-controls-top,5px) [-webkit-app-region:drag]"
-                  data-window-drag-handle=""
-                />
-              </div>
-              <div className="w-3 [-webkit-app-region:drag]" data-window-drag-handle="" />
-            </div>
+          {topEdge && (
+            <div aria-hidden="true" className="shrink-0" style={{ width: 'var(--panel-titlebar-left, 100%)' }} />
           )}
           {headerVisible ? (
             <ZoneMenu {...zoneMenu}>
               <PaneTabStrip
-                className="flex-1"
+                className={cn('flex-1', tabsBelowControls && 'absolute inset-x-0 bottom-0')}
                 // data-zone-tabstrip: a drop over here STACKS (drag-session reads it).
                 data-zone-tabstrip={node.id}
                 listRef={tabsRef}
                 onPointerDown={event => {
                   // Native titlebar gaps move the window; tabs keep their own drag.
-                  if (!topEdge) {
+                  if (!tabsInTitlebar) {
                     startPaneDrag(
                       activeId,
                       event,
@@ -537,7 +533,7 @@ export function TreeGroup({
                 }}
                 ref={stripRef}
                 style={{ cursor: 'grab', WebkitAppRegion: dragging ? 'no-drag' : undefined } as CSSProperties}
-                titlebar={topEdge}
+                titlebar={tabsInTitlebar}
                 trailing={
                   <>
                     {minimizable && (
@@ -694,18 +690,16 @@ export function TreeGroup({
                 )}
               </PaneTabStrip>
             </ZoneMenu>
-          ) : (
-            <div className="min-w-0 flex-1 [-webkit-app-region:drag]" />
+          ) : null}
+          {topEdge && (!headerVisible || tabsBelowControls) && (
+            <div
+              className="min-w-0 flex-1 self-start [-webkit-app-region:drag]"
+              data-window-drag-handle=""
+              style={{ height: TITLEBAR_HEIGHT }}
+            />
           )}
-          {topEdge && rightEdge && (
-            <div className="flex shrink-0">
-              <div
-                className="w-6"
-                data-window-drag-handle=""
-                style={{ WebkitAppRegion: dragging ? 'no-drag' : 'drag' } as CSSProperties}
-              />
-              <div className="w-[calc(var(--titlebar-tools-right,0.75rem)+var(--titlebar-tools-width,24px))] [-webkit-app-region:no-drag]" />
-            </div>
+          {topEdge && (
+            <div aria-hidden="true" className="shrink-0" style={{ width: 'var(--panel-titlebar-right, 0px)' }} />
           )}
         </div>
       )}
@@ -781,7 +775,7 @@ export function TreeGroup({
             className="absolute inset-x-0 bottom-0 z-50 flex cursor-grab items-center justify-center outline-1 -outline-offset-2 outline-dashed backdrop-blur-[2px]"
             onPointerDown={e => startPaneDrag(activeId, e, undefined, undefined, active?.title ?? activeId)}
             style={{
-              top: topEdge ? TITLEBAR_HEIGHT : headerVisible ? 28 : 0,
+              top: topEdge ? TITLEBAR_HEIGHT + (tabsBelowControls && headerVisible ? 28 : 0) : headerVisible ? 28 : 0,
               background:
                 'color-mix(in srgb, var(--ui-accent) 6%, color-mix(in srgb, var(--ui-bg-chrome) 55%, transparent))',
               outlineColor: 'color-mix(in srgb, var(--ui-accent) 55%, transparent)'

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -24,6 +24,7 @@ import {
   $hiddenTreePanes,
   $narrowViewport,
   isCollapsePane,
+  paneRootSide,
   persistTree,
   presetSplitWeights,
   setTreeGroupMinimized,
@@ -42,7 +43,6 @@ import {
   paneChrome,
   type PaneSizing,
   resolveCssPx,
-  rootChildSide,
   shownPaneIds,
   subtreeGone,
   type TrackContext
@@ -610,10 +610,8 @@ export function TreeSplit({
   // leftover; capped sidebars (review/files) keep their max and stay put.
   const isMinimized = (child: LayoutNode) => child.type === 'group' && Boolean(child.minimized)
 
-  // SEMANTIC side collapse (titlebar toggles / ⌘B / ⌘J): at the ROOT row,
-  // ⌘B owns the sessions column and ⌘J the other side columns — by pane
-  // placement, NOT position, so a ⌘\ flip moves the columns without
-  // rewiring the toggles (main parity). In edit mode sides stay visible.
+  // Side toggles own physical sides of the root row, including after a flip.
+  // In edit mode sides stay visible.
   // `rootRow` covers both a row root (Default, Focus) and a row nested inside
   // a column root (Terminal deck, Quad) — wherever the side columns live.
   const semanticSides = rootRow && horizontal && collapsedSides.size > 0 && !editMode
@@ -623,7 +621,7 @@ export function TreeSplit({
       return false
     }
 
-    const side = rootChildSide(node.children[i], paneFor)
+    const side = paneRootSide(allPaneIds(node.children[i])[0])
 
     return side !== null && collapsedSides.has(side)
   }
@@ -704,7 +702,7 @@ export function TreeSplit({
               collapsed
                 ? { display: 'none' }
                 : minimized
-                  ? { flex: `0 0 ${MINIMIZED_TRACK}` }
+                  ? { flex: `0 0 ${horizontal ? MINIMIZED_TRACK : 'auto'}` }
                   : {
                       // One flexbox formula for everything: a sized zone is
                       // grow-0 shrink-1 from its preferred basis (it yields

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -897,7 +897,9 @@ export function paneRootSide(paneId: string): null | TreeSide {
 
   const mainIndices = row.children.flatMap((child, i) =>
     allPaneIds(child).some(
-      id => (panes.find(p => p.id === id)?.data as { placement?: string } | undefined)?.placement === 'main'
+      id =>
+        id === 'workspace' ||
+        (panes.find(p => p.id === id)?.data as { placement?: string } | undefined)?.placement === 'main'
     )
       ? [i]
       : []

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -43,7 +43,6 @@ import {
 } from './model'
 import { FLOATING_PLACEMENT } from './renderer/floating-rect'
 import { tabStripVisibleForZone } from './renderer/strip-visibility'
-import { rootChildSide } from './renderer/track-model'
 
 // v2: v1 trees were saved against placeholder panes with index-order zone
 // assignment (chat could land in a corner cell). Retire them wholesale.
@@ -894,9 +893,21 @@ export function paneRootSide(paneId: string): null | TreeSide {
   }
 
   const panes = registry.getArea('panes')
-  const child = row.children.find(c => allPaneIds(c).includes(paneId))
+  const index = row.children.findIndex(c => allPaneIds(c).includes(paneId))
 
-  return child ? rootChildSide(child, id => panes.find(p => p.id === id)) : null
+  const mainIndices = row.children.flatMap((child, i) =>
+    allPaneIds(child).some(
+      id => (panes.find(p => p.id === id)?.data as { placement?: string } | undefined)?.placement === 'main'
+    )
+      ? [i]
+      : []
+  )
+
+  if (index < 0 || mainIndices.length === 0) {
+    return null
+  }
+
+  return index < mainIndices[0] ? 'left' : index > mainIndices[mainIndices.length - 1] ? 'right' : null
 }
 
 /** The closer-less Close: dismiss the pane (removed + remembered; reveal
@@ -985,11 +996,52 @@ export function setTreeSideCollapsed(side: TreeSide, collapsed: boolean) {
   }
 }
 
+/** Explicit side-open also recovers hide-only tabs, without fronting over Bots. */
+export function restoreHiddenTreeSideTabs(side: TreeSide): void {
+  for (const paneId of [...$hiddenStripTabs.get()]) {
+    if (paneRootSide(paneId) === side) {
+      setStripTabHidden(paneId, false)
+    }
+  }
+}
+
+/** Restore minimized zones without changing their active tab (including Bots). */
+export function restoreMinimizedTreeSide(side: TreeSide): boolean {
+  const tree = $layoutTree.get()
+  const row = rootRow()
+
+  if (!tree || !row) {
+    return false
+  }
+
+  let next = tree
+
+  for (const child of row.children) {
+    if (paneRootSide(allPaneIds(child)[0]) !== side) {
+      continue
+    }
+
+    for (const id of groupLeafIds(child)) {
+      if (findGroup(next, id)?.minimized) {
+        next = setGroupMinimized(next, id, false)
+      }
+    }
+  }
+
+  if (next === tree) {
+    return false
+  }
+
+  commit(next)
+
+  return true
+}
+
 /**
  * Does the layout have a collapsible root side of `side`? ⌘J's normal target is
  * the right sidebar; a layout without one (e.g. a terminal-on-bottom preset)
- * lets callers fall back to the terminal so ⌘J is never a dead key. Semantic —
- * reuses `rootChildSide`, so it tracks a ⌘\ flip / drag like the toggles do.
+ * lets callers fall back to the terminal so ⌘J is never a dead key. Tracks
+ * physical position through a ⌘\ flip / drag, just like the toggles.
  */
 export function layoutHasRootSide(side: TreeSide): boolean {
   const row = rootRow()
@@ -998,9 +1050,7 @@ export function layoutHasRootSide(side: TreeSide): boolean {
     return false
   }
 
-  const panes = registry.getArea('panes')
-
-  return row.children.some(child => rootChildSide(child, id => panes.find(p => p.id === id)) === side)
+  return row.children.some(child => paneRootSide(allPaneIds(child)[0]) === side)
 }
 
 /**
@@ -1049,33 +1099,9 @@ export function bindTreeSideVisibility(
   $open.listen(open => setTreeSideCollapsed(side, !open))
 }
 
-/** The chrome toggle owning `paneId`'s root-row column — SEMANTIC, matching
- *  the renderer's `rootChildSide`: ⌘B ⇔ the sessions column (left-placement
- *  panes) wherever it sits, ⌘J ⇔ the other side columns. Null for the main
- *  column (never side-collapsed). */
+/** The physical column's chrome toggle; main columns never side-collapse. */
 export function treeSideOfPane(paneId: string): TreeSide | null {
-  const row = rootRow()
-
-  if (!row) {
-    return null
-  }
-
-  const child = row.children.find(node => allPaneIds(node).includes(paneId))
-
-  if (!child) {
-    return null
-  }
-
-  const placementOf = (id: string) =>
-    (registry.getArea('panes').find(c => c.id === id)?.data as { placement?: string } | undefined)?.placement
-
-  const placements = allPaneIds(child).map(placementOf)
-
-  if (placements.includes('main')) {
-    return null
-  }
-
-  return placements.includes('left') ? 'left' : 'right'
+  return paneRootSide(paneId)
 }
 
 /**

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -2,13 +2,17 @@ import { atom, computed, type ReadableAtom, type WritableAtom } from 'nanostores
 
 import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '@/app/layout-constants'
 import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
-import { isPaneVisible, revealTreePane } from '@/components/pane-shell/tree/store'
+import {
+  restoreHiddenTreeSideTabs,
+  restoreMinimizedTreeSide,
+  setTreeSideCollapsed
+} from '@/components/pane-shell/tree/store'
 import { matchesQuery } from '@/hooks/use-media-query'
 import { connectionScopedAtom } from '@/lib/connection-scoped'
 import { type Codec, Codecs, persistentAtom } from '@/lib/persisted'
 import { arraysEqual, insertUniqueId, readKey } from '@/lib/storage'
 
-import { $paneStates, ensurePaneRegistered, setPaneOpen, setPaneWidthOverride, togglePane } from './panes'
+import { $paneStates, ensurePaneRegistered, setPaneOpen, setPaneWidthOverride } from './panes'
 import { $showAllProfiles, setShowAllProfiles } from './profile'
 import type { PullRequestBucket } from './pull-requests'
 import type { SessionStatusBucket } from './session-dot-state'
@@ -529,12 +533,21 @@ function revealNarrowPane(id: string, mode: 'close' | 'open' | 'toggle'): boolea
 
 export function setSidebarOpen(open: boolean) {
   setPaneOpen(CHAT_SIDEBAR_PANE_ID, open)
+  setTreeSideCollapsed('left', !open)
+
+  if (open) {
+    restoreMinimizedTreeSide('left')
+    restoreHiddenTreeSideTabs('left')
+  }
+
   revealNarrowPane(CHAT_SIDEBAR_PANE_ID, open ? 'open' : 'close')
 }
 
 export function toggleSidebarOpen() {
   if (!revealNarrowPane(CHAT_SIDEBAR_PANE_ID, 'toggle')) {
-    togglePane(CHAT_SIDEBAR_PANE_ID)
+    const open = restoreMinimizedTreeSide('left') || !$sidebarOpen.get()
+    setPaneOpen(CHAT_SIDEBAR_PANE_ID, open)
+    setTreeSideCollapsed('left', !open)
   }
 }
 
@@ -543,23 +556,20 @@ export function toggleFileBrowserOpen() {
     return
   }
 
-  // Ask the TREE, not the pane's boolean. `$fileBrowserOpen` stays true while
-  // the tree pane sits behind a sibling tab in the shared right column (the
-  // preview rail, the diff) or inside a minimized zone, so ⌘J spent its press
-  // re-asserting a value it already held and read as a dead key. Only fold the
-  // side when the tree is genuinely the thing on screen; otherwise bring it
-  // forward through the reveal path, which fronts and un-minimizes.
-  if (!isPaneVisible(FILES_PANE_ID) && $fileBrowserOpen.get()) {
-    revealTreePane(FILES_PANE_ID)
-
-    return
-  }
-
-  togglePane(FILE_BROWSER_PANE_ID)
+  const open = restoreMinimizedTreeSide('right') || !$fileBrowserOpen.get()
+  setPaneOpen(FILE_BROWSER_PANE_ID, open)
+  setTreeSideCollapsed('right', !open)
 }
 
 export function setFileBrowserOpen(open: boolean) {
   setPaneOpen(FILE_BROWSER_PANE_ID, open)
+  setTreeSideCollapsed('right', !open)
+
+  if (open) {
+    restoreMinimizedTreeSide('right')
+    restoreHiddenTreeSideTabs('right')
+  }
+
   revealNarrowPane(FILE_BROWSER_PANE_ID, open ? 'open' : 'close')
 }
 

--- a/apps/desktop/src/store/sidebar-collapse-persistence.test.ts
+++ b/apps/desktop/src/store/sidebar-collapse-persistence.test.ts
@@ -123,8 +123,8 @@ describe('sidebar collapse persistence', () => {
       const main = group(['workspace'])
       const files = group(['files'], { id: 'files-zone' })
       s1.tree.declareDefaultTree(split('row', flipped ? [files, main, sidebar] : [sidebar, main, files]))
-      s1.tree.setTreeGroupMinimized(sidebar.id, true)
       s1.layout.setFileBrowserOpen(true)
+      s1.tree.setTreeGroupMinimized(sidebar.id, true)
 
       reload()
       const { layout, tree, bind } = await loadStores()

--- a/apps/desktop/src/store/sidebar-collapse-persistence.test.ts
+++ b/apps/desktop/src/store/sidebar-collapse-persistence.test.ts
@@ -61,4 +61,111 @@ describe('sidebar collapse persistence', () => {
     s2.bind()
     expect(s2.leftCollapsed()).toBe(true)
   })
+
+  it('explicit open restores hidden strip tabs and minimized groups only on that physical side', async () => {
+    for (const flipped of [false, true]) {
+      window.localStorage.clear()
+      reload()
+      const { layout, tree, bind } = await loadStores()
+      const { findGroup, group, split } = await import('@/components/pane-shell/tree/model')
+      const { registry } = await import('@/contrib/registry')
+
+      const disposers = [
+        registry.register({ area: 'panes', id: 'sessions', data: { placement: 'left' } }),
+        registry.register({ area: 'panes', id: 'bots', data: { placement: 'left' } }),
+        registry.register({ area: 'panes', id: 'workspace', data: { placement: 'main' } }),
+        registry.register({ area: 'panes', id: 'files', data: { placement: 'right' } }),
+        registry.register({ area: 'panes', id: 'review', data: { placement: 'right' } })
+      ]
+
+      try {
+        const sidebar = group(['sessions', 'bots'], { active: 'bots', id: 'sidebar' })
+        const main = group(['workspace'])
+        const other = group(['files', 'review'], { id: 'other' })
+        tree.declareDefaultTree(split('row', flipped ? [other, main, sidebar] : [sidebar, main, other]))
+        bind()
+        tree.bindTreeSideVisibility('right', layout.$fileBrowserOpen, layout.setFileBrowserOpen)
+        layout.setFileBrowserOpen(true)
+        tree.setStripTabHidden('sessions', true)
+        tree.setStripTabHidden('review', true)
+        tree.setTreeGroupMinimized('sidebar', true)
+        tree.setTreeGroupMinimized('other', true)
+        const open = flipped ? layout.setFileBrowserOpen : layout.setSidebarOpen
+
+        open(true) // already true: must not depend on a nanostores notification
+        expect(tree.isStripTabHidden('sessions')).toBe(false)
+        expect(tree.$hiddenTreePanes.get().has('sessions')).toBe(false)
+        expect(tree.isStripTabHidden('review')).toBe(true)
+        expect(findGroup(tree.$layoutTree.get()!, 'sidebar')).toMatchObject({ active: 'bots', minimized: false })
+        expect(findGroup(tree.$layoutTree.get()!, 'other')?.minimized).toBe(true)
+        expect(JSON.parse(window.localStorage.getItem('hermes.desktop.hiddenStripTabs.v1')!)).toEqual(['review'])
+        const restored = tree.$layoutTree.get()
+        open(true)
+        expect(tree.$layoutTree.get()).toBe(restored)
+        tree.setStripTabHidden('sessions', true)
+        const toggle = flipped ? layout.toggleFileBrowserOpen : layout.toggleSidebarOpen
+        toggle()
+        toggle()
+        expect(tree.isStripTabHidden('sessions')).toBe(true) // ordinary toggles preserve the tab choice
+      } finally {
+        disposers.forEach(dispose => dispose())
+      }
+    }
+  })
+
+  it('recovers the minimized physical side after reload without changing its active tab', async () => {
+    for (const flipped of [false, true]) {
+      window.localStorage.clear()
+      reload()
+      const s1 = await loadStores()
+      const { group, split } = await import('@/components/pane-shell/tree/model')
+      const sidebar = group(['sessions', 'bots'], { active: 'bots', id: 'sidebar' })
+      const main = group(['workspace'])
+      const files = group(['files'], { id: 'files-zone' })
+      s1.tree.declareDefaultTree(split('row', flipped ? [files, main, sidebar] : [sidebar, main, files]))
+      s1.tree.setTreeGroupMinimized(sidebar.id, true)
+      s1.layout.setFileBrowserOpen(true)
+
+      reload()
+      const { layout, tree, bind } = await loadStores()
+      const { findGroup } = await import('@/components/pane-shell/tree/model')
+      const { registry } = await import('@/contrib/registry')
+
+      const disposers = [
+        registry.register({ area: 'panes', id: 'sessions', data: { placement: 'left' } }),
+        registry.register({ area: 'panes', id: 'bots', data: { placement: 'left' } }),
+        registry.register({ area: 'panes', id: 'workspace', data: { placement: 'main' } }),
+        registry.register({ area: 'panes', id: 'files', data: { placement: 'right' } })
+      ]
+
+      try {
+        bind()
+        tree.bindTreeSideVisibility('right', layout.$fileBrowserOpen, layout.setFileBrowserOpen)
+        const side = flipped ? 'right' : 'left'
+        const toggle = flipped ? layout.toggleFileBrowserOpen : layout.toggleSidebarOpen
+        const $open = flipped ? layout.$fileBrowserOpen : layout.$sidebarOpen
+        const otherToggle = flipped ? layout.toggleSidebarOpen : layout.toggleFileBrowserOpen
+
+        // Boot respects minimize; the OTHER physical button must not restore it.
+        expect(findGroup(tree.$layoutTree.get()!, sidebar.id)?.minimized).toBe(true)
+        otherToggle()
+        expect(tree.$collapsedTreeSides.get().has(flipped ? 'left' : 'right')).toBe(true)
+        expect(findGroup(tree.$layoutTree.get()!, sidebar.id)?.minimized).toBe(true)
+
+        toggle()
+        expect($open.get()).toBe(true)
+        expect(tree.$collapsedTreeSides.get().has(side)).toBe(false)
+        expect(findGroup(tree.$layoutTree.get()!, sidebar.id)).toMatchObject({ active: 'bots', minimized: false })
+        toggle()
+        expect($open.get()).toBe(false)
+        expect(tree.$collapsedTreeSides.get().has(side)).toBe(true)
+        toggle()
+        expect($open.get()).toBe(true)
+        expect(tree.$collapsedTreeSides.get().has(side)).toBe(false)
+        expect(findGroup(tree.$layoutTree.get()!, sidebar.id)?.active).toBe('bots')
+      } finally {
+        disposers.forEach(dispose => dispose())
+      }
+    }
+  })
 })


### PR DESCRIPTION
## Summary

Fix the Sessions/Bots sidebar trap introduced by titlebar tabs. Narrow sidebar tabs get their full-width row below the controls instead of being clipped beside the minimize chevron. Header reservations use the actual rendered control rectangles, so a minimized neighbor cannot let tabs or native drag regions cover the toolbar.

The existing side buttons and shortcuts now restore minimized groups on their physical side, including persisted states, without switching the active Bots tab to Sessions. Minimized multi-tab row groups retain vertical restore tabs instead of squeezing a horizontal strip into a 28px track. Explicit side-open also recovers hidden strip tabs.

Fixes https://github.com/NousResearch/hermes-agent/issues/107196
Fixes https://github.com/NousResearch/hermes-agent/issues/107774
Addresses the minimized-state reproduction in https://github.com/NousResearch/hermes-agent/issues/106009 and the persistent restore-affordance problem in https://github.com/NousResearch/hermes-agent/issues/107927.

## Related fixes

This combines the geometry and recovery paths that need to work together. It supersedes the covered fixes proposed in:
- https://github.com/NousResearch/hermes-agent/pull/107223
- https://github.com/NousResearch/hermes-agent/pull/107217
- https://github.com/NousResearch/hermes-agent/pull/107209
- https://github.com/NousResearch/hermes-agent/pull/107823
- https://github.com/NousResearch/hermes-agent/pull/107776

The restore approach builds on wukangcheng1994's work in the first sidebar-recovery PR, with physical-side ownership shared between store and renderer. Existing PRs remain open for maintainers to reconcile.

The action-placement preference in https://github.com/NousResearch/hermes-agent/pull/107456 is independent. This fix preserves current icon placement rather than making recovery depend on moving the buttons.

## Verification

- 87 focused tests passed across 15 files covering the pane renderer, restore affordances, hidden tabs, and sidebar persistence.
- Renderer TypeScript check and changed-file ESLint passed.
- Isolated macOS Electron using real TitlebarControls, LayoutTreeRoot and stores: Sessions/Bots fully visible; minimize, reload persisted state, toolbar restore, Cmd+B restore, repeated minimize/restore, hide/show. Bots remains selected.
- Native Electron pointer clicks reach Settings after each state. DOM hit tests show no covered controls; native drag-region rectangles do not intersect the action clusters.
- Windows overlay geometry inputs of 138px and 174px retain clickable chrome. This is geometry coverage, not a native Windows test.

No layout reset, profile edits, or deletion of user state is required. Full repository tests and native Windows interaction were not run.
