### PR TITLE
test(windows): create=True for the start_unix_server tripwire patch

### DIFF
--- a/tests/gateway/test_shutdown_watchdog.py
+++ b/tests/gateway/test_shutdown_watchdog.py
@@ -152,6 +152,13 @@ async def test_loop_tick_witness_arms_over_tcp_on_windows(
         shutdown_watchdog_module.asyncio,
         "start_unix_server",
         side_effect=_forbid_start_unix_server,
+        # ``asyncio.start_unix_server`` only exists where an AF_UNIX event loop
+        # does. On native Windows the attribute is absent, so without create=True
+        # patch.object itself raises AttributeError — the test could only ever
+        # pass on POSIX, the platform it pretends not to be. create=True arms
+        # the forbidden-call tripwire everywhere and mock deletes the created
+        # attribute on exit.
+        create=True,
     ), caplog.at_level(logging.DEBUG, logger="gateway.shutdown_watchdog"):
         payload = await _run_heartbeat_until_payload(tmp_path)
 


### PR DESCRIPTION
## Summary

`test_loop_tick_witness_arms_over_tcp_on_windows` arms a forbidden-call tripwire with `patch.object(shutdown_watchdog_module.asyncio, "start_unix_server", side_effect=...)` — but `asyncio.start_unix_server` only exists where an AF_UNIX event loop does. On native Windows the attribute is absent, so `patch.object` itself raises `AttributeError` while setting up: the test could only ever pass on POSIX, the platform it pretends not to be.

- Add `create=True` so the tripwire arms on every platform; mock deletes the created attribute on exit, so no cross-test leakage
- Test body unchanged; assertions unchanged
- Verified the previously-failing test now passes on native Windows

## Test plan

- [x] Before (native Windows): `pytest tests/gateway/test_shutdown_watchdog.py` → `test_loop_tick_witness_arms_over_tcp_on_windows` FAILED (`AttributeError: module 'asyncio' does not have the attribute 'start_unix_server'`)
- [x] After: 4/4 pass in `test_shutdown_watchdog.py`, 13/13 in `test_loop_liveness_watchdog.py` (native Windows, Python 3.11)
- [x] On POSIX the attribute exists and the patch behaves identically — no behavior change where the test previously passed

Found while auditing which local fixes `hermes update` auto-stash had silently parked: the superseded local test used `create=True` — upstream's replacement dropped it.