### PR TITLE
fix(desktop): preserve keyboard context and restore tab placement

### DIFF
--- a/apps/desktop/src/app/chat/composer/model-pill.test.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.test.tsx
@@ -1,12 +1,16 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { atom } from 'nanostores'
+import { useContext } from 'react'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import type { ChatBarState } from '@/app/chat/composer/types'
 import { type SessionView, SessionViewProvider } from '@/app/chat/session-view'
+import { ModelMenuCloseContext } from '@/app/shell/model-menu-panel'
 import { $activeSessionId, $currentModel, setCurrentModel, setCurrentModelSource } from '@/store/session'
 
+import { requestModelMenuToggle } from './focus'
 import { ModelPill } from './model-pill'
+import { RICH_INPUT_SLOT } from './rich-editor'
 
 const modelState = (over: Partial<ChatBarState['model']> = {}): ChatBarState['model'] => ({
   canSwitch: true,
@@ -78,6 +82,49 @@ describe('ModelPill pinned-override badge', () => {
     expect(screen.getByTestId('model-pinned-dot')).toBeTruthy()
     expect($currentModel.get()).toBe('deepseek/deepseek-v4-flash')
   })
+})
+
+function MenuChoice() {
+  const close = useContext(ModelMenuCloseContext)
+
+  return <button onClick={() => close?.()}>Choose model</button>
+}
+
+it('returns to the exact caret or backward selection after the model menu closes', async () => {
+  const surface = document.createElement('div')
+  surface.dataset.composerTarget = 'main'
+  const editor = document.createElement('div')
+  editor.dataset.slot = RICH_INPUT_SLOT
+  editor.contentEditable = 'true'
+  editor.tabIndex = 0
+  editor.textContent = 'before and after'
+  surface.append(editor)
+  document.body.append(surface)
+
+  try {
+    render(<ModelPill disabled={false} model={modelState({ modelMenuContent: <MenuChoice /> })} />)
+
+    for (const [anchor, focus] of [
+      [3, 3],
+      [10, 4]
+    ]) {
+      editor.focus()
+      window.getSelection()!.setBaseAndExtent(editor.firstChild!, anchor, editor.firstChild!, focus)
+      await act(async () => {
+        requestModelMenuToggle()
+        await new Promise(resolve => setTimeout(resolve, 0))
+      })
+      const choice = await screen.findByText('Choose model')
+      choice.focus()
+      window.getSelection()!.removeAllRanges()
+      fireEvent.click(choice)
+      await waitFor(() => expect(document.activeElement).toBe(editor))
+      expect(window.getSelection()!.anchorOffset).toBe(anchor)
+      expect(window.getSelection()!.focusOffset).toBe(focus)
+    }
+  } finally {
+    surface.remove()
+  }
 })
 
 describe('ModelPill per-surface model label', () => {

--- a/apps/desktop/src/app/chat/composer/model-pill.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.tsx
@@ -1,9 +1,10 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useSessionView } from '@/app/chat/session-view'
 import { useTourMarker } from '@/app/chat/tour-marker'
 import { ModelMenuCloseContext } from '@/app/shell/model-menu-panel'
+import { isElementInHiddenPane } from '@/components/pane-shell/pane-visibility'
 import { Button } from '@/components/ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
@@ -16,6 +17,7 @@ import { cn } from '@/lib/utils'
 import { $currentModelSource, $defaultReasoningEffort, setModelPickerOpen } from '@/store/session'
 
 import { onComposerModelMenuRequest } from './focus'
+import { RICH_INPUT_SLOT } from './rich-editor'
 import { useComposerScope } from './scope'
 import type { ChatBarState } from './types'
 
@@ -60,6 +62,7 @@ export function ModelPill({
   const defaultEffort = useStore($defaultReasoningEffort)
   const runtimeId = useStore(view.$runtimeId)
   const [open, setOpen] = useState(false)
+  const restoreSelection = useRef<(() => void) | null>(null)
   const scope = useComposerScope()
   const hasLiveMenu = Boolean(model.modelMenuContent)
 
@@ -75,6 +78,34 @@ export function ModelPill({
         }
 
         if (hasLiveMenu) {
+          const editor = document.activeElement
+          const selection = window.getSelection()
+
+          if (
+            editor instanceof HTMLElement &&
+            editor.dataset.slot === RICH_INPUT_SLOT &&
+            selection?.anchorNode &&
+            selection.focusNode &&
+            editor.contains(selection.anchorNode) &&
+            editor.contains(selection.focusNode)
+          ) {
+            const { anchorNode, anchorOffset, focusNode, focusOffset } = selection
+
+            restoreSelection.current = () => {
+              if (
+                !editor.isConnected ||
+                isElementInHiddenPane(editor) ||
+                !editor.contains(anchorNode) ||
+                !editor.contains(focusNode)
+              ) {
+                return
+              }
+
+              editor.focus({ preventScroll: true })
+              window.getSelection()?.setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset)
+            }
+          }
+
           setOpen(prev => !prev)
         } else {
           setModelPickerOpen(true)
@@ -178,7 +209,22 @@ export function ModelPill({
           </Button>
         </DropdownMenuTrigger>
       </Tip>
-      <DropdownMenuContent align="end" className="w-64 p-0" side="top" sideOffset={8}>
+      <DropdownMenuContent
+        align="end"
+        className="w-64 p-0"
+        onCloseAutoFocus={event => {
+          if (restoreSelection.current) {
+            event.preventDefault()
+            restoreSelection.current()
+            restoreSelection.current = null
+          }
+        }}
+        onInteractOutside={() => {
+          restoreSelection.current = null
+        }}
+        side="top"
+        sideOffset={8}
+      >
         <ModelMenuCloseContext.Provider value={() => setMenuOpen(false)}>
           {model.modelMenuContent}
         </ModelMenuCloseContext.Provider>

--- a/apps/desktop/src/app/chat/scroll-to-bottom-button.test.tsx
+++ b/apps/desktop/src/app/chat/scroll-to-bottom-button.test.tsx
@@ -1,7 +1,7 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { clearAllPrompts, setApprovalRequest } from '@/store/prompts'
+import { clearAllPrompts, clearApprovalRequest, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
 import {
   onScrollToBottomRequest,
@@ -45,7 +45,7 @@ describe('ScrollToBottomButton', () => {
   it('morphs into the approval pill when scrolled up with a pending approval', () => {
     pendingApproval()
     setThreadAtBottom(false)
-    render(<ScrollToBottomButton sessionId={null} />)
+    render(<ScrollToBottomButton sessionId="sess-1" />)
 
     expect(screen.getByRole('button', { name: 'Approval needed' })).toBeTruthy()
     expect(screen.getByText('Approval needed')).toBeTruthy()
@@ -57,6 +57,22 @@ describe('ScrollToBottomButton', () => {
 
     // Parked at bottom → control hidden, so it can't claim "approval needed".
     expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('labels uncounted content without zero and follows only its own approval', () => {
+    pendingApproval()
+    setThreadAtBottom(false)
+    const view = render(<ScrollToBottomButton sessionId="tile-runtime" />)
+    expect(screen.getByRole('button', { name: 'Scroll to bottom' }).textContent).toBe('Scroll to bottom')
+
+    act(() => setApprovalRequest({ command: 'x', description: 'd', sessionId: 'tile-runtime', requestId: 'r1' }))
+    expect(screen.getByRole('button', { name: 'Approval needed' })).toBeTruthy()
+    act(() => clearApprovalRequest('tile-runtime', 'r1'))
+    expect(screen.queryByText('Approval needed')).toBeNull()
+    expect(screen.getByRole('button').textContent).toBe('Scroll to bottom')
+
+    view.rerender(<ScrollToBottomButton sessionId="sess-1" />)
+    expect(screen.getByRole('button', { name: 'Approval needed' })).toBeTruthy()
   })
 
   it('re-arms sticky-bottom on click', () => {

--- a/apps/desktop/src/app/chat/scroll-to-bottom-button.tsx
+++ b/apps/desktop/src/app/chat/scroll-to-bottom-button.tsx
@@ -1,13 +1,13 @@
 import { useStore } from '@nanostores/react'
 import { useReducedMotion } from 'motion/react'
-import { useRef } from 'react'
+import { useMemo, useRef } from 'react'
 
 import { Codicon } from '@/components/ui/codicon'
 import { AnimatedInt } from '@/components/ui/diff-count'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
-import { $approvalRequest } from '@/store/prompts'
+import { sessionApprovalRequest } from '@/store/prompts'
 import { $threadJumpButtonVisible, $threadMessagesBelow, requestScrollToBottom } from '@/store/thread-scroll'
 
 /**
@@ -36,11 +36,11 @@ export function ScrollToBottomButton({ sessionId }: { sessionId: string | null }
   const visible = useStore($threadJumpButtonVisible)
   const count = useStore($threadMessagesBelow)
   const reducedMotion = useReducedMotion()
-  const request = useStore($approvalRequest)
+  const request = useStore(useMemo(() => sessionApprovalRequest(sessionId), [sessionId]))
   // Scrolled away while an approval is pending → the inline Run/Reject bar is
   // below the fold. Relabel so the user knows the session needs them, not just
   // that there's more to read.
-  const approval = visible && Boolean(request)
+  const visibleApproval = Boolean(request)
   const hasShownRef = useRef(false)
 
   if (visible) {
@@ -48,10 +48,14 @@ export function ScrollToBottomButton({ sessionId }: { sessionId: string | null }
   }
 
   const state = visible ? 'in' : hasShownRef.current ? 'out' : 'idle'
-  const countLabel = t.sidebar.messageCount(count)
-  const [beforeCount, afterCount] = countLabel.split(String(count))
+  const countLabel = count > 0 ? t.sidebar.messageCount(count) : ''
+  const [beforeCount, afterCount] = countLabel ? countLabel.split(String(count)) : ['', '']
 
-  const label = approval ? t.assistant.approval.jumpToApproval : `${t.assistant.thread.scrollToBottom} · ${countLabel}`
+  const label = visibleApproval
+    ? t.assistant.approval.jumpToApproval
+    : countLabel
+      ? `${t.assistant.thread.scrollToBottom} · ${countLabel}`
+      : t.assistant.thread.scrollToBottom
 
   return (
     <button
@@ -59,7 +63,7 @@ export function ScrollToBottomButton({ sessionId }: { sessionId: string | null }
       aria-label={label}
       className={cn(
         'thread-jump-button absolute left-1/2 z-20 flex h-8 items-center gap-1.5 rounded-full border bg-(--composer-fill) px-3 text-xs font-medium backdrop-blur-[0.75rem] [-webkit-backdrop-filter:blur(0.75rem)]',
-        approval
+        visibleApproval
           ? 'border-primary/40 text-primary hover:bg-primary/10'
           : 'border-border/65 text-muted-foreground hover:text-foreground',
         !visible && 'pointer-events-none'
@@ -76,7 +80,7 @@ export function ScrollToBottomButton({ sessionId }: { sessionId: string | null }
       type="button"
     >
       <Codicon name="arrow-down" size="0.875rem" />
-      {approval ? (
+      {visibleApproval || count <= 0 ? (
         <span>{label}</span>
       ) : (
         <span aria-hidden className="whitespace-nowrap tabular-nums">

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -162,6 +162,8 @@ export function openSession(
       openSessionTile(storedSessionId, 'center')
     }
 
+    focusOpenSession(storedSessionId, workspaceScope)
+
     return
   }
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -111,6 +111,7 @@ import {
   $sessionTiles,
   closeSessionTile,
   dropSessionState,
+  focusOpenSession,
   holdSessionOwnerUntilForeground,
   openSessionTile,
   patchSessionTile,
@@ -850,7 +851,7 @@ export function useSessionActions({
           setWorkspaceCwdOwner(stored)
         }
 
-        revealTreePane(`session-tile:${stored}`)
+        focusOpenSession(stored, workspaceScope)
 
         if (listed) {
           broadcastSessionsChanged()

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -133,6 +133,31 @@ describe('approval prompt store', () => {
     ])
   })
 
+  it('clears an absent approval without overwriting a newer live request', async () => {
+    const old = { command: 'x', description: 'd', requestId: 'old', sessionId: 's1' }
+    setApprovalRequest(old)
+    await replayPendingApproval({ request: async () => ({ approvals: [] }) }, 's1')
+    expect($approvalRequest.get()).toBeNull()
+
+    setApprovalRequest(old)
+    let resolve!: (value: unknown) => void
+
+    const pending = replayPendingApproval(
+      {
+        request: () =>
+          new Promise(done => {
+            resolve = done
+          })
+      },
+      's1'
+    )
+
+    setApprovalRequest({ ...old, requestId: 'new' })
+    resolve({ approvals: [] })
+    await pending
+    expect($approvalRequest.get()?.requestId).toBe('new')
+  })
+
   it('does not replay a pending approval after the runtime is rejected as gone', async () => {
     const request = vi.fn(async () => {
       throw new JsonRpcGatewayError('session not found', { code: 4001 })

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -173,6 +173,7 @@ export async function replayPendingApproval(gateway: ApprovalGateway | null, ses
     return
   }
 
+  const previous = approval.$all.get()[keyFor(sessionId)]
   let rawResult: unknown
 
   try {
@@ -192,9 +193,20 @@ export async function replayPendingApproval(gateway: ApprovalGateway | null, ses
   const result =
     rawResult && typeof rawResult === 'object' ? (rawResult as { approvals?: PendingApprovalPayload[] }) : {}
 
-  const pending = Array.isArray(result?.approvals) ? result.approvals[0] : undefined
+  // Live requests/responses outrank a replay that was already in flight.
+  if (approval.$all.get()[keyFor(sessionId)] !== previous || !Array.isArray(result.approvals)) {
+    return
+  }
 
-  if (!pending || typeof pending.request_id !== 'string') {
+  const pending = result.approvals[0]
+
+  if (!pending) {
+    clearApprovalRequest(sessionId, previous?.requestId)
+
+    return
+  }
+
+  if (typeof pending.request_id !== 'string') {
     return
   }
 

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -1136,40 +1136,19 @@ describe('reopenLastClosedTile focuses the restored tab', () => {
       title: 'chat'
     })
 
-    // panes ← $sessionTiles (paneMirror stub). Adoption is synchronous on
-    // register, so openSessionTile + focusOpenSession works the same tick.
-    const registered = new Map<string, () => void>()
-
-    const syncTiles = () => {
-      const wanted = new Set(states.$sessionTiles.get().map(t => t.storedSessionId))
-
-      for (const id of wanted) {
-        if (registered.has(id)) {
-          continue
-        }
-
-        registered.set(
-          id,
-          registry.register({
-            area: 'panes',
-            data: { dock: { pane: 'workspace', pos: 'center' }, placement: 'main' },
-            id: tilePane(id),
-            render: () => null,
-            title: id
-          })
-        )
-      }
-
-      for (const [id, dispose] of registered) {
-        if (!wanted.has(id)) {
-          dispose()
-          registered.delete(id)
-          tree.removeTreePane(tilePane(id))
-        }
-      }
-    }
-
-    states.$sessionTiles.listen(syncTiles)
+    const { paneMirror } = await import('@/app/chat/pane-mirror')
+    paneMirror({
+      source: states.$sessionTiles,
+      key: tile => tile.storedSessionId,
+      prefix: 'session-tile',
+      dir: tile => tile.dir,
+      anchor: tile => tile.anchor,
+      before: tile => tile.before,
+      minWidth: '10rem',
+      title: id => id,
+      render: () => null,
+      close: states.closeSessionTile
+    })()
     tree.watchContributedPanes()
     session.$selectedStoredSessionId.set('primary')
     tree.declareDefaultTree(model.group(['workspace'], { active: 'workspace', id: 'grp-main' }))
@@ -1181,6 +1160,32 @@ describe('reopenLastClosedTile focuses the restored tab', () => {
 
     return { states, tree }
   }
+
+  it('restores the live strip slot after reordering and retains the exact owner', async () => {
+    const { states, tree } = await setup()
+    states.openSessionTile('after', 'center', 'workspace')
+    tree.moveTreePane(tilePane('closed'), { groupId: 'grp-main', pos: 'center', before: 'workspace' })
+    const order = findGroupOfPane(tree.$layoutTree.get()!, 'workspace')!.panes
+    const ownerRoute = { connectionId: 'cloud', profile: 'agent' }
+    states.patchSessionTile('closed', { ownerRoute })
+    states.closeSessionTile('closed')
+    tree.noteActiveTreeGroup(null)
+    states.reopenLastClosedTile()
+    expect(findGroupOfPane(tree.$layoutTree.get()!, 'workspace')!.panes).toEqual(order)
+    expect(states.$focusedStoredSessionId.get()).toBe('closed')
+    expect(states.sessionTileOwnerRoute('closed')).toEqual(ownerRoute)
+  })
+
+  it('fronts a palette-opened tab from sidebar focus without replacing main', async () => {
+    const { states, tree } = await setup()
+    const { openSession } = await import('@/app/open-session')
+    const navigate = vi.fn()
+    tree.noteActiveTreeGroup('sidebar')
+    openSession('palette-result', navigate, 'stack')
+    expect(states.$focusedStoredSessionId.get()).toBe('palette-result')
+    expect(findGroupOfPane(tree.$layoutTree.get()!, 'workspace')!.active).toBe(tilePane('palette-result'))
+    expect(navigate).not.toHaveBeenCalled()
+  })
 
   it('fronts the restored tab after ⌘⇧T', async () => {
     const { states, tree } = await setup()

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1729,7 +1729,20 @@ export function closeSessionTile(storedSessionId: string) {
   const tile = $sessionTiles.get().find(t => t.storedSessionId === storedSessionId)
 
   if (tile) {
-    closedStack().push(toStored(tile))
+    const tree = $layoutTree.get()
+    const paneId = `${TILE_PANE_PREFIX}${storedSessionId}`
+    const group = tree ? findGroupOfPane(tree, paneId) : null
+    const siblings = group?.panes.filter(id => id !== paneId) ?? []
+    closedStack().push({
+      ...toStored(tile),
+      ...(group && siblings.length
+        ? {
+            anchor: siblings[0],
+            before: group.panes[group.panes.indexOf(paneId) + 1] ?? null,
+            dir: 'center'
+          }
+        : {})
+    })
   }
 
   saveTiles($sessionTiles.get().filter(t => t.storedSessionId !== storedSessionId))
@@ -1905,7 +1918,9 @@ export function reopenLastClosedTile(): void {
     if (!$sessionTiles.get().some(t => t.storedSessionId === storedSessionId)) {
       openSessionTile(storedSessionId, tile.dir, tile.anchor, tile.before, {
         workspaceMode: tile.workspaceMode ?? 'sessions',
-        workspaceOwnerKey: tile.workspaceOwnerKey
+        workspaceOwnerKey: tile.workspaceOwnerKey,
+        workspaceTabTitle: tile.workspaceTabTitle,
+        ownerRoute: tile.ownerRoute
       })
       focusOpenSession(storedSessionId)
 


### PR DESCRIPTION
## Summary
Preserve editing context when choosing a model, focus sessions opened from the palette or new-tab action, and restore closed tabs to their current strip position rather than their original append placement.

- Capture the composer's caret or selection before the model menu takes focus; restore it on close, but leave outside-click navigation alone. Draft insertion behavior is unchanged.
- Reuse `focusOpenSession` for new tabs and palette results. Capture live tab neighbors when closing, and retain owner routing and Bot tab titles on reopen.
- Read approval hints from the displayed session. An explicitly empty pending-approval response clears the stale prompt without overwriting a newer live request. Show “Scroll to bottom” rather than “0 messages.”

## Interaction intent
Existing desktop contracts already require explicit session opens to take focus and closed tabs to return in place. Sidebar browsing still retains the last content pane, and background pane adoption remains non-focusing. The related Teknium sidebar change aligns highlighting with the focused session; this preserves it.

Prior art: [Apple's tab shortcuts](https://support.apple.com/en-us/102650). The exact restored placement follows Hermes' existing closed-tab contract; the shortcut documentation does not specify that detail.

## Test plan
- [x] Focused Vitest run: 8 files, 172 tests passed, including real pane-mirror adoption, reordered-tab restoration, palette focus, model-menu caret/backward-selection restoration, session-scoped approval labels, and stale replay ordering.
- [x] New-session creation regression: 1 passed (96 unrelated tests skipped).
- [x] Renderer TypeScript check: `npx tsc -p . --noEmit` passed.
- [x] Touched-file ESLint: no errors; four DOM-access warnings in the new component regression.
- [x] `git diff --check`.
- [ ] Native Electron keyboard walkthrough. The user's running app was not restarted or switched to this worktree.

No full suite or packaged build was run. Approval recovery here covers session mis-scoping and authoritative empty replay, not every possible backend timeout or reconnect race.
