### PR TITLE
fix(restart-loop-guard): bound clock-rollback future-entry adjacency by gap

### DIFF
--- a/gateway/restart_loop_guard.py
+++ b/gateway/restart_loop_guard.py
@@ -67,7 +67,16 @@ def _chain_ending_at(boots: List[float], ts: float, gap: float) -> List[float]:
     chain: List[float] = []
     prev = ts
     for t in sorted(boots, reverse=True):
-        if t > ts:  # clock moved backwards (NTP step, restored file): future entry is adjacent, not a break
+        if t > ts:
+            # Clock moved backwards (NTP step, restored RTC/file): a *small* future entry is
+            # adjacent to `ts`, not a break. An arbitrary distant one is not — admitting it
+            # would chain boots from an unrelated episode weeks ago into "now" and trip the
+            # breaker, violating this module's fail-open contract (#93427). Bound the
+            # adjacency by the same `gap` every other link uses, and `continue` rather than
+            # `break`: the walk is sorted descending, so a distant future entry is visited
+            # FIRST and breaking there would silently drop an otherwise valid chain.
+            if t - ts > gap:
+                continue
             chain.append(t)
             continue
         if prev - t > gap:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1837,6 +1837,42 @@ class TestRestartLoopGuard:
         for ts in (1000.0, 1150.0, 1300.0, 1450.0):
             assert rlg.check_and_record(0, 60, now=ts) is False
 
+    def test_clock_rollback_does_not_chain_distant_future_boots(self):
+        """#93427: admitting *any* entry timestamped after ``ts`` let a single
+        backward clock step (NTP correction, restored RTC) chain an unrelated
+        episode into "now" and trip the breaker — sessions then stay
+        resume-pending until the user manually messages. Future entries must be
+        bounded by the same ``gap`` every other link uses.
+        """
+        import gateway.restart_loop_guard as rlg
+        # Boots from a resolved episode weeks ago, then a large backward step:
+        # pre-fix this returned [1000.0, 1010.0].
+        assert rlg._chain_ending_at([1000.0, 1010.0], ts=500.0, gap=300.0) == []
+
+    def test_distant_future_entry_is_skipped_not_a_break(self):
+        """Skipping a far-future entry must not end the walk. The list is sorted
+        descending, so a distant future entry is visited FIRST — a ``break``
+        there drops an otherwise valid chain entirely (the variant rejected in
+        #93427: boots=[2000, 1100, 1050], ts=1060, gap=300 -> []).
+        """
+        import gateway.restart_loop_guard as rlg
+        assert rlg._chain_ending_at([2000.0, 1100.0, 1050.0], ts=1060.0, gap=300.0) == [1050.0, 1100.0]
+
+    def test_small_backward_clock_step_stays_adjacent(self):
+        """The original intent survives: a seconds-long NTP step keeps the
+        future entry in the chain rather than ending it."""
+        import gateway.restart_loop_guard as rlg
+        assert rlg._chain_ending_at([1010.0], ts=1000.0, gap=300.0) == [1010.0]
+
+    def test_backward_clock_step_cannot_trip_on_old_episode(self):
+        """End-to-end through the public entry point: an old episode in
+        restart_loop.json plus a backward step must not reach max_restarts."""
+        import gateway.restart_loop_guard as rlg
+        rlg.record_restart_interrupted_boot(60, now=1000.0)
+        rlg.record_restart_interrupted_boot(60, now=1010.0)
+        # Clock steps back ~8 minutes; only this boot belongs to the chain.
+        assert rlg.check_and_record(3, 60, now=500.0, max_gap_seconds=300) is False
+
 class TestTerminalToolGatewayLifecycleGuardRemote:
     """Remote-backend and two-session cwd regression coverage."""
 


### PR DESCRIPTION
## Bug

`_chain_ending_at()` admitted **any** boot timestamped after `ts` into the chain and skipped the gap check entirely:

```python
if t > ts:  # future entry is adjacent, not a break
    chain.append(t)
    continue
```

After one large backward clock step (NTP correction, restored RTC, manual time change) arbitrarily old boots chain in. With two boots from an episode weeks ago in `restart_loop.json`, one backward step plus one new boot reaches `max_restarts(3)` — the auto-resume breaker fires on unrelated history and restart-interrupted sessions stay resume-pending until the user manually messages. That violates the module's own documented fail-open contract ("a broken breaker must never wedge a healthy gateway").

Repro (direct module call, pre-fix):

```python
_chain_ending_at([1000.0, 1010.0], ts=500.0, gap=300.0)
# -> [1000.0, 1010.0]  -- weeks-old boots chained into "now"
```

## Fix

Bound the future-entry adjacency by the same `gap` every other link uses, and `continue` rather than `break` when skipping it:

```python
if t > ts:
    if t - ts > gap:
        continue          # too far ahead -> skip it, keep walking the rest
    chain.append(t)
    continue
```

- `break` (the variant in #93427) exits the walk on the first distant entry — and because the walk is sorted descending, a distant future entry is always visited *first*: `boots=[2000, 1100, 1050], ts=1060, gap=300` -> `chain=[]`, silently losing a valid chain.
- Small backward steps (seconds) keep the intended adjacency behaviour unchanged.

## How to verify

```bash
python -m pytest tests/hermes_cli/test_gateway_restart_loop.py -q -o 'addopts='
```

## Test evidence

4 new cases in `tests/hermes_cli/test_gateway_restart_loop.py`:

- `test_clock_rollback_does_not_chain_distant_future_boots` — the direct repro above returns `[]`;
- `test_distant_future_entry_is_skipped_not_a_break` — the far-future entry is skipped and the valid chain survives;
- `test_backward_clock_step_cannot_trip_on_old_episode` — end-to-end through `check_and_record`: an old episode in `restart_loop.json` plus a backward step does not trip the breaker (pre-fix it logs "Restart-loop breaker TRIPPED");
- `test_small_backward_clock_step_stays_adjacent` — pins the behaviour the change must not regress.

Three of the four fail against current `main` and pass with the fix (verified by stashing only the source change); the fourth passes both ways by design. Full module: 301 passed.

---

Rebuilt cleanly on current `main`; supersedes #93870 (same fix, branch had drifted into a merge conflict).
