### PR TITLE
fix(feishu): scope the allow_bots YAML->env bridge write to unscoped profiles

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -92,7 +92,8 @@ from gateway.status import acquire_scoped_lock, release_scoped_lock
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write, env_float, env_int
 
-from gateway.platforms._shared import get_scoped_secret as _get_scoped_secret
+from gateway.platforms._shared import (
+    get_scoped_secret as _get_scoped_secret, profile_scoped as _profile_scoped_config_load)
 
 
 logger = logging.getLogger(__name__)
@@ -4299,8 +4300,13 @@ def _apply_yaml_config(yaml_cfg: dict, feishu_cfg: dict) -> dict | None:
 
     Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy feishu_cfg block from
     gateway/config.py::load_gateway_config() (allow_bots). Env vars take precedence over YAML.
+
+    Under a multiplexed secondary profile the write is skipped: ``os.environ`` is process-global, so
+    it would leak this profile's ``allow_bots`` into the unscoped default profile's reads (both
+    ``_load_settings`` above and ``gateway/authz_mixin.py``'s gate read this env var directly, by
+    design, so a scoped write here couldn't reach them anyway — see #86905/#72348).
     """
-    if "allow_bots" in feishu_cfg and not os.getenv("FEISHU_ALLOW_BOTS"):
+    if "allow_bots" in feishu_cfg and not _profile_scoped_config_load() and not os.getenv("FEISHU_ALLOW_BOTS"):
         os.environ["FEISHU_ALLOW_BOTS"] = str(feishu_cfg["allow_bots"]).lower()
     return None
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -68,6 +68,50 @@ class TestConfigEnvOverrides(unittest.TestCase):
         self.assertEqual(config.platforms[Platform.FEISHU].extra["connection_mode"], "websocket")
 
 
+class TestApplyYamlConfigProfileScope(unittest.TestCase):
+    """_apply_yaml_config's FEISHU_ALLOW_BOTS bridge write must not leak across profiles under
+    multiplex. ``os.environ`` is process-global; a secondary profile's own reads are already
+    scoped (``gateway/authz_mixin.py``'s gate, ``FeishuAdapter._load_settings`` via
+    ``get_scoped_secret``) and never consult it -- but the unscoped DEFAULT profile falls back to
+    ``os.getenv``, so an unguarded write here would silently flip the default profile's
+    allow_bots gate to whatever a secondary profile's config.yaml asked for."""
+
+    def setUp(self):
+        super().setUp()
+        self._scope_tokens = []
+
+    def tearDown(self):
+        from agent.secret_scope import reset_secret_scope, set_multiplex_active
+        for token in reversed(self._scope_tokens):
+            reset_secret_scope(token)
+        set_multiplex_active(False)
+        super().tearDown()
+
+    def _install_scope(self, mapping=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+        set_multiplex_active(True)
+        self._scope_tokens.append(set_secret_scope(mapping or {}))
+
+    def test_scoped_secondary_profile_skips_the_env_write(self):
+        from plugins.platforms.feishu.adapter import _apply_yaml_config
+
+        self._install_scope()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FEISHU_ALLOW_BOTS", None)
+            result = _apply_yaml_config({}, {"allow_bots": True})
+            self.assertIsNone(result)
+            self.assertNotIn("FEISHU_ALLOW_BOTS", os.environ)
+
+    def test_unscoped_single_profile_still_bridges_the_env_write(self):
+        """Single-profile deployments (no scope installed) keep the legacy behavior."""
+        from plugins.platforms.feishu.adapter import _apply_yaml_config
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FEISHU_ALLOW_BOTS", None)
+            _apply_yaml_config({}, {"allow_bots": True})
+            self.assertEqual(os.environ.get("FEISHU_ALLOW_BOTS"), "true")
+
+
 class TestFeishuMessageNormalization(unittest.TestCase):
 
 


### PR DESCRIPTION
## Summary
- `_apply_yaml_config` bridges `config.yaml`'s `feishu.allow_bots` into `FEISHU_ALLOW_BOTS` unconditionally (guarded only by "not already set"). `os.environ` is process-global, so under `gateway.multiplex_profiles` a secondary profile's own config value gets written there too, since `_load_secondary_profile_config` runs `_apply_yaml_config` inside `_profile_runtime_scope`.
- That write is dead weight for the profile that made it: both `FeishuAdapter._load_settings` (via `get_scoped_secret`) and `gateway/authz_mixin.py`'s gate (via `_platform_gate_env`) already read this env var scope-aware, and per `agent/secret_scope.py::get_secret`, a scoped miss under multiplex returns `default` without ever falling through to `os.environ` (#86905/#72348 — the read-side fail-closed fix from closed PR #86908 is already present in current code).
- But the **default profile runs unscoped** under multiplex by design, and its reads deliberately *do* fall back to `os.getenv` (`get_scoped_secret`'s `except UnscopedSecretError` branch, `_platform_gate_env`'s `scope is None` branch) — that's how single-profile deployments and the default profile keep working without a scope installed. A secondary profile's unguarded write pollutes exactly the env var that fallback trusts, silently flipping the **default profile's** bot-admission gate to whatever a secondary profile's `config.yaml` asked for.
- Fix mirrors the `profile_scoped()` write-skip Discord/Mattermost's own `_apply_yaml_config` already use. Unlike those, this doesn't seed `PlatformConfig.extra`: the env var is deliberately the single source both `_load_settings` and the `authz_mixin` gate read (existing `#86905` comment) — `extra` isn't visible to the gate, so seeding it wouldn't help and would add a second, inconsistent read path.

## Test plan
- [x] Added `tests/gateway/test_feishu.py::TestApplyYamlConfigProfileScope` — one test confirms the write is skipped under an installed multiplex scope, a second confirms unscoped/single-profile behavior is unchanged (legacy env bridge still fires).
- [x] Mutation-verified: reverted the fix, confirmed the scoped test fails (`FEISHU_ALLOW_BOTS` leaks into `os.environ`); restored the fix, confirmed both tests pass. (First pass of this test had the assertions outside the `patch.dict` context manager, which silently passed regardless of the fix — caught and corrected before relying on it.)
- [x] `uv run --frozen --extra dev pytest tests/gateway/test_feishu*.py -q` → 147 passed, 2 pre-existing failures (`TestAdapterBehavior::test_url_verification_*` / `test_webhook_request_uses_same_message_dispatch_path`, both `AttributeError: 'NoneType' object has no attribute 'json_response'` — an aiohttp `web` import issue). Confirmed pre-existing and unrelated by stashing this fix and re-running against clean `upstream/main`: identical failures.
- [x] Confirmed no overlap with closed PR #86908: it fixed the read-side (`_get_scoped_secret`/`_auth_env` fail-closed on scoped miss), already present in current code; it never touches `_apply_yaml_config`.

## Scope note
This targets `allow_bots` specifically, the one field `_apply_yaml_config` currently bridges. If other Feishu fields get a similar YAML→env bridge added later, they'd need the same guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)