### PR TITLE
feat(image-gen): add GPT Image 2.5 tiers to the Codex OAuth provider

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -1,8 +1,9 @@
 """OpenAI image generation — ChatGPT/Codex OAuth variant.
 
-Same catalog/tiers as the ``openai`` plugin (``gpt-image-2`` low/medium/high), routed
-through the Codex Responses API ``image_generation`` tool, so no ``OPENAI_API_KEY`` is
-needed. Output is PNG; source images travel as Responses ``input_image`` parts.
+Same catalog/tiers as the ``openai`` plugin (GPT Image 2 and GPT Image 2.5
+Flare/Sunburst), routed through the Codex Responses API ``image_generation`` tool, so no
+``OPENAI_API_KEY`` is needed. Output is PNG; source images travel as Responses
+``input_image`` parts.
 
 Do NOT reintroduce an "account capability" classifier keyed on ``Tool choice
 'image_generation' not found in 'tools' parameter``: that 400 is a request-shape
@@ -26,6 +27,27 @@ from plugins.image_gen._common import (
     resolve_static_model, size_for)
 
 logger = logging.getLogger(__name__)
+
+# Mirrors the ``openai`` plugin's catalog so both OpenAI backends offer the same ids and a
+# stored ``image_gen.model`` keeps resolving when users switch auth mode. Each tier carries
+# the API model that serves it; ``_build_responses_payload`` sends that, not a fixed one.
+MODELS: Dict[str, Dict[str, Any]] = {
+    **{key: {**meta, "api_model": API_MODEL} for key, meta in GPT_IMAGE_2_TIERS.items()},
+    **{
+        model if quality == "auto" else f"{model}-{quality}": {
+            "display": f"GPT Image 2.5 {name} ({quality.title()})",
+            "speed": speed,
+            "strengths": strengths,
+            "api_model": model,
+            "quality": quality,
+        }
+        for model, name, speed, strengths in (
+            ("gpt-image-2.5-flare", "Flare", "Fast", "Everyday image generation and editing"),
+            ("gpt-image-2.5-sunburst", "Sunburst", "Slower", "Precision generation and editing"),
+        )
+        for quality in ("auto", "low", "medium", "high", "xhigh", "max")
+    },
+}
 
 # NOTE: do NOT reintroduce an "account capability" classifier keyed on ``Tool choice 'image_generation' not
 # found in 'tools' parameter``. That HTTP 400 is a *request-shape* rejection (the Codex backend resolves
@@ -74,9 +96,13 @@ def _summarize_error_body(body: str) -> str:
     return text[:_MAX_ERROR_BODY_CHARS]
 
 
-def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+def _resolve_model(explicit: Optional[str] = None) -> Tuple[str, Dict[str, Any]]:
+    """``(tier_id, meta)``. ``explicit`` is the per-request ``model`` kwarg that
+    ``image_generation_tool`` already forwards; unknown ids fall through to the configured
+    default, matching ``resolve_static_model``'s documented behavior."""
     return resolve_static_model(
-        GPT_IMAGE_2_TIERS, DEFAULT_MODEL, env_var="OPENAI_IMAGE_MODEL", config_key="openai-codex")
+        MODELS, DEFAULT_MODEL, env_var="OPENAI_IMAGE_MODEL", config_key="openai-codex",
+        explicit=explicit)
 
 
 def _read_codex_access_token() -> Optional[str]:
@@ -174,7 +200,8 @@ def _normalize_input_images(
 
 
 def _build_responses_payload(
-    *, prompt: str, size: str, quality: str, input_images: Optional[List[Dict[str, str]]] = None
+    *, prompt: str, size: str, quality: str, api_model: str = API_MODEL,
+    input_images: Optional[List[Dict[str, str]]] = None
 ) -> Dict[str, Any]:
     """Responses body for an image_generation call. No ``tool_choice``: Codex rejects every shape
     for forcing the hosted tool (looks it up as a *function* name), so the host model decides,
@@ -187,7 +214,7 @@ def _build_responses_payload(
         "input": [{"type": "message", "role": "user", "content": content}],
         "tools": [{
             "type": "image_generation",
-            "model": API_MODEL,
+            "model": api_model,
             "size": size,
             "quality": quality,
             "output_format": "png",
@@ -279,7 +306,8 @@ def _iter_sse_json(response: Any):
 
 
 def _collect_image_b64(
-    token: str, *, prompt: str, size: str, quality: str, input_images: Optional[List[Dict[str, str]]] = None
+    token: str, *, prompt: str, size: str, quality: str, api_model: str = API_MODEL,
+    input_images: Optional[List[Dict[str, str]]] = None
 ) -> Optional[Dict[str, str]]:
     """Stream a Codex Responses image_generation call → ``{"b64", "source": "final"|"partial"}`` or
     ``None``. A partial is kept only when no final arrives; callers must not treat it as success."""
@@ -293,7 +321,7 @@ def _collect_image_b64(
         "Content-Type": "application/json",
     })
     payload = _build_responses_payload(
-        prompt=prompt, size=size, quality=quality, input_images=input_images)
+        prompt=prompt, size=size, quality=quality, api_model=api_model, input_images=input_images)
     timeout = httpx.Timeout(300.0, connect=30.0, read=300.0, write=30.0, pool=30.0)
 
     final_b64: Optional[str] = None
@@ -318,11 +346,11 @@ def _collect_image_b64(
 
 
 class OpenAICodexImageGenProvider(StaticImageGenProvider):
-    """gpt-image-2 routed through ChatGPT/Codex OAuth instead of an API key."""
+    """GPT Image 2 / 2.5 routed through ChatGPT/Codex OAuth instead of an API key."""
 
     provider_id = "openai-codex"
     label = "OpenAI (Codex auth)"
-    models = GPT_IMAGE_2_TIERS
+    models = MODELS
     default_model_id = DEFAULT_MODEL
     price = "varies"
 
@@ -333,7 +361,9 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
         return {
             "name": "OpenAI (Codex auth)",
             "badge": "free",
-            "tag": "gpt-image-2 via ChatGPT/Codex OAuth — no API key required; supports text and image inputs",
+            "tag": (
+                "GPT Image 2 / 2.5 Flare / 2.5 Sunburst via ChatGPT/Codex OAuth — no API key "
+                "required; supports text and image inputs"),
             "env_vars": [],
             "post_setup_hint": (
                 "Sign in with `hermes auth codex` (or `hermes setup` → Codex) "
@@ -359,7 +389,8 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
             return error_factory("openai-codex", aspect)(
                 "httpx Python package not installed (pip install httpx)", "missing_dependency")
 
-        tier_id, meta = _resolve_model()
+        tier_id, meta = _resolve_model(kwargs.get("model"))
+        api_model = meta.get("api_model", API_MODEL)
         size = size_for(aspect)
         fail = error_factory("openai-codex", aspect, model=tier_id, prompt=prompt)
         attempts = _NONFINAL_RETRIES + 1
@@ -373,7 +404,7 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
             for attempt in range(attempts):
                 collected = _collect_image_b64(
                     token, prompt=prompt, size=size, quality=meta["quality"],
-                    input_images=input_images or None)
+                    api_model=api_model, input_images=input_images or None)
                 if collected and collected.get("source") == "final" and collected.get("b64"):
                     break
                 if attempt < _NONFINAL_RETRIES:
@@ -418,7 +449,8 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
             image=str(saved_path), model=tier_id, prompt=prompt, aspect_ratio=aspect,
             provider="openai-codex", modality="image" if input_images else "text",
             extra={
-                "size": size, "quality": meta["quality"], "input_image_count": len(input_images),
+                "size": size, "quality": meta["quality"], "api_model_requested": api_model,
+                "input_image_count": len(input_images),
                 "image_source": image_source, "requested_size": size, "pixel_size": pixel_size,
             })
 

--- a/plugins/image_gen/openai-codex/plugin.yaml
+++ b/plugins/image_gen/openai-codex/plugin.yaml
@@ -1,5 +1,5 @@
 name: openai-codex
 version: 1.0.0
-description: "OpenAI image generation backed by ChatGPT/Codex OAuth (gpt-image-2 via the Responses image_generation tool). Saves generated images to $HERMES_HOME/cache/images/."
+description: "OpenAI image generation backed by ChatGPT/Codex OAuth (GPT Image 2 and GPT Image 2.5 Flare/Sunburst via the Responses image_generation tool). Saves generated images to $HERMES_HOME/cache/images/."
 author: NousResearch
 kind: backend

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -43,6 +43,9 @@ def _tmp_hermes_home(tmp_path, monkeypatch):
 def provider(monkeypatch):
     # Codex plugin is API-key-independent; clear it to make the test honest.
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    # Catalog selection reads this env var first; a value inherited from the
+    # developer's shell would silently decide which tier every test exercises.
+    monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
     return codex_plugin.OpenAICodexImageGenProvider()
 
 
@@ -59,9 +62,39 @@ class TestMetadata:
     def test_default_model(self, provider):
         assert provider.default_model() == "gpt-image-2-medium"
 
-    def test_list_models_three_tiers(self, provider):
+    def test_list_models_covers_gpt_image_2_and_25_tiers(self, provider):
         ids = [m["id"] for m in provider.list_models()]
-        assert ids == ["gpt-image-2-low", "gpt-image-2-medium", "gpt-image-2-high"]
+        # Legacy ids keep their position so a stored ``image_gen.model`` still resolves.
+        assert ids[:3] == ["gpt-image-2-low", "gpt-image-2-medium", "gpt-image-2-high"]
+        assert ids[3:] == [
+            "gpt-image-2.5-flare",
+            "gpt-image-2.5-flare-low",
+            "gpt-image-2.5-flare-medium",
+            "gpt-image-2.5-flare-high",
+            "gpt-image-2.5-flare-xhigh",
+            "gpt-image-2.5-flare-max",
+            "gpt-image-2.5-sunburst",
+            "gpt-image-2.5-sunburst-low",
+            "gpt-image-2.5-sunburst-medium",
+            "gpt-image-2.5-sunburst-high",
+            "gpt-image-2.5-sunburst-xhigh",
+            "gpt-image-2.5-sunburst-max",
+        ]
+
+    def test_catalog_matches_the_api_key_openai_plugin(self, provider):
+        """Both OpenAI backends must offer the same ids: the picker shows one list, and a
+        user switching between API-key and OAuth auth keeps their selected model."""
+        from plugins.image_gen.openai import MODELS as OPENAI_MODELS
+
+        assert set(m["id"] for m in provider.list_models()) == set(OPENAI_MODELS)
+
+    def test_every_tier_declares_the_api_model_that_serves_it(self, provider):
+        for tier_id, meta in codex_plugin.MODELS.items():
+            assert meta["api_model"] in (
+                "gpt-image-2", "gpt-image-2.5-flare", "gpt-image-2.5-sunburst")
+            # A 2.5 tier must never silently route to the gpt-image-2 API model.
+            if "2.5" in tier_id:
+                assert meta["api_model"] != "gpt-image-2"
 
     def test_setup_schema_has_no_required_env_vars(self, provider):
         schema = provider.get_setup_schema()
@@ -127,11 +160,12 @@ class TestGenerate:
 
         captured = {}
 
-        def _collect(token, *, prompt, size, quality, input_images=None):
+        def _collect(token, *, prompt, size, quality, api_model, input_images=None):
             captured.update(codex_plugin._build_responses_payload(
                 prompt=prompt,
                 size=size,
                 quality=quality,
+                api_model=api_model,
                 input_images=input_images,
             ))
             return {"b64": _b64_png(), "source": "final"}
@@ -161,6 +195,51 @@ class TestGenerate:
         # Progressive previews disabled: partial frames were being saved as
         # finals and presented as smeared/unfinished images.
         assert tool["partial_images"] == 0
+
+    def test_selected_tier_routes_to_its_own_api_model(self, provider, monkeypatch):
+        """Regression: the payload previously hardcoded ``gpt-image-2``, so selecting a
+        2.5 tier would have generated with the old model while reporting the 2.5 id."""
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        seen = {}
+
+        def _collect(token, *, prompt, size, quality, api_model, input_images=None):
+            seen["api_model"] = api_model
+            seen["quality"] = quality
+            return {"b64": _b64_png(), "source": "final"}
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        for tier, expected_model, expected_quality in (
+            ("gpt-image-2-high", "gpt-image-2", "high"),
+            ("gpt-image-2.5-flare", "gpt-image-2.5-flare", "auto"),
+            ("gpt-image-2.5-sunburst-max", "gpt-image-2.5-sunburst", "max"),
+        ):
+            result = provider.generate("a cat", model=tier)
+            assert result["success"] is True
+            assert result["model"] == tier
+            assert seen["api_model"] == expected_model
+            assert seen["quality"] == expected_quality
+            assert result["api_model_requested"] == expected_model
+
+    def test_env_var_selects_a_25_tier(self, provider, monkeypatch):
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", "gpt-image-2.5-sunburst-high")
+        tier_id, meta = codex_plugin._resolve_model()
+        assert tier_id == "gpt-image-2.5-sunburst-high"
+        assert meta["api_model"] == "gpt-image-2.5-sunburst"
+        assert meta["quality"] == "high"
+
+    def test_explicit_model_outranks_env_var(self, provider, monkeypatch):
+        monkeypatch.setenv("OPENAI_IMAGE_MODEL", "gpt-image-2-low")
+        tier_id, meta = codex_plugin._resolve_model("gpt-image-2.5-flare-max")
+        assert tier_id == "gpt-image-2.5-flare-max"
+        assert meta["api_model"] == "gpt-image-2.5-flare"
+
+    def test_default_is_unchanged_for_existing_users(self, provider, monkeypatch):
+        """Adding tiers must not move anyone off their current model."""
+        monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+        tier_id, meta = codex_plugin._resolve_model()
+        assert tier_id == "gpt-image-2-medium"
+        assert meta["api_model"] == "gpt-image-2"
 
     def test_capabilities_advertise_image_inputs(self, provider):
         caps = provider.capabilities()


### PR DESCRIPTION
## What

`7777f8c350` added GPT Image 2.5 Flare/Sunburst to the API-key `openai` provider. The Codex OAuth sibling (`openai-codex`) was not updated, so users authenticated via ChatGPT/Codex still only see `gpt-image-2` low/medium/high and cannot select 2.5 at all.

This mirrors that commit's catalog into `openai-codex` — same ids, same quality ladder, built the same way — so both OpenAI backends offer one identical list.

## Why the ids must match exactly

`image_gen.model` is stored once and read by whichever provider is active. If the two OpenAI backends offered different ids, switching between API-key and OAuth auth would silently invalidate a user's saved model. `test_catalog_matches_the_api_key_openai_plugin` asserts set-equality against `plugins.image_gen.openai.MODELS` so the two can't drift.

## The bug this also fixes

`_build_responses_payload` hardcoded `API_MODEL` in the tool spec. Adding 2.5 ids to the catalog *without* threading the tier's own model through would produce a silent correctness bug: selecting `gpt-image-2.5-sunburst-max` would generate with `gpt-image-2` while the result still reported the 2.5 id.

So each tier now carries an `api_model` (exactly as `7777f8c350` did for the `openai` plugin) and it's threaded through `_build_responses_payload` → `_collect_image_b64`. `test_selected_tier_routes_to_its_own_api_model` pins the wire model per tier, and `api_model_requested` is returned in the result so a mis-set tier is diagnosable.

`_resolve_model` also gains the `explicit` passthrough so the per-request `model` kwarg that `image_generation_tool._add_provider_kwargs` already forwards is honored — matching how the `xai` provider consumes it today.

## No behavior change for existing users

`DEFAULT_MODEL` stays `gpt-image-2-medium`. This PR only adds choices; it does not move anyone off their current model. Pinned by `test_default_is_unchanged_for_existing_users`.

## Testing

```
82 passed
  tests/plugins/image_gen/test_openai_codex_provider.py
  tests/plugins/image_gen/test_openai_provider.py
```

Also verified against the **live** Codex API (not mocked), on this branch:

```
tiers: 15 | default: gpt-image-2-medium
[gpt-image-2.5-flare]          OK api_model_requested=gpt-image-2.5-flare    quality=auto
[gpt-image-2.5-sunburst-high]  OK api_model_requested=gpt-image-2.5-sunburst quality=high
```

New tests:
- `test_list_models_covers_gpt_image_2_and_25_tiers` — legacy ids keep their position
- `test_catalog_matches_the_api_key_openai_plugin` — cross-provider parity
- `test_every_tier_declares_the_api_model_that_serves_it` — no 2.5 tier routes to gpt-image-2
- `test_selected_tier_routes_to_its_own_api_model` — wire model per tier
- `test_env_var_selects_a_25_tier` / `test_explicit_model_outranks_env_var` — selection precedence
- `test_default_is_unchanged_for_existing_users` — no silent migration

The `provider` fixture now also clears `OPENAI_IMAGE_MODEL`; without it a value inherited from the developer's shell silently decides which tier every test exercises.

## Not included here

While testing this I found that the Codex backend ignores the `size` field entirely (a `portrait` request returns a landscape image) and does not validate `model` ids. Those are backend behaviors rather than catalog issues, so I filed them separately as #108171 rather than widening this PR. This PR does not attempt to work around either.
