### PR TITLE
feat(a2a): deliver inline push callbacks on loopback-bound inbound

### DIFF
--- a/plugins/platforms/a2a/DESIGN.md
+++ b/plugins/platforms/a2a/DESIGN.md
@@ -62,12 +62,16 @@ Peers resolved from `config.yaml` → `a2a_agents`, or a direct URL.
 - **input-required:** the platform hint tells the agent to start a reply with
   `[INPUT_REQUIRED]` when it needs clarification; the adapter maps that to
   `TASK_STATE_INPUT_REQUIRED` with the question in `status.message`.
-- **Push notifications:** config accepted inline in `message/send`
-  (`configuration.taskPushNotificationConfig`) or via the create method
-  (returns `configId` + `createdAt`). On terminal transition the callback
-  receives a v1.0 `StreamResponse` (`statusUpdate`) payload, HMAC-SHA256
-  signed (`X-A2A-Signature`, secret `A2A_PUSH_SECRET` falling back to the
-  bearer token), with SSRF-guarded callback URLs.
+- **Push notifications:** config accepted inline in `message/send` per
+  A2A Protocol 1.0 §3.2.2 `SendMessageConfiguration.taskPushNotificationConfig`
+  (JSON-RPC alias `configuration.pushNotificationConfig` also accepted) or
+  via §3.1.7 `tasks/pushNotificationConfig/create` (returns `configId` +
+  `createdAt`). On terminal transition the callback receives a v1.0
+  `StreamResponse` (`statusUpdate`) payload, HMAC-SHA256 signed
+  (`X-A2A-Signature`, secret `A2A_PUSH_SECRET` falling back to the bearer
+  token). Callback URLs are SSRF-guarded; loopback targets are allowed
+  only when this server is loopback-bound (same-host doors such as
+  `127.0.0.1:3979/push/…`).
 
 ## v1.0 wire format notes
 - Task states / roles are SCREAMING_SNAKE_CASE (TASK_STATE_*, ROLE_*).

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -718,8 +718,14 @@ class A2AAdapter(BasePlatformAdapter):
         return _ok(req_id, protocol.TaskStore.to_task(rec))
 
     def _register_inline_push(self, task_id: str, params: dict, agent: Optional[dict] = None) -> None:
-        """v1.0: message/send can carry configuration.taskPushNotificationConfig."""
-        cfg = (params.get("configuration") or {}).get("taskPushNotificationConfig") or {}
+        """A2A 1.0 §3.2.2: message/send carries configuration.taskPushNotificationConfig.
+
+        JSON-RPC peers also send the v0.3 name ``configuration.pushNotificationConfig``.
+        """
+        conf = params.get("configuration") or {}
+        if not isinstance(conf, dict):
+            return
+        cfg = conf.get("taskPushNotificationConfig") or conf.get("pushNotificationConfig") or {}
         url = (cfg.get("url") or (cfg.get("pushNotificationConfig") or {}).get("url") or "") if isinstance(cfg, dict) else ""
         if url:
             self.tasks.set_push_config(task_id, str(url), *self._scope_for_agent(agent))
@@ -760,7 +766,8 @@ class A2AAdapter(BasePlatformAdapter):
         callback_url = self.tasks.pop_push_url(task_id)
         if not callback_url:
             return
-        if not security.is_safe_callback_url(callback_url, localhost_mode=self._security_context.localhost_only()):
+        if not security.is_safe_callback_url(
+                callback_url, localhost_mode=self._security_context.allow_loopback_callbacks()):
             return fail("blocked — unsafe callback URL: %s", callback_url)
         payload = protocol.status_update(task_id, context_id, state, (reply or "")[:2000])
         headers = {"Content-Type": "application/json"}

--- a/plugins/platforms/a2a/security.py
+++ b/plugins/platforms/a2a/security.py
@@ -73,6 +73,16 @@ class A2ASecurityContext:
     def localhost_only(self) -> bool:
         return not (self.bearer_token or self.peer_tokens)
 
+    def allow_loopback_callbacks(self) -> bool:
+        """Loopback push URLs are safe only when this server cannot be reached remotely.
+
+        Peer tokens on a 127.0.0.1 bind (same-host loopback door) are same-host.
+        A tokened 0.0.0.0 bind must still refuse 127.0.0.1 callbacks (SSRF).
+        """
+        if self.localhost_only():
+            return True
+        return self.resolve_bind_host() in {"127.0.0.1", "localhost", "::1"}
+
     def resolve_bind_host(self) -> str:
         """Localhost unless a token is configured AND a wider host was asked for."""
         if self.requested_host in {"127.0.0.1", "localhost", "::1"}:

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -668,6 +668,28 @@ class TestSSRFProtection:
         assert security.is_safe_callback_url("http://127.0.0.1:8080/hook") is True
         assert security.is_safe_callback_url("http://localhost:8080/hook") is True
 
+    def test_loopback_bind_with_peer_tokens_allows_loopback_callback(self, monkeypatch):
+        """Loopback-bound inbound (Hermes :9900) may push to a same-host door (:3979)."""
+        monkeypatch.setenv("A2A_PEER_TOKENS", "alice:tok-alice")
+        monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
+        monkeypatch.setenv("A2A_HOST", "127.0.0.1")
+        ctx = security.A2ASecurityContext.capture()
+        assert ctx.allow_loopback_callbacks() is True
+        assert security.is_safe_callback_url(
+            "http://127.0.0.1:3979/push/hermes",
+            localhost_mode=ctx.allow_loopback_callbacks(),
+        ) is True
+
+    def test_wide_bind_with_peer_tokens_blocks_loopback_callback(self, monkeypatch):
+        monkeypatch.setenv("A2A_PEER_TOKENS", "alice:tok-alice")
+        monkeypatch.setenv("A2A_HOST", "0.0.0.0")
+        ctx = security.A2ASecurityContext.capture()
+        assert ctx.allow_loopback_callbacks() is False
+        assert security.is_safe_callback_url(
+            "http://127.0.0.1:3979/push/hermes",
+            localhost_mode=ctx.allow_loopback_callbacks(),
+        ) is False
+
     def test_aws_metadata_blocked(self, monkeypatch):
         monkeypatch.setenv("A2A_BEARER_TOKEN", "tok")
         assert security.is_safe_callback_url("http://169.254.169.254/latest/meta-data/") is False

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -856,6 +856,28 @@ class TestTaskRpcHandlers:
         resp = adapter._rpc_push_config_delete(1, {"taskId": "task-d3", "id": "cfg-wrong"})
         assert resp["error"]["code"] == protocol.ERR_TASK_NOT_FOUND
 
+    def test_inline_push_reads_spec_task_push_notification_config(self):
+        """A2A 1.0 §3.2.2 SendMessageConfiguration.taskPushNotificationConfig."""
+        adapter = _bare_adapter()
+        adapter.tasks.create("task-i", "ctx-i", "peer")
+        adapter._register_inline_push("task-i", {
+            "configuration": {
+                "taskPushNotificationConfig": {"url": "https://example.com/hook"},
+            },
+        })
+        assert adapter.tasks.get("task-i")["push_url"] == "https://example.com/hook"
+
+    def test_inline_push_reads_jsonrpc_push_notification_config(self):
+        """JSON-RPC peers (Seed call_agent) send configuration.pushNotificationConfig."""
+        adapter = _bare_adapter()
+        adapter.tasks.create("task-j", "ctx-j", "peer")
+        adapter._register_inline_push("task-j", {
+            "configuration": {
+                "pushNotificationConfig": {"url": "http://127.0.0.1:3979/push/hermes"},
+            },
+        })
+        assert adapter.tasks.get("task-j")["push_url"] == "http://127.0.0.1:3979/push/hermes"
+
 
 # --------------------------------------------------------------------------
 # End-to-end inbound round-trip (real http.server + mocked agent)
@@ -1300,6 +1322,62 @@ class TestPushNotificationEndToEnd:
             ).hexdigest()
             assert received["signature"] == expected
 
+            await adapter.disconnect()
+
+        try:
+            asyncio.run(run())
+        finally:
+            hook_server.shutdown()
+            hook_server.server_close()
+
+    def test_jsonrpc_push_config_delivers_on_loopback_bind_with_peer_tokens(self, monkeypatch):
+        """Seed call_agent shape: configuration.pushNotificationConfig to /push/<agent>
+        while inbound has peer tokens on a 127.0.0.1 bind."""
+        monkeypatch.setenv("A2A_PEER_TOKENS", "alice:tok-alice")
+        monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
+        monkeypatch.setenv("A2A_HOST", "127.0.0.1")
+
+        received = {}
+        received_evt = threading.Event()
+
+        class _Hook(BaseHTTPRequestHandler):
+            def log_message(self, *a):  # noqa: A002
+                pass
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                received["path"] = self.path
+                received["body"] = json.loads(self.rfile.read(length).decode())
+                self.send_response(200)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                received_evt.set()
+
+        hook_port = _free_port()
+        hook_server = HTTPServer(("127.0.0.1", hook_port), _Hook)
+        hook_thread = threading.Thread(target=hook_server.serve_forever, daemon=True)
+        hook_thread.start()
+
+        adapter, base = _make_live_adapter(monkeypatch)
+
+        async def run():
+            assert await adapter.connect() is True
+            body = _send_body("ping with jsonrpc push", extra_params={
+                "configuration": {
+                    "pushNotificationConfig": {
+                        "url": f"http://127.0.0.1:{hook_port}/push/hermes",
+                    },
+                },
+            })
+            resp = await asyncio.to_thread(
+                _post_json, base + "/", body, {"Authorization": "Bearer tok-alice"})
+            task = resp["result"]
+            assert received_evt.wait(timeout=5), "push callback never received"
+            assert received["path"] == "/push/hermes"
+            su = received["body"]["statusUpdate"]
+            assert su["taskId"] == task["id"]
+            assert su["status"]["state"] == "TASK_STATE_COMPLETED"
+            assert "ECHO:" in protocol.extract_text(su["status"]["message"])
             await adapter.disconnect()
 
         try:


### PR DESCRIPTION
## Summary

- Accept inline push config on `message/send` per A2A Protocol 1.0 **§3.2.2** `SendMessageConfiguration.taskPushNotificationConfig` (JSON-RPC alias `configuration.pushNotificationConfig` also accepted).
- On terminal task state, POST a v1.0 `StreamResponse` `statusUpdate` (including reply text) to that URL.
- Allow loopback callback URLs only when this A2A server is loopback-bound (same-host doors such as `127.0.0.1:3979/push/…`). A tokened `0.0.0.0` bind still SSRF-blocks `127.0.0.1`.

## Motivation

Callers that put `pushNotificationConfig` on every `message/send` should close on the pushed terminal state. `tasks/get` remains an explicit governor tool, not the observation path.

Does not close an upstream issue.

## Changes

- `_register_inline_push` reads §3.2.2 `taskPushNotificationConfig` and the JSON-RPC alias.
- `A2ASecurityContext.allow_loopback_callbacks()` is true for localhost-only **or** loopback bind; `_send_push_notification` uses that for the SSRF check.
- DESIGN.md cites §3.2.2 and §3.1.7.

## Test Plan

- [x] `test_inline_push_reads_spec_task_push_notification_config`
- [x] `test_inline_push_reads_jsonrpc_push_notification_config` (sabotage RED, then GREEN)
- [x] `test_loopback_bind_with_peer_tokens_allows_loopback_callback`
- [x] `test_wide_bind_with_peer_tokens_blocks_loopback_callback`
- [x] `TestPushNotificationEndToEnd` including `/push/hermes` with peer tokens
- [x] `scripts/run_tests.sh tests/plugins/test_a2a_plugin.py tests/plugins/test_a2a_phase23.py` — 154 passed, 0 failed

## Notes for Reviewers

Live proof (one send with push config → COMPLETED pushed to `:3979` with zero `tasks/get`) needs the running gateway pin and is a separate activation step. This PR is source only.
