### PR TITLE
fix(honcho): bound synced local message cache

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import queue
 import logging
+import sys
 import threading
 import time
 from dataclasses import dataclass, field
@@ -27,6 +28,28 @@ _ASYNC_SHUTDOWN = object()
 # Sessions remembered in _joined_author_peers; the oldest is dropped past this and its authors rejoin on their next write.
 _SESSION_CACHE_MAX_SIZE = 128
 
+# The local list exists only to batch messages not yet durable in Honcho. Once a message
+# is synced, retaining an unlimited transcript duplicates the remote source of truth and
+# lets one long-lived gateway channel pin arbitrarily large tool/chat payloads.
+_SYNCED_MESSAGE_CACHE_MAX_COUNT = 256
+_SYNCED_MESSAGE_CACHE_MAX_BYTES = 4 * 1024 * 1024
+
+
+def _retained_heap_bytes(value: Any, seen: set[int] | None = None) -> int:
+    """Immediate Python heap owned by a message graph (cycle/alias safe)."""
+    seen = set() if seen is None else seen
+    marker = id(value)
+    if marker in seen:
+        return 0
+    seen.add(marker)
+    size = sys.getsizeof(value)
+    if isinstance(value, dict):
+        size += sum(_retained_heap_bytes(k, seen) + _retained_heap_bytes(v, seen)
+                    for k, v in value.items())
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        size += sum(_retained_heap_bytes(item, seen) for item in value)
+    return size
+
 
 @dataclass
 class HonchoSession:
@@ -45,6 +68,35 @@ class HonchoSession:
         """Add a message to the local cache."""
         self.messages.append({"role": role, "content": content, "timestamp": datetime.now().isoformat(), **kwargs})
         self.updated_at = datetime.now()
+
+    def trim_synced_cache(self) -> int:
+        """Drop oldest durable rows until the local cache fits both memory bounds.
+
+        Unsynced rows are never discarded, even when they alone exceed the limits: failed
+        delivery must trade boundedness for durability explicitly rather than lose data.
+        """
+        sizes = [_retained_heap_bytes(message) for message in self.messages]
+        retained_bytes = sum(sizes)
+        retained_count = len(self.messages)
+        if (retained_count <= _SYNCED_MESSAGE_CACHE_MAX_COUNT
+                and retained_bytes <= _SYNCED_MESSAGE_CACHE_MAX_BYTES):
+            return 0
+
+        keep = [True] * retained_count
+        removed = 0
+        for index, (message, size) in enumerate(zip(self.messages, sizes)):
+            if (retained_count <= _SYNCED_MESSAGE_CACHE_MAX_COUNT
+                    and retained_bytes <= _SYNCED_MESSAGE_CACHE_MAX_BYTES):
+                break
+            if not message.get("_synced"):
+                continue
+            keep[index] = False
+            retained_count -= 1
+            retained_bytes -= size
+            removed += 1
+        if removed:
+            self.messages[:] = [message for message, retain in zip(self.messages, keep) if retain]
+        return removed
 
 
 class HonchoSessionManager(SessionAuthMixin, SessionPeersMixin, SessionContextMixin, SessionMigrationMixin):
@@ -284,6 +336,7 @@ class HonchoSessionManager(SessionAuthMixin, SessionPeersMixin, SessionContextMi
         """Write unsynced messages to Honcho synchronously."""
         new_messages = [m for m in session.messages if not m.get("_synced")]
         if not new_messages:
+            session.trim_synced_cache()
             return True
 
         # Resolved inside the operation so a retry after a client rebuild gets fresh objects.
@@ -313,6 +366,9 @@ class HonchoSessionManager(SessionAuthMixin, SessionPeersMixin, SessionContextMi
             ok = False
         for msg in new_messages:
             msg["_synced"] = ok
+        trimmed = session.trim_synced_cache()
+        if trimmed:
+            logger.debug("Trimmed %d durable Honcho message(s) from local cache for %s", trimmed, session.key)
         with self._cache_lock:
             self._cache[session.key] = session
         return ok

--- a/tests/honcho_plugin/test_session_message_cache_bounds.py
+++ b/tests/honcho_plugin/test_session_message_cache_bounds.py
@@ -1,0 +1,59 @@
+"""Bounds for Honcho's local post-sync message cache (#71461)."""
+
+import threading
+
+from plugins.memory.honcho import session as session_mod
+from plugins.memory.honcho.session import HonchoSession, HonchoSessionManager
+
+
+def _session(messages):
+    return HonchoSession(
+        key="channel:1", user_peer_id="user", assistant_peer_id="assistant",
+        honcho_session_id="session-1", messages=messages,
+    )
+
+
+def _message(index: int, *, synced: bool = True, size: int = 32):
+    return {"role": "user", "content": f"{index}:" + "x" * size, "_synced": synced}
+
+
+def test_trim_synced_cache_keeps_recent_tail_within_count_bound(monkeypatch):
+    monkeypatch.setattr(session_mod, "_SYNCED_MESSAGE_CACHE_MAX_COUNT", 4)
+    monkeypatch.setattr(session_mod, "_SYNCED_MESSAGE_CACHE_MAX_BYTES", 1_000_000)
+    session = _session([_message(index) for index in range(8)])
+
+    assert session.trim_synced_cache() == 4
+    assert [message["content"].split(":", 1)[0] for message in session.messages] == ["4", "5", "6", "7"]
+
+
+def test_trim_synced_cache_bounds_retained_heap_bytes(monkeypatch):
+    monkeypatch.setattr(session_mod, "_SYNCED_MESSAGE_CACHE_MAX_COUNT", 100)
+    monkeypatch.setattr(session_mod, "_SYNCED_MESSAGE_CACHE_MAX_BYTES", 2_000)
+    session = _session([_message(index, size=700) for index in range(8)])
+
+    assert session.trim_synced_cache() > 0
+    assert sum(session_mod._retained_heap_bytes(message) for message in session.messages) <= 2_000
+
+
+def test_trim_synced_cache_never_drops_unsynced_rows(monkeypatch):
+    monkeypatch.setattr(session_mod, "_SYNCED_MESSAGE_CACHE_MAX_COUNT", 1)
+    monkeypatch.setattr(session_mod, "_SYNCED_MESSAGE_CACHE_MAX_BYTES", 1)
+    unsynced = _message(2, synced=False, size=20_000)
+    session = _session([_message(1), unsynced, _message(3)])
+
+    session.trim_synced_cache()
+
+    assert unsynced in session.messages
+    assert all(not message.get("_synced") for message in session.messages)
+
+
+def test_flush_without_new_messages_still_trims_old_durable_history(monkeypatch):
+    monkeypatch.setattr(session_mod, "_SYNCED_MESSAGE_CACHE_MAX_COUNT", 2)
+    monkeypatch.setattr(session_mod, "_SYNCED_MESSAGE_CACHE_MAX_BYTES", 1_000_000)
+    session = _session([_message(index) for index in range(6)])
+    manager = HonchoSessionManager.__new__(HonchoSessionManager)
+    manager._cache_lock = threading.RLock()
+    manager._cache = {session.key: session}
+
+    assert manager._flush_session(session) is True
+    assert [message["content"].split(":", 1)[0] for message in session.messages] == ["4", "5"]


### PR DESCRIPTION
## Summary

Refs #71461.

Honcho already owns the durable conversation, but each in-process `HonchoSession` retained every successfully delivered message forever. Long-lived gateway channels therefore accumulated a second unbounded transcript in `session.messages`, independent of Hermes context compression and the remote Honcho source of truth.

This PR bounds only that first, isolated retention path:

- keep at most 256 locally cached messages after successful delivery;
- keep at most 4 MiB of immediate Python heap across their nested message graphs;
- evict oldest `_synced` rows first;
- never discard unsynced rows, even when a failed-delivery backlog itself exceeds the bounds;
- trim both after a sync attempt and on later flushes that find no new messages.

The four SDK/session/context dictionaries identified in #71461 remain separate follow-up work; this PR does not claim to close the whole issue.

## Why trimming is safe

`HonchoSession.messages` is used as the local delivery queue. Repository search found its production consumers in:

1. `_flush_session()`, which selects rows without `_synced`;
2. the one-time memory-file migration gate, which runs before normal post-init message delivery.

Only rows confirmed durable in Honcho are eligible for removal. The bounded recent tail remains available for diagnostics and existing code that inspects the session object.

## Byte accounting

A serialized-text limit would undercount Python dictionaries, lists and Unicode strings. `_retained_heap_bytes()` walks the retained built-in object graph with `sys.getsizeof`, deduplicating aliases/cycles, and the cache trims against that representation's immediate heap ownership.

## Regression coverage

The focused tests cover:

- oldest-first count trimming while retaining the recent tail;
- byte-budget trimming;
- strict preservation of unsynced rows;
- trimming an already-durable cache when a flush has no new messages.

## Verification

A fork workflow applied this exact pair of file blobs and completed successfully:

- source/test `py_compile`;
- isolated behavior smoke test covering count + byte trimming and oversized unsynced preservation.

The branch was then rebuilt as one clean commit directly on upstream `0b8daf30aae1d0b129ede9b857cac2158eb50324`. Compare result: one commit, two files, no staging workflow or unrelated changes. Upstream CI remains authoritative for the complete Honcho suite.