### PR TITLE
fix(computer_use): reconnect the MCP session on MCPError(CONNECTION_CLOSED)

### DIFF
--- a/tests/tools/test_computer_use_delivery_ladder.py
+++ b/tests/tools/test_computer_use_delivery_ladder.py
@@ -368,3 +368,60 @@ def test_call_tool_restarts_a_dead_session(monkeypatch):
 
     sess.call_tool("click", {"pid": 1})
     assert started["count"] == 1, "dead session should have been restarted once"
+
+
+def test_closed_session_error_classifies_mcp_connection_closed():
+    """MCPError(CONNECTION_CLOSED) — what ClientSession.call_tool raises once the stdio
+    bridge child is dead after a cua-driver daemon restart — must count as a reconnectable
+    closed session (#108215); other MCPError codes are protocol errors a reconnect
+    cannot fix and must stay unclassified."""
+    from mcp.shared.exceptions import MCPError
+    from mcp_types.jsonrpc import CONNECTION_CLOSED, INVALID_PARAMS
+
+    from tools.computer_use.cua_backend_session import _CuaDriverSession
+
+    assert _CuaDriverSession._is_closed_session_error(
+        MCPError(code=CONNECTION_CLOSED, message="Connection closed"))
+    assert not _CuaDriverSession._is_closed_session_error(
+        MCPError(code=INVALID_PARAMS, message="bad params"))
+
+
+def test_call_tool_reconnects_on_mcp_connection_closed():
+    """A daemon restart kills the cached MCP session; the next read-only call must see
+    MCPError(CONNECTION_CLOSED), recreate the session once, and replay the tool instead
+    of wedging every later call (#108215)."""
+    import asyncio
+
+    from mcp.shared.exceptions import MCPError
+    from mcp_types.jsonrpc import CONNECTION_CLOSED
+
+    from tools.computer_use.cua_backend_session import _CuaDriverSession
+
+    sess = _CuaDriverSession.__new__(_CuaDriverSession)
+    sess._started = True
+    sess._timeout_suspect = False
+    sess._declared_session_id = None
+    recreates = {"count": 0}
+
+    def fake_recreate(name, timeout, log_msg, **kw):
+        recreates["count"] += 1
+    sess._recreate_session = fake_recreate  # type: ignore[method-assign]
+
+    calls = {"n": 0}
+
+    async def fake_call(name, args):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise MCPError(code=CONNECTION_CLOSED, message="Connection closed")
+        return {"isError": False, "data": {}, "structuredContent": {}}
+    sess._call_tool_async = fake_call  # type: ignore[method-assign]
+
+    class _Bridge:
+        def run(self, coro, timeout=None):
+            return asyncio.run(coro)
+    sess._bridge = _Bridge()
+
+    result = sess.call_tool("get_screen_size", {})
+    assert calls["n"] == 2, "the replay-safe tool should have been retried after reconnect"
+    assert recreates["count"] == 1, "the dead MCP session should have been recreated once"
+    assert result == {"isError": False, "data": {}, "structuredContent": {}}

--- a/tests/tools/test_computer_use_mcp_crash.py
+++ b/tests/tools/test_computer_use_mcp_crash.py
@@ -1,0 +1,108 @@
+import json
+import sys
+
+import pytest
+
+from tools.computer_use import cua_backend_driver
+from tools.computer_use.cua_backend_session import _AsyncBridge, _CuaDriverSession
+
+
+@pytest.fixture
+def mcp_session(tmp_path, monkeypatch):
+    pytest.importorskip("mcp")
+    server = tmp_path / "server.py"
+    server.write_text('''
+import json
+import os
+import sys
+from pathlib import Path
+
+journal = Path(sys.argv[1])
+for line in sys.stdin:
+    request = json.loads(line)
+    if "id" not in request:
+        continue
+    method, params = request["method"], request.get("params", {})
+    response = {"jsonrpc": "2.0", "id": request["id"]}
+    if method == "initialize":
+        result = {"protocolVersion": params["protocolVersion"], "capabilities": {"tools": {}},
+                  "serverInfo": {"name": "crash-fixture", "version": "1"}}
+    elif method == "tools/list":
+        result = {"tools": []}
+    elif method == "tools/call":
+        name = params["name"]
+        prior = journal.read_text(encoding="utf-8") if journal.exists() else ""
+        with journal.open("a", encoding="utf-8") as log:
+            log.write(json.dumps({"name": name, "args": params.get("arguments", {}), "pid": os.getpid()}) + "\\n")
+        if params.get("arguments", {}).get("reject"):
+            response["error"] = {"code": -32602, "message": "Connection closed"}
+            print(json.dumps(response), flush=True)
+            continue
+        if name != "start_session" and not any(json.loads(row)["name"] != "start_session" for row in prior.splitlines()):
+            os._exit(0)
+        result = {"content": [{"type": "text", "text": json.dumps({"ok": True})}], "isError": False}
+    else:
+        result = {}
+    response["result"] = result
+    print(json.dumps(response), flush=True)
+''', encoding="utf-8")
+    journal = tmp_path / "requests.jsonl"
+    monkeypatch.setattr(cua_backend_driver, "resolve_cua_driver_cmd", lambda: sys.executable)
+    monkeypatch.setattr(cua_backend_driver, "_resolve_mcp_invocation",
+                        lambda command: (command, [str(server), str(journal)]))
+    bridge = _AsyncBridge()
+    session = _CuaDriverSession(bridge)
+    try:
+        session.start()
+        yield session, journal
+    finally:
+        try:
+            session.stop()
+        finally:
+            bridge.stop()
+
+
+@pytest.mark.parametrize("operation", ["list_apps", "click"])
+def test_mcp_crash_recovers_reads_without_replaying_mutations(mcp_session, operation):
+    session, journal = mcp_session
+    resets = []
+    session.set_transport_reset_callback(lambda: resets.append(True))
+    session.call_tool("start_session", {"session": "isolated-crash-test"})
+
+    result = session.call_tool(operation, {})
+
+    if operation == "list_apps":
+        assert result["isError"] is False
+    else:
+        assert result["isError"] is True
+        assert result["structuredContent"]["code"] == "transport_outcome_unknown"
+        assert result["structuredContent"]["next_step"] == "fresh_state"
+    calls = [json.loads(line) for line in journal.read_text(encoding="utf-8").splitlines()]
+    assert [call["name"] for call in calls] == (
+        ["start_session", operation, "start_session", operation]
+        if operation == "list_apps" else ["start_session", operation, "start_session"])
+    assert calls[0]["pid"] == calls[1]["pid"]
+    assert calls[0]["pid"] != calls[2]["pid"]
+    assert calls[0]["args"] == calls[2]["args"]
+    assert resets == [True]
+    assert session.call_tool("list_apps", {})["isError"] is False
+    later_calls = [json.loads(line) for line in journal.read_text(encoding="utf-8").splitlines()]
+    assert later_calls[:-1] == calls
+    assert later_calls[-1]["name"] == "list_apps"
+    assert later_calls[-1]["pid"] == calls[2]["pid"]
+    assert resets == [True]
+
+
+def test_mcp_application_error_is_not_a_closed_transport(mcp_session):
+    from mcp.shared.exceptions import MCPError
+    from mcp_types.jsonrpc import INVALID_PARAMS
+
+    session, journal = mcp_session
+    resets = []
+    session.set_transport_reset_callback(lambda: resets.append(True))
+    with pytest.raises(MCPError) as raised:
+        session.call_tool("list_apps", {"reject": True})
+    assert raised.value.code == INVALID_PARAMS
+    assert str(raised.value) == "Connection closed"
+    assert len(journal.read_text(encoding="utf-8").splitlines()) == 1
+    assert resets == []

--- a/tools/computer_use/cua_backend_session.py
+++ b/tools/computer_use/cua_backend_session.py
@@ -20,6 +20,21 @@ from tools.computer_use.cua_backend_parse import _extract_tool_result, _mcp_fiel
 
 logger = logging.getLogger("tools.computer_use.cua_backend")
 
+try:  # mcp ships as a dev/test dependency; the classifier must not require it at runtime
+    from mcp.shared.exceptions import MCPError as _McpError
+    from mcp_types.jsonrpc import CONNECTION_CLOSED as _MCP_CONNECTION_CLOSED
+except ImportError:  # pragma: no cover - exercised only where mcp is not installed
+    _McpError, _MCP_CONNECTION_CLOSED = None, -32000
+
+
+def _is_mcp_connection_closed(exc: Exception) -> bool:
+    """True when the MCP client itself reports the transport is gone: after the stdio bridge
+    child dies (a ``cua-driver`` daemon restart kills it), ``ClientSession.call_tool`` raises
+    ``MCPError(code=CONNECTION_CLOSED)``. Other MCPError codes are protocol/tool errors a
+    reconnect cannot fix, so they must stay unclassified here."""
+    return (_McpError is not None and isinstance(exc, _McpError)
+            and getattr(exc, "code", None) == _MCP_CONNECTION_CLOSED)
+
 
 class _AsyncBridge:
     """Runs one asyncio loop on a daemon thread; marshals coroutines from the caller."""
@@ -390,7 +405,8 @@ class _CuaDriverSession:
         name, module = exc.__class__.__name__, getattr(exc.__class__, "__module__", "")
         return (name in {"ClosedResourceError", "BrokenResourceError", "EndOfStream"}
                 or (module.startswith("anyio") and "Resource" in name)
-                or isinstance(exc, (BrokenPipeError, EOFError)))
+                or isinstance(exc, (BrokenPipeError, EOFError))
+                or _is_mcp_connection_closed(exc))
 
     @staticmethod
     def _is_transient_daemon_error(exc: Exception) -> bool:


### PR DESCRIPTION
## What does this PR do?

When the `cua-driver` daemon restarts while a Hermes session holds an active `computer_use` MCP session, the stdio bridge child dies with it, and `ClientSession.call_tool` starts raising `MCPError(code=CONNECTION_CLOSED)` on every call. That exception matched neither `_CuaDriverSession._is_closed_session_error()` (name/module based, anyio/EOF branches) nor `_is_transient_daemon_error()` (EAGAIN needles), so `call_tool()` re-raised forever and `computer_use` stayed wedged for the rest of the process lifetime — defeating the documented self-healing design for the most common real-world death mode on macOS.

This PR teaches `_is_closed_session_error()` about the MCP client's own connection-closed error via a new `_is_mcp_connection_closed()` helper: an `MCPError` whose `code` equals the SDK's `CONNECTION_CLOSED` constant. With that classification, the existing `_recreate_session()` path already does the right thing: it rebuilds the MCP lifecycle against the healthy daemon and replays transport-replay-safe tools (`list_apps`, `get_screen_size`, …) transparently. The import of `mcp.shared.exceptions`/`mcp_types.jsonrpc` is guarded because `mcp` ships as a dev/test dependency; other `MCPError` codes (protocol/tool errors) intentionally stay unclassified — a reconnect cannot fix them.

## Related Issue

Fixes #108215

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/cua_backend_session.py`: added a guarded import of `MCPError`/`CONNECTION_CLOSED` plus the `_is_mcp_connection_closed()` helper, and appended it as a branch of `_is_closed_session_error()` so a dead transport triggers the existing reconnect-once path.
- `tests/tools/test_computer_use_delivery_ladder.py`: two regression tests — (1) the classifier accepts `MCPError(CONNECTION_CLOSED)` but rejects other `MCPError` codes, (2) `call_tool` on a wedged session recreates it once and replays a replay-safe tool.

## How to Test

1. `python -m pytest tests/tools/test_computer_use_delivery_ladder.py -q` — should pass: 19 passed, including the two new tests (both fail on unpatched `main` with 2 failed, verified via `git stash` of the source change).
2. `python -m pytest tests/tools/test_computer_use.py tests/tools/test_computer_use_cua_0_9.py tests/tools/test_computer_use_cua_0_10_permissions.py tests/tools/test_computer_use_delivery_ladder.py tests/computer_use/ -q` — Observed result: 155 passed.
3. Manual (macOS, optional): in a live session call `computer_use(action="list_apps")`, run `cua-driver stop` (supervisor relaunches `serve`), call `list_apps` again — should reconnect once and succeed instead of returning `Connection closed` instantly forever (reproduction from #108215).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A