### PR TITLE
fix(mcp): never treat an unresolved ${VAR} placeholder as the OAuth client identity

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -728,6 +728,45 @@ class TestInvalidateTokensOnClientChange:
         _maybe_preregister_client(storage, cfg, meta)
         assert (d / "chg-server.json").exists()
 
+    def test_preregister_flow_unresolved_placeholder_keeps_tokens(self, tmp_path, monkeypatch, caplog):
+        """A ${VAR} the current context never expanded must not be treated as a new client
+        identity: pre-registering it would rewrite client.json with the literal placeholder
+        and drop the valid stored tokens, forcing a re-login on every session open (#108253
+        — a unified-dashboard process serving a secondary profile whose .env it never loaded)."""
+        pytest.importorskip("mcp")
+        from tools.mcp_oauth import (
+            _build_client_metadata, _maybe_preregister_client,
+        )
+        storage, d = self._seed(tmp_path, monkeypatch, client_id="real-client")
+        cfg = {"client_id": "${HA_MCP_CLIENT_ID}", "_resolved_port": 1455}
+        meta = _build_client_metadata(dict(cfg))
+        with caplog.at_level("WARNING", logger="tools.mcp_oauth"):
+            _maybe_preregister_client(storage, cfg, meta)
+        assert (d / "chg-server.json").exists(), (
+            "an unresolved placeholder must not invalidate the stored token")
+        assert (d / "chg-server.meta.json").exists()
+        info = json.loads((d / "chg-server.client.json").read_text())
+        assert info["client_id"] == "real-client", (
+            "client.json must keep the registered identity, not the placeholder")
+        assert any("unresolved ${VAR}" in r.getMessage() for r in caplog.records)
+
+    def test_preregister_flow_placeholder_secret_keeps_tokens(self, tmp_path, monkeypatch):
+        """A placeholder secret alone must skip the overwrite too: the identity comparison
+        would see None vs "${...}" as a changed secret and drop the tokens."""
+        pytest.importorskip("mcp")
+        from tools.mcp_oauth import (
+            _build_client_metadata, _maybe_preregister_client,
+        )
+        storage, d = self._seed(tmp_path, monkeypatch, client_id="real-client")
+        cfg = {"client_id": "real-client",
+               "client_secret": "${HA_MCP_CLIENT_SECRET}",
+               "_resolved_port": 1455}
+        meta = _build_client_metadata(dict(cfg))
+        _maybe_preregister_client(storage, cfg, meta)
+        assert (d / "chg-server.json").exists()
+        info = json.loads((d / "chg-server.client.json").read_text())
+        assert info["client_id"] == "real-client"
+
 
 # ---------------------------------------------------------------------------
 # Non-interactive / startup-safety tests

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -899,6 +899,19 @@ def _build_client_metadata(cfg: dict) -> "OAuthClientMetadata":
         return metadata_cls.model_validate(metadata_kwargs)
 
 
+# A ``${VAR}`` the env expansion missed (hermes_cli.config keeps unresolved refs verbatim so
+# callers can detect them). In a context that never loaded the profile's ``.env`` — e.g. the
+# launch profile's unified-dashboard process opening a secondary profile's session (#108253) —
+# the placeholder is NOT the configured client identity: pre-registering it would rewrite
+# ``client.json`` with the literal placeholder and drop the valid stored tokens.
+_UNRESOLVED_ENV_REF_RE = re.compile(r"\$\{[^}]+\}")
+
+
+def _is_unresolved_env_ref(value: Any) -> bool:
+    """True when a config string still carries a ``${VAR}`` placeholder the env expansion missed."""
+    return isinstance(value, str) and _UNRESOLVED_ENV_REF_RE.search(value) is not None
+
+
 def _invalidate_tokens_on_client_change(
     storage: "HermesTokenStorage", new_client_id: str, new_client_secret: str | None) -> None:
     """Drop cached tokens when the configured client identity changes: tokens minted under the old
@@ -933,6 +946,12 @@ def _maybe_preregister_client(storage: "HermesTokenStorage", cfg: dict, client_m
     """If cfg has a pre-registered client_id, persist it to storage."""
     client_id = cfg.get("client_id")
     if not client_id:
+        return
+    if _is_unresolved_env_ref(client_id) or _is_unresolved_env_ref(cfg.get("client_secret")):
+        logger.warning(
+            "MCP OAuth '%s': oauth client_id/client_secret still contain an unresolved ${VAR} placeholder "
+            "(the referenced env var is not set in this context); leaving the stored client and tokens "
+            "untouched", storage._server_name)
         return
     info_cls = _sdk_class("OAuthClientInformationFull")
     _invalidate_tokens_on_client_change(storage, client_id, cfg.get("client_secret"))


### PR DESCRIPTION
## What does this PR do?

Stops the destructive half of #108253: when `oauth.client_id`/`client_secret` still carry a literal `${VAR}` placeholder that the env expansion missed (e.g. a unified-dashboard process serving a secondary profile whose `.env` was never loaded in that context), `_maybe_preregister_client()` currently:

1. calls `_invalidate_tokens_on_client_change()`, which compares the on-disk registered `client_id` against the literal `${HA_MCP_CLIENT_ID}` mismatch → unlinks the valid `<server>.json` token and `<server>.meta.json`, and
2. rewrites `.client.json` with the placeholder,

so every session open forces a new interactive OAuth login. This adds a guard at the pre-registration entry: if `client_id` or `client_secret` still contains an unresolved `${...}` ref, the stored client and tokens are left untouched and a warning is logged instead. An unresolved placeholder is never a client identity, so it can never legitimately reach this path's identity comparison — the guard makes the token-loss invariant independent of which upstream resolution path regressed (the scope-propagation half is carried separately by #104607 / #104534, tracked in #67605).

## Related Issue

Fixes #108253

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_oauth.py`: added `_UNRESOLVED_ENV_REF_RE` + `_is_unresolved_env_ref()`; `_maybe_preregister_client()` now skips pre-registration (and therefore the token/meta purge and the `.client.json` rewrite) when the configured `client_id`/`client_secret` still carries a `${...}` placeholder, logging a warning instead.
- `tests/tools/test_mcp_oauth.py`: two regression tests in `TestInvalidateTokensOnClientChange` — placeholder `client_id` keeps token/meta/registered identity on disk and warns; placeholder `client_secret` alone (same real `client_id`) also keeps the token.

## How to Test

1. `python -m pytest tests/tools/test_mcp_oauth.py -k TestInvalidateTokensOnClientChange -q` — 8 passed (6 existing + 2 new).
2. `python -m pytest tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_cold_load_expiry.py tests/tools/test_mcp_tool.py tests/hermes_cli/test_mcp_startup.py -q` — Observed result: 202 passed, 0 failed.
3. Manual reproduction of the destructive sequence (pre-fix behavior): seed `mcp-tokens/x.client.json` with a real `client_id` plus a valid `x.json` token, call `_maybe_preregister_client()` with `client_id="${HA_MCP_CLIENT_ID}"` → before this PR the token was deleted and `.client.json` rewritten with the placeholder; with this PR both files survive untouched (covered by `test_preregister_flow_unresolved_placeholder_keeps_tokens`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (MCP OAuth/tool + mcp_startup suites: 202 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring on the new helper + inline invariant comment)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python string check, no platform surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Warning emitted instead of the destructive rewrite:

```
MCP OAuth 'ha_mcp': oauth client_id/client_secret still contain an unresolved ${VAR} placeholder (the referenced env var is not set in this context); leaving the stored client and tokens untouched
```
