### PR TITLE
fix(update): avoid false macOS failure during launchd restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4200,8 +4200,14 @@ def wait_for_launchd_gateway_supervision(
     timeout: float = LAUNCHD_SUPERVISION_VERIFY_TIMEOUT,
     label: str | None = None,
     poll_interval: float = 0.5,
+    previous_pid: int | None = None,
 ) -> bool:
-    """Poll launchd until it supervises a live gateway; True at once if the detached fallback is active.
+    """Poll launchd until it supervises the expected live gateway.
+
+    When ``previous_pid`` is provided, also require ``gateway_state.json`` to
+    identify a different live PID.  This keeps an asynchronous self-restart's
+    still-supervised old process from satisfying the post-update readiness gate.
+    True at once if the detached fallback is active.
     ``launchd_restart`` returns once the restart is *requested* (asynchronous), so it can't see a helper
     dying before bootstrap or a ``launchctl bootstrap`` that exits 0 without registering.
 
@@ -4220,7 +4226,13 @@ def wait_for_launchd_gateway_supervision(
     label = label or get_launchd_label()
     deadline = time.monotonic() + max(timeout, 0.0)
     while True:
-        if _launchctl_label_supervising_process(label):
+        runtime_ready = True
+        if previous_pid is not None:
+            from gateway.status import get_running_pid
+
+            current_pid = get_running_pid()
+            runtime_ready = current_pid is not None and current_pid != previous_pid
+        if runtime_ready and _launchctl_label_supervising_process(label):
             return True
         if time.monotonic() >= deadline:
             return False

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -551,7 +551,9 @@ def _restart_launchd_gateway_after_update(*, supervision_verify: bool = True) ->
     # domain locate fails on macOS-26 per-user domains.
     # launchd_restart() returning is only "restart REQUESTED" — the self-restart branch hands work to the
     # running gateway, a plist reload to a detached helper; both asynchronous. See #88848.
-    if wait_for_launchd_gateway_supervision(label=current_label, previous_pid=previous_pid):
+    if wait_for_launchd_gateway_supervision(
+        label=current_label, previous_pid=previous_pid, timeout=90.0
+    ):
         return [current_label], []
     print(
         f"  ✗ {current_label} restarted but launchd is not supervising it.\n"

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -515,10 +515,12 @@ def _restart_launchd_gateway_after_update(*, supervision_verify: bool = True) ->
     from hermes_cli.gateway import (
         get_launchd_label, get_launchd_plist_path, launchd_restart, wait_for_launchd_gateway_supervision,
     )
+    from gateway.status import get_running_pid
     current_label = get_launchd_label()
     try:
         if not get_launchd_plist_path().exists():
             return [], []  # not a launchd install — nothing to do or warn
+        previous_pid = get_running_pid()
         try:
             launchd_restart()
         except subprocess.CalledProcessError as e:
@@ -549,7 +551,7 @@ def _restart_launchd_gateway_after_update(*, supervision_verify: bool = True) ->
     # domain locate fails on macOS-26 per-user domains.
     # launchd_restart() returning is only "restart REQUESTED" — the self-restart branch hands work to the
     # running gateway, a plist reload to a detached helper; both asynchronous. See #88848.
-    if wait_for_launchd_gateway_supervision(label=current_label):
+    if wait_for_launchd_gateway_supervision(label=current_label, previous_pid=previous_pid):
         return [current_label], []
     print(
         f"  ✗ {current_label} restarted but launchd is not supervising it.\n"

--- a/tests/hermes_cli/test_update_launchd_restart_verification.py
+++ b/tests/hermes_cli/test_update_launchd_restart_verification.py
@@ -114,6 +114,23 @@ class TestWaitForLaunchdGatewaySupervision:
         assert gateway_cli.wait_for_launchd_gateway_supervision(label=LABEL) is True
         assert sum(clock.slept) == pytest.approx(10.0)
 
+    def test_previous_pid_requires_fresh_runtime_state(self, monkeypatch, clock):
+        """The old supervised process is not the replacement requested by update."""
+        pids = iter([101, 202])
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid", lambda: next(pids)
+        )
+        probe = _supervision_returning(True)
+        monkeypatch.setattr(
+            gateway_cli, "_launchctl_label_supervising_process", probe
+        )
+
+        assert gateway_cli.wait_for_launchd_gateway_supervision(
+            label=LABEL, previous_pid=101
+        ) is True
+        assert clock.slept == [0.5]
+        assert probe.calls == [LABEL]
+
     def test_gives_up_at_the_deadline(self, monkeypatch, clock):
         """A job that never comes back must fail, and must fail bounded."""
         probe = _supervision_returning(False)
@@ -178,8 +195,9 @@ def _patch_launchd_env(
     monkeypatch.setattr(
         gateway_cli, "launchd_gateway_labels_for_install", lambda: [LABEL]
     )
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 101)
 
-    calls = {"restart": 0, "verify": 0, "label": None}
+    calls = {"restart": 0, "verify": 0, "label": None, "previous_pid": None}
 
     def _restart():
         calls["restart"] += 1
@@ -188,9 +206,10 @@ def _patch_launchd_env(
 
     monkeypatch.setattr(gateway_cli, "launchd_restart", _restart)
 
-    def _verify(*, label=None, **_kw):
+    def _verify(*, label=None, previous_pid=None, **_kw):
         calls["verify"] += 1
         calls["label"] = label
+        calls["previous_pid"] = previous_pid
         return supervised
 
     monkeypatch.setattr(
@@ -224,6 +243,7 @@ class TestInvokingProfileIsVerifiedLikeItsSiblings:
         assert calls["restart"] == 1
         assert calls["verify"] == 1
         assert calls["label"] == LABEL
+        assert calls["previous_pid"] == 101
 
     def test_unverified_restart_is_not_reported_as_restarted(
         self, monkeypatch, capsys

--- a/tests/hermes_cli/test_update_launchd_restart_verification.py
+++ b/tests/hermes_cli/test_update_launchd_restart_verification.py
@@ -197,7 +197,13 @@ def _patch_launchd_env(
     )
     monkeypatch.setattr("gateway.status.get_running_pid", lambda: 101)
 
-    calls = {"restart": 0, "verify": 0, "label": None, "previous_pid": None}
+    calls = {
+        "restart": 0,
+        "verify": 0,
+        "label": None,
+        "previous_pid": None,
+        "timeout": None,
+    }
 
     def _restart():
         calls["restart"] += 1
@@ -206,10 +212,11 @@ def _patch_launchd_env(
 
     monkeypatch.setattr(gateway_cli, "launchd_restart", _restart)
 
-    def _verify(*, label=None, previous_pid=None, **_kw):
+    def _verify(*, label=None, previous_pid=None, timeout=None, **_kw):
         calls["verify"] += 1
         calls["label"] = label
         calls["previous_pid"] = previous_pid
+        calls["timeout"] = timeout
         return supervised
 
     monkeypatch.setattr(
@@ -244,6 +251,7 @@ class TestInvokingProfileIsVerifiedLikeItsSiblings:
         assert calls["verify"] == 1
         assert calls["label"] == LABEL
         assert calls["previous_pid"] == 101
+        assert calls["timeout"] == 90.0
 
     def test_unverified_restart_is_not_reported_as_restarted(
         self, monkeypatch, capsys


### PR DESCRIPTION
## What does this PR do?

Prevents successful macOS updates from exiting 1 when a launchd self-restart is still replacing the gateway. The update now waits for both a fresh runtime-state PID and launchd supervision before starting the existing fleet settle window.

### Symptom

After the code update succeeds, `hermes update` can print `Fleet version check returned no rows even though gateway runtimes were expected` and exit 1. Hermes Desktop then reports that the update failed even though the replacement gateway later starts on the updated checkout.

### Impact

Users with a launchd-managed gateway can receive a false update failure when restart or interpreter startup is slow. The observed report was on macOS 12.7.6 under memory pressure.

### Bug Cause

**Trigger:** `hermes_cli/update_cmd_fleet.py:498` / `_restart_launchd_gateway_after_update()` after an asynchronous launchd self-restart.

**Causal chain:**
1. `launchd_restart()` requests a self-restart and returns while the old gateway PID is still supervised.
2. `wait_for_launchd_gateway_supervision()` accepts that old supervised PID as readiness, so the fleet settle window starts before the replacement publishes `gateway_state.json`.
3. The probe can exhaust its 30-second window with no current runtime row and report a successful update as incomplete.

**Why it is wrong:** launchd supervision alone does not prove that the requested replacement exists or has published the runtime state consumed by fleet verification.

**Working sibling / contrast:** sibling LaunchAgents use `_wait_for_launchd_service_pid(..., old_pid=...)`, so their restart accounting requires a replacement PID instead of accepting the old process.

**Ruled out:** the launchd path does have readiness checks. The defect is specifically that the invoking profile's check did not distinguish the old PID or require fresh runtime state.

### Fix

Capture the pre-restart runtime PID and pass it to the launchd supervision wait. For update verification, the wait now requires `gateway_state.json` to identify a different live PID and requires launchd to supervise that process. A 90-second update-specific budget covers slow launchd replacement startup before the existing 30-second fleet settle begins. Calls without a previous PID retain their existing behavior.

## Related Issue
N/A
## Why this PR vs existing PR #108227

PR #108227 changes the general `launchd_restart()` command and waits only until launchd reports a new process PID. It explicitly leaves the interval before that process publishes `gateway_state.json` uncovered. This PR limits the longer wait to `hermes update` and gates on the fresh runtime-state PID that the fleet probe actually consumes, while retaining launchd supervision as the second readiness condition.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py` - optionally require a fresh runtime-state PID in the launchd supervision wait.
- `hermes_cli/update_cmd_fleet.py` - capture the pre-restart PID and wait up to 90 seconds for the replacement state before fleet verification.
- `tests/hermes_cli/test_update_launchd_restart_verification.py` - cover rejection of the old supervised PID and the update-path wiring.

## How to Test

1. Install the gateway as a launchd user service on macOS.
2. Run `hermes update` with a pulled range while gateway replacement startup is delayed.
3. Confirm fleet verification starts only after the replacement writes a fresh runtime PID and the update no longer exits 1 for the reported race.
4. Run `scripts/run_tests.sh tests/hermes_cli/test_update_launchd_restart_verification.py tests/hermes_cli/test_update_launchd_unloaded_gateway.py tests/hermes_cli/test_update_launchd_fleet_restart.py tests/hermes_cli/test_gateway_service.py`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and compared this implementation with PR #108227
- [x] My PR contains only changes related to this fix
- [x] I've added behavior tests for the change

### Documentation & Housekeeping

- [x] Relevant behavior is documented in the updated helper docstring
- [x] Config examples are not applicable because no config keys changed
- [x] Architecture documentation is not applicable because the update pipeline shape is unchanged
- [x] Cross-platform impact is isolated to the launchd branch
- [x] Tool descriptions and schemas are not applicable
