### PR TITLE
fix(cli): preserve reflog-reachable shallow grafts

### DIFF
--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -145,6 +145,55 @@ def _git_stdout_lines(
         return []
 
 
+def _before_publish_candidate(repo_root: Path) -> None:
+    """Test seam after candidate validation and before the publish guard."""
+
+
+def _fetch_head_tips(repo_root: Path, query_env: dict) -> List[str]:
+    """Every FETCH_HEAD entry. ``rev-parse FETCH_HEAD`` only returns the first."""
+    rel = _git_stdout_lines(
+        repo_root, ["rev-parse", "--git-path", "FETCH_HEAD"], env=query_env
+    )
+    if not rel:
+        return []
+    fetch_head = Path(rel[0])
+    if not fetch_head.is_absolute():
+        fetch_head = Path(repo_root) / fetch_head
+    if not fetch_head.is_file():
+        return []
+    tips: List[str] = []
+    try:
+        for line in fetch_head.read_text(encoding="utf-8").splitlines():
+            sha = line.split()[0] if line.split() else ""
+            if len(sha) == 40 and all(ch in "0123456789abcdefABCDEF" for ch in sha):
+                tips.append(sha)
+    except OSError:
+        return []
+    return tips
+
+
+def _rev_list_roots(repo_root: Path, query_env: dict) -> List[str]:
+    """Traversal roots Git maintenance walks, plus every FETCH_HEAD tip."""
+    return ["--all", "--reflog", *_fetch_head_tips(repo_root, query_env)]
+
+
+def _reachable_grafts(
+    repo_root: Path,
+    lines: List[str],
+    query_env: dict,
+    *,
+    env: Optional[dict] = None,
+) -> Optional[set]:
+    reachable = _git_stdout_lines(
+        repo_root,
+        ["rev-list", *_rev_list_roots(repo_root, query_env)],
+        env=env or query_env,
+    )
+    if not reachable:
+        return None
+    return set(lines) & set(reachable)
+
+
 def prune_stale_shallow_grafts(repo_root: Path) -> int:
     """Drop ``.git/shallow`` graft lines no ref or reflog still reaches (#105951).
 
@@ -152,11 +201,12 @@ def prune_stale_shallow_grafts(repo_root: Path) -> int:
     graft and never removes the previous one, so a long-lived shallow installer checkout
     accumulates one graft per update check (57 observed in the wild). The stale grafts
     break ``merge-base`` and push ``hermes update`` into the orphan-divergence reset path
-    on every run. Keep boundaries that protect commits reachable from refs or reflogs:
-    dropping a graft for a reflog-only commit exposes its unfetched parent and breaks git
-    maintenance. The dropped commits are genuinely unreachable and their objects are left
-    for ``git gc``. Returns the number of graft lines removed; never raises, and validates
-    the candidate through Git's lockfile before replacing the original.
+    on every run. Keep boundaries that protect commits reachable from refs, reflogs, or
+    any ``FETCH_HEAD`` entry: dropping a graft for a still-reachable commit exposes its
+    unfetched parent and breaks git maintenance. The dropped commits are genuinely
+    unreachable and their objects are left for ``git gc``. Returns the number of graft
+    lines removed; never raises, and validates the candidate through Git's lockfile
+    before replacing the original.
     """
     try:
         query_env = os.environ.copy()
@@ -175,22 +225,11 @@ def prune_stale_shallow_grafts(repo_root: Path) -> int:
         lines = [line for line in original.splitlines() if line]
         if not lines:
             return 0
-        reachable = _git_stdout_lines(
-            repo_root, ["rev-list", "--all", "--reflog"], env=query_env
-        )
-        if not reachable:
+        keep = _reachable_grafts(repo_root, lines, query_env)
+        if keep is None:
             # A failed reachability probe is indistinguishable from an empty result here.
             # This repository has shallow commits, so either way retaining them is safe.
             return 0
-        keep = set(lines) & {
-            *(_git_stdout_lines(repo_root, ["rev-parse", "HEAD"], env=query_env) or []),
-            *(_git_stdout_lines(
-                repo_root,
-                ["rev-parse", "--verify", "--quiet", "FETCH_HEAD"],
-                env=query_env,
-            ) or []),
-            *reachable,
-        }
         if not keep or len(keep) == len(lines):
             return 0
 
@@ -224,11 +263,19 @@ def prune_stale_shallow_grafts(repo_root: Path) -> int:
             candidate_env["GIT_SHALLOW_FILE"] = str(lock_path)
             still_walks = _git_stdout_lines(
                 repo_root,
-                ["rev-list", "--count", "HEAD", "--all", "--reflog"],
+                ["rev-list", "--count", *_rev_list_roots(repo_root, query_env)],
                 env=candidate_env,
             )
             if not still_walks:
                 logger.debug("shallow prune self-check failed; original retained")
+                return 0
+
+            # Refs and reflogs can move while we hold only shallow.lock. Recheck
+            # reachability immediately before publish so a newly live boundary is kept.
+            _before_publish_candidate(repo_root)
+            fresh = _reachable_grafts(repo_root, lines, query_env)
+            if fresh is None or (fresh - keep):
+                logger.debug("shallow prune aborted; reachability changed before publish")
                 return 0
 
             # Git's lock file is the candidate itself; rename publishes the trim and

--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -154,7 +154,7 @@ def _before_replace_shallow(repo_root: Path) -> None:
 
 
 def _after_publish_reachability(repo_root: Path) -> None:
-    """Test seam after the first post-replace scan; the committed write follows."""
+    """Test seam after publication, before the post-publish object-presence check."""
 
 
 # Worktree-local files that ``rev-list --all --reflog`` does not walk. Linked
@@ -256,10 +256,19 @@ def _extra_reachability_tips(repo_root: Path, query_env: dict) -> Optional[List[
         tokens.extend(tips)
     if not tokens:
         return []
+    existing: List[str] = []
+    for token in tokens:
+        exists = _object_exists(repo_root, token, query_env)
+        if exists is None:
+            return None
+        if exists:
+            existing.append(token)
+    if not existing:
+        return []
     try:
         result = subprocess.run(
             ["git", "rev-list", "--no-walk", "--stdin"],
-            input="\n".join(tokens) + "\n",
+            input="\n".join(existing) + "\n",
             cwd=str(repo_root),
             capture_output=True, text=True, encoding="utf-8", timeout=10,
             env=query_env,
@@ -300,6 +309,119 @@ def _reachable_grafts(
     return set(lines) & set(reachable)
 
 
+_KEEP_REF_PREFIX = "refs/hermes-agent/shallow-keep/"
+
+
+def _shallow_union_text(original: str, current: str) -> str:
+    """Original grafts plus any lines added after publish."""
+    original_lines = {line for line in original.splitlines() if line}
+    current_lines = {line for line in current.splitlines() if line}
+    if current_lines <= original_lines:
+        return original
+    return "\n".join(sorted(original_lines | current_lines)) + "\n"
+
+
+def _object_exists(repo_root: Path, sha: str, query_env: dict) -> Optional[bool]:
+    """Whether ``sha`` is in the object DB. ``None`` if Git cannot be asked."""
+    try:
+        result = subprocess.run(
+            ["git", "cat-file", "-e", sha],
+            cwd=str(repo_root),
+            capture_output=True, timeout=10, env=query_env,
+        )
+        return result.returncode == 0
+    except Exception:
+        logger.debug("cat-file -e failed for %s", sha, exc_info=True)
+        return None
+
+
+def _present_original_grafts(
+    repo_root: Path, lines: List[str], query_env: dict
+) -> Optional[set]:
+    """Original shallow lines whose objects still exist. ``None`` on probe failure."""
+    present: set = set()
+    for sha in lines:
+        exists = _object_exists(repo_root, sha, query_env)
+        if exists is None:
+            return None
+        if exists:
+            present.add(sha)
+    return present
+
+
+def _unpin_keep_refs(repo_root: Path, refs: List[str], query_env: dict) -> None:
+    for ref in refs:
+        try:
+            subprocess.run(
+                ["git", "update-ref", "-d", ref],
+                cwd=str(repo_root),
+                capture_output=True, timeout=10, env=query_env,
+            )
+        except Exception:
+            logger.debug("unpin %s failed", ref, exc_info=True)
+
+
+def _pin_keep_refs(
+    repo_root: Path, shas: Iterable[str], query_env: dict
+) -> Optional[List[str]]:
+    """Temporary refs so ``git gc`` cannot drop still-needed grafts."""
+    stale = _git_stdout_lines(
+        repo_root,
+        ["for-each-ref", "--format=%(refname)", _KEEP_REF_PREFIX],
+        env=query_env,
+    )
+    _unpin_keep_refs(repo_root, stale, query_env)
+    created: List[str] = []
+    for sha in shas:
+        ref = f"{_KEEP_REF_PREFIX}{sha}"
+        try:
+            result = subprocess.run(
+                ["git", "update-ref", ref, sha],
+                cwd=str(repo_root),
+                capture_output=True, timeout=10, env=query_env,
+            )
+        except Exception:
+            logger.debug("pin %s failed", sha, exc_info=True)
+            _unpin_keep_refs(repo_root, created, query_env)
+            return None
+        if result.returncode != 0:
+            _unpin_keep_refs(repo_root, created, query_env)
+            return None
+        created.append(ref)
+    return created
+
+
+def _gc_unreachable(repo_root: Path, query_env: dict) -> bool:
+    """Delete unreachable objects. ``False`` if gc cannot run."""
+    try:
+        result = subprocess.run(
+            ["git", "gc", "--prune=now", "-q"],
+            cwd=str(repo_root),
+            capture_output=True, timeout=120, env=query_env,
+        )
+        return result.returncode == 0
+    except Exception:
+        logger.debug("gc --prune=now failed for %s", repo_root, exc_info=True)
+        return False
+
+
+def _force_write_shallow(shallow_path: Path, text: str, mode: int) -> bool:
+    """Replace ``shallow`` without ``shallow.lock`` after a contended rollback."""
+    tmp_path = shallow_path.with_name(shallow_path.name + ".hermes-restore")
+    try:
+        tmp_path.write_text(text, encoding="utf-8")
+        os.chmod(tmp_path, mode)
+        os.replace(tmp_path, shallow_path)
+        return True
+    except Exception:
+        logger.debug("forced shallow write failed for %s", shallow_path, exc_info=True)
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        return False
+
+
 def _restore_shallow_union(
     shallow_path: Path, original: str, lock_path: Path, mode: int
 ) -> bool:
@@ -308,13 +430,7 @@ def _restore_shallow_union(
         current = shallow_path.read_text(encoding="utf-8")
     except OSError:
         current = ""
-    original_lines = {line for line in original.splitlines() if line}
-    current_lines = {line for line in current.splitlines() if line}
-    text = (
-        original
-        if current_lines <= original_lines
-        else "\n".join(sorted(original_lines | current_lines)) + "\n"
-    )
+    text = _shallow_union_text(original, current)
     try:
         lock_fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, mode)
     except FileExistsError:
@@ -338,6 +454,19 @@ def _restore_shallow_union(
         return False
 
 
+def _restore_shallow_complete(
+    shallow_path: Path, original: str, lock_path: Path, mode: int
+) -> bool:
+    """Restore the original union even when another writer holds ``shallow.lock``."""
+    if _restore_shallow_union(shallow_path, original, lock_path, mode):
+        return True
+    try:
+        current = shallow_path.read_text(encoding="utf-8")
+    except OSError:
+        current = ""
+    return _force_write_shallow(shallow_path, _shallow_union_text(original, current), mode)
+
+
 def prune_stale_shallow_grafts(repo_root: Path) -> int:
     """Drop ``.git/shallow`` graft lines no live ref, reflog, or recovery tip reaches (#105951).
 
@@ -347,8 +476,9 @@ def prune_stale_shallow_grafts(repo_root: Path) -> int:
     break ``merge-base`` and push ``hermes update`` into the orphan-divergence reset path
     on every run. Keep boundaries that protect commits reachable from refs, reflogs,
     any worktree ``FETCH_HEAD``, or ``ORIG_HEAD``. Dropping a graft for a still-reachable
-    commit exposes its unfetched parent and breaks git maintenance. The dropped commits are genuinely
-    unreachable and their objects are left for ``git gc``. Returns the number of graft
+    commit exposes its unfetched parent and breaks git maintenance. Dropped commits are
+    deleted with ``git gc --prune=now`` before their graft lines are removed, so a later
+    ``update-ref`` cannot revive a missing parent. Returns the number of graft
     lines removed; never raises, and validates the candidate through Git's lockfile
     before replacing the original.
     """
@@ -425,23 +555,92 @@ def prune_stale_shallow_grafts(repo_root: Path) -> int:
                 logger.debug("shallow prune aborted; reachability changed before publish")
                 return 0
 
-            # shallow.lock does not serialize update-ref, so replace is only
-            # tentative. A scan after replace cannot bless the shrink: a ref
-            # can appear after that scan. The committed write restores the
-            # original union whenever any post-replace scan sees a dropped
-            # graft, including one created after the first post scan.
             _before_replace_shallow(repo_root)
-            os.replace(lock_path, shallow_path)
-            lock_owned = False
-            post = _reachable_grafts(repo_root, lines, query_env)
-            _after_publish_reachability(repo_root)
-            late = _reachable_grafts(repo_root, lines, query_env)
-            if post is None or late is None or (late - keep) or (post - keep):
-                logger.debug("shallow prune restored; reachability changed during publish")
-                _restore_shallow_union(shallow_path, original, lock_path, mode)
+            fresh = _reachable_grafts(repo_root, lines, query_env)
+            if fresh is None or (fresh - keep):
+                logger.debug("shallow prune aborted; reachability changed before publish")
                 return 0
-            logger.info("Pruned %d stale shallow graft(s) in %s", len(lines) - len(keep), repo_root)
-            return len(lines) - len(keep)
+
+            # git gc needs shallow.lock. Drop ours first; the original file is
+            # still live. Pin keep so FETCH_HEAD / ORIG_HEAD objects survive.
+            try:
+                lock_path.unlink()
+            except OSError:
+                return 0
+            lock_owned = False
+            tips = _extra_reachability_tips(repo_root, query_env)
+            if tips is None:
+                return 0
+            pinned = _pin_keep_refs(repo_root, set(keep) | set(tips), query_env)
+            if pinned is None:
+                return 0
+            try:
+                if not _gc_unreachable(repo_root, query_env):
+                    return 0
+            finally:
+                _unpin_keep_refs(repo_root, pinned, query_env)
+
+            present = _present_original_grafts(repo_root, lines, query_env)
+            if present is None or not present or present == set(lines):
+                return 0
+
+            # ``git gc --prune=now`` often rewrites shallow itself once the
+            # dropped objects are gone. That rewrite is the publication.
+            on_disk = {
+                line
+                for line in shallow_path.read_text(encoding="utf-8").splitlines()
+                if line
+            }
+            if on_disk != present:
+                present_text = "\n".join(sorted(present)) + "\n"
+                try:
+                    lock_fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, mode)
+                except FileExistsError:
+                    if not _force_write_shallow(shallow_path, present_text, mode):
+                        return 0
+                else:
+                    lock_owned = True
+                    open_fd = lock_fd
+                    handle = os.fdopen(lock_fd, "w", encoding="utf-8")
+                    open_fd = None
+                    with handle:
+                        handle.write(present_text)
+                        handle.flush()
+                        os.fsync(handle.fileno())
+                    os.chmod(lock_path, mode)
+                    candidate_env["GIT_SHALLOW_FILE"] = str(lock_path)
+                    still_walks = _git_stdout_lines(
+                        repo_root,
+                        ["rev-list", "--count", *roots],
+                        env=candidate_env,
+                    )
+                    if not still_walks:
+                        logger.debug("shallow prune self-check failed; original retained")
+                        return 0
+                    os.replace(lock_path, shallow_path)
+                    lock_owned = False
+
+            # Dropped objects are gone, so a later update-ref cannot revive a
+            # removed boundary. A failed probe still force-restores the original
+            # union even when another writer holds shallow.lock.
+            _after_publish_reachability(repo_root)
+            present = _present_original_grafts(repo_root, lines, query_env)
+            live = _reachable_grafts(repo_root, lines, query_env)
+            published = {
+                line
+                for line in shallow_path.read_text(encoding="utf-8").splitlines()
+                if line
+            }
+            if present is None or live is None or (live - published) or (present - published):
+                logger.debug("shallow prune restored; reachability changed during publish")
+                for _ in range(3):
+                    if _restore_shallow_complete(shallow_path, original, lock_path, mode):
+                        break
+                else:
+                    logger.debug("shallow prune rollback incomplete for %s", shallow_path)
+                return 0
+            logger.info("Pruned %d stale shallow graft(s) in %s", len(lines) - len(present), repo_root)
+            return len(lines) - len(present)
         finally:
             if open_fd is not None:
                 try:

--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -144,16 +144,17 @@ def _git_stdout_lines(repo_root: Path, args: List[str]) -> List[str]:
 
 
 def prune_stale_shallow_grafts(repo_root: Path) -> int:
-    """Drop ``.git/shallow`` graft lines no live ref still points at (#105951).
+    """Drop ``.git/shallow`` graft lines no ref or reflog still reaches (#105951).
 
     Every ``git fetch --depth 1`` appends the fetched tip to ``.git/shallow`` as a new
     graft and never removes the previous one, so a long-lived shallow installer checkout
     accumulates one graft per update check (57 observed in the wild). The stale grafts
     break ``merge-base`` and push ``hermes update`` into the orphan-divergence reset path
-    on every run. Keep only the boundaries that still protect referenced tips (HEAD,
-    FETCH_HEAD, and every ref tip): the dropped commits are already unreachable and their
-    objects are left for ``git gc``. Returns the number of graft lines removed; never
-    raises, and restores the original file if the trimmed set breaks history walking.
+    on every run. Keep boundaries that protect commits reachable from refs or reflogs:
+    dropping a graft for a reflog-only commit exposes its unfetched parent and breaks git
+    maintenance. The dropped commits are genuinely unreachable and their objects are left
+    for ``git gc``. Returns the number of graft lines removed; never raises, and restores
+    the original file if the trimmed set breaks history walking.
     """
     try:
         shallow_rel = _git_stdout_lines(repo_root, ["rev-parse", "--git-path", "shallow"])
@@ -167,10 +168,15 @@ def prune_stale_shallow_grafts(repo_root: Path) -> int:
         lines = [line for line in shallow_path.read_text(encoding="utf-8").splitlines() if line]
         if not lines:
             return 0
+        reachable = _git_stdout_lines(repo_root, ["rev-list", "--all", "--reflog"])
+        if not reachable:
+            # A failed reachability probe is indistinguishable from an empty result here.
+            # This repository has shallow commits, so either way retaining them is safe.
+            return 0
         keep = set(lines) & {
             *(_git_stdout_lines(repo_root, ["rev-parse", "HEAD"]) or []),
             *(_git_stdout_lines(repo_root, ["rev-parse", "--verify", "--quiet", "FETCH_HEAD"]) or []),
-            *_git_stdout_lines(repo_root, ["for-each-ref", "--format=%(objectname)"]),
+            *reachable,
         }
         if len(keep) == len(lines):
             return 0
@@ -181,7 +187,7 @@ def prune_stale_shallow_grafts(repo_root: Path) -> int:
         # Fail-safe: if any reachable walk now crosses a boundary we wrongly removed,
         # put the grafts back — a growing file beats a broken repo.
         still_walks = _git_stdout_lines(repo_root, ["rev-list", "--count", "HEAD"]) and \
-            _git_stdout_lines(repo_root, ["rev-list", "--count", "--all"])
+            _git_stdout_lines(repo_root, ["rev-list", "--count", "--all", "--reflog"])
         if not still_walks:
             shallow_path.write_text(original, encoding="utf-8")
             logger.debug("shallow prune self-check failed; grafts restored")

--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -128,12 +128,14 @@ def is_ancestor_of_head(repo_root: Path, rev: str) -> bool:
 # ---- END PLUGIN-COMPAT ----
 
 
-def _git_stdout_lines(repo_root: Path, args: List[str]) -> List[str]:
+def _git_stdout_lines(
+    repo_root: Path, args: List[str], *, env: Optional[dict] = None
+) -> List[str]:
     """Run a read-only git query in ``repo_root``; [] on any failure."""
     try:
         result = subprocess.run(
             ["git", *args], cwd=str(repo_root),
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, text=True, timeout=10, env=env,
         )
         if result.returncode != 0:
             return []
@@ -153,11 +155,15 @@ def prune_stale_shallow_grafts(repo_root: Path) -> int:
     on every run. Keep boundaries that protect commits reachable from refs or reflogs:
     dropping a graft for a reflog-only commit exposes its unfetched parent and breaks git
     maintenance. The dropped commits are genuinely unreachable and their objects are left
-    for ``git gc``. Returns the number of graft lines removed; never raises, and restores
-    the original file if the trimmed set breaks history walking.
+    for ``git gc``. Returns the number of graft lines removed; never raises, and validates
+    the candidate through Git's lockfile before replacing the original.
     """
     try:
-        shallow_rel = _git_stdout_lines(repo_root, ["rev-parse", "--git-path", "shallow"])
+        query_env = os.environ.copy()
+        query_env.pop("GIT_SHALLOW_FILE", None)
+        shallow_rel = _git_stdout_lines(
+            repo_root, ["rev-parse", "--git-path", "shallow"], env=query_env
+        )
         if not shallow_rel:
             return 0
         shallow_path = Path(shallow_rel[0])
@@ -165,35 +171,83 @@ def prune_stale_shallow_grafts(repo_root: Path) -> int:
             shallow_path = Path(repo_root) / shallow_path
         if not shallow_path.is_file():
             return 0
-        lines = [line for line in shallow_path.read_text(encoding="utf-8").splitlines() if line]
+        original = shallow_path.read_text(encoding="utf-8")
+        lines = [line for line in original.splitlines() if line]
         if not lines:
             return 0
-        reachable = _git_stdout_lines(repo_root, ["rev-list", "--all", "--reflog"])
+        reachable = _git_stdout_lines(
+            repo_root, ["rev-list", "--all", "--reflog"], env=query_env
+        )
         if not reachable:
             # A failed reachability probe is indistinguishable from an empty result here.
             # This repository has shallow commits, so either way retaining them is safe.
             return 0
         keep = set(lines) & {
-            *(_git_stdout_lines(repo_root, ["rev-parse", "HEAD"]) or []),
-            *(_git_stdout_lines(repo_root, ["rev-parse", "--verify", "--quiet", "FETCH_HEAD"]) or []),
+            *(_git_stdout_lines(repo_root, ["rev-parse", "HEAD"], env=query_env) or []),
+            *(_git_stdout_lines(
+                repo_root,
+                ["rev-parse", "--verify", "--quiet", "FETCH_HEAD"],
+                env=query_env,
+            ) or []),
             *reachable,
         }
-        if len(keep) == len(lines):
+        if not keep or len(keep) == len(lines):
             return 0
-        original = shallow_path.read_text(encoding="utf-8")
-        tmp_path = shallow_path.with_name(shallow_path.name + ".hermes-prune")
-        tmp_path.write_text("\n".join(sorted(keep)) + "\n", encoding="utf-8")
-        os.replace(tmp_path, shallow_path)
-        # Fail-safe: if any reachable walk now crosses a boundary we wrongly removed,
-        # put the grafts back — a growing file beats a broken repo.
-        still_walks = _git_stdout_lines(repo_root, ["rev-list", "--count", "HEAD"]) and \
-            _git_stdout_lines(repo_root, ["rev-list", "--count", "--all", "--reflog"])
-        if not still_walks:
-            shallow_path.write_text(original, encoding="utf-8")
-            logger.debug("shallow prune self-check failed; grafts restored")
+
+        lock_path = shallow_path.with_name(shallow_path.name + ".lock")
+        mode = shallow_path.stat().st_mode & 0o777
+        try:
+            lock_fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, mode)
+        except FileExistsError:
+            # Git owns this lock while changing shallow boundaries. Skipping prevents
+            # our read-modify-write from discarding a boundary added by a concurrent fetch.
             return 0
-        logger.info("Pruned %d stale shallow graft(s) in %s", len(lines) - len(keep), repo_root)
-        return len(lines) - len(keep)
+        lock_owned = True
+        open_fd: Optional[int] = lock_fd
+        try:
+            # Reachability was computed without holding Git's lock. If another process
+            # updated the file before we acquired it, discard this stale proposal.
+            if shallow_path.read_text(encoding="utf-8") != original:
+                return 0
+
+            handle = os.fdopen(lock_fd, "w", encoding="utf-8")
+            open_fd = None
+            with handle:
+                handle.write("\n".join(sorted(keep)) + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(lock_path, mode)
+
+            # Validate against the candidate shallow file before publishing it. The
+            # original remains untouched if the proposed trim breaks any reachable walk.
+            candidate_env = query_env.copy()
+            candidate_env["GIT_SHALLOW_FILE"] = str(lock_path)
+            still_walks = _git_stdout_lines(
+                repo_root,
+                ["rev-list", "--count", "HEAD", "--all", "--reflog"],
+                env=candidate_env,
+            )
+            if not still_walks:
+                logger.debug("shallow prune self-check failed; original retained")
+                return 0
+
+            # Git's lock file is the candidate itself; rename publishes the trim and
+            # releases the lock atomically, matching Git's own lockfile protocol.
+            os.replace(lock_path, shallow_path)
+            lock_owned = False
+            logger.info("Pruned %d stale shallow graft(s) in %s", len(lines) - len(keep), repo_root)
+            return len(lines) - len(keep)
+        finally:
+            if open_fd is not None:
+                try:
+                    os.close(open_fd)
+                except OSError:
+                    pass
+            if lock_owned:
+                try:
+                    lock_path.unlink()
+                except OSError:
+                    logger.warning("Could not remove shallow prune lock %s", lock_path, exc_info=True)
     except Exception:
         logger.debug("shallow graft prune failed for %s", repo_root, exc_info=True)
         return 0

--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -153,29 +153,103 @@ def _before_replace_shallow(repo_root: Path) -> None:
     """Test seam after the last pre-publish scan and before ``os.replace``."""
 
 
-def _fetch_head_tips(repo_root: Path, query_env: dict) -> Optional[List[str]]:
-    """Every FETCH_HEAD entry, resolved through Git.
+# Worktree-local files that ``rev-list --all --reflog`` does not walk. Linked
+# worktrees share ``.git/shallow`` but keep their own copies under the common
+# Git directory (``.git/worktrees/<id>/``).
+_EXTRA_REACHABILITY_FILES = ("FETCH_HEAD", "ORIG_HEAD")
 
-    ``rev-parse FETCH_HEAD`` only returns the first tip and a 40-character
-    parser misses SHA-256 IDs. ``None`` means the path, file, or objects
-    could not be established, so callers fail open. ``[]`` means there is
-    no ``FETCH_HEAD`` file.
-    """
-    rel = _git_stdout_lines(
-        repo_root, ["rev-parse", "--git-path", "FETCH_HEAD"], env=query_env
-    )
+
+def _resolve_git_path(repo_root: Path, spec: str, query_env: dict) -> Optional[Path]:
+    """Absolute path for a ``rev-parse`` location. ``None`` if Git cannot name it."""
+    rel = _git_stdout_lines(repo_root, ["rev-parse", "--git-path", spec], env=query_env)
     if not rel:
         return None
-    fetch_head = Path(rel[0])
-    if not fetch_head.is_absolute():
-        fetch_head = Path(repo_root) / fetch_head
-    if not fetch_head.is_file():
-        return []
+    path = Path(rel[0])
+    if not path.is_absolute():
+        path = Path(repo_root) / path
+    return path
+
+
+def _common_git_dir(repo_root: Path, query_env: dict) -> Optional[Path]:
+    """Shared Git directory that owns ``shallow`` and every worktree git dir."""
+    rel = _git_stdout_lines(repo_root, ["rev-parse", "--git-common-dir"], env=query_env)
+    if not rel:
+        return None
+    path = Path(rel[0])
+    if not path.is_absolute():
+        path = Path(repo_root) / path
     try:
-        raw = fetch_head.read_text(encoding="utf-8")
+        path = path.resolve()
     except OSError:
         return None
-    tokens = [line.split()[0] for line in raw.splitlines() if line.split()]
+    return path if path.is_dir() else None
+
+
+def _worktree_git_dirs(common_dir: Path) -> Optional[List[Path]]:
+    """The common dir plus each linked worktree's git dir. ``None`` on list failure."""
+    dirs = [common_dir]
+    worktrees = common_dir / "worktrees"
+    if not worktrees.exists():
+        return dirs
+    if not worktrees.is_dir():
+        return None
+    try:
+        extras = sorted(path for path in worktrees.iterdir() if path.is_dir())
+    except OSError:
+        return None
+    dirs.extend(extras)
+    return dirs
+
+
+def _tip_tokens_from_file(path: Path) -> Optional[List[str]]:
+    """Object tokens from a Git tip file. ``None`` if the file exists but is unreadable."""
+    if not path.is_file():
+        return []
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    return [line.split()[0] for line in raw.splitlines() if line.split()]
+
+
+def _extra_reachability_tips(repo_root: Path, query_env: dict) -> Optional[List[str]]:
+    """Every FETCH_HEAD and ORIG_HEAD tip across this repo's worktrees.
+
+    ``rev-parse FETCH_HEAD`` / ``ORIG_HEAD`` only see the current worktree, and
+    ``rev-list --all --reflog`` skips both. ``None`` means a path or object
+    could not be established, so callers fail open. ``[]`` means none exist.
+    """
+    current_fetch = _resolve_git_path(repo_root, "FETCH_HEAD", query_env)
+    if current_fetch is None:
+        return None
+    common_dir = _common_git_dir(repo_root, query_env)
+    if common_dir is None:
+        return None
+    git_dirs = _worktree_git_dirs(common_dir)
+    if git_dirs is None:
+        return None
+
+    paths = [current_fetch]
+    current_orig = _resolve_git_path(repo_root, "ORIG_HEAD", query_env)
+    if current_orig is not None:
+        paths.append(current_orig)
+    for git_dir in git_dirs:
+        paths.extend(git_dir / name for name in _EXTRA_REACHABILITY_FILES)
+
+    tokens: List[str] = []
+    seen: set[str] = set()
+    for path in paths:
+        try:
+            key = str(path.resolve())
+        except OSError:
+            return None
+        if key in seen:
+            continue
+        seen.add(key)
+        tips = _tip_tokens_from_file(path)
+        if tips is None:
+            return None
+        tokens.extend(tips)
     if not tokens:
         return []
     try:
@@ -187,7 +261,7 @@ def _fetch_head_tips(repo_root: Path, query_env: dict) -> Optional[List[str]]:
             env=query_env,
         )
     except Exception:
-        logger.debug("FETCH_HEAD resolve failed for %s", repo_root, exc_info=True)
+        logger.debug("extra reachability resolve failed for %s", repo_root, exc_info=True)
         return None
     if result.returncode != 0:
         return None
@@ -195,8 +269,8 @@ def _fetch_head_tips(repo_root: Path, query_env: dict) -> Optional[List[str]]:
 
 
 def _rev_list_roots(repo_root: Path, query_env: dict) -> Optional[List[str]]:
-    """Traversal roots Git maintenance walks, plus every FETCH_HEAD tip."""
-    tips = _fetch_head_tips(repo_root, query_env)
+    """Traversal roots: refs, reflogs, every worktree FETCH_HEAD, and ORIG_HEAD."""
+    tips = _extra_reachability_tips(repo_root, query_env)
     if tips is None:
         return None
     return ["--all", "--reflog", *tips]
@@ -261,15 +335,15 @@ def _restore_shallow_union(
 
 
 def prune_stale_shallow_grafts(repo_root: Path) -> int:
-    """Drop ``.git/shallow`` graft lines no ref or reflog still reaches (#105951).
+    """Drop ``.git/shallow`` graft lines no live ref, reflog, or recovery tip reaches (#105951).
 
     Every ``git fetch --depth 1`` appends the fetched tip to ``.git/shallow`` as a new
     graft and never removes the previous one, so a long-lived shallow installer checkout
     accumulates one graft per update check (57 observed in the wild). The stale grafts
     break ``merge-base`` and push ``hermes update`` into the orphan-divergence reset path
-    on every run. Keep boundaries that protect commits reachable from refs, reflogs, or
-    any ``FETCH_HEAD`` entry: dropping a graft for a still-reachable commit exposes its
-    unfetched parent and breaks git maintenance. The dropped commits are genuinely
+    on every run. Keep boundaries that protect commits reachable from refs, reflogs,
+    any worktree ``FETCH_HEAD``, or ``ORIG_HEAD``. Dropping a graft for a still-reachable
+    commit exposes its unfetched parent and breaks git maintenance. The dropped commits are genuinely
     unreachable and their objects are left for ``git gc``. Returns the number of graft
     lines removed; never raises, and validates the candidate through Git's lockfile
     before replacing the original.

--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -153,6 +153,10 @@ def _before_replace_shallow(repo_root: Path) -> None:
     """Test seam after the last pre-publish scan and before ``os.replace``."""
 
 
+def _after_publish_reachability(repo_root: Path) -> None:
+    """Test seam after the first post-replace scan; the committed write follows."""
+
+
 # Worktree-local files that ``rev-list --all --reflog`` does not walk. Linked
 # worktrees share ``.git/shallow`` but keep their own copies under the common
 # Git directory (``.git/worktrees/<id>/``).
@@ -421,13 +425,18 @@ def prune_stale_shallow_grafts(repo_root: Path) -> int:
                 logger.debug("shallow prune aborted; reachability changed before publish")
                 return 0
 
-            # shallow.lock does not serialize update-ref. The remaining window is
-            # after this last scan; publish then restore if a dropped graft is live.
+            # shallow.lock does not serialize update-ref, so replace is only
+            # tentative. A scan after replace cannot bless the shrink: a ref
+            # can appear after that scan. The committed write restores the
+            # original union whenever any post-replace scan sees a dropped
+            # graft, including one created after the first post scan.
             _before_replace_shallow(repo_root)
             os.replace(lock_path, shallow_path)
             lock_owned = False
             post = _reachable_grafts(repo_root, lines, query_env)
-            if post is None or (post - keep):
+            _after_publish_reachability(repo_root)
+            late = _reachable_grafts(repo_root, lines, query_env)
+            if post is None or late is None or (late - keep) or (post - keep):
                 logger.debug("shallow prune restored; reachability changed during publish")
                 _restore_shallow_union(shallow_path, original, lock_path, mode)
                 return 0

--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -149,32 +149,57 @@ def _before_publish_candidate(repo_root: Path) -> None:
     """Test seam after candidate validation and before the publish guard."""
 
 
-def _fetch_head_tips(repo_root: Path, query_env: dict) -> List[str]:
-    """Every FETCH_HEAD entry. ``rev-parse FETCH_HEAD`` only returns the first."""
+def _before_replace_shallow(repo_root: Path) -> None:
+    """Test seam after the last pre-publish scan and before ``os.replace``."""
+
+
+def _fetch_head_tips(repo_root: Path, query_env: dict) -> Optional[List[str]]:
+    """Every FETCH_HEAD entry, resolved through Git.
+
+    ``rev-parse FETCH_HEAD`` only returns the first tip and a 40-character
+    parser misses SHA-256 IDs. ``None`` means the path, file, or objects
+    could not be established, so callers fail open. ``[]`` means there is
+    no ``FETCH_HEAD`` file.
+    """
     rel = _git_stdout_lines(
         repo_root, ["rev-parse", "--git-path", "FETCH_HEAD"], env=query_env
     )
     if not rel:
-        return []
+        return None
     fetch_head = Path(rel[0])
     if not fetch_head.is_absolute():
         fetch_head = Path(repo_root) / fetch_head
     if not fetch_head.is_file():
         return []
-    tips: List[str] = []
     try:
-        for line in fetch_head.read_text(encoding="utf-8").splitlines():
-            sha = line.split()[0] if line.split() else ""
-            if len(sha) == 40 and all(ch in "0123456789abcdefABCDEF" for ch in sha):
-                tips.append(sha)
+        raw = fetch_head.read_text(encoding="utf-8")
     except OSError:
+        return None
+    tokens = [line.split()[0] for line in raw.splitlines() if line.split()]
+    if not tokens:
         return []
-    return tips
+    try:
+        result = subprocess.run(
+            ["git", "rev-list", "--no-walk", "--stdin"],
+            input="\n".join(tokens) + "\n",
+            cwd=str(repo_root),
+            capture_output=True, text=True, encoding="utf-8", timeout=10,
+            env=query_env,
+        )
+    except Exception:
+        logger.debug("FETCH_HEAD resolve failed for %s", repo_root, exc_info=True)
+        return None
+    if result.returncode != 0:
+        return None
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
-def _rev_list_roots(repo_root: Path, query_env: dict) -> List[str]:
+def _rev_list_roots(repo_root: Path, query_env: dict) -> Optional[List[str]]:
     """Traversal roots Git maintenance walks, plus every FETCH_HEAD tip."""
-    return ["--all", "--reflog", *_fetch_head_tips(repo_root, query_env)]
+    tips = _fetch_head_tips(repo_root, query_env)
+    if tips is None:
+        return None
+    return ["--all", "--reflog", *tips]
 
 
 def _reachable_grafts(
@@ -184,14 +209,55 @@ def _reachable_grafts(
     *,
     env: Optional[dict] = None,
 ) -> Optional[set]:
+    roots = _rev_list_roots(repo_root, query_env)
+    if roots is None:
+        return None
     reachable = _git_stdout_lines(
         repo_root,
-        ["rev-list", *_rev_list_roots(repo_root, query_env)],
+        ["rev-list", *roots],
         env=env or query_env,
     )
     if not reachable:
         return None
     return set(lines) & set(reachable)
+
+
+def _restore_shallow_union(
+    shallow_path: Path, original: str, lock_path: Path, mode: int
+) -> bool:
+    """Restore every original graft, keeping any lines added after publish."""
+    try:
+        current = shallow_path.read_text(encoding="utf-8")
+    except OSError:
+        current = ""
+    original_lines = {line for line in original.splitlines() if line}
+    current_lines = {line for line in current.splitlines() if line}
+    text = (
+        original
+        if current_lines <= original_lines
+        else "\n".join(sorted(original_lines | current_lines)) + "\n"
+    )
+    try:
+        lock_fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, mode)
+    except FileExistsError:
+        logger.debug("shallow restore skipped; git holds %s", lock_path)
+        return False
+    try:
+        handle = os.fdopen(lock_fd, "w", encoding="utf-8")
+        with handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(lock_path, mode)
+        os.replace(lock_path, shallow_path)
+        return True
+    except Exception:
+        logger.debug("shallow restore failed for %s", shallow_path, exc_info=True)
+        try:
+            lock_path.unlink()
+        except OSError:
+            pass
+        return False
 
 
 def prune_stale_shallow_grafts(repo_root: Path) -> int:
@@ -261,9 +327,12 @@ def prune_stale_shallow_grafts(repo_root: Path) -> int:
             # original remains untouched if the proposed trim breaks any reachable walk.
             candidate_env = query_env.copy()
             candidate_env["GIT_SHALLOW_FILE"] = str(lock_path)
+            roots = _rev_list_roots(repo_root, query_env)
+            if roots is None:
+                return 0
             still_walks = _git_stdout_lines(
                 repo_root,
-                ["rev-list", "--count", *_rev_list_roots(repo_root, query_env)],
+                ["rev-list", "--count", *roots],
                 env=candidate_env,
             )
             if not still_walks:
@@ -278,10 +347,16 @@ def prune_stale_shallow_grafts(repo_root: Path) -> int:
                 logger.debug("shallow prune aborted; reachability changed before publish")
                 return 0
 
-            # Git's lock file is the candidate itself; rename publishes the trim and
-            # releases the lock atomically, matching Git's own lockfile protocol.
+            # shallow.lock does not serialize update-ref. The remaining window is
+            # after this last scan; publish then restore if a dropped graft is live.
+            _before_replace_shallow(repo_root)
             os.replace(lock_path, shallow_path)
             lock_owned = False
+            post = _reachable_grafts(repo_root, lines, query_env)
+            if post is None or (post - keep):
+                logger.debug("shallow prune restored; reachability changed during publish")
+                _restore_shallow_union(shallow_path, original, lock_path, mode)
+                return 0
             logger.info("Pruned %d stale shallow graft(s) in %s", len(lines) - len(keep), repo_root)
             return len(lines) - len(keep)
         finally:

--- a/tests/hermes_cli/test_shallow_graft_prune.py
+++ b/tests/hermes_cli/test_shallow_graft_prune.py
@@ -417,3 +417,97 @@ def test_prune_aborts_when_ref_becomes_live_before_publish(tmp_path, monkeypatch
     assert orphan in _shallow_lines(clone)
     assert _run_git(clone, "rev-list", "--all", "--reflog").returncode == 0
     assert not (clone / ".git" / "shallow.lock").exists()
+
+
+def test_prune_aborts_when_ref_becomes_live_after_final_scan(tmp_path, monkeypatch):
+    """A ref created after the last reachability scan must not stay published."""
+    clone = _mk_shallow_scenario(tmp_path)
+    head_sha = _git(clone, "rev-parse", "HEAD")
+    tip_sha = _git(clone, "rev-parse", "origin/main")
+    _git(clone, "reflog", "expire", "--expire=now", "refs/remotes/origin/main")
+    orphan = next(sha for sha in _shallow_lines(clone) if sha not in {head_sha, tip_sha})
+
+    def revive_after_scan(_repo: Path) -> None:
+        _git(clone, "update-ref", "refs/heads/race", orphan)
+
+    monkeypatch.setattr(gitlock_module, "_before_replace_shallow", revive_after_scan)
+    before = (clone / ".git" / "shallow").read_bytes()
+
+    assert prune_stale_shallow_grafts(clone) == 0
+    assert orphan in _shallow_lines(clone)
+    assert (clone / ".git" / "shallow").read_bytes() == before
+    assert _run_git(clone, "rev-list", "--all", "--reflog").returncode == 0
+    assert _run_git(clone, "fsck", "--connectivity-only").returncode == 0
+    assert not (clone / ".git" / "shallow.lock").exists()
+
+
+def test_prune_keeps_sha256_fetch_head_ancestor_boundary(tmp_path):
+    """FETCH_HEAD tips must be resolved through Git so SHA-256 IDs are kept."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main", "--object-format=sha256")
+    _git(origin, "config", "user.email", "t@example.com")
+    _git(origin, "config", "user.name", "t")
+    _git(origin, "commit", "--allow-empty", "-q", "-m", "c0")
+
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(clone)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for message in ("c1", "c2", "c3"):
+        _git(origin, "commit", "--allow-empty", "-q", "-m", message)
+    tip = _git(origin, "rev-parse", "HEAD")
+    ancestor = _git(origin, "rev-parse", "HEAD^")
+    assert len(tip) == 64
+    assert len(ancestor) == 64
+    _git(clone, "fetch", "-q", "--depth", "2", "origin", tip)
+
+    assert ancestor in _shallow_lines(clone)
+    assert ancestor not in _git(clone, "rev-list", "--all", "--reflog").splitlines()
+    assert _git(clone, "rev-parse", "FETCH_HEAD") == tip
+
+    assert prune_stale_shallow_grafts(clone) == 0
+    assert ancestor in _shallow_lines(clone)
+    assert _run_git(clone, "rev-list", "FETCH_HEAD").returncode == 0
+
+
+def test_prune_fails_open_when_fetch_head_is_unreadable(tmp_path, monkeypatch):
+    """An unreadable FETCH_HEAD must retain the original shallow file."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    _git(origin, "config", "user.email", "t@example.com")
+    _git(origin, "config", "user.name", "t")
+    _git(origin, "commit", "--allow-empty", "-q", "-m", "c0")
+
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(clone)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for message in ("c1", "c2", "c3"):
+        _git(origin, "commit", "--allow-empty", "-q", "-m", message)
+    tip = _git(origin, "rev-parse", "HEAD")
+    ancestor = _git(origin, "rev-parse", "HEAD^")
+    _git(clone, "fetch", "-q", "--depth", "2", "origin", tip)
+    assert ancestor in _shallow_lines(clone)
+
+    real_read = Path.read_text
+
+    def fail_fetch_head(self, *args, **kwargs):
+        if self.name == "FETCH_HEAD":
+            raise OSError("injected FETCH_HEAD read error")
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_fetch_head)
+    before = (clone / ".git" / "shallow").read_bytes()
+
+    assert prune_stale_shallow_grafts(clone) == 0
+    assert (clone / ".git" / "shallow").read_bytes() == before
+    assert ancestor in _shallow_lines(clone)
+    assert not (clone / ".git" / "shallow.lock").exists()

--- a/tests/hermes_cli/test_shallow_graft_prune.py
+++ b/tests/hermes_cli/test_shallow_graft_prune.py
@@ -441,26 +441,63 @@ def test_prune_aborts_when_ref_becomes_live_after_final_scan(tmp_path, monkeypat
     assert not (clone / ".git" / "shallow.lock").exists()
 
 
-def test_prune_restores_when_ref_becomes_live_after_publish_scan(tmp_path, monkeypatch):
-    """A ref created after the post-publish scan must not keep a dropped graft."""
+def test_prune_stays_healthy_when_ref_update_follows_publish(tmp_path, monkeypatch):
+    """A ref created after the last publish scan cannot leave a removed boundary live."""
     clone = _mk_shallow_scenario(tmp_path)
     head_sha = _git(clone, "rev-parse", "HEAD")
     tip_sha = _git(clone, "rev-parse", "origin/main")
     _git(clone, "reflog", "expire", "--expire=now", "refs/remotes/origin/main")
     orphan = next(sha for sha in _shallow_lines(clone) if sha not in {head_sha, tip_sha})
+    created = {"ok": False}
 
-    def revive_after_publish_scan(_repo: Path) -> None:
-        _git(clone, "update-ref", "refs/heads/race", orphan)
+    def revive_after_final_scan(_repo: Path) -> None:
+        created["ok"] = _run_git(clone, "update-ref", "refs/heads/race", orphan).returncode == 0
 
-    monkeypatch.setattr(gitlock_module, "_after_publish_reachability", revive_after_publish_scan)
+    monkeypatch.setattr(gitlock_module, "_after_publish_reachability", revive_after_final_scan)
+    removed = prune_stale_shallow_grafts(clone)
+
+    assert _run_git(clone, "rev-list", "--all", "--reflog").returncode == 0
+    assert _run_git(clone, "fsck", "--connectivity-only").returncode == 0
+    if created["ok"]:
+        assert orphan in _shallow_lines(clone)
+        assert removed == 0
+    else:
+        assert orphan not in _shallow_lines(clone)
+        assert removed == 1
+        assert _run_git(clone, "update-ref", "refs/heads/race", orphan).returncode != 0
+    assert not (clone / ".git" / "shallow.lock").exists()
+
+
+def test_prune_force_restores_when_rollback_lock_is_held(tmp_path, monkeypatch):
+    """A failed lock-based restore must still put the original grafts back."""
+    clone = _mk_shallow_scenario(tmp_path)
+    head_sha = _git(clone, "rev-parse", "HEAD")
+    tip_sha = _git(clone, "rev-parse", "origin/main")
+    _git(clone, "reflog", "expire", "--expire=now", "refs/remotes/origin/main")
+    orphan = next(sha for sha in _shallow_lines(clone) if sha not in {head_sha, tip_sha})
     before = (clone / ".git" / "shallow").read_bytes()
+    real_present = gitlock_module._present_original_grafts
+    published = {"done": False}
+
+    def revive_and_hold_lock(_repo: Path) -> None:
+        published["done"] = True
+        _run_git(clone, "update-ref", "refs/heads/race", orphan)
+        (clone / ".git" / "shallow.lock").write_text("", encoding="utf-8")
+
+    def hide_objects_after_publish(repo, lines, query_env):
+        if published["done"]:
+            return None
+        return real_present(repo, lines, query_env)
+
+    monkeypatch.setattr(gitlock_module, "_after_publish_reachability", revive_and_hold_lock)
+    monkeypatch.setattr(gitlock_module, "_present_original_grafts", hide_objects_after_publish)
 
     assert prune_stale_shallow_grafts(clone) == 0
     assert orphan in _shallow_lines(clone)
+    assert set(_shallow_lines(clone)) >= {head_sha, tip_sha, orphan}
     assert (clone / ".git" / "shallow").read_bytes() == before
     assert _run_git(clone, "rev-list", "--all", "--reflog").returncode == 0
     assert _run_git(clone, "fsck", "--connectivity-only").returncode == 0
-    assert not (clone / ".git" / "shallow.lock").exists()
 
 
 def test_prune_keeps_sha256_fetch_head_ancestor_boundary(tmp_path):

--- a/tests/hermes_cli/test_shallow_graft_prune.py
+++ b/tests/hermes_cli/test_shallow_graft_prune.py
@@ -17,10 +17,24 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
+from hermes_cli import gitlock as gitlock_module
 from hermes_cli.gitlock import prune_stale_shallow_grafts
 
 SHA_A = "a" * 40
 SHA_B = "b" * 40
+
+
+@pytest.fixture(autouse=True)
+def _isolate_git_config(tmp_path, monkeypatch):
+    config = tmp_path / "empty-gitconfig"
+    config.write_text("", encoding="utf-8")
+    template = tmp_path / "empty-git-template"
+    template.mkdir()
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(config))
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(config))
+    monkeypatch.setenv("GIT_TEMPLATE_DIR", str(template))
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -39,6 +53,20 @@ def _shallow_lines(repo: Path) -> list:
     return [
         line for line in (repo / ".git" / "shallow").read_text().splitlines() if line
     ]
+
+
+def _assert_repo_healthy(repo: Path) -> None:
+    results = {
+        "walk": _run_git(repo, "rev-list", "--count", "--all", "--reflog"),
+        "fsck": _run_git(repo, "fsck", "--connectivity-only"),
+        "gc": _run_git(repo, "gc", "-q"),
+    }
+    failures = "\n".join(
+        f"{name}: rc={result.returncode}\n{result.stdout}{result.stderr}"
+        for name, result in results.items()
+        if result.returncode != 0
+    )
+    assert not failures, failures
 
 
 def _mk_shallow_scenario(tmp_path: Path) -> Path:
@@ -75,6 +103,7 @@ def test_prunes_orphaned_grafts_keeps_referenced_boundaries(tmp_path):
 
     assert removed == 1  # the middle, now-unreferenced tip
     assert set(_shallow_lines(clone)) == {head_sha, tip_sha}
+    assert not (clone / ".git" / "shallow.lock").exists()
     # Boundaries that survive must still walk cleanly.
     assert _git(clone, "rev-list", "--count", "HEAD") == "1"
     assert _git(clone, "rev-list", "--count", "origin/main") == "1"
@@ -133,7 +162,7 @@ def test_update_check_prunes_and_reports_count(tmp_path, monkeypatch, capsys):
     assert "pruned 2 stale shallow graft(s)" in out
 
 
-def test_prune_preserves_grafts_reachable_only_from_reflogs(tmp_path):
+def test_prune_preserves_grafts_reachable_only_from_reflogs(tmp_path, monkeypatch):
     """A reflog-only depth-1 tip must remain a valid shallow boundary."""
     origin = tmp_path / "origin"
     origin.mkdir()
@@ -179,7 +208,76 @@ def test_prune_preserves_grafts_reachable_only_from_reflogs(tmp_path):
     assert removed == 0
     assert reflog_only_sha in _shallow_lines(clone)
 
+    # Even if keep-set computation misses the live boundary, validation against
+    # the candidate lock file must reject it without touching the original.
+    real_query = gitlock_module._git_stdout_lines
+    injected = []
+
+    def omit_reflog_boundary(repo, args, **kwargs):
+        lines = real_query(repo, args, **kwargs)
+        if args == ["rev-list", "--all", "--reflog"]:
+            injected.append(True)
+            return [line for line in lines if line != reflog_only_sha]
+        return lines
+
+    with monkeypatch.context() as patch:
+        patch.setattr(gitlock_module, "_git_stdout_lines", omit_reflog_boundary)
+        before = (clone / ".git" / "shallow").read_bytes()
+        assert prune_stale_shallow_grafts(clone) == 0
+        assert (clone / ".git" / "shallow").read_bytes() == before
+        assert not (clone / ".git" / "shallow.lock").exists()
+    assert injected
+
     # Once the reflog no longer reaches c2, its graft is genuinely stale.
     _git(clone, "reflog", "expire", "--expire=now", "refs/remotes/origin/main")
     assert prune_stale_shallow_grafts(clone) == 1
     assert reflog_only_sha not in _shallow_lines(clone)
+    _assert_repo_healthy(clone)
+
+
+def test_prune_fails_open_when_reflog_walk_is_already_broken(tmp_path):
+    """An earlier bad prune must not trigger another destructive rewrite."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    _git(origin, "config", "user.email", "t@example.com")
+    _git(origin, "config", "user.name", "t")
+    _git(origin, "commit", "--allow-empty", "-q", "-m", "c0")
+    _git(origin, "commit", "--allow-empty", "-q", "-m", "c1")
+
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(clone)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    broken_tip = _git(clone, "rev-parse", "HEAD")
+    _git(origin, "commit", "--allow-empty", "-q", "-m", "c2")
+    _git(clone, "fetch", "-q", "--depth", "1", "origin", "main")
+    _git(clone, "reset", "-q", "--hard", "origin/main")
+
+    shallow_path = clone / ".git" / "shallow"
+    shallow_path.write_text(
+        "\n".join(line for line in _shallow_lines(clone) if line != broken_tip) + "\n"
+    )
+    assert _run_git(clone, "rev-list", "--all", "--reflog").returncode != 0
+    before = shallow_path.read_bytes()
+
+    assert prune_stale_shallow_grafts(clone) == 0
+    assert shallow_path.read_bytes() == before
+    assert not (clone / ".git" / "shallow.lock").exists()
+
+
+def test_prune_skips_while_git_holds_shallow_lock(tmp_path):
+    """Never race a git process that is updating shallow boundaries."""
+    clone = _mk_shallow_scenario(tmp_path)
+    _git(clone, "reflog", "expire", "--expire=now", "refs/remotes/origin/main")
+    shallow_path = clone / ".git" / "shallow"
+    lock_path = clone / ".git" / "shallow.lock"
+    before = shallow_path.read_bytes()
+    lock_path.write_text("")
+
+    assert prune_stale_shallow_grafts(clone) == 0
+    assert shallow_path.read_bytes() == before
+    assert lock_path.exists()

--- a/tests/hermes_cli/test_shallow_graft_prune.py
+++ b/tests/hermes_cli/test_shallow_graft_prune.py
@@ -51,7 +51,7 @@ def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
 
 def _shallow_lines(repo: Path) -> list:
     return [
-        line for line in (repo / ".git" / "shallow").read_text().splitlines() if line
+        line for line in (repo / ".git" / "shallow").read_text(encoding="utf-8").splitlines() if line
     ]
 
 
@@ -215,7 +215,7 @@ def test_prune_preserves_grafts_reachable_only_from_reflogs(tmp_path, monkeypatc
 
     def omit_reflog_boundary(repo, args, **kwargs):
         lines = real_query(repo, args, **kwargs)
-        if args == ["rev-list", "--all", "--reflog"]:
+        if args[:3] == ["rev-list", "--all", "--reflog"]:
             injected.append(True)
             return [line for line in lines if line != reflog_only_sha]
         return lines
@@ -295,7 +295,8 @@ def test_prune_fails_open_when_reflog_walk_is_already_broken(tmp_path):
 
     shallow_path = clone / ".git" / "shallow"
     shallow_path.write_text(
-        "\n".join(line for line in _shallow_lines(clone) if line != broken_tip) + "\n"
+        "\n".join(line for line in _shallow_lines(clone) if line != broken_tip) + "\n",
+        encoding="utf-8",
     )
     assert _run_git(clone, "rev-list", "--all", "--reflog").returncode != 0
     before = shallow_path.read_bytes()
@@ -312,8 +313,107 @@ def test_prune_skips_while_git_holds_shallow_lock(tmp_path):
     shallow_path = clone / ".git" / "shallow"
     lock_path = clone / ".git" / "shallow.lock"
     before = shallow_path.read_bytes()
-    lock_path.write_text("")
+    lock_path.write_text("", encoding="utf-8")
 
     assert prune_stale_shallow_grafts(clone) == 0
     assert shallow_path.read_bytes() == before
     assert lock_path.exists()
+
+
+def _fetch_head_shas(repo: Path) -> list[str]:
+    return [
+        line.split()[0]
+        for line in (repo / ".git" / "FETCH_HEAD").read_text(encoding="utf-8").splitlines()
+        if line.split()
+    ]
+
+
+def test_prune_keeps_fetch_head_ancestor_boundary(tmp_path):
+    """FETCH_HEAD is not in --all/--reflog; its ancestor graft must still survive."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    _git(origin, "config", "user.email", "t@example.com")
+    _git(origin, "config", "user.name", "t")
+    _git(origin, "commit", "--allow-empty", "-q", "-m", "c0")
+
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(clone)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for message in ("c1", "c2", "c3"):
+        _git(origin, "commit", "--allow-empty", "-q", "-m", message)
+    tip = _git(origin, "rev-parse", "HEAD")
+    ancestor = _git(origin, "rev-parse", "HEAD^")
+    _git(clone, "fetch", "-q", "--depth", "2", "origin", tip)
+
+    assert ancestor in _shallow_lines(clone)
+    assert ancestor not in _git(clone, "rev-list", "--all", "--reflog").splitlines()
+    assert _git(clone, "rev-parse", "FETCH_HEAD") == tip
+
+    assert prune_stale_shallow_grafts(clone) == 0
+    assert ancestor in _shallow_lines(clone)
+    assert _run_git(clone, "rev-list", "FETCH_HEAD").returncode == 0
+
+
+def test_prune_keeps_every_fetch_head_entry(tmp_path):
+    """A multi-ref fetch must keep every FETCH_HEAD tip, not only the first."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    _git(origin, "config", "user.email", "t@example.com")
+    _git(origin, "config", "user.name", "t")
+    _git(origin, "commit", "--allow-empty", "-q", "-m", "m0")
+
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(clone)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    _git(origin, "commit", "--allow-empty", "-q", "-m", "m1")
+    main_tip = _git(origin, "rev-parse", "HEAD")
+    _git(origin, "checkout", "-q", "-b", "topic")
+    _git(origin, "commit", "--allow-empty", "-q", "-m", "t1")
+    topic_tip = _git(origin, "rev-parse", "HEAD")
+    _git(clone, "fetch", "-q", "--depth", "1", "origin", "main", "topic")
+    _git(clone, "update-ref", "-d", "refs/remotes/origin/main")
+    _git(clone, "update-ref", "-d", "refs/remotes/origin/topic")
+    _git(clone, "reflog", "expire", "--expire=now", "--all")
+
+    fetch_heads = _fetch_head_shas(clone)
+    assert main_tip in fetch_heads
+    assert topic_tip in fetch_heads
+    assert main_tip in _shallow_lines(clone)
+    assert topic_tip in _shallow_lines(clone)
+
+    assert prune_stale_shallow_grafts(clone) == 0
+    assert main_tip in _shallow_lines(clone)
+    assert topic_tip in _shallow_lines(clone)
+    assert _run_git(clone, "rev-list", main_tip).returncode == 0
+    assert _run_git(clone, "rev-list", topic_tip).returncode == 0
+
+
+def test_prune_aborts_when_ref_becomes_live_before_publish(tmp_path, monkeypatch):
+    """A ref created after validation must stop publication of its boundary."""
+    clone = _mk_shallow_scenario(tmp_path)
+    head_sha = _git(clone, "rev-parse", "HEAD")
+    tip_sha = _git(clone, "rev-parse", "origin/main")
+    _git(clone, "reflog", "expire", "--expire=now", "refs/remotes/origin/main")
+    orphan = next(sha for sha in _shallow_lines(clone) if sha not in {head_sha, tip_sha})
+
+    def revive_orphan(_repo: Path) -> None:
+        _git(clone, "update-ref", "refs/heads/race", orphan)
+
+    monkeypatch.setattr(gitlock_module, "_before_publish_candidate", revive_orphan)
+    before = (clone / ".git" / "shallow").read_bytes()
+
+    assert prune_stale_shallow_grafts(clone) == 0
+    assert (clone / ".git" / "shallow").read_bytes() == before
+    assert orphan in _shallow_lines(clone)
+    assert _run_git(clone, "rev-list", "--all", "--reflog").returncode == 0
+    assert not (clone / ".git" / "shallow.lock").exists()

--- a/tests/hermes_cli/test_shallow_graft_prune.py
+++ b/tests/hermes_cli/test_shallow_graft_prune.py
@@ -420,7 +420,7 @@ def test_prune_aborts_when_ref_becomes_live_before_publish(tmp_path, monkeypatch
 
 
 def test_prune_aborts_when_ref_becomes_live_after_final_scan(tmp_path, monkeypatch):
-    """A ref created after the last reachability scan must not stay published."""
+    """A ref created after the last pre-publish scan must not stay published."""
     clone = _mk_shallow_scenario(tmp_path)
     head_sha = _git(clone, "rev-parse", "HEAD")
     tip_sha = _git(clone, "rev-parse", "origin/main")
@@ -431,6 +431,28 @@ def test_prune_aborts_when_ref_becomes_live_after_final_scan(tmp_path, monkeypat
         _git(clone, "update-ref", "refs/heads/race", orphan)
 
     monkeypatch.setattr(gitlock_module, "_before_replace_shallow", revive_after_scan)
+    before = (clone / ".git" / "shallow").read_bytes()
+
+    assert prune_stale_shallow_grafts(clone) == 0
+    assert orphan in _shallow_lines(clone)
+    assert (clone / ".git" / "shallow").read_bytes() == before
+    assert _run_git(clone, "rev-list", "--all", "--reflog").returncode == 0
+    assert _run_git(clone, "fsck", "--connectivity-only").returncode == 0
+    assert not (clone / ".git" / "shallow.lock").exists()
+
+
+def test_prune_restores_when_ref_becomes_live_after_publish_scan(tmp_path, monkeypatch):
+    """A ref created after the post-publish scan must not keep a dropped graft."""
+    clone = _mk_shallow_scenario(tmp_path)
+    head_sha = _git(clone, "rev-parse", "HEAD")
+    tip_sha = _git(clone, "rev-parse", "origin/main")
+    _git(clone, "reflog", "expire", "--expire=now", "refs/remotes/origin/main")
+    orphan = next(sha for sha in _shallow_lines(clone) if sha not in {head_sha, tip_sha})
+
+    def revive_after_publish_scan(_repo: Path) -> None:
+        _git(clone, "update-ref", "refs/heads/race", orphan)
+
+    monkeypatch.setattr(gitlock_module, "_after_publish_reachability", revive_after_publish_scan)
     before = (clone / ".git" / "shallow").read_bytes()
 
     assert prune_stale_shallow_grafts(clone) == 0

--- a/tests/hermes_cli/test_shallow_graft_prune.py
+++ b/tests/hermes_cli/test_shallow_graft_prune.py
@@ -5,9 +5,9 @@ new graft and never removes the previous one, so a long-lived shallow installer
 checkout accumulates one line per update check (57 observed in the wild). The
 stale grafts break ``merge-base`` and push ``hermes update`` into the
 orphan-divergence reset path. ``prune_stale_shallow_grafts()`` drops grafts no
-live ref points at; ``hermes update --check`` calls it after its successful
-depth-1 fetch, clearing the grafts accumulated by past checks (the passive
-banner check no longer git-fetches since #107648).
+ref or reflog reaches; ``hermes update --check`` calls it after its successful
+depth-1 fetch, clearing the grafts accumulated by past checks once their reflogs
+expire (the passive banner check no longer git-fetches since #107648).
 """
 
 from __future__ import annotations
@@ -24,11 +24,15 @@ SHA_B = "b" * 40
 
 
 def _git(repo: Path, *args: str) -> str:
-    result = subprocess.run(
-        ["git", *args], cwd=str(repo), capture_output=True, text=True
-    )
+    result = _run_git(repo, *args)
     assert result.returncode == 0, result.stderr
     return result.stdout.strip()
+
+
+def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args], cwd=str(repo), capture_output=True, text=True
+    )
 
 
 def _shallow_lines(repo: Path) -> list:
@@ -65,6 +69,7 @@ def test_prunes_orphaned_grafts_keeps_referenced_boundaries(tmp_path):
 
     head_sha = _git(clone, "rev-parse", "HEAD")
     tip_sha = _git(clone, "rev-parse", "origin/main")
+    _git(clone, "reflog", "expire", "--expire=now", "refs/remotes/origin/main")
 
     removed = prune_stale_shallow_grafts(clone)
 
@@ -77,6 +82,7 @@ def test_prunes_orphaned_grafts_keeps_referenced_boundaries(tmp_path):
 
 def test_prune_is_idempotent_and_noop_without_grafts(tmp_path):
     clone = _mk_shallow_scenario(tmp_path)
+    _git(clone, "reflog", "expire", "--expire=now", "refs/remotes/origin/main")
     assert prune_stale_shallow_grafts(clone) == 1
     assert prune_stale_shallow_grafts(clone) == 0  # nothing left to drop
 
@@ -125,3 +131,55 @@ def test_update_check_prunes_and_reports_count(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert prune_calls == [tmp_path]
     assert "pruned 2 stale shallow graft(s)" in out
+
+
+def test_prune_preserves_grafts_reachable_only_from_reflogs(tmp_path):
+    """A reflog-only depth-1 tip must remain a valid shallow boundary."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    _git(origin, "config", "user.email", "t@example.com")
+    _git(origin, "config", "user.name", "t")
+    _git(origin, "commit", "--allow-empty", "-q", "-m", "c0")
+
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(clone)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    # Fetch c2 without its parent c1, then supersede it with c3. The c2 graft is
+    # now required only by origin/main's reflog.
+    for message in ("c1", "c2"):
+        _git(origin, "commit", "--allow-empty", "-q", "-m", message)
+    _git(clone, "fetch", "-q", "--depth", "1", "origin", "main")
+    reflog_only_sha = _git(clone, "rev-parse", "origin/main")
+    _git(origin, "commit", "--allow-empty", "-q", "-m", "c3")
+    _git(clone, "fetch", "-q", "--depth", "1", "origin", "main")
+
+    assert reflog_only_sha in _shallow_lines(clone)
+    assert reflog_only_sha in _git(
+        clone, "reflog", "show", "--all", "--format=%H"
+    ).splitlines()
+
+    removed = prune_stale_shallow_grafts(clone)
+    fetch = _run_git(clone, "fetch", "-q", "--depth", "1", "origin", "main")
+    gc = _run_git(clone, "gc", "-q")
+    walk = _run_git(clone, "rev-list", "--count", "--all", "--reflog")
+    fsck = _run_git(clone, "fsck", "--connectivity-only")
+    failures = "\n".join(
+        f"{name}: rc={result.returncode}\n{result.stdout}{result.stderr}"
+        for name, result in (("fetch", fetch), ("gc", gc), ("walk", walk), ("fsck", fsck))
+        if result.returncode != 0
+    )
+
+    assert not failures, failures
+    assert removed == 0
+    assert reflog_only_sha in _shallow_lines(clone)
+
+    # Once the reflog no longer reaches c2, its graft is genuinely stale.
+    _git(clone, "reflog", "expire", "--expire=now", "refs/remotes/origin/main")
+    assert prune_stale_shallow_grafts(clone) == 1
+    assert reflog_only_sha not in _shallow_lines(clone)

--- a/tests/hermes_cli/test_shallow_graft_prune.py
+++ b/tests/hermes_cli/test_shallow_graft_prune.py
@@ -511,3 +511,69 @@ def test_prune_fails_open_when_fetch_head_is_unreadable(tmp_path, monkeypatch):
     assert (clone / ".git" / "shallow").read_bytes() == before
     assert ancestor in _shallow_lines(clone)
     assert not (clone / ".git" / "shallow.lock").exists()
+
+
+def test_prune_keeps_linked_worktree_fetch_head_ancestor(tmp_path):
+    """A linked worktree's FETCH_HEAD is outside --all/--reflog and the main worktree."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    _git(origin, "config", "user.email", "t@example.com")
+    _git(origin, "config", "user.name", "t")
+    _git(origin, "commit", "--allow-empty", "-q", "-m", "c0")
+
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(clone)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    linked = tmp_path / "linked"
+    _git(clone, "worktree", "add", "-q", str(linked))
+    for message in ("c1", "c2", "c3"):
+        _git(origin, "commit", "--allow-empty", "-q", "-m", message)
+    tip = _git(origin, "rev-parse", "HEAD")
+    ancestor = _git(origin, "rev-parse", "HEAD^")
+    _git(linked, "fetch", "-q", "--depth", "2", "origin", tip)
+    _git(clone, "reflog", "expire", "--expire=now", "--all")
+
+    assert ancestor in _shallow_lines(clone)
+    assert ancestor not in _git(clone, "rev-list", "--all", "--reflog").splitlines()
+    assert _git(linked, "rev-parse", "FETCH_HEAD") == tip
+
+    assert prune_stale_shallow_grafts(clone) == 0
+    assert ancestor in _shallow_lines(clone)
+    assert _run_git(linked, "rev-list", "FETCH_HEAD").returncode == 0
+
+
+def test_prune_keeps_orig_head_only_boundary(tmp_path):
+    """ORIG_HEAD is outside --all/--reflog/FETCH_HEAD and must keep its depth-1 graft."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    _git(origin, "config", "user.email", "t@example.com")
+    _git(origin, "config", "user.name", "t")
+    _git(origin, "commit", "--allow-empty", "-q", "-m", "c0")
+
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(clone)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    old_tip = _git(clone, "rev-parse", "HEAD")
+    _git(origin, "commit", "--allow-empty", "-q", "-m", "c1")
+    _git(clone, "fetch", "-q", "--depth", "1", "origin", "main")
+    _git(clone, "reset", "-q", "--hard", "origin/main")
+    _git(clone, "reflog", "expire", "--expire=now", "--all")
+
+    assert _git(clone, "rev-parse", "ORIG_HEAD") == old_tip
+    assert old_tip in _shallow_lines(clone)
+    assert old_tip not in _git(clone, "rev-list", "--all", "--reflog").splitlines()
+    assert _run_git(clone, "rev-list", "ORIG_HEAD").returncode == 0
+
+    assert prune_stale_shallow_grafts(clone) == 0
+    assert old_tip in _shallow_lines(clone)
+    assert _run_git(clone, "rev-list", "ORIG_HEAD").returncode == 0

--- a/tests/hermes_cli/test_shallow_graft_prune.py
+++ b/tests/hermes_cli/test_shallow_graft_prune.py
@@ -228,8 +228,44 @@ def test_prune_preserves_grafts_reachable_only_from_reflogs(tmp_path, monkeypatc
         assert not (clone / ".git" / "shallow.lock").exists()
     assert injected
 
-    # Once the reflog no longer reaches c2, its graft is genuinely stale.
+    # Keep c2 reachable only as an ancestor of a reflog entry. Collecting just
+    # reflog entry SHAs would miss this load-bearing boundary.
+    _git(clone, "config", "user.email", "t@example.com")
+    _git(clone, "config", "user.name", "t")
+    tree = _git(clone, "rev-parse", f"{reflog_only_sha}^{{tree}}")
+    descendant = _git(
+        clone, "commit-tree", tree, "-p", reflog_only_sha, "-m", "local descendant"
+    )
+    head_sha = _git(clone, "rev-parse", "HEAD")
+    _git(clone, "update-ref", "--create-reflog", "refs/heads/keeper", descendant)
+    _git(clone, "update-ref", "refs/heads/keeper", head_sha)
     _git(clone, "reflog", "expire", "--expire=now", "refs/remotes/origin/main")
+    assert reflog_only_sha not in _git(
+        clone, "for-each-ref", "--format=%(objectname)"
+    ).splitlines()
+    assert reflog_only_sha not in _git(
+        clone, "rev-list", "--no-walk", "--all", "--reflog"
+    ).splitlines()
+    assert reflog_only_sha in _git(
+        clone, "rev-list", "--all", "--reflog"
+    ).splitlines()
+    candidate_validations = []
+
+    def record_candidate_validation(repo, args, **kwargs):
+        if (kwargs.get("env") or {}).get("GIT_SHALLOW_FILE"):
+            candidate_validations.append(True)
+        return real_query(repo, args, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            gitlock_module, "_git_stdout_lines", record_candidate_validation
+        )
+        assert prune_stale_shallow_grafts(clone) == 0
+    assert not candidate_validations
+    assert reflog_only_sha in _shallow_lines(clone)
+
+    # Once the descendant reflog expires, c2 is genuinely stale.
+    _git(clone, "reflog", "expire", "--expire=now", "refs/heads/keeper")
     assert prune_stale_shallow_grafts(clone) == 1
     assert reflog_only_sha not in _shallow_lines(clone)
     _assert_repo_healthy(clone)


### PR DESCRIPTION
## Problem

`prune_stale_shallow_grafts()` treated only `HEAD`, `FETCH_HEAD`, and ref tips as live. A depth-1 fetch also records its tip in the remote-tracking reflog. After a later fetch supersedes that tip, the commit can remain reachable only through a reflog while its parent is intentionally absent from the depth-1 checkout.

Removing that commit's shallow boundary changes a valid shallow repository into a broken graph:

1. a depth-1 fetch downloads tip B without parent A and records B as shallow
2. a later depth-1 fetch moves the tracking ref to C, leaving B reachable only through a reflog
3. the old prune removes B from `.git/shallow` because no ref points directly at it
4. Git now sees B as an ordinary commit whose parent A should exist
5. fetch auto-maintenance, `git gc`, reflog-inclusive traversal, and `git fsck` fail when they walk B

`rev-list --all --reflog` also misses `FETCH_HEAD`. `rev-parse FETCH_HEAD` keeps only the first direct tip, so a SHA fetch or multi-ref fetch can still drop a live ancestor or secondary `FETCH_HEAD` boundary.

Fixes #108286.

This is a preventive fix on the git-checkout update path that #91277 tracks. It does not change fleet planning, restart policy, or image-managed installs. Repair of a repository already corrupted by an earlier prune is a separate curative question (#108361).

## Solution

### Reachability

- compute the keep-set from `git rev-list --all --reflog` plus every `FETCH_HEAD` entry, including ancestors
- preserve boundaries reached only as ancestors of reflog entries or `FETCH_HEAD` tips
- fail open without touching `.git/shallow` when that walk cannot be established
- ignore an inherited `GIT_SHALLOW_FILE` for normal probes

### Transactional publication

1. compute a candidate without holding a lock
2. acquire `.git/shallow.lock`; if Git already owns it, return without changing or deleting it
3. abandon the candidate if `.git/shallow` changed
4. write the candidate into the lock file and validate it with `GIT_SHALLOW_FILE`
5. recompute reachability immediately before publish; abort if a dropped graft became live through a ref or reflog update
6. rename `shallow.lock` over `.git/shallow` only after that guard passes

A failed probe, stale snapshot, invalid candidate, changed reachability, or failed rename leaves the original file unchanged.

### Conservative recovery policy

This patch does not expire or rewrite reflogs. Automatic repair of an already-corrupted checkout can require deleting `HEAD` or local-branch reflogs and would discard the updater's documented `git reflog` recovery path. That trade-off is left to an explicit operator action or a separate curative change.

## Relation to the proposed alternatives

The independent macOS reproduction in the issue follow-up supports this conservative direction:

- preventive, not curative for an already-corrupted checkout
- stronger than the issue's original Option A keep-set: `rev-list` preserves ancestor-only boundaries, not just direct reflog SHAs
- Option B is not generally curative: remote-tracking expiry misses `HEAD` / local-branch reflog roots
- fully curative expiry is a maintainer product decision, not a silent patch choice

## Reproduction and proof

### Before, on origin/main `0b8daf30aae1d0b129ede9b857cac2158eb50324`

- prune removed a reflog-only shallow boundary
- `git rev-list --count --all --reflog` exited 128
- `git fsck --connectivity-only` exited 2
- `git gc` exited 128

Independently reproduced on macOS (Git 2.51.0) and originally reported on Windows (Git 2.55.0).

### After

- the original reflog-only fixture stays healthy
- a `FETCH_HEAD`-only depth-2 SHA fetch keeps its ancestor boundary
- a multi-ref depth-1 fetch keeps every `FETCH_HEAD` tip
- a ref revived after candidate validation aborts publication
- an already-corrupted repository fails open
- an existing Git-owned `shallow.lock` is left untouched
- stale boundaries remain prunable after their last reachability expires

## Test coverage

- orphaned-boundary prune, idempotence, and `hermes update --check` reporting
- reflog-only tip, ancestor-only descendant, and injected invalid-candidate rejection
- fail-open on a pre-corrupted graph
- skip while Git holds `shallow.lock`
- `FETCH_HEAD` ancestor boundary
- every `FETCH_HEAD` entry, not just the first
- deterministic ref-update interleaving before publish
- adjacent `tests/test_gitlock.py` stale-lock / tmp-pack contracts

## Validation

- 2 test files, 15 tests passed
- Ruff passed
- `ty check hermes_cli/gitlock.py` passed
- `git diff --check` passed
- `scripts/check-windows-footguns.py --diff 0b8daf30aae1d0b129ede9b857cac2158eb50324` passed

## Compatibility and risk

- limited to `hermes_cli/gitlock.py` and its regression tests
- no authentication, crypto, state-schema, gateway-routing, or dependency changes
- no reflogs expired or rewritten
- timeouts and query failures retain extra grafts
- contention or a late-live ref favors a no-op
