### PR TITLE
fix(approval): clear the process-global ask hint on unattended platforms

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -824,6 +824,61 @@ class TestWebhookApprovalExclusion:
         result = check_all_command_guards("ls -la /tmp", "local")
         assert result["approved"] is True
 
+    def test_webhook_dangerous_command_denies_despite_gateway_ask_marker(self, monkeypatch):
+        """A gateway process sets HERMES_EXEC_ASK=1 once at boot (start_gateway); a
+        webhook session in that process must still deny instantly.
+
+        Regression: the process-global ask hint kept ``is_ask`` true, which
+        skipped the unattended branch (``not is_cli and not is_gateway and
+        not is_ask``) and routed the flagged command to a pending approval
+        nobody could answer — the session dead-waited ``approvals.timeout``
+        (~300 s) and failed closed, the exact #37284 dead-end for the ask path.
+        Guardian ESCALATE must not re-open the interactive wait either.
+        """
+        import tools.approval as approval_mod
+        from tools.approval import check_all_command_guards
+
+        self._isolate(monkeypatch)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "webhook")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-webhook-session")
+
+        with mock_patch.object(
+            approval_smart, "_smart_approve", return_value="escalate"
+        ) as smart_approve:
+            result = check_all_command_guards(
+                "sudo systemctl restart nginx", "local"
+            )
+
+        assert result["approved"] is False
+        assert "unattended platform" in result["message"]
+        assert "approvals.unattended_mode" in result["message"]
+        assert "test-webhook-session" not in approval_mod._pending
+        smart_approve.assert_not_called()
+
+    def test_webhook_unattended_approve_overrides_gateway_ask_marker(self, monkeypatch):
+        """approvals.unattended_mode: approve still auto-approves when the gateway's
+        process-global HERMES_EXEC_ASK marker is set (the ask hint must not mask
+        the operator's explicit opt-in for listener-less sessions)."""
+        from tools.approval import check_all_command_guards
+
+        self._isolate(monkeypatch)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "webhook")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-webhook-session")
+        monkeypatch.setattr(
+            approval_context, "_get_unattended_approval_mode", lambda: "approve"
+        )
+
+        result = check_all_command_guards("sudo systemctl restart nginx", "local")
+        assert result["approved"] is True
+
     def test_api_server_dangerous_command_denies_by_default(self, monkeypatch):
         """api_server sessions get the same instant deny (#87509)."""
         from tools.approval import check_all_command_guards

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -787,12 +787,24 @@ def _human_decision(spec: _GateSpec, *, command: str, description: str,
 def _presence(approval_callback=None) -> tuple:
     """``(approval_callback, is_cli, is_gateway, is_ask)`` for the current context. Single-query
     (-q) exports HERMES_INTERACTIVE=1 but nobody answers prompts, and HERMES_EXEC_ASK has no
-    human either — both are cleared so single_query_mode actually takes effect."""
+    human either — both are cleared so single_query_mode actually takes effect.
+
+    HERMES_EXEC_ASK is a process-global hint the gateway sets once at boot
+    (``start_gateway``), so it reads "an ask surface exists" for EVERY session in
+    that process. Listener-less unattended platforms (webhook, msgraph_webhook,
+    api_server) have nobody behind that hint: honoring it there routes a flagged
+    command to a pending approval that waits ``approvals.timeout`` and fails
+    closed anyway — the exact dead-wait #37284 removed for the gateway branch.
+    Clearing ``is_ask`` lets the unattended deny/approve mode resolve instantly,
+    matching the ``is_gateway`` exclusion in ``_is_gateway_approval_context``
+    and the unconditional unattended check in ``check_execute_code_guard``."""
     approval_callback = _resolve_cli_approval_callback(approval_callback)
     is_cli, is_gateway = _is_interactive_cli(), _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
     if _is_single_query_approval_context():
         is_cli = is_gateway = is_ask = False
+    if _is_unattended_platform_approval_context():
+        is_ask = False
     return approval_callback, is_cli, is_gateway, is_ask
 
 


### PR DESCRIPTION
## Bug Description

Webhook sessions dead-wait the full `approvals.timeout` (~300 s) on dangerous commands and then fail closed. It is the #37284 dead-end again, entering through the ask path.

`start_gateway()` sets process-global `HERMES_EXEC_ASK=1` at boot (gateway/run.py:5191). `_presence()` only clears `is_ask` for single-query sessions, so a webhook session keeps `is_ask=True`. That skips the unattended branch in `check_all_command_guards` (`not is_cli and not is_gateway and not is_ask`) and submits a pending approval nobody can answer. The webhook adapter has no `send_exec_approval`, so nothing is ever delivered; the gate waits out the timeout and returns `gateway_refused: timed out without user response`.

Observed live on 0.21.1 (uptime-kuma webhook route): an alert run spent 2 x 307.35 s in these dead-waits for guardian-ESCALATE'd commands (`docker exec ... sh -c 'curl ...'`, `docker exec ... node -e ...`), while `execute_code` in the same run denied instantly and correctly. `check_execute_code_guard` resolves `_unattended_contexts()` unconditionally before consulting the presence flags, so it never had this bug.

Fixes #108251

## Root Cause

The process-global `HERMES_EXEC_ASK=1` marker (set once by `start_gateway`) leaks into the session-scoped presence check. `_presence()` clears `is_ask` only for single-query sessions, not for listener-less unattended platforms (`_UNATTENDED_APPROVAL_PLATFORMS`: webhook, msgraph_webhook, api_server).

## Fix

- In `_presence()` (tools/approval.py): clear `is_ask` when `_is_unattended_platform_approval_context()` is true, so the unattended deny/approve mode resolves instantly.
- This mirrors the `is_gateway` exclusion already in `_is_gateway_approval_context()` and the unconditional unattended check in `check_execute_code_guard()`. One predicate, no per-platform plumbing, no behavior change for any attended surface.

## How to Verify

1. `scripts/run_tests.sh tests/tools/test_approval.py -k ask_marker -q`
2. On current main the two new tests fail (with the ask marker set); with this patch they pass.
3. Manual repro of the live symptom: gateway process + webhook route with terminal access, then run any pattern-flagged command (for example `sudo systemctl restart nginx`). Pre-patch it dead-waits `approvals.timeout` and then BLOCKs; post-patch it denies in under 0.1 s with the `approvals.unattended_mode` guidance message.

## Test Plan

- [x] Regression test: dangerous command + `HERMES_EXEC_ASK=1` + webhook platform + guardian ESCALATE produces an instant deny with nothing queued (`smart_approve` is never called; the guardian must not re-open the wait)
- [x] Regression test: `approvals.unattended_mode: approve` + ask marker still auto-approves (the hint must not mask the explicit opt-in)
- [x] Sabotage run: both tests proven red on pre-fix code, green with the patch
- [x] Full `tests/tools/test_approval.py`: 120 passed
- [x] Sibling suites pass: `test_approval_config_readonly.py` (3), `test_approval_mode_parity.py` (7), `test_approval_outcome_parity.py` (2), `test_approval_deny_rules.py` (34), `test_cron_approval_mode.py` (30)
- [x] `ruff check` clean; both files already had pre-existing `ruff format` drift, so no formatting churn was added

## Risk Assessment

Low. `is_ask` is cleared only for session platforms already classified as listener-less unattended (webhook, msgraph_webhook, api_server), whose pending approvals are guaranteed unresolvable today: they time out into a deny. Safety is unchanged; the default `approvals.unattended_mode: deny` still blocks the command, just instantly and with the correct guidance instead of after a dead 300 s wait. Attended surfaces (CLI, Telegram, Slack, remote Desktop/TUI sessions, ask-mode) keep the existing ask-path behavior.

Related open work this does not duplicate: #100554 fixes the same leak for api_server, and this PR's `_presence` fix covers that platform too through the same predicate. #71571 is the larger cross-session `/approve` routing design.

🤖 Wrote this PR description together with Hermes Agent.
