### PR TITLE
fix(desktop): republish composer clearance after an effect replay

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-metrics.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-metrics.test.tsx
@@ -1,0 +1,122 @@
+import { cleanup, render } from '@testing-library/react'
+import { type RefObject, StrictMode, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { COMPOSER_HEIGHT_VAR, COMPOSER_SURFACE_HEIGHT_VAR } from '@/app/chat/surface-vars'
+
+import { useComposerMetrics } from './use-composer-metrics'
+
+vi.mock('@assistant-ui/react', () => ({
+  useAuiState: (selector: (state: { composer: { text: string } }) => unknown) => selector({ composer: { text: '' } })
+}))
+
+// The shared ResizeObserver delivers once per observed element after
+// observe(); replay that by hand so the hook's initial measurement runs where
+// it would in Chromium.
+const observers: FakeResizeObserver[] = []
+
+class FakeResizeObserver implements ResizeObserver {
+  readonly targets = new Set<Element>()
+
+  constructor(readonly callback: ResizeObserverCallback) {
+    observers.push(this)
+  }
+
+  disconnect() {
+    this.targets.clear()
+  }
+
+  observe(target: Element) {
+    this.targets.add(target)
+  }
+
+  unobserve(target: Element) {
+    this.targets.delete(target)
+  }
+}
+
+const deliverResize = () => {
+  for (const observer of observers) {
+    const entries = [...observer.targets].map(target => ({ target }) as ResizeObserverEntry)
+
+    if (entries.length > 0) {
+      observer.callback(entries, observer)
+    }
+  }
+}
+
+const sized =
+  (ref: RefObject<HTMLDivElement | null>, height: number) =>
+  (node: HTMLDivElement | null): void => {
+    if (node) {
+      node.getBoundingClientRect = () =>
+        ({ bottom: height, height, left: 0, right: 640, top: 0, width: 640, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect
+    }
+
+    ref.current = node
+  }
+
+function Harness({ dockHeight, surfaceHeight }: { dockHeight: number; surfaceHeight: number }) {
+  const composerDockRef = useRef<HTMLDivElement | null>(null)
+  const composerRef = useRef<HTMLFormElement | null>(null)
+  const composerSurfaceRef = useRef<HTMLDivElement | null>(null)
+  const editorRef = useRef<HTMLDivElement | null>(null)
+
+  useComposerMetrics({ composerDockRef, composerRef, composerSurfaceRef, editorRef, poppedOut: false })
+
+  return (
+    <div data-chat-surface="">
+      <div ref={sized(composerDockRef, dockHeight)}>
+        <form ref={composerRef}>
+          <div ref={sized(composerSurfaceRef, surfaceHeight)}>
+            <div ref={editorRef} />
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+const surfaceOf = (container: HTMLElement) => container.querySelector<HTMLElement>('[data-chat-surface]')!
+
+describe('useComposerMetrics — published clearance survives an effect replay', () => {
+  beforeEach(() => {
+    observers.length = 0
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('republishes the dock height after StrictMode replays the cleanup', () => {
+    // StrictMode replays every effect: mount → cleanup → mount. The cleanup
+    // clears the surface vars; the replayed measurement must write them back
+    // even though the dock's size has not changed since the first write.
+    const { container } = render(
+      <StrictMode>
+        <Harness dockHeight={200} surfaceHeight={120} />
+      </StrictMode>
+    )
+
+    deliverResize()
+
+    const surface = surfaceOf(container)
+
+    expect(surface.style.getPropertyValue(COMPOSER_HEIGHT_VAR)).toBe('200px')
+    expect(surface.style.getPropertyValue(COMPOSER_SURFACE_HEIGHT_VAR)).toBe('120px')
+  })
+
+  it('skips the write when the bucketed height is unchanged within one mount', () => {
+    const { container } = render(<Harness dockHeight={200} surfaceHeight={120} />)
+
+    deliverResize()
+
+    const setProperty = vi.spyOn(surfaceOf(container).style, 'setProperty')
+
+    deliverResize()
+
+    expect(setProperty).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-metrics.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-metrics.ts
@@ -193,6 +193,7 @@ export function useComposerMetrics({
     syncComposerMetrics()
   }, [poppedOut, syncComposerMetrics])
 
+  // eslint-disable-next-line no-restricted-syntax -- resets a publish-dedupe cache in cleanup, not a mirrored atom
   useEffect(() => {
     // Resolve the owning surface while the composer is still attached; the
     // unmount cleanup runs after React detached the node, where closest() can
@@ -202,6 +203,16 @@ export function useComposerMetrics({
     return () => {
       clearSurfaceVar(root, COMPOSER_HEIGHT_VAR)
       clearSurfaceVar(root, COMPOSER_SURFACE_HEIGHT_VAR)
+      // The bucket refs mirror what is published, so clearing the vars must
+      // clear them too. This cleanup also runs on a non-final unmount (a
+      // StrictMode effect replay, a Suspense hide); the re-mount then
+      // re-measures the same dock, and with the refs still holding the old
+      // bucket the unchanged-skip check swallowed the republish. The thread
+      // fell back to the :root estimate (~62px) under a dock that could be
+      // 200px tall, and the status stack sat on top of the last turn until a
+      // real resize happened to fire.
+      lastBucketedHeightRef.current = 0
+      lastBucketedSurfaceHeightRef.current = 0
     }
   }, [composerRef])
 


### PR DESCRIPTION
## What does this PR do?

The thread's bottom clearance (`--composer-measured-height`) intermittently fell back to the `:root` estimate (~62px) while the composer dock was much taller, so the status stack (subagents, background tasks, artifact links) sat on top of the last turn and the transcript ran under the card.

`useComposerMetrics` dedupes its var writes against a "last published bucket" ref. The unmount cleanup cleared the surface vars but left that ref alone. After a non-final unmount (StrictMode effect replay, a Suspense hide of `ChatBar`) the re-mount measured the same dock, saw an unchanged bucket, and skipped the write. Nothing republished until the dock happened to resize by 8px or more, which is why it came and went.

Confirmed on a live dev app over CDP: all three mounted chat surfaces had the var empty on the surface element while their docks measured 77px, 200px and 130px. The 200px one (with a status stack) is the reported screenshot: 94px of clearance under a 200px dock.

The fix resets the bucket refs in the same cleanup that clears the vars, so a re-mount always republishes.

## Related Issue

Reported directly (screenshot in desktop chat); no tracker issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/composer/hooks/use-composer-metrics.ts`: reset `lastBucketedHeightRef` / `lastBucketedSurfaceHeightRef` alongside `clearSurfaceVar` in the unmount cleanup.
- `apps/desktop/src/app/chat/composer/hooks/use-composer-metrics.test.tsx`: renders the hook under `StrictMode` with a faked ResizeObserver and asserts both vars land on the surface after the replay; a second case checks the dedupe still skips unchanged writes within one mount.

## How to Test

1. `cd apps/desktop && npx vitest run src/app/chat/composer/hooks/use-composer-metrics.test.tsx`
2. On `main` the StrictMode case fails with `expected '' to be '200px'`; on this branch both cases pass.
3. In a dev app with a session that has subagents or background tasks, open it in a split tile: the last turn should sit fully above the status card, and `node scripts/eval.mjs "document.querySelector('[data-chat-surface]').style.getPropertyValue('--composer-measured-height')"` returns a pixel value rather than an empty string.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (desktop-only change; ran the vitest file plus eslint/prettier on the touched files)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
