### PR TITLE
fix(sessions): preserve live Fast metadata across compression

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2985,7 +2985,7 @@ def _publish_rotated_compaction(
     agent._session_db.publish_compression_child(
         parent_session_id=old_session_id, child_session_id=new_session_id,
         source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"), model=agent.model,
-        model_config=agent._session_init_model_config, system_prompt=new_system_prompt, messages=compressed,
+        model_config=agent._session_row_model_config(), system_prompt=new_system_prompt, messages=compressed,
         cwd=getattr(agent, "working_directory", None), profile_name=_profile_for_child,
         compression_lock_holder=lease.holder, require_compression_lease=lease.holder is not None,
         require_lease_refresh=lease.holder is not None, lease_ttl_seconds=lease.ttl,

--- a/run_agent.py
+++ b/run_agent.py
@@ -299,12 +299,24 @@ class AIAgent(
             return None
 
     def _session_row_model_config(self) -> Any:
-        """``model_config`` for the session row: the init config plus the live YOLO bypass.
+        """Session metadata at publication time, not the constructor's stale runtime.
 
         The row is created lazily on the first turn, so this is the only chance to record a pre-first-turn
         /yolo toggle for ``hermes --resume``.
         """
-        model_config = self._session_init_model_config
+        model_config = dict(self._session_init_model_config or {})
+        # Only persist the resume-safe fields, never credentials or request payloads.
+        for key in ("model", "provider", "reasoning_config", "max_iterations", "max_tokens"):
+            if hasattr(self, key):
+                model_config[key] = getattr(self, key)
+        if model_config.get("provider") == "custom":
+            from hermes_cli.runtime_provider import canonical_custom_identity
+            model_config["provider"] = canonical_custom_identity(
+                base_url=getattr(self, "base_url", None), model=getattr(self, "model", None),
+            ) or "custom"
+        if hasattr(self, "service_tier"):
+            # None is an observed normal mode; missing metadata must stay distinguishable.
+            model_config["service_tier"] = self.service_tier or "normal"
         try:
             from tools.approval import is_session_yolo_enabled
             if is_session_yolo_enabled(self.session_id):

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -18,6 +18,7 @@ These tests drive the real ``compress_context`` path against a real SessionDB.
 from __future__ import annotations
 
 import copy
+import json
 import os
 import time
 from pathlib import Path
@@ -106,6 +107,74 @@ def refresh_state_db(tmp_path: Path):
         yield db
     finally:
         db.close()
+
+
+@pytest.mark.parametrize("tier", ["priority", None, "auto", "cold"])
+@pytest.mark.parametrize("provider", ["openai", "custom"])
+def test_runtime_metadata_survives_creation_and_rotations(refresh_state_db, monkeypatch, tier, provider):
+    import hermes_cli.runtime_provider as rp
+
+    endpoint = "https://example.invalid/v1"
+    monkeypatch.setattr(rp, "load_config", lambda: {
+        "custom_providers": [{"name": "test-route", "base_url": endpoint}],
+    })
+    db = refresh_state_db
+    agent = _build_agent_with_db(db, "runtime-parent")
+    agent.service_tier = tier
+    agent.provider = provider
+    agent.base_url = endpoint
+    agent._session_init_model_config["_delegate_from"] = "spawner"
+    agent._ensure_db_session()
+    try:
+        initial = json.loads(db.get_session(agent.session_id)["model_config"])
+        assert initial["service_tier"] == (tier or "normal")
+        assert initial["provider"] == ("custom:test-route" if provider == "custom" else provider)
+
+        # Live switches must win over the constructor snapshot on every rotation.
+        for current_tier in (None, "priority", "auto", "cold"):
+            parent = agent.session_id
+            agent.service_tier = current_tier
+            agent.provider = "openai"
+            agent.model = "runtime-model"
+            agent.reasoning_config = {"effort": "high"}
+            agent._compress_context(_msgs(), "sys", approx_tokens=120_000)
+            assert agent.session_id != parent
+            row = db.get_session(agent.session_id)
+            config = json.loads(row["model_config"])
+            assert row["parent_session_id"] == parent
+            assert row["model"] == agent.model
+            assert config["provider"] == agent.provider
+            assert config["service_tier"] == (current_tier or "normal")
+            assert config["reasoning_config"] == agent.reasoning_config
+            assert config["_delegate_from"] == "spawner"
+            assert "api_key" not in config
+            assert "base_url" not in config
+            assert "request_overrides" not in config
+        assert json.loads(db.get_session("runtime-parent")["model_config"]) == initial
+    finally:
+        agent.close()
+
+
+def test_desktop_persist_keeps_observed_normal_distinct_from_missing(refresh_state_db):
+    from types import SimpleNamespace
+
+    from tui_gateway.server import (
+        _persist_live_session_runtime,
+        _runtime_model_config,
+        _stored_session_runtime_overrides,
+    )
+
+    db = refresh_state_db
+    agent = _build_agent_with_db(db, "normal-runtime", platform="desktop")
+    agent._ensure_db_session()
+    try:
+        _persist_live_session_runtime({"agent": agent, "session_key": agent.session_id})
+        row = db.get_session(agent.session_id)
+        assert json.loads(row["model_config"])["service_tier"] == "normal"
+        assert _stored_session_runtime_overrides(row)["service_tier_override"] == ""
+        assert "service_tier" not in _runtime_model_config(SimpleNamespace())
+    finally:
+        agent.close()
 
 
 class TestGoalMigratesOnRotation:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9987,6 +9987,7 @@ def test_config_set_model_recovers_failed_profile_resume_after_build_completes(
                     "base_url": profile_url,
                     "api_mode": "chat_completions",
                     "reasoning_config": reasoning,
+                    "service_tier": "normal",
                 },
             }
         ]

--- a/tests/tui_gateway/test_custom_provider_session_persistence.py
+++ b/tests/tui_gateway/test_custom_provider_session_persistence.py
@@ -844,6 +844,8 @@ class TestRuntimeModelConfigDropsStaleKeys:
 
         config = _runtime_model_config(_agent_like(provider="nous"), None)
 
-        assert config == {"model": "deepseek/deepseek-v4-flash-0731", "provider": "nous"}
+        assert config == {
+            "model": "deepseek/deepseek-v4-flash-0731", "provider": "nous", "service_tier": "normal",
+        }
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1557,7 +1557,7 @@ def _runtime_model_config(agent, existing: dict | None = None) -> dict:
         "model": model, "provider": provider, "base_url": base_url, "api_mode": attr("api_mode"),
         # An empty dict is still a real (present) reasoning config.
         "reasoning_config": reasoning_config if isinstance(reasoning_config, dict) else None,
-        "service_tier": getattr(agent, "service_tier", None),
+        "service_tier": (agent.service_tier or "normal") if hasattr(agent, "service_tier") else None,
     }
     for key, value in live.items():
         if value or isinstance(value, dict):


### PR DESCRIPTION
## Summary

Preserve the live Fast setting and provider in persisted session metadata at first creation and after context-compression rotation. A normal setting is recorded explicitly as `normal`; a genuinely missing runtime attribute remains unknown.

**User-visible symptom:** tools reading `sessions.model_config` lose Fast/provider after compaction even though the running agent still has them. A resumed session can also fall back to the profile instead of its observed normal setting.

**Root cause:** initial persistence only adds YOLO to the constructor snapshot, while compression publishes that original snapshot directly. Desktop persistence separately removes `service_tier` when the live value is `None` (normal).

## Changes

- Extend the existing `_session_row_model_config()` projection with the current model, canonical provider, reasoning configuration, existing limits, and service tier.
- Reuse that projection for atomic compression-child publication, retaining delegation metadata and the existing YOLO handling.
- Retain observed normal in Desktop's runtime projection. Do not infer normal when the runtime attribute is absent.
- Add behavioral regression tests using real AIAgent initialization, SQLite session persistence and repeated compression rotations, with standard/custom providers and live setting changes. Adapt neighboring projection expectations.

No transport/request routing change, schema migration, new dependency, historical backfill, or live-installation patch. `auto`/`cold` describe the configured mode, not proof of the provider tier used for every request. Existing parent rows are not rewritten.

## Validation

- Regression first reproduced against the base: five failing cases (`KeyError: service_tier`), then green after the fix; coverage expanded to standard/custom providers and repeated switches.
- The isolated neighboring run passes 785 tests; the sole failure, `test_model_options_preserves_canonical_custom_row_after_agent_init`, was reproduced unchanged on the base commit.
- Ruff, Python compilation, compatibility-pointer check and `git diff --check` pass.
- Independent read-only Hermes review: approved, no blocking findings.
- Final-commit targeted run: **109 passed, 0 failed** across compression rotation, compression lineage, Desktop Fast scope and custom-provider persistence.
- The full-suite attempt did **not** complete: the runner exited with SIGTERM/143 at approximately 55% progress, with nine failures observed outside these targeted suites. That run is not claimed green; those failures have not all been baseline-qualified. This PR is draft pending the remaining validation.

A private consumer probe also exercised the real creation/rotation path through an external journal-heading consumer against synthetic SQLite sessions. All four modes were observed and rendered correctly; no production sessions or historical journal entries were changed.

## Scope and risk

The persistence path intentionally distinguishes an observed normal setting from unknown metadata. On resume, normal reuses the existing explicit-normal sentinel instead of silently inheriting a later profile change. Custom-provider identity uses the existing resolver. No credential or request-overrides field is added to the projection.

This is separate from transport fixes such as #101524, which bridge the selected tier into API request overrides rather than preserving session metadata across rotation.

## Checklist

- [x] Bounded bug fix; no new dependency or provider-specific transport branch.
- [x] Regression tests reproduce the real behavioral failure.
- [x] No new compatibility shim or legacy API surface.
- [x] No secret or personal session data in the diff.
- [x] Documentation instructions reviewed; unchanged because persistence is repaired within the existing contract.
- [x] Prepared with AI assistance (Hermes); diff and test results checked before publication.
