### PR TITLE
fix(windows): probe %LOCALAPPDATA%\hermes\bin for the vendored uv in _find_uv_binary

### DIFF
--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -269,9 +269,17 @@ def _find_uv_binary() -> str | None:
 
     uv-managed base interpreters carry an ``EXTERNALLY-MANAGED`` marker, so the stdlib ``pip``
     fallback refuses to touch them; the only sanctioned installer is then uv itself, which Hermes
-    vendors (``~/.hermes/bin/uv.exe``) or the user has on PATH.
+    vendors (``~/.hermes/bin/uv.exe`` on POSIX, ``%LOCALAPPDATA%\\hermes\\bin`` on Windows)
+    or the user has on PATH.
     """
     exe = "uv.exe" if sys.platform == "win32" else "uv"
+    # Windows-first: Hermes vendors uv to %LOCALAPPDATA%\hermes\bin, but Path.home()
+    # there is not where the vendor dir lives. Probe the managed location before the
+    # POSIX-style home candidates so recovery works even when no uv is on PATH.
+    if sys.platform == "win32" and os.environ.get("LOCALAPPDATA"):
+        managed = Path(os.environ["LOCALAPPDATA"]) / "hermes" / "bin" / exe
+        if managed.is_file():
+            return str(managed)
     for sub in ((".hermes", "bin"), (".local", "bin"), (".cargo", "bin")):
         path = Path.home().joinpath(*sub, exe)
         if path.is_file():

--- a/tests/hermes_cli/test_early_recovery.py
+++ b/tests/hermes_cli/test_early_recovery.py
@@ -345,6 +345,40 @@ def test_externally_managed_detection(tmp_path, monkeypatch):
     assert er._base_interpreter_is_externally_managed() is True
 
 
+def test_find_uv_binary_prefers_windows_localappdata(monkeypatch, tmp_path):
+    """Windows vendors uv to %LOCALAPPDATA%\\hermes\\bin, not Path.home() — the
+    managed location must win over home candidates and PATH (recovery must not
+    depend on the user having uv on PATH)."""
+    managed_uv = tmp_path / "hermes" / "bin" / "uv.exe"
+    managed_uv.parent.mkdir(parents=True)
+    managed_uv.touch()
+    monkeypatch.setattr(er.sys, "platform", "win32")
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    monkeypatch.setattr(er.shutil, "which", lambda _exe: "C:/old/uv.exe")
+
+    assert er._find_uv_binary() == str(managed_uv)
+
+
+def test_find_uv_binary_falls_back_to_home_candidates_then_path(monkeypatch, tmp_path):
+    """Without %LOCALAPPDATA%\\hermes\\bin (or on POSIX), the documented home
+    candidates and PATH order still apply."""
+    monkeypatch.setattr(er.sys, "platform", "win32")
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "empty-localappdata"))
+    empty_home = tmp_path / "empty-home"
+    monkeypatch.setattr(er.Path, "home", staticmethod(lambda: empty_home))
+    # No managed uv and no home candidates: falls through to PATH.
+    monkeypatch.setattr(er.shutil, "which", lambda _exe: "C:/old/uv.exe")
+
+    assert er._find_uv_binary() == "C:/old/uv.exe"
+
+    # A home candidate still wins over PATH when the managed location is absent.
+    home_uv = empty_home / ".local" / "bin" / "uv.exe"
+    home_uv.parent.mkdir(parents=True)
+    home_uv.touch()
+
+    assert er._find_uv_binary() == str(home_uv)
+
+
 # ---------------------------------------------------------------------------
 # Pending core install (.update-incomplete) — completed BEFORE native imports
 # (#83569 review: a deferred update must not re-lock itself on the next launch)


### PR DESCRIPTION
## Summary

On Windows, Hermes vendors uv to `%LOCALAPPDATA%\hermes\bin\uv.exe`, but `_find_uv_binary()` only probed POSIX-style `Path.home()` candidates (`~/.hermes/bin`, `~/.local/bin`, `~/.cargo/bin`) before falling back to PATH. When the vendored uv.exe is the only one present, early venv recovery skipped it and fell back to stdlib pip — which aborts on uv-managed base interpreters (`EXTERNALLY-MANAGED`, #83569), leaving the venv unrepaired.

- Probe the managed Windows location (`%LOCALAPPDATA%\hermes\bin\uv.exe`) first on `sys.platform == "win32"`
- Home-candidate and PATH fallback order unchanged otherwise
- stdlib-only, no new imports (module contract preserved)
- Two new tests: managed location wins over PATH; fallback order preserved when it is absent

## Test plan

- [x] `venv/Scripts/python.exe -m pytest tests/hermes_cli/test_early_recovery.py -q` → 19/19 pass on native Windows (2 new)
- [x] Live check on a Windows machine with the vendored uv and none in POSIX-style home dirs: `_find_uv_binary()` now resolves the managed uv.exe (previously relied on PATH)

Found while recovering local fixes that `hermes update` auto-stash had silently parked (the same fix survived as a carried patch on an install until an orphan-reset update dropped it).