### PR TITLE
fix(tui_gateway): gate reasoning event emissions on display.show_reasoning config (#107094)

### DIFF
--- a/tests/tui_gateway/test_show_reasoning_gating.py
+++ b/tests/tui_gateway/test_show_reasoning_gating.py
@@ -1,0 +1,48 @@
+"""Tests for display.show_reasoning gating on reasoning emissions in tui_gateway."""
+
+import pytest
+from tui_gateway import server
+
+
+def test_show_reasoning_enabled_default(monkeypatch):
+    monkeypatch.setattr(server, "_display_cfg", lambda: {"show_reasoning": True})
+    assert server._show_reasoning_enabled("s1") is True
+
+    monkeypatch.setattr(server, "_display_cfg", lambda: {"show_reasoning": False})
+    assert server._show_reasoning_enabled("s1") is False
+
+
+def test_show_reasoning_enabled_session_override(monkeypatch):
+    monkeypatch.setattr(server, "_display_cfg", lambda: {"show_reasoning": True})
+    monkeypatch.setattr(server, "_sessions", {"s1": {"show_reasoning": False}})
+
+    assert server._show_reasoning_enabled("s1") is False
+
+
+def test_reasoning_delta_and_available_gated(monkeypatch):
+    emitted = []
+
+    def mock_emit(event_type, sid, payload=None):
+        emitted.append((event_type, sid, payload))
+
+    monkeypatch.setattr(server, "_emit", mock_emit)
+    monkeypatch.setattr(server, "_session_verbose", lambda sid: False)
+
+    # Disabled
+    monkeypatch.setattr(server, "_display_cfg", lambda: {"show_reasoning": False})
+    monkeypatch.setattr(server, "_sessions", {})
+
+    cbs = server._agent_cbs("s1")
+    cbs["reasoning_callback"]("some reasoning text")
+    server._progress_reasoning("s1", "reasoning", "some preview text", {})
+
+    assert len(emitted) == 0
+
+    # Enabled
+    monkeypatch.setattr(server, "_display_cfg", lambda: {"show_reasoning": True})
+    cbs["reasoning_callback"]("some reasoning text")
+    server._progress_reasoning("s1", "reasoning", "some preview text", {})
+
+    assert len(emitted) == 2
+    assert emitted[0][0] == "reasoning.delta"
+    assert emitted[1][0] == "reasoning.available"

--- a/tui_gateway/agent_callbacks.py
+++ b/tui_gateway/agent_callbacks.py
@@ -95,7 +95,7 @@ def _agent_cbs(sid: str) -> dict:
         "thinking_callback": lambda text: _emit("thinking.delta", sid, {"text": text}),
         # Affection reaction (ily / <3 / good bot) → hearts; core-detected so TUI/desktop share it.
         "reaction_callback": lambda kind: _emit("reaction", sid, {"kind": kind}),
-        "reasoning_callback": lambda text: _emit(
+        "reasoning_callback": lambda text: _show_reasoning_enabled(sid) and _emit(
             "reasoning.delta", sid, {"text": text, **({"verbose": True} if _session_verbose(sid) else {})}),
         "status_callback": lambda kind, text=None: _status_update(sid, str(kind), None if text is None else str(text)),
         # Credits/notice spine: AgentNotice → notification.show; recovery → notification.clear.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1754,6 +1754,13 @@ def _load_show_reasoning() -> bool:
     return bool(_display_cfg().get("show_reasoning", True))
 
 
+def _show_reasoning_enabled(sid: str) -> bool:
+    session = _sessions.get(sid)
+    if isinstance(session, dict) and "show_reasoning" in session and session["show_reasoning"] is not None:
+        return bool(session["show_reasoning"])
+    return _load_show_reasoning()
+
+
 def _load_memory_notifications() -> str:
     """``display.memory_notifications`` (``off`` / ``on`` default / ``verbose``; bool normalized) — gates the
     "💾 Self-improvement review" summary (gateway/CLI parity)."""

--- a/tui_gateway/tool_progress.py
+++ b/tui_gateway/tool_progress.py
@@ -258,7 +258,8 @@ def _progress_output_risk(sid, name, preview, kw):
 
 
 def _progress_reasoning(sid, name, preview, kw):
-    _emit("reasoning.available", sid, {"text": str(preview), **({"verbose": True} if _session_verbose(sid) else {})})
+    if _show_reasoning_enabled(sid):
+        _emit("reasoning.available", sid, {"text": str(preview), **({"verbose": True} if _session_verbose(sid) else {})})
 
 
 def _progress_moa_reference(sid, name, preview, kw):


### PR DESCRIPTION
### Summary
Gate `reasoning.delta` and `reasoning.available` stream event emissions in the `tui_gateway` backend on `display.show_reasoning` / per-session `show_reasoning` configuration.

### Context & Problem
Setting `display.show_reasoning: false` hides reasoning in the CLI, TUI, and Telegram gateway, but the Desktop app continued to display reasoning streams. `tui_gateway/agent_callbacks.py` (`reasoning_callback`) and `tui_gateway/tool_progress.py` (`_progress_reasoning`) emitted reasoning events unconditionally over the gateway RPC socket.

### Solution
- Added `_show_reasoning_enabled(sid: str) -> bool` helper in `tui_gateway/server.py` that checks per-session `show_reasoning` setting or falls back to global `_load_show_reasoning()`.
- Gated `reasoning_callback` in `tui_gateway/agent_callbacks.py` and `_progress_reasoning` in `tui_gateway/tool_progress.py` on `_show_reasoning_enabled(sid)`.
- Added unit tests in `tests/tui_gateway/test_show_reasoning_gating.py`.

Closes #107094
