### PR TITLE
fix(desktop): recover remote OAuth without blocking healthy gateways

### DIFF
--- a/apps/desktop/e2e/remote-oauth-recovery.spec.ts
+++ b/apps/desktop/e2e/remote-oauth-recovery.spec.ts
@@ -1,0 +1,111 @@
+import * as fs from 'node:fs'
+import * as http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import * as path from 'node:path'
+
+import { buildAppEnv, createSandbox, launchDesktop } from './fixtures'
+import { allowErrorBanners, expect, test } from './test'
+
+type DesktopWindow = Window & {
+  hermesDesktop: {
+    getBootProgress: () => Promise<{ running: boolean; retryable?: boolean; statusCode?: number; error?: string }>
+    getConnection: () => Promise<unknown>
+  }
+}
+
+// Real Electron/preload/renderer against a loopback gateway whose session was
+// lost during restart. No real credentials or installed user state are used.
+for (const status of [401, 403]) {
+  test(`unsigned gateway ${status} leaves recovery settings usable`, async () => {
+    allowErrorBanners()
+    const sandbox = createSandbox(`oauth-recovery-${status}`)
+    let mints = 0
+    let signedIn = false
+    const server = http.createServer((req, res) => {
+      req.resume()
+      req.on('end', () => {
+        const pathname = new URL(req.url ?? '/', 'http://localhost').pathname
+        res.setHeader('Content-Type', 'application/json')
+        if (pathname === '/api/status') {
+          res.end(JSON.stringify({ auth_required: true, auth_flows: [], version: 'test' }))
+        } else if (pathname === '/api/auth/providers') {
+          res.end(JSON.stringify({ providers: [{ name: 'portal', supports_password: false }] }))
+        } else if (pathname === '/login') {
+          signedIn = true
+          res.setHeader('Set-Cookie', 'hermes_session_at=fixture-session; Path=/; HttpOnly; SameSite=Lax')
+          res.end('{}')
+        } else if (signedIn && pathname === '/api/auth/ws-ticket') {
+          mints += 1
+          res.end(JSON.stringify({ ticket: `fixture-ticket-${mints}` }))
+        } else if (signedIn && pathname === '/api/health') {
+          res.end(JSON.stringify({ ok: true, status: 'ok' }))
+        } else {
+          if (pathname === '/api/auth/ws-ticket') {
+            mints += 1
+            if (mints === 1) {
+              // A NAS restart can truncate a response after headers. Exercise
+              // Electron's real IncomingMessage error, then recover on retry.
+              res.setHeader('Content-Length', '1024')
+              res.write('{"partial":')
+              setTimeout(() => res.destroy(), 20)
+              return
+            }
+          }
+          res.statusCode = status
+          res.end(JSON.stringify({ error: 'unauthenticated', reason: 'no_cookie' }))
+        }
+      })
+    })
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+    fs.writeFileSync(path.join(sandbox.userDataDir, 'connection.json'), JSON.stringify({
+      mode: 'remote', remote: { url, authMode: 'oauth' }, profiles: {}
+    }))
+    let app: Awaited<ReturnType<typeof launchDesktop>>['app'] | undefined
+    try {
+      const launched = await launchDesktop(buildAppEnv(sandbox, {
+        HERMES_DESKTOP_DEV_SERVER: ''
+      }))
+      app = launched.app
+      const page = launched.page
+      await expect(page.getByRole('button', { name: /gateway settings/i })).toBeVisible({ timeout: 60_000 })
+      const snapshot = await page.evaluate(() => (window as unknown as DesktopWindow).hermesDesktop.getBootProgress())
+      expect(snapshot).toMatchObject({ running: false, retryable: false, statusCode: status })
+      expect(snapshot.error).toMatch(/not signed in/)
+      expect(mints).toBeGreaterThan(0)
+      const settledMints = mints
+      await page.getByRole('button', { name: /gateway settings/i }).click()
+      const back = page.getByRole('button', { name: /^back$/i })
+      await expect(back).toBeVisible()
+      const gatewayUrl = page.getByPlaceholder('https://gateway.example.com/hermes')
+      await expect(gatewayUrl).toHaveValue(url)
+      // Concurrent IPC readers must reuse the terminal failure, not republish
+      // startup progress and unmount the settings form.
+      await page.evaluate(async () => {
+        await Promise.allSettled(Array.from({ length: 20 }, () => (window as unknown as DesktopWindow).hermesDesktop.getConnection()))
+      })
+      await expect(back).toBeVisible()
+      await expect(gatewayUrl).toHaveValue(url)
+      expect(mints).toBe(settledMints)
+      await page.screenshot({ path: test.info().outputPath(`gateway-settings-${status}.png`) })
+      await back.click()
+      const signIn = page.getByRole('button', { name: /sign in/i })
+      await expect(signIn).toBeEnabled()
+      await signIn.click()
+      await expect.poll(() => signedIn).toBe(true)
+      await expect.poll(async () => {
+        try {
+          return await page.evaluate(() => (window as unknown as DesktopWindow).hermesDesktop.getConnection())
+        } catch {
+          return null
+        }
+      }).toMatchObject({ mode: 'remote', baseUrl: url })
+      expect(mints).toBeGreaterThan(settledMints)
+    } finally {
+      await app?.close()
+      server.closeAllConnections()
+      await new Promise<void>(resolve => server.close(() => resolve()))
+      sandbox.cleanup()
+    }
+  })
+}

--- a/apps/desktop/electron/fetch-json-oauth-session.test.ts
+++ b/apps/desktop/electron/fetch-json-oauth-session.test.ts
@@ -1,0 +1,113 @@
+import { Buffer } from 'node:buffer'
+import { EventEmitter } from 'node:events'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { httpStatusError, readStatusCode } from './api-transport'
+import { wireOauthSessionResponse } from './oauth-session-response'
+
+function makeResponse(statusCode = 200, headers: Record<string, string | undefined> = {}) {
+  return Object.assign(new EventEmitter(), { statusCode, headers })
+}
+
+function wire(res: ReturnType<typeof makeResponse>) {
+  const resolve = vi.fn()
+  const reject = vi.fn()
+  const clearTimer = vi.fn()
+  let timedOut = false
+
+  wireOauthSessionResponse(res, {
+    url: 'https://gw.example.com/api',
+    isTimedOut: () => timedOut,
+    clearTimer,
+    resolve,
+    reject,
+  })
+
+  return {
+    resolve,
+    reject,
+    clearTimer,
+    timeOut: () => {
+      timedOut = true
+    },
+  }
+}
+
+describe('OAuth session response', () => {
+  it('settles once when a response body fails after headers', () => {
+    const res = makeResponse()
+    const state = wire(res)
+    const error = new Error('net::ERR_CONTENT_LENGTH_MISMATCH')
+
+    res.emit('data', Buffer.from('{"partial":'))
+    expect(() => res.emit('error', error)).not.toThrow()
+
+    // Neither another loader failure nor end may settle a failed body again.
+    expect(() => res.emit('error', new Error('late failure'))).not.toThrow()
+    res.emit('end')
+
+    expect(state.reject).toHaveBeenCalledExactlyOnceWith(error)
+    expect(state.resolve).not.toHaveBeenCalled()
+    expect(state.clearTimer).toHaveBeenCalledTimes(1)
+    expect(() => res.emit('data', null)).not.toThrow()
+
+    const timedOutRes = makeResponse()
+    const timedOutState = wire(timedOutRes)
+    timedOutRes.emit('data', Buffer.from('{"partial":'))
+    timedOutState.timeOut()
+    expect(() => timedOutRes.emit('error', error)).not.toThrow()
+    timedOutRes.emit('end')
+    expect(() => timedOutRes.emit('data', null)).not.toThrow()
+    expect(timedOutState.reject).not.toHaveBeenCalled()
+    expect(timedOutState.resolve).not.toHaveBeenCalled()
+    expect(timedOutState.clearTimer).not.toHaveBeenCalled()
+  })
+
+  it('preserves JSON and HTTP error contracts when end wins settlement', () => {
+    const cases = [
+      { status: 200, body: '{"ok":"✓"}', headers: {}, value: { ok: '✓' } },
+      { status: 204, body: '', headers: {}, value: null },
+      { status: 401, body: '{"error":"session_expired"}', headers: {} },
+      { status: 403, body: '', headers: {} },
+      { status: 503, body: 'unavailable', headers: {} },
+      { status: 0, body: 'missing status', headers: {} },
+      { status: 200, body: ' \n<!doctype html><html></html>', headers: {}, error: /got HTML/ },
+      { status: 200, body: '{}', headers: { 'Content-Type': 'text/html' }, error: /got HTML/ },
+      { status: 200, body: '{"partial":', headers: {}, error: /Invalid JSON/ },
+    ]
+
+    for (const entry of cases) {
+      const res = makeResponse(entry.status, entry.headers)
+      const state = wire(res)
+      // Splitting every byte also covers UTF-8 characters split across chunks.
+      for (const byte of Buffer.from(entry.body)) {
+        res.emit('data', Buffer.from([byte]))
+      }
+      res.emit('end')
+
+      // Late terminal events must not overwrite either success or rejection.
+      expect(() => res.emit('error', new Error('late loader failure'))).not.toThrow()
+      res.emit('end')
+      expect(() => res.emit('data', null)).not.toThrow()
+      expect(state.clearTimer).toHaveBeenCalledTimes(1)
+
+      if ('value' in entry) {
+        expect(state.resolve).toHaveBeenCalledExactlyOnceWith(entry.value)
+        expect(state.reject).not.toHaveBeenCalled()
+      } else {
+        expect(state.resolve).not.toHaveBeenCalled()
+        expect(state.reject).toHaveBeenCalledTimes(1)
+        const error = state.reject.mock.calls[0][0]
+        if (entry.error) {
+          expect(error.message).toMatch(entry.error)
+          expect(readStatusCode(error)).toBeNaN()
+        } else {
+          const expected = httpStatusError(entry.status, entry.body)
+          expect(error.message).toBe(expected.message)
+          expect(readStatusCode(error)).toBe(readStatusCode(expected))
+        }
+      }
+    }
+  })
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -55,12 +55,7 @@ import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { BackendDialClaims } from './backend-dial-claim'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
-import {
-  isReauthRequiredError,
-  makeNousCloudBackendDownError,
-  makeUnsignedOauthError,
-  waitForHermesReady
-} from './backend-health'
+import { isReauthRequiredError, waitForHermesReady } from './backend-health'
 import { backendCommandMatches, createBackendOwnership, createBackendShutdownCoordinator } from './backend-ownership'
 import {
   canImportHermesCli,
@@ -109,7 +104,6 @@ import {
   cookiesHavePrivyAccessToken,
   cookiesHavePrivySession,
   cookiesHaveSession,
-  gatewayTicketFailure,
   gatewayWsUrlIpcResult,
   hostLabelFromBaseUrl,
   localProfileEntry,
@@ -263,9 +257,7 @@ import {
 import { registerMcpOauthCallbackIpc } from './mcp-oauth-callback-ipc'
 import { createMediaProtocolHandler, MEDIA_PROTOCOL } from './media-protocol'
 import {
-  oauthGuardMayHardFail,
   oauthSessionIsLive,
-  oauthTicketFailureAuthMessage,
   resolveGatedDownloadAuth,
   resolveJsonBody,
   resolveOauthRestAuth,
@@ -284,6 +276,7 @@ import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } fr
 import { registerNativeNotifications } from './notification-ipc'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { LEGACY_OAUTH_PARTITION, resolveOauthPartition } from './oauth-partition'
+import { wireOauthSessionResponse } from './oauth-session-response'
 import { createParentStartMarkerResolver, parentWatchdogEnv } from './parent-process-identity'
 import { registerPetOverlayIpc } from './pet-overlay-ipc'
 import {
@@ -350,6 +343,7 @@ import {
   revalidateRemoteConnection,
   revalidateSuspectPooledRemoteBackends
 } from './remote-liveness'
+import { resolveRemoteOauthTicket, rosterSourceEnumerationTimeoutMs } from './remote-oauth-ticket'
 import {
   applyRemoteRequestHeaders,
   createRegistryGatewayWsUrlHandler,
@@ -7857,43 +7851,12 @@ function fetchJsonViaOauthSession(url, options: any = {}) {
     }, timeoutMs)
 
     request.on('response', res => {
-      const chunks = []
-      res.on('data', chunk => chunks.push(Buffer.from(chunk)))
-      res.on('end', () => {
-        if (timedOut) {
-          return
-        }
-
-        clearTimeout(timer)
-        const text = Buffer.concat(chunks).toString('utf8')
-        const statusCode = res.statusCode || 500
-
-        if (statusCode >= 400) {
-          reject(httpStatusError(statusCode, text))
-
-          return
-        }
-
-        if (!text) {
-          resolve(null)
-
-          return
-        }
-
-        const looksHtml = /^\s*<(?:!doctype|html)/i.test(text)
-        const contentType = String(res.headers['content-type'] || res.headers['Content-Type'] || '')
-
-        if (looksHtml || contentType.includes('text/html')) {
-          reject(new Error(`Expected JSON from ${url} but got HTML (status ${statusCode}).`))
-
-          return
-        }
-
-        try {
-          resolve(JSON.parse(text))
-        } catch {
-          reject(new Error(`Invalid JSON from ${url} (status ${statusCode}): ${text.slice(0, 200)}`))
-        }
+      wireOauthSessionResponse(res, {
+        url,
+        isTimedOut: () => timedOut,
+        clearTimer: () => clearTimeout(timer),
+        resolve,
+        reject
       })
     })
     request.on('error', error => {
@@ -10154,58 +10117,10 @@ async function buildRemoteConnection(
   const host = remoteHost || hostLabelFromBaseUrl(baseUrl)
 
   if (authMode === 'oauth') {
-    // OAuth gateway: auth comes from EITHER a native bearer token (cookieless
-    // RFC 8252 flow) OR the session cookies in the OAuth partition. Liveness is
-    // NOT "is the access-token cookie present?" — Portal issues a 24h rotating
-    // refresh token (hermes #37247), and the gateway middleware transparently
-    // rotates a fresh ~15-min access token from it on the next authenticated
-    // request. So a session with an expired AT cookie but a live RT cookie is
-    // still perfectly connectable. We early-out only when NEITHER a native
-    // token NOR any cookie is present, then mint a ws-ticket (which itself
-    // prefers the native bearer) as the authoritative liveness check.
-    //
-    // The native-token check is essential: the native login stores bearer
-    // tokens (no cookie is ever set), so gating solely on hasLiveOauthSession
-    // here would reject a freshly-completed native sign-in and loop the UI back
-    // into "not signed in" even though mintGatewayWsTicket would succeed with
-    // the stored bearer.
-    if (
-      !oauthSessionIsLive(hasNativeSession(baseUrl), await hasLiveOauthSession(baseUrl)) &&
-      oauthGuardMayHardFail(await gatewayAuthProviders(baseUrl, remoteHeaders))
-    ) {
-      throw makeUnsignedOauthError()
-    }
-
-    // Snapshot BEFORE the mint: a confirmed native rejection drops the dead
-    // token set on its way out (mintGatewayWsTicket's forced rotation), and
-    // the failure copy must still say "session expired" for a session that
-    // did exist — "not signed in" is for a jar that never held one.
-    const hadNativeSession = hasNativeSession(baseUrl)
-
-    let ticket
-
-    try {
-      ticket = await mintGatewayWsTicket(baseUrl, remoteHeaders)
-    } catch (error) {
-      // For a Nous-managed Cloud agent, a 502/503/504 from the WS-ticket mint
-      // means the backend server itself is down — the actionable Cloud-down
-      // error. This boundary runs BEFORE the readiness loop, so without this
-      // the ticket wrapper below would swallow the server-fault classification
-      // and the renderer would never see isCloudBackendDown. Preserve the
-      // existing 401/403 reauth and generic transport behavior for everything
-      // else (#85335).
-      const cloudError = makeNousCloudBackendDownError(baseUrl, error)
-
-      if (cloudError !== null) {
-        throw cloudError
-      }
-
-      throw gatewayTicketFailure(
-        error,
-        oauthTicketFailureAuthMessage(hadNativeSession),
-        'Could not reach the remote Hermes gateway while refreshing its WebSocket ticket. Try reconnecting.'
-      )
-    }
+    const ticket = await resolveRemoteOauthTicket(baseUrl, remoteHeaders, {
+      hasNativeSession,
+      mintGatewayWsTicket
+    })
 
     const wsUrl = buildGatewayWsUrlWithTicket(baseUrl, ticket)
 
@@ -15811,9 +15726,7 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
   // the renderer painted stale rows for the entire outage (and the roster IPC
   // hung >30s in live repro). Bound each source's enumeration; a timeout is
   // reported like any other unreachable source and retried on the next poll.
-  const perSourceTimeoutMs = 10_000
-
-  const withEnumerationDeadline = async <T>(work: Promise<T>): Promise<T> => {
+  const withEnumerationDeadline = async <T>(work: Promise<T>, perSourceTimeoutMs: number): Promise<T> => {
     let timer: ReturnType<typeof setTimeout> | null = null
 
     try {
@@ -15877,7 +15790,8 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
               backendDialClaims.run(backendScopeKey(connection.id, null), () =>
                 ensureRegistryBackend(connection.id, null)
               )
-            )
+            ),
+            rosterSourceEnumerationTimeoutMs(connection)
           )
 
           const { body, installId } = await fetchRosterSourceData(

--- a/apps/desktop/electron/oauth-session-response.ts
+++ b/apps/desktop/electron/oauth-session-response.ts
@@ -1,0 +1,82 @@
+import { Buffer } from 'node:buffer'
+
+import { httpStatusError } from './api-transport'
+
+// Response-stream extraction based on Bartok9's #99135 (original issue #72530).
+export interface OauthResponseLike {
+  on(event: 'data', cb: (chunk: Buffer) => void): void
+  on(event: 'error', cb: (error: Error) => void): void
+  on(event: 'end', cb: () => void): void
+  statusCode?: number
+  headers: Record<string, string | string[] | undefined>
+}
+
+export interface WireOauthResponseOptions {
+  url: string
+  isTimedOut: () => boolean
+  clearTimer: () => void
+  resolve: (value: unknown) => void
+  reject: (error: Error) => void
+}
+
+export function wireOauthSessionResponse(res: OauthResponseLike, opts: WireOauthResponseOptions): void {
+  const { url, isTimedOut, clearTimer, resolve, reject } = opts
+  const chunks: Buffer[] = []
+  let settled = false
+
+  res.on('data', chunk => {
+    if (!settled && !isTimedOut()) {
+      chunks.push(Buffer.from(chunk))
+    }
+  })
+  // Electron emits post-header loader failures on the response, not the request.
+  // Keep the listener after settlement: a late error must not become uncaught.
+  res.on('error', error => {
+    if (settled || isTimedOut()) {
+      return
+    }
+
+    settled = true
+    chunks.length = 0
+    clearTimer()
+    reject(error)
+  })
+  res.on('end', () => {
+    if (settled || isTimedOut()) {
+      return
+    }
+
+    settled = true
+    clearTimer()
+    const text = Buffer.concat(chunks).toString('utf8')
+    chunks.length = 0
+    const statusCode = res.statusCode || 500
+
+    if (statusCode >= 400) {
+      reject(httpStatusError(statusCode, text))
+
+      return
+    }
+
+    if (!text) {
+      resolve(null)
+
+      return
+    }
+
+    const looksHtml = /^\s*<(?:!doctype|html)/i.test(text)
+    const contentType = String(res.headers['content-type'] || res.headers['Content-Type'] || '')
+
+    if (looksHtml || contentType.includes('text/html')) {
+      reject(new Error(`Expected JSON from ${url} but got HTML (status ${statusCode}).`))
+
+      return
+    }
+
+    try {
+      resolve(JSON.parse(text))
+    } catch {
+      reject(new Error(`Invalid JSON from ${url} (status ${statusCode}): ${text.slice(0, 200)}`))
+    }
+  })
+}

--- a/apps/desktop/electron/remote-oauth-ticket.test.ts
+++ b/apps/desktop/electron/remote-oauth-ticket.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { isReauthRequiredError } from './backend-health'
+import { oauthTicketFailureAuthMessage } from './native-auth-decisions'
+import { resolveRemoteOauthTicket, rosterSourceEnumerationTimeoutMs } from './remote-oauth-ticket'
+
+describe('resolveRemoteOauthTicket', () => {
+  it('reserves a larger bounded roster dial budget only for OAuth remote sources', () => {
+    const defaultBudget = rosterSourceEnumerationTimeoutMs({ kind: 'local' })
+    for (const kind of ['remote', 'cloud']) {
+      expect(rosterSourceEnumerationTimeoutMs({ kind, authMode: 'oauth' })).toBeGreaterThan(defaultBudget)
+      expect(rosterSourceEnumerationTimeoutMs({ kind, authMode: 'token' })).toBe(defaultBudget)
+    }
+    expect(rosterSourceEnumerationTimeoutMs({ kind: 'ssh', authMode: 'oauth' })).toBe(defaultBudget)
+    expect(rosterSourceEnumerationTimeoutMs({ kind: 'remote', authMode: 'oauth' })).toBeLessThanOrEqual(30_000)
+    expect(defaultBudget).toBeGreaterThan(0)
+  })
+
+  it('mints a fresh ticket on every dial even without a preflight native session', async () => {
+    let mints = 0
+    const deps = {
+      hasNativeSession: () => false,
+      mintGatewayWsTicket: async (baseUrl: string, headers: Record<string, string>) => {
+        expect(baseUrl).toBe('https://gateway.example.com')
+        expect(headers).toEqual({ 'X-Access': 'proxy-token' })
+        return `ticket-${++mints}`
+      }
+    }
+
+    const first = await resolveRemoteOauthTicket('https://gateway.example.com', { 'X-Access': 'proxy-token' }, deps)
+    const second = await resolveRemoteOauthTicket('https://gateway.example.com', { 'X-Access': 'proxy-token' }, deps)
+    expect(first).not.toBe(second)
+    expect(mints).toBe(2)
+  })
+
+  it('classifies only confirmed auth rejection as reauth and retains the pre-mint session copy', async () => {
+    for (const baseUrl of ['https://gateway.example.com', 'https://lab.agents.nousresearch.com']) {
+      for (const hadNativeSession of [false, true]) {
+        for (const statusCode of [401, 403, 500, 502, 503, 504, undefined]) {
+          let nativeSession = hadNativeSession
+          const cause = Object.assign(new Error('ticket request failed'), { statusCode })
+          const error = await resolveRemoteOauthTicket(baseUrl, {}, {
+            hasNativeSession: () => nativeSession,
+            mintGatewayWsTicket: async () => {
+              nativeSession = false
+              throw cause
+            }
+          }).catch((failure: Error & { isCloudBackendDown?: boolean; statusCode?: number }) => failure)
+
+          expect(error).toBeInstanceOf(Error)
+          if (!(error instanceof Error)) {
+            throw new Error('Expected ticket rejection')
+          }
+          expect(error.cause).toBe(cause)
+          expect(error.statusCode).toBe(statusCode)
+          const authRejected = statusCode === 401 || statusCode === 403
+          expect(isReauthRequiredError(error)).toBe(authRejected)
+          expect(error.isCloudBackendDown === true).toBe(
+            baseUrl.includes('.agents.nousresearch.com') && [502, 503, 504].includes(statusCode ?? 0)
+          )
+          if (authRejected) {
+            expect(error.message).toBe(oauthTicketFailureAuthMessage(hadNativeSession))
+          }
+        }
+      }
+    }
+  })
+})

--- a/apps/desktop/electron/remote-oauth-ticket.ts
+++ b/apps/desktop/electron/remote-oauth-ticket.ts
@@ -1,0 +1,36 @@
+import { makeNousCloudBackendDownError } from './backend-health'
+import { gatewayTicketFailure } from './connection-config'
+import { oauthTicketFailureAuthMessage } from './native-auth-decisions'
+
+interface RemoteOauthTicketDeps {
+  hasNativeSession: (baseUrl: string) => boolean
+  mintGatewayWsTicket: (baseUrl: string, headers: Record<string, string>) => Promise<string>
+}
+
+// Roster dials use this same mint path before readiness; the ordinary 10s
+// deadline can discard a healthy OAuth source while its cold session warms.
+export function rosterSourceEnumerationTimeoutMs(connection: { kind?: string; authMode?: string }): number {
+  return (connection.kind === 'remote' || connection.kind === 'cloud') && connection.authMode === 'oauth'
+    ? 30_000
+    : 10_000
+}
+
+export async function resolveRemoteOauthTicket(
+  baseUrl: string,
+  headers: Record<string, string>,
+  deps: RemoteOauthTicketDeps
+): Promise<string> {
+  // The mint is authoritative: a cold cookie partition may not yet report a
+  // session. Snapshot native state only for copy; a rejected mint can erase it.
+  const hadNativeSession = deps.hasNativeSession(baseUrl)
+
+  try {
+    return await deps.mintGatewayWsTicket(baseUrl, headers)
+  } catch (error) {
+    throw makeNousCloudBackendDownError(baseUrl, error) ?? gatewayTicketFailure(
+      error,
+      oauthTicketFailureAuthMessage(hadNativeSession),
+      'Could not reach the remote Hermes gateway while refreshing its WebSocket ticket. Try reconnecting.'
+    )
+  }
+}

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -360,6 +360,214 @@ async function advanceBackoff() {
   })
 }
 
+describe('primary failure foreground isolation', () => {
+  it('ignores a boot snapshot superseded by a successful connection', async () => {
+    const snapshot = deferred<Awaited<ReturnType<ReturnType<typeof fakeDesktop>['getBootProgress']>>>()
+    const desktop = fakeDesktop()
+    desktop.getBootProgress.mockReturnValue(snapshot.promise)
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+    render(<Harness />)
+    await flushAsync()
+    expect($gatewayState.get()).toBe('open')
+
+    act(() => snapshot.resolve({
+      error: 'Your remote gateway session has expired.',
+      fakeMode: false,
+      message: 'previous rejection',
+      phase: 'backend.error',
+      progress: 94,
+      retryable: false,
+      running: false,
+      timestamp: Date.now()
+    }))
+    await flushAsync()
+    expect($desktopBoot.get().error).toBeNull()
+    expect($desktopBoot.get().visible).toBe(false)
+  })
+  it('ignores a boot snapshot superseded by a newer progress event', async () => {
+    const snapshot = deferred<Awaited<ReturnType<ReturnType<typeof fakeDesktop>['getBootProgress']>>>()
+    const connection = deferred<typeof primaryConn>()
+    const desktop = fakeDesktop()
+    desktop.getBootProgress.mockReturnValue(snapshot.promise)
+    desktop.getConnection.mockReturnValue(connection.promise)
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+    render(<Harness />)
+    await flushAsync()
+    const newer = {
+      error: null,
+      fakeMode: false,
+      message: 'Connecting after sign-in',
+      retryable: false,
+      phase: 'backend.remote',
+      progress: 24,
+      running: true,
+      timestamp: Date.now()
+    }
+    act(() => desktop.emitBootProgress(newer))
+    act(() => snapshot.resolve({ ...newer, error: 'Your remote gateway session has expired.', running: false }))
+    await flushAsync()
+    expect($desktopBoot.get().error).toBeNull()
+    act(() => connection.resolve(primaryConn))
+    await flushAsync()
+  })
+
+  it.each(['local', 'remote'] as const)(
+    'ordinary %s primary outage leaves the other foreground usable',
+    async primaryMode => {
+      const foregroundId = primaryMode === 'local' ? 'healthy-remote' : 'local'
+
+      const desktop = Object.assign(fakeDesktop(), {
+        getGatewayWsUrlFor: vi.fn(async () => coderConn.wsUrl),
+        getConnectionFor: vi.fn(async () => ({
+          ...coderConn,
+          connectionId: foregroundId,
+          profile: 'default',
+          mode: primaryMode === 'local' ? 'remote' : 'local',
+          remoteKind: primaryMode === 'local' ? 'cloud' : undefined,
+          authMode: primaryMode === 'local' ? 'oauth' : 'token'
+        }))
+      })
+
+      desktop.getConnection.mockResolvedValue({
+        ...primaryConn,
+        connectionId: primaryMode === 'local' ? 'local' : 'primary-vps',
+        mode: primaryMode
+      } as typeof primaryConn)
+      ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+      render(<Harness />)
+      await flushAsync()
+      let opening!: Promise<boolean>
+      act(() => {
+        opening = ensureGatewayForAgent(foregroundId, 'default')
+      })
+      await flushAsync()
+      expect(await opening).toBe(true)
+      desktop.getConnection.mockRejectedValue(new Error('ECONNREFUSED'))
+      act(() => FakeWebSocket.instances[0].drop())
+      await advanceBackoff()
+      expect(isActivePrimary()).toBe(false)
+      expect($gatewayState.get()).toBe('open')
+      await expect(requestGatewayForAgent(foregroundId, 'default', 'ping')).resolves.toEqual({ pong: true })
+      expect($desktopBoot.get().error).toBeNull()
+      expect($desktopBoot.get().visible).toBe(false)
+    }
+  )
+  it.each(['progress', 'reconnect'] as const)(
+    'primary auth via %s follows the foreground, including a latched error',
+    async path => {
+      const error = 'Your remote gateway session has expired.'
+
+      const cloud = {
+        ...primaryConn,
+        mode: 'remote' as const,
+        remoteKind: 'cloud' as const,
+        authMode: 'oauth' as const
+      }
+
+      const desktop = Object.assign(fakeDesktop(), {
+        getRecentLogs: vi.fn(async () => ({ lines: [] })),
+        getConnectionConfig: vi.fn(async () => ({ mode: 'cloud', remoteAuthMode: 'oauth', remoteUrl: cloud.baseUrl })),
+        getConnectionFor: vi.fn(async () => ({
+          ...coderConn,
+          connectionId: 'local',
+          profile: 'default',
+          mode: 'local',
+          baseUrl: 'http://127.0.0.1:9191',
+          wsUrl: 'ws://127.0.0.1:9191/api/ws?token=c'
+        }))
+      })
+
+      desktop.getConnection.mockResolvedValue(cloud as typeof primaryConn)
+
+      ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+      const { BootFailureOverlay } = await import('@/components/boot-failure-overlay')
+
+      const overlay = render(
+        <>
+          <Harness />
+          <BootFailureOverlay />
+        </>
+      )
+
+      await flushAsync()
+      expect($desktopBoot.get().visible).toBe(false)
+
+      const selectLocal = async () => {
+        let opening!: Promise<boolean>
+        act(() => {
+          opening = ensureGatewayForAgent('local', 'default')
+        })
+        await flushAsync()
+        expect(await opening).toBe(true)
+      }
+
+      await selectLocal()
+      const foreground = activeGateway()
+
+      const progress = {
+        error,
+        fakeMode: false,
+        message: error,
+        phase: 'backend.error',
+        progress: 94,
+        retryable: false,
+        running: false,
+        timestamp: Date.now()
+      }
+
+      if (path === 'reconnect') {
+        desktop.getGatewayWsUrl.mockRejectedValue(Object.assign(new Error(error), { needsOauthLogin: true }))
+        act(() => FakeWebSocket.instances[0].drop())
+        await advanceBackoff()
+      } else {
+        act(() => desktop.emitBootProgress(progress))
+        await flushAsync()
+      }
+
+      expect(activeGateway()).toBe(foreground)
+      expect($connection.get()?.connectionId).toBe('local')
+      expect($gatewayState.get()).toBe('open')
+      await expect(requestGatewayForAgent('local', 'default', 'ping')).resolves.toEqual({ pong: true })
+      expect(overlay.queryByRole('heading')).toBeNull()
+      expect($desktopBoot.get().error).toBeNull()
+      expect($desktopBoot.get().visible).toBe(false)
+      expect(notifyError).not.toHaveBeenCalled()
+
+      await act(async () => {
+        await ensureGatewayForProfile('default')
+      })
+      await flushAsync()
+      expect(isActivePrimary()).toBe(true)
+      expect($desktopBoot.get().error).toContain(error)
+      expect(overlay.getByRole('heading', { name: /sign-in required/i })).toBeTruthy()
+      expect(overlay.getByRole('button', { name: /sign in/i })).toBeTruthy()
+
+      // A now-latched foreground error must release boot readiness when leaving,
+      // but returning to its primary must retain the authentication recovery.
+      await selectLocal()
+      expect($desktopBoot.get().error).toBeNull()
+      expect($desktopBoot.get().visible).toBe(false)
+      expect(overlay.queryByRole('heading')).toBeNull()
+      await act(async () => {
+        await ensureGatewayForProfile('default')
+      })
+      expect($desktopBoot.get().error).toContain(error)
+
+      desktop.getGatewayWsUrl.mockImplementation(async conn => conn?.wsUrl ?? primaryConn.wsUrl)
+      act(() => FakeWebSocket.instances[0].drop())
+      await advanceBackoff()
+      expect($gatewayState.get()).toBe('open')
+      expect($desktopBoot.get().error).toBeNull()
+      expect(overlay.queryByRole('heading')).toBeNull()
+      await selectLocal()
+      await act(async () => {
+        await ensureGatewayForProfile('default')
+      })
+      expect($desktopBoot.get().error).toBeNull()
+    }
+  )
+})
+
 describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => {
   it('INITIAL boot against a dead VPS: getConnection hangs (waitForHermes) → app sits in the connecting combo, then fails', async () => {
     // The report's actual path: a fresh launch pointed at an unreachable VPS.

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -7,7 +7,7 @@ import {
 import { useEffect, useRef } from 'react'
 
 import { shouldApplyPostBootProgressError } from '@/components/boot-failure-reauth'
-import type { HermesConnection } from '@/global'
+import type { DesktopBootProgress, HermesConnection } from '@/global'
 import { HermesGateway } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { desktopDefaultCwd } from '@/lib/desktop-fs'
@@ -64,6 +64,7 @@ import {
   $activeSessionId,
   $connection,
   $currentCwd,
+  $gatewayState,
   $selectedStoredSessionId,
   $sessions,
   ensureDefaultWorkspaceCwd,
@@ -243,6 +244,21 @@ export function useGatewayBoot({
     // tick — a stale OAuth ticket fails every attempt and would otherwise stack
     // identical error toasts (and their haptics). Reset on the next clean open.
     let reauthNotified = false
+    // After boot, a primary auth failure must not cover a healthy secondary.
+    let primaryReauthError: string | null = null
+
+    const syncPrimaryReauthError = () => {
+      if (!bootCompleted || !primaryReauthError) {
+        return
+      }
+
+      if (isActivePrimary()) {
+        failDesktopBoot(primaryReauthError)
+      } else if (activeGateway()?.connectionState === 'open' && $desktopBoot.get().error === primaryReauthError) {
+        completeDesktopBoot()
+      }
+    }
+
     // Raised once the reconnect loop has been failing for
     // RECONNECT_ESCALATE_AFTER_MS so we fire a single non-blocking toast.
     // Reset on a clean open or a manual/wake-driven reconnect.
@@ -407,10 +423,13 @@ export function useGatewayBoot({
         // through to the backoff in the finally block below — they must NOT
         // take the full-screen "couldn't start" path (locks reading/drafting).
         if (!cancelled && isGatewayReauthRequired(err) && !reauthNotified) {
-          reauthNotified = true
-          const message = err instanceof Error ? err.message : String(err)
-          failDesktopBoot(message)
-          notifyError(err, translateNow('boot.errors.gatewaySignInRequired'))
+          primaryReauthError = err instanceof Error ? err.message : String(err)
+          syncPrimaryReauthError()
+
+          if (isActivePrimary()) {
+            reauthNotified = true
+            notifyError(err, translateNow('boot.errors.gatewaySignInRequired'))
+          }
         }
       } finally {
         reconnecting = false
@@ -604,6 +623,7 @@ export function useGatewayBoot({
         reconnectFailingSince = null
         escalated = false
         reauthNotified = false
+        primaryReauthError = null
 
         gateway.close()
         // The primary mode is changing, but registered v2 sources remain
@@ -709,7 +729,11 @@ export function useGatewayBoot({
       }
     }
 
-    const offBootProgress = desktop.onBootProgress(payload => {
+    const onBootProgress = (payload: DesktopBootProgress) => {
+      if (cancelled) {
+        return
+      }
+
       // Soft switch / post-boot startHermes re-emits progress — ignore so the
       // cold-boot CONNECTING overlay stays down. Post-boot errors are gated:
       // only confirmed reauth takes the full-screen recovery surface. Transient
@@ -717,18 +741,35 @@ export function useGatewayBoot({
       // (otherwise a 1–3 min blip bricks reading/drafting behind "couldn't start").
       if ($gatewaySwitching.get() || bootCompleted) {
         if (payload.error && shouldApplyPostBootProgressError(payload.error)) {
-          applyDesktopBootProgress(payload)
+          primaryReauthError = payload.error
+
+          if (bootCompleted) {
+            syncPrimaryReauthError()
+          } else {
+            applyDesktopBootProgress(payload)
+          }
         }
 
         return
       }
 
       applyDesktopBootProgress(payload)
+    }
+
+    let bootSnapshotSuperseded = false
+
+    const offBootProgress = desktop.onBootProgress(payload => {
+      bootSnapshotSuperseded = true
+      onBootProgress(payload)
     })
 
     void desktop
       .getBootProgress()
-      .then(snapshot => applyDesktopBootProgress(snapshot))
+      .then(snapshot => {
+        if (!bootSnapshotSuperseded && !gatewayOpen()) {
+          onBootProgress(snapshot)
+        }
+      })
       .catch(() => undefined)
 
     setDesktopBootStep({
@@ -820,15 +861,20 @@ export function useGatewayBoot({
       }
     })
 
+    const offActiveGatewayReauth = $gateway.listen(syncPrimaryReauthError)
+    const offActiveStateReauth = $gatewayState.listen(syncPrimaryReauthError)
+
     const offState = gateway.onState(st => {
       // Mirror to the composer only while the primary is the active profile —
       // a background secondary reconnect mustn't flip the foreground state.
       reportPrimaryGatewayState(st)
 
       if (st === 'open') {
+        bootSnapshotSuperseded = true
         reconnectAttempt = 0
         reconnectFailingSince = null
         reauthNotified = false
+        primaryReauthError = null
         escalated = false
         livenessProbeFailures = 0
         clearReconnectTimer()
@@ -1224,6 +1270,8 @@ export function useGatewayBoot({
       offConnectionApplied?.()
       offConnectionsChanged?.()
       offGatewayReconnect()
+      offActiveGatewayReauth()
+      offActiveStateReauth()
       offState()
       offEvent()
       offExit()

--- a/apps/desktop/src/app/settings/connections-registry.test.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DesktopConnectionsRegistry } from '@/global'
+import { _resetFleetRosterForTests, refreshFleetRoster } from '@/store/fleet-roster'
 import { $connection } from '@/store/session'
 
 import {
@@ -68,6 +69,21 @@ afterEach(() => {
 })
 
 describe('ConnectionsRegistrySection', () => {
+  it('refreshes a cached roster immediately after a successful connection test', async () => {
+    _resetFleetRosterForTests()
+    const getAgentRoster = vi.fn().mockResolvedValue({ agents: [], sources: [] })
+    Object.assign(window.hermesDesktop!, { getAgentRoster })
+
+    try {
+      await refreshFleetRoster()
+      render(<ConnectionsRegistrySection />)
+      await screen.findByText('Homelab')
+      fireEvent.click(screen.getAllByRole('button', { name: /^test$/i })[0])
+      await waitFor(() => expect(getAgentRoster).toHaveBeenCalledTimes(2))
+    } finally {
+      _resetFleetRosterForTests()
+    }
+  })
   it('distinguishes the current connection from the registry primary', async () => {
     render(<ConnectionsRegistrySection />)
 

--- a/apps/desktop/src/app/settings/connections-registry.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/lib/icons'
 import { coerceRemoteUrlScheme } from '@/lib/remote-url'
 import { $activeConnectionId, setConnectionsRegistry } from '@/store/connections'
+import { refreshFleetRoster } from '@/store/fleet-roster'
 import { notify, notifyError } from '@/store/notifications'
 
 import { EmptyState, ListRow, Pill, SectionHeading, ToggleRow } from './primitives'
@@ -552,6 +553,9 @@ export function ConnectionsRegistrySection() {
 
         if (reachable) {
           notify({ title: conn.label, message: s.testOk })
+          // A successful Test may have warmed a cold OAuth session that the
+          // roster missed; explicit recovery should bypass its cache window.
+          void refreshFleetRoster({ force: true })
         } else {
           notifyError(new Error(result.error || conn.label), s.testFailed)
         }

--- a/apps/desktop/src/store/fleet-roster.test.ts
+++ b/apps/desktop/src/store/fleet-roster.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { DesktopAgentRoster } from '@/global'
+
+import { $fleetRoster, _resetFleetRosterForTests, refreshFleetRoster } from './fleet-roster'
+
+afterEach(() => {
+  _resetFleetRosterForTests()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+const unreachable: DesktopAgentRoster = {
+  agents: [],
+  sources: [{ connectionId: 'lab', label: 'Lab', kind: 'remote', reachable: false, error: 'timed out' }]
+}
+
+const recovered: DesktopAgentRoster = {
+  agents: [{ connectionId: 'lab', connectionLabel: 'Lab', connectionKind: 'remote', profile: 'default', handle: 'default' }],
+  sources: [{ connectionId: 'lab', label: 'Lab', kind: 'remote', reachable: true }]
+}
+
+describe('fleet roster recovery', () => {
+  it('queues one fresh enumeration when recovery overlaps an older request', async () => {
+    let finish!: (roster: DesktopAgentRoster) => void
+    const pending = new Promise<DesktopAgentRoster>(resolve => { finish = resolve })
+    const getAgentRoster = vi.fn().mockReturnValueOnce(pending).mockResolvedValue(recovered)
+    vi.stubGlobal('window', { hermesDesktop: { getAgentRoster } })
+
+    const initial = refreshFleetRoster()
+    const recovery = refreshFleetRoster({ force: true })
+    const repeated = refreshFleetRoster({ force: true })
+    expect(getAgentRoster).toHaveBeenCalledTimes(1)
+    finish(unreachable)
+    await Promise.all([initial, recovery, repeated])
+    expect(getAgentRoster).toHaveBeenCalledTimes(2)
+    expect($fleetRoster.get()).toBe(recovered)
+  })
+  it('keeps on-demand sources cached but lets explicit recovery bypass the cooldown', async () => {
+    vi.useFakeTimers()
+    const onDemand: DesktopAgentRoster = {
+      agents: [],
+      sources: [{ connectionId: 'ssh', label: 'Box', kind: 'ssh', reachable: false, error: 'connect-on-demand' }]
+    }
+    const getAgentRoster = vi.fn().mockResolvedValueOnce(onDemand).mockResolvedValue(recovered)
+    vi.stubGlobal('window', { hermesDesktop: { getAgentRoster } })
+
+    await refreshFleetRoster()
+    await vi.advanceTimersByTimeAsync(5_000)
+    await refreshFleetRoster()
+    expect(getAgentRoster).toHaveBeenCalledTimes(1)
+
+    await refreshFleetRoster({ force: true })
+    expect(getAgentRoster).toHaveBeenCalledTimes(2)
+    expect($fleetRoster.get()).toBe(recovered)
+  })
+
+  it('retries incomplete rosters before the normal stale window without a focus-event hot loop', async () => {
+    vi.useFakeTimers()
+    const getAgentRoster = vi.fn().mockResolvedValueOnce(unreachable).mockResolvedValue(recovered)
+    vi.stubGlobal('window', { hermesDesktop: { getAgentRoster } })
+
+    await refreshFleetRoster()
+    await refreshFleetRoster()
+    expect(getAgentRoster).toHaveBeenCalledTimes(1)
+    expect($fleetRoster.get()).toBe(unreachable)
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    await Promise.all([refreshFleetRoster(), refreshFleetRoster()])
+    expect(getAgentRoster).toHaveBeenCalledTimes(2)
+    expect($fleetRoster.get()).toBe(recovered)
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    await refreshFleetRoster()
+    expect(getAgentRoster).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/store/fleet-roster.ts
+++ b/apps/desktop/src/store/fleet-roster.ts
@@ -11,9 +11,12 @@ import type { DesktopAgentRoster } from '@/global'
 export const $fleetRoster = atom<DesktopAgentRoster | null>(null)
 
 const FLEET_ROSTER_STALE_MS = 60_000
+// Focus/mount may retry a partial result sooner, but never on every event.
+const FLEET_ROSTER_RETRY_MS = 5_000
 
 let fetchedAt = 0
 let inflight: null | Promise<void> = null
+let forcedRefresh: null | Promise<void> = null
 
 export async function refreshFleetRoster(options: { force?: boolean } = {}): Promise<void> {
   const bridge = window.hermesDesktop?.getAgentRoster
@@ -22,11 +25,25 @@ export async function refreshFleetRoster(options: { force?: boolean } = {}): Pro
     return
   }
 
-  if (!options.force && $fleetRoster.get() && Date.now() - fetchedAt < FLEET_ROSTER_STALE_MS) {
+  const current = $fleetRoster.get()
+  const incomplete = current?.sources.some(source => !source.reachable && source.error !== 'connect-on-demand')
+  const staleMs = incomplete ? FLEET_ROSTER_RETRY_MS : FLEET_ROSTER_STALE_MS
+
+  if (!options.force && current && Date.now() - fetchedAt < staleMs) {
     return
   }
 
   if (inflight) {
+    if (options.force) {
+      forcedRefresh ??= inflight.then(() => {
+        forcedRefresh = null
+
+        return refreshFleetRoster({ force: true })
+      })
+
+      return forcedRefresh
+    }
+
     return inflight
   }
 
@@ -52,4 +69,5 @@ export function _resetFleetRosterForTests(): void {
   $fleetRoster.set(null)
   fetchedAt = 0
   inflight = null
+  forcedRefresh = null
 }


### PR DESCRIPTION
## What does this PR do?

Keeps Desktop recoverable when a remote gateway restarts or rejects its saved session. Consolidates the remaining startup, response-stream, foreground-isolation, and roster-recovery fixes from the linked PRs.

## Related issues and credit

Closes https://github.com/NousResearch/hermes-agent/issues/72530.
Closes https://github.com/NousResearch/hermes-agent/issues/101339.

Supersedes:
- https://github.com/NousResearch/hermes-agent/pull/107375 — @xxxigm: unsigned-auth recovery diagnosis and latch requirements.
- https://github.com/NousResearch/hermes-agent/pull/106206 — @ctaylor86: foreground-scoped primary recovery and behavioral tests.
- https://github.com/NousResearch/hermes-agent/pull/101547 — @FalconOrtiz: mint-first OAuth and roster recovery.
- https://github.com/NousResearch/hermes-agent/pull/72128 — @ugoenyioha: response-error and recovery investigation.
- https://github.com/NousResearch/hermes-agent/pull/99135 — @Bartok9: extracted OAuth response handling and behavioral coverage.

All contributors are credited in commit trailers. The larger route-identity architecture issue https://github.com/NousResearch/hermes-agent/issues/90149 remains open and is not claimed fixed.

## Type of change

- [x] Bug fix

## Changes made

- Use the WebSocket-ticket mint as the authoritative OAuth check instead of rejecting on a cookie preflight. Preserve pre-mint native-session history for error copy and retain structured 401/403 versus transport/Cloud-down classification.
- Handle Electron response-stream errors, including truncated bodies, without uncaught exceptions. Reuse `httpStatusError` and prevent repeated response settlement.
- Keep post-boot primary authentication recovery off a healthy secondary. Ignore startup snapshots superseded by newer progress or a successful connection.
- Give OAuth roster dials a bounded longer deadline. Retry incomplete caches sooner without a focus-event hot loop; a successful connection Test queues a fresh enumeration even when another is still pending.

Current main already latches failures before awaiting teardown, checks attempt ownership before latching, uses connection-aware primary/pooled probes, scopes recovery logout to the failed gateway, and clears the latch on confirmed login. Those fixes are retained. This does not carry the unsafe pre-ownership latch reorder, message matching without a demonstrated production boundary, source-regex tests, or stale transport changes from the older PRs.

## Verification

- Built the renderer and bundled Electron main/preload from this worktree.
- Real Electron/IPC/renderer E2E: both 401 and 403 cases pass. A loopback gateway first truncates a response, then rejects auth; the actual Gateway settings URL input stays usable during 20 concurrent connection calls. Embedded login establishes a fixture HttpOnly cookie and a subsequent connection returns a fresh remote descriptor.
- Post-rebase targeted backend/renderer run: 300 tests across 13 files passed, including forced-refresh overlap and stale-snapshot regressions. The foreground bug failed on main before the fix; the overlap and snapshot review findings were separately reproduced red then fixed.
- All three Desktop TypeScript projects pass. Changed production files pass ESLint; `git diff --check` passes.
- Full Electron suite: 2168 passed, 6 skipped, 2 failed. Failures are the POSIX launcher status and installer-wrapper PID recognition tests in unchanged `managed-ssh-update.test.ts` and `remote-lifecycle.test.ts`; both also fail in an isolated rerun. No unrelated SSH code or tests were changed.

The E2E gateway is an explicit loopback fixture, not the reporter's NAS or a hosted OAuth service. No real credentials or installed user state were used. Native Windows/Linux, packaged installers, the full renderer suite, and Python tests were not run.

## Checklist

- [x] Read contribution guidance and checked sibling PRs/current main.
- [x] Topical commits with contributor credit.
- [x] Added behavioral regression coverage and exercised the Electron boundary on macOS.
- [x] No new dependencies, config keys, model tools, or visual redesign.
- [x] Reported CI checks pass; no unresolved review threads.
