### PR TITLE
fix(gateway): unblock clarify wait on /stop or interrupt-mode messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -805,6 +805,16 @@ def _clarify_send_then_wait(fut, *, clarify_id: str, session_key: str, clarify_m
         return abort
     timeout = clarify_mod.get_clarify_timeout()
     response = clarify_mod.wait_for_response(clarify_id, timeout=float(timeout))
+    # ``wait_for_response`` also unblocks on the per-thread interrupt flag (#83889): /stop and
+    # interrupt-mode messages set it on the agent thread. Surface that as an explicit interrupt
+    # sentinel rather than a misleading "user did not respond" timeout — the turn is already
+    # winding down and any reply the user typed in the meantime was dropped with it.
+    try:
+        from tools.interrupt import is_interrupted
+    except Exception:  # pragma: no cover - optional
+        is_interrupted = None
+    if is_interrupted is not None and is_interrupted():
+        return "[interrupted by user]"
     if response is None or response == "":
         return f"[user did not respond within {int(timeout / 60)}m]"
     return response

--- a/tests/gateway/test_clarify_send_timeout_ambiguity.py
+++ b/tests/gateway/test_clarify_send_timeout_ambiguity.py
@@ -173,3 +173,45 @@ def test_failed_send_result_error_detail_is_logged(caplog):
     with caplog.at_level("WARNING", logger="gateway.run"):
         _clarify_send_disposition(fut, session_key="sk", clarify_mod=clarify_mod)
     assert "relay prompt op unavailable" in caplog.text
+
+
+# --- Interrupt attribution (#83889) ---------------------------------------
+
+
+def test_interrupt_during_wait_returns_interrupt_sentinel(monkeypatch):
+    """A /stop that unblocked the wait must be reported as an interrupt.
+
+    `wait_for_response` now also returns on the per-thread interrupt flag, so a
+    cancelled turn would otherwise fall through to the "user did not respond"
+    wording — misattributing a deliberate stop to user silence.
+    """
+    import tools.interrupt as interrupt_mod
+
+    monkeypatch.setattr(interrupt_mod, "is_interrupted", lambda: True)
+    fut = MagicMock()
+    fut.result.return_value = _Result(True)
+    clarify_mod = MagicMock()
+    clarify_mod.get_clarify_timeout.return_value = 600
+    clarify_mod.wait_for_response.return_value = None
+
+    assert (
+        _clarify_send_then_wait(fut, clarify_id="cid", session_key="sk", clarify_mod=clarify_mod)
+        == "[interrupted by user]"
+    )
+
+
+def test_timeout_without_interrupt_keeps_timeout_wording(monkeypatch):
+    """The interrupt check must not steal the ordinary timeout sentinel."""
+    import tools.interrupt as interrupt_mod
+
+    monkeypatch.setattr(interrupt_mod, "is_interrupted", lambda: False)
+    fut = MagicMock()
+    fut.result.return_value = _Result(True)
+    clarify_mod = MagicMock()
+    clarify_mod.get_clarify_timeout.return_value = 600
+    clarify_mod.wait_for_response.return_value = None
+
+    assert (
+        _clarify_send_then_wait(fut, clarify_id="cid", session_key="sk", clarify_mod=clarify_mod)
+        == "[user did not respond within 10m]"
+    )

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -42,6 +42,39 @@ class TestClarifyPrimitive:
         result = cm.wait_for_response("id1", timeout=10.0)
         assert result == "B"
 
+    def test_wait_for_response_unblocks_on_interrupt(self):
+        """#83889: a /stop or interrupt-mode message must unblock the wait well
+        before the timeout.
+
+        ``wait_for_response`` runs ON the agent thread, so signalling the
+        per-thread interrupt flag — exactly what the gateway's interrupt path
+        does — must make it return immediately. Otherwise the agent thread stays
+        inside the tool, the run's ``finally`` cleanup cannot execute, and
+        /stop does nothing until the full clarify timeout.
+        """
+        from tools import clarify_gateway as cm
+        from tools.interrupt import clear_current_thread_interrupt, set_interrupt
+
+        tid = threading.current_thread().ident
+        cm.register("id-int", "sk-int", "Pick one", ["A", "B"])
+
+        def signal_interrupt():
+            time.sleep(0.05)
+            set_interrupt(True, tid)
+
+        threading.Thread(target=signal_interrupt).start()
+        start = time.monotonic()
+        try:
+            result = cm.wait_for_response("id-int", timeout=30.0)
+            elapsed = time.monotonic() - start
+        finally:
+            clear_current_thread_interrupt()
+
+        assert result is None
+        assert elapsed < 5.0, f"wait blocked {elapsed:.1f}s despite interrupt"
+        # Interrupt exits through the same cleanup path as a timeout.
+        assert cm.get_pending_for_session("sk-int") is None
+
     def test_first_resolution_wins(self):
         """A late cancellation must not overwrite an already-selected choice."""
         from tools import clarify_gateway as cm

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -67,9 +67,20 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
         from tools.environments.base import touch_activity_if_due
     except Exception:  # pragma: no cover - optional
         touch_activity_if_due = None
+    # Per-thread interrupt flag (#83889): /stop and interrupt-mode messages mark the agent thread
+    # (tools.interrupt) while this wait runs ON that thread, so the loop must observe it — without
+    # it the agent stays blocked here until the full clarify timeout even though the run is already
+    # being cancelled, and the user's typed reply is dead. Mirrors the approval wait
+    # (tools/approval_gateway_wait._poll_event) and BaseEnvironment._wait_for_process.
+    try:
+        from tools.interrupt import is_interrupted
+    except Exception:  # pragma: no cover - optional
+        is_interrupted = lambda: False
     deadline = None if timeout is None or float(timeout) <= 0.0 else time.monotonic() + float(timeout)
     activity_state = {"last_touch": time.monotonic(), "start": time.monotonic()}
     while True:
+        if is_interrupted():
+            break
         remaining = 1.0 if deadline is None else deadline - time.monotonic()
         if remaining <= 0 or entry.event.wait(timeout=min(1.0, remaining)):
             break


### PR DESCRIPTION
## Bug

When an agent in a gateway session calls `clarify`, the agent thread blocks in `tools/clarify_gateway.wait_for_response` on a `threading.Event` with a 1s-slice poll loop whose only side-channel is the inactivity heartbeat. The gateway's interrupt path (`_interrupt_and_clear_session` -> `request_hard_interrupt` -> agent `_set_interrupt(True, thread_id)`) sets the per-thread interrupt flag in `tools.interrupt`, but the blocked wait never checked it. Because the agent thread is stuck inside the tool, the run's `finally` cleanup (`clear_session` in `run_sync`) could not run either, so the clarify stayed blocked for the full timeout (600s default) — `/stop` did nothing and a reply typed in the meantime was dead. Confirmed on multiplexed Feishu groups (#83889); the same mechanism applies to every platform with text-fallback clarify.

## Root cause

`wait_for_response` polled only:

1. `entry.event.wait(timeout=slice_s)` — set by `resolve_gateway_clarify` / `clear_session`
2. `touch_activity_if_due` — inactivity heartbeat

No interrupt flag check. The per-thread interrupt mechanism is exactly designed for this — the wait runs on the agent thread and `/stop` marks that same thread. The approval wait (`tools/approval_gateway_wait._poll_event`) and `BaseEnvironment._wait_for_process` already observe `tools.interrupt`; the clarify wait was the outlier.

## Fix

- `tools/clarify_gateway.py` — `wait_for_response` polls `tools.interrupt.is_interrupted()` once per 1s slice (same cadence as the heartbeat, import guarded the same way). On interrupt it breaks, returns `None`, and the existing post-loop cleanup removes the entry — the identical exit path a timeout takes.
- `gateway/run.py::_clarify_send_then_wait` — attributes the unblocked wait to the interrupt with a `[interrupted by user]` sentinel instead of the misleading `[user did not respond within Nm]`, since the turn is already winding down and the user's typed reply was dropped with it.

## How to verify

```bash
python -m pytest tests/tools/test_clarify_gateway.py tests/gateway/test_clarify_send_timeout_ambiguity.py -q -o 'addopts='
```

## Test evidence

- `tests/tools/test_clarify_gateway.py::test_wait_for_response_unblocks_on_interrupt` — signals the real per-thread interrupt flag from another thread and asserts the wait returns in well under the timeout (pre-fix: blocks the full 30s and fails) with the entry cleaned up.
- `tests/gateway/test_clarify_send_timeout_ambiguity.py::test_interrupt_during_wait_returns_interrupt_sentinel` — the sentinel attribution.
- `tests/gateway/test_clarify_send_timeout_ambiguity.py::test_timeout_without_interrupt_keeps_timeout_wording` — pins that the ordinary timeout wording survives.

Both discriminating cases fail against current `main` (verified by stashing only the source change); 41 passed across both modules.

Fixes #83889

---

Rebuilt cleanly on current `main`; supersedes #84119 (same fix rebased by hand onto today's code — the clarify wait now lives behind `_clarify_send_then_wait` in `gateway/run.py`).
