### PR TITLE
fix(skills): resolve skills.create_dir in skill_view, skills_list and slash commands

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -377,19 +377,19 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     try:
         from tools.skills_tool import _skills_dir, _get_disabled_skill_names
         from agent.skill_utils import (
-            get_external_skills_dirs, get_project_skills_dirs, iter_project_skill_files, iter_skill_index_files,
+            get_all_skills_dirs, get_project_skills_dirs, iter_project_skill_files, iter_skill_index_files,
         )
         from hermes_cli.commands import resolve_command
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
-        # Precedence: project (through the quarantine chokepoint) > local > external.
+        # Precedence: project (through the quarantine chokepoint) > local > create_dir > external.
         # Resolve the local dir at call time: import-time SKILLS_DIR is frozen to
         # the launch home, but a multiplexed profile scope may have changed it.
         # See #67277.
         skills_dir = _skills_dir()
         iters = [iter_project_skill_files(d) for d in get_project_skills_dirs()]
         local = [skills_dir] if skills_dir.exists() else []
-        iters += [iter_skill_index_files(d, "SKILL.md") for d in local + get_external_skills_dirs()]
+        iters += [iter_skill_index_files(d, "SKILL.md") for d in local + get_all_skills_dirs()[1:]]
         for _iter in iters:
             for skill_md in _iter:
                 try:

--- a/hermes_cli/commands_platforms.py
+++ b/hermes_cli/commands_platforms.py
@@ -182,7 +182,7 @@ def _iter_gateway_skills(platform: str):
 
     from agent.skill_commands import get_skill_commands
     from agent.skill_utils import (
-        get_disabled_skill_names, get_external_skills_dirs, get_project_skills_dirs)
+        get_all_skills_dirs, get_disabled_skill_names, get_project_skills_dirs)
     from tools.skills_tool import SKILLS_DIR
 
     try:
@@ -191,7 +191,8 @@ def _iter_gateway_skills(platform: str):
         disabled = set()
     hub_dir = (SKILLS_DIR / ".hub").resolve()
     roots = [SKILLS_DIR.resolve()]
-    for getter in (get_external_skills_dirs, get_project_skills_dirs):
+    # [1:] = skills.create_dir + external_dirs (index 0 is the local dir, already a root).
+    for getter in (lambda: get_all_skills_dirs()[1:], get_project_skills_dirs):
         try:
             for d in getter():
                 try:

--- a/tests/tools/test_skill_create_dir.py
+++ b/tests/tools/test_skill_create_dir.py
@@ -187,3 +187,85 @@ class TestCreateRouting:
         }]))
         assert res.get("success"), res
         assert "Patched." in (brain / "patchable-skill" / "SKILL.md").read_text()
+
+
+class TestReadPathDiscovery:
+    """The system-prompt skill index is built from ``get_all_skills_dirs()``,
+    which folds ``create_dir`` in — so a create_dir skill is advertised to the
+    model. Every path that then resolves an advertised name (skill_view,
+    skills_list, /slash dispatch, gateway menus) must scan the same dirs, or
+    the model is offered a skill it cannot load."""
+
+    @staticmethod
+    def _seed(brain: Path, name: str = "brain-skill", category: str = "devops") -> Path:
+        skill_dir = brain / category / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(_skill_md(name), encoding="utf-8")
+        return skill_dir
+
+    def test_skill_view_finds_create_dir_skill(self, isolated_home, tmp_path):
+        from tools.skills_tool import skill_view
+        brain = tmp_path / "brain-skills"
+        skill_dir = self._seed(brain)
+        _write_config(isolated_home, f"skills:\n  create_dir: {brain}\n")
+        res = json.loads(skill_view("brain-skill"))
+        assert res.get("success"), res
+        assert Path(res["skill_dir"]).resolve() == skill_dir.resolve()
+
+    def test_skill_created_via_skill_manage_is_viewable(self, isolated_home, tmp_path):
+        from tools.skill_manager_tool import skill_manage
+        from tools.skills_tool import skill_view
+        brain = tmp_path / "brain-skills"
+        _write_config(isolated_home, f"skills:\n  create_dir: {brain}\n")
+        created = json.loads(skill_manage("", "", operations=[{
+            "action": "create", "name": "fresh-skill",
+            "content": _skill_md("fresh-skill"),
+        }]))
+        assert created.get("success"), created
+        res = json.loads(skill_view("fresh-skill"))
+        assert res.get("success"), res
+
+    def test_skills_list_includes_create_dir_skill_with_category(self, isolated_home, tmp_path):
+        from tools.skills_tool import _find_all_skills
+        brain = tmp_path / "brain-skills"
+        self._seed(brain)
+        _write_config(isolated_home, f"skills:\n  create_dir: {brain}\n")
+        by_name = {s["name"]: s for s in _find_all_skills()}
+        assert "brain-skill" in by_name
+        assert by_name["brain-skill"]["category"] == "devops"
+
+    def test_create_dir_also_listed_in_external_dirs_is_not_ambiguous(self, isolated_home, tmp_path):
+        """Listing the same dir under both keys must not surface one skill twice."""
+        from tools.skills_tool import skill_view
+        brain = tmp_path / "brain-skills"
+        self._seed(brain)
+        _write_config(
+            isolated_home,
+            f"skills:\n  create_dir: {brain}\n  external_dirs:\n    - {brain}\n",
+        )
+        res = json.loads(skill_view("brain-skill"))
+        assert res.get("success"), res
+
+    def test_slash_command_registered_for_create_dir_skill(self, isolated_home, tmp_path, monkeypatch):
+        import agent.skill_commands as sc_mod
+        brain = tmp_path / "brain-skills"
+        self._seed(brain)
+        _write_config(isolated_home, f"skills:\n  create_dir: {brain}\n")
+        monkeypatch.setattr(sc_mod, "_skill_commands", {})
+        monkeypatch.setattr(sc_mod, "_skill_commands_platform", None)
+        monkeypatch.setattr(sc_mod, "_skill_commands_home", None)
+        assert "/brain-skill" in sc_mod.get_skill_commands()
+
+    def test_gateway_menu_admits_create_dir_skill(self, isolated_home, tmp_path):
+        from unittest.mock import patch
+        from hermes_cli.commands_platforms import telegram_menu_commands
+        brain = (tmp_path / "brain-skills")
+        skill_dir = self._seed(brain).resolve()
+        _write_config(isolated_home, f"skills:\n  create_dir: {brain}\n")
+        fake_cmds = {"/brain-skill": {
+            "name": "brain-skill", "description": "create_dir skill",
+            "skill_md_path": str(skill_dir / "SKILL.md"), "skill_dir": str(skill_dir),
+        }}
+        with patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds):
+            menu, _ = telegram_menu_commands(max_commands=100)
+        assert "brain_skill" in {n for n, _ in menu}

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -129,11 +129,11 @@ def check_skills_requirements() -> bool:
 
 def _get_category_from_path(skill_path: Path) -> Optional[str]:
     """``~/.hermes/skills/mlops/axolotl/SKILL.md`` -> ``"mlops"``; active profile dir first
-    (respects test monkeypatching), then skills.external_dirs."""
+    (respects test monkeypatching), then skills.create_dir and skills.external_dirs."""
     dirs_to_check = [_skills_dir()]
     with suppress(Exception):
-        from agent.skill_utils import get_external_skills_dirs
-        dirs_to_check.extend(get_external_skills_dirs())
+        from agent.skill_utils import get_all_skills_dirs
+        dirs_to_check.extend(get_all_skills_dirs()[1:])
     for skills_dir in dirs_to_check:
         with suppress(ValueError):
             if len(parts := skill_path.relative_to(skills_dir).parts) >= 3:
@@ -177,11 +177,12 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
 def _skill_search_dirs() -> Tuple[list, list, Path]:
     """(project_dirs, all_dirs, active_skills_dir); trusted project-local dirs come FIRST so
     first-wins dedup / the collision resolver prefer them."""
-    from agent.skill_utils import get_external_skills_dirs, get_project_skills_dirs
+    from agent.skill_utils import get_all_skills_dirs, get_project_skills_dirs
     project_dirs = list(get_project_skills_dirs())
     active_skills_dir = _skills_dir()
     all_dirs = project_dirs + ([active_skills_dir] if active_skills_dir.exists() else [])
-    all_dirs += get_external_skills_dirs()
+    # [1:] = skills.create_dir + external_dirs: the same dirs the prompt index advertises.
+    all_dirs += get_all_skills_dirs()[1:]
     return project_dirs, all_dirs, active_skills_dir
 
 


### PR DESCRIPTION
## What does this PR do?

Skills in `skills.create_dir` (#100377) show up in the system-prompt skill index, because `build_skills_system_prompt` uses `get_all_skills_dirs()[1:]`. But `skill_view` returns "not found" for them, `skills_list` leaves them out, and they get no `/slash` command or Telegram/Discord menu entry. Those read paths each build their directory list by hand as local + `get_external_skills_dirs()`, which skips `create_dir`.

This PR moves those call sites to `get_all_skills_dirs()[1:]`, the form `prompt_builder` and `skill_usage` already use. Every discovery surface then scans the same directories the index advertises.

`get_all_skills_dirs()` already removes duplicates between `create_dir` and `external_dirs`, and `_collect_skill_candidates` removes duplicates by resolved path. So a directory listed under both keys stays unambiguous, and a regression test covers that.

## Related Issue

Fixes #108157

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/skills_tool.py`: `_skill_search_dirs` (backs `skill_view` + `skills_list`) and `_get_category_from_path` (so `create_dir` skills get their category in `skills_list`)
- `agent/skill_commands.py`: `scan_skill_commands`, so `/skill-name` registers for `create_dir` skills; the precedence comment now reads project > local > create_dir > external
- `hermes_cli/commands_platforms.py`: `_iter_gateway_skills` roots (Telegram menu, Discord `/skill` groups, inline picker)
- `tests/tools/test_skill_create_dir.py`: new `TestReadPathDiscovery` class with 6 tests: `skill_view`, `skill_manage` create → `skill_view` end to end, `skills_list` with category, `create_dir` also listed in `external_dirs` (no ambiguity), slash-command registration, and the gateway menu

Deliberately **not** touched:

- `hermes_cli/commands.py`'s legacy `_collect_gateway_skill_entries` / `discord_skill_commands`. They have the same pattern, but no live caller uses them (the compat map redirects to `commands_platforms`), and they are due for removal on 2026-09-14.
- `tools/credential_files.py::_skill_dir_roots` (remote-sandbox skill sync). It also skips `create_dir`, but it uses a different mount layout, so it is flagged in #108157 as a follow-up.

This PR shares no files with the open #108040.

## How to Test

1. Show the bug on `origin/main` with the new tests only: `scripts/run_tests.sh tests/tools/test_skill_create_dir.py -q -k TestReadPathDiscovery` gives **5 failed, 1 passed**. The one that passes is the dedup guard, which holds both before and after the fix. Each failure is the reported symptom, e.g. `{'success': False, 'error': "Skill 'brain-skill' not found.", ...}`.
2. With this patch, `scripts/run_tests.sh tests/tools/test_skill_create_dir.py -q` gives **22 passed**.
3. Neighbouring suites all pass: **386 passed** across `test_skill_create_dir`, `test_skill_commands`, `test_commands`, `test_discord_skill_clamp_warning`, `test_skills_tool`, `test_skill_utils`, `test_external_skills`, `test_project_skills`, `test_prompt_builder`, `test_skill_manager_tool`, `test_skill_usage` and `test_web_server_skills_profiles`. The gateway consumers also pass: **53 passed** across `test_telegram_inline_picker`, `test_discord_slash_commands`, `test_reload_skills_discord_resync`, `test_telegram_forum_commands` and `test_discord_slash_auth`.
4. Run the standalone repro from #108157 on a fresh synthetic `HERMES_HOME`:

```
# origin/main
in prompt index     : True
skills_list names   : []
skill_view          : Skill 'demo-skill' not found.

# this branch
in prompt index     : True
skills_list names   : ['demo-skill']
skill_view          : ok
```

5. Full suite (`scripts/run_tests.sh`, Linux, Python 3.12, `.[dev]` extras only): 4033 files, **48,349 passed, 151 failed, 441 skipped**. None of the failures come from this PR. I re-ran every failing file on unpatched `origin/main` and compared test IDs, and **no test fails on this branch that doesn't also fail on `main`**. `main` fails 169 IDs to this branch's 167. The two extra ones are a flaky subagent-handoff test and an FTS5 test in a file that timed out here under full parallel load. The failures come from missing optional extras (ACP, platform SDKs), provider/credential tests, gateway adapters and wisdom setup; none of them touch skills. Two files did not run in the full pass because of per-file timeouts, `tests/test_hermes_state.py` and `tests/wisdom/test_installed_setup.py`. Run on their own, both give identical results on this branch and on `main`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full suite: it introduces no new failures, and every failure on this runner also happens on unpatched `origin/main` (see How to Test §5)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux 6.8), Python 3.12.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings/comments only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, no new path handling (the same `get_all_skills_dirs()` values already used by the prompt builder)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jsCfn6VnuphwzZTrqcfwM
