### PR TITLE
fix(tui): fan approval.request out to live transports when the session is detached

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -22678,3 +22678,127 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
     assert captured["row_update"] == (target, str(new_cwd))
     assert live["cwd"] == str(new_cwd)
     assert live.get("explicit_cwd") is True
+
+
+class _RecordingTransport:
+    """Minimal transport double: records frames, configurable write() result."""
+
+    def __init__(self, *, ok: bool = True):
+        self.frames = []
+        self.ok = ok
+
+    def write(self, obj):
+        self.frames.append(obj)
+        return self.ok
+
+    def close(self):
+        pass
+
+
+def test_emit_approval_request_falls_back_to_live_transports_when_session_detached(caplog):
+    """A detached (drop-sentinel) session must not lose approval events.
+
+    #83443 / #84395: when the desktop WebSocket disconnects, the session is parked on
+    _detached_ws_transport (a write-returns-False black hole). An approval.request emitted
+    through that session silently vanished and the agent thread blocked the full approval
+    timeout with nothing rendered. The emitter must fall back to the registered live
+    transports so a still-connected peer receives the prompt.
+    """
+    live = _RecordingTransport()
+    sid = "detached-approval-sid"
+    server.register_live_transport(live)
+    server._sessions[sid] = {"transport": server._detached_ws_transport}
+    try:
+        with caplog.at_level(logging.WARNING, logger="tui_gateway.server"):
+            server._emit_approval_request(
+                sid,
+                {
+                    "command": "rm -rf /tmp/x",
+                    "pattern_key": "dangerous",
+                    "description": "dangerous command",
+                    "allow_permanent": True,
+                },
+            )
+    finally:
+        server.unregister_live_transport(live)
+        server._sessions.pop(sid, None)
+
+    assert len(live.frames) == 1, "approval must be fanned out to live transports"
+    frame = live.frames[0]
+    assert frame["params"]["type"] == "approval.request"
+    # The frame keeps its session_id so the client routes it to the right session.
+    assert frame["params"]["session_id"] == sid
+    # Redaction must still apply on the broadcast path.
+    assert "rm -rf" in frame["params"]["payload"]["command"]
+    assert "broadcasting" in caplog.text
+
+
+def test_emit_approval_request_uses_session_transport_when_live():
+    """A live session keeps the direct transport path (no broadcast, no duplicate)."""
+    session_transport = _RecordingTransport()
+    other = _RecordingTransport()
+    sid = "live-approval-sid"
+    server.register_live_transport(other)
+    server._sessions[sid] = {"transport": session_transport}
+    try:
+        server._emit_approval_request(sid, {"command": "ls"})
+    finally:
+        server.unregister_live_transport(other)
+        server._sessions.pop(sid, None)
+
+    assert len(session_transport.frames) == 1, "session transport gets the frame"
+    assert len(other.frames) == 0, "live transports are not spammed when the session is live"
+
+
+def test_emit_approval_request_dropped_write_is_broadcast_not_lost():
+    """A session transport that reports False (mid-close) must fall through to the broadcast."""
+    half_closed = _RecordingTransport(ok=False)
+    live = _RecordingTransport()
+    sid = "half-closed-approval-sid"
+    server.register_live_transport(live)
+    server._sessions[sid] = {"transport": half_closed}
+    try:
+        server._emit_approval_request(sid, {"command": "ls"})
+    finally:
+        server.unregister_live_transport(live)
+        server._sessions.pop(sid, None)
+
+    assert len(half_closed.frames) == 1 and half_closed.ok is False
+    assert len(live.frames) == 1, "dropped write must not lose the approval"
+
+
+def test_emit_approval_request_without_any_transport_is_silent():
+    """No session transport and no live peers: nothing to deliver, and no crash."""
+    sid = "orphan-approval-sid"
+    server._sessions[sid] = {"transport": server._detached_ws_transport}
+    try:
+        server._emit_approval_request(sid, {"command": "ls"})
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_approval_notify_registration_failure_logs_loudly(caplog, monkeypatch):
+    """A failed register_gateway_notify must not be swallowed silently.
+
+    #83443 / #84395 silent-approval-timeout family: a session whose notify callback never
+    registered would block the agent for the full timeout with nothing rendered. The build
+    path must log the failure loudly (it previously hid behind contextlib.suppress).
+    """
+    import tools.approval as _approval
+
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(
+        _approval,
+        "register_gateway_notify",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("injected registration failure")),
+    )
+
+    class _Agent:
+        model = "test"
+
+    with caplog.at_level(logging.ERROR, logger="tui_gateway.server"):
+        registered = server._wire_session_agent("fail-reg-sid", "fail-reg-key", _Agent())
+
+    assert registered is False
+    assert "Failed to register gateway approval notify" in caplog.text
+    assert "injected registration failure" in caplog.text

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -688,10 +688,44 @@ def _pending_approval_request_payload(session_key: str) -> dict | None:
 def _emit_approval_request(sid: str, data: dict | None) -> None:
     """Emit ``approval.request`` with the command redacted: a credential-shaped value Tirith flagged would
     otherwise echo verbatim to the TUI (third egress alongside chat platforms and the SSE/API stream).
+    Reuse the shared gateway seam so all approval transports redact consistently (#48456, #50767).
 
-    Reuse the shared gateway See #48456, #50767.
+    Delivery hardening (#83443, #84395): a session whose WebSocket disconnected is parked on
+    ``_detached_ws_transport`` — a drop sink whose ``write()`` returns False. Writing the frame through
+    the session transport loses it there, and the agent thread then blocks the full
+    ``approvals.timeout`` with no prompt ever rendered. Fan the frame out to the registered live
+    transports instead, so a still-connected peer receives the prompt.
     """
-    _emit("approval.request", sid, _approval_request_payload(data))
+    payload = _approval_request_payload(data)
+    from tui_gateway.event_replay import _stamp_event
+    frame = _event_frame("approval.request", sid, payload)
+    _stamp_event(frame)  # same seq/replay bookkeeping write_json applies to event frames
+    transport = (_sessions.get(sid) or {}).get("transport")
+    if transport is not None:
+        try:
+            # Trust the write() result, not just liveness: the drop sentinel — and a transport
+            # mid-close (disconnect received, teardown not yet run) — returns False, which is the
+            # signal to fall through to the broadcast rather than lose the approval.
+            if transport.write(frame):
+                return
+        except Exception:
+            logger.debug("approval.request session write failed sid=%s", sid, exc_info=True)
+    with _live_transports_lock:
+        targets = [t for t in _live_transports if t is not transport]
+    if not targets:
+        return
+    # The frame keeps its session_id, so the frontend still routes it to the right session on the
+    # broadcast path. This intentionally crosses session boundaries (a second connected peer can
+    # render another session's prompt); safe only because approval.respond is session/ownership
+    # scoped server-side — keep that invariant.
+    logger.warning(
+        "approval.request for session %s has no live transport; broadcasting to %d connected client(s)",
+        sid, len(targets))
+    for target in targets:
+        try:
+            target.write(frame)
+        except Exception:  # one wedged peer must not stall the rest
+            logger.debug("approval.request broadcast write failed peer=%r", target, exc_info=True)
 
 
 def _status_update(sid: str, kind: str, text: str | None = None):
@@ -932,11 +966,22 @@ def _wire_session_agent(sid: str, key: str, agent) -> bool:
     client; the self-improvement "💾 …" summary is emitted as review.summary (no print surface), honoring
     display.memory_notifications."""
     notify_registered = False
-    with contextlib.suppress(Exception):
+    try:
         from tools.approval import load_permanent_allowlist, register_gateway_notify
         register_gateway_notify(key, lambda data: _emit_approval_request(sid, data))
         notify_registered = True
         load_permanent_allowlist()
+    except Exception:
+        # Never swallow this silently: a session with no notify callback blocks the agent thread
+        # for the full approvals.timeout with nothing rendered (#83443, #84395). The live-transport
+        # fallback in _emit_approval_request only covers a socket that died after registration —
+        # this log covers the case where the session never registered at all.
+        logger.exception(
+            "Failed to register gateway approval notify for session %s (key=%s) — "
+            "approval prompts for this session may not reach the client",
+            sid,
+            key,
+        )
     _wire_callbacks(sid)
     with contextlib.suppress(Exception):  # bare agents without the attribute must not break startup
         agent.background_review_callback = lambda message, _sid=sid: _emit("review.summary", _sid, {"text": str(message)})


### PR DESCRIPTION
## Problem

Remote-Desktop approvals time out silently with no visible prompt (#83443, #84395). Two backend seams conspire:

1. **Dead-socket black hole.** When the desktop WebSocket disconnects, the session is parked on the drop sentinel — `_detached_ws_transport`, whose `write()` returns `False`. `_emit_approval_request` wrote the `approval.request` frame through the session transport, i.e. straight into that black hole. The agent thread then blocks for the full `approvals.timeout` (default 300 s) with nothing rendered — exactly the "timed out without user response" symptom in both reports.

2. **Silent registration failure.** The approval notify callback registration in the agent-build path was wrapped in `contextlib.suppress(Exception)`. If `register_gateway_notify` or `load_permanent_allowlist` raised, the session had no notify callback at all and approvals silently degraded, with no log line pointing at the gap.

## Fix

- **`_emit_approval_request`** writes the frame to the session transport and, when that write reports `False` (drop sentinel — or a transport mid-close, which looks alive but drops the frame), fans it out to every registered live transport (the set `tui_gateway.ws` maintains for connected peers). The frame keeps its `session_id`, so the frontend still routes it to the right session, and the seq/replay bookkeeping is preserved by stamping the frame the way `write_json` does.
- **Registration failure logging**: `_wire_session_agent` now uses `logger.exception` instead of `contextlib.suppress(Exception)`, so an unregistered session (one the delivery fallback cannot help) is visible in logs.

The healthy path is unchanged: when the session transport is live and accepts the frame, nothing is broadcast.

## Scope note

The fallback is applied to `approval.request` specifically, not to every session-scoped event. Approvals are the case that gates the agent thread for the full timeout; status/stream events are cheap to lose and replay on resume, and broadcasting them would spam every connected peer when a session is detached. `approval.respond` remains session/ownership-scoped server-side, which is what makes the cross-session broadcast safe — the code comment records that invariant.

## Validation

```bash
python -m pytest tests/test_tui_gateway_server.py -q -o 'addopts='
```

- 658 passed (5 new cases in `tests/test_tui_gateway_server.py`):
  1. detached session → frame fanned out to live transports, `session_id` preserved, redaction intact;
  2. live session → direct transport path, live transports not spammed;
  3. transport returning `False` (mid-close) → falls through to the broadcast instead of losing the approval;
  4. no session transport and no live peers → silent, no crash;
  5. `_wire_session_agent` with `register_gateway_notify` raising → returns `False` and logs the failure through the real function.
- Cases 1, 3 and 5 fail against current `main` (verified by stashing only the source change); 2 and 4 assert preserved behaviour by design.

Refs #83443, #84395

---

Rebuilt cleanly on current `main`; supersedes #85967 (same fix, branch was based on an older tree and had drifted into a merge conflict).
