### PR TITLE
feat(skills): add bundled cursor-cloud-agents skill for the Cloud Agents API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -542,3 +542,11 @@ IMAGE_TOOLS_DEBUG=false
 # at https://www.reddit.com/prefs/apps and paste its id and secret here.
 # REDDIT_CLIENT_ID=
 # REDDIT_CLIENT_SECRET=
+
+# =============================================================================
+# cursor-cloud-agents skill (bundled) — Cursor Cloud Agents API
+# =============================================================================
+# Create a key at https://cursor.com/dashboard (Settings -> API Keys) and paste
+# it here. The helper reads CURSOR_API_KEY from the environment and always talks
+# to https://api.cursor.com. Never commit the key or paste it into a prompt.
+# CURSOR_API_KEY=

--- a/skills/autonomous-ai-agents/cursor-cloud-agents/SKILL.md
+++ b/skills/autonomous-ai-agents/cursor-cloud-agents/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: cursor-cloud-agents
+description: Launch and manage Cursor Cloud Agents from Hermes.
+version: 1.0.0
+author: Finn763
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Coding-Agent, Cursor, Cloud-Agents, Delegation, GitHub, API]
+    related_skills: [claude-code, codex, hermes-agent]
+---
+
+# Cursor Cloud Agents Skill
+
+Delegate repository work to [Cursor Cloud Agents](https://cursor.com/docs/cloud-agent/api/endpoints) — ephemeral coding agents that run in Cursor-hosted VMs against a GitHub repository. This skill covers the public Cloud Agents HTTP API only: launching agents, sending follow-ups, polling status, cancelling runs, and listing models. It does not drive the local `cursor-agent` CLI and it never opens a shell inside the agent VM.
+
+## When to Use
+
+- Long-running repo work that should not occupy the Hermes host (large refactors, dependency migrations, test-suite repair).
+- Several independent workstreams at once — each agent gets its own VM, its own branch, and its own PR.
+- Work that must outlive the current session: the agent keeps running after Hermes exits.
+- Delegating to a model that only exists inside Cursor's runtime (`composer-*`).
+
+Not for: quick edits to the local checkout (use `patch`), interactive pair-programming (that is the local CLI), or repos outside GitHub.
+
+## Prerequisites
+
+- **API key:** create one at https://cursor.com/dashboard (Settings → API Keys) and export it as `CURSOR_API_KEY`. In a gateway/service install put it in the profile `.env`; never paste the key into a prompt, a commit, or a file in the repo.
+- **GitHub App:** Cursor's GitHub App must be installed for the target repository, otherwise the launch fails with `400`. Confirm with the `repos` command.
+- **Python 3.10+** on the host running Hermes. The helper uses the standard library only — nothing to install.
+- **Host is fixed.** The helper always talks to `https://api.cursor.com`; there is no host override by design, so the key cannot be redirected to a third party.
+
+## How to Run
+
+Copy the script path once, then drive it through `terminal`:
+
+```bash
+CCA=~/.hermes/skills/autonomous-ai-agents/cursor-cloud-agents/scripts/cursor_cloud.py
+```
+
+```bash
+python "$CCA" models
+```
+
+Every command prints tab-separated `label<TAB>value` lines, so results are readable and easy to parse.
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Check the key | `python "$CCA" me` |
+| List models | `python "$CCA" models` |
+| List visible repos | `python "$CCA" repos` |
+| Launch an agent | `python "$CCA" launch --prompt "<task>" --repo owner/name` |
+| Follow up | `python "$CCA" followup <agent-id> --prompt "<task>"` |
+| Latest status | `python "$CCA" status <agent-id>` |
+| Poll to completion | `python "$CCA" watch <agent-id> --run <run-id>` |
+| Cancel | `python "$CCA" cancel <agent-id> --run <run-id>` |
+| List agents | `python "$CCA" list --limit 20` |
+
+| Flag | Effect |
+|------|--------|
+| `--repo` | `owner/name`, an HTTPS URL, or an SSH URL (normalised to `https://github.com/...`) |
+| `--ref` | Starting branch or commit SHA; requires `--repo` |
+| `--model` | Model id returned by `models`; omit to use the account default |
+| `--mode agent\|plan` | `plan` explores before coding, `agent` implements directly |
+| `--work-on-current-branch` | Commit to the starting ref instead of a new `cursor/...` branch |
+| `--auto-create-pr` | Have Cursor open a pull request when the run finishes |
+| `--interval` / `--timeout` | Poll cadence and give-up window for `watch` |
+
+Endpoint shapes and status codes: `references/api.md` in this skill.
+
+## Procedure
+
+1. **Verify credentials and model.** Run the `models` command; a `401` means the key is wrong or unset, and the printed ids are what `--model` accepts.
+2. **Confirm repo access.** Run the `repos` command when unsure. It is rate-limited to one request per minute, so cache the answer instead of calling it in a loop.
+3. **Launch.** Pass the task text verbatim in `--prompt`, the repo in `--repo`, and a base branch in `--ref`. Add `--auto-create-pr` when you want a PR, `--model` for a specific model, and `--mode plan` when you want a plan before code.
+4. **Record both ids.** The launch output carries a durable `agent` id and a per-run `run` id. Follow-ups and cancellation need the agent id; polling needs both.
+5. **Follow the run.** Run `watch` in the background for long tasks and read output with `process(action="poll")`:
+
+   ```bash
+   python "$CCA" watch <agent-id> --run <run-id> --interval 30 --timeout 3600
+   ```
+
+   `watch` exits `0` at the first terminal status and `1` on timeout, printing the final `result`, branches, and PR URLs.
+6. **Report.** Quote the `result` text and the PR URL back to the user. Do not paraphrase a `FINISHED` result as a success until the PR or branch listing confirms it.
+7. **Iterate or stop.** Send another `followup` to continue the same conversation, or `cancel` the active run. Review the diff in the PR before merging anything the agent produced.
+
+## Pitfalls
+
+- **One active run per agent.** A follow-up while a run is in flight returns `409`. Wait for a terminal status, or cancel first.
+- **Branching default.** Without `--work-on-current-branch`, commits land on a new `cursor/...` branch. That is usually what you want; only opt in when the task is explicitly meant to push to the base branch.
+- **`EXPIRED` is not success.** A sandbox that gets reclaimed terminates the run as `EXPIRED` with no result. Treat only `FINISHED` as a completed run.
+- **`--ref` without `--repo`** is rejected locally; the API cannot infer a base branch.
+- **`envVars` are off-limits for secrets you care about.** They are session-scoped, names cannot start with `CURSOR_`, and the field is beta (silently ignored on some accounts). Keep long-lived credentials in the environment that runs Hermes.
+- **Streaming endpoints are not used here.** `watch` polls REST instead of the SSE stream, which avoids `410 stream_expired` after the retention window and needs no reconnect bookkeeping.
+- **Never echo the key.** Error messages from the helper carry the HTTP status and response body only.
+
+## Verification
+
+- `python "$CCA" models` prints at least one model id — proves the key and the network path.
+- `python "$CCA" launch --prompt "Add a CONTRIBUTING.md" --repo owner/name` prints `agent`, `run`, and `status` lines — proves request construction against the live API.
+- `python "$CCA" status <agent-id>` shows the latest run's `status`, and after completion the `result`, `branch`, and `pr` lines.
+- Offline contract tests (no API key, no network): `scripts/run_tests.sh tests/skills/test_cursor_cloud_agents_skill.py -q` — pins the payload shape, the Basic auth header, the fixed host, and the polling loop.

--- a/skills/autonomous-ai-agents/cursor-cloud-agents/references/api.md
+++ b/skills/autonomous-ai-agents/cursor-cloud-agents/references/api.md
@@ -1,0 +1,106 @@
+# Cursor Cloud Agents API — surface used by this skill
+
+Authoritative sources, both maintained by Cursor:
+
+- Endpoint docs: https://cursor.com/docs/cloud-agent/api/endpoints
+- OpenAPI spec: https://cursor.com/docs-static/cloud-agents-openapi.yaml
+
+Base URL: `https://api.cursor.com` (no host override in the helper).
+
+## Authentication
+
+```http
+Authorization: Basic <base64(api-key + ":")>
+```
+
+The API key is the Basic username with an empty password. `Authorization: Bearer <key>` is accepted as an equivalent. Keys come from https://cursor.com/dashboard → Settings → API Keys, and are read here from the `CURSOR_API_KEY` environment variable.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/v1/agents` | Create an agent and enqueue its first run |
+| GET | `/v1/agents` | List agents (newest first; `limit`, `cursor`, `prUrl`, `includeArchived`) |
+| GET | `/v1/agents/{id}` | Durable agent metadata (execution status lives on runs) |
+| DELETE | `/v1/agents/{id}` | Permanent delete; prefer archive |
+| POST | `/v1/agents/{id}/runs` | Follow-up run on an existing agent |
+| GET | `/v1/agents/{id}/runs` | List runs (newest first) |
+| GET | `/v1/agents/{id}/runs/{runId}` | One run's status and timestamps |
+| GET | `/v1/agents/{id}/runs/{runId}/stream` | Server-sent events for one run |
+| POST | `/v1/agents/{id}/runs/{runId}/cancel` | Cancel the active run (terminal) |
+| GET | `/v1/agents/{id}/usage` | Per-run token usage (early access; `403 feature_unavailable`) |
+| POST | `/v1/agents/{id}/archive` · `/unarchive` | Reversible removal |
+| GET | `/v1/agents/{id}/artifacts` · `/artifacts/download` | Run artifacts |
+| GET | `/v1/me` | Identity of the API key |
+| GET | `/v1/models` | Recommended models; use `id` (and optional `params`) |
+| GET | `/v1/repositories` | GitHub repos reachable through Cursor's GitHub App |
+| POST | `/v1/sub-tokens` | One-hour user-scoped worker token (My Machines) |
+
+## Create agent request
+
+Only `prompt` is required. The fields the helper sets:
+
+```json
+{
+  "prompt": { "text": "Add a README with setup instructions" },
+  "repos": [{ "url": "https://github.com/acme/widgets", "startingRef": "main" }],
+  "model": { "id": "composer-2" },
+  "name": "Add README",
+  "mode": "agent",
+  "workOnCurrentBranch": false,
+  "autoCreatePR": false
+}
+```
+
+- `repos[].url` is always required on a repo entry; `startingRef` may be a branch or a commit SHA.
+- `repos[].prUrl` makes the agent work on that PR's branches; `startingRef` is then ignored.
+- `workOnCurrentBranch: false` (default) pushes to a new `cursor/...` branch. `true` pushes directly to the starting ref.
+- `autoCreatePR` opens a pull request on completion; `skipReviewerRequest` only applies alongside it.
+- `repos` is mutually exclusive with a named cloud environment (`env: {"type": "cloud"|"pool"|"machine", "name": "..."}`).
+- Omit `repos` (or pass `[]`) for a repo-less agent.
+- `envVars` are session-scoped, encrypted at rest, cannot be combined with a client-supplied `agentId`, and names cannot start with `CURSOR_`. The field is beta and may be silently ignored.
+
+Response: `{"agent": {...}, "run": {...}}`. Keep the agent id — follow-ups and cancellation are agent-scoped.
+
+## Run object
+
+| Field | Meaning |
+|-------|---------|
+| `id` | Run id (`run-...`) |
+| `agentId` | Owning agent |
+| `status` | `CREATING`, `RUNNING`, `FINISHED`, `ERROR`, `CANCELLED`, `EXPIRED` |
+| `createdAt` / `updatedAt` / `durationMs` | Timestamps; duration populated once terminal |
+| `result` | Final assistant reply, populated once terminal |
+| `git.branches` / `git.prs` | Pushed branches and PR URLs; per-agent state, not per-run |
+
+Terminal statuses: `FINISHED`, `ERROR`, `CANCELLED`, `EXPIRED`. Everything else is in flight.
+
+## Follow-up run request
+
+```json
+{ "prompt": { "text": "Also add troubleshooting steps" }, "mode": "plan" }
+```
+
+`mode` is optional on follow-ups: omitting it keeps the conversation's current mode. Only one run may be active per agent — a second create returns `409`.
+
+## Cancellation
+
+`POST /v1/agents/{id}/runs/{runId}/cancel` transitions the run to `CANCELLED`. Cancelling a run that is already terminal or was never active returns `409 run_not_cancellable`; continue the conversation by creating a new run instead.
+
+## Streaming (not used by the helper)
+
+`GET /v1/agents/{id}/runs/{runId}/stream` emits SSE events `status`, `assistant`, `thinking`, `tool_call`, `interaction_update`, `heartbeat`, `result`, `error`, `done`. Reconnect with the `Last-Event-ID` header; an event id from a different run returns `400 invalid_last_event_id`. `X-Cursor-Stream-Retention-Seconds` gives the retention window, after which the endpoint may return `410 stream_expired`. Polling `GET .../runs/{runId}` sidesteps all of this, which is why `watch` polls.
+
+## Errors
+
+| Status | Typical cause |
+|--------|---------------|
+| `400` | Malformed body, unknown pool name, `startingRef` without a repo |
+| `401` | Missing/invalid API key |
+| `403` | Key lacks access, or `feature_unavailable` (e.g. usage endpoint) |
+| `404` | Unknown agent/run id |
+| `409` | Active run already exists, `run_not_cancellable`, `agent_id_conflict` |
+| `410` | `stream_expired` |
+| `429` | Rate limited. `/v1/repositories` is 1 request/user/minute and 30/hour — cache it |
+
+The helper surfaces these as `error: <METHOD> <path> failed: HTTP <code> <body>` on stderr and exits `2`.

--- a/skills/autonomous-ai-agents/cursor-cloud-agents/scripts/cursor_cloud.py
+++ b/skills/autonomous-ai-agents/cursor-cloud-agents/scripts/cursor_cloud.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Drive Cursor Cloud Agents (https://api.cursor.com) from a Hermes terminal.
+
+Stdlib only. The API key is read from the ``CURSOR_API_KEY`` environment
+variable and is never written to disk, echoed, or embedded in a prompt. The
+API host is fixed at ``BASE_URL`` — Cloud Agents are a remote service, so a
+caller-supplied host would only ever be a way to leak the key to a third party.
+
+Usage:
+    python cursor_cloud.py models
+    python cursor_cloud.py launch --prompt "<task>" --repo owner/name [--ref main]
+    python cursor_cloud.py followup <agent-id> --prompt "<task>"
+    python cursor_cloud.py status <agent-id>
+    python cursor_cloud.py watch <agent-id> --run <run-id>
+    python cursor_cloud.py cancel <agent-id> --run <run-id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+
+BASE_URL = "https://api.cursor.com"
+ENV_VAR = "CURSOR_API_KEY"
+USER_AGENT = "hermes-cursor-cloud-agents/1.0"
+DEFAULT_TIMEOUT = 60.0
+
+# Run.status enum from the Cloud Agents OpenAPI spec: everything else is
+# in-flight and worth polling.
+TERMINAL_STATUSES = frozenset({"FINISHED", "ERROR", "CANCELLED", "EXPIRED"})
+
+_HTTPS_REPO = re.compile(
+    r"^https://github\.com/(?P<owner>[A-Za-z0-9._-]+)/(?P<name>[A-Za-z0-9._-]+?)"
+    r"(?:\.git)?/?$"
+)
+_SSH_REPO = re.compile(
+    r"^git@github\.com:(?P<owner>[A-Za-z0-9._-]+)/(?P<name>[A-Za-z0-9._-]+?)(?:\.git)?$"
+)
+_SLUG_REPO = re.compile(
+    r"^(?P<owner>[A-Za-z0-9._-]+)/(?P<name>[A-Za-z0-9._-]+?)(?:\.git)?$"
+)
+
+
+class CursorCloudError(RuntimeError):
+    """User-facing failure: bad input, missing credential, or API error."""
+
+
+def is_terminal(status: str) -> bool:
+    return status in TERMINAL_STATUSES
+
+
+def auth_header(api_key: str) -> str:
+    """Cloud Agents accepts the key as Basic user with an empty password."""
+    token = base64.b64encode(f"{api_key}:".encode("utf-8")).decode("ascii")
+    return f"Basic {token}"
+
+
+def normalize_repo(value: str) -> str:
+    """Accept owner/name, an HTTPS URL, or an SSH URL; emit the canonical URL."""
+    for pattern in (_HTTPS_REPO, _SSH_REPO, _SLUG_REPO):
+        match = pattern.match(value.strip())
+        if match:
+            return f"https://github.com/{match.group('owner')}/{match.group('name')}"
+    raise CursorCloudError(
+        f"not a GitHub repository: {value!r} (use owner/name or a github.com URL)"
+    )
+
+
+def api_key_from_env() -> str:
+    key = os.environ.get(ENV_VAR, "").strip()
+    if not key:
+        raise CursorCloudError(
+            f"{ENV_VAR} is not set. Create a key at https://cursor.com/dashboard "
+            "and export it in the environment that launches the agent."
+        )
+    return key
+
+
+def _urlopen(req, timeout):  # pragma: no cover - thin seam, stubbed in tests
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+def api_request(
+    method: str,
+    path: str,
+    payload: dict | None = None,
+    *,
+    api_key: str | None = None,
+    base_url: str = BASE_URL,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict:
+    headers = {
+        "Authorization": auth_header(api_key or api_key_from_env()),
+        "Accept": "application/json",
+        "User-Agent": USER_AGENT,
+    }
+    body = None
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(
+        base_url.rstrip("/") + path, data=body, headers=headers, method=method
+    )
+    try:
+        with _urlopen(req, timeout) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:500]
+        raise CursorCloudError(f"{method} {path} failed: HTTP {exc.code} {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise CursorCloudError(f"{method} {path} failed: {exc.reason}") from exc
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CursorCloudError(f"{method} {path} returned non-JSON: {raw[:200]!r}") from exc
+
+
+def build_launch_payload(
+    prompt: str,
+    *,
+    repo: str | None = None,
+    ref: str | None = None,
+    model: str | None = None,
+    name: str | None = None,
+    mode: str | None = None,
+    work_on_current_branch: bool = False,
+    auto_create_pr: bool = False,
+) -> dict:
+    payload: dict = {"prompt": {"text": prompt}}
+    if repo:
+        entry = {"url": normalize_repo(repo)}
+        if ref:
+            entry["startingRef"] = ref
+        payload["repos"] = [entry]
+    elif ref:
+        raise CursorCloudError("--ref only applies with --repo")
+    if model:
+        payload["model"] = {"id": model}
+    if name:
+        payload["name"] = name
+    if mode:
+        payload["mode"] = mode
+    # Both defaults are spelled out because the docs' default (a new cursor/...
+    # branch, no PR) is what a caller usually wants, not a silent server default.
+    payload["workOnCurrentBranch"] = bool(work_on_current_branch)
+    payload["autoCreatePR"] = bool(auto_create_pr)
+    return payload
+
+
+def build_followup_payload(prompt: str, *, mode: str | None = None) -> dict:
+    payload: dict = {"prompt": {"text": prompt}}
+    if mode:
+        payload["mode"] = mode
+    return payload
+
+
+def print_run(run: dict) -> None:
+    for label, value in (
+        ("run", run.get("id")),
+        ("status", run.get("status")),
+    ):
+        if value:
+            print(f"{label}\t{value}")
+    git = run.get("git") or {}
+    for branch in git.get("branches") or []:
+        print(f"branch\t{branch}")
+    for pr in git.get("prs") or []:
+        print(f"pr\t{pr}")
+    if run.get("result"):
+        print(f"result\t{run['result']}")
+
+
+# --- commands --------------------------------------------------------------
+
+
+def cmd_models(args) -> int:
+    data = api_request("GET", "/v1/models")
+    for item in data.get("items") or []:
+        label = item.get("displayName") or item.get("name") or ""
+        print(f"{item.get('id', '?')}\t{label}".rstrip())
+    return 0
+
+
+def cmd_me(args) -> int:
+    data = api_request("GET", "/v1/me")
+    print(f"apiKeyName\t{data.get('apiKeyName', '?')}")
+    print(f"createdAt\t{data.get('createdAt', '?')}")
+    return 0
+
+
+def cmd_repos(args) -> int:
+    data = api_request("GET", "/v1/repositories")
+    for item in data.get("items") or []:
+        print(item.get("url", "?"))
+    return 0
+
+
+def cmd_list(args) -> int:
+    data = api_request("GET", f"/v1/agents?limit={args.limit}")
+    for item in data.get("items") or []:
+        print(f"{item.get('id', '?')}\t{item.get('status', '')}\t{item.get('name', '')}".rstrip())
+    if data.get("nextCursor"):
+        print(f"nextCursor\t{data['nextCursor']}")
+    return 0
+
+
+def cmd_launch(args) -> int:
+    payload = build_launch_payload(
+        args.prompt,
+        repo=args.repo,
+        ref=args.ref,
+        model=args.model,
+        name=args.name,
+        mode=args.mode,
+        work_on_current_branch=args.work_on_current_branch,
+        auto_create_pr=args.auto_create_pr,
+    )
+    data = api_request("POST", "/v1/agents", payload)
+    agent = data.get("agent") or {}
+    run = data.get("run") or {}
+    if agent.get("id"):
+        print(f"agent\t{agent['id']}")
+    print_run(run)
+    return 0
+
+
+def cmd_followup(args) -> int:
+    payload = build_followup_payload(args.prompt, mode=args.mode)
+    data = api_request("POST", f"/v1/agents/{args.agent}/runs", payload)
+    print_run(data.get("run") or {})
+    return 0
+
+
+def cmd_status(args) -> int:
+    agent = api_request("GET", f"/v1/agents/{args.agent}")
+    runs = api_request("GET", f"/v1/agents/{args.agent}/runs?limit=1")
+    print(f"agent\t{agent.get('id', args.agent)}\t{agent.get('name', '')}".rstrip())
+    items = runs.get("items") or []
+    if not items:
+        print("run\t(none)")
+        return 0
+    print_run(items[0])
+    return 0
+
+
+def cmd_watch(args) -> int:
+    deadline = time.monotonic() + args.timeout
+    while True:
+        run = api_request("GET", f"/v1/agents/{args.agent}/runs/{args.run}")
+        status = run.get("status", "?")
+        print(f"status\t{status}", flush=True)
+        if is_terminal(status):
+            print_run(run)
+            return 0
+        if time.monotonic() >= deadline:
+            print(f"timed out after {args.timeout}s with status {status}", file=sys.stderr)
+            return 1
+        if args.interval:
+            time.sleep(args.interval)
+
+
+def cmd_cancel(args) -> int:
+    data = api_request("POST", f"/v1/agents/{args.agent}/runs/{args.run}/cancel")
+    print(f"cancelled\t{data.get('id', args.run)}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cursor_cloud.py",
+        description="Launch and manage Cursor Cloud Agents.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    p = subparsers.add_parser("models", help="list models usable with launch --model")
+    p.set_defaults(handler=cmd_models)
+
+    p = subparsers.add_parser("me", help="show the API key identity")
+    p.set_defaults(handler=cmd_me)
+
+    p = subparsers.add_parser("repos", help="list GitHub repos visible to the key")
+    p.set_defaults(handler=cmd_repos)
+
+    p = subparsers.add_parser("list", help="list agents, newest first")
+    p.add_argument("--limit", type=int, default=20)
+    p.set_defaults(handler=cmd_list)
+
+    p = subparsers.add_parser("launch", help="create an agent and enqueue its first run")
+    p.add_argument("--prompt", required=True)
+    p.add_argument("--repo", help="owner/name or a github.com URL")
+    p.add_argument("--ref", help="starting branch or commit SHA (requires --repo)")
+    p.add_argument("--model", help="model id from the models command")
+    p.add_argument("--name", help="display name for the agent")
+    p.add_argument("--mode", choices=("agent", "plan"))
+    p.add_argument("--work-on-current-branch", action="store_true")
+    p.add_argument("--auto-create-pr", action="store_true")
+    p.set_defaults(handler=cmd_launch)
+
+    p = subparsers.add_parser("followup", help="send a follow-up prompt to an agent")
+    p.add_argument("agent")
+    p.add_argument("--prompt", required=True)
+    p.add_argument("--mode", choices=("agent", "plan"))
+    p.set_defaults(handler=cmd_followup)
+
+    p = subparsers.add_parser("status", help="show an agent and its latest run")
+    p.add_argument("agent")
+    p.set_defaults(handler=cmd_status)
+
+    p = subparsers.add_parser("watch", help="poll a run until it reaches a terminal status")
+    p.add_argument("agent")
+    p.add_argument("--run", required=True)
+    p.add_argument("--interval", type=float, default=10.0, help="seconds between polls")
+    p.add_argument("--timeout", type=float, default=900.0, help="give up after this many seconds")
+    p.set_defaults(handler=cmd_watch)
+
+    p = subparsers.add_parser("cancel", help="cancel the active run of an agent")
+    p.add_argument("agent")
+    p.add_argument("--run", required=True)
+    p.set_defaults(handler=cmd_cancel)
+
+    return parser
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return args.handler(args)
+    except CursorCloudError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skills/test_cursor_cloud_agents_skill.py
+++ b/tests/skills/test_cursor_cloud_agents_skill.py
@@ -1,0 +1,267 @@
+"""Contract tests for the bundled `cursor-cloud-agents` skill.
+
+Feature request: #107480 — first-class Cursor Cloud Agents support under
+`skills/autonomous-ai-agents/`, alongside the bundled claude-code / codex skills.
+
+Two layers, stdlib + pytest only, no live network:
+
+  1. Structural contract on SKILL.md (skills/AGENTS.md authoring standards):
+     frontmatter fields, description hardline, section order, credential hygiene.
+  2. Behavioral: drive the real request path in `scripts/cursor_cloud.py`
+     against a stubbed `_urlopen` seam, asserting the URL, method, auth header,
+     payload shape and CLI output for each lifecycle command.
+"""
+
+import base64
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "autonomous-ai-agents" / "cursor-cloud-agents"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+SCRIPT = SKILL_DIR / "scripts" / "cursor_cloud.py"
+API_REFERENCE = SKILL_DIR / "references" / "api.md"
+
+API_KEY = "crsr_test_key_do_not_use"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("cursor_cloud_undertest", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode("utf-8")
+        self.status = 200
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _Transport:
+    """Records every Request object and replays canned JSON responses."""
+
+    def __init__(self, *payloads):
+        self._payloads = list(payloads)
+        self.requests = []
+
+    def __call__(self, req, timeout):
+        self.requests.append(req)
+        payload = self._payloads.pop(0) if self._payloads else {}
+        return _FakeResponse(payload)
+
+    def headers(self, index=0):
+        return {k.lower(): v for k, v in self.requests[index].headers.items()}
+
+    def body(self, index=0):
+        return json.loads(self.requests[index].data.decode("utf-8"))
+
+
+@pytest.fixture
+def transport(monkeypatch, mod):
+    def _install(*payloads):
+        t = _Transport(*payloads)
+        monkeypatch.setattr(mod, "_urlopen", t)
+        monkeypatch.setenv(mod.ENV_VAR, API_KEY)
+        return t
+
+    return _install
+
+
+# --- structural contract ---------------------------------------------------
+
+
+def test_skill_files_exist():
+    assert SKILL_MD.is_file(), "SKILL.md must ship with the bundled skill"
+    assert SCRIPT.is_file(), "the helper script must ship with the skill"
+    assert API_REFERENCE.is_file(), "the endpoint reference must ship with the skill"
+
+
+@pytest.fixture(scope="module")
+def skill_text():
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def test_frontmatter_declares_required_fields(skill_text):
+    assert skill_text.startswith("---\n")
+    head = skill_text.split("---", 2)[1]
+    for field in ("name:", "description:", "version:", "author:", "license:", "platforms:"):
+        assert field in head, f"frontmatter missing {field}"
+    assert "name: cursor-cloud-agents" in head
+    assert "tags:" in head
+
+
+def test_description_is_one_short_sentence(skill_text):
+    line = next(l for l in skill_text.splitlines() if l.startswith("description:"))
+    desc = line.split(":", 1)[1].strip().strip('"')
+    assert len(desc) <= 60, f"description is {len(desc)} chars: {desc!r}"
+    assert desc.endswith(".")
+
+
+def test_required_sections_in_order(skill_text):
+    headings = ["## When to Use", "## Prerequisites", "## How to Run",
+                "## Quick Reference", "## Procedure", "## Pitfalls", "## Verification"]
+    positions = [skill_text.find(h) for h in headings]
+    assert all(p != -1 for p in positions), f"missing section: {headings[positions.index(-1)]}"
+    assert positions == sorted(positions), "sections must follow the documented order"
+
+
+def test_credentials_come_from_the_environment(skill_text):
+    assert "CURSOR_API_KEY" in skill_text, "the skill must document the env var"
+    assert "https://api.cursor.com" in skill_text
+
+
+# --- behavioral: request construction --------------------------------------
+
+
+def test_api_key_missing_fails_closed(monkeypatch, mod, capsys):
+    monkeypatch.delenv(mod.ENV_VAR, raising=False)
+    rc = mod.main(["models"])
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert mod.ENV_VAR in err
+
+
+def test_auth_header_is_basic_with_empty_password(mod):
+    header = mod.auth_header(API_KEY)
+    assert header.startswith("Basic ")
+    decoded = base64.b64decode(header.split(" ", 1)[1]).decode("utf-8")
+    assert decoded == f"{API_KEY}:"
+
+
+def test_models_lists_from_the_fixed_host(transport, mod, capsys):
+    t = transport({"items": [{"id": "composer-2", "name": "Composer 2"}]})
+    assert mod.main(["models"]) == 0
+    assert t.requests[0].full_url == "https://api.cursor.com/v1/models"
+    assert t.requests[0].get_method() == "GET"
+    assert t.headers()["authorization"] == mod.auth_header(API_KEY)
+    assert "composer-2" in capsys.readouterr().out
+
+
+def test_host_cannot_be_overridden_from_the_cli(mod):
+    with pytest.raises(SystemExit):
+        mod.main(["models", "--base-url", "https://attacker.example"])
+
+
+def test_launch_builds_the_documented_create_agent_body(transport, mod, capsys):
+    t = transport({"agent": {"id": "bc-1"}, "run": {"id": "run-1", "status": "CREATING"}})
+    rc = mod.main([
+        "launch", "--prompt", "Add a README", "--repo", "acme/widgets",
+        "--ref", "main", "--model", "composer-2", "--auto-create-pr",
+    ])
+    assert rc == 0
+    req = t.requests[0]
+    assert req.get_method() == "POST"
+    assert req.full_url == "https://api.cursor.com/v1/agents"
+    body = t.body()
+    assert body["prompt"]["text"] == "Add a README"
+    assert body["repos"][0]["url"] == "https://github.com/acme/widgets"
+    assert body["repos"][0]["startingRef"] == "main"
+    assert body["model"] == {"id": "composer-2"}
+    assert body["autoCreatePR"] is True
+    # Branching default must stay on the documented "new cursor/... branch" path.
+    assert body["workOnCurrentBranch"] is False
+    out = capsys.readouterr().out
+    assert "bc-1" in out and "run-1" in out
+    assert API_KEY not in out, "the API key must never be echoed"
+
+
+def test_launch_can_opt_into_the_current_branch(transport, mod):
+    t = transport({"agent": {"id": "bc-1"}, "run": {"id": "run-1"}})
+    mod.main(["launch", "--prompt", "p", "--repo", "https://github.com/acme/widgets.git",
+              "--work-on-current-branch"])
+    assert t.body()["workOnCurrentBranch"] is True
+    assert t.body()["repos"][0]["url"] == "https://github.com/acme/widgets"
+
+
+def test_followup_posts_a_new_run_with_mode(transport, mod):
+    t = transport({"run": {"id": "run-2", "status": "CREATING"}})
+    rc = mod.main(["followup", "bc-1", "--prompt", "also document it", "--mode", "plan"])
+    assert rc == 0
+    assert t.requests[0].get_method() == "POST"
+    assert t.requests[0].full_url == "https://api.cursor.com/v1/agents/bc-1/runs"
+    assert t.body() == {"prompt": {"text": "also document it"}, "mode": "plan"}
+
+
+def test_status_reads_agent_and_latest_run(transport, mod, capsys):
+    t = transport(
+        {"id": "bc-1", "name": "README"},
+        {"items": [{
+            "id": "run-9",
+            "status": "FINISHED",
+            "result": "done",
+            "git": {"branches": ["cursor/readme"],
+                    "prs": ["https://github.com/acme/widgets/pull/7"]},
+        }]},
+    )
+    assert mod.main(["status", "bc-1"]) == 0
+    urls = [r.full_url for r in t.requests]
+    assert urls == [
+        "https://api.cursor.com/v1/agents/bc-1",
+        "https://api.cursor.com/v1/agents/bc-1/runs?limit=1",
+    ]
+    out = capsys.readouterr().out
+    assert "FINISHED" in out
+    assert "https://github.com/acme/widgets/pull/7" in out
+
+
+def test_cancel_targets_the_run(transport, mod):
+    t = transport({"id": "run-9"})
+    assert mod.main(["cancel", "bc-1", "--run", "run-9"]) == 0
+    assert t.requests[0].get_method() == "POST"
+    assert t.requests[0].full_url == "https://api.cursor.com/v1/agents/bc-1/runs/run-9/cancel"
+
+
+def test_watch_polls_until_the_run_is_terminal(transport, mod, capsys):
+    t = transport(
+        {"id": "run-9", "status": "CREATING"},
+        {"id": "run-9", "status": "RUNNING"},
+        {"id": "run-9", "status": "FINISHED", "result": "shipped"},
+    )
+    rc = mod.main(["watch", "bc-1", "--run", "run-9", "--interval", "0", "--timeout", "30"])
+    assert rc == 0
+    assert len(t.requests) == 3, "polling must stop at the first terminal status"
+    assert all(r.get_method() == "GET" for r in t.requests)
+    assert t.requests[-1].full_url == "https://api.cursor.com/v1/agents/bc-1/runs/run-9"
+    assert "shipped" in capsys.readouterr().out
+
+
+def test_watch_times_out_without_a_terminal_status(transport, mod, capsys):
+    t = transport(*[{"id": "run-9", "status": "RUNNING"}] * 50)
+    rc = mod.main(["watch", "bc-1", "--run", "run-9", "--interval", "0", "--timeout", "0"])
+    assert rc == 1
+    assert "RUNNING" in capsys.readouterr().out
+    assert t.requests, "watch must poll at least once before timing out"
+
+
+def test_terminal_status_set_matches_the_api_enum(mod):
+    assert {s for s in ("CREATING", "RUNNING") if mod.is_terminal(s)} == set()
+    assert all(mod.is_terminal(s) for s in ("FINISHED", "ERROR", "CANCELLED", "EXPIRED"))
+
+
+def test_repo_url_normalisation(mod):
+    cases = {
+        "acme/widgets": "https://github.com/acme/widgets",
+        "https://github.com/acme/widgets": "https://github.com/acme/widgets",
+        "https://github.com/acme/widgets.git": "https://github.com/acme/widgets",
+        "git@github.com:acme/widgets.git": "https://github.com/acme/widgets",
+    }
+    for raw, expected in cases.items():
+        assert mod.normalize_repo(raw) == expected
+    for bad in ("gitlab.com/acme/widgets", "acme", "https://example.com/a/b"):
+        with pytest.raises(mod.CursorCloudError):
+            mod.normalize_repo(bad)

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -28,6 +28,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`claude-code`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-claude-code) | Delegate coding to Claude Code CLI (features, PRs). | `autonomous-ai-agents\claude-code` |
 | [`codex`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex) | Delegate coding to OpenAI Codex CLI (features, PRs). | `autonomous-ai-agents\codex` |
 | [`computer-use`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use) | Drive the desktop background-first; escalate on signal. | `autonomous-ai-agents\computer-use` |
+| [`cursor-cloud-agents`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-cursor-cloud-agents) | Launch and manage Cursor Cloud Agents from Hermes. | `autonomous-ai-agents\cursor-cloud-agents` |
 | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent) | Use, configure, theme, extend, and orchestrate Hermes Agent. | `autonomous-ai-agents\hermes-agent` |
 | [`merge-reconciler`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-merge-reconciler) | Neutral third-party resolution of agent merge conflicts. | `autonomous-ai-agents\merge-reconciler` |
 | [`opencode`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-opencode) | Delegate coding to OpenCode CLI (features, PR review). | `autonomous-ai-agents\opencode` |

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-cursor-cloud-agents.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-cursor-cloud-agents.md
@@ -1,0 +1,123 @@
+---
+title: "Cursor Cloud Agents — Launch and manage Cursor Cloud Agents from Hermes"
+sidebar_label: "Cursor Cloud Agents"
+description: "Launch and manage Cursor Cloud Agents from Hermes"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Cursor Cloud Agents
+
+Launch and manage Cursor Cloud Agents from Hermes.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/autonomous-ai-agents\cursor-cloud-agents` |
+| Version | `1.0.0` |
+| Author | Finn763 |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Coding-Agent`, `Cursor`, `Cloud-Agents`, `Delegation`, `GitHub`, `API` |
+| Related skills | [`claude-code`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-claude-code), [`codex`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex), [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Cursor Cloud Agents Skill
+
+Delegate repository work to [Cursor Cloud Agents](https://cursor.com/docs/cloud-agent/api/endpoints) — ephemeral coding agents that run in Cursor-hosted VMs against a GitHub repository. This skill covers the public Cloud Agents HTTP API only: launching agents, sending follow-ups, polling status, cancelling runs, and listing models. It does not drive the local `cursor-agent` CLI and it never opens a shell inside the agent VM.
+
+## When to Use
+
+- Long-running repo work that should not occupy the Hermes host (large refactors, dependency migrations, test-suite repair).
+- Several independent workstreams at once — each agent gets its own VM, its own branch, and its own PR.
+- Work that must outlive the current session: the agent keeps running after Hermes exits.
+- Delegating to a model that only exists inside Cursor's runtime (`composer-*`).
+
+Not for: quick edits to the local checkout (use `patch`), interactive pair-programming (that is the local CLI), or repos outside GitHub.
+
+## Prerequisites
+
+- **API key:** create one at https://cursor.com/dashboard (Settings → API Keys) and export it as `CURSOR_API_KEY`. In a gateway/service install put it in the profile `.env`; never paste the key into a prompt, a commit, or a file in the repo.
+- **GitHub App:** Cursor's GitHub App must be installed for the target repository, otherwise the launch fails with `400`. Confirm with the `repos` command.
+- **Python 3.10+** on the host running Hermes. The helper uses the standard library only — nothing to install.
+- **Host is fixed.** The helper always talks to `https://api.cursor.com`; there is no host override by design, so the key cannot be redirected to a third party.
+
+## How to Run
+
+Copy the script path once, then drive it through `terminal`:
+
+```bash
+CCA=~/.hermes/skills/autonomous-ai-agents/cursor-cloud-agents/scripts/cursor_cloud.py
+```
+
+```bash
+python "$CCA" models
+```
+
+Every command prints tab-separated `label<TAB>value` lines, so results are readable and easy to parse.
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Check the key | `python "$CCA" me` |
+| List models | `python "$CCA" models` |
+| List visible repos | `python "$CCA" repos` |
+| Launch an agent | `python "$CCA" launch --prompt "<task>" --repo owner/name` |
+| Follow up | `python "$CCA" followup <agent-id> --prompt "<task>"` |
+| Latest status | `python "$CCA" status <agent-id>` |
+| Poll to completion | `python "$CCA" watch <agent-id> --run <run-id>` |
+| Cancel | `python "$CCA" cancel <agent-id> --run <run-id>` |
+| List agents | `python "$CCA" list --limit 20` |
+
+| Flag | Effect |
+|------|--------|
+| `--repo` | `owner/name`, an HTTPS URL, or an SSH URL (normalised to `https://github.com/...`) |
+| `--ref` | Starting branch or commit SHA; requires `--repo` |
+| `--model` | Model id returned by `models`; omit to use the account default |
+| `--mode agent\|plan` | `plan` explores before coding, `agent` implements directly |
+| `--work-on-current-branch` | Commit to the starting ref instead of a new `cursor/...` branch |
+| `--auto-create-pr` | Have Cursor open a pull request when the run finishes |
+| `--interval` / `--timeout` | Poll cadence and give-up window for `watch` |
+
+Endpoint shapes and status codes: `references/api.md` in this skill.
+
+## Procedure
+
+1. **Verify credentials and model.** Run the `models` command; a `401` means the key is wrong or unset, and the printed ids are what `--model` accepts.
+2. **Confirm repo access.** Run the `repos` command when unsure. It is rate-limited to one request per minute, so cache the answer instead of calling it in a loop.
+3. **Launch.** Pass the task text verbatim in `--prompt`, the repo in `--repo`, and a base branch in `--ref`. Add `--auto-create-pr` when you want a PR, `--model` for a specific model, and `--mode plan` when you want a plan before code.
+4. **Record both ids.** The launch output carries a durable `agent` id and a per-run `run` id. Follow-ups and cancellation need the agent id; polling needs both.
+5. **Follow the run.** Run `watch` in the background for long tasks and read output with `process(action="poll")`:
+
+   ```bash
+   python "$CCA" watch <agent-id> --run <run-id> --interval 30 --timeout 3600
+   ```
+
+   `watch` exits `0` at the first terminal status and `1` on timeout, printing the final `result`, branches, and PR URLs.
+6. **Report.** Quote the `result` text and the PR URL back to the user. Do not paraphrase a `FINISHED` result as a success until the PR or branch listing confirms it.
+7. **Iterate or stop.** Send another `followup` to continue the same conversation, or `cancel` the active run. Review the diff in the PR before merging anything the agent produced.
+
+## Pitfalls
+
+- **One active run per agent.** A follow-up while a run is in flight returns `409`. Wait for a terminal status, or cancel first.
+- **Branching default.** Without `--work-on-current-branch`, commits land on a new `cursor/...` branch. That is usually what you want; only opt in when the task is explicitly meant to push to the base branch.
+- **`EXPIRED` is not success.** A sandbox that gets reclaimed terminates the run as `EXPIRED` with no result. Treat only `FINISHED` as a completed run.
+- **`--ref` without `--repo`** is rejected locally; the API cannot infer a base branch.
+- **`envVars` are off-limits for secrets you care about.** They are session-scoped, names cannot start with `CURSOR_`, and the field is beta (silently ignored on some accounts). Keep long-lived credentials in the environment that runs Hermes.
+- **Streaming endpoints are not used here.** `watch` polls REST instead of the SSE stream, which avoids `410 stream_expired` after the retention window and needs no reconnect bookkeeping.
+- **Never echo the key.** Error messages from the helper carry the HTTP status and response body only.
+
+## Verification
+
+- `python "$CCA" models` prints at least one model id — proves the key and the network path.
+- `python "$CCA" launch --prompt "Add a CONTRIBUTING.md" --repo owner/name` prints `agent`, `run`, and `status` lines — proves request construction against the live API.
+- `python "$CCA" status <agent-id>` shows the latest run's `status`, and after completion the `result`, `branch`, and `pr` lines.
+- Offline contract tests (no API key, no network): `scripts/run_tests.sh tests/skills/test_cursor_cloud_agents_skill.py -q` — pins the payload shape, the Basic auth header, the fixed host, and the polling loop.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -173,6 +173,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-claude-code',
                     'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex',
                     'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use',
+                    'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-cursor-cloud-agents',
                     'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent',
                     'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-merge-reconciler',
                     'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-opencode',


### PR DESCRIPTION
## What Problem This Solves

Hermes bundles `claude-code` and `codex` under `skills/autonomous-ai-agents/` but has no first-class support for [Cursor Cloud Agents](https://cursor.com/docs/cloud-agent/api/endpoints) — ephemeral coding agents that run in Cursor-hosted VMs against a GitHub repo. Users doing long-running, isolated repo work had nothing bundled to reach that runtime, even though Hermes already orchestrates the peer agent runtimes as skills.

This lands the skill as **bundled** (not optional), matching parity with its peers:

- `skills/autonomous-ai-agents/cursor-cloud-agents/SKILL.md` — when to use, prerequisites, run procedure, pitfalls, verification.
- `skills/autonomous-ai-agents/cursor-cloud-agents/scripts/cursor_cloud.py` — stdlib-only helper (no `pip install`) with `models`, `me`, `repos`, `list`, `launch`, `followup`, `status`, `watch`, `cancel`.
- `skills/autonomous-ai-agents/cursor-cloud-agents/references/api.md` — endpoint/payload/status reference for the surface the helper uses.
- `tests/skills/test_cursor_cloud_agents_skill.py` — offline contract + behavior tests.
- `.env.example` block for `CURSOR_API_KEY`, plus the regenerated bundled-catalog row, sidebar entry, and generated docs page.

Design decisions worth a reviewer's attention:

- **The API host is fixed at `https://api.cursor.com`.** There is deliberately no CLI override, and the helper reads `CURSOR_API_KEY` from the environment only, never from a prompt or a repo file. A caller-supplied host would exist only to redirect the key somewhere else.
- **`watch` polls REST instead of consuming the SSE stream.** Polling `GET /v1/agents/{id}/runs/{runId}` avoids `410 stream_expired` after the retention window and needs no `Last-Event-ID` bookkeeping. The stream endpoint and its caveats are documented in `references/api.md` for agents that want it.
- **`workOnCurrentBranch` and `autoCreatePR` are always sent explicitly**, because the API default (a new `cursor/...` branch, no PR) is what a caller usually wants rather than a silent server default.

### Scope

Covers: launch, follow-up runs, status, polling to terminal, cancel, model discovery, key identity, repo listing, and credential hygiene.

Deliberately not covered in this PR: the SSE `stream` endpoint, agent archive/delete/artifacts/usage endpoints, `env`/`envVars`/`mcpServers`/`customSubagents` request fields, and per-model `params`. The helper is small and additive, so these can land on top without reworking anything.

Partial fix for #107480. The optional variant in #96753 is untouched; if maintainers prefer opt-in first, that PR is still the smaller-footprint path.

## Evidence

Pre-fix on the base commit (the skill does not exist yet):

```text
$ HERMES_PYTHON=<venv> bash scripts/run_tests.sh tests/skills/test_cursor_cloud_agents_skill.py -q
FAILED tests/skills/test_cursor_cloud_agents_skill.py::test_skill_files_exist
    AssertionError: SKILL.md must ship with the bundled skill
ERROR tests/skills/test_cursor_cloud_agents_skill.py::test_frontmatter_declares_required_fields
... (16 more errors, all FileNotFoundError loading the helper)
1 failed, 17 errors in 1.40s
```

Post-fix, same command:

```text
$ HERMES_PYTHON=<venv> bash scripts/run_tests.sh tests/skills/test_cursor_cloud_agents_skill.py -q
=== Summary: 1 files, 18 tests passed, 0 failed (100% complete) in 1.0s (40 workers) ===
```

The authoring-standards gate (which parametrizes over every bundled and optional `SKILL.md`, so the new skill is included):

```text
$ HERMES_PYTHON=<venv> bash scripts/run_tests.sh tests/skills/test_authoring_standards.py -q
=== Summary: 1 files, 1208 tests passed, 0 failed (100% complete) in 33.4s (40 workers) ===
```

Skill-loader suites (bundles, invocation descriptions, `skill_utils`, external skills):

```text
$ HERMES_PYTHON=<venv> bash scripts/run_tests.sh tests/agent/test_skill_utils.py \
    tests/agent/test_skill_invocation_description.py tests/agent/test_skill_bundles.py \
    tests/agent/test_external_skills.py -q
=== Summary: 4 files, 54 tests passed, 0 failed (100% complete) in 3.1s (40 workers) ===
```

End-to-end against the real install path — the repo's own sync puts the skill in a user profile, the deployed script runs, and the real `api.cursor.com` answers the request (a deliberately fake key, so the receipt is an auth rejection rather than billable agent work):

```text
$ python _e2e_check.py
sync_skills -> ['cleaned', 'copied', ..., 'updated']
synced SKILL.md: True
synced script:   True
deployed no-key run -> exit 2
  stderr: error: CURSOR_API_KEY is not set. Create a key at https://cursor.com/dashboard and export it in the environment that launches the agent.
deployed launch (real network, fake key) -> exit 2
  stderr: error: POST /v1/agents failed: HTTP 401 {"code":"error","message":"Invalid User API Key"}
loopback saw: POST /v1/agents
  auth: Basic Y3Jzcl9lMmVfa2V5Og==   # base64("<fake-key>:") — empty password, per the OpenAPI securitySchemes
  body: {'prompt': {'text': 'Add a README'}, 'repos': [{'url': 'https://github.com/acme/widgets'}], 'workOnCurrentBranch': False, 'autoCreatePR': True}
  response: {'agent': {'id': 'bc-e2e'}, 'run': {'id': 'run-e2e', 'status': 'CREATING'}}
```

The `401` is the point: the request reached Cursor's API, was parsed, and rejected only for the credential — closing the loop from the helper through TLS, the auth scheme, and the response decoding. A successful launch is not exercised here because it would create real agent work on a live account.

Lint:

```text
$ python -m ruff check skills/autonomous-ai-agents/cursor-cloud-agents/scripts/cursor_cloud.py \
    tests/skills/test_cursor_cloud_agents_skill.py
All checks passed!
```

Environment note, not a regression: on this Windows host `tests/website/test_generate_llms_txt.py` (4) and `tests/skills/test_setup_wizard_generator_skill.py::TestTemplate::test_bash_syntax` (1) fail identically on a stashed, pristine tree — path-separator and `bash -n` issues unrelated to this change.

Sources: <https://cursor.com/docs/cloud-agent/api/endpoints> and <https://cursor.com/docs-static/cloud-agents-openapi.yaml> (the API surface used here is taken from the published OpenAPI spec: `/v1/agents`, `/v1/agents/{id}/runs`, `/v1/agents/{id}/runs/{runId}`, `/cancel`, `/v1/models`, `/v1/me`, `/v1/repositories`).
