### PR TITLE
fix(telegram): preserve argument separator space on /cmd@botname mention stripping (#107082)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5399,7 +5399,10 @@ class TelegramAdapter(BasePlatformAdapter):
         bot_username = self._current_bot_username()
         if not text or not bot_username:
             return text
-        cleaned = re.sub(rf"(?i)@{re.escape(bot_username)}\b[,:\-]*\s*", "", text).strip()
+        pattern = rf"(?i)@{re.escape(bot_username)}\b[,:\-]*"
+        if not text.startswith("/"):
+            pattern += r"\s*"
+        cleaned = re.sub(pattern, "", text).strip()
         return cleaned or text
 
     def _topic_gates_pass(self, thread_id, *, warn_non_numeric: bool) -> Optional[bool]:

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -939,3 +939,14 @@ def test_human_reply_unaffected_by_bots_require_mention():
         gated._should_process_message(_group_message("replying", reply_to_bot=True))
         is True
     )
+
+
+def test_clean_bot_trigger_text_preserves_slash_command_spaces():
+    """Verify /cmd@botname args retains space, whereas @botname plain text strips leading space."""
+    adapter = _make_adapter(bot_username="my_bot")
+
+    assert adapter._clean_bot_trigger_text("/queue@my_bot do something") == "/queue do something"
+    assert adapter._clean_bot_trigger_text("/queue@my_bot") == "/queue"
+    assert adapter._clean_bot_trigger_text("@my_bot do something") == "do something"
+    assert adapter._clean_bot_trigger_text("@my_bot: do something") == "do something"
+


### PR DESCRIPTION
### Summary
Prevent `TelegramAdapter._clean_bot_trigger_text` from consuming trailing whitespace when cleaning `@botname` mentions from slash commands (e.g. `/queue@botname args`).

### Context & Problem
In Telegram group chats, selecting slash commands from Telegram's command menu appends the `@botname` suffix (e.g., `/queue@bot_name do something`).
`_clean_bot_trigger_text` used the regex `rf"(?i)@{re.escape(bot_username)}\b[,:\-]*\s*"`. The trailing `\s*` greedily consumed the space between `/queue` and its arguments, turning `/queue@bot_name do something` into `/queue_do something` (no space). Downstream command parsing then failed to recognize the slash command and fell through to treating it as a plain-text prompt (triggering interrupts instead of queueing).

### Solution
- Updated `_clean_bot_trigger_text` in `plugins/platforms/telegram/adapter.py` so trailing `\s*` is only appended when the text does NOT start with `/`.
- Added unit test `test_clean_bot_trigger_text_preserves_slash_command_spaces` in `tests/gateway/test_telegram_group_gating.py`.

Closes #107082
