### PR TITLE
fix: harden cron and Codex Kanban worker updates

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -13,6 +13,7 @@ import os
 import queue
 import re
 import subprocess
+import sys
 import threading
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -72,10 +73,20 @@ class CodexAppServerClient:
         # environment, never by granting the whole executor process ownership.
         owned_task = os.environ.get("HERMES_KANBAN_TASK") and is_dispatcher_owned_worker_context()
         if owned_task:
+            # Kanban workers may run with a profile HOME that has no Codex
+            # config.toml. Provide a complete Hermes MCP server override, not
+            # only env subkeys, so Codex does not synthesize an env-only server
+            # and reject it as an invalid MCP transport.
+            cmd += [
+                "-c", f"mcp_servers.hermes-tools.command={json.dumps(sys.executable)}",
+                "-c", "mcp_servers.hermes-tools.args=[\"-m\",\"agent.transports.hermes_tools_mcp_server\"]",
+                "-c", "mcp_servers.hermes-tools.startup_timeout_sec=30.0",
+                "-c", "mcp_servers.hermes-tools.tool_timeout_sec=600.0",
+            ]
             for key in (*KANBAN_ENV_KEYS, "HERMES_KANBAN_DB", "HERMES_KANBAN_BOARD"):
                 if key in os.environ:
-                    cmd += ["-c", f"mcp_servers.hermes-mcp.env.{key}={json.dumps(os.environ[key])}"]
-            cmd += ["-c", f'mcp_servers.hermes-mcp.env.{DELEGATED_CHILD_ENV_MARKER}=""']
+                    cmd += ["-c", f"mcp_servers.hermes-tools.env.{key}={json.dumps(os.environ[key])}"]
+            cmd += ["-c", f'mcp_servers.hermes-tools.env.{DELEGATED_CHILD_ENV_MARKER}=""']
         spawn_env = delegated_child_subprocess_env(spawn_env)
         # Kanban workers must write handoff/status to the board DB outside the
         # workspace: keep the sandbox on, add the Kanban root as writable.

--- a/cron/ledger.py
+++ b/cron/ledger.py
@@ -11,9 +11,10 @@ from typing import Callable, Iterator
 
 def open_ledger(path: Path) -> sqlite3.Connection:
     """Open a profile-local ledger DB, creating its cron directory securely."""
-    from cron.jobs import _ensure_cron_dir
+    from cron.jobs import ensure_dirs
 
-    _ensure_cron_dir(path.parent)
+    ensure_dirs()
+    path.parent.mkdir(exist_ok=True)
     return sqlite3.connect(path, timeout=5)
 
 

--- a/cron/monitor.py
+++ b/cron/monitor.py
@@ -76,10 +76,11 @@ def _read_last_output(job_id: str) -> str:
 
 def _write_last_output(job_id: str, output: str) -> None:
     try:
-        from cron.jobs import _ensure_cron_dir
+        from cron.jobs import ensure_dirs
 
         path = _snapshot_path(job_id)
-        _ensure_cron_dir(path.parent)
+        ensure_dirs()
+        path.parent.mkdir(exist_ok=True)
         path.write_text(output, encoding="utf-8")
     except Exception as exc:
         logger.warning("Monitor: failed to persist last output for %r: %s", job_id, exc)

--- a/cron/scheduler_script.py
+++ b/cron/scheduler_script.py
@@ -18,7 +18,6 @@ import subprocess
 import sys
 import threading
 import time
-from cron.jobs import _ensure_cron_dir
 from pathlib import Path
 from typing import Any, Callable, Optional, TYPE_CHECKING
 
@@ -258,7 +257,7 @@ def _resolve_script_path(script_path: str) -> tuple[Optional[Path], Optional[str
     inside HERMES_HOME/scripts/ (relative, absolute and ``~`` paths are all validated — path
     traversal / absolute-path injection); contract of lifecycle_guard._expand_candidate_path."""
     scripts_dir = _sched._get_hermes_home() / "scripts"
-    _ensure_cron_dir(scripts_dir)
+    scripts_dir.mkdir(parents=True, exist_ok=True)
     scripts_dir_resolved = scripts_dir.resolve()
 
     # Reject NUL eagerly: on Windows Path ops raise ValueError *after* expanduser so the try below

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -262,6 +262,10 @@ class TestSpawnEnvIsolation:
             in cmd
         )
         assert "sandbox_workspace_write.network_access=false" in cmd
+        assert any("mcp_servers.hermes-tools.command" in part for part in cmd)
+        assert any("mcp_servers.hermes-tools.args" in part for part in cmd)
+        assert any("mcp_servers.hermes-tools.env.HERMES_KANBAN_TASK" in part for part in cmd)
+        assert not any("mcp_servers.hermes-mcp" in part for part in cmd)
         assert all("danger" not in part for part in cmd)
 
 

--- a/tests/cron/test_stale_module_leaf_imports.py
+++ b/tests/cron/test_stale_module_leaf_imports.py
@@ -13,6 +13,39 @@ import sys
 from types import SimpleNamespace
 
 
+def test_cron_consumers_do_not_depend_on_removed_private_directory_helper(monkeypatch, tmp_path):
+    """A gateway can retain ``cron.jobs`` while newer cron consumers load from disk.
+
+    ``_ensure_cron_dir`` was a private helper and disappeared during a cron
+    refactor. Consumers must use the public ``ensure_dirs`` contract or local
+    Path creation, so a partial update cannot brick every cron job at import or
+    first write.
+    """
+    from cron import jobs, ledger, monitor, scheduler_script
+
+    monkeypatch.delattr(jobs, "_ensure_cron_dir", raising=False)
+    calls = []
+    monkeypatch.setattr(jobs, "ensure_dirs", lambda: calls.append("ensure_dirs"))
+
+    connection = ledger.open_ledger(tmp_path / "ledger" / "runs.db")
+    connection.close()
+    assert (tmp_path / "ledger" / "runs.db").exists()
+
+    monitor_snapshot = tmp_path / "monitor" / "last-output.txt"
+    monkeypatch.setattr(monitor, "_snapshot_path", lambda _job_id: monitor_snapshot)
+    monitor._write_last_output("job-1", "snapshot")
+    assert monitor_snapshot.read_text(encoding="utf-8") == "snapshot"
+
+    (tmp_path / "scripts").mkdir()
+    expected_script = tmp_path / "scripts" / "relative.py"
+    expected_script.write_text("print('ok')\n", encoding="utf-8")
+    monkeypatch.setattr(scheduler_script._sched, "_get_hermes_home", lambda: tmp_path)
+    script, error = scheduler_script._resolve_script_path("relative.py")
+    assert script == expected_script.resolve()
+    assert error is None
+    assert calls == ["ensure_dirs", "ensure_dirs"]
+
+
 def test_primary_client_ignores_stale_auxiliary_router(monkeypatch):
     from agent import agent_runtime_helpers, auxiliary_client
 


### PR DESCRIPTION
## Summary
- Remove cron consumers' dependency on private `cron.jobs._ensure_cron_dir`, preventing a partial code update from breaking scheduled jobs.
- Build a complete `hermes-tools` MCP override for dispatcher-owned Codex Kanban workers, avoiding invalid env-only MCP transport configuration when the worker profile has no Codex config.
- Add regression coverage for both update-skew and worker-command contracts.

## Validation
- `python3 -m py_compile` for changed runtime and test files.
- Exercised the cron skew path by removing the private helper from the loaded `cron.jobs` module and running ledger, monitor, and script resolution.
- Exercised the Codex Kanban worker command construction with a subprocess capture.
- The repository's `scripts/run_tests.sh` could not run locally because the installed venv has no pytest.

## Incident context
A long-lived gateway retained a `cron.jobs` module without `_ensure_cron_dir` while current consumers imported that private symbol, causing every watchdog run to fail. A dispatcher-owned Codex worker also received an incomplete MCP override and Codex rejected it as `invalid transport`.
