### PR TITLE
fix(update): bound fork upstream fetch/pull; profile-aware gmail-triage path

### DIFF
--- a/hermes_cli/update_cmd_deps.py
+++ b/hermes_cli/update_cmd_deps.py
@@ -419,8 +419,11 @@ def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
         return system_uv
     with suppress(Exception):
         print("  → Termux detected: trying to install uv for faster dependency updates...")
+        # Bounded like every other network step in the update path: a stalled
+        # PyPI/proxy must halt this optional bootstrap, not `hermes update`.
         result = subprocess.run(
-            pip_cmd + ["install", "uv", "--only-binary", ":all:"], cwd=_m().PROJECT_ROOT, check=False)
+            pip_cmd + ["install", "uv", "--only-binary", ":all:"], cwd=_m().PROJECT_ROOT, check=False,
+            timeout=600)
         if result.returncode != 0:
             return None
     return resolve_uv() or shutil.which("uv")

--- a/hermes_cli/update_cmd_git.py
+++ b/hermes_cli/update_cmd_git.py
@@ -273,15 +273,15 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path, *, assume_yes: 
 
     See #97052.
     """
-    from hermes_cli.update_cmd import _count_commits_between, _has_upstream_remote, _no_prompt_git_kwargs, _should_skip_upstream_prompt
+    from hermes_cli.update_cmd import _count_commits_between, _has_upstream_remote, _should_skip_upstream_prompt
     if not _has_upstream_remote(git_cmd, cwd) and (
         _should_skip_upstream_prompt() or not _offer_upstream_remote(git_cmd, cwd, assume_yes=assume_yes, input_fn=input_fn)
     ):
         return False
     print("\n→ Fetching upstream...")
-    try:
-        subprocess.run(git_cmd + ["fetch", "upstream", "main", "--quiet"], cwd=cwd, capture_output=True, check=True, **_no_prompt_git_kwargs())
-    except subprocess.CalledProcessError:
+    # network=True: a transport dead-stall must end in a failed sync, not a hung
+    # update (same class as #93759; the push below already rides this path).
+    if not _git_ok(git_cmd, ["fetch", "upstream", "main", "--quiet"], cwd, network=True):
         print("  ✗ Failed to fetch upstream. Skipping upstream sync.")
         return False
     origin_ahead = _count_commits_between(git_cmd, cwd, "upstream/main", "origin/main")
@@ -300,9 +300,7 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path, *, assume_yes: 
         print("  ✓ Fork is up to date with upstream")
         return True
     print(f"\n→ Fork is {upstream_ahead} commit(s) behind upstream\n→ Pulling from upstream...")
-    try:
-        subprocess.run(git_cmd + ["pull", "--ff-only", "upstream", "main"], cwd=cwd, check=True, **_no_prompt_git_kwargs())
-    except subprocess.CalledProcessError:
+    if not _git_ok(git_cmd, ["pull", "--ff-only", "upstream", "main"], cwd, network=True):
         print("  ✗ Failed to pull from upstream. You may need to resolve conflicts manually.")
         return False
     print("  ✓ Updated from upstream\n→ Syncing fork...")

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4500,7 +4500,10 @@ class TelegramAdapter(TelegramWisdomMixin, BasePlatformAdapter):
             await query.answer(text=f"Unknown verb: {verb}")
             return
         script_name, extra_args, success_label, is_state_verb = entry
-        script_path = _Path.home() / ".hermes" / "scripts" / "gmail-triage" / script_name
+        # Profile-aware (root rule: never hardcode ~/.hermes) — matches every other
+        # scripts-dir resolution (cron/scheduler_script.py, whatsapp_common.py).
+        from hermes_constants import get_hermes_home
+        script_path = get_hermes_home() / "scripts" / "gmail-triage" / script_name
         if not script_path.exists():
             await query.answer(text=f"❌ {script_name} missing")
             logger.error("[%s] gmail-triage script missing: %s", self.name, script_path)

--- a/tests/hermes_cli/test_update_upstream_sync_network_timeout.py
+++ b/tests/hermes_cli/test_update_upstream_sync_network_timeout.py
@@ -1,0 +1,64 @@
+"""Fork upstream sync must ride the bounded network path (#93759 bug class).
+
+``_sync_with_upstream_if_needed`` runs ``git fetch upstream`` and
+``git pull --ff-only upstream`` — network operations that dead-stall on a
+black-holed proxy. Every other network git step in the update path goes
+through ``_git_run(..., network=True)`` which bounds the wait
+(``NETWORK_GIT_TIMEOUT_SECONDS``); the sync's own fetch/pull previously ran a
+bare ``subprocess.run`` and hung ``hermes update`` forever on a stalled
+transport. These tests pin the invariant: the fetch and the pull are bounded
+the same way the fork push already is.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+from hermes_cli import update_cmd
+
+
+def _fake_git_run(calls):
+    """Stand-in for update_cmd._git_run: records kwargs, answers rev-list counts.
+
+    First ``rev-list`` (origin ahead of upstream) reports 0, the second (upstream
+    ahead of origin) reports 5 — the strictly-behind fork state that triggers
+    pull + push.
+    """
+    counts = iter(["0", "5"])
+
+    def run(git_cmd, args, cwd=None, *, check=False, network=False):
+        calls.append({"args": list(args), "network": network})
+        stdout = next(counts) if args[0] == "rev-list" else ""
+        return subprocess.CompletedProcess(git_cmd + args, 0, stdout=stdout, stderr="")
+
+    return run
+
+
+def _sync_behind_fork(tmp_path):
+    """Drive the sync with upstream present and origin strictly behind upstream."""
+    calls: list[dict] = []
+    with (
+        patch.object(update_cmd, "_git_run", _fake_git_run(calls)),
+        patch.object(update_cmd, "_has_upstream_remote", return_value=True),
+    ):
+        checked = update_cmd._sync_with_upstream_if_needed(["git"], tmp_path)
+    return checked, calls
+
+
+class TestUpstreamSyncNetworkBounded:
+    def test_behind_fork_sync_is_verified(self, tmp_path):
+        checked, _calls = _sync_behind_fork(tmp_path)
+        assert checked is True
+
+    def test_fetch_and_pull_are_network_bounded_like_the_push(self, tmp_path):
+        _checked, calls = _sync_behind_fork(tmp_path)
+        network_steps = [c for c in calls if c["args"][0] in {"fetch", "pull", "push"}]
+        assert [c["args"][0] for c in network_steps] == ["fetch", "pull", "push"]
+        assert all(c["network"] is True for c in network_steps), (
+            "every upstream network step must opt into the bounded network path"
+        )


### PR DESCRIPTION
## What

Three small fixes in the `hermes update` path, each the surviving half of a bug class the repo already handles elsewhere (found in an end-to-end review of main @ 04dd80a977, every claim reproduced live):

1. **`_sync_with_upstream_if_needed` fetch/pull were the un-timed siblings of the #93759 fix class.** `git fetch upstream` / `git pull --ff-only upstream` ran bare `subprocess.run(..., **_no_prompt_git_kwargs())` — prompt-safe but unbounded — while every other network git step in the update path, including the fork `push` **two lines below the fetch**, rides `_git_run(..., network=True)` with `NETWORK_GIT_TIMEOUT_SECONDS`. A dead-stalled transport (HTTP/2 black-hole, proxy) left `hermes update` on "Fetching upstream..." forever. Both calls now ride `_git_ok(..., network=True)`, so a timeout reports as the existing "Failed to fetch/pull upstream" line; the sync was already non-fatal by design.
2. **Termux `pip install uv` bootstrap had no bound** — a stalled PyPI/proxy halted the whole update on an optional step (`timeout=600` now; the surrounding `suppress(Exception)` already treats failure as "keep going without uv").
3. **gmail-triage inline-button path was the only scripts-dir resolution not profile-aware.** `plugins/platforms/telegram/adapter.py` built the script path from `_Path.home() / ".hermes"` while every sibling (`cron/scheduler_script.py`, `whatsapp_common.py`, `webhook_filters.py`, and the same file's own `.update_response` write) uses `get_hermes_home()`. Non-default profiles got "❌ script missing" (and on Windows the default profile too, since the default home is `%LOCALAPPDATA%\hermes`). One-line switch to `get_hermes_home()`.

## Tests

`tests/hermes_cli/test_update_upstream_sync_network_timeout.py` — 2 invariant tests pinning that every network step of the fork sync (fetch, pull, push) opts into the bounded path through the `_git_run` seam. Proven red on base (bare fetch/pull never reaches `_git_run`), green with the fix; `scripts/run_tests.sh` green on this file plus the neighbouring update/upstream suites (65 tests) and the telegram callback-adapter suites (43 tests).

## Out of scope (deliberately)

The `_run_logged_subprocess` Popen/read1 loop has no watchdog, but that drives the Electron desktop build whose runtimes legitimately vary — a fixed cap would kill slow-but-valid builds; left as the design trade-off it is.