### PR TITLE
fix(desktop): deliver preview watch events to the window that created the watch

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6411,33 +6411,18 @@ async function filePathFromPreviewUrl(rawUrl) {
   return resolvedPath
 }
 
-function sendPreviewFileChanged(payload) {
-  if (!mainWindow || mainWindow.isDestroyed()) {
-    return
-  }
-
-  const { webContents } = mainWindow
-
-  if (!webContents || webContents.isDestroyed()) {
-    return
-  }
-
-  webContents.send('hermes:preview-file-changed', payload)
-}
-
 // Watcher lifecycle lives in ./preview-watch (unit-tested there); this module
-// keeps only URL resolution and the renderer payload shape.
+// keeps only URL resolution and hands the registry the window that asked for
+// the watch, so change events are delivered back to that window.
 const previewWatchRegistry = createPreviewWatchRegistry({
   fileExists,
-  debounceMs: PREVIEW_WATCH_DEBOUNCE_MS,
-  sendChanged: ({ id, path: changedPath }) =>
-    sendPreviewFileChanged({ id, path: changedPath, url: pathToFileURL(changedPath).toString() })
+  debounceMs: PREVIEW_WATCH_DEBOUNCE_MS
 })
 
-async function watchPreviewFile(rawUrl) {
+async function watchPreviewFile(rawUrl, owner) {
   const filePath = await filePathFromPreviewUrl(rawUrl)
 
-  return previewWatchRegistry.watch(filePath)
+  return previewWatchRegistry.watch(filePath, owner)
 }
 
 function stopPreviewFileWatch(id) {
@@ -6463,14 +6448,14 @@ function requestOptionsWithHeaders(options: any = {}, headers = {}) {
  *  readdir poll. Same registry + change channel as the preview file watchers
  *  (the renderer reconciles on any tick; per-file edits stay on their own
  *  watches), so stopPreviewFileWatch/closePreviewWatchers manage these too. */
-function watchDirectory(rawDir) {
+function watchDirectory(rawDir, owner) {
   const watchDir = path.resolve(String(rawDir || ''))
 
   if (!fs.existsSync(watchDir) || !fs.statSync(watchDir).isDirectory()) {
     throw new Error(`Not a directory: ${watchDir}`)
   }
 
-  return previewWatchRegistry.watchDirectory(watchDir)
+  return previewWatchRegistry.watchDirectory(watchDir, owner)
 }
 
 // Best-effort read of a gateway's advertised auth providers, cached per base
@@ -16962,9 +16947,9 @@ ipcMain.handle('hermes:normalizePreviewTarget', (_event, target, baseDir) =>
   normalizePreviewTarget(String(target || ''), baseDir ? String(baseDir) : '')
 )
 
-ipcMain.handle('hermes:watchPreviewFile', (_event, url) => watchPreviewFile(String(url || '')))
+ipcMain.handle('hermes:watchPreviewFile', (event, url) => watchPreviewFile(String(url || ''), event.sender))
 
-ipcMain.handle('hermes:watchDirectory', (_event, dir) => watchDirectory(String(dir || '')))
+ipcMain.handle('hermes:watchDirectory', (event, dir) => watchDirectory(String(dir || ''), event.sender))
 
 ipcMain.handle('hermes:stopPreviewFileWatch', (_event, id) => stopPreviewFileWatch(String(id || '')))
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -308,6 +308,7 @@ import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
 import { capturePreviewContents } from './preview-capture'
 import { PreviewReachRegistry } from './preview-reach'
+import { createPreviewWatchRegistry } from './preview-watch'
 import {
   createPrimaryRemoteConnection,
   FirstRunSetupResetError,
@@ -1708,7 +1709,6 @@ let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
 const remoteWsHeaderStore = createRemoteWsHeaderStore()
-const previewWatchers = new Map()
 let previewShortcutActive = false
 let nativeThemeListenerInstalled = false
 
@@ -6425,65 +6425,27 @@ function sendPreviewFileChanged(payload) {
   webContents.send('hermes:preview-file-changed', payload)
 }
 
+// Watcher lifecycle lives in ./preview-watch (unit-tested there); this module
+// keeps only URL resolution and the renderer payload shape.
+const previewWatchRegistry = createPreviewWatchRegistry({
+  fileExists,
+  debounceMs: PREVIEW_WATCH_DEBOUNCE_MS,
+  sendChanged: ({ id, path: changedPath }) =>
+    sendPreviewFileChanged({ id, path: changedPath, url: pathToFileURL(changedPath).toString() })
+})
+
 async function watchPreviewFile(rawUrl) {
   const filePath = await filePathFromPreviewUrl(rawUrl)
-  const watchDir = path.dirname(filePath)
-  const targetName = path.basename(filePath)
-  const id = crypto.randomBytes(12).toString('base64url')
-  let timer = null
 
-  const watcher = fs.watch(watchDir, (_eventType, filename) => {
-    const changedName = filename ? path.basename(String(filename)) : ''
-
-    if (changedName && changedName !== targetName) {
-      return
-    }
-
-    if (timer) {
-      clearTimeout(timer)
-    }
-
-    timer = setTimeout(() => {
-      timer = null
-
-      if (!fileExists(filePath)) {
-        return
-      }
-
-      sendPreviewFileChanged({ id, path: filePath, url: pathToFileURL(filePath).toString() })
-    }, PREVIEW_WATCH_DEBOUNCE_MS)
-  })
-
-  previewWatchers.set(id, {
-    close: () => {
-      if (timer) {
-        clearTimeout(timer)
-      }
-
-      watcher.close()
-    }
-  })
-
-  return { id, path: filePath }
+  return previewWatchRegistry.watch(filePath)
 }
 
 function stopPreviewFileWatch(id) {
-  const watcher = previewWatchers.get(id)
-
-  if (!watcher) {
-    return false
-  }
-
-  watcher.close()
-  previewWatchers.delete(id)
-
-  return true
+  return previewWatchRegistry.stop(id)
 }
 
 function closePreviewWatchers() {
-  for (const id of previewWatchers.keys()) {
-    stopPreviewFileWatch(id)
-  }
+  previewWatchRegistry.closeAll()
 }
 
 function requestOptionsWithHeaders(options: any = {}, headers = {}) {
@@ -6508,31 +6470,7 @@ function watchDirectory(rawDir) {
     throw new Error(`Not a directory: ${watchDir}`)
   }
 
-  const id = crypto.randomBytes(12).toString('base64url')
-  let timer = null
-
-  const watcher = fs.watch(watchDir, () => {
-    if (timer) {
-      clearTimeout(timer)
-    }
-
-    timer = setTimeout(() => {
-      timer = null
-      sendPreviewFileChanged({ id, path: watchDir, url: pathToFileURL(watchDir).toString() })
-    }, PREVIEW_WATCH_DEBOUNCE_MS)
-  })
-
-  previewWatchers.set(id, {
-    close: () => {
-      if (timer) {
-        clearTimeout(timer)
-      }
-
-      watcher.close()
-    }
-  })
-
-  return { id, path: watchDir }
+  return previewWatchRegistry.watchDirectory(watchDir)
 }
 
 // Best-effort read of a gateway's advertised auth providers, cached per base

--- a/apps/desktop/electron/preview-watch.test.ts
+++ b/apps/desktop/electron/preview-watch.test.ts
@@ -13,6 +13,7 @@ import type { PreviewFileChangedPayload, PreviewWatchImpl } from './preview-watc
 interface FakeWatcher extends EventEmitter {
   close: () => void
   closed: boolean
+  dir: string
   emitChange: (filename: Buffer | null | string) => void
   emitRename: (filename: Buffer | null | string) => void
 }
@@ -20,10 +21,11 @@ interface FakeWatcher extends EventEmitter {
 function fakeWatchImpl() {
   const created: FakeWatcher[] = []
 
-  const impl: PreviewWatchImpl = (_dirPath, listener) => {
+  const impl: PreviewWatchImpl = (dirPath, listener) => {
     const watcher = new EventEmitter() as FakeWatcher
 
     watcher.closed = false
+    watcher.dir = dirPath
 
     watcher.close = () => {
       watcher.closed = true
@@ -168,6 +170,14 @@ describe('createPreviewWatchRegistry — file watches', () => {
     ])
   })
 
+  it('registers the watch on the parent directory (save-by-rename contract)', () => {
+    const { created, registry } = makeRegistry()
+
+    registry.watch('/tmp/preview/note.md', fakeOwner())
+
+    expect(created[0].dir).toBe('/tmp/preview')
+  })
+
   it('rename events (atomic save-by-rename) trigger a reload', () => {
     const { created, registry } = makeRegistry()
     const owner = fakeOwner()
@@ -258,6 +268,20 @@ describe('createPreviewWatchRegistry — file watches', () => {
     expect(registry.size()).toBe(0)
     expect(created[0].closed).toBe(true)
     expect(created[1].closed).toBe(true)
+  })
+
+  it('closeAll cancels a pending debounce — a closed watch never reloads', () => {
+    const { created, registry } = makeRegistry()
+    const owner = fakeOwner()
+
+    registry.watch('/tmp/preview/note.md', owner)
+    created[0].emitChange('note.md')
+
+    registry.closeAll()
+    vi.advanceTimersByTime(1000)
+
+    expect(owner.sent).toHaveLength(0)
+    expect(registry.size()).toBe(0)
   })
 })
 

--- a/apps/desktop/electron/preview-watch.test.ts
+++ b/apps/desktop/electron/preview-watch.test.ts
@@ -1,0 +1,229 @@
+import { EventEmitter } from 'node:events'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createPreviewWatchRegistry } from './preview-watch'
+import type { PreviewWatchImpl, PreviewWatchPayload } from './preview-watch'
+
+// Fake FSWatcher, faithful to real Node semantics where it matters: an
+// EventEmitter, and SILENT after close() (a real FSWatcher delivers no events
+// once closed). `closed` is fake bookkeeping only — a real FSWatcher exposes
+// no such property.
+interface FakeWatcher extends EventEmitter {
+  close: () => void
+  closed: boolean
+  emitChange: (filename: Buffer | null | string) => void
+  emitRename: (filename: Buffer | null | string) => void
+}
+
+function fakeWatchImpl() {
+  const created: FakeWatcher[] = []
+
+  const impl: PreviewWatchImpl = (_dirPath, listener) => {
+    const watcher = new EventEmitter() as FakeWatcher
+
+    watcher.closed = false
+
+    watcher.close = () => {
+      watcher.closed = true
+    }
+
+    watcher.emitChange = filename => {
+      if (!watcher.closed) {
+        listener('change', filename)
+      }
+    }
+
+    watcher.emitRename = filename => {
+      if (!watcher.closed) {
+        listener('rename', filename)
+      }
+    }
+
+    created.push(watcher)
+
+    return watcher
+  }
+
+  return { created, impl }
+}
+
+function makeRegistry(overrides: Partial<Parameters<typeof createPreviewWatchRegistry>[0]> = {}) {
+  const sent: PreviewWatchPayload[] = []
+  const { created, impl } = fakeWatchImpl()
+
+  const registry = createPreviewWatchRegistry({
+    fileExists: () => true,
+    sendChanged: payload => sent.push(payload),
+    debounceMs: 120,
+    watchImpl: impl,
+    ...overrides
+  })
+
+  return { created, registry, sent }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createPreviewWatchRegistry — file watches', () => {
+  it('debounces a burst of changes into one sendChanged with the watch id and path', () => {
+    const { created, registry, sent } = makeRegistry()
+
+    const { id } = registry.watch('/tmp/preview/note.md')
+
+    created[0].emitChange('note.md')
+    created[0].emitChange('note.md')
+    expect(sent).toHaveLength(0)
+
+    vi.advanceTimersByTime(200)
+    expect(sent).toEqual([{ id, path: '/tmp/preview/note.md' }])
+  })
+
+  it('rename events (atomic save-by-rename) trigger a reload', () => {
+    const { created, registry, sent } = makeRegistry()
+
+    registry.watch('/tmp/preview/note.md')
+    created[0].emitRename('note.md')
+
+    vi.advanceTimersByTime(200)
+    expect(sent).toHaveLength(1)
+  })
+
+  it('changes to sibling files in the same directory are ignored', () => {
+    const { created, registry, sent } = makeRegistry()
+
+    registry.watch('/tmp/preview/note.md')
+    created[0].emitChange('other.md')
+    created[0].emitChange('note.md.tmp')
+
+    vi.advanceTimersByTime(1000)
+    expect(sent).toHaveLength(0)
+  })
+
+  it('null filename (documented fs.watch behavior) is treated as a match — a reload beats a missed save', () => {
+    const { created, registry, sent } = makeRegistry()
+
+    registry.watch('/tmp/preview/note.md')
+    created[0].emitChange(null)
+
+    vi.advanceTimersByTime(200)
+    expect(sent).toHaveLength(1)
+  })
+
+  it('a deleted target file does not send', () => {
+    const { created, registry, sent } = makeRegistry({ fileExists: () => false })
+
+    registry.watch('/tmp/preview/note.md')
+    created[0].emitChange('note.md')
+
+    vi.advanceTimersByTime(1000)
+    expect(sent).toHaveLength(0)
+  })
+
+  it('a second change resets the debounce window', () => {
+    const { created, registry, sent } = makeRegistry()
+
+    registry.watch('/tmp/preview/note.md')
+
+    created[0].emitChange('note.md')
+    vi.advanceTimersByTime(100)
+    created[0].emitChange('note.md')
+    vi.advanceTimersByTime(100)
+    expect(sent).toHaveLength(0)
+
+    vi.advanceTimersByTime(100)
+    expect(sent).toHaveLength(1)
+  })
+
+  it('two watches of the same directory are independent and keep their own ids', () => {
+    const { created, registry, sent } = makeRegistry()
+
+    const a = registry.watch('/tmp/preview/note.md')
+    const b = registry.watch('/tmp/preview/other.md')
+
+    expect(created).toHaveLength(2)
+    expect(a.id).not.toBe(b.id)
+
+    created[0].emitChange('note.md')
+    vi.advanceTimersByTime(200)
+
+    expect(sent).toEqual([{ id: a.id, path: '/tmp/preview/note.md' }])
+  })
+
+  it('stop closes the watcher, suppresses a pending debounce, and reports unknown ids as false', () => {
+    const { created, registry, sent } = makeRegistry()
+
+    const { id } = registry.watch('/tmp/preview/note.md')
+
+    created[0].emitChange('note.md')
+    expect(registry.stop(id)).toBe(true)
+    expect(created[0].closed).toBe(true)
+
+    vi.advanceTimersByTime(1000)
+    expect(sent).toHaveLength(0)
+
+    expect(registry.stop(id)).toBe(false)
+    expect(registry.stop('never-existed')).toBe(false)
+  })
+
+  it('closeAll tears down every registered watch', () => {
+    const { created, registry } = makeRegistry()
+
+    registry.watch('/tmp/preview/a.md')
+    registry.watch('/tmp/preview/b.md')
+    expect(registry.size()).toBe(2)
+
+    registry.closeAll()
+
+    expect(registry.size()).toBe(0)
+    expect(created[0].closed).toBe(true)
+    expect(created[1].closed).toBe(true)
+  })
+})
+
+describe('createPreviewWatchRegistry — directory watches', () => {
+  it('debounces directory churn and sends the directory path', () => {
+    const { created, registry, sent } = makeRegistry()
+
+    const { id } = registry.watchDirectory('/tmp/plugins')
+
+    created[0].emitChange('new-plugin')
+    created[0].emitChange('another-plugin')
+
+    vi.advanceTimersByTime(200)
+    expect(sent).toEqual([{ id, path: '/tmp/plugins' }])
+  })
+
+  it('stop suppresses a pending directory debounce', () => {
+    const { created, registry, sent } = makeRegistry()
+
+    const { id } = registry.watchDirectory('/tmp/plugins')
+    created[0].emitChange('new-plugin')
+
+    expect(registry.stop(id)).toBe(true)
+    expect(created[0].closed).toBe(true)
+
+    vi.advanceTimersByTime(1000)
+    expect(sent).toHaveLength(0)
+  })
+
+  it('closeAll reaps directory watches alongside file watches', () => {
+    const { created, registry } = makeRegistry()
+
+    registry.watch('/tmp/preview/note.md')
+    registry.watchDirectory('/tmp/plugins')
+    expect(registry.size()).toBe(2)
+
+    registry.closeAll()
+
+    expect(registry.size()).toBe(0)
+    expect(created[0].closed).toBe(true)
+    expect(created[1].closed).toBe(true)
+  })
+})

--- a/apps/desktop/electron/preview-watch.test.ts
+++ b/apps/desktop/electron/preview-watch.test.ts
@@ -1,9 +1,10 @@
 import { EventEmitter } from 'node:events'
+import { pathToFileURL } from 'node:url'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createPreviewWatchRegistry } from './preview-watch'
-import type { PreviewWatchImpl, PreviewWatchPayload } from './preview-watch'
+import { createPreviewWatchRegistry, PREVIEW_FILE_CHANGED_CHANNEL } from './preview-watch'
+import type { PreviewFileChangedPayload, PreviewWatchImpl } from './preview-watch'
 
 // Fake FSWatcher, faithful to real Node semantics where it matters: an
 // EventEmitter, and SILENT after close() (a real FSWatcher delivers no events
@@ -48,20 +49,41 @@ function fakeWatchImpl() {
   return { created, impl }
 }
 
+// Stands in for a window's WebContents: `send` records what was delivered.
+interface FakeOwner {
+  destroyed: boolean
+  isDestroyed: () => boolean
+  send: (channel: string, payload: PreviewFileChangedPayload) => void
+  sent: Array<{ channel: string; payload: PreviewFileChangedPayload }>
+}
+
+function fakeOwner(): FakeOwner {
+  const owner: FakeOwner = {
+    destroyed: false,
+    isDestroyed: () => owner.destroyed,
+    send: (channel, payload) => {
+      owner.sent.push({ channel, payload })
+    },
+    sent: []
+  }
+
+  return owner
+}
+
 function makeRegistry(overrides: Partial<Parameters<typeof createPreviewWatchRegistry>[0]> = {}) {
-  const sent: PreviewWatchPayload[] = []
   const { created, impl } = fakeWatchImpl()
 
   const registry = createPreviewWatchRegistry({
     fileExists: () => true,
-    sendChanged: payload => sent.push(payload),
     debounceMs: 120,
     watchImpl: impl,
     ...overrides
   })
 
-  return { created, registry, sent }
+  return { created, registry }
 }
+
+const fileUrl = (filePath: string) => pathToFileURL(filePath).toString()
 
 beforeEach(() => {
   vi.useFakeTimers()
@@ -71,102 +93,154 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-describe('createPreviewWatchRegistry — file watches', () => {
-  it('debounces a burst of changes into one sendChanged with the watch id and path', () => {
-    const { created, registry, sent } = makeRegistry()
+describe('createPreviewWatchRegistry — delivery to the owning window', () => {
+  it('delivers each change only to the window that created the watch, under that watch id', () => {
+    const { created, registry } = makeRegistry()
+    const secondary = fakeOwner()
+    const main = fakeOwner()
 
-    const { id } = registry.watch('/tmp/preview/note.md')
+    const a = registry.watch('/tmp/preview/note.md', secondary)
+    const b = registry.watch('/tmp/preview/note.md', main)
 
-    created[0].emitChange('note.md')
-    created[0].emitChange('note.md')
-    expect(sent).toHaveLength(0)
-
-    vi.advanceTimersByTime(200)
-    expect(sent).toEqual([{ id, path: '/tmp/preview/note.md' }])
-  })
-
-  it('rename events (atomic save-by-rename) trigger a reload', () => {
-    const { created, registry, sent } = makeRegistry()
-
-    registry.watch('/tmp/preview/note.md')
-    created[0].emitRename('note.md')
-
-    vi.advanceTimersByTime(200)
-    expect(sent).toHaveLength(1)
-  })
-
-  it('changes to sibling files in the same directory are ignored', () => {
-    const { created, registry, sent } = makeRegistry()
-
-    registry.watch('/tmp/preview/note.md')
-    created[0].emitChange('other.md')
-    created[0].emitChange('note.md.tmp')
-
-    vi.advanceTimersByTime(1000)
-    expect(sent).toHaveLength(0)
-  })
-
-  it('null filename (documented fs.watch behavior) is treated as a match — a reload beats a missed save', () => {
-    const { created, registry, sent } = makeRegistry()
-
-    registry.watch('/tmp/preview/note.md')
-    created[0].emitChange(null)
-
-    vi.advanceTimersByTime(200)
-    expect(sent).toHaveLength(1)
-  })
-
-  it('a deleted target file does not send', () => {
-    const { created, registry, sent } = makeRegistry({ fileExists: () => false })
-
-    registry.watch('/tmp/preview/note.md')
-    created[0].emitChange('note.md')
-
-    vi.advanceTimersByTime(1000)
-    expect(sent).toHaveLength(0)
-  })
-
-  it('a second change resets the debounce window', () => {
-    const { created, registry, sent } = makeRegistry()
-
-    registry.watch('/tmp/preview/note.md')
-
-    created[0].emitChange('note.md')
-    vi.advanceTimersByTime(100)
-    created[0].emitChange('note.md')
-    vi.advanceTimersByTime(100)
-    expect(sent).toHaveLength(0)
-
-    vi.advanceTimersByTime(100)
-    expect(sent).toHaveLength(1)
-  })
-
-  it('two watches of the same directory are independent and keep their own ids', () => {
-    const { created, registry, sent } = makeRegistry()
-
-    const a = registry.watch('/tmp/preview/note.md')
-    const b = registry.watch('/tmp/preview/other.md')
-
-    expect(created).toHaveLength(2)
     expect(a.id).not.toBe(b.id)
 
     created[0].emitChange('note.md')
     vi.advanceTimersByTime(200)
 
-    expect(sent).toEqual([{ id: a.id, path: '/tmp/preview/note.md' }])
+    expect(secondary.sent).toEqual([
+      {
+        channel: PREVIEW_FILE_CHANGED_CHANNEL,
+        payload: { id: a.id, path: '/tmp/preview/note.md', url: fileUrl('/tmp/preview/note.md') }
+      }
+    ])
+    // The other window's watch is independent: nothing foreign was delivered.
+    expect(main.sent).toHaveLength(0)
+
+    created[1].emitChange('note.md')
+    vi.advanceTimersByTime(200)
+
+    expect(main.sent).toEqual([
+      {
+        channel: PREVIEW_FILE_CHANGED_CHANNEL,
+        payload: { id: b.id, path: '/tmp/preview/note.md', url: fileUrl('/tmp/preview/note.md') }
+      }
+    ])
+    expect(secondary.sent).toHaveLength(1)
+  })
+
+  it('a destroyed owner gets no send and its watch is dropped, not leaked', () => {
+    const { created, registry } = makeRegistry()
+    const owner = fakeOwner()
+
+    const { id } = registry.watch('/tmp/preview/note.md', owner)
+
+    // Window closed while the watch lived: the next fs tick must stop the
+    // watch (no leak) and skip the send (nothing left to deliver to).
+    owner.destroyed = true
+    expect(registry.size()).toBe(1)
+
+    created[0].emitChange('note.md')
+    vi.advanceTimersByTime(200)
+
+    expect(owner.sent).toHaveLength(0)
+    expect(registry.size()).toBe(0)
+    expect(registry.stop(id)).toBe(false)
+  })
+})
+
+describe('createPreviewWatchRegistry — file watches', () => {
+  it('debounces a burst of changes into one delivery with id, path and url', () => {
+    const { created, registry } = makeRegistry()
+    const owner = fakeOwner()
+
+    const { id } = registry.watch('/tmp/preview/note.md', owner)
+
+    created[0].emitChange('note.md')
+    created[0].emitChange('note.md')
+    expect(owner.sent).toHaveLength(0)
+
+    vi.advanceTimersByTime(200)
+    expect(owner.sent).toEqual([
+      {
+        channel: PREVIEW_FILE_CHANGED_CHANNEL,
+        payload: { id, path: '/tmp/preview/note.md', url: fileUrl('/tmp/preview/note.md') }
+      }
+    ])
+  })
+
+  it('rename events (atomic save-by-rename) trigger a reload', () => {
+    const { created, registry } = makeRegistry()
+    const owner = fakeOwner()
+
+    registry.watch('/tmp/preview/note.md', owner)
+    created[0].emitRename('note.md')
+
+    vi.advanceTimersByTime(200)
+    expect(owner.sent).toHaveLength(1)
+  })
+
+  it('changes to sibling files in the same directory are ignored', () => {
+    const { created, registry } = makeRegistry()
+    const owner = fakeOwner()
+
+    registry.watch('/tmp/preview/note.md', owner)
+    created[0].emitChange('other.md')
+    created[0].emitChange('note.md.tmp')
+
+    vi.advanceTimersByTime(1000)
+    expect(owner.sent).toHaveLength(0)
+  })
+
+  it('null filename (documented fs.watch behavior) is treated as a match — a reload beats a missed save', () => {
+    const { created, registry } = makeRegistry()
+    const owner = fakeOwner()
+
+    registry.watch('/tmp/preview/note.md', owner)
+    created[0].emitChange(null)
+
+    vi.advanceTimersByTime(200)
+    expect(owner.sent).toHaveLength(1)
+  })
+
+  it('a deleted target file does not send', () => {
+    const { created, registry } = makeRegistry({ fileExists: () => false })
+    const owner = fakeOwner()
+
+    registry.watch('/tmp/preview/note.md', owner)
+    created[0].emitChange('note.md')
+
+    vi.advanceTimersByTime(1000)
+    expect(owner.sent).toHaveLength(0)
+  })
+
+  it('a second change resets the debounce window', () => {
+    const { created, registry } = makeRegistry()
+    const owner = fakeOwner()
+
+    registry.watch('/tmp/preview/note.md', owner)
+
+    created[0].emitChange('note.md')
+    vi.advanceTimersByTime(100)
+    created[0].emitChange('note.md')
+    vi.advanceTimersByTime(100)
+    expect(owner.sent).toHaveLength(0)
+
+    vi.advanceTimersByTime(100)
+    expect(owner.sent).toHaveLength(1)
   })
 
   it('stop closes the watcher, suppresses a pending debounce, and reports unknown ids as false', () => {
-    const { created, registry, sent } = makeRegistry()
+    const { created, registry } = makeRegistry()
+    const owner = fakeOwner()
 
-    const { id } = registry.watch('/tmp/preview/note.md')
+    const { id } = registry.watch('/tmp/preview/note.md', owner)
 
     created[0].emitChange('note.md')
     expect(registry.stop(id)).toBe(true)
     expect(created[0].closed).toBe(true)
 
     vi.advanceTimersByTime(1000)
-    expect(sent).toHaveLength(0)
+    expect(owner.sent).toHaveLength(0)
 
     expect(registry.stop(id)).toBe(false)
     expect(registry.stop('never-existed')).toBe(false)
@@ -175,8 +249,8 @@ describe('createPreviewWatchRegistry — file watches', () => {
   it('closeAll tears down every registered watch', () => {
     const { created, registry } = makeRegistry()
 
-    registry.watch('/tmp/preview/a.md')
-    registry.watch('/tmp/preview/b.md')
+    registry.watch('/tmp/preview/a.md', fakeOwner())
+    registry.watch('/tmp/preview/b.md', fakeOwner())
     expect(registry.size()).toBe(2)
 
     registry.closeAll()
@@ -188,36 +262,43 @@ describe('createPreviewWatchRegistry — file watches', () => {
 })
 
 describe('createPreviewWatchRegistry — directory watches', () => {
-  it('debounces directory churn and sends the directory path', () => {
-    const { created, registry, sent } = makeRegistry()
+  it('debounces directory churn and sends the directory path to its owner', () => {
+    const { created, registry } = makeRegistry()
+    const owner = fakeOwner()
 
-    const { id } = registry.watchDirectory('/tmp/plugins')
+    const { id } = registry.watchDirectory('/tmp/plugins', owner)
 
     created[0].emitChange('new-plugin')
     created[0].emitChange('another-plugin')
 
     vi.advanceTimersByTime(200)
-    expect(sent).toEqual([{ id, path: '/tmp/plugins' }])
+    expect(owner.sent).toEqual([
+      {
+        channel: PREVIEW_FILE_CHANGED_CHANNEL,
+        payload: { id, path: '/tmp/plugins', url: fileUrl('/tmp/plugins') }
+      }
+    ])
   })
 
   it('stop suppresses a pending directory debounce', () => {
-    const { created, registry, sent } = makeRegistry()
+    const { created, registry } = makeRegistry()
+    const owner = fakeOwner()
 
-    const { id } = registry.watchDirectory('/tmp/plugins')
+    const { id } = registry.watchDirectory('/tmp/plugins', owner)
     created[0].emitChange('new-plugin')
 
     expect(registry.stop(id)).toBe(true)
     expect(created[0].closed).toBe(true)
 
     vi.advanceTimersByTime(1000)
-    expect(sent).toHaveLength(0)
+    expect(owner.sent).toHaveLength(0)
   })
 
   it('closeAll reaps directory watches alongside file watches', () => {
     const { created, registry } = makeRegistry()
 
-    registry.watch('/tmp/preview/note.md')
-    registry.watchDirectory('/tmp/plugins')
+    registry.watch('/tmp/preview/note.md', fakeOwner())
+    registry.watchDirectory('/tmp/plugins', fakeOwner())
     expect(registry.size()).toBe(2)
 
     registry.closeAll()
@@ -225,5 +306,19 @@ describe('createPreviewWatchRegistry — directory watches', () => {
     expect(registry.size()).toBe(0)
     expect(created[0].closed).toBe(true)
     expect(created[1].closed).toBe(true)
+  })
+
+  it('a destroyed owner takes its directory watch down too', () => {
+    const { created, registry } = makeRegistry()
+    const owner = fakeOwner()
+
+    registry.watchDirectory('/tmp/plugins', owner)
+    owner.destroyed = true
+
+    created[0].emitChange('new-plugin')
+    vi.advanceTimersByTime(200)
+
+    expect(owner.sent).toHaveLength(0)
+    expect(registry.size()).toBe(0)
   })
 })

--- a/apps/desktop/electron/preview-watch.ts
+++ b/apps/desktop/electron/preview-watch.ts
@@ -1,0 +1,163 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Live-reload watching for previewed files and the disk-plugin door, extracted
+ * from main.ts so the lifecycle is unit-testable (Vitest project `electron`).
+ *
+ * A watch exists because a renderer asked the main process to report when
+ * something changes on disk: the preview pane reloads its file, and the
+ * desktop plugin loader reconciles its folder set. Both consumers only care
+ * that "it changed", so events are debounced per watch — editors write in
+ * bursts (in-place save, rename dance) and one tick per burst is enough.
+ *
+ * File watches are registered on the file's PARENT directory: a watch on the
+ * file itself does not survive atomic save-by-rename, which is how most
+ * editors write. A change to a sibling in that directory is filtered out by
+ * name.
+ *
+ * main.ts keeps what does not belong here: resolving a preview URL to a
+ * readable path (the IPC path-security check), the directory-exists check,
+ * and shaping the renderer payload for `hermes:preview-file-changed`.
+ */
+
+/** What a watch reports when its target changed; main.ts shapes the IPC. */
+export interface PreviewWatchPayload {
+  id: string
+  path: string
+}
+
+/**
+ * Directory + listener -> a close()-able watcher. Injected so tests can use a
+ * deterministic EventEmitter instead of real fs events; defaults to fs.watch.
+ */
+export type PreviewWatchImpl = (
+  dirPath: string,
+  listener: (eventType: string, filename: Buffer | null | string) => void
+) => { close: () => void }
+
+export interface PreviewWatchDeps {
+  /** Whether the watched file still exists (the debounce may fire post-delete). */
+  fileExists: (filePath: string) => boolean
+  /** Renderer-facing sink, called at most once per debounce window. */
+  sendChanged: (payload: PreviewWatchPayload) => void
+  /** Coalescing window per watch, in milliseconds. */
+  debounceMs: number
+  /** Injectable for tests. */
+  watchImpl?: PreviewWatchImpl
+}
+
+export interface PreviewWatchHandle {
+  id: string
+  path: string
+}
+
+export interface PreviewWatchRegistry {
+  closeAll: () => void
+  /** Registered watches right now; bookkeeping counterpart to stop(). */
+  size: () => number
+  /** Drop one watch. False when the id is unknown (already stopped). */
+  stop: (id: string) => boolean
+  watch: (filePath: string) => PreviewWatchHandle
+  watchDirectory: (dirPath: string) => PreviewWatchHandle
+}
+
+export function createPreviewWatchRegistry({
+  fileExists,
+  sendChanged,
+  debounceMs,
+  watchImpl = fs.watch as PreviewWatchImpl
+}: PreviewWatchDeps): PreviewWatchRegistry {
+  const watchers = new Map<string, { close: () => void }>()
+
+  function watch(filePath: string): PreviewWatchHandle {
+    const watchDir = path.dirname(filePath)
+    const targetName = path.basename(filePath)
+    const id = crypto.randomBytes(12).toString('base64url')
+    let timer: null | ReturnType<typeof setTimeout> = null
+
+    const watcher = watchImpl(watchDir, (_eventType, filename) => {
+      const changedName = filename ? path.basename(String(filename)) : ''
+
+      if (changedName && changedName !== targetName) {
+        return
+      }
+
+      if (timer) {
+        clearTimeout(timer)
+      }
+
+      timer = setTimeout(() => {
+        timer = null
+
+        if (!fileExists(filePath)) {
+          return
+        }
+
+        sendChanged({ id, path: filePath })
+      }, debounceMs)
+    })
+
+    watchers.set(id, {
+      close: () => {
+        if (timer) {
+          clearTimeout(timer)
+        }
+
+        watcher.close()
+      }
+    })
+
+    return { id, path: filePath }
+  }
+
+  function watchDirectory(dirPath: string): PreviewWatchHandle {
+    const id = crypto.randomBytes(12).toString('base64url')
+    let timer: null | ReturnType<typeof setTimeout> = null
+
+    const watcher = watchImpl(dirPath, () => {
+      if (timer) {
+        clearTimeout(timer)
+      }
+
+      timer = setTimeout(() => {
+        timer = null
+        sendChanged({ id, path: dirPath })
+      }, debounceMs)
+    })
+
+    watchers.set(id, {
+      close: () => {
+        if (timer) {
+          clearTimeout(timer)
+        }
+
+        watcher.close()
+      }
+    })
+
+    return { id, path: dirPath }
+  }
+
+  function stop(id: string): boolean {
+    const watcher = watchers.get(id)
+
+    if (!watcher) {
+      return false
+    }
+
+    watcher.close()
+    watchers.delete(id)
+
+    return true
+  }
+
+  function closeAll(): void {
+    for (const id of [...watchers.keys()]) {
+      stop(id)
+    }
+  }
+
+  return { watch, watchDirectory, stop, closeAll, size: () => watchers.size }
+}

--- a/apps/desktop/electron/preview-watch.ts
+++ b/apps/desktop/electron/preview-watch.ts
@@ -1,31 +1,45 @@
 import crypto from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 /**
  * Live-reload watching for previewed files and the disk-plugin door, extracted
  * from main.ts so the lifecycle is unit-testable (Vitest project `electron`).
  *
- * A watch exists because a renderer asked the main process to report when
+ * A watch exists because a RENDERER asked the main process to report when
  * something changes on disk: the preview pane reloads its file, and the
- * desktop plugin loader reconciles its folder set. Both consumers only care
- * that "it changed", so events are debounced per watch — editors write in
- * bursts (in-place save, rename dance) and one tick per burst is enough.
+ * desktop plugin loader reconciles its folder set. Both consumers receive
+ * change events on `hermes:preview-file-changed` and each filters them by its
+ * own watch id — so a watch's events must go back to the WebContents that
+ * created it, not to whichever window happens to be the main one. The owner
+ * is captured at watch creation and delivery is routed to it; a window that
+ * died while its watch lived takes the watch down instead of delivering
+ * nowhere.
  *
- * File watches are registered on the file's PARENT directory: a watch on the
- * file itself does not survive atomic save-by-rename, which is how most
- * editors write. A change to a sibling in that directory is filtered out by
- * name.
+ * Events are debounced per watch — editors write in bursts (in-place save,
+ * rename dance) and one tick per burst is enough. File watches are registered
+ * on the file's PARENT directory: a watch on the file itself does not survive
+ * atomic save-by-rename, which is how most editors write. A change to a
+ * sibling in that directory is filtered out by name.
  *
  * main.ts keeps what does not belong here: resolving a preview URL to a
- * readable path (the IPC path-security check), the directory-exists check,
- * and shaping the renderer payload for `hermes:preview-file-changed`.
+ * readable path (the IPC path-security check) and the directory-exists check.
  */
 
-/** What a watch reports when its target changed; main.ts shapes the IPC. */
-export interface PreviewWatchPayload {
+export const PREVIEW_FILE_CHANGED_CHANNEL = 'hermes:preview-file-changed'
+
+/** The renderer that created a watch; an Electron WebContents satisfies this. */
+export interface PreviewWatchOwner {
+  isDestroyed: () => boolean
+  send: (channel: string, payload: PreviewFileChangedPayload) => void
+}
+
+/** What a watch reports when its target changed. */
+export interface PreviewFileChangedPayload {
   id: string
   path: string
+  url: string
 }
 
 /**
@@ -40,8 +54,6 @@ export type PreviewWatchImpl = (
 export interface PreviewWatchDeps {
   /** Whether the watched file still exists (the debounce may fire post-delete). */
   fileExists: (filePath: string) => boolean
-  /** Renderer-facing sink, called at most once per debounce window. */
-  sendChanged: (payload: PreviewWatchPayload) => void
   /** Coalescing window per watch, in milliseconds. */
   debounceMs: number
   /** Injectable for tests. */
@@ -59,19 +71,34 @@ export interface PreviewWatchRegistry {
   size: () => number
   /** Drop one watch. False when the id is unknown (already stopped). */
   stop: (id: string) => boolean
-  watch: (filePath: string) => PreviewWatchHandle
-  watchDirectory: (dirPath: string) => PreviewWatchHandle
+  watch: (filePath: string, owner: PreviewWatchOwner) => PreviewWatchHandle
+  watchDirectory: (dirPath: string, owner: PreviewWatchOwner) => PreviewWatchHandle
 }
 
 export function createPreviewWatchRegistry({
   fileExists,
-  sendChanged,
   debounceMs,
   watchImpl = fs.watch as PreviewWatchImpl
 }: PreviewWatchDeps): PreviewWatchRegistry {
   const watchers = new Map<string, { close: () => void }>()
 
-  function watch(filePath: string): PreviewWatchHandle {
+  /** Deliver to the owner that created the watch, and only to it. A window
+   *  that died while its watch lived takes the watch down with the event. */
+  const deliver = (id: string, owner: PreviewWatchOwner, targetPath: string) => {
+    if (owner.isDestroyed()) {
+      stop(id)
+
+      return
+    }
+
+    owner.send(PREVIEW_FILE_CHANGED_CHANNEL, {
+      id,
+      path: targetPath,
+      url: pathToFileURL(targetPath).toString()
+    })
+  }
+
+  function watch(filePath: string, owner: PreviewWatchOwner): PreviewWatchHandle {
     const watchDir = path.dirname(filePath)
     const targetName = path.basename(filePath)
     const id = crypto.randomBytes(12).toString('base64url')
@@ -95,7 +122,7 @@ export function createPreviewWatchRegistry({
           return
         }
 
-        sendChanged({ id, path: filePath })
+        deliver(id, owner, filePath)
       }, debounceMs)
     })
 
@@ -112,7 +139,7 @@ export function createPreviewWatchRegistry({
     return { id, path: filePath }
   }
 
-  function watchDirectory(dirPath: string): PreviewWatchHandle {
+  function watchDirectory(dirPath: string, owner: PreviewWatchOwner): PreviewWatchHandle {
     const id = crypto.randomBytes(12).toString('base64url')
     let timer: null | ReturnType<typeof setTimeout> = null
 
@@ -123,7 +150,7 @@ export function createPreviewWatchRegistry({
 
       timer = setTimeout(() => {
         timer = null
-        sendChanged({ id, path: dirPath })
+        deliver(id, owner, dirPath)
       }, debounceMs)
     })
 


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop watch-notification **delivery layer**: change events for previewed files and disk-plugin folders are now delivered to the WebContents that created the watch, not unconditionally to the main window.

`sendPreviewFileChanged()` sent every notification to `mainWindow`, and the watch IPC handlers discarded `event.sender`. Both renderer consumers filter `hermes:preview-file-changed` by their own watch id (`preview-pane.tsx`, `runtime-loader.ts`), so watches created by a secondary window (session/instance) never received their own events — plugins there never hot-reloaded and previews went stale until a manual window reload.

This PR:

- extracts the watch lifecycle from `main.ts` into `apps/desktop/electron/preview-watch.ts` (unit-testable; injectable `fs.watch` and timers),
- captures the owner (`event.sender`) at watch creation and routes each change back to it,
- tears a watch down when its owner window is gone instead of delivering nowhere.

Relationship to #73524 (open — same watcher block, different layer):

- #73524 creates the same module paths (`apps/desktop/electron/preview-watch.ts` + its test) with **error containment** for the `FSWatcher` `'error'` event, and keeps a single `sendChanged` sink — it does not route to owners.
- This PR mirrors that module name and the injectable-deps factory shape on purpose: whichever lands first, the other rebases on top. If #73524 merges first, this PR's delivery-layer delta (owner per watch) rebases onto its registry; if this PR merges first, #73524's containment delta rebases onto these same paths. I deliberately did **not** absorb the containment work — no duplicate authorship.
- Also related, different layer: #91503 + #92011/#91648 touch the renderer-side manual plugin rescan (`runtime-loader.ts`); untouched here.

## Related Issue

Fixes #108189

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/preview-watch.ts` (new): watch registry for files and directories — per-watch 120ms debounce, filename filter for file watches, `fileExists` gate before reporting, owner-routed delivery on `hermes:preview-file-changed`, destroyed-owner teardown, `stop`/`closeAll`/`size` bookkeeping. (Three commits: the write-for-write extraction from `main.ts`, the owner-routed delivery, and a small test follow-up pinning the parent-directory registration and `closeAll` timer contracts.)
- `apps/desktop/electron/main.ts`: watch IPC handlers pass `event.sender` as the owner; `watchPreviewFile`/`watchDirectory` keep only URL resolution and the directory-exists check; the old `previewWatchers` map and `sendPreviewFileChanged` are gone.
- `apps/desktop/electron/preview-watch.test.ts` (new): 16 invariant tests — debounce coalescing/reset, rename saves, parent-directory registration, sibling filtering, null-filename match, deleted-file gate, per-window routing with distinct ids, destroyed-owner teardown, stop/closeAll timer teardown, directory variants.

## How to Test

1. `cd apps/desktop && npm run check:lint` — tsc (three configs) + eslint on `src/` and `electron/`.
2. `cd apps/desktop && npx vitest run --project electron electron/preview-watch.test.ts` — expect `16 passed`.
3. Manual (two windows): open a preview (`::preview{file=...}`) target or a disk plugin in a secondary window, then edit the file on disk. Before: only the main window reacted. After: every window that created a watch receives its own change event.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`refactor(desktop):` + `fix(desktop):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — closest is #73524 (error containment, no routing); related, deliberately complementary (see the relationship note above)
- [x] My PR contains **only** changes related to this fix (3 files, 3 commits)
- [x] I've run `pytest tests/ -q` and all tests pass — JS/TS-only diff under `apps/desktop`; the Python suite is untouched by this branch.
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Windows 11 (bug reproduced in a two-window session; unit lane `--project electron` green locally)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new module carries explanatory docblocks
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architecture or workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — the module preserves the existing `fs.watch` semantics exactly (parent-directory watch for rename-safe saves, null-filename treated as a match)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (two windows, live session): editing a disk plugin re-registers it only in the main window's renderer; the session window's renderer keeps the previous plugin build for the rest of the session. After: delivery is routed per owner, covered by the routing invariants in `preview-watch.test.ts` (two owners on the same file each receive only their own id).
