### PR TITLE
Guided first launch: review fixes from #107985 and the free-tier chip badge (NS-848, NS-855)

### DIFF
--- a/apps/desktop/electron/chat-onboarding-window.ts
+++ b/apps/desktop/electron/chat-onboarding-window.ts
@@ -1,6 +1,6 @@
 import { type BrowserWindow, ipcMain, screen } from 'electron'
 
-import { type GrowRequest, growWindowBounds } from './window-growth'
+import { centeredBounds, type GrowRequest, growWindowBounds } from './window-growth'
 
 interface ChatOnboardingWindowOptions {
   enabled: boolean
@@ -40,14 +40,6 @@ export function registerChatOnboardingWindow({ enabled, mainWindow }: ChatOnboar
     const width = Math.min(600, area.width)
     const height = Math.min(640, area.height)
 
-    win.setBounds(
-      {
-        height,
-        width,
-        x: Math.round(area.x + (area.width - width) / 2),
-        y: Math.round(area.y + (area.height - height) / 2)
-      },
-      true
-    )
+    win.setBounds(centeredBounds(area, width, height), true)
   })
 }

--- a/apps/desktop/electron/window-growth.ts
+++ b/apps/desktop/electron/window-growth.ts
@@ -6,6 +6,8 @@
  * asserted rather than eyeballed on a first run.
  */
 
+import type { Rectangle } from 'electron'
+
 export interface GrowRequest {
   bottom?: number
   left?: number
@@ -65,6 +67,10 @@ export function growWindowBounds(
     Math.round(workArea.height * MAX_WORK_AREA)
   )
 
+  return centeredBounds(workArea, width, height)
+}
+
+export function centeredBounds(workArea: Rectangle, width: number, height: number): Rectangle {
   return {
     height,
     width,

--- a/apps/desktop/src/app/contrib/handoff-receipt.test.ts
+++ b/apps/desktop/src/app/contrib/handoff-receipt.test.ts
@@ -1,0 +1,18 @@
+import { expect, it } from 'vitest'
+
+import { readKey, writeKey } from '@/lib/storage'
+
+import { handoffReceiptKey, quarantineHandoffReceipt, readHandoffReceipt } from './handoff-receipt'
+
+it('preserves an unreadable receipt and removes it from the retry lookup', () => {
+  const key = handoffReceiptKey('receipt-recovery', 'guide')
+  const corrupt = '{unreadable receipt'
+  writeKey(key, corrupt)
+
+  expect(() => readHandoffReceipt(key)).toThrow()
+
+  quarantineHandoffReceipt(key)
+
+  expect(readKey(`${key}.unreadable`)).toBe(corrupt)
+  expect(readHandoffReceipt(key)).toBeNull()
+})

--- a/apps/desktop/src/app/contrib/handoff-receipt.ts
+++ b/apps/desktop/src/app/contrib/handoff-receipt.ts
@@ -1,4 +1,4 @@
-import { readKey, writeJson } from '@/lib/storage'
+import { readKey, writeJson, writeKey } from '@/lib/storage'
 
 import type { HandoffReceipt } from './handoff-leg'
 
@@ -57,6 +57,11 @@ export function readHandoffReceipt(key: string): HandoffReceipt | null {
   }
 
   return value
+}
+
+export function quarantineHandoffReceipt(key: string): void {
+  writeKey(`${key}.unreadable`, readKey(key))
+  writeKey(key, null)
 }
 
 export function saveHandoffReceipt(key: string, receipt: HandoffReceipt): void {

--- a/apps/desktop/src/app/contrib/onboarding-handoff.ts
+++ b/apps/desktop/src/app/contrib/onboarding-handoff.ts
@@ -14,6 +14,7 @@ import {
   buildHandoffCompleteNote,
   firstTaskTitle,
   guideSourceConnectionId,
+  readGuideHandoffReceipt,
   retrySetupHandoff,
   SETUP_PROFILE
 } from '@/components/onboarding-chat/setup-profile'
@@ -40,7 +41,7 @@ import {
 import { patchSessionTile } from '@/store/session-states'
 
 import { BUILD_PROFILE, type HandoffDeps, type HandoffReceipt, paintHandoffBrief, startHandoff } from './handoff-leg'
-import { handoffReceiptKey, readHandoffReceipt, saveHandoffReceipt } from './handoff-receipt'
+import { saveHandoffReceipt } from './handoff-receipt'
 import type { AmbientGatewayRequest } from './session-rpc-dispatcher'
 
 export interface OnboardingHandoffOptions extends Pick<
@@ -82,7 +83,7 @@ export function useOnboardingHandoff({
     const connectionId = guideSourceConnectionId(selectedStoredId)
 
     try {
-      const saved = readHandoffReceipt(handoffReceiptKey(connectionId, selectedStoredId))
+      const { receipt: saved } = readGuideHandoffReceipt(selectedStoredId)
 
       if (!saved) {
         return
@@ -146,8 +147,8 @@ export function useOnboardingHandoff({
 
         $setupSession.set(setupSession)
         // Resume only has the guide's stored id, so its source must also key the saved receipt.
-        const receiptKey = handoffReceiptKey(guideSourceConnectionId(setupSession.storedId), setupSession.storedId)
-        receipt = readHandoffReceipt(receiptKey)
+        const { key: receiptKey, receipt: saved } = readGuideHandoffReceipt(setupSession.storedId)
+        receipt = saved
         const owner: HandoffReceipt['owner'] = receipt?.owner ?? { connectionId, profile: BUILD_PROFILE }
         // Save facts before session.create freezes the new agent's memory.
         // A retry never re-creates the session or copies the guide's memory.

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -467,7 +467,10 @@ export function useStatusbarItems({
             <span className="font-mono text-[0.625rem] text-muted-foreground/70">
               {freeTier?.model ?? FREE_TIER_MODEL}
             </span>
-            <Badge size="xs" variant="solid">
+            {/* The class merger drops Badge's own leading-none behind the size's
+                font-size class, so the badge grows to the inherited 1.5 leading and
+                overhangs an 11px label. Restating it here keeps it 11.6px tall. */}
+            <Badge className="leading-none" size="xs" variant="solid">
               {freeTierCopy.signIn}
             </Badge>
           </span>

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -463,14 +463,14 @@ export function useStatusbarItems({
         // The model id is the quiet part; the sign-in is the action, so it is
         // solid and set off by a gap instead of touching the label.
         detail: (
-          <>
+          <span className="inline-flex items-center gap-2">
             <span className="font-mono text-[0.625rem] text-muted-foreground/70">
               {freeTier?.model ?? FREE_TIER_MODEL}
             </span>
-            <Badge className="ml-2" size="xs" variant="solid">
+            <Badge size="xs" variant="solid">
               {freeTierCopy.signIn}
             </Badge>
-          </>
+          </span>
         ),
         // Shown while a free-tier identity exists and the tier is on: it names the
         // identity that carries the connectors (and inference when nothing else

--- a/apps/desktop/src/components/onboarding-chat/cards/build.tsx
+++ b/apps/desktop/src/components/onboarding-chat/cards/build.tsx
@@ -11,7 +11,7 @@ import { useEffect, useMemo, useState } from 'react'
 
 import { requestComposerSubmit } from '@/app/chat/composer/focus'
 import { useSessionView } from '@/app/chat/session-view'
-import { handoffReceiptKey, quarantineHandoffReceipt } from '@/app/contrib/handoff-receipt'
+import { quarantineHandoffReceipt } from '@/app/contrib/handoff-receipt'
 import { resolveSessionOwner } from '@/app/session/hooks/use-session-actions/utils'
 import type { CardProps } from '@/components/onboarding-chat/cards/frame'
 import { Chip } from '@/components/onboarding-chat/chip'
@@ -19,7 +19,7 @@ import {
   $handoffError,
   $setupHandoff,
   firstTaskTitle,
-  guideSourceConnectionId,
+  guideHandoffReceiptKey,
   parseHandoffPlan,
   readGuideHandoffReceipt,
   requestSetupHandoff,
@@ -172,7 +172,7 @@ export function HandoffCard({ attrs, locked }: CardProps) {
 
     try {
       if (receipt.error && storedId) {
-        quarantineHandoffReceipt(handoffReceiptKey(guideSourceConnectionId(storedId), storedId))
+        quarantineHandoffReceipt(guideHandoffReceiptKey(storedId))
       }
 
       if (!state.guide && storedId && runtimeId) {

--- a/apps/desktop/src/components/onboarding-chat/cards/build.tsx
+++ b/apps/desktop/src/components/onboarding-chat/cards/build.tsx
@@ -221,29 +221,27 @@ export function ProgressCard({ attrs, locked }: CardProps) {
   const messageId = useAuiState(state => state.message.id)
   const title = (attrs.title ?? '').trim() || 'Working on it'
 
-  const steps = useMemo(() => {
-    const index = messages.findIndex(message => message.id === messageId)
-    const previous = index < 0 ? [] : messages.slice(0, index)
+  const index = messages.findIndex(message => message.id === messageId)
+  const previous = index < 0 ? [] : messages.slice(0, index)
 
-    return previous.flatMap(message => {
-      const directives = message.parts.flatMap(part =>
-        part.type === 'text' ? (segmentTranscriptDirectives(part.text) ?? []) : []
+  const steps = previous.flatMap(message => {
+    const directives = message.parts.flatMap(part =>
+      part.type === 'text' ? (segmentTranscriptDirectives(part.text) ?? []) : []
+    )
+
+    const progress = directives
+      .filter(
+        segment =>
+          segment.kind === 'directive' &&
+          segment.directive.name === 'onboarding' &&
+          segment.directive.attrs.step === 'progress'
       )
+      .at(-1)
 
-      const progress = directives
-        .filter(
-          segment =>
-            segment.kind === 'directive' &&
-            segment.directive.name === 'onboarding' &&
-            segment.directive.attrs.step === 'progress'
-        )
-        .at(-1)
-
-      return progress?.kind === 'directive'
-        ? [{ id: message.id, title: progress.directive.attrs.title?.trim() || 'Working on it' }]
-        : []
-    })
-  }, [messages, messageId])
+    return progress?.kind === 'directive'
+      ? [{ id: message.id, title: progress.directive.attrs.title?.trim() || 'Working on it' }]
+      : []
+  })
 
   return (
     <div className="my-3 grid max-w-md gap-1.5" data-onboarding-card>

--- a/apps/desktop/src/components/onboarding-chat/cards/build.tsx
+++ b/apps/desktop/src/components/onboarding-chat/cards/build.tsx
@@ -11,7 +11,6 @@ import { useEffect, useMemo, useState } from 'react'
 
 import { requestComposerSubmit } from '@/app/chat/composer/focus'
 import { useSessionView } from '@/app/chat/session-view'
-import { handoffReceiptKey, readHandoffReceipt } from '@/app/contrib/handoff-receipt'
 import { resolveSessionOwner } from '@/app/session/hooks/use-session-actions/utils'
 import type { CardProps } from '@/components/onboarding-chat/cards/frame'
 import { Chip } from '@/components/onboarding-chat/chip'
@@ -19,8 +18,8 @@ import {
   $handoffError,
   $setupHandoff,
   firstTaskTitle,
-  guideSourceConnectionId,
   parseHandoffPlan,
+  readGuideHandoffReceipt,
   requestSetupHandoff,
   retrySetupHandoff,
   SETUP_PROFILE
@@ -117,7 +116,7 @@ export function HandoffCard({ attrs, locked }: CardProps) {
   try {
     completed =
       !!storedId &&
-      readHandoffReceipt(handoffReceiptKey(guideSourceConnectionId(storedId), storedId))?.status === 'accepted'
+      readGuideHandoffReceipt(storedId).receipt?.status === 'accepted'
   } catch (receiptError) {
     error = String(receiptError)
   }

--- a/apps/desktop/src/components/onboarding-chat/cards/build.tsx
+++ b/apps/desktop/src/components/onboarding-chat/cards/build.tsx
@@ -11,6 +11,7 @@ import { useEffect, useMemo, useState } from 'react'
 
 import { requestComposerSubmit } from '@/app/chat/composer/focus'
 import { useSessionView } from '@/app/chat/session-view'
+import { handoffReceiptKey, quarantineHandoffReceipt } from '@/app/contrib/handoff-receipt'
 import { resolveSessionOwner } from '@/app/session/hooks/use-session-actions/utils'
 import type { CardProps } from '@/components/onboarding-chat/cards/frame'
 import { Chip } from '@/components/onboarding-chat/chip'
@@ -18,6 +19,7 @@ import {
   $handoffError,
   $setupHandoff,
   firstTaskTitle,
+  guideSourceConnectionId,
   parseHandoffPlan,
   readGuideHandoffReceipt,
   requestSetupHandoff,
@@ -110,16 +112,19 @@ export function HandoffCard({ attrs, locked }: CardProps) {
   const brief = (attrs.brief ?? '').trim().slice(0, 240)
   const plan = parseHandoffPlan(attrs.plan)
   const state = useStore($setupHandoff)
-  let error = useStore($handoffError)
-  let completed = false
+  const receipt = useMemo(() => {
+    try {
+      return {
+        completed: !!storedId && readGuideHandoffReceipt(storedId).receipt?.status === 'accepted',
+        error: null
+      }
+    } catch (error) {
+      return { completed: false, error: String(error) }
+    }
+  }, [storedId, state?.phase])
 
-  try {
-    completed =
-      !!storedId &&
-      readGuideHandoffReceipt(storedId).receipt?.status === 'accepted'
-  } catch (receiptError) {
-    error = String(receiptError)
-  }
+  const error = useStore($handoffError) ?? receipt.error
+  const completed = receipt.completed
 
   useEffect(() => {
     if (!task || !brief || locked || !storedId || !runtimeId || $setupHandoff.get() || completed) {
@@ -160,6 +165,36 @@ export function HandoffCard({ attrs, locked }: CardProps) {
   const failed = state?.phase === 'error' || error !== null
   const title = state?.sessionTitle ?? firstTaskTitle(task)
 
+  const retry = async () => {
+    if (state?.phase !== 'error') {
+      return
+    }
+
+    try {
+      if (receipt.error && storedId) {
+        quarantineHandoffReceipt(handoffReceiptKey(guideSourceConnectionId(storedId), storedId))
+      }
+
+      if (!state.guide && storedId && runtimeId) {
+        const owner = await resolveSessionOwner(storedId)
+        assertSessionOwnerResolved(owner, { method: 'onboarding.handoff', sessionId: storedId })
+        $setupHandoff.set({
+          ...state,
+          guide: {
+            storedId,
+            runtimeId,
+            connectionId: isSessionOwnerRoute(owner) ? owner.connectionId : null,
+            profile: isSessionOwnerRoute(owner) ? owner.profile : owner || SETUP_PROFILE
+          }
+        })
+      }
+
+      retrySetupHandoff()
+    } catch (error) {
+      $handoffError.set(String(error))
+    }
+  }
+
   return (
     <div className="my-3 flex max-w-md items-center gap-2 text-sm" data-onboarding-card>
       <StatusDot live={!settled && !failed} />
@@ -170,8 +205,8 @@ export function HandoffCard({ attrs, locked }: CardProps) {
             ? `${title} was started — find it in your sessions`
             : `Opening ${title}\u2026`}
       </span>
-      {failed && (
-        <Button disabled={locked} onClick={retrySetupHandoff} size="sm" variant="text">
+      {state?.phase === 'error' && (
+        <Button disabled={locked} onClick={() => void retry()} size="sm" variant="text">
           Retry first build
         </Button>
       )}

--- a/apps/desktop/src/components/onboarding-chat/setup-profile.ts
+++ b/apps/desktop/src/components/onboarding-chat/setup-profile.ts
@@ -112,8 +112,12 @@ export function guideSourceConnectionId(guideStoredId: null | string | undefined
   return (guideStoredId && getSessionOwnerHint(guideStoredId)?.connectionId) || activeGatewayConnectionId() || null
 }
 
+export function guideHandoffReceiptKey(guideStoredId: string): string {
+  return handoffReceiptKey(guideSourceConnectionId(guideStoredId), guideStoredId)
+}
+
 export function readGuideHandoffReceipt(guideStoredId: string): { key: string; receipt: HandoffReceipt | null } {
-  const key = handoffReceiptKey(guideSourceConnectionId(guideStoredId), guideStoredId)
+  const key = guideHandoffReceiptKey(guideStoredId)
 
   return { key, receipt: readHandoffReceipt(key) }
 }

--- a/apps/desktop/src/components/onboarding-chat/setup-profile.ts
+++ b/apps/desktop/src/components/onboarding-chat/setup-profile.ts
@@ -24,6 +24,7 @@
 
 import { atom } from 'nanostores'
 
+import type { HandoffReceipt } from '@/app/contrib/handoff-leg'
 import { handoffReceiptKey, readHandoffReceipt } from '@/app/contrib/handoff-receipt'
 import type { GatewayRequest } from '@/app/session/hooks/use-prompt-actions/utils'
 import { activeGatewayConnectionId } from '@/store/gateway'
@@ -111,13 +112,17 @@ export function guideSourceConnectionId(guideStoredId: null | string | undefined
   return (guideStoredId && getSessionOwnerHint(guideStoredId)?.connectionId) || activeGatewayConnectionId() || null
 }
 
+export function readGuideHandoffReceipt(guideStoredId: string): { key: string; receipt: HandoffReceipt | null } {
+  const key = handoffReceiptKey(guideSourceConnectionId(guideStoredId), guideStoredId)
+
+  return { key, receipt: readHandoffReceipt(key) }
+}
+
 /** The request atom suppresses remounts; only an accepted receipt suppresses relaunches. */
 export function requestSetupHandoff(task: string, brief: string, plan: HandoffPlan, guide: SetupSession): boolean {
   if (
     $setupHandoff.get() !== null ||
-    (guide.storedId &&
-      readHandoffReceipt(handoffReceiptKey(guideSourceConnectionId(guide.storedId), guide.storedId))?.status ===
-        'accepted')
+    (guide.storedId && readGuideHandoffReceipt(guide.storedId).receipt?.status === 'accepted')
   ) {
     return false
   }

--- a/apps/desktop/src/store/onboarding-gate.test.ts
+++ b/apps/desktop/src/store/onboarding-gate.test.ts
@@ -1,0 +1,37 @@
+import { expect, it, vi } from 'vitest'
+
+import type * as storageModule from '@/lib/storage'
+
+const storage = vi.hoisted(() => new Map<string, string>())
+
+vi.mock('@/lib/onboarding-enabled', () => ({ isOnboardingEnabled: () => true }))
+vi.mock('@/lib/storage', async importOriginal => ({
+  ...(await importOriginal<typeof storageModule>()),
+  readKey: (key: string) => storage.get(key) ?? null,
+  writeKey: (key: string, value: string | null) => {
+    if (value === null) {
+      storage.delete(key)
+    } else {
+      storage.set(key, value)
+    }
+  }
+}))
+
+it('restores every persisted onboarding phase and rejects unknown phases', async () => {
+  const { ONBOARDING_PHASES } = await import('./onboarding-gate')
+
+  for (const phase of ONBOARDING_PHASES.filter(phase => phase !== 'idle')) {
+    storage.clear()
+    storage.set('hermes-onboarding-phase-v1', phase)
+    vi.resetModules()
+    const { $onboardingGate } = await import('./onboarding-gate')
+
+    expect($onboardingGate.get().phase).toBe(phase)
+  }
+
+  storage.set('hermes-onboarding-phase-v1', 'unknown-phase')
+  vi.resetModules()
+  const { $onboardingGate } = await import('./onboarding-gate')
+
+  expect($onboardingGate.get().phase).toBe('idle')
+})

--- a/apps/desktop/src/store/onboarding-gate.ts
+++ b/apps/desktop/src/store/onboarding-gate.ts
@@ -8,7 +8,13 @@ import { DEFAULT_ANSWERS, setOnboardingAnswers } from './onboarding-answers'
 
 const PHASE_KEY = 'hermes-onboarding-phase-v1'
 
-export type OnboardingPhase = 'idle' | 'cinematic' | 'guided' | 'skipped' | 'handoff' | 'done'
+export const ONBOARDING_PHASES = ['idle', 'cinematic', 'guided', 'skipped', 'handoff', 'done'] as const
+
+export type OnboardingPhase = (typeof ONBOARDING_PHASES)[number]
+
+function isOnboardingPhase(value: string | null): value is OnboardingPhase {
+  return ONBOARDING_PHASES.some(phase => phase === value)
+}
 
 export interface OnboardingGateState {
   phase: OnboardingPhase
@@ -20,11 +26,7 @@ type GuideKickoff = { status: 'idle' } | { status: 'starting'; promise: Promise<
 function loadGate(): OnboardingGateState {
   const saved = readKey(PHASE_KEY)
 
-  const phase =
-    isOnboardingEnabled() &&
-    (saved === 'cinematic' || saved === 'guided' || saved === 'skipped' || saved === 'handoff' || saved === 'done')
-      ? saved
-      : 'idle'
+  const phase = isOnboardingEnabled() && isOnboardingPhase(saved) ? saved : 'idle'
 
   return { phase, guideQueued: phase === 'cinematic' && hasSeenIntroReveal() }
 }


### PR DESCRIPTION
The guided first launch is the scripted session a new user sees the first time the desktop app opens: a short intro, a welcome chat that asks a few questions, then a first task handed to a fresh session. It shipped in #107958 and #107985 behind the flag `HERMES_GUEST_ONBOARDING`, and it is off by default. Nothing in this pull request runs unless that flag is set.

This is six fixes in eight commits. Five come from the review on #107985. One is a status-bar defect seen in the first rehearsal of the flow. Two of the eight commits are follow-ups to fixes 1 and 6, kept separate so each cause is visible in the history.

Fixes 1, 3 and 6 change behaviour. Fixes 2, 4 and 5 change no behaviour.

## Behaviour changes

### 1. A retry that could never succeed

**Where:** the first-build card in the welcome chat. The guide is the model that runs the welcome chat. When it hands the first task to a new session, the app saves a small receipt in local storage, keyed by the welcome chat's id, so a relaunch does not start a second build.

**What went wrong:** the card read that receipt on every render. If the receipt was unreadable (a corrupt JSON string), the card showed an error and a "Retry first build" button. Retry re-read the same receipt, hit the same error, and showed the same button. Nothing ever cleared the bad entry.

**Now:** the receipt is read once per welcome-chat id. The Retry button shows only in the error state it can act on. A retry on an unreadable receipt first moves the bad entry from its key to the same key with `.unreadable` appended, then starts a fresh build. One test covers that move.

### 3. A phase list the type checker can see

The onboarding gate decides which stage of the first launch to show. Its phase is one of six values: `idle`, `cinematic`, `guided`, `skipped`, `handoff`, `done`. The gate saves the current phase in local storage and falls back to `idle` when it does not recognise the saved string.

**What went wrong:** the loader compared the saved string against five literals in an `||` chain with no link to the phase type. Adding a phase compiled fine and silently reset that phase to `idle` on relaunch.

**Now:** the six values live in one `as const` array. The type and the loader both derive from it. One test saves each phase and loads it back, and checks that an unknown string loads as `idle`.

### 6. The Sign in badge sits with its label

**Where:** the status bar's free-tier chip. It reads `Nous nous/welcome [Sign in]`: the provider name, the model id in monospace, and a solid badge that opens sign-in.

**What went wrong:** the badge looked detached from the label, a pixel or two high. Two things stacked. First, the badge rendered inside an inline text span, so it aligned to the text baseline rather than the button's centre. Second, the badge was 16 px tall beside an 11 px label. `Badge` sets `leading-none`, which asks for a line height equal to the font size. The component builds its class list with tailwind-merge, which removes an earlier class when a later class covers the same property. The size variant supplies a font-size class, so tailwind-merge removes `leading-none`, and the badge inherits the page line height of 1.5.

**Now:** the chip's detail is one centred flex row, and the chip's badge restates `leading-none`. The badge is 11.6 px tall and sits inside the label's cap height. The geometry is identical in light and dark mode and in the Nous, GitHub and Midnight skins. Screenshots stay with the private rehearsal evidence. The `Badge` component itself is untouched: every other badge in the app has the same dropped leading, and changing all of them is a separate decision.

## No behaviour change

### 2. One receipt read instead of four

The expression that finds and reads the receipt for a welcome chat was spelled out in four places. One helper, `readGuideHandoffReceipt`, replaces them, and a second, `guideHandoffReceiptKey`, gives the retry path the key without re-reading. The next change to the receipt has one place to land.

### 4. One centring function for two windows

The solo onboarding window (the welcome chat before the rest of the app appears) and the window-growth step (the resize when the app assembles around it) both clamped a size to the display's work area and then centred it, with the same arithmetic in two files. It is one exported function now, `centeredBounds`.

### 5. A memo that never hit

The progress card, which lists the first build's steps, memoised its step list on the chat's messages array. That array is a fresh object on every streamed chunk, so the memo recomputed every time anyway. The memo is gone; the computation is the same.

## How to test

Run from `apps/desktop`. `npm run check` runs the typecheck, lint, the renderer and Electron unit suites, and the packaging smoke test. `LANG=en_US.UTF-8` pins the locale because one renderer test formats a thousands separator and fails under a non-English machine locale.

```
cd apps/desktop
LANG=en_US.UTF-8 npm run check
npx vitest run src/app/contrib/handoff-receipt.test.ts src/store/onboarding-gate.test.ts
```

On macOS the Electron suite has one known failure unrelated to this change, `electron/managed-ssh-update.test.ts`, which shells out to a launcher that is not present on a dev machine. Everything else passes: 7583 renderer tests, 2164 Electron tests, and the packaging smoke test.

To see the flow by hand, start the app with `HERMES_GUEST_ONBOARDING=1` and a fresh `HERMES_HOME`.

## What this does not do

It does not change the guide's script, the connector card, or any wording in the flow. Two other findings from the same rehearsal, where hidden setup notes and the model's reasoning show in the transcript when they should not (Linear NS-856 and NS-858), are changes to the Python gateway and come separately.
