### PR TITLE
fix(hermes-cli): refuse a second hermes serve for the same profile

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -35,6 +35,8 @@ _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
 _GATEWAY_LOCK_FILENAME = "gateway.lock"
 _gateway_lock_handle = None
+_SERVE_LOCK_FILENAME = "serve.lock"
+_serve_lock_handle = None
 # Windows byte-range locks are mandatory for other readers: lock a byte well past
 # the JSON payload so status/PID readers can read while another process holds it.
 _WINDOWS_LOCK_OFFSET = 1024 * 1024
@@ -703,6 +705,59 @@ def owns_gateway_runtime_lock() -> bool:
     """True when THIS process holds the runtime lock. ``is_gateway_runtime_lock_active`` answers
     "does anyone?"; re-probing our own flock succeeds on POSIX, so only the handle discriminates."""
     return _gateway_lock_handle is not None
+
+
+def _get_serve_lock_path() -> Path:
+    return _get_process_hermes_home() / _SERVE_LOCK_FILENAME
+
+
+def acquire_backend_serve_lock() -> bool:
+    """Claim the per-profile backend-serve lock; the OS releases it if the process dies.
+
+    Same refuse-to-start convention as :func:`acquire_gateway_runtime_lock`: non-blocking,
+    never kills the current holder. Two ``serve``/``dashboard`` backends on one profile
+    both write the same WAL-mode state.db — a Hermes Desktop re-spawn bug did exactly
+    that and corrupted it. The port-bind probe cannot catch it: desktop spawns pass
+    ``--port 0``.
+    """
+    global _serve_lock_handle
+    if _serve_lock_handle is not None:
+        return True
+    path = _get_serve_lock_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        handle = open(path, "a+", encoding="utf-8")
+    except PermissionError:
+        # Stale root-owned lock (see acquire_gateway_runtime_lock): retry with a fresh file.
+        try:
+            path.unlink()
+            handle = open(path, "a+", encoding="utf-8")
+        except OSError:
+            return False
+    if not _try_acquire_file_lock(handle):
+        handle.close()
+        return False
+    handle.seek(0)
+    handle.truncate()
+    record = _build_pid_record()
+    record["kind"] = "hermes-serve"
+    json.dump(record, handle)
+    handle.flush()
+    with contextlib.suppress(OSError):
+        os.fsync(handle.fileno())
+    _serve_lock_handle = handle
+    return True
+
+
+def release_backend_serve_lock() -> None:
+    """Release the backend-serve lock when owned by this process."""
+    global _serve_lock_handle
+    handle, _serve_lock_handle = _serve_lock_handle, None
+    if handle is None:
+        return
+    _release_file_lock(handle)
+    with contextlib.suppress(OSError):
+        handle.close()
 
 
 def _probe_lock_file(handle) -> bool:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -74,6 +74,27 @@ from hermes_cli.web_server_lifecycle import (  # noqa: E402
 )
 
 
+# Per-profile backend singleton: a second ``serve``/``dashboard`` for the same
+# profile refuses to start with ONE machine-readable stdout sentinel plus a
+# distinct exit code — same convention as the port-conflict sentinel in
+# web_server_lifecycle (75 == BSD EX_TEMPFAIL, the repo's transient-condition
+# code). Desktop's spawn watches stdout for sentinels, so wrappers can grep it.
+BACKEND_PROFILE_ALREADY_RUNNING_EXIT_CODE = 75
+_PROFILE_ALREADY_RUNNING_SENTINEL = "BACKEND_PROFILE_ALREADY_RUNNING"
+
+
+def _report_profile_already_running() -> None:
+    """Print the machine sentinel + a human hint for the singleton refusal."""
+    _write_machine_sentinel_line(_PROFILE_ALREADY_RUNNING_SENTINEL)
+    print(
+        "  Another 'hermes serve' / 'hermes dashboard' backend is already running "
+        "for this profile (serve.lock is held). Stop the other process first — two "
+        "backends writing the same state.db corrupted it. "
+        "HERMES_SERVE_ALLOW_DUPLICATE=1 bypasses this guard.",
+        flush=True,
+    )
+
+
 def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60) -> None:
     """Tick the cron scheduler from inside the desktop dashboard backend.
 
@@ -1379,6 +1400,22 @@ def start_server(
     until the ready sentinel is written so its SDK import can't hold the GIL
     against the pre-bind path.
     """
+    # Per-profile singleton: Hermes Desktop's startHermes() re-spawn path once
+    # started a second backend for the same profile without stopping the first;
+    # both wrote the same WAL-mode state.db concurrently and corrupted it. The
+    # port-bind probe below cannot catch this — desktop spawns pass ``--port 0``.
+    # Refuse the newcomer, never auto-kill the peer (same convention as the
+    # gateway runtime lock). HERMES_SERVE_ALLOW_DUPLICATE=1 is the escape hatch.
+    if os.environ.get("HERMES_SERVE_ALLOW_DUPLICATE") != "1":
+        import atexit
+
+        from gateway.status import acquire_backend_serve_lock, release_backend_serve_lock
+
+        if not acquire_backend_serve_lock():
+            _report_profile_already_running()
+            raise SystemExit(BACKEND_PROFILE_ALREADY_RUNNING_EXIT_CODE)
+        atexit.register(release_backend_serve_lock)
+
     _apply_ssh_session_token(ssh_session_token or "")
     _apply_ssh_owner_nonce(ssh_owner_nonce)
 

--- a/tests/hermes_cli/_serve_lock_holder.py
+++ b/tests/hermes_cli/_serve_lock_holder.py
@@ -1,0 +1,15 @@
+"""Helper for test_serve_profile_singleton: take an exclusive flock on the
+path in sys.argv[1] and HOLD it until killed. The test reads the lock file's
+existence + a peer-process probe (via /proc on POSIX) to confirm contention.
+Prints nothing — the parent probes the lock state directly."""
+import fcntl, os, sys, time
+path = sys.argv[1]
+os.makedirs(os.path.dirname(path), exist_ok=True)
+h = open(path, "a+b")
+fcntl.flock(h.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+# Hold until SIGTERM. Parent kills us when done.
+try:
+    while True:
+        time.sleep(1)
+except KeyboardInterrupt:
+    pass

--- a/tests/hermes_cli/test_serve_profile_singleton.py
+++ b/tests/hermes_cli/test_serve_profile_singleton.py
@@ -1,0 +1,153 @@
+"""Per-profile backend singleton (2026-09-01 state.db corruption, second cause).
+
+Hermes Desktop's ``startHermes()`` re-spawn path once started a second
+default-profile backend without stopping the first; both wrote the same
+736MB WAL-mode ``state.db`` concurrently and corrupted the
+``gateway_heartbeats`` index in about an hour. A second ``hermes serve`` /
+``hermes dashboard`` for the same profile MUST refuse to start with a
+machine-readable sentinel + exit 75 (BSD ``EX_TEMPFAIL`` convention used
+elsewhere in this repo). Escape hatch: ``HERMES_SERVE_ALLOW_DUPLICATE=1``.
+
+Linux ``flock`` is per-open-file-description, so same-process reentry
+through ``acquire_backend_serve_lock`` is intentionally idempotent (the
+caller already knows it owns the lock). Real conflict is across processes,
+which is what this test exercises.
+"""
+import contextlib
+import fcntl
+import os
+import pathlib
+import subprocess
+import sys
+import unittest
+from unittest.mock import patch
+
+
+_REAL_ENV = os.environ.copy()
+
+
+def _reset_env():
+    for k in list(os.environ):
+        os.environ.pop(k, None)
+    for k, v in _REAL_ENV.items():
+        os.environ[k] = v
+
+
+@contextlib.contextmanager
+def _patched_home(tmp_path, profile="default"):
+    """Route ``get_hermes_home()`` at a tmp_path so the lock file is local
+    and isolated from the host's actual ``~/.hermes``."""
+    from hermes_constants import get_hermes_home
+    fake = tmp_path / profile
+    fake.mkdir(parents=True, exist_ok=True)
+    with patch("hermes_constants.get_hermes_home", return_value=fake), \
+         patch("gateway.status._get_process_hermes_home", return_value=fake):
+        yield fake
+
+
+class TestServeProfileSingleton(unittest.TestCase):
+
+    def setUp(self):
+        _reset_env()
+
+    def test_lock_path_under_hermes_home(self):
+        """Lock file lives next to ``gateway.lock``, scoped per-profile via ``get_hermes_home``."""
+        from gateway.status import _get_serve_lock_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = pathlib.Path(tmp) / "my-profile"
+            fake.mkdir()
+            with _patched_home(fake):
+                self.assertEqual(_get_serve_lock_path(), fake / "default" / "serve.lock")
+
+    def test_acquire_returns_true_idempotently_in_same_process(self):
+        """Linux flock is per-open-file-description; same-process reentry
+        through ``acquire_backend_serve_lock`` is intentionally idempotent so
+        a caller that already owns the lock is not falsely refused."""
+        from gateway.status import acquire_backend_serve_lock, release_backend_serve_lock
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            with _patched_home(pathlib.Path(tmp)):
+                self.assertTrue(acquire_backend_serve_lock())
+                self.assertTrue(acquire_backend_serve_lock(),
+                                "same-process reentry must be idempotent")
+                release_backend_serve_lock()
+                # After release, re-acquire still works.
+                self.assertTrue(acquire_backend_serve_lock())
+                release_backend_serve_lock()
+
+    def test_release_then_reacquire_works(self):
+        from gateway.status import acquire_backend_serve_lock, release_backend_serve_lock
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            with _patched_home(pathlib.Path(tmp)):
+                self.assertTrue(acquire_backend_serve_lock())
+                release_backend_serve_lock()
+                self.assertTrue(acquire_backend_serve_lock())
+                release_backend_serve_lock()
+
+    def test_external_subprocess_holding_lock_blocks_acquire(self):
+        """A different process holding the lock must cause ``acquire_backend_serve_lock``
+        to return False — the actual cross-process collision the fix exists to
+        prevent."""
+        from gateway.status import acquire_backend_serve_lock, release_backend_serve_lock, _get_serve_lock_path
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_p = pathlib.Path(tmp)
+            with _patched_home(tmp_p):
+                lock_path = str(_get_serve_lock_path())
+                helper = pathlib.Path(__file__).parent / "_serve_lock_holder.py"
+                # Spawn a child that holds an EX flock on the SAME path the
+                # parent is about to try. Pass the path explicitly — the
+                # child cannot see this process's monkeypatch of
+                # get_hermes_home().
+                child = subprocess.Popen(
+                    [sys.executable, str(helper), lock_path])
+                try:
+                    # Wait for the child to actually take the flock by
+                    # probing it from a fresh OFD in this process: a non-
+                    # blocking EX probe fails iff another process holds it.
+                    self.assertTrue(self._wait_for_peer_lock(lock_path, timeout=5.0),
+                                    "child did not acquire the lock in time")
+                    self.assertFalse(acquire_backend_serve_lock(),
+                                     "acquire returned True while a peer process held the lock")
+                finally:
+                    child.terminate(); child.wait(timeout=5)
+                # After the child released the lock, acquire succeeds again.
+                self.assertTrue(acquire_backend_serve_lock())
+                release_backend_serve_lock()
+
+    @staticmethod
+    def _wait_for_peer_lock(lock_path: str, *, timeout: float) -> bool:
+        """True when a non-blocking flock on *lock_path* fails — meaning a
+        different process holds it. Polls because the child races its own
+        imports vs the Popen returning to the parent."""
+        import time as _time
+        deadline = _time.monotonic() + timeout
+        while _time.monotonic() < deadline:
+            try:
+                h = open(lock_path, "a+b")
+            except OSError:
+                _time.sleep(0.05)
+                continue
+            try:
+                fcntl.flock(h.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except (BlockingIOError, OSError):
+                return True  # peer is holding it
+            else:
+                # We just acquired it — release and keep polling; the peer
+                # hasn't taken it yet.
+                fcntl.flock(h.fileno(), fcntl.LOCK_UN)
+                h.close()
+                _time.sleep(0.05)
+        return False
+
+    def test_escape_hatch_constant_and_exit_code(self):
+        """The sentinel and exit code are part of the public contract that
+        the Desktop spawn watcher greps — keep them stable."""
+        from hermes_cli.web_server import (
+            BACKEND_PROFILE_ALREADY_RUNNING_EXIT_CODE,
+            _PROFILE_ALREADY_RUNNING_SENTINEL,
+        )
+        self.assertEqual(BACKEND_PROFILE_ALREADY_RUNNING_EXIT_CODE, 75)
+        self.assertEqual(_PROFILE_ALREADY_RUNNING_SENTINEL, "BACKEND_PROFILE_ALREADY_RUNNING")


### PR DESCRIPTION
## Problem

On 2026-09-01 Hermes Desktop's `startHermes()` re-spawn path started a second `default`-profile backend without stopping the first; both wrote the same 736MB WAL-mode `state.db` concurrently and corrupted the `gateway_heartbeats` index within about an hour (`PRAGMA integrity_check` -> `wrong # of entries in index sqlite_autoindex_gateway_heartbeats_1`). The port-bind-conflict probe cannot catch this: desktop's re-spawn passes `--port 0`, so the probe is skipped and the second backend was born silent.

A third, unrelated stray process (an old `.venv` interpreter, reparented to launchd) was also found holding a `-p default` backend open from an earlier, unrelated session — so this class of collision is not theoretical.

## Fix

A per-profile flock in `gateway/status.py`:

- `acquire_backend_serve_lock()` — non-blocking, **refuse-to-start** (never auto-kill a peer, matching the existing `acquire_gateway_runtime_lock` / `STATE_DB_SINGLE_WRITER` convention).
- `release_backend_serve_lock()` — idempotent release.

Wired into `hermes_cli/web_server.py::start_server` BEFORE the existing port-bind-conflict probe; a second `serve`/`dashboard` for the same profile now prints the machine-readable sentinel `BACKEND_PROFILE_ALREADY_RUNNING` and exits 75 (BSD `EX_TEMPFAIL`, the repo's transient-condition code). Wrappers and Desktop's spawn watcher can grep the sentinel.

Escape hatch: `HERMES_SERVE_ALLOW_DUPLICATE=1` bypasses the lock.

## Tests

`tests/hermes_cli/test_serve_profile_singleton.py` covers the lock path under `get_hermes_home()`, same-process reentry being idempotent (Linux `flock` is per-open-file-description), release/reacquire, and a real cross-process collision via a subprocess that holds the flock while the parent asserts `acquire_backend_serve_lock` returns False. The escape-hatch sentinel and exit code are pinned by name.
