### PR TITLE
fix(bedrock): key stream blocks off contentBlockIndex

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -781,8 +781,7 @@ def stream_converse_with_callbacks(
     stop_reason = "end_turn"
     usage_data: Dict[str, int] = {}
 
-    def current_block(default: Dict[str, Any]) -> Dict[str, Any]:
-        idx = current_block_index if current_block_index is not None else len(stream_blocks)
+    def block_at(idx: int, default: Dict[str, Any]) -> Dict[str, Any]:
         return stream_blocks.setdefault(idx, default)
 
     def flush_text() -> None:
@@ -808,10 +807,12 @@ def stream_converse_with_callbacks(
                 if on_tool_start:
                     on_tool_start(current_tool["name"])
         elif "contentBlockDelta" in event:
-            delta = event["contentBlockDelta"].get("delta", {})
+            delta_event = event["contentBlockDelta"]
+            delta = delta_event.get("delta", {})
+            idx = delta_event.get("contentBlockIndex", len(stream_blocks))
             if "text" in delta:
                 text = delta["text"]
-                block = current_block({"text": ""})
+                block = block_at(idx, {"text": ""})
                 block["text"] = block.get("text", "") + text
                 current_text_buffer.append(text)
                 if on_text_delta and not has_tool_use:
@@ -821,7 +822,9 @@ def stream_converse_with_callbacks(
             elif "reasoningContent" in delta:
                 reasoning = delta["reasoningContent"]
                 if isinstance(reasoning, dict) and (reasoning.get("text", "") or _encode_redacted(reasoning.get("redactedContent"))):
-                    block = current_block({"reasoningContent": {}}).setdefault("reasoningContent", {})
+                    block = block_at(idx, {"reasoningContent": {}}).setdefault(
+                        "reasoningContent", {}
+                    )
                     parts.absorb_reasoning(reasoning, block, on_reasoning_delta)
         elif "contentBlockStop" in event:
             if current_tool is not None:

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -461,6 +461,73 @@ class TestNormalizeConverseStreamEvents:
             "data": "c3RyZWFtLXNlY3JldA==",
         }]
 
+    def test_text_deltas_without_block_start_merge_into_one_block(self):
+        from agent.bedrock_adapter import normalize_converse_stream_events
+
+        events = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "Let me che"}}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "ck that."}}},
+            {"contentBlockStart": {"contentBlockIndex": 1, "start": {
+                "toolUse": {"toolUseId": "call_1", "name": "read_file"},
+            }}},
+            {"contentBlockDelta": {"contentBlockIndex": 1, "delta": {
+                "toolUse": {"input": '{"path":'},
+            }}},
+            {"contentBlockDelta": {"contentBlockIndex": 1, "delta": {
+                "toolUse": {"input": '"/tmp/f"}'},
+            }}},
+            {"contentBlockStop": {"contentBlockIndex": 1}},
+            {"messageStop": {"stopReason": "tool_use"}},
+            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 8}}},
+        ]}
+
+        result = normalize_converse_stream_events(events)
+        message = result.choices[0].message
+        assert message.bedrock_content_blocks == [
+            {"text": "Let me check that."},
+            {"toolUse": {"toolUseId": "call_1", "name": "read_file", "input": {"path": "/tmp/f"}}},
+        ]
+        assert message.content == "Let me check that."
+        assert json.loads(message.tool_calls[0].function.arguments) == {"path": "/tmp/f"}
+
+    def test_text_after_tool_use_stays_in_its_own_block_on_replay(self):
+        from agent.bedrock_adapter import convert_messages_to_converse, normalize_converse_stream_events
+
+        events = {"stream": [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockStart": {"contentBlockIndex": 0, "start": {}}},
+            {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "Working on it."}}},
+            {"contentBlockStop": {"contentBlockIndex": 0}},
+            {"contentBlockStart": {"contentBlockIndex": 1, "start": {
+                "toolUse": {"toolUseId": "call_1", "name": "read_file"},
+            }}},
+            {"contentBlockDelta": {"contentBlockIndex": 1, "delta": {
+                "toolUse": {"input": '{"path": "/tmp/f"}'},
+            }}},
+            {"contentBlockStop": {"contentBlockIndex": 1}},
+            {"contentBlockDelta": {"contentBlockIndex": 2, "delta": {"text": "Done."}}},
+            {"messageStop": {"stopReason": "tool_use"}},
+            {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 8}}},
+        ]}
+
+        result = normalize_converse_stream_events(events)
+        message = result.choices[0].message
+        assert [list(block) for block in message.bedrock_content_blocks] == [["text"], ["toolUse"], ["text"]]
+        assert message.bedrock_content_blocks[1]["toolUse"]["input"] == {"path": "/tmp/f"}
+
+        history = {
+            "role": "assistant",
+            "content": message.content,
+            "tool_calls": [{
+                "id": "call_1", "type": "function",
+                "function": {"name": "read_file", "arguments": '{"path": "/tmp/f"}'},
+            }],
+            "bedrock_content_blocks": message.bedrock_content_blocks,
+        }
+        _system, converse = convert_messages_to_converse([{"role": "user", "content": "go"}, history])
+        assert [next(iter(block)) for block in converse[1]["content"]] == ["text", "toolUse", "text"]
+
     def test_tool_use_stream(self):
         from agent.bedrock_adapter import normalize_converse_stream_events
         events = {"stream": [


### PR DESCRIPTION
## Summary

Fixes #108200.

`stream_converse_with_callbacks()` in `agent/bedrock_adapter.py` inferred each `contentBlockDelta`'s block position from the last seen `contentBlockStart` and fell back to `len(stream_blocks)`. Bedrock emits `contentBlockStart` for structured blocks (`toolUse`) but not for plain text, so:

- text deltas without a preceding `contentBlockStart` each landed in a fresh block (`idx = len(stream_blocks)` grows with every delta), later overwritten wholesale by the next tool block assigned to the same index;
- once a `toolUse` block stopped, `current_block_index` stayed stale and `setdefault` returned the toolUse dict, so trailing text deltas bolted a stray `text` key onto the tool block — which `_replay_ordered_blocks()` then renders as a bare text block, dropping the `toolUse`.

The persisted `bedrock_content_blocks` sidecar ended up with text blocks after `toolUse`; on replay the assistant turn carries trailing text inside a tool-use turn, which `us.anthropic.claude-opus-4-8` / `opus-5` reject as assistant prefill ("This model does not support assistant message prefill") — bricking every subsequent request in the session (sonnet-4-6 tolerates the payload, which is why it slips through).

## Fix

Every `contentBlockDelta` event carries `contentBlockIndex`; the delta branch now keys `stream_blocks` off that field for text and reasoningContent accumulation instead of inferring position. `contentBlockStart`/`Stop` keep driving only the tool bookkeeping they already own. Interleaved replay semantics (`reasoningContent ↔ toolUse` alternation) are untouched.

## Tests

Two regression tests in `TestNormalizeConverseStreamEvents`:

- `test_text_deltas_without_block_start_merge_into_one_block` — text deltas with no `contentBlockStart` (real Bedrock wire shape) must merge into one block before the toolUse block; sidecar is exactly `[text, toolUse]`.
- `test_text_after_tool_use_stays_in_its_own_block_on_replay` — trailing text after a toolUse stays in its own block (no stray `text` key on the tool block), and `convert_messages_to_converse` replays the turn as `[text, toolUse, text]` with the tool input intact.

Mutation-verified: reverting the delta branch to `len(stream_blocks)` or to the stale `current_block_index` makes both tests fail (split-text / stray-key shapes respectively). Full local runs green: `tests/agent/test_bedrock_adapter.py` (80), `test_bedrock_transport_replay.py`, `test_bedrock_interrupt_post_worker.py`, `tests/run_agent/test_streaming.py`, `tests/run_agent/test_plugin_stream_hooks.py` (54).
