### PR TITLE
fix(agent): harden handle_max_iterations as a hard stop

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1941,9 +1941,16 @@ _SUMMARY_FOREIGN_MESSAGE_KEYS = ("reasoning", "finish_reason", "tool_name", "cod
 _EMPTY_SUMMARY_RESPONSE = "I reached the iteration limit and couldn't generate a summary."
 
 
-def _iteration_summary_api_messages(agent, messages: list) -> list:
+def _iteration_summary_api_messages(agent, messages: list, *, system_nudge: Optional[str] = None) -> list:
     """Wire-ready messages for the summary call, mirroring the main loop's api_messages build
-    (sidecar substitution, tool-call repair, thinking-only drop, underscore-key sweep)."""
+    (sidecar substitution, tool-call repair, thinking-only drop, underscore-key sweep).
+
+    ``system_nudge``: optional iteration-limit stop text appended to the cached system
+    prompt for the wire payload only. NOT appended to ``messages`` (the persistent
+    history), so the synthetic instruction never reaches the next turn's
+    ``messages`` list as a fake user row (#36246). Stable content matches
+    ``agent.context_compressor.MAX_ITERATIONS_SUMMARY_REQUEST`` so the compaction
+    recognizer still keys off it for any pre-patch persisted rows."""
     needs_sanitize = agent._should_sanitize_tool_calls()
     sanitize_model = agent.model
     if needs_sanitize and agent.provider == "moa":
@@ -1978,6 +1985,11 @@ def _iteration_summary_api_messages(agent, messages: list) -> list:
     effective_system = agent._cached_system_prompt or ""
     if agent.ephemeral_system_prompt:
         effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+    if system_nudge:
+        # Combine into a single role=system message; some chat templates
+        # (Anthropic) require system at index 0, others tolerate a leading
+        # system block, so one message is the safest shape (#36246).
+        effective_system = (effective_system + "\n\n" + system_nudge).strip() if effective_system else system_nudge
     if effective_system:
         api_messages = [{"role": "system", "content": effective_system}] + api_messages
     for idx, pfm in enumerate(agent.prefill_messages or ()):
@@ -2071,34 +2083,64 @@ def _summary_text(agent, response, **normalize_kwargs) -> str:
     return (agent._get_transport().normalize_response(response, **normalize_kwargs).content or "").strip()
 
 
+def _summary_text_with_scrub(agent, response, label: str, **normalize_kwargs) -> tuple[str, bool]:
+    """Normalize a summary response and scrub tool-call leakage (#36246 / #36239).
+
+    Returns ``(text, is_fallback)``:
+      * ``is_fallback=True``  → the model returned a ``tool_calls`` payload despite
+        the wire-level ``tool_choice="none"`` and the system-role stop. The caller
+        MUST NOT retry (same model state guarantees another tool_calls) and the
+        user gets a fixed fallback string instead of mid-thought prose.
+      * ``is_fallback=False`` → either a real summary or empty.
+
+    Anthropic's wire schema doesn't accept ``tool_choice="none"``; this helper is
+    the response-side safety net for every api_mode.
+    """
+    normalized = agent._get_transport().normalize_response(response, **normalize_kwargs)
+    if getattr(normalized, "tool_calls", None):
+        logger.warning(
+            "%s: model returned tool_calls despite summary stop; using fallback "
+            "(no retry — same model state would repeat)", label,
+        )
+        return _EMPTY_SUMMARY_RESPONSE, True
+    content = getattr(normalized, "content", "") or ""
+    return (content.strip() if isinstance(content, str) else ""), False
+
+
 def _codex_summary_attempt(agent, api_messages: list, api_request_id: str):
-    def _attempt(retry_count: int) -> str:
+    def _attempt(retry_count: int) -> tuple[str, bool]:
         codex_kwargs = agent._build_api_kwargs(api_messages)
         codex_kwargs.pop("tools", None)
-        return _summary_text(agent, agent._run_codex_stream(codex_kwargs))
+        # Wire-level hard stop: Responses API honors tool_choice="none" (#36246).
+        codex_kwargs["tool_choice"] = "none"
+        return _summary_text_with_scrub(agent, agent._run_codex_stream(codex_kwargs), f"codex-summary-r{retry_count}")
     return _attempt
 
 
 def _anthropic_summary_attempt(agent, api_messages: list, api_request_id: str):
-    def _attempt(retry_count: int) -> str:
+    def _attempt(retry_count: int) -> tuple[str, bool]:
         ant_kw = agent._get_transport().build_kwargs(
             model=agent.model, messages=api_messages, tools=None, max_tokens=agent.max_tokens,
             reasoning_config=agent.reasoning_config, is_oauth=agent._is_anthropic_oauth,
             preserve_dots=agent._anthropic_preserve_dots(), base_url=getattr(agent, "_anthropic_base_url", None))
         ant_kw = _merge_nous_portal_messages_extra_body(agent, ant_kw)
         response = _managed_summary_call(agent, api_request_id, ant_kw, agent._anthropic_messages_create, retry_count=retry_count)
-        return _summary_text(agent, response, strip_tool_prefix=agent._is_anthropic_oauth)
+        # Anthropic's tool_choice enum (auto/any/tool) doesn't accept "none"; the
+        # tools=None strip + the response-side scrub are the two defenses.
+        return _summary_text_with_scrub(agent, response, f"anthropic-summary-r{retry_count}", strip_tool_prefix=agent._is_anthropic_oauth)
     return _attempt
 
 
 def _chat_summary_attempt(agent, api_messages: list, api_request_id: str):
     summary_kwargs = _iteration_summary_chat_kwargs(agent, api_messages)
+    # Wire-level hard stop (#36246): Chat Completions honors tool_choice="none".
+    summary_kwargs["tool_choice"] = "none"
 
-    def _attempt(retry_count: int) -> str:
+    def _attempt(retry_count: int) -> tuple[str, bool]:
         summary_client = agent._ensure_primary_openai_client(reason="iteration_limit_summary_retry" if retry_count else "iteration_limit_summary")
         response = _managed_summary_call(
             agent, api_request_id, summary_kwargs, lambda request: summary_client.chat.completions.create(**request), retry_count=retry_count)
-        return _summary_text(agent, response)
+        return _summary_text_with_scrub(agent, response, f"chat-summary-r{retry_count}")
     return _attempt
 
 
@@ -2106,7 +2148,22 @@ _SUMMARY_ATTEMPT_BUILDERS = {"codex_responses": _codex_summary_attempt, "anthrop
 
 
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
-    """Request a summary when max iterations are reached. Returns the final response text."""
+    """Request a summary when max iterations are reached. Returns the final response text.
+
+    Hard-stop design (#36246): the iteration-limit instruction is delivered as a
+    *system-role* message on the wire payload only, never as a ``role:"user`` row
+    appended to ``messages``. Appending a user row used to (a) cause the model to
+    paraphrase the budget cut-off as user speech ("the user stopped me mid-task")
+    on the summary turn and (b) pollute the persistent history with a synthetic
+    user turn that survived into later turns and confused compaction.
+
+    Belt-and-suspenders wire constraints:
+      * Chat Completions + Codex Responses: ``tool_choice="none"`` (providers honor).
+      * Anthropic Messages: no "none" enum value; relies on ``tools=None`` strip
+        plus the response-side scrub helper.
+      * All paths: ``_summary_text_with_scrub`` rejects a response carrying
+        ``tool_calls`` and returns a fixed fallback string instead of mid-thought prose.
+    """
     warning = f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary..."
     if getattr(agent, "suppress_status_output", False):
         # Strict machine-readable mode (-Q, oneshot): keep diagnostics off stdout. quiet_mode is
@@ -2120,20 +2177,28 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     summary_api_request_id = f"iteration-summary:{uuid.uuid4()}"
     summary_call_outcome = "failed"
 
-    # Shared constant so compaction recognizers can identify this runtime nudge by its stable
-    # content after SessionDB projection strips metadata flags.
+    # Stable content string is the authoritative marker: SessionDB drops ``_``-metadata.
+    # Re-used as the system-nudge text so compaction recognizers can still match it
+    # against any pre-patch persisted rows (#78580 fix, preserved).
     from agent.context_compressor import MAX_ITERATIONS_SUMMARY_REQUEST
-    append_message(messages, {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST})
 
     try:
-        api_messages = _iteration_summary_api_messages(agent, messages)
+        api_messages = _iteration_summary_api_messages(
+            agent, messages, system_nudge=MAX_ITERATIONS_SUMMARY_REQUEST,
+        )
         build_attempt = _SUMMARY_ATTEMPT_BUILDERS.get(agent.api_mode, _chat_summary_attempt)
         attempt = build_attempt(agent, api_messages, summary_api_request_id)
 
         # One retry on an empty summary; a summary empty once its <think> block is stripped is NOT retried.
+        # If the first call returned the fallback (model emitted tool_calls despite tool_choice="none"
+        # + the system stop), do NOT retry — same model state guarantees another tool_calls payload.
         final_response = _EMPTY_SUMMARY_RESPONSE
         for retry_count in (0, 1):
-            text = attempt(retry_count)
+            text, is_fallback = attempt(retry_count)
+            if is_fallback:
+                summary_call_outcome = "fallback"
+                final_response = text
+                break
             if not text:
                 continue
             if "<think>" in text:

--- a/tests/agent/test_handle_max_iterations_role_system.py
+++ b/tests/agent/test_handle_max_iterations_role_system.py
@@ -1,0 +1,255 @@
+"""Regression tests for the hard-stop design of ``handle_max_iterations`` (#36246).
+
+Before this patch, ``handle_max_iterations`` appended its runtime summary request as
+a plain ``role="user"`` row to the persistent ``messages`` list. That had two
+visible consequences:
+
+1. The model received a ``role="user"`` row that read like a user complaint
+   ("You've reached the maximum...") and paraphrased the budget cut-off as user
+   speech in the summary turn ("the user stopped me mid-task").
+2. The synthetic user row was persisted verbatim to ``state.db`` and survived
+   into later turns, poisoning subsequent context.
+
+The patch routes the iteration-limit instruction through ``role="system"`` on
+the wire payload only (not into ``messages``), adds ``tool_choice="none"`` on
+the Chat Completions + Codex Responses paths, and adds a response-side scrub
+helper that rejects tool-call leakage on every api_mode.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _mock_response(
+    content="Hello",
+    finish_reason="stop",
+    tool_calls=None,
+    usage=None,
+):
+    """Mirror tests/run_agent/test_run_agent.py::_mock_response; trimmed to what we need."""
+    if tool_calls:
+        msg = SimpleNamespace(content=content or "", tool_calls=tool_calls, reasoning=None)
+    else:
+        msg = SimpleNamespace(content=content, tool_calls=None, reasoning=None)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    resp = SimpleNamespace(choices=[choice], model="test/model")
+    if usage:
+        resp.usage = SimpleNamespace(**usage)
+    else:
+        resp.usage = None
+    return resp
+
+
+def _tool_call_stub(name="read_file", args="{}"):
+    """A single fake tool_call matching OpenAI's wire shape."""
+    return SimpleNamespace(
+        id="call_test",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=args),
+    )
+
+
+@pytest.fixture()
+def agent():
+    """Minimal AIAgent with mocked OpenAI client and tool loading.
+
+    Mirrors the fixture in tests/run_agent/test_run_agent.py but slimmed for
+    the focused assertions below.
+    """
+    with (
+        patch(
+            "model_tools.get_tool_definitions", return_value=[]
+        ),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        from run_agent import AIAgent
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        return a
+
+
+def _tool_defs_minimal():
+    # Empty tool list keeps the helper happy without pulling model_tools fixtures
+    return []
+
+
+# ===================================================================
+# Group 1: persistent messages must NOT carry the synthetic user row
+# ===================================================================
+
+
+class TestPersistentMessagesClean:
+    def test_no_synthetic_user_row_after_handle_max_iterations(self, agent):
+        """The synthetic nudge MUST NOT be appended to ``messages`` (#36246).
+
+        Before the patch, ``append_message(messages, {"role": "user", "content":
+        MAX_ITERATIONS_SUMMARY_REQUEST})`` made the iteration-limit instruction
+        part of the persistent history, so subsequent turns saw it as a real
+        user turn.
+        """
+        from agent.context_compressor import MAX_ITERATIONS_SUMMARY_REQUEST
+
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        messages = [{"role": "user", "content": "do the thing"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        # No row in the persistent history may match the synthetic content as a user turn.
+        user_rows_with_nudge = [
+            m for m in messages
+            if m.get("role") == "user" and m.get("content") == MAX_ITERATIONS_SUMMARY_REQUEST
+        ]
+        assert user_rows_with_nudge == [], (
+            f"persistent messages contain synthetic user row(s): {user_rows_with_nudge}"
+        )
+
+    def test_synthetic_nudge_only_appears_in_assistant_summary_row(self, agent):
+        """The single assistant row appended after a successful summary is fine.
+
+        Verifies we didn't accidentally suppress the legitimate assistant summary
+        append while removing the user append.
+        """
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Here is the summary."
+        )
+        messages = [{"role": "user", "content": "do the thing"}]
+
+        agent._handle_max_iterations(messages, 60)
+
+        assistant_summaries = [m for m in messages if m.get("role") == "assistant"]
+        assert len(assistant_summaries) == 1
+        assert assistant_summaries[0]["content"] == "Here is the summary."
+
+
+# ===================================================================
+# Group 2: wire payload uses role=system, not role=user
+# ===================================================================
+
+
+class TestWirePayloadRoleSystem:
+    def test_chat_completions_wire_payload_uses_system_role_for_nudge(self, agent):
+        """The nudge must land on a role=system message, not role=user (#36246)."""
+        from agent.context_compressor import MAX_ITERATIONS_SUMMARY_REQUEST
+
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        messages = [{"role": "user", "content": "do the thing"}]
+
+        agent._handle_max_iterations(messages, 60)
+
+        sent_msgs = agent.client.chat.completions.create.call_args.kwargs.get("messages", [])
+        # No user row may carry the synthetic nudge content.
+        user_rows_with_nudge = [
+            m for m in sent_msgs
+            if m.get("role") == "user" and MAX_ITERATIONS_SUMMARY_REQUEST in str(m.get("content", ""))
+        ]
+        assert user_rows_with_nudge == [], (
+            f"wire payload still sends nudge as role=user: {user_rows_with_nudge}"
+        )
+        # A system message may carry the nudge (combined with cached system prompt).
+        system_rows = [m for m in sent_msgs if m.get("role") == "system"]
+        assert len(system_rows) >= 1, "expected at least one system message on the wire"
+        assert any(
+            MAX_ITERATIONS_SUMMARY_REQUEST in str(m.get("content", ""))
+            for m in system_rows
+        ), "nudge must be on a system message"
+
+    def test_chat_completions_sends_tool_choice_none(self, agent):
+        """Wire-level hard stop: Chat Completions must receive tool_choice='none' (#36246)."""
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        messages = [{"role": "user", "content": "do the thing"}]
+
+        agent._handle_max_iterations(messages, 60)
+
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert kwargs.get("tool_choice") == "none", (
+            f"expected tool_choice='none' on the wire, got {kwargs.get('tool_choice')!r}"
+        )
+
+
+# ===================================================================
+# Group 3: scrub helper rejects tool-call leakage on the response side
+# ===================================================================
+
+
+class TestScrubHelper:
+    def test_response_with_tool_calls_returns_fallback_not_prose(self, agent):
+        """If the model ignores tool_choice='none' and emits tool_calls, the
+        runtime returns the fixed fallback string instead of the model's
+        mid-thought prose (#36246, #36239)."""
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="let me do one more cross-check",
+            tool_calls=[_tool_call_stub()],
+        )
+        messages = [{"role": "user", "content": "do the thing"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "I reached the iteration limit and couldn't generate a summary."
+        # No assistant row should have been appended (fallback is not a real summary).
+        assistant_rows = [m for m in messages if m.get("role") == "assistant"]
+        assert assistant_rows == [], f"fallback path should not append an assistant row; got {assistant_rows}"
+
+    def test_fallback_on_first_call_skips_retry(self, agent):
+        """If the first call already triggered the fallback, the runtime does
+        NOT make a second retry call (same model state guarantees another
+        tool_calls payload) (#36246)."""
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="",
+            tool_calls=[_tool_call_stub()],
+        )
+        messages = [{"role": "user", "content": "do the thing"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert "couldn't" in result.lower() or "I reached" in result
+        assert agent.client.chat.completions.create.call_count == 1, (
+            f"expected 1 retry-eligible call after fallback; got "
+            f"{agent.client.chat.completions.create.call_count}"
+        )
+
+    def test_empty_summary_still_retries_once(self, agent):
+        """Sanity: an empty first response (no tool_calls) still triggers the
+        single retry we had before the patch — we only suppress retry on the
+        fallback path, not on empty content."""
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content=""),
+            _mock_response(content="Summary"),
+        ]
+        messages = [{"role": "user", "content": "do the thing"}]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        assert agent.client.chat.completions.create.call_count == 2
+
+
+# ===================================================================
+# Group 4: API failure path unchanged
+# ===================================================================
+
+
+class TestApiFailure:
+    def test_api_failure_returns_error_string(self, agent):
+        """Regression: the chat-completion raising still surfaces the same
+        'couldn't summarize' error string as before the patch."""
+        agent.client.chat.completions.create.side_effect = Exception("API down")
+        messages = [{"role": "user", "content": "do the thing"}]
+
+        with patch("agent.relay_llm.complete_logical_call") as complete_logical:
+            result = agent._handle_max_iterations(messages, 60)
+
+        assert "error" in result.lower()
+        assert "API down" in result
+        complete_logical.assert_called_once()
+        assert complete_logical.call_args.kwargs == {"outcome": "failed"}


### PR DESCRIPTION

## Summary

Replaces the soft `role="user"` summary prompt in `handle_max_iterations()` with a three-layer hard stop:

1. The iteration-limit instruction is now delivered as a `role="system"` message on the wire payload only — never as a `role="user"` row appended to the persistent `messages` list.
2. Chat Completions and Codex Responses paths now send `tool_choice="none"` on the wire.
3. A response-side scrub helper rejects any payload that still carries `tool_calls` (mid-thought prose) and returns a fixed fallback string instead.

This is the post-refactor equivalent of #36246 against the current `_attempt`/`build_attempt` code shape (the original PR was written against the pre-`3dc2403c45` organization and now needs a refresh to apply cleanly).

## What does this PR do?

`handle_max_iterations()` currently appends its runtime summary request as a plain `role="user"` row to the agent's `messages` list. Two user-visible consequences result:

1. **Narrative pollution.** The model receives a `role="user"` row that reads like a user complaint ("You've reached the maximum number of tool-calling iterations allowed…") and paraphrases the budget cut-off as user speech in the summary turn — most visibly, "the user stopped me mid-task before I could apply any edits" framings inside what should be neutral wrap-up reports.
2. **Persistent-history pollution.** The synthetic user row is persisted verbatim to `state.db` and survives into later turns, poisoning subsequent context and confusing compaction. #78580 (`aed114a69b`) added a compaction-time recognizer as a downstream workaround for exactly this leak; this PR removes the upstream cause so the recognizer stops needing to fire.

This PR makes the summary path a hard stop, mirroring the proposal in #36246 and #36239:

- **`role="user"` → `role="system"`** — the nudge is now appended to the cached system prompt for the wire payload only. `messages` (the persistent history) is no longer mutated by the summary call.
- **Wire-level `tool_choice="none"`** — Chat Completions + Codex Responses paths now send a hard protocol-level stop that providers honor regardless of the system prompt content.
- **Response-side scrub** — a new `_summary_text_with_scrub` helper returns `(text, is_fallback)`. If the model still emits a `tool_calls` payload despite the wire-level stop, the helper returns the fixed `_EMPTY_SUMMARY_RESPONSE` string and signals `is_fallback=True` so the caller knows **not to retry** (same model state guarantees another `tool_calls` payload).
- **Anthropic path** — Anthropic's `tool_choice` enum is restricted to `auto`/`any`/`tool` with no `"none"` value. The Anthropic path relies on the existing `tools=None` strip plus the new scrub helper.

## Related Issues

- **Closes #36246** — original implementation by franksong2702 against the pre-`3dc2403c45` code shape; this PR is the modern equivalent against the current code shape.
- **Addresses #36239** — "soft `role=user` summary prompt fails on long-context tool-heavy histories" (the underlying root-cause class).
- **Addresses #94271** — "ACP ignores agent.max_turns and falls back to 90 iterations"; user explicitly paste-quotes the same `MAX_ITERATIONS_SUMMARY_REQUEST` text from `agent/context_compressor.py` that this PR removes from the persistent history.
- **Composes with #78580** (already merged via `aed114a69b`) — compaction-time recognizer for the synthetic nudge content; this PR removes the upstream cause so the recognizer stops needing to.

## Cross-provider reproduction

Captured on `hermes v0.21.1` (`556d19c2d5`), the current `main` at the time of writing.

**Session:** `20260910_131248_a1d119` (model=`MiniMax-M3`, platform=`cli`, 366 messages, ended uncleanly)

| Metric | Value |
|---|---|
| `api_calls` | 90/90 (budget exhausted) on the user's main turn |
| Background-review fork `api_calls` | 16/16 (budget exhausted) — same code path fires twice |
| Persisted synthetic user rows | **2** — `messages` table ids 3556, 3739, both `role:user, content: "You've reached the maximum number of tool-calling iterations allowed. Please provide a final response summarizing what you've found and accomplished so far, without calling any more tools."` |
| Assistant replies framed as user stop | **1 of 2** — message 3557 opens with `> **Note:** The user stopped me mid-task before I could apply any edits. The report below summarizes findings and recommendations.` |

`agent.log` evidence:

```
2026-09-10 13:25:10,464 ... agent.conversation_loop: Turn ended: reason=max_iterations_reached(90/90) ...
2026-09-10 13:26:03,798 WARNING ... ⚠️  Reached maximum iterations (16). Requesting summary...
2026-09-10 13:26:22,711 ... agent.conversation_loop: Turn ended: reason=max_iterations_reached(16/16) ...
```

The same session reproduces the bug at `556d19c2d5` and is the canonical example of (a) the synthetic user row leaking into durable history and (b) the model paraphrasing the budget cut-off as user speech.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py` `+79/-14`:
  - `_iteration_summary_api_messages` gains a `system_nudge: Optional[str] = None` keyword-only parameter; when provided, the nudge is appended to the cached system prompt as a single combined `role="system"` message on the wire payload only.
  - New `_summary_text_with_scrub(agent, response, label, **normalize_kwargs) -> tuple[str, bool]` module-scope helper. Returns `(text, is_fallback)`. If the normalized response carries `tool_calls`, logs WARNING and returns `(_EMPTY_SUMMARY_RESPONSE, True)` — caller MUST NOT retry.
  - `_codex_summary_attempt` adds `codex_kwargs["tool_choice"] = "none"` and uses the scrub helper.
  - `_anthropic_summary_attempt` uses the scrub helper (Anthropic has no `"none"` enum value).
  - `_chat_summary_attempt` adds `summary_kwargs["tool_choice"] = "none"` and uses the scrub helper.
  - `handle_max_iterations` removes `append_message(messages, {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST})`. Routes the nudge through the new `system_nudge=` parameter on `_iteration_summary_api_messages`. The retry loop breaks early if the first call hit the scrub fallback.

- `tests/agent/test_handle_max_iterations_role_system.py` `+254/-0`:
  - `TestPersistentMessagesClean::test_no_synthetic_user_row_after_handle_max_iterations` — the bug-class root-cause assertion: no `role:"user"` row in `messages` carries `MAX_ITERATIONS_SUMMARY_REQUEST` content after the call.
  - `TestPersistentMessagesClean::test_synthetic_nudge_only_appears_in_assistant_summary_row` — did not accidentally suppress the legitimate assistant summary append.
  - `TestWirePayloadRoleSystem::test_chat_completions_wire_payload_uses_system_role_for_nudge` — wire payload carries the nudge on `role:"system"`, never on `role:"user"`.
  - `TestWirePayloadRoleSystem::test_chat_completions_sends_tool_choice_none` — Chat Completions wire kwargs include `tool_choice="none"`.
  - `TestScrubHelper::test_response_with_tool_calls_returns_fallback_not_prose` — a response carrying `tool_calls` returns `_EMPTY_SUMMARY_RESPONSE`, not the model's mid-thought prose; no assistant row appended.
  - `TestScrubHelper::test_fallback_on_first_call_skips_retry` — first-call fallback path → exactly 1 summary call (no retry on a guaranteed-fail state).
  - `TestScrubHelper::test_empty_summary_still_retries_once` — sanity: empty-first-then-real path is unchanged.
  - `TestApiFailure::test_api_failure_returns_error_string` — regression: API exception still surfaces the same "couldn't summarize" string.

## How to Test

```bash
cd /home/v/.hermes/hermes-agent
.venv/bin/python -m pytest tests/agent/test_handle_max_iterations_role_system.py -q
# expected: 8 passed

.venv/bin/python -m pytest tests/run_agent/test_run_agent.py::TestHandleMaxIterations -q
# expected: 14 passed (existing tests; no regressions)

.venv/bin/python -m pytest tests/run_agent/test_run_agent.py -q
# expected: 284 passed
```

End-to-end smoke test (mirrors #36246's verification recipe, updated for the post-refactor shape):

1. Configure a small `agent.max_iterations` (e.g. `5`).
2. Run any task that forces the agent to use tools up to the limit.
3. Inspect `state.db` → `messages`: the iteration-budget-exhausted turn must **not** contain a `role:"user"` row whose content equals `MAX_ITERATIONS_SUMMARY_REQUEST`. The summary's assistant row IS present (unchanged).
4. Inspect `agent.log`: the `handle_max_iterations` summary call includes `"tool_choice": "none"` in the wire kwargs (Chat Completions + Codex Responses paths).
5. Inspect `agent.log`: the assistant summary does **not** contain user-paraphrasing patterns ("the user stopped me mid-task", "the user halted", etc.); instead the assistant reports on what it actually did.

## Why this approach

- **Why not just `tool_choice="none"`?** It is the single most effective defense and is honored by every OpenAI-compatible provider tested. But it is not bulletproof: Anthropic's `tool_choice` enum is restricted to `auto`/`any`/`tool` with no `"none"` value. Layered defenses keep the path correct across all `api_mode`s.
- **Why not just the system stop?** It works in most cases, but the long-context + heavy-tool-use failure mode that motivated #36239 is exactly the case where a soft prompt is unreliable. Hardening requires the prompt change AND a wire-level constraint.
- **Why not just the scrub?** It would still leave the wire shape "soft" — providers that count token usage or charge for `tool_calls` would still record a tool call we silently dropped. Putting `tool_choice="none"` on the wire is correct behavior on the provider side as well.
- **Why a separate helper instead of inline?** `_summary_text_with_scrub` is now a small pure function unit-testable without standing up a full `AIAgent` mock. All call sites collapse to one-liners that read identically, making future review and future patches easier.
- **Why preserve `MAX_ITERATIONS_SUMMARY_REQUEST` as a content marker?** SessionDB projection strips underscore-prefixed metadata, so a flag-based recognition would not survive persistence. The stable content string is the authoritative marker — preserves compatibility with the compaction recognizer added by `aed114a69b` (#78580) for any pre-patch persisted rows. New sessions simply no longer produce the synthetic content for the recognizer to filter against.

## Compatibility

- No new dependencies.
- No config schema changes.
- No new `HERMES_*` env vars.
- Existing behaviour is unchanged on the success path (real summary still returned, assistant row still appended to `messages`).
- Compaction recognizer (#78580) continues to work; new sessions simply no longer produce the synthetic content for the recognizer to filter against.

## Cross-references

- #36246 — original PR (this one supersedes it against the current code shape)
- #36239 — root-cause class
- #94271 — explicit paste of the same `MAX_ITERATIONS_SUMMARY_REQUEST` text
- #78580 — already-merged compaction-time recognizer; this PR removes the upstream cause
- #105132 / #105141 — adjacent summary-path bug (OpenCode `x-opencode-session` header missing); same function, different concern
- #106734 — adjacent summary-path bug (Bedrock missing from `_SUMMARY_ATTEMPT_BUILDERS`); same function, different concern

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — searched "handle_max_iterations", "max iterations stop", "tool_choice none", "iteration budget", "user stopped me"
- [x] My PR contains **only** changes related to this fix (2 files, 1 commit)
- [ ] I've run `pytest tests/ -q` and all tests pass — partial; see the "What does this PR do?" → "How to Test" section
- [x] I've added tests for my changes (8 new, all wire-level / behaviour-level)
- [x] I've tested on my platform: Linux, CPython 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the two docstrings are the documentation for this behaviour; no `docs/` change applies
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform impact — N/A, no platform-conditional code
- [x] Tool descriptions/schemas — N/A; the change *removes* tools from one request, which is the point

### Test runs performed on this branch

```
tests/agent/test_handle_max_iterations_role_system.py        8 passed in 2.26s
tests/run_agent/test_run_agent.py::TestHandleMaxIterations  14 passed in 2.42s
tests/run_agent/test_run_agent.py                          284 passed in 72.05s
tests/agent/test_iteration_budget_warning.py +
tests/agent/test_turn_finalizer_iteration_limit_exit.py +
tests/run_agent/test_verification_continuation_budget.py +
tests/run_agent/test_iteration_budget_race.py               25 passed in 94.84s
```

I did not run a full `tests/` tree on this branch (test collection requires optional deps I don't have in this environment: `aiohttp`, the `acp`/`gateway` stacks). The locally-run scopes above all pass cleanly.