### PR TITLE
feat(desktop): reset current chat with /clear

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -520,6 +520,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     createBackendSessionForSend,
     openNewSessionTile,
     removeSession,
+    resetCurrentSession,
     resumeSession,
     selectSidebarItem,
     startFreshSessionDraft
@@ -722,6 +723,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     openMemoryGraph: openStarmap,
     refreshSessions,
     requestGateway,
+    resetCurrentSession,
     resumeStoredSession: resumeSession,
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionIdRef,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -237,6 +237,7 @@ interface PromptActionsOptions {
   openMemoryGraph: () => void
   refreshSessions: () => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
+  resetCurrentSession?: () => Promise<boolean>
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionIdRef: MutableRefObject<string | null>
@@ -269,6 +270,7 @@ export function usePromptActions({
   openMemoryGraph,
   refreshSessions,
   requestGateway,
+  resetCurrentSession,
   resumeStoredSession,
   runtimeIdByStoredSessionIdRef,
   selectedStoredSessionIdRef,
@@ -597,6 +599,7 @@ export function usePromptActions({
     openMemoryGraph,
     refreshSessions,
     requestGateway,
+    resetCurrentSession,
     resumeStoredSession,
     selectedStoredSessionIdRef,
     startFreshSessionDraft,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -148,6 +148,7 @@ interface SlashCommandDeps {
   openMemoryGraph: () => void
   refreshSessions: () => Promise<void>
   requestGateway: GatewayRequest
+  resetCurrentSession?: () => Promise<boolean>
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   startFreshSessionDraft: () => void
@@ -175,6 +176,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
     openMemoryGraph,
     refreshSessions,
     requestGateway,
+    resetCurrentSession,
     resumeStoredSession,
     selectedStoredSessionIdRef,
     startFreshSessionDraft,
@@ -495,6 +497,9 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       const actionHandlers: Record<DesktopActionId, (ctx: SlashActionCtx) => Promise<void>> = {
         new: async () => {
           startFreshSessionDraft()
+        },
+        clear: async () => {
+          await resetCurrentSession?.()
         },
         branch: async () => {
           await branchCurrentSession()
@@ -1231,6 +1236,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       openMemoryGraph,
       refreshSessions,
       requestGateway,
+      resetCurrentSession,
       resumeStoredSession,
       selectedStoredSessionIdRef,
       startFreshSessionDraft,

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -117,6 +117,7 @@ type HarnessHandle = Pick<
   | 'createBackendSessionForSend'
   | 'openNewSessionTile'
   | 'removeSession'
+  | 'resetCurrentSession'
   | 'selectSidebarItem'
   | 'startFreshSessionDraft'
 >
@@ -358,6 +359,95 @@ describe('connection-qualified session deletion', () => {
       session_id: 'runtime-shared'
     })
     expect(requestGateway).not.toHaveBeenCalledWith('session.close', expect.anything())
+  })
+
+  it('replaces a chat only after its persisted successor exists, preserving owner, title, cwd, and pin order', async () => {
+    const requestGateway = vi.fn(async () => ({} as never))
+    const navigate = vi.fn()
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: 'runtime-original' }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'original' }
+    let actions: HarnessHandle | null = null
+
+    setSessions([
+      storedSession({
+        connection_id: 'source-a',
+        cwd: '/remote/worktree',
+        id: 'original',
+        profile: 'worker',
+        title: 'Keep me'
+      })
+    ])
+    $pinnedSessionIds.set(['before', 'original', 'after'])
+    vi.mocked(requestGatewayForAgent).mockImplementation((async (_connection: string, _profile: string, method: string) => {
+      if (method === 'session.create') {
+        return {
+          info: { cwd: '/remote/worktree' },
+          session_id: 'runtime-replacement',
+          stored_session_id: 'replacement'
+        } as never
+      }
+
+      return {} as never
+    }) as never)
+    vi.mocked(deleteSession).mockResolvedValue({ ok: true })
+
+    render(
+      <Harness
+        activeSessionIdRef={activeSessionIdRef}
+        navigate={navigate}
+        onReady={value => (actions = value)}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+      />
+    )
+    await waitFor(() => expect(actions).not.toBeNull())
+
+    await act(async () => {
+      await expect(actions!.resetCurrentSession()).resolves.toBe(true)
+    })
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith(
+      'source-a',
+      'worker',
+      'session.create',
+      expect.objectContaining({ cwd: '/remote/worktree', persist: true, profile: 'worker', title: 'Keep me' })
+    )
+    expect(deleteSession).toHaveBeenCalledWith('original', { connectionId: 'source-a', profile: 'worker' })
+    expect($sessions.get()).toEqual([
+      expect.objectContaining({ cwd: '/remote/worktree', id: 'replacement', title: 'Keep me' })
+    ])
+    expect($pinnedSessionIds.get()).toEqual(['before', 'replacement', 'after'])
+    expect($selectedStoredSessionId.get()).toBe('replacement')
+    expect(activeSessionIdRef.current).toBe('runtime-replacement')
+    expect(navigate).toHaveBeenCalledWith(sessionRoute('replacement'), { replace: true })
+  })
+
+  it('keeps the original selected, listed, and pinned when replacement persistence fails', async () => {
+    const requestGateway = vi.fn(async () => ({} as never))
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: 'original' }
+    let actions: HarnessHandle | null = null
+
+    setSessions([storedSession({ id: 'original', profile: 'worker', title: 'Keep me' })])
+    $pinnedSessionIds.set(['before', 'original', 'after'])
+    vi.mocked(requestGatewayForProfile).mockRejectedValueOnce(new Error('disk unavailable'))
+
+    render(
+      <Harness
+        onReady={value => (actions = value)}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+      />
+    )
+    await waitFor(() => expect(actions).not.toBeNull())
+
+    await act(async () => {
+      await expect(actions!.resetCurrentSession()).resolves.toBe(false)
+    })
+
+    expect(deleteSession).not.toHaveBeenCalled()
+    expect($sessions.get()).toEqual([expect.objectContaining({ id: 'original', title: 'Keep me' })])
+    expect($pinnedSessionIds.get()).toEqual(['before', 'original', 'after'])
+    expect($selectedStoredSessionId.get()).toBe('original')
   })
 
   it('tears down the selected session from synchronous refs when render state is stale', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2407,6 +2407,166 @@ export function useSessionActions({
     [copy, forkBranch]
   )
 
+  const resetCurrentSession = useCallback(async (): Promise<boolean> => {
+    const storedSessionId = selectedStoredSessionIdRef.current
+
+    // A reset must never race an in-flight turn: that turn can still persist
+    // messages or update the old row after its replacement is made durable.
+    if (!storedSessionId || busyRef.current) {
+      return false
+    }
+
+    // The selected row is the authoritative source of the durable presentation
+    // state that /clear carries forward. Do not create a replacement when that
+    // source cannot be resolved: an ownerless reset is worse than keeping the
+    // chat the user can still see.
+    const listed = findListedSession(storedSessionId)
+    const original = listed?.session ?? (await resolveStoredSession(storedSessionId))
+
+    if (!original) {
+      notifyError(new Error('Session could not be resolved'), copy.createSessionFailed)
+
+      return false
+    }
+
+    const ownerRoute = getSessionOwnerHint(storedSessionId) ?? sessionOwnerRouteFromRow(original)
+    const owner: SessionOwnerScope = ownerRoute ?? original.profile
+    const profile = ownerRoute?.targetProfile || ownerRoute?.profile || original.profile?.trim() || 'default'
+    const cwd = original.cwd?.trim() || ''
+    const title = original.title ?? null
+    const originalPinId = sessionPinId(original)
+    const previousPinned = $pinnedSessionIds.get()
+    const previousMessages = $messages.get()
+    const previousRuntimeId = activeSessionIdRef.current
+    let replacementId: string | null = null
+    let originalDeleted = false
+
+    try {
+      // This request is the reset linearization point. `persist: true` makes
+      // the gateway commit the empty successor (and title) before *any* delete,
+      // list, pin, selection, or route mutation can touch the original.
+      if (ownerRoute) {
+        await ensureGatewayAgent(ownerRoute.connectionId, ownerRoute.profile)
+      } else {
+        await ensureGatewayProfile(profile)
+      }
+
+      const created = await requestForSessionProfile<SessionCreateResponse>(owner, requestGateway, 'session.create', {
+        cols: 96,
+        source: 'desktop',
+        persist: true,
+        ...(cwd ? { cwd } : {}),
+        ...(profile ? { profile } : {}),
+        ...(title ? { title } : {})
+      })
+
+      const persistedReplacementId = created.stored_session_id
+
+      if (!persistedReplacementId) {
+        throw new Error('Gateway did not return a persisted replacement session')
+      }
+
+      replacementId = persistedReplacementId
+
+      if (ownerRoute) {
+        setSessionOwnerHint(replacementId, ownerRoute)
+      }
+
+      // The original is still selected/listed/pinned until the replacement is
+      // durable AND its delete succeeds. A failed delete therefore leaves the
+      // old conversation exactly intact; best-effort cleanup only removes the
+      // unused durable successor.
+      const deleted = await deleteSession(storedSessionId, owner)
+
+      if (!deleted.ok) {
+        throw new Error('Gateway did not delete the original session')
+      }
+
+      originalDeleted = true
+
+      const originalIds = [storedSessionId, original.id, original._lineage_root_id].filter(
+        (id): id is string => Boolean(id)
+      )
+
+      tombstoneSessions(originalIds)
+      beginSessionMutation(originalIds)
+
+      try {
+        dropListedSession(storedSessionId)
+        $archivedSessions.set($archivedSessions.get().filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+        upsertOptimisticSession(created, persistedReplacementId, title, null, null, undefined, ownerRoute)
+        $pinnedSessionIds.set(previousPinned.map(pinId => (pinId === originalPinId ? persistedReplacementId : pinId)))
+
+        resetViewSync()
+        activeSessionIdRef.current = created.session_id
+        selectedStoredSessionIdRef.current = persistedReplacementId
+        ensureSessionState(created.session_id, persistedReplacementId)
+        setActiveSessionId(created.session_id)
+        setSelectedStoredSessionId(persistedReplacementId)
+        setMessages([])
+        setBusy(false)
+        setAwaitingResponse(false)
+        setFreshDraftReady(false)
+        setSessionStartedAt(Date.now())
+        setTurnStartedAt(null)
+        setCurrentUsage({ calls: 0, input: 0, output: 0, total: 0 })
+        setYoloActive(false)
+
+        const runtimeInfo = applyRuntimeInfo(created.info)
+
+        if (runtimeInfo) {
+          updateSessionState(created.session_id, state => ({ ...state, ...runtimeInfo }), persistedReplacementId)
+        }
+
+        navigate(sessionRoute(persistedReplacementId), { replace: true })
+        broadcastSessionsChanged()
+      } finally {
+        endSessionMutation(originalIds)
+      }
+
+      // Closing after the durable delete means a delete failure never leaves
+      // the original selected but backed by a deliberately closed runtime.
+      if (previousRuntimeId) {
+        await requestForSessionProfile(owner, requestGateway, 'session.close', { session_id: previousRuntimeId }).catch(
+          () => undefined
+        )
+      }
+
+      dropTranscriptTailEverywhere(storedSessionId)
+      forgetSessionUnread(originalIds, profile)
+      clearQueuedPrompts(storedSessionId)
+      clearSessionControl(previousRuntimeId ?? storedSessionId)
+
+      return true
+    } catch (error) {
+      // No original mutation occurs before deleteSession succeeds. If creation
+      // or delete fails, leave its selection, sidebar row and pin untouched.
+      if (replacementId && !originalDeleted) {
+        await deleteSession(replacementId, owner).catch(() => undefined)
+      }
+
+      setSelectedStoredSessionId(storedSessionId)
+      selectedStoredSessionIdRef.current = storedSessionId
+      activeSessionIdRef.current = previousRuntimeId
+      setActiveSessionId(previousRuntimeId)
+      setMessages(previousMessages)
+      $pinnedSessionIds.set(previousPinned)
+      notifyError(error, copy.createSessionFailed)
+
+      return false
+    }
+  }, [
+    activeSessionIdRef,
+    busyRef,
+    copy,
+    ensureSessionState,
+    navigate,
+    requestGateway,
+    resetViewSync,
+    selectedStoredSessionIdRef,
+    updateSessionState
+  ])
+
   const removeSession = useCallback(
     async (storedSessionId: string) => {
       clearNotifications()
@@ -2642,6 +2802,7 @@ export function useSessionActions({
     openNewSessionTile,
     openSettings,
     removeSession,
+    resetCurrentSession,
     resumeSession,
     selectSidebarItem,
     startFreshSessionDraft

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -135,7 +135,7 @@ describe('desktop slash command curation', () => {
   })
 
   it('hides terminal, messaging, and dedicated-UI commands from suggestions', () => {
-    expect(isDesktopSlashSuggestion('/clear')).toBe(false)
+    expect(isDesktopSlashSuggestion('/clear')).toBe(true)
     expect(isDesktopSlashSuggestion('/density')).toBe(false)
     expect(isDesktopSlashSuggestion('/redraw')).toBe(false)
     expect(isDesktopSlashSuggestion('/approve')).toBe(false)
@@ -337,7 +337,13 @@ describe('desktop slash command curation', () => {
     })
 
     expect(filtered.categories).toEqual([
-      { name: 'Session', pairs: [['/new', 'Start a new desktop chat']] },
+      {
+        name: 'Session',
+        pairs: [
+          ['/new', 'Start a new desktop chat'],
+          ['/clear', 'Reset this chat and keep its title, workspace, and pin']
+        ]
+      },
       { name: 'User commands', pairs: [['/ship-it', 'Run release checklist']] }
     ])
     expect(filtered.pairs).toEqual([
@@ -361,7 +367,7 @@ describe('desktop slash command curation', () => {
       skill_count: 12
     })
 
-    expect(filtered.pairs?.map(([cmd]) => cmd)).toEqual(['/new', '/gif-search', '/ship-it'])
+    expect(filtered.pairs?.map(([cmd]) => cmd)).toEqual(['/new', '/clear', '/gif-search', '/ship-it'])
     expect(filtered.skill_count).toBe(2)
   })
 
@@ -402,7 +408,7 @@ describe('desktop slash command curation', () => {
   it('explains known commands that desktop owns elsewhere', () => {
     expect(desktopSlashUnavailableMessage('/model sonnet')).toContain('model picker')
     expect(desktopSlashUnavailableMessage('/skills')).toContain('desktop sidebar')
-    expect(desktopSlashUnavailableMessage('/clear')).toContain('terminal interface')
+    expect(desktopSlashUnavailableMessage('/clear')).toBeNull()
   })
 
   it('flags /model as a picker-owned command so the desktop opens the overlay', () => {
@@ -429,7 +435,7 @@ describe('desktop slash command curation', () => {
     expect(resolveDesktopCommand('/reset')?.surface).toEqual({ kind: 'action', action: 'new' })
     expect(resolveDesktopCommand('/resume')?.surface).toEqual({ kind: 'picker', picker: 'session' })
     expect(resolveDesktopCommand('/usage')?.surface).toEqual({ kind: 'exec' })
-    expect(resolveDesktopCommand('/clear')?.surface).toEqual({ kind: 'unavailable', reason: 'terminal' })
+    expect(resolveDesktopCommand('/clear')?.surface).toEqual({ kind: 'action', action: 'clear' })
     // Skill / quick commands aren't in the registry.
     expect(resolveDesktopCommand('/gif-search')).toBeNull()
   })

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -56,6 +56,7 @@ export type DesktopActionId =
   | 'branch'
   | 'browser'
   | 'btw'
+  | 'clear'
   | 'compress'
   | 'handoff'
   | 'hatch'
@@ -174,6 +175,7 @@ const rpc = (
 const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   // Local client actions
   { name: '/new', description: 'Start a new desktop chat', aliases: ['/reset'], surface: action('new') },
+  { name: '/clear', description: 'Reset this chat and keep its title, workspace, and pin', surface: action('clear') },
   {
     name: '/stop',
     description: 'Stop the active turn and background processes',
@@ -285,7 +287,6 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
 const NO_DESKTOP_SURFACE: Record<DesktopUnavailableReason, readonly string[]> = {
   terminal: [
     '/busy',
-    '/clear',
     '/config',
     '/copy',
     '/cron',

--- a/tests/tui_gateway/test_seeded_session_create.py
+++ b/tests/tui_gateway/test_seeded_session_create.py
@@ -64,6 +64,33 @@ def test_parentless_seed_survives_a_restart_and_hides_its_runbook(monkeypatch, t
         db.close()
 
 
+def test_explicit_persist_keeps_an_empty_replacement_row(monkeypatch, tmp_path):
+    """A reset successor is durable before the client deletes its original row."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _quiet_create(monkeypatch, db)
+    sid = None
+    try:
+        result = _create({
+            "cols": 96,
+            "cwd": str(tmp_path),
+            "persist": True,
+            "source": "desktop",
+            "title": "Keep this title"
+        })
+        sid, key = result["session_id"], result["stored_session_id"]
+
+        row = db.get_session(key)
+        assert row is not None
+        assert row["title"] == "Keep this title"
+        assert row["cwd"] == str(tmp_path)
+        assert db.get_messages_as_conversation(key) == []
+        assert server._sessions[sid]["pending_title"] is None
+    finally:
+        if sid:
+            server._sessions.pop(sid, None)
+        db.close()
+
+
 def test_branch_child_seed_is_written_once(monkeypatch, tmp_path):
     """A seeded branch child persists its copied transcript at create (#93959); the first prompt's seed
     persist is the fallback for a failed create-time copy, not a second copy."""

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -322,6 +322,30 @@ def _create_overrides(params: dict) -> tuple:
     return model_override, reasoning_override, service_tier_override
 
 
+def _persist_requested_empty_row(record: dict) -> bool:
+    """Persist an otherwise-lazy empty row only when the client explicitly asks.
+
+    Ordinary drafts stay lazy so abandoned composers do not create sidebar
+    clutter. Desktop /clear is different: it needs a durable replacement before
+    it may delete the original session, including its copied title.
+    """
+    key = record.get("session_key")
+    try:
+        if _ensure_session_db_row(record) is not True:
+            return False
+        with _session_db(record) as db:
+            if db is None or db.get_session(key) is None:
+                return False
+            if (title := record.get("pending_title")) and not db.set_session_title(key, title):
+                return False
+            if title:
+                record["pending_title"] = None
+        return True
+    except Exception:
+        logger.warning("requested empty-session persistence failed for %s", key, exc_info=True)
+        return False
+
+
 @method("session.create")
 def _(rid, params: dict) -> dict:
     (sid, source), key = _new_runtime_ids(params), _new_session_key()
@@ -359,6 +383,12 @@ def _(rid, params: dict) -> dict:
             "slash_worker": None, "tool_progress_mode": _load_tool_progress_mode(), "tool_started_at": {},
             "transport": current_transport() or _stdio_transport}
         _register_session_cwd(_sessions[sid])
+    # Explicit persistence is for callers replacing an existing chat. Keep the
+    # normal draft path lazy below.
+    if _flag(params, "persist") and not _persist_requested_empty_row(_sessions[sid]):
+        with _sessions_lock:
+            _sessions.pop(sid, None)
+        return _err(rid, 5006, "failed to persist requested empty session")
     # No DB row here (drafts left "Untitled" litter): created on the first prompt — except seeded sessions.
     # NOTE: we intentionally do NOT persist a DB row here. Every TUI/desktop launch (and every "New agent" /
     # draft) opens a session here just to paint the composer, so eagerly creating a row left an "Untitled"


### PR DESCRIPTION
## Summary
- make Desktop `/clear` replace the current chat with a persisted empty successor
- preserve title, workspace, pin state, and pin order
- retain the old chat until successor creation and deletion succeed

## Validation
- `uv run --with pytest pytest -q tests/tui_gateway/test_seeded_session_create.py`
- `npx vitest run --project ui src/app/session/hooks/use-session-actions.test.tsx src/lib/desktop-slash-commands.test.ts`
- `npm run typecheck -- --pretty false`
- targeted ESLint and `git diff --check`