### PR TITLE
fix(gateway): secondary profiles keep their session keys and own state.db on every path (#98292, salvage #105942 #98294)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -650,9 +650,15 @@ class QQAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _parse_gateway_session_key(session_key: str) -> Optional[Dict[str, str]]:
-        """Parse ``agent:main:<platform>:<chat_type>:<chat_id>[:<user_id>]``."""
+        """Parse ``agent:<namespace>:<platform>:<chat_type>:<chat_id>[:<user_id>]``.
+
+        The namespace slot carries the multiplex profile ("main" for the
+        default profile — see ``gateway.session._session_key_namespace``);
+        it takes no part in any authorization decision, so any non-empty
+        value is accepted and every later slot keeps its position.
+        """
         parts = str(session_key or "").split(":")
-        if len(parts) < 5 or parts[0] != "agent" or parts[1] != "main":
+        if len(parts) < 5 or parts[0] != "agent" or not parts[1]:
             return None
         parsed = {"platform": parts[2], "chat_type": parts[3], "chat_id": parts[4]}
         if len(parts) > 5:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2907,13 +2907,27 @@ def _resolve_hermes_bin() -> Optional[list[str]]:
     return None
 
 
+_PROFILE_ID_KEY_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
 def _parse_session_key(session_key: str) -> "dict | None":
-    """Parse a session key (``agent:main:{platform}:{chat_type}:{chat_id}[:{extra}...]``).
-    For group/channel sessions the suffix may be a user_id, not a thread_id, so ``thread_id`` is omitted.
+    """Parse a session key (``agent:{ns}:{platform}:{chat_type}:{chat_id}[:{extra}...]``).
+
+    ``{ns}`` is ``main`` for the default profile or a named-profile id (profile ids match
+    ``[a-z0-9][a-z0-9_-]{0,63}`` — never contain ``:`` — so a plain split stays unambiguous).
+    For group/channel sessions the suffix may be a user_id, not a thread_id, so ``thread_id``
+    is omitted. Named profiles are reported as ``profile``; ``main`` keys keep their historical
+    shape exactly (no ``profile`` key) so equality assertions on parsed dicts stay stable.
     """
     parts = session_key.split(":")
-    if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
+    if (
+        len(parts) >= 5
+        and parts[0] == "agent"
+        and (parts[1] == "main" or _PROFILE_ID_KEY_RE.match(parts[1]))
+    ):
         result = {"platform": parts[2], "chat_type": parts[3], "chat_id": parts[4]}
+        if parts[1] != "main":
+            result["profile"] = parts[1]
         if len(parts) > 5 and parts[3] in {"dm", "thread"}:
             result["thread_id"] = parts[5]
         return result

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -19,7 +19,7 @@ from agent.session_activity import format_iteration_progress
 from gateway.config import Platform
 from gateway.platforms.base import EphemeralReply
 from gateway.platforms.event import MessageEvent, MessageType
-from gateway.session import SessionSource
+from gateway.session import SessionSource, _session_key_namespace
 from typing import Any, Dict, Optional, Union
 
 if TYPE_CHECKING:  # string annotations only; never imported at runtime (cycle)
@@ -1001,8 +1001,15 @@ class GatewayBusySessionMixin:
         platform = source.platform.value
         chat_type = getattr(source, "chat_type", None) or ""
         # Match the exact key or prefix + ":" so a thread id that merely starts with this one
-        # is not matched.
-        prefix = ":".join(["agent:main", platform, chat_type, str(chat_id), str(thread_id)])
+        # is not matched. The namespace follows the source's profile so a named-profile run
+        # under multiplexing still matches its own keys.
+        prefix = ":".join([
+            _session_key_namespace(getattr(source, "profile", None)),
+            platform,
+            chat_type,
+            str(chat_id),
+            str(thread_id),
+        ])
         return [
             key
             for key, agent in self._running_agent_items()

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -885,8 +885,6 @@ class GatewayNotificationsMixin:
         from gateway.run import _parse_session_key
         session_key = str(evt.get("session_key") or "").strip()
         derived = {}
-        parts = session_key.split(":")
-        profile = parts[1] if len(parts) >= 5 and parts[0] == "agent" and parts[1] != "main" else None
         if session_key:
             try:
                 self.session_store._ensure_loaded()
@@ -898,8 +896,8 @@ class GatewayNotificationsMixin:
             cached_source = self._get_cached_session_source(session_key)
             if cached_source is not None:
                 return cached_source
-            parse_key = ":".join(["agent", "main", *parts[2:]]) if profile else session_key
-            derived = _parse_session_key(parse_key) or {}
+            derived = _parse_session_key(session_key) or {}
+        profile = derived.get("profile")
         platform_name = str(evt.get("platform") or derived.get("platform") or "").strip().lower()
         chat_type = str(evt.get("chat_type") or derived.get("chat_type") or "").strip().lower()
         chat_id = str(evt.get("chat_id") or derived.get("chat_id") or "").strip()

--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -893,14 +893,10 @@ class GatewayShutdownMixin:
             source = self._get_cached_session_source(session_key)
         if source is not None:
             return source, source.platform.value, str(source.chat_id), source.thread_id, getattr(source, "profile", None)
-        parts = session_key.split(":")
-        profile = parts[1] if len(parts) >= 5 and parts[0] == "agent" and parts[1] != "main" else None
-        # _parse_session_key only understands the ``agent:main:`` lane; a secondary's key is parsed on
-        # the same shape with its profile carried separately.
-        _parsed = _parse_session_key(":".join(["agent", "main", *parts[2:]]) if profile else session_key)
+        _parsed = _parse_session_key(session_key)
         if not _parsed:
             return None
-        return None, _parsed["platform"], _parsed["chat_id"], _parsed.get("thread_id"), profile
+        return None, _parsed["platform"], _parsed["chat_id"], _parsed.get("thread_id"), _parsed.get("profile")
 
     async def _send_shutdown_notice(
         self, adapter, chat_id: str, msg: str, kind: str, platform_str: str, **send_kwargs

--- a/gateway/session_persistence.py
+++ b/gateway/session_persistence.py
@@ -156,7 +156,16 @@ class SessionPersistenceMixin:
             return pinned
         profile = self._named_profile_for_key(session_key)
         if profile is None:
-            return self._db
+            # Default-profile (``agent:main``) rows belong to the launch home, not to whichever
+            # profile's scope happens to be active: a scoped drain tick or cron mirror touching a
+            # default chat used to write its rows into the secondary's store (#102157's picture).
+            routing_home = getattr(self, "_routing_home", None)
+            if routing_home is None or not getattr(self.config, "multiplex_profiles", False):
+                return self._db
+            try:
+                return self._open_session_db_for_active_scope(db_path=routing_home / "state.db")
+            except Exception:
+                return None
         home = self._profile_home_for_key(session_key)
         if home is None:
             # Falling back to the ambient store would split ONE session identity across two

--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -443,7 +443,9 @@ class GatewaySessionCommandsMixin:
             return t("gateway.undo.nothing")
         session_entry.last_prompt_tokens = 0  # transcript was truncated
         try:
-            self._evict_cached_agent(build_session_key(source))
+            # The cache is keyed by the profile-namespaced key; a bare build_session_key(source)
+            # yields ``agent:main:…`` and misses for every secondary profile.
+            self._evict_cached_agent(self._session_key_for_source(source))
         except Exception as e:
             logger.debug("undo: cached-agent eviction skipped: %s", e)
         target_text = result["target_text"]

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -19,6 +19,7 @@ import threading
 import time
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli._subprocess_compat import noninteractive_git_env
@@ -518,24 +519,17 @@ _DB_BOOTSTRAP_INIT_WAIT_S = 1.5
 def _bootstrap_session_db(home: str, done: threading.Event) -> None:
     """Construct SessionDB off-loop and populate the cache (worker thread)."""
     try:
-        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
-        from hermes_state import SessionDB
-
-        # Bind the caller's home for this thread: the cache key is the caller's scoped home, and
-        # without the override a multiplexed worker thread would resolve the process env (default
-        # profile) and cache the wrong profile's DB under this profile's key.
-        token = set_hermes_home_override(home)
-        try:
-            db = SessionDB()
-        finally:
-            reset_hermes_home_override(token)
+        db = _acquire_session_db(home)
     except Exception as exc:  # pragma: no cover
         logger.debug("GoalManager: background SessionDB() raised (%s)", exc)
         db = None
     with _DB_BOOTSTRAP_LOCK:
         if db is not None and home not in _DB_CACHE:
             _DB_CACHE[home] = db
+            db = None
         _DB_BOOTSTRAP_INFLIGHT.pop(home, None)
+    if db is not None:  # lost the race; drop our reference
+        _release_session_db(db)
     done.set()
 
 
@@ -548,7 +542,6 @@ def _get_session_db() -> Optional[Any]:
     """
     try:
         from hermes_constants import get_hermes_home
-        from hermes_state import SessionDB
 
         home = str(get_hermes_home())
     except Exception as exc:  # pragma: no cover
@@ -582,21 +575,34 @@ def _get_session_db() -> Optional[Any]:
         return _DB_CACHE.get(home)
 
     try:
-        db = SessionDB()
+        db = _acquire_session_db(home)
     except Exception as exc:  # pragma: no cover
         logger.debug("GoalManager: SessionDB() raised (%s)", exc)
         return None
     with _DB_BOOTSTRAP_LOCK:
         existing = _DB_CACHE.get(home)
         if existing is not None:
-            # A concurrent bootstrap won the race; close ours so connections don't leak.
-            try:
-                db.close()
-            except Exception:
-                pass
+            # A concurrent bootstrap won the race; drop our reference so connections don't leak.
+            _release_session_db(db)
             return existing
         _DB_CACHE[home] = db
     return db
+
+
+def _acquire_session_db(home: str):
+    """The registry's shared handle for ``home/state.db``. A bare ``SessionDB()`` here was a SECOND
+    writer per profile beside the gateway's registry handle — its own token-writer thread and
+    close-time checkpoint (the #90837 corruption shape), doubled under multiplexing."""
+    from hermes_state_registry import acquire
+    return acquire(Path(home) / "state.db")
+
+
+def _release_session_db(db) -> None:
+    from hermes_state_registry import release_or_close
+    try:
+        release_or_close(db)
+    except Exception:
+        pass
 
 
 def _warn_dropped_write(manager: str, kind: str, session_id: str) -> None:

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -520,6 +520,73 @@ def test_parse_session_key_with_extra_parts():
     assert result == {"platform": "discord", "chat_type": "group", "chat_id": "chan123"}
 
 
+def test_parse_session_key_named_profile():
+    """A named-profile namespace parses and is reported as ``profile``."""
+    result = _parse_session_key("agent:work:telegram:dm:123")
+    assert result == {
+        "profile": "work",
+        "platform": "telegram",
+        "chat_type": "dm",
+        "chat_id": "123",
+    }
+
+
+def test_parse_session_key_named_profile_thread_id():
+    """Thread-slot handling is identical for named-profile keys."""
+    result = _parse_session_key("agent:work:telegram:thread:100:42")
+    assert result == {
+        "profile": "work",
+        "platform": "telegram",
+        "chat_type": "thread",
+        "chat_id": "100",
+        "thread_id": "42",
+    }
+
+
+def test_parse_session_key_named_profile_group_suffix_omitted():
+    """Group-suffix (user_id) stays omitted for named-profile keys too."""
+    result = _parse_session_key("agent:work:discord:group:chan1:user9")
+    assert result == {
+        "profile": "work",
+        "platform": "discord",
+        "chat_type": "group",
+        "chat_id": "chan1",
+    }
+
+
+def test_parse_session_key_main_shape_unchanged():
+    """``main`` keys keep their historical dict shape exactly (no ``profile`` key)."""
+    result = _parse_session_key("agent:main:telegram:dm:123:42")
+    assert result == {
+        "platform": "telegram",
+        "chat_type": "dm",
+        "chat_id": "123",
+        "thread_id": "42",
+    }
+
+
+def test_parse_session_key_rejects_invalid_namespace():
+    """A namespace slot that cannot be a profile id still parses to None."""
+    assert _parse_session_key("agent:Bad_NS:telegram:dm:123") is None
+    assert _parse_session_key("agent:main:telegram:dm") is None
+    assert _parse_session_key("raw-session-id") is None
+
+
+def test_build_process_event_source_named_profile_key(monkeypatch, tmp_path):
+    """A synthetic event keyed by a named-profile session resolves platform/chat and keeps
+    the profile, instead of being unresolvable and dropped with a warning."""
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    source = runner._build_process_event_source({
+        "session_id": "proc_watch",
+        "session_key": "agent:work:telegram:dm:123",
+    })
+    assert source is not None
+    assert source.platform is Platform.TELEGRAM
+    assert source.chat_id == "123"
+    assert source.chat_type == "dm"
+    assert source.profile == "work"
+
+
 # ---------------------------------------------------------------------------
 # api_server (stateless) wake routing — gateway/wake.py self-post path
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_multiplex_session_db_profile_scope.py
+++ b/tests/gateway/test_multiplex_session_db_profile_scope.py
@@ -773,3 +773,20 @@ def test_crash_marker_from_a_secondary_profile_survives_restart(multiplex_homes)
     assert recovered.resume_pending is True
     assert recovered.resume_reason == "restart_interrupted"
     assert recovered.active_turn_token is None
+
+
+def test_default_namespace_rows_stay_in_launch_store_under_secondary_scope(multiplex_homes):
+    """``agent:main`` rows belong to the launch home even while a secondary profile's scope is
+    active. A scoped background tick (async-delegation drain, cron mirror) that touches a
+    default-profile chat used to persist it into the secondary's ``state.db`` — the
+    ``profile_name='<A>'`` row inside B's store from #102157."""
+    root, profile = multiplex_homes
+    store = _multiplex_store(root)
+
+    scope = set_hermes_home_override(str(profile))
+    try:
+        db = store._db_for_key("agent:main:telegram:dm:1")
+    finally:
+        reset_hermes_home_override(scope)
+
+    assert Path(db.db_path) == root / "state.db"

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -978,6 +978,132 @@ class TestDefaultInteractionDispatch:
         assert response.read_text() == "y"
 
 
+class TestProfileNamespaceApprovalAuthz:
+    """Named-profile (multiplex) session keys must authorize like ``main``.
+
+    ``build_session_key`` namespaces named-profile keys as ``agent:<profile>:...``
+    while the default profile keeps the legacy ``agent:main`` prefix
+    (``gateway/session.py::_session_key_namespace``). The interaction authz
+    parser used to require the literal ``main`` in the namespace slot, so
+    every approval button click in a named profile was rejected as
+    unauthorized and the pending approval timed out (fail-closed block).
+    """
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    @staticmethod
+    def _parse(key):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter._parse_gateway_session_key(key)
+
+    def test_parse_accepts_named_profile_namespace(self):
+        parsed = self._parse("agent:coder:qqbot:dm:u-1")
+        assert parsed is not None
+        assert parsed["platform"] == "qqbot"
+        assert parsed["chat_type"] == "dm"
+        assert parsed["chat_id"] == "u-1"
+
+    def test_parse_accepts_main_namespace_with_user_id(self):
+        parsed = self._parse("agent:main:qqbot:group:g-1:owner")
+        assert parsed is not None
+        assert parsed["platform"] == "qqbot"
+        assert parsed["chat_type"] == "group"
+        assert parsed["chat_id"] == "g-1"
+        assert parsed["user_id"] == "owner"
+
+    def test_parse_still_rejects_non_agent_and_malformed_keys(self):
+        assert self._parse("session:main:qqbot:c2c:u-1") is None
+        assert self._parse("agent::qqbot:c2c:u-1") is None
+        assert self._parse("agent:main") is None
+        assert self._parse("") is None
+
+    @pytest.mark.asyncio
+    async def test_c2c_click_on_named_profile_key_resolves(self):
+        """Approval click carrying a named-profile c2c key resolves (was rejected)."""
+        adapter = self._make_adapter()
+
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i",
+                "chat_type": 2,
+                "user_openid": "u-42",
+                "data": {"resolved": {"button_data": "approve:agent:coder:qqbot:c2c:u-42:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [("agent:coder:qqbot:c2c:u-42", "once", False)]
+
+    @pytest.mark.asyncio
+    async def test_group_click_on_named_profile_key_authorizes_session_owner(self):
+        """Group approval click under a named profile authorizes the session owner."""
+        adapter = self._make_adapter()
+
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i", "chat_type": 1,
+                "group_openid": "g-1",
+                "group_member_openid": "owner",
+                "data": {"resolved": {"button_data": "approve:agent:coder:qqbot:group:g-1:owner:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [("agent:coder:qqbot:group:g-1:owner", "once", False)]
+
+    @pytest.mark.asyncio
+    async def test_named_profile_key_still_rejects_wrong_operator(self):
+        """The namespace relaxation must not weaken the operator check."""
+        adapter = self._make_adapter()
+
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i", "chat_type": 1,
+                "group_openid": "g-1",
+                "group_member_openid": "attacker",
+                "data": {"resolved": {"button_data": "approve:agent:coder:qqbot:group:g-1:owner:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == []
+
+
 class TestSendExecApproval:
     """Verify the gateway contract: QQAdapter.send_exec_approval(...)."""
 

--- a/tests/gateway/test_stop_thread_sibling.py
+++ b/tests/gateway/test_stop_thread_sibling.py
@@ -57,6 +57,36 @@ def test_sibling_returns_empty_for_non_thread_source():
     assert runner._sibling_thread_run_keys(nonthread, "agent:main:discord:group:chan1:userA") == []
 
 
+def test_sibling_matches_named_profile_runs():
+    # Under multiplexing the sibling prefix must follow the source's profile namespace,
+    # so /stop finds another participant's run under the SAME named profile...
+    runner = object.__new__(GatewayRunner)
+    source = _thread_source("userA")
+    source.profile = "work"
+    key_b = build_session_key(
+        _thread_source("userB"), thread_sessions_per_user=True, profile="work"
+    )
+    runner._running_agents = {key_b: _FakeAgent()}
+    assert runner._sibling_thread_run_keys(
+        source, "agent:work:discord:forum:chan1:thr1:userA"
+    ) == [key_b]
+
+
+def test_sibling_does_not_cross_profiles():
+    # ...and never reaches a DIFFERENT profile's run in the same chat/thread.
+    runner = object.__new__(GatewayRunner)
+    source = _thread_source("userA")
+    source.profile = "work"
+    main_key = build_session_key(_thread_source("userB"), thread_sessions_per_user=True)
+    runner._running_agents = {main_key: _FakeAgent()}
+    assert (
+        runner._sibling_thread_run_keys(
+            source, "agent:work:discord:forum:chan1:thr1:userA"
+        )
+        == []
+    )
+
+
 # ---------------------------------------------------------------------------
 # _handle_stop_command fallback path
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_undo_rewind_session.py
+++ b/tests/gateway/test_undo_rewind_session.py
@@ -144,3 +144,40 @@ def test_rewind_fails_closed_when_new_turn_lands_after_id_snapshot(
         ("a3-from-other-process", 1),
     ]
     sibling.close()
+
+
+@pytest.mark.asyncio
+async def test_undo_evicts_cached_agent_under_profile_namespaced_key():
+    """/undo must evict under the key the cache is keyed by. On a multiplexed gateway that is
+    ``agent:<profile>:…``; a bare ``build_session_key(source)`` yields ``agent:main:…``, the
+    eviction misses and the next turn reuses an agent still holding the undone turns."""
+    from gateway.platforms.base import Platform, SessionSource
+    from gateway.platforms.event import MessageEvent, MessageType
+    from gateway.run import GatewayRunner
+    from gateway.session import build_session_key
+
+    class _Entry:
+        session_id = "sid"
+        last_prompt_tokens = 0
+
+    class _Store:
+        async def get_or_create_session(self, source):
+            return _Entry()
+
+        async def rewind_session(self, sid, n):
+            return {"target_text": "q3", "turns_undone": 1, "rewound_count": 2}
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", chat_type="dm", user_id="u1")
+    source.profile = "work"
+    evicted = []
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.session_store = _Store()
+    runner._async_session_store = _Store()
+    runner._async_session_store._store = runner.session_store
+    runner._evict_cached_agent = evicted.append
+    runner._session_key_for_source = lambda s: build_session_key(s, profile=s.profile)
+
+    await runner._handle_undo_command(MessageEvent(text="/undo", message_type=MessageType.TEXT, source=source))
+
+    assert evicted == ["agent:work:telegram:dm:123"]

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -873,3 +873,20 @@ class TestBlockedVerdict:
         assert mgr.state is not None
         assert mgr.state.status == "paused"
         assert "unachievable" in (mgr.state.paused_reason or "").lower()
+
+
+def test_goal_session_db_is_the_registry_shared_handle(hermes_home):
+    """GoalManager must borrow the process-wide registry handle for ``state.db`` rather than
+    minting a bare ``SessionDB()``: a second writer per profile carries its own token-writer
+    thread and close-time checkpoint beside the gateway's handle (the #90837 corruption shape)."""
+    from hermes_cli import goals
+    import hermes_state_registry as registry
+
+    db = goals._get_session_db()
+    assert db is not None
+    try:
+        assert any(shared is db for shared in registry.live_shared_session_dbs())
+        assert goals._get_session_db() is db
+    finally:
+        goals._DB_CACHE.clear()
+        registry.release_or_close(db)

--- a/tests/hermes_cli/test_goals_db_bootstrap_off_loop.py
+++ b/tests/hermes_cli/test_goals_db_bootstrap_off_loop.py
@@ -33,7 +33,7 @@ class _RecordingDB:
 
     constructed_on: list = []
 
-    def __init__(self):
+    def __init__(self, db_path=None):
         _RecordingDB.constructed_on.append(threading.get_ident())
 
     def get_meta(self, key):
@@ -47,10 +47,12 @@ def _clean_cache(monkeypatch):
     yield
 
 
-def _patch_sessiondb(monkeypatch):
-    import hermes_state
+def _patch_sessiondb(monkeypatch, cls=_RecordingDB):
+    # goals.py acquires through hermes_state_registry (shared writer per home); patch its
+    # construction seam, and keep every acquired fake out of the registry so tests don't share.
+    import hermes_state_registry
 
-    monkeypatch.setattr(hermes_state, "SessionDB", _RecordingDB)
+    monkeypatch.setattr(hermes_state_registry, "_open_session_db", lambda path: cls(db_path=path))
 
 
 def test_loop_thread_cache_miss_constructs_off_loop(monkeypatch):
@@ -119,13 +121,12 @@ def test_slow_construction_does_not_block_the_loop(monkeypatch):
     1.5s window plus margins; the two-window CONTRACT is what's under
     test, not the production constants.
     """
-    import hermes_state
 
     monkeypatch.setattr(goals, "_DB_BOOTSTRAP_INIT_WAIT_S", 0.3)
     monkeypatch.setattr(goals, "_DB_BOOTSTRAP_LOOP_WAIT_S", 0.05)
 
     class _BlockingDB:
-        def __init__(self):
+        def __init__(self, db_path=None):
             # Far past both (shrunk) wait windows. The margin keeps the
             # "still None" assertions from racing the bootstrap thread on
             # a loaded runner (negative-timing race, flake policy).
@@ -134,7 +135,7 @@ def test_slow_construction_does_not_block_the_loop(monkeypatch):
         def get_meta(self, key):
             return None
 
-    monkeypatch.setattr(hermes_state, "SessionDB", _BlockingDB)
+    _patch_sessiondb(monkeypatch, _BlockingDB)
     elapsed = None
     elapsed2 = None
     result = "UNSET"

--- a/tests/tui_gateway/test_launch_db_home_override_race.py
+++ b/tests/tui_gateway/test_launch_db_home_override_race.py
@@ -44,3 +44,60 @@ def test_get_db_first_touch_under_foreign_override_uses_launch_path(launch_db_en
         assert server._get_db() is db
     finally:
         reset_hermes_home_override(token)
+
+
+def test_insights_get_reads_the_requested_profile_store_not_the_launch_handle(launch_db_env, monkeypatch, tmp_path):
+    """``insights.get {profile}`` was ``scoped=True`` then ``_get_db()``: a scoped first touch pinned
+    the launch handle to the foreign store. It must count the requested profile's sessions through
+    ``_profile_db`` and leave the launch handle on the launch home."""
+    launch_home, _foreign = launch_db_env
+    profiles_root = tmp_path / "profiles"
+    work = profiles_root / "work"
+    work.mkdir(parents=True)
+    monkeypatch.setattr("hermes_cli.profiles.get_profile_dir", lambda name: profiles_root / name)
+    monkeypatch.setattr(server, "_canonical_profile_request", lambda name: name or None)
+
+    seeded = registry.acquire(work / "state.db")
+    seeded.create_session("work-only", source="tui", model="m")
+    registry.release(seeded)
+
+    result = server._methods["insights.get"]("rid", {"profile": "work", "days": 30})
+
+    assert result["result"]["sessions"] == 1
+    assert server._get_db().db_path.resolve() == (launch_home / "state.db").resolve()
+    assert server._get_db().get_session("work-only") is None
+
+
+def test_background_side_agent_persists_into_the_parent_agent_store(launch_db_env, monkeypatch):
+    """``prompt.background`` side agents write ``bg_*`` rows next to their parent's transcript: a
+    named-profile chat's parent holds a dedicated profile handle, and handing the launch handle
+    instead made those rows show up in the default profile's history."""
+    import types
+
+    parent_db = object()
+    agent = types.SimpleNamespace(model="m", provider="p", _fallback_chain=[], _session_db=parent_db)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"max_turns": 25})
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda *_a, **_kw: ["file"])
+
+    assert server._background_agent_kwargs(agent, "bg_1")["session_db"] is parent_db
+
+
+def test_notification_owner_gate_resolves_rotated_key_in_the_session_profile_store(launch_db_env, tmp_path):
+    """A compression-rotated NAMED-PROFILE session must still claim events keyed by its compressed
+    parent: the lineage lives in ``profiles/<x>/state.db``, which the launch handle cannot see, so
+    the fail-closed owner gate silently dropped every post-compression notification."""
+    profile_home = tmp_path / "profiles" / "work"
+    profile_home.mkdir(parents=True)
+    db = registry.acquire(profile_home / "state.db")
+    db.create_session("parent", source="tui", model="m")
+    db.append_message("parent", "user", "hello")
+    db.end_session("parent", "compression")
+    db.create_session("child", source="tui", model="m", parent_session_id="parent")
+    db.append_message("child", "user", "later")
+    registry.release(db)
+
+    session = {"profile_home": str(profile_home), "session_key": "child", "agent": None}
+    evt = {"type": "async_delegation", "session_key": "parent"}
+
+    assert server._session_owns_notification_event("ui1", session, evt) is True
+    assert server._get_db().get_session("parent") is None  # never looked up through the launch store

--- a/tui_gateway/agent_callbacks.py
+++ b/tui_gateway/agent_callbacks.py
@@ -298,7 +298,9 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "reasoning_config": g("reasoning_config") or _load_reasoning_config(str(g("model", "") or "")),
         "service_tier": g("service_tier") or _load_service_tier(),
         "request_overrides": dict(g("request_overrides", {}) or {}),
-        "platform": "tui", "session_db": _get_db(), "fallback_model": fallback}
+        # The side agent persists into the PARENT's store: a named-profile chat's ``bg_*`` rows
+        # belong to that profile's state.db, not the launch handle.
+        "platform": "tui", "session_db": getattr(agent, "_session_db", None) or _get_db(), "fallback_model": fallback}
 
 
 def _ephemeral_preview_agent_kwargs(agent, task_id: str) -> dict:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -887,13 +887,16 @@ def _(rid, params: dict) -> dict:
 
 
 # ─── Insights / rollback / browser / config ──────────────────────────────────
-@_rpc("insights.get", 5017)
+@_scoped_rpc("insights.get", 5017)
 def _(rid, params: dict) -> dict:
     days = params.get("days", 30)
-    if (db := _get_db()) is None:
-        return _db_unavailable_error(rid, code=5017)
-    cutoff = time.time() - days * 86400
-    rows = [s for s in db.list_sessions_rich(limit=500, compact_rows=True) if (s.get("started_at") or 0) >= cutoff]
+    # ``profile`` selects that profile's store; the launch handle is never the fallback for a
+    # scoped call (a foreign first touch used to pin the process-wide handle, #102526).
+    with _profile_db(params) as db:
+        if db is None:
+            return _db_unavailable_error(rid, code=5017)
+        cutoff = time.time() - days * 86400
+        rows = [s for s in db.list_sessions_rich(limit=500, compact_rows=True) if (s.get("started_at") or 0) >= cutoff]
     return _ok(rid, {"days": days, "sessions": len(rows), "messages": sum(s.get("message_count", 0) for s in rows)})
 
 

--- a/tui_gateway/session_lifecycle.py
+++ b/tui_gateway/session_lifecycle.py
@@ -438,8 +438,9 @@ def _session_has_active_delegations(sid: str, session: dict | None = None) -> bo
     if session_id:
         # Only when this session may end its durable row by key — never for gateway-originated sessions (TUI is a
         # viewer there). Unknown DB state -> assume ownership.
-        with contextlib.suppress(Exception):
-            db = _get_db()
+        # The row lives in the session's OWN store (a named-profile session's row is invisible to
+        # the launch handle, which would leave this guard permanently dead).
+        with contextlib.suppress(Exception), _session_db(session) as db:
             if db is not None and _is_gateway_owned_source((db.get_session(session_id) or {}).get("source", "")):
                 owned_session_key = ""
     if not own_sid and not owned_session_key:

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -35,11 +35,13 @@ def _notif_live_session_matches(keys, exclude: dict | None = None) -> bool:
         False)
 
 
-def _notif_resolve_event_key(evt_key: str) -> str:
-    """Resolve a compression-rotated session key to its continuation tip (or itself)."""
+def _notif_resolve_event_key(evt_key: str, session: dict | None = None) -> str:
+    """Resolve a compression-rotated session key to its continuation tip (or itself). Looked up in
+    ``session``'s own store: a named-profile session's lineage lives in ``profiles/<x>/state.db``,
+    where the launch handle cannot see it."""
     try:
-        db = _get_db()
-        return (db.resolve_resume_session_id(evt_key) if db is not None else evt_key) or evt_key
+        with _session_db(session or {}) as db:
+            return (db.resolve_resume_session_id(evt_key) if db is not None else evt_key) or evt_key
     except Exception:
         return evt_key
 
@@ -62,7 +64,7 @@ def _notification_event_belongs_elsewhere(sid: str, session: dict, evt: dict) ->
     # Compression can rotate AIAgent.session_id while the detached child is still running: map the event's original
     # key to its continuation tip so it reaches the live session instead of becoming an orphan any poller may consume.
     # A live continuation wins over the compressed parent, else a stale parent tab could consume the event first.
-    resolved_key = _notif_resolve_event_key(evt_key)
+    resolved_key = _notif_resolve_event_key(evt_key, session)
     if resolved_key != evt_key:
         if resolved_key in current_keys:
             return False
@@ -82,7 +84,7 @@ def _session_owns_notification_event(sid: str, session: dict, evt: dict) -> bool
         return True
     evt_key = str(evt.get("session_key") or "")
     current_keys = _notif_current_keys(sid, session)
-    return bool(evt_key) and (evt_key in current_keys or _notif_resolve_event_key(evt_key) in current_keys)
+    return bool(evt_key) and (evt_key in current_keys or _notif_resolve_event_key(evt_key, session) in current_keys)
 
 
 def _notification_event_requires_owner(evt: dict) -> bool:

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -208,7 +208,18 @@ Each profile's sessions live under an `agent:<profile>:…` namespace so two
 profiles on the same platform/chat never collide in the shared session store.
 The **default** profile keeps the historical `agent:main:…` namespace
 byte-for-byte, so existing default-profile sessions are unaffected — no
-migration, no orphaned history.
+migration, no orphaned history. Every gateway path that reads a key back —
+delegation completions after a restart, shutdown notices, a per-user-thread
+`/stop` of a sibling's run, `/undo`, QQ approval buttons — accepts the
+`agent:<profile>:…` shape too, so secondary profiles get the same behaviour
+as the default one.
+
+Each profile's rows land in **its own** `state.db`: a named profile's under
+`profiles/<name>/state.db`, the default profile's under the launch home — even
+when the write happens inside another profile's routed turn or background tick.
+The Desktop/TUI backend's own store is likewise pinned to the home it launched
+under, and a Bot Chat's side agents (`prompt.background`) persist next to their
+parent conversation.
 
 #### 5. One PID/lock and one status surface
 


### PR DESCRIPTION
Under `gateway.multiplex_profiles`, secondary profiles now get the same session-key handling and land their rows in their own `state.db` on every gateway and TUI/Desktop path — no more lost wake-ups, dead `/stop`/`/undo`, rejected QQ approval buttons, or default-profile rows persisted into another profile's store.

## Changes

- **Session keys (`agent:<profile>:…`) parse everywhere.** `gateway/run.py::_parse_session_key` accepts any profile-id namespace and reports it as `profile` (`agent:main` keys keep their exact historical dict shape); `run_busy.py::_sibling_thread_run_keys` builds the sibling `/stop` prefix from the source's namespace; `run_notifications.py::_build_process_event_source` and `run_shutdown.py::_shutdown_notification_target` drop their rewrite-to-`agent:main` workarounds; qqbot `_parse_gateway_session_key` no longer requires the literal `main` (namespace plays no role in authz — operator/chat checks unchanged).
- **Default-profile rows stay in the launch store.** `SessionStore._db_for_key` resolves `agent:main` keys to `_routing_home/state.db` under multiplexing instead of the ambient (currently scoped) store; named-profile keys were already pinned (#97309). Multiplex-off keeps the ambient store byte-for-byte.
- **`/undo` evicts under the profile-namespaced key** (`_session_key_for_source`, like `/reset` and `/retry`).
- **TUI/Desktop backend:** `insights.get` goes through `_profile_db(params)` (was `scoped=True` + `_get_db()` — the poison vector behind the #102526 first-touch race, whose pin landed in #108074); `prompt.background` side agents inherit the parent agent's `_session_db`; `session_lifecycle`'s gateway-owned guard and `session_notifications`' compression-tip resolver look the session up in its own store via `_session_db(session)`.
- **GoalManager** acquires `state.db` through `hermes_state_registry` instead of a bare `SessionDB()` second writer per profile (the shape #100682 removed from the API server).
- Docs: `website/docs/user-guide/multi-profile-gateways.md` § "Session keys are namespaced by profile".

## Live repro (temp `HERMES_HOME` with `profiles/alpha`, real imports; `/tmp/mux_audit/fix-sessions-statedb/repro.py`)

**Before** (origin/main `04dd80a977f`):
```
[FIRE ] F1 _parse_session_key(agent:alpha): agent:alpha:telegram:dm:123 -> None
[FIRE ] F1 run_busy sibling /stop under named profile: siblings=[] (expected [agent:alpha:discord:forum:chan1:thr1:userB])
[FIRE ] F1 qqbot _parse_gateway_session_key(agent:alpha): -> None
[FIRE ] F6 scoped(alpha) _db_for_key(agent:main): -> <tmp>/.hermes/profiles/alpha/state.db
[FIRE ] F7 /undo eviction key: evicted=['agent:main:telegram:dm:123'] (agent key agent:alpha:telegram:dm:123)
[FIRE ] F5 goals SessionDB is registry-managed: registry-shared=False live=0
[FIRE ] F3 prompt.background side agent session_db: F3 launch
[FIRE ] F9 notif owner gate, rotated profile session: F9 notif owns: False
```
**After:**
```
[clean] F1 _parse_session_key(agent:alpha): -> {'platform': 'telegram', 'chat_type': 'dm', 'chat_id': '123', 'profile': 'alpha'}
[clean] F1 run_busy sibling /stop under named profile: siblings=['agent:alpha:discord:forum:chan1:thr1:userB']
[clean] F1 qqbot _parse_gateway_session_key(agent:alpha): -> {'platform': 'qqbot', 'chat_type': 'c2c', 'chat_id': 'op1'}
[clean] F6 scoped(alpha) _db_for_key(agent:main): -> <tmp>/.hermes/state.db
[clean] F7 /undo eviction key: evicted=['agent:alpha:telegram:dm:123']
[clean] F5 goals SessionDB is registry-managed: registry-shared=True live=1
[clean] F3 prompt.background side agent session_db: F3 parent
[clean] F9 notif owner gate, rotated profile session: F9 notif owns: True
FIRED: none
```

## Root cause

Session keys gained an `agent:<profile>:` namespace and stores gained per-profile pinning, but several readers still hardcoded `agent:main` / the ambient or launch handle, so a secondary profile's keys were rejected and default-profile rows followed whichever scope was active.

## Tests (each proven red on base)

`tests/gateway/test_multiplex_session_db_profile_scope.py::test_default_namespace_rows_stay_in_launch_store_under_secondary_scope`, `tests/gateway/test_undo_rewind_session.py::test_undo_evicts_cached_agent_under_profile_namespaced_key`, `tests/tui_gateway/test_launch_db_home_override_race.py::{test_insights_get_reads_the_requested_profile_store_not_the_launch_handle, test_background_side_agent_persists_into_the_parent_agent_store, test_notification_owner_gate_resolves_rotated_key_in_the_session_profile_store}`, `tests/hermes_cli/test_goals.py::test_goal_session_db_is_the_registry_shared_handle`, plus the salvaged tests from #105942 / #98294.

`scripts/run_tests.sh tests/tui_gateway/ tests/test_tui_gateway_server.py tests/hermes_cli/test_goals.py` → 1834 passed, 0 failed. `tests/gateway/` → 8397 passed, 0 failed, 45 skipped.

## Credits

- @kokhlo — salvaged #105942 (`_parse_session_key` / `run_busy` / `run_notifications` namespace parsing), cherry-picked with authorship.
- @LovePlayCode — salvaged #98294 (qqbot approval buttons, reporter's fix for #98292), cherry-picked with authorship.
- @Hotragn — earliest fix for the `/stop` sibling half (#91939); superseded by the shared `_session_key_namespace` shape.
- @HexLab98 — #102534 `_get_db` launch-home pin (already on main via #108074; this PR closes the `insights.get` poison vector it left).

Fixes #98292.
Addresses #102157, #102526, #102120, #103339.

Not in this PR: F4 (`hosted_rooms` raw `sqlite3.connect` of the shared root store) and F8 (`doctor --fix` WAL checkpoint / session count without holder + deleted-generation guards) — neither fits the one-line `acquire` + `refuse_deleted_wal_generation` shape (hosted_rooms uses a connection-per-op DDL helper; doctor needs a "stop the gateway first" UX), so they stay open under #103339.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aaa0189/9fWZZaVu8lM774amzp6Mo_btb5rLG5.png)
