### PR TITLE
feat(hooks): expose provider usage field availability

### DIFF
--- a/agent/api_request_hooks.py
+++ b/agent/api_request_hooks.py
@@ -10,7 +10,7 @@ from contextlib import suppress
 from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
-from agent.usage_pricing import normalize_usage
+from agent.usage_pricing import normalize_usage, usage_field_availability
 
 _SENSITIVE_HOOK_KEYS = {"api_key", "authorization", "proxy_authorization", "cookie", "set_cookie"}
 
@@ -46,6 +46,9 @@ class ApiRequestHooksMixin:
         summary.pop("raw_usage", None)
         summary["prompt_tokens"] = cu.prompt_tokens
         summary["total_tokens"] = cu.total_tokens
+        summary["available_fields"] = usage_field_availability(
+            raw_usage, provider=getattr(self, "provider", None), api_mode=getattr(self, "api_mode", None)
+        )
         return summary
 
     @staticmethod

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -319,7 +319,9 @@ def _usage_path_is_present(obj: Any, *path: str) -> bool:
                 return False
             obj = obj[hop]
             continue
-        fields_set = getattr(obj, "model_fields_set", getattr(obj, "__fields_set__", None))
+        fields_set = getattr(obj, "model_fields_set", None)
+        if fields_set is None:
+            fields_set = getattr(obj, "__fields_set__", None)
         if fields_set is not None and hop not in fields_set:
             return False
         if not hasattr(obj, hop):

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -311,6 +311,23 @@ def _first_nonzero(obj: Any, *paths: tuple[str, ...]) -> int:
     return next((v for v in (_usage_field(obj, *path) for path in paths) if v), 0)
 
 
+def _usage_path_is_present(obj: Any, *path: str) -> bool:
+    """Whether a provider supplied a usage path, preserving explicit zeroes."""
+    for hop in path:
+        if isinstance(obj, dict):
+            if hop not in obj:
+                return False
+            obj = obj[hop]
+            continue
+        fields_set = getattr(obj, "model_fields_set", getattr(obj, "__fields_set__", None))
+        if fields_set is not None and hop not in fields_set:
+            return False
+        if not hasattr(obj, hop):
+            return False
+        obj = getattr(obj, hop)
+    return obj is not None
+
+
 # Picker slugs → snapshot provider key ("openai-api" is the slug for direct
 # api.openai.com). Google and Fireworks are matched by name OR host below.
 _SNAPSHOT_PROVIDER_ALIASES = {
@@ -488,6 +505,38 @@ _CHAT_USAGE_SHAPE = (
     (("prompt_tokens_details", "cache_write_tokens"), ("prompt_tokens_details", "cache_creation_input_tokens"),
      ("cache_creation_input_tokens",), ("cache_write_tokens",)),
 )
+
+
+def usage_field_availability(
+    response_usage: Any, *, provider: Optional[str] = None, api_mode: Optional[str] = None
+) -> Dict[str, bool]:
+    """Report which canonical token buckets were present in raw provider usage.
+
+    Normalized counters intentionally use zero for both missing and explicit-zero
+    fields. Hook consumers need this side channel to avoid reporting unsupported
+    cache accounting as a zero-percent cache hit rate.
+    """
+    provider_name = (provider or "").strip().lower()
+    mode = (api_mode or "").strip().lower()
+    if mode == "anthropic_messages" or provider_name == "anthropic":
+        shape = _ANTHROPIC_USAGE_SHAPE
+    elif mode == "codex_responses":
+        shape = _CODEX_USAGE_SHAPE
+    else:
+        shape = _CHAT_USAGE_SHAPE
+    names = ("input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens")
+    available = {
+        name: any(_usage_path_is_present(response_usage, *path) for path in paths)
+        for name, paths in zip(names, shape)
+    }
+    available["reasoning_tokens"] = any(
+        _usage_path_is_present(response_usage, *path)
+        for path in (
+            ("output_tokens_details", "reasoning_tokens"),
+            ("completion_tokens_details", "reasoning_tokens"),
+        )
+    )
+    return available
 
 
 def normalize_usage(

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -32,6 +32,20 @@ def test_usage_field_availability_distinguishes_explicit_zero_from_missing_cache
     }
     assert usage_field_availability(missing, api_mode="codex_responses")["cache_read_tokens"] is False
 
+    defaulted_details = SimpleNamespace(cached_tokens=0, model_fields_set=set())
+    defaulted = SimpleNamespace(
+        input_tokens=100,
+        output_tokens=10,
+        input_tokens_details=defaulted_details,
+        model_fields_set={"input_tokens", "output_tokens", "input_tokens_details"},
+    )
+    assert (
+        usage_field_availability(defaulted, api_mode="codex_responses")[
+            "cache_read_tokens"
+        ]
+        is False
+    )
+
 
 def test_api_request_hook_usage_includes_field_availability():
     class Hooks(ApiRequestHooksMixin):

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -8,8 +8,49 @@ from agent.usage_pricing import (
     get_pricing_entry,
     normalize_usage,
     resolve_billing_route,
+    usage_field_availability,
 )
 from decimal import Decimal
+
+from agent.api_request_hooks import ApiRequestHooksMixin
+
+
+def test_usage_field_availability_distinguishes_explicit_zero_from_missing_cache_metadata():
+    explicit_zero = {
+        "input_tokens": 100,
+        "output_tokens": 10,
+        "input_tokens_details": {"cached_tokens": 0},
+    }
+    missing = {"input_tokens": 100, "output_tokens": 10}
+
+    assert usage_field_availability(explicit_zero, api_mode="codex_responses") == {
+        "input_tokens": True,
+        "output_tokens": True,
+        "cache_read_tokens": True,
+        "cache_write_tokens": False,
+        "reasoning_tokens": False,
+    }
+    assert usage_field_availability(missing, api_mode="codex_responses")["cache_read_tokens"] is False
+
+
+def test_api_request_hook_usage_includes_field_availability():
+    class Hooks(ApiRequestHooksMixin):
+        provider = "openai-codex"
+        api_mode = "codex_responses"
+
+    hooks = Hooks()
+    response = SimpleNamespace(
+        usage=SimpleNamespace(
+            input_tokens=100,
+            output_tokens=10,
+            input_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+    )
+
+    summary = hooks._usage_summary_for_api_request_hook(response)
+
+    assert summary is not None
+    assert summary["available_fields"]["cache_read_tokens"] is True
 
 
 def test_astra_whole_request_price_tier_includes_cache_writes():

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -476,6 +476,11 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `on_kanban_task_updated` | Observer | After a committed task-field write outside the claim/complete/block lifecycle (assign, overrides, dashboard editors). Return ignored. | `task_id`, `profile_name`, `board`, `assignee`, `run_id`, `changed_fields` | `changed_fields` carries field names only, never values; the named title/body values in the board DB may contain user/project content. |
 | `on_kanban_dispatch_tick` | Observer | Once per dispatcher tick, strictly after the dispatch lock is released; idle and contended ticks fire too. Return ignored. | `board`, `profile_name`, `dry_run`, `outcome`, `result` | `result` is the tick's `DispatchResult` and carries task ids, assignees, and workspace paths. |
 
+`post_api_request.usage.available_fields` maps each normalized token counter to a boolean
+that distinguishes provider-reported zero from unavailable metadata. This matters for
+cache telemetry: `cache_read_tokens: 0` plus `available_fields.cache_read_tokens: true`
+is an observed cache miss, while `false` is unknown rather than a zero-percent hit rate.
+
 ---
 
 ### Streaming output hooks


### PR DESCRIPTION
## Summary

- add `usage.available_fields` to the sanitized `post_api_request` hook payload
- preserve the distinction between provider-reported zero and unavailable token metadata
- support mapping, regular object, and Pydantic field-set presence semantics
- document the additive hook contract

## Why

Normalized usage counters intentionally collapse missing and explicit-zero values to `0`. Observability plugins therefore cannot distinguish an observed zero cache read from a provider that did not expose cache metadata, which makes a trustworthy cache-hit rate impossible.

This adds a content-free side channel while leaving existing canonical counters and billing behavior unchanged.

## Verification

- `scripts/run_tests.sh tests/agent/test_usage_pricing.py` — 52 passed
- focused Ruff checks passed
- `git diff --check` passed
- adversarial review found no correctness or PR-readiness issues
