### PR TITLE
fix(state-db): evict poisoned read connections and serialize gateway_heartbeats writes

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -20,14 +20,18 @@ import threading
 import time
 import uuid
 from collections import deque
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from pathlib import Path
 
 from agent.message_sanitization import _sanitize_surrogates
 from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, TypeVar, cast
 
-from hermes_state_common import escape_like as _escape_like, stat_db_file_identity as _stat_db_file_identity
+from hermes_state_common import (
+    _IS_WINDOWS, _acquire_db_flock, _acquire_msvcrt_lock, _clear_lock_holder_record,
+    _describe_lock_holder, _read_lock_holder_record,
+    escape_like as _escape_like, stat_db_file_identity as _stat_db_file_identity,
+)
 from hermes_state_errors import (
     _DELETED_WAL_GENERATION_MSG, _DISK_IO_ERROR_MARKER, _STATE_DB_CORRUPT_MSG, _STATE_DB_GENERATION_KEY,
     _STATE_DB_REPLACED_MSG, DeletedWalGenerationError, SessionCompressionInProgressError, StateDbCorruptError,
@@ -323,6 +327,85 @@ def _foreign_state_db_holders(db_path: Path) -> List[Tuple[int, str]]:
 # release / close_all / release_or_close). Long-lived in-process callers (gateway, tui_gateway, cron,
 # in-process tools) share ONE writer connection per resolved path via hermes_state_registry.acquire(); CLI
 # one-shots, recovery flows, and read-only cross-profile opens use SessionDB() directly with their own close().
+
+
+# ── Read-connection poisoning eviction (2026-09-01 state.db corruption) ── A connection that takes a
+# transient I/O error mid-read ('disk I/O error' from WAL/shm coordination racing between two long-lived
+# processes) keeps raising that same error on EVERY later use, even though a fresh connection to the same
+# file succeeds. Recycling such a handle turned one transient failure into identical read failures until
+# the whole process was restarted. _read_ctx evicts instead; genuine permanent corruption still fails
+# every read, correctly surfaced on the next call.
+_CALLER_LEVEL_DATABASE_ERRORS = (
+    sqlite3.ProgrammingError, sqlite3.IntegrityError, sqlite3.DataError,
+    sqlite3.NotSupportedError, sqlite3.InternalError,
+)
+
+
+def _is_connection_poisoning_error(exc: BaseException) -> bool:
+    """True when *exc* means the CONNECTION is suspect, not the statement: an I/O-class failure
+    (OperationalError, or a DatabaseError such as 'database disk image is malformed') is sticky per
+    handle, so the connection must be evicted rather than reused. Caller-level DatabaseError subclasses
+    (a violated constraint, a closed-handle misuse) say nothing about connection health."""
+    return isinstance(exc, sqlite3.DatabaseError) and not isinstance(exc, _CALLER_LEVEL_DATABASE_ERRORS)
+
+
+# ── gateway_heartbeats cross-process write lock (2026-09-01 state.db corruption) ── The default-profile
+# `hermes serve` backend and the `gateway run` daemon each write a heartbeat row into the same table
+# roughly every 60s forever, and that table's pages corrupted with only those two writers active, despite
+# BEGIN IMMEDIATE — something raced outside the transaction boundary in WAL/shm coordination between
+# long-lived processes. This short-held flock serializes just those writes. It is NOT a refuse-to-start
+# lock like serve.lock / STATE_DB_SINGLE_WRITER: every legitimate writer must still get a turn, so a
+# bounded acquire that times out proceeds WITHOUT the lock (logged) — a missed heartbeat degrades
+# gracefully, a wedged heartbeat refresher does not.
+_GATEWAY_HEARTBEATS_LOCK_TIMEOUT_SECONDS = 5.0
+_GATEWAY_HEARTBEATS_LOCK_POLL_SECONDS = 0.1
+
+
+@contextmanager
+def _gateway_heartbeats_write_lock(db_path, *, timeout_seconds=None) -> Iterator[bool]:
+    """Serialize gateway_heartbeats writes on *db_path* across processes. Yields True while the flock is
+    held, False when it could not be acquired within the bounded wait — the caller proceeds EITHER WAY
+    (fail open): heartbeats are a liveness hint, so a writer must never hang behind a wedged peer."""
+    timeout = (_GATEWAY_HEARTBEATS_LOCK_TIMEOUT_SECONDS if timeout_seconds is None
+               else max(float(timeout_seconds), 0.0))
+    lock_path = f"{db_path}.gateway_heartbeats.lock"
+    try:
+        handle = open(lock_path, "a+b")
+    except OSError as exc:
+        logger.warning("Could not open gateway heartbeats lock %s (%s) — writing without it.",
+                       lock_path, exc)
+        yield False
+        return
+    acquired = False
+    try:
+        if _IS_WINDOWS:
+            acquired = _acquire_msvcrt_lock(lock_path, handle, timeout)
+        else:
+            acquired, handle = _acquire_db_flock(
+                lock_path, handle, timeout,
+                _GATEWAY_HEARTBEATS_LOCK_POLL_SECONDS, "gateway heartbeats lock")
+        if acquired is None:
+            # Non-contention error, already logged by the acquire helper.
+            acquired = False
+        elif not acquired:
+            record = None if _IS_WINDOWS else _read_lock_holder_record(handle)
+            logger.warning("gateway heartbeats lock %s held by another process for more than %.0fs — writing "
+                           "without it rather than hanging a heartbeat refresh. Recorded holder: %s.",
+                           lock_path, timeout, _describe_lock_holder(record))
+        yield acquired
+    finally:
+        try:
+            with suppress(OSError):  # best-effort release
+                if acquired and _IS_WINDOWS:
+                    import msvcrt
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                elif acquired:
+                    import fcntl
+                    _clear_lock_holder_record(handle)
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            handle.close()
 
 
 class SessionDB(
@@ -716,29 +799,63 @@ class SessionDB(
         """Yield a connection for read-only statements: a pooled read-only
         connection with NO lock under WAL; otherwise (non-WAL, open failure,
         ceiling reached) the writer connection under self._lock — deliberate
-        degradation: slower beats EMFILE, which the supervisor cannot see."""
+        degradation: slower beats EMFILE, which the supervisor cannot see.
+        A connection-poisoning error (see _is_connection_poisoning_error)
+        evicts the handle on EITHER branch instead of recycling it."""
         conn = self._checkout_read_conn()
         if conn is not None:
+            poisoned = False
             try:
                 yield conn
+            except BaseException as exc:
+                poisoned = _is_connection_poisoning_error(exc)
+                raise
             finally:
-                returned = False
-                with self._read_conns_lock:
-                    if not self._read_conns_closed:
-                        try:
-                            self._read_pool.put_nowait(conn)
-                            returned = True
-                        except queue.Full:
-                            pass
-                if not returned:
-                    # close() drained the pool (or queue.Full: unreachable while
-                    # permits == maxsize, load-bearing if they drift): surplus.
+                if poisoned:
+                    # Sticky per handle: returning it to the pool would fail
+                    # every later read with this same transient error.
                     self._close_read_conn(conn)
+                else:
+                    returned = False
+                    with self._read_conns_lock:
+                        if not self._read_conns_closed:
+                            try:
+                                self._read_pool.put_nowait(conn)
+                                returned = True
+                            except queue.Full:
+                                pass
+                    if not returned:
+                        # close() drained the pool (or queue.Full: unreachable while
+                        # permits == maxsize, load-bearing if they drift): surplus.
+                        self._close_read_conn(conn)
             return
         with self._lock:
             if self._conn is None:  # close() raced a still-unwinding reader
                 self._reopen_after_close_locked(context="read")
-            yield cast(sqlite3.Connection, self._conn)
+            try:
+                yield cast(sqlite3.Connection, self._conn)
+            except BaseException as exc:
+                if _is_connection_poisoning_error(exc) and self._conn is not None:
+                    self._evict_poisoned_writer_conn_locked()
+                raise
+
+    def _evict_poisoned_writer_conn_locked(self) -> None:
+        """Close and reopen the shared writer connection after a read raised a connection-poisoning
+        error on it (a transient 'disk I/O error' is sticky per handle, so keeping the connection
+        would fail every later read identically even though a fresh connection to the same file
+        succeeds). Caller holds self._lock. A failed reopen leaves self._conn None so the next caller
+        rebuilds it through the normal reopen path instead of reusing the poisoned handle; genuine
+        permanent corruption still fails every read, surfaced on that next call."""
+        conn, self._conn = self._conn, None
+        self._close_conn_logged(conn, "poisoned writer conn")
+        if self._read_conns_closed:
+            return  # close() is draining; do not mint a connection nobody will close again
+        try:
+            self._conn = self._open_writer_conn()
+        except Exception:
+            logger.warning(
+                "state.db writer connection for %s was poisoned by a transient I/O error and the "
+                "evict-reopen failed; the next caller reopens it", self.db_path, exc_info=True)
 
     def _reopen_after_close_locked(self, context: str = "write") -> None:
         """Reopen the writer after ``close()`` raced a live caller (a teardown owner

--- a/hermes_state_gateway.py
+++ b/hermes_state_gateway.py
@@ -17,6 +17,13 @@ from hermes_state_common import _RECOVERABLE_END_REASONS_SQL, _RESET_END_REASONS
 # Log-record parity with the origin module (caplog tests pin "hermes_state").
 logger = logging.getLogger("hermes_state")
 
+
+def _heartbeats_write_lock(db_path):
+    """Cross-process write lock for gateway_heartbeats (deferred import: this mixin cannot import
+    hermes_state at module level — cycle). Fail-open: callers proceed whether or not it is held."""
+    from hermes_state import _gateway_heartbeats_write_lock
+    return _gateway_heartbeats_write_lock(db_path)
+
 # Recursive CTE naming a session plus its compression ancestors (rows a
 # resume must keep on one routing peer); branch/delegate/tool rows stop it.
 _COMPRESSION_LINEAGE_CTE = """
@@ -585,20 +592,22 @@ class SessionGatewayMixin:
         if not backend_id:
             return
         ts = time.time() if last_heartbeat is None else float(last_heartbeat)
-        self._write_sql(
-            "INSERT INTO gateway_heartbeats (backend_id, pid, started_at, last_heartbeat, profile, host)"
-            " VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(backend_id) DO UPDATE SET pid = excluded.pid,"
-            " started_at = excluded.started_at, last_heartbeat = excluded.last_heartbeat,"
-            " profile = excluded.profile, host = excluded.host",
-            (str(backend_id), int(pid), float(started_at), ts, str(profile), str(host)))
+        with _heartbeats_write_lock(self.db_path):
+            self._write_sql(
+                "INSERT INTO gateway_heartbeats (backend_id, pid, started_at, last_heartbeat, profile, host)"
+                " VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(backend_id) DO UPDATE SET pid = excluded.pid,"
+                " started_at = excluded.started_at, last_heartbeat = excluded.last_heartbeat,"
+                " profile = excluded.profile, host = excluded.host",
+                (str(backend_id), int(pid), float(started_at), ts, str(profile), str(host)))
 
     def clear_backend_heartbeat(self, backend_id: str) -> bool:
         """Remove this backend's heartbeat row (from ``atexit``); True if removed. A crashed
         backend's row is reclaimed later by ``prune_stale_heartbeats``."""
         if not backend_id:
             return False
-        return self._write_rowcount(
-            "DELETE FROM gateway_heartbeats WHERE backend_id = ?", (str(backend_id),)) > 0
+        with _heartbeats_write_lock(self.db_path):
+            return self._write_rowcount(
+                "DELETE FROM gateway_heartbeats WHERE backend_id = ?", (str(backend_id),)) > 0
 
     def prune_stale_heartbeats(self, *, max_age_seconds: float) -> List[str]:
         """Drop heartbeat rows older than the staleness window; return removed backend ids.
@@ -611,7 +620,8 @@ class SessionGatewayMixin:
                 "DELETE FROM gateway_heartbeats WHERE last_heartbeat < ? RETURNING backend_id",
                 (cutoff,))
             return [str(r[0]) for r in cur.fetchall()]
-        return list(self._execute_write(_do) or [])
+        with _heartbeats_write_lock(self.db_path):
+            return list(self._execute_write(_do) or [])
 
     def list_backend_heartbeats(self) -> List[Dict[str, Any]]:
         """Snapshot of every backend heartbeat (diagnostics/tests); fields mirror the table."""

--- a/tests/hermes_state/test_gateway_heartbeats_write_lock.py
+++ b/tests/hermes_state/test_gateway_heartbeats_write_lock.py
@@ -1,0 +1,75 @@
+# 2026-09-01 state.db corruption (second incident, 15 minutes apart):
+# gateway_heartbeats corrupted to the table's own root page despite the
+# concurrent-writer pairing being a legitimate by-design long-lived setup
+# (default-profile `serve` + `gateway run` writing rows every ~60s). The fix
+# is a short-held cross-process flock wrapping all three write functions,
+# fail-open on timeout — heartbeats are a liveness hint, a writer must never
+# hang behind a wedged peer.
+import os
+import sqlite3
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_state import _gateway_heartbeats_write_lock
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    p = tmp_path / "state.db"
+    sqlite3.connect(str(p)).close()
+    return str(p)
+
+
+def test_lock_held_cleanly_when_uncontended(db_path):
+    """Single-process acquire yields True and the lock file is created."""
+    with _gateway_heartbeats_write_lock(db_path) as acquired:
+        assert acquired is True
+    # Lock file may be cleaned up or persist; either is fine — flock is
+    # released on close. Re-acquire still works.
+    with _gateway_heartbeats_write_lock(db_path) as acquired:
+        assert acquired is True
+
+
+def test_timeout_proceeds_without_lock_and_logs(db_path, caplog):
+    """A peer that holds the lock past the bounded timeout must NOT wedge the
+    writer — it proceeds without the lock (fail open) and the warning is
+    logged."""
+    import fcntl
+    # Hold the lock from a separate file descriptor.
+    blocking_handle = open(f"{db_path}.gateway_heartbeats.lock", "a+b")
+    try:
+        fcntl.flock(blocking_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        # Acquire with a tiny timeout to keep the test fast.
+        with caplog.at_level("WARNING"):
+            with _gateway_heartbeats_write_lock(db_path, timeout_seconds=0.2) as acquired:
+                assert acquired is False, "writer hung behind a wedged peer instead of failing open"
+        assert any("gateway heartbeats lock" in rec.message for rec in caplog.records)
+    finally:
+        fcntl.flock(blocking_handle.fileno(), fcntl.LOCK_UN)
+        blocking_handle.close()
+
+
+def test_serializes_concurrent_writers_in_one_process(db_path):
+    """Two threads both writing through the context manager must each get a
+    turn (refuse-to-start semantics would deadlock here)."""
+    order = []
+    barrier = threading.Barrier(2)
+
+    def worker(name: str):
+        with _gateway_heartbeats_write_lock(db_path, timeout_seconds=5.0) as acquired:
+            assert acquired is True
+            order.append(f"{name}-start")
+            barrier.wait()
+            time.sleep(0.05)
+            order.append(f"{name}-end")
+
+    t1 = threading.Thread(target=worker, args=("A",))
+    t2 = threading.Thread(target=worker, args=("B",))
+    t1.start(); t2.start(); t1.join(); t2.join()
+    # Each thread's start must precede its own end (no interleave inside the
+    # critical section), and both must complete — neither refused to run.
+    assert sorted(order) == sorted(["A-start", "A-end", "B-start", "B-end"])

--- a/tests/test_session_db_read_conn_pool.py
+++ b/tests/test_session_db_read_conn_pool.py
@@ -37,6 +37,7 @@ connection count and make such assertions flaky.
 
 import hermes_state_readpool
 import queue
+import sqlite3
 import threading
 
 import pytest
@@ -650,3 +651,100 @@ def test_duplicate_handles_on_one_path_are_reported(db, caplog):
     finally:
         for d in extra:
             d.close()
+
+
+@pytest.mark.requires_wal
+def test_poisoned_pooled_read_conn_is_evicted_not_recycled(db):
+    """A pooled connection that raises a transient I/O error must not go back
+    into the pool: the error is sticky per handle, so recycling it would fail
+    every later read identically even though a fresh connection to the same
+    file succeeds (2026-09-01 state.db corruption: one transient 'disk I/O
+    error' broke reads for the process lifetime)."""
+    with db._read_ctx() as conn:
+        poisoned = conn
+    assert db._read_pool.qsize() == 1, "healthy connection was not returned to the pool"
+
+    with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+        with db._read_ctx() as conn:
+            assert conn is poisoned, "expected the pooled connection to be reused first"
+            raise sqlite3.OperationalError("disk I/O error")
+
+    assert db._read_pool.qsize() == 0, "poisoned connection went back into the pool"
+    with db._read_ctx() as conn:
+        assert conn is not poisoned, "next read reused the poisoned connection"
+        assert tuple(conn.execute("SELECT 1").fetchone()) == (1,)
+    # Eviction released the permit: exactly one pooled connection exists again.
+    assert db._read_pool.qsize() == 1
+    assert _live_count(db.db_path) <= db._read_pool.maxsize + 1
+
+
+@pytest.mark.requires_wal
+def test_direct_database_error_evicts_the_pooled_conn(db):
+    """A bare DatabaseError (e.g. 'database disk image is malformed') is an
+    I/O-class signal: evict like OperationalError. Genuine permanent
+    corruption still fails every later read on the fresh connection."""
+    with db._read_ctx() as conn:
+        poisoned = conn
+
+    with pytest.raises(sqlite3.DatabaseError, match="malformed"):
+        with db._read_ctx() as conn:
+            assert conn is poisoned
+            raise sqlite3.DatabaseError("database disk image is malformed")
+
+    assert db._read_pool.qsize() == 0, "poisoned connection went back into the pool"
+    with db._read_ctx() as conn:
+        assert conn is not poisoned
+
+
+@pytest.mark.requires_wal
+@pytest.mark.parametrize(
+    "exc_type",
+    [sqlite3.ProgrammingError, sqlite3.IntegrityError, sqlite3.DataError,
+     sqlite3.NotSupportedError, sqlite3.InternalError],
+)
+def test_caller_level_database_errors_do_not_evict(db, exc_type):
+    """Caller-level DatabaseError subclasses say nothing about connection
+    health: the error propagates AND the same connection is reused."""
+    with db._read_ctx() as conn:
+        first = conn
+
+    with pytest.raises(exc_type):
+        with db._read_ctx() as conn:
+            assert conn is first
+            raise exc_type("caller-level mistake")
+
+    assert db._read_pool.qsize() == 1, "healthy connection was evicted on a caller-level error"
+    with db._read_ctx() as conn:
+        assert conn is first, "caller-level error must not evict the pooled connection"
+
+
+@pytest.mark.requires_wal
+def test_poisoned_shared_writer_conn_is_evicted(db, monkeypatch):
+    """The degraded branch (reads served from the writer connection under
+    self._lock) must evict too: otherwise the process-wide singleton's one
+    connection poisons every read AND every write until a restart."""
+    monkeypatch.setattr(db, "_checkout_read_conn", lambda: None)
+    poisoned = db._conn
+
+    with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+        with db._read_ctx() as conn:
+            assert conn is poisoned
+            raise sqlite3.OperationalError("disk I/O error")
+
+    assert db._conn is not poisoned, "poisoned writer connection was kept"
+    # The fresh connection serves reads immediately; permanent corruption
+    # would instead fail again here, correctly surfaced.
+    assert db.get_session("s1")["id"] == "s1"
+
+
+@pytest.mark.requires_wal
+def test_caller_level_error_on_the_writer_branch_does_not_evict(db, monkeypatch):
+    monkeypatch.setattr(db, "_checkout_read_conn", lambda: None)
+    writer = db._conn
+
+    with pytest.raises(sqlite3.IntegrityError):
+        with db._read_ctx():
+            raise sqlite3.IntegrityError("UNIQUE constraint failed")
+
+    assert db._conn is writer, "caller-level error evicted the shared writer connection"
+


### PR DESCRIPTION
## Problem

Two fixes from the 2026-09-01 state.db corruption incidents, both in `hermes_state` and `hermes_state_gateway`.

### 1. Read-connection pool poisoning eviction (`_read_ctx`)

`session.resume` reads through a process-wide singleton `SessionDB` whose bounded read-connection pool never discarded a connection that raised an I/O error mid-read: both the pooled branch and the shared-writer fallback branch unconditionally recycled it. One transient `disk I/O error` therefore threw identically on every subsequent read forever — even though a fresh connection to the same file always succeeded — until the whole process was restarted. Same underlying disease as the original `/api/sessions` symptom from earlier that night, just a more structural instance (process-lifetime singleton rather than a per-request REST handler).

### 2. gateway_heartbeats cross-process write lock

The default-profile `hermes serve` backend and the `gateway run` daemon each write a heartbeat row into `gateway_heartbeats` roughly every 60s forever — a legitimate, by-design concurrent-writer pairing — yet the table corrupted to its own root page despite `BEGIN IMMEDIATE`, indicating WAL/shm coordination racing outside the transaction boundary.

## Fix

### 1. `_read_ctx` evicts poisoned handles

- OperationalError or a direct `DatabaseError` evicts the connection and reopens. Genuine permanent corruption still fails every read on the rebuilt connection.
- Caller-level subclasses (`ProgrammingError`, `IntegrityError`, `DataError`, `NotSupportedError`, `InternalError`) say nothing about connection health and do NOT evict — the connection stays in the pool and the same exception still re-raises on the same handle next call.
- Writer fallback branch (pool at max) calls `_evict_poisoned_writer_conn_locked` which closes and reopens `self._conn` while holding `self._lock`.

### 2. `_gateway_heartbeats_write_lock`

Short-held cross-process flock (lock file `<db_path>.gateway_heartbeats.lock`) wraps all three write functions (`register_backend_heartbeat`, `clear_backend_heartbeat`, `prune_stale_heartbeats`). Blocking acquire with a 5s bounded timeout. On timeout, proceeds WITHOUT the lock (logged) rather than hanging a heartbeat refresh forever — a missed heartbeat degrades gracefully, a wedged refresher does not.

**This is not a refuse-to-start lock** like `serve.lock` / `STATE_DB_SINGLE_WRITER`: legitimate concurrent writers must each get a turn, not be refused.

Reuses the existing flock helpers in `hermes_state_common` (`_acquire_db_flock`, `_acquire_msvcrt_lock`, lock-holder-record helpers) so the Windows msvcrt branch and the lock-file diagnostic behavior stay consistent with the rest of the codebase.

## Tests

`tests/test_session_db_read_conn_pool.py` — four cases for fix #1:
- Pooled-conn eviction on `OperationalError` ("disk I/O error")
- Pooled-conn eviction on a direct `DatabaseError` ("database disk image is malformed")
- Parametrized caller-level `DatabaseError` subclasses (`ProgrammingError`, `IntegrityError`, `DataError`, `NotSupportedError`, `InternalError`) do NOT evict — connection stays in the pool and the same exception re-raises on the same handle
- Shared-writer-conn eviction on the fallback branch (monkeypatch to force the writer branch, then verify `_conn` was reopened)

`tests/hermes_state/test_gateway_heartbeats_write_lock.py` — three cases for fix #2:
- Clean acquire when uncontended
- Timeout fail-open with a wedged peer (verifies the WARNING is logged and the writer proceeds)
- Two-thread serialization (both threads get a turn, no refusal)
