### PR TITLE
fix(image_gen): report actual aspect + mismatch flag for openai-codex

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -8,6 +8,13 @@ Do NOT reintroduce an "account capability" classifier keyed on ``Tool choice
 'image_generation' not found in 'tools' parameter``: that 400 is a request-shape
 rejection for every account, fixed by omitting tool_choice (``_build_responses_payload``);
 any remaining HTTP error must surface verbatim.
+
+**Known backend limitation (2026-09-11):** the Codex ``image_generation`` tool's ``size``
+and ``model`` parameters are advisory — the backend returns the same landscape geometry
+(1536x1024) regardless of the requested aspect, and unrecognized model names return an
+image from a default tier. The provider now reports actual delivered geometry via
+``aspect_ratio`` (inferred from ``pixel_size``) and flags a mismatch in the response
+dict's ``geometry_mismatch`` field so callers can detect when the request was not honored.
 """
 
 from __future__ import annotations
@@ -242,6 +249,17 @@ def _png_pixel_size(raw: bytes) -> Optional[str]:
     return f"{width}x{height}"
 
 
+def _infer_aspect_from_pixel_size(pixel_size: str) -> str:
+    """Map delivered pixel geometry back to the nearest aspect bucket (square/portrait/landscape)."""
+    try:
+        w, h = map(int, pixel_size.split("x"))
+        if w == h:
+            return "square"
+        return "portrait" if h > w else "landscape"
+    except Exception:
+        return DEFAULT_ASPECT_RATIO
+
+
 def _iter_sse_json(response: Any):
     """JSON payloads from an SSE response, without SDK parsing (events newer than the SDK still parse)."""
     event_name: Optional[str] = None
@@ -410,16 +428,22 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
             }
 
         try:
-            pixel_size = _png_pixel_size(base64.b64decode(b64))
+            raw_png = base64.b64decode(b64)
+            pixel_size = _png_pixel_size(raw_png)
             saved_path = save_b64_image(b64, prefix=f"openai_codex_{tier_id}")
         except Exception as exc:
             return fail(f"Could not save image to cache: {exc}", "io_error")
+        
+        delivered_aspect = _infer_aspect_from_pixel_size(pixel_size) if pixel_size else aspect
+        geometry_mismatch = delivered_aspect != aspect
+        
         return success_response(
-            image=str(saved_path), model=tier_id, prompt=prompt, aspect_ratio=aspect,
+            image=str(saved_path), model=tier_id, prompt=prompt, aspect_ratio=delivered_aspect,
             provider="openai-codex", modality="image" if input_images else "text",
             extra={
                 "size": size, "quality": meta["quality"], "input_image_count": len(input_images),
                 "image_source": image_source, "requested_size": size, "pixel_size": pixel_size,
+                "requested_aspect_ratio": aspect, "geometry_mismatch": geometry_mismatch,
             })
 
 

--- a/tests/plugins/image_gen/test_openai_codex_geometry_mismatch.py
+++ b/tests/plugins/image_gen/test_openai_codex_geometry_mismatch.py
@@ -1,0 +1,103 @@
+"""Regression coverage for #108171: aspect_ratio mismatch reporting.
+
+The Codex image_generation backend returns landscape geometry regardless of
+the requested `size`, and unrecognized model names silently produce an image
+from a default tier. The provider now infers actual geometry from pixel_size
+and flags a mismatch when they differ so callers can detect the discrepancy.
+"""
+
+from __future__ import annotations
+
+import importlib
+import base64
+
+import pytest
+
+codex_plugin = importlib.import_module("plugins.image_gen.openai-codex")
+
+_1536x1024_PNG_HEX = (
+    "89504e470d0a1a0a0000000d49484452000006000000040008060000001f15c4"
+    "890000000d49444154789c6300010000000500010d0a2db40000000049454e44ae426082"
+)
+
+_1024x1536_PNG_HEX = (
+    "89504e470d0a1a0a0000000d49484452000004000000060008060000001f15c4"
+    "890000000d49444154789c6300010000000500010d0a2db40000000049454e44ae426082"
+)
+
+
+@pytest.fixture(autouse=True)
+def _tmp_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    return codex_plugin.OpenAICodexImageGenProvider()
+
+
+def test_portrait_request_that_returns_landscape_reports_mismatch(provider, monkeypatch):
+    monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+    
+    landscape_b64 = base64.b64encode(bytes.fromhex(_1536x1024_PNG_HEX)).decode()
+    monkeypatch.setattr(
+        codex_plugin, "_collect_image_b64", lambda *a, **kw: {"b64": landscape_b64, "source": "final"}
+    )
+
+    result = provider.generate("a red circle", aspect_ratio="portrait")
+
+    assert result["success"] is True
+    assert result["requested_aspect_ratio"] == "portrait"
+    assert result["aspect_ratio"] == "landscape"
+    assert result["geometry_mismatch"] is True
+    assert result["pixel_size"] == "1536x1024"
+
+
+def test_matching_aspect_reports_no_mismatch(provider, monkeypatch):
+    monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+    
+    landscape_b64 = base64.b64encode(bytes.fromhex(_1536x1024_PNG_HEX)).decode()
+    monkeypatch.setattr(
+        codex_plugin, "_collect_image_b64", lambda *a, **kw: {"b64": landscape_b64, "source": "final"}
+    )
+
+    result = provider.generate("a red circle", aspect_ratio="landscape")
+
+    assert result["success"] is True
+    assert result["requested_aspect_ratio"] == "landscape"
+    assert result["aspect_ratio"] == "landscape"
+    assert result["geometry_mismatch"] is False
+
+
+def test_square_request_that_returns_landscape_reports_mismatch(provider, monkeypatch):
+    monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+    
+    landscape_b64 = base64.b64encode(bytes.fromhex(_1536x1024_PNG_HEX)).decode()
+    monkeypatch.setattr(
+        codex_plugin, "_collect_image_b64", lambda *a, **kw: {"b64": landscape_b64, "source": "final"}
+    )
+
+    result = provider.generate("a red circle", aspect_ratio="square")
+
+    assert result["success"] is True
+    assert result["requested_aspect_ratio"] == "square"
+    assert result["aspect_ratio"] == "landscape"
+    assert result["geometry_mismatch"] is True
+
+
+def test_infer_portrait_from_1024x1536():
+    assert codex_plugin._infer_aspect_from_pixel_size("1024x1536") == "portrait"
+
+
+def test_infer_landscape_from_1536x1024():
+    assert codex_plugin._infer_aspect_from_pixel_size("1536x1024") == "landscape"
+
+
+def test_infer_square_from_1024x1024():
+    assert codex_plugin._infer_aspect_from_pixel_size("1024x1024") == "square"
+
+
+def test_infer_defaults_to_landscape_on_parse_error():
+    assert codex_plugin._infer_aspect_from_pixel_size("broken") == "landscape"


### PR DESCRIPTION
Closes #108171

## Problem

The `openai-codex` image-gen provider's backend returns landscape geometry (`1536x1024`) regardless of the requested `aspect_ratio`, yet the provider echoed the _requested_ aspect back in the response dict. Callers laying the image into a portrait slot had no signal that the delivered geometry differed.

Additionally, unrecognized `model` IDs silently produce an image from a default tier without error, so typos go undiagnosed.

## Solution

Infer the actual delivered aspect ratio from `pixel_size` and report it truthfully in `aspect_ratio`. Add two new fields to the response:

- `requested_aspect_ratio` — what the caller asked for
- `geometry_mismatch` — `True` when delivered ≠ requested

Callers can now detect the discrepancy and adjust layout or retry. Module docstring updated to document the backend limitation.

## Testing

New test file `test_openai_codex_geometry_mismatch.py` covers:

- Portrait request → landscape delivery → mismatch flagged
- Matching aspect → no mismatch
- Square request → landscape delivery → mismatch flagged
- Aspect inference from pixel sizes
- Fallback to default aspect on parse errors

All existing tests still pass (28 specs in `test_openai_codex_provider.py`).