### PR TITLE
fix(desktop): recognize the workspace pane in rootRow()'s own hasMain() too

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/store.root-row.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.root-row.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// rootRow() has its own hasMain() closure, separate from paneRootSide()'s own
+// mainIndices check (a sibling of the fix in aa05e5c0f4 "resolve side ownership
+// before workspace registration"). In a column-root layout (Terminal deck, Quad),
+// rootRow() runs FIRST inside paneRootSide() -- if its hasMain() fails to
+// recognize the workspace pane before the registry has registered its
+// data.placement === 'main' metadata, rootRow() returns null and every caller
+// (paneRootSide, layoutHasRootSide, restoreMinimizedTreeSide, treeSideOfPane)
+// short-circuits before aa05e5c0f4's own fix (inside paneRootSide's mainIndices)
+// ever runs.
+describe('rootRow() column-root workspace recognition', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('paneRootSide finds the side even when the workspace pane has not registered its placement yet', async () => {
+    const { split, group } = await import('./model')
+    const tree = await import('./store')
+    const { registry } = await import('@/contrib/registry')
+
+    const sidebar = group(['sessions'], { id: 'sidebar' })
+    const main = group(['workspace'], { id: 'main' })
+    const files = group(['files'], { id: 'files-zone' })
+    // Column root: a row of sidebar/main/files nested under a column split --
+    // the shape rootRow() must unwrap to find the side-eligible row.
+    tree.declareDefaultTree(split('column', [split('row', [sidebar, main, files])]))
+
+    // Deliberately do NOT register 'workspace' in the panes area -- rootRow()'s
+    // hasMain() must still recognize it by id, the same way paneRootSide()'s own
+    // mainIndices check already does.
+    const disposers = [
+      registry.register({ area: 'panes', id: 'sessions', data: { placement: 'left' } }),
+      registry.register({ area: 'panes', id: 'files', data: { placement: 'right' } })
+    ]
+
+    try {
+      expect(tree.paneRootSide('sessions')).toBe('left')
+      expect(tree.paneRootSide('files')).toBe('right')
+      expect(tree.layoutHasRootSide('left')).toBe(true)
+      expect(tree.layoutHasRootSide('right')).toBe(true)
+    } finally {
+      disposers.forEach(dispose => dispose())
+    }
+  })
+
+  it('restoreMinimizedTreeSide recovers a minimized side in a column-root layout without a registered workspace pane', async () => {
+    const { split, group, findGroup } = await import('./model')
+    const tree = await import('./store')
+    const { registry } = await import('@/contrib/registry')
+
+    const sidebar = group(['sessions'], { id: 'sidebar' })
+    const main = group(['workspace'], { id: 'main' })
+    const files = group(['files'], { id: 'files-zone' })
+    tree.declareDefaultTree(split('column', [split('row', [sidebar, main, files])]))
+
+    const disposers = [
+      registry.register({ area: 'panes', id: 'sessions', data: { placement: 'left' } }),
+      registry.register({ area: 'panes', id: 'files', data: { placement: 'right' } })
+    ]
+
+    try {
+      tree.setTreeGroupMinimized('sidebar', true)
+      expect(findGroup(tree.$layoutTree.get()!, 'sidebar')?.minimized).toBe(true)
+
+      const restored = tree.restoreMinimizedTreeSide('left')
+
+      expect(restored).toBe(true)
+      expect(findGroup(tree.$layoutTree.get()!, 'sidebar')?.minimized).toBe(false)
+    } finally {
+      disposers.forEach(dispose => dispose())
+    }
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -869,7 +869,9 @@ function rootRow(): SplitNode | null {
   const hasMain = (node: LayoutNode): boolean => {
     if (node.type === 'group') {
       return node.panes.some(
-        id => (panes.find(p => p.id === id)?.data as { placement?: string } | undefined)?.placement === 'main'
+        id =>
+          id === 'workspace' ||
+          (panes.find(p => p.id === id)?.data as { placement?: string } | undefined)?.placement === 'main'
       )
     }
 


### PR DESCRIPTION
## Summary
- `aa05e5c0f4` ("resolve side ownership before workspace registration") fixed `paneRootSide()`'s own `mainIndices` check to treat `id === 'workspace'` as main even before the registry has that pane's `data.placement === 'main'` metadata.
- But `paneRootSide()` calls `rootRow()` as its very first step, and `rootRow()` has an identical, *separate* `hasMain()` closure for locating the side-eligible row in a column-root layout (Terminal deck, Quad) — that closure still only checked `data.placement`, with no workspace special case.
- In a column-root layout evaluated before the workspace pane's placement metadata is registered, `rootRow()`'s `hasMain()` returns `false` for every child, so `rootRow()` returns `null` and `paneRootSide()` short-circuits before its own (already-fixed) `mainIndices` check ever runs. Same failure mode for every other caller of `rootRow()`: `layoutHasRootSide()`, `restoreMinimizedTreeSide()`, and `treeSideOfPane()` (a thin alias of `paneRootSide()`).
- Same one-line fix, mirrored from the sibling.

## Test plan
- [x] Added `apps/desktop/src/components/pane-shell/tree/store.root-row.test.ts` — two tests build a column-root layout (`split('column', [split('row', [sidebar, main, files])])`) with the `workspace` pane deliberately left unregistered in the panes area, then assert `paneRootSide`/`layoutHasRootSide`/`restoreMinimizedTreeSide` all correctly recognize the side anyway.
- [x] Mutation-verified: reverted the fix, confirmed both new tests fail (`expected null to be 'left'`, `expected false to be true`); restored the fix, both pass.
- [x] `npx vitest run src/components/pane-shell src/store/sidebar-collapse-persistence.test.ts` → 183 passed, 0 failed.
- [x] `npx tsc -p tsconfig.json --noEmit` → clean, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)