### PR TITLE
fix(update): preserve clean refusal when gateway resume fails

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -36,6 +36,7 @@ from hermes_cli.update_cmd_windows import (  # noqa: F401
     _refresh_bootstrap_cache_scripts, _refresh_windows_gateway_launchers,
     _refuse_gateway_ancestor_tree_kill, _relaunch_stopped_serves,
     _restore_windows_gateway_service, _resume_windows_gateways_after_update,
+    _resume_windows_gateways_after_update_best_effort,
     _resume_windows_gateways_and_merge_outcome, _self_and_non_gateway_ancestor_pids,
     _serve_relaunch_commands, _start_windows_gateway_service, _stop_process_trees,
     _stop_windows_gateway_service, _venv_launcher_ancestors,
@@ -1294,7 +1295,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
     _windows_gateway_resume = _m()._pause_windows_gateways_for_update()
     if _windows_gateway_resume:
         import atexit as _atexit
-        _atexit.register(_m()._resume_windows_gateways_after_update, _windows_gateway_resume)
+        _atexit.register(_resume_windows_gateways_after_update_best_effort, _windows_gateway_resume)
 
     # Any venv python still running (typically the Desktop `hermes serve` backend) keeps .pyd
     # locked and would corrupt the sync; refuse rather than race (the app respawns a killed

--- a/hermes_cli/update_cmd_windows.py
+++ b/hermes_cli/update_cmd_windows.py
@@ -1209,7 +1209,9 @@ def _clear_windows_venv_holders_or_exit(args, gateway_mode: bool, _windows_gatew
     from hermes_cli.update_cmd import _m, _record_update_step, _refuse_gateway_ancestor_tree_kill
 
     def _resume_and_exit():
-        _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
+        with _best_effort("Windows gateway service restart incomplete: %s"):
+            _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
+        # Keep a failed token pending for the registered atexit retry.
         sys.exit(2)
 
     holders = _m()._detect_venv_python_processes()

--- a/hermes_cli/update_cmd_windows.py
+++ b/hermes_cli/update_cmd_windows.py
@@ -1108,6 +1108,16 @@ def _resume_windows_gateways_after_update(token: dict | None) -> None:
     if not _m()._is_windows():
         token["resume_needed"] = False
         return
+    pending_verification = token.get("relaunch_verification_pending")
+    if isinstance(pending_verification, dict):
+        profiles = pending_verification.get("profiles") or {}
+        unmapped = pending_verification.get("unmapped") or []
+        _verify_relaunched_gateways_alive(token, profiles, unmapped)
+        token.pop("relaunch_verification_pending", None)
+        token["profiles"] = {}
+        token["unmapped"] = []
+        token["resume_needed"] = False
+        return
     # Regenerate launcher scripts before respawning so a legacy pythonw-era
     # autostart entry comes back on the current design at next login too.
     _m()._refresh_windows_gateway_launchers()
@@ -1123,13 +1133,26 @@ def _resume_windows_gateways_after_update(token: dict | None) -> None:
         return
     relaunched, unmapped_relaunched = _relaunch_paused_gateways(token, profiles, unmapped)
     if relaunched or unmapped_relaunched:
+        token["relaunch_verification_pending"] = {
+            "profiles": dict(profiles),
+            "unmapped": list(unmapped),
+        }
         _verify_relaunched_gateways_alive(token, profiles, unmapped)
+        token.pop("relaunch_verification_pending", None)
     token["resume_needed"] = False
     if relaunched:
         print(f"\n  ✓ Restarting Windows gateway profile(s): {', '.join(relaunched)}")
     if unmapped_relaunched:
         lead = "" if relaunched else "\n"
         print(f"{lead}  ✓ Restarting {unmapped_relaunched} unmapped Windows gateway process(es)")
+
+
+def _resume_windows_gateways_after_update_best_effort(token: dict | None) -> None:
+    """Resume paused Windows gateways without letting cleanup failure escape."""
+    from hermes_cli.update_cmd import _m
+
+    with _best_effort("Windows gateway service restart incomplete: %s"):
+        _m()._resume_windows_gateways_after_update(token)
 
 
 def _resume_windows_gateways_and_merge_outcome(outcome, _windows_gateway_resume, gateway_mode: bool):
@@ -1209,9 +1232,14 @@ def _clear_windows_venv_holders_or_exit(args, gateway_mode: bool, _windows_gatew
     from hermes_cli.update_cmd import _m, _record_update_step, _refuse_gateway_ancestor_tree_kill
 
     def _resume_and_exit():
-        with _best_effort("Windows gateway service restart incomplete: %s"):
-            _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
-        # Keep a failed token pending for the registered atexit retry.
+        _resume_windows_gateways_after_update_best_effort(_windows_gateway_resume)
+        if (
+            isinstance(_windows_gateway_resume, dict)
+            and _windows_gateway_resume.get("resume_needed")
+            and os.environ.get(_m()._UPDATE_REEXEC_ENV) == "1"
+        ):
+            # The Windows hand-off boundary uses os._exit(), which skips atexit.
+            _resume_windows_gateways_after_update_best_effort(_windows_gateway_resume)
         sys.exit(2)
 
     holders = _m()._detect_venv_python_processes()

--- a/tests/hermes_cli/test_update_orphan_backend_reap.py
+++ b/tests/hermes_cli/test_update_orphan_backend_reap.py
@@ -23,8 +23,10 @@ import types
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from hermes_cli import main as cli_main
-from hermes_cli import update_cmd
+from hermes_cli import update_cmd, update_cmd_windows
 
 
 class _FakeNoSuchProcess(Exception):
@@ -314,3 +316,30 @@ def test_guard_refuses_when_reap_does_not_clear_holders():
     )
     assert result == "exit_2"
     assert killed == [[200]]
+
+
+def test_guard_keeps_clean_refusal_when_gateway_resume_fails():
+    token = {"resume_needed": True}
+    resume = MagicMock(side_effect=RuntimeError("gateway liveness timed out"))
+
+    with patch.object(
+        cli_main, "_detect_venv_python_processes", return_value=_holders()
+    ), patch.object(
+        cli_main, "_leftover_pausable_gateway_pids", return_value=None
+    ), patch.object(
+        cli_main, "_ledger_reapable_backend_pids", return_value=[]
+    ), patch.object(
+        cli_main, "_orphaned_desktop_backend_pids", return_value=None
+    ), patch.object(
+        cli_main, "_ledger_manual_serve_holders", return_value=[]
+    ), patch.object(
+        cli_main, "_resume_windows_gateways_after_update", resume
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            update_cmd_windows._clear_windows_venv_holders_or_exit(
+                _update_args(), gateway_mode=False, _windows_gateway_resume=token
+            )
+
+    assert excinfo.value.code == 2
+    resume.assert_called_once_with(token)
+    assert token["resume_needed"] is True

--- a/tests/hermes_cli/test_update_orphan_backend_reap.py
+++ b/tests/hermes_cli/test_update_orphan_backend_reap.py
@@ -318,10 +318,7 @@ def test_guard_refuses_when_reap_does_not_clear_holders():
     assert killed == [[200]]
 
 
-def test_guard_keeps_clean_refusal_when_gateway_resume_fails():
-    token = {"resume_needed": True}
-    resume = MagicMock(side_effect=RuntimeError("gateway liveness timed out"))
-
+def _run_refusal_with_resume(token, resume):
     with patch.object(
         cli_main, "_detect_venv_python_processes", return_value=_holders()
     ), patch.object(
@@ -339,7 +336,93 @@ def test_guard_keeps_clean_refusal_when_gateway_resume_fails():
             update_cmd_windows._clear_windows_venv_holders_or_exit(
                 _update_args(), gateway_mode=False, _windows_gateway_resume=token
             )
+    return excinfo.value.code
 
-    assert excinfo.value.code == 2
+
+def test_guard_keeps_clean_refusal_when_gateway_resume_fails(monkeypatch):
+    monkeypatch.delenv(cli_main._UPDATE_REEXEC_ENV, raising=False)
+    token = {"resume_needed": True}
+    resume = MagicMock(side_effect=RuntimeError("gateway liveness timed out"))
+
+    assert _run_refusal_with_resume(token, resume) == 2
+    resume.assert_called_once_with(token)
+    assert token["resume_needed"] is True
+
+
+def test_handoff_refusal_retries_gateway_resume_before_hard_exit(monkeypatch):
+    monkeypatch.setenv(cli_main._UPDATE_REEXEC_ENV, "1")
+    token = {"resume_needed": True}
+    attempts = []
+
+    def resume(resume_token):
+        attempts.append(resume_token)
+        if len(attempts) == 1:
+            raise RuntimeError("gateway liveness timed out")
+        resume_token["resume_needed"] = False
+
+    assert _run_refusal_with_resume(token, resume) == 2
+    assert attempts == [token, token]
+    assert token["resume_needed"] is False
+
+
+def test_handoff_retry_rechecks_liveness_without_duplicate_relaunch(monkeypatch):
+    from hermes_cli import gateway, gateway_windows
+
+    monkeypatch.setenv(cli_main._UPDATE_REEXEC_ENV, "1")
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(cli_main, "_refresh_windows_gateway_launchers", lambda: None)
+    relaunch = MagicMock(return_value=True)
+    monkeypatch.setattr(gateway, "launch_detached_profile_gateway_restart", relaunch)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_wait_for_gateway_ready",
+        MagicMock(side_effect=[[], [4321]]),
+    )
+    monkeypatch.setattr(gateway_windows, "_write_start_attestation", lambda *_a, **_kw: None)
+    token = {
+        "resume_needed": True,
+        "profiles": {"default": 1234},
+        "unmapped": [],
+    }
+
+    assert _run_refusal_with_resume(
+        token, cli_main._resume_windows_gateways_after_update
+    ) == 2
+    relaunch.assert_called_once_with("default", 1234)
+    assert token["resume_needed"] is False
+
+
+def test_registered_gateway_resume_retry_is_best_effort():
+    token = {"resume_needed": True}
+    resume = MagicMock(side_effect=RuntimeError("gateway liveness timed out"))
+    registered = []
+    opts = SimpleNamespace(gw_input_fn=input, assume_yes=True)
+
+    with patch.object(
+        update_cmd, "_resolve_update_options", return_value=opts
+    ), patch.object(
+        update_cmd, "_begin_update_receipt_and_plan", return_value=None
+    ), patch.object(
+        update_cmd, "_record_update_step"
+    ), patch.object(
+        cli_main, "_run_pre_update_backup", return_value=None
+    ), patch.object(
+        cli_main, "_pause_windows_gateways_for_update", return_value=token
+    ), patch.object(
+        cli_main, "_resume_windows_gateways_after_update", resume
+    ), patch.object(
+        cli_main, "_is_windows", return_value=True
+    ), patch.object(
+        update_cmd, "_clear_windows_venv_holders_or_exit", side_effect=SystemExit(2)
+    ), patch(
+        "atexit.register", side_effect=lambda callback, *args: registered.append((callback, args))
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            update_cmd._cmd_update_impl(_update_args(), gateway_mode=False)
+        assert excinfo.value.code == 2
+        assert len(registered) == 1
+        callback, callback_args = registered[0]
+        callback(*callback_args)
+
     resume.assert_called_once_with(token)
     assert token["resume_needed"] is True


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Keeps the Windows venv-holder refusal path on its intended exit-2 contract when best-effort gateway recovery raises. Recovery exceptions are contained on both the synchronous refusal path and the registered `atexit` retry, so neither can replace the refusal with a traceback.

The Windows hand-off child performs its pending retry before the existing `os._exit` boundary, which skips `atexit`. If the first launch reached liveness verification, the retry verifies that launch again instead of creating duplicate detached restart watchers.

This complements #106702, which covers the separate already-up-to-date path.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Related to #106692. Complements #106702.

## Type of Change

<!-- Mark the applicable type with ☑ and leave the other options as ☐. These are static status glyphs, not GitHub task-list items. -->

- ☑ 🐛 Bug fix (non-breaking change that fixes an issue)
- ☐ ✨ New feature (non-breaking change that adds functionality)
- ☐ 🔒 Security fix
- ☐ 📝 Documentation update
- ☐ ✅ Tests (adding or improving test coverage)
- ☐ ♻️ Refactor (no behavior change)
- ☐ 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Describe the behavior or subsystem; do not include local or repository-relative paths. -->

- Treat gateway recovery as best effort before a venv-holder refusal exits with status 2.
- Register the best-effort recovery wrapper for the `atexit` path so repeated liveness failures cannot emit an exit-time traceback.
- Run pending gateway cleanup before the Windows hand-off child reaches its existing hard-exit boundary.
- Preserve retry state while preventing a liveness retry from launching duplicate detached restart watchers.
- Add regression tests for the refusal, `atexit`, hand-off retry, and duplicate-launch paths.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. The clean-refusal regression fails without exception containment because the simulated gateway liveness error escapes before `SystemExit(2)`.
2. The duplicate-launch regression fails without verification-pending state because the hand-off retry creates the same detached restart watcher twice.
3. Run the focused Windows updater suites: 151 tests pass with 0 failures; 4 Windows-only tests skip on the Linux harness across 11 files.
4. Run Ruff, bytecode compilation, the Windows-footgun scanner, and the whitespace error check: all exit 0.
5. The earlier canonical full-suite run completed with 9 failed tests across eight files, and three additional files hit the 300-second per-file timeout. All failures were outside the changed files; the updater-adjacent failure reproduced unchanged on the unmodified base (1 passed, 1 failed).

## Checklist

<!-- Replace ☐ with ☑ only after verification. Use N/A where the published template permits it. Keep these as static status glyphs, not GitHub task-list items. -->

### Code

- ☑ I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- ☑ My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- ☑ I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- ☑ My PR contains **only** changes related to this fix/feature (no unrelated commits)
- ☐ I've run `pytest tests/ -q` and all tests pass
- ☑ I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- ☑ I've tested on my platform: Linux test harness exercising the Windows-specific path with controlled fakes; live Windows validation was not rerun

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to mark an item N/A if a category doesn't apply to your change. -->

- ☑ I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing documentation changed
- ☑ I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- ☑ I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changed
- ☑ I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows-only recovery behavior is isolated and covered by host-independent tests
- ☑ I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool contract changed

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

Not applicable. Deterministic regression and focused-suite evidence are listed above.

## Infographic

![Initial diagnostic poster showing a recovery error causing a traceback before the fix, then best-effort containment preserving exit status 2 and a pending retry; the initial candidate passed 75 targeted tests.](https://v3b.fal.media/files/b/0aaa01d9/izMygVLmJPdTETL3oKdXn_eDmMWFTF.png)

The infographic reflects the initial candidate. The current candidate passed the expanded 151-test focused gate described above.
