### PR TITLE
fix(feishu): scope comment-rules and pairing-store caches per profile

### DIFF
--- a/plugins/platforms/feishu/feishu_comment_rules.py
+++ b/plugins/platforms/feishu/feishu_comment_rules.py
@@ -12,14 +12,18 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, hermes_home_key
 
 logger = logging.getLogger(__name__)
 
-# Resolved at import time: this module is lazy-imported by the comment event handler,
-# long after profile/HERMES_HOME overrides have been applied, so freezing is safe.
-RULES_FILE = get_hermes_home() / "feishu_comment_rules.json"
-PAIRING_FILE = get_hermes_home() / "feishu_comment_pairing.json"
+
+def _rules_file() -> Path:
+    return get_hermes_home() / "feishu_comment_rules.json"
+
+
+def _pairing_file() -> Path:
+    return get_hermes_home() / "feishu_comment_pairing.json"
+
 
 _VALID_POLICIES = ("allowlist", "pairing")
 
@@ -74,8 +78,31 @@ class _MtimeCache:
         return self._data
 
 
-_rules_cache = _MtimeCache(RULES_FILE)
-_pairing_cache = _MtimeCache(PAIRING_FILE)
+# Per-profile: this module is lazy-imported (by the comment event handler) once for the
+# process's lifetime, so a single module-level cache would freeze onto whichever profile's
+# HERMES_HOME happened to trigger that first import -- every other multiplexed profile's
+# comment rules / pairing store would then be silently read from and written to that
+# profile's files instead of its own. Keyed by hermes_home_key() (#63962/#107620 leaves this
+# half of the leak open; #107620 only made handle_drive_comment_event's own agent-execution
+# context profile-scoped, not this adjacent access-control gate).
+_rules_caches: Dict[str, _MtimeCache] = {}
+_pairing_caches: Dict[str, _MtimeCache] = {}
+
+
+def _rules_cache() -> _MtimeCache:
+    key = hermes_home_key()
+    cache = _rules_caches.get(key)
+    if cache is None:
+        cache = _rules_caches[key] = _MtimeCache(_rules_file())
+    return cache
+
+
+def _pairing_cache() -> _MtimeCache:
+    key = hermes_home_key()
+    cache = _pairing_caches.get(key)
+    if cache is None:
+        cache = _pairing_caches[key] = _MtimeCache(_pairing_file())
+    return cache
 
 
 def _parse_frozenset(raw: Any) -> Optional[frozenset]:
@@ -95,8 +122,8 @@ def _parse_document_rule(raw: dict) -> CommentDocumentRule:
 
 
 def load_config() -> CommentsConfig:
-    """Load comment rules from disk (mtime-cached)."""
-    raw = _rules_cache.load()
+    """Load comment rules from disk (mtime-cached, per profile)."""
+    raw = _rules_cache().load()
     if not raw:
         return CommentsConfig()
     raw_docs = raw.get("documents", {})
@@ -131,22 +158,24 @@ def resolve_rule(cfg: CommentsConfig, file_type: str, file_token: str, wiki_toke
 
 
 def _load_pairing_approved() -> set:
-    """Return set of approved user open_ids (mtime-cached)."""
-    approved = _pairing_cache.load().get("approved", {})
+    """Return set of approved user open_ids (mtime-cached, per profile)."""
+    approved = _pairing_cache().load().get("approved", {})
     return set(approved.keys()) if isinstance(approved, dict) else ({str(u) for u in approved if u} if isinstance(approved, list) else set())
 
 
 def _save_pairing(data: dict) -> None:
-    PAIRING_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with open(PAIRING_FILE.with_suffix(".tmp"), "w", encoding="utf-8") as f:
+    path = _pairing_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path.with_suffix(".tmp"), "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
-    PAIRING_FILE.with_suffix(".tmp").replace(PAIRING_FILE)
-    _pairing_cache._mtime, _pairing_cache._data = 0.0, None  # invalidate so the next load re-reads
+    path.with_suffix(".tmp").replace(path)
+    cache = _pairing_cache()
+    cache._mtime, cache._data = 0.0, None  # invalidate so the next load re-reads
 
 
 def _mutate_pairing(user_open_id: str, add: bool) -> bool:
     """Add/remove *user_open_id* in the approved dict; True when the store actually changed."""
-    data = _pairing_cache.load()
+    data = _pairing_cache().load()
     approved = data.get("approved", {}) if isinstance(data.get("approved"), dict) else {}
     if (user_open_id in approved) == add:
         return False
@@ -171,7 +200,7 @@ def pairing_remove(user_open_id: str) -> bool:
 
 def pairing_list() -> Dict[str, Any]:
     """Return the approved dict  {user_open_id: {approved_at: ...}}."""
-    approved = _pairing_cache.load().get("approved", {})
+    approved = _pairing_cache().load().get("approved", {})
     return dict(approved) if isinstance(approved, dict) else {}
 
 
@@ -186,7 +215,8 @@ def _fmt_allow(allow_from) -> str:
 
 def _print_status() -> None:
     cfg = load_config()
-    print(f"Rules file: {RULES_FILE}\n  exists: {RULES_FILE.exists()}\nPairing file: {PAIRING_FILE}\n  exists: {PAIRING_FILE.exists()}\n")
+    rules_file, pairing_file = _rules_file(), _pairing_file()
+    print(f"Rules file: {rules_file}\n  exists: {rules_file.exists()}\nPairing file: {pairing_file}\n  exists: {pairing_file.exists()}\n")
     print(f"Top-level:\n  enabled:    {cfg.enabled}\n  policy:     {cfg.policy}\n  allow_from: {_fmt_allow(cfg.allow_from)}\n")
     print(f"Document rules ({len(cfg.documents)}):" if cfg.documents else "Document rules: (none)")
     for key, rule in sorted(cfg.documents.items()):
@@ -242,7 +272,7 @@ Commands:
   pairing remove <user_open_id>        Remove user from pairing-approved list
   pairing list                         List pairing-approved users
 
-Rules config file: {RULES_FILE}
+Rules config file: {_rules_file()}
   Edit this JSON file directly to configure policies and document rules.
   Changes take effect on the next comment event (no restart needed).
 """

--- a/tests/gateway/test_feishu_comment_rules.py
+++ b/tests/gateway/test_feishu_comment_rules.py
@@ -114,8 +114,8 @@ class TestLoadConfig(unittest.TestCase):
             json.dump(raw, f)
             path = Path(f.name)
         try:
-            with patch("plugins.platforms.feishu.feishu_comment_rules.RULES_FILE", path):
-                with patch("plugins.platforms.feishu.feishu_comment_rules._rules_cache", _MtimeCache(path)):
+            with patch("plugins.platforms.feishu.feishu_comment_rules._rules_file", return_value=path):
+                with patch("plugins.platforms.feishu.feishu_comment_rules._rules_caches", {}):
                     cfg = load_config()
             self.assertTrue(cfg.enabled)
             self.assertEqual(cfg.policy, "allowlist")
@@ -133,16 +133,14 @@ class TestPairingStore(unittest.TestCase):
         self._pairing_file = Path(self._tmpdir) / "pairing.json"
         with open(self._pairing_file, "w") as f:
             json.dump({"approved": {}}, f)
-        self._patcher_file = patch("plugins.platforms.feishu.feishu_comment_rules.PAIRING_FILE", self._pairing_file)
-        self._patcher_cache = patch(
-            "plugins.platforms.feishu.feishu_comment_rules._pairing_cache",
-            _MtimeCache(self._pairing_file),
-        )
+        self._patcher_file = patch(
+            "plugins.platforms.feishu.feishu_comment_rules._pairing_file", return_value=self._pairing_file)
+        self._patcher_caches = patch("plugins.platforms.feishu.feishu_comment_rules._pairing_caches", {})
         self._patcher_file.start()
-        self._patcher_cache.start()
+        self._patcher_caches.start()
 
     def tearDown(self):
-        self._patcher_cache.stop()
+        self._patcher_caches.stop()
         self._patcher_file.stop()
         if self._pairing_file.exists():
             self._pairing_file.unlink()
@@ -152,6 +150,65 @@ class TestPairingStore(unittest.TestCase):
         self.assertTrue(pairing_add("ou_new"))
         approved = pairing_list()
         self.assertIn("ou_new", approved)
+
+
+class TestPerProfileScope(unittest.TestCase):
+    """The rules/pairing caches must not freeze onto whichever profile's HERMES_HOME happened
+    to trigger the module's first (lazy) import -- each profile's own files must stay isolated
+    under multiplex. Regression for the #107620-adjacent gap left in #63962/#86905."""
+
+    def setUp(self):
+        self._tmpdir = Path(tempfile.mkdtemp())
+        self._home_a = self._tmpdir / "profile_a"
+        self._home_b = self._tmpdir / "profile_b"
+        self._home_a.mkdir()
+        self._home_b.mkdir()
+        (self._home_a / "feishu_comment_rules.json").write_text(json.dumps({"policy": "allowlist"}))
+        (self._home_b / "feishu_comment_rules.json").write_text(json.dumps({"policy": "pairing"}))
+        import plugins.platforms.feishu.feishu_comment_rules as rules_mod
+        self._rules_mod = rules_mod
+        self._patcher_rules_caches = patch.object(rules_mod, "_rules_caches", {})
+        self._patcher_pairing_caches = patch.object(rules_mod, "_pairing_caches", {})
+        self._patcher_rules_caches.start()
+        self._patcher_pairing_caches.start()
+        self._current_home = self._home_a
+        self._patcher_home = patch.object(rules_mod, "get_hermes_home", side_effect=lambda: self._current_home)
+        # hermes_home_key() is imported directly into this module's namespace, so it must be
+        # patched here too (patching hermes_constants.get_hermes_home wouldn't reach it) -- real
+        # hermes_home_key(path=None) resolves via get_hermes_home() internally, which this test
+        # cannot see through the patch above since it's a separate module-level binding.
+        self._patcher_key = patch.object(
+            rules_mod, "hermes_home_key", side_effect=lambda path=None: str(path or self._current_home))
+        self._patcher_home.start()
+        self._patcher_key.start()
+
+    def tearDown(self):
+        self._patcher_key.stop()
+        self._patcher_home.stop()
+        self._patcher_pairing_caches.stop()
+        self._patcher_rules_caches.stop()
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_two_profiles_read_their_own_rules_file(self):
+        self._current_home = self._home_a
+        self.assertEqual(load_config().policy, "allowlist")
+        self._current_home = self._home_b
+        self.assertEqual(load_config().policy, "pairing")
+        # Switching back to A must still see A's file, not a value cached under B's key.
+        self._current_home = self._home_a
+        self.assertEqual(load_config().policy, "allowlist")
+
+    def test_two_profiles_have_independent_pairing_stores(self):
+        self._current_home = self._home_a
+        self.assertTrue(pairing_add("ou_a_only"))
+        self._current_home = self._home_b
+        self.assertNotIn("ou_a_only", pairing_list())
+        self.assertTrue(pairing_add("ou_b_only"))
+        self._current_home = self._home_a
+        approved_a = pairing_list()
+        self.assertIn("ou_a_only", approved_a)
+        self.assertNotIn("ou_b_only", approved_a)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `RULES_FILE`/`PAIRING_FILE` and the `_rules_cache`/`_pairing_cache` `_MtimeCache` singletons in `feishu_comment_rules.py` were resolved once at module import time. The module is lazy-imported by `handle_drive_comment_event` on the first drive-comment event *any* profile receives, so under `gateway.multiplex_profiles`, whichever profile's `HERMES_HOME` triggers that first import freezes every other profile's comment access-control policy and pairing-approval store onto that one profile's files for the rest of the process — `load_config()`, `_load_pairing_approved()`, `_save_pairing()` and `pairing_add/remove/list()` all end up reading and writing the wrong profile's rules/pairing files.
- #107620 (merged earlier today) fixed `handle_drive_comment_event`'s own agent-execution context to run profile-scoped, and its own PR body explicitly disclosed this half was left open: *"The `feishu_comment_rules` per-profile path/cache half of #63962 is not covered by this PR."* This PR is that disclosed follow-up.
- Fix: `RULES_FILE`/`PAIRING_FILE` become `_rules_file()`/`_pairing_file()`, resolved at call time; the single cache instances become per-profile dicts keyed by `hermes_home_key()` (the established scoping idiom used throughout the codebase — `agent/*_registry.py`, `tools/registry.py`, `hermes_cli/plugins.py`, etc.), with `_rules_cache()`/`_pairing_cache()` lazily building one `_MtimeCache` per profile. Same lazy-import-once module, but each profile now gets its own cache entry instead of sharing the first importer's.

## Test plan
- [x] Updated the existing `tests/gateway/test_feishu_comment_rules.py::TestLoadConfig`/`TestPairingStore` to patch the new `_rules_file`/`_pairing_file` functions and `_rules_caches`/`_pairing_caches` dicts instead of the old frozen constants/singleton.
- [x] Added `TestPerProfileScope` — two new regression tests simulating two profiles with different `HERMES_HOME`s and different rules/pairing content, asserting each profile's `load_config()`/`pairing_add`/`pairing_list()` only ever sees its own files, including switching back and forth (not just first-vs-second).
- [x] Mutation-verified: reverted the source fix (kept the updated tests), confirmed 4 tests fail (`TestLoadConfig`, `TestPairingStore` — `AttributeError`, since the old module has no `_rules_caches`/`_pairing_caches`; both new `TestPerProfileScope` tests fail too); restored the fix, all 12 tests in the file pass.
- [x] `uv run --frozen --extra dev pytest tests/gateway/test_feishu*.py -q` → 147 passed, 2 pre-existing failures (`TestAdapterBehavior::test_url_verification_*` / `test_webhook_request_uses_same_message_dispatch_path`, an aiohttp `web` import issue unrelated to this change — same failures present on clean `upstream/main`).

## Scope note
Closed PR #63962 (superseded by #107620, "the `feishu_comment_rules` half... not covered") took a different implementation shape for this same gap — module-level `RULES_FILE`/`PAIRING_FILE` constants kept for backward compatibility with a mutable-sentinel comparison to detect test patches, cache dicts keyed by raw `Path`. This PR is written independently, favoring the simpler, already-established `hermes_home_key()` cache-keying idiom over reproducing that sentinel trick, and updates the existing tests to patch the new call-time functions directly rather than preserving the old constant-patching seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)