### PR TITLE
fix(review): bound idle-review queue memory with weak parents and frozen snapshots

### DIFF
--- a/agent/review_idle_queue.py
+++ b/agent/review_idle_queue.py
@@ -8,6 +8,10 @@ explicit /refine never defers). One slot per session, newest snapshot wins (a re
 the whole conversation, so coalescing is dedup, not loss); aged-out items (defer_max_age_s,
 default 30 min) dispatch regardless of idleness; in-memory best-effort like the immediate
 fork. Idle truth is the supervisor's /slots held for a settle window.
+
+Deferral must never become an unbounded memory owner: queued entries hold the snapshot as
+frozen JSON bytes (detached from the live transcript's object graph) and the parent agent
+weakly, under a process-wide byte/session budget that evicts the oldest best-effort reviews.
 """
 
 from __future__ import annotations
@@ -17,6 +21,7 @@ import logging
 import threading
 import time
 import urllib.request
+import weakref
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
 
@@ -25,6 +30,9 @@ logger = logging.getLogger(__name__)
 _IDLE_SETTLE_S = 15.0  # quiet window: two back-to-back prompts must not look idle, a coffee break must
 _POLL_INTERVAL_S = 5.0  # poll cadence while non-empty; the thread parks when empty
 _MAX_AGE_DEFAULT_S = 30.0 * 60.0  # dispatch regardless of idleness past this age
+# aggregate caps on what the queue may retain (best-effort reviews must not outrank foreground memory)
+_SNAPSHOT_BUDGET_BYTES = 8 * 1024 * 1024
+_SESSION_BUDGET = 16
 
 
 def defer_mode(task_cfg: Optional[Dict[str, Any]]) -> str:
@@ -58,20 +66,49 @@ def review_targets_managed_local(agent: Any, task_cfg: Optional[Dict[str, Any]])
         return False
 
 
+def _dead_ref(_agent: Any = None) -> Any:
+    """Stand-in for objects that cannot be weak-referenced: the review drops at dispatch."""
+    return None
+
+
+def _freeze_snapshot(messages_snapshot: Any) -> Optional[bytes]:
+    """UTF-8 JSON bytes for the cloned transcript, or None when it is not serializable.
+
+    Freezing detaches the queue from the transcript's nested object graph and large immutable
+    strings while preserving exact message data for reconstruction at dispatch.
+    """
+    try:
+        return json.dumps(
+            messages_snapshot, ensure_ascii=False, separators=(",", ":")
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        return None
+
+
 @dataclass(slots=True)
 class _PendingReview:
-    agent: Any
+    agent_ref: Callable[[], Any]
     session_key: str
+    frozen_snapshot: bytes
+    # dispatch arguments minus messages_snapshot (frozen separately)
     kwargs: Dict[str, Any]
+    snapshot_bytes: int
     enqueued_at: float
 
 
 class ReviewIdleQueue:
     """Session-coalescing queue + idle-gated dispatcher thread."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        snapshot_budget_bytes: int = _SNAPSHOT_BUDGET_BYTES,
+        session_budget: int = _SESSION_BUDGET,
+    ) -> None:
         self._lock = threading.Lock()
         self._pending: Dict[str, _PendingReview] = {}
+        self._snapshot_bytes = 0
+        self._snapshot_budget_bytes = snapshot_budget_bytes
+        self._session_budget = session_budget
         self._wake = threading.Event()
         self._thread: Optional[threading.Thread] = None
         self._live_turns = 0
@@ -94,11 +131,43 @@ class ReviewIdleQueue:
 
     def enqueue(self, agent: Any, session_key: str, kwargs: Dict[str, Any]) -> None:
         """Add (or replace — newest snapshot wins) a session's pending review, keeping the ORIGINAL
-        enqueue time on coalesce so a busy session cannot push its age-out forever."""
+        enqueue time on coalesce so a busy session cannot push its age-out forever.
+
+        The snapshot is frozen into JSON bytes and the parent held weakly, so a pending entry pins
+        neither the live transcript graph nor an otherwise-collected AIAgent. Entries that cannot
+        be frozen, or whose snapshot alone exceeds the whole queue budget, are rejected — background
+        review is best-effort and must not outrank foreground memory ownership.
+        """
+        rest = dict(kwargs)
+        frozen = _freeze_snapshot(rest.pop("messages_snapshot", None))
+        if frozen is None:
+            logger.warning(
+                "Deferred background review rejected: snapshot is not JSON-serializable (session=%s)",
+                session_key[-12:],
+            )
+            return
+        if len(frozen) > self._snapshot_budget_bytes:
+            logger.warning(
+                "Deferred background review rejected: snapshot %d bytes exceeds queue budget %d (session=%s)",
+                len(frozen),
+                self._snapshot_budget_bytes,
+                session_key[-12:],
+            )
+            return
+        try:
+            agent_ref = weakref.ref(agent)
+        except TypeError:
+            agent_ref = _dead_ref
         with self._lock:
             existing = self._pending.get(session_key)
             enqueued_at = existing.enqueued_at if existing is not None else self._now()
-            self._pending[session_key] = _PendingReview(agent, session_key, kwargs, enqueued_at)
+            if existing is not None:
+                self._snapshot_bytes -= existing.snapshot_bytes
+            self._pending[session_key] = _PendingReview(
+                agent_ref, session_key, frozen, rest, len(frozen), enqueued_at
+            )
+            self._snapshot_bytes += len(frozen)
+            self._evict_over_budget_locked()
         self._ensure_thread()
         self._wake.set()
         logger.info("Background review deferred (session=%s, queued=%d)", session_key[-12:], len(self._pending))
@@ -106,6 +175,29 @@ class ReviewIdleQueue:
     def pending_count(self) -> int:
         with self._lock:
             return len(self._pending)
+
+    def pending_bytes(self) -> int:
+        with self._lock:
+            return self._snapshot_bytes
+
+    def _evict_over_budget_locked(self) -> None:
+        """Oldest best-effort reviews go first once the queue exceeds its byte/session budget."""
+        while len(self._pending) > self._session_budget:
+            self._evict_oldest_locked("pending sessions over budget")
+        while self._snapshot_bytes > self._snapshot_budget_bytes and self._pending:
+            self._evict_oldest_locked("snapshot bytes over budget")
+
+    def _evict_oldest_locked(self, reason: str) -> None:
+        oldest = min(
+            self._pending.values(), key=lambda p: (p.enqueued_at, p.session_key)
+        )
+        del self._pending[oldest.session_key]
+        self._snapshot_bytes -= oldest.snapshot_bytes
+        logger.warning(
+            "Deferred background review evicted: %s (session=%s)",
+            reason,
+            oldest.session_key[-12:],
+        )
 
     def _ensure_thread(self) -> None:
         with self._lock:
@@ -136,7 +228,48 @@ class ReviewIdleQueue:
                 if not self._pending:
                     return None
                 candidate = min(self._pending.values(), key=lambda p: p.enqueued_at)
-            return self._pending.pop(candidate.session_key, None)
+            popped = self._pending.pop(candidate.session_key, None)
+            if popped is not None:
+                self._snapshot_bytes -= popped.snapshot_bytes
+            return popped
+
+    def _dispatch(self, item: _PendingReview) -> None:
+        """Run one popped review: enabled gate, live-parent check, snapshot thaw, spawn.
+
+        A dead parent or an unreadable frozen snapshot drops the best-effort review instead of
+        raising — the dispatcher thread must survive anything its entries hand it.
+        """
+        if not self._still_enabled(item):
+            logger.info(
+                "Deferred background review dropped: reviews were disabled while it was queued (session=%s)",
+                item.session_key[-12:],
+            )
+            return
+        agent = item.agent_ref()
+        if agent is None:
+            logger.info(
+                "Deferred background review dropped: parent agent is gone (session=%s)",
+                item.session_key[-12:],
+            )
+            return
+        try:
+            kwargs = dict(item.kwargs)
+            kwargs["messages_snapshot"] = json.loads(
+                item.frozen_snapshot.decode("utf-8")
+            )
+        except (UnicodeDecodeError, ValueError):
+            logger.warning(
+                "Deferred background review dropped: frozen snapshot unreadable (session=%s)",
+                item.session_key[-12:],
+            )
+            return
+        logger.info(
+            "Dispatching deferred background review (session=%s, waited=%.0fs, queued=%d)",
+            item.session_key[-12:],
+            self._now() - item.enqueued_at,
+            self.pending_count(),
+        )
+        agent._spawn_background_review_now(**kwargs)
 
     def _run(self) -> None:
         while True:
@@ -149,15 +282,7 @@ class ReviewIdleQueue:
             try:
                 item = self._pop_dispatchable()
                 if item is not None:
-                    if not self._still_enabled(item):
-                        logger.info(
-                            "Deferred background review dropped: reviews were disabled while it was queued (session=%s)",
-                            item.session_key[-12:])
-                        continue
-                    logger.info(
-                        "Dispatching deferred background review (session=%s, waited=%.0fs, queued=%d)",
-                        item.session_key[-12:], self._now() - item.enqueued_at, self.pending_count())
-                    item.agent._spawn_background_review_now(**item.kwargs)
+                    self._dispatch(item)
             except Exception:  # noqa: BLE001 — dispatcher must survive anything
                 logger.warning("Deferred review dispatch failed", exc_info=True)
             if item is None:

--- a/tests/agent/test_review_idle_queue.py
+++ b/tests/agent/test_review_idle_queue.py
@@ -89,7 +89,8 @@ def test_enqueue_coalesces_per_session_newest_wins_oldest_age():
         item = q._pending["s1"]
     # Newest snapshot won, but the age clock kept the ORIGINAL enqueue
     # time so a busy session cannot push its own age-out forever.
-    assert item.kwargs["messages_snapshot"] == ["new"]
+    assert item.frozen_snapshot == b'["new"]'
+    assert "messages_snapshot" not in item.kwargs
     assert item.enqueued_at == 100.0
 
 
@@ -345,3 +346,152 @@ def test_requeue_skips_non_managed(monkeypatch):
             {"task_cfg": {"defer": "auto"}, "focus": None,
              "_requeue_attempts": 1})
     assert calls["enqueued"] == []
+
+
+# ── queue memory ownership: weak parent, frozen snapshots, budgets ─
+
+
+def test_pending_entry_holds_frozen_bytes_not_transcript_objects():
+    q, clock = _make_queue()
+    agent = _FakeAgent()
+    transcript = [{"role": "user", "content": "x" * 500}]
+    q.enqueue(agent, "s1", {"messages_snapshot": transcript, "task_cfg": {}})
+
+    with q._lock:
+        item = q._pending["s1"]
+    assert isinstance(item.frozen_snapshot, bytes)
+    assert "messages_snapshot" not in item.kwargs
+    # The queue does not alias the live transcript's nested objects.
+    assert not any(
+        v is transcript
+        for v in (item.frozen_snapshot, item.kwargs, getattr(item, "agent_ref", None))
+    )
+
+
+def test_dead_parent_weakref_drops_review_at_dispatch():
+    q, clock = _make_queue()
+    agent = _FakeAgent()
+    q.enqueue(
+        agent,
+        "s1",
+        {"messages_snapshot": [{"role": "user", "content": "hi"}], "task_cfg": {}},
+    )
+    q.note_turn_started()
+    q.note_turn_finished()
+    clock["t"] += _IDLE_SETTLE_S + 1
+    item = q._pop_dispatchable()
+    assert item is not None
+    # The list outlives the agent; a strong-ref queue would keep the agent
+    # alive and the spawn would land here.
+    spy = agent.spawned
+    del agent
+    import gc
+
+    gc.collect()
+    q._dispatch(item)
+    assert spy == []
+
+
+def test_live_parent_dispatch_reconstructs_messages_and_releases_accounting():
+    q, clock = _make_queue()
+    agent = _FakeAgent()
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    q.enqueue(
+        agent,
+        "s1",
+        {"messages_snapshot": messages, "review_memory": True, "task_cfg": {}},
+    )
+    assert q.pending_bytes() > 0
+    q.note_turn_started()
+    q.note_turn_finished()
+    clock["t"] += _IDLE_SETTLE_S + 1
+    item = q._pop_dispatchable()
+    assert item is not None
+    assert q.pending_bytes() == 0  # popped accounting released
+    q._dispatch(item)
+    assert len(agent.spawned) == 1
+    assert agent.spawned[0]["messages_snapshot"] == messages
+    assert agent.spawned[0]["review_memory"] is True
+
+
+def test_coalesce_replaces_byte_accounting():
+    q, clock = _make_queue()
+    agent = _FakeAgent()
+    q.enqueue(agent, "s1", {"messages_snapshot": ["a" * 1000], "task_cfg": {}})
+    first = q.pending_bytes()
+    q.enqueue(agent, "s1", {"messages_snapshot": ["b" * 100], "task_cfg": {}})
+    with q._lock:
+        item = q._pending["s1"]
+    assert q.pending_count() == 1
+    assert q.pending_bytes() == item.snapshot_bytes
+    assert q.pending_bytes() < first
+
+
+def test_session_budget_evicts_oldest():
+    q, clock = _make_queue()
+    q._session_budget = 2
+    agent = _FakeAgent()
+    clock["t"] = 10.0
+    q.enqueue(agent, "s-old", {"messages_snapshot": ["x"], "task_cfg": {}})
+    clock["t"] = 20.0
+    q.enqueue(agent, "s-mid", {"messages_snapshot": ["x"], "task_cfg": {}})
+    clock["t"] = 30.0
+    q.enqueue(agent, "s-new", {"messages_snapshot": ["x"], "task_cfg": {}})
+    assert q.pending_count() == 2
+    with q._lock:
+        assert "s-old" not in q._pending
+        assert "s-mid" in q._pending
+        assert "s-new" in q._pending
+
+
+def test_byte_budget_evicts_oldest():
+    q, clock = _make_queue()
+    q._session_budget = 100
+    q._snapshot_budget_bytes = 2500
+    agent = _FakeAgent()
+    clock["t"] = 8.0
+    q.enqueue(agent, "s1", {"messages_snapshot": ["a" * 1000], "task_cfg": {}})
+    clock["t"] = 9.0
+    q.enqueue(agent, "s2", {"messages_snapshot": ["b" * 1000], "task_cfg": {}})
+    clock["t"] = 10.0
+    q.enqueue(agent, "s3", {"messages_snapshot": ["c" * 1000], "task_cfg": {}})
+    assert q.pending_count() == 2
+    assert q.pending_bytes() <= 2500
+    with q._lock:
+        assert "s1" not in q._pending
+        assert "s2" in q._pending
+        assert "s3" in q._pending
+
+
+def test_oversized_snapshot_rejected_whole():
+    q, clock = _make_queue()
+    q._snapshot_budget_bytes = 500
+    agent = _FakeAgent()
+    q.enqueue(agent, "s1", {"messages_snapshot": ["a" * 1000], "task_cfg": {}})
+    assert q.pending_count() == 0
+    assert q.pending_bytes() == 0
+
+
+def test_non_serializable_snapshot_rejected():
+    q, clock = _make_queue()
+    agent = _FakeAgent()
+    q.enqueue(agent, "s1", {"messages_snapshot": {object()}, "task_cfg": {}})
+    assert q.pending_count() == 0
+
+
+def test_corrupt_frozen_snapshot_fails_closed_at_dispatch():
+    q, clock = _make_queue()
+    agent = _FakeAgent()
+    q.enqueue(agent, "s1", {"messages_snapshot": ["ok"], "task_cfg": {}})
+    with q._lock:
+        q._pending["s1"].frozen_snapshot = b"\xff\xfe not json"
+    q.note_turn_started()
+    q.note_turn_finished()
+    clock["t"] += _IDLE_SETTLE_S + 1
+    item = q._pop_dispatchable()
+    assert item is not None
+    q._dispatch(item)  # corrupt payload: drop + warn, no spawn, no raise
+    assert agent.spawned == []


### PR DESCRIPTION
## What

`agent/review_idle_queue.ReviewIdleQueue` kept every deferred review alive with two unbounded strong owners: the parent `AIAgent` instance and a structural clone of the whole transcript (`messages_snapshot`). On a busy managed-local host one such entry could sit per session for the full defer window (default 30 min), pinning agents that the cache had already evicted plus every large immutable tool-result string in the clone (#108234).

## Change — all at the queue boundary, no call-site changes

- `_PendingReview` now holds the parent through `weakref.ref` (objects that cannot be weak-referenced degrade to a dead ref — the review drops at dispatch). A collected parent drops the best-effort review with a log line instead of extending the lifetime of clients, tool state and provider state.
- The already-cloned snapshot is frozen into UTF-8 JSON bytes at `enqueue` (`json.dumps(..., ensure_ascii=False)`), detaching the queue from the transcript's nested object graph. It is thawed back into a message list only after an item is popped, so dispatch semantics (`_spawn_background_review_now(**kwargs)`) are unchanged; the JSON round-trip preserves exact message data.
- Aggregate accounting (`_snapshot_bytes`) is maintained under the existing lock: coalescing replaces the previous entry's bytes, popping releases them immediately.
- Process-wide budgets (8 MiB of frozen snapshots / 16 pending sessions, constants `_SNAPSHOT_BUDGET_BYTES` / `_SESSION_BUDGET`): pressure evicts the **oldest** entries with a warning; a single snapshot larger than the whole budget is rejected rather than retained forever; non-serializable snapshots are rejected at enqueue. Background review stays best-effort and never outranks foreground memory ownership.
- The dispatcher now runs through `_dispatch()`, which keeps the existing enabled-gate recheck and adds fail-closed handling: dead parent or unreadable frozen payload → drop + warn, never poison the thread.

## Tests

`tests/agent/test_review_idle_queue.py` grew from 19 to 28 tests, covering every regression item from the issue: frozen bytes (not the transcript list) in pending entries, weakref clearing after the last external reference dies, coalesce-replaces-accounting, byte- and session-budget eviction of the oldest entry, oversized/non-serializable rejection, dispatch round-trip reconstructing the message list with accounting back to zero, and corrupt-payload fail-closed. All pre-existing 19 tests still pass unchanged (one assertion updated to the new frozen-snapshot contract).

Fixes #108234
