### PR TITLE
fix(desktop): bound Preview console string retention

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-console-state.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-console-state.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createPreviewConsoleState,
+  PREVIEW_CONSOLE_MAX_ENTRIES,
+  PREVIEW_CONSOLE_MAX_MESSAGE_CHARS,
+  PREVIEW_CONSOLE_MAX_SOURCE_CHARS,
+  PREVIEW_CONSOLE_MAX_TOTAL_CHARS
+} from './preview-console-state'
+
+type PreviewLogs = ReturnType<ReturnType<typeof createPreviewConsoleState>['$logs']['get']>
+
+const retainedChars = (logs: PreviewLogs) =>
+  logs.reduce((total, entry) => total + entry.message.length + (entry.source?.length ?? 0), 0)
+
+describe('preview console retention', () => {
+  it('truncates one oversized message and source before retaining them', () => {
+    const state = createPreviewConsoleState()
+
+    state.append({
+      level: 0,
+      message: 'x'.repeat(PREVIEW_CONSOLE_MAX_MESSAGE_CHARS * 4),
+      source: 's'.repeat(PREVIEW_CONSOLE_MAX_SOURCE_CHARS * 4)
+    })
+
+    const [entry] = state.$logs.get()
+
+    expect(entry.message).toHaveLength(PREVIEW_CONSOLE_MAX_MESSAGE_CHARS)
+    expect(entry.message).toMatch(/… \[truncated\]$/)
+    expect(entry.source).toHaveLength(PREVIEW_CONSOLE_MAX_SOURCE_CHARS)
+    expect(entry.source).toMatch(/… \[truncated\]$/)
+  })
+
+  it('does not split a UTF-16 surrogate pair at the truncation boundary', () => {
+    const state = createPreviewConsoleState()
+    const marker = '\n… [truncated]'
+    const prefixChars = PREVIEW_CONSOLE_MAX_MESSAGE_CHARS - marker.length
+    // The high surrogate begins exactly at the final retained code-unit slot;
+    // enough tail follows to force truncation rather than exercising pass-through.
+    const message = `${'x'.repeat(prefixChars - 1)}😀${'tail'.repeat(10)}`
+
+    state.append({ level: 0, message })
+
+    const [entry] = state.$logs.get()
+    const beforeMarker = entry.message.slice(0, -marker.length)
+
+    expect(message.length).toBeGreaterThan(PREVIEW_CONSOLE_MAX_MESSAGE_CHARS)
+    expect(entry.message).toHaveLength(PREVIEW_CONSOLE_MAX_MESSAGE_CHARS)
+    expect(entry.message.endsWith(marker)).toBe(true)
+    expect(beforeMarker.endsWith('\ufffd')).toBe(true)
+  })
+
+  it('evicts oldest large entries and their selections to stay under the tab budget', () => {
+    const state = createPreviewConsoleState()
+
+    state.append({ level: 0, message: 'first'.repeat(PREVIEW_CONSOLE_MAX_MESSAGE_CHARS) })
+    const selectedId = state.$logs.get()[0].id
+    state.toggleSelection(selectedId)
+
+    for (let index = 0; index < 20; index++) {
+      state.append({ level: 0, message: `${index}`.repeat(PREVIEW_CONSOLE_MAX_MESSAGE_CHARS) })
+    }
+
+    const logs = state.$logs.get()
+
+    expect(retainedChars(logs)).toBeLessThanOrEqual(PREVIEW_CONSOLE_MAX_TOTAL_CHARS)
+    expect(logs.at(-1)?.id).toBe(21)
+    expect(logs.some(entry => entry.id === selectedId)).toBe(false)
+    expect(state.$selectedLogIds.get().has(selectedId)).toBe(false)
+  })
+
+  it('preserves the existing 200-entry cap for small logs', () => {
+    const state = createPreviewConsoleState()
+
+    for (let index = 0; index < PREVIEW_CONSOLE_MAX_ENTRIES + 10; index++) {
+      state.append({ level: 0, message: `line-${index}` })
+    }
+
+    expect(state.$logs.get()).toHaveLength(PREVIEW_CONSOLE_MAX_ENTRIES)
+    expect(state.$logs.get()[0].message).toBe('line-10')
+    expect(retainedChars(state.$logs.get())).toBeLessThanOrEqual(PREVIEW_CONSOLE_MAX_TOTAL_CHARS)
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-console-state.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-console-state.ts
@@ -8,6 +8,11 @@ interface WritableStore<T> {
 }
 
 const DEFAULT_CONSOLE_HEIGHT = 240
+export const PREVIEW_CONSOLE_MAX_ENTRIES = 200
+export const PREVIEW_CONSOLE_MAX_MESSAGE_CHARS = 64 * 1024
+export const PREVIEW_CONSOLE_MAX_SOURCE_CHARS = 4 * 1024
+export const PREVIEW_CONSOLE_MAX_TOTAL_CHARS = 512 * 1024
+const PREVIEW_CONSOLE_TRUNCATION_MARKER = '\n… [truncated]'
 
 export interface ConsoleEntry {
   id: number
@@ -28,6 +33,50 @@ function updateAtom<T>(store: WritableStore<T>, next: Updater<T>) {
   store.set(typeof next === 'function' ? (next as (current: T) => T)(store.get()) : next)
 }
 
+function truncateConsoleText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) {
+    return value
+  }
+
+  const marker = PREVIEW_CONSOLE_TRUNCATION_MARKER.slice(0, maxChars)
+  const kept = Math.max(0, maxChars - marker.length)
+  let prefix = value.slice(0, kept)
+
+  // Avoid manufacturing a lone UTF-16 high surrogate at the cut. Replacing
+  // the partial code point keeps the exact code-unit budget and produces a
+  // display-safe string for React/Electron.
+  const last = prefix.charCodeAt(prefix.length - 1)
+
+  if (last >= 0xd800 && last <= 0xdbff) {
+    prefix = `${prefix.slice(0, -1)}\ufffd`
+  }
+
+  return `${prefix}${marker}`
+}
+
+function consoleEntryChars(entry: ConsoleEntry): number {
+  return entry.message.length + (entry.source?.length ?? 0)
+}
+
+function fitConsoleHistory(entries: ConsoleEntry[]): ConsoleEntry[] {
+  let kept = entries.slice(-PREVIEW_CONSOLE_MAX_ENTRIES)
+  let chars = kept.reduce((total, entry) => total + consoleEntryChars(entry), 0)
+  let drop = 0
+
+  // Each field is truncated far below the aggregate cap, so the newest entry
+  // always fits. Evict oldest-first to preserve the most useful recent logs.
+  while (drop < kept.length - 1 && chars > PREVIEW_CONSOLE_MAX_TOTAL_CHARS) {
+    chars -= consoleEntryChars(kept[drop])
+    drop++
+  }
+
+  if (drop > 0) {
+    kept = kept.slice(drop)
+  }
+
+  return kept
+}
+
 export function createPreviewConsoleState() {
   const $height = atom(DEFAULT_CONSOLE_HEIGHT)
   const $logs = atom<ConsoleEntry[]>([])
@@ -43,7 +92,28 @@ export function createPreviewConsoleState() {
     $open,
     $selectedLogIds,
     append(entry: ConsoleEntryInput) {
-      $logs.set([...$logs.get().slice(-199), { ...entry, id: ++nextLogId }])
+      const nextEntry: ConsoleEntry = {
+        ...entry,
+        id: ++nextLogId,
+        message: truncateConsoleText(entry.message, PREVIEW_CONSOLE_MAX_MESSAGE_CHARS),
+        ...(entry.source === undefined
+          ? {}
+          : { source: truncateConsoleText(entry.source, PREVIEW_CONSOLE_MAX_SOURCE_CHARS) })
+      }
+      const logs = fitConsoleHistory([...$logs.get(), nextEntry])
+
+      $logs.set(logs)
+
+      const selected = $selectedLogIds.get()
+
+      if (selected.size > 0) {
+        const retained = new Set(logs.map(log => log.id))
+        const nextSelected = new Set([...selected].filter(id => retained.has(id)))
+
+        if (nextSelected.size !== selected.size) {
+          $selectedLogIds.set(nextSelected)
+        }
+      }
     },
     clear() {
       $logs.set([])


### PR DESCRIPTION
## Summary

Fixes #108161.

The Preview console kept at most 200 entries, but each entry's `message` and `source` strings were unbounded. A single preview-page `console.log()` could therefore retain tens of megabytes in the per-tab nanostore, and 200 large entries could retain far more despite the count cap.

This change bounds the payload actually retained by each Preview console tab:

- 64 Ki UTF-16 code units per message;
- 4 Ki code units per source;
- 512 Ki code units across the tab;
- 200 entries, unchanged.

Oversized fields keep their prefix and receive an explicit `… [truncated]` suffix. A cut that lands between a UTF-16 surrogate pair replaces the partial code point with `U+FFFD`, preserving the exact code-unit budget without creating malformed text. When the aggregate budget is exceeded, oldest entries are evicted until the newest history fits. Selection IDs for evicted logs are pruned at the same boundary.

## Why code units

The retained object is a JavaScript string. Counting UTF-16 code units gives a conservative bound of roughly two bytes per code unit without allocating a temporary `TextEncoder` buffer merely to decide whether the original string should stay resident. The 512 Ki-code-unit cap therefore limits backing-string storage to roughly 1 MiB per tab, excluding small object/array overhead.

## Verification

Strict TypeScript 5.8 (`target: ES2023`, `strict: true`) passes for the changed state implementation.

A focused behavior harness passes all four retention contracts:

```json
{"checks":4,"finalRetainedEntries":1,"finalRetainedChars":65536}
```

Committed Vitest coverage verifies:

- oversized message and source fields are truncated before retention;
- truncation does not split a UTF-16 surrogate pair;
- repeated large logs remain within the aggregate per-tab budget;
- newest entries survive while oldest entries and their selected IDs are evicted;
- the existing 200-entry behavior remains unchanged for ordinary small logs.

The branch is one commit directly on upstream `dee30d123defbb61ec53ec17bf7aae281563db49`; only `preview-console-state.ts` and its focused test are changed. Repository CI remains authoritative for the full Desktop suite.