### PR TITLE
fix(agent): bound deferred background review memory

### DIFF
--- a/agent/review_idle_queue.py
+++ b/agent/review_idle_queue.py
@@ -8,15 +8,22 @@ explicit /refine never defers). One slot per session, newest snapshot wins (a re
 the whole conversation, so coalescing is dedup, not loss); aged-out items (defer_max_age_s,
 default 30 min) dispatch regardless of idleness; in-memory best-effort like the immediate
 fork. Idle truth is the supervisor's /slots held for a settle window.
+
+Pending reviews are a bounded cache, not a second owner of live agents: parents are weakly
+referenced and the retained size of structurally isolated transcript snapshots is bounded by
+aggregate bytes and session count. Under pressure the oldest best-effort review is shed
+rather than allowing self-improvement work to OOM a foreground session.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import sys
 import threading
 import time
 import urllib.request
+import weakref
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
 
@@ -25,6 +32,10 @@ logger = logging.getLogger(__name__)
 _IDLE_SETTLE_S = 15.0  # quiet window: two back-to-back prompts must not look idle, a coffee break must
 _POLL_INTERVAL_S = 5.0  # poll cadence while non-empty; the thread parks when empty
 _MAX_AGE_DEFAULT_S = 30.0 * 60.0  # dispatch regardless of idleness past this age
+# Background review is best-effort. Bound the process-wide deferred payload below the
+# 10s-of-MiB range where a busy multi-session local runtime can materially inflate RSS.
+_PENDING_SNAPSHOT_BYTES_MAX = 8 * 1024 * 1024
+_PENDING_REVIEWS_MAX = 16
 
 
 def defer_mode(task_cfg: Optional[Dict[str, Any]]) -> str:
@@ -58,20 +69,62 @@ def review_targets_managed_local(agent: Any, task_cfg: Optional[Dict[str, Any]])
         return False
 
 
+def _retained_snapshot_bytes(value: Any, *, stop_after: Optional[int] = None) -> int:
+    """Approximate the Python heap reachable from a JSON-shaped snapshot without copying it.
+
+    The review clone is documented as dict/list/immutable-leaf shaped and acyclic, but ``seen``
+    makes this safe for a malformed cycle too. Shared leaves are counted once within an entry;
+    summing entries may conservatively over-count inter-entry sharing, which is the safe direction
+    for a memory-pressure valve.
+    """
+    total = 0
+    seen: set[int] = set()
+    stack = [value]
+    while stack:
+        current = stack.pop()
+        identity = id(current)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        total += sys.getsizeof(current)
+        if stop_after is not None and total > stop_after:
+            return total
+        if isinstance(current, dict):
+            stack.extend(current.keys())
+            stack.extend(current.values())
+        elif isinstance(current, (list, tuple, set, frozenset)):
+            stack.extend(current)
+    return total
+
+
+def _agent_ref(agent: Any) -> Callable[[], Any]:
+    """Weak parent ownership; strong fallback only for legacy non-weakref test doubles."""
+    try:
+        return weakref.ref(agent)
+    except TypeError:
+        logger.debug("Deferred review parent is not weak-referenceable; retaining compatibility reference")
+        return lambda: agent
+
+
 @dataclass(slots=True)
 class _PendingReview:
-    agent: Any
+    agent_ref: Callable[[], Any]
     session_key: str
     kwargs: Dict[str, Any]
     enqueued_at: float
+    snapshot_bytes: int = 0
+
+    def parent(self) -> Any:
+        return self.agent_ref()
 
 
 class ReviewIdleQueue:
-    """Session-coalescing queue + idle-gated dispatcher thread."""
+    """Session-coalescing, memory-bounded queue + idle-gated dispatcher thread."""
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._pending: Dict[str, _PendingReview] = {}
+        self._pending_snapshot_bytes = 0
         self._wake = threading.Event()
         self._thread: Optional[threading.Thread] = None
         self._live_turns = 0
@@ -92,20 +145,79 @@ class ReviewIdleQueue:
                 self._quiet_since = self._now()
         self._wake.set()
 
-    def enqueue(self, agent: Any, session_key: str, kwargs: Dict[str, Any]) -> None:
-        """Add (or replace — newest snapshot wins) a session's pending review, keeping the ORIGINAL
-        enqueue time on coalesce so a busy session cannot push its age-out forever."""
+    def _pop_pending_locked(self, session_key: str) -> Optional[_PendingReview]:
+        item = self._pending.pop(session_key, None)
+        if item is not None:
+            self._pending_snapshot_bytes = max(0, self._pending_snapshot_bytes - item.snapshot_bytes)
+        return item
+
+    def _enforce_bounds_locked(self) -> list[str]:
+        evicted: list[str] = []
+        while (
+            len(self._pending) > _PENDING_REVIEWS_MAX
+            or self._pending_snapshot_bytes > _PENDING_SNAPSHOT_BYTES_MAX
+        ):
+            oldest = min(self._pending.values(), key=lambda pending: pending.enqueued_at)
+            evicted.append(oldest.session_key)
+            self._pop_pending_locked(oldest.session_key)
+        return evicted
+
+    def enqueue(self, agent: Any, session_key: str, kwargs: Dict[str, Any]) -> bool:
+        """Add/replace one session review without strongly retaining its parent.
+
+        Newest snapshot wins while the ORIGINAL enqueue time survives coalescing. Returns whether
+        this session remains queued after admission and process-wide pressure eviction.
+        """
+        stored_kwargs = dict(kwargs)
+        snapshot_bytes = _retained_snapshot_bytes(
+            stored_kwargs.get("messages_snapshot", ()),
+            stop_after=_PENDING_SNAPSHOT_BYTES_MAX,
+        )
+        if snapshot_bytes > _PENDING_SNAPSHOT_BYTES_MAX:
+            logger.warning(
+                "Deferred background review dropped: snapshot>%d bytes exceeds queue budget",
+                _PENDING_SNAPSHOT_BYTES_MAX,
+            )
+            return False
+
         with self._lock:
             existing = self._pending.get(session_key)
             enqueued_at = existing.enqueued_at if existing is not None else self._now()
-            self._pending[session_key] = _PendingReview(agent, session_key, kwargs, enqueued_at)
-        self._ensure_thread()
-        self._wake.set()
-        logger.info("Background review deferred (session=%s, queued=%d)", session_key[-12:], len(self._pending))
+            if existing is not None:
+                self._pop_pending_locked(session_key)
+            item = _PendingReview(
+                _agent_ref(agent), session_key, stored_kwargs, enqueued_at,
+                snapshot_bytes=snapshot_bytes,
+            )
+            self._pending[session_key] = item
+            self._pending_snapshot_bytes += snapshot_bytes
+            evicted = self._enforce_bounds_locked()
+            retained = self._pending.get(session_key) is item
+            queued, retained_bytes = len(self._pending), self._pending_snapshot_bytes
+
+        if queued:
+            self._ensure_thread()
+            self._wake.set()
+        if evicted:
+            logger.warning(
+                "Deferred background review queue pressure: evicted %d oldest review(s) "
+                "(queued=%d snapshot_bytes=%d limit=%d)",
+                len(evicted), queued, retained_bytes, _PENDING_SNAPSHOT_BYTES_MAX,
+            )
+        if retained:
+            logger.info(
+                "Background review deferred (session=%s, queued=%d, snapshot_bytes=%d)",
+                session_key[-12:], queued, retained_bytes,
+            )
+        return retained
 
     def pending_count(self) -> int:
         with self._lock:
             return len(self._pending)
+
+    def pending_snapshot_bytes(self) -> int:
+        with self._lock:
+            return self._pending_snapshot_bytes
 
     def _ensure_thread(self) -> None:
         with self._lock:
@@ -136,7 +248,7 @@ class ReviewIdleQueue:
                 if not self._pending:
                     return None
                 candidate = min(self._pending.values(), key=lambda p: p.enqueued_at)
-            return self._pending.pop(candidate.session_key, None)
+            return self._pop_pending_locked(candidate.session_key)
 
     def _run(self) -> None:
         while True:
@@ -154,10 +266,16 @@ class ReviewIdleQueue:
                             "Deferred background review dropped: reviews were disabled while it was queued (session=%s)",
                             item.session_key[-12:])
                         continue
+                    agent = item.parent()
+                    if agent is None:
+                        logger.info(
+                            "Deferred background review dropped: parent agent was released (session=%s)",
+                            item.session_key[-12:])
+                        continue
                     logger.info(
                         "Dispatching deferred background review (session=%s, waited=%.0fs, queued=%d)",
                         item.session_key[-12:], self._now() - item.enqueued_at, self.pending_count())
-                    item.agent._spawn_background_review_now(**item.kwargs)
+                    agent._spawn_background_review_now(**item.kwargs)
             except Exception:  # noqa: BLE001 — dispatcher must survive anything
                 logger.warning("Deferred review dispatch failed", exc_info=True)
             if item is None:

--- a/tests/agent/test_review_idle_queue_memory.py
+++ b/tests/agent/test_review_idle_queue_memory.py
@@ -1,0 +1,114 @@
+"""Memory-ownership regressions for deferred background reviews."""
+
+import gc
+import weakref
+
+from agent import review_idle_queue as riq
+from agent.review_idle_queue import ReviewIdleQueue, _retained_snapshot_bytes
+
+
+class _Agent:
+    def __init__(self) -> None:
+        self.spawned = []
+
+    def _spawn_background_review_now(self, **kwargs) -> None:
+        self.spawned.append(kwargs)
+
+
+def _queue():
+    queue = ReviewIdleQueue()
+    clock = {"t": 0.0}
+    queue._now = lambda: clock["t"]
+    queue._server_idle = lambda: True
+    queue._ensure_thread = lambda: None
+    return queue, clock
+
+
+def test_retained_size_counts_nested_snapshot_without_copying_or_looping():
+    shared = "x" * 10_000
+    snapshot = [{"role": "tool", "content": shared}, {"role": "assistant", "content": shared}]
+    snapshot.append(snapshot)
+
+    measured = _retained_snapshot_bytes(snapshot)
+
+    assert measured >= len(shared)
+    assert measured < len(shared) * 2 + 4_096  # shared leaf and cycle counted once
+
+
+def test_queue_does_not_keep_parent_agent_alive():
+    queue, _ = _queue()
+    agent = _Agent()
+    parent_ref = weakref.ref(agent)
+    assert queue.enqueue(agent, "s1", {"messages_snapshot": []})
+
+    del agent
+    gc.collect()
+
+    assert parent_ref() is None
+    with queue._lock:
+        assert queue._pending["s1"].parent() is None
+
+
+def test_queue_pressure_evicts_oldest_and_bounds_snapshot_bytes(monkeypatch):
+    monkeypatch.setattr(riq, "_PENDING_SNAPSHOT_BYTES_MAX", 2_000)
+    monkeypatch.setattr(riq, "_PENDING_REVIEWS_MAX", 2)
+    queue, clock = _queue()
+    agents = [_Agent(), _Agent(), _Agent()]
+
+    for index, agent in enumerate(agents):
+        clock["t"] = float(index)
+        assert queue.enqueue(
+            agent, f"s{index}",
+            {"messages_snapshot": [{"role": "user", "content": "x" * 120}]},
+        )
+
+    assert queue.pending_count() <= 2
+    assert queue.pending_snapshot_bytes() <= 2_000
+    with queue._lock:
+        assert "s0" not in queue._pending
+        assert set(queue._pending) == {"s1", "s2"}
+
+
+def test_oversized_snapshot_is_rejected_without_replacing_existing(monkeypatch):
+    monkeypatch.setattr(riq, "_PENDING_SNAPSHOT_BYTES_MAX", 800)
+    queue, _ = _queue()
+    agent = _Agent()
+    assert queue.enqueue(agent, "s1", {"messages_snapshot": [{"content": "small"}]})
+
+    assert not queue.enqueue(agent, "s1", {"messages_snapshot": [{"content": "x" * 2_000}]})
+    assert queue.pending_count() == 1
+    with queue._lock:
+        assert queue._pending["s1"].kwargs["messages_snapshot"] == [{"content": "small"}]
+
+
+def test_coalescing_replaces_accounting_instead_of_adding_it():
+    queue, _ = _queue()
+    agent = _Agent()
+    assert queue.enqueue(agent, "s1", {"messages_snapshot": [{"content": "x" * 1_000}]})
+    first_bytes = queue.pending_snapshot_bytes()
+
+    assert queue.enqueue(agent, "s1", {"messages_snapshot": [{"content": "tiny"}]})
+
+    assert queue.pending_count() == 1
+    assert queue.pending_snapshot_bytes() < first_bytes
+
+
+def test_pop_releases_accounting_and_preserves_snapshot_for_dispatch():
+    queue, clock = _queue()
+    agent = _Agent()
+    messages = [{"role": "user", "content": "remember this"}]
+    assert queue.enqueue(agent, "s1", {"messages_snapshot": messages, "task_cfg": {}})
+    assert queue.pending_snapshot_bytes() > 0
+
+    queue.note_turn_started()
+    queue.note_turn_finished()
+    clock["t"] += riq._IDLE_SETTLE_S + 1
+    item = queue._pop_dispatchable()
+
+    assert item is not None
+    assert queue.pending_count() == 0
+    assert queue.pending_snapshot_bytes() == 0
+    parent = item.parent()
+    assert parent is agent
+    parent._spawn_background_review_now(**item.kwargs)
+    assert agent.spawned[0]["messages_snapshot"] == messages


### PR DESCRIPTION
## Summary

Fixes #108234.

The managed-local background-review queue was one-slot-per-session but had no process-wide memory/session bound. Every pending item strongly retained both the complete parent `AIAgent` and the complete structurally cloned conversation snapshot for up to the default 30-minute defer age.

This change makes deferred self-improvement a bounded cache rather than a second owner of foreground agent state:

- parent agents are held through `weakref.ref`; an otherwise-evicted parent can be collected and its best-effort review is dropped at dispatch;
- the actual Python heap reachable from the isolated `messages_snapshot` is measured iteratively with `sys.getsizeof`, identity de-duplication, cycle protection, and early stop at the budget;
- aggregate queued snapshot heap is capped at **8 MiB** and pending sessions at **16**;
- replacing, dispatching, or pressure-evicting an entry decrements accounting through one `_pop_pending_locked` chokepoint;
- the oldest pending reviews are evicted under aggregate pressure;
- an individually oversized replacement is rejected before the existing smaller review is removed;
- admitted snapshots reach `_spawn_background_review_now` unchanged — no JSON round-trip or content truncation.

## Why retained-graph accounting instead of JSON freezing

`_clone_background_review_messages()` already creates a recursively isolated dict/list graph and shares only immutable leaves. Serializing that clone into JSON bytes would temporarily allocate a full string and permanently add a second full content copy while the live agent still owns the same strings.

The implemented traversal counts the actual retained containers and immutable leaves without copying them. It also preserves exact Python snapshot semantics and remains safe on a malformed cycle.

## Root cause

Before:

```python
@dataclass(slots=True)
class _PendingReview:
    agent: Any
    session_key: str
    kwargs: Dict[str, Any]
    enqueued_at: float
```

Per-session coalescing prevented duplicate entries for one session, but an active multi-session host could still queue an unbounded number of complete transcripts. The strong `agent` field independently defeated normal agent-cache lifetime.

## Verification

Focused local checks against the exact final files:

```text
python -m pytest -q tests/agent/test_review_idle_queue_memory.py
6 passed

python -m py_compile agent/review_idle_queue.py tests/agent/test_review_idle_queue_memory.py
passed
```

The regressions cover:

1. shared leaves and malformed cycles are counted once/terminate safely;
2. the queue does not keep a parent agent alive;
3. byte/session pressure evicts the oldest entry;
4. an oversized replacement preserves an existing admissible review;
5. coalescing replaces rather than accumulates accounting;
6. dispatch releases accounting and preserves the exact snapshot.

The branch is one commit directly on upstream `8706517544bcc3f41f3b6521725f80b349ead3c7`; only `agent/review_idle_queue.py` and one focused test file are changed. Repository CI remains authoritative for the full suite.