### PR TITLE
fix(cron): honor job-level request_overrides in runtime resolution

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1494,6 +1494,24 @@ def _resolve_job_runtime(job: dict, job_id: str, jc: _CronJobConfig) -> tuple[di
     from hermes_cli.auth import AuthError
 
     model = jc.model
+    # Per-job request_overrides (top-level keys = API kwargs, e.g. service_tier) mirror
+    # delegation.request_overrides semantics and are merged into the resolved runtime so
+    # they reach AIAgent via _construct_cron_agent. Explicit job values win over any
+    # provider-resolved overrides; absent/ non-dict job key is a None-safe no-op.
+    job_overrides = job.get("request_overrides")
+    if not isinstance(job_overrides, dict):
+        job_overrides = None
+
+    def _merge_overrides(runtime: dict) -> dict:
+        if not job_overrides:
+            return runtime
+        merged = dict(runtime)
+        merged["request_overrides"] = {
+            **(runtime.get("request_overrides") or {}),
+            **job_overrides,
+        }
+        return merged
+
     requested = job.get("provider") or jc.cron_default_provider or None
     if not requested:
         global_provider = (
@@ -1511,7 +1529,7 @@ def _resolve_job_runtime(job: dict, job_id: str, jc: _CronJobConfig) -> tuple[di
         }
         if job.get("base_url"):
             runtime_kwargs["explicit_base_url"] = job.get("base_url")
-        return resolve_runtime_provider(**runtime_kwargs), model
+        return _merge_overrides(resolve_runtime_provider(**runtime_kwargs)), model
     except Exception as resolve_exc:
         # Walk the fallback chain on AuthError AND transient network/DNS failures (e.g. during
         # OAuth refresh); anything else re-raises.
@@ -1543,7 +1561,7 @@ def _resolve_job_runtime(job: dict, job_id: str, jc: _CronJobConfig) -> tuple[di
                 logger.info(
                     "Job '%s': fallback resolved to %s model %s",
                     job_id, runtime.get("provider"), fb_model)
-                return runtime, fb_model
+                return _merge_overrides(runtime), fb_model
             except Exception as fb_exc:
                 logger.debug("Job '%s': fallback %s failed: %s", job_id, fb_provider, fb_exc)
         raise RuntimeError(format_runtime_provider_error(resolve_exc)) from resolve_exc

--- a/tests/cron/test_cron_job_request_overrides.py
+++ b/tests/cron/test_cron_job_request_overrides.py
@@ -1,0 +1,129 @@
+"""Invariant tests: per-job request_overrides reach the cron agent runtime.
+
+A cron job dict may carry top-level ``request_overrides`` (top-level keys = API kwargs,
+e.g. ``service_tier``), mirroring delegation.request_overrides semantics. The scheduler
+merges them into the resolved runtime in ``_resolve_job_runtime`` (both the primary and the
+fallback-chain paths), and ``_construct_cron_agent`` already forwards
+``runtime.get("request_overrides")`` into AIAgent — so the merged value must land on the
+constructed agent.
+
+Contract under test:
+  (a) a job with ``request_overrides`` produces an AIAgent carrying the merged overrides,
+      even when the provider resolver returns a plain dict WITHOUT its own
+      ``request_overrides`` key (the current empirical behaviour);
+  (b) a job WITHOUT the key behaves exactly as before — no ``request_overrides`` key is
+      added to the runtime and the agent sees none.
+These are invariants, not change-detectors: they pin the observable behaviour, not internal
+implementation details.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Ensure project root is importable.
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.scheduler import run_job
+
+
+def _base_job(**overrides):
+    job = {
+        "id": "req-overrides-job",
+        "name": "req overrides job",
+        "prompt": "hello",
+        "model": None,
+        "provider": None,
+        "provider_snapshot": None,
+        "base_url": None,
+    }
+    job.update(overrides)
+    return job
+
+
+def _run(job, tmp_path):
+    """Drive run_job with resolve_runtime_provider returning a plain dict (no
+    ``request_overrides`` key — matching current resolver behaviour). Returns
+    ``(success, error, agent_kwargs)``; agent_kwargs is None when AIAgent was never built."""
+    (tmp_path / "config.yaml").write_text("")
+
+    def _resolve(**kwargs):
+        return {
+            "api_key": "test-key",
+            "base_url": "https://example.invalid/v1",
+            "provider": kwargs.get("requested") or "openrouter",
+            "api_mode": "chat_completions",
+        }
+
+    fake_db = MagicMock()
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("cron.scheduler._get_hermes_home", return_value=tmp_path), \
+         patch("cron.scheduler_delivery._resolve_origin", return_value=None), \
+         patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+         patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+         patch("hermes_state_registry.acquire", return_value=fake_db), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=_resolve), \
+         patch("run_agent.AIAgent") as mock_agent_cls:
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent_cls.return_value = mock_agent
+        success, _output, _final, error = run_job(job)
+        agent_kwargs = mock_agent_cls.call_args.kwargs if mock_agent_cls.called else None
+    return success, error, agent_kwargs
+
+
+class TestJobLevelRequestOverrides:
+    def test_job_request_overrides_merge_into_runtime_reaching_agent(self, tmp_path):
+        job = _base_job(request_overrides={"service_tier": "flex"})
+        success, error, agent_kwargs = _run(job, tmp_path)
+
+        assert success is True, error
+        assert agent_kwargs is not None
+        assert agent_kwargs.get("request_overrides") == {"service_tier": "flex"}
+
+    def test_job_without_request_overrides_adds_none(self, tmp_path):
+        """Absent job key is a None-safe no-op: no request_overrides value is introduced.
+
+        ``_construct_cron_agent`` always forwards ``runtime.get("request_overrides")``
+        (None when the key is absent), so the invariant is that the value stays None —
+        matching today's behaviour exactly.
+        """
+        job = _base_job()
+        success, error, agent_kwargs = _run(job, tmp_path)
+
+        assert success is True, error
+        assert agent_kwargs is not None
+        assert agent_kwargs.get("request_overrides") is None
+
+    def test_job_explicit_overrides_win_over_provider_resolved(self, tmp_path):
+        """Explicit job values override any request_overrides the resolver may have returned."""
+        job = _base_job(request_overrides={"service_tier": "flex"})
+        (tmp_path / "config.yaml").write_text("")
+
+        def _resolve(**kwargs):
+            return {
+                "api_key": "test-key",
+                "base_url": "https://example.invalid/v1",
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "request_overrides": {"service_tier": "standard"},
+            }
+
+        fake_db = MagicMock()
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._get_hermes_home", return_value=tmp_path), \
+             patch("cron.scheduler_delivery._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state_registry.acquire", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=_resolve), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _output, _final, error = run_job(job)
+            agent_kwargs = mock_agent_cls.call_args.kwargs if mock_agent_cls.called else None
+
+        assert success is True, error
+        assert agent_kwargs is not None
+        assert agent_kwargs.get("request_overrides") == {"service_tier": "flex"}


### PR DESCRIPTION
## Summary

Cron job dicts can now carry a top-level `request_overrides` (mirroring `delegation.request_overrides` semantics), and the scheduler merges it into the resolved runtime so it reaches the ephemeral `AIAgent` on every fire.

**Why:** scheduled batch jobs that are latency-tolerant (weekly reviews, nightly cleanup, intake sweeps) should be able to opt into the API's low-priority `service_tier` (e.g. `flex`) to cut cost, just like delegated subagents already can via `delegate_tool_config.request_overrides`. `delegation.request_overrides` documents top-level keys as API kwargs (e.g. `service_tier`) — see `hermes_cli/config_defaults.py` (~1226) and `tests/tools/test_delegate_request_overrides.py`.

## What changed

- `cron/scheduler.py` `_resolve_job_runtime`: after runtime resolution on **both** the primary path and the fallback chain, merge the job's `request_overrides` into the runtime dict (explicit job values win over any provider-resolved overrides). `_construct_cron_agent` already forwards `runtime.get("request_overrides")` into `AIAgent`, so no further change was needed there.
- New invariant tests in `tests/cron/test_cron_job_request_overrides.py`.

## None-safe no-op evidence

`resolve_runtime_provider` returns **no** `request_overrides` key today, so the merge is additive and None-safe: a job without the key is byte-for-byte behaviour-identical to before (the agent receives `request_overrides=None`, exactly today's contract). The merge short-circuits when the job key is absent or not a dict.

## Invariant tests (not change-detectors)

1. Job with `request_overrides={"service_tier": "flex"}` → `AIAgent` is constructed with that merged value, even when the (monkeypatched) resolver returns a plain dict with no `request_overrides` key.
2. Job **without** the key → agent still gets `request_overrides=None`, matching current behaviour (no key introduced).
3. Job override wins over a provider-resolved `request_overrides`.

All drive the full `run_job` path (mocked resolver + `AIAgent`) so they assert the observable end-to-end invariant rather than an implementation detail.

## Test plan

- `scripts/run_tests.sh tests/cron/test_cron_job_request_overrides.py tests/cron/test_cron_request_overrides.py` — pass
- Full `tests/cron/` suite — pass (101 files, 1216 tests, 0 failed)
