### PR TITLE
fix(gateway): protect launchd-owned process trees during cleanup

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1615,8 +1615,30 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
         if _windows_scheduled_task_supervises(_task_name):
             return False
 
+    # launchd reports the stderr_timestamp WRAPPER as the service PID, while
+    # the process scan also sees its ``gateway run`` child. Protect the whole
+    # supervised tree: excluding only the wrapper lets a Desktop serve startup
+    # SIGTERM the real messaging gateway (#105938). Process-table uncertainty
+    # is not permission to kill; fail closed while a launchd job is loaded.
+    launchd_loaded = False
+    if is_macos():
+        launchd_snapshot = _strict_launchd_gateway_service_snapshot()
+        if launchd_snapshot is None:
+            return False
+        service_roots, launchd_loaded = launchd_snapshot
+    else:
+        try:
+            service_roots = _get_service_pids(all_profiles=True)
+        except Exception:
+            return False
+    service_tree = _supervised_service_tree_pids(service_roots)
+    if service_tree is None:
+        return False
+    if launchd_loaded and not service_roots:
+        return False
+
     from gateway.status import _pid_exists, get_process_start_time, write_planned_stop_marker
-    own = _reaper_exclusion_pids(extra_exclude)
+    own = _reaper_exclusion_pids(extra_exclude, service_pids=service_tree)
     try:
         # On Windows also drop Task Scheduler-owned candidates (the pidfile-less gap).
         orphans = [
@@ -1661,7 +1683,66 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     return reaped
 
 
-def _reaper_exclusion_pids(extra_exclude: set | None) -> set[int]:
+def _supervised_service_tree_pids(service_roots: set[int]) -> set[int] | None:
+    """Return service roots plus all live descendants, or ``None`` when the
+    supervised tree cannot be read safely."""
+    protected = set(service_roots)
+    if not protected:
+        return protected
+    try:
+        import psutil  # type: ignore
+
+        for pid in service_roots:
+            protected.update(int(child.pid) for child in psutil.Process(pid).children(recursive=True))
+    except Exception:
+        return None
+    return protected
+
+
+def _strict_launchd_gateway_service_snapshot() -> tuple[set[int], bool] | None:
+    """Return ``(pids, any_loaded)`` for every gateway launchd label.
+
+    Unlike the status-oriented discovery helpers, this kill-safety probe keeps
+    ``unknown`` distinct from ``unloaded``. A timeout, missing launchctl, or
+    unclassified failure on ANY label/domain returns ``None`` so the reaper
+    fails closed instead of acting on a partial fleet snapshot.
+    """
+    labels = {get_launchd_label(), *launchd_gateway_labels_for_install()}
+    try:
+        fleet = subprocess.run(["launchctl", "list"], timeout=5, **_CAPTURE_TEXT)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if fleet.returncode != 0:
+        return None
+    for line in fleet.stdout.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[-1].startswith("ai.hermes.gateway"):
+            labels.add(parts[-1])
+    roots: set[int] = set()
+    any_loaded = False
+    uid = os.getuid()  # windows-footgun: macOS-only caller
+    for label in labels:
+        for domain in (f"gui/{uid}", f"user/{uid}"):
+            try:
+                result = subprocess.run(
+                    ["launchctl", "print", f"{domain}/{label}"], timeout=5, **_CAPTURE_TEXT
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                return None
+            if result.returncode == 0:
+                any_loaded = True
+                pid = _parse_launchd_pid_from_print_output(result.stdout)
+                if pid is None:
+                    return None
+                roots.add(pid)
+            elif result.returncode not in _LAUNCHD_JOB_UNLOADED_EXIT_CODES:
+                return None
+    return roots, any_loaded
+
+
+def _reaper_exclusion_pids(
+    extra_exclude: set | None, *, service_pids: set[int] | None = None
+) -> set[int]:
     """PIDs the orphan reaper must never kill: self, caller extras, service-managed, recorded."""
     own = {os.getpid()} | (extra_exclude or set())
     # Service-managed gateways are never orphans (on macOS supports_systemd_services() is False, so a
@@ -1676,7 +1757,7 @@ def _reaper_exclusion_pids(extra_exclude: set | None) -> set[int]:
         # cover the whole ai.hermes.gateway* fleet — not just the current profile's label — or a sibling
         # profile's launchd gateway is misclassified as an unsupervised orphan and reaped. Same class as the
         # update-sweep fix in #74075.
-        own |= _get_service_pids(all_profiles=True)
+        own |= service_pids if service_pids is not None else _get_service_pids(all_profiles=True)
     # Exempt the recorded gateway PID and its parent chain (on Windows the Scheduled-Task bootstrap's
     # ``gateway run`` argv matches the scan; killing it takes the gateway down). Use the RAW pidfile +
     # lock records, not only the validated probe: get_running_pid returns None on any validation

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1720,7 +1720,7 @@ def _strict_launchd_gateway_service_snapshot() -> tuple[set[int], bool] | None:
             labels.add(parts[-1])
     roots: set[int] = set()
     any_loaded = False
-    uid = os.getuid()  # windows-footgun: macOS-only caller
+    uid = getattr(os, "getuid", lambda: 0)()
     for label in labels:
         for domain in (f"gui/{uid}", f"user/{uid}"):
             try:

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -607,10 +607,13 @@ class TestReapUnsupervisedGatewayOrphansMacOS:
         monkeypatch.setattr(gateway, "is_macos", lambda: True)
         monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
 
-        # _get_service_pids returns the launchd-managed gateway PID.
-        # (accepts all_profiles: the reaper asks for the whole fleet, #74075)
         monkeypatch.setattr(
-            gateway, "_get_service_pids", lambda all_profiles=False: {launchd_pid}
+            gateway,
+            "_strict_launchd_gateway_service_snapshot",
+            lambda: ({launchd_pid}, True),
+        )
+        monkeypatch.setattr(
+            gateway, "_supervised_service_tree_pids", lambda roots: set(roots)
         )
         # No pidfile-recorded gateway in this scenario.
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
@@ -645,7 +648,12 @@ class TestReapUnsupervisedGatewayOrphansMacOS:
         monkeypatch.setattr(gateway, "is_macos", lambda: True)
         monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
         monkeypatch.setattr(
-            gateway, "_get_service_pids", lambda all_profiles=False: {launchd_pid}
+            gateway,
+            "_strict_launchd_gateway_service_snapshot",
+            lambda: ({launchd_pid}, True),
+        )
+        monkeypatch.setattr(
+            gateway, "_supervised_service_tree_pids", lambda roots: set(roots)
         )
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
 
@@ -663,6 +671,175 @@ class TestReapUnsupervisedGatewayOrphansMacOS:
 
         assert result is False  # no orphans reaped
         assert killed_pids == []  # nothing was killed
+
+    def test_macos_excludes_launchd_wrapper_descendants_without_pidfile(self, monkeypatch):
+        """A launchd label reports the stderr wrapper PID, while the process
+        scan sees both wrapper and gateway child.  Losing the pidfile during a
+        Desktop quit race must not make that child reapable (#105938)."""
+        wrapper_pid = 52615
+        gateway_pid = 52616
+        orphan_pid = 99998
+
+        monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(
+            gateway,
+            "_strict_launchd_gateway_service_snapshot",
+            lambda: ({wrapper_pid}, True),
+        )
+        monkeypatch.setattr("gateway.status._pid_from_record", lambda _record: None)
+        monkeypatch.setattr("gateway.status._read_pid_record", lambda: None)
+        monkeypatch.setattr("gateway.status._read_gateway_lock_record", lambda: None)
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid", lambda cleanup_stale=False: None
+        )
+
+        wrapper = SimpleNamespace(
+            pid=wrapper_pid,
+            children=lambda recursive=False: [SimpleNamespace(pid=gateway_pid)],
+        )
+        fake_psutil = SimpleNamespace(Process=lambda pid: wrapper if pid == wrapper_pid else (_ for _ in ()).throw(KeyError(pid)))
+        monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: [
+                p
+                for p in [wrapper_pid, gateway_pid, orphan_pid]
+                if p not in (exclude_pids or set())
+            ],
+        )
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+        monkeypatch.setattr("gateway.status.write_planned_stop_marker", lambda pid: None)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        monkeypatch.setattr("time.monotonic", lambda: 1.0)
+
+        assert gateway._reap_unsupervised_gateway_orphans() is True
+        killed = [pid for pid, _ in killed_pids]
+        assert orphan_pid in killed
+        assert wrapper_pid not in killed
+        assert gateway_pid not in killed
+
+    def test_macos_reaper_fails_closed_when_launchd_tree_is_uncertain(self, monkeypatch):
+        """A live launchd service plus an unreadable process tree is not
+        permission to SIGTERM anything that merely resembles a gateway."""
+        wrapper_pid = 52615
+        monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(
+            gateway,
+            "_strict_launchd_gateway_service_snapshot",
+            lambda: ({wrapper_pid}, True),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "psutil",
+            SimpleNamespace(Process=lambda _pid: (_ for _ in ()).throw(PermissionError())),
+        )
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: (_ for _ in ()).throw(
+                AssertionError("uncertain supervised tree must prevent process scanning")
+            ),
+        )
+        killed_pids = []
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig)))
+
+        assert gateway._reap_unsupervised_gateway_orphans() is False
+        assert killed_pids == []
+
+    def test_macos_reaper_fails_closed_when_service_discovery_errors(self, monkeypatch):
+        monkeypatch.setattr(gateway, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(
+            gateway,
+            "_strict_launchd_gateway_service_snapshot",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: (_ for _ in ()).throw(
+                AssertionError("failed service discovery must prevent process scanning")
+            ),
+        )
+
+        assert gateway._reap_unsupervised_gateway_orphans() is False
+
+    def test_strict_launchd_snapshot_reads_wrapper_pid_and_known_absent_domain(self, monkeypatch):
+        wrapper_pid = 52615
+        monkeypatch.setattr(gateway, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway, "launchd_gateway_labels_for_install", lambda: set())
+        monkeypatch.setattr(gateway.os, "getuid", lambda: 501)
+
+        def fake_run(command, **_kwargs):
+            if command == ["launchctl", "list"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="52615\t0\tai.hermes.gateway\n",
+                    stderr="",
+                )
+            target = command[-1]
+            if target == "gui/501/ai.hermes.gateway":
+                return SimpleNamespace(returncode=0, stdout=f"pid = {wrapper_pid}\n", stderr="")
+            assert target == "user/501/ai.hermes.gateway"
+            return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+
+        monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+        assert gateway._strict_launchd_gateway_service_snapshot() == ({wrapper_pid}, True)
+
+    def test_strict_launchd_snapshot_fails_closed_on_partial_timeout(self, monkeypatch):
+        monkeypatch.setattr(gateway, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway, "launchd_gateway_labels_for_install", lambda: set())
+        monkeypatch.setattr(gateway.os, "getuid", lambda: 501)
+
+        def fake_run(command, **_kwargs):
+            if command == ["launchctl", "list"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="52615\t0\tai.hermes.gateway\n",
+                    stderr="",
+                )
+            if command[-1].startswith("gui/"):
+                return SimpleNamespace(returncode=0, stdout="pid = 52615\n", stderr="")
+            raise subprocess.TimeoutExpired(command, 5)
+
+        monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+        assert gateway._strict_launchd_gateway_service_snapshot() is None
+
+    def test_strict_launchd_snapshot_fails_when_any_loaded_label_has_no_pid(self, monkeypatch):
+        monkeypatch.setattr(gateway, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway, "launchd_gateway_labels_for_install", lambda: set())
+        monkeypatch.setattr(gateway.os, "getuid", lambda: 501)
+
+        def fake_run(command, **_kwargs):
+            if command == ["launchctl", "list"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout=(
+                        "52615\t0\tai.hermes.gateway\n"
+                        "-\t0\tai.hermes.gateway-renamed\n"
+                    ),
+                    stderr="",
+                )
+            target = command[-1]
+            if target == "gui/501/ai.hermes.gateway":
+                return SimpleNamespace(returncode=0, stdout="pid = 52615\n", stderr="")
+            if target == "user/501/ai.hermes.gateway":
+                return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+            if target == "gui/501/ai.hermes.gateway-renamed":
+                return SimpleNamespace(returncode=0, stdout="state = waiting\n", stderr="")
+            raise AssertionError(target)
+
+        monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+        assert gateway._strict_launchd_gateway_service_snapshot() is None
 
 
 class TestReapUnsupervisedGatewayOrphansWindows:
@@ -865,7 +1042,7 @@ class TestReaperCandidateIsSupervisorOwned:
         # No pidfile => get_running_pid() returns None.
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
         # _get_service_pids() is empty on Windows.
-        monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+        monkeypatch.setattr(gateway, "_get_service_pids", lambda all_profiles=False: set())
 
         # Parent chain: gateway -> bootstrap -> services.exe (Task Scheduler).
         services = SimpleNamespace(pid=4, parent=lambda: None, name=lambda: "services.exe")
@@ -916,7 +1093,11 @@ class TestReaperCandidateIsSupervisorOwned:
         monkeypatch.setattr(gateway, "is_windows", lambda: False)
         monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
-        monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+        monkeypatch.setattr(
+            gateway,
+            "_strict_launchd_gateway_service_snapshot",
+            lambda: (set(), False),
+        )
 
         # Realistic macOS topology: the orphan's parent IS launchd (PID 1).
         launchd = SimpleNamespace(pid=1, parent=lambda: None, name=lambda: "launchd")
@@ -1058,7 +1239,7 @@ class TestWindowsScheduledTaskSupervisorGuard:
         monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
         monkeypatch.setattr(gateway, "_windows_scheduled_task_supervises", lambda name: False)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
-        monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+        monkeypatch.setattr(gateway, "_get_service_pids", lambda all_profiles=False: set())
 
         monkeypatch.setattr(
             gateway,


### PR DESCRIPTION
Quitting Hermes Desktop used to be able to restart the separately supervised launchd gateway. Current `main` now owns the Desktop shutdown latch and backend lifecycle, so this refreshed PR keeps only the remaining Python-side safety boundary: gateway cleanup must never signal a process tree owned by a loaded `ai.hermes.gateway*` launchd service.

The reaper now builds a strict launchd snapshot across configured and discovered labels, protects the wrapper and all descendants, and fails closed when launchctl state, PID identity, or the supervised tree cannot be read reliably. Genuine unowned gateways remain reapable.

Production verification on Hermes core 0.21.2 / Desktop 0.17.2 launched and quit the installed app while the default gateway stayed on the same wrapper PID 37229 and worker PID 37232. Telegram, Weixin, and WeCom remained connected.

Validation on current `main`:

- `tests/hermes_cli/test_gateway.py`: 43 passed, 3 platform skips
- Ruff and `git diff --check`: passed
- The corresponding release candidate also passed the complete Desktop UI and platform suites, build, and installed lifecycle check

Related to #105938 and the broader process-discovery design in #92091.
