### PR TITLE
hermes update turns on the Connections toolset for installs with a saved toolset list

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2397,7 +2397,7 @@ DEFAULT_CONFIG = {
         # Extra ports detection probes for an external llama-server (besides 8080).
         "detect_ports": [],
     },
-    "_config_version": 42,  # Config schema version - bump this when adding new required fields
+    "_config_version": 43,  # Config schema version - bump this when adding new required fields
 }
 
 

--- a/hermes_cli/config_migrations.py
+++ b/hermes_cli/config_migrations.py
@@ -542,6 +542,57 @@ def _migrate_to_41(results: Dict[str, Any], quiet: bool) -> None:
                   f"({', '.join(cleaned)}) — Bot Chat sessions now get the live roster instead.")
 
 
+def _migrate_to_43(results: Dict[str, Any], quiet: bool) -> None:
+    # 42 → 43: turn the `connections` toolset on for every platform whose saved `platform_toolsets`
+    # list predates it. `hermes tools` writes an explicit list, and absence from that list reads as
+    # "unchecked", so a toolset that ships later stays off for picker users while composite users
+    # inherit it. Two "no"s are kept: a platform whose `known_builtin_toolsets` records `connections`
+    # saw the checkbox and left it off, and `agent.disabled_toolsets` (Blank Slate, `hermes tools
+    # --disable`) is subtracted last by the resolver, so appending there would claim an enable that
+    # never takes effect.
+    from agent.skill_utils import parse_config_string_list
+    from hermes_cli.tools_config import _configurable_keys, _get_plugin_toolset_keys
+    from hermes_cli.toolset_scope import toolset_allowed_for_platform
+
+    config = read_raw_config()
+    saved = config.get("platform_toolsets")
+    if not isinstance(saved, dict):
+        return
+    if "connections" in parse_config_string_list(_dict_at(config, "agent").get("disabled_toolsets")):
+        return
+    known = _dict_at(config, "known_builtin_toolsets")
+    # Same predicate the resolver uses to pick its explicit branch: any configurable or plugin key.
+    explicit_keys = _configurable_keys() | _get_plugin_toolset_keys()
+    enabled_for: List[str] = []
+    for platform, toolsets in saved.items():
+        if not isinstance(toolsets, list) or "connections" in toolsets:
+            continue
+        if not toolset_allowed_for_platform("connections", platform):
+            continue
+        # A composite like [hermes-cli] already inherits every core tool at read time.
+        if not any(str(ts) in explicit_keys for ts in toolsets):
+            continue
+        offered = known.get(platform)
+        if isinstance(offered, list) and "connections" in offered:
+            continue
+        saved[platform] = sorted({*map(str, toolsets), "connections"})
+        if isinstance(offered, list):
+            known[platform] = sorted({*map(str, offered), "connections"})
+        enabled_for.append(str(platform))
+    if not enabled_for:
+        return
+    config["platform_toolsets"] = saved
+    if known:
+        config["known_builtin_toolsets"] = known
+    platforms = ", ".join(sorted(enabled_for))
+    _commit(
+        config, results, quiet,
+        f"enabled the connections toolset for {platforms}",
+        f"  ✓ Enabled the Connections toolset (Gmail, Linear, Notion, ...) for {platforms} — "
+        "the manage_connections tool appears when your Nous Portal account has tool access "
+        "(paid plan or active free pool). Uncheck Connections in `hermes tools` to turn it off.")
+
+
 #: Registry of (target_version, step), strictly ascending; simple default-flip steps are
 #: declared inline via _rewrite_stale_default / _rewrite_key partials. Later steps observe
 #: earlier steps' writes via read_raw_config() (filesystem state). v12 is the support floor:
@@ -637,6 +688,7 @@ MIGRATIONS: Tuple[Tuple[int, Callable[[Dict[str, Any], bool], None]], ...] = (
             "  ✓ Removed cron.model_drift_guard — unpinned cron jobs now keep running on the "
             "model/provider they were created under when the global default changes, instead "
             "of being skipped. Pin a job or set cron.model to move it."))),
+    (43, _migrate_to_43),
 )
 
 

--- a/tests/hermes_cli/test_config_migration_43_connections.py
+++ b/tests/hermes_cli/test_config_migration_43_connections.py
@@ -1,0 +1,144 @@
+"""Migration 42→43: saved ``platform_toolsets`` lists gain the ``connections`` toolset.
+
+``hermes tools`` persists an explicit per-platform toolset list, and absence from
+that list reads as "unchecked" — so a toolset that ships after the list was saved
+stays off for picker users while composite (``[hermes-cli]``) users inherit it.
+The 42→43 step turns ``connections`` on for stale lists, preserves an explicit
+decline, and leaves composites/empty lists alone.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+
+class TestConnectionsToolsetMigration:
+    """Behaviour contract for ``_migrate_to_43`` driven through ``run_migrations``."""
+
+    @staticmethod
+    def _run_ladder(tmp_path, current_ver=42):
+        from hermes_cli.config_migrations import run_migrations
+
+        results = {"env_added": [], "config_added": [], "warnings": []}
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            run_migrations(current_ver, results, quiet=True)
+        return results
+
+    @staticmethod
+    def _write_config(tmp_path, config):
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump(config), encoding="utf-8"
+        )
+
+    @staticmethod
+    def _read_config(tmp_path):
+        return yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+
+    def test_stale_list_gains_connections_for_every_platform(self, tmp_path):
+        """A list saved before the toolset shipped is offered it (and records the offer)."""
+        platforms = {
+            "cli": ["file", "terminal", "web"],
+            "telegram": ["file", "web"],
+        }
+        self._write_config(
+            tmp_path,
+            {
+                "_config_version": 42,
+                "platform_toolsets": platforms,
+                "known_builtin_toolsets": {
+                    "cli": ["browser", "file", "memory", "skills", "terminal", "todo", "web"]
+                },
+            },
+        )
+
+        results = self._run_ladder(tmp_path)
+        raw = self._read_config(tmp_path)
+
+        assert "connections" in raw["platform_toolsets"]["cli"]
+        assert "connections" in raw["platform_toolsets"]["telegram"]
+        # The offer is recorded so a later uncheck is a recorded decline, not another migration.
+        assert "connections" in raw["known_builtin_toolsets"]["cli"]
+        added = [entry for entry in results["config_added"] if "connections" in entry.lower()]
+        assert len(added) == 1, results["config_added"]
+
+    @pytest.mark.parametrize(
+        "platform_toolsets, known",
+        [
+            pytest.param(  # (a) the user saw the checkbox and left it off
+                {"cli": ["file", "terminal", "web"]},
+                {"cli": ["browser", "connections", "file", "web"]},
+                id="declined",
+            ),
+            pytest.param(  # (b) composite list already inherits every core tool
+                {"cli": ["hermes-cli"]},
+                {},
+                id="composite",
+            ),
+            pytest.param(  # (c) empty picker selection — no configurable key to extend
+                {"cli": []},
+                {},
+                id="empty",
+            ),
+        ],
+    )
+    def test_declines_composites_and_empty_lists_are_untouched(
+        self, tmp_path, platform_toolsets, known
+    ):
+        self._write_config(
+            tmp_path,
+            {
+                "_config_version": 42,
+                "platform_toolsets": platform_toolsets,
+                "known_builtin_toolsets": known,
+            },
+        )
+
+        results = self._run_ladder(tmp_path)
+        raw = self._read_config(tmp_path)
+
+        assert raw["platform_toolsets"] == platform_toolsets
+        assert results["config_added"] == []
+
+    @pytest.mark.parametrize("disabled", [["browser", "connections", "web"], '["connections"]'], ids=["list", "json-string"])
+    def test_global_disable_is_not_overridden_or_claimed(self, tmp_path, disabled):
+        """Blank Slate and `hermes tools --disable` write agent.disabled_toolsets, which the resolver
+        subtracts last; appending to the platform list would print an enable that never takes effect."""
+        platform_toolsets = {"cli": ["file", "skills", "terminal", "vision"]}
+        self._write_config(
+            tmp_path,
+            {
+                "_config_version": 42,
+                "platform_toolsets": platform_toolsets,
+                "agent": {"disabled_toolsets": disabled},
+            },
+        )
+
+        results = self._run_ladder(tmp_path)
+        raw = self._read_config(tmp_path)
+
+        assert raw["platform_toolsets"] == platform_toolsets
+        assert raw["agent"]["disabled_toolsets"] == disabled
+        assert results["config_added"] == []
+
+    def test_rerun_adds_nothing_and_keeps_one_connections(self, tmp_path):
+        """Running the step twice is a no-op; the toolset appears exactly once."""
+        self._write_config(
+            tmp_path,
+            {
+                "_config_version": 42,
+                "platform_toolsets": {"cli": ["file", "terminal", "web"]},
+                "known_builtin_toolsets": {"cli": ["file", "terminal", "web"]},
+            },
+        )
+
+        self._run_ladder(tmp_path)
+        after_first = self._read_config(tmp_path)["platform_toolsets"]["cli"]
+        second = self._run_ladder(tmp_path)
+        after_second = self._read_config(tmp_path)["platform_toolsets"]["cli"]
+
+        # Running the step again rewrites nothing and never appends a duplicate.
+        assert second["config_added"] == []
+        assert after_second == after_first
+        assert after_second.count("connections") <= 1


### PR DESCRIPTION
After `hermes update`, every install that saved a toolset list before 2026-09-10 gets the `manage_connections` tool. Until now those installs never saw it, even signed in to a paid Nous org.

## The problem

`hermes tools` (and the desktop Toolsets panel) writes an explicit list of toolset names to `config.yaml`:

```yaml
platform_toolsets:
  cli: [file, terminal, web]
```

The resolver reads "not in the list" as "the user unchecked it". The `connections` toolset, which carries `manage_connections`, shipped on 2026-09-10 (#106842). It is absent from every list saved before that date. So the toolset is off, the tool is stripped from the model's schema, and the agent reports it as missing. The Nous sign-in check never gets a vote.

Users who never opened the picker are on the `[hermes-cli]` composite, which expands to every core tool at read time. They got the tool on update. Picker users did not. Same release, two outcomes.

```mermaid
flowchart LR
    U[hermes update] --> C[new code on disk]
    C --> R{platform_toolsets.cli<br/>saved before 09-10?}
    R -- "[hermes-cli] composite" --> ON[connections on]
    R -- "[file, terminal, web]" --> OFF[connections off<br/>manage_connections absent]
```

<!-- before-and-after:start -->
| Before (hermes chat -q, same prompt and saved list, before and after the migration) | After (hermes chat -q, same prompt and saved list, before and after the migration) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/ac4ab1f6-a113-40b2-ac06-b6117b563b93) | ![After](https://github.com/user-attachments/assets/cf96edd8-79fb-4700-8345-b1e26456f577) |

| The migration step (what `hermes update` runs post-pull), and `config.yaml` after |
|:---:|
| ![Migrate](https://github.com/user-attachments/assets/ce4457b4-8427-45b2-920c-b798352c2f2f) |

<!-- before-and-after:end -->

## What changes

One config migration, `42 → 43`, in `hermes_cli/config_migrations.py`. `hermes update` runs migrations after the pull for the active profile and every sibling profile (`update_cmd_config.py:46,84`), so one update is enough. Docker runs the same step on container boot.

For each platform in `platform_toolsets`:

| Saved list looks like | Migration does | Why |
|---|---|---|
| `[file, terminal, web]`, no record of the Connections checkbox | appends `connections` | shipped after the save |
| `[file, terminal, web]`, `known_builtin_toolsets` records `connections` | nothing | user saw the checkbox on a newer build and left it off |
| `[hermes-cli]` | nothing | composite already expands to every core tool |
| `[]` | nothing | user chose no tools |
| platform where the toolset is not allowed | nothing | platform restriction |

Words: `known_builtin_toolsets` is the list of checkboxes the picker showed at last save, written on every save since July. A toolset in that record but not in the saved list is a decline. A toolset in neither is one that did not exist yet.

`agent.disabled_toolsets` is untouched. The resolver applies it last, so a Blank Slate install that lists `connections` there stays minimal.

Prints one line when it changes something:

```
✓ Enabled the Connections toolset (Gmail, Linear, Notion, ...) for cli, telegram — the manage_connections tool appears once you sign in to the Nous Portal. Uncheck Connections in `hermes tools` to turn it off.
```

## What the user experiences

| | Before | After `hermes update` |
|---|---|---|
| Saved list from before 09-10, signed in to a paid org | agent: "I don't have that tool" | `manage_connections status` returns the connector list |
| Same, then unchecks Connections in `hermes tools` | n/a | stays off; the save records the decline |
| Fresh install or `[hermes-cli]` composite | present | present, no change |
| Signed out, or free tier with no tool pool | absent | absent (`check_fn`, no change) |
| nix / apt / manual `git pull`, never runs `hermes update` | absent | absent until they run `hermes config migrate` or `hermes tools` once |

## Not in this PR

The general rule ("a new built-in toolset is on for everyone who has not declined it, with no per-toolset code") is a resolver change. Built-ins would follow the rule plugin toolsets already get from `known_plugin_toolsets` (`tools_config.py:536-542`). That deletes the `_RECENTLY_SHIPPED_TOOLSETS` frozenset and its six skip-when-empty tests. Separate PR; this one unblocks users today.

#108142 (the frozenset approach) is closed in favour of this.

## Tests

`tests/hermes_cli/test_config_migration_43_connections.py`, 4 functions, 7 cases, run through `scripts/run_tests.sh`:

| Test | Base `a3190625c0` | This branch |
|---|---|---|
| stale list gains `connections` on every platform and in the record | fail | pass |
| declined / composite / empty list are untouched (3 cases) | pass | pass |
| `agent.disabled_toolsets` names it, list or JSON-string form: untouched, nothing claimed (2 cases) | pass | pass |
| second run adds nothing | pass | pass |

Sibling files: `test_config.py` and `test_tools_config.py`, 173 passed, 10 skipped.

## Live repro

Temp `HERMES_HOME`, real `auth.json` from a paid Nous org, `config.yaml` at v42 with `platform_toolsets.cli: [file, terminal, web]` and a `known_builtin_toolsets.cli` record without `connections`. Same `hermes chat -q` prompt before and after, fresh session each time. Ground truth from `state.db`, not the transcript.

| State | Command | Tool the agent called (`state.db`) | Reply |
|---|---|---|---|
| before | `hermes chat -q "..."` | none (0 tool calls) | `TOOL NOT AVAILABLE: manage_connections` |
| migrate | `hermes config migrate` (the step `hermes update` runs post-pull) | n/a | `✓ Enabled the Connections toolset ... for cli` / `Config version: 42 → 43`; `platform_toolsets.cli` now lists `connections` |
| after | identical `hermes chat -q "..."` | `manage_connections {"action": "status"}` | `CONNECTED: googlecalendar, slack, linear, discord, figma, confluence, granola_mcp` |

Before the migration the agent made zero tool calls rather than hunting with `tool_search`: the search bridge only advertises `manage_connections` when the Connections toolset is granted (`tools/tool_search.py:217-239`), so the tool was invisible to search too. Screenshots in the block above; the middle frame shows the migration output and the resulting `config.yaml` in one capture.

## Review

Adversarial review by a zero-context subagent against the first draft found two defects, both fixed before this PR was opened:

- Blank Slate installs and `hermes tools --disable connections` write `agent.disabled_toolsets`. The draft appended `connections` to the platform list and printed `✓ Enabled`, but the resolver subtracts that list last, so the enable never took effect and the message was false. Now the step returns early when `connections` is in `agent.disabled_toolsets`.
- The draft's "is this an explicit list" test used built-in keys only. The resolver's own test also counts plugin keys, so a list like `cli: [spotify]` was misread as a composite and skipped. Now uses the same predicate the resolver does.

Confirmed OK: int keys, null `known_builtin_toolsets`, unknown platform names, mixed `[file, hermes-cli]` lists, docker boot, sibling profiles, idempotency.
