### PR TITLE
fix(desktop): weakly retain transcript source arrays

### DIFF
--- a/apps/desktop/src/app/chat/transcript-window-retention.test.ts
+++ b/apps/desktop/src/app/chat/transcript-window-retention.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ChatMessage } from '@/lib/chat-messages'
+import { RENDER_WEIGHT_CHARS } from '@/lib/render-weight'
+
+import {
+  advanceSessionTranscriptWindow,
+  type SessionWindowMemo,
+  TRANSCRIPT_WINDOW_MIN_MESSAGES
+} from './transcript-window'
+
+const transcript = (count: number, chars: number): ChatMessage[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `message-${index}`,
+    parts: [{ type: 'text', text: 'x'.repeat(chars) }],
+    role: 'assistant'
+  }))
+
+describe('session transcript-window retention', () => {
+  it('weakly remembers a windowed source array without breaking warm slice reuse', () => {
+    const memos = new Map<string, SessionWindowMemo>()
+    const messages = transcript(80, RENDER_WEIGHT_CHARS * 100)
+
+    const first = advanceSessionTranscriptWindow(memos, 'session-a', messages)
+    const memo = memos.get('session-a')
+
+    expect(first.window.windowed).toBe(true)
+    expect(first.window.messages).not.toBe(messages)
+    expect(memo?.messages).toBeInstanceOf(WeakRef)
+    expect(memo?.messages.deref()).toBe(messages)
+
+    const warm = advanceSessionTranscriptWindow(memos, 'session-a', messages)
+
+    expect(warm).toBe(first)
+    expect(warm.window.messages).toBe(first.window.messages)
+  })
+
+  it('does not memoize an unwindowed source array that would remain strongly retained', () => {
+    const memos = new Map<string, SessionWindowMemo>()
+    // The minimum-message floor deliberately keeps this enormous short
+    // transcript whole. Its pass-through identity needs no memo.
+    const messages = transcript(TRANSCRIPT_WINDOW_MIN_MESSAGES - 1, RENDER_WEIGHT_CHARS * 10_000)
+
+    const state = advanceSessionTranscriptWindow(memos, 'session-short-heavy', messages)
+
+    expect(state.window.windowed).toBe(false)
+    expect(state.window.messages).toBe(messages)
+    expect(memos.has('session-short-heavy')).toBe(false)
+  })
+
+  it('drops an old window memo when paging expands the session to pass-through', () => {
+    const memos = new Map<string, SessionWindowMemo>()
+    const messages = transcript(80, RENDER_WEIGHT_CHARS * 20)
+
+    const first = advanceSessionTranscriptWindow(memos, 'session-expanded', messages)
+    expect(first.window.windowed).toBe(true)
+    expect(memos.has('session-expanded')).toBe(true)
+
+    const expanded = advanceSessionTranscriptWindow(memos, 'session-expanded', messages, 100)
+
+    expect(expanded.window.windowed).toBe(false)
+    expect(expanded.window.messages).toBe(messages)
+    expect(memos.has('session-expanded')).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/transcript-window.ts
+++ b/apps/desktop/src/app/chat/transcript-window.ts
@@ -175,15 +175,15 @@ export function advanceTranscriptWindow(
 export const MAX_SESSION_WINDOWS = 12
 
 /**
- * A window state plus the exact message array it was computed from.
- * The array identity is load-bearing: when a session is re-entered with the
- * IDENTICAL transcript (the warm-switch path of #95595), the stored window —
- * including the exact `window.messages` slice reference — is reused as-is.
- * The reference reuse is what stops `useRuntimeMessageRepository` from
- * rebuilding (and every row from re-rendering) on a warm switch.
+ * A window state plus a weak identity reference to the exact source array it
+ * was computed from. While the session store still owns that array, a warm
+ * switch can reuse the exact `window.messages` slice and avoid rebuilding the
+ * runtime. Once cold-session cleanup releases the store transcript, this memo
+ * must not become an independent strong owner of every old tool result; the
+ * bounded window slice in `state` is the only payload intentionally retained.
  */
 export interface SessionWindowMemo {
-  messages: readonly ChatMessage[]
+  messages: WeakRef<readonly ChatMessage[]>
   state: TranscriptWindowState
 }
 
@@ -194,18 +194,21 @@ export interface SessionWindowMemo {
  * re-entry always re-ran the weight walk and rebuilt the windowed slice —
  * which re-indexed the whole windowed transcript (markdown re-parse +
  * re-highlight per row) even though nothing had changed. This keeps one memo
- * per session:
+ * per windowed session:
  *
- * - Re-entering a session with the same transcript array returns the cached
- *   windowed slice BY REFERENCE — the runtime repository and every message
- *   row stay mounted, so the switch is O(1).
+ * - Re-entering a session with the same live transcript array returns the
+ *   cached windowed slice BY REFERENCE — the runtime repository and every
+ *   message row stay mounted, so the switch is O(1).
  * - Re-entering with a changed transcript keeps the sticky cut (anchor still
  *   present, tail within budget + slack) instead of re-walking from scratch.
  * - The anchor vanishing (compression rewrite) or a pages change falls
  *   through to `advanceTranscriptWindow`'s existing fresh-walk behaviour.
+ * - An unwindowed result is the source array itself, so caching it adds no
+ *   identity benefit and would make `state.window.messages` a second strong
+ *   owner of the complete transcript. Pass-through sessions are not memoized.
  *
- * The map is bounded (oldest session evicted) so an unbounded session list
- * cannot grow it without limit.
+ * The map is bounded (oldest session evicted) and source arrays are weakly held,
+ * so cold-session cleanup can release the full transcript independently.
  */
 export function advanceSessionTranscriptWindow(
   memos: Map<string, SessionWindowMemo>,
@@ -215,15 +218,23 @@ export function advanceSessionTranscriptWindow(
 ): TranscriptWindowState {
   const memo = memos.get(sessionKey)
 
-  // Warm re-visit with the identical transcript and page count: reuse the
+  // Warm re-visit with the identical live transcript and page count: reuse the
   // cached state wholesale, preserving the windowed slice reference.
-  if (memo && memo.messages === messages && memo.state.pages === pages) {
+  if (memo && memo.messages.deref() === messages && memo.state.pages === pages) {
     return memo.state
   }
 
   const state = advanceTranscriptWindow(memo?.state ?? null, messages, pages)
 
-  memos.set(sessionKey, { messages, state })
+  if (!state.window.windowed) {
+    // The pass-through state already returns `messages` itself. Keeping it in
+    // the component-local map would pin the complete source array after the
+    // session store intentionally releases a cold transcript.
+    memos.delete(sessionKey)
+    return state
+  }
+
+  memos.set(sessionKey, { messages: new WeakRef(messages), state })
 
   if (memos.size > MAX_SESSION_WINDOWS) {
     const oldest = memos.keys().next().value as string


### PR DESCRIPTION
## Summary

Fixes #108153. Related to the broader renderer-retention report #77311.

The per-session transcript-window memo preserved warm-switch performance by holding the exact source `ChatMessage[]` array. That also made the component-local memo an independent strong owner of the complete transcript after `releaseSessionTranscript()` intentionally made the store state cold.

For a heavy windowed session, the memo therefore retained every old tool result in addition to the bounded `state.window.messages` tail. A second residual existed for pass-through windows: when the whole transcript was returned directly, `state.window.messages` itself was the complete source array. This matters especially below the 30-message floor, where a small number of multi-megabyte results deliberately remains unwindowed.

## Changes

- Store windowed source-array identity as `WeakRef<readonly ChatMessage[]>`.
- Compare `memo.messages.deref() === messages` on the unchanged-transcript fast path.
- Keep the render-weight-bounded window slice strongly cached by design.
- Do not memoize pass-through windows at all: their returned `messages` reference is already the source array, so a memo provides no identity benefit and would pin the complete cold transcript.
- Delete a previous window memo when paging expands that session to pass-through.
- Keep the 12-window cap and oldest-first eviction behavior unchanged.

## Behavior

- While the session/store still owns a windowed source array, warm re-entry returns the identical cached `TranscriptWindowState` and window slice.
- After cold-session cleanup drops that source array, the memo no longer prevents collection of the complete transcript.
- Rehydrating a cold session supplies a new array and naturally follows the existing sticky-anchor recomputation path.
- Unwindowed sessions remain pass-through and preserve the incoming array identity without any component-local cache entry.

## Verification

Focused retention coverage asserts that:

1. a heavy session is windowed, its source is held through `WeakRef`, and warm slice/state identity is preserved;
2. an enormous transcript below `TRANSCRIPT_WINDOW_MIN_MESSAGES` remains pass-through but is not memoized;
3. paging a previously windowed session to a full pass-through view removes its old memo.

Additional local checks:

```text
TypeScript 5.8 strict check of the changed WeakRef/memo contract: passed
Focused memo lifecycle harness: 3 passed
```

The branch is one commit directly on upstream `5e9157658a51e92066fc4de26113ac91572ea414`; only `transcript-window.ts` and its focused retention test are changed. Repository CI remains authoritative for the full Desktop suite.