### PR TITLE
fix(gateway): wait for the replacement in launchd self-restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4145,6 +4145,20 @@ def launchd_restart():
         pid = get_running_pid()
         if pid is not None and _request_gateway_self_restart(pid):
             _launchd_ok("✓ Service restart requested")
+            # _selfrestart_wait_for_replacement (local patch; upstream #108220):
+            # the kickstart branch below waits via _wait_for_launchd_service_pid,
+            # but this branch used to return the moment the request was
+            # delivered. The post-update fleet probe then opens its 30s window
+            # against a gateway that has not begun starting, reads zero rows and
+            # exits 1 on a successful update. Waiting here costs nothing when the
+            # respawn is quick and prevents the false failure when it is not.
+            if not _wait_for_launchd_service_pid(
+                label, old_pid=pid, timeout=90.0, domain=domain
+            ):
+                print(
+                    "  ⚠ Gateway restart requested but no replacement PID yet; "
+                    "post-update verification may report it as down."
+                )
             return
         if pid is not None and probe_gateway_loop_liveness(pid) == GATEWAY_LOOP_WEDGED:
             # Event loop provably dead: it can't process a graceful shutdown, so a full drain wait


### PR DESCRIPTION
## What and why

`launchd_restart()` has two paths, and only one waits for the replacement gateway:

```python
pid = get_running_pid()
if pid is not None and _request_gateway_self_restart(pid):
    _launchd_ok("✓ Service restart requested")
    return                      # <-- returns immediately

...
_launchd_kickstart(label, domain)
if _wait_for_launchd_service_pid(label, old_pid=old_pid, timeout=15.0, domain=domain):
    restarted_services.append(label)   # <-- this path waits
```

The post-update fleet probe (`_collect_fleet_snapshot`) then opens its fixed 30s
window against a gateway that has not started yet, collects zero rows, and
`hermes update` exits 1 — on an update that fully succeeded. Hermes Desktop
surfaces this as a modal **"Hermes update did not finish — Update failed (exit 1)"**.

This makes the self-restart branch wait the same way the kickstart branch does.

Fixes #108220

## Evidence

macOS 12.7.6, Intel, 8 GB RAM, swap in active use, gateway installed as a
launchd user service:

| event | time |
|---|---|
| update logs `retry exit code: 1` | `13:52:04` |
| replacement logs `Starting Hermes Gateway...` | `13:52:09.8` |
| replacement ready (`Press Ctrl+C to stop`) | `13:52:25.3` |

The replacement had not begun starting when the probe gave up. Running the probe
by hand moments later returns a healthy row:

```python
from hermes_cli.update_receipt import collect_fleet_versions
collect_fleet_versions(pre_restart_pids=None)
# [{'profile': 'default', 'state': 'current',
#   'code_sha': '0591da2ba65f1e8bc61e5b5f2ae1dab579e73451', 'pid': 90824}]
```

The log line `✓ Service restart requested` is emitted only by the self-restart
branch, which is how the failing path was identified.

## How to test

1. Install the gateway as a user service (`hermes gateway install`).
2. Put the machine under enough memory pressure that interpreter startup is slow
   (swap in active use).
3. Run `hermes update` with a pulled range.

Before: update completes, then exits 1 on the fleet check.
After: the restart waits for a fresh PID, and the probe finds its row.

## Platforms tested

macOS 12.7.6 (Intel). Not tested on Linux or WSL2 — the change is inside the
launchd branch, so the systemd and Windows paths are untouched.

## Notes

- The wait is bounded (90s) and non-fatal: a timeout prints a warning and returns,
  so the previous behaviour remains the worst case rather than becoming an error.
- Targeted tests run: `test_update_launchd_restart_verification.py`,
  `test_update_launchd_unloaded_gateway.py`, `test_update_launchd_fleet_restart.py`,
  `test_gateway_service.py`, `test_update_wedged_gateway.py`.
  Four failures in that set (three in `test_update_launchd_fleet_restart.py`, one
  in `test_update_wedged_gateway.py::TestLoopTickWitness`) reproduce identically on
  a clean tree without this patch, so they are pre-existing and unrelated.
- A more complete fix might additionally gate the probe on `gateway_state.json`
  being *fresh* rather than on a PID existing — `_wait_for_launchd_service_pid`
  returns once the process is spawned, which is still several seconds before it
  publishes state on a slow machine. Happy to extend this PR that way if preferred.
