### PR TITLE
[superseded by #108156] fix(desktop): stop transcript window memo pinning cold history

### DIFF
--- a/apps/desktop/src/app/chat/transcript-window-memory.test.ts
+++ b/apps/desktop/src/app/chat/transcript-window-memory.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ChatMessage } from '@/lib/chat-messages'
+import { RENDER_WEIGHT_CHARS } from '@/lib/render-weight'
+
+import {
+  advanceSessionTranscriptWindow,
+  type SessionWindowMemo,
+  TRANSCRIPT_WINDOW_MIN_MESSAGES
+} from './transcript-window'
+
+const message = (id: string, chars: number): ChatMessage => ({
+  id,
+  parts: [{ type: 'text', text: 'x'.repeat(chars) }],
+  role: 'assistant'
+})
+
+const heavyTranscript = (): ChatMessage[] =>
+  Array.from({ length: TRANSCRIPT_WINDOW_MIN_MESSAGES * 3 }, (_, index) =>
+    message(`m-${index}`, RENDER_WEIGHT_CHARS * 200)
+  )
+
+describe('SessionWindowMemo memory ownership', () => {
+  it('holds the complete source transcript weakly while preserving warm slice identity', () => {
+    const memos = new Map<string, SessionWindowMemo>()
+    const messages = heavyTranscript()
+
+    const first = advanceSessionTranscriptWindow(memos, 'session-a', messages)
+    const memo = memos.get('session-a')
+
+    expect(memo).toBeDefined()
+    expect(first.window.windowed).toBe(true)
+    expect(first.window.messages).not.toBe(messages)
+    expect(memo?.messagesRef.deref()).toBe(messages)
+    expect(Object.hasOwn(memo!, 'messages')).toBe(false)
+
+    const second = advanceSessionTranscriptWindow(memos, 'session-a', messages)
+
+    expect(second).toBe(first)
+    expect(second.window.messages).toBe(first.window.messages)
+  })
+})

--- a/apps/desktop/src/app/chat/transcript-window.ts
+++ b/apps/desktop/src/app/chat/transcript-window.ts
@@ -175,15 +175,16 @@ export function advanceTranscriptWindow(
 export const MAX_SESSION_WINDOWS = 12
 
 /**
- * A window state plus the exact message array it was computed from.
- * The array identity is load-bearing: when a session is re-entered with the
- * IDENTICAL transcript (the warm-switch path of #95595), the stored window —
- * including the exact `window.messages` slice reference — is reused as-is.
- * The reference reuse is what stops `useRuntimeMessageRepository` from
- * rebuilding (and every row from re-rendering) on a warm switch.
+ * A window state plus a weak identity reference to the exact message array it
+ * was computed from.
+ *
+ * Weakness is load-bearing: the authoritative session-state cache may release
+ * a cold transcript while this memo remains mounted. A strong source-array
+ * reference here would keep every message outside the bounded window alive.
+ * While the store still owns the same array, identity reuse remains O(1).
  */
 export interface SessionWindowMemo {
-  messages: readonly ChatMessage[]
+  messagesRef: WeakRef<readonly ChatMessage[]>
   state: TranscriptWindowState
 }
 
@@ -196,16 +197,16 @@ export interface SessionWindowMemo {
  * re-highlight per row) even though nothing had changed. This keeps one memo
  * per session:
  *
- * - Re-entering a session with the same transcript array returns the cached
- *   windowed slice BY REFERENCE — the runtime repository and every message
- *   row stay mounted, so the switch is O(1).
+ * - Re-entering a session whose live store still owns the same transcript
+ *   array returns the cached windowed slice BY REFERENCE — the runtime
+ *   repository and every message row stay mounted, so the switch is O(1).
  * - Re-entering with a changed transcript keeps the sticky cut (anchor still
  *   present, tail within budget + slack) instead of re-walking from scratch.
  * - The anchor vanishing (compression rewrite) or a pages change falls
  *   through to `advanceTranscriptWindow`'s existing fresh-walk behaviour.
  *
- * The map is bounded (oldest session evicted) so an unbounded session list
- * cannot grow it without limit.
+ * The map is bounded (oldest session evicted), and each full source transcript
+ * is referenced weakly so the map cannot defeat cold-session state eviction.
  */
 export function advanceSessionTranscriptWindow(
   memos: Map<string, SessionWindowMemo>,
@@ -215,15 +216,15 @@ export function advanceSessionTranscriptWindow(
 ): TranscriptWindowState {
   const memo = memos.get(sessionKey)
 
-  // Warm re-visit with the identical transcript and page count: reuse the
+  // Warm re-visit with the identical live transcript and page count: reuse the
   // cached state wholesale, preserving the windowed slice reference.
-  if (memo && memo.messages === messages && memo.state.pages === pages) {
+  if (memo && memo.messagesRef.deref() === messages && memo.state.pages === pages) {
     return memo.state
   }
 
   const state = advanceTranscriptWindow(memo?.state ?? null, messages, pages)
 
-  memos.set(sessionKey, { messages, state })
+  memos.set(sessionKey, { messagesRef: new WeakRef(messages), state })
 
   if (memos.size > MAX_SESSION_WINDOWS) {
     const oldest = memos.keys().next().value as string


### PR DESCRIPTION
Superseded by #108156, which contains the same WeakRef fix **and** closes the residual pass-through retention path: an unwindowed `state.window.messages` is the full source array, so #108156 deliberately does not memoize it and drops an old memo when paging expands to pass-through.

This PR is closed to keep one canonical implementation. No merge is intended here.