### PR TITLE
fix(gateway): re-resolve /model override credentials each turn

### DIFF
--- a/gateway/run_agent_cache.py
+++ b/gateway/run_agent_cache.py
@@ -210,6 +210,39 @@ class GatewayAgentCacheMixin:
             session_key, override.get("model"), provider or "",
         )
 
+    def _refresh_override_credentials(self, session_key: str, override: dict) -> None:
+        """Re-resolve the override's credentials from the live provider runtime before each turn.
+
+        The ``api_key`` captured at /model time (or on rehydration) is a snapshot. For OAuth
+        providers it is a short-lived bearer (xai-oauth access tokens live ~6h): replaying the
+        snapshot forever eventually 403s, and the credential pool cannot match the dead key to
+        any entry, so the turn falls straight through to the fallback chain instead of the
+        refreshed token that is already sitting in auth.json. Resolution goes through the same
+        pool/OAuth ladder the non-override path uses every turn; on failure the snapshot is kept.
+        """
+        from gateway.run import _resolve_runtime_agent_kwargs_for_provider
+        provider = override.get("provider")
+        if not provider or not str(provider).strip():
+            return
+        try:
+            runtime = _resolve_runtime_agent_kwargs_for_provider(str(provider).strip())
+        except Exception:
+            logger.debug(
+                "Credential re-resolution failed for session=%s provider=%s; keeping override snapshot",
+                session_key, provider, exc_info=True,
+            )
+            return
+        fresh_key = runtime.get("api_key")
+        if fresh_key and fresh_key != override.get("api_key"):
+            override["api_key"] = fresh_key
+            logger.info(
+                "Refreshed /model override credentials for session=%s provider=%s (rotated token adopted)",
+                session_key, provider,
+            )
+        pool = runtime.get("credential_pool")
+        if pool is not None:
+            override["credential_pool"] = pool
+
     def _apply_session_model_override(self, session_key: str, model: str, runtime_kwargs: dict) -> tuple:
         """Apply /model session overrides (precedence over config.yaml defaults; ``None`` fields skipped
         so partial overrides don't clobber defaults), returning (model, runtime_kwargs)."""
@@ -218,6 +251,7 @@ class GatewayAgentCacheMixin:
         if not override:
             return model, runtime_kwargs
         model = override.get("model", model)
+        self._refresh_override_credentials(session_key, override)
         for key in _OVERRIDE_APPLY_KEYS:
             val = override.get(key)
             if val is not None:

--- a/tests/gateway/test_session_model_override_persistence.py
+++ b/tests/gateway/test_session_model_override_persistence.py
@@ -150,3 +150,51 @@ def test_sanitize_model_override():
         "provider": "openai",
         "base_url": "https://api.openai.example/v1",
     }
+
+
+def test_override_re_resolves_stale_oauth_token_each_turn(store_factory):
+    """A /model override snapshots api_key once; OAuth bearers (xai-oauth ~6h) expire under a
+    long-lived gateway session. Each turn must adopt the rotated token from live resolution,
+    otherwise the dead key 403s, the pool cannot match it, and the turn falls to the fallback chain."""
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+    runner = _make_runner(store)
+    runner._session_model_overrides[session_key] = {
+        "model": "grok-4.6", "provider": "xai-oauth", "api_key": "xai-token-stale-6h-old",
+        "base_url": "https://api.x.ai/v1", "api_mode": "codex_responses",
+    }
+    fresh_pool = object()
+    with patch(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        return_value={
+            "api_key": "xai-token-rotated-by-refresh", "base_url": "https://api.x.ai/v1",
+            "provider": "xai-oauth", "api_mode": "codex_responses", "credential_pool": fresh_pool,
+        },
+    ) as resolve:
+        model, runtime = runner._apply_session_model_override(
+            session_key, "global-model", {"api_key": "config-default-key"},
+        )
+    resolve.assert_called_once_with("xai-oauth")
+    assert model == "grok-4.6"
+    assert runtime["api_key"] == "xai-token-rotated-by-refresh"
+    assert runtime["credential_pool"] is fresh_pool
+    # The override itself is updated so the next turn compares against the adopted token.
+    assert runner._session_model_overrides[session_key]["api_key"] == "xai-token-rotated-by-refresh"
+
+
+def test_override_keeps_snapshot_when_re_resolution_fails(store_factory):
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+    runner = _make_runner(store)
+    runner._session_model_overrides[session_key] = {
+        "model": "grok-4.6", "provider": "xai-oauth", "api_key": "xai-token-snapshot",
+        "base_url": "https://api.x.ai/v1", "api_mode": "codex_responses",
+    }
+    with patch(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider", side_effect=RuntimeError("creds gone"),
+    ), patch("gateway.run._credential_pool_for_provider", return_value=None):
+        model, runtime = runner._apply_session_model_override(session_key, "global-model", {})
+    assert model == "grok-4.6"
+    assert runtime["api_key"] == "xai-token-snapshot"


### PR DESCRIPTION
## Problem

A `/model` session override (typed, or rehydrated after a gateway restart) snapshots `api_key` once and replays it on every turn via `_OVERRIDE_APPLY_KEYS` in `gateway/run_agent_cache.py`.

For OAuth providers that bearer is short-lived (xai-oauth access tokens live ~6h). Once it expires under a long-lived gateway session:

1. xAI returns `403 unauthenticated:bad-credentials — The OAuth2 access token could not be validated`
2. `recover_with_credential_pool` logs `failed credential identity matched no xai-oauth entry` because the pool entry already holds the refreshed token, not the dead snapshot
3. The turn escalates with `🔐 Authentication failed and could not be refreshed — switching to fallback provider`

All while `auth.json` already holds a valid, refreshed token (a cron job in a fresh process succeeded against the same model seconds later).

## Fix

Before applying the override, re-resolve its `api_key` / `credential_pool` from the live provider runtime (`_resolve_runtime_agent_kwargs_for_provider`), the same ladder the non-override path walks every turn. The override dict is updated in place so subsequent turns compare against the adopted token. On resolution failure the snapshot is kept (unchanged behavior).

## Tests

- `test_override_re_resolves_stale_oauth_token_each_turn`
- `test_override_keeps_snapshot_when_re_resolution_fails`
- Existing override/model-switch suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpUaYkjJ1yW66N5bHuiKiY
