### PR TITLE
fix(state): chunk the remaining unbounded IN-list writes below SQLite's variable limit

### DIFF
--- a/hermes_state_maintenance.py
+++ b/hermes_state_maintenance.py
@@ -169,11 +169,15 @@ class SessionMaintenanceMixin:
                        if sid not in excluded and not self._write_guards_reject(conn, sid)]
             if not victims:
                 return []
-            # Re-apply every predicate under the write lock.
-            conn.execute(
-                f"UPDATE sessions SET ended_at = ?, end_reason = 'startup_orphan_reap'"
-                f" WHERE id IN ({_placeholders(victims)}) AND ended_at IS NULL{scope_sql}",
-                (time.time(), *victims, *scope_params))
+            # Re-apply every predicate under the write lock. Batched: a dead gateway that sat
+            # orphaned across a long outage can leave far more rows than SQLite's bound-variable
+            # ceiling tolerates in one IN (...) list.
+            reaped_at = time.time()
+            for chunk in _id_chunks(victims):
+                conn.execute(
+                    f"UPDATE sessions SET ended_at = ?, end_reason = 'startup_orphan_reap'"
+                    f" WHERE id IN ({_placeholders(chunk)}) AND ended_at IS NULL{scope_sql}",
+                    (reaped_at, *chunk, *scope_params))
             return victims
         return self._execute_write(_do) or []
 

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -15,7 +15,7 @@ from agent.message_sanitization import _sanitize_surrogates
 from hermes_cli.timefmt import coerce_epoch
 from hermes_state_common import (
     _COMPRESSION_LOCK_ROW_SQL, _ENDED_ROW_SQL, _RESET_END_REASONS, _RESET_END_REASONS_SQL, _ended_by_compression,
-    _legacy_reset_child_sql, _placeholders, _sql_json_extract)
+    _id_chunks, _legacy_reset_child_sql, _placeholders, _sql_json_extract)
 
 logger = logging.getLogger("hermes_state")  # caplog tests pin the origin module's name
 
@@ -1178,8 +1178,10 @@ class SessionMessagesMixin:
                 replacement = self._split_rewind_target(target_row, expected_target_content, preserve_compaction_handoff)
             ids = [r[0] for r in conn.execute("SELECT id FROM messages WHERE session_id = ? AND id >= ? AND active = 1",
                                              (session_id, target_message_id)).fetchall()]
-            if ids:
-                conn.execute(f"UPDATE messages SET active = 0 WHERE id IN ({_placeholders(ids)})", ids)
+            # Batched: a rewind target near the head of a long-lived session can soft-delete far
+            # more ids than SQLite's bound-variable ceiling tolerates in one IN (...) list.
+            for chunk in _id_chunks(ids):
+                conn.execute(f"UPDATE messages SET active = 0 WHERE id IN ({_placeholders(chunk)})", chunk)
             if replacement is not None:
                 self._insert_message_rows(conn, session_id, [replacement])
                 replacement_message_id = int(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
@@ -1295,8 +1297,10 @@ class SessionMessagesMixin:
             logger.info("Backed up state.db to %s before clean-markers write", backup_path)
         def _do(conn):
             ids = _find_affected(conn)
-            if ids:
-                conn.execute(f"UPDATE messages SET content = '' WHERE id IN ({_placeholders(ids)})", ids)
+            # Batched: an operator running this cleanup on a long-accumulated store can hit far
+            # more affected rows than SQLite's bound-variable ceiling tolerates in one IN (...) list.
+            for chunk in _id_chunks(ids):
+                conn.execute(f"UPDATE messages SET content = '' WHERE id IN ({_placeholders(chunk)})", chunk)
             return ids
         affected_ids = self._execute_write(_do)
         if affected_ids:

--- a/tests/hermes_state/test_bulk_mutation_sql_variable_limit.py
+++ b/tests/hermes_state/test_bulk_mutation_sql_variable_limit.py
@@ -1,0 +1,83 @@
+"""Bulk in-place mutations (not just delete/prune) must stay below SQLite's bound-variable ceiling.
+
+Sibling of ``test_corrupt_row_robustness.py::test_bulk_delete_and_prune_stay_below_sqlite_variable_limit``:
+that test pins ``prune_sessions``/``delete_sessions`` against an oversized ``IN (...)`` list via
+``_id_chunks``. ``sweep_orphaned_sessions``, ``rewind_to_message`` and ``purge_stale_tool_call_markers``
+build the exact same shape of unbounded id list for an ``UPDATE ... WHERE id IN (...)`` and must chunk
+the same way — each is reachable automatically (gateway startup) or by an operator on exactly the kind
+of long-accumulated store where the id count is largest.
+"""
+
+import sqlite3
+import time
+
+from hermes_state import SessionDB
+
+
+def _force_legacy_variable_ceiling(db):
+    db._conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 999)  # the legacy ceiling, deterministic
+
+
+def test_sweep_orphaned_sessions_stays_below_sqlite_variable_limit(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        old = time.time() - 100_000
+        ids = [f"orphan_{i}" for i in range(1200)]
+
+        def seed(conn):
+            conn.executemany(
+                "INSERT INTO sessions (id, source, started_at, ended_at) VALUES (?, 'tui', ?, NULL)",
+                [(sid, old) for sid in ids])
+
+        db._execute_write(seed)
+        _force_legacy_variable_ceiling(db)
+        reaped = db.sweep_orphaned_sessions(max_idle_seconds=60)
+        assert len(reaped) == 1200
+        assert db._read_one(
+            "SELECT COUNT(*) FROM sessions WHERE end_reason = 'startup_orphan_reap'")[0] == 1200
+    finally:
+        db.close()
+
+
+def test_rewind_to_message_stays_below_sqlite_variable_limit(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s", "cli")
+        target_id = db.append_message("s", "user", "rewind target")
+        now = time.time()
+
+        def seed(conn):
+            conn.executemany(
+                "INSERT INTO messages (session_id, role, content, timestamp, active) "
+                "VALUES ('s', 'assistant', 'x', ?, 1)",
+                [(now,) for _ in range(1200)])
+
+        db._execute_write(seed)
+        _force_legacy_variable_ceiling(db)
+        result = db.rewind_to_message("s", target_id)
+        assert result["rewound_count"] == 1201  # the target row plus the 1200 seeded rows after it
+        assert db._read_one(
+            "SELECT COUNT(*) FROM messages WHERE session_id = 's' AND active = 1")[0] == 0
+    finally:
+        db.close()
+
+
+def test_purge_stale_tool_call_markers_stays_below_sqlite_variable_limit(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s", "cli")
+        now = time.time()
+
+        def seed(conn):
+            conn.executemany(
+                "INSERT INTO messages (session_id, role, content, tool_calls, timestamp) "
+                "VALUES ('s', 'assistant', '[memory]', 'x', ?)",
+                [(now,) for _ in range(1200)])
+
+        db._execute_write(seed)
+        _force_legacy_variable_ceiling(db)
+        result = db.purge_stale_tool_call_markers(dry_run=False, backup=False)
+        assert result["rows_affected"] == 1200
+        assert db._read_one("SELECT COUNT(*) FROM messages WHERE content = '[memory]'")[0] == 0
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- `sweep_orphaned_sessions`, `rewind_to_message` and `purge_stale_tool_call_markers` each build one unbounded `UPDATE ... WHERE id IN (?,...)` over a full id list — the same shape that #108086 just chunked in `prune_sessions`/`delete_empty_sessions`/`prune_empty_ghost_sessions`/`delete_sessions` via `_id_chunks`/`_SQL_IN_CHUNK`. These three were left unchunked.
- `sweep_orphaned_sessions` runs automatically on every gateway startup (`tui_gateway/session_reaper.py`) to reap `ended_at IS NULL` rows; with enough orphaned rows (a long outage, heavy subagent churn) it fails `sqlite3.OperationalError: too many SQL variables` on the same sweep every startup, silently (caught and logged as a warning by the reaper's wrapper) — orphaned rows never get reaped.
- `rewind_to_message` is a live, user-triggered `/rewind` path; a rewind target near the head of a long-lived session can soft-delete more ids than the limit tolerates.
- `purge_stale_tool_call_markers` backs the `hermes sessions clean-markers` operator command, run on exactly the large, long-accumulated stores most likely to exceed the limit.
- Same fix shape as the already-shipped siblings: wrap the id list in `for chunk in _id_chunks(ids): ...`, same transaction, same predicates re-applied per chunk (no change to cascade/orphan semantics).

## Test plan
- [x] Added `tests/hermes_state/test_bulk_mutation_sql_variable_limit.py` — three tests, each forces the legacy 999-variable ceiling via `conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 999)` (mirroring `test_corrupt_row_robustness.py::test_bulk_delete_and_prune_stay_below_sqlite_variable_limit`) and seeds 1200 affected rows for each function.
- [x] Mutation-verified: reverted the fix, confirmed all three new tests fail with `sqlite3.OperationalError: too many SQL variables`; restored the fix, confirmed all three pass.
- [x] `uv run --frozen --extra dev pytest tests/hermes_state/ tests/test_hermes_state.py -q` → 602 passed, 20 skipped, no failures.
- [x] Ran the existing directly-related suites (`test_sweep_orphaned_sessions.py`, `test_94895_orphan_sweep_cross_backend.py`, `test_composite_carrier_rewind.py` x2, `test_86366_tail_rewind_semantics.py`, `test_stale_tool_call_marker_session_repair.py`, `test_startup_orphan_sweep.py`, `test_undo_rewind_session.py`) → all pass.
- [x] Confirmed no overlap with #108086 (just merged): its hunks in `hermes_state_maintenance.py`/`hermes_state_messages.py` touch `prune_empty_ghost_sessions`/`prune_sessions`/`_json_or`/`resolve_resume_session_id` — different functions than the three fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)