### PR TITLE
fix(bot-mode): retain failed CLI/peer DM payloads

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -499,7 +499,7 @@ def test_delivery_runner_keeps_file_for_child_then_unlinks(tmp_path, stdin_file)
     assert not dm_file.exists()
 
 
-def test_delivery_runner_unlinks_when_child_launch_raises(tmp_path, monkeypatch):
+def test_delivery_runner_retains_payload_when_child_launch_raises(tmp_path, monkeypatch):
     dm_file = tmp_path / "message.txt"
     dm_file.write_text("secret", encoding="utf-8")
 
@@ -509,10 +509,11 @@ def test_delivery_runner_unlinks_when_child_launch_raises(tmp_path, monkeypatch)
     monkeypatch.setattr(subprocess, "run", boom)
     with pytest.raises(RuntimeError, match="child launch failed"):
         bot_mode_dm._run_delivery(["hermes"], str(dm_file), stdin_file=False)
-    assert not dm_file.exists()
+    assert dm_file.exists()
+    assert dm_file.read_text(encoding="utf-8") == "secret"
 
 
-def test_delivery_runner_preserves_child_failure_and_unlinks(tmp_path):
+def test_delivery_runner_preserves_child_failure_and_payload(tmp_path):
     dm_file = tmp_path / "message.txt"
     dm_file.write_text("secret", encoding="utf-8")
     child = tmp_path / "fail.py"
@@ -528,7 +529,62 @@ def test_delivery_runner_preserves_child_failure_and_unlinks(tmp_path):
     )
 
     assert returncode == 7
-    assert not dm_file.exists()
+    assert dm_file.exists()
+    assert dm_file.read_text(encoding="utf-8") == "secret"
+
+
+def test_non_delivered_payload_is_retained_and_replay_returns_cached_receipt(
+    tmp_path, monkeypatch, capsys
+):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    calls = []
+
+    def failed_transport(*args, **kwargs):
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(
+            args[0],
+            1,
+            stdout="",
+            stderr="Session abc already has a live owner (desktop, pid 1).",
+        )
+
+    monkeypatch.setattr(subprocess, "run", failed_transport)
+
+    assert bot_mode_dm._run_delivery(["hermes"], str(dm_file), stdin_file=False) == 1
+    first = json.loads(capsys.readouterr().out)
+    assert dm_file.exists()
+    assert first["reason"] == "target_busy"
+    assert first["payload_file"] == str(dm_file)
+    assert first["retry_command"]
+
+    assert bot_mode_dm._run_delivery(["hermes"], str(dm_file), stdin_file=False) == 1
+    second = json.loads(capsys.readouterr().out)
+    assert second == first
+    assert len(calls) == 1
+
+
+def test_peer_stdin_failure_retains_payload_and_replays_receipt(tmp_path, monkeypatch, capsys):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    calls = []
+
+    def failed_transport(*args, **kwargs):
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(args[0], 3, stdout="", stderr="peer refused")
+
+    monkeypatch.setattr(subprocess, "run", failed_transport)
+
+    assert bot_mode_dm._run_delivery(["hermes", "peer", "dm", "spark/ops"], str(dm_file), stdin_file=True) == 3
+    first = json.loads(capsys.readouterr().out)
+    assert dm_file.exists()
+    assert first["payload_file"] == str(dm_file)
+    assert first["reason"]
+
+    assert bot_mode_dm._run_delivery(["hermes", "peer", "dm", "spark/ops"], str(dm_file), stdin_file=True) == 3
+    second = json.loads(capsys.readouterr().out)
+    assert second == first
+    assert len(calls) == 1
 
 
 def test_delivery_runner_surfaces_live_owner_refusal(tmp_path, capsys):
@@ -673,7 +729,7 @@ def test_delivery_main_runs_valid_cli_and_unlinks(tmp_path, mode):
     assert not dm_file.exists()
 
 
-def test_delivery_main_maps_launch_exception_to_one_and_unlinks(tmp_path, monkeypatch):
+def test_delivery_main_maps_launch_exception_to_one_and_retains_payload(tmp_path, monkeypatch):
     dm_file = tmp_path / "message.txt"
     dm_file.write_text("secret", encoding="utf-8")
 
@@ -687,7 +743,8 @@ def test_delivery_main_maps_launch_exception_to_one_and_unlinks(tmp_path, monkey
         )
         == 1
     )
-    assert not dm_file.exists()
+    assert dm_file.exists()
+    assert dm_file.read_text(encoding="utf-8") == "secret"
 
 
 @pytest.mark.parametrize("stdin_file", [False, True])

--- a/tests/tools/test_bot_mode_refusal_contract.py
+++ b/tests/tools/test_bot_mode_refusal_contract.py
@@ -17,8 +17,10 @@ def test_delivery_uses_refusal_code_before_human_wording(tmp_path, capsys):
         child.write_text(f"import sys\nprint({f'hermes-refusal-reason: {code}'!r}, file=sys.stderr)\nprint({message!r}, file=sys.stderr)\nraise SystemExit(1)\n", encoding="utf-8")
         assert bot_mode_dm._run_delivery([sys.executable, str(child)], str(dm), stdin_file=False) == 1
         output = capsys.readouterr()
-        assert (json.loads(output.out)["reason"] == "target_busy") if busy else not output.out
-        assert not dm.exists()
+        payload = json.loads(output.out)
+        assert (payload["reason"] == "target_busy") is busy
+        assert payload["payload_file"] == str(dm)
+        assert dm.exists()
 
 
 def test_one_shot_cli_preserves_refusal_reason(monkeypatch, capsys):

--- a/tests/tools/test_bot_mode_refusal_contract.py
+++ b/tests/tools/test_bot_mode_refusal_contract.py
@@ -11,9 +11,9 @@ def test_delivery_uses_refusal_code_before_human_wording(tmp_path, capsys):
         ("SESSION_COORDINATION_UNAVAILABLE", "Cannot verify whether session already has a live owner", False),
         ("SESSION_NOT_OWNED_EXTRA", "Different failure", False),
     ):
-        dm = tmp_path / "message.txt"
+        dm = tmp_path / f"message-{code}.txt"
         dm.write_text("isolated probe", encoding="utf-8")
-        child = tmp_path / "child.py"
+        child = tmp_path / f"child-{code}.py"
         child.write_text(f"import sys\nprint({f'hermes-refusal-reason: {code}'!r}, file=sys.stderr)\nprint({message!r}, file=sys.stderr)\nraise SystemExit(1)\n", encoding="utf-8")
         assert bot_mode_dm._run_delivery([sys.executable, str(child)], str(dm), stdin_file=False) == 1
         output = capsys.readouterr()

--- a/tests/tools/test_bot_turn_lock.py
+++ b/tests/tools/test_bot_turn_lock.py
@@ -203,10 +203,11 @@ def test_delivery_main_reports_target_busy_json(root, tmp_path, monkeypatch, cap
         payload = json.loads(capsys.readouterr().out.strip())
         assert payload["reason"] == "target_busy"  # #93091 item-1 enum extension
         assert "ops" in payload["error"]
+        assert payload["payload_file"] == str(dm)
     finally:
         release.set()
         t.join(timeout=5)
-    assert not dm.exists(), "DM plaintext must be reclaimed even on refusal"
+    assert dm.exists(), "failed CLI delivery retains the payload for replay"
 
 
 def test_peer_stdin_delivery_skips_local_lock(root, tmp_path, monkeypatch):

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -325,6 +325,39 @@ def _unlink_dm_file(path: str) -> None:
         os.unlink(path)
 
 
+def _delivery_receipt_path(path: str) -> Path:
+    return Path(f"{path}.receipt.json")
+
+
+def _read_delivery_receipt(path: str) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(_delivery_receipt_path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _write_delivery_receipt(
+    path: str, argv: list[str], *, stdin_file: bool, reason: str, error: str,
+    profile_home: Path | None = None, author: Optional[dict] = None, returncode: int = 1,
+) -> dict[str, Any]:
+    receipt = {
+        "status": "not_delivered" if reason == "target_busy" else "ambiguous",
+        "reason": reason or "unknown",
+        "error": error,
+        "delivery_id": hashlib.sha256(str(Path(path).resolve()).encode()).hexdigest(),
+        "payload_file": path,
+        "returncode": returncode,
+        "retry_command": _delivery_command(
+            argv, path, stdin_file=stdin_file, profile_home=profile_home, author=author,
+        ),
+    }
+    _delivery_receipt_path(path).write_text(
+        json.dumps(receipt, ensure_ascii=False, sort_keys=True), encoding="utf-8",
+    )
+    return receipt
+
+
 def _write_dm_file(content: str) -> str:
     """The message rides a temp file — never inline shell text."""
     cleanup_bot_dm_cache()
@@ -361,9 +394,9 @@ def _delivery_lock(argv: list[str], *, stdin_file: bool):
     return acquire_turn_lock(_hermes_root(Path(_default_home())), argv[2])
 
 
-def _run_local_turn(argv: list[str], dm_file: str, *, env: Optional[dict[str, str]] = None) -> int:
+def _run_local_turn(argv: list[str], dm_file: str, *, env: Optional[dict[str, str]] = None) -> tuple[int, str, str]:
     """One Bot Chat turn via ``--query-file`` (plus one policy-gated retry); re-emits
-    the transport's streams and returns its exit code. Transient failures re-run the
+    the transport's streams and returns ``(exit code, reason, error)``. Transient failures re-run the
     same session; a context_overflow re-run lets the retried turn's pre-API compaction
     compact the transcript first (no fresh session is ever minted). Auth/quota/config never retry."""
 
@@ -390,19 +423,23 @@ def _run_local_turn(argv: list[str], dm_file: str, *, env: Optional[dict[str, st
         # never ran — tell the sender plainly instead of leaking a raw lease error.
         # See #100523.
         who = argv[argv.index("-p") + 1] if "-p" in argv[:-1] else "the teammate"
-        print(json.dumps({
-            "error": f"Delivery failed: @{who}'s Bot Chat is open on another "
-                     "surface right now, so your message was NOT delivered. Try again later.",
-            "reason": "target_busy",
-        }))
-        return 1
+        error = (
+            f"Delivery failed: @{who}'s Bot Chat is open on another "
+            "surface right now, so your message was NOT delivered. Try again later."
+        )
+        return 1, "target_busy", error
     # Re-emit the transport's streams: stdout is the reply text the
     # completion notification carries back to the sending agent.
     for stream, text in ((sys.stdout, proc.stdout), (sys.stderr, proc.stderr)):
         if text:
             stream.write(text)
             stream.flush()
-    return proc.returncode
+    if proc.returncode != 0:
+        from tools.bot_failure_reasons import classify_agent_error
+
+        detail = (proc.stderr or proc.stdout or "").strip()[-500:]
+        return proc.returncode, classify_agent_error(detail), detail
+    return 0, "", ""
 
 
 def _admit_live_dm(profile_home: Path | None, dm_file: str, author: Optional[dict] = None) -> dict | None:
@@ -471,8 +508,10 @@ def _local_delivery_home(argv: list[str]) -> Path | None:
 def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool,
                   profile_home: Path | None = None, author: Optional[dict] = None) -> int:
     """Route to the live owner before attempting a CLI transport. Live deliveries
-    retain their intent/payload and immutable receipt; only CLI/peer payloads are
-    removed after consumption. The CLI turn window holds the profile lock, so two
+    retain their intent/payload and immutable receipt; CLI/peer payloads are
+    removed only after successful consumption. A failed CLI/peer attempt keeps the
+    payload and a typed receipt so a re-run reports that outcome instead of sending
+    the DM twice. The CLI turn window holds the profile lock, so two
     deliveries into one profile queue; a bounded wait ends in a 'target_busy' refusal.
     ``author`` rides to the child as HERMES_TURN_AUTHOR; ``hermes peer dm`` forwards it in the request body.
 
@@ -482,6 +521,15 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool,
     ever minted. Auth/quota/config failures never retry. Peer transports (stdin mode) retry on their own
     gateway's deliver path, not here.
     """
+    cached_receipt = _read_delivery_receipt(dm_file)
+    if cached_receipt is not None:
+        print(json.dumps(cached_receipt, ensure_ascii=False))
+        if cached_receipt.get("status") == "delivered":
+            return 0
+        try:
+            return int(cached_receipt.get("returncode") or 1)
+        except (TypeError, ValueError):
+            return 1
     # The live consumer owns turn admission; never compete for its CLI lease.
     if not stdin_file:
         home = profile_home or _local_delivery_home(argv)
@@ -496,19 +544,44 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool,
                 return 1
             if record is not None:
                 return _wait_live_dm(record["profile_home"], record["delivery_id"])
+    delivered = False
+    failure_reason = "unknown"
+    failure_error = ""
+    returncode = 1
     try:
         from tools.bot_relay import delivery_env
 
         env = delivery_env(author)
         with _delivery_lock(argv, stdin_file=stdin_file):
             if not stdin_file:
-                return _run_local_turn(argv, dm_file, env=env)
-            # Keep the file open until the transport exits; cleanup occurs
-            # after subprocess.run returns, not merely after stdin reaches EOF.
-            with open(dm_file, "r", encoding="utf-8") as stream:
-                return subprocess.run(argv, stdin=stream, check=False, env=env).returncode
+                returncode, failure_reason, failure_error = _run_local_turn(argv, dm_file, env=env)
+            else:
+                # Keep the file open until the transport exits; cleanup occurs
+                # after subprocess.run returns, not merely after stdin reaches EOF.
+                with open(dm_file, "r", encoding="utf-8") as stream:
+                    returncode = subprocess.run(argv, stdin=stream, check=False, env=env).returncode
+            delivered = returncode == 0
+            return returncode
+    except Exception as exc:
+        failure_reason = getattr(exc, "reason", None) or "unknown"
+        failure_error = str(exc)
+        if failure_reason == "target_busy":
+            return 1
+        raise
     finally:
-        _unlink_dm_file(dm_file)
+        if delivered:
+            _unlink_dm_file(dm_file)
+            _delivery_receipt_path(dm_file).unlink(missing_ok=True)
+        else:
+            try:
+                receipt = _write_delivery_receipt(
+                    dm_file, argv, stdin_file=stdin_file, reason=failure_reason,
+                    error=failure_error, profile_home=profile_home, author=author,
+                    returncode=returncode,
+                )
+                print(json.dumps(receipt, ensure_ascii=False))
+            except Exception:
+                logger.warning("failed to retain undelivered DM payload", exc_info=True)
 
 
 def _delivery_command(argv: list[str], dm_file: str, *, stdin_file: bool,


### PR DESCRIPTION
## Why

#105442 shipped live-owner ingress with retained receipts. The leftover from #101564 is the legacy CLI/peer runner. `_run_delivery` still unlinked the payload in `finally` on failure, so a retry could not inspect the original message and a second run could execute again.

## Scope

- `tools/bot_mode_dm.py` `_run_delivery` unlinks CLI/peer payloads only after a successful consume.
- Failed attempts write `{dm_file}.receipt.json` with `reason`, `payload_file`, `retry_command`, and `returncode`.
- A second `_run_delivery` on the same file prints the cached receipt and does not launch the child.
- Live-owner admission (`_admit_live_dm` / `_wait_live_dm`) is unchanged.
- Tests in `tests/tools/test_bot_mode_dm.py`, `test_bot_mode_refusal_contract.py`, and `test_bot_turn_lock.py` pin retain-on-failure and replay.

Out of scope: tui_gateway live-owner poller, `bot_live_delivery.py` protocol, Desktop relay, closing #101564.

## Tradeoffs

Receipt check runs before live-owner admission so a failed CLI payload cannot execute a second time if a live owner appears later. Success still unlinks the plaintext file.

## Blast Radius

Local and peer `message_agent` deliveries that use the `--run-delivery` runner. Successful deliveries still delete the tempfile. Spawn-failure cleanup for untransferred files is unchanged.

## Verification

```
uv run --extra dev python -m pytest tests/tools/test_bot_mode_dm.py tests/tools/test_bot_mode_refusal_contract.py tests/tools/test_bot_live_owner_delivery.py tests/tui_gateway/test_bot_live_owner_delivery.py tests/tools/test_bot_retry_policy.py::test_run_delivery_retries_transient_and_reemits_stdout tests/tools/test_bot_retry_policy.py::test_run_delivery_no_retry_for_missing_config -q
```

Retain, replay, success-unlink, and live-owner tests passed (60 passed, 1 skipped). Three Windows-only failures in `test_bot_mode_dm.py` also fail on unmodified origin/main on this host (`test_delivery_command_author_json_survives_quoting_and_windows_slash_rewrite`, `test_dm_dir_is_private_and_uid_scoped_on_posix`, `test_dm_dir_repairs_restrictive_owner_mode`).

Related: #101564, #101060
