### PR TITLE
fix(search_files): didactic glob-vs-regex error instead of looping

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -509,9 +509,10 @@ def _tool_failure_recovery_hint(tool_name: str, count: int) -> str:
             "search_files uses REGEX for target='content' (the default) and GLOB "
             "for target='files'. A leading '*' is invalid regex (\"nothing to "
             "repeat\") — the most common cause of this loop. To find a file/folder "
-            "BY NAME use target='files' (e.g. pattern='config'); to search file "
-            "CONTENTS use a regex like 'foo' or 'foo.*bar'. If the path is wrong, "
-            "use the 'Similar paths' in the error or run terminal with find/ls."
+            "BY NAME keep the glob and set target='files' (e.g. pattern='*.py'); "
+            "to search file CONTENTS use a regex, not a glob (e.g. 'foo' or "
+            "'foo.*bar'). If the path is wrong, use the 'Similar paths' in the "
+            "error or run terminal with find/ls."
         )
     return common + (
         "Try different arguments, a narrower query/path, an absolute path when relevant, "

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -504,6 +504,15 @@ def _tool_failure_recovery_hint(tool_name: str, count: int) -> str:
             "in the same tool, then try an absolute path, a simpler command, a different "
             "working directory, or a different tool such as read_file/write_file/patch."
         )
+    if tool_name == "search_files":
+        return common + (
+            "search_files uses REGEX for target='content' (the default) and GLOB "
+            "for target='files'. A leading '*' is invalid regex (\"nothing to "
+            "repeat\") — the most common cause of this loop. To find a file/folder "
+            "BY NAME use target='files' (e.g. pattern='config'); to search file "
+            "CONTENTS use a regex like 'foo' or 'foo.*bar'. If the path is wrong, "
+            "use the 'Similar paths' in the error or run terminal with find/ls."
+        )
     return common + (
         "Try different arguments, a narrower query/path, an absolute path when relevant, "
         "or a different tool that can make progress. If the blocker is external, report "

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -142,16 +142,43 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
     assert blocked.count == 2
 
 
+def test_search_files_failure_hint_names_target_files_and_regex():
+    """search_files recovery hint points at target='files' vs regex (glob pitfall).
+
+    Uses *varying* args so the hint comes through ``same_tool_failure_warning``
+    (which routes via ``_tool_failure_recovery_hint``). With identical args the
+    controller prefers ``repeated_exact_failure_warning`` and its own message.
+    """
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(same_tool_failure_warn_after=2, same_tool_failure_halt_after=3)
+    )
+
+    first = controller.after_call(
+        "search_files", {"pattern": "*config*"}, '{"error":"boom"}', failed=True
+    )
+    second = controller.after_call(
+        "search_files", {"pattern": "*x*"}, '{"error":"boom"}', failed=True
+    )
+
+    assert first.action == "allow"
+    assert second.action == "warn"
+    assert second.code == "same_tool_failure_warning"
+    # The hint must teach the glob-vs-regex distinction, not just "change args".
+    assert "target='files'" in second.message
+    assert "REGEX" in second.message
+    assert "nothing to repeat" in second.message
+    assert controller.halt_decision is None
 
 
-
-
-
-
-
-
-
-
+def test_search_files_failure_hint_only_for_search_files():
+    """The search_files-specific hint does not leak into other tools' hints."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(same_tool_failure_warn_after=1, same_tool_failure_halt_after=99)
+    )
+    decision = controller.after_call("web_search", {"query": "q"}, '{"error":"boom"}', failed=True)
+    assert decision.code == "same_tool_failure_warning"
+    assert "target='files'" not in decision.message
+    assert "nothing to repeat" not in decision.message
 
 
 def test_skill_read_tools_are_idempotent_and_block_repeated_identical_success_output():

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -167,6 +167,7 @@ def test_search_files_failure_hint_names_target_files_and_regex():
     assert "target='files'" in second.message
     assert "REGEX" in second.message
     assert "nothing to repeat" in second.message
+    assert "pattern='*.py'" in second.message
     assert controller.halt_decision is None
 
 

--- a/tests/tools/test_search_glob_regex_hint.py
+++ b/tests/tools/test_search_glob_regex_hint.py
@@ -48,9 +48,20 @@ def test_glob_as_regex_error_names_corrected_call():
     assert "looks like a glob" in msg
     assert "target='content'" in msg
     assert "target='files'" in msg
-    assert "search_files(pattern='config', target='files'" in msg
-    # the star is stripped from the suggested bare pattern
-    assert "pattern='*config*'" not in msg
+    # files-mode example keeps the original glob
+    assert "search_files(pattern='*config*', target='files'" in msg
+    # content example strips wrapping * only
+    assert "e.g. 'config'" in msg
+
+
+def test_glob_as_regex_error_keeps_star_dot_py_as_glob():
+    msg = _glob_as_regex_error("*.py", "content", "/tmp/repo")
+    assert "search_files(pattern='*.py', target='files', path='/tmp/repo')" in msg
+    # must NOT strip to '.py' (that is not a useful glob)
+    assert "pattern='.py'" not in msg
+    # content example must not be the leftover extension
+    assert "e.g. 'foo'" in msg
+    assert "e.g. '.py'" not in msg
 
 
 # --- search_tool pre-validation (no rg/grep invocation) ---------------------

--- a/tests/tools/test_search_glob_regex_hint.py
+++ b/tests/tools/test_search_glob_regex_hint.py
@@ -1,0 +1,120 @@
+"""search_files: glob-vs-regex didactic error and guardrail-prevention tests.
+
+Covers the case where a glob pattern (e.g. ``*.py``) is passed to
+``target='content'`` (regex mode). A leading ``*`` is invalid regex
+("nothing to repeat") -> rg parse error -> tool failure -> repeated-failure
+guardrail. The tool now pre-validates and returns a didactic error naming the
+corrected call BEFORE invoking rg/grep.
+"""
+
+import json
+
+from tools.file_operations_search import _maybe_enrich_regex_error
+from tools.file_tools import (
+    _glob_as_regex_error,
+    _looks_like_glob_pattern,
+    search_tool,
+)
+
+
+# --- heuristic ---------------------------------------------------------------
+
+def test_looks_like_glob_flags_only_invalid_regex():
+    # leading '*' and '*' after '(' or '|' -> guaranteed regex parse error
+    assert _looks_like_glob_pattern("*config*") is True
+    assert _looks_like_glob_pattern("*.py") is True
+    assert _looks_like_glob_pattern("(*x)") is True
+    assert _looks_like_glob_pattern("a|*b") is True
+    assert _looks_like_glob_pattern("**config") is True
+
+
+def test_looks_like_glob_does_not_flag_valid_regex():
+    # valid regex must NEVER be misreported (would break real searches)
+    assert _looks_like_glob_pattern("config") is False
+    assert _looks_like_glob_pattern("config.*py") is False
+    assert _looks_like_glob_pattern("foo.*") is False
+    assert _looks_like_glob_pattern("a.*b") is False
+    assert _looks_like_glob_pattern("[a-z]*") is False
+    assert _looks_like_glob_pattern("config*") is False   # valid: zero+ 'g'
+    assert _looks_like_glob_pattern("foo*bar") is False
+    assert _looks_like_glob_pattern("") is False
+    assert _looks_like_glob_pattern("no_star") is False
+
+
+# --- didactic error string ---------------------------------------------------
+
+def test_glob_as_regex_error_names_corrected_call():
+    msg = _glob_as_regex_error("*config*", "content", ".")
+    assert "looks like a glob" in msg
+    assert "target='content'" in msg
+    assert "target='files'" in msg
+    assert "search_files(pattern='config', target='files'" in msg
+    # the star is stripped from the suggested bare pattern
+    assert "pattern='*config*'" not in msg
+
+
+# --- search_tool pre-validation (no rg/grep invocation) ---------------------
+
+def test_search_tool_glob_in_content_mode_returns_didactic_error_without_running():
+    # A glob pattern in content (regex) mode returns the didactic error and
+    # never reaches the path-resolution / rg execution path, so an empty/
+    # bogus path does not raise and no shell search runs.
+    raw = search_tool(pattern="*config*", target="content", path="/nonexistent", task_id="t-glob")
+    data = json.loads(raw)
+    assert "error" in data
+    assert "looks like a glob" in data["error"]
+    assert "target='files'" in data["error"]
+
+
+def test_search_tool_valid_regex_in_content_mode_is_not_blocked_by_hint():
+    # Valid regex (config.*py) is NOT flagged by the pre-validation; it proceeds
+    # to a real search. With a bogus path it surfaces "Path not found" (not the
+    # glob hint), proving the pre-validation left it alone.
+    raw = search_tool(pattern="config.*py", target="content", path="/nonexistent/here", task_id="t-regex")
+    data = json.loads(raw)
+    # Either no error key (matches path resolved) or a non-glob error.
+    if "error" in data:
+        assert "looks like a glob" not in data["error"]
+
+
+def test_search_tool_files_mode_with_glob_is_not_flagged():
+    # target='files' is glob mode by design — a glob pattern here is correct and
+    # must NOT trigger the content-mode pre-validation.
+    raw = search_tool(pattern="*config*", target="files", path="/nonexistent/here", task_id="t-files")
+    data = json.loads(raw)
+    # Path-not-found is expected (bogus path); the glob didactic hint is not.
+    if "error" in data:
+        assert "looks like a glob" not in data["error"]
+        assert "target='content' uses REGEX" not in data["error"]
+
+
+def test_search_tool_repeated_glob_call_keeps_didactic_error():
+    # Even on repeat, the pre-validation fires first and returns the didactic
+    # error (it runs before the consecutive-search tracker's own block), so the
+    # agent keeps seeing the actionable message rather than a generic block.
+    for _ in range(3):
+        raw = search_tool(pattern="*config*", target="content", path=".", task_id="t-repeat")
+        data = json.loads(raw)
+        assert "looks like a glob" in data["error"]
+
+
+# --- regex parse-error enrichment (fallback if pre-validation is skipped) ---
+
+def test_enrich_regex_error_for_repetition_only():
+    # "nothing to repeat" (leading '*') is the glob pitfall -> enriched.
+    out = _maybe_enrich_regex_error(
+        "Search failed: rg: regex parse error: missing operand, nothing to repeat",
+        "*config*",
+    )
+    assert "looks like a glob" in out
+    assert "target='files'" in out
+
+
+def test_enrich_regex_error_leaves_non_repetition_parse_errors_alone():
+    # An unclosed "[" is a parse error but NOT a glob mistake -> untouched, so
+    # we never mislabel bracket/escape errors as glob confusion.
+    bracket = "Search failed: rg: regex parse error: unclosed character class"
+    assert _maybe_enrich_regex_error(bracket, "[") == bracket
+    # Non-regex errors (permissions, etc.) are never enriched.
+    perm = "Search failed: rg: permission denied"
+    assert _maybe_enrich_regex_error(perm, "foo") == perm

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1382,7 +1382,7 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
                 pattern, path, target, file_glob, limit, offset, output_mode, context, order)
             if multi is not None:
                 return multi
-            return self._path_not_found_result(path)
+            return self._path_not_found_result(path, target)
         result = self._dispatch_search(pattern, path, target, file_glob, limit, offset,
                                        output_mode, context, order)
         exclusions = self._macos_search_exclusions(path)

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -160,6 +160,52 @@ def _parse_search_context_line(line: str) -> tuple[str, int, str] | None:
 
 _REGEX_NEWLINE_ESCAPE_RE = re.compile(r"(?<!\\)(?:\\\\)*\\n")
 
+# Substrings rg/grep emit when a content-mode regex fails to parse *because of
+# a repetition/quantifier problem* — the signature of a glob-style pattern
+# (e.g. "*.py") used in target='content', where a leading '*' is "nothing to
+# repeat". Only these trigger the glob hint; a generic "regex parse error"
+# (e.g. an unclosed "[" bracket) is left untouched so we never mislabel
+# non-glob errors as glob mistakes.
+_REGEX_REPETITION_ERROR_MARKERS = (
+    "nothing to repeat",
+    "repetition operator",
+    "bad repetition",
+    "unrecognized character after",
+)
+
+
+def _glob_as_regex_hint_suffix(pattern: str) -> str:
+    """Didactic suffix for a content-mode regex *repetition* error.
+
+    Mirrors ``tools.file_tools._glob_as_regex_error`` but lives here to avoid
+    an import cycle (file_tools imports from file_operations). Returns an empty
+    string only when ``pattern`` is empty.
+    """
+    bare = (pattern or "").replace("*", "") or "query"
+    return (
+        f" {pattern!r} looks like a glob but target='content' uses REGEX. "
+        "To find files/folders BY NAME use target='files' (glob): "
+        f"search_files(pattern={bare!r}, target='files'). "
+        f"To search file CONTENTS use regex like {bare!r} or {bare + '.*'!r}."
+    )
+
+
+def _maybe_enrich_regex_error(error: str, pattern: str) -> str:
+    """Append the glob-as-regex hint only for a regex *repetition* failure.
+
+    A leading '*' ("nothing to repeat") is the glob pitfall this targets; other
+    parse errors (unclosed brackets, bad escapes) are unrelated to glob/regex
+    confusion and are returned unchanged.
+    """
+    if not error or not pattern:
+        return error
+    lower = error.lower()
+    if not any(marker in lower for marker in _REGEX_REPETITION_ERROR_MARKERS):
+        return error
+    if "looks like a glob" in error:
+        return error  # already enriched
+    return error + _glob_as_regex_hint_suffix(pattern)
+
 
 def _pattern_has_regex_newline(pattern: str) -> bool:
     """True when a content regex wants to match a newline: a literal newline or a
@@ -485,7 +531,7 @@ class SearchMixin:
             return self._search_files(pattern, path, limit, offset, order)
         return self._search_content(pattern, path, file_glob, limit, offset, output_mode, context)
 
-    def _path_not_found_result(self, path: str) -> SearchResult:
+    def _path_not_found_result(self, path: str, target: str = "content") -> SearchResult:
         """Error result for a missing search root, with nearby-entry suggestions."""
         parent = os.path.dirname(path) or "."
         basename_query = os.path.basename(path)
@@ -500,6 +546,11 @@ class SearchMixin:
                     if e and (lq in e.lower() or e.lower() in lq or e.lower().startswith(lq[:3]))]
                 if candidates:
                     hint_parts.append("Similar paths: " + ", ".join(candidates[:5]))
+        if target != "files":
+            hint_parts.append(
+                "Tip: to search by NAME use target='files' (glob); the "
+                "default target='content' searches file CONTENTS with regex"
+            )
         return SearchResult(error=". ".join(hint_parts), total_count=0)
 
     def _try_multi_path_search(self, pattern: str, path: str, target: str,
@@ -809,6 +860,8 @@ class SearchMixin:
             return SearchResult(
                 error="Content search requires ripgrep (rg) or grep. "
                       "Install ripgrep: https://github.com/BurntSushi/ripgrep#installation")
+        if result.error:
+            result.error = _maybe_enrich_regex_error(result.error, pattern)
         if (not result.error and result.total_count == 0
                 and not result.matches and not result.files and not result.counts):
             try:

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -174,19 +174,31 @@ _REGEX_REPETITION_ERROR_MARKERS = (
 )
 
 
+def _content_regex_example(pattern: str) -> str:
+    """Conservative content-regex example from a glob. Wrapping ``*`` only."""
+    s = (pattern or "").strip()
+    while s.startswith("*"):
+        s = s[1:]
+    while s.endswith("*"):
+        s = s[:-1]
+    if not s or s.startswith("."):
+        return "foo"
+    return s
+
+
 def _glob_as_regex_hint_suffix(pattern: str) -> str:
     """Didactic suffix for a content-mode regex *repetition* error.
 
     Mirrors ``tools.file_tools._glob_as_regex_error`` but lives here to avoid
-    an import cycle (file_tools imports from file_operations). Returns an empty
-    string only when ``pattern`` is empty.
+    an import cycle (file_tools imports from file_operations). The files-mode
+    example keeps the original glob (``*.py`` stays ``*.py``).
     """
-    bare = (pattern or "").replace("*", "") or "query"
+    regex_ex = _content_regex_example(pattern)
     return (
         f" {pattern!r} looks like a glob but target='content' uses REGEX. "
         "To find files/folders BY NAME use target='files' (glob): "
-        f"search_files(pattern={bare!r}, target='files'). "
-        f"To search file CONTENTS use regex like {bare!r} or {bare + '.*'!r}."
+        f"search_files(pattern={pattern!r}, target='files'). "
+        f"To search file CONTENTS use a regex (not a glob), e.g. {regex_ex!r}."
     )
 
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -926,6 +926,57 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         return tool_error(str(e))
 
 
+# Hint shown when a glob-style pattern is used in content (regex) mode.
+# `*` at the start of a regex is "nothing to repeat" -> rg parse error, which
+# counts as a tool failure and can trip the repeated-failure guardrail. Point
+# the agent at target='files' (glob) instead, in the message itself.
+_GLOB_AS_REGEX_HINT = (
+    "To find files/folders BY NAME use target='files' (glob): "
+    "search_files(pattern='{bare}', target='files', path='{path}'). "
+    "To search file CONTENTS use regex like '{bare}' or '{bare_dot}'."
+)
+
+
+def _glob_as_regex_error(pattern: str, target: str, path: str = ".") -> str:
+    """Build the didactic error string for a glob pattern used in content mode.
+
+    Returned as a JSON ``{"error": ...}`` via :func:`tool_error` by the caller.
+    The message is short and names the exact corrected call so the agent can
+    retry without re-deriving the regex/glob distinction.
+    """
+    bare = pattern.replace("*", "") or "query"
+    hint = _GLOB_AS_REGEX_HINT.format(bare=bare, path=path, bare_dot=f"{bare}.*")
+    return (
+        f"pattern {pattern!r} looks like a glob, but target={target!r} uses "
+        f"REGEX (a leading '*' is invalid: \"nothing to repeat\"). {hint}"
+    )
+
+
+def _looks_like_glob_pattern(pattern: str) -> bool:
+    """Heuristic: does ``pattern`` look like a glob that would break regex mode?
+
+    Conservative on purpose — never flags *valid* regex. Only flags patterns
+    where a ``*`` quantifier has "nothing to repeat", i.e. rg/grep will emit a
+    regex parse error (which counts as a tool failure and is the common entry
+    point into the repeated-failure guardrail):
+
+    - a leading ``*`` (e.g. ``*.py``, ``*config*``);
+    - a ``*`` immediately after ``(`` or ``|`` (e.g. ``(*x``, ``a|*b``).
+
+    A trailing/mid ``*`` after a char or class (``config*``, ``[a-z]*``,
+    ``foo.*``) is *valid* regex and is left alone — if it still finds nothing,
+    the regex-parse-error path enriches the message instead.
+    """
+    if not pattern or "*" not in pattern:
+        return False
+    if pattern.startswith("*"):
+        return True
+    for i, ch in enumerate(pattern):
+        if ch == "*" and i > 0 and pattern[i - 1] in "(|":
+            return True
+    return False
+
+
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
@@ -934,6 +985,15 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
     """Search for content or files."""
     try:
         offset, limit = normalize_search_pagination(offset, limit)
+
+        # Pre-validate glob-style patterns in content (regex) mode BEFORE
+        # calling rg/grep. A leading '*' is invalid regex ("nothing to repeat")
+        # and produces a parse error that counts as a tool failure — a common
+        # way agents loop into the repeated-failure guardrail. Return a
+        # didactic error naming the corrected call instead of running a search
+        # that is guaranteed to fail. target='files' (glob) is unaffected.
+        if target != "files" and _looks_like_glob_pattern(pattern):
+            return tool_error(_glob_as_regex_error(pattern, target, path))
 
         # Pagination args (and order) are part of the key so paging through truncated
         # results doesn't trip the repeated-search guard.
@@ -1156,11 +1216,11 @@ def _is_openai_family_main() -> bool:
 
 SEARCH_FILES_SCHEMA = {
     "name": "search_files",
-    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents. On macOS, broad searches above the user home automatically skip TCC-protected folders (Desktop, Documents, Downloads, Library, Movies, Music, Pictures); target one directly when access is intentional.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls. Discovery order is the fast bounded default; exact global newest-first order is an explicit opt-in and may scan the full tree.",
+    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents. On macOS, broad searches above the user home automatically skip TCC-protected folders (Desktop, Documents, Downloads, Library, Movies, Music, Pictures); target one directly when access is intentional.\n\nIMPORTANT — target decides the pattern syntax: target='content' (the DEFAULT) searches inside file CONTENTS using REGEX; target='files' searches for files/folders BY NAME using GLOB (e.g., '*.py', '*config*'). A leading '*' is INVALID in content/regex mode ('nothing to repeat') — to find a file by name, use target='files'.\n\nContent search output modes: full matches with line numbers, file paths only, or match counts. File search: discovery order is the fast bounded default; exact global newest-first order is an explicit opt-in and may scan the full tree. Also use target='files' instead of ls.",
     "parameters": {
         "type": "object",
         "properties": {
-            "pattern": {"type": "string", "description": "Regex pattern for content search, or glob pattern (e.g., '*.py') for file search"},
+            "pattern": {"type": "string", "description": "Regex pattern (when target='content', the default) or glob pattern (when target='files', e.g. '*.py', '*config*'). A leading '*' is INVALID regex — to find files by name use target='files'."},
             "target": {"type": "string", "enum": ["content", "files"], "description": "'content' searches inside file contents, 'files' searches for files by name", "default": "content"},
             "path": {"type": "string", "description": "Directory or file to search in (default: current working directory)", "default": "."},
             "file_glob": {"type": "string", "description": "Filter files by pattern in grep mode (e.g., '*.py' to only search Python files)"},

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -930,22 +930,36 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 # `*` at the start of a regex is "nothing to repeat" -> rg parse error, which
 # counts as a tool failure and can trip the repeated-failure guardrail. Point
 # the agent at target='files' (glob) instead, in the message itself.
-_GLOB_AS_REGEX_HINT = (
-    "To find files/folders BY NAME use target='files' (glob): "
-    "search_files(pattern='{bare}', target='files', path='{path}'). "
-    "To search file CONTENTS use regex like '{bare}' or '{bare_dot}'."
-)
+def _content_regex_example(pattern: str) -> str:
+    """A conservative content-regex example derived from a glob.
+
+    Strips wrapping ``*`` so ``*config*`` -> ``config``. If that leaves an
+    extension (``*.py`` -> ``.py``) or nothing useful, fall back to ``foo``
+    rather than inventing ``.py.*``.
+    """
+    s = (pattern or "").strip()
+    while s.startswith("*"):
+        s = s[1:]
+    while s.endswith("*"):
+        s = s[:-1]
+    if not s or s.startswith("."):
+        return "foo"
+    return s
 
 
 def _glob_as_regex_error(pattern: str, target: str, path: str = ".") -> str:
     """Build the didactic error string for a glob pattern used in content mode.
 
     Returned as a JSON ``{"error": ...}`` via :func:`tool_error` by the caller.
-    The message is short and names the exact corrected call so the agent can
-    retry without re-deriving the regex/glob distinction.
+    The files-mode example keeps the original glob (``*.py`` stays ``*.py``).
+    The content example is a regex, not a stripped glob.
     """
-    bare = pattern.replace("*", "") or "query"
-    hint = _GLOB_AS_REGEX_HINT.format(bare=bare, path=path, bare_dot=f"{bare}.*")
+    regex_ex = _content_regex_example(pattern)
+    hint = (
+        "To find files/folders BY NAME use target='files' (glob): "
+        f"search_files(pattern={pattern!r}, target='files', path={path!r}). "
+        f"To search file CONTENTS use a regex (not a glob), e.g. {regex_ex!r}."
+    )
     return (
         f"pattern {pattern!r} looks like a glob, but target={target!r} uses "
         f"REGEX (a leading '*' is invalid: \"nothing to repeat\"). {hint}"


### PR DESCRIPTION
## Bug Description

`search_files` with `target="content"` (the default) and a glob-style pattern such as `*.py` or `*config*` is passed straight to ripgrep as a regex. A leading `*` is invalid (`nothing to repeat`), the call counts as a tool failure, and the model retries the same args until the repeated-failure guardrail trips.

Fixes #66129

This is the content/regex direction of the glob vs regex mismatch. It does **not** silently rewrite the pattern (contrast #66230).

## Root Cause

The schema describes both regex and glob, but the default target is regex. rg's parse error is not a zero-match and does not name the corrected call, so the model has nothing actionable to copy.

## Fix

- Pre-validate glob-shaped *invalid* regex (`*` at the start, or immediately after `(` / `|`) in content mode and return a didactic error that names the corrected `target='files'` call.
- Leave valid regex alone (`config*`, `foo.*`, `[a-z]*`).
- If a repetition parse error still reaches rg/grep, enrich that error with the same hint. No glob→regex conversion.
- Spell the distinction out in the tool schema and in the search_files recovery hint.

## How to Verify

1. `search_files(pattern="*config*", target="content")` returns an error containing `looks like a glob` and `target='files'`.
2. `search_files(pattern="config.*py", target="content")` is not blocked by the heuristic.
3. `search_files(pattern="*config*", target="files")` is not flagged.

## Test Plan

- [x] Added `tests/tools/test_search_glob_regex_hint.py`
- [x] Guardrail tests for the search_files-specific recovery hint
- [x] Existing search tests still pass
- [x] Sabotage: disabling pre-validate fails the new test; restoring passes

## Risk Assessment

Low — failure-path only. Valid regex is never rewritten. `target='files'` is unchanged.
