### PR TITLE
fix(desktop): quit once and drain owned backend work

### DIFF
--- a/apps/desktop/electron/backend-child.ts
+++ b/apps/desktop/electron/backend-child.ts
@@ -46,7 +46,70 @@ export interface BackendProcessRoot {
 
 export interface KillableChild extends BackendProcessRoot {
   killed?: boolean
-  kill: (signal: string) => void
+  kill: (signal: NodeJS.Signals) => void
+}
+
+export interface WaitableChild extends KillableChild {
+  exitCode: number | null
+  signalCode: string | null
+  once: (event: 'exit', listener: () => void) => unknown
+  removeListener: (event: 'exit', listener: () => void) => unknown
+}
+
+/** Graceful exit, SIGKILL escalation, then a bounded wait for the escalation. */
+export async function waitForBackendExit(
+  child: WaitableChild | null | undefined,
+  deps: StopBackendChildDeps,
+  timeoutMs = 5000
+): Promise<void> {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return
+  }
+
+  const exited = () => child.exitCode !== null || child.signalCode !== null
+
+  const wait = (delay: number) =>
+    new Promise<void>(resolve => {
+      if (exited()) {
+        resolve()
+
+        return
+      }
+
+      const finish = () => {
+        clearTimeout(timer)
+        child.removeListener('exit', finish)
+        resolve()
+      }
+
+      const timer = setTimeout(finish, delay)
+      child.once('exit', finish)
+    })
+
+  await wait(timeoutMs)
+
+  if (exited()) {
+    return
+  }
+
+  try {
+    if ((deps.isWindows ?? process.platform === 'win32') && Number.isInteger(child.pid)) {
+      deps.forceKillProcessTree(child.pid as number)
+    } else if (Number.isInteger(child.pid)) {
+      try {
+        const killGroup = deps.killGroup ?? ((pid, signal) => process.kill(pid, signal))
+        killGroup(-(child.pid as number), 'SIGKILL')
+      } catch {
+        child.kill('SIGKILL')
+      }
+    } else {
+      child.kill('SIGKILL')
+    }
+  } catch {
+    return
+  }
+
+  await wait(1000)
 }
 
 /**

--- a/apps/desktop/electron/backend-connection-state.test.ts
+++ b/apps/desktop/electron/backend-connection-state.test.ts
@@ -105,3 +105,19 @@ test('an invalidated attempt cannot attach a late-spawned process', () => {
   assert.equal(state.attachProcess(staleAttempt, { id: 'late' }), null)
   assert.equal(state.getProcess(), null)
 })
+
+test('distinguishes a pending connection attempt from a cached settled descriptor', async () => {
+  const state = createBackendConnectionState<FakeProcess, string>()
+  const connection = deferred<string>()
+  const attempt = state.startAttempt()
+
+  state.setPromise(attempt, connection.promise)
+  assert.equal(state.getPendingPromise(), connection.promise)
+
+  connection.resolve('https://remote.example')
+  await connection.promise
+  await Promise.resolve()
+
+  assert.equal(state.getPromise(), connection.promise)
+  assert.equal(state.getPendingPromise(), null)
+})

--- a/apps/desktop/electron/backend-connection-state.ts
+++ b/apps/desktop/electron/backend-connection-state.ts
@@ -12,6 +12,7 @@ export function createBackendConnectionState<TProcess, TConnection>() {
   let generation = 0
   let process: TProcess | null = null
   let promise: Promise<TConnection> | null = null
+  let pendingPromise: Promise<TConnection> | null = null
 
   return {
     startAttempt(): BackendConnectionAttempt<TConnection> {
@@ -25,6 +26,20 @@ export function createBackendConnectionState<TProcess, TConnection>() {
 
       attempt.promise = nextPromise
       promise = nextPromise
+      pendingPromise = nextPromise
+
+      void nextPromise.then(
+        () => {
+          if (attempt.generation === generation && promise === nextPromise) {
+            pendingPromise = null
+          }
+        },
+        () => {
+          if (attempt.generation === generation && promise === nextPromise) {
+            pendingPromise = null
+          }
+        }
+      )
 
       return true
     },
@@ -53,6 +68,7 @@ export function createBackendConnectionState<TProcess, TConnection>() {
 
       process = null
       promise = null
+      pendingPromise = null
 
       return true
     },
@@ -63,6 +79,7 @@ export function createBackendConnectionState<TProcess, TConnection>() {
       }
 
       promise = null
+      pendingPromise = null
 
       return true
     },
@@ -75,12 +92,17 @@ export function createBackendConnectionState<TProcess, TConnection>() {
       return promise
     },
 
+    getPendingPromise(): Promise<TConnection> | null {
+      return pendingPromise
+    },
+
     invalidate(): TProcess | null {
       const currentProcess = process
 
       generation += 1
       process = null
       promise = null
+      pendingPromise = null
 
       return currentProcess
     }

--- a/apps/desktop/electron/backend-exit.test.ts
+++ b/apps/desktop/electron/backend-exit.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import { test, vi } from 'vitest'
+
+import { waitForBackendExit } from './backend-child'
+
+test('backend exit escalation remains bounded when no exit or close arrives', async () => {
+  vi.useFakeTimers()
+
+  try {
+    const child = Object.assign(new EventEmitter(), { exitCode: null, signalCode: null, kill: vi.fn() })
+    const waiting = waitForBackendExit(child, { forceKillProcessTree: () => {} }, 20)
+    await vi.advanceTimersByTimeAsync(1020)
+    await waiting
+    assert.equal(child.kill.mock.calls.length, 1)
+    assert.equal(child.kill.mock.calls[0][0], 'SIGKILL')
+    assert.equal(child.listenerCount('exit'), 0)
+    assert.equal(vi.getTimerCount(), 0)
+  } finally {
+    vi.useRealTimers()
+  }
+})

--- a/apps/desktop/electron/backend-ownership.test.ts
+++ b/apps/desktop/electron/backend-ownership.test.ts
@@ -319,8 +319,8 @@ test('shutdown coordinator returns one promise and awaits teardown exactly once'
 
   assert.equal(first, second)
   assert.equal(coordinator.hasStarted(), true)
-  await Promise.resolve()
   assert.equal(teardown.mock.calls.length, 1)
+  assert.equal(coordinator.isPending(), true)
 
   let finished = false
   first.then(() => {
@@ -332,6 +332,7 @@ test('shutdown coordinator returns one promise and awaits teardown exactly once'
   completion.resolve()
   await second
   assert.equal(finished, true)
+  assert.equal(coordinator.isPending(), false)
   assert.equal(coordinator.run(), first)
 })
 

--- a/apps/desktop/electron/backend-ownership.ts
+++ b/apps/desktop/electron/backend-ownership.ts
@@ -320,17 +320,36 @@ export function backendCommandMatches(command: unknown): boolean {
 /** Coordinates all quit paths so asynchronous backend teardown runs once. */
 export function createBackendShutdownCoordinator(teardown: () => Promise<void> | void) {
   let completion: Promise<void> | undefined
+  let settled = false
 
   return {
     run(): Promise<void> {
       if (!completion) {
-        completion = Promise.resolve().then(teardown)
+        try {
+          // Invoke synchronously so no-wait quit paths still invalidate cached
+          // connection state and stop timers before Electron exits.
+          completion = Promise.resolve(teardown())
+        } catch (error) {
+          completion = Promise.reject(error)
+        }
+
+        void completion.then(
+          () => {
+            settled = true
+          },
+          () => {
+            settled = true
+          }
+        )
       }
 
       return completion
     },
     hasStarted(): boolean {
       return completion !== undefined
+    },
+    isPending(): boolean {
+      return completion !== undefined && !settled
     }
   }
 }

--- a/apps/desktop/electron/backend-start-cancellation.ts
+++ b/apps/desktop/electron/backend-start-cancellation.ts
@@ -1,0 +1,24 @@
+/** Cancel a startup wait, and check ownership before invoking its continuation. */
+export async function runBackendStartStep<T>(signal: AbortSignal | undefined, run: () => T | Promise<T>): Promise<T> {
+  signal?.throwIfAborted()
+
+  if (!signal) {
+    return run()
+  }
+
+  let onAbort: () => void = () => {}
+
+  const cancelled = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(signal.reason)
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+
+  try {
+    const result = await Promise.race([run(), cancelled])
+    signal.throwIfAborted()
+
+    return result
+  } finally {
+    signal.removeEventListener('abort', onAbort)
+  }
+}

--- a/apps/desktop/electron/bootstrap-quit.test.ts
+++ b/apps/desktop/electron/bootstrap-quit.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { runBootstrap } from './bootstrap-runner'
+
+for (const boundary of ['resolution', 'manifest'] as const) {
+  test.skipIf(process.platform === 'win32')(`quit during ${boundary} cancels bootstrap before stages`, async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-bootstrap-quit-'))
+    const controller = new AbortController()
+    const marker = path.join(home, 'manifest-started')
+    let manifestPid: number | undefined
+
+    fs.mkdirSync(path.join(home, 'scripts'))
+    fs.writeFileSync(
+      path.join(home, 'scripts/install.sh'),
+      `#!/bin/bash\nprintf started > "$HERMES_HOME/manifest-started"\nprintf 'manifest-pid=%s\\n' "$$"\nwhile :; do :; done\n`
+    )
+
+    try {
+      const result = await runBootstrap({
+        installStamp: null,
+        activeRoot: path.join(home, 'agent'),
+        sourceRepoRoot: home,
+        hermesHome: home,
+        abortSignal: controller.signal,
+        onEvent: event => {
+          if (boundary === 'resolution' && event.line?.includes('using local')) {
+            controller.abort()
+          }
+
+          const match = event.line?.match(/^manifest-pid=(\d+)$/)
+
+          if (match) {
+            manifestPid = Number(match[1])
+            controller.abort()
+          }
+        }
+      })
+
+      assert.equal(result.ok, false)
+      assert.equal(result.cancelled, true)
+      assert.equal(fs.existsSync(marker), boundary === 'manifest')
+
+      if (manifestPid) {
+        assert.throws(() => process.kill(manifestPid!, 0))
+      }
+    } finally {
+      controller.abort()
+
+      if (manifestPid) {
+        try {
+          process.kill(manifestPid, 'SIGKILL')
+        } catch {
+          /* already exited */
+        }
+      }
+
+      fs.rmSync(home, { recursive: true, force: true })
+    }
+  })
+}

--- a/apps/desktop/electron/bootstrap-runner.ts
+++ b/apps/desktop/electron/bootstrap-runner.ts
@@ -690,7 +690,17 @@ function buildPosixPinArgs({ installStamp, activeRoot, hermesHome, pinCommit = t
   return args
 }
 
-async function fetchManifest({ scriptPath, installerKind, emit, hermesHome, activeRoot, installStamp, pinCommit }) {
+async function fetchManifest({
+  scriptPath,
+  installerKind,
+  emit,
+  hermesHome,
+  activeRoot,
+  installStamp,
+  pinCommit,
+  abortSignal
+}) {
+  abortSignal?.throwIfAborted()
   const isPosix = installerKind === 'posix'
 
   const args = isPosix
@@ -700,6 +710,7 @@ async function fetchManifest({ scriptPath, installerKind, emit, hermesHome, acti
   const result = await (isPosix ? spawnBash : spawnPowerShell)(scriptPath, args, {
     emit,
     stageName: '__manifest__',
+    abortSignal,
     hermesHome
   })
 
@@ -928,6 +939,8 @@ async function runBootstrap(opts) {
 
     // 1. Resolve the platform installer.
     const scriptInfo = await resolveInstallScript({ installStamp, sourceRepoRoot, hermesHome, emit })
+    abortSignal?.throwIfAborted()
+
     const installerKind = scriptInfo.kind || 'powershell'
 
     // 2. Fetch manifest
@@ -938,8 +951,11 @@ async function runBootstrap(opts) {
       hermesHome,
       activeRoot,
       installStamp,
-      pinCommit
+      pinCommit,
+      abortSignal
     })
+
+    abortSignal?.throwIfAborted()
 
     emit({
       type: 'manifest',
@@ -1007,12 +1023,18 @@ async function runBootstrap(opts) {
 
     return { ok: true, marker }
   } catch (err) {
+    if (abortSignal?.aborted) {
+      emit({ type: 'failed', error: 'bootstrap cancelled by user' })
+
+      return { ok: false, cancelled: true }
+    }
+
     emit({ type: 'failed', error: err.message || String(err) })
 
     return { ok: false, error: err.message || String(err) }
   } finally {
     try {
-      runLog.stream.end()
+      await new Promise<void>(resolve => runLog.stream.end(resolve))
     } catch {
       void 0
     }

--- a/apps/desktop/electron/connection-apply.test.ts
+++ b/apps/desktop/electron/connection-apply.test.ts
@@ -4,7 +4,6 @@ import {
   applyConnectionChange,
   commitConnectionFailure,
   resolveTerminalConnection,
-  sshQuitShouldBlock,
   teardownSshState
 } from './connection-apply'
 
@@ -89,48 +88,6 @@ describe('resolveTerminalConnection', () => {
         async () => undefined
       )
     ).rejects.toThrow('not ready')
-  })
-})
-
-describe('sshQuitShouldBlock', () => {
-  it('waits when connections exist and teardown has not finished', () => {
-    expect(sshQuitShouldBlock({ teardownDone: false, connectionCount: 1, bootstrapPending: 0, inFlight: null })).toBe(
-      true
-    )
-  })
-
-  it('waits when bootstrap is still running', () => {
-    expect(sshQuitShouldBlock({ teardownDone: false, connectionCount: 0, bootstrapPending: 1, inFlight: null })).toBe(
-      true
-    )
-  })
-
-  it('waits when the map is empty but a remote kill is already in flight', () => {
-    expect(
-      sshQuitShouldBlock({
-        teardownDone: false,
-        connectionCount: 0,
-        bootstrapPending: 0,
-        inFlight: Promise.resolve()
-      })
-    ).toBe(true)
-  })
-
-  it('does not block a second quit after teardown finished', () => {
-    expect(
-      sshQuitShouldBlock({
-        teardownDone: true,
-        connectionCount: 1,
-        bootstrapPending: 1,
-        inFlight: Promise.resolve()
-      })
-    ).toBe(false)
-  })
-
-  it('does not block quit when there is nothing to tear down', () => {
-    expect(sshQuitShouldBlock({ teardownDone: false, connectionCount: 0, bootstrapPending: 0, inFlight: null })).toBe(
-      false
-    )
   })
 })
 

--- a/apps/desktop/electron/connection-apply.ts
+++ b/apps/desktop/electron/connection-apply.ts
@@ -61,21 +61,6 @@ async function resolveTerminalConnectionForSender(webContentsId, getTarget, ensu
   )
 }
 
-/** A second before-quit must still wait for an in-flight remote kill.
- *
- *  teardownSshConnection deletes the sshConnections entry first, then
- *  SSH-execs kill. backendShutdown's finally() calls app.quit() and
- *  re-enters before-quit with an empty map. Without `inFlight`, Electron
- *  exits while disconnect is running and the detached serve --isolated
- *  stays at pid 1 (post-#95085 leftover on #91668: window X on Windows). */
-function sshQuitShouldBlock({ teardownDone, connectionCount, bootstrapPending, inFlight }) {
-  if (teardownDone) {
-    return false
-  }
-
-  return connectionCount > 0 || bootstrapPending > 0 || Boolean(inFlight)
-}
-
 async function teardownSshState(state, { cleanupRemote }) {
   // Remote process first, while the SSH channel can still exec kill.
   // Then drop the local forward and close the transport. Each step is
@@ -106,6 +91,5 @@ export {
   commitConnectionFailure,
   resolveTerminalConnection,
   resolveTerminalConnectionForSender,
-  sshQuitShouldBlock,
   teardownSshState
 }

--- a/apps/desktop/electron/local-backend-lifecycle.test.ts
+++ b/apps/desktop/electron/local-backend-lifecycle.test.ts
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+
+import { test, vi } from 'vitest'
+
+import { createFirstRunSetupGate } from './first-run-setup-gate'
+import { createLocalBackendLifecycle } from './local-backend-lifecycle'
+import { runPrimaryBackendStartup } from './primary-backend-startup'
+import { createQuitTeardownCoordinator } from './quit-teardown'
+
+function deferred() {
+  let resolve!: () => void
+
+  const promise = new Promise<void>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+test('shutdown joins a removed start and prevents its late spawn', async () => {
+  const resume = deferred()
+  const spawn = vi.fn(() => ({}))
+
+  const lifecycle = createLocalBackendLifecycle({
+    stopChild: () => {},
+    waitForExit: async () => {},
+    cancelSetup: () => {}
+  })
+
+  const start = lifecycle.start(async () => {
+    await resume.promise
+    lifecycle.spawn(spawn)
+  })
+
+  void start.catch(() => {})
+  await Promise.resolve()
+  assert.equal(lifecycle.hasPending(), true)
+  const shutdown = lifecycle.shutdown()
+  resume.resolve()
+  await shutdown
+  await assert.rejects(start)
+  assert.equal(spawn.mock.calls.length, 0)
+  await assert.rejects(lifecycle.start(async () => {}))
+})
+
+test('shutdown retains a child before asynchronous claim and joins an earlier stop', async () => {
+  const exit = deferred()
+  const stopChild = vi.fn()
+  const lifecycle = createLocalBackendLifecycle({ stopChild, waitForExit: () => exit.promise, cancelSetup: () => {} })
+  const child = lifecycle.spawn(() => ({}))
+  const stopping = lifecycle.stop(child)
+  let done = false
+
+  const shutdown = lifecycle.shutdown().then(() => {
+    done = true
+  })
+
+  await Promise.resolve()
+  assert.equal(done, false)
+  assert.equal(stopChild.mock.calls.length, 1)
+  exit.resolve()
+  await Promise.all([shutdown, stopping])
+})
+
+test('shutdown is bounded even if startup ignores cancellation', async () => {
+  vi.useFakeTimers()
+
+  try {
+    const lifecycle = createLocalBackendLifecycle({
+      stopChild: () => {},
+      waitForExit: async () => {},
+      cancelSetup: () => {},
+      timeoutMs: 20
+    })
+
+    void lifecycle.start(() => new Promise(() => {}))
+    await Promise.resolve()
+    const shutdown = lifecycle.shutdown()
+    await vi.advanceTimersByTimeAsync(20)
+    await shutdown
+    assert.throws(() => lifecycle.spawn(() => ({})))
+    assert.equal(vi.getTimerCount(), 0)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+test('the quit barrier cancels real first-run startup and waits for both local and SSH drains', async () => {
+  const gate = createFirstRunSetupGate({ stuckAfterMs: 0 })
+  const localExit = deferred()
+  const sshExit = deferred()
+  const finalQuit = vi.fn()
+  const install = vi.fn(async () => ({}))
+
+  const lifecycle = createLocalBackendLifecycle({
+    stopChild: () => {},
+    waitForExit: () => localExit.promise,
+    cancelSetup: () => gate.resetForRetry()
+  })
+
+  lifecycle.spawn(() => ({}))
+
+  const startup = lifecycle.start(() =>
+    runPrimaryBackendStartup({
+      signal: lifecycle.signal,
+      resolveRemote: async () => null,
+      connectRemote: async () => ({}),
+      waitForLocalStart: async () => {},
+      prepareLocalBackend: () => ({ kind: 'bootstrap-needed' }),
+      waitForDecision: backend => gate.wait(backend),
+      ensureLocalRuntime: install
+    })
+  )
+
+  void startup.catch(() => {})
+
+  for (let i = 0; i < 30; i++) {
+    await Promise.resolve()
+  }
+
+  assert.equal(gate.hasWaiter(), true)
+  const quit = createQuitTeardownCoordinator(finalQuit)
+  assert.equal(
+    quit.begin([
+      { run: () => lifecycle.shutdown(), waitForCompletion: lifecycle.hasPending() },
+      { run: () => sshExit.promise, waitForCompletion: true }
+    ]),
+    true
+  )
+  await assert.rejects(startup)
+  assert.equal(gate.hasWaiter(), false)
+  assert.equal(install.mock.calls.length, 0)
+  localExit.resolve()
+  await lifecycle.shutdown()
+  assert.equal(quit.begin([]), true)
+  assert.equal(finalQuit.mock.calls.length, 0)
+  sshExit.resolve()
+
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve()
+  }
+
+  assert.equal(finalQuit.mock.calls.length, 1)
+  assert.equal(quit.begin([]), false)
+})
+
+test('a child spawned before claim remains owned after the routing entry disappears', async () => {
+  const lifecycle = createLocalBackendLifecycle<ReturnType<typeof spawn>>({
+    stopChild: child => {
+      child.kill()
+    },
+    waitForExit: async child => {
+      if (child.exitCode === null && child.signalCode === null) {
+        await once(child, 'exit')
+      }
+    },
+    cancelSetup: () => {}
+  })
+
+  const child = lifecycle.spawn(() =>
+    spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' })
+  )
+
+  child.once('exit', () => lifecycle.release(child))
+
+  try {
+    await once(child, 'spawn')
+    // No connection-state attachment or persisted claim has happened yet.
+    await lifecycle.shutdown()
+    assert.ok(child.exitCode !== null || child.signalCode !== null)
+    assert.equal(lifecycle.hasPending(), false)
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL')
+      await once(child, 'exit')
+    }
+  }
+})

--- a/apps/desktop/electron/local-backend-lifecycle.ts
+++ b/apps/desktop/electron/local-backend-lifecycle.ts
@@ -1,0 +1,105 @@
+import { createBackendShutdownCoordinator } from './backend-ownership'
+
+/** Observe every branch, but never leave quit parked on a lost exit/SSH callback. */
+export async function waitForTeardown(tasks: readonly Promise<unknown>[], timeoutMs: number): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    await Promise.race([
+      Promise.allSettled(tasks),
+      new Promise<void>(resolve => {
+        timer = setTimeout(resolve, timeoutMs)
+      })
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+interface LocalBackendLifecycleDeps<Child> {
+  stopChild: (child: Child) => void
+  waitForExit: (child: Child) => Promise<void>
+  cancelSetup: () => void
+  timeoutMs?: number
+}
+
+/**
+ * Physical ownership outlives routing entries: track starts before their first
+ * await and children before their asynchronous identity claim. The permanent
+ * shutdown signal and synchronous spawn fence make bounded waiting safe: a late
+ * resolver can finish, but can never create another owned backend.
+ */
+export function createLocalBackendLifecycle<Child>(deps: LocalBackendLifecycleDeps<Child>) {
+  const controller = new AbortController()
+  const starts = new Set<Promise<unknown>>()
+  const children = new Set<Child>()
+  const stops = new Map<Child, Promise<void>>()
+
+  function stop(child: Child | null | undefined): Promise<void> {
+    if (child == null) {
+      return Promise.resolve()
+    }
+
+    const existing = stops.get(child)
+
+    if (existing) {
+      return existing
+    }
+
+    const stopping = (async () => {
+      deps.stopChild(child)
+      await deps.waitForExit(child)
+    })()
+
+    stops.set(child, stopping)
+    void stopping.then(
+      () => stops.delete(child),
+      () => stops.delete(child)
+    )
+
+    return stopping
+  }
+
+  const shutdown = createBackendShutdownCoordinator(() => {
+    controller.abort(new Error('Hermes Desktop is quitting.'))
+    deps.cancelSetup()
+
+    return waitForTeardown([...starts, ...[...children].map(stop), ...stops.values()], deps.timeoutMs ?? 7_000)
+  })
+
+  return {
+    signal: controller.signal,
+    assertCanStart: () => controller.signal.throwIfAborted(),
+    hasPending: () => starts.size > 0 || children.size > 0 || stops.size > 0 || shutdown.isPending(),
+    start<T>(run: () => Promise<T>): Promise<T> {
+      if (controller.signal.aborted) {
+        return Promise.reject(controller.signal.reason)
+      }
+
+      // Defer invocation one microtask so the inventory precedes all work.
+      const promise = Promise.resolve().then(() => {
+        controller.signal.throwIfAborted()
+
+        return run()
+      })
+
+      starts.add(promise)
+      void promise.then(
+        () => starts.delete(promise),
+        () => starts.delete(promise)
+      )
+
+      return promise
+    },
+    spawn(create: () => Child): Child {
+      controller.signal.throwIfAborted()
+      const child = create()
+      children.add(child)
+
+      return child
+    },
+    release: (child: Child) => children.delete(child),
+    stop,
+    shutdown: shutdown.run
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -39,7 +39,11 @@ import {
   withRetry
 } from './api-transport'
 import { appIconCandidates, resolveAppIcon } from './app-icon'
-import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
+import {
+  stopBackendChild as stopBackendChildImpl,
+  stopBackendTreesForUpdate,
+  waitForBackendExit as waitForBackendExitImpl
+} from './backend-child'
 import {
   type BackendOutputTail,
   claimDecision,
@@ -98,7 +102,7 @@ import {
 import { detectBundleSkew } from './bundle-skew'
 import { detectBundleSwap } from './bundle-swap'
 import { registerChatOnboardingWindow } from './chat-onboarding-window'
-import { applyConnectionChange, sshQuitShouldBlock, teardownSshState } from './connection-apply'
+import { applyConnectionChange, teardownSshState } from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
   authModeFromStatus,
@@ -242,6 +246,7 @@ import { buildHudWindowUrl } from './hud-url'
 import { resolveHudWindowing } from './hud-windowing'
 import { createIntroRevealWindowController } from './intro-reveal-window'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
+import { createLocalBackendLifecycle, waitForTeardown } from './local-backend-lifecycle'
 import { ensureMainWindow } from './main-window-lifecycle'
 import {
   assertManagedUpdatePreflightClear,
@@ -340,6 +345,7 @@ import {
 } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
+import { backendQuitNeedsWait, createQuitTeardownCoordinator } from './quit-teardown'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
   attachPowerResumeRemoteRevalidation,
@@ -379,6 +385,7 @@ import { ensureLoginShellPath } from './shell-path'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'
 import { createSshProbeConnection, pickLocalPort, redactSecrets, SshConnection } from './ssh-connection'
+import { createSshTeardownTracker } from './ssh-teardown'
 import { createStreamThrottle } from './stream-throttle'
 import { registerTerminalIpc } from './terminal-ipc'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
@@ -1415,6 +1422,32 @@ function registerMediaProtocol() {
 
 let mainWindow = null
 const backendConnectionState = createBackendConnectionState<ReturnType<typeof spawn>, any>()
+
+const localBackendLifecycle = createLocalBackendLifecycle<ReturnType<typeof spawn>>({
+  stopChild: child => {
+    if (child.exitCode === null && child.signalCode === null) {
+      stopBackendChildImpl(child, { forceKillProcessTree, isWindows: IS_WINDOWS })
+    }
+  },
+  waitForExit: child => waitForBackendExit(child),
+  cancelSetup: () => {
+    firstRunSetupGate?.resetForRetry()
+    bootstrapAbortController?.abort()
+  }
+})
+
+function spawnOwnedBackend(...args: Parameters<typeof spawn>) {
+  const child = localBackendLifecycle.spawn(() => spawn(...args))
+  child.once('exit', () => localBackendLifecycle.release(child))
+  child.once('error', () => {
+    if (!child.pid) {
+      localBackendLifecycle.release(child)
+    }
+  })
+
+  return child
+}
+
 const remoteLiveness = new RemoteLivenessTracker()
 const remoteRevalidation = new RemoteRevalidationCoordinator()
 const registryDispatchRevalidation = new RemoteRevalidationCoordinator()
@@ -2413,6 +2446,7 @@ async function waitForUpdateToFinish() {
   let announced = false
 
   const outcome = await waitForUpdateClearance(updateGateDeps(), {
+    signal: localBackendLifecycle.signal,
     onWaitTick: async reason => {
       if (!announced) {
         announced = true
@@ -2460,6 +2494,10 @@ async function waitForUpdateToFinish() {
     }
   } catch (err) {
     rememberLog(`[updates] could not read hand-off result: ${err.message}`)
+  }
+
+  if (outcome === 'cancelled') {
+    localBackendLifecycle.assertCanStart()
   }
 
   if (outcome === 'clear') {
@@ -4395,6 +4433,9 @@ async function handOffWindowsBootstrapRecovery(reason) {
 
   await releaseBackendLockForUpdate(updateRoot)
 
+  // The recovery resolver may have awaited while quit sealed local startup.
+  localBackendLifecycle.assertCanStart()
+
   const child = spawnUpdaterProcess(updater, updaterArgs, {
     cwd: HERMES_HOME,
     env: {
@@ -5189,7 +5230,13 @@ function resolveHermesBackend(backendArgs) {
   }
 }
 
-async function ensureRuntime(backend) {
+function ensureRuntime(backend: any): Promise<any> {
+  return localBackendLifecycle.start(() => runEnsureRuntime(backend))
+}
+
+async function runEnsureRuntime(backend: any): Promise<any> {
+  localBackendLifecycle.assertCanStart()
+
   if (!backend.bootstrap) {
     await advanceBootProgress('runtime.external', `Using ${backend.label}`, 32)
 
@@ -5235,6 +5282,7 @@ async function ensureRuntime(backend) {
       void 0
     }
 
+    localBackendLifecycle.assertCanStart()
     bootstrapAbortController = new AbortController()
 
     // The repair request has been honoured by reaching the installer; clear it
@@ -10432,10 +10480,7 @@ function clearManagedSshRecovery(connectionId, correlationId) {
 }
 
 const sshBootstrapCoordinator = createBootstrapCoordinator()
-
-let sshQuitTeardownDone = false
-let sshQuitTeardownPromise: Promise<void> | null = null
-let backendQuitTeardownDone = false
+const sshTeardowns = createSshTeardownTracker()
 
 function sshScopeKey(profile) {
   return connectionScopeKey(profile) || ''
@@ -10480,22 +10525,24 @@ async function teardownSshConnection(profile) {
   // alone leaves the backend at pid 1 holding state.db (#91668).
   // Windows remotes use a different lifecycle (connectWindowsRemote) and
   // are left to a follow-up; POSIX is the leak that OOM'd gateways.
-  await teardownSshState(
-    {
-      ...state,
-      ownershipId: state.ownershipId || sshOwnershipKey(profile)
-    },
-    {
-      cleanupRemote:
-        state.remotePlatform === 'Windows'
-          ? async () => {
-              // connectWindowsRemote does not share POSIX lock/kill. Stay
-              // silent on the kill path, but leave a log so quit is not a
-              // mysterious no-op on Windows remotes.
-              sshRememberLog('[ssh] skip remote serve teardown on Windows remotes; POSIX disconnect does not apply')
-            }
-          : remoteLifecycle.disconnect
-    }
+  await sshTeardowns.track(state.ssh, () =>
+    teardownSshState(
+      {
+        ...state,
+        ownershipId: state.ownershipId || sshOwnershipKey(profile)
+      },
+      {
+        cleanupRemote:
+          state.remotePlatform === 'Windows'
+            ? async () => {
+                // connectWindowsRemote does not share POSIX lock/kill. Stay
+                // silent on the kill path, but leave a log so quit is not a
+                // mysterious no-op on Windows remotes.
+                sshRememberLog('[ssh] skip remote serve teardown on Windows remotes; POSIX disconnect does not apply')
+              }
+            : remoteLifecycle.disconnect
+      }
+    )
   )
 }
 
@@ -11427,7 +11474,7 @@ function resetBootProgressForReconnect() {
 }
 
 function stopBackendChild(child) {
-  stopBackendChildImpl(child, { forceKillProcessTree, isWindows: IS_WINDOWS })
+  void localBackendLifecycle.stop(child).catch(error => rememberLog(`Backend teardown failed: ${error.message}`))
 }
 
 // Soft gateway-mode apply: tear down the primary without resetting boot UI or
@@ -11498,53 +11545,23 @@ function broadcastConnectionsChanged(payload: { connectionId: string; reason: 'r
   }
 }
 
-async function waitForBackendExit(child, timeoutMs = 5000) {
-  if (!child || child.exitCode !== null || child.signalCode !== null) {
-    return
+const backendExitWaits = new Map<any, Promise<void>>()
+
+function waitForBackendExit(child, timeoutMs = 5000) {
+  const existing = backendExitWaits.get(child)
+
+  if (existing) {
+    return existing
   }
 
-  const exited = () => child.exitCode !== null || child.signalCode !== null
+  const waiting = waitForBackendExitImpl(child, { forceKillProcessTree, isWindows: IS_WINDOWS }, timeoutMs)
+  backendExitWaits.set(child, waiting)
+  void waiting.then(
+    () => backendExitWaits.delete(child),
+    () => backendExitWaits.delete(child)
+  )
 
-  const wait = delay =>
-    new Promise<void>(resolve => {
-      if (exited()) {
-        resolve()
-
-        return
-      }
-
-      const timer = setTimeout(resolve, delay)
-      child.once('exit', () => {
-        clearTimeout(timer)
-        resolve()
-      })
-    })
-
-  await wait(timeoutMs)
-
-  if (exited()) {
-    return
-  }
-
-  try {
-    if (IS_WINDOWS && Number.isInteger(child.pid)) {
-      forceKillProcessTree(child.pid)
-    } else if (Number.isInteger(child.pid)) {
-      try {
-        process.kill(-child.pid, 'SIGKILL')
-      } catch {
-        child.kill('SIGKILL')
-      }
-    } else {
-      child.kill('SIGKILL')
-    }
-  } catch {
-    return
-  }
-
-  // Await the escalation as well; do not let shutdown or failed adoption race
-  // a still-running backend.
-  await wait(1000)
+  return waiting
 }
 
 // The profile the primary (window) backend runs as. readActiveDesktopProfile()
@@ -11583,6 +11600,7 @@ function profileRouteOptions(profile, request?) {
 // resolveProfileBackendRoute(). An empty / unknown profile resolves to the
 // primary, so legacy callers are unchanged.
 async function ensureBackend(profile, opts: { passive?: boolean; spawnPriority?: LocalBackendSpawnPriority } = {}) {
+  localBackendLifecycle.assertCanStart()
   const key = profile && String(profile).trim() ? String(profile).trim() : primaryProfileKey()
   const spawnPriority = spawnPriorityFrom(opts.spawnPriority)
   const passive = Boolean(opts.passive)
@@ -12589,7 +12607,7 @@ function releaseLocalBackendSlot(entry: any) {
 }
 
 function assertPoolEntryStillOwned(poolKey: string, entry: any) {
-  if (backendPool.get(poolKey) !== entry) {
+  if (localBackendLifecycle.signal.aborted || backendPool.get(poolKey) !== entry) {
     releaseLocalBackendSlot(entry)
     throw new Error(`Profile backend start for "${poolKey}" was cancelled before spawn.`)
   }
@@ -12638,7 +12656,11 @@ function teardownFailedLocalBackend(poolKey: string, entry: any): Promise<void> 
 // entry means THIS machine regardless of the v1 routing table); `opts.poolKey`
 // is the backendPool key when it differs from the profile name (composite
 // registry scopes) so the exit/error cleanup evicts the right entry.
-async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; poolKey?: string } = {}) {
+function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; poolKey?: string } = {}) {
+  return localBackendLifecycle.start(() => runPoolBackendStart(profile, entry, opts))
+}
+
+async function runPoolBackendStart(profile, entry, opts: { forceLocal?: boolean; poolKey?: string } = {}) {
   const poolKey = opts.poolKey || profile
 
   await reapOrphanedBackendsOnce()
@@ -12681,6 +12703,8 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
 
   const spawnPriority: LocalBackendSpawnPriority = spawnPriorityFrom(entry.spawnPriority)
 
+  assertPoolEntryStillOwned(poolKey, entry)
+
   const spawnRequest = localBackendSpawnCoordinator.request(poolKey, {
     timeoutMs: POOL_SLOT_WAIT_MS,
     priority: spawnPriority
@@ -12695,7 +12719,14 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
     )
   }
 
-  entry.releaseLocalBackendSlot = await spawnRequest.acquired
+  const cancelRequest = () => spawnRequest.cancel()
+  localBackendLifecycle.signal.addEventListener('abort', cancelRequest, { once: true })
+
+  try {
+    entry.releaseLocalBackendSlot = await spawnRequest.acquired
+  } finally {
+    localBackendLifecycle.signal.removeEventListener('abort', cancelRequest)
+  }
 
   if (entry.localBackendSpawnRequest === spawnRequest) {
     entry.localBackendSpawnRequest = null
@@ -12713,7 +12744,9 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   {
     let poolAnnounced = false
 
-    await waitForUpdateClearance(updateGateDeps(), {
+    const clearance = await waitForUpdateClearance(updateGateDeps(), {
+      signal: localBackendLifecycle.signal,
+      isCancelled: () => backendPool.get(poolKey) !== entry,
       onWaitTick: reason => {
         if (!poolAnnounced) {
           poolAnnounced = true
@@ -12723,9 +12756,14 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
       pollMs: UPDATE_WAIT_POLL_MS,
       timeoutMs: UPDATE_WAIT_TIMEOUT_MS
     })
+
+    if (clearance === 'cancelled') {
+      assertPoolEntryStillOwned(poolKey, entry)
+    }
   }
 
   profileDeletionGate.assertCanStart(profile)
+  assertPoolEntryStillOwned(poolKey, entry)
 
   // --profile wins over the inherited HERMES_HOME env (see _apply_profile_override
   // step 3 in hermes_cli/main.py), so the child re-homes to this profile.
@@ -12753,7 +12791,7 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   const parentIdentityEnv = parentWatchdogEnv(process.pid, parentStartMarker, backendNonce)
   assertPoolEntryStillOwned(poolKey, entry)
 
-  const child = spawn(
+  const child = spawnOwnedBackend(
     backend.command,
     backend.args,
     hiddenWindowsChildOptions({
@@ -12922,6 +12960,7 @@ async function stopAllPoolBackends() {
 }
 
 const backendShutdown = createBackendShutdownCoordinator(async () => {
+  const localShutdown = localBackendLifecycle.shutdown()
   const primary = backendConnectionState.invalidate()
 
   stopBackendChild(primary)
@@ -12932,8 +12971,20 @@ const backendShutdown = createBackendShutdownCoordinator(async () => {
     poolIdleReaper = null
   }
 
-  await Promise.all([waitForBackendExit(primary), pooledStops])
+  await waitForTeardown([localShutdown, waitForBackendExit(primary), pooledStops], 7_000)
 })
+
+const quitTeardown = createQuitTeardownCoordinator(() => app.quit())
+
+async function teardownSshForQuit() {
+  const scopes = [...sshConnections.keys()]
+
+  for (const scope of scopes) {
+    void teardownSshConnection(scope || null).catch(error => rememberLog(`SSH teardown failed: ${error.message}`))
+  }
+
+  await sshTeardowns.finish(sshBootstrapCoordinator.promises(), () => sshBootstrapCoordinator.forceCleanupAll())
+}
 
 async function exitAfterBackendShutdown(code) {
   await backendShutdown.run()
@@ -12992,7 +13043,11 @@ async function prepareProfileRenameRequest(request) {
   })
 }
 
-async function startHermes() {
+function startHermes() {
+  return localBackendLifecycle.start(runHermesStart)
+}
+
+async function runHermesStart() {
   // Only the single-instance lock holder may reap/spawn/claim the desktop
   // backend. A lock-losing instance must stay inert even if some path reaches
   // here (e.g. the deferred-quit window before `ready`): its reapOrphans()
@@ -13003,6 +13058,9 @@ async function startHermes() {
   }
 
   await reapOrphanedBackendsOnce()
+
+  // Shutdown may have started while the orphan sweep was awaiting probes.
+  localBackendLifecycle.assertCanStart()
 
   // Latched-failure short-circuit: once bootstrap has failed in this
   // process, every subsequent startHermes() call re-throws the same error
@@ -13125,6 +13183,7 @@ async function startHermes() {
     }
 
     const setup = await runPrimaryBackendStartup({
+      signal: localBackendLifecycle.signal,
       connectRemote,
       ensureLocalRuntime: ensureRuntime,
       prepareLocalBackend: async () => {
@@ -13173,7 +13232,11 @@ async function startHermes() {
     const backendNonce = crypto.randomBytes(16).toString('hex')
     const parentIdentityEnv = parentWatchdogEnv(process.pid, parentStartMarker, backendNonce)
 
-    const hermesProcess = spawn(
+    if (!backendConnectionState.isCurrentAttempt(connectionAttempt)) {
+      throw new Error('Hermes backend start was superseded by a newer connection attempt.')
+    }
+
+    const hermesProcess = spawnOwnedBackend(
       backend.command,
       backend.args,
       hiddenWindowsChildOptions({
@@ -18440,50 +18503,24 @@ app.on('before-quit', event => {
   // already quitting (#91668).
   sshBootstrapCoordinator.shutdown()
 
-  if (!backendQuitTeardownDone) {
-    event.preventDefault()
-    void backendShutdown.run().finally(() => {
-      backendQuitTeardownDone = true
-      app.quit()
-    })
+  const backendNeedsWait = backendQuitNeedsWait({
+    connectionPending: backendConnectionState.getPendingPromise() !== null || localBackendLifecycle.hasPending(),
+    poolPending: poolStopper.hasPending(),
+    processAttached: backendConnectionState.getProcess() !== null,
+    shutdownPending: backendShutdown.isPending()
+  })
+
+  const sshNeedsWait =
+    sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0 || sshTeardowns.hasPending()
+
+  const teardownTasks = [{ run: () => backendShutdown.run(), waitForCompletion: backendNeedsWait }]
+
+  if (sshNeedsWait) {
+    teardownTasks.push({ run: teardownSshForQuit, waitForCompletion: true })
   }
 
-  // backendShutdown.finally() re-enters before-quit. teardownSshConnection
-  // already deleted the map entries, so size===0 would skip the kill wait
-  // and let window-X quit finish while SSH exec is still running (#91668).
-  if (
-    sshQuitShouldBlock({
-      teardownDone: sshQuitTeardownDone,
-      connectionCount: sshConnections.size,
-      bootstrapPending: sshBootstrapCoordinator.promises().length,
-      inFlight: sshQuitTeardownPromise
-    })
-  ) {
+  if (quitTeardown.begin(teardownTasks)) {
     event.preventDefault()
-
-    if (!sshQuitTeardownPromise) {
-      const scopes = [...sshConnections.keys()]
-
-      const pending = Promise.allSettled([
-        ...scopes.map(scope => teardownSshConnection(scope || null)),
-        ...sshBootstrapCoordinator.promises()
-      ])
-
-      // cleanupStale waits up to 5s for the owned pid to exit (50 * 100ms).
-      // The previous 4s race could close SSH first and leave serve --isolated
-      // reparented to pid 1. Latch this promise BEFORE those deletes land so
-      // a re-entrant quit still waits.
-      sshQuitTeardownPromise = Promise.race([pending, new Promise<void>(resolve => setTimeout(resolve, 6_000))]).then(
-        async () => {
-          await sshBootstrapCoordinator.forceCleanupAll()
-        }
-      )
-    }
-
-    void sshQuitTeardownPromise.then(() => {
-      sshQuitTeardownDone = true
-      app.quit()
-    })
   }
 
   // Clean quit mid-boot should not trip next-launch --no-sandbox (#38216).

--- a/apps/desktop/electron/pool-stop.test.ts
+++ b/apps/desktop/electron/pool-stop.test.ts
@@ -89,6 +89,14 @@ test('stop of an unknown key resolves without signalling anything', async () => 
   assert.equal(stopper.inFlight('ghost'), undefined)
 })
 
+test('a remote pooled descriptor without a local child does not require quit deferral', () => {
+  const { pool, stopper } = harness()
+
+  pool.set('remote', {})
+
+  assert.equal(stopper.hasPending(), false)
+})
+
 test('stopAll stops every pooled backend and resolves after all exits', async () => {
   const { addChild, exitResolvers, pool, stopper } = harness()
   const a = addChild('a')
@@ -111,6 +119,31 @@ test('stopAll stops every pooled backend and resolves after all exits', async ()
   exitResolvers.get(b)?.()
   await all
   assert.equal(settled, true)
+})
+
+test('stopAll joins a stop whose pool entry was already evicted', async () => {
+  const { addChild, exitResolvers, pool, stopper } = harness()
+  const child = addChild('already-stopping')
+
+  const first = stopper.stop('already-stopping')
+
+  assert.equal(pool.size, 0)
+  assert.equal(stopper.hasPending(), true)
+
+  let settled = false
+
+  const all = stopper.stopAll().then(() => {
+    settled = true
+  })
+
+  await Promise.resolve()
+
+  assert.equal(settled, false)
+
+  exitResolvers.get(child)?.()
+  await Promise.all([first, all])
+  assert.equal(settled, true)
+  assert.equal(stopper.hasPending(), false)
 })
 
 test('a respawn can await the in-flight stop before reusing the key', async () => {

--- a/apps/desktop/electron/pool-stop.ts
+++ b/apps/desktop/electron/pool-stop.ts
@@ -38,9 +38,11 @@ export interface PoolStopperDeps {
 export interface PoolStopper {
   /** The in-flight stop for a key, if any — await before respawning it. */
   inFlight: (key: string) => Promise<void> | undefined
+  /** Whether the pool has a local child or an already-evicted stop in flight. */
+  hasPending: () => boolean
   /** Stop one pooled backend; concurrent calls share the same promise. */
   stop: (key: string) => Promise<void>
-  /** Stop every pooled backend currently in the pool. */
+  /** Stop every pooled backend and join stops already in flight. */
   stopAll: () => Promise<void>
 }
 
@@ -78,9 +80,12 @@ export function createPoolStopper(deps: PoolStopperDeps): PoolStopper {
 
   return {
     inFlight: key => stops.get(key),
+    hasPending: () => stops.size > 0 || [...deps.pool.values()].some(entry => entry.process != null),
     stop,
     stopAll: async () => {
-      await Promise.all([...deps.pool.keys()].map(stop))
+      const currentStops = [...deps.pool.keys()].map(stop)
+
+      await Promise.all(new Set([...stops.values(), ...currentStops]))
     }
   }
 }

--- a/apps/desktop/electron/primary-backend-cancellation.test.ts
+++ b/apps/desktop/electron/primary-backend-cancellation.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { createFirstRunSetupGate } from './first-run-setup-gate'
+import { runPrimaryBackendStartup } from './primary-backend-startup'
+
+test('quit cancels first-run startup without entering the installer', async () => {
+  const controller = new AbortController()
+  const gate = createFirstRunSetupGate({ stuckAfterMs: 0 })
+  let installed = false
+
+  const startup = runPrimaryBackendStartup({
+    signal: controller.signal,
+    resolveRemote: async () => null,
+    connectRemote: async () => ({}),
+    waitForLocalStart: async () => {},
+    prepareLocalBackend: () => ({ kind: 'bootstrap-needed' }),
+    waitForDecision: backend => gate.wait(backend),
+    ensureLocalRuntime: async () => {
+      installed = true
+
+      return {}
+    }
+  })
+
+  for (let i = 0; i < 20; i++) {
+    await Promise.resolve()
+  }
+
+  assert.equal(gate.hasWaiter(), true)
+  let settled = false
+  void startup.catch(() => {
+    settled = true
+  })
+  controller.abort()
+
+  for (let i = 0; i < 20; i++) {
+    await Promise.resolve()
+  }
+
+  assert.equal(settled, true, 'quit must not wait for a user choice')
+  gate.continueLocal()
+  await startup.catch(() => {})
+  assert.equal(installed, false, 'a late choice must not launch the installer')
+})

--- a/apps/desktop/electron/primary-backend-startup.ts
+++ b/apps/desktop/electron/primary-backend-startup.ts
@@ -1,6 +1,8 @@
+import { runBackendStartStep } from './backend-start-cancellation'
 import type { FirstRunSetupDecision } from './first-run-setup-gate'
 
 export interface PrimaryBackendStartupOptions<Backend, RuntimeBackend, Remote, Connection> {
+  signal?: AbortSignal
   connectRemote: (remote: Remote) => Promise<Connection>
   ensureLocalRuntime: (backend: Backend) => Promise<RuntimeBackend>
   prepareLocalBackend: () => Backend | Promise<Backend>
@@ -80,34 +82,36 @@ export async function runPrimaryBackendStartup<Backend, RuntimeBackend, Remote, 
   prepareLocalBackend,
   resolveRemote,
   waitForDecision,
-  waitForLocalStart
+  waitForLocalStart,
+  signal
 }: PrimaryBackendStartupOptions<Backend, RuntimeBackend, Remote, Connection>): Promise<
   PrimaryBackendStartupResult<RuntimeBackend, Connection>
 > {
-  const savedRemote = await resolveRemote()
+  const step = <T>(run: () => T | Promise<T>) => runBackendStartStep(signal, run)
+  const savedRemote = await step(resolveRemote)
 
   if (savedRemote) {
-    return { kind: 'remote', connection: await connectRemote(savedRemote) }
+    return { kind: 'remote', connection: await step(() => connectRemote(savedRemote)) }
   }
 
-  await waitForLocalStart()
+  await step(waitForLocalStart)
 
-  const backend = await prepareLocalBackend()
-  const decision = await waitForDecision(backend)
+  const backend = await step(prepareLocalBackend)
+  const decision = await step(() => waitForDecision(backend))
 
   if (decision === 'remote-applied') {
-    const appliedRemote = await resolveRemote()
+    const appliedRemote = await step(resolveRemote)
 
     if (!appliedRemote) {
       throw new Error('First-run remote setup completed without a saved remote backend.')
     }
 
-    return { kind: 'remote', connection: await connectRemote(appliedRemote) }
+    return { kind: 'remote', connection: await step(() => connectRemote(appliedRemote)) }
   }
 
   if (decision === 'reset') {
     throw new FirstRunSetupResetError()
   }
 
-  return { kind: 'local', backend: await ensureLocalRuntime(backend) }
+  return { kind: 'local', backend: await step(() => ensureLocalRuntime(backend)) }
 }

--- a/apps/desktop/electron/quit-teardown.test.ts
+++ b/apps/desktop/electron/quit-teardown.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+import { backendQuitNeedsWait, createQuitTeardownCoordinator } from './quit-teardown'
+
+function deferred() {
+  let resolve!: () => void
+
+  const promise = new Promise<void>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+test('remote-only cleanup does not cancel the original quit', () => {
+  const cleanup = vi.fn()
+  const requestFinalQuit = vi.fn()
+  const coordinator = createQuitTeardownCoordinator(requestFinalQuit)
+
+  const shouldPrevent = coordinator.begin([{ run: cleanup, waitForCompletion: false }])
+
+  assert.equal(shouldPrevent, false)
+  assert.equal(cleanup.mock.calls.length, 1)
+  assert.equal(requestFinalQuit.mock.calls.length, 0)
+})
+
+test('a settled remote descriptor is not backend work that requires a deferred quit', () => {
+  assert.equal(
+    backendQuitNeedsWait({
+      connectionPending: false,
+      poolPending: false,
+      processAttached: false,
+      shutdownPending: false
+    }),
+    false
+  )
+
+  for (const key of ['connectionPending', 'poolPending', 'processAttached', 'shutdownPending'] as const) {
+    assert.equal(
+      backendQuitNeedsWait({
+        connectionPending: false,
+        poolPending: false,
+        processAttached: false,
+        shutdownPending: false,
+        [key]: true
+      }),
+      true,
+      `${key} must defer quit`
+    )
+  }
+})
+
+test('one final quit waits for every required teardown branch', async () => {
+  const backend = deferred()
+  const ssh = deferred()
+  const requestFinalQuit = vi.fn()
+  const backendRun = vi.fn(() => backend.promise)
+  const sshRun = vi.fn(() => ssh.promise)
+  const coordinator = createQuitTeardownCoordinator(requestFinalQuit)
+
+  const tasks = [
+    { run: backendRun, waitForCompletion: true },
+    { run: sshRun, waitForCompletion: true }
+  ]
+
+  assert.equal(coordinator.begin(tasks), true)
+  assert.equal(coordinator.begin(tasks), true, 'a re-entrant quit stays deferred while teardown is pending')
+  assert.equal(backendRun.mock.calls.length, 1)
+  assert.equal(sshRun.mock.calls.length, 1)
+
+  backend.resolve()
+  await Promise.resolve()
+  assert.equal(requestFinalQuit.mock.calls.length, 0)
+
+  ssh.resolve()
+  await Promise.all([backend.promise, ssh.promise])
+  await Promise.resolve()
+  assert.equal(requestFinalQuit.mock.calls.length, 1)
+
+  assert.equal(coordinator.begin(tasks), false, 'the coordinator must not cancel its own final quit')
+  assert.equal(backendRun.mock.calls.length, 1)
+  assert.equal(sshRun.mock.calls.length, 1)
+})
+
+test('teardown failure still releases the final quit after all branches settle', async () => {
+  const requestFinalQuit = vi.fn()
+  const coordinator = createQuitTeardownCoordinator(requestFinalQuit)
+
+  assert.equal(
+    coordinator.begin([
+      {
+        run: () => {
+          throw new Error('cleanup failed')
+        },
+        waitForCompletion: true
+      }
+    ]),
+    true
+  )
+
+  await Promise.resolve()
+  await Promise.resolve()
+  assert.equal(requestFinalQuit.mock.calls.length, 1)
+})
+
+test('a synchronous reentrant quit cannot start a second teardown', async () => {
+  const finalQuit = vi.fn()
+  const coordinator = createQuitTeardownCoordinator(finalQuit)
+  const duplicate = vi.fn()
+  assert.equal(
+    coordinator.begin([
+      {
+        waitForCompletion: true,
+        run: () => {
+          assert.equal(coordinator.begin([{ run: duplicate, waitForCompletion: false }]), true)
+        }
+      }
+    ]),
+    true
+  )
+  await Promise.resolve()
+  await Promise.resolve()
+  assert.equal(duplicate.mock.calls.length, 0)
+  assert.equal(finalQuit.mock.calls.length, 1)
+})

--- a/apps/desktop/electron/quit-teardown.ts
+++ b/apps/desktop/electron/quit-teardown.ts
@@ -1,0 +1,75 @@
+export interface QuitTeardownTask {
+  /** Whether Electron must defer this quit until the task settles. */
+  waitForCompletion: boolean
+  /** Starts teardown. This is invoked synchronously from before-quit. */
+  run: () => Promise<unknown> | unknown
+}
+
+export interface QuitTeardownCoordinator {
+  /**
+   * Starts teardown once and reports whether the current quit must be
+   * prevented. Re-entrant quit requests are held until all required teardown
+   * settles; the coordinator then requests exactly one final quit.
+   */
+  begin: (tasks: readonly QuitTeardownTask[]) => boolean
+}
+
+export interface BackendQuitActivity {
+  connectionPending: boolean
+  poolPending: boolean
+  processAttached: boolean
+  shutdownPending: boolean
+}
+
+export function backendQuitNeedsWait(activity: BackendQuitActivity): boolean {
+  return activity.shutdownPending || activity.processAttached || activity.connectionPending || activity.poolPending
+}
+
+function runTask(task: QuitTeardownTask): Promise<unknown> {
+  try {
+    return Promise.resolve(task.run())
+  } catch (error) {
+    return Promise.reject(error)
+  }
+}
+
+/**
+ * Coordinates Electron's before-quit teardown without cancelling a quit that
+ * has no asynchronous work to wait for.
+ */
+export function createQuitTeardownCoordinator(requestFinalQuit: () => void): QuitTeardownCoordinator {
+  let started = false
+  let finished = false
+
+  return {
+    begin(tasks): boolean {
+      if (finished) {
+        return false
+      }
+
+      if (started) {
+        return true
+      }
+
+      started = true
+      const executions = tasks.map(task => ({ promise: runTask(task), waitForCompletion: task.waitForCompletion }))
+      const mustWait = executions.some(task => task.waitForCompletion)
+
+      if (!mustWait) {
+        // Observe asynchronous no-wait cleanup so a late rejection cannot
+        // become unhandled, but let Electron continue the original quit.
+        void Promise.allSettled(executions.map(task => task.promise))
+        finished = true
+
+        return false
+      }
+
+      void Promise.allSettled(executions.map(task => task.promise)).then(() => {
+        finished = true
+        requestFinalQuit()
+      })
+
+      return true
+    }
+  }
+}

--- a/apps/desktop/electron/ssh-teardown.test.ts
+++ b/apps/desktop/electron/ssh-teardown.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+import { createSshTeardownTracker } from './ssh-teardown'
+
+function deferred() {
+  let resolve!: () => void
+
+  const promise = new Promise<void>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+test('quit joins teardown whose SSH routing entry was already removed', async () => {
+  const exit = deferred()
+  const tracker = createSshTeardownTracker()
+  const close = vi.fn(async () => {})
+  const stopped = tracker.track({ close }, () => exit.promise)
+  let done = false
+
+  const quit = tracker
+    .finish([], async () => {})
+    .then(() => {
+      done = true
+    })
+
+  await Promise.resolve()
+  assert.equal(done, false)
+  assert.equal(tracker.hasPending(), true)
+  exit.resolve()
+  await Promise.all([stopped, quit])
+  assert.equal(tracker.hasPending(), false)
+})
+
+test('a stuck SSH teardown and force cleanup cannot hang quit forever', async () => {
+  vi.useFakeTimers()
+
+  try {
+    const tracker = createSshTeardownTracker()
+    const close = vi.fn(() => new Promise<void>(() => {}))
+    void tracker.track({ close }, () => new Promise<void>(() => {}))
+    const force = vi.fn(() => new Promise<void>(() => {}))
+    const quit = tracker.finish([], force, 20, 10)
+    await vi.advanceTimersByTimeAsync(30)
+    await quit
+    assert.equal(close.mock.calls.length, 1)
+    assert.equal(force.mock.calls.length, 1)
+    assert.equal(vi.getTimerCount(), 0)
+  } finally {
+    vi.useRealTimers()
+  }
+})

--- a/apps/desktop/electron/ssh-teardown.ts
+++ b/apps/desktop/electron/ssh-teardown.ts
@@ -1,0 +1,38 @@
+import { waitForTeardown } from './local-backend-lifecycle'
+
+/** Retain transports removed from routing until their remote kill has settled. */
+export function createSshTeardownTracker() {
+  const pending = new Map<Promise<void>, { close: () => Promise<unknown> }>()
+
+  return {
+    hasPending: () => pending.size > 0,
+    track(ssh: { close: () => Promise<unknown> }, teardown: () => Promise<void>): Promise<void> {
+      const promise = Promise.resolve().then(teardown)
+      pending.set(promise, ssh)
+      void promise.then(
+        () => pending.delete(promise),
+        () => pending.delete(promise)
+      )
+
+      return promise
+    },
+    async finish(
+      bootstraps: Promise<unknown>[],
+      forceCleanup: () => Promise<unknown>,
+      graceMs = 6_000,
+      forceMs = 1_000
+    ) {
+      await waitForTeardown([...pending.keys(), ...bootstraps], graceMs)
+      // Only abandon the transport after the existing remote-kill grace period.
+      // Closing SSH unblocks a wedged exec; both close and bootstrap force cleanup
+      // are bounded too, not an unbounded await after a nominal timeout.
+      await waitForTeardown(
+        [
+          Promise.resolve().then(forceCleanup),
+          ...[...new Set(pending.values())].map(ssh => Promise.resolve().then(() => ssh.close()))
+        ],
+        forceMs
+      )
+    }
+  }
+}

--- a/apps/desktop/electron/update-gate-cancellation.test.ts
+++ b/apps/desktop/electron/update-gate-cancellation.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { waitForUpdateClearance } from './update-gate'
+
+test('quit interrupts an update-gated wait instead of waiting for the next poll', async () => {
+  const controller = new AbortController()
+  let slept = false
+
+  const waiting = waitForUpdateClearance(
+    { hasLiveMarker: () => true, isUpdateInFlight: () => false },
+    {
+      signal: controller.signal,
+      pollMs: 1000,
+      timeoutMs: 120000,
+      sleep: () => {
+        slept = true
+
+        return new Promise(() => {})
+      }
+    }
+  )
+
+  let outcome: unknown
+  void waiting.then(result => {
+    outcome = result
+  })
+
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve()
+  }
+
+  assert.equal(slept, true)
+  controller.abort()
+
+  for (let i = 0; i < 20; i++) {
+    await Promise.resolve()
+  }
+
+  assert.equal(outcome, 'cancelled')
+})

--- a/apps/desktop/electron/update-gate.ts
+++ b/apps/desktop/electron/update-gate.ts
@@ -1,5 +1,7 @@
 'use strict'
 
+import { runBackendStartStep } from './backend-start-cancellation'
+
 /**
  * update-gate.ts
  *
@@ -47,9 +49,11 @@ export function updateGateReason(deps: UpdateGateDeps): UpdateGateReason {
   return null
 }
 
-export type UpdateClearanceOutcome = 'clear' | 'finished' | 'timeout'
+export type UpdateClearanceOutcome = 'clear' | 'finished' | 'timeout' | 'cancelled'
 
 export interface WaitForUpdateClearanceOptions {
+  signal?: AbortSignal
+  isCancelled?: () => boolean
   timeoutMs: number
   pollMs: number
   /** Invoked once per poll while parked (boot progress / logging). */
@@ -74,6 +78,12 @@ export async function waitForUpdateClearance(
   const now = options.now || Date.now
   const sleep = options.sleep || (ms => new Promise<void>(r => setTimeout(r, ms)))
 
+  const isCancelled = () => options.signal?.aborted || options.isCancelled?.()
+
+  if (isCancelled()) {
+    return 'cancelled'
+  }
+
   let reason = updateGateReason(deps)
 
   if (!reason) {
@@ -83,11 +93,42 @@ export async function waitForUpdateClearance(
   const deadline = now() + options.timeoutMs
 
   while (reason && now() < deadline) {
-    if (options.onWaitTick) {
-      await options.onWaitTick(reason)
+    if (isCancelled()) {
+      return 'cancelled'
     }
 
-    await sleep(options.pollMs)
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    try {
+      if (options.onWaitTick) {
+        await runBackendStartStep(options.signal, () => options.onWaitTick!(reason!))
+      }
+
+      if (isCancelled()) {
+        return 'cancelled'
+      }
+
+      await runBackendStartStep(options.signal, () =>
+        options.sleep
+          ? sleep(options.pollMs)
+          : new Promise<void>(resolve => {
+              timer = setTimeout(resolve, options.pollMs)
+            })
+      )
+    } catch (error) {
+      if (isCancelled()) {
+        return 'cancelled'
+      }
+
+      throw error
+    } finally {
+      clearTimeout(timer)
+    }
+
+    if (isCancelled()) {
+      return 'cancelled'
+    }
+
     reason = updateGateReason(deps)
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop quit coordination so a settled URL-backed remote connection exits on the first request, while local and SSH sessions finish their owned cleanup before Electron exits.

Quit now cancels pending setup and update-gated startup, prevents late local spawns, and retains children and teardown work after their routing entries disappear. One bounded coordinator replaces the independent backend and SSH quit loops. Managed SSH update recovery still completes before teardown begins.

## Related work and credit

Supersedes https://github.com/NousResearch/hermes-agent/pull/102429, https://github.com/NousResearch/hermes-agent/pull/92598, and https://github.com/NousResearch/hermes-agent/pull/82461.

- @helix4u: settled-remote fast quit, shared quit barrier, pending-connection state, and joining already-evicted pool stops.
- @ChanPark03: pending-start and child ownership tracking, prior teardown inventory, and cancellation of update-gated starts.
- Earlier drain/barrier work by @spfcraze is acknowledged in the source proposals. The merged SSH teardown guarantee from @686f6c61 is preserved.

Both cluster authors are credited with `Co-authored-by` trailers. This does not change window-close conventions, active-work confirmation, tray behavior, or Python shutdown policy. The issues linked by the older teardown proposal are already closed; no unrelated issues are claimed.

## Tests

- 102 focused lifecycle tests passed using the standard Electron Vitest project.
- Electron TypeScript check passed; main/preload bundles built successfully.
- Full Electron suite: 2,177 passed, 6 skipped, 1 failure in an unchanged Linux managed-updater launcher test. That test invokes `setsid`, which is unavailable on this macOS host (exit 127).
- Native macOS smoke: full Electron main process against a real, isolated URL-backed `hermes serve`; one `app.quit()` exited with code 0 in 46 ms. All captured Electron helper PIDs exited and the independently owned remote backend remained healthy. This used an unpackaged development bundle, not a signed release or physical keyboard input.
- Independent review found a bootstrap manifest cancellation gap; the follow-up forwards the abort signal and prevents manifest dispatch after cancellation, with two real subprocess regressions.
- Behavioral coverage includes first-run choice cancellation, removed starts, pre-claim children, SIGKILL escalation, pre-existing local/SSH drains, repeated quit, failures, and bounded cleanup.

## Type of change

- [x] Bug fix
- [x] Regression tests

