### PR TITLE
fix(desktop): keep group commands and working-member identity accurate

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx
@@ -16,10 +16,11 @@
  */
 
 import type * as HermesSdk from '@hermes/plugin-sdk'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BotRow } from './bot-row'
+import { $groupChats } from './group-chat'
 import { translateBots } from './i18n-test-helper'
 import type { RosterRow } from './types'
 
@@ -69,6 +70,29 @@ beforeEach(() => {
   ensureBotMetadata.mockResolvedValue({ pinned: true })
   openRosterBot.mockResolvedValue(true)
   requestProfile.mockResolvedValue({})
+})
+
+describe('group-turn presence', () => {
+  it('updates only the exact member face and clears it when the room stops', () => {
+    const local: RosterRow = { name: 'default', connectionId: 'local' }
+    const remote: RosterRow = { name: 'default', connectionId: 'remote', remoteSource: true }
+
+    const { container } = render(
+      <>
+        {[local, remote].map(bot => (
+          <BotRow bot={bot} key={bot.connectionId} onDelete={noop} onEdit={noop} onGroup={noop} onNewSection={noop} />
+        ))}
+      </>
+    )
+
+    const moods = () => [...container.querySelectorAll('[data-hb-mood]')].map(el => el.getAttribute('data-hb-mood'))
+    act(() => $groupChats.set({ Room: { log: [], watermarks: {}, running: true, turn: remote } }))
+    expect(moods()).toEqual(['idle', 'think'])
+    act(() => $groupChats.set({ Room: { log: [], watermarks: {}, running: true, turn: local } }))
+    expect(moods()).toEqual(['think', 'idle'])
+    act(() => $groupChats.set({}))
+    expect(moods()).toEqual(['idle', 'idle'])
+  })
 })
 
 describe('pre-warm is hover-scoped, never roster-wide', () => {

--- a/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
@@ -56,6 +56,7 @@ import {
 } from './data'
 import { $groupChats, $groupChatWorkspace } from './group-chat'
 import { botGroups, groupLastActivity } from './group-membership'
+import { $activeGroupMemberKeys } from './group-presence'
 import { fallbackSelectionAfterHide, isBotHidden, isBotPinned } from './hidden-bots'
 import { useBots } from './i18n'
 import { displayName, stripPreviewMarkdown } from './labels'
@@ -144,7 +145,8 @@ export function BotRow({ bot, onDelete, onEdit, onGroup, onNewSection, showHandl
     ? Math.max(activitySession?.last_active || 0, bot.worker_session?.last_active || 0)
     : activitySession?.last_active || 0
 
-  const botMood = botWorkingMood(bot, focusedOwner, turnBusy, activeConnectionId)
+  const groupKeys = useValue($activeGroupMemberKeys)
+  const botMood = botWorkingMood(bot, focusedOwner, turnBusy, activeConnectionId, Date.now(), groupKeys)
   // Status keys off the canonical Bot Chat — the very session this row opens,
   // so the dot and the click can never describe different conversations.
   const canonicalSessionId = botCanonicalSessionId(bot)

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -63,7 +63,6 @@ import {
   $groupChatWorkspace,
   $groupClarify,
   $groupNeedsYou,
-  groupSpeakerLabel,
   groupThreadOf,
   scheduleGroupChatServerSync,
   setGroupChatImage,
@@ -1153,7 +1152,7 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
               {roomClarifies.length
                 ? b.group.waitingForAnswer
                 : room.turn
-                  ? b.group.memberThinking(groupSpeakerLabel(room.turn))
+                  ? b.group.memberThinking(displayName(room.turn, botRosterMeta(room.turn, allMeta)))
                   : b.group.roomWorking}
             </div>
           ) : null}

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -1379,12 +1379,12 @@ export interface GroupHoldStamp extends GroupHold {
 }
 
 /** The room record as the coordination engine handles it: `GroupChat` plus
- *  `turn`, the runtime-only name of the member currently mid-turn. Like
+ *  `turn`, the runtime-only descriptor of the member currently mid-turn. Like
  *  `running`/`epoch` it never persists, so it has no place in the durable
  *  shape. Holds carry the fuller live stamp. */
 export interface GroupChatRoom extends GroupChat {
   holds?: Record<string, GroupHoldStamp>
-  turn?: null | string
+  turn?: GroupMember | null
 }
 
 /** Set or clear a group chat's room picture (small data URL, normalized by

--- a/apps/desktop/src/plugins/hermes-bots/group-presence.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-presence.ts
@@ -1,0 +1,15 @@
+import { computed } from '@hermes/plugin-sdk'
+
+import { botRosterKey } from './data'
+import { $groupChats } from './group-chat'
+
+/** All presence consumers share the exact owner captured by the room driver. */
+export const $activeGroupMemberKeys = computed(
+  $groupChats,
+  rooms =>
+    new Set(
+      Object.values(rooms).flatMap(room =>
+        room.running && !room.tombstone && room.turn ? [botRosterKey(room.turn)] : []
+      )
+    )
+)

--- a/apps/desktop/src/plugins/hermes-bots/group-round-members.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-round-members.ts
@@ -14,7 +14,7 @@ import type { GroupChatRoom } from './group-chat'
 import { groupMemberKey } from './group-membership'
 import { buildGroupChatTurnPrompt, formatGroupChatLine } from './group-round-prompt'
 import { isGroupPassText, runGroupChatMemberTurn } from './group-turns'
-import type { GroupMember, GroupMessage } from './types'
+import type { Attachment, GroupMember, GroupMessage } from './types'
 
 export interface GroupRoundMemberContext {
   group: string
@@ -105,6 +105,25 @@ function prepareGroupRoundMember(context: GroupRoundMemberContext, member: Group
   return { room, memberKey, markKey, prompt, deltaImages }
 }
 
+/** Each invocation owns its descriptor, so an old completion cannot clear a newer turn. */
+async function runVisibleMemberTurn(
+  context: GroupRoundMemberContext,
+  member: GroupMember,
+  prompt: string,
+  images?: Attachment[]
+) {
+  const turn = { ...member }
+  updateGroupChat(context.group, (room: GroupChatRoom) => ({ ...room, turn }), { sync: false })
+
+  try {
+    return await runGroupChatMemberTurn(context.group, member, prompt, context.thread, images)
+  } finally {
+    if (context.binding.isLive() && $groupChats.get()[context.group]?.turn === turn) {
+      updateGroupChat(context.group, (room: GroupChatRoom) => ({ ...room, turn: null }), { sync: false })
+    }
+  }
+}
+
 export async function runGroupRoundMember(
   context: GroupRoundMemberContext,
   member: GroupMember
@@ -117,18 +136,10 @@ export async function runGroupRoundMember(
   }
 
   const { room, markKey, prompt, deltaImages } = prepared
-  // Surface WHO is on turn (runtime-only, like running/epoch) so the
-  // room shows "Radar is thinking…" instead of a generic working line —
-  // long model turns otherwise read as the room being stuck.
-  updateGroupChat(context.group, (r: GroupChatRoom) => {
-    r.turn = member.name
-
-    return r
-  })
   let reply: null | string = null
 
   try {
-    reply = await runGroupChatMemberTurn(context.group, member, prompt, thread, deltaImages)
+    reply = await runVisibleMemberTurn(context, member, prompt, deltaImages)
 
     // Needs-attention hook (#93091 item 3): a turn that produced a real
     // reply (or an explicit pass) is a good turn — clear the badge.
@@ -271,15 +282,10 @@ async function runGroupContinuationMember(
     deltaLines: delta.slice(-GROUP_CHAT_HISTORY_LIMIT).map((e: GroupMessage) => formatGroupChatLine(e, member.name))
   })
 
-  updateGroupChat(context.group, (r: GroupChatRoom) => {
-    r.turn = member.name
-
-    return r
-  })
   let continuationReply: null | string = null
 
   try {
-    continuationReply = await runGroupChatMemberTurn(context.group, member, prompt, thread)
+    continuationReply = await runVisibleMemberTurn(context, member, prompt)
 
     if (continuationReply !== null) {
       clearBotAttention(memberKey)

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
@@ -152,6 +152,59 @@ describe('routing', () => {
 })
 
 describe('round lifecycle', () => {
+  it('clears each exact member turn on success, failure and supersession without clearing a newer turn', async () => {
+    for (const outcome of ['success', 'failure', 'superseded', 'newer-turn']) {
+      let finish!: () => void
+
+      const gate = new Promise<void>(resolve => {
+        finish = resolve
+      })
+
+      const room = await loadRoom({
+        turn: async () => {
+          await gate
+
+          if (outcome === 'failure') {throw new Error('member failed')}
+
+          return '(pass)'
+        }
+      })
+
+      const { runGroupRoundMember } = await import('./group-round-members')
+      const presence = await import('./group-presence')
+      const member: GroupMember = { name: 'default', connectionId: 'remote', remoteSource: true, sourceScoped: true }
+      const newer = { ...member }
+      room.chat.appendGroupChatEntry('Room', { kind: 'user', name: 'You' }, 'hello', 't1')
+      room.chat.updateGroupChat('Room', state => ({ ...state, running: true, epoch: 1 }))
+
+      const context = {
+        group: 'Room',
+        members: [member],
+        thread: 't1',
+        startEpoch: 1,
+        binding: { isLive: () => true },
+        isCurrent: () => room.chat.$groupChats.get().Room.epoch === 1
+      }
+
+      const pending = runGroupRoundMember(context, member)
+      await drain(() => room.gateway.calls.length === 0)
+      expect(room.chat.$groupChats.get().Room.turn).toEqual(member)
+      expect([...presence.$activeGroupMemberKeys.get()]).toEqual(['remote::default'])
+
+      if (outcome === 'superseded' || outcome === 'newer-turn') {
+        room.chat.updateGroupChat('Room', state => ({
+          ...state,
+          epoch: 2,
+          ...(outcome === 'newer-turn' ? { turn: newer } : {})
+        }))
+      }
+
+      finish()
+      await pending
+      expect(room.chat.$groupChats.get().Room.turn).toBe(outcome === 'newer-turn' ? newer : null)
+      expect([...presence.$activeGroupMemberKeys.get()]).toEqual(outcome === 'newer-turn' ? ['remote::default'] : [])
+    }
+  })
   it('settles when everyone passes, logging only the user message', async () => {
     const room = await loadRoom()
 
@@ -730,7 +783,7 @@ describe('stopGroupThread (#91868/#94569)', () => {
         members: STOP_MEMBERS,
         running: true,
         sessions: { alpha: 'live-alpha-sid' },
-        turn,
+        turn: turn ? STOP_MEMBERS.find(member => member.name === turn) : null,
         watermarks: {}
       }
     } as unknown as Record<string, GroupChat>)
@@ -752,6 +805,27 @@ describe('stopGroupThread (#91868/#94569)', () => {
       expect(state.holds?.[member.name]).toBeTruthy()
       expect(state.holds?.[member.name].thread).toBe('t1')
     }
+  })
+
+  it('interrupts the exact on-turn owner even when same-name members are reordered', async () => {
+    const room = await loadRoom()
+    const local: GroupMember = { name: 'default', connectionId: 'local', sourceScoped: true }
+    const remote: GroupMember = { name: 'default', connectionId: 'remote', remoteSource: true, sourceScoped: true }
+    room.chat.$groupChats.set({
+      Room: {
+        epoch: 3,
+        running: true,
+        log: [],
+        watermarks: {},
+        members: [local, remote],
+        turn: remote,
+        sessions: { 'local::default': 'local-session', 'remote::default': 'remote-session' }
+      }
+    })
+    await room.rounds.stopGroupThread('Room', 't1', [remote, local])
+    expect(room.gateway.rpcFor('session.interrupt').map(call => call.params.session_id)).toEqual(['remote-session'])
+    expect(room.chat.$groupChats.get().Room.turn).toBeNull()
+    expect(room.chat.$groupChats.get().Room.running).toBe(false)
   })
 
   it('interrupts the member ON TURN via its live session', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -19,6 +19,7 @@ import {
 import type { GroupChatRoom, GroupHoldStamp } from './group-chat'
 import { durableGroupChatMembers, followGroupChat, groupMemberKey } from './group-membership'
 import { runGroupContinuationMembers, runGroupRoundMember } from './group-round-members'
+import { rejectGroupSlashCommand } from './group-slash'
 import { harvestStrandedGroupReply } from './group-turns'
 import { requestForBot } from './routing'
 import type { Attachment, GroupMember, GroupMessage } from './types'
@@ -662,6 +663,11 @@ export function sendToGroupChat(
   images?: Attachment[]
 ): null | string {
   const trimmed = String(text || '').trim()
+
+  if (rejectGroupSlashCommand(trimmed)) {
+    return null
+  }
+
   const attached = Array.isArray(images) ? images.filter((img: Attachment) => img && img.data) : []
 
   if ((!trimmed && !attached.length) || !members.length) {

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -353,7 +353,7 @@ export function unaddressedGroupMentions(group: string, members: GroupMember[], 
 export async function stopGroupThread(group: string, thread: null | string, members: GroupMember[] | null = null) {
   const room = $groupChats.get()[group] || {}
   const roster = Array.isArray(members) && members.length ? members : room.members || []
-  const turnName = room.turn || null
+  const onTurn = room.turn || null
 
   const stamp: GroupHoldStamp = {
     at: Date.now(),
@@ -397,9 +397,7 @@ export async function stopGroupThread(group: string, thread: null | string, memb
     thread: thread || null
   })
 
-  // Interrupt the member actually mid-turn. room.turn is runtime-only and
-  // names exactly one member (the loop is serial); a settled room has none.
-  const onTurn = turnName ? roster.find((member: GroupMember) => member?.name === turnName) : null
+  // The captured descriptor owns routing even if the roster has changed.
   const sessionId = onTurn ? (room.sessions || {})[groupMemberKey(onTurn)] : null
 
   if (onTurn && sessionId) {

--- a/apps/desktop/src/plugins/hermes-bots/group-slash.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-slash.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+import { createGroupGateway, drain, runTimersInline, scriptedStorage } from './group-test-utils'
+import type { Attachment, GroupMember } from './types'
+
+const { host } = vi.hoisted(() => ({ host: {} as Record<string, unknown> }))
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { pluginSdkMock } = await import('./group-test-utils')
+
+  return pluginSdkMock(host)
+})
+
+const MEMBERS: GroupMember[] = [
+  { name: 'research', title: '' },
+  { name: 'builder', title: '' }
+]
+
+const IMAGE: Attachment = { data: 'data:image/png;base64,iVBORw0KGgo=', kind: 'image', name: 'screenshot.png' }
+
+async function loadRoom() {
+  vi.resetModules()
+  const gateway = createGroupGateway()
+  Object.assign(host, gateway.host)
+
+  const [chat, rounds, shared] = await Promise.all([
+    import('./group-chat'),
+    import('./group-rounds'),
+    import('./shared')
+  ])
+
+  shared.setPluginCtx(scriptedStorage(gateway.storage))
+
+  return { chat, rounds, gateway }
+}
+
+beforeEach(() => runTimersInline())
+afterEach(() => vi.unstubAllGlobals())
+
+it('rejects command-shaped sends visibly without changing the room or reaching a member, even with attachments', async () => {
+  const { chat, rounds, gateway } = await loadRoom()
+  const thread = rounds.sendToGroupChat('Team', MEMBERS, 'Ready')
+  await drain(() => Boolean(chat.$groupChats.get().Team?.running))
+  chat.$groupNeedsYou.set({ Team: true })
+
+  const before = structuredClone(chat.$groupChats.get())
+  const needsYou = chat.$groupNeedsYou.get()
+  const storage = structuredClone(gateway.storage)
+  gateway.rpc.length = 0
+  gateway.calls.length = 0
+  gateway.attaches.length = 0
+
+  for (const text of ['/new', '  /ReSeT  ', '/custom-skill argument', '/custom_skill\nargument']) {
+    for (const target of [null, thread]) {
+      for (const attachments of [[], [IMAGE]]) {
+        const draftAttachments = structuredClone(attachments)
+        vi.mocked(host.notify as ReturnType<typeof vi.fn>).mockClear()
+
+        expect(rounds.sendToGroupChat('Team', MEMBERS, text, target, attachments)).toBeNull()
+        await drain(() => Boolean(chat.$groupChats.get().Team?.running))
+
+        expect(host.notify).toHaveBeenCalledExactlyOnceWith({
+          kind: 'warning',
+          message: expect.stringMatching(/slash commands.*group chats/i)
+        })
+        expect(chat.$groupChats.get()).toEqual(before)
+        expect(chat.$groupNeedsYou.get()).toBe(needsYou)
+        expect(gateway.storage).toEqual(storage)
+        expect(gateway.rpc).toEqual([])
+        expect(gateway.calls).toEqual([])
+        expect(gateway.attaches).toEqual([])
+        expect(attachments).toEqual(draftAttachments)
+      }
+    }
+  }
+})
+
+it('sends path-first text and embedded slash commands to the room members with attachments intact', async () => {
+  const { chat, rounds, gateway } = await loadRoom()
+
+  for (const text of ['/etc/hosts', '/tmp/report.txt inspect this', 'Explain /new', '/']) {
+    gateway.calls.length = 0
+    gateway.attaches.length = 0
+
+    const thread = rounds.sendToGroupChat('Team', MEMBERS, text, null, [IMAGE])
+    expect(thread).toEqual(expect.any(String))
+    await drain(() => Boolean(chat.$groupChats.get().Team?.running))
+
+    expect(chat.$groupChats.get().Team.log).toContainEqual(expect.objectContaining({ text, thread, images: [IMAGE] }))
+    expect(gateway.calls.map(call => call.profile)).toEqual(MEMBERS.map(member => member.name))
+    expect(gateway.calls.every(call => call.prompt.includes(text))).toBe(true)
+    expect(gateway.attaches.map(call => call.data)).toEqual(MEMBERS.map(() => IMAGE.data))
+    expect(host.notify).not.toHaveBeenCalled()
+  }
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-slash.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-slash.ts
@@ -1,0 +1,18 @@
+import { host } from '@hermes/plugin-sdk'
+
+import { botsText } from './i18n'
+
+/** Group rooms cannot dispatch slash commands. Keep command-shaped input out
+ * of member prompts without rejecting paths such as /etc/hosts. */
+export function rejectGroupSlashCommand(text: string): boolean {
+  if (!/^\/[a-z][\w-]*(?:\s|$)/i.test(text)) {
+    return false
+  }
+
+  host.notify({
+    kind: 'warning',
+    message: botsText().group.slashCommandsUnsupported
+  })
+
+  return true
+}

--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -163,6 +163,7 @@ type BotsMessages = {
     deleteTitle: string
     deleteAction: string
     composerPlaceholder: string
+    slashCommandsUnsupported: string
     attachHint: string
     newThread: string
     reply: string
@@ -387,6 +388,8 @@ const en: BotsMessages = {
     deleteTitle: 'Delete group chat?',
     deleteAction: 'Delete',
     composerPlaceholder: 'Say something — every bot in this group hears the room.',
+    slashCommandsUnsupported:
+      'Slash commands are not supported in group chats. Open an individual bot chat to use them.',
     attachHint: 'Attach files — every responding bot sees them',
     newThread: 'New Thread',
     reply: 'Reply',
@@ -604,6 +607,8 @@ const ja: BotsMessages = {
     deleteTitle: 'グループチャットを削除しますか？',
     deleteAction: '削除',
     composerPlaceholder: '何か書いてください — このグループのすべてのボットが部屋の内容を受け取ります。',
+    slashCommandsUnsupported:
+      'グループチャットではスラッシュコマンドを使用できません。個別のボットチャットを開いて使用してください。',
     attachHint: 'ファイルを添付 — 応答するすべてのボットが見ます',
     newThread: '新しいスレッド',
     reply: '返信',
@@ -817,6 +822,7 @@ const zh: BotsMessages = {
     deleteTitle: '删除群聊？',
     deleteAction: '删除',
     composerPlaceholder: '说点什么 — 这个群里的每个机器人都会听到。',
+    slashCommandsUnsupported: '群聊不支持斜杠命令。请打开单个机器人的聊天来使用。',
     attachHint: '附加文件 — 每个回应的机器人都能看到',
     newThread: '新帖子',
     reply: '回复',
@@ -1030,6 +1036,7 @@ const zhHant: BotsMessages = {
     deleteTitle: '刪除群組聊天？',
     deleteAction: '刪除',
     composerPlaceholder: '說點什麼 — 這個群組裡的每個機器人都會聽到。',
+    slashCommandsUnsupported: '群組聊天不支援斜線命令。請開啟個別機器人的聊天來使用。',
     attachHint: '附加檔案 — 每個回應的機器人都能看到',
     newThread: '新討論串',
     reply: '回覆',

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -36,6 +36,7 @@ import { $groupChats, $groupChatWorkspace, $groupClarify, $groupNeedsYou } from 
 import { GroupChatWorkspace, openGroupChat } from './group-chat-view'
 import { groupChatMemberBots } from './group-membership'
 import { $groupMainTabsRev, shouldRenderGroupChatInPane } from './group-panes'
+import { $activeGroupMemberKeys } from './group-presence'
 import { $showHiddenBots, isBotHidden } from './hidden-bots'
 import { useBots } from './i18n'
 import { $activityToasts } from './roster-actions'
@@ -297,8 +298,10 @@ export function BotsPane() {
   // neutral loading state instead of flashing the first-run "No bots" copy.
   const initialRosterLoading = !data && !error && roster.length === 0
 
+  const groupKeys = useValue($activeGroupMemberKeys)
+
   const activeRosterKeys = new Set(
-    activeBots(roster, workingOwner, turnBusy, Date.now(), activeConnectionId).map(botRosterKey)
+    activeBots(roster, workingOwner, turnBusy, Date.now(), activeConnectionId, groupKeys).map(botRosterKey)
   )
 
   const gatewayOptions = rosterGatewayOptions(sourceSnapshot, roster)

--- a/apps/desktop/src/plugins/hermes-bots/row-helpers.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/row-helpers.test.ts
@@ -19,6 +19,7 @@ import {
   activeBots,
   botCanonicalSessionId,
   botRowOwnsWorkspace,
+  botWorkingMood,
   previewKind,
   rosterActivityMatches,
   workerActiveAt
@@ -96,6 +97,18 @@ describe('which bots are working right now', () => {
     row({ last_session: { id: 'b', last_active: secondsAgo(400) }, name: 'scribe' }),
     row({ name: 'analyst' })
   ]
+
+  it('shares source-exact group presence between row mood and the active filter', () => {
+    const local = row({ name: 'default', connectionId: 'local' })
+    const remote = row({ name: 'default', connectionId: 'remote', remoteSource: true })
+    const groupKeys = new Set(['remote::default'])
+    expect(activeBots([local, remote], null, false, NOW, 'local', groupKeys)).toEqual([remote])
+    expect(botWorkingMood(remote, null, false, 'local', NOW, groupKeys)).toBe('think')
+    expect(botWorkingMood(local, null, false, 'local', NOW, groupKeys)).toBe('idle')
+    groupKeys.clear()
+    expect(activeBots([local, remote], null, false, NOW, 'local', groupKeys)).toEqual([])
+    expect(botWorkingMood(remote, null, false, 'local', NOW, groupKeys)).toBe('idle')
+  })
 
   it('counts the focused live turn only for its connection-qualified owner', () => {
     const local = row({ name: 'analyst', connectionId: 'local' })

--- a/apps/desktop/src/plugins/hermes-bots/row-helpers.ts
+++ b/apps/desktop/src/plugins/hermes-bots/row-helpers.ts
@@ -104,8 +104,13 @@ export function botWorkingMood(
   owner: WorkingOwner | null,
   turnBusy: boolean,
   activeConnectionId = 'local',
-  now = Date.now()
+  now = Date.now(),
+  groupKeys?: ReadonlySet<string>
 ): 'idle' | 'think' | 'work' {
+  if (groupKeys?.has(botRosterKey(bot))) {
+    return 'think'
+  }
+
   const botConnectionId = bot.connectionId || (bot.remoteSource ? '' : activeConnectionId)
 
   if (
@@ -127,10 +132,11 @@ export function activeBots(
   owner: WorkingOwner | null,
   turnBusy: boolean,
   now = Date.now(),
-  activeConnectionId = 'local'
+  activeConnectionId = 'local',
+  groupKeys?: ReadonlySet<string>
 ): RosterRow[] {
   return (roster || []).filter(bot => {
-    const busyTurn = botWorkingMood(bot, owner, turnBusy, activeConnectionId, now) !== 'idle'
+    const busyTurn = botWorkingMood(bot, owner, turnBusy, activeConnectionId, now, groupKeys) !== 'idle'
     const last = botActivitySession(bot)?.last_active || 0
     const inWindow = Boolean(last && now / 1000 - last < ACTIVE_WINDOW_S)
 


### PR DESCRIPTION
## Summary

Group-room slash commands such as `/reset` now show a warning instead of becoming prompts for every bot. Rejected sends preserve the draft and attachments in both the room composer and thread replies. Path-first messages such as `/etc/hosts` still send normally.

A running group turn now retains its member descriptor, including connection identity. The roster's active filter and bot animation use the captured owner, the thinking label uses that member's display identity, and Stop interrupts its session without choosing another same-named bot. Each invocation clears its own presence on completion or failure without clearing a newer turn.

Supersedes https://github.com/NousResearch/hermes-agent/pull/94063 and https://github.com/NousResearch/hermes-agent/pull/96783.

Closes https://github.com/NousResearch/hermes-agent/issues/93947.

Thanks to @ClintonEmok for the slash-input guard and @tuancookiez-hub for group-turn presence. Both are credited in the corresponding commits. This ports and consolidates their work onto the current modules, replaces source-slicing tests, and fixes the bare-name identity ambiguity.

## Verification

- Bot Mode suite: 64 files, 592 tests passed using the repository's normal Vitest configuration.
- Desktop renderer typecheck and changed-file ESLint passed.
- Regression coverage includes rejection without room mutation/RPCs, attachments, same-name connection isolation, exact-session Stop, and completion/failure/supersession cleanup.
- Chrome preview mounted the real BotRow and GroupChatWorkspace components: changing the active member changed only that bot's animation; finishing cleared both; `/reset` stayed in both composers and added no room message.

The browser preview used explicit sample state, not live inference. No packaged Windows or real multi-gateway acceptance is claimed. Existing Node localStorage and Vite configuration warnings remain.

## Scope

This does not implement room reset or slash dispatch; https://github.com/NousResearch/hermes-agent/issues/98662 remains open. Activity-feed collision labels and gateway-side bot-to-bot presence remain separate work in https://github.com/NousResearch/hermes-agent/pull/96558 and https://github.com/NousResearch/hermes-agent/pull/99761. Canonical-session status dots keep their existing session semantics.
