### PR TITLE
fix(tools): resolve Nous provider state via the profile→global-root auth fallback

### DIFF
--- a/tests/tools/test_managed_tool_gateway.py
+++ b/tests/tools/test_managed_tool_gateway.py
@@ -208,3 +208,117 @@ def test_default_bearer_gate_accepts_both_deployed_hosts_only():
             "http://tool-gateway.nousresearch.com/api/vendorx/generations",
         ):
             assert not managed_gateway_auth.is_managed_nous_gateway_url(untrusted)
+
+
+def _stored_nous_provider(token: str) -> dict:
+    """A stored Nous provider entry carrying an unexpired cached token.
+
+    Do NOT drop ``expires_at`` while "simplifying" this fixture — it is load-bearing, not
+    decoration. ``_access_token_is_expiring()`` answers True for a *missing* timestamp, so a
+    timestamp-free stub silently routes ``read_nous_access_token()`` through
+    ``hermes_cli.auth.resolve_nous_access_token()`` (the OAuth refresh path). The assertion then
+    measures whatever the environment's credential pool happens to do instead of the fallback
+    under test, and turns into a flaky environment probe that passes or fails for reasons
+    unrelated to this module.
+
+    An unexpired timestamp keeps ``read_nous_access_token()`` on its cached-token branch, so the
+    tests stay hermetic while still exercising the real reader chain.
+    """
+    return {
+        "agent_key": f"{token}-key",
+        "access_token": token,
+        # Unused by the fallback, but required to keep the refresh path off the network: see the
+        # docstring above before removing.
+        "expires_at": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+    }
+
+
+def _write_profile_and_global_auth_stores(
+    tmp_path: Path, monkeypatch, *, profile_providers: dict, global_providers: dict
+) -> Path:
+    """Lay out a profile HERMES_HOME plus the global-root ``.hermes`` beside it.
+
+    Mirrors the real shape: the profile's own ``auth.json`` and the default profile's
+    ``auth.json`` at ``Path.home()/.hermes/auth.json`` (what ``get_default_hermes_root()``
+    resolves to, and the per-provider fallback source).
+    """
+    from hermes_cli import auth as auth_mod
+
+    hermes_root = tmp_path / ".hermes"
+    profile_home = hermes_root / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
+
+    version = auth_mod.AUTH_STORE_VERSION
+    (profile_home / "auth.json").write_text(
+        json.dumps({"version": version, "providers": profile_providers}), encoding="utf-8"
+    )
+    hermes_root.mkdir(parents=True, exist_ok=True)
+    (hermes_root / "auth.json").write_text(
+        json.dumps({"version": version, "providers": global_providers}), encoding="utf-8"
+    )
+    return profile_home
+
+
+def test_nous_provider_state_falls_back_to_the_global_root(tmp_path, monkeypatch):
+    """A profile with no Nous credential of its own inherits the default profile's.
+
+    Profile workers spawn as ``hermes -p <profile>`` subprocesses; without this fallback every
+    managed tool (web, image_gen, tts, stt, browser) reports the false "Nous Tool Gateway is
+    not available (not entitled or unreachable)".
+
+    Both readers are pinned: the readiness probes go through ``peek_nous_access_token`` while
+    the live client paths (``plugins/web/firecrawl/provider.py`` and
+    ``tools/managed_gateway_auth.py``) default to ``read_nous_access_token``.
+    """
+    _write_profile_and_global_auth_stores(
+        tmp_path,
+        monkeypatch,
+        profile_providers={},
+        global_providers={"nous": _stored_nous_provider("global-token")},
+    )
+
+    state = managed_tool_gateway._read_nous_provider_state()
+
+    assert state is not None
+    assert state["agent_key"] == "global-token-key"
+    assert managed_tool_gateway.peek_nous_access_token() == "global-token"
+    assert managed_tool_gateway.read_nous_access_token() == "global-token"
+
+    with patch.object(managed_tool_gateway, "managed_nous_tools_enabled", return_value=True):
+        config = resolve_managed_tool_gateway(
+            "firecrawl", token_reader=managed_tool_gateway.read_nous_access_token
+        )
+
+    assert config is not None
+    assert config.nous_user_token == "global-token"
+
+
+def test_nous_provider_state_prefers_the_profile_local_credential(tmp_path, monkeypatch):
+    """A profile-local entry still shadows the global root, as ``read_credential_pool`` does."""
+    _write_profile_and_global_auth_stores(
+        tmp_path,
+        monkeypatch,
+        profile_providers={"nous": _stored_nous_provider("profile-token")},
+        global_providers={"nous": _stored_nous_provider("global-token")},
+    )
+
+    state = managed_tool_gateway._read_nous_provider_state()
+
+    assert state is not None
+    assert state["agent_key"] == "profile-token-key"
+    assert managed_tool_gateway.peek_nous_access_token() == "profile-token"
+    assert managed_tool_gateway.read_nous_access_token() == "profile-token"
+
+
+def test_no_nous_identity_yields_no_token(tmp_path, monkeypatch):
+    """The fallback must never invent a credential: with neither store holding a Nous entry,
+    neither reader answers with one (and no refresh is attempted)."""
+    _write_profile_and_global_auth_stores(
+        tmp_path, monkeypatch, profile_providers={}, global_providers={}
+    )
+
+    assert managed_tool_gateway.peek_nous_access_token() is None
+    assert managed_tool_gateway.read_nous_access_token() is None

--- a/tools/managed_tool_gateway.py
+++ b/tools/managed_tool_gateway.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 from datetime import datetime, timezone
@@ -38,15 +37,15 @@ def auth_json_path():
 
 
 def _read_nous_provider_state() -> Optional[dict]:
-    """The profile's Nous state, or None. A free-tier identity counts only while the free tier is on:
-    with ``nous.guest: false`` it is invisible here, so no cached or refreshed token of it is ever
+    """The profile's Nous state, else the global-root profile's (the per-provider fallback
+    ``hermes_cli.auth._load_provider_state`` applies, so profile workers see globally-authed
+    providers), else None. A free-tier identity counts only while the free tier is on: with
+    ``nous.guest: false`` it is invisible here, so no cached or refreshed token of it is ever
     attached to a request."""
     try:
-        path = auth_json_path()
-        if not path.is_file():
-            return None
-        providers = json.loads(path.read_text(encoding="utf-8-sig")).get("providers", {})
-        nous_provider = providers.get("nous", {}) if isinstance(providers, dict) else None
+        from hermes_cli.auth import _load_auth_store, _load_provider_state
+
+        nous_provider = _load_provider_state(_load_auth_store(), "nous")
         if not isinstance(nous_provider, dict):
             return None
         from hermes_cli.anon_auth import guest_enabled, is_guest_state


### PR DESCRIPTION
## What does this PR do?

`tools/managed_tool_gateway._read_nous_provider_state()` read the profile's **own**
`auth.json` directly and returned `None` whenever it held no `providers.nous` entry. It
therefore skipped the per-provider **profile → global-root** fallback that the rest of
`hermes_cli/auth.py` applies (`_load_provider_state`: *"in profile mode falls back to the
global-root `auth.json` per provider …, so profile workers see globally-authed providers"*).

A profile that stores no Nous credential of its own can never resolve the managed tool
gateway, even when the account is entitled, so every managed tool fails on those profiles with
a false entitlement error:

```
web is configured to use nous (set via hermes tools), but the Nous Tool Gateway
is not available (not entitled or unreachable). Run 'hermes tools' to change it.
```

Affected surfaces (all read the token through `_read_nous_provider_state`, via
`peek_nous_access_token()` / `read_nous_access_token()`): `web_search`, `web_extract`, browser
automation, `image_gen`, TTS, STT, `video_gen`. The auth layer and the gateway layer disagree
about whether the profile is authenticated — `hermes -p <profile> auth list` lists the shared
login while `hermes -p <profile> status` says `Web tools: included by subscription, not
currently selected`.

Resolving through the shared, fallback-aware loader is the right approach because that fallback
is already the documented contract for every other provider read in `hermes_cli/auth.py`
(`read_credential_pool` shadows the same way); this function was the one reader that bypassed
it. The free-tier guard and `TOOL_GATEWAY_USER_TOKEN` short-circuit are unchanged.

## Related Issue

Fixes #108302

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/managed_tool_gateway.py` — `_read_nous_provider_state()` resolves through
  `hermes_cli.auth._load_provider_state(_load_auth_store(), "nous")` instead of reading
  `auth_json_path()` directly; the free-tier guard is preserved, and a profile-local
  `providers.nous` entry still shadows the global root. Dropped the now-unused `import json`.
- `tests/tools/test_managed_tool_gateway.py` — three behaviour tests (see below).

## How to Test

1. Create a profile `HERMES_HOME` whose `auth.json` has no `providers.nous`, with a Nous entry
   in the global-root `auth.json` beside it (`Path.home()/.hermes/auth.json`).
2. `peek_nous_access_token()` / `read_nous_access_token()` must both return the inherited token,
   and `resolve_managed_tool_gateway("firecrawl", token_reader=read_nous_access_token)` must
   return a config. On unmodified base, `_read_nous_provider_state()` returns `None` and the
   client path raises `ValueError: … the Nous Tool Gateway is not available`.
3. `scripts/run_tests.sh tests/tools/test_managed_tool_gateway.py tests/hermes_cli/test_auth_store_windows_encoding.py`

```
base, core unmodified:  1 failed, 12 passed
  FAILED test_nous_provider_state_falls_back_to_the_global_root
with fix:              44 passed, 0 failed   (that file + test_auth_store_windows_encoding.py
                                             + test_nous_subscription.py)
```

Tests added:

- `test_nous_provider_state_falls_back_to_the_global_root` — **red on base**, green after.
  Pins both readers and the production call: `peek_nous_access_token()` (readiness probes),
  `read_nous_access_token()` (the refresh path the live clients default to —
  `plugins/web/firecrawl/provider.py:154`, `tools/managed_gateway_auth.py:69`), and
  `resolve_managed_tool_gateway("firecrawl", token_reader=read_nous_access_token)`.
- `test_nous_provider_state_prefers_the_profile_local_credential` — guards the shadowing rule.
- `test_no_nous_identity_yields_no_token` — the fallback can never invent a credential.

Fixtures carry an unexpired `expires_at` (documented in the fixture docstring) so
`read_nous_access_token()` stays on its cached-token branch instead of taking the OAuth refresh
path — the tests remain hermetic.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run.** This is a Windows 11 host on the released install venv (no `pytest` there), so the full suite was not executed here; the files above were run with the documented runner (`scripts/run_tests.sh`). Flagging rather than checking this box.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11.16

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the function docstring is updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the previous code read `auth.json` itself with `encoding="utf-8-sig"` precisely to survive Windows' default codec; `_load_auth_store()` reads with `utf-8-sig` too (`hermes_cli/auth.py:656`), and `test_managed_tool_gateway_reads_non_ascii_nous_state` (added for exactly that hazard) still passes. No new POSIX assumptions.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Measured on the reporting install (one account, default profile authed; bot profiles with an
empty `auth.json`):

| profile | `auth._load_provider_state(..., 'nous')` | `_read_nous_provider_state()` | `resolve_managed_tool_gateway()` |
|---|---|---|---|
| default (global root) | found | found | config returned |
| profile with empty `auth.json`, before | **found** (fallback) | **None** | **None** |
| profile with empty `auth.json`, after | found | found | config returned |

One disclosure: with neither store holding a Nous entry the reader now returns `None` rather
than the empty dict it previously fell through to. Both are falsy, every caller normalizes with
`or {}`, `is_guest_state()` is `isinstance`-guarded, and `None` matches the function's own
`Optional[dict]` contract and docstring — but it is a (benign) behavior change, so it is stated
rather than buried.

Credit to @webtecnica for the review delta pinning `read_nous_access_token()` alongside
`peek_nous_access_token()`, and for the standalone negative case.
