### PR TITLE
fix(acp): clear is_running in finally so a cancelled turn never bricks the session

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -877,37 +877,50 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         self, state: SessionState, session_id: str, conn: Any, result: dict, pre_turn_hermes_id: Any,
         streamed_message: bool,
     ) -> PromptResponse:
-        """Persist, emit provenance/final text, drain queued prompts, report usage."""
-        if result.get("messages"):
-            state.history = result["messages"]
-            self.session_manager.save_session(session_id)
+        """Persist, emit provenance/final text, drain queued prompts, report usage.
 
-        # Head rotated (compression split): emit provenance so clients can render the boundary.
-        post_turn_hermes_id = getattr(state.agent, "session_id", None)
-        if conn and post_turn_hermes_id and pre_turn_hermes_id and post_turn_hermes_id != pre_turn_hermes_id:
-            try:
-                await self._send_session_info_update(
-                    session_id, current_hermes_session_id=post_turn_hermes_id,
-                    previous_hermes_session_id=pre_turn_hermes_id,
-                )
-            except Exception:
-                logger.debug("Could not emit ACP provenance update after rotation for %s", session_id, exc_info=True)
+        The pre-drain tail runs inside a ``try`` whose ``finally`` clears ``is_running``: an
+        exception anywhere in it (a cancelled turn's ``final_response=None`` reaching
+        ``startswith``, ``save_session`` failing, a ``conn.session_update`` error) would
+        otherwise escape with the session still marked running, so every later prompt —
+        the queued ones included — would be answered with "Queued for the next turn" until
+        the process died (#86798).
+        """
+        try:
+            if result.get("messages"):
+                state.history = result["messages"]
+                self.session_manager.save_session(session_id)
 
-        final_response = result.get("final_response", "")
-        cancelled = bool(state.cancel_event and state.cancel_event.is_set())
-        # The local "waiting for model" interrupt status is metadata, not prose; stop_reason carries it.
-        from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+            # Head rotated (compression split): emit provenance so clients can render the boundary.
+            post_turn_hermes_id = getattr(state.agent, "session_id", None)
+            if conn and post_turn_hermes_id and pre_turn_hermes_id and post_turn_hermes_id != pre_turn_hermes_id:
+                try:
+                    await self._send_session_info_update(
+                        session_id, current_hermes_session_id=post_turn_hermes_id,
+                        previous_hermes_session_id=pre_turn_hermes_id,
+                    )
+                except Exception:
+                    logger.debug("Could not emit ACP provenance update after rotation for %s", session_id, exc_info=True)
 
-        interrupted = bool(result.get("interrupted")) or cancelled
-        suppress = interrupted and final_response.startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX)
-        # Send the final text unless already streamed — or if a plugin hook transformed it after.
-        if final_response and conn and not suppress and (not streamed_message or result.get("response_transformed")):
-            await conn.session_update(session_id, acp.update_agent_message_text(final_response))
+            # `or ""` rather than the .get(key, "") default: a cancelled/interrupted turn
+            # returns an explicit {"final_response": None}, which only a missing KEY would
+            # have defaulted — the None reached startswith() and crashed the tail (#86798).
+            final_response = result.get("final_response") or ""
+            cancelled = bool(state.cancel_event and state.cancel_event.is_set())
+            # The local "waiting for model" interrupt status is metadata, not prose; stop_reason carries it.
+            from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 
-        # Go idle before draining so recursive prompt() calls can acquire the session.
-        with state.runtime_lock:
-            state.is_running = False
-            state.current_prompt_text = ""
+            interrupted = bool(result.get("interrupted")) or cancelled
+            suppress = interrupted and final_response.startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX)
+            # Send the final text unless already streamed — or if a plugin hook transformed it after.
+            if final_response and conn and not suppress and (not streamed_message or result.get("response_transformed")):
+                await conn.session_update(session_id, acp.update_agent_message_text(final_response))
+        finally:
+            # Go idle before draining so recursive prompt() calls can acquire the session. Runs on
+            # every exit path, including a raise from the tail above.
+            with state.runtime_lock:
+                state.is_running = False
+                state.current_prompt_text = ""
         while True:
             with state.runtime_lock:
                 if not state.queued_prompts:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -726,3 +726,87 @@ class TestRegisterSessionMcpServers:
         with patch("tools.mcp_tool_discovery.register_mcp_servers", side_effect=RuntimeError("boom")):
             # Should not raise
             await agent._register_session_mcp_servers(state, [server])
+
+
+@pytest.mark.asyncio
+async def test_prompt_cancelled_turn_with_none_response_does_not_brick_session(agent):
+    """#86798: a cancelled turn whose final_response is None must not crash the
+    post-turn tail nor leave the session permanently running with prompts queued
+    forever.
+
+    ``result.get("final_response", "")`` only defaults a MISSING key, so the
+    explicit None from a cancelled turn reached ``startswith()`` — before the
+    ``is_running`` reset, which sat later in the tail.
+    """
+    new_resp = await agent.new_session(cwd=".")
+    state = agent.session_manager.get_session(new_resp.session_id)
+
+    def mock_run(*args, **kwargs):
+        state.cancel_event.set()
+        return {
+            "final_response": None,
+            "messages": [],
+            "interrupted": True,
+            "completed": False,
+        }
+
+    state.agent.run_conversation = mock_run
+    mock_conn = MagicMock(spec=acp.Client)
+    mock_conn.session_update = AsyncMock()
+    agent._conn = mock_conn
+
+    resp = await agent.prompt(
+        prompt=[TextContentBlock(type="text", text="do something slow")],
+        session_id=new_resp.session_id,
+    )
+
+    assert resp.stop_reason == "cancelled"
+    assert state.is_running is False
+    assert state.queued_prompts == []
+
+    # A follow-up prompt must actually run, not sit queued forever.
+    state.cancel_event.clear()
+    follow_up_ran = []
+
+    def mock_run_ok(*args, **kwargs):
+        follow_up_ran.append(True)
+        return {"final_response": "done", "messages": [], "completed": True}
+
+    state.agent.run_conversation = mock_run_ok
+    resp2 = await agent.prompt(
+        prompt=[TextContentBlock(type="text", text="follow up")],
+        session_id=new_resp.session_id,
+    )
+
+    assert resp2.stop_reason == "end_turn"
+    assert follow_up_ran, "follow-up prompt was queued instead of running"
+
+
+@pytest.mark.asyncio
+async def test_prompt_tail_exception_still_releases_session(agent):
+    """#86798: if the post-turn tail (save_session etc.) raises, is_running must
+    still be cleared through the finally so the session is not bricked."""
+    new_resp = await agent.new_session(cwd=".")
+    state = agent.session_manager.get_session(new_resp.session_id)
+
+    def mock_run(*args, **kwargs):
+        return {
+            "final_response": "ok",
+            "messages": [{"role": "user", "content": "x"}],
+            "completed": True,
+        }
+
+    state.agent.run_conversation = mock_run
+    agent.session_manager.save_session = MagicMock(side_effect=RuntimeError("disk full"))
+    mock_conn = MagicMock(spec=acp.Client)
+    mock_conn.session_update = AsyncMock()
+    agent._conn = mock_conn
+
+    with pytest.raises(RuntimeError, match="disk full"):
+        await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="hi")],
+            session_id=new_resp.session_id,
+        )
+
+    assert state.is_running is False
+    assert state.current_prompt_text == ""


### PR DESCRIPTION
## Bug

An ACP turn that is cancelled returns `{"final_response": None}`, and the post-turn tail then crashed on `final_response.startswith(...)`:

```
'NoneType' object has no attribute 'startswith'
```

`result.get("final_response", "")` only defaults when the **key** is absent — the explicit `None` passed straight through. The crash happened *before* `state.is_running = False`, which sat later in the tail, so the session stayed permanently `running` and every later prompt was answered with `"Queued for the next turn. (N queued)"` until the process was killed. Any orchestration client that sends a system message while a turn runs could reproduce it, not just editor cancel-and-resend.

## Fix

1. Coerce with `or ""` instead of the `.get(key, "")` default: `final_response = result.get("final_response") or ""` — normalizes the explicit `None` (cancelled/interrupted turn) before `startswith`.
2. Move the `is_running = False` / `current_prompt_text = ""` reset into a `finally` covering the whole pre-drain tail (history save, provenance update, `session_update` delivery). It now runs on every exit path, including an exception raised mid-tail by `save_session` or `conn.session_update`. The reset still happens *before* the queued-prompt drain, so recursive `prompt()` calls can acquire the session.

## How to verify

```bash
python -m pytest tests/acp/test_server.py -q -o 'addopts='
```

## Test evidence

`tests/acp/test_server.py` adds two regressions:

- `test_prompt_cancelled_turn_with_none_response_does_not_brick_session` — a cancelled turn (`final_response=None`) stops as `cancelled`, releases the session, and a follow-up prompt actually runs instead of queueing (pre-fix: `is_running` stays `True`).
- `test_prompt_tail_exception_still_releases_session` — a tail that raises (`save_session` -> RuntimeError) still clears `is_running` and `current_prompt_text`.

Both fail against current `main` (verified by stashing only the source change). `tests/acp` + `tests/acp_adapter`: 156 passed.

Fixes #86798

---

Rebuilt cleanly on current `main`; supersedes #100800 (same fix, branch had drifted into a merge conflict).
