### PR TITLE
fix(deepseek): preserve canonical deepseek-flash model ID

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -13,11 +13,11 @@ Different LLM providers expect model identifiers in different formats:
   ``claude-sonnet-4-6``.
 - **OpenCode Go** preserves dots in model names: ``minimax-m2.7``.
 - **DeepSeek** accepts ``deepseek-chat`` (V3), ``deepseek-reasoner``
-  (R1-family), and the first-class V-series IDs (``deepseek-v4-pro``,
-  ``deepseek-v4-flash``, and any future ``deepseek-v<N>-*``).  Older
-  Hermes revisions folded every non-reasoner input into
-  ``deepseek-chat``, which on aggregators routes to V3 — so a user
-  picking V4 Pro was silently downgraded.
+  (R1-family), and the first-class V-series IDs (``deepseek-flash``,
+  ``deepseek-v4-pro``, ``deepseek-v4-flash``, and any future
+  ``deepseek-v<N>-*``).  Older Hermes revisions folded every non-reasoner
+  input into ``deepseek-chat``, which on aggregators routes to V3 — so a
+  user picking V4 Pro was silently downgraded.
 - **Custom** and remaining providers pass the name through as-is.
 
 This module centralises that translation so callers can simply write::
@@ -118,8 +118,11 @@ _LOWERCASE_MODEL_PROVIDERS: frozenset[str] = frozenset({
 # ---------------------------------------------------------------------------
 # DeepSeek special handling
 # ---------------------------------------------------------------------------
-# DeepSeek's API only recognises exactly two model identifiers.  We map
-# common aliases and patterns to the canonical names.
+# DeepSeek's API recognises the canonical ``deepseek-chat`` /
+# ``deepseek-reasoner`` aliases plus the first-class V-series IDs
+# (``deepseek-flash``, ``deepseek-v4-pro``, ...).  Everything else is
+# folded onto an alias it accepts, so an unrecognised name never reaches
+# the API verbatim.
 
 _DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset({
     "reasoner",
@@ -132,8 +135,9 @@ _DEEPSEEK_REASONER_KEYWORDS: frozenset[str] = frozenset({
 _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
     "deepseek-chat",       # V3 on DeepSeek direct and most aggregators
     "deepseek-reasoner",   # R1-family reasoning model
+    "deepseek-flash",      # V4 Flash — canonical ID returned by the API
     "deepseek-v4-pro",     # V4 Pro — first-class model ID
-    "deepseek-v4-flash",   # V4 Flash — first-class model ID
+    "deepseek-v4-flash",   # V4 Flash — accepted alias, resolves to deepseek-flash
 })
 
 # First-class V-series IDs (``deepseek-v4-pro``, ``deepseek-v4-flash``,
@@ -150,7 +154,8 @@ def _normalize_for_deepseek(model_name: str) -> str:
 
     Rules:
     - Already a known canonical (``deepseek-chat``/``deepseek-reasoner``/
-      ``deepseek-v4-pro``/``deepseek-v4-flash``) -> pass through.
+      ``deepseek-flash``/``deepseek-v4-pro``/``deepseek-v4-flash``) -> pass
+      through.
     - Matches the V-series pattern ``deepseek-v<digit>...`` -> pass through
       (covers future ``deepseek-v5-*`` and dated variants without a release).
     - Contains a reasoner keyword (r1, think, reasoning, cot, reasoner)

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -231,6 +231,24 @@ class TestDeepseekVSeriesPassThrough:
         result = normalize_model_for_provider("deepseek-v4-flash", "deepseek")
         assert result == "deepseek-v4-flash"
 
+    def test_deepseek_provider_preserves_bare_flash(self):
+        """Regression: ``deepseek-flash`` is the canonical ID DeepSeek's API
+        returns in the response body.  It must reach the API verbatim rather
+        than being folded into ``deepseek-chat`` (V3) by the catch-all
+        fallback — a silent downgrade from V4 Flash to V3."""
+        result = normalize_model_for_provider("deepseek-flash", "deepseek")
+        assert result == "deepseek-flash"
+        assert result != "deepseek-chat"
+
+    def test_bare_flash_is_canonical(self):
+        assert _normalize_for_deepseek("deepseek-flash") == "deepseek-flash"
+        # case-insensitive, like the other canonical IDs
+        assert _normalize_for_deepseek("DeepSeek-Flash") == "deepseek-flash"
+
+    def test_vendor_prefixed_flash_is_stripped(self):
+        result = normalize_model_for_provider("deepseek/deepseek-flash", "deepseek")
+        assert result == "deepseek-flash"
+
 
 # ── DeepSeek regressions (existing behaviour still holds) ──────────────
 


### PR DESCRIPTION
## Summary

`deepseek-flash` is the canonical model ID DeepSeek's API returns in the response body, but Hermes was silently downgrading it to `deepseek-chat` (V3 / `deepseek-reasoner`-sibling chat alias).

## Root cause

`deepseek-flash` was absent from `_DEEPSEEK_CANONICAL_MODELS` and does not match `_DEEPSEEK_V_SERIES_RE`, which requires a **digit** directly after `deepseek-v`:

```python
_DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v\d+([-.].+)?$")
```

`deepseek-flash` has no `v<digit>`, so it fell through to the catch-all at the end of `_normalize_for_deepseek`:

```python
    return "deepseek-chat"   # <- silent downgrade
```

Result: selecting V4 Flash via its real ID silently ran V3, with only a yellow console warning (`⚠️  Normalized model 'deepseek-flash' to 'deepseek-chat' for deepseek.`) to explain it.

## Verification against the live API

Confirmed empirically — the API echoes the resolved model ID in the response body:

| Requested `model` | API response `"model"` field |
|---|---|
| `deepseek-flash` | `deepseek-flash` |
| `deepseek-v4-flash` | `deepseek-flash` |
| `deepseek-v4-pro` | `deepseek-v4-pro` |

This shows `deepseek-flash` is the canonical ID and `deepseek-v4-flash` is an accepted alias that resolves to it — the reverse of how the canonical set was labelled.

## Changes

- Add `deepseek-flash` to `_DEEPSEEK_CANONICAL_MODELS`.
- Relabel `deepseek-v4-flash` as the alias it actually is, rather than "first-class model ID".
- Refresh three stale docstrings claiming DeepSeek "only recognises exactly two model identifiers".

## Behavior contract

The invariant asserted is that a canonical ID **reaches the API unchanged** — not that any particular list is frozen. `unknown-model` and other non-DeepSeek names still fall through to `deepseek-chat` as before.

## Tests

Added three regressions: bare (`deepseek-flash`), case-insensitive (`DeepSeek-Flash`), and vendor-prefixed (`deepseek/deepseek-flash`).

All three **fail without the fix** on current `main`:

```
E       AssertionError: assert 'deepseek-chat' == 'deepseek-flash'
E         - deepseek-flash
E         + deepseek-chat
tests/hermes_cli/test_model_normalize.py:250: AssertionError
FAILED test_deepseek_provider_preserves_bare_flash
FAILED test_bare_flash_is_canonical
FAILED test_vendor_prefixed_flash_is_stripped
3 failed, 4 passed
```

And pass with it:

```
tests/hermes_cli/test_model_normalize.py  83 passed in 1.53s
```

Related suites, unregressed:

```
tests/hermes_cli/test_models.py
tests/hermes_cli/test_model_switch_custom_providers.py
tests/agent/test_auxiliary_named_custom_providers.py
139 passed, 3 warnings in 40.53s
```

No prompt-caching, role-alternation, or system-prompt behavior is touched — this is a pure mapping change in one normalization function.
