### PR TITLE
fix(file_ops): probe tsconfig.json on the backend for remote sandboxes

### DIFF
--- a/tests/tools/test_lint_tsconfig_probe.py
+++ b/tests/tools/test_lint_tsconfig_probe.py
@@ -1,0 +1,45 @@
+"""On remote backends the tsconfig.json walk must run inside the sandbox.
+
+The file being patched lives in the container (Docker/SSH/Modal/...), so a
+host-side ``os.path`` walk never finds the project's tsconfig.json and the
+per-file ``tsc`` shell linter runs on every ``.ts`` patch — phantom errors and
+up to the 30s linter timeout each time.
+"""
+from tools.file_operations import ShellFileOperations
+
+
+class _RemoteEnv:
+    """Not a LocalEnvironment, so ``_lsp_local_only()`` is False."""
+    cwd = "/workspace"
+
+    def __init__(self, has_tsconfig: bool):
+        self.has_tsconfig = has_tsconfig
+        self.commands = []
+
+    def execute(self, command: str, cwd=None, **kwargs) -> dict:
+        self.commands.append(command)
+        if "tsconfig.json" in command:
+            return {"output": "", "returncode": 0 if self.has_tsconfig else 1}
+        return {"output": "", "returncode": 1}
+
+
+def test_remote_backend_finds_tsconfig_through_the_sandbox():
+    env = _RemoteEnv(has_tsconfig=True)
+    ops = ShellFileOperations(env)
+    assert ops._has_ancestor_tsconfig("/workspace/app/src/server.ts") is True
+    probe = next(c for c in env.commands if "tsconfig.json" in c)
+    assert "/workspace/app/src/server.ts" in probe
+
+
+def test_remote_backend_without_tsconfig_keeps_the_shell_linter():
+    ops = ShellFileOperations(_RemoteEnv(has_tsconfig=False))
+    assert ops._has_ancestor_tsconfig("/workspace/app/src/server.ts") is False
+
+
+def test_probe_failure_never_suppresses_lint():
+    class _Down(_RemoteEnv):
+        def execute(self, command: str, cwd=None, **kwargs) -> dict:
+            raise RuntimeError("container is not running")
+
+    ops = ShellFileOperations(_Down(has_tsconfig=True))
+    assert ops._has_ancestor_tsconfig("/workspace/app/src/server.ts") is False

--- a/tools/file_operations_lint.py
+++ b/tools/file_operations_lint.py
@@ -7,6 +7,7 @@ linters are pure functions importable from this module.
 import ast
 import json
 import os
+import shlex
 import tomllib
 from typing import Callable, Dict, Optional
 
@@ -229,18 +230,28 @@ class LintMixin:
 
     def _has_ancestor_tsconfig(self, path: str) -> bool:
         """True iff a tsconfig.json exists in ``path``'s directory or any ancestor.
-        Host-side walk, local backend only: on a remote backend this answers False so
-        the shell linter still runs — never suppress lint on a probe that couldn't answer."""
-        if not self._lsp_local_only():
-            return False
+        Local backend: host-side walk. Remote backends (Docker/SSH/Modal/...): one
+        shell probe on the backend, because the file lives there, not on the host —
+        walking the host here answered False for every sandboxed TS project and ran
+        a per-file ``tsc`` (phantom errors, up to the 30s timeout) on every patch.
+        Any failure answers False so lint is never suppressed by a probe that
+        couldn't answer."""
         try:
-            d = os.path.dirname(os.path.abspath(path))
-            while not os.path.isfile(os.path.join(d, "tsconfig.json")):
-                parent = os.path.dirname(d)
-                if parent == d:
-                    return False
-                d = parent
-            return True
+            if self._lsp_local_only():
+                d = os.path.dirname(os.path.abspath(path))
+                while not os.path.isfile(os.path.join(d, "tsconfig.json")):
+                    parent = os.path.dirname(d)
+                    if parent == d:
+                        return False
+                    d = parent
+                return True
+            probe = (
+                "d=$(dirname -- " + shlex.quote(path) + "); "
+                'while :; do [ -f "$d/tsconfig.json" ] && exit 0; '
+                '{ [ "$d" = / ] || [ "$d" = . ]; } && exit 1; '
+                'd=$(dirname -- "$d"); done'
+            )
+            return self._exec(probe, timeout=10).exit_code == 0
         except Exception:  # noqa: BLE001
             return False
 


### PR DESCRIPTION
## Problem

`LintMixin._has_ancestor_tsconfig` walks the **host** filesystem and, by its own docstring, answers `False` on any remote backend. With `terminal.backend: docker` the file being patched lives in the container, so the walk never finds the project's `tsconfig.json` and the per-file `npx tsc --noEmit <file>` shell linter runs on **every** `.ts` patch — exactly the case the skip was added for (single-file tsc floods phantom `TS1378`/`TS2307` errors).

Measured on a Docker-backend gateway working in a TypeScript monorepo: 98 `patch` calls in a day, median 20s, 24 of them hitting ~120s, 67 minutes of wall time inside `patch`. `write_file` on the same box: median 0.3s.

## Fix

On a non-local backend, run the ancestor walk as one shell probe through `self._exec` (the file is there, not here). Local backend keeps the host walk. Any exception still returns `False`, so lint is never suppressed by a probe that couldn't answer.

## Tests

`tests/tools/test_lint_tsconfig_probe.py`: remote env with tsconfig → `True` and the probe carries the path; remote env without → `False`; backend raising → `False`. `pytest tests/tools/test_lint_tsconfig_probe.py tests/tools/test_file_ops_env_not_ready.py tests/tools/test_file_operations_edge_cases.py` → 31 passed.