### PR TITLE
[main] Fix Discord auto-thread routing for quote replies

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1605,6 +1605,31 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> tuple[bool, bool]:
         """Return ``(admitted, role_authorized)`` for one Discord event."""
         message_id = str(getattr(message, "id", ""))
+        channel = getattr(message, "channel", None)
+        thread_parent = getattr(channel, "parent", None)
+        forum_parent_types = tuple(
+            channel_type
+            for channel_type in (
+                getattr(discord, "ForumChannel", None),
+                getattr(discord, "MediaChannel", None),
+            )
+            if isinstance(channel_type, type)
+        )
+        # A message-attached thread mirrors its parent starter as a second
+        # MESSAGE_CREATE whose id equals the new thread id. Drop that mirror
+        # by shape before the async thread-creation path can race the dedup
+        # pre-seed below (#51057). Forum/media starters have the same shape but
+        # no separate parent-channel MESSAGE_CREATE, so they must be admitted.
+        if (
+            isinstance(channel, discord.Thread)
+            and message_id
+            and message_id == str(getattr(channel, "id", ""))
+            and not (
+                forum_parent_types
+                and isinstance(thread_parent, forum_parent_types)
+            )
+        ):
+            return False, False
         if claim:
             if self._dedup.is_duplicate(message_id):
                 return False, False
@@ -8187,6 +8212,33 @@ class DiscordAdapter(BasePlatformAdapter):
         normalized_content = raw_content
         mention_prefix = False
 
+        # ``message.create_thread()`` may mutate the discord.py message
+        # object. Preserve quote context and attachments before awaiting it,
+        # just as we already preserve normalized_content for command parsing.
+        original_attachments = list(getattr(message, "attachments", []) or [])
+        reference = getattr(message, "reference", None)
+        resolved_reference = getattr(reference, "resolved", None) if reference else None
+        referenced_attachments = (
+            list(getattr(resolved_reference, "attachments", []) or [])
+            if resolved_reference is not None
+            else []
+        )
+        reference_message_id = (
+            getattr(reference, "message_id", None)
+            if reference is not None
+            else None
+        )
+        reply_to_id = (
+            str(reference_message_id)
+            if reference_message_id is not None
+            else None
+        )
+        reply_to_text = (
+            getattr(resolved_reference, "content", None) or None
+            if resolved_reference is not None
+            else None
+        )
+
         snapshot_attachments = []
         if hasattr(message, "message_snapshots") and message.message_snapshots:
             snapshot_text_parts = []
@@ -8259,8 +8311,11 @@ class DiscordAdapter(BasePlatformAdapter):
             no_thread_channels = self._get_no_thread_channels()
             skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
-            is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
-            if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
+            # Discord quote-replies posted in a parent text channel are still
+            # new conversation roots for routing purposes. Excluding
+            # MessageType.reply here silently bypassed auto-threading and sent
+            # the agent's answer inline in the shared parent channel.
+            if auto_thread and not skip_thread and not is_voice_linked_channel:
                 thread = await self._auto_create_thread(message)
                 if thread:
                     parent_channel_id = str(message.channel.id)
@@ -8299,13 +8354,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         )
                     return False
 
-        referenced_attachments = []
-        reference = getattr(message, "reference", None)
-        resolved_reference = getattr(reference, "resolved", None) if reference else None
-        if resolved_reference is not None:
-            referenced_attachments = list(getattr(resolved_reference, "attachments", []) or [])
-
-        all_attachments = list(message.attachments) + snapshot_attachments + referenced_attachments
+        all_attachments = original_attachments + snapshot_attachments + referenced_attachments
 
         # Determine message type
         msg_type = MessageType.TEXT
@@ -8602,13 +8651,6 @@ class DiscordAdapter(BasePlatformAdapter):
         _chan_id = str(getattr(_chan, "id", ""))
         _skills = self._resolve_channel_skills(_chan_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(_chan_id, _parent_id or None)
-
-        reply_to_id = None
-        reply_to_text = None
-        if message.reference:
-            reply_to_id = str(message.reference.message_id)
-            if message.reference.resolved:
-                reply_to_text = getattr(message.reference.resolved, "content", None) or None
 
         event = MessageEvent(
             text=event_text,

--- a/tests/gateway/test_discord_double_dispatch.py
+++ b/tests/gateway/test_discord_double_dispatch.py
@@ -61,6 +61,10 @@ class _TextChannel:
         return _empty()
 
 
+class _ForumChannel(_TextChannel):
+    """Fake Discord forum parent whose starter exists only in its post thread."""
+
+
 class _Thread:
     """Fake Discord thread (not a DM, not a top-level channel)."""
 
@@ -199,6 +203,64 @@ class TestThreadStarterDedup:
         assert adapter.handle_message.call_count == 1, (
             "handle_message should only be called once — duplicate starter dropped"
         )
+
+    @pytest.mark.asyncio
+    async def test_thread_starter_racing_creation_is_dropped(self, adapter, monkeypatch):
+        """A starter mirror arriving before dedup pre-seeding cannot dispatch."""
+        monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+        monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+        monkeypatch.setattr(discord_platform.discord, "Thread", _Thread)
+        adapter._ready_event.set()
+
+        channel = _TextChannel(channel_id=100)
+        thread = _Thread(thread_id=55555, parent=channel)
+
+        async def create_thread_with_racing_starter(message):
+            starter = _make_message(
+                msg_id=thread.id,
+                channel=thread,
+                content=message.content,
+            )
+            dispatched = await adapter._dispatch_discord_message(starter)
+            assert dispatched is False
+            return thread
+
+        monkeypatch.setattr(
+            adapter, "_auto_create_thread", create_thread_with_racing_starter
+        )
+
+        user_msg = _make_message(
+            msg_id=42,
+            channel=channel,
+            content="replying to an earlier message",
+            msg_type=discord_platform.discord.MessageType.reply,
+        )
+        await adapter._handle_message(user_msg)
+
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_forum_starter_with_thread_id_is_admitted(self, adapter, monkeypatch):
+        """A forum post starter is not mistaken for a text-channel mirror."""
+        monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+        monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+        monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+        monkeypatch.setattr(discord_platform.discord, "Thread", _Thread)
+        monkeypatch.setattr(discord_platform.discord, "ForumChannel", _ForumChannel)
+        adapter._ready_event.set()
+
+        forum = _ForumChannel(channel_id=100)
+        post = _Thread(thread_id=55555, parent=forum)
+        starter = _make_message(
+            msg_id=post.id,
+            channel=post,
+            content="new forum post",
+        )
+
+        dispatched = await adapter._dispatch_discord_message(starter)
+
+        assert dispatched is True
+        adapter.handle_message.assert_awaited_once()
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -228,8 +228,8 @@ async def test_discord_accepts_and_strips_bot_mentions_when_required(adapter, mo
 
 
 @pytest.mark.asyncio
-async def test_discord_reply_message_skips_auto_thread(adapter, monkeypatch):
-    """Quote-replies should stay in-channel instead of trying to create a thread."""
+async def test_discord_reply_in_free_response_channel_skips_auto_thread(adapter, monkeypatch):
+    """Free-response policy, not the quote-reply type, keeps a reply inline."""
     monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "123")
@@ -250,6 +250,58 @@ async def test_discord_reply_message_skips_auto_thread(adapter, monkeypatch):
     assert event.text == "reply without mention"
     assert event.source.chat_id == "123"
     assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_discord_reply_message_auto_threads_in_parent_channel(adapter, monkeypatch):
+    """Quote-replies in a normal parent channel must retain thread isolation."""
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+
+    thread = FakeThread(channel_id=999)
+    quoted_image = SimpleNamespace(
+        content_type="image/png",
+        filename="quoted.png",
+        url="https://cdn.discordapp.com/quoted.png",
+        size=123,
+    )
+    reference = SimpleNamespace(
+        message_id=456,
+        resolved=SimpleNamespace(
+            content="quoted context",
+            attachments=[quoted_image],
+        ),
+    )
+
+    async def create_thread_and_clobber_context(message):
+        message.reference = None
+        message.attachments = []
+        return thread
+
+    adapter._auto_create_thread = AsyncMock(side_effect=create_thread_and_clobber_context)
+    adapter._cache_discord_image = AsyncMock(return_value="/tmp/quoted.png")
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=123),
+        content="reply without mention",
+        msg_type=discord_platform.discord.MessageType.reply,
+    )
+    message.reference = reference
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once_with(message)
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "999"
+    assert event.source.chat_type == "thread"
+    assert event.source.parent_chat_id == "123"
+    assert event.reply_to_message_id == "456"
+    assert event.reply_to_text == "quoted context"
+    assert event.media_urls == ["/tmp/quoted.png"]
+    assert event.media_types == ["image/png"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 概要
- 親チャンネルのDiscord引用返信（`MessageType.reply`）も通常投稿と同様にauto-threadへ移します。
- free-response／no-thread／voice-linked channelの既存例外は維持します。
- 通常テキストチャンネルのthread-starter mirrorだけを形状で早期除外し、非同期thread作成中の二重dispatchを防ぎます。Forum／Media Channelのstarterは除外しません。
- `message.create_thread()`前に引用本文・添付を退避し、引用文脈を保持します。

## 原因
`discord.auto_thread: true`でも、アダプターが`MessageType.reply`を明示的に除外していたため、引用返信から始まった依頼だけ`chat_type=group`として処理されていました。

## 検証
- RED: 新規回帰テストが旧分岐で失敗することを確認
- GREEN: focused Discord routing tests: 35 passed
- Discord adapter E2E: 7 passed
- thread作成中のstarter競合テスト: passed
- Forum starter保持テスト: passed
- 引用本文・添付の保持テスト: passed
- Ruff: passed
- `git diff --check`: passed