### PR TITLE
feat(loop): turn-boundary contract v2 — mark this turn's user row and export it on every result envelope

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -545,6 +545,8 @@ def _merge_consecutive_users(messages: List[Dict]) -> Tuple[List[Dict], int]:
             )
             # Merged content invalidates the api_content sidecar; drop it so replay cannot use stale bytes.
             drop_stale_api_content(prev)
+            if msg.get("_turn_id"):
+                prev["_turn_id"] = msg["_turn_id"]  # the merged row now IS the current turn's row
             repairs += 1
             continue
         merged.append(msg)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1609,7 +1609,7 @@ def run_conversation(
         moa_config=moa_config,
         turn_author=turn_author,
     )
-    return export_current_turn_boundary(agent, result, user_message)
+    return export_current_turn_boundary(agent, result)
 
 
 __all__ = ["run_conversation"]

--- a/agent/micro_compaction.py
+++ b/agent/micro_compaction.py
@@ -414,6 +414,8 @@ class MicroCompactionMixin:
             if _plain_user(msg) and _plain_user(prev):
                 prev["content"] = "\n\n".join(c for c in (prev["content"], msg["content"]) if c)
                 drop_stale_api_content(prev)  # merged content invalidates the api_content sidecar
+                if msg.get("_turn_id"):
+                    prev["_turn_id"] = msg["_turn_id"]  # the merged row now IS the current turn's row
             else:
                 merged.append(msg)
         return merged

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -206,8 +206,29 @@ def _maybe_title_session_at_turn_start(agent: Any, messages: List[Any]) -> None:
         logger.debug("Turn-start auto-title dispatch failed", exc_info=True)
 
 
-def reanchor_current_turn_user_idx(messages: List[Any], user_message: Any) -> int:
+TURN_ROW_MARKER = "_turn_id"
+
+
+def find_current_turn_row_idx(messages: List[Any], turn_id: Any) -> int:
+    """Index of the user row carrying this turn's ``_turn_id`` marker (last one), else -1.
+
+    This is the only text-free identification of the current row: an identical
+    historical prompt never carries the live turn id.
+    """
+    if not turn_id:
+        return -1
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if isinstance(msg, dict) and msg.get("role") == "user" and msg.get(TURN_ROW_MARKER) == turn_id:
+            return i
+    return -1
+
+
+def reanchor_current_turn_user_idx(messages: List[Any], user_message: Any, *, turn_id: Any = None) -> int:
     """Locate this turn's user message after compaction rebuilt ``messages``.
+
+    With ``turn_id`` the row is found by its ``_turn_id`` marker first (text-free);
+    the text rules below are the fallback for rows that lost the marker.
 
     Prefers the LAST user message whose content exactly matches this turn's text, else
     the last user-originated turn; compaction handoffs are never the fallback.
@@ -224,6 +245,9 @@ def reanchor_current_turn_user_idx(messages: List[Any], user_message: Any) -> in
     """
     from agent.context_compressor import user_originated_turn_view
 
+    marked = find_current_turn_row_idx(messages, turn_id)
+    if marked >= 0:
+        return marked
     fallback = -1
     for i in range(len(messages) - 1, -1, -1):
         msg = messages[i]
@@ -245,41 +269,36 @@ def reanchor_current_turn_user_idx(messages: List[Any], user_message: Any) -> in
     return fallback
 
 
-def export_current_turn_boundary(agent: Any, result: Any, user_message: Any) -> Any:
-    """Stamp ``{turn_id, current_turn_user_idx}`` on a result envelope, proven against the
-    exact ``result["messages"]`` projection it travels with.
+def export_current_turn_boundary(agent: Any, result: Any, user_message: Any = None) -> Any:
+    """Stamp the turn-boundary contract (v2) on a result envelope.
 
-    Hosts that settle their own transcript by index (hermes-webui) must never guess which
-    row is the current user turn after this loop rewrote history (alternation repair,
-    compaction, post-turn micro-compaction): a guessed index or a text match can relabel an
-    identical historical prompt and claim its old answer as this turn's. So the producer
-    exports the coordinate, computed on the final list, only when the addressed row is this
-    turn's user message verbatim. Otherwise the keys are omitted and hosts fail closed.
+    On every envelope that carries a ``messages`` list — success, partial/error,
+    interrupt, retry-exhausted, tool-limit, preflight timeout, codex runtime and the
+    durable-lease early return — export:
 
-    A preflight-timeout envelope carries the prior history without this turn's row (#7100), so a
-    repeated prompt would resolve to its historical copy: nothing is exported there.
+    - ``turn_boundary_contract``: 2 (capability/version);
+    - ``turn_id``: this invocation's id (hosts bind the envelope to the live Agent);
+    - ``messages_projection``: ``"full"`` — the loop always returns the full transcript
+      projection of exactly this final ``messages`` list, never an output-only delta;
+    - ``current_turn_user_idx``: the row carrying this turn's ``_turn_id`` marker, or
+      ``None`` when no row does (rewritten away, preflight timeout, lease early return).
+
+    The row is identified by the marker stamped at append time, never by prompt text:
+    an identical historical prompt can never receive the live turn id. Hosts must treat
+    ``None`` as capable-but-unproven and fail closed. ``user_message`` is accepted for
+    call-site compatibility and unused.
     """
-    if not isinstance(result, dict) or result.get("turn_exit_reason") == "context_compression_timeout":
+    if not isinstance(result, dict):
         return result
     messages = result.get("messages")
     turn_id = str(getattr(agent, "_current_turn_id", "") or "")
-    if not isinstance(messages, list) or not turn_id or user_message is None:
+    if not isinstance(messages, list) or not turn_id:
         return result
-    idx = reanchor_current_turn_user_idx(messages, user_message)
-    if idx < 0 or idx >= len(messages):
-        return result
-    row = messages[idx]
-    if not (isinstance(row, dict) and row.get("role") == "user"):
-        return result
-    from agent.context_compressor import user_originated_turn_view
-
-    live_view = user_originated_turn_view(row)
-    if row.get("content") != user_message and not (
-        isinstance(live_view, dict) and live_view.get("content") == user_message
-    ):
-        return result  # rewritten (merge-into-tail) row: not a proven boundary
+    result["turn_boundary_contract"] = 2
     result["turn_id"] = turn_id
-    result["current_turn_user_idx"] = idx
+    result["messages_projection"] = "full"
+    idx = find_current_turn_row_idx(messages, turn_id)
+    result["current_turn_user_idx"] = idx if idx >= 0 else None
     return result
 
 
@@ -928,6 +947,11 @@ def build_turn_context(
     append_message(messages, user_msg)
     current_turn_user_idx = len(messages) - 1
     agent._persist_user_message_idx = current_turn_user_idx
+    # Identity of THIS turn's user row, independent of its text: survives compaction's
+    # deep copies and is carried across user-row merges; never sent to providers
+    # (build_api_messages pops it) and never persisted (rows are column-based).
+    if isinstance(messages[current_turn_user_idx], dict):
+        messages[current_turn_user_idx][TURN_ROW_MARKER] = turn_id
 
     agent._user_turn_count += 1
     # Copilot x-initiator: the first API call of this user turn is user-initiated;
@@ -1058,7 +1082,7 @@ def build_api_messages(
         # (strict OpenAI backends reject unknown keys); _row_id is the durable row id
         # from _rows_to_conversation and only chat-completions strips underscore keys.
         _api_content = api_msg.pop("api_content", None)
-        for key in ("display_kind", "display_metadata", "_row_id"):
+        for key in ("display_kind", "display_metadata", "_row_id", TURN_ROW_MARKER):
             api_msg.pop(key, None)
 
         # Inject ephemeral context (memory prefetch + pre_llm_call user hooks)

--- a/agent/turn_context_compaction.py
+++ b/agent/turn_context_compaction.py
@@ -117,7 +117,7 @@ def _reanchor(agent: Any, messages: List[Any], user_message: Any) -> int:
     api_content stamp, injection site and persist-override row hit the same dict."""
     from agent.turn_context import reanchor_current_turn_user_idx
 
-    idx = reanchor_current_turn_user_idx(messages, user_message)
+    idx = reanchor_current_turn_user_idx(messages, user_message, turn_id=getattr(agent, "_current_turn_id", ""))
     agent._persist_user_message_idx = idx
     return idx
 

--- a/agent/turn_facade.py
+++ b/agent/turn_facade.py
@@ -84,7 +84,12 @@ class TurnFacadeMixin:
                 relay_outcome = (
                     "cancelled" if admission.early_result.get("interrupted") else "timed_out"
                 )
-                return admission.early_result
+                # The loop never ran, so bind this invocation's id here: the early
+                # envelope carries the same contract as every other one (no row proven).
+                from agent.turn_context import export_current_turn_boundary
+
+                self._current_turn_id = relay_turn_id
+                return export_current_turn_boundary(self, admission.early_result)
             lease = admission.lease
             conversation_history = admission.conversation_history
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -215,6 +215,13 @@ class AIAgent(
 ):
     """AI Agent with tool calling capabilities."""
 
+    # Turn-boundary contract exported on every run_conversation() result envelope
+    # (agent.turn_context.export_current_turn_boundary). Hosts read this from the
+    # callable BEFORE invoking it; 2 = {turn_boundary_contract, turn_id,
+    # current_turn_user_idx (nullable, proven by the row's _turn_id marker),
+    # messages_projection} on every envelope including durable-lease early returns.
+    TURN_BOUNDARY_CONTRACT = 2
+
     _TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER = (
         "[hermes-agent: tool call arguments were corrupted in this session and "
         "have been dropped to keep the conversation alive. See issue #15236.]"

--- a/tests/run_agent/test_export_current_turn_boundary.py
+++ b/tests/run_agent/test_export_current_turn_boundary.py
@@ -1,11 +1,10 @@
-"""The loop exports ``{turn_id, current_turn_user_idx}`` beside the exact ``messages`` it
-addresses, and only when that row is this turn's user message verbatim.
+"""Turn-boundary contract v2 on every ``run_conversation`` result envelope.
 
-Hosts that settle a transcript by index (hermes-webui) must not guess the current-turn
-row after the loop rewrote history (alternation repair, compaction, post-turn
-micro-compaction): with a repeated prompt a guessed index or a text match relabels the
-historical copy and claims its old answer. The producer therefore proves the coordinate on
-the final list; when it cannot, the keys are omitted and hosts fail closed.
+The current user row is identified by the ``_turn_id`` marker stamped at append time,
+never by prompt text: an identical historical prompt can never receive the live turn
+id. Every envelope carries ``turn_boundary_contract``, ``turn_id`` and
+``messages_projection``; ``current_turn_user_idx`` is the marked row or ``None``
+(hosts treat ``None`` as capable-but-unproven and fail closed).
 """
 
 from __future__ import annotations
@@ -15,50 +14,90 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from agent.turn_context import export_current_turn_boundary
+from agent.turn_context import (
+    TURN_ROW_MARKER,
+    export_current_turn_boundary,
+    find_current_turn_row_idx,
+    reanchor_current_turn_user_idx,
+)
+
+LIVE = "session:task:live0001"
+OLD = "session:task:old00001"
 
 
 class _Agent:
-    def __init__(self, turn_id="session:task:abcd1234"):
+    def __init__(self, turn_id=LIVE):
         self._current_turn_id = turn_id
         self._persist_user_message_idx = None
 
 
-@pytest.mark.parametrize("user_message, messages, expected_idx", [
-    # a repeated prompt resolves to the LAST verbatim row, never the historical copy
-    ("same question", [
-        {"role": "user", "content": "same question"}, {"role": "assistant", "content": "old answer"},
-        {"role": "user", "content": "same question"}, {"role": "assistant", "content": "new answer"},
-    ], 2),
-    # multimodal content matches by structural equality
-    ([{"type": "text", "text": "look"}, {"type": "image_url", "image_url": {"url": "data:x"}}],
-     [{"role": "user", "content": [{"type": "text", "text": "look"}, {"type": "image_url", "image_url": {"url": "data:x"}}]},
-      {"role": "assistant", "content": "ok"}], 0),
-    # a row the repair rewrote (merge-into-tail) is not a proven boundary: export nothing
-    ("same question", [{"role": "user", "content": "summary\n\nsame question"}, {"role": "assistant", "content": "answer"}], None),
-    # no current row at all: export nothing, persist override untouched
-    ("another question", [{"role": "user", "content": "same question"}, {"role": "assistant", "content": "old answer"}], None),
+def _u(text, turn_id=None):
+    row = {"role": "user", "content": text}
+    if turn_id:
+        row[TURN_ROW_MARKER] = turn_id
+    return row
+
+
+def _keys(result):
+    return {k: result.get(k) for k in ("turn_boundary_contract", "turn_id", "messages_projection", "current_turn_user_idx")}
+
+
+def test_repeated_prompt_is_resolved_by_marker_never_by_text():
+    messages = [_u("same question", OLD), {"role": "assistant", "content": "old answer"},
+                _u("same question", LIVE), {"role": "assistant", "content": "new answer"}]
+    out = export_current_turn_boundary(_Agent(), {"messages": messages})
+    assert _keys(out) == {"turn_boundary_contract": 2, "turn_id": LIVE, "messages_projection": "full", "current_turn_user_idx": 2}
+
+
+def test_rewrite_that_dropped_the_current_row_exports_a_null_index():
+    # the identical historical prompt survives; its marker is another turn's (or none)
+    for hist in (_u("same question", OLD), _u("same question")):
+        out = export_current_turn_boundary(_Agent(), {"messages": [hist, {"role": "assistant", "content": "old answer"}]})
+        assert _keys(out) == {"turn_boundary_contract": 2, "turn_id": LIVE, "messages_projection": "full", "current_turn_user_idx": None}
+
+
+def test_stale_index_on_the_envelope_is_replaced_not_trusted():
+    out = export_current_turn_boundary(_Agent(), {"messages": [_u("q")], "current_turn_user_idx": 0})
+    assert out["current_turn_user_idx"] is None
+
+
+@pytest.mark.parametrize("shape", [
+    {"turn_exit_reason": "context_compression_timeout"},   # preflight timeout: prior history only
+    {"completed": False, "interrupted": True},             # lease early return shape
+    {"partial": True, "error": "boom"},
 ])
-def test_boundary_is_exported_only_for_the_verbatim_current_row(user_message, messages, expected_idx):
-    agent = _Agent()
-    result = export_current_turn_boundary(agent, {"messages": messages}, user_message)
-    if expected_idx is None:
-        assert "current_turn_user_idx" not in result and "turn_id" not in result
-    else:
-        assert result["current_turn_user_idx"] == expected_idx
-        assert result["turn_id"] == agent._current_turn_id
-    # the persist funnel has already run by the time the envelope is stamped: never re-anchor it here
-    assert agent._persist_user_message_idx is None
+def test_every_envelope_shape_carries_the_contract(shape):
+    out = export_current_turn_boundary(_Agent(), {"messages": [_u("continue", OLD)], **shape})
+    assert out["turn_boundary_contract"] == 2 and out["turn_id"] == LIVE and out["messages_projection"] == "full"
+    assert out["current_turn_user_idx"] is None
 
 
-def test_preflight_timeout_envelope_exports_nothing():
-    """The preflight-timeout result carries the prior history without this turn's row (#7100);
-    a repeated prompt must not be resolved to its historical copy."""
-    agent = _Agent()
-    result = {"messages": [{"role": "user", "content": "continue"}, {"role": "assistant", "content": "old"}],
-              "turn_exit_reason": "context_compression_timeout"}
-    out = export_current_turn_boundary(agent, result, "continue")
-    assert "current_turn_user_idx" not in out and "turn_id" not in out
+def test_no_turn_id_or_non_dict_result_is_left_alone():
+    assert export_current_turn_boundary(_Agent(turn_id=""), {"messages": [_u("q", LIVE)]}) == {"messages": [_u("q", LIVE)]}
+    assert export_current_turn_boundary(_Agent(), None) is None
+    assert export_current_turn_boundary(_Agent(), {"messages": None}) == {"messages": None}
+
+
+def test_find_and_reanchor_prefer_the_marker_over_text():
+    messages = [_u("same question", LIVE), {"role": "assistant", "content": "a"}, _u("same question")]
+    assert find_current_turn_row_idx(messages, LIVE) == 0
+    assert reanchor_current_turn_user_idx(messages, "same question", turn_id=LIVE) == 0
+    assert reanchor_current_turn_user_idx(messages, "same question") == 2  # text fallback: last match
+
+
+def test_user_row_merges_carry_the_marker_to_the_surviving_row():
+    from agent.agent_runtime_helpers import repair_message_sequence
+    from agent.micro_compaction import MicroCompactionMixin
+
+    for merge in (
+        lambda rows: (repair_message_sequence(SimpleNamespace(), rows), rows)[1],
+        lambda rows: MicroCompactionMixin._merge_adjacent_user_turns(rows),
+    ):
+        rows = [_u("todo snapshot"), _u("the question", LIVE), {"role": "assistant", "content": "a"}]
+        merged = merge(rows)
+        assert [m["role"] for m in merged] == ["user", "assistant"]
+        assert merged[0][TURN_ROW_MARKER] == LIVE and "the question" in merged[0]["content"]
+        assert find_current_turn_row_idx(merged, LIVE) == 0
 
 
 @pytest.fixture()
@@ -96,12 +135,12 @@ def _stub(content, finish_reason="stop"):
     )
 
 
-def test_run_conversation_exports_the_pair_on_a_success_envelope(loop_agent):
+def test_run_conversation_marks_the_row_and_exports_the_contract(loop_agent):
+    from run_agent import AIAgent
+
+    assert AIAgent.TURN_BOUNDARY_CONTRACT == 2
     loop_agent.client.chat.completions.create.side_effect = [_stub("new answer")]
-    history = [
-        {"role": "user", "content": "same question"},
-        {"role": "assistant", "content": "old answer"},
-    ]
+    history = [{"role": "user", "content": "same question"}, {"role": "assistant", "content": "old answer"}]
     with (
         patch.object(loop_agent, "_persist_session"),
         patch.object(loop_agent, "_save_trajectory"),
@@ -110,9 +149,12 @@ def test_run_conversation_exports_the_pair_on_a_success_envelope(loop_agent):
         result = loop_agent.run_conversation("same question", conversation_history=history)
 
     assert result["completed"] is True
-    idx = result["current_turn_user_idx"]
-    assert result["messages"][idx]["role"] == "user"
-    assert result["messages"][idx]["content"] == "same question"
-    assert idx > 0  # the historical identical prompt at index 0 is never the export
+    assert result["turn_boundary_contract"] == 2 and result["messages_projection"] == "full"
     assert result["turn_id"] == loop_agent._current_turn_id
-    assert result["messages"][-1]["content"] == "new answer"
+    idx = result["current_turn_user_idx"]
+    assert idx == 2  # the historical identical prompt at 0 is never the export
+    assert result["messages"][idx][TURN_ROW_MARKER] == result["turn_id"]
+    assert TURN_ROW_MARKER not in result["messages"][0]
+    # the marker never reaches the provider
+    sent = loop_agent.client.chat.completions.create.call_args.kwargs["messages"]
+    assert all(TURN_ROW_MARKER not in m for m in sent if isinstance(m, dict))


### PR DESCRIPTION
## feat(loop): turn-boundary contract v2 — mark this turn's user row and export it on every result envelope

Follow-up to #106312 / #106335, driven by the hermes-webui consumer review (nesquena/hermes-webui#7461). The #106312 export identified the current user row by prompt text (`reanchor_current_turn_user_idx`): after a rewrite that drops this turn's row but leaves an identical historical prompt, it attached the live `turn_id` to the historical row, and a host trusting that pair settled the old answer as the live turn. The producer must identify its own row **without prompt-text matching** and say so on every envelope.

### Contract v2
- **Row identity.** `build_turn_context` stamps this turn's user row with a `_turn_id` marker at append time. It survives compaction's deep copies, is carried across both user-row merges (`repair_message_sequence` pass 3 and micro-compaction's `_merge_adjacent_user_turns`) to the surviving row, is popped in `build_api_messages` so it never reaches a provider (some transports keep underscore keys), and is not persisted (`state.db` rows are column-based).
- **Re-anchor by marker.** `reanchor_current_turn_user_idx(..., turn_id=)` resolves the marked row first; the text rules stay as the fallback for a row that lost the marker. `turn_context_compaction._reanchor` passes the live turn id.
- **Every envelope.** `export_current_turn_boundary` stamps every envelope that carries a `messages` list with `turn_boundary_contract: 2`, `turn_id` (this invocation's), `messages_projection: "full"` (the exact final list — the loop never returns an output-only delta) and `current_turn_user_idx` = the marked row or `None` (rewritten away, preflight timeout, lease early return). A stale index already on the envelope is replaced. Applied at the `run_conversation` chokepoint after `finalize_turn` and post-turn micro-compaction, **and** to the durable-lease early return in `turn_facade` (which binds the invocation's turn id first, so the live id and the envelope agree).
- **Capability on the callable.** `AIAgent.TURN_BOUNDARY_CONTRACT = 2` lets a host negotiate the contract before invoking, replacement Agents included, instead of inferring it from optional envelope keys.

State layer: the result envelope returned by `run_conversation` and the live `messages` row metadata.

### Tests
`tests/run_agent/test_export_current_turn_boundary.py`: repeated prompt resolved by marker never by text; rewrite that dropped the current row exports `None` (with the historical row unmarked or marked by another turn); stale envelope index replaced; every shape (preflight timeout, lease early return, partial/error) carries the contract; marker-first reanchor with text fallback; both user-row merges carry the marker; end-to-end `run_conversation` with a repeated prompt: the row is marked, the contract exported, index never 0, and the marker absent from the provider payload. Direct callers of the touched modules plus every test file driving `run_conversation` are green locally except one pre-existing failure on `main` (`test_between_turns_refresh_adds_late_tool_when_servers_registered`) and one environmental import (`anthropic` not installed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gp366ijf39n4UUtJhZuMh
