### PR TITLE
fix(mcp): keep the whole MCP teardown funnel inside the supervisor kill grace

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4644,14 +4644,23 @@ async def _await_thread_exit(
     return not thread.is_alive()
 
 
-async def _shutdown_mcp_servers_nonblocking(timeout: float = 5.0) -> bool:
+async def _shutdown_mcp_servers_nonblocking(timeout: float | None = None) -> bool:
     """Close MCP servers off-loop with a bounded wait; True when done within ``timeout``.
     ``shutdown_mcp_servers()`` can block ~15s; on the loop thread short-grace supervisors (s6 3s)
     SIGKILL us before ``mark_exited()`` runs, so every later boot reports a phantom unclean death.
     On timeout shutdown proceeds and the daemon thread is left to finish or die.
 
+    ``timeout`` defaults to ``tools.mcp_tool._MCP_TEARDOWN_BUDGET_SECONDS`` rather than a bare
+    5.0s: the whole funnel must stay under a container supervisor's ~3s kill grace so the
+    clean-exit marker is still written before SIGKILL (#82874 round-2).
+
     See #82874.
     """
+    if timeout is None:
+        from tools.mcp_tool import _MCP_TEARDOWN_BUDGET_SECONDS
+
+        timeout = _MCP_TEARDOWN_BUDGET_SECONDS
+
     def _do() -> None:
         try:
             from tools.mcp_tool_lifecycle import shutdown_mcp_servers

--- a/tests/gateway/test_82874_mcp_teardown_budget.py
+++ b/tests/gateway/test_82874_mcp_teardown_budget.py
@@ -1,0 +1,147 @@
+"""Regression tests for #82874 round-2: MCP teardown must fit the kill grace.
+
+On the gateway clean-exit critical path a container supervisor (s6-overlay and
+friends) grants only ~3s of kill grace before SIGKILL. If the whole MCP teardown
+funnel exceeds that, ``lifecycle_ledger.mark_exited()`` never runs and every
+subsequent boot reports a phantom unclean exit.
+
+Main already runs ``shutdown_mcp_servers()`` on a daemon thread
+(``_shutdown_mcp_servers_nonblocking``) so the event loop stays responsive. These
+tests guard the round-2 concern: the teardown must ALSO fit inside the ~3s grace.
+
+- ``_MCP_TEARDOWN_BUDGET_SECONDS`` bounds the whole funnel (server drain + loop
+  drain + thread join) as ONE shared budget, and every segment wait clamps to it
+  through ``_teardown_clamp``.
+- The gateway's nonblocking wrapper defaults its wait to that budget, not a bare
+  5.0s — verified behaviourally by timing it against a wedged teardown.
+- The orphan-PID reap (SIGTERM -> 2s -> SIGKILL) runs on a detached thread the
+  exit path never joins, so its dance cannot hold the funnel open.
+
+The budget arithmetic lives in ``tools.mcp_tool`` (the origin module) and is
+consumed across ``tools.mcp_tool_lifecycle`` (segment 1) and ``tools.mcp_tool_loop``
+(segments 2-4), so the source-level guards inspect those modules individually.
+"""
+
+import asyncio
+import inspect
+import threading
+import time
+from unittest.mock import patch
+
+from gateway.run import _shutdown_mcp_servers_nonblocking
+from tools import mcp_tool
+from tools import mcp_tool_lifecycle as _mcp_lifecycle
+from tools import mcp_tool_loop as _mcp_loop
+
+
+def test_teardown_budget_fits_supervisor_kill_grace():
+    """The whole funnel must stay under the ~3s supervisor kill grace."""
+    budget = mcp_tool._MCP_TEARDOWN_BUDGET_SECONDS
+    assert 0 < budget < 3, (
+        "MCP teardown budget must stay under the ~3s supervisor kill grace; "
+        f"got {budget}s"
+    )
+    # Segment 1 (server shutdown) must never exceed the total budget.
+    assert 0 < mcp_tool._MCP_SHUTDOWN_DRAIN_SECONDS <= budget, (
+        "server-shutdown drain must not exceed the total teardown budget"
+    )
+
+
+def test_teardown_clamp_obeys_budget():
+    """Every bounded wait clamps to the remaining budget; never negative."""
+    assert mcp_tool._teardown_clamp(2.0, 2.75) == 2.0   # own limit fits -> keep it
+    assert mcp_tool._teardown_clamp(13.0, 0.6) == 0.6   # exceeds remaining -> clamp down
+    assert mcp_tool._teardown_clamp(5.0, 0.0) == 0.0    # budget spent -> zero
+    assert mcp_tool._teardown_clamp(5.0, -1.0) == 0.0   # never negative
+
+
+def test_gateway_nonblocking_wait_is_bounded_by_the_budget(monkeypatch):
+    """Behavioural: a wedged teardown must not hold the exit path past the budget.
+
+    Pre-fix the wrapper defaulted to a bare 5.0s wait, so this returns only after
+    ~5s — longer than the supervisor's whole kill grace.
+    """
+    release = threading.Event()
+
+    def _wedged_shutdown():
+        # Stands in for a server whose shutdown() never returns.
+        release.wait(timeout=10)
+
+    monkeypatch.setattr(_mcp_lifecycle, "shutdown_mcp_servers", _wedged_shutdown)
+    monkeypatch.setattr(mcp_tool, "_MCP_TEARDOWN_BUDGET_SECONDS", 0.2)
+    try:
+        start = time.monotonic()
+        completed = asyncio.run(_shutdown_mcp_servers_nonblocking())
+        elapsed = time.monotonic() - start
+    finally:
+        release.set()
+
+    assert completed is False, "a wedged teardown must report as not-completed"
+    assert elapsed < 1.5, (
+        f"exit funnel waited {elapsed:.2f}s; the budget (0.2s) must bound it, "
+        "not a bare 5.0s default"
+    )
+
+
+def test_gateway_nonblocking_signature_resolves_budget_lazily():
+    """The default must be resolved from the budget, not frozen at import time.
+
+    A bare ``timeout: float = 5.0`` default is exactly what overran the grace.
+    """
+    sig = inspect.signature(_shutdown_mcp_servers_nonblocking)
+    assert sig.parameters["timeout"].default is None, (
+        "gateway nonblocking shutdown should resolve the budget lazily "
+        f"(default None), got {sig.parameters['timeout'].default!r}"
+    )
+    src = inspect.getsource(_shutdown_mcp_servers_nonblocking)
+    assert "timeout = _MCP_TEARDOWN_BUDGET_SECONDS" in src
+
+
+def test_orphan_reaper_never_blocks_the_caller(monkeypatch):
+    """The reap's SIGTERM -> 2s -> SIGKILL dance must not sit on the exit path."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def _slow_reap(include_active):
+        started.set()
+        release.wait(timeout=10)
+
+    monkeypatch.setattr(_mcp_lifecycle, "_kill_orphaned_mcp_children", _slow_reap)
+    try:
+        start = time.monotonic()
+        _mcp_loop._start_orphan_reaper()
+        elapsed = time.monotonic() - start
+        assert elapsed < 1.0, f"_start_orphan_reaper blocked for {elapsed:.2f}s"
+        assert started.wait(timeout=2), "the reaper thread never ran"
+    finally:
+        release.set()
+
+
+def test_teardown_segments_thread_the_shared_budget():
+    """Source-level guard: no teardown segment may escape the one budget.
+
+    The funnel spans two modules (lifecycle = segment 1, loop = segments 2-4), so
+    a caller-visible signature change is the cheapest place to catch a regression
+    of the arithmetic itself.
+    """
+    lifecycle_src = inspect.getsource(_mcp_lifecycle)
+    loop_src = inspect.getsource(_mcp_loop)
+
+    # Segment 1 clamps its wait and hands the remainder on.
+    assert "_MCP_SHUTDOWN_DRAIN_SECONDS, teardown_budget" in lifecycle_src
+    assert "future.result(timeout=drain_wait)" in lifecycle_src
+    assert "teardown_budget = max(0.0, teardown_budget - drain_wait)" in lifecycle_src
+    assert "future.result(timeout=15)" not in lifecycle_src, (
+        "a bare 15s server-drain wait would outrun the kill grace"
+    )
+    assert "_stop_mcp_loop(only_if_idle=scope is not None, teardown_budget=teardown_budget)" in lifecycle_src
+
+    # Segments 2-4 derive from what the budget still leaves.
+    assert "_MCP_LOOP_DRAIN_TIMEOUT + 1, teardown_budget" in loop_src
+    assert "_teardown_clamp(5.0, teardown_budget)" in loop_src
+    assert "thread.join(timeout=join_wait)" in loop_src
+    assert "_start_orphan_reaper()" in loop_src
+    stop_src = inspect.getsource(_mcp_loop._stop_mcp_loop)
+    assert "_kill_orphaned_mcp_children" not in stop_src, (
+        "the orphan reap must not run inline on the exit path"
+    )

--- a/tests/tools/test_mcp_initial_connect_shutdown.py
+++ b/tests/tools/test_mcp_initial_connect_shutdown.py
@@ -70,11 +70,11 @@ def test_initial_connect_failure_is_registry_owned_and_reaped(monkeypatch, tmp_p
             if task is not current and not task.done()
         )
 
-    def _observed_stop(*, only_if_idle=False):
+    def _observed_stop(*, only_if_idle=False, teardown_budget=None):
         pending_at_stop.extend(
             _mcp_loop._run_on_mcp_loop(_pending_tasks, timeout=5)
         )
-        return real_stop(only_if_idle=only_if_idle)
+        return real_stop(only_if_idle=only_if_idle, teardown_budget=teardown_budget)
 
     monkeypatch.setattr(_mcp_loop, "_stop_mcp_loop", _observed_stop)
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -245,6 +245,36 @@ _STDIO_RESPAWN_WAIT_SEC = 15.0
 _DEFAULT_KEEPALIVE_INTERVAL, _MIN_KEEPALIVE_INTERVAL = 180, 5
 # One bounded cancellation cycle at final shutdown so resistant tasks cannot hang exit.
 _MCP_LOOP_DRAIN_TIMEOUT = 3.0
+
+# Ceiling for the server-drain segment of shutdown_mcp_servers() (#82874 round-2). Container
+# supervisors (s6-overlay, etc.) grant only ~3s of kill grace before SIGKILL, and the bare 15s
+# wait here held the exit funnel open past the grace period, so a wedged MCP server silently cost
+# the gateway its clean-exit record. 2s is ample for well-behaved server.shutdown()
+# implementations (they self-enforce their own close timeouts); a server that has not returned in
+# 2s will not return in 15s either.
+_MCP_SHUTDOWN_DRAIN_SECONDS = 2
+
+# Total wall-clock budget for the WHOLE MCP teardown funnel in shutdown_mcp_servers(): the
+# server-shutdown drain plus the loop drain and the thread join inside _stop_mcp_loop(). The
+# funnel sits on the gateway's clean-exit critical path: on SIGTERM a container supervisor grants
+# only ~3s of kill grace before SIGKILL, so a teardown that exceeds it silently loses the
+# clean-exit record (#82874). Each blocking segment derives its own wait from this ONE budget (see
+# _teardown_clamp), so no sub-wait can push the TOTAL past it. The orphan-PID reap at the end of
+# _stop_mcp_loop() is deliberately EXCLUDED: it runs on its own detached thread the exit path never
+# joins, so its SIGTERM -> 2s -> SIGKILL dance cannot hold the funnel open right when a slow stdio
+# child most needs its graceful window.
+_MCP_TEARDOWN_BUDGET_SECONDS = 2.75
+
+
+def _teardown_clamp(seconds: float, budget_remaining: float) -> float:
+    """Clamp a teardown segment's own wait to the budget left for it.
+
+    Returns 0.0 when the budget is empty (min/max stop negatives). Used by every bounded wait in
+    shutdown_mcp_servers()/_stop_mcp_loop() so no sub-wait can push the TOTAL teardown past
+    _MCP_TEARDOWN_BUDGET_SECONDS.
+    """
+    return max(0.0, min(seconds, budget_remaining))
+
 # JSON-RPC 2.0 "method not found" (server without optional ``ping``); _ensure_mcp_sdk()
 # overrides it from mcp.types once loaded.
 _JSONRPC_METHOD_NOT_FOUND = -32601

--- a/tools/mcp_tool_lifecycle.py
+++ b/tools/mcp_tool_lifecycle.py
@@ -121,6 +121,12 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
             _core._server_scope_keys.pop(name, None)
             _core._server_tool_scopes.pop(name, None)
 
+    # Single budget common to the whole teardown funnel. Segment 1 (the server drain below) keeps
+    # _MCP_SHUTDOWN_DRAIN_SECONDS as its ceiling but must not exceed it; the leftover is handed to
+    # _stop_mcp_loop() for the loop-drain and thread-join segments that follow, so no sub-wait can
+    # push the TOTAL past _MCP_TEARDOWN_BUDGET_SECONDS (#82874 round-2).
+    teardown_budget = _core._MCP_TEARDOWN_BUDGET_SECONDS
+
     # Fast path: nothing to shut down. The connect-cooldown maps can still be populated here — a server that
     # failed to connect is never recorded in ``_servers`` (that is the very premise of the #50394 cooldown),
     # so "no live servers" is the MOST likely state in which stale backoff entries exist. Clear them so a
@@ -144,10 +150,15 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
             from agent.async_utils import safe_schedule_threadsafe
             future = safe_schedule_threadsafe(_shutdown(), loop, logger=logger, log_message="MCP shutdown: failed to schedule")
             if future is not None:
+                # Segment 1: the server-shutdown drain. Derives its wait from the shared teardown
+                # budget, not a bare fixed timeout, so a wedged server cannot push the total funnel
+                # past the supervisor kill grace (#82874 round-2).
+                drain_wait = _core._teardown_clamp(_core._MCP_SHUTDOWN_DRAIN_SECONDS, teardown_budget)
                 try:
-                    future.result(timeout=15)
+                    future.result(timeout=drain_wait)
                 except BaseException as exc:
                     logger.debug("Error during MCP shutdown: %s", exc)
+                teardown_budget = max(0.0, teardown_budget - drain_wait)
 
     # Unconditional final sweep: whether ``_shutdown`` ran, timed out, or was never scheduled
     # (a server that failed to connect is never in ``_servers`` — the most likely state for
@@ -156,7 +167,7 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
         if not servers_snapshot:
             clear_selected_status()
         _clear_connect_cooldowns(None if scope is None else selected_status)
-    _loop._stop_mcp_loop(only_if_idle=scope is not None)
+    _loop._stop_mcp_loop(only_if_idle=scope is not None, teardown_budget=teardown_budget)
 
 
 def _take_reapable_pids(include_active: bool, server_name: Optional[str]) -> tuple[Dict[int, str], Dict[int, int]]:

--- a/tools/mcp_tool_loop.py
+++ b/tools/mcp_tool_loop.py
@@ -251,9 +251,34 @@ def _ensure_mcp_loop():
         _origin._mcp_thread.start()
 
 
-def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
-    """Stop the background event loop and join its thread."""
+def _start_orphan_reaper() -> None:
+    """Reap orphaned MCP stdio children off the teardown critical path.
+
+    Called once the MCP loop is closed. Its ``_kill_orphaned_mcp_children()`` does a
+    SIGTERM -> 2s -> SIGKILL dance; running that inline here would add ~2s to a funnel that must
+    stay under ``_MCP_TEARDOWN_BUDGET_SECONDS``. It is dispatched on a short daemon thread the exit
+    path never joins — best effort, never waited on, failures just logged (#82874 round-2).
+    """
+    def _reap() -> None:
+        try:
+            _lifecycle._kill_orphaned_mcp_children(include_active=True)
+        except BaseException:
+            logger.warning("MCP orphan reaping failed", exc_info=True)
+
+    threading.Thread(target=_reap, name="mcp-orphan-reaper", daemon=True).start()
+
+
+def _stop_mcp_loop(*, only_if_idle: bool = False, teardown_budget: Optional[float] = None) -> bool:
+    """Stop the background event loop and join its thread.
+
+    ``teardown_budget`` is the remaining seconds from the single shared MCP teardown budget
+    (``_MCP_TEARDOWN_BUDGET_SECONDS``); the loop-drain and thread-join waits clamp to it so the
+    whole funnel stays under one ceiling. Defaults to the full budget for standalone callers
+    (#82874 round-2).
+    """
     from tools import mcp_tool as _origin
+    if teardown_budget is None:
+        teardown_budget = _core._MCP_TEARDOWN_BUDGET_SECONDS
     with _core._lock:
         if only_if_idle and (_core._servers or _core._server_connecting):
             logger.debug("Leaving MCP event loop running; active servers are registered or connecting")
@@ -275,27 +300,39 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
             _lifecycle._drain_and_stop_mcp_loop(), loop, logger=logger,
             log_message="MCP loop drain: failed to schedule", log_level=logging.WARNING)
         if future is not None:
+            # Segment 2: the loop-drain wait. Clamps to the shared teardown budget so it cannot,
+            # together with the earlier server drain, outrun the kill grace (#82874 round-2).
+            drain_wait = _core._teardown_clamp(_core._MCP_LOOP_DRAIN_TIMEOUT + 1, teardown_budget)
             try:
-                future.result(timeout=_core._MCP_LOOP_DRAIN_TIMEOUT + 1)
+                future.result(timeout=drain_wait)
             except TimeoutError:
-                logger.warning("Timed out waiting for MCP loop drain after %.1fs", _core._MCP_LOOP_DRAIN_TIMEOUT + 1)
+                logger.warning("Timed out waiting for MCP loop drain after %.1fs", drain_wait)
             except BaseException as exc:
                 logger.warning("Error draining MCP loop tasks: %s", exc)
+            teardown_budget = max(0.0, teardown_budget - drain_wait)
     elif not loop.is_closed():
         try:
-            loop.run_until_complete(_lifecycle._drain_mcp_loop_tasks(timeout=_core._MCP_LOOP_DRAIN_TIMEOUT))
+            loop.run_until_complete(_lifecycle._drain_mcp_loop_tasks(
+                timeout=_core._teardown_clamp(_core._MCP_LOOP_DRAIN_TIMEOUT, teardown_budget)))
         except BaseException as exc:
             logger.warning("Error draining stopped MCP loop tasks: %s", exc)
     if future is None and loop.is_running():  # drain-and-stop wasn't scheduled: stop it ourselves
         loop.call_soon_threadsafe(loop.stop)
     if thread is not None:
-        thread.join(timeout=5)
+        # Segment 3: joining the loop thread. Clamps to what the budget still leaves so a stuck
+        # loop cannot hold exit past the supervisor grace (#82874 round-2).
+        join_wait = _core._teardown_clamp(5.0, teardown_budget)
+        thread.join(timeout=join_wait)
         if thread.is_alive():
-            logger.warning("MCP event loop thread did not stop within 5.0s")
+            logger.warning("MCP event loop thread did not stop within %.1fs", join_wait)
+        teardown_budget = max(0.0, teardown_budget - join_wait)
     try:
         loop.close()
     except Exception as exc:
         logger.warning("Unable to close MCP event loop cleanly: %s", exc)
-    # The loop is gone, so no session can be in flight: reap active too.
-    _lifecycle._kill_orphaned_mcp_children(include_active=True)
+    # The loop is gone, so no session can be in flight: reap active orphans too. The reap's
+    # SIGTERM -> 2s -> SIGKILL dance runs on its own detached thread the exit path never joins
+    # (segment 4), so it cannot hold the clean-exit funnel open past the kill grace right when a
+    # slow stdio child most needs its graceful window (#82874 round-2).
+    _start_orphan_reaper()
     return True


### PR DESCRIPTION
## 背景

修复 #82874 round-2：MCP teardown 在 SIGTERM 时必须落在容器 supervisor 的 ~3s kill grace 之内，否则 `lifecycle_ledger.mark_exited()` 来不及写，之后每次启动都误报「上次是脏退出」。

上游已合并的 #99675 把 `shutdown_mcp_servers()` 移上 daemon 线程（`_shutdown_mcp_servers_nonblocking`），解决了 event-loop 被冻结的那条腿。但整个 funnel 仍没有统一上限：

- server drain：裸 `future.result(timeout=15)`
- loop drain：`_MCP_LOOP_DRAIN_TIMEOUT + 1`（4s）
- thread join：`thread.join(timeout=5)`
- gateway 包装层：默认 `timeout=5.0`
- 末尾的 orphan reap（SIGTERM → 2s → SIGKILL）还在关键路径上

任何一段慢都足以让 exit funnel 超过 ~3s 被 SIGKILL，clean-exit 标记丢失。

## 改动

给整条 funnel 一个共享预算，每段按剩余额 clamp。

**`tools/mcp_tool.py`**
- `_MCP_TEARDOWN_BUDGET_SECONDS = 2.75`：整条 funnel（server drain + loop drain + thread join）共享的总预算。
- `_MCP_SHUTDOWN_DRAIN_SECONDS = 2`：server drain 段的上限（2s 足够——2s 内没返回的 server，15s 也不会返回）。
- `_teardown_clamp(seconds, budget_remaining)`：每段自己的等待上限 clamp 到剩余预算，杜绝子段把 Total 顶破。

**`tools/mcp_tool_lifecycle.py`**：段 1（server drain）用 clamp 后的 `drain_wait`，并把剩余预算传给 `_stop_mcp_loop()`。

**`tools/mcp_tool_loop.py`**：段 2（loop drain）、段 3（thread join）都从剩余预算推演；orphan reap 移到 `_start_orphan_reaper()` —— 一个 detached daemon 线程，exit path 绝不 join 它，所以那 2s 不会卡住 clean-exit funnel。

**`gateway/run.py`**：`_shutdown_mcp_servers_nonblocking` 默认值改为惰性解析该预算，不再是裸 5.0s。

## 验证

```bash
python -m pytest tests/gateway/test_82874_mcp_teardown_budget.py tests/tools/test_mcp_initial_connect_shutdown.py -q -o 'addopts='
```

## 测试

新增 `tests/gateway/test_82874_mcp_teardown_budget.py`（6 条）：

1. 总预算与 server drain 段都 < 3s supervisor grace；
2. `_teardown_clamp` 语义（自身上限内保留、超剩余则 clamp、预算耗尽为 0、不为负）；
3. **行为测试**：把 `shutdown_mcp_servers` 换成一个永不返回的 wedged 实现 + 预算压到 0.2s，断言 `_shutdown_mcp_servers_nonblocking()` 在预算内返回 `False`（修前会等满 5.0s 默认值）；
4. 签名必须惰性解析预算（default None）；
5. orphan reaper 不阻塞调用方（reap 被卡住时 `_start_orphan_reaper()` 仍立即返回）；
6. 源码级守卫：每段都走同一个预算、没有裸 `future.result(timeout=15)` / `thread.join(timeout=5)` 回归。

6 条在未修复源码上全部失败（只 stash 源码改动验证）。`test_mcp_initial_connect_shutdown.py` 的 `_stop_mcp_loop` 探针跟进新关键字。相关套件 183 passed（mcp tool/loop/stdio/parked + gateway shutdown/clean-marker）。

Fixes #82874

---

在最新 `main` 上干净重建；取代 #82892（同一组改动，旧分支已与他人上游重构冲突）。
