### PR TITLE
fix(desktop): separate titlebar contribution regions

### DIFF
--- a/apps/desktop/src/app/shell/titlebar-controls.test.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.test.tsx
@@ -87,6 +87,24 @@ describe('TitlebarControls fixed clusters', () => {
     expect(pluginTool()).not.toBeNull()
   })
 
+  it('places mounted titlebar slots in their physical titlebar regions', () => {
+    const disposeSlots = registry.registerMany([
+      { area: 'titleBar.left', id: 'test-left-slot', render: () => <span>left-slot</span> },
+      { area: 'titleBar.center', id: 'test-center-slot', render: () => <span>center-slot</span> },
+      { area: 'titleBar.right', id: 'test-right-slot', render: () => <span>right-slot</span> }
+    ])
+
+    renderControls('/')
+
+    expect(screen.getByText('left-slot').closest('[data-titlebar-cluster]')).toBe(windowControls())
+    expect(screen.getByText('center-slot').closest('[data-titlebar-cluster]')?.getAttribute('data-titlebar-cluster')).toBe(
+      'center'
+    )
+    expect(screen.getByText('right-slot').closest('[data-titlebar-cluster]')).toBe(appControls())
+
+    act(() => disposeSlots())
+  })
+
   describe('when the page projects titlebar chrome', () => {
     let disposeChrome: () => void
 

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -253,17 +253,17 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     return null
   }
 
-  const titlebarSlots = (
-    <>
-      <Slot area="titleBar.left" />
-      <Slot area="titleBar.center" />
-      <Slot area="titleBar.right" />
-    </>
-  )
-
   const leftClusterClass = cn(
     titlebarToolClusterClass,
     'left-(--titlebar-controls-left) top-(--titlebar-controls-top) translate-y-(--titlebar-controls-y-nudge)'
+  )
+  const centerClusterClass = cn(
+    titlebarToolClusterClass,
+    'left-1/2 top-(--titlebar-controls-top) -translate-x-1/2'
+  )
+  const rightClusterClass = cn(
+    titlebarToolClusterClass,
+    'right-(--titlebar-tools-right) top-(--titlebar-controls-top)'
   )
 
   // A contributed full page (`extension`) yields the fixed clusters only while
@@ -276,12 +276,20 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     const pageTools = [...leftTools, ...tools].filter(tool => !tool.hidden)
 
     return (
-      <div className={leftClusterClass}>
-        {pageTools.map(tool => (
-          <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
-        ))}
-        {titlebarSlots}
-      </div>
+      <>
+        <div className={leftClusterClass} data-titlebar-cluster="left">
+          {pageTools.map(tool => (
+            <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
+          ))}
+          <Slot area="titleBar.left" />
+        </div>
+        <div className={centerClusterClass} data-titlebar-cluster="center">
+          <Slot area="titleBar.center" />
+        </div>
+        <div className={rightClusterClass} data-titlebar-cluster="right">
+          <Slot area="titleBar.right" />
+        </div>
+      </>
     )
   }
 
@@ -293,14 +301,19 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
         {visibleLeftTools.map(tool => (
           <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
         ))}
-        {titlebarSlots}
+        <Slot area="titleBar.left" />
+      </div>
+
+      <div className={centerClusterClass} data-titlebar-cluster="center">
+        <Slot area="titleBar.center" />
       </div>
 
       <div
         aria-label={t.shell.appControls}
-        className={cn(titlebarToolClusterClass, 'right-(--titlebar-tools-right) top-(--titlebar-controls-top)')}
+        className={rightClusterClass}
         data-titlebar-cluster="right"
       >
+        <Slot area="titleBar.right" />
         <TitlebarToolButton navigate={navigate} tool={flipTool} />
         <TitlebarToolButton navigate={navigate} tool={rightSidebarTool} />
       </div>


### PR DESCRIPTION
## Summary

- render `titleBar.left`, `titleBar.center`, and `titleBar.right` contributions in dedicated physical titlebar clusters
- keep the center contribution window-centered and the right contribution anchored by the existing live `--titlebar-tools-right` reservation
- preserve overlay suppression, extension-owned chrome behavior, native window-control spacing, and absent-slot behavior

Fixes #108181

## Proof receipt

On current main, the focused regression failed because the center slot was mounted in the left cluster:

```text
AssertionError: expected "left" to be "center"
Expected: "center"
Received: "left"
Test Files  1 failed (1)
Tests       1 failed | 9 skipped (10)
```

After the fix, the same focused test passed, and the complete affected test file passed:

```text
Test Files  1 passed (1)
Tests       10 passed (10)
```

## Tests

```text
env PATH=/opt/homebrew/opt/node@24/bin:/usr/bin:/bin npx vitest run --project ui src/app/shell/titlebar-controls.test.tsx
```

## Risk

Validation is DOM/invariant-level rather than a packaged macOS visual E2E. The change is limited to titlebar slot placement and its focused test; P0 self-review found no blocker.