### PR TITLE
feat(gateway): model_scope=turn for a per-message model pick on session chat

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -253,6 +253,26 @@ _REASONING_EFFORTS = frozenset({"none", "minimal", "low", "medium", "high", "xhi
 _RUNTIME_AGENT_OVERRIDE_KEYS = (
     "api_key", "base_url", "provider", "api_mode", "command", "args", "credential_pool")
 
+_SESSION_MODEL_SCOPES = ("session", "turn")
+
+
+def _session_model_scope(body: Any) -> str:
+    """Body ``model_scope`` for the session chat endpoints: ``session`` (default) keeps the
+    model persisted on the session row as a standing selection, ``turn`` scopes this request's
+    ``model`` / ``provider`` / ``model_options`` to the current turn only. An unrecognized
+    value raises instead of falling back: a client that misspelled the scope would otherwise
+    silently run on the persisted model and never learn its pick was dropped."""
+    if not isinstance(body, dict):
+        return "session"
+    raw = body.get("model_scope")
+    if raw is None:
+        return "session"
+    scope = str(raw).strip().lower()
+    if scope not in _SESSION_MODEL_SCOPES:
+        raise ValueError(
+            f"model_scope must be one of {', '.join(_SESSION_MODEL_SCOPES)}; got {str(raw)[:32]!r}")
+    return scope
+
 
 def _clean_request_string(value: Any) -> Optional[str]:
     """Return a stripped request string, or None for absent/non-string values."""
@@ -2986,7 +3006,9 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         """Shared prelude for /api/sessions/{id}/chat[/stream]: header/body validation, then
         runtime selection — a Browser model lock (body ``require_model_lock`` or a confirmed
         persisted lock) wins; else the session-persisted model routes via model_routes when an
-        alias or threads through as ``session_model`` when raw, then body values.
+        alias or threads through as ``session_model`` when raw, then body values. Body
+        ``model_scope: "turn"`` skips that persisted tier so the body's model owns this turn
+        only; it is refused alongside a model lock.
         Returns ``(ctx, None)`` or ``(None, error)``; ``ctx["run_kwargs"]`` feeds ``_run_agent``."""
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
@@ -3008,7 +3030,18 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         system_prompt = body.get("system_message") or body.get("instructions")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return None, _error_response("system_message must be a string", 400, code="invalid_system_message")
+        try:
+            model_scope = _session_model_scope(body)
+        except ValueError as exc:
+            return None, _error_response(str(exc), 400, code="invalid_model_scope")
         runtime_request = self._effective_session_runtime_request(session=session, body=body)
+        if model_scope == "turn" and runtime_request.get("require_model_lock"):
+            # A lock pins this session's model on purpose, so a one-turn pick contradicts it.
+            # Rejected before `_persist_session_runtime_lock` so the refusal writes nothing.
+            return None, _error_response(
+                "model_scope=turn cannot be combined with require_model_lock: the lock pins this "
+                "session's model. Drop the lock to select a model for a single turn.",
+                400, code="invalid_model_scope")
         lock_error = self._runtime_lock_error(runtime_request)
         if lock_error is not None:
             return None, lock_error
@@ -3027,7 +3060,10 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             if runtime_request.get("model_options"):
                 agent_overrides["model_options"] = runtime_request["model_options"]
         else:
-            stored_model = self._stored_session_model(session)
+            # #108145: a turn-scoped pick does not thread the row's persisted model as a standing
+            # selection, so the body's `model`/`provider` reaches the per-request branch of
+            # _select_agent_runtime. Nothing is written back to the row either way.
+            stored_model = None if model_scope == "turn" else self._stored_session_model(session)
             stored_route = self._resolve_route(stored_model)
             route = stored_route or self._resolve_route(body.get("model"))
             session_model = stored_model if (stored_model and stored_route is None) else None

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -459,6 +459,96 @@ async def test_session_chat_stream_treats_pre_existing_poisoned_row_as_no_model(
     assert kwargs["session_model"] is None
 
 
+@pytest.mark.asyncio
+async def test_session_chat_model_scope_turn_outranks_the_persisted_model_for_one_turn(session_db):
+    """``model_scope: "turn"`` is the supported per-message model pick (#108145): the row's
+    persisted model stays the standing selection, a turn-scoped body model wins for exactly
+    that turn on both session chat surfaces, and the row is never rewritten."""
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._session_db = session_db
+    session_id = session_db.create_session("turn-scoped-session", "api_server", model="pinned/model")
+
+    async def fake_run(**kwargs):
+        return {"final_response": "ok", "session_id": session_id}, {"total_tokens": 1}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", side_effect=fake_run) as mock_run:
+        async with TestClient(TestServer(app)) as cli:
+            # Unscoped: a body model does not displace the session's standing selection.
+            persistent_turn = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                json={"message": "hi", "model": "once/model"},
+            )
+            assert persistent_turn.status == 200, await persistent_turn.text()
+            # Turn-scoped: the body model is this turn's model.
+            turn_scoped = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                json={"message": "hi", "model": "once/model", "model_scope": "turn"},
+            )
+            assert turn_scoped.status == 200, await turn_scoped.text()
+            # The next unscoped turn is back on the persisted model.
+            resumed = await cli.post(f"/api/sessions/{session_id}/chat", json={"message": "hi"})
+            assert resumed.status == 200, await resumed.text()
+            # Same contract on the SSE surface (shared prelude).
+            streamed = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "hi", "model": "once/model", "model_scope": "turn"},
+            )
+            assert streamed.status == 200, await streamed.text()
+            await streamed.text()
+
+    persistent_kwargs, turn_kwargs, resumed_kwargs, streamed_kwargs = (
+        call.kwargs for call in mock_run.call_args_list)
+
+    assert persistent_kwargs["session_model"] == "pinned/model"
+    assert turn_kwargs["session_model"] is None
+    assert turn_kwargs["requested_model"] == "once/model"
+    assert resumed_kwargs["session_model"] == "pinned/model"
+    assert streamed_kwargs["session_model"] is None
+    assert streamed_kwargs["requested_model"] == "once/model"
+    assert session_db.get_session(session_id)["model"] == "pinned/model"
+
+
+@pytest.mark.asyncio
+async def test_session_chat_model_scope_rejects_an_unknown_scope_or_a_model_lock(session_db):
+    """A mistyped scope must 400 (silently ignoring it is the bug this fixes), and a
+    turn-scoped pick cannot be combined with a lock that pins the session's model."""
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._session_db = session_db
+    session_id = session_db.create_session("turn-scope-guards", "api_server", model="pinned/model")
+
+    mock_run = AsyncMock(return_value=(
+        {"final_response": "ok", "session_id": session_id}, {"total_tokens": 1}))
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", mock_run):
+        async with TestClient(TestServer(app)) as cli:
+            unknown_scope = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                json={"message": "hi", "model": "once/model", "model_scope": "per-turn"},
+            )
+            assert unknown_scope.status == 400, await unknown_scope.text()
+            assert (await unknown_scope.json())["error"]["code"] == "invalid_model_scope"
+
+            locked = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                json={
+                    "message": "hi",
+                    "model": "once/model",
+                    "model_scope": "turn",
+                    "require_model_lock": True,
+                },
+            )
+            assert locked.status == 400, await locked.text()
+            assert (await locked.json())["error"]["code"] == "invalid_model_scope"
+
+    assert mock_run.call_count == 0
+    import json as _json
+    model_config = session_db.get_session(session_id).get("model_config")
+    if isinstance(model_config, str):
+        model_config = _json.loads(model_config)
+    assert "browser_model_lock" not in (model_config or {})
+
+
 def _register_session_model_route(app, adapter):
     app.router.add_post("/api/sessions/{session_id}/model", adapter._handle_session_model_lock)
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -378,6 +378,32 @@ If a request sends a `provider` that conflicts with a configured `model_routes`
 alias, Hermes rejects the request with `400` instead of silently remixing route
 credentials with another provider.
 
+### Per-turn model scope on session chat
+
+A session row can carry a persisted model, which is a standing selection that
+outranks the request's `model` on every later turn. Clients that let the user
+pick a model per message can opt out of that tier for one request:
+
+```json
+{
+  "message": "Summarize the repo status.",
+  "model": "MiniMax-M3",
+  "provider": "minimax",
+  "model_scope": "turn"
+}
+```
+
+- `model_scope: "session"` (the default) keeps the persisted model as the
+  standing selection.
+- `model_scope: "turn"` applies this request's `model` / `provider` /
+  `model_options` to this turn only. Nothing is written back to the session row,
+  and the next request without `model_scope` is back on the persisted model. A
+  session `/model` override still wins, since that is an explicit user command.
+- `model_scope` is accepted on `POST /api/sessions/{session_id}/chat` and
+  `POST /api/sessions/{session_id}/chat/stream`. Combining `"turn"` with
+  `require_model_lock` — or any unrecognized value — is rejected with `400` and
+  code `invalid_model_scope` rather than silently ignored.
+
 **Bare `model` values on the OpenAI-compatible endpoints are opt-in.** Generic
 OpenAI clients routinely hardcode model names (`gpt-4o`, ...), and existing
 deployments rely on those falling back to the gateway default. On


### PR DESCRIPTION
# api_server: `model_scope: "turn"` for a per-message model pick on session chat

## What Problem This Solves

`POST /api/sessions/{session_id}/chat` and `/chat/stream` already accept `model`, `provider`
and `model_options` in the body, but `_prepare_session_chat` also threads the session row's
persisted model through as `session_model`, and `_select_agent_runtime` ranks
"session-persisted model" above "per-request provider/model" (`gateway/platforms/api_server.py`,
the `session-persisted model wins` branch). A client that lets the user choose a model per
message therefore cannot express "this turn only": the pick is silently outranked on every
turn, with no error and no signal on the response.

This is part 1 of #108145. It adds the supported way to say it, reusing the existing
per-request body-field shape (no new hook, no new runtime path):

- **`model_scope: "session" | "turn"`** on both session-chat endpoints. They share the
  `_prepare_session_chat` prelude, so `/chat` and `/chat/stream` behave identically.
  - `"session"` (default) is exactly today's behaviour: the row's model stays the standing
    selection.
  - `"turn"` does not thread the row's model as a standing selection, so the body's
    `model` / `provider` / `model_options` reach the existing per-request branch of
    `_select_agent_runtime`. Nothing is written to the row either way, the next request
    without the field is back on the persisted model, and a session `/model` override still
    wins — that is an explicit user command, and `_select_agent_runtime` already documents
    that order.
- **A typo is a `400`, not a silent fallback.** An unrecognized `model_scope` returns
  `400 invalid_model_scope`. Falling back to the persisted model would reproduce exactly the
  invisible failure this field exists to fix: the client believes the pick applied and the
  user gets a different model.
- **`"turn"` plus a model lock is a `400`.** A lock (body `require_model_lock`, or a confirmed
  lock persisted on the row) pins this session's model on purpose, so a one-turn pick
  contradicts it. The rejection happens before `_persist_session_runtime_lock`, so a refused
  request writes nothing to the row.

Docs: `website/docs/user-guide/features/api-server.md` gains a "Per-turn model scope on
session chat" section next to the existing per-request model-selection precedence list.

### Scope of this PR

Partial fix for #108145 — the other three parts are deliberately not here, so this one stays
reviewable on its own:

- Approval events on the session stream (part 2) — separate transport work.
- `steer.delivered` and `pending_steer` on the failure path (part 3) — best rebased on the
  open drain-site PRs the issue names.
- The disconnect policy (part 4) — would compete with the open #96507, which the issue itself
  says not to duplicate.

## Evidence

Regression test added in this PR: `tests/gateway/test_session_api.py`
(`test_session_chat_model_scope_turn_outranks_the_persisted_model_for_one_turn` and
`test_session_chat_model_scope_rejects_an_unknown_scope_or_a_model_lock`). It walks a session
whose row is pinned to `pinned/model`: an unscoped turn with a body model still runs on the
row's model, a `model_scope: "turn"` turn runs on the body's model, the next unscoped turn is
back on the row's model, and the row is unchanged afterwards.

**Pre-fix** (tests only, against unmodified `main` @ `a2413495ad`):

```
>       assert turn_kwargs["session_model"] is None
E       AssertionError: assert 'pinned/model' is None

>               assert unknown_scope.status == 400, await unknown_scope.text()
E               AssertionError: {"object": "hermes.session.chat.completion", ..., "runtime": {"provider": "", "model": "", "route_source": "raw_request", "requested": {"provider": "", "model": "once/model"}}}
E               assert 200 == 400

FAILED tests/gateway/test_session_api.py::test_session_chat_model_scope_turn_outranks_the_persisted_model_for_one_turn
FAILED tests/gateway/test_session_api.py::test_session_chat_model_scope_rejects_an_unknown_scope_or_a_model_lock
====================== 2 failed, 30 deselected in 1.93s =======================
=== 1 file with test failures (2 tests failed) ===
  tests\gateway\test_session_api.py  (2 tests failed)
```

The first failure is the reported bug verbatim: the row's `pinned/model` was threaded as
`session_model` and outranked the request's `once/model`.

**Post-fix:**

```
[100.0% |    25/~25 | ✓2 | ✗0] ✓ tests\gateway\test_session_api.py (2✓, 3.3s)
=== Summary: 1 files, 2 tests passed, 0 failed (100% complete) in 3.3s (40 workers) ===
```

**Neighbouring API-server suites** (the shared prelude is on the session-chat path, so the
whole session/runs surface was re-run):

```
[ 71.4% |   135/~189 | ✓142 | ✗  0] ✓ tests\gateway\test_api_server.py (110✓, 38.9s)
[100.0% |   189/~189 | ✓206 | ✗  0] ✓ tests\gateway\test_api_server_runs.py (64✓, 41.0s)
=== Summary: 3 files, 206 tests passed, 0 failed (100% complete) in 41.0s (40 workers) ===
```

**Model-resolution and session-endpoint suites** touched by the same precedence chain:

```
Discovered 4 test files (~11 tests); running with -j 40
✓ tests\gateway\test_25107_stale_base_url_api_mode.py (2✓)
✓ tests\gateway\test_custom_provider_request_overrides.py (5✓)
✓ tests\gateway\test_empty_model_recovery.py (3✓)
✓ tests\gateway\test_model_command_request_overrides.py (1✓)

Discovered 2 test files (~23 tests); running with -j 40
✓ tests\gateway\test_peer_dm_hidden_e2e.py (3✓)
✓ tests\gateway\test_api_server_active_work_drain.py (20✓)
```

All runs via `scripts/run_tests.sh` (file-granular, per-file subprocess isolation), not bare
`pytest`.
