### PR TITLE
fix(desktop): warn before a typo'd profile name scaffolds a live agent

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -544,6 +544,14 @@ export function ProfileRail() {
           await refreshActiveProfile()
           selectProfile(name)
         }}
+        onUseExisting={async name => {
+          // A name one keystroke from an existing profile resolves to that
+          // profile: leave the create flow and land on it instead of scaffolding
+          // a stray agent.
+          setCreateOpen(false)
+          await refreshActiveProfile()
+          selectProfile(name)
+        }}
         open={createOpen}
         profiles={profiles}
       />

--- a/apps/desktop/src/app/profiles/create-profile-dialog.test.tsx
+++ b/apps/desktop/src/app/profiles/create-profile-dialog.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createProfile } from '@/hermes'
+import type { ProfileInfo } from '@/types/hermes'
+
+import { CreateProfileDialog } from './create-profile-dialog'
+
+// These pin the guardrail this dialog owes the fleet: the one free-text door that
+// mints a profile must not silently scaffold a typo. `veste-frontend-dev` beside
+// `vestr-frontend-dev` is the reported incident, verbatim.
+//
+// Real i18n (no provider → English), so the assertions read the copy a user sees.
+
+afterEach(cleanup)
+
+vi.mock('@/hermes', () => ({
+  createProfile: vi.fn(async () => ({ name: 'x', ok: true, path: '/x' })),
+  updateProfileSoul: vi.fn(async () => ({ ok: true }))
+}))
+
+function makeProfile(name: string, isDefault = false): ProfileInfo {
+  return {
+    has_env: false,
+    is_default: isDefault,
+    model: null,
+    name,
+    path: `/home/user/.hermes/profiles/${name}`,
+    provider: null,
+    skill_count: 0
+  }
+}
+
+const PROFILES = [makeProfile('default', true), makeProfile('vestr-frontend-dev')]
+
+function renderDialog() {
+  const onUseExisting = vi.fn()
+
+  render(
+    <CreateProfileDialog onClose={vi.fn()} onCreated={vi.fn()} onUseExisting={onUseExisting} open profiles={PROFILES} />
+  )
+
+  return { onUseExisting }
+}
+
+const typeName = (value: string) => fireEvent.change(screen.getByLabelText('Name'), { target: { value } })
+
+beforeEach(() => {
+  vi.mocked(createProfile).mockClear()
+})
+
+describe('CreateProfileDialog typo guard', () => {
+  it('flags a one-keystroke name and offers the profile that was meant', async () => {
+    const { onUseExisting } = renderDialog()
+
+    typeName('veste-frontend-dev')
+
+    expect(await screen.findByText(/one character away from the existing profile “vestr-frontend-dev”/)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use vestr-frontend-dev' }))
+
+    expect(onUseExisting).toHaveBeenCalledWith('vestr-frontend-dev')
+    expect(createProfile).not.toHaveBeenCalled()
+  })
+
+  it('names the scaffold cost and still creates when the user insists', async () => {
+    renderDialog()
+
+    typeName('veste-frontend-dev')
+
+    await screen.findByText(/scaffolds a stock SOUL\.md and boots its own backend/)
+    fireEvent.click(screen.getByRole('button', { name: 'Create anyway' }))
+
+    await waitFor(() =>
+      expect(createProfile).toHaveBeenCalledWith({ name: 'veste-frontend-dev', clone_from: 'default' })
+    )
+  })
+
+  it('refuses a name that is already taken instead of round-tripping the backend', async () => {
+    renderDialog()
+
+    typeName('vestr-frontend-dev')
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }))
+
+    expect(await screen.findByText(/A profile named “vestr-frontend-dev” already exists/)).toBeTruthy()
+    expect(createProfile).not.toHaveBeenCalled()
+  })
+
+  it('stays out of the way for a deliberate new name', async () => {
+    renderDialog()
+
+    typeName('scratch-space')
+
+    expect(screen.queryByText(/one character away/)).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Create profile' }))
+
+    await waitFor(() => expect(createProfile).toHaveBeenCalledWith({ name: 'scratch-space', clone_from: 'default' }))
+  })
+})

--- a/apps/desktop/src/app/profiles/create-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/create-profile-dialog.tsx
@@ -17,6 +17,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { createProfile, updateProfileSoul } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { AlertTriangle } from '@/lib/icons'
+import { findProfileNameConflict } from '@/lib/profile-name-guard'
 import { slug } from '@/lib/sanitize'
 import type { ProfileInfo } from '@/types/hermes'
 
@@ -32,11 +33,15 @@ export function isValidProfileName(name: string): boolean {
 export function CreateProfileDialog({
   onClose,
   onCreated,
+  onUseExisting,
   open,
   profiles = []
 }: {
   onClose: () => void
   onCreated?: (name: string) => Promise<void> | void
+  // "Take me to the profile this name was probably meant to be" — the caller owns
+  // selection, so a typo is one click from the profile that already exists.
+  onUseExisting: (name: string) => Promise<void> | void
   open: boolean
   profiles?: ProfileInfo[]
 }) {
@@ -64,11 +69,29 @@ export function CreateProfileDialog({
   const invalid = trimmed !== '' && !isValidProfileName(trimmed)
   const busy = status === 'saving' || status === 'done'
 
+  // This dialog is the one free-text door that mints a profile. A name one
+  // keystroke from an existing one is almost always a typo, and a typo'd profile
+  // boots as a real agent (stock SOUL.md, its own backend), so say so before the
+  // scaffold instead of letting it happen silently.
+  const conflict =
+    trimmed && !invalid
+      ? findProfileNameConflict(
+          trimmed,
+          profiles.map(profile => profile.name)
+        )
+      : null
+
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
 
     if (!trimmed || invalid) {
       setError(invalid ? p.invalidName(p.nameHint) : p.nameRequired)
+
+      return
+    }
+
+    if (conflict?.kind === 'duplicate') {
+      setError(p.createConflict.duplicate(conflict.name))
 
       return
     }
@@ -144,6 +167,25 @@ export function CreateProfileDialog({
             />
           </Field>
 
+          {conflict?.kind === 'near-miss' && (
+            <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+              <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+              <div className="grid gap-1.5">
+                <span>{p.createConflict.nearMiss(trimmed, conflict.name)}</span>
+                <span>{p.createConflict.scaffoldNote}</span>
+                <Button
+                  className="justify-self-start"
+                  onClick={() => onUseExisting(conflict.name)}
+                  size="xs"
+                  type="button"
+                  variant="outline"
+                >
+                  {p.createConflict.useExisting(conflict.name)}
+                </Button>
+              </div>
+            </div>
+          )}
+
           {error && (
             <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
               <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
@@ -156,7 +198,12 @@ export function CreateProfileDialog({
               {t.common.cancel}
             </Button>
             <Button disabled={busy || !trimmed || invalid} type="submit">
-              <ActionStatus busy={p.creating} done={p.created} idle={p.createAction} state={status} />
+              <ActionStatus
+                busy={p.creating}
+                done={p.created}
+                idle={conflict?.kind === 'near-miss' ? p.createConflict.createAnyway : p.createAction}
+                state={status}
+              />
             </Button>
           </DialogFooter>
         </form>

--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -173,6 +173,10 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
       <CreateProfileDialog
         onClose={() => setCreateOpen(false)}
         onCreated={selectAndRefresh}
+        onUseExisting={async name => {
+          setCreateOpen(false)
+          await selectAndRefresh(name)
+        }}
         open={createOpen}
         profiles={profiles ?? []}
       />

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2532,6 +2532,13 @@ export const en: Translations = {
     deleting: 'Deleting...',
     createDesc: 'Profiles are independent Hermes environments: separate config, skills, and SOUL.md.',
     nameLabel: 'Name',
+    createConflict: {
+      duplicate: name => `A profile named “${name}” already exists.`,
+      nearMiss: (typed, existing) => `“${typed}” is one character away from the existing profile “${existing}”.`,
+      scaffoldNote: 'Creating a new profile scaffolds a stock SOUL.md and boots its own backend on first switch.',
+      useExisting: name => `Use ${name}`,
+      createAnyway: 'Create anyway'
+    },
     cloneFrom: 'Clone from',
     cloneFromNone: 'None (blank)',
     cloneFromDesc: 'Copies config, skills, and SOUL.md from the selected source profile.',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2176,6 +2176,16 @@ export interface Translations {
     deleting: string
     createDesc: string
     nameLabel: string
+    createConflict: {
+      /** The name is taken already — creation must not proceed. */
+      duplicate: (name: string) => string
+      /** The typed name is one edit from an existing profile (the typo guard). */
+      nearMiss: (typed: string, existing: string) => string
+      /** What a brand-new profile actually costs on its first switch. */
+      scaffoldNote: string
+      useExisting: (name: string) => string
+      createAnyway: string
+    }
     cloneFrom: string
     cloneFromNone: string
     cloneFromDesc: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2680,6 +2680,13 @@ export const zh: Translations = {
     deleting: '删除中…',
     createDesc: '配置档案是相互独立的 Hermes 环境：各自拥有独立的配置、技能和 SOUL.md。',
     nameLabel: '名称',
+    createConflict: {
+      duplicate: name => `已存在名为“${name}”的配置档案。`,
+      nearMiss: (typed, existing) => `“${typed}”与现有配置档案“${existing}”只差一个字符。`,
+      scaffoldNote: '新建配置档案会生成默认的 SOUL.md，并在首次切换时启动独立后端。',
+      useExisting: name => `使用 ${name}`,
+      createAnyway: '仍然新建'
+    },
     cloneFrom: '克隆来源',
     cloneFromNone: '无（空白）',
     cloneFromDesc: '从选中的来源配置档案复制配置、技能和 SOUL.md。',

--- a/apps/desktop/src/lib/profile-name-guard.test.ts
+++ b/apps/desktop/src/lib/profile-name-guard.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { findProfileNameConflict, isOneEditApart } from './profile-name-guard'
+
+// The behavior this pins: a typed profile name that is one keystroke from a
+// profile that already exists is surfaced as a conflict BEFORE the create path
+// scaffolds a stock profile + backend for the typo. The regression data is the
+// reported fleet drift (veste/vestg minted beside vestr).
+
+describe('isOneEditApart', () => {
+  it.each([
+    ['equal', 'vestr', 'vestr', true],
+    ['substitution', 'veste', 'vestr', true],
+    ['one extra character', 'vestr-frontend-devv', 'vestr-frontend-dev', true],
+    ['one missing character', 'vestr-frontend-de', 'vestr-frontend-dev', true],
+    ['adjacent transposition', 'defualt', 'default', true],
+    ['two substitutions', 'veste', 'vastr', false],
+    ['non-adjacent swap', 'aest', 'seat', false],
+    ['unrelated', 'frontend-dev', 'vestr-frontend-dev', false],
+    ['length gap beyond one', 'vest', 'vestr-frontend-dev', false]
+  ])('%s: %s vs %s -> %s', (_label, a, b, expected) => {
+    expect(isOneEditApart(a, b)).toBe(expected)
+  })
+})
+
+describe('findProfileNameConflict', () => {
+  const fleet = ['default', 'vestr-frontend-dev', 'vestr-curriculum-admin']
+
+  it('flags the reported typo and names the profile that was meant', () => {
+    expect(findProfileNameConflict('veste-frontend-dev', fleet)).toEqual({
+      kind: 'near-miss',
+      name: 'vestr-frontend-dev'
+    })
+    expect(findProfileNameConflict('vestg-curriculum-admin', fleet)).toEqual({
+      kind: 'near-miss',
+      name: 'vestr-curriculum-admin'
+    })
+  })
+
+  it('treats a taken name as a duplicate, ignoring case and padding', () => {
+    expect(findProfileNameConflict('  Vestr-Frontend-Dev ', fleet)).toEqual({
+      kind: 'duplicate',
+      name: 'vestr-frontend-dev'
+    })
+  })
+
+  it('returns the same suggestion regardless of profile-list order', () => {
+    expect(findProfileNameConflict('xest', ['best', 'aest'])).toEqual({ kind: 'near-miss', name: 'aest' })
+    expect(findProfileNameConflict('xest', ['aest', 'best'])).toEqual({ kind: 'near-miss', name: 'aest' })
+  })
+
+  it('stays quiet for a deliberate new name, an empty one, and tiny names', () => {
+    expect(findProfileNameConflict('scratch', fleet)).toBeNull()
+    expect(findProfileNameConflict('   ', fleet)).toBeNull()
+    // One edit from a 3-char name says nothing — too short to be a typo signal.
+    expect(findProfileNameConflict('abc', ['abd'])).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/profile-name-guard.ts
+++ b/apps/desktop/src/lib/profile-name-guard.ts
@@ -1,0 +1,121 @@
+// Guardrail for the ONE free-text door that creates a profile (the explicit
+// "New profile" affordance behind the switcher's picker).
+//
+// A mistyped profile name is not a harmless empty directory: the first switch
+// scaffolds a profile with a stock SOUL.md and boots a real backend for it
+// (own serve port, sessions, cron state), so it presents as an agent nobody
+// provisioned. The reported fleet drift was exactly this — `veste-frontend-dev`
+// and `vestg-curriculum-admin` minted beside `vestr-frontend-dev` /
+// `vestr-curriculum-admin`, one keystroke off the real names.
+//
+// Picking an existing profile is the picker's job; this is the backstop that
+// notices when a typed name is a near-miss of one and says so before the
+// scaffold happens.
+
+export interface ProfileNameConflict {
+  // `duplicate` — the name is taken (creation must not proceed).
+  // `near-miss` — the name is one edit from an existing profile (warn + offer it).
+  kind: 'duplicate' | 'near-miss'
+  name: string
+}
+
+// Names shorter than this make one-edit-apart a meaningless signal ("res" is
+// one edit from half the alphabet), so the near-miss warning stays off below it.
+// Real profile slugs are far longer; the incident names were 16+ chars.
+const MIN_NEAR_MISS_LENGTH = 4
+
+/**
+ * True when `a` and `b` differ by at most one edit: a substitution, a single
+ * inserted/removed character, or one adjacent transposition ("defualt" →
+ * "default"). Case-sensitive on purpose — callers compare normalized names.
+ */
+export function isOneEditApart(a: string, b: string): boolean {
+  const short = a.length <= b.length ? a : b
+  const long = a.length <= b.length ? b : a
+
+  if (long.length - short.length > 1) {
+    return false
+  }
+
+  if (short.length === long.length) {
+    let first = -1
+
+    for (let i = 0; i < short.length; i += 1) {
+      if (short[i] !== long[i]) {
+        first = i
+
+        break
+      }
+    }
+
+    if (first < 0) {
+      return true // identical
+    }
+
+    for (let i = first + 1; i < short.length; i += 1) {
+      if (short[i] === long[i]) {
+        continue
+      }
+
+      // A second difference is only one edit away when it and the first form an
+      // adjacent transposition; everything after must match again.
+      if (i !== first + 1 || short[first] !== long[i] || short[i] !== long[first]) {
+        return false
+      }
+
+      for (let j = i + 1; j < short.length; j += 1) {
+        if (short[j] !== long[j]) {
+          return false
+        }
+      }
+
+      return true
+    }
+
+    return true
+  }
+
+  // One character longer: skip exactly one character in `long` and the rest must
+  // line up.
+  let i = 0
+
+  while (i < short.length && short[i] === long[i]) {
+    i += 1
+  }
+
+  for (let j = i; j < short.length; j += 1) {
+    if (short[j] !== long[j + 1]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Classify a typed profile name against the profiles that already exist.
+ *
+ * Returns the taken name for an exact (case-insensitive) match, else the
+ * alphabetically-first near-miss so the dialog can nudge to it deterministically
+ * (the ordering never depends on the caller's profile-list order). Null means
+ * the name is safe to create.
+ */
+export function findProfileNameConflict(candidate: string, existing: readonly string[]): null | ProfileNameConflict {
+  const typed = candidate.trim().toLowerCase()
+
+  if (!typed) {
+    return null
+  }
+
+  const names = [...new Set(existing.map(name => name.trim().toLowerCase()).filter(Boolean))].sort()
+
+  if (names.includes(typed)) {
+    return { kind: 'duplicate', name: typed }
+  }
+
+  const near = names.find(
+    name => typed.length >= MIN_NEAR_MISS_LENGTH && name.length >= MIN_NEAR_MISS_LENGTH && isOneEditApart(typed, name)
+  )
+
+  return near ? { kind: 'near-miss', name: near } : null
+}


### PR DESCRIPTION
## What Problem This Solves

#107681 asks for two things: a profile **picker** instead of free text in the desktop app (a mistyped name was minting a real profile — stock `SOUL.md`, its own backend, sessions, cron state — so it presented as an agent nobody provisioned), plus a fleet view.

The picker half already ships on `main`: the profile rail is a strip of the existing profiles, the condensed rail is a dropdown, the all-profiles sidebar tree lists every profile as a clickable lane, and the Kanban assignee field is a profile `<select>`. The desktop backend also already refuses an unknown profile outright:

```
$ HERMES_HOME=<temp> python -m hermes_cli.main --profile veste-frontend-dev status
Error: Profile 'veste-frontend-dev' does not exist. Create it with: hermes profile create veste-frontend-dev
$ ls <temp>/profiles
(no such directory — nothing was scaffolded)
```

That leaves exactly **one** free-text door that mints a profile: the "New profile" dialog behind the picker's `+` / dropdown item. Today it accepts any valid slug, so `veste-frontend-dev` (one substitution from `vestr-frontend-dev`) creates a profile indistinguishable from an intentional one — the reported fleet drift (`veste-frontend-dev`, `vestg-curriculum-admin` beside the `vestr-*` fleet).

This change is that guardrail:

- A typed name that is **one edit** from an existing profile (substitution, one extra/missing character, or one adjacent transposition) surfaces the profile that was probably meant and offers a one-click **Use `<existing>`** that lands on it, instead of creating anything.
- The same notice states what creation actually costs — a stock `SOUL.md` and its own backend on first switch — and the primary button becomes **Create anyway**, so the scaffold is a deliberate choice rather than an accidental one.
- A name that **already exists** is refused inside the dialog (with a **Use `<existing>`** action on the rail/panel) instead of round-tripping to the backend error.
- Pure logic lives in `apps/desktop/src/lib/profile-name-guard.ts` (`isOneEditApart`, `findProfileNameConflict`), so the policy is testable without React.

## Evidence

Pre-fix run (dialog guard wiring reverted, new tests present) — the tree pins `veste-frontend-dev` / `vestg-curriculum-admin` as the regression data:

```
$ npx vitest run --project ui --reporter=verbose src/lib/profile-name-guard.test.ts src/app/profiles/create-profile-dialog.test.tsx
× |ui| create-profile-dialog.test.tsx > CreateProfileDialog typo guard > flags a one-keystroke name and offers the profile that was meant 12154ms
× |ui| create-profile-dialog.test.tsx > CreateProfileDialog typo guard > names the scaffold cost and still creates when the user insists 12077ms
× |ui| create-profile-dialog.test.tsx > CreateProfileDialog typo guard > refuses a name that is already taken instead of round-tripping the backend 12113ms
✓ |ui| create-profile-dialog.test.tsx > CreateProfileDialog typo guard > stays out of the way for a deliberate new name 83ms
Test Files  1 failed | 1 passed (2)
     Tests  3 failed | 14 passed (17)
```

Post-fix, same command:

```
✓ |ui| src/lib/profile-name-guard.test.ts > findProfileNameConflict > flags the reported typo and names the profile that was meant 1ms
✓ |ui| src/lib/profile-name-guard.test.ts > findProfileNameConflict > treats a taken name as a duplicate, ignoring case and padding 0ms
✓ |ui| src/lib/profile-name-guard.test.ts > findProfileNameConflict > returns the same suggestion regardless of profile-list order 0ms
✓ |ui| src/lib/profile-name-guard.test.ts > findProfileNameConflict > stays quiet for a deliberate new name, an empty one, and tiny names 0ms
✓ |ui| src/app/profiles/create-profile-dialog.test.tsx > CreateProfileDialog typo guard > flags a one-keystroke name and offers the profile that was meant 1316ms
✓ |ui| src/app/profiles/create-profile-dialog.test.tsx > CreateProfileDialog typo guard > names the scaffold cost and still creates when the user insists 918ms
✓ |ui| src/app/profiles/create-profile-dialog.test.tsx > CreateProfileDialog typo guard > refuses a name that is already taken instead of round-tripping the backend 316ms
✓ |ui| src/app/profiles/create-profile-dialog.test.tsx > CreateProfileDialog typo guard > stays out of the way for a deliberate new name 266ms
Test Files  2 passed (2)
     Tests  17 passed (17)
```

Regression sweep over the touched surfaces:

```
$ npx vitest run --project ui --reporter=dot src/app/profiles src/app/chat/sidebar
Test Files  35 passed (35)
     Tests  267 passed (267)
```

```
$ npx eslint <changed files>            # no output
$ npx prettier --check <changed files>
All matched files use Prettier code style!
$ npx tsc -p . --noEmit
src/app/messaging/telegram-qr-setup.tsx(48,31): error TS2307: Cannot find module 'qrcode' ...
```

The single `tsc` error is environmental and pre-existing: `qrcode` is declared in `apps/desktop/package.json` but its `node_modules` copy is not installed in this checkout (`apps/desktop/node_modules/qrcode` → not found), and no changed file is involved. The only non-English locale that fully types `Translations` (`zh`) got its copy for the new strings, so no locale regressed.

## Scope

Partial implementation for #107681 — Part A only, and only the piece that was still missing. Not in this PR:

- Part B (a fleet roster sidebar with a broadcast input fanned out over multiplexed backends) — the per-gateway fleet strip already exists; a broadcast compose box does not, and it is a design question of its own.
- #30437's dashboard assignee field. The desktop Kanban assignee picker is already a profile `<select>`; the web dashboard's assignee input is the remaining freeform surface and belongs with that issue.

The near-miss rule is deliberately bounded: one edit, both names at least 4 characters, and it warns rather than blocks (creation stays reachable through the explicitly labeled **Create anyway**), so a genuinely new name that happens to sit one edit from an existing one is never a dead end.
