### PR TITLE
feat(gateway,desktop): per-turn model note + display-only mode label (composer-mode frame)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -526,10 +526,16 @@ _CONTROL_STATE: Dict[str, Any] = {
     # batch — no interrupt, no new user turn (role alternation preserved).
     "_pending_steer": None,
     "_pending_steer_lock": threading.Lock,
+    # Optional per-turn model note (+ display-only mode label) queued with the steer above:
+    # the note rides the delivered row's api_content, the label its display_metadata.
+    "_pending_steer_note": "",
+    "_pending_steer_mode": "",
     # Active-turn redirect: keep the valid turn prefix, cancel only the in-flight request,
     # rebuild the tail with the correction. Drained at a role-safe boundary.
     "_pending_redirect": None,
     "_pending_redirect_lock": threading.Lock,
+    "_pending_redirect_note": "",
+    "_pending_redirect_mode": "",
     # Concurrent-tool worker tids: `_set_interrupt` on `_execution_thread_id` alone doesn't
     # reach ThreadPoolExecutor workers, so interrupt()/clear_interrupt() fan out to these.
     "_tool_worker_threads": set,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3210,6 +3210,9 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
     steer_text = agent._drain_pending_steer()
     if not steer_text:
         return
+    # The per-turn note/label queued with this steer rides the delivered row: api_content
+    # (model-side bytes) carries the note, display_metadata the opaque mode label.
+    steer_note, steer_mode = agent._take_correction_note("_pending_steer")
     # Skip non-tool messages in the tail in case something else is appended at the boundary.
     tail = range(len(messages) - 1, max(len(messages) - num_tool_msgs - 1, -1), -1)
     target = next((messages[j] for j in tail if isinstance(messages[j], dict) and messages[j].get("role") == "tool"), None)
@@ -3218,8 +3221,9 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
         # requeue so the fallback path delivers it as a normal next-turn
         # user message (which persists like any other user turn).
         _requeue_pending_steer(agent, steer_text)
+        agent._queue_correction_note("_pending_steer", steer_note, steer_mode)
         return
-    messages.append(steer_user_row(steer_text))
+    messages.append(steer_user_row(steer_text, note=steer_note, mode=steer_mode))
     _ra().logger.info(
         "Delivered /steer to agent after tool batch (%d chars) as new user message: %s", len(steer_text),
         steer_text[:120] + ("..." if len(steer_text) > 120 else ""),

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -19,6 +19,7 @@ from hermes_cli.timeouts import get_provider_request_timeout
 from agent.message_sanitization import (
     _FULL_ARGS_LOG_BOUND, coalesce_tool_call_id, tool_call_id_variants, tool_result_id_variants
 )
+from agent.interrupt_control import _ic_queue_correction_note, _ic_take_correction_note
 from agent.prompt_builder import STEER_DISPLAY_KIND, steer_user_row
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
@@ -3212,7 +3213,7 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
         return
     # The per-turn note/label queued with this steer rides the delivered row: api_content
     # (model-side bytes) carries the note, display_metadata the opaque mode label.
-    steer_note, steer_mode = agent._take_correction_note("_pending_steer")
+    steer_note, steer_mode = _ic_take_correction_note(agent, "_pending_steer")
     # Skip non-tool messages in the tail in case something else is appended at the boundary.
     tail = range(len(messages) - 1, max(len(messages) - num_tool_msgs - 1, -1), -1)
     target = next((messages[j] for j in tail if isinstance(messages[j], dict) and messages[j].get("role") == "tool"), None)
@@ -3221,7 +3222,7 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
         # requeue so the fallback path delivers it as a normal next-turn
         # user message (which persists like any other user turn).
         _requeue_pending_steer(agent, steer_text)
-        agent._queue_correction_note("_pending_steer", steer_note, steer_mode)
+        _ic_queue_correction_note(agent, "_pending_steer", steer_note, steer_mode)
         return
     messages.append(steer_user_row(steer_text, note=steer_note, mode=steer_mode))
     _ra().logger.info(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -308,7 +308,15 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
             placeholder["api_content"] = _INTERRUPTED_PLACEHOLDER
         append_message(messages, placeholder)
     # Transcript shows the user's own words; the provider replays the scaffolded form.
-    append_message(messages, {"role": "user", "content": text, "api_content": correction})
+    # A per-turn model note (composer mode framing) rides the same sidecar: content keeps the
+    # user's words, api_content replays note + scaffold, and the label stays display-only.
+    note, mode = agent._take_correction_note("_pending_redirect") if hasattr(agent, "_take_correction_note") else ("", "")
+    if note:
+        correction = f"{note}\n\n{correction}"
+    redirect_row: Dict[str, Any] = {"role": "user", "content": text, "api_content": correction}
+    if mode:
+        redirect_row["display_metadata"] = {"mode": mode}
+    append_message(messages, redirect_row)
 
     # Stateful scrubber for <memory-context> spans split across stream deltas (#5719).  sanitize_context()
     # alone can't survive chunk boundaries because the block regex needs both tags in one string.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.fast_mode import begin_turn as begin_fast_mode_turn
+from agent.interrupt_control import _ic_take_correction_note
 from agent.message_metadata import append_message
 from agent.message_sanitization import _repair_tool_call_arguments, _sanitize_surrogates
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, _estimate_tools_tokens_rough
@@ -310,7 +311,7 @@ def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text
     # Transcript shows the user's own words; the provider replays the scaffolded form.
     # A per-turn model note (composer mode framing) rides the same sidecar: content keeps the
     # user's words, api_content replays note + scaffold, and the label stays display-only.
-    note, mode = agent._take_correction_note("_pending_redirect") if hasattr(agent, "_take_correction_note") else ("", "")
+    note, mode = _ic_take_correction_note(agent, "_pending_redirect")
     if note:
         correction = f"{note}\n\n{correction}"
     redirect_row: Dict[str, Any] = {"role": "user", "content": text, "api_content": correction}

--- a/agent/interrupt_control.py
+++ b/agent/interrupt_control.py
@@ -152,6 +152,7 @@ class InterruptControlMixin:
                 _fence(), when_in_flight=False, failure_log="Compression hard-cancel fence admission failed"
             )
             self._pending_redirect = None
+            self._pending_redirect_note = self._pending_redirect_mode = ""
 
         # Codex watches a private interrupt event rather than Hermes' per-thread flag.
         _request_interrupt = _ic_codex_method(self, "request_interrupt")
@@ -205,6 +206,7 @@ class InterruptControlMixin:
             getattr(self, "_hard_interrupt_requested", threading.Event()).clear()
             if not preserve_redirect:
                 self._pending_redirect = None
+                self._pending_redirect_note = self._pending_redirect_mode = ""
         self._interrupt_thread_signal_pending = False
         if self._execution_thread_id is not None:
             _set_interrupt(False, self._execution_thread_id)
@@ -212,24 +214,50 @@ class InterruptControlMixin:
         # A hard interrupt supersedes any pending /steer — its target iteration will no longer happen.
         with _ic_lock(self, "_pending_steer_lock"):
             self._pending_steer = None
+            self._pending_steer_note = self._pending_steer_mode = ""
         return True
 
-    def steer(self, text: str) -> bool:
+    def steer(self, text: str, note: Optional[str] = None, mode: Optional[str] = None) -> bool:
         """Queue user text for delivery as its own user row after the current tool batch finishes (no
-        interrupt); multiple calls concatenate with newlines. Returns False for empty text."""
+        interrupt); multiple calls concatenate with newlines. Returns False for empty text. An optional
+        per-turn ``note`` (composer mode framing) rides the delivered row's ``api_content`` — model-side
+        bytes only — and the opaque ``mode`` label lands on its display_metadata for client badges."""
         if not text or not text.strip():
             return False
         cleaned = text.strip()
         with _ic_lock(self, "_pending_steer_lock"):
             existing = _ic_slot(self, "_pending_steer_lock", "_pending_steer")
             self._pending_steer = (existing + "\n" + cleaned) if existing else cleaned
+            self._queue_correction_note("_pending_steer", note, mode)
         return True
 
-    def redirect(self, text: str) -> bool:
+    def _queue_correction_note(self, slot: str, note: Optional[str], mode: Optional[str]) -> None:
+        """Attach a per-turn model note (+ display-only mode label) to the pending ``slot`` correction:
+        notes concatenate, the label is last-wins. Call under the slot's own lock."""
+        note = (note or "").strip()
+        mode = (mode or "").strip()
+        if note:
+            existing_note = getattr(self, f"{slot}_note", "") or ""
+            setattr(self, f"{slot}_note", f"{existing_note}\n\n{note}" if existing_note else note)
+        if mode:
+            setattr(self, f"{slot}_mode", mode)
+
+    def _take_correction_note(self, slot: str) -> "tuple[str, str]":
+        """One-shot consume of the note/label queued for the pending ``slot`` correction."""
+        with _ic_lock(self, f"{slot}_lock"):
+            note = getattr(self, f"{slot}_note", "") or ""
+            mode = getattr(self, f"{slot}_mode", "") or ""
+            setattr(self, f"{slot}_note", "")
+            setattr(self, f"{slot}_mode", "")
+        return note, mode
+
+    def redirect(self, text: str, note: Optional[str] = None, mode: Optional[str] = None) -> bool:
         """Redirect the active turn without converting it into a new task: during a model request only that
         request is cancelled (completed messages kept, partial reasoning becomes assistant context, the
         correction is appended as a real user message, the loop retries); during tool execution it degrades
-        to ``steer()``; Codex app-server uses native ``turn/steer``. False when no live turn / empty text."""
+        to ``steer()``; Codex app-server uses native ``turn/steer``. False when no live turn / empty text.
+        Like ``steer``, an optional per-turn ``note``/``mode`` rides the correction (api_content /
+        display_metadata); the Codex native path carries neither (documented edge)."""
         if not text or not text.strip():
             return False
         cleaned = text.strip()
@@ -250,7 +278,7 @@ class InterruptControlMixin:
         # `sleep` poller, a build), so ask the tool workers to YIELD: terminal hands the live
         # process to the background registry and returns; tools that don't yield are unaffected.
         if getattr(self, "_executing_tools", False):
-            accepted = self.steer(cleaned)
+            accepted = self.steer(cleaned, note=note, mode=mode)
             if accepted:
                 tracker = getattr(self, "_tool_worker_threads", None)
                 tracker_lock = getattr(self, "_tool_worker_threads_lock", None)
@@ -271,6 +299,7 @@ class InterruptControlMixin:
             self._pending_redirect = (
                 f"{existing}\n\n[Additional user correction]\n{cleaned}" if existing else cleaned
             )
+            self._queue_correction_note("_pending_redirect", note, mode)
             self._interrupt_requested = True
             self._interrupt_message = None
 

--- a/agent/interrupt_control.py
+++ b/agent/interrupt_control.py
@@ -50,6 +50,32 @@ def _ic_slot(agent, lock_attr: str, slot: str):
     return getattr(agent, slot)
 
 
+def _ic_queue_correction_note(agent, slot: str, note: Optional[str], mode: Optional[str]) -> None:
+    """Attach a per-turn model note (+ display-only mode label) to the pending ``slot`` correction:
+    notes concatenate, the label is last-wins. Call it under the slot's own lock. Module-level and
+    ``getattr``-based on purpose — an ``__init__``-less stub must stay usable (``_ic_lock`` contract)."""
+    note = (note or "").strip()
+    mode = (mode or "").strip()
+    if not note and not mode:
+        return
+    if note:
+        existing_note = getattr(agent, f"{slot}_note", "") or ""
+        setattr(agent, f"{slot}_note", f"{existing_note}\n\n{note}" if existing_note else note)
+    if mode:
+        setattr(agent, f"{slot}_mode", mode)
+
+
+def _ic_take_correction_note(agent, slot: str) -> "tuple[str, str]":
+    """One-shot consume of the note/label queued for the pending ``slot`` correction (empty strings
+    when none). Stub-safe like ``_ic_queue_correction_note``: no lock, no attributes, no failure."""
+    with _ic_lock(agent, f"{slot}_lock"):
+        note = getattr(agent, f"{slot}_note", "") or ""
+        mode = getattr(agent, f"{slot}_mode", "") or ""
+        setattr(agent, f"{slot}_note", "")
+        setattr(agent, f"{slot}_mode", "")
+    return note, mode
+
+
 def _ic_codex_method(agent, name: str):
     """Codex app-server owns its model/tool loop; return its ``name`` hook or None."""
     if getattr(agent, "api_mode", None) != "codex_app_server":
@@ -228,28 +254,8 @@ class InterruptControlMixin:
         with _ic_lock(self, "_pending_steer_lock"):
             existing = _ic_slot(self, "_pending_steer_lock", "_pending_steer")
             self._pending_steer = (existing + "\n" + cleaned) if existing else cleaned
-            self._queue_correction_note("_pending_steer", note, mode)
+            _ic_queue_correction_note(self, "_pending_steer", note, mode)
         return True
-
-    def _queue_correction_note(self, slot: str, note: Optional[str], mode: Optional[str]) -> None:
-        """Attach a per-turn model note (+ display-only mode label) to the pending ``slot`` correction:
-        notes concatenate, the label is last-wins. Call under the slot's own lock."""
-        note = (note or "").strip()
-        mode = (mode or "").strip()
-        if note:
-            existing_note = getattr(self, f"{slot}_note", "") or ""
-            setattr(self, f"{slot}_note", f"{existing_note}\n\n{note}" if existing_note else note)
-        if mode:
-            setattr(self, f"{slot}_mode", mode)
-
-    def _take_correction_note(self, slot: str) -> "tuple[str, str]":
-        """One-shot consume of the note/label queued for the pending ``slot`` correction."""
-        with _ic_lock(self, f"{slot}_lock"):
-            note = getattr(self, f"{slot}_note", "") or ""
-            mode = getattr(self, f"{slot}_mode", "") or ""
-            setattr(self, f"{slot}_note", "")
-            setattr(self, f"{slot}_mode", "")
-        return note, mode
 
     def redirect(self, text: str, note: Optional[str] = None, mode: Optional[str] = None) -> bool:
         """Redirect the active turn without converting it into a new task: during a model request only that
@@ -299,7 +305,7 @@ class InterruptControlMixin:
             self._pending_redirect = (
                 f"{existing}\n\n[Additional user correction]\n{cleaned}" if existing else cleaned
             )
-            self._queue_correction_note("_pending_redirect", note, mode)
+            _ic_queue_correction_note(self, "_pending_redirect", note, mode)
             self._interrupt_requested = True
             self._interrupt_message = None
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -519,13 +519,21 @@ def format_steer_marker(steer_text: str) -> str:
 STEER_DISPLAY_KIND = "steer"
 
 
-def steer_user_row(steer_text: str) -> Dict[str, Any]:
+def steer_user_row(steer_text: str, note: str = "", mode: str = "") -> Dict[str, Any]:
     """The standalone ``role:user`` row a mid-turn /steer is delivered as (after the newest tool
     result). Its own row — never smeared onto the already-persisted tool row, which append-only
     persistence would leave divergent from the live request — and typed so the alternation repair
-    never merges the next real prompt into it and history renderers can label it."""
-    return {"role": "user", "content": format_steer_marker(steer_text).lstrip(),
-            "display_kind": STEER_DISPLAY_KIND}
+    never merges the next real prompt into it and history renderers can label it. An optional
+    per-turn model ``note`` (composer mode framing) rides ``api_content`` — the exact bytes the
+    provider sees — so the user's own ``content`` stays untouched; the opaque ``mode`` label lands
+    on display_metadata (display-only, popped from every outbound copy)."""
+    content = format_steer_marker(steer_text).lstrip()
+    row: Dict[str, Any] = {"role": "user", "content": content, "display_kind": STEER_DISPLAY_KIND}
+    if note:
+        row["api_content"] = f"{note}\n\n{content}"
+    if mode:
+        row["display_metadata"] = {"mode": mode}
+    return row
 
 
 STEER_CHANNEL_NOTE = (

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -165,11 +165,18 @@ def _maybe_title_session_at_turn_start(agent: Any, messages: List[Any]) -> None:
         from agent.title_generator import maybe_auto_title
 
         # Turn's user message as text; image-only turns yield "" and are skipped.
+        # Prefer the pristine persist override (str or multimodal list): the live
+        # content can carry API-only scaffolding (ask sandwich, reaction/speech
+        # notes), and a title must come from what the USER typed, never from it.
         user_text = ""
-        for msg in reversed(messages or []):
-            if isinstance(msg, dict) and msg.get("role") == "user":
-                user_text = flatten_message_text(msg.get("content")).strip()
-                break
+        persist_text = getattr(agent, "_persist_user_message_override", None)
+        if persist_text:
+            user_text = flatten_message_text(persist_text).strip()
+        if not user_text:
+            for msg in reversed(messages or []):
+                if isinstance(msg, dict) and msg.get("role") == "user":
+                    user_text = flatten_message_text(msg.get("content")).strip()
+                    break
         if not user_text:
             return
         # The session row is created lazily; force it now or the title write matches

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -585,6 +585,9 @@ def finalize_turn(
     _leftover_steer = agent._drain_pending_steer()
     if _leftover_steer:
         result["pending_steer"] = _leftover_steer
+        # Its per-turn note/label died with this turn: consume so they cannot leak into a
+        # later correction (the recycled message is a fresh next-turn submit, no sidecar).
+        agent._take_correction_note("_pending_steer")
     agent._response_was_previewed = False
     if interrupted and agent._interrupt_message:
         result["interrupt_message"] = agent._interrupt_message

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, List, Optional, Tuple
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.context_compressor import _DB_PERSISTED_MARKER
+from agent.interrupt_control import _ic_take_correction_note
 from agent.message_content import flatten_message_text
 from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.message_sanitization import _sanitize_surrogates
@@ -587,7 +588,7 @@ def finalize_turn(
         result["pending_steer"] = _leftover_steer
         # Its per-turn note/label died with this turn: consume so they cannot leak into a
         # later correction (the recycled message is a fresh next-turn submit, no sidecar).
-        agent._take_correction_note("_pending_steer")
+        _ic_take_correction_note(agent, "_pending_steer")
     agent._response_was_previewed = False
     if interrupted and agent._interrupt_message:
         result["interrupt_message"] = agent._interrupt_message

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -173,6 +173,12 @@ global that would leak across sends or providers.
   `note`/`mode`, `runComposerMiddleware` runs ONCE per send, and the frame
   travels as submit options → `prompt.submit {note, mode}` (typed, voice, and
   queued drains all pass `onSubmit`).
+- A queued entry OWNS its frame: `queueCurrentDraft` runs the chain once at
+  enqueue and seals `{mode, note}` onto the entry (`QueuedPromptEntry`); every
+  drain (foreground, background, steer) hands the sealed frame back as submit
+  options with `fromQueue`, and the chain sees `fromQueue` in the draft so it
+  must pass the frame through untouched — re-deriving at drain time would
+  stamp the send with whatever mode is live then.
 - Steers are sends too: `redirectPrompt` runs the middleware before the RPC and
   before the session-not-found retry; `steerPrompt` (tile) runs it BEFORE the
   optimistic append so a cancel leaves no bubble behind.

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -162,6 +162,27 @@ availability off the session source the app already sends on `session.create`
 process might be a remote or cloud gateway this app merely connected to. See
 the root AGENTS.md, "Surface capability is a property of the SESSION."
 
+## Composer modes ride the turn, not the prompt
+
+A composer mode (plan / debug / …) is a property of ONE send. It reaches the
+model as a per-turn note the gateway carries through the `api_content` sidecar —
+never as text typed into the user's own `content`, and never as an env/config
+global that would leak across sends or providers.
+
+- The middleware chain is the only producer of the frame: `ComposerDraft` gains
+  `note`/`mode`, `runComposerMiddleware` runs ONCE per send, and the frame
+  travels as submit options → `prompt.submit {note, mode}` (typed, voice, and
+  queued drains all pass `onSubmit`).
+- Steers are sends too: `redirectPrompt` runs the middleware before the RPC and
+  before the session-not-found retry; `steerPrompt` (tile) runs it BEFORE the
+  optimistic append so a cancel leaves no bubble behind.
+- `'canceled'` is not a rejection: a cancel returns the draft to the composer
+  (`steerDraft` → `loadIntoComposer`) and never enqueues the raw text; a queued
+  entry is consumed only by a DELIVERED redirect (`accepted === true`) —
+  `'canceled'` is a truthy string, so a truthiness test would eat the words.
+- `mode` is display-only (the row's `display_metadata`); nothing in the frame
+  may change prompt bytes, toolsets, or the system prompt.
+
 ## Respect the person using it
 
 Design and engineering meet at intent. The user's attention and context are

--- a/apps/desktop/src/app/chat/composer/contrib.ts
+++ b/apps/desktop/src/app/chat/composer/contrib.ts
@@ -54,6 +54,10 @@ export interface ComposerModeFrame {
 export interface ComposerDraft extends ComposerModeFrame {
   text: string
   attachments?: ComposerAttachment[]
+  /** True when this draft is the drain of a queued entry. The chain must hand
+   *  `note`/`mode` back UNTOUCHED in that case: the queue sealed the frame at
+   *  enqueue time, and re-deriving would stamp the send with the live mode. */
+  fromQueue?: boolean
 }
 
 /** Payload of a `composer.middleware` data contribution. */

--- a/apps/desktop/src/app/chat/composer/contrib.ts
+++ b/apps/desktop/src/app/chat/composer/contrib.ts
@@ -40,7 +40,18 @@ export const COMPOSER_AREAS = {
   atCompletions: 'composer.atCompletions'
 } as const
 
-export interface ComposerDraft {
+/** Per-turn composer-mode frame: the model note + the display-only mode label.
+ *  Carried by `ComposerDraft` and handed to the gateway, which delivers the
+ *  note through the per-turn api_content sidecar (never mixed into the user's
+ *  `content`) and stores the label as the row's display_metadata. */
+export interface ComposerModeFrame {
+  /** Framing instructions for the model on this specific send. */
+  note?: string
+  /** Opaque composer-mode label (display-only; the transcript may badge it). */
+  mode?: string
+}
+
+export interface ComposerDraft extends ComposerModeFrame {
   text: string
   attachments?: ComposerAttachment[]
 }

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -1,6 +1,7 @@
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { registry } from '@/contrib/registry'
 import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
@@ -13,6 +14,7 @@ import {
 import { setSessionsLoading } from '@/store/session'
 
 import type { QueueEditState } from '../composer-utils'
+import { COMPOSER_AREAS, type ComposerDraft, type ComposerMiddleware } from '../contrib'
 import type { ChatBarProps } from '../types'
 
 import { useComposerQueue } from './use-composer-queue'
@@ -25,7 +27,9 @@ import { useComposerQueue } from './use-composer-queue'
 
 const SESSION_KEY = 'stored-session-queue-hook'
 
-function renderQueueHook(overrides: { busy?: boolean; onCancel?: () => void; onSteer?: ChatBarProps['onSteer'] } = {}) {
+function renderQueueHook(
+  overrides: { busy?: boolean; draftText?: string; onCancel?: () => void; onSteer?: ChatBarProps['onSteer'] } = {}
+) {
   const onSubmit = vi.fn<ChatBarProps['onSubmit']>(async () => true)
   const onCancel = overrides.onCancel ?? vi.fn()
   const onSteer = overrides.onSteer
@@ -38,7 +42,7 @@ function renderQueueHook(overrides: { busy?: boolean; onCancel?: () => void; onS
         attachments: [],
         busy,
         clearDraft: () => undefined,
-        draftRef: { current: '' },
+        draftRef: { current: overrides.draftText ?? '' },
         focusInput: () => undefined,
         loadIntoComposer: () => undefined,
         onCancel,
@@ -334,6 +338,51 @@ describe('steer-now honors a canceled composer frame', () => {
       await hook.result.current.steerQueuedNow(entry.id)
     })
 
+    expect(getQueuedPrompts(SESSION_KEY)).toEqual([])
+  })
+
+  it('seals the frame into the entry at enqueue (chain runs once)', async () => {
+    const disposed = registry.register({
+      id: 'test-queued-frame-seal',
+      area: COMPOSER_AREAS.middleware,
+      data: {
+        handler: (draft: ComposerDraft) => ({ ...draft, mode: 'debug', note: 'DEBUG-NOTE' })
+      } satisfies ComposerMiddleware
+    })
+
+    try {
+      const { hook } = renderQueueHook({ busy: true, draftText: 'framed while queued' })
+
+      await act(async () => {
+        await hook.result.current.queueCurrentDraft()
+      })
+
+      expect(getQueuedPrompts(SESSION_KEY)[0]).toMatchObject({
+        text: 'framed while queued',
+        mode: 'debug',
+        note: 'DEBUG-NOTE'
+      })
+    } finally {
+      disposed()
+    }
+  })
+
+  it('drains with the frame sealed at enqueue time, not the live one', async () => {
+    enqueueQueuedPrompt(SESSION_KEY, {
+      attachments: [],
+      text: 'frozen ask',
+      mode: 'ask',
+      note: 'ASK-NOTE'
+    })
+
+    const { onSubmit } = renderQueueHook({ busy: false })
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled())
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      'frozen ask',
+      expect.objectContaining({ fromQueue: true, mode: 'ask', note: 'ASK-NOTE' })
+    )
     expect(getQueuedPrompts(SESSION_KEY)).toEqual([])
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -289,3 +289,51 @@ describe('useComposerQueue park integration', () => {
     expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0)
   })
 })
+
+// 'canceled' (the composer middleware declined the send) is a TRUTHY string:
+// a truthiness test would consume the queued entry while delivering nothing.
+// Only a delivered redirect (`true`) may remove it — the settle drain owns the
+// rest, so the user's words are never lost.
+describe('steer-now honors a canceled composer frame', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    $queuedPromptsBySession.set({})
+    $parkedQueueSessions.set({})
+    setSessionsLoading(false)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    $queuedPromptsBySession.set({})
+    $parkedQueueSessions.set({})
+    setSessionsLoading(true)
+  })
+
+  it('keeps the entry queued when the middleware cancels', async () => {
+    const entry = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'ship it' })!
+    const onSteer = vi.fn<NonNullable<ChatBarProps['onSteer']>>(async () => 'canceled' as const)
+    const { hook } = renderQueueHook({ busy: true, onSteer })
+
+    let consumed = true
+
+    await act(async () => {
+      consumed = await hook.result.current.steerQueuedNow(entry.id)
+    })
+
+    expect(consumed).toBe(false)
+    expect(getQueuedPrompts(SESSION_KEY).map(item => item.id)).toEqual([entry.id])
+  })
+
+  it('consumes the entry only on a delivered redirect', async () => {
+    const entry = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'ship it' })!
+    const onSteer = vi.fn<NonNullable<ChatBarProps['onSteer']>>(async () => true)
+    const { hook } = renderQueueHook({ busy: true, onSteer })
+
+    await act(async () => {
+      await hook.result.current.steerQueuedNow(entry.id)
+    })
+
+    expect(getQueuedPrompts(SESSION_KEY)).toEqual([])
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -25,6 +25,7 @@ import { notify } from '@/store/notifications'
 import { $sessionsLoading } from '@/store/session'
 
 import { cloneAttachments, type QueueEditState } from '../composer-utils'
+import { runComposerMiddleware } from '../contrib'
 import { useComposerScope } from '../scope'
 import type { ChatBarProps } from '../types'
 
@@ -181,14 +182,31 @@ export function useComposerQueue({
     return true
   }
 
-  const queueCurrentDraft = useCallback(() => {
+  const queueCurrentDraft = useCallback(async (): Promise<boolean> => {
     const text = draftRef.current
 
     if (!activeQueueSessionKey || (!text.trim() && attachments.length === 0)) {
       return false
     }
 
-    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments })) {
+    // Seal the composer-mode frame HERE, at enqueue: run the middleware chain
+    // once for this entry so the drain can hand the mode the user queued WITH
+    // to the submit options. Re-deriving at drain time would leak whatever
+    // mode is live THEN into a send the user framed earlier.
+    const sealed = await runComposerMiddleware({ text, attachments })
+
+    if (!sealed) {
+      return false
+    }
+
+    if (
+      !enqueueQueuedPrompt(activeQueueSessionKey, {
+        text,
+        attachments,
+        ...(sealed.mode ? { mode: sealed.mode } : {}),
+        ...(sealed.note ? { note: sealed.note } : {})
+      })
+    ) {
       return false
     }
 
@@ -223,6 +241,10 @@ export function useComposerQueue({
             attachments: entry.attachments,
             ...(entry.displayText ? { displayText: entry.displayText } : {}),
             ...(entry.displayKind ? { displayKind: entry.displayKind } : {}),
+            // The frame sealed at enqueue travels back with the drain — the
+            // drain's mode is the queue-time mode, never the live one.
+            ...(entry.mode ? { mode: entry.mode } : {}),
+            ...(entry.note ? { note: entry.note } : {}),
             fromQueue: true,
             sessionId: drainRuntimeSessionId,
             storedSessionId: drainQueueSessionKey
@@ -310,7 +332,14 @@ export function useComposerQueue({
 
       triggerHaptic('submit')
 
-      const accepted = await Promise.resolve(onSteer(entry.text))
+      const accepted = await Promise.resolve(
+        entry.mode || entry.note
+          ? onSteer(entry.text, {
+              ...(entry.mode ? { mode: entry.mode } : {}),
+              ...(entry.note ? { note: entry.note } : {})
+            })
+          : onSteer(entry.text)
+      )
 
       // Rejected (turn already settling, gateway said no) OR canceled by the
       // composer middleware: leave the entry queued exactly where it was — the

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -25,7 +25,7 @@ import { notify } from '@/store/notifications'
 import { $sessionsLoading } from '@/store/session'
 
 import { cloneAttachments, type QueueEditState } from '../composer-utils'
-import { runComposerMiddleware } from '../contrib'
+import { sealQueuedFrame } from '../queue-frame'
 import { useComposerScope } from '../scope'
 import type { ChatBarProps } from '../types'
 
@@ -189,24 +189,12 @@ export function useComposerQueue({
       return false
     }
 
-    // Seal the composer-mode frame HERE, at enqueue: run the middleware chain
-    // once for this entry so the drain can hand the mode the user queued WITH
-    // to the submit options. Re-deriving at drain time would leak whatever
-    // mode is live THEN into a send the user framed earlier.
-    const sealed = await runComposerMiddleware({ text, attachments })
+    // Seal the composer-mode frame HERE, at enqueue (see sealQueuedFrame):
+    // every enqueue path must capture it so the drain hands the mode the user
+    // queued WITH back to the submit options.
+    const frame = await sealQueuedFrame(text, attachments)
 
-    if (!sealed) {
-      return false
-    }
-
-    if (
-      !enqueueQueuedPrompt(activeQueueSessionKey, {
-        text,
-        attachments,
-        ...(sealed.mode ? { mode: sealed.mode } : {}),
-        ...(sealed.note ? { note: sealed.note } : {})
-      })
-    ) {
+    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments, ...frame })) {
       return false
     }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -312,10 +312,12 @@ export function useComposerQueue({
 
       const accepted = await Promise.resolve(onSteer(entry.text))
 
-      // Rejected (turn already settling, gateway said no): leave the entry
-      // queued exactly where it was — the settle drain picks it up, so the
-      // words are never lost. Only a delivered redirect consumes the entry.
-      if (!accepted) {
+      // Rejected (turn already settling, gateway said no) OR canceled by the
+      // composer middleware: leave the entry queued exactly where it was — the
+      // settle drain picks it up, so the words are never lost. Only a DELIVERED
+      // redirect (`true`) consumes the entry: 'canceled' is a truthy string, so
+      // a truthiness test would silently drop the queued words.
+      if (accepted !== true) {
         return false
       }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -60,7 +60,7 @@ function renderSubmitHook({
   const onSubmit = vi.fn(async () => true)
   const loadIntoComposer = vi.fn()
   const stashAt = vi.fn()
-  const queueCurrentDraft = vi.fn(() => true)
+  const queueCurrentDraft = vi.fn(async () => true)
   let updatePaneVisible: Dispatch<SetStateAction<boolean>> | undefined
 
   const clearDraft = vi.fn(() => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
 import { $clarifyRequests } from '@/store/clarify'
 import type { ComposerAttachment } from '@/store/composer'
-import { clearQueuedPrompts, getQueuedPrompts } from '@/store/composer-queue'
+import { $queuedPromptsBySession, clearQueuedPrompts, getQueuedPrompts } from '@/store/composer-queue'
 import { $gateway } from '@/store/gateway'
 import {
   clearAllPrompts,
@@ -17,6 +17,7 @@ import {
 
 import { type ComposerTarget, requestComposerSubmit } from '../focus'
 import { ComposerScopeProvider, ComposerSurfaceProvider, MAIN_COMPOSER_SCOPE } from '../scope'
+import type { ChatBarProps } from '../types'
 
 import { useComposerSubmit } from './use-composer-submit'
 
@@ -54,7 +55,7 @@ function renderSubmitHook({
   editor.textContent = text
   const editorRef = { current: editor }
   const onCancel = vi.fn()
-  const onSteer = vi.fn(async () => true)
+  const onSteer = vi.fn<NonNullable<ChatBarProps['onSteer']>>(async () => true)
   const onSteerHidden = vi.fn(async () => true)
   const onSubmit = vi.fn(async () => true)
   const loadIntoComposer = vi.fn()
@@ -128,6 +129,7 @@ function renderSubmitHook({
   return {
     clearDraft,
     hook,
+    loadIntoComposer,
     onCancel,
     onSteer,
     onSteerHidden,
@@ -631,5 +633,45 @@ describe('useComposerSubmit with a blocking prompt parked on the session', () =>
 
     // The approval card is still the turn's owner; only its own buttons answer it.
     expect(hasBlockingPromptRequest('runtime-session')).toBe(true)
+  })
+})
+
+// The composer frame survives the steer path: 'canceled' is the middleware
+// consuming the send (restore the draft, enqueue NOTHING), while a rejection
+// keeps its old "queue the words" meaning.
+describe('steerDraft composer-frame semantics', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    $queuedPromptsBySession.set({})
+  })
+
+  it('restores the draft and queues nothing when the middleware cancels', async () => {
+    window.localStorage.clear()
+    $queuedPromptsBySession.set({})
+    const { hook, loadIntoComposer, onSteer } = renderSubmitHook({ busy: true, text: 'ship it' })
+    onSteer.mockResolvedValue('canceled')
+
+    await act(async () => {
+      hook.result.current.steerDraft()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(loadIntoComposer).toHaveBeenCalledWith('ship it', []))
+    expect(getQueuedPrompts('stored-session')).toEqual([])
+  })
+
+  it('queues the words when the steer is rejected', async () => {
+    window.localStorage.clear()
+    $queuedPromptsBySession.set({})
+    const { hook, onSteer } = renderSubmitHook({ busy: true, text: 'ship it' })
+    onSteer.mockResolvedValue(false)
+
+    await act(async () => {
+      hook.result.current.steerDraft()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(getQueuedPrompts('stored-session').map(entry => entry.text)).toEqual(['ship it']))
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -3,6 +3,7 @@ import { type Dispatch, type PropsWithChildren, type SetStateAction, useLayoutEf
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
+import { registry } from '@/contrib/registry'
 import { $clarifyRequests } from '@/store/clarify'
 import type { ComposerAttachment } from '@/store/composer'
 import { $queuedPromptsBySession, clearQueuedPrompts, getQueuedPrompts } from '@/store/composer-queue'
@@ -15,6 +16,7 @@ import {
   setSudoRequest
 } from '@/store/prompts'
 
+import { COMPOSER_AREAS, type ComposerDraft, type ComposerMiddleware } from '../contrib'
 import { type ComposerTarget, requestComposerSubmit } from '../focus'
 import { ComposerScopeProvider, ComposerSurfaceProvider, MAIN_COMPOSER_SCOPE } from '../scope'
 import type { ChatBarProps } from '../types'
@@ -673,5 +675,36 @@ describe('steerDraft composer-frame semantics', () => {
     })
 
     await waitFor(() => expect(getQueuedPrompts('stored-session').map(entry => entry.text)).toEqual(['ship it']))
+  })
+
+  it('seals the composer-mode frame when a rejected steer re-queues the words', async () => {
+    const disposed = registry.register({
+      id: 'test-steer-fallback-seal',
+      area: COMPOSER_AREAS.middleware,
+      data: {
+        handler: (draft: ComposerDraft) => ({ ...draft, mode: 'debug', note: 'DEBUG-NOTE' })
+      } satisfies ComposerMiddleware
+    })
+
+    try {
+      $queuedPromptsBySession.set({})
+      const { hook, onSteer } = renderSubmitHook({ busy: true, text: 'frame me' })
+      onSteer.mockResolvedValue(false)
+
+      await act(async () => {
+        hook.result.current.steerDraft()
+        await Promise.resolve()
+      })
+
+      await waitFor(() => {
+        expect(getQueuedPrompts('stored-session')[0]).toMatchObject({
+          text: 'frame me',
+          mode: 'debug',
+          note: 'DEBUG-NOTE'
+        })
+      })
+    } finally {
+      disposed()
+    }
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -36,7 +36,7 @@ interface UseComposerSubmitArgs {
   onSteer: ChatBarProps['onSteer']
   onSteerHidden: ChatBarProps['onSteerHidden']
   onSubmit: ChatBarProps['onSubmit']
-  queueCurrentDraft: () => boolean
+  queueCurrentDraft: () => Promise<boolean>
   queueEdit: QueueEditState | null
   queuedPrompts: QueuedPromptEntry[]
   sessionId: string | null | undefined
@@ -273,7 +273,7 @@ export function useComposerSubmit({
         // queue the whole payload for the next turn. Same for a turn parked on
         // an approval/sudo/secret prompt: a steer can't reach the model while
         // the tool batch is blocked, so the message runs as the next turn.
-        queueCurrentDraft()
+        void queueCurrentDraft()
       } else {
         // Stop button (the only way to reach here while busy with an empty
         // composer — empty Enter is short-circuited in the keydown handler).
@@ -332,7 +332,7 @@ export function useComposerSubmit({
       return
     }
 
-    queueCurrentDraft()
+    void queueCurrentDraft()
     focusInput()
   }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -310,7 +310,18 @@ export function useComposerSubmit({
     clearDraft()
 
     void Promise.resolve(onSteer(text)).then(accepted => {
-      if (!accepted && activeQueueSessionKey) {
+      if (accepted === 'canceled') {
+        // The composer middleware consumed this steer — a cancel, not a
+        // rejection. Put the words back in the composer instead of queueing
+        // raw text the middleware just declined: nothing is lost and no
+        // unframed copy rides the queue behind the live turn.
+        loadIntoComposer(text, [])
+        focusInput()
+
+        return
+      }
+
+      if (accepted !== true && activeQueueSessionKey) {
         enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments: [] })
       }
     })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -12,6 +12,7 @@ import { hasBlockingPromptRequest } from '@/store/prompts'
 
 import { cloneAttachments, type QueueEditState } from '../composer-utils'
 import { onComposerSubmitRequest } from '../focus'
+import { sealQueuedFrame } from '../queue-frame'
 import { pathifyRefs } from '../path-refs'
 import { composerPlainText } from '../rich-editor'
 import { useComposerScope, useComposerSurfaceId } from '../scope'
@@ -322,7 +323,13 @@ export function useComposerSubmit({
       }
 
       if (accepted !== true && activeQueueSessionKey) {
-        enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments: [] })
+        // A rejected steer re-queues the words — seal the frame on THIS path
+        // too, or the drained send arrives without the mode the user had.
+        const queueKey = activeQueueSessionKey
+
+        void sealQueuedFrame(text, []).then(frame => {
+          enqueueQueuedPrompt(queueKey, { text, attachments: [], ...frame })
+        })
       }
     })
   }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -152,11 +152,23 @@ export function ChatBar({
         return true
       }
 
-      const draft = await runComposerMiddleware({ text: value, attachments: options?.attachments })
+      const draft = await runComposerMiddleware({
+        text: value,
+        attachments: options?.attachments,
+        // A queue drain carries the frame sealed at enqueue time. Pass it INTO
+        // the chain so the middleware can hand it back untouched; re-deriving
+        // here would stamp the drain with whatever mode is live NOW.
+        ...(options?.note ? { note: options.note } : {}),
+        ...(options?.mode ? { mode: options.mode } : {}),
+        ...(options?.fromQueue ? { fromQueue: true } : {})
+      })
 
       if (!draft) {
         return false
       }
+
+      const note = draft.note ?? options?.note
+      const mode = draft.mode ?? options?.mode
 
       return onSubmitProp(draft.text, {
         ...options,
@@ -165,8 +177,8 @@ export function ChatBar({
         // gateway delivers the note through the api_content sidecar (the
         // user's `content` stays their words) and persists the label as
         // display_metadata for the transcript to badge.
-        ...(draft.note ? { note: draft.note } : {}),
-        ...(draft.mode ? { mode: draft.mode } : {})
+        ...(note ? { note } : {}),
+        ...(mode ? { mode } : {})
       })
     },
     [onSubmitProp]

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -158,7 +158,16 @@ export function ChatBar({
         return false
       }
 
-      return onSubmitProp(draft.text, { ...options, attachments: draft.attachments })
+      return onSubmitProp(draft.text, {
+        ...options,
+        attachments: draft.attachments,
+        // Composer-mode frame: per-turn model note + display-only label. The
+        // gateway delivers the note through the api_content sidecar (the
+        // user's `content` stays their words) and persists the label as
+        // display_metadata for the transcript to badge.
+        ...(draft.note ? { note: draft.note } : {}),
+        ...(draft.mode ? { mode: draft.mode } : {})
+      })
     },
     [onSubmitProp]
   )

--- a/apps/desktop/src/app/chat/composer/queue-frame.ts
+++ b/apps/desktop/src/app/chat/composer/queue-frame.ts
@@ -1,0 +1,28 @@
+import type { ComposerAttachment } from '@/store/composer'
+
+import { runComposerMiddleware, type ComposerModeFrame } from './contrib'
+
+/**
+ * Seal the composer-mode frame for a draft that is about to be QUEUED.
+ *
+ * Every enqueue path must capture the frame at enqueue time: the drain hands
+ * the sealed frame back as submit options, so the send carries the mode the
+ * user queued WITH. Re-deriving at drain time would stamp the queued send with
+ * whatever mode is live then. Runs the middleware chain once; a cancel yields
+ * an empty frame — queueing must never lose the words over a frame lookup.
+ */
+export async function sealQueuedFrame(
+  text: string,
+  attachments: ComposerAttachment[]
+): Promise<ComposerModeFrame> {
+  const sealed = await runComposerMiddleware({ text, attachments })
+
+  if (!sealed) {
+    return {}
+  }
+
+  return {
+    ...(sealed.mode ? { mode: sealed.mode } : {}),
+    ...(sealed.note ? { note: sealed.note } : {})
+  }
+}

--- a/apps/desktop/src/app/chat/composer/types.ts
+++ b/apps/desktop/src/app/chat/composer/types.ts
@@ -5,6 +5,8 @@ import type { HermesGateway } from '@/hermes'
 
 import type { DroppedFile } from '../hooks/use-composer-actions'
 
+import type { ComposerModeFrame } from './contrib'
+
 export interface ContextSuggestion {
   text: string
   display: string
@@ -55,7 +57,11 @@ export interface ChatBarProps {
   onPickFolders?: () => void
   onPickImages?: () => void
   onRemoveAttachment?: (id: string) => void
-  onSteer?: (text: string) => Promise<boolean> | boolean
+  /** Steer the live turn (`session.redirect`/`session.steer`). Accepts true on
+   *  delivery, false when the turn raced to completion (callers queue the
+   *  words), or 'canceled' when the composer middleware consumed the send —
+   *  the caller must then restore the draft, NEVER queue the raw text. */
+  onSteer?: (text: string, opts?: ComposerModeFrame) => Promise<boolean | 'canceled'> | boolean
   /** Delivers a hidden note to the model mid-turn with no user turn (gateway session.steer). */
   onSteerHidden?: (text: string) => Promise<boolean> | boolean
   onSubmit: (value: string, options?: SubmitTextOptions) => Promise<boolean> | boolean

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -6,6 +6,7 @@ import type * as React from 'react'
 import { memo, Suspense, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router'
 
+import type { ComposerModeFrame } from '@/app/chat/composer/contrib'
 import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
 import { sessionShouldHaveTranscript } from '@/app/session/hooks/use-session-actions/utils'
 import { Thread } from '@/components/assistant-ui/thread'
@@ -102,7 +103,7 @@ interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   onPickFolders: () => void
   onPickImages: () => void
   onRemoveAttachment: (id: string) => void
-  onSteer: (text: string) => Promise<boolean> | boolean
+  onSteer: (text: string, opts?: ComposerModeFrame) => Promise<boolean | 'canceled'> | boolean
   onSteerHidden?: (text: string) => Promise<boolean> | boolean
   onSubmit: (text: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
   onThreadMessagesChange: (messages: readonly ThreadMessage[]) => void

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -11,6 +11,7 @@
 import type { AppendMessage, ThreadMessage } from '@assistant-ui/react'
 import { useCallback, useMemo, useRef } from 'react'
 
+import { runComposerMiddleware } from '@/app/chat/composer/contrib'
 import type { ClientSessionState } from '@/app/types'
 import { useI18n } from '@/i18n'
 import { textPart } from '@/lib/chat-messages'
@@ -395,13 +396,27 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
   )
 
   const steerPrompt = useCallback(
-    async (rawText: string): Promise<boolean> => {
+    async (rawText: string): Promise<boolean | 'canceled'> => {
       const text = rawText.trim()
       const sessionId = runtimeIdRef.current
 
       if (!text || !sessionId) {
         return false
       }
+
+      // The composer middleware runs BEFORE the optimistic append: a cancel
+      // ('canceled') must leave no bubble behind — nothing was sent — while a
+      // rejection (false) discards the row further down. Same 'canceled' ≠
+      // false split as the main composer's redirect path.
+      const draft = await runComposerMiddleware({ text })
+
+      if (!draft) {
+        return 'canceled'
+      }
+
+      const framedText = draft.text
+      const note = draft.note
+      const mode = draft.mode
 
       const messageId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
@@ -419,7 +434,7 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
         appendMidTurnUserMessage(state, {
           id: messageId,
           role: 'user' as const,
-          parts: [textPart(text)]
+          parts: [textPart(framedText)]
         })
       )
 
@@ -442,7 +457,12 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
         const { result } = await withSessionNotFoundResume(
           sessionId,
           storedIdRef.current,
-          liveId => requestSessionGateway<{ status?: string }>('session.redirect', { session_id: liveId, text }),
+          liveId => requestSessionGateway<{ status?: string }>('session.redirect', {
+            session_id: liveId,
+            text: framedText,
+            ...(note ? { note } : {}),
+            ...(mode ? { mode } : {})
+          }),
           {
             requestGateway: requestSessionGateway,
             onRecovered: bindRecoveredRuntime

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -122,6 +122,9 @@ export function useBackgroundQueueDrain({
           const accepted = await Promise.resolve(
             submitTextRef.current(liveEntry.text, {
               attachments: liveEntry.attachments,
+              // Frozen composer-mode frame (sealed at enqueue) — see runDrain.
+              ...(liveEntry.mode ? { mode: liveEntry.mode } : {}),
+              ...(liveEntry.note ? { note: liveEntry.note } : {}),
               fromQueue: true,
               sessionId: runtimeSessionId,
               storedSessionId: sessionKey

--- a/apps/desktop/src/app/session/hooks/use-message-stream/steer-arrival-order.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/steer-arrival-order.test.tsx
@@ -19,6 +19,7 @@ import { act, cleanup, render } from '@testing-library/react'
 import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ComposerModeFrame } from '@/app/chat/composer/contrib'
 import { usePromptActions } from '@/app/session/hooks/use-prompt-actions'
 import type { ClientSessionState } from '@/app/types'
 import { chatMessageText } from '@/lib/chat-messages'
@@ -32,7 +33,7 @@ import { useMessageStream } from './index'
 const SID = 'steer-order-session'
 
 let handleEvent: ((event: RpcEvent) => void) | null = null
-let redirect: ((text: string) => Promise<boolean>) | null = null
+let redirect: ((text: string, opts?: ComposerModeFrame) => Promise<boolean | 'canceled'>) | null = null
 let states: Map<string, ClientSessionState>
 
 /** The gateway accepts every redirect — these suites pin CLIENT ordering. */

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -3,6 +3,7 @@ import { JsonRpcGatewayError } from '@hermes/shared'
 import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
+import { type ComposerModeFrame, runComposerMiddleware } from '@/app/chat/composer/contrib'
 import { transcribeAudio } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { stripAnsi } from '@/lib/ansi'
@@ -734,7 +735,7 @@ export function usePromptActions({
   // completed work intact. During a tool it waits for the safe result boundary.
   // Returns false when the turn raced to completion so the composer can queue.
   const redirectPrompt = useCallback(
-    async (rawText: string): Promise<boolean> => {
+    async (rawText: string, opts?: ComposerModeFrame): Promise<boolean | 'canceled'> => {
       const text = sanitizeComposerInput(rawText).trim()
       // Ref, not the closure-captured prop — see cancelRun above. A redirect
       // reaches the live model mid-turn, so a stale target delivers the user's
@@ -744,6 +745,27 @@ export function usePromptActions({
       if (!text || !sessionId) {
         return false
       }
+
+      // The composer middleware runs exactly ONCE here — before the RPC and
+      // before the session-not-found retry — so a redirect that races a
+      // reconnect is framed exactly like the retry that finally delivers it
+      // (inside `send` it would fire twice). `null` is a CANCEL, not a
+      // rejection: it returns 'canceled' so the caller restores the draft
+      // instead of queueing raw text the middleware just declined — `false`
+      // keeps its "queue the words" meaning.
+      const draft = await runComposerMiddleware({
+        text,
+        ...(opts?.note ? { note: opts.note } : {}),
+        ...(opts?.mode ? { mode: opts.mode } : {})
+      })
+
+      if (!draft) {
+        return 'canceled'
+      }
+
+      const framedText = draft.text
+      const note = draft.note
+      const mode = draft.mode
 
       // Accepted whether the live turn was redirected in place or queued for
       // the next turn (the build window, before the agent is wired) — either
@@ -756,7 +778,9 @@ export function usePromptActions({
         // gateway, in arrival order: sealed already-streamed output above,
         // correction bubble below it, post-redirect deltas below that
         // (#73793, #83151).
-        const messageId = appendSessionTextMessage(id, 'user', text, undefined, { appendAfterActiveReply: true })
+        const messageId = appendSessionTextMessage(id, 'user', framedText, undefined, {
+          appendAfterActiveReply: true
+        })
 
         const discardOptimisticMessage = () =>
           updateSessionState(id, state => ({
@@ -774,7 +798,12 @@ export function usePromptActions({
           })
 
         try {
-          const result = await requestGateway<SessionRedirectResponse>('session.redirect', { session_id: id, text })
+          const result = await requestGateway<SessionRedirectResponse>('session.redirect', {
+            session_id: id,
+            text: framedText,
+            ...(note ? { note } : {}),
+            ...(mode ? { mode } : {})
+          })
 
           if (result?.status === 'redirected') {
             triggerHaptic('submit')

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -761,6 +761,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           // Off-screen widget intent: the gateway types the persisted user
           // row display_kind=hidden so no client renders it as a bubble.
           ...(options?.displayKind === 'hidden' && { display_kind: 'hidden' }),
+          // Per-turn composer-mode frame: the gateway delivers the note to the
+          // model through the api_content sidecar (content stays the user's
+          // words) and stores the label as display_metadata (display-only).
+          ...(options?.note ? { note: options.note } : {}),
+          ...(options?.mode ? { mode: options.mode } : {}),
           // Typed into the floating HUD, so the user is looking at another app
           // rather than at Hermes. The gateway turns this into a per-turn hint
           // to read the window underneath and work in it.

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -727,6 +727,12 @@ export interface SubmitTextOptions {
    *  model-bound note by the gateway (never persisted, never rendered). */
   voiceContext?: string
   fromQueue?: boolean
+  /** Per-turn composer-mode frame from the middleware chain: the gateway
+   *  delivers `note` to the model through the api_content sidecar (it never
+   *  becomes part of the user's `content`) and persists `mode` as the row's
+   *  display_metadata (display-only; the transcript may badge the message). */
+  note?: string
+  mode?: string
   /** Runtime session id to submit into. Queue drains pass this so a
    *  backgrounded/source session cannot be replaced by the current foreground
    *  session between enqueue and drain. */

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -69,6 +69,27 @@ describe('composer queue store', () => {
     expect(getQueuedPrompts(SESSION_KEY).map(entry => entry.text)).toEqual(['draft two'])
   })
 
+  it('seals the composer-mode frame on the entry and keeps it across edits', () => {
+    const entry = enqueueQueuedPrompt(SESSION_KEY, {
+      attachments: [],
+      text: 'freeze me',
+      mode: 'plan',
+      note: 'PLAN-NOTE'
+    })
+
+    expect(entry).toMatchObject({ mode: 'plan', note: 'PLAN-NOTE' })
+    expect(getQueuedPrompts(SESSION_KEY)[0]).toMatchObject({ mode: 'plan', note: 'PLAN-NOTE' })
+
+    // Rewriting the text must not drop the sealed frame: the entry still
+    // drains with the mode it was queued with.
+    expect(updateQueuedPrompt(SESSION_KEY, entry!.id, { text: 'edited' })).toBe(true)
+    expect(getQueuedPrompts(SESSION_KEY)[0]).toMatchObject({
+      text: 'edited',
+      mode: 'plan',
+      note: 'PLAN-NOTE'
+    })
+  })
+
   it('promotes a queued entry to the front', () => {
     const first = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'first' })
     const second = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'second' })

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -16,6 +16,12 @@ export interface QueuedPromptEntry {
   displayKind?: 'hidden'
   attachments: ComposerAttachment[]
   queuedAt: number
+  /** Composer-mode frame sealed at ENQUEUE time (`note` model framing + the
+   *  display-only `mode` label). Every drain hands the sealed frame back to
+   *  the submit options so a queued send carries the mode it was queued
+   *  WITH — never whatever mode happens to be live when the drain runs. */
+  mode?: string
+  note?: string
 }
 
 /** Whether a queued entry can ride a mid-turn redirect: text-only, non-empty,
@@ -128,7 +134,14 @@ export const getQueuedPrompts = (key: string | null | undefined): QueuedPromptEn
 
 export const enqueueQueuedPrompt = (
   key: string | null | undefined,
-  payload: { text: string; attachments: ComposerAttachment[]; displayText?: string; displayKind?: 'hidden' }
+  payload: {
+    text: string
+    attachments: ComposerAttachment[]
+    displayText?: string
+    displayKind?: 'hidden'
+    mode?: string
+    note?: string
+  }
 ): null | QueuedPromptEntry => {
   const sid = sidOf(key)
 
@@ -141,6 +154,8 @@ export const enqueueQueuedPrompt = (
     text: payload.text,
     ...(payload.displayText ? { displayText: payload.displayText } : {}),
     ...(payload.displayKind ? { displayKind: payload.displayKind } : {}),
+    ...(payload.mode ? { mode: payload.mode } : {}),
+    ...(payload.note ? { note: payload.note } : {}),
     attachments: cloneAttachments(payload.attachments),
     queuedAt: Date.now()
   }

--- a/tests/tui_gateway/test_bot_live_owner_delivery.py
+++ b/tests/tui_gateway/test_bot_live_owner_delivery.py
@@ -31,7 +31,7 @@ def test_refused_input_commits_failed_mailbox_receipt(tmp_path):
         "_current_runtime_session_record": contextvars.ContextVar("refused_turn"),
         "_TurnRun": prompt_turn._TurnRun,
         "_record_turn_marker": lambda *args, **kwargs: "marker",
-        "_prepare_turn_input": lambda *args: None,
+        "_prepare_turn_input": lambda *args, **kwargs: None,
         "_finish_turn": noop, "_clear_inflight_turn": noop,
         "_retire_turn_marker": lambda *args: retired.append(args),
         "_emit_settled_session_info": noop,

--- a/tests/tui_gateway/test_turn_note_frame.py
+++ b/tests/tui_gateway/test_turn_note_frame.py
@@ -6,7 +6,11 @@ pair: the note reaches the model through the per-turn ``api_content`` sidecar
 rides ``display_metadata`` (display-only, popped from every outbound copy).
 Everything below is pure: no gateway, no agent construction.
 """
-from agent.interrupt_control import InterruptControlMixin
+from agent.interrupt_control import (
+    InterruptControlMixin,
+    _ic_queue_correction_note,
+    _ic_take_correction_note
+)
 from agent.prompt_builder import steer_user_row
 from tui_gateway.methods_prompt import parse_turn_note
 from tui_gateway.session_auto_continue import _enqueue_prompt, _sanitize_queued_entry_vs_inflight_user
@@ -44,18 +48,34 @@ def test_correction_frame_is_one_shot_per_slot():
     agent = _CorrectionAgent()
     assert agent.steer("fix the bug", note="MODE: plan", mode="plan") is True
     assert agent._pending_steer.endswith("fix the bug")
-    assert agent._take_correction_note("_pending_steer") == ("MODE: plan", "plan")
+    assert _ic_take_correction_note(agent, "_pending_steer") == ("MODE: plan", "plan")
     # Consumed: a later delivery must never inherit a stale frame.
-    assert agent._take_correction_note("_pending_steer") == ("", "")
+    assert _ic_take_correction_note(agent, "_pending_steer") == ("", "")
     assert agent.steer("plain") is True
-    assert agent._take_correction_note("_pending_steer") == ("", "")
+    assert _ic_take_correction_note(agent, "_pending_steer") == ("", "")
+
+
+def test_frame_helpers_never_break_init_less_stubs():
+    """Same contract as ``_ic_lock``/``_ic_slot``: a bare stub has no lock and no attributes."""
+
+    class _Bare:
+        pass
+
+    agent = _Bare()
+    _ic_queue_correction_note(agent, "_pending_steer", "MODE: plan", "plan")
+    assert agent._pending_steer_note == "MODE: plan"
+    assert _ic_take_correction_note(agent, "_pending_steer") == ("MODE: plan", "plan")
+    # An empty frame on a stub is a no-op, not an AttributeError.
+    _ic_queue_correction_note(agent, "_pending_steer", "", "")
+    assert _ic_take_correction_note(agent, "_pending_steer") == ("", "")
+    assert InterruptControlMixin.steer(agent, "a") is True
 
 
 def test_frames_concatenate_and_the_mode_label_is_last_wins():
     agent = _CorrectionAgent()
-    agent._queue_correction_note("_pending_redirect", "first", "plan")
-    agent._queue_correction_note("_pending_redirect", "second", "debug")
-    assert agent._take_correction_note("_pending_redirect") == ("first\n\nsecond", "debug")
+    _ic_queue_correction_note(agent, "_pending_redirect", "first", "plan")
+    _ic_queue_correction_note(agent, "_pending_redirect", "second", "debug")
+    assert _ic_take_correction_note(agent, "_pending_redirect") == ("first\n\nsecond", "debug")
 
 
 def test_a_framed_queued_prompt_never_merges_into_a_plain_slot():

--- a/tests/tui_gateway/test_turn_note_frame.py
+++ b/tests/tui_gateway/test_turn_note_frame.py
@@ -1,0 +1,83 @@
+"""Contract tests for the optional per-turn composer-mode frame (``note``/``mode``).
+
+The frame rides ``prompt.submit`` and the steer/redirect RPCs as an OPTIONAL
+pair: the note reaches the model through the per-turn ``api_content`` sidecar
+(the user's own ``content`` is never polluted) and the opaque ``mode`` label
+rides ``display_metadata`` (display-only, popped from every outbound copy).
+Everything below is pure: no gateway, no agent construction.
+"""
+from agent.interrupt_control import InterruptControlMixin
+from agent.prompt_builder import steer_user_row
+from tui_gateway.methods_prompt import parse_turn_note
+from tui_gateway.session_auto_continue import _enqueue_prompt, _sanitize_queued_entry_vs_inflight_user
+
+
+class _CorrectionAgent(InterruptControlMixin):
+    """__init__-less stub: the mixin's lock helpers fall back to unlocked slots."""
+
+    def __init__(self):
+        self._pending_steer = None
+        self._pending_redirect = None
+
+
+def test_parse_turn_note_sanitizes_and_caps():
+    assert parse_turn_note({"note": "  keep it short  ", "mode": " plan "}) == ("keep it short", "plan")
+    assert parse_turn_note({"note": 123, "mode": None}) == ("", "")
+    assert parse_turn_note({"note": "x" * 9000})[0] == "x" * 8192
+    assert parse_turn_note({"mode": "m" * 64})[1] == "m" * 32
+
+
+def test_steer_row_keeps_the_users_words_clean():
+    row = steer_user_row("hello", note="MODE: plan", mode="plan")
+    # The note never leaks into the transcript bytes...
+    assert "MODE: plan" not in row["content"]
+    assert row["content"].strip().endswith("[/OUT-OF-BAND USER MESSAGE]")
+    # ...it rides the API-side bytes, and the label stays display-only.
+    assert row["api_content"].startswith("MODE: plan")
+    assert row["display_metadata"] == {"mode": "plan"}
+    # A frame-less steer keeps the exact pre-existing row shape.
+    plain = steer_user_row("hello")
+    assert "api_content" not in plain and "display_metadata" not in plain
+
+
+def test_correction_frame_is_one_shot_per_slot():
+    agent = _CorrectionAgent()
+    assert agent.steer("fix the bug", note="MODE: plan", mode="plan") is True
+    assert agent._pending_steer.endswith("fix the bug")
+    assert agent._take_correction_note("_pending_steer") == ("MODE: plan", "plan")
+    # Consumed: a later delivery must never inherit a stale frame.
+    assert agent._take_correction_note("_pending_steer") == ("", "")
+    assert agent.steer("plain") is True
+    assert agent._take_correction_note("_pending_steer") == ("", "")
+
+
+def test_frames_concatenate_and_the_mode_label_is_last_wins():
+    agent = _CorrectionAgent()
+    agent._queue_correction_note("_pending_redirect", "first", "plan")
+    agent._queue_correction_note("_pending_redirect", "second", "debug")
+    assert agent._take_correction_note("_pending_redirect") == ("first\n\nsecond", "debug")
+
+
+def test_a_framed_queued_prompt_never_merges_into_a_plain_slot():
+    session: dict = {}
+    _enqueue_prompt(session, "first", None)
+    _enqueue_prompt(session, "second", None, turn_note="MODE: plan", turn_mode="plan")
+    # The framed arrival did NOT merge into the plain slot (its frame would die there).
+    assert session["queued_prompt"]["text"] == "first"
+    assert session["queued_prompts"][-1]["note"] == "MODE: plan"
+    assert session["queued_prompts"][-1]["mode"] == "plan"
+
+
+def test_a_plain_arrival_never_merges_into_a_framed_slot():
+    session: dict = {}
+    _enqueue_prompt(session, "framed", None, turn_note="MODE: plan", turn_mode="plan")
+    _enqueue_prompt(session, "plain", None)
+    assert session["queued_prompt"]["text"] == "framed"
+    assert session["queued_prompt"]["note"] == "MODE: plan"
+    assert session["queued_prompts"][-1]["text"] == "plain"
+
+
+def test_sanitize_keeps_a_framed_entry():
+    entry = {"text": "x", "note": "MODE: plan", "mode": "plan"}
+    # Same text as the live prompt, but framed: it survives instead of being dropped.
+    assert _sanitize_queued_entry_vs_inflight_user(entry, "x") == entry

--- a/tui_gateway/AGENTS.md
+++ b/tui_gateway/AGENTS.md
@@ -39,6 +39,20 @@ existing topical sibling, registered in the table — no `if method == ...` chai
 | Theming | `theme.ts` + `branding.tsx` | `gateway.ready` carries skin data |
 | Plugin compat notice | — | `plugins.compat_report` (see `plugins/AGENTS.md`) |
 
+## Per-turn composer-mode frame (`note` / `mode`)
+
+`prompt.submit` and the `session.steer` / `session.redirect` RPCs accept an
+OPTIONAL pair parsed by `parse_turn_note`: `note` (sanitized + capped, model
+instructions for THIS send) and `mode` (opaque, display-only label). The note is
+prepended to the run message at turn assembly (`_prepare_turn_input`) and to the
+delivered correction's `api_content`, so the persisted/displayed `content` stays
+the user's own words; `mode` rides `display_metadata` (popped from every
+outbound copy — never on the wire). A queued arrival keeps its frame in its OWN
+envelope (never merged into a plain slot), and the compute-host turn frame
+carries the same keys. Corrections carry the frame in the agent's pending
+slot (`_pending_steer*` / `_pending_redirect*`) and consume it one-shot at the
+delivery site.
+
 ## Shared subagent snapshots
 
 `subagent.list({session_id})` returns `{subagents, delegations}` for the calling

--- a/tui_gateway/AGENTS.md
+++ b/tui_gateway/AGENTS.md
@@ -53,6 +53,14 @@ carries the same keys. Corrections carry the frame in the agent's pending
 slot (`_pending_steer*` / `_pending_redirect*`) and consume it one-shot at the
 delivery site.
 
+ASK-mode notes are SANDWICHED for primacy+recency: besides the leading copy from
+`_prepare_turn_input`, the same note is parked in the one-shot slot
+(`agent._gateway_turn_context_notes`) gated on the `[mode:ask]` head, so
+`_merge_gateway_notes` appends it too — `api_content = note + text + note`.
+Ask-only: plan/debug keep their single leading copy. Session auto-titles prefer
+`agent._persist_user_message_override` (str or multimodal list) over the live
+message content, so API-only scaffolding never leaks into a session title.
+
 ## Shared subagent snapshots
 
 `subagent.list({session_id})` returns `{subagents, delegations}` for the calling

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -234,7 +234,8 @@ class ComputeHost:
             with contextlib.suppress(Exception):
                 server._persist_branch_seed(session)
             server._run_prompt_submit(
-                request_id, sid, session, text, display_kind=frame.get("display_kind") or None)
+                request_id, sid, session, text, display_kind=frame.get("display_kind") or None,
+                turn_note=str(frame.get("note") or ""), turn_mode=str(frame.get("mode") or ""))
             run_thread = session.get("_run_thread")
             if run_thread is not None and hasattr(run_thread, "join"):
                 while run_thread.is_alive():

--- a/tui_gateway/compute_host_bridge.py
+++ b/tui_gateway/compute_host_bridge.py
@@ -49,7 +49,8 @@ def _get_compute_host_supervisor(cfg: dict | None = None):
 
 def _compute_host_turn_frame(
     rid: str, sid: str, session: dict, text: Any, image_paths: list[str] | None = None,
-    queued_prompt_generation: int | None = None, display_kind: str | None = None) -> dict:
+    queued_prompt_generation: int | None = None, display_kind: str | None = None,
+    turn_note: str = "", turn_mode: str = "") -> dict:
     with session["history_lock"]:
         history = list(session.get("history", []))
         history_version = int(session.get("history_version", 0))
@@ -57,7 +58,9 @@ def _compute_host_turn_frame(
     return {
         "type": "turn.start", "sid": sid, "request_id": rid,
         "session_key": session.get("session_key") or sid, "text": text,
-        **({"display_kind": display_kind} if display_kind else {}), "history": history,
+        **({"display_kind": display_kind} if display_kind else {}),
+        **({"note": turn_note} if turn_note else {}), **({"mode": turn_mode} if turn_mode else {}),
+        "history": history,
         "history_version": history_version, "cols": int(session.get("cols", 80) or 80),
         "cwd": _session_cwd(session),
         "context_cwd_is_launch_artifact": _context_cwd_is_launch_artifact(session),
@@ -212,11 +215,13 @@ def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -
 
 def _submit_prompt_to_compute_host(
     rid: str, sid: str, session: dict, text: Any, image_paths: list[str] | None = None,
-    queued_prompt_generation: int | None = None, display_kind: str | None = None) -> dict:
+    queued_prompt_generation: int | None = None, display_kind: str | None = None,
+    turn_note: str = "", turn_mode: str = "") -> dict:
     cfg = _load_dashboard_process_isolation_config()
     frame = _compute_host_turn_frame(rid, sid, session, text, image_paths=image_paths,
                                      queued_prompt_generation=queued_prompt_generation,
-                                     display_kind=display_kind)
+                                     display_kind=display_kind,
+                                     turn_note=turn_note, turn_mode=turn_mode)
     # Caller JSON-RPC ids may repeat across sockets and turns. Use an opaque
     # dispatch lifetime token, installed before a fast child can send activity.
     turn_id = frame["turn_id"] = frame["request_id"] = uuid.uuid4().hex

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -471,7 +471,8 @@ def _persist_session_row_for_submit(rid, session):
     return error
 
 
-def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_terminal_callback, turn_author=None):
+def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_terminal_callback, turn_author=None,
+                           turn_note="", turn_mode=""):
     """Turn thread body: patient wait for a deferred build (a slow build must not eat the
     accepted in-flight message), then run."""
     # The wait delivers the prompt when the still-running build completes, honors a cancel promptly, notices
@@ -501,8 +502,29 @@ def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_termina
             return
     _run_prompt_submit(
         rid, sid, session, text, display_kind=display_kind,
-        terminal_callback=hosted_terminal_callback, turn_author=turn_author)
+        terminal_callback=hosted_terminal_callback, turn_author=turn_author,
+        turn_note=turn_note, turn_mode=turn_mode)
 
+
+# Bounds for the optional per-turn model note (`prompt.submit`/`session.redirect` `note`) and
+# its display-only `mode` label. A note is advisory text, never user content: oversized notes
+# are truncated here rather than refused, and the label is an opaque short tag.
+_TURN_NOTE_MAX_CHARS = 8192
+_TURN_MODE_MAX_CHARS = 32
+
+
+def parse_turn_note(params: dict) -> "tuple[str, str]":
+    """``(note, mode)`` from RPC params — the shared contract for ``prompt.submit`` and the
+    steer/redirect RPCs: the note is sanitized + capped, the mode is an opaque display-only
+    label truncated to a badge-sized token. Empty strings mean "none"."""
+    from hermes_cli.input_sanitize import sanitize_user_prompt_text
+    raw_note = params.get("note")
+    note = sanitize_user_prompt_text(raw_note).strip() if isinstance(raw_note, str) else ""
+    if note and len(note) > _TURN_NOTE_MAX_CHARS:
+        note = note[:_TURN_NOTE_MAX_CHARS]
+    raw_mode = params.get("mode")
+    mode = raw_mode.strip()[:_TURN_MODE_MAX_CHARS] if isinstance(raw_mode, str) else ""
+    return note, mode
 
 _TRUNCATION_PARAMS = (
     "truncate_before_user_ordinal", "truncate_before_row_id", "truncate_before_message_id")
@@ -550,6 +572,12 @@ def _(rid, params: dict) -> dict:
     # Off-screen sends (widget intents) type the row so no client renders a bubble;
     # whitelisted to "hidden" — this RPC must not mint kinds.
     display_kind = "hidden" if params.get("display_kind") == "hidden" else None
+    # Client-authored PER-TURN model note (composer modes): an instruction that must reach the
+    # model without being typed into the user's own row. Sanitized + capped (parse_turn_note);
+    # delivered one-shot through the per-turn api_content sidecar, so `content` stays the
+    # user's words. `mode` is an OPAQUE display-only label (never sent to the wire) kept on the
+    # row's display_metadata so a client can badge the message it sent — display-only, never policy.
+    turn_note, turn_mode = parse_turn_note(params)
     if (stopped := _typed_stop_phrase_response(rid, text)) is not None:
         return stopped
     if params.get("interrupted"):
@@ -615,7 +643,8 @@ def _(rid, params: dict) -> dict:
                 return _err(rid, 4091, "hosted room member session is busy")
             busy_transport = t or session.get("transport")
         busy_response = _handle_busy_submit(
-            rid, sid, session, text, busy_transport, queued=bool(params.get("queued")), turn_author=turn_author)
+            rid, sid, session, text, busy_transport, queued=bool(params.get("queued")), turn_author=turn_author,
+            turn_note=turn_note, turn_mode=turn_mode)
         if busy_response is not None:
             return busy_response
     raw_rebind_ids = params.get("rebind_survivor_row_ids")
@@ -631,7 +660,8 @@ def _(rid, params: dict) -> dict:
             logger.debug("isolated compute turns carry no author yet; the turn from %s runs unattributed",
                          turn_author.get("id"))
         isolated_response = _submit_prompt_to_compute_host(
-            rid, sid, session, text, display_kind=display_kind)
+            rid, sid, session, text, display_kind=display_kind,
+            turn_note=turn_note, turn_mode=turn_mode)
         if not isolated_response.get("error"):
             # The truncation already happened inline above (memory + DB).
             isolated_response["result"].update(survivor_fields)
@@ -654,7 +684,8 @@ def _(rid, params: dict) -> dict:
         _start_agent_build(sid, session)
     run_thread = threading.Thread(
         target=lambda: _run_after_agent_ready(
-            rid, sid, session, text, display_kind, hosted_terminal_callback, turn_author),
+            rid, sid, session, text, display_kind, hosted_terminal_callback, turn_author,
+            turn_note, turn_mode),
         daemon=True)
     # Handle lets session.interrupt tell a live turn from a stuck `running` flag.
     session["_run_thread"] = run_thread

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2015,11 +2015,19 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"status": "interrupted"})
 
 
-def _apply_correction(rid, session: dict, verb: str, text: str, accepted_status: str) -> dict:
+def _apply_correction(rid, session: dict, verb: str, text: str, accepted_status: str,
+                      turn_note: str = "", turn_mode: str = "") -> dict:
     """``agent.<verb>(text)``; on acceptance record it on the live turn (mid-turn resume rebuilds the bubble)
-    and purge queued self-copies so post-turn drain cannot re-fire the old prompt."""
+    and purge queued self-copies so post-turn drain cannot re-fire the old prompt. The optional per-turn
+    note/mode ride the correction: the model reads the note from the delivered row's api_content sidecar,
+    the client badges its display_metadata."""
+    _extra: dict = {}
+    if turn_note:
+        _extra["note"] = turn_note
+    if turn_mode:
+        _extra["mode"] = turn_mode
     try:
-        accepted = getattr(session["agent"], verb)(text)
+        accepted = getattr(session["agent"], verb)(text, **_extra)
     except Exception as exc:
         return _err(rid, 5000, f"{verb} failed: {exc}")
     if accepted:
@@ -2036,7 +2044,8 @@ def _apply_correction(rid, session: dict, verb: str, text: str, accepted_status:
 
 def _correction_method(name: str, verb: str, accepted_status: str, supported, unsupported: str):
     """steer/redirect RPC: ``params.text`` (4002, checked before the session) into a live session;
-    ``supported(agent)`` gates 4010."""
+    ``supported(agent)`` gates 4010. ``params.note``/``params.mode`` (same sanitize+cap contract as
+    ``prompt.submit``: per-turn model note + display-only label) ride the correction."""
     @method(name)
     def _(rid, params: dict) -> dict:
         if not (text := (params.get("text") or "").strip()):
@@ -2044,16 +2053,19 @@ def _correction_method(name: str, verb: str, accepted_status: str, supported, un
         session, err = _sess_nowait(params, rid)
         if err:
             return err
+        turn_note, turn_mode = parse_turn_note(params)
         agent = session.get("agent")
         # Redirect during the turn-build window (running=True, agent None): queue for the next turn instead of
         # a misleading 4010 the client swallows into a lost follow-up.
         if verb == "redirect" and agent is None and session.get("running"):
-            _enqueue_prompt(session, text, current_transport() or _stdio_transport)
+            _enqueue_prompt(session, text, current_transport() or _stdio_transport,
+                            turn_note=turn_note, turn_mode=turn_mode)
             session["last_active"] = time.time()
             return _ok(rid, {"status": "queued", "text": text})
         if not supported(agent):
             return _err(rid, 4010, unsupported)
-        return _apply_correction(rid, session, verb, text, accepted_status)
+        return _apply_correction(rid, session, verb, text, accepted_status,
+                                 turn_note=turn_note, turn_mode=turn_mode)
 
 
 # Inject text into the next tool result without interrupting (AIAgent.steer(): no new user turn, no role

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -842,6 +842,12 @@ def _run_prompt_submit(
                     st.receipt_committed = True
                 return
             prompt, run_message, cols, streamer = prepared
+            # Sandwich ask (primacy+recency): the SAME note also TRAILS the sent
+            # bytes — the one-shot slot is appended by _merge_gateway_notes while
+            # the prepend above leads them. Ask-only; plan/debug keep their single
+            # leading copy.
+            if turn_note and turn_note.lstrip().startswith("[mode:ask]"):
+                agent._gateway_turn_context_notes = turn_note
             _invoke_agent(
                 sid, session, st, prompt, run_message, streamer, images, display_kind,
                 display_metadata, turn_author)

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -432,7 +432,8 @@ class _TurnRun:
     receipt_attempted: bool = False
 
 
-def _prepare_turn_input(sid: str, session: dict, st: _TurnRun, text: Any, images: list[str]):
+def _prepare_turn_input(sid: str, session: dict, st: _TurnRun, text: Any, images: list[str],
+                        turn_note: str = ""):
     """Bind scopes, sync the agent, snapshot history, build the run message; returns
     ``(prompt, run_message, cols, streamer)`` or None when @-expansion was refused.
     Scopes fill field by field so a failure midway still leaves every bound token for the
@@ -505,7 +506,10 @@ def _prepare_turn_input(sid: str, session: dict, st: _TurnRun, text: Any, images
     if take_speech_interrupted():
         run_message = _prepend_note(run_message, SPEECH_INTERRUPTED_NOTE)
     run_message = _prepend_note(run_message, _pending_reaction_notes(session))
-    return prompt, _prepend_note(run_message, _hud_surface_note(session)), cols, streamer
+    run_message = _prepend_note(run_message, _hud_surface_note(session))
+    # Per-turn mode note (composer mode framing, client-authored): model-only, exactly like the
+    # notes above — the user's own text and the durable transcript stay untouched.
+    return prompt, _prepend_note(run_message, turn_note), cols, streamer
 
 
 def _invoke_agent(
@@ -544,7 +548,7 @@ def _invoke_agent(
         run_params = {}
     if "task_id" in run_params:
         run_kwargs["task_id"] = session["session_key"]
-    if display_kind and "persist_user_display_kind" in run_params:
+    if (display_kind or display_metadata) and "persist_user_display_kind" in run_params:
         run_kwargs["persist_user_display_kind"] = display_kind
         run_kwargs["persist_user_display_metadata"] = display_metadata
     if turn_author and "turn_author" in run_params:
@@ -793,11 +797,15 @@ def _run_prompt_submit(
     display_metadata: dict | None = None, image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
     terminal_callback: Callable[[dict[str, Any]], None] | None = None,
-    turn_author: dict | None = None) -> bool:
+    turn_author: dict | None = None, turn_note: str = "", turn_mode: str = "") -> bool:
     admitted = _admit_prompt_turn(sid, session, text, image_paths, queued_prompt_generation)
     if admitted is None:
         return False
     images, agent = admitted
+    if turn_mode:
+        # Display-only label from the sending client (composer mode). It never reaches the
+        # wire: build_api_messages pops display_metadata from every outbound copy.
+        display_metadata = {**(display_metadata or {}), "mode": turn_mode}
     # The ONE INFO record proving a prompt was accepted by THIS process; ties ui sid,
     # session_key and the agent's live session_id together.  No prompt content is logged.
     _turn_started_monotonic = time.monotonic()
@@ -825,7 +833,7 @@ def _run_prompt_submit(
         st.marker_key = _record_turn_marker(session, text, auto_continue=terminal_callback is None)
         goal_followup = None
         try:
-            prepared = _prepare_turn_input(sid, session, st, text, images)
+            prepared = _prepare_turn_input(sid, session, st, text, images, turn_note=turn_note)
             if prepared is None:
                 if st.terminal_callback is not None and not st.receipt_attempted:
                     st.receipt_attempted = True

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -126,11 +126,12 @@ def _ac_inflight_original(session: dict) -> str:
 
 
 def _enqueue_prompt(session: dict, text: Any, transport: Any, image_paths: list[str] | None = None,
-                    turn_author: dict | None = None) -> None:
+                    turn_author: dict | None = None, turn_note: str = "", turn_mode: str = "") -> None:
     """Queue a message for the next turn. Text-only arrivals share a slot and merge losslessly (like the
     consecutive-user merge in ``repair_message_sequence``); image-bearing and authored ones stay separate
     envelopes so attachment chronology and the sender survive. ``transport`` is pinned so the drained turn
-    streams to its sender."""
+    streams to its sender. A per-turn ``note``/``mode`` (composer mode framing) rides its OWN envelope: a
+    note must never merge into a plain slot (`content` is the user's words) nor be dropped in the merge."""
     image_paths = list(image_paths or [])
     # Scrub live-turn self-duplicates first so the text merge below can't glue "{original}\n\n{later}" and re-fire the
     # original after a correction settles.
@@ -141,10 +142,13 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any, image_paths: list[
     if text_only and not turn_author and text.strip() == _ac_inflight_original(session) != "":
         return
     queued = {"text": text, "transport": transport, **({"image_paths": image_paths} if image_paths else {}),
-              **({"turn_author": turn_author} if turn_author else {})}
+              **({"turn_author": turn_author} if turn_author else {}),
+              **({"note": turn_note} if turn_note else {}), **({"mode": turn_mode} if turn_mode else {})}
     existing = session.get("queued_prompt")
-    if (existing and text_only and not turn_author and isinstance(existing.get("text"), str)
+    if (existing and text_only and not turn_author and not turn_note and not turn_mode
+            and isinstance(existing.get("text"), str)
             and not existing.get("image_paths") and not existing.get("turn_author")
+            and not existing.get("note") and not existing.get("mode")
             and not session.get("queued_prompts")):
         prev = existing["text"]
         existing["text"] = f"{prev}\n\n{text}" if prev and text else (prev or text)
@@ -166,7 +170,8 @@ def _sanitize_queued_entry_vs_inflight_user(entry: Any, original: str) -> dict |
     if not isinstance(entry, dict):
         return None
     text = entry.get("text")
-    if not original or entry.get("image_paths") or entry.get("turn_author") or not isinstance(text, str):
+    if not original or entry.get("image_paths") or entry.get("turn_author") or entry.get("note") \
+            or entry.get("mode") or not isinstance(text, str):
         return entry
     # A lossless text-merge may have glued the live original onto a later follow-up: keep the remainder.
     rest = next((text[len(original + sep):] for sep in ("\n\n", "\n") if text.startswith(original + sep)), text).strip()
@@ -221,12 +226,19 @@ def _interrupt_busy_session(sid: str, session: dict, agent: Any) -> None:
     threading.Thread(target=interrupt, daemon=True, name=f"busy-interrupt-{sid}").start()
 
 
-def _ac_try_correction(rid, session: dict, agent: Any, method: str, plain_text: str, status: str) -> dict | None:
+def _ac_try_correction(rid, session: dict, agent: Any, method: str, plain_text: str, status: str,
+                       turn_note: str = "", turn_mode: str = "") -> dict | None:
     """Apply ``agent.<method>(plain_text)`` (steer/redirect); on acceptance record the correction, scrub stale
     self-duplicates so the live turn's original text is not re-fired after settle, and return the ``status`` reply.
-    None → caller falls through to the queue path."""
+    None → caller falls through to the queue path. The per-turn ``note``/``mode`` ride the correction itself:
+    the runtime stamps the note into the correction row's ``api_content`` and the label into display_metadata."""
+    extra: dict = {}
+    if turn_note:
+        extra["note"] = turn_note
+    if turn_mode:
+        extra["mode"] = turn_mode
     try:
-        if not getattr(agent, method)(plain_text):
+        if not getattr(agent, method)(plain_text, **extra):
             return None
     except Exception:
         return None
@@ -238,7 +250,7 @@ def _ac_try_correction(rid, session: dict, agent: Any, method: str, plain_text: 
 
 
 def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any, queued: bool = False,
-                        turn_author: dict | None = None) -> dict | None:
+                        turn_author: dict | None = None, turn_note: str = "", turn_mode: str = "") -> dict | None:
     """Apply ``display.busy_input_mode`` to a mid-turn prompt instead of rejecting it (rejection made clients busy-retry
     and drop sends): ``interrupt`` (default) → redirect, falling back to hard interrupt + queue; ``queue`` → queue only;
     ``steer`` → inject after the current atomic action. ``queued=True`` (client queue drain) forces queue mode: a "run
@@ -260,7 +272,8 @@ def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any,
             "interrupt": getattr(agent, "_supports_active_turn_redirect", False) is True and hasattr(agent, "redirect")}
         method, status = {"steer": ("steer", "steered"), "interrupt": ("redirect", "redirected")}.get(mode, (None, None))
         if (method and supported[mode]
-                and (resp := _ac_try_correction(rid, session, agent, method, plain_text, status)) is not None):
+                and (resp := _ac_try_correction(rid, session, agent, method, plain_text, status,
+                                                turn_note=turn_note, turn_mode=turn_mode)) is not None):
             return resp
     # Queue before asking the live turn to stop. Never call a provider/compute-host method under history_lock: an
     # interrupt can wait behind the op it cancels.
@@ -269,7 +282,8 @@ def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any,
             if image_paths:
                 session["attached_images"] = image_paths + list(session.get("attached_images", []))
             return None
-        _enqueue_prompt(session, text, transport, image_paths=image_paths, turn_author=turn_author)
+        _enqueue_prompt(session, text, transport, image_paths=image_paths, turn_author=turn_author,
+                        turn_note=turn_note, turn_mode=turn_mode)
         session["last_active"] = time.time()
     # Attachments need their own model invocation: queue without cancelling so the user gets both results in order.
     # ``steer`` must NEVER escalate to a hard interrupt: it would kill the live turn AND drop ``AIAgent._pending_steer``
@@ -312,6 +326,10 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     kwargs: dict = {"queued_prompt_generation": queue_generation}
     if queued.get("image_paths"):
         kwargs["image_paths"] = queued["image_paths"]
+    if queued.get("note"):
+        kwargs["turn_note"] = queued["note"]
+    if queued.get("mode"):
+        kwargs["turn_mode"] = queued["mode"]
     # The compute-host frame has no author field, so only the inline runner receives it.
     author_kwargs = {"turn_author": queued["turn_author"]} if queued.get("turn_author") else {}
     dispatch_failed = False


### PR DESCRIPTION
## What does this PR do?

Adds an optional **per-turn frame** (`note` + `mode`) to the turn RPCs, so a client can frame ONE send — a Cursor-style composer mode, an internal note, a surface hint — without typing it into the user's message:

- `note` (sanitized + capped via `parse_turn_note`) is a model instruction for THIS send. It is delivered through the per-turn `api_content` sidecar — the same channel the existing per-turn notes use (`/steer` markers, speech-interrupted, hud surface) — so the durable `content` and every bubble keep the user's own words.
- `mode` is an opaque, display-only label stored in the row's `display_metadata` (popped from every outbound copy). It never reaches the wire and is never policy.

Why the core: only the backend knows which model/provider serves a turn, and a mid-turn steer never runs a client's composer middleware — so a plugin can only fake this by rewriting the draft (the note then lives in the transcript forever) or silently losing the mode on every steer.

Fixes #108241

## Related work

Adjacent, still-open PRs on the same surfaces — cross-linked, no overlap:

- #96081 — persist `display_metadata` for every user message, derived from source
- #97523 — surface `display_metadata` in `session_search` output
- #69735 — drop the stale `api_content` sidecar when merging consecutive assistants
- #74350 — stop the personality marker from swallowing the next real prompt

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

**Gateway (`tui_gateway/`)**
- `methods_prompt.py` — `parse_turn_note(params)` + `prompt.submit` threads `turn_note`/`turn_mode` through `_run_after_agent_ready`, the busy path, and the compute-host dispatch.
- `prompt_turn.py` — `_run_prompt_submit` merges `mode` into display_metadata and prepends `note` to the run message in `_prepare_turn_input` (a mode-only turn still persists display_metadata).
- `session_auto_continue.py` — `_handle_busy_submit` / `_ac_try_correction` / `_enqueue_prompt` carry the frame; a framed arrival keeps its OWN queue envelope (never merged into a plain slot) and survives `_sanitize_queued_entry_vs_inflight_user`; the drain hands it back to the turn.
- `methods_session.py` — `session.steer` / `session.redirect` parse the frame and pass it to the agent (only when present, so agents without the kwargs keep working).
- `compute_host_bridge.py` / `compute_host.py` — the isolated-turn frame carries `note`/`mode`.

**Agent (`agent/`)**
- `interrupt_control.py` — `steer()` / `redirect()` accept `note`/`mode`, queue them beside their pending slot (`_queue_correction_note`, notes concatenate, label last-wins) and expose a one-shot `_take_correction_note`; interrupt/clear paths drop the frame with their slot.
- `prompt_builder.py` (`steer_user_row`) — note → `api_content`, label → `display_metadata`.
- `conversation_loop.py` (`_apply_active_turn_redirect`) — note prepended to the correction's `api_content`, label carried on the row.
- `agent_runtime_helpers.py` / `turn_finalizer.py` — the steer delivery takes the frame one-shot; a requeued or leftover steer keeps/drops it explicitly, so a stale frame can never attach to a later correction.

**Desktop (`apps/desktop/src/`)**
- `composer/contrib.ts` + `composer/index.tsx` — `ComposerModeFrame` / `ComposerDraft.note|mode`, forwarded into `SubmitTextOptions` → `prompt.submit {note, mode}`.
- `use-prompt-actions/index.ts` (`redirectPrompt`) — runs `runComposerMiddleware` exactly ONCE, before the RPC and before the session-not-found retry; returns `'canceled'` for a cancel (never confused with a rejection, which keeps queueing the words).
- `session-tile-actions.ts` (`steerPrompt`) — same, BEFORE the optimistic append so a cancel leaves no bubble behind.
- `use-composer-submit.ts` (`steerDraft`) — `'canceled'` restores the draft (`loadIntoComposer`) and queues nothing; `use-composer-queue.ts` (`steerQueuedNow`) consumes a queued entry only on a delivered redirect (`accepted === true`) — `'canceled'` is a truthy string, so the old truthiness test silently ate the queued words.
- `store/composer-queue.ts` + `use-composer-queue.ts` — a queued entry OWNS its frame: `queueCurrentDraft` runs the chain once at enqueue and seals `{mode, note}` onto the `QueuedPromptEntry`; the foreground drain, the background drain, and `steerQueuedNow` hand the sealed frame back as submit options with `fromQueue`, and the wrapper passes `note`/`mode`/`fromQueue` INTO the chain so the middleware hands the frame back untouched. Changing modes while entries are still queued no longer restamps every drain with the live mode (nor erases a queued Plan/Ask/Debug frame on an Agent switch).
- `composer/queue-frame.ts` (`sealQueuedFrame`) + the enqueue paths — every requeue path seals: a steer rejected mid-turn (reconnect / settle race) used to requeue raw text (`use-composer-submit` fallback) — a frameless entry whose drain arrived note-less (observed live during a backend recycle). The chain runs once per seal; a cancel yields an empty frame — queueing never loses the words over a frame lookup.

**Docs** — `apps/desktop/AGENTS.md`, `tui_gateway/AGENTS.md`.

## Reference client compatibility (`composer-modes` v12.1, verified)

The local plugin that motivated the frame now SHIPS the frame (its v10.10–v12 line,
independent of this change):

- its `composer.middleware` derives `{mode, note}` per send — every send carries its
  own frame (Agent = no note, by design) and a queued drain passes the sealed entry
  frame through untouched (`fromQueue` short-circuits re-derivation). The wrapper and
  queue plumbing added here are what make that pass-through possible;
- its direct `prompt.submit {session_id, text, display_kind}` (the plan-approve path)
  keeps working — the frame params are optional and only sent when present;
- mid-turn steers now run the middleware chain (its v9 header documented the opposite
  as a known limit — the simple Enter during a live turn went straight to
  `session.redirect`, bypassing the chain). The mode now rides the steer instead of
  being dropped;
- live-verified on the author's desktop client: a message queued in Ask and drained
  after switching the plugin to Agent kept `content` = the user's words while
  `api_content` carried the Ask note (the frame frozen at enqueue), and the 4-mode
  matrix (ask/plan/debug framed, agent clean) landed as designed;
- the earlier migration path is DONE: the client emits `{text, note, mode}`, the
  transcript keeps the user's words, and the label lands in `display_metadata`;
- v12.1 adds the STRICT ASK shield: the ask note is a full read-only contract
  (allowed/forbidden lists + a mandatory Spanish closing sentence on actionable
  requests) and rides BOTH ends of the send — `api_content = note + text + note`,
  ask-only (the sandwich this PR implements). A rejected steer's requeue seals its
  frame too (`sealQueuedFrame`), closing the one frameless path a live
  backend-recycle repro exposed;
- session titles come from the pristine user text (`agent._persist_user_message_override`
  first), so API-only scaffolding — ask sandwich included — never becomes a sidebar title.

## How to Test

1. `python -m pytest tests/tui_gateway/test_turn_note_frame.py -q` → **7 passed** (new contract suite; its 6 behaviour tests fail on the pre-fix tree).
2. `python -m pytest tests/run_agent/test_steer.py tests/test_tui_gateway_queue_on_busy.py tests/agent/test_api_content_sidecar.py tests/agent/test_gateway_turn_sidecar.py tests/agent/test_compression_busy_steer_anchor.py -q` → **111 passed**.
3. `cd apps/desktop && npx vitest run --project ui src/store/composer-queue.test.ts src/app/chat/composer/hooks/use-composer-queue.test.tsx src/app/chat/composer/hooks/use-composer-submit.test.tsx src/app/chat/composer/contrib.test.ts src/app/chat/session-tile-actions.test.ts src/app/session/hooks/use-prompt-actions/index.test.tsx src/app/session/hooks/use-message-stream/steer-arrival-order.test.tsx` → **216 passed** (the cancel-semantics cases, the queued-frame seal/drain cases, and the steer-fallback seal fail with the old logic). The gateway contract suite stays green with the ask sandwich added: `bash scripts/run_tests.sh tests/tui_gateway/test_turn_note_frame.py` → **8 passed**.
4. `npx tsc -p apps/desktop/tsconfig.json --noEmit` → clean; `ruff check` on the touched Python files → clean; `eslint` on the touched TS files → clean.
5. Manual (needs a client that sends the frame): send a message in a mode and check the persisted row keeps the clean `content` (no note text); then type mid-turn (steer) in a mode and check the correction row carries the note in `api_content` and the label in `display_metadata`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (none found; #108241 opened as the feature record)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I ran the full Python suite locally — `scripts/run_tests.sh` (the same runner `tests.yml` uses): **41,629 tests, 1,107 failures** on this Windows box. Every failing file was re-run against a clean `main` worktree: **327 of the 334 fail identically there** (environment/OS), and the run caught **3 real regressions that this PR fixes** (2 lock-semantics cases — the `_ic_*` helpers are now module-level and stub-safe — and a stale `_prepare_turn_input` test double). After those fixes the candidate set is green except one known-flaky log-append race that also fails 5/5 on clean `main`.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (git-bash), desktop app suites + gateway suites green

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `apps/desktop/AGENTS.md` + `tui_gateway/AGENTS.md` document the frame contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — done (both area guides)
- [x] I've considered cross-platform impact (Windows, macOS) — pure Python/TS, no platform-specific code paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

### Full-suite A/B (local, Windows 11)

```
# branch (pre-fix run): 334 failing files, 1107 failing tests
# clean main worktree, same 334 files: 327 failing files, 1098 failing tests  -> environment
# 7 files failed only on the branch:
#   2  lock-semantics            -> fixed (35cd2649, helpers now module-level/stub-safe)
#   1  stale test double         -> fixed (a8806974)
#   4  load-flaky (compression x2, heartbeat, run_tests_parallel) -> green standalone
#   compute_host_phase1: log-append race fails 5/5 on clean main too (known flaky on Windows)
```

```
$ python -m pytest tests/tui_gateway/test_turn_note_frame.py -q
7 passed in 0.34s

$ cd apps/desktop && npx vitest run <the 6 touched suites>
 Test Files  6 passed (6)
      Tests  189 passed (189)

# red proofs (mutating back to the old logic):
#   steerQueuedNow `if (!accepted)`      -> 1 failed  (keeps the entry queued when the middleware cancels)
#   steerDraft without the 'canceled' branch -> 1 failed (restores the draft and queues nothing)
```




