### PR TITLE
fix(gateway): extend auto-reset continuity hint to all human chat platforms

### DIFF
--- a/gateway/run_topics.py
+++ b/gateway/run_topics.py
@@ -640,22 +640,35 @@ class GatewayTopicThreadsMixin:
         # mistake an explicit restore of the just-retired session for a stale binding
         # (binding == the successor's prev_session_id) and repoint it at the reset successor,
         # breaking the "Session restored" promise on the next prompt. If the switch fails,
-        # roll the binding back and fail loudly: a committed restore binding over the old
-        # entry is exactly the inconsistent state the heal would then undo.
+        # roll the binding and the route back and fail loudly: a committed restore over the
+        # old entry is exactly the inconsistent state the heal would then undo.
+        session_key = self._session_key_for_source(source)
+        prior_session_id = ""
         try:
-            await self.async_session_store.switch_session(
-                self._session_key_for_source(source), session_id,
-            )
+            prior_entry = await self.async_session_store.lookup_by_session_key(session_key)
+            prior_session_id = str(getattr(prior_entry, "session_id", "") or "")
+        except Exception:
+            logger.debug("Failed to read prior topic route before restore switch", exc_info=True)
+        try:
+            await self.async_session_store.switch_session(session_key, session_id)
         except Exception:
             logger.warning("Failed to switch topic store to restored session", exc_info=True)
+            if prior_session_id:
+                # switch_session() can raise after _replace_route_locked already swapped the
+                # in-process entry; put the prior route back so the live store matches the
+                # rollback we report. Best effort — logged, never masks the failure response.
+                try:
+                    await self.async_session_store.switch_session(session_key, prior_session_id)
+                except Exception:
+                    logger.warning(
+                        "Failed to restore prior topic route after restore failure", exc_info=True
+                    )
             try:
                 if current_binding and current_binding.get("session_id"):
                     await db.bind_telegram_topic(
                         chat_id=str(source.chat_id), thread_id=str(source.thread_id),
                         user_id=str(current_binding.get("user_id") or source.user_id or ""),
-                        session_key=str(
-                            current_binding.get("session_key") or self._session_key_for_source(source)
-                        ),
+                        session_key=str(current_binding.get("session_key") or session_key),
                         session_id=str(current_binding["session_id"]),
                         managed_mode=str(current_binding.get("managed_mode") or "auto"),
                         profile_name=topic_profile,
@@ -663,7 +676,7 @@ class GatewayTopicThreadsMixin:
                 else:
                     await db.delete_telegram_topic_binding(
                         chat_id=str(source.chat_id), thread_id=str(source.thread_id),
-                        profile_name=topic_profile,
+                        profile_name=topic_profile, disable_mode_when_last=False,
                     )
             except Exception:
                 logger.warning("Failed to roll back topic binding after restore failure", exc_info=True)

--- a/gateway/run_topics.py
+++ b/gateway/run_topics.py
@@ -643,22 +643,26 @@ class GatewayTopicThreadsMixin:
         # roll the binding and the route back and fail loudly: a committed restore over the
         # old entry is exactly the inconsistent state the heal would then undo.
         session_key = self._session_key_for_source(source)
-        prior_session_id = ""
+        prior_entry = None
         try:
             prior_entry = await self.async_session_store.lookup_by_session_key(session_key)
-            prior_session_id = str(getattr(prior_entry, "session_id", "") or "")
         except Exception:
             logger.debug("Failed to read prior topic route before restore switch", exc_info=True)
         try:
             await self.async_session_store.switch_session(session_key, session_id)
         except Exception:
             logger.warning("Failed to switch topic store to restored session", exc_info=True)
-            if prior_session_id:
-                # switch_session() can raise after _replace_route_locked already swapped the
-                # in-process entry; put the prior route back so the live store matches the
-                # rollback we report. Best effort — logged, never masks the failure response.
+            if prior_entry is not None:
+                # switch_session() can raise from _save() after _replace_route_locked already
+                # swapped the in-process entry (its database bookkeeping runs later, so it has
+                # not advanced here). Reinstall the captured snapshot verbatim — switching back
+                # by ID would build a fresh shell entry, losing counters, model overrides and
+                # the pending auto-reset metadata. Best effort — logged, never masks the
+                # failure response.
                 try:
-                    await self.async_session_store.switch_session(session_key, prior_session_id)
+                    await asyncio.to_thread(
+                        self.session_store.restore_route_entry, session_key, prior_entry
+                    )
                 except Exception:
                     logger.warning(
                         "Failed to restore prior topic route after restore failure", exc_info=True

--- a/gateway/run_topics.py
+++ b/gateway/run_topics.py
@@ -636,6 +636,16 @@ class GatewayTopicThreadsMixin:
             if "already linked" in str(exc):
                 return already_linked
             raise
+        # Switch the lane's store entry now — deferring to the next inbound heal would let it
+        # mistake an explicit restore of the just-retired session for a stale binding
+        # (binding == the successor's prev_session_id) and repoint it at the reset successor,
+        # breaking the "Session restored" promise on the next prompt.
+        try:
+            await self.async_session_store.switch_session(
+                self._session_key_for_source(source), session_id,
+            )
+        except Exception:
+            logger.debug("Failed to switch topic store to restored session", exc_info=True)
         title = await db.get_session_title(session_id) or session_id
         last_assistant = None
         with suppress(Exception):

--- a/gateway/run_topics.py
+++ b/gateway/run_topics.py
@@ -639,13 +639,38 @@ class GatewayTopicThreadsMixin:
         # Switch the lane's store entry now — deferring to the next inbound heal would let it
         # mistake an explicit restore of the just-retired session for a stale binding
         # (binding == the successor's prev_session_id) and repoint it at the reset successor,
-        # breaking the "Session restored" promise on the next prompt.
+        # breaking the "Session restored" promise on the next prompt. If the switch fails,
+        # roll the binding back and fail loudly: a committed restore binding over the old
+        # entry is exactly the inconsistent state the heal would then undo.
         try:
             await self.async_session_store.switch_session(
                 self._session_key_for_source(source), session_id,
             )
         except Exception:
-            logger.debug("Failed to switch topic store to restored session", exc_info=True)
+            logger.warning("Failed to switch topic store to restored session", exc_info=True)
+            try:
+                if current_binding and current_binding.get("session_id"):
+                    await db.bind_telegram_topic(
+                        chat_id=str(source.chat_id), thread_id=str(source.thread_id),
+                        user_id=str(current_binding.get("user_id") or source.user_id or ""),
+                        session_key=str(
+                            current_binding.get("session_key") or self._session_key_for_source(source)
+                        ),
+                        session_id=str(current_binding["session_id"]),
+                        managed_mode=str(current_binding.get("managed_mode") or "auto"),
+                        profile_name=topic_profile,
+                    )
+                else:
+                    await db.delete_telegram_topic_binding(
+                        chat_id=str(source.chat_id), thread_id=str(source.thread_id),
+                        profile_name=topic_profile,
+                    )
+            except Exception:
+                logger.warning("Failed to roll back topic binding after restore failure", exc_info=True)
+            return (
+                "Session restore failed: the topic's session store could not be switched, so "
+                "the restore was rolled back. Resend /topic <id> to retry."
+            )
         title = await db.get_session_title(session_id) or session_id
         last_assistant = None
         with suppress(Exception):

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -377,6 +377,18 @@ class GatewayTurnMixin:
             if canonical_session_id and canonical_session_id != bound_session_id:
                 bound_session_id = canonical_session_id
         if bound_session_id and bound_session_id != session_entry.session_id:
+            if getattr(session_entry, "was_auto_reset", False):
+                # The store already replaced this lane's conversation (auto-reset): the stored
+                # binding names the predecessor it just retired. Repoint the binding at the
+                # successor instead of switching back — switching would end the fresh successor
+                # and drop was_auto_reset/prev_session_id, silently undoing the reset and its
+                # continuity note (the stale-binding trap #31501 and the /new rebind already
+                # guard against).
+                await asyncio.to_thread(
+                    self._sync_telegram_topic_binding, source, session_entry,
+                    reason="auto-reset-repoint",
+                )
+                return session_entry
             # Route through SessionStore so the key → id mapping persists and the previous lane
             # session ends cleanly (in-place mutation split-brained the JSON index).
             switched = await self.async_session_store.switch_session(session_key, bound_session_id)

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -377,13 +377,17 @@ class GatewayTurnMixin:
             if canonical_session_id and canonical_session_id != bound_session_id:
                 bound_session_id = canonical_session_id
         if bound_session_id and bound_session_id != session_entry.session_id:
-            if getattr(session_entry, "was_auto_reset", False):
-                # The store already replaced this lane's conversation (auto-reset): the stored
-                # binding names the predecessor it just retired. Repoint the binding at the
+            prev_id = str(getattr(session_entry, "prev_session_id", None) or "")
+            if getattr(session_entry, "was_auto_reset", False) or (
+                prev_id and prev_id in {stored_session_id, bound_session_id}
+            ):
+                # The store's current conversation replaced the one this binding names: either the
+                # fresh auto-reset successor is current (was_auto_reset), or its predecessor
+                # matches the binding — the typed /model path consumes was_auto_reset early
+                # (#48031), so trust prev_session_id metadata too. Repoint the binding at the
                 # successor instead of switching back — switching would end the fresh successor
-                # and drop was_auto_reset/prev_session_id, silently undoing the reset and its
-                # continuity note (the stale-binding trap #31501 and the /new rebind already
-                # guard against).
+                # and drop its reset metadata, silently undoing the reset (the stale-binding
+                # trap #31501 and the /new rebind already guard against).
                 await asyncio.to_thread(
                     self._sync_telegram_topic_binding, source, session_entry,
                     reason="auto-reset-repoint",

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -378,16 +378,15 @@ class GatewayTurnMixin:
                 bound_session_id = canonical_session_id
         if bound_session_id and bound_session_id != session_entry.session_id:
             prev_id = str(getattr(session_entry, "prev_session_id", None) or "")
-            if getattr(session_entry, "was_auto_reset", False) or (
-                prev_id and prev_id in {stored_session_id, bound_session_id}
-            ):
-                # The store's current conversation replaced the one this binding names: either the
-                # fresh auto-reset successor is current (was_auto_reset), or its predecessor
-                # matches the binding — the typed /model path consumes was_auto_reset early
-                # (#48031), so trust prev_session_id metadata too. Repoint the binding at the
-                # successor instead of switching back — switching would end the fresh successor
-                # and drop its reset metadata, silently undoing the reset (the stale-binding
-                # trap #31501 and the /new rebind already guard against).
+            if prev_id and prev_id in {stored_session_id, bound_session_id}:
+                # The binding names the exact conversation this entry replaced: it is the
+                # auto-reset leftover, so repoint it at the successor instead of switching back —
+                # switching would end the fresh successor and drop its reset metadata, silently
+                # undoing the reset. A binding naming anything else (e.g. a deliberate
+                # /topic <id> restore, which relies on this heal to switch) is followed, never
+                # overwritten. Keys off prev_session_id metadata because the typed /model path
+                # can consume was_auto_reset early (#48031); the stale-binding trap and the
+                # /new rebind are the same family (#31501).
                 await asyncio.to_thread(
                     self._sync_telegram_topic_binding, source, session_entry,
                     reason="auto-reset-repoint",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -591,14 +591,16 @@ class SessionEntry:
 
 
 # Sources with no durable human thread — inbound machine callers (api_server, webhook,
-# msgraph_webhook) and system-generated event streams (Home Assistant state changes; the
-# Raft wake bridge's content-free hints).  A continuity pointer here would aim the agent at
-# unrelated history and cost tokens for nothing, so they stay silent.  Everything else is a
-# real conversation that survives a session reset and benefits from the hint — including
-# callback transports that carry per-user DMs (WeCom) and dynamic plugin platforms
-# (Platform._missing_), which an allowlist would silently exclude.  Listed by platform VALUE
-# so dynamic platforms can be classified explicitly.
+# msgraph_webhook), system-generated event streams (Home Assistant state changes; the Raft
+# wake bridge's content-free hints), and agent-peer transports (the A2A task protocol's
+# framed peer messages).  A continuity pointer here would aim the agent at unrelated history
+# and cost tokens for nothing, so they stay silent.  Everything else is a real conversation
+# that survives a session reset and benefits from the hint — including callback transports
+# that carry per-user DMs (WeCom) and dynamic plugin platforms (Platform._missing_), which
+# an allowlist would silently exclude.  Listed by platform VALUE so dynamic platforms can be
+# classified explicitly.
 _NON_HUMAN_SESSION_HINT_PLATFORMS = frozenset({
+    "a2a",
     "api_server",
     "homeassistant",
     "msgraph_webhook",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -591,19 +591,20 @@ class SessionEntry:
 
 
 # Sources with no durable human thread — inbound machine callers (api_server, webhook,
-# msgraph_webhook), system-generated event streams (Home Assistant state changes; the Raft
-# wake bridge's content-free hints), and agent-peer transports (the A2A task protocol's
-# framed peer messages).  A continuity pointer here would aim the agent at unrelated history
-# and cost tokens for nothing, so they stay silent.  Everything else is a real conversation
-# that survives a session reset and benefits from the hint — including callback transports
-# that carry per-user DMs (WeCom) and dynamic plugin platforms (Platform._missing_), which
-# an allowlist would silently exclude.  Listed by platform VALUE so dynamic platforms can be
-# classified explicitly.
+# msgraph_webhook), system-generated event streams (Home Assistant state changes; ntfy
+# broadcast topics; the Raft wake bridge's content-free hints), and agent-peer transports
+# (the A2A task protocol's framed peer messages).  A continuity pointer here would aim the
+# agent at unrelated history and cost tokens for nothing, so they stay silent.  Everything
+# else is a real conversation that survives a session reset and benefits from the hint —
+# including callback transports that carry per-user DMs (WeCom) and dynamic plugin platforms
+# (Platform._missing_), which an allowlist would silently exclude.  Listed by platform VALUE
+# so dynamic platforms can be classified explicitly.
 _NON_HUMAN_SESSION_HINT_PLATFORMS = frozenset({
     "a2a",
     "api_server",
     "homeassistant",
     "msgraph_webhook",
+    "ntfy",
     "raft",
     "webhook",
 })

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1175,6 +1175,20 @@ class SessionStore(
             )
         return new_entry
 
+    def restore_route_entry(self, session_key: str, entry: SessionEntry) -> None:
+        """Reinstall a captured entry snapshot (undo of a partially applied ``switch_session``).
+
+        ``switch_session`` can raise from ``_save()`` *after* ``_replace_route_locked`` already
+        swapped ``_entries`` — and its database bookkeeping only runs after that point. Callers
+        that captured the prior entry before switching put it back verbatim, so the live route
+        keeps its counters, model overrides and auto-reset metadata instead of a fresh shell
+        entry. Persists via the same save path; a save failure propagates to the caller.
+        """
+        with self._lock:
+            self._ensure_loaded_locked()
+            self._entries[session_key] = entry
+            self._save()
+
     def list_sessions(self, active_minutes: Optional[int] = None) -> List[SessionEntry]:
         """List all sessions, optionally filtered by activity."""
         with self._lock:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -590,24 +590,26 @@ class SessionEntry:
         )
 
 
-# Sources with no durable human thread — inbound machine callers and system-generated event
-# streams (Home Assistant state changes).  A continuity pointer here would aim the agent at
-# unrelated history and cost tokens for nothing, so they stay silent.  Everything else
-# (Telegram, Signal, WhatsApp, Matrix, email, plugin platforms, ...) is a real conversation
-# that survives a session reset and benefits from the hint — hence a DENYLIST, not an
-# allowlist, which would silently exclude dynamic plugin platforms (Platform._missing_).
+# Sources with no durable human thread — inbound machine callers (api_server, webhook,
+# msgraph_webhook) and system-generated event streams (Home Assistant state changes; the
+# Raft wake bridge's content-free hints).  A continuity pointer here would aim the agent at
+# unrelated history and cost tokens for nothing, so they stay silent.  Everything else is a
+# real conversation that survives a session reset and benefits from the hint — including
+# callback transports that carry per-user DMs (WeCom) and dynamic plugin platforms
+# (Platform._missing_), which an allowlist would silently exclude.  Listed by platform VALUE
+# so dynamic platforms can be classified explicitly.
 _NON_HUMAN_SESSION_HINT_PLATFORMS = frozenset({
-    Platform.API_SERVER,
-    Platform.HOMEASSISTANT,
-    Platform.WEBHOOK,
-    Platform.MSGRAPH_WEBHOOK,
-    Platform.WECOM_CALLBACK,
+    "api_server",
+    "homeassistant",
+    "msgraph_webhook",
+    "raft",
+    "webhook",
 })
 
 
 def supports_human_session_hints(platform: Platform) -> bool:
     """Whether a source represents a durable human conversation."""
-    return platform not in _NON_HUMAN_SESSION_HINT_PLATFORMS
+    return platform.value not in _NON_HUMAN_SESSION_HINT_PLATFORMS
 
 
 def build_channel_continuity_note(entry: "SessionEntry", source: SessionSource) -> Optional[str]:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -590,19 +590,49 @@ class SessionEntry:
         )
 
 
+# Sources with no durable human thread — inbound machine callers and system-generated event
+# streams (Home Assistant state changes).  A continuity pointer here would aim the agent at
+# unrelated history and cost tokens for nothing, so they stay silent.  Everything else
+# (Telegram, Signal, WhatsApp, Matrix, email, plugin platforms, ...) is a real conversation
+# that survives a session reset and benefits from the hint — hence a DENYLIST, not an
+# allowlist, which would silently exclude dynamic plugin platforms (Platform._missing_).
+_NON_HUMAN_SESSION_HINT_PLATFORMS = frozenset({
+    Platform.API_SERVER,
+    Platform.HOMEASSISTANT,
+    Platform.WEBHOOK,
+    Platform.MSGRAPH_WEBHOOK,
+    Platform.WECOM_CALLBACK,
+})
+
+
+def supports_human_session_hints(platform: Platform) -> bool:
+    """Whether a source represents a durable human conversation."""
+    return platform not in _NON_HUMAN_SESSION_HINT_PLATFORMS
+
+
 def build_channel_continuity_note(entry: "SessionEntry", source: SessionSource) -> Optional[str]:
-    """One-line continuity hint for long-lived Slack/Discord channels/threads.
+    """One-line continuity hint for long-lived human chat sessions.
 
     After an auto-reset the agent could bind a new request to an unrelated recent session; this
-    points it at the prior session in *this* channel (via ``session_search``). ``None`` unless the
-    platform is Slack/Discord, the auto-reset had real activity, and prev_session_id is set.
+    points it at the prior session in *this* conversation (via ``session_search``). ``None``
+    unless the source is a human chat surface (see the denylist above), the auto-reset had real
+    activity, and ``prev_session_id`` is set.  No LLM calls or extra lookups: the previous
+    session id is already known, and the agent pays retrieval cost only when the user actually
+    refers back.
     """
-    if source.platform not in (Platform.SLACK, Platform.DISCORD):
+    if not supports_human_session_hints(source.platform):
         return None
     prev = entry.prev_session_id
     if not entry.reset_had_activity or not prev:
         return None
-    where = "thread" if source.thread_id else "channel"
+    if source.thread_id:
+        where = "thread"
+    elif source.platform in (Platform.SLACK, Platform.DISCORD):
+        where = "channel"
+    else:
+        # DMs are conversations, not channels — "channel" is Slack/Discord vocabulary and
+        # reads wrong to a model reasoning about a 1:1 chat.
+        where = "conversation"
     return (
         f"[System note: This {where} had an earlier Hermes session (session_id: {prev}) that was "
         f"auto-reset. If the user refers to earlier work here, or the request depends on this "

--- a/hermes_state_telegram.py
+++ b/hermes_state_telegram.py
@@ -245,7 +245,10 @@ class SessionTelegramTopicsMixin:
                     """, (str(session_id),))
         return dict(row) if row else None
 
-    def delete_telegram_topic_binding(self, *, chat_id: str, thread_id: str, profile_name: str = "default") -> int:
+    def delete_telegram_topic_binding(
+        self, *, chat_id: str, thread_id: str, profile_name: str = "default",
+        disable_mode_when_last: bool = True,
+    ) -> int:
         """Remove the binding row for one (chat, thread) pair. Called when the Bot API confirms
         a topic was deleted externally (``Thread not found`` after the same-thread retry
         failed); otherwise ``gateway.run._recover_telegram_topic_thread_id`` keeps
@@ -253,7 +256,9 @@ class SessionTelegramTopicsMixin:
         binding, ``telegram_dm_topic_mode`` is flipped to ``enabled = 0`` in the same
         transaction, or a user who disabled topics in the Telegram client (not via
         ``/topic off``) stays stuck. Returns the number of rows deleted; absent binding or
-        unmigrated tables are silent no-ops (never raise from a cleanup hot path).
+        unmigrated tables are silent no-ops (never raise from a cleanup hot path). Pass
+        ``disable_mode_when_last=False`` to remove the row without toggling the chat-wide
+        topic mode — rollback of a failed binding write, not a deleted-topic prune.
 
         Without this prune, the stale row keeps living in ``telegram_dm_topic_bindings`` and the recovery
         logic in ``gateway.run._recover_telegram_topic_thread_id`` cheerfully redirects future inbound
@@ -280,7 +285,7 @@ class SessionTelegramTopicsMixin:
                     SELECT 1 FROM telegram_dm_topic_bindings
                     WHERE profile_name = ? AND chat_id = ? LIMIT 1
                     """, (profile_name, chat_id)).fetchone()
-                if remaining is None:
+                if remaining is None and disable_mode_when_last:
                     conn.execute(
                         "UPDATE telegram_dm_topic_mode SET enabled = 0, updated_at = ? "
                         "WHERE profile_name = ? AND chat_id = ?",

--- a/tests/gateway/test_channel_continuity_hint.py
+++ b/tests/gateway/test_channel_continuity_hint.py
@@ -8,7 +8,8 @@ Covers:
 - build_channel_continuity_note() emits a hint for human chat surfaces (Slack,
   Discord, Telegram, WeCom callback DMs, plugin platforms, ...) that were
   auto-reset with real prior activity, and stays silent for machine callers,
-  Home Assistant events, and agent-peer transports (Raft wakes, A2A tasks).
+  system-generated events, and agent-peer transports (Home Assistant, ntfy,
+  Raft wakes, A2A tasks).
 """
 
 from datetime import datetime, timedelta
@@ -142,6 +143,7 @@ class TestBuildChannelContinuityNote:
             Platform.WEBHOOK,
             Platform.MSGRAPH_WEBHOOK,
             Platform.HOMEASSISTANT,
+            Platform("ntfy"),  # broadcast topic, no user identity
             Platform("raft"),  # machine-only wake bridge
             Platform("a2a"),  # agent-peer task protocol
         ],

--- a/tests/gateway/test_channel_continuity_hint.py
+++ b/tests/gateway/test_channel_continuity_hint.py
@@ -1,12 +1,13 @@
-"""Tests for the lightweight Slack/Discord channel session-continuity hint.
+"""Tests for the lightweight session-continuity hint on human chat surfaces.
 
 Salvaged from PR #36220 (metamon-p), ported onto the current SessionStore.
 
 Covers:
 - SessionStore records the previous session_id on auto-reset (and only then).
 - prev_session_id survives a to_dict() → from_dict() roundtrip (gateway restart).
-- build_channel_continuity_note() emits a hint only for Slack/Discord sessions
-  that were auto-reset with real prior activity, and stays silent otherwise.
+- build_channel_continuity_note() emits a hint for human chat surfaces (Slack,
+  Discord, Telegram, plugin platforms, ...) that were auto-reset with real prior
+  activity, and stays silent for machine callers and Home Assistant events.
 """
 
 from datetime import datetime, timedelta
@@ -46,6 +47,16 @@ def _slack_source(thread_id=None):
     )
 
 
+def _human_source(platform, thread_id=None, chat_type="dm"):
+    return SessionSource(
+        platform=platform,
+        chat_id="C1",
+        chat_type=chat_type,
+        user_id="U1",
+        thread_id=thread_id,
+    )
+
+
 # ---------------------------------------------------------------------------
 # SessionStore records prev_session_id on auto-reset
 # ---------------------------------------------------------------------------
@@ -72,7 +83,7 @@ class TestPrevSessionIdCapture:
 # build_channel_continuity_note
 # ---------------------------------------------------------------------------
 
-def _reset_entry(platform, prev="20260101_000000_abc", had_activity=True):
+def _reset_entry(platform, prev: str | None = "20260101_000000_abc", had_activity=True):
     return SessionEntry(
         session_key="k",
         session_id="20260101_010000_def",
@@ -95,7 +106,45 @@ class TestBuildChannelContinuityNote:
         assert entry.prev_session_id in note
         assert "channel" in note
 
+    def test_telegram_dm_emits_hint(self):
+        entry = _reset_entry(Platform.TELEGRAM)
+        note = build_channel_continuity_note(entry, _human_source(Platform.TELEGRAM))
+        assert note is not None
+        assert "session_search" in note
+        assert "20260101_000000_abc" in note
+        assert "conversation" in note  # DM wording, not Slack/Discord "channel"
+        assert "channel" not in note
+
+    def test_telegram_topic_uses_thread_wording(self):
+        entry = _reset_entry(Platform.TELEGRAM)
+        note = build_channel_continuity_note(entry, _human_source(Platform.TELEGRAM, thread_id="77"))
+        assert note is not None
+        assert "thread" in note
+
+    def test_plugin_platform_emits_hint(self):
+        # Scoped by denylist: plugin platforms created via Platform._missing_ qualify too.
+        irc = Platform("irc")
+        entry = _reset_entry(irc)
+        assert build_channel_continuity_note(entry, _human_source(irc)) is not None
+
+    @pytest.mark.parametrize(
+        "platform",
+        [
+            Platform.API_SERVER,
+            Platform.WEBHOOK,
+            Platform.MSGRAPH_WEBHOOK,
+            Platform.WECOM_CALLBACK,
+            Platform.HOMEASSISTANT,
+        ],
+    )
+    def test_non_human_sources_stay_silent(self, platform):
+        entry = _reset_entry(platform)
+        assert build_channel_continuity_note(entry, _human_source(platform)) is None
 
     def test_no_activity_returns_none(self):
         entry = _reset_entry(Platform.SLACK, had_activity=False)
         assert build_channel_continuity_note(entry, _slack_source()) is None
+
+    def test_no_prev_session_id_returns_none(self):
+        entry = _reset_entry(Platform.TELEGRAM, prev=None)
+        assert build_channel_continuity_note(entry, _human_source(Platform.TELEGRAM)) is None

--- a/tests/gateway/test_channel_continuity_hint.py
+++ b/tests/gateway/test_channel_continuity_hint.py
@@ -8,7 +8,7 @@ Covers:
 - build_channel_continuity_note() emits a hint for human chat surfaces (Slack,
   Discord, Telegram, WeCom callback DMs, plugin platforms, ...) that were
   auto-reset with real prior activity, and stays silent for machine callers,
-  Home Assistant events, and the Raft wake bridge.
+  Home Assistant events, and agent-peer transports (Raft wakes, A2A tasks).
 """
 
 from datetime import datetime, timedelta
@@ -143,6 +143,7 @@ class TestBuildChannelContinuityNote:
             Platform.MSGRAPH_WEBHOOK,
             Platform.HOMEASSISTANT,
             Platform("raft"),  # machine-only wake bridge
+            Platform("a2a"),  # agent-peer task protocol
         ],
     )
     def test_non_human_sources_stay_silent(self, platform):

--- a/tests/gateway/test_channel_continuity_hint.py
+++ b/tests/gateway/test_channel_continuity_hint.py
@@ -6,8 +6,9 @@ Covers:
 - SessionStore records the previous session_id on auto-reset (and only then).
 - prev_session_id survives a to_dict() → from_dict() roundtrip (gateway restart).
 - build_channel_continuity_note() emits a hint for human chat surfaces (Slack,
-  Discord, Telegram, plugin platforms, ...) that were auto-reset with real prior
-  activity, and stays silent for machine callers and Home Assistant events.
+  Discord, Telegram, WeCom callback DMs, plugin platforms, ...) that were
+  auto-reset with real prior activity, and stays silent for machine callers,
+  Home Assistant events, and the Raft wake bridge.
 """
 
 from datetime import datetime, timedelta
@@ -121,6 +122,13 @@ class TestBuildChannelContinuityNote:
         assert note is not None
         assert "thread" in note
 
+    def test_wecom_callback_dm_emits_hint(self):
+        # Callback transport, but durable per-user DMs — a human chat surface.
+        entry = _reset_entry(Platform.WECOM_CALLBACK)
+        note = build_channel_continuity_note(entry, _human_source(Platform.WECOM_CALLBACK))
+        assert note is not None
+        assert "conversation" in note
+
     def test_plugin_platform_emits_hint(self):
         # Scoped by denylist: plugin platforms created via Platform._missing_ qualify too.
         irc = Platform("irc")
@@ -133,8 +141,8 @@ class TestBuildChannelContinuityNote:
             Platform.API_SERVER,
             Platform.WEBHOOK,
             Platform.MSGRAPH_WEBHOOK,
-            Platform.WECOM_CALLBACK,
             Platform.HOMEASSISTANT,
+            Platform("raft"),  # machine-only wake bridge
         ],
     )
     def test_non_human_sources_stay_silent(self, platform):

--- a/tests/gateway/test_session_store_lock_io.py
+++ b/tests/gateway/test_session_store_lock_io.py
@@ -252,3 +252,37 @@ def test_auto_reset_does_not_recover_session_being_ended(tmp_path):
         old.session_id, "suspended"
     )
     db.end_session.assert_not_called()
+
+
+def test_restore_route_entry_reinstates_snapshot(tmp_path):
+    """``restore_route_entry`` puts a captured entry back verbatim.
+
+    Route-rollback primitive for a failed /topic restore: reinstating the snapshot keeps
+    counters, model overrides and auto-reset metadata that a switch-back-by-ID would lose.
+    """
+    source = _source()
+    db = _db_with_rows({})
+    store = _make_store(tmp_path, db)
+    key = store._generate_session_key(source)
+    prior = _seed_entry(store, key, "sid_prior")
+    prior.model_override = {"model": "m1", "provider": "p1"}
+    prior.was_auto_reset = True
+    prior.prev_session_id = "sid_retired"
+    store._save()
+
+    switched = store.switch_session(key, "sid_target")
+    assert switched is not None
+    assert switched.session_id == "sid_target"
+    target = store.lookup_by_session_key(key)
+    assert target is not None
+    assert target.session_id == "sid_target"
+
+    store.restore_route_entry(key, prior)
+
+    current = store.lookup_by_session_key(key)
+    assert current is not None
+    assert current is prior  # the exact snapshot, not a fresh shell entry
+    assert current.session_id == "sid_prior"
+    assert current.model_override == {"model": "m1", "provider": "p1"}
+    assert current.was_auto_reset is True
+    assert current.prev_session_id == "sid_retired"

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -6,7 +6,7 @@ Telegram topics act as independent Hermes session lanes.
 
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
@@ -698,6 +698,7 @@ async def test_restore_failure_is_visible_and_rolls_back_binding(tmp_path):
     topic_source = _make_source(thread_id="17585")
 
     runner = _make_runner(session_db=session_db)
+    runner.session_store.lookup_by_session_key.return_value = None
     runner.session_store.switch_session = MagicMock(
         side_effect=RuntimeError("store unavailable")
     )
@@ -707,10 +708,15 @@ async def test_restore_failure_is_visible_and_rolls_back_binding(tmp_path):
 
     assert "Session restored" not in response
     assert "restore failed" in response.lower()
+    assert runner.session_store.switch_session.call_count == 1  # no prior route to restore
     binding = session_db.get_telegram_topic_binding(
         chat_id="208214988", thread_id="17585",
     )
     assert binding is None  # no prior binding → rollback removed the row
+    # Rollback must not toggle the chat-wide topic mode (that is the deleted-topic prune path).
+    assert session_db.is_telegram_topic_mode_enabled(
+        chat_id="208214988", user_id="208214988"
+    )
 
 
 @pytest.mark.asyncio
@@ -739,14 +745,21 @@ async def test_restore_failure_restores_previous_binding(tmp_path):
     )
 
     runner = _make_runner(session_db=session_db)
+    runner.session_store.lookup_by_session_key.return_value = SimpleNamespace(
+        session_id="prev-session"
+    )
     runner.session_store.switch_session = MagicMock(
-        side_effect=RuntimeError("store unavailable")
+        side_effect=[RuntimeError("store unavailable"), None]
     )
     event = _make_event("/topic old-topic-session", thread_id="17585")
 
     response = await runner._restore_telegram_topic_session(event, "old-topic-session")
 
     assert "restore failed" in response.lower()
+    assert runner.session_store.switch_session.call_args_list == [
+        call(topic_key, "old-topic-session"),
+        call(topic_key, "prev-session"),  # failed switch rolled the route back too
+    ]
     binding = session_db.get_telegram_topic_binding(
         chat_id="208214988", thread_id="17585",
     )

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -6,7 +6,7 @@ Telegram topics act as independent Hermes session lanes.
 
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -709,6 +709,7 @@ async def test_restore_failure_is_visible_and_rolls_back_binding(tmp_path):
     assert "Session restored" not in response
     assert "restore failed" in response.lower()
     assert runner.session_store.switch_session.call_count == 1  # no prior route to restore
+    runner.session_store.restore_route_entry.assert_not_called()
     binding = session_db.get_telegram_topic_binding(
         chat_id="208214988", thread_id="17585",
     )
@@ -756,10 +757,12 @@ async def test_restore_failure_restores_previous_binding(tmp_path):
     response = await runner._restore_telegram_topic_session(event, "old-topic-session")
 
     assert "restore failed" in response.lower()
-    assert runner.session_store.switch_session.call_args_list == [
-        call(topic_key, "old-topic-session"),
-        call(topic_key, "prev-session"),  # failed switch rolled the route back too
-    ]
+    runner.session_store.switch_session.assert_called_once_with(
+        topic_key, "old-topic-session"
+    )
+    # The snapshot — not another ID switch — goes back into the store.
+    prior = runner.session_store.lookup_by_session_key.return_value
+    runner.session_store.restore_route_entry.assert_called_once_with(topic_key, prior)
     binding = session_db.get_telegram_topic_binding(
         chat_id="208214988", thread_id="17585",
     )

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -450,6 +450,74 @@ async def test_new_inside_telegram_topic_rewrites_binding_to_new_session(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_auto_reset_repoints_topic_binding_instead_of_switching_back(tmp_path):
+    """Suspension auto-reset in a topic lane must rebind, not resurrect the predecessor.
+
+    Sibling of the /new rebind above: the resolve-time topic heal used to switch
+    the lane back to the bound (pre-reset) session even when the store had just
+    replaced it, which ended the fresh successor and dropped was_auto_reset /
+    prev_session_id — so the continuity note never fired and the reset was
+    silently undone. On an auto-reset successor the binding is repointed to the
+    new session instead, and the successor stays current.
+    """
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    session_db.create_session(
+        session_id="old-topic-session",
+        source="telegram",
+        user_id="208214988",
+    )
+    topic_source = _make_source(thread_id="17585")
+    topic_key = build_session_key(topic_source)
+    session_db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="208214988",
+        session_key=topic_key,
+        session_id="old-topic-session",
+    )
+    session_db.create_session(
+        session_id="new-topic-session",
+        source="telegram",
+        user_id="208214988",
+    )
+
+    runner = _make_runner(session_db=session_db)
+    successor = SessionEntry(
+        session_key=topic_key,
+        session_id="new-topic-session",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        origin=topic_source,
+        was_auto_reset=True,
+        auto_reset_reason="suspended",
+        reset_had_activity=True,
+        prev_session_id="old-topic-session",
+    )
+    runner.session_store.get_or_create_session.side_effect = (
+        lambda source, **_kwargs: successor
+    )
+
+    resolved = await runner._hmwa_resolve_session(
+        _make_event("hello", thread_id="17585"), topic_source
+    )
+
+    assert resolved is not None
+    _, entry, _ = resolved
+    assert entry.session_id == "new-topic-session"
+    assert getattr(entry, "was_auto_reset", False) is True
+    runner.session_store.switch_session.assert_not_called()
+
+    binding = session_db.get_telegram_topic_binding(
+        chat_id="208214988", thread_id="17585",
+    )
+    assert binding is not None
+    assert binding["session_id"] == "new-topic-session"
+
+
+@pytest.mark.asyncio
 async def test_topic_binding_follows_compression_tip_on_read(tmp_path, monkeypatch):
     """Stale topic bindings auto-heal to the compression child on next inbound.
 

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -518,6 +518,65 @@ async def test_auto_reset_repoints_topic_binding_instead_of_switching_back(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_topic_binding_repoints_when_reset_flag_already_consumed(tmp_path):
+    """Typed /model as the first post-reset message consumes the auto-reset flag (#48031);
+    the topic heal must still recognize the replacement from prev_session_id metadata and
+    rebind, not switch back to the retired predecessor."""
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    session_db.create_session(
+        session_id="old-topic-session",
+        source="telegram",
+        user_id="208214988",
+    )
+    topic_source = _make_source(thread_id="17585")
+    topic_key = build_session_key(topic_source)
+    session_db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="208214988",
+        session_key=topic_key,
+        session_id="old-topic-session",
+    )
+    session_db.create_session(
+        session_id="new-topic-session",
+        source="telegram",
+        user_id="208214988",
+    )
+
+    runner = _make_runner(session_db=session_db)
+    successor = SessionEntry(
+        session_key=topic_key,
+        session_id="new-topic-session",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        origin=topic_source,
+        was_auto_reset=False,  # consumed by the typed /model path (#48031)
+        prev_session_id="old-topic-session",
+    )
+    runner.session_store.get_or_create_session.side_effect = (
+        lambda source, **_kwargs: successor
+    )
+
+    resolved = await runner._hmwa_resolve_session(
+        _make_event("hello", thread_id="17585"), topic_source
+    )
+
+    assert resolved is not None
+    _, entry, _ = resolved
+    assert entry.session_id == "new-topic-session"
+    runner.session_store.switch_session.assert_not_called()
+
+    binding = session_db.get_telegram_topic_binding(
+        chat_id="208214988", thread_id="17585",
+    )
+    assert binding is not None
+    assert binding["session_id"] == "new-topic-session"
+
+
+@pytest.mark.asyncio
 async def test_topic_binding_follows_compression_tip_on_read(tmp_path, monkeypatch):
     """Stale topic bindings auto-heal to the compression child on next inbound.
 

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -577,6 +577,73 @@ async def test_topic_binding_repoints_when_reset_flag_already_consumed(tmp_path)
 
 
 @pytest.mark.asyncio
+async def test_restored_topic_binding_is_followed_not_overwritten(tmp_path):
+    """A pending auto-reset must not clobber a user's explicit /topic <id> restore.
+
+    When the auto-reset is first observed by an off-turn command, was_auto_reset is
+    still set; if the user then restores an older session into the topic, the heal
+    must follow the restored binding (switch), not repoint it at the reset successor.
+    """
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    session_db.create_session(
+        session_id="old-topic-session",
+        source="telegram",
+        user_id="208214988",
+    )
+    session_db.create_session(
+        session_id="restored-session",
+        source="telegram",
+        user_id="208214988",
+    )
+    topic_source = _make_source(thread_id="17585")
+    topic_key = build_session_key(topic_source)
+    session_db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="208214988",
+        session_key=topic_key,
+        session_id="restored-session",
+        managed_mode="restored",
+    )
+
+    runner = _make_runner(session_db=session_db)
+    successor = SessionEntry(
+        session_key=topic_key,
+        session_id="new-topic-session",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        origin=topic_source,
+        was_auto_reset=True,  # off-turn command created it without consuming the flag
+        auto_reset_reason="suspended",
+        reset_had_activity=True,
+        prev_session_id="old-topic-session",
+    )
+    runner.session_store.get_or_create_session.side_effect = (
+        lambda source, **_kwargs: successor
+    )
+
+    resolved = await runner._hmwa_resolve_session(
+        _make_event("hello", thread_id="17585"), topic_source
+    )
+
+    assert resolved is not None
+    _, entry, _ = resolved
+    assert entry.session_id == "restored-session"
+    runner.session_store.switch_session.assert_called_once_with(
+        topic_key, "restored-session"
+    )
+
+    binding = session_db.get_telegram_topic_binding(
+        chat_id="208214988", thread_id="17585",
+    )
+    assert binding is not None
+    assert binding["session_id"] == "restored-session"
+
+
+@pytest.mark.asyncio
 async def test_topic_binding_follows_compression_tip_on_read(tmp_path, monkeypatch):
     """Stale topic bindings auto-heal to the compression child on next inbound.
 

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -680,6 +680,81 @@ async def test_restore_switches_store_immediately(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_restore_failure_is_visible_and_rolls_back_binding(tmp_path):
+    """A failed store switch must not leave a committed restore binding behind.
+
+    Binding-then-switch with a suppressed switch error could leave the durable
+    binding on the restored session while the store kept the auto-reset
+    successor — the next heal would then treat the explicit restore as stale
+    and undo it. The command now rolls the binding back and reports failure.
+    """
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    session_db.create_session(
+        session_id="old-topic-session",
+        source="telegram",
+        user_id="208214988",
+    )
+    topic_source = _make_source(thread_id="17585")
+
+    runner = _make_runner(session_db=session_db)
+    runner.session_store.switch_session = MagicMock(
+        side_effect=RuntimeError("store unavailable")
+    )
+    event = _make_event("/topic old-topic-session", thread_id="17585")
+
+    response = await runner._restore_telegram_topic_session(event, "old-topic-session")
+
+    assert "Session restored" not in response
+    assert "restore failed" in response.lower()
+    binding = session_db.get_telegram_topic_binding(
+        chat_id="208214988", thread_id="17585",
+    )
+    assert binding is None  # no prior binding → rollback removed the row
+
+
+@pytest.mark.asyncio
+async def test_restore_failure_restores_previous_binding(tmp_path):
+    """When a prior binding existed, a failed restore puts it back verbatim."""
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    session_db.create_session(
+        session_id="prev-session",
+        source="telegram",
+        user_id="208214988",
+    )
+    session_db.create_session(
+        session_id="old-topic-session",
+        source="telegram",
+        user_id="208214988",
+    )
+    topic_source = _make_source(thread_id="17585")
+    topic_key = build_session_key(topic_source)
+    session_db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="208214988",
+        session_key=topic_key,
+        session_id="prev-session",
+    )
+
+    runner = _make_runner(session_db=session_db)
+    runner.session_store.switch_session = MagicMock(
+        side_effect=RuntimeError("store unavailable")
+    )
+    event = _make_event("/topic old-topic-session", thread_id="17585")
+
+    response = await runner._restore_telegram_topic_session(event, "old-topic-session")
+
+    assert "restore failed" in response.lower()
+    binding = session_db.get_telegram_topic_binding(
+        chat_id="208214988", thread_id="17585",
+    )
+    assert binding is not None
+    assert binding["session_id"] == "prev-session"
+
+
+@pytest.mark.asyncio
 async def test_topic_binding_follows_compression_tip_on_read(tmp_path, monkeypatch):
     """Stale topic bindings auto-heal to the compression child on next inbound.
 

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -644,6 +644,42 @@ async def test_restored_topic_binding_is_followed_not_overwritten(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_restore_switches_store_immediately(tmp_path):
+    """`/topic <id>` must switch the lane's store entry at command time.
+
+    Restoring the session that was just auto-reset makes the binding equal the
+    successor's prev_session_id; if the switch were left to the next inbound
+    heal, the heal could mistake the explicit restore for a stale binding and
+    repoint it at the successor — the next prompt would stay in the new session
+    despite "Session restored". The command now switches immediately.
+    """
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    session_db.create_session(
+        session_id="old-topic-session",
+        source="telegram",
+        user_id="208214988",
+    )
+    topic_source = _make_source(thread_id="17585")
+    topic_key = build_session_key(topic_source)
+
+    runner = _make_runner(session_db=session_db)
+    event = _make_event("/topic old-topic-session", thread_id="17585")
+
+    response = await runner._restore_telegram_topic_session(event, "old-topic-session")
+
+    assert "Session restored" in response
+    runner.session_store.switch_session.assert_called_once_with(
+        topic_key, "old-topic-session"
+    )
+    binding = session_db.get_telegram_topic_binding(
+        chat_id="208214988", thread_id="17585",
+    )
+    assert binding is not None
+    assert binding["session_id"] == "old-topic-session"
+
+
+@pytest.mark.asyncio
 async def test_topic_binding_follows_compression_tip_on_read(tmp_path, monkeypatch):
     """Stale topic bindings auto-heal to the compression child on next inbound.
 


### PR DESCRIPTION
## What does this PR do?

Extends the auto-reset session-continuity hint — the one-line *"This conversation had an earlier Hermes session (session_id: …) that was auto-reset; use `session_search` before acting"* pointer — from Slack/Discord to **all human chat platforms** (Telegram, Signal, WhatsApp, Matrix, email, plugin platforms, …).

Today `build_channel_continuity_note()` allowlists Slack/Discord. Everywhere else, when the gateway replaces a conversation with an auto-reset, the fresh session receives the reset notice with **no pointer at the prior session** — the agent cannot find the thread the user is replying to, and may bind the request to an unrelated recent session. That is the gap reported on Telegram in #43008 and #100177.

_Current `main` context:_ scheduled idle/daily resets were removed; the remaining automatic replacement path is **suspension** (unclean stop/restart, stuck-loop escalation), which rides this same note. Installations still on the older scheduled-reset behavior benefit identically.

## Related Issue

Refs #43008, #100177 — this covers the continuity-pointer half; the post-reset delivery-mirroring half is separate.

Split/salvage of the continuity portion of #70972 (by @joelbrilliant): that PR no longer merges against current `main` and bundles an unrelated size-rotate nudge, so this isolates the focused change suggested in that thread. Related: #98640 (root-lineage enrichment across chained resets — complementary, not included here), #31501 (the stale-binding trap the run_turn change aligns with).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session.py` — re-gate `build_channel_continuity_note()` by **denylist** (`_NON_HUMAN_SESSION_HINT_PLATFORMS`, listed by platform value so dynamic plugin platforms can be classified explicitly) instead of the Slack/Discord allowlist:
  - silent: `api_server`, `webhook`, `msgraph_webhook` (machine callers), `homeassistant` (system-generated state events), `ntfy` (broadcast topics with no user identity), `raft` (content-free machine wake bridge), and `a2a` (agent-peer task protocol);
  - everything else — including dynamic plugin platforms created via `Platform._missing_()` (which an allowlist would silently exclude) and callback transports that carry per-user DMs like `wecom_callback` (a human chat surface) — now gets the pointer.
- `gateway/session.py` — DM wording: non-Slack/Discord sources say "conversation"; Slack/Discord keep "channel" and threads keep "thread".
- `gateway/session.py` — `SessionStore.restore_route_entry()`: reinstalls a captured entry snapshot verbatim (undo of a partially applied `switch_session`), preserving counters, model overrides and auto-reset metadata that a switch-back-by-ID would lose.
- `gateway/run_turn.py` — companion resolution fix: the Telegram topic-lane binding heal now repoints a stale `(chat_id, thread_id)` binding **only when it names the exact conversation the current entry replaced** (`prev_session_id` metadata — which survives the typed `/model` path's early `was_auto_reset` consumption, #48031). Everything else is followed — never overwritten. Without the repoint, topic lanes silently undid the reset and dropped the successor's metadata (same stale-binding trap `/new` already guards against, #31501).
- `gateway/run_topics.py` — `/topic <id>` restores now switch the lane's store entry **immediately at command time** (deferring to the next inbound heal could mistake a restore of the just-retired session for a stale auto-reset binding and repoint it at the successor). If the switch fails, the command **rolls back both the binding and the in-process route** — the latter via the captured snapshot (`switch_session()` can raise after its entry swap) — and reports the failure: no committed restore over the old entry, no misleading "Session restored", no shell entry replacing the real one.
- `hermes_state_telegram.py` — `delete_telegram_topic_binding()` gains `disable_mode_when_last` (default `True`, preserving the deleted-topic prune behavior). Rollback callers pass `False` so clearing a failed restore's first-ever binding does not disable Telegram topic mode for the whole chat.
- `tests/gateway/test_channel_continuity_hint.py` — new coverage: Telegram DM wording, Telegram topic ("thread") wording, WeCom callback DMs, a plugin platform, silence for the seven machine/system/agent sources, and a no-prior-id case.
- `tests/gateway/test_telegram_topic_mode.py` — six regressions: auto-reset successor repoints its binding (not switch-back); the repoint still happens when the flag was already consumed (typed `/model` first); a `/topic <id>` restore of a different session is followed, not overwritten; restore switches the store immediately; restore failure is visible, rolls back the binding, keeps topic mode enabled, and reinstates the prior route **snapshot** (not a fresh ID switch).
- `tests/gateway/test_session_store_lock_io.py` — store-level test: `restore_route_entry` reinstates the exact snapshot (identity, model override, `was_auto_reset`, `prev_session_id` preserved).

All new tests verified **red before / green after**.

The note remains a **pointer, not a carried summary**: no LLM calls, no extra DB lookups — the previous session id is already on the routing entry, and the agent pays `session_search` retrieval only when the user actually refers back.

## How to Test

1. Focused suites (Linux x86_64, Python 3.11.15):
   - `scripts/run_tests.sh tests/gateway/test_channel_continuity_hint.py` → **15 passed**
   - `scripts/run_tests.sh tests/gateway/test_telegram_topic_mode.py` → **25 passed**
   - plus 18 adjacent auto-reset / topic-binding / heartbeat / session-store files → **179 passed, 0 failed (20 files)**
2. Manual: on any non-Slack/Discord chat (e.g. Telegram), let a session auto-reset after real activity, then send a follow-up that refers to earlier work — the first message of the fresh session now carries the pointer naming the prior session id, and the agent can `session_search` it. In a Telegram topic lane, the follow-up lands in the fresh session instead of silently resuming the pre-reset one, and `/topic <id>` restores take effect immediately (or fail visibly without side effects).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — this is the requested split/rebuild of #70972; no other open PR covers the continuity pointer
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run tests — focused + adjacent gateway files above (full suite left to CI)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux x86_64, Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation — N/A (behavior rides the existing reset notice; no user-facing config or docs change)
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] Cross-platform impact — N/A (pure Python, no OS-specific code)
- [x] Tool descriptions/schemas — N/A (no tool changes)

## Screenshots / Logs

```text
=== Summary: 1 files, 15 tests passed, 0 failed (100% complete) in 0.5s
=== Summary: 1 files, 25 tests passed, 0 failed (100% complete) in 2.1s
=== Summary: 20 files, 179 tests passed, 0 failed (100% complete) in 13.6s
```
