### PR TITLE
feat(desktop): group sidebar sessions into folders with drag and drop

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/chat-sidebar.integration.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/chat-sidebar.integration.test.tsx
@@ -8,6 +8,7 @@ import { $layoutTree, noteActiveTreeGroup } from '@/components/pane-shell/tree/s
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { registry } from '@/contrib/registry'
 import { $selectedStoredSessionId, $sessions } from '@/store/session'
+import { $sessionFolderStore } from '@/store/session-folders'
 import { $removedSessionIds } from '@/store/session-removal'
 import { makeSessionInfo } from '@/test/session-info'
 
@@ -96,6 +97,7 @@ describe('ChatSidebar navigation activity', () => {
     $selectedStoredSessionId.set(null)
     $sessions.set([])
     $removedSessionIds.set(new Set())
+    $sessionFolderStore.set({})
     $layoutTree.set(null)
     noteActiveTreeGroup(null)
   })
@@ -160,5 +162,22 @@ describe('ChatSidebar navigation activity', () => {
     expect(screen.queryByRole('button', { name: 'Kanban' })).toBeNull()
     expectOnlyCurrent(null)
     expectOnlySelectedSession(null)
+  })
+
+  it('groups a filed session under its folder, out of the flat list', () => {
+    $sessionFolderStore.set({
+      default: { filed: { 'tile-one': 'f_work' }, folders: [{ collapsed: false, id: 'f_work', name: 'Work' }] }
+    })
+
+    const { container } = renderSidebar('/kanban', 'extension')
+    const folder = container.querySelector('[data-session-folder-id="f_work"]') as HTMLElement
+
+    // The flat Sessions list carries the strip, and the filed row lives in it.
+    expect(container.querySelector('[data-session-folders]')).not.toBeNull()
+    expect(folder.textContent).toContain('Work')
+    expect(folder.textContent).toContain('Tile one')
+    expect(folder.textContent).not.toContain('Tile two')
+    // Filed once: it is not also listed in the flat list below its folder.
+    expect(screen.getAllByText('Tile one')).toHaveLength(1)
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1713,6 +1713,10 @@ export function ChatSidebar({
                     </div>
                   )
                 }
+                // Only the flat Sessions list groups by folder: the archived and
+                // magnitude-ranked views are not "the sessions you organize",
+                // and the grouped project views already group by workspace.
+                enableFolders={sessionsMode === 'flat'}
                 footer={
                   // Hidden only when workspace-grouped — those groups page
                   // themselves. Profile groups don't: this one footer fetches the

--- a/apps/desktop/src/app/chat/sidebar/reorderable-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/reorderable-list.tsx
@@ -1,5 +1,5 @@
 import type { useSensors } from '@dnd-kit/core'
-import { closestCenter, DndContext, type DragEndEvent } from '@dnd-kit/core'
+import { closestCenter, DndContext, type DragEndEvent, useDraggable, useDroppable } from '@dnd-kit/core'
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import type * as React from 'react'
 
@@ -15,13 +15,69 @@ const reorderAutoScroll = { threshold: { x: 0, y: 0.2 } }
 // around or inside it. Pair each item with useSortableBindings(id); the list reports
 // the new id order and the caller persists it. This is the single generic primitive
 // behind every reorderable surface in the sidebar.
+/**
+ * A droppable that is NOT one of the list's sortable rows (a session-folder
+ * header, say). A drop on it is reported through `onDrop` instead of a reorder,
+ * so a list can carry both gestures over one DndContext — and over one press,
+ * which is what lets a session row be reordered BY the list and filed into a
+ * folder by the same drag session (see session-row.tsx's dual-gesture note).
+ */
+export interface ReorderDropTarget {
+  id: string
+  onDrop: (activeId: string) => void
+}
+
+/** What a finished drag resolved to. */
+export type ReorderDrop =
+  { kind: 'drop-target'; targetId: string } | { ids: string[]; kind: 'reorder' } | { kind: 'none' }
+
+/**
+ * Arbitrate a completed drag: a drop on a registered target is reported, a drop
+ * on another row reorders, anything else (a miss, a row on itself) does nothing.
+ * A row the list does NOT order — a session inside a folder — can be dragged but
+ * never reorders, so dropping it on a row is a no-op rather than a reorder from
+ * an index the list never had.
+ *
+ * Exported because it is the whole rule: dnd-kit owns the geometry, this owns
+ * what the gesture means.
+ */
+export function resolveReorderDrop(
+  activeId: unknown,
+  overId: null | unknown,
+  ids: string[],
+  dropTargets?: ReorderDropTarget[]
+): ReorderDrop {
+  if (overId === null || overId === undefined) {
+    return { kind: 'none' }
+  }
+
+  const over = String(overId)
+
+  if (dropTargets?.some(candidate => candidate.id === over)) {
+    // A drop target wins over the row it may sit next to: the user aimed at the
+    // folder, and the row under the pointer is just what the geometry found.
+    return { kind: 'drop-target', targetId: over }
+  }
+
+  if (String(activeId) === over) {
+    return { kind: 'none' }
+  }
+
+  const from = ids.indexOf(String(activeId))
+  const to = ids.indexOf(over)
+
+  return from >= 0 && to >= 0 ? { ids: arrayMove(ids, from, to), kind: 'reorder' } : { kind: 'none' }
+}
+
 export function ReorderableList({
   children,
+  dropTargets,
   ids,
   onReorder,
   sensors
 }: {
   children: React.ReactNode
+  dropTargets?: ReorderDropTarget[]
   ids: string[]
   onReorder: (ids: string[]) => void
   sensors?: ReturnType<typeof useSensors>
@@ -35,15 +91,12 @@ export function ReorderableList({
       ;(document.activeElement as HTMLElement | null)?.blur()
     }
 
-    if (!over || active.id === over.id) {
-      return
-    }
+    const resolved = resolveReorderDrop(active.id, over?.id ?? null, ids, dropTargets)
 
-    const from = ids.indexOf(String(active.id))
-    const to = ids.indexOf(String(over.id))
-
-    if (from >= 0 && to >= 0) {
-      onReorder(arrayMove(ids, from, to))
+    if (resolved.kind === 'drop-target') {
+      dropTargets?.find(candidate => candidate.id === resolved.targetId)?.onDrop(String(active.id))
+    } else if (resolved.kind === 'reorder') {
+      onReorder(resolved.ids)
     }
   }
 
@@ -75,6 +128,33 @@ export function useSortableBindings(id: string) {
       // group/row from drifting sideways or morphing its size mid-drag.
       transform: transform ? `translate3d(0px, ${transform.y}px, 0)` : undefined,
       transition: isDragging ? undefined : transition,
+      willChange: isDragging ? 'transform' : undefined
+    }
+  }
+}
+
+/** Droppable-only binding: a target that is not a sortable row (a folder
+ *  header). A drop on it is routed through the list's `dropTargets`. */
+export function useDropTargetBindings(id: string) {
+  const { isOver, setNodeRef } = useDroppable({ id })
+
+  return { dropHighlight: isOver, dropRef: setNodeRef }
+}
+
+/** Drag-source-only binding: a row that can be dragged onto a drop target but is
+ *  NOT a member of the reorder order — a session that lives inside a folder.
+ *  Dropping it on a sortable row is a no-op (the list cannot place a row it does
+ *  not order); dropping it on a folder files it there. */
+export function useDraggableBindings(id: string) {
+  const { attributes, isDragging, listeners, setNodeRef, transform } = useDraggable({ id })
+
+  return {
+    dragging: isDragging,
+    dragHandleProps: { ...attributes, ...listeners },
+    ref: setNodeRef,
+    reorderable: true as const,
+    style: {
+      transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
       willChange: isDragging ? 'transform' : undefined
     }
   }

--- a/apps/desktop/src/app/chat/sidebar/session-folders.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-folders.test.tsx
@@ -1,0 +1,184 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+import { $activeGatewayProfile, $showAllProfiles } from '@/store/profile'
+import { $sessionFolderStore } from '@/store/session-folders'
+
+import { type ReorderDropTarget, resolveReorderDrop } from './reorderable-list'
+import { folderDropTarget, UNFILED_DROP_TARGET } from './session-folders'
+import { SidebarSessionsSection } from './sessions-section'
+
+afterEach(cleanup)
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        dateDivider: {
+          earlierThisMonth: 'Earlier this month',
+          lastMonth: 'Last month',
+          lastWeek: 'Last week',
+          older: 'Older',
+          today: 'Today',
+          yesterday: 'Yesterday'
+        },
+        folders: {
+          delete: 'Delete folder',
+          deleteHint: 'Delete this folder?',
+          label: 'Folders',
+          newFolder: 'New folder',
+          rename: 'Rename folder',
+          unfiled: 'Not in a folder',
+          unfiledHint: 'Drop a session here'
+        }
+      }
+    }
+  })
+}))
+
+// Flat-list tests only care about WHERE a row landed: keep rows inert so they
+// can't collide on accessible names or pull in row-level store dependencies.
+vi.mock('./session-row', () => ({
+  SidebarSessionRow: ({ session }: { session: SessionInfo }) => (
+    <div data-testid={`session-row-${session.id}`}>{session.id}</div>
+  )
+}))
+
+const noop = () => {}
+
+const session = (id: string, startedAt = 1000): SessionInfo =>
+  ({ id, last_active: startedAt, profile: 'default', started_at: startedAt }) as unknown as SessionInfo
+
+const folderStore = (filed: Record<string, string>, collapsed = false) => ({
+  default: {
+    filed,
+    folders: [{ collapsed, id: 'f_work', name: 'Work' }]
+  }
+})
+
+const renderSection = (sessions: SessionInfo[], enableFolders = true) =>
+  render(
+    <SidebarSessionsSection
+      activeSessionId={null}
+      emptyState={<div>Empty</div>}
+      enableFolders={enableFolders}
+      label="Sessions"
+      onArchiveSession={noop}
+      onDeleteSession={noop}
+      onReorderSessions={noop}
+      onResumeSession={noop}
+      onToggle={noop}
+      onTogglePin={noop}
+      onToggleUnread={noop}
+      open
+      pinned={false}
+      sessions={sessions}
+      sortable
+    />
+  )
+
+beforeEach(() => {
+  window.localStorage.clear()
+  $showAllProfiles.set(false)
+  $activeGatewayProfile.set('default')
+  $sessionFolderStore.set({})
+})
+
+describe('sidebar session folders', () => {
+  it('lists a filed session under its folder and out of the flat list', () => {
+    $sessionFolderStore.set(folderStore({ s1: 'f_work' }))
+
+    const { container } = renderSection([session('s1'), session('s2')])
+    const folder = container.querySelector('[data-session-folder-id="f_work"]') as HTMLElement
+
+    // The folder header is the drop target for its own id, so a row dropped on
+    // it routes to this folder.
+    expect(folder.querySelector('[data-folder-drop="f_work"]')).not.toBeNull()
+    expect(within(folder).getByText('Work')).toBeTruthy()
+
+    // Filed once, in the folder — never also in the main list below it.
+    expect(container.querySelectorAll('[data-testid="session-row-s1"]')).toHaveLength(1)
+    expect(folder.contains(screen.getByTestId('session-row-s1'))).toBe(true)
+
+    // Its unfiled sibling stays in the main list.
+    expect(folder.contains(screen.getByTestId('session-row-s2'))).toBe(false)
+  })
+
+  it('hides a collapsed folder\u2019s sessions', () => {
+    $sessionFolderStore.set(folderStore({ s1: 'f_work' }, true))
+
+    renderSection([session('s1'), session('s2')])
+
+    expect(screen.queryByTestId('session-row-s1')).toBeNull()
+    expect(screen.getByTestId('session-row-s2')).toBeTruthy()
+  })
+
+  it('leaves the list alone where folders are not enabled', () => {
+    $sessionFolderStore.set(folderStore({ s1: 'f_work' }))
+
+    const { container } = renderSection([session('s1'), session('s2')], false)
+
+    expect(container.querySelector('[data-session-folders]')).toBeNull()
+    expect(screen.getByTestId('session-row-s1')).toBeTruthy()
+  })
+
+  it('creates, renames and deletes a folder from the strip', () => {
+    $sessionFolderStore.set(folderStore({ s1: 'f_work' }))
+
+    const { container } = renderSection([session('s1'), session('s2')])
+
+    fireEvent.click(screen.getByRole('button', { name: 'New folder' }))
+    expect($sessionFolderStore.get().default.folders.map(folder => folder.name)).toEqual(['Work', 'New folder'])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename folder: Work' }))
+    const input = screen.getByLabelText('Rename folder')
+    fireEvent.change(input, { target: { value: 'Deep work' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect($sessionFolderStore.get().default.folders[0].name).toBe('Deep work')
+    // Renaming keeps the membership: the row is still inside the folder.
+    expect(
+      (container.querySelector('[data-session-folder-id="f_work"]') as HTMLElement).contains(
+        screen.getByTestId('session-row-s1')
+      )
+    ).toBe(true)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete folder: Deep work' }))
+
+    // The folder is gone and its session is back in the main list — the session
+    // itself was never touched. The folder made earlier in this test stays.
+    expect($sessionFolderStore.get().default.folders.map(folder => folder.name)).toEqual(['New folder'])
+    expect(screen.getByTestId('session-row-s1')).toBeTruthy()
+  })
+
+  it('routes a drop on a folder to that folder, and a drop on a row to the list', () => {
+    const fileInFolder = vi.fn<ReorderDropTarget['onDrop']>()
+    const unfiled = vi.fn<ReorderDropTarget['onDrop']>()
+
+    const targets: ReorderDropTarget[] = [
+      { id: folderDropTarget('f_work'), onDrop: fileInFolder },
+      { id: UNFILED_DROP_TARGET, onDrop: unfiled }
+    ]
+
+    const ids = ['s1', 's2']
+
+    expect(resolveReorderDrop('s1', folderDropTarget('f_work'), ids, targets)).toEqual({
+      kind: 'drop-target',
+      targetId: folderDropTarget('f_work')
+    })
+    expect(resolveReorderDrop('s1', UNFILED_DROP_TARGET, ids, targets)).toEqual({
+      kind: 'drop-target',
+      targetId: UNFILED_DROP_TARGET
+    })
+
+    // A drop on another row is still an ordinary reorder.
+    expect(resolveReorderDrop('s1', 's2', ids, targets)).toEqual({ ids: ['s2', 's1'], kind: 'reorder' })
+
+    // A folder's own row is not in the reorder order: dropping it on a row does
+    // neither (it is moved by dropping it on a folder).
+    expect(resolveReorderDrop('s9', 's2', ids, targets)).toEqual({ kind: 'none' })
+    expect(resolveReorderDrop('s1', null, ids, targets)).toEqual({ kind: 'none' })
+    expect(resolveReorderDrop('s1', 's1', ids, targets)).toEqual({ kind: 'none' })
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/session-folders.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-folders.tsx
@@ -1,0 +1,317 @@
+/**
+ * Session folders — the sidebar's own grouping of sessions, rendered as a strip
+ * above the flat list (folders first, then the sessions that are in none).
+ *
+ * Folders are not sessions and not projects: a project groups sessions by WHERE
+ * they run (its folders are filesystem paths, and moving a session into one
+ * re-homes its cwd), while a session folder is the user's own label and touches
+ * nothing about the session. So this rides the desktop's local folder store
+ * (`@/store/session-folders`) and the sidebar's existing dnd-kit list: a row is
+ * dropped onto a folder header to file it, onto "None" to take it back out.
+ */
+
+import { useStore } from '@nanostores/react'
+import type * as React from 'react'
+import { useCallback, useMemo, useState } from 'react'
+
+import { Codicon } from '@/components/ui/codicon'
+import { RowButton } from '@/components/ui/row-button'
+import { Tip } from '@/components/ui/tooltip'
+import type { SessionInfo } from '@/hermes'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+import {
+  $sessionFoldersAvailable,
+  $sessionFolderScope,
+  createSessionFolder,
+  deleteSessionFolder,
+  fileSessionInFolder,
+  groupSessionsByFolder,
+  renameSessionFolder,
+  type SessionFolder,
+  toggleSessionFolderCollapsed
+} from '@/store/session-folders'
+
+import { SidebarRowLead } from './chrome'
+import { type ReorderDropTarget, useDropTargetBindings } from './reorderable-list'
+import { SIDEBAR_LEAD_ICON_SIZE, SIDEBAR_ROW_LABEL } from './row-geometry'
+
+// dnd-kit ids of the strip's drop targets. Prefixed so they can never collide
+// with a session id (the ids the reorder list carries).
+const FOLDER_DROP_PREFIX = 'session-folder:'
+
+/** Drop target that takes a session back out of every folder. */
+export const UNFILED_DROP_TARGET = 'session-folder:none'
+
+export const folderDropTarget = (folderId: string) => `${FOLDER_DROP_PREFIX}${folderId}`
+
+// A folder that a drag is hovering over has to read as "it will land HERE" —
+// the same weight the row's own lifted state uses.
+const DROP_HIGHLIGHT = 'rounded-md bg-(--ui-row-active-background) ring-1 ring-inset ring-(--ui-border-strong)'
+
+const HOVER_ACTION =
+  'grid size-4 shrink-0 place-items-center rounded-sm bg-transparent text-(--ui-text-quaternary) opacity-0 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground group-hover/folder:opacity-100 focus-visible:opacity-100'
+
+export interface SessionFolderSection {
+  /** Session ids the flat list must leave out of its rows (empty wherever the
+   *  folders are not on screen). */
+  filedIds: ReadonlySet<string>
+  /** Extra dnd-kit drop targets for the list the strip renders in. */
+  dropTargets: ReorderDropTarget[] | undefined
+  /** The strip itself, or null when this list doesn't group by folder. */
+  strip: React.ReactNode
+}
+
+const NO_FILED_IDS: ReadonlySet<string> = new Set()
+
+/**
+ * Everything the flat Sessions list needs to group by folder: the ids that leave
+ * the list, the drop targets their rows can land on, and the strip that renders
+ * the folders. One call, so the section component doesn't grow a second,
+ * folder-shaped body.
+ */
+export function useSessionFolderSection({
+  enabled,
+  renderMembers,
+  sessions
+}: {
+  /** Whether THIS list groups by folder at all. */
+  enabled: boolean
+  /** The folder's member rows, rendered by the owner (which owns the row
+   *  renderer and its per-row props). */
+  renderMembers: (members: SessionInfo[]) => React.ReactNode
+  sessions: SessionInfo[]
+}): SessionFolderSection {
+  const { t } = useI18n()
+  const scope = useStore($sessionFolderScope)
+  const available = useStore($sessionFoldersAvailable)
+  const active = enabled && available
+  // Folders first, then the sessions in none — which is what the ordinary flat
+  // rendering already is when there are no folders.
+  const split = useMemo(() => groupSessionsByFolder(sessions, scope), [scope, sessions])
+  // Empty wherever folders are NOT on screen (archived, all-profiles, grouped
+  // views): those lists still show every session, filed or not, or a filed chat
+  // would go missing the moment the sidebar left the flat list.
+  const filedIds = useMemo(() => (active ? new Set(Object.keys(scope.filed)) : NO_FILED_IDS), [active, scope.filed])
+
+  // Dropping a row on a folder files it there; on "Not in a folder" it leaves
+  // every folder. Both ride the ONE dnd-kit list the rows already belong to, so
+  // a drag over the sidebar routes here and a drag over a chat pane still routes
+  // to the pane drag session.
+  const dropTargets = useMemo(
+    () =>
+      active && scope.folders.length
+        ? [
+            ...scope.folders.map(folder => ({
+              id: folderDropTarget(folder.id),
+              onDrop: (sessionId: string) => fileSessionInFolder(sessionId, folder.id)
+            })),
+            { id: UNFILED_DROP_TARGET, onDrop: (sessionId: string) => fileSessionInFolder(sessionId, null) }
+          ]
+        : undefined,
+    [active, scope.folders]
+  )
+
+  const counts = useMemo(
+    () => Object.fromEntries(split.groups.map(group => [group.folder.id, group.sessions.length])),
+    [split.groups]
+  )
+
+  const renderSessions = useCallback(
+    (folderId: string) => {
+      const group = split.groups.find(candidate => candidate.folder.id === folderId)
+
+      return group?.sessions.length ? renderMembers(group.sessions) : null
+    },
+    [renderMembers, split.groups]
+  )
+
+  const strip = active ? (
+    <SessionFolderStrip
+      counts={counts}
+      folders={scope.folders}
+      onCreate={() => createSessionFolder(t.sidebar.folders.newFolder)}
+      onDelete={deleteSessionFolder}
+      onRename={renameSessionFolder}
+      onToggleCollapsed={toggleSessionFolderCollapsed}
+      renderSessions={renderSessions}
+    />
+  ) : null
+
+  return { dropTargets, filedIds, strip }
+}
+
+export interface SessionFolderStripProps {
+  counts: Record<string, number>
+  folders: SessionFolder[]
+  onCreate: () => void
+  onDelete: (folderId: string) => void
+  onRename: (folderId: string, name: string) => void
+  onToggleCollapsed: (folderId: string) => void
+  /** The folder's member rows, in list order (rendered by the owner, which owns
+   *  the row renderer). */
+  renderSessions: (folderId: string) => React.ReactNode
+}
+
+export function SessionFolderStrip({
+  counts,
+  folders,
+  onCreate,
+  onDelete,
+  onRename,
+  onToggleCollapsed,
+  renderSessions
+}: SessionFolderStripProps) {
+  const { t } = useI18n()
+  const f = t.sidebar.folders
+  const { dropHighlight, dropRef } = useDropTargetBindings(UNFILED_DROP_TARGET)
+
+  return (
+    <div className="flex flex-col gap-px pb-1" data-session-folders="">
+      <div className="group/folders flex min-h-6 items-center gap-1.5 px-2 text-[0.6875rem] font-medium text-(--ui-text-tertiary)">
+        <SidebarRowLead>
+          <Codicon name="new-folder" size={SIDEBAR_LEAD_ICON_SIZE} />
+        </SidebarRowLead>
+        <span className="min-w-0 flex-1 truncate">{f.label}</span>
+        <Tip label={f.newFolder}>
+          <button
+            aria-label={f.newFolder}
+            className={cn(HOVER_ACTION, 'group-hover/folders:opacity-100')}
+            onClick={onCreate}
+            type="button"
+          >
+            <Codicon name="add" size="0.75rem" />
+          </button>
+        </Tip>
+      </div>
+
+      {folders.map(folder => (
+        <SessionFolderRow
+          count={counts[folder.id] ?? 0}
+          folder={folder}
+          key={folder.id}
+          onDelete={onDelete}
+          onRename={onRename}
+          onToggleCollapsed={onToggleCollapsed}
+          renderSessions={renderSessions}
+        />
+      ))}
+
+      {folders.length > 0 && (
+        <Tip label={f.unfiledHint}>
+          <div
+            className={cn(
+              'flex min-h-6 items-center gap-1.5 px-2 text-[0.6875rem] text-(--ui-text-quaternary)',
+              dropHighlight && DROP_HIGHLIGHT
+            )}
+            data-folder-drop="none"
+            ref={dropRef}
+          >
+            {f.unfiled}
+          </div>
+        </Tip>
+      )}
+    </div>
+  )
+}
+
+interface SessionFolderRowProps {
+  count: number
+  folder: SessionFolder
+  onDelete: (folderId: string) => void
+  onRename: (folderId: string, name: string) => void
+  onToggleCollapsed: (folderId: string) => void
+  renderSessions: (folderId: string) => React.ReactNode
+}
+
+function SessionFolderRow({
+  count,
+  folder,
+  onDelete,
+  onRename,
+  onToggleCollapsed,
+  renderSessions
+}: SessionFolderRowProps) {
+  const { t } = useI18n()
+  const f = t.sidebar.folders
+  const [draft, setDraft] = useState(folder.name)
+  const [renaming, setRenaming] = useState(false)
+  const { dropHighlight, dropRef } = useDropTargetBindings(folderDropTarget(folder.id))
+  const open = !folder.collapsed
+
+  const startRenaming = () => {
+    setDraft(folder.name)
+    setRenaming(true)
+  }
+
+  const commitRename = () => {
+    setRenaming(false)
+
+    if (draft.trim() && draft.trim() !== folder.name) {
+      onRename(folder.id, draft)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-px" data-session-folder-id={folder.id}>
+      <div
+        className={cn('group/folder flex min-h-6 items-center gap-1 px-2', dropHighlight && DROP_HIGHLIGHT)}
+        data-folder-drop={folder.id}
+        ref={dropRef}
+      >
+        {renaming ? (
+          <input
+            aria-label={f.rename}
+            autoFocus
+            className="min-w-0 flex-1 rounded-sm bg-transparent px-1 text-[0.8125rem] text-foreground outline-none ring-1 ring-inset ring-(--ui-border-strong)"
+            onBlur={commitRename}
+            onChange={event => setDraft(event.target.value)}
+            onKeyDown={event => {
+              if (event.key === 'Enter') {
+                commitRename()
+              } else if (event.key === 'Escape') {
+                setRenaming(false)
+              }
+            }}
+            value={draft}
+          />
+        ) : (
+          <>
+            <RowButton
+              aria-expanded={open}
+              className="flex min-w-0 flex-1 items-center gap-1.5 bg-transparent text-left"
+              onClick={() => onToggleCollapsed(folder.id)}
+            >
+              <SidebarRowLead>
+                <Codicon name={open ? 'chevron-down' : 'chevron-right'} size={SIDEBAR_LEAD_ICON_SIZE} />
+              </SidebarRowLead>
+              <span className={cn(SIDEBAR_ROW_LABEL, 'flex-1')}>{folder.name}</span>
+              <span className="shrink-0 text-[0.6875rem] text-(--ui-text-quaternary)">{count}</span>
+            </RowButton>
+            <Tip label={f.rename}>
+              <button
+                aria-label={`${f.rename}: ${folder.name}`}
+                className={HOVER_ACTION}
+                onClick={startRenaming}
+                type="button"
+              >
+                <Codicon name="edit" size="0.75rem" />
+              </button>
+            </Tip>
+            <Tip label={f.deleteHint}>
+              <button
+                aria-label={`${f.delete}: ${folder.name}`}
+                className={HOVER_ACTION}
+                onClick={() => onDelete(folder.id)}
+                type="button"
+              >
+                <Codicon name="trash" size="0.75rem" />
+              </button>
+            </Tip>
+          </>
+        )}
+      </div>
+      {open && renderSessions(folder.id)}
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -42,8 +42,9 @@ import {
   type SidebarWorkspaceTree
 } from './projects'
 import { WorkspaceAddButton } from './projects/workspace-header'
-import { ReorderableList, useSortableBindings } from './reorderable-list'
+import { ReorderableList, useDraggableBindings, useSortableBindings } from './reorderable-list'
 import { SidebarSessionSkeletons } from './section-states'
+import { useSessionFolderSection } from './session-folders'
 import { SidebarSessionRow } from './session-row'
 import { VirtualSessionList } from './virtual-session-list'
 
@@ -153,6 +154,9 @@ interface SidebarSessionsSectionProps {
   // When false the section header is static (no caret/toggle) and always open.
   collapsible?: boolean
   sortable?: boolean
+  // Renders the session-folder strip above this list. Only the flat Sessions
+  // list groups by folder, so only it opts in.
+  enableFolders?: boolean
   // The persisted drag order, applied WITHIN each date group (see
   // orderRowsWithinGroups). Chronology decides the groups; this decides the
   // sequence inside one, so a reorder no longer costs the whole list its
@@ -218,6 +222,7 @@ export function SidebarSessionsSection({
   labelIcon,
   collapsible = true,
   sortable = false,
+  enableFolders = false,
   manualOrderIds,
   onReorderSessions,
   onReorderProjects,
@@ -264,7 +269,7 @@ export function SidebarSessionsSection({
   )
 
   const renderRow = useCallback(
-    (session: SessionInfo, draggable: boolean, branchStem?: string) => {
+    (session: SessionInfo, draggable: boolean, branchStem?: string, folderMember = false) => {
       const rowProps = {
         branchStem,
         card,
@@ -285,11 +290,19 @@ export function SidebarSessionsSection({
       // Key by (profile, id): twins with the same stored id in two profiles
       // are distinct rows (#92454) — a bare-id key makes React misattribute
       // one twin's rendered state to the other.
-      return draggable && !branchStem ? (
-        <SortableSidebarSessionRow key={`${session.profile ?? ''}::${session.id}`} {...rowProps} />
-      ) : (
-        <SidebarSessionRow key={`${session.profile ?? ''}::${session.id}`} {...rowProps} />
-      )
+      const key = `${session.profile ?? ''}::${session.id}`
+
+      if (draggable && !branchStem) {
+        return <SortableSidebarSessionRow key={key} {...rowProps} />
+      }
+
+      // A folder's own rows can't join the reorder order — the list isn't
+      // ordering them — but must stay draggable in and out of other folders.
+      if (folderMember && !branchStem) {
+        return <DraggableSessionRow key={key} {...rowProps} />
+      }
+
+      return <SidebarSessionRow key={key} {...rowProps} />
     },
     [
       activeSessionId,
@@ -303,6 +316,31 @@ export function SidebarSessionsSection({
       pinned,
       showProfileTags
     ]
+  )
+
+  // A folder's rows reuse the section's own renderer (same actions, same
+  // density/card variant), bound as drag sources so they can be moved again.
+  // The flat Sessions list is the one surface that groups by folder; the hook
+  // owns the store read, the membership split and the drop targets. Its `strip`
+  // renders nothing where a list can't group by folder (archived, all-profiles,
+  // grouped views) and its `filedIds` is then empty, so those lists still show
+  // every session rather than losing the filed ones.
+  const renderFolderMembers = useCallback(
+    (members: SessionInfo[]) => members.map(session => renderRow(session, false, undefined, true)),
+    [renderRow]
+  )
+
+  const {
+    dropTargets: folderDropTargets,
+    filedIds,
+    strip: folderStrip
+  } = useSessionFolderSection({ enabled: enableFolders, renderMembers: renderFolderMembers, sessions })
+
+  // A filed session leaves the flat rows for its folder. No folders, no
+  // filtering, so the plain path keeps its exact array identity.
+  const unfiledEntries = useMemo(
+    () => (filedIds.size ? displayEntries.filter(entry => !filedIds.has(entry.session.id)) : displayEntries),
+    [displayEntries, filedIds]
   )
 
   // Date dividers head a group the same way a repo header does, so they carry
@@ -410,17 +448,17 @@ export function SidebarSessionsSection({
   const flatRows: SidebarListRow[] = useMemo(() => {
     const rows =
       grouping === 'date'
-        ? groupEntriesByRecency(displayEntries)
+        ? groupEntriesByRecency(unfiledEntries)
         : grouping === 'status'
           ? groupEntriesByStatus(
-              displayEntries,
+              unfiledEntries,
               entry => hasLiveTurn(dotStates[entry.session.id] ?? 'idle'),
               statusDividerLabels
             )
-          : toSessionRows(displayEntries)
+          : toSessionRows(unfiledEntries)
 
     return manualOrderIds?.length ? orderRowsWithinGroups(rows, manualOrderIds) : rows
-  }, [grouping, displayEntries, dotStates, manualOrderIds, statusDividerLabels])
+  }, [grouping, unfiledEntries, dotStates, manualOrderIds, statusDividerLabels])
 
   // Closed date/status buckets keep their divider and drop the sessions under
   // it. Same array when nothing is collapsed so the virtualizer's rows ref
@@ -468,6 +506,24 @@ export function SidebarSessionsSection({
   // background refresh keeps the prior tree, so this only fires when empty.
   const showProjectsSkeleton =
     projectsLoading && !hasProjectOverview && !hasProjectContent && !projectContent && !groups?.length
+
+  // The flat list's own dnd-kit context. Folder drop targets must live inside
+  // the SAME context as the rows they accept — a nested one would trap the drag
+  // — so the strip wraps together with the rows, and the list gets a context
+  // whenever folders are on screen even with nothing left to reorder.
+  const wrapList = (children: React.ReactNode) =>
+    sessionsDraggable || folderStrip ? (
+      <ReorderableList
+        dropTargets={folderDropTargets}
+        ids={sortableRowIds}
+        onReorder={persistSessionOrder}
+        sensors={dndSensors}
+      >
+        {children}
+      </ReorderableList>
+    ) : (
+      children
+    )
 
   let inner: React.ReactNode
 
@@ -582,21 +638,20 @@ export function SidebarSessionsSection({
       />
     )
 
-    inner = sessionsDraggable ? (
-      <ReorderableList ids={sortableRowIds} onReorder={persistSessionOrder} sensors={dndSensors}>
+    inner = wrapList(
+      <>
+        {folderStrip}
         {virtual}
-      </ReorderableList>
-    ) : (
-      virtual
-    )
-  } else if (sessionsDraggable) {
-    inner = (
-      <ReorderableList ids={sortableRowIds} onReorder={persistSessionOrder} sensors={dndSensors}>
-        {visibleRows.map(row => renderListRow(row, true, dividerAction))}
-      </ReorderableList>
+      </>
     )
   } else {
-    inner = visibleRows.map(row => renderListRow(row, false, dividerAction))
+    // The flat list, hand-reorderable when a reorder handler is wired.
+    inner = wrapList(
+      <>
+        {folderStrip}
+        {visibleRows.map(row => renderListRow(row, sessionsDraggable, dividerAction))}
+      </>
+    )
   }
 
   // The virtualizer owns its own scroller, so suppress the wrapper's overflow
@@ -640,6 +695,13 @@ interface SortableSessionRowProps {
 
 function SortableSidebarSessionRow(props: SortableSessionRowProps) {
   return <SidebarSessionRow {...props} {...useSortableBindings(props.session.id)} />
+}
+
+/** A session rendered inside a folder: a drag source (so it can be moved to
+ *  another folder or back out) but no sortable membership — the list it lives in
+ *  orders nothing. */
+function DraggableSessionRow(props: SortableSessionRowProps) {
+  return <SidebarSessionRow {...props} {...useDraggableBindings(props.session.id)} />
 }
 
 function SortableProjectOverviewRow(props: React.ComponentProps<typeof ProjectOverviewRow>) {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2882,6 +2882,15 @@ export const en: Translations = {
       toggle: (label, open) => `${open ? 'Show' : 'Hide'} ${label} sessions`,
       back: 'All projects'
     },
+    folders: {
+      label: 'Folders',
+      newFolder: 'New folder',
+      rename: 'Rename folder',
+      delete: 'Delete folder',
+      deleteHint: 'Delete this folder? Its sessions go back to the main list.',
+      unfiled: 'Not in a folder',
+      unfiledHint: 'Drop a session here to take it out of its folder'
+    },
     newSessionIn: label => `New session in ${label}`,
     showMoreIn: (count, label) => `Show ${count} more in ${label}`,
     loading: 'Loading…',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2475,6 +2475,15 @@ export interface Translations {
       toggle: (label: string, open: boolean) => string
       back: string
     }
+    folders: {
+      label: string
+      newFolder: string
+      rename: string
+      delete: string
+      deleteHint: string
+      unfiled: string
+      unfiledHint: string
+    }
     newSessionIn: (label: string) => string
     showMoreIn: (count: number, label: string) => string
     loading: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3026,6 +3026,15 @@ export const zh: Translations = {
       toggle: (label, open) => `${open ? '展开' : '收起'} ${label} 会话`,
       back: '全部项目'
     },
+    folders: {
+      label: '文件夹',
+      newFolder: '新建文件夹',
+      rename: '重命名文件夹',
+      delete: '删除文件夹',
+      deleteHint: '删除此文件夹？其中的会话会回到主列表。',
+      unfiled: '未归入文件夹',
+      unfiledHint: '将会话拖到这里即可移出文件夹'
+    },
     newSessionIn: label => `在 ${label} 中新建会话`,
     showMoreIn: (count, label) => `在 ${label} 中再显示 ${count} 个`,
     loading: '加载中…',

--- a/apps/desktop/src/store/session-folders.test.ts
+++ b/apps/desktop/src/store/session-folders.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+
+// The profile scope is the axis folders are keyed by, so drive it directly
+// instead of booting the profile store's gateway machinery.
+vi.mock('@/store/profile', async () => {
+  const { atom, computed } = await import('nanostores')
+
+  const $activeGatewayProfile = atom('default')
+  const $showAllProfiles = atom(false)
+
+  return {
+    ALL_PROFILES: '__all__',
+    $activeGatewayProfile,
+    $profileScope: computed([$showAllProfiles, $activeGatewayProfile], (all: boolean, profile: string) =>
+      all ? '__all__' : profile
+    ),
+    $showAllProfiles
+  }
+})
+
+const { $activeGatewayProfile, $showAllProfiles } = await import('@/store/profile')
+
+const {
+  $sessionFolders,
+  $sessionFoldersAvailable,
+  $sessionFolderScope,
+  $sessionFolderStore,
+  createSessionFolder,
+  deleteSessionFolder,
+  fileSessionInFolder,
+  groupSessionsByFolder,
+  renameSessionFolder,
+  toggleSessionFolderCollapsed
+} = await import('./session-folders')
+
+const session = (id: string): SessionInfo => ({ id, profile: 'default' }) as unknown as SessionInfo
+
+beforeEach(() => {
+  window.localStorage.clear()
+  $showAllProfiles.set(false)
+  $activeGatewayProfile.set('default')
+  $sessionFolderStore.set({})
+})
+
+describe('session folders', () => {
+  it('files a session into a folder and lists it nowhere else', () => {
+    const folder = createSessionFolder('Work')
+    const sessions = [session('s1'), session('s2')]
+
+    fileSessionInFolder('s1', folder!.id)
+
+    const byFolder = groupSessionsByFolder(sessions, $sessionFolderScope.get())
+
+    expect(byFolder.groups.map(group => [group.folder.name, group.sessions.map(s => s.id)])).toEqual([['Work', ['s1']]])
+    expect(byFolder.unfiled.map(s => s.id)).toEqual(['s2'])
+  })
+
+  it('moves a session between folders and back out to the main list', () => {
+    const work = createSessionFolder('Work')
+    const ideas = createSessionFolder('Ideas')
+    const sessions = [session('s1')]
+
+    fileSessionInFolder('s1', work!.id)
+    fileSessionInFolder('s1', ideas!.id)
+
+    expect(groupSessionsByFolder(sessions, $sessionFolderScope.get()).groups.map(g => g.folder.name)).toEqual([
+      'Work',
+      'Ideas'
+    ])
+
+    const [workGroup, ideasGroup] = groupSessionsByFolder(sessions, $sessionFolderScope.get()).groups
+
+    expect(workGroup.sessions).toEqual([])
+    expect(ideasGroup.sessions.map(s => s.id)).toEqual(['s1'])
+
+    fileSessionInFolder('s1', null)
+
+    expect(groupSessionsByFolder(sessions, $sessionFolderScope.get()).unfiled.map(s => s.id)).toEqual(['s1'])
+  })
+
+  it('returns a deleted folder\u2019s sessions to the main list', () => {
+    const folder = createSessionFolder('Work')
+    const sessions = [session('s1')]
+
+    fileSessionInFolder('s1', folder!.id)
+    deleteSessionFolder(folder!.id)
+
+    expect($sessionFolders.get()).toEqual([])
+    expect(groupSessionsByFolder(sessions, $sessionFolderScope.get()).unfiled.map(s => s.id)).toEqual(['s1'])
+  })
+
+  it('renames and collapses a folder', () => {
+    const folder = createSessionFolder('Work')
+
+    renameSessionFolder(folder!.id, ' Deep work ')
+
+    expect($sessionFolders.get()).toEqual([{ collapsed: false, id: folder!.id, name: 'Deep work' }])
+
+    toggleSessionFolderCollapsed(folder!.id)
+
+    expect($sessionFolders.get()[0].collapsed).toBe(true)
+  })
+
+  it('keeps folders on the profile they were made for', () => {
+    createSessionFolder('Work')
+
+    $activeGatewayProfile.set('other')
+
+    expect($sessionFolders.get()).toEqual([])
+    // A session filed under one profile must not be grouped under another.
+    expect(groupSessionsByFolder([session('s1')], $sessionFolderScope.get()).unfiled.map(s => s.id)).toEqual(['s1'])
+
+    $activeGatewayProfile.set('default')
+
+    expect($sessionFolders.get().map(folder => folder.name)).toEqual(['Work'])
+  })
+
+  it('groups nothing while the sidebar spans every profile', () => {
+    const folder = createSessionFolder('Work')
+
+    fileSessionInFolder('s1', folder!.id)
+    $showAllProfiles.set(true)
+
+    expect($sessionFoldersAvailable.get()).toBe(false)
+    expect($sessionFolders.get()).toEqual([])
+    expect(createSessionFolder('Late')).toBeNull()
+    expect(groupSessionsByFolder([session('s1')], $sessionFolderScope.get()).unfiled.map(s => s.id)).toEqual(['s1'])
+  })
+
+  it('hands the list straight back when there are no folders', () => {
+    const sessions = [session('s1')]
+
+    expect(groupSessionsByFolder(sessions, $sessionFolderScope.get()).unfiled).toBe(sessions)
+  })
+
+  it('drops a persisted assignment whose folder no longer exists', async () => {
+    // Another window deleted the folder: its assignments are on disk with no
+    // folder to honour. Load them the way a cold boot does — through the
+    // persisted codec — so the drop is proven on the real path.
+    window.localStorage.setItem(
+      'hermes.desktop.sessionFolders',
+      JSON.stringify({
+        default: {
+          filed: { s1: 'f_gone', s2: 'f_kept' },
+          folders: [{ collapsed: false, id: 'f_kept', name: 'Kept' }]
+        }
+      })
+    )
+    vi.resetModules()
+
+    const fresh = await import('./session-folders')
+    const scope = fresh.$sessionFolderScope.get()
+
+    expect(scope.filed).toEqual({ s2: 'f_kept' })
+    // The stranded session is still listed rather than hidden from both places.
+    expect(groupSessionsByFolder([session('s1'), session('s2')], scope).unfiled.map(s => s.id)).toEqual(['s1'])
+  })
+})

--- a/apps/desktop/src/store/session-folders.ts
+++ b/apps/desktop/src/store/session-folders.ts
@@ -1,0 +1,250 @@
+/**
+ * Desktop session folders — the user's own grouping of the sidebar's sessions.
+ *
+ * A folder is desktop-local organization, NOT session state: filing a chat
+ * changes nothing about the session (no cwd move, no backend write, no second
+ * copy of the row) — the issue's "without changing the sessions themselves".
+ * The renderer is therefore the authority for it, held in one localStorage
+ * record keyed by PROFILE (the axis the session list itself switches on), so
+ * one profile's folders can never group another profile's chats.
+ *
+ * Membership keys off the session's DURABLE stored id — the identity rows
+ * resume with, the same one pins and the persisted drag order use.
+ */
+
+import { computed, type ReadableAtom } from 'nanostores'
+
+import type { SessionInfo } from '@/hermes'
+import { Codecs, persistentAtom } from '@/lib/persisted'
+import { $profileScope, ALL_PROFILES } from '@/store/profile'
+
+export interface SessionFolder {
+  collapsed: boolean
+  id: string
+  name: string
+}
+
+/** One profile's folders plus which session is filed where. */
+export interface SessionFolderScope {
+  /** stored session id -> folder id */
+  filed: Record<string, string>
+  folders: SessionFolder[]
+}
+
+export type SessionFolderStore = Record<string, SessionFolderScope>
+
+const STORAGE_KEY = 'hermes.desktop.sessionFolders'
+
+const EMPTY_SCOPE: SessionFolderScope = { filed: {}, folders: [] }
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+/**
+ * Coerce a persisted record into folders + membership, dropping what can't be
+ * honoured: entries with no id, and — the case that matters — assignments
+ * pointing at a folder that no longer exists. A stale assignment would hide the
+ * session from BOTH the folder strip and the main list.
+ */
+function sanitizeScope(value: unknown): SessionFolderScope {
+  if (!isRecord(value)) {
+    return EMPTY_SCOPE
+  }
+
+  const folders: SessionFolder[] = Array.isArray(value.folders)
+    ? value.folders.flatMap(entry =>
+        isRecord(entry) && typeof entry.id === 'string' && entry.id
+          ? [
+              {
+                collapsed: entry.collapsed === true,
+                id: entry.id,
+                name: typeof entry.name === 'string' ? entry.name : ''
+              }
+            ]
+          : []
+      )
+    : []
+
+  const known = new Set(folders.map(folder => folder.id))
+  const filed: Record<string, string> = {}
+
+  if (isRecord(value.filed)) {
+    for (const [sessionId, folderId] of Object.entries(value.filed)) {
+      if (sessionId && typeof folderId === 'string' && known.has(folderId)) {
+        filed[sessionId] = folderId
+      }
+    }
+  }
+
+  return { filed, folders }
+}
+
+export function sanitizeSessionFolderStore(value: unknown): SessionFolderStore {
+  if (!isRecord(value)) {
+    return {}
+  }
+
+  return Object.fromEntries(Object.entries(value).map(([profile, scope]) => [profile, sanitizeScope(scope)]))
+}
+
+export const $sessionFolderStore = persistentAtom<SessionFolderStore>(
+  STORAGE_KEY,
+  {},
+  Codecs.json(sanitizeSessionFolderStore)
+)
+
+/** The profile whose folders are live; `null` in the all-profiles view, where
+ *  one folder list cannot describe a session list spanning profiles. */
+export function sessionFolderProfile(): null | string {
+  const scope = $profileScope.get()
+
+  return scope === ALL_PROFILES ? null : scope
+}
+
+export const $sessionFolderScope: ReadableAtom<SessionFolderScope> = computed(
+  [$sessionFolderStore, $profileScope],
+  (store, scope) => (scope === ALL_PROFILES ? EMPTY_SCOPE : (store[scope] ?? EMPTY_SCOPE))
+)
+
+export const $sessionFolders: ReadableAtom<SessionFolder[]> = computed($sessionFolderScope, scope => scope.folders)
+
+/** Whether this desktop can group sessions at all (the all-profiles view can't). */
+export const $sessionFoldersAvailable: ReadableAtom<boolean> = computed($profileScope, scope => scope !== ALL_PROFILES)
+
+export interface SessionFolderGroup {
+  folder: SessionFolder
+  sessions: SessionInfo[]
+}
+
+export interface SessionsByFolder {
+  groups: SessionFolderGroup[]
+  unfiled: SessionInfo[]
+}
+
+/**
+ * Split a session list into its folders (in folder order) plus everything else
+ * (in list order). With no folders this hands the list straight back, so the
+ * ordinary flat rendering keeps its exact array identity.
+ */
+export function groupSessionsByFolder(sessions: SessionInfo[], scope: SessionFolderScope): SessionsByFolder {
+  const { filed, folders } = scope
+
+  if (!folders.length) {
+    return { groups: [], unfiled: sessions }
+  }
+
+  const byFolder = new Map<string, SessionInfo[]>(folders.map(folder => [folder.id, []]))
+  const unfiled: SessionInfo[] = []
+
+  for (const session of sessions) {
+    const bucket = byFolder.get(filed[session.id] ?? '')
+
+    if (bucket) {
+      bucket.push(session)
+    } else {
+      unfiled.push(session)
+    }
+  }
+
+  return {
+    groups: folders.map(folder => ({ folder, sessions: byFolder.get(folder.id) ?? [] })),
+    unfiled
+  }
+}
+
+let folderSeq = 0
+
+const nextFolderId = () => `f_${Date.now().toString(36)}-${(folderSeq++).toString(36)}`
+
+type ScopeMutation = (scope: SessionFolderScope) => SessionFolderScope
+
+/** Apply a mutation to the live profile's scope. Writes only when the mutation
+ *  actually changed something, so a no-op drop can't churn localStorage. */
+function mutateScope(mutate: ScopeMutation): null | SessionFolderScope {
+  const profile = sessionFolderProfile()
+
+  if (!profile) {
+    return null
+  }
+
+  const store = $sessionFolderStore.get()
+  const current = store[profile] ?? EMPTY_SCOPE
+  const next = mutate(current)
+
+  if (next !== current) {
+    $sessionFolderStore.set({ ...store, [profile]: next })
+  }
+
+  return next
+}
+
+export function createSessionFolder(name: string): null | SessionFolder {
+  const trimmed = name.trim()
+
+  if (!trimmed) {
+    return null
+  }
+
+  const folder: SessionFolder = { collapsed: false, id: nextFolderId(), name: trimmed }
+
+  return mutateScope(scope => ({ ...scope, folders: [...scope.folders, folder] })) ? folder : null
+}
+
+export function renameSessionFolder(folderId: string, name: string): void {
+  const trimmed = name.trim()
+
+  if (!trimmed) {
+    return
+  }
+
+  mutateScope(scope => ({
+    ...scope,
+    folders: scope.folders.map(folder => (folder.id === folderId ? { ...folder, name: trimmed } : folder))
+  }))
+}
+
+/** Deleting a folder returns its sessions to the main list; nothing about the
+ *  sessions themselves is touched. */
+export function deleteSessionFolder(folderId: string): void {
+  mutateScope(scope => ({
+    filed: Object.fromEntries(Object.entries(scope.filed).filter(([, id]) => id !== folderId)),
+    folders: scope.folders.filter(folder => folder.id !== folderId)
+  }))
+}
+
+export function toggleSessionFolderCollapsed(folderId: string): void {
+  mutateScope(scope => ({
+    ...scope,
+    folders: scope.folders.map(folder =>
+      folder.id === folderId ? { ...folder, collapsed: !folder.collapsed } : folder
+    )
+  }))
+}
+
+/** File a session into a folder, or back into the main list with `null`. */
+export function fileSessionInFolder(sessionId: string, folderId: null | string): void {
+  const id = sessionId.trim()
+
+  if (!id) {
+    return
+  }
+
+  mutateScope(scope => {
+    if (folderId === null) {
+      if (!(id in scope.filed)) {
+        return scope
+      }
+
+      const filed = { ...scope.filed }
+      delete filed[id]
+
+      return { ...scope, filed }
+    }
+
+    if (scope.filed[id] === folderId || !scope.folders.some(folder => folder.id === folderId)) {
+      return scope
+    }
+
+    return { ...scope, filed: { ...scope.filed, [id]: folderId } }
+  })
+}


### PR DESCRIPTION
The desktop sidebar's session list is one flat, recency-ordered stream. As it grows there is no way to keep related conversations together (#107115), and the only grouping the sidebar has today is by workspace (Projects), which groups sessions by *where they run* and re-homes a session's cwd when you move it into one. This adds **named session folders** that organize the *list* itself and touch nothing about the sessions.

## What Problem This Solves

- A **Folders** strip above the flat Sessions list: create a folder, collapse or expand it, rename it inline, delete it.
- **Drag and drop**: drop a session row on a folder header to file it there, on "Not in a folder" to take it back out, or on another folder to move it between folders. Filed rows stay draggable, so a session can be moved again after it lands.
- Filed sessions leave the flat list and render under their folder. Deleting a folder returns its sessions to the main list. Nothing about a session changes: no cwd move, no backend write, no new RPC.
- State is desktop-local and **per profile** (`apps/desktop/src/store/session-folders.ts`, one localStorage record keyed by profile, the axis the session list itself switches on). Loading drops any assignment whose folder is gone (deleted in another window) rather than stranding a chat in neither list.
- Folders render only on the flat Sessions list and are hidden in the All-profiles view, the same call Projects make ("unavailable while viewing all profiles"): one folder list cannot describe a list that spans profiles. Wherever they are not rendered the filtered-out id set is empty, so every session still shows. A filed chat must never vanish from a list that cannot show folders.
- The drop rides the sidebar's existing dnd-kit list. `ReorderableList` now accepts extra droppable targets and routes a drop on one through `onDrop` instead of a reorder; `resolveReorderDrop` is that arbitration, kept pure so it is provable without dnd-kit geometry. One context and one press, so a drag over the sidebar files the row while a drag over a chat pane still opens a tile, exactly as before.

This is a partial fix for #107115: folders, filing by drag and drop, rename, collapse and delete are in.

## Evidence

Pre-fix, with the implementation stashed and only the new tests present:

```
$ npx vitest run --project ui src/store/session-folders.test.ts src/app/chat/sidebar/session-folders.test.tsx
 FAIL  |ui| src/app/chat/sidebar/session-folders.test.tsx [ src/app/chat/sidebar/session-folders.test.tsx ]
Error: Failed to resolve import "./session-folders" from "src/app/chat/sidebar/session-folders.test.tsx". Does the file exist?
 Test Files  2 failed (2)
      Tests  no tests
```

The base revision has nothing to fold sessions into: no folder store, no strip, no drop target.

Post-fix, the same command:

```
$ npx vitest run --project ui src/store/session-folders.test.ts src/app/chat/sidebar/session-folders.test.tsx
 Test Files  2 passed (2)
      Tests  13 passed (13)
```

Those 13 cover: filing, moving between folders, moving back out, deleting a folder (sessions return to the main list), rename, collapse, per-profile isolation, the all-profiles scope, a stale persisted assignment, the rendered grouping (a filed session appears under its folder and nowhere else), create/rename/delete through the strip, and the drop arbitration (folder target vs reorder vs nothing). One more test drives the real `ChatSidebar`: with a folder in the store, the flat Sessions list renders the strip and the filed session appears inside its folder exactly once.

Adjacent suites, which are every consumer of `ReorderableList` plus the store and i18n trees:

```
$ npx vitest run --project ui --maxWorkers=4 src/app/chat/sidebar src/store src/i18n
 Test Files  166 passed (166)
      Tests  1824 passed (1824)
```

Typecheck (`npx tsc -p . --noEmit`) is clean apart from a pre-existing, unrelated `Cannot find module 'qrcode'` in `src/app/messaging/telegram-qr-setup.tsx` (the dependency is declared in `apps/desktop/package.json` but absent from this worktree's `node_modules`). Lint and Prettier are clean on every touched file.

## Not in this change

- Nested folders, and drag-reordering the folders themselves (they render in creation order).
- Any cross-surface copy of the folder list: the TUI and the web dashboard do not see these folders, they stay a desktop-local organization of the sidebar.
- The strip is on screen only when the list has sessions; with an empty list the section's empty state owns that area.
