### PR TITLE
fix(gateway): guard stale model imports at command entry

### DIFF
--- a/gateway/slash_commands_model.py
+++ b/gateway/slash_commands_model.py
@@ -464,6 +464,13 @@ class GatewayModelCommandsMixin:
 
     async def _handle_model_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /model command — switch model."""
+        # Guard before every lazy import below. A bare /model only lists choices and never reaches
+        # _perform_model_switch(), but newly pulled model modules can still import names missing from
+        # this long-lived process's cached dependencies.
+        skew_error = _model_switch_skew_guard()
+        if skew_error:
+            return skew_error
+
         from gateway.run import _hermes_home
         from hermes_cli.model_switch import parse_model_switch_args, resolve_persist_behavior
 

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -71,6 +71,24 @@ class TestModelSwitchSkewGuard:
         assert "def4567890" in msg
         assert "hermes gateway restart" in msg
 
+    def test_model_handler_checks_guard_before_lazy_imports(self, monkeypatch):
+        """Bare /model must reject stale code before importing newly updated modules."""
+        from gateway import slash_commands_model as slash_commands
+        from gateway.config import Platform
+        from gateway.platforms.event import MessageEvent, MessageType
+        from gateway.session import SessionSource
+
+        expected = "restart required"
+        monkeypatch.setattr(slash_commands, "_model_switch_skew_guard", lambda: expected)
+        event = MessageEvent(
+            text="/model",
+            message_type=MessageType.TEXT,
+            source=SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm"),
+        )
+
+        handler = object.__new__(slash_commands.GatewayModelCommandsMixin)
+        assert asyncio.run(handler._handle_model_command(event)) == expected
+
 
 class TestDashboardCodeSkewGuard:
     """Dashboard mirror of the gateway's model-switch skew guard (#86207)."""


### PR DESCRIPTION
## Summary
- Run the gateway code-skew guard at `/model` handler entry, before lazy imports.
- Protect bare `/model` listing as well as model-switch execution after a hot checkout update.
- Add a call-site regression test so helper-only coverage cannot hide missing wiring.

## Root cause
The existing guard ran only inside `_perform_model_switch`. A bare `/model` command imports `hermes_cli.model_switch` first and uses the listing path, so a newly pulled top-level import could resolve against a stale cached `utils` module and raise `ImportError` before the guard ran.

## Test plan
- `HERMES_TEST_PATHS='tests/test_code_skew.py:tests/test_stale_utils_module_import.py:tests/hermes_cli/test_model_alias_credentials_83612.py:tests/gateway/test_model_command_async_offload.py:tests/gateway/test_model_command_request_overrides.py:tests/gateway/test_model_command_flat_string_config.py' scripts/run_tests.sh -j 4`
- Result: 79 passed, 0 failed.
