### PR TITLE
fix(desktop): route approval responses for legacy messaging rows (#108102)

### DIFF
--- a/apps/desktop/src/store/session-states-runtime-map.test.ts
+++ b/apps/desktop/src/store/session-states-runtime-map.test.ts
@@ -4,7 +4,7 @@ import { createClientSessionState } from '@/lib/chat-runtime'
 import { $connectionsRegistry } from '@/store/connection-registry-state'
 import { setPrimaryGateway, setPrimaryGatewayConnection } from '@/store/gateway'
 import { $profiles } from '@/store/profile'
-import { _resetSessionOwnerHintsForTests, setSessionOwnerHint, setSessions } from '@/store/session'
+import { _resetSessionOwnerHintsForTests, setMessagingSessions, setSessionOwnerHint, setSessions } from '@/store/session'
 import { isSessionOwnerResolutionError } from '@/store/session-owner-resolution'
 import {
   $sessionTiles,
@@ -95,7 +95,11 @@ describe('knownOwnerForSession / requestForOwnedSession', () => {
     $sessionTiles.set([])
     clearAllSessionStates()
     setSessions([])
+    setMessagingSessions([])
     $profiles.set([])
+    setPrimaryGateway(null)
+    setPrimaryGatewayConnection(null)
+    $connectionsRegistry.set(null)
     _resetSessionOwnerHintsForTests({ storage: true })
   })
 
@@ -129,6 +133,38 @@ describe('knownOwnerForSession / requestForOwnedSession', () => {
       requestForOwnedSession('rt-orphan', ambient as never, 'approval.respond', { session_id: 'rt-orphan' })
     ).resolves.toEqual({ ok: true })
     expect(ambient).toHaveBeenCalledWith('approval.respond', { session_id: 'rt-orphan' })
+  })
+
+  it('routes approval.respond for a restarted messaging row that omits legacy profile metadata (#108102)', async () => {
+    // Telegram-resumed sessions can be present in the messaging slice after a
+    // Desktop restart before any tile, owner hint, or fresh approval.request
+    // event has recorded an exact runtime owner. Older primary backends omit
+    // `profile` on those rows; the row itself still proves this is the default
+    // profile on the backend that served the list, not an unknown orphan.
+    $profiles.set([{ name: 'default' }, { name: 'omar' }] as never)
+    setMessagingSessions([makeSessionInfo({ id: 'telegram-stored', source: 'telegram' })])
+
+    const primaryRequest = vi.fn(async (method: string, params: unknown) => ({ method, params, via: 'primary' }))
+    setPrimaryGateway({ onEvent: () => () => undefined, request: primaryRequest, state: 'open' } as never, 'default')
+
+    const ambient = vi.fn(async () => ({ via: 'ambient' }))
+
+    await expect(
+      requestForOwnedSession('telegram-stored', ambient as never, 'approval.respond', {
+        choice: 'once',
+        session_id: 'telegram-stored'
+      })
+    ).resolves.toEqual({
+      method: 'approval.respond',
+      params: { choice: 'once', session_id: 'telegram-stored' },
+      via: 'primary'
+    })
+
+    expect(primaryRequest).toHaveBeenCalledWith('approval.respond', {
+      choice: 'once',
+      session_id: 'telegram-stored'
+    })
+    expect(ambient).not.toHaveBeenCalled()
   })
 
   it('routes a connection-tagged orphan runtime through the owner its inbound event recorded (#97511)', () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -183,7 +183,8 @@ export function knownSessionProfile(sessions: readonly SessionInfo[], sessionId:
  * profile name, so returning only that name silently collapses the route back
  * to the local/profile-only path. The exact rungs are what let a session's
  * owner be reconstructed after the bounded hint map has evicted it or the app
- * relaunched.
+ * relaunched. A present row that omits `profile` is the legacy/default-profile
+ * shape from the primary backend, not an unknown owner.
  */
 export function knownSessionOwner(sessions: readonly SessionInfo[], sessionId: null | string): SessionOwnerScope {
   if (!sessionId) {
@@ -191,7 +192,7 @@ export function knownSessionOwner(sessions: readonly SessionInfo[], sessionId: n
   }
 
   const session = sessions.find(candidate => sessionMatchesStoredId(candidate, sessionId))
-  const profile = session?.profile?.trim()
+  const profile = session ? session.profile?.trim() || 'default' : undefined
   const connectionId = session?.connection_id?.trim()
   const hint = getSessionOwnerHint(sessionId)
 


### PR DESCRIPTION
## Summary
- Treat a loaded legacy Desktop session row with no `profile` metadata as the documented default-profile row shape.
- Restores owner resolution for Telegram/messaging sessions resumed into Desktop after restart, so `approval.respond` routes to the owning primary gateway instead of failing before the RPC is sent.
- Keeps truly unknown runtimes fail-closed; the existing multi-profile owner-resolution tests still reject ambient guessing.

## Verification
- `npm --workspace apps/desktop exec vitest -- run src/store/session-states-runtime-map.test.ts src/store/session-owner-resolution.test.ts src/store/session-request-router.test.ts src/store/gateway-profile-only-owner.integration.test.ts` → 4 files passed, 44 tests passed.
- `npm --workspace apps/desktop run typecheck` → passed.
- `npm --workspace apps/desktop run lint` → passed with 0 errors; existing warnings only.
- `git diff --check upstream/main...HEAD` → passed.
- `git rev-list --left-right --count upstream/main...HEAD` → `0 1` after rebasing on upstream/main `a3190625c0`.

## Regression proof
The new regression test failed on upstream/main before the production change with `SessionOwnerResolutionError: Session owner could not be resolved for "telegram-stored" (approval.respond)`. With the fix, the same production `requestForOwnedSession(..., 'approval.respond', ...)` path calls the primary default-profile gateway request and does not call the ambient fallback.

## Duplicate / competitor check
- Same-author issue and branch checks for `108102` returned no open Tranquil-Flow PRs.
- Focused searches for `108102`, `approval.respond "Session owner could not be resolved"`, `knownSessionOwner approval.respond`, and `Telegram Desktop approval.respond` returned no blocking PRs.
- Broad topic-overlap results (#106742, #59298, #65982, #101057) are not focused fixes for this issue; #106742/#101057 are also merge-conflicted/large-scope and not a blocking high-quality duplicate for this surgical desktop owner-resolution regression.

Auto-published by Moonsong via Path B automated pipeline.
