### PR TITLE
feat(cron): deliver report questions as inline buttons instead of dead text

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2155,6 +2155,11 @@ def remove_job(job_id: str) -> bool:
             clear_notepad(canonical_id)
         except Exception:
             logger.debug("Failed to clear notepad for removed job %s", canonical_id, exc_info=True)
+        try:
+            from cron.questions import clear_for_job
+            clear_for_job(canonical_id)
+        except Exception:
+            logger.debug("Failed to clear pending questions for removed job %s", canonical_id, exc_info=True)
         # Prune the fire-fence lock entry so the registry doesn't grow monotonically.
         _fence_key = f"{_current_cron_store().cron_dir.resolve()}::{canonical_id}"
         with _fire_fence_locks_guard:

--- a/cron/questions.py
+++ b/cron/questions.py
@@ -1,0 +1,433 @@
+"""Inline-button questions in cron reports (issue #107138).
+
+Cron reports regularly end with a decision the user has to make ("do I merge PR
+#1827?"). The agent cannot call ``clarify`` during a cron run (it blocks the run
+awaiting input), so today those decisions arrive as dead text. This module lets
+a job's final response carry the decision as a documented ``<question>`` block
+that the DELIVERY layer turns into inline buttons: the run finishes without
+blocking, and the answer arrives whenever the user taps.
+
+Markup contract (one block per question, options are ``-``/``*``/``•``/numbered
+list items)::
+
+    <question>
+    Je merge la PR #1827 ?
+    - ✅ Oui (Recommended)
+    - ⏸️ Plus tard
+    </question>
+
+The parser is lossless by construction: a block that does not match the contract
+(no options, too many options, a prose line among the options, an unterminated
+tag) is left VERBATIM in the delivered text. A malformed block therefore degrades
+to today's dead text instead of swallowing part of the report.
+
+The pending-question store is profile-local SQLite next to the executions ledger
+(same connection/pragma pattern as ``cron/notepad.py``) because the tap can land
+days later, from a gateway that restarted in between. Recording an answer is
+first-write-wins so a double tap cannot re-inject the same turn twice.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import threading
+import uuid
+from dataclasses import dataclass, field
+from contextlib import contextmanager
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from cron.ledger import ledger_transaction, open_ledger, prepare_ledger
+from hermes_constants import get_hermes_home
+from hermes_time import now as _hermes_now
+
+# Optional test override; production resolves the path at transaction time so a
+# multiplexed profile cannot read another profile's pending questions.
+QUESTIONS_FILE: Optional[Path] = None
+
+# Telegram caps callback_data at 64 bytes; "cq:<12-hex token>:<index>" is ~18.
+CALLBACK_PREFIX = "cq:"
+MAX_CALLBACK_DATA_BYTES = 64
+# A question is a decision, not a menu: past this the block stays verbatim text.
+MAX_OPTIONS = 8
+MAX_QUESTION_CHARS = 500
+TOKEN_HEX_CHARS = 12
+MAX_PENDING_ROWS = 500
+# A button nobody tapped within this window loses its context: the row goes, and a
+# later tap is answered with "no longer available" (bounded growth for unattended jobs).
+MAX_PENDING_AGE_DAYS = 90
+
+_lock = threading.RLock()
+
+_BLOCK_RE = re.compile(r"<question>(.*?)</question>", re.DOTALL | re.IGNORECASE)
+_OPTION_RE = re.compile(r"^(?:[-*\u2022]|\d+[.)])\s+(?P<label>.+)$")
+# Models bold the recommended option but not the others; keep labels comparable.
+_EMPHASIS_WRAPPERS = (("**", "**"), ("__", "__"), ("`", "`"))
+_RECOMMENDED_RE = re.compile(
+    r"\s*[\(\[]\s*(?:recommended|recommand\u00e9|empfohlen|recomendado)\s*[\)\]]\s*$",
+    re.IGNORECASE,
+)
+
+QUESTION_MARKUP = "<question>"
+
+
+@dataclass
+class QuestionOption:
+    """One tappable answer. ``label`` is both the button text and the injected answer."""
+
+    label: str
+    recommended: bool = False
+
+
+@dataclass
+class Question:
+    """One parsed ``<question>`` block."""
+
+    text: str
+    options: List[QuestionOption] = field(default_factory=list)
+
+
+@dataclass
+class PendingQuestion:
+    """A parsed question with the store token a tap will resolve (the adapter wire shape)."""
+
+    token: str
+    question: str
+    options: List[str] = field(default_factory=list)
+    recommended_index: Optional[int] = None
+
+
+def to_payload(questions: List[Question], tokens: List[str]) -> List[PendingQuestion]:
+    """Pair parsed questions with their tokens for the adapter."""
+    return [
+        PendingQuestion(
+            token=token,
+            question=question.text,
+            options=[option.label for option in question.options],
+            recommended_index=next(
+                (i for i, option in enumerate(question.options) if option.recommended), None),
+        )
+        for question, token in zip(questions, tokens)
+    ]
+
+
+def _strip_emphasis(value: str) -> str:
+    label = value.strip()
+    for opening, closing in _EMPHASIS_WRAPPERS:
+        if label.startswith(opening) and label.endswith(closing) and len(label) > len(opening) + len(closing):
+            return label[len(opening):-len(closing)].strip()
+    return label
+
+
+def _parse_block(body: str) -> Optional[Question]:
+    """Parse one block body; None when it does not match the contract."""
+    lines = [line.strip() for line in body.splitlines()]
+    lines = [line for line in lines if line]
+    if not lines:
+        return None
+    question_text = _strip_emphasis(lines[0])
+    if not question_text or len(question_text) > MAX_QUESTION_CHARS:
+        return None
+    options: List[QuestionOption] = []
+    for line in lines[1:]:
+        match = _OPTION_RE.match(line)
+        if match is None:
+            # A prose line among the options is not a question block: keep the text as-is.
+            return None
+        label = _strip_emphasis(match.group("label"))
+        if not label:
+            return None
+        recommended = bool(_RECOMMENDED_RE.search(label))
+        label = _RECOMMENDED_RE.sub("", label).strip()
+        if not label:
+            return None
+        options.append(QuestionOption(label=label, recommended=recommended))
+    if not options or len(options) > MAX_OPTIONS:
+        return None
+    return Question(text=question_text, options=options)
+
+
+def parse_questions(text: str) -> Tuple[str, List[Question]]:
+    """Extract ``<question>`` blocks: ``(text_without_them, questions)``.
+
+    Returns the input unchanged with an empty list when there is nothing to
+    parse, so callers can branch on ``questions`` alone.
+    """
+    raw = "" if text is None else str(text)
+    if QUESTION_MARKUP not in raw.lower():
+        return raw, []
+    questions: List[Question] = []
+    spans: List[Tuple[int, int]] = []
+    for match in _BLOCK_RE.finditer(raw):
+        question = _parse_block(match.group(1))
+        if question is None:
+            continue
+        questions.append(question)
+        spans.append(match.span())
+    if not spans:
+        return raw, []
+    body = raw
+    for start, end in reversed(spans):
+        body = body[:start] + body[end:]
+    # The blocks leave their surrounding blank lines behind; collapse them so the
+    # delivered report does not gain a gap where the buttons used to be.
+    body = re.sub(r"\n{3,}", "\n\n", body)
+    return body.strip("\n"), questions
+
+
+def render_questions_text(questions: List[PendingQuestion], *, hint: bool = True) -> str:
+    """Platform-agnostic rendering (button-less adapters and the text fallback)."""
+    blocks = []
+    for index, question in enumerate(questions, start=1):
+        head = f"\u2753 {question.question}" if len(questions) == 1 else f"\u2753 {index}. {question.question}"
+        options = "\n".join(
+            f"  {position}. {label}"
+            for position, label in enumerate(question.options, start=1)
+        )
+        blocks.append(f"{head}\n{options}")
+    body = "\n\n".join(blocks)
+    if hint and len(questions) == 1:
+        return (
+            f"{body}\n\nReply with the number or the option text to answer "
+            "\u2014 your answer continues the conversation."
+        )
+    return body
+
+
+def build_callback_data(token: str, index: int) -> str:
+    """``cq:<token>:<index>``, the tap payload (callback_data size is the constraint)."""
+    return f"{CALLBACK_PREFIX}{token}:{int(index)}"
+
+
+def parse_callback_data(data: str) -> Optional[Tuple[str, int]]:
+    """Inverse of :func:`build_callback_data`; None for anything else."""
+    if not data or not data.startswith(CALLBACK_PREFIX):
+        return None
+    remainder = data[len(CALLBACK_PREFIX):]
+    token, separator, raw_index = remainder.rpartition(":")
+    if not separator or not token or len(data.encode("utf-8")) > MAX_CALLBACK_DATA_BYTES:
+        return None
+    try:
+        return token, int(raw_index)
+    except ValueError:
+        return None
+
+
+def button_rows(questions: List[PendingQuestion]) -> List[List[Dict[str, str]]]:
+    """Button rows in the shape ``telegram_notification_markup`` consumes.
+
+    One option per row (labels are the answers, and a multi-option row truncates
+    on mobile); the question number prefixes the label when a report asks more
+    than one thing, so a row is never ambiguous.
+    """
+    rows: List[List[Dict[str, str]]] = []
+    for question_index, question in enumerate(questions):
+        for option_index, label in enumerate(question.options):
+            text = label if len(questions) == 1 else f"{question_index + 1}. {label}"
+            rows.append([{
+                "label": text,
+                "callback_data": build_callback_data(question.token, option_index),
+            }])
+    return rows
+
+
+def answers_prompt(questions: List[PendingQuestion]) -> str:
+    """Intro line above the questions in the delivered button message."""
+    if len(questions) == 1:
+        return "\u2753 This report has a question for you:"
+    return f"\u2753 This report has {len(questions)} questions for you:"
+
+
+# -- pending-question store ---------------------------------------------------
+
+
+def _current_file() -> Path:
+    return QUESTIONS_FILE or (get_hermes_home().resolve() / "cron" / "questions.db")
+
+
+def _connect() -> sqlite3.Connection:
+    return open_ledger(_current_file())
+
+
+def _initialize_schema(conn: sqlite3.Connection) -> None:
+    prepare_ledger(conn, db_label="cron/questions.db", synchronous_full=False)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS cron_questions (
+             token TEXT PRIMARY KEY,
+             job_id TEXT NOT NULL,
+             platform TEXT NOT NULL,
+             chat_id TEXT NOT NULL,
+             question TEXT NOT NULL,
+             options_json TEXT NOT NULL,
+             created_at TEXT NOT NULL,
+             answered_at TEXT,
+             answer_index INTEGER,
+             answer_text TEXT
+           )"""
+    )
+
+
+@contextmanager
+def _transaction() -> Iterator[sqlite3.Connection]:
+    with ledger_transaction(_lock, _connect, _initialize_schema) as conn:
+        yield conn
+
+
+def _prune_unlocked(conn: sqlite3.Connection) -> None:
+    """Bounded retention: a job whose questions are never answered must not grow forever.
+
+    Answered rows past the cap go first (they carry no more information than the
+    injected answer turn), then unanswered rows older than ``MAX_PENDING_AGE_DAYS``
+    — a tap that late has no context left to continue from anyway.
+    """
+    answered = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM cron_questions WHERE answered_at IS NOT NULL"
+        ).fetchone()[0]
+    )
+    excess = answered - MAX_PENDING_ROWS
+    if excess > 0:
+        conn.execute(
+            """DELETE FROM cron_questions WHERE token IN (
+                 SELECT token FROM cron_questions WHERE answered_at IS NOT NULL
+                 ORDER BY answered_at, token LIMIT ?)""",
+            (excess,),
+        )
+    cutoff = (_hermes_now() - timedelta(days=MAX_PENDING_AGE_DAYS)).isoformat()
+    conn.execute(
+        "DELETE FROM cron_questions WHERE answered_at IS NULL AND created_at < ?",
+        (cutoff,),
+    )
+
+
+def record_questions(
+    job_id: str, platform: str, chat_id: str, questions: List[Question]
+) -> List[str]:
+    """Persist one pending row per question; returns tokens in question order.
+
+    Called BEFORE the button message is sent, so a tap can never arrive for a
+    token the store does not know yet.
+    """
+    if not questions:
+        return []
+    tokens = [
+        uuid.uuid4().hex[:TOKEN_HEX_CHARS] for _ in questions
+    ]
+    now = _hermes_now().isoformat()
+    with _transaction() as conn:
+        for token, question in zip(tokens, questions):
+            conn.execute(
+                """INSERT INTO cron_questions
+                   (token, job_id, platform, chat_id, question, options_json, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    token,
+                    str(job_id),
+                    str(platform),
+                    str(chat_id),
+                    question.text,
+                    json.dumps([option.label for option in question.options], ensure_ascii=False),
+                    now,
+                ),
+            )
+        _prune_unlocked(conn)
+    return tokens
+
+
+def get_question(token: str) -> Optional[Dict[str, Any]]:
+    with _transaction() as conn:
+        row = conn.execute(
+            "SELECT * FROM cron_questions WHERE token=?", (str(token),)
+        ).fetchone()
+    return None if row is None else dict(row)
+
+
+def forget_questions(tokens: List[str]) -> int:
+    """Drop pending rows whose buttons provably never reached the platform."""
+    if not tokens:
+        return 0
+    with _transaction() as conn:
+        cursor = conn.executemany(
+            "DELETE FROM cron_questions WHERE token=? AND answered_at IS NULL",
+            [(str(token),) for token in tokens],
+        )
+        return cursor.rowcount if cursor.rowcount is not None else 0
+
+
+def claim_answer(token: str, index: int) -> Dict[str, Any]:
+    """Claim a tap; first write wins. ``status`` is one of:
+
+    ``answered`` (this tap recorded the answer), ``already_answered`` (a previous
+    tap did, or the same tap was replayed), ``unknown`` (expired/pruned token),
+    ``invalid_option`` (index outside the recorded options).
+    """
+    token = str(token)
+    now = _hermes_now().isoformat()
+    with _transaction() as conn:
+        row = conn.execute(
+            "SELECT * FROM cron_questions WHERE token=?", (token,)
+        ).fetchone()
+        if row is None:
+            return {"status": "unknown"}
+        record = dict(row)
+        options = json.loads(record["options_json"])
+        if not 0 <= int(index) < len(options):
+            return {
+                "status": "invalid_option",
+                "question": record["question"],
+                "options": options,
+            }
+        if record["answered_at"] is not None:
+            return {
+                "status": "already_answered",
+                "question": record["question"],
+                "answer_text": record["answer_text"],
+                "job_id": record["job_id"],
+            }
+        answer_text = options[int(index)]
+        cursor = conn.execute(
+            """UPDATE cron_questions SET answered_at=?, answer_index=?, answer_text=?
+               WHERE token=? AND answered_at IS NULL""",
+            (now, int(index), answer_text, token),
+        )
+        if cursor.rowcount != 1:  # raced by another tap: that one owns the answer
+            fresh = conn.execute(
+                "SELECT * FROM cron_questions WHERE token=?", (token,)
+            ).fetchone()
+            return {
+                "status": "already_answered",
+                "question": record["question"],
+                "answer_text": fresh["answer_text"] if fresh else None,
+                "job_id": record["job_id"],
+            }
+        _prune_unlocked(conn)
+    return {
+        "status": "answered",
+        "token": token,
+        "question": record["question"],
+        "answer_text": answer_text,
+        "job_id": record["job_id"],
+        "platform": record["platform"],
+        "chat_id": record["chat_id"],
+    }
+
+
+def clear_for_job(job_id: str) -> int:
+    """Delete a removed job's pending questions; no-op without creating the DB."""
+    if not _current_file().exists():
+        return 0
+    with _transaction() as conn:
+        cursor = conn.execute("DELETE FROM cron_questions WHERE job_id=?", (str(job_id),))
+    return cursor.rowcount
+
+
+def answer_reply_text(question: str, answer: str) -> str:
+    """The user turn injected back into the conversation when a button is tapped."""
+    return (
+        "You asked this question in a scheduled report:\n\n"
+        f"Q: {question}\n"
+        f"A: {answer}"
+    )

--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -1660,6 +1660,94 @@ def _unresolved_delivery_outcome(job: dict, for_failure: bool) -> Optional[str]:
     return msg
 
 
+def _cron_question_buttons_enabled(user_cfg: Optional[dict]) -> bool:
+    """Whether the delivery layer may turn ``<question>`` blocks into buttons.
+
+    The job opts in by emitting the markup (existing jobs are byte-identically
+    unaffected); ``cron.question_buttons: false`` disables the parsing process-wide.
+    """
+    cron_cfg = (user_cfg or {}).get("cron") or {}
+    if not isinstance(cron_cfg, dict):
+        return True
+    return bool(cron_cfg.get("question_buttons", True))
+
+
+def _parse_delivery_questions(content: str, user_cfg: Optional[dict]) -> tuple[str, list]:
+    """Split a cron response into ``(body_without_question_blocks, questions)``.
+
+    A parser failure must never cost the report its text, so anything unexpected
+    degrades to "no questions" and the untouched content.
+    """
+    if not _cron_question_buttons_enabled(user_cfg):
+        return content, []
+    try:
+        from cron.questions import parse_questions
+        return parse_questions(content)
+    except Exception as exc:
+        logger.warning("Question markup parsing failed; delivering the text as-is: %s", exc)
+        return content, []
+
+
+def _deliver_questions_via_live_adapter(
+    t: _TargetDelivery, questions: list, delivery_errors: list
+) -> None:
+    """Send the report's questions as native inline buttons on the live adapter.
+
+    The body was already delivered without them, so a failure here has to be loud
+    (run status, hence `hermes cron list`) rather than swallowed: the recipient is
+    looking at a report whose questions are not on screen. Answer rows are recorded
+    before the send, so a tap that somehow arrives early still resolves.
+    """
+    from agent.async_utils import safe_schedule_threadsafe
+    from cron.questions import forget_questions, record_questions, to_payload
+
+    def _reported(message: str) -> None:
+        delivery_errors.append(
+            f"{len(questions)} question(s) from this report reached {t.where} without "
+            f"buttons and were dropped from the body: {message}")
+
+    job = t.job
+    _, route_metadata, _ = _live_route_metadata(t)
+    try:
+        tokens = record_questions(job["id"], t.platform_name, t.chat_id, questions)
+    except Exception as exc:
+        logger.error(
+            "Job '%s': question buttons to %s were not sent (store write failed: %s)",
+            job["id"], t.where, exc, exc_info=True)
+        _reported(f"question store write failed: {exc}")
+        return
+    payload = to_payload(questions, tokens)
+    send_metadata = {**route_metadata, "question_tokens": tokens}
+    future = safe_schedule_threadsafe(
+        t.runtime_adapter.send_cron_questions(t.chat_id, payload, metadata=send_metadata),
+        t.loop,
+    )
+    if future is None:
+        forget_questions(tokens)
+        _reported("the gateway event loop refused the send")
+        return
+    try:
+        result = future.result(timeout=60)
+    except Exception as exc:
+        # Ambiguous (the coroutine may still be in flight): keep the rows so a tap resolves.
+        logger.warning(
+            "Job '%s': question buttons to %s failed: %s", job["id"], t.where, exc)
+        _reported(f"send raised {exc}")
+        return
+    if not _result_field(result, "success"):
+        # A refused send is definite: no buttons exist anywhere, so drop the rows
+        # rather than leaving tokens no tap can ever reach.
+        forget_questions(tokens)
+        error = _result_field(result, "error") or "unconfirmed result"
+        logger.warning(
+            "Job '%s': question buttons to %s were not delivered: %s", job["id"], t.where, error)
+        _reported(f"adapter refused the send ({error})")
+        return
+    logger.info(
+        "Job '%s': delivered %d question(s) as buttons to %s:%s",
+        job["id"], len(questions), t.platform_name, t.chat_id)
+
+
 def _deliver_result(
     job: dict, content: str, adapters=None, loop=None, *, for_failure: bool = False
 ) -> Optional[str]:
@@ -1704,18 +1792,28 @@ def _deliver_result(
     # Targets acked with NO evidence (bare SendResult(success=True) — Slack/Matrix/Mattermost);
     # persisted as ``last_delivery_unverified`` so `hermes cron list` shows it.
     unverified_targets: list = []
-    if wrap_response:
+    # ``<question>`` blocks in the report become inline buttons on a target that can render them
+    # (#107138) — the job opts in by emitting the markup, nothing else changes for existing jobs.
+    # The plain-text variant is kept for every lane that cannot render buttons so the questions are
+    # never dropped: only the lane that actually delivers the buttons gets the stripped body.
+    body_content, questions = _parse_delivery_questions(content, user_cfg)
+
+    def _wrap(text: str) -> str:
+        if not wrap_response:
+            return text
         task_name = job.get("name", job["id"])
-        delivery_content = (
+        return (
             f"Cronjob Response: {task_name}\n"
             f"(job_id: {job.get('id', '')})\n"
             f"-------------\n\n"
-            f"{content}\n\n"
+            f"{text}\n\n"
             "To stop or manage this job, send me a new message "
             f"(e.g. \"stop reminder {task_name}\")."
         )
-    else:
-        delivery_content = content
+
+    delivery_content = _wrap(body_content)
+    # Same message with the questions left inline, for button-less lanes (see loop below).
+    delivery_content_with_questions = _wrap(content) if questions else delivery_content
 
     from gateway.platforms.base import BasePlatformAdapter
     # Bridge media-policy config into the env vars the path validator reads. The gateway does this
@@ -1723,6 +1821,10 @@ def _deliver_result(
     from gateway.media_policy import apply_media_policy_env
     apply_media_policy_env(user_cfg)
     media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
+    # Questions kept inline (same MEDIA handling) for the lanes that cannot render buttons.
+    cleaned_delivery_content_with_questions = (
+        BasePlatformAdapter.extract_media(delivery_content_with_questions)[1]
+        if questions else cleaned_delivery_content)
     requested_media = len(media_files)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
     # Policy-dropped attachments will never be sent on ANY lane — record them in run status.
@@ -1772,14 +1874,20 @@ def _deliver_result(
         if t is None:
             continue
         target_errors: list = []
+        # Buttons only exist on the live lane: the standalone senders have no reply_markup path, so
+        # those targets keep the questions inline rather than losing them.
+        as_buttons = bool(questions) and t.live_adapter_ready
+        target_text = cleaned_delivery_content if as_buttons else cleaned_delivery_content_with_questions
         delivered = t.live_adapter_ready and _deliver_via_live_adapter(
-            t, cleaned_delivery_content, media_files,
+            t, target_text, media_files,
             target_errors=target_errors, delivery_errors=delivery_errors,
             unverified_targets=unverified_targets,
         )
+        if delivered and as_buttons:
+            _deliver_questions_via_live_adapter(t, questions, delivery_errors)
         if not delivered:
             _deliver_standalone(
-                t, cleaned_delivery_content, media_files, target_errors, delivery_errors)
+                t, target_text, media_files, target_errors, delivery_errors)
 
     # Filter-time drops apply to every target; report them once.
     delivery_errors.extend(policy_drop_errors)

--- a/cron/scheduler_prompt.py
+++ b/cron/scheduler_prompt.py
@@ -200,6 +200,24 @@ _CRON_HINT = (
 )
 
 
+_QUESTIONS_HINT = (
+    "QUESTIONS: when your report ends with a decision the user has to make, put it in a "
+    "<question>...</question> block instead of prose — the delivery layer renders the options "
+    "as buttons and the run finishes without waiting. Format:\n"
+    "<question>\nMerge PR #1827?\n- Yes (Recommended)\n- Not yet\n</question>\n\n"
+)
+
+
+def _questions_hint_enabled() -> bool:
+    """Mirror the delivery-side `cron.question_buttons` switch so the prompt never asks for markup
+    the delivery layer has been told not to render."""
+    try:
+        cron_cfg = (_sched.load_config() or {}).get("cron") or {}
+        return bool(cron_cfg.get("question_buttons", True)) if isinstance(cron_cfg, dict) else True
+    except Exception:
+        return True
+
+
 def _build_job_prompt(
     job: dict, prerun_script: Optional[tuple] = None, extra_prompt: Optional[str] = None) -> str:
     """Build the effective prompt for a cron job, optionally loading skills first.
@@ -244,7 +262,7 @@ def _build_job_prompt(
         prompt = f"{notepad_section}{prompt}"
         has_injected_data = True
 
-    prompt = _CRON_HINT + prompt
+    prompt = _CRON_HINT + (_QUESTIONS_HINT if _questions_hint_enabled() else "") + prompt
     skill_names = _job_skill_names(job)
     if not skill_names:
         return _scan_assembled_cron_prompt(

--- a/gateway/platforms/ADDING_A_PLATFORM.md
+++ b/gateway/platforms/ADDING_A_PLATFORM.md
@@ -119,10 +119,11 @@ If your platform supports interactive button/menu messages, implement these for 
 | `send_clarify(chat_id, question, choices, clarify_id, session_key, ...)` | Render the `clarify` tool's multi-choice question as tappable buttons. Pair with inbound dispatch that routes button taps to `tools.clarify_gateway.resolve_gateway_clarify`. |
 | `send_exec_approval(chat_id, command, session_key, description, ...)` | Render dangerous-command approval as Approve/Deny buttons. Inbound dispatch routes to `tools.approval.resolve_gateway_approval`. |
 | `send_slash_confirm(chat_id, title, message, session_key, confirm_id, ...)` | Render slash-command confirmations (e.g. `/reload-mcp`) as Once/Always/Cancel buttons. Inbound dispatch routes to `tools.slash_confirm.resolve`. |
+| `send_cron_questions(chat_id, questions, ...)` | Render the `<question>` blocks at the end of a scheduled report as tappable buttons (`cq:<token>:<idx>`). Inbound dispatch records the tap via `cron.questions.claim_answer` and re-enters the answer as a user turn. Nothing blocks — the run finished long before the tap. |
 | `send_model_picker(...)` | Interactive `/model` picker. Used by Telegram, Discord, and Slack (Socket Mode). |
 | `send_choice_picker(...)` | Flat single-level picker for finite-choice commands (`/reasoning`, `/fast`). Implemented by Telegram (inline keyboard), Discord (select menu), and Matrix (reactions). Platforms without it fall back to the text status card automatically. |
 
-See `gateway/platforms/telegram.py`, `discord.py`, and `whatsapp_cloud.py` for reference implementations. The button-callback id convention (`cl:<id>:<idx>`, `appr:<id>:<choice>`, `sc:<choice>:<id>`) is shared across adapters — match it so the gateway-side resolvers work without modification.
+See `gateway/platforms/telegram.py`, `discord.py`, and `whatsapp_cloud.py` for reference implementations. The button-callback id convention (`cl:<id>:<idx>`, `appr:<id>:<choice>`, `sc:<choice>:<id>`, `cq:<token>:<idx>`) is shared across adapters — match it so the gateway-side resolvers work without modification.
 
 ### Required function
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2549,6 +2549,17 @@ class BasePlatformAdapter(ABC):
             text = f"❓ {question}"
         return await self.send(chat_id=chat_id, content=text, metadata=metadata)
 
+    async def send_cron_questions(
+        self, chat_id: str, questions: list, metadata: Optional[Dict[str, Any]] = None
+    ) -> SendResult:
+        """A scheduled report's questions (#107138). Button-capable adapters SHOULD override; a
+        tap MUST resolve through ``cron.questions.claim_answer(token, index)`` and re-inject the
+        answer as a user turn. Default: numbered text — the delivery layer only strips the
+        ``<question>`` markup on a lane that reaches this method, so nothing is lost here."""
+        from cron.questions import render_questions_text
+        return await self.send(
+            chat_id=chat_id, content=render_questions_text(list(questions)), metadata=metadata)
+
     async def send_private_notice(
         self, chat_id: str, user_id: Optional[str], content: str, reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None) -> SendResult:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1689,6 +1689,10 @@ DEFAULT_CONFIG = {
         # Wrap delivered cron responses with a task-name header and "The agent cannot see this
         # message" footer. False = clean output.
         "wrap_response": True,
+        # Deliver ``<question>`` blocks at the end of a report as inline buttons on platforms that
+        # support them (Telegram), instead of leaving the decision as dead text. The job opts in by
+        # emitting the markup; False disables the parsing process-wide.
+        "question_buttons": True,
         "delivery": {  # Delivery behaviour for cron output sent through a live gateway adapter.
             # Mark cron deliveries FINAL so the platform pushes them (Telegram's "important" mode
             # otherwise sends with disable_notification=True and briefs look undelivered). False =

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3871,6 +3871,33 @@ class TelegramAdapter(TelegramWisdomMixin, BasePlatformAdapter):
         return await self._send_prompt(
             "send_clarify", chat_id, metadata, build, parse_mode=ParseMode.HTML, thread_id=self._metadata_thread_id(metadata))
 
+    async def send_cron_questions(
+        self, chat_id: str, questions: list, metadata: Optional[Dict[str, Any]] = None
+    ) -> SendResult:
+        """Render a scheduled report's questions as inline buttons (#107138).
+
+        ``cq:<token>:<idx>`` buttons; a tap records the answer and re-injects it into the
+        conversation as a user turn (see ``_handle_cron_question_callback``). Unlike
+        ``send_clarify`` nothing here blocks: the report is already delivered, and the user
+        answers whenever they get to it.
+        """
+        from cron.questions import answers_prompt, button_rows, render_questions_text
+        from tools.wisdom_notifications import telegram_notification_markup
+
+        def build():
+            items = list(questions)
+            # Labels are the answers, so they stay on the buttons; the body repeats them
+            # numbered because phones truncate button text and replies may quote it.
+            text = "\n\n".join([
+                _html.escape(answers_prompt(items)),
+                _html.escape(render_questions_text(items, hint=False)),
+            ])
+            return text, telegram_notification_markup(action_button_rows=button_rows(items)), None
+
+        return await self._send_prompt(
+            "send_cron_questions", chat_id, metadata, build, parse_mode=ParseMode.HTML,
+            thread_id=self._metadata_thread_id(metadata))
+
     @staticmethod
     def _provider_get_label():
         try:
@@ -4284,6 +4311,7 @@ class TelegramAdapter(TelegramWisdomMixin, BasePlatformAdapter):
         for prefix, handler in (
             ("gt:", self._handle_gmail_triage_callback), ("ea:", self._handle_exec_approval_callback),
             ("sc:", self._handle_slash_confirm_callback), ("cl:", self._handle_clarify_callback),
+            ("cq:", self._handle_cron_question_callback),
             ("update_prompt:", self._handle_update_prompt_callback)):
             if data.startswith(prefix):
                 await handler(query, data, cb)
@@ -4453,6 +4481,87 @@ class TelegramAdapter(TelegramWisdomMixin, BasePlatformAdapter):
             # Entry evicted / gateway restarted between ask and tap.
             await self._notify_clarify_expired(query, user_display)
             logger.warning("Telegram clarify button: resolve_gateway_clarify returned False (id=%s)", clarify_id)
+
+    async def _handle_cron_question_callback(self, query, data: str, cb: Dict[str, Any]) -> None:
+        """``cq:<token>:<idx>`` — record an answer to a scheduled report's question (#107138).
+
+        Non-blocking by construction: the report already went out, the answer is written to
+        the durable store first (first write wins, so a double tap cannot answer twice), and
+        the tap is then handed to the conversation as an ordinary user turn.
+        """
+        from cron.questions import claim_answer, parse_callback_data
+
+        parsed = parse_callback_data(data)
+        if parsed is None:
+            return
+        token, index = parsed
+        if not await self._callback_authorized(
+            query, cb, "⛔ You are not authorized to answer this question."
+        ):
+            return
+        user_display = getattr(query.from_user, "first_name", "User")
+        result = claim_answer(token, index)
+        status = result.get("status")
+        if status == "unknown":
+            await query.answer(text="This question is no longer available.")
+            logger.info("Telegram cron question: unknown/expired token (token=%s, user=%s)", token, user_display)
+            return
+        if status == "invalid_option":
+            await query.answer(text="That option is no longer part of the question.")
+            return
+        if status == "already_answered":
+            await query.answer(text=f"Already answered: {result.get('answer_text') or '—'}")
+            return
+        answer_text = str(result.get("answer_text") or "")
+        await query.answer(text=f"✓ {answer_text[:60]}")
+        await self._edit_html_quiet(
+            query,
+            f"❓ {_html.escape(str(result.get('question') or ''))}\n\n"
+            f"<b>{_html.escape(user_display)}:</b> {_html.escape(answer_text)}",
+        )
+        logger.info(
+            "Telegram cron question answered (token=%s, choice=%r, user=%s)",
+            token, answer_text, user_display)
+        await self._inject_cron_question_answer(query, cb, result)
+
+    async def _inject_cron_question_answer(self, query, cb: Dict[str, Any], result: Dict[str, Any]) -> None:
+        """Re-enter the tapped answer as a user turn, so the job (or the chat) continues with it."""
+        from cron.questions import answer_reply_text
+
+        if self._message_handler is None:
+            # Buttons only exist through a live gateway, so this is a torn-down adapter; the
+            # answer is already durable, and the next report run re-reads the job state.
+            logger.warning(
+                "Telegram cron question answered with no gateway handler attached (token=%s)",
+                result.get("token"))
+            return
+        message = getattr(query, "message", None)
+        user = getattr(query, "from_user", None)
+        chat = getattr(message, "chat", None)
+        message_id = getattr(message, "message_id", None)
+        source = self.build_source(
+            chat_id=str(cb["chat_id"]),
+            chat_name=getattr(chat, "title", None) or getattr(chat, "full_name", None),
+            chat_type=self._normalize_chat_type(cb["chat_type"], is_forum=cb["thread_id"] is not None),
+            user_id=str(getattr(user, "id", "") or "") or None,
+            user_name=getattr(user, "full_name", None) or getattr(user, "first_name", None),
+            thread_id=str(cb["thread_id"]) if cb["thread_id"] is not None else None,
+            message_id=str(message_id) if message_id is not None else None,
+            is_bot=False,
+        )
+        question = str(result.get("question") or "")
+        answer_text = str(result.get("answer_text") or "")
+        await self.handle_message(MessageEvent(
+            text=answer_reply_text(question, answer_text),
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=str(message_id) if message_id is not None else None,
+            reply_to_message_id=str(message_id) if message_id is not None else None,
+            reply_to_is_own_message=True,
+            allow_gateway_control=False,
+        ))
+        logger.info(
+            "Telegram cron question answer delivered to the conversation (token=%s)", result.get("token"))
 
     async def _handle_update_prompt_callback(self, query, data: str, cb: Dict[str, Any]) -> None:
         """``update_prompt:<y|n>`` — forward the answer to the update process."""

--- a/tests/cron/test_cron_question_buttons.py
+++ b/tests/cron/test_cron_question_buttons.py
@@ -1,0 +1,286 @@
+"""Cron reports deliver ``<question>`` blocks as inline buttons (#107138).
+
+A scheduled run cannot call ``clarify`` (it blocks awaiting input), so decisions
+at the end of a report used to arrive as dead text. The delivery layer now parses
+the documented markup, strips it from the body, and hands the questions to the
+platform adapter — which renders buttons wherever the platform supports them. The
+run never blocks, and the tap re-enters the conversation as a user turn.
+
+Two invariants these tests pin, both of which have bitten real delivery code:
+
+* the parser is LOSSLESS — a block that does not match the contract stays in the
+  text, so a malformed block can never swallow part of a report;
+* a lane that cannot render buttons keeps the questions INLINE instead of
+  stripping them into nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from concurrent.futures import Future
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron import questions as questions_mod  # noqa: E402
+from cron.questions import (  # noqa: E402
+    MAX_OPTIONS,
+    Question,
+    QuestionOption,
+    build_callback_data,
+    claim_answer,
+    forget_questions,
+    get_question,
+    parse_callback_data,
+    parse_questions,
+    record_questions,
+    to_payload,
+)
+from cron.scheduler import _deliver_result  # noqa: E402
+from gateway.config import Platform, PlatformConfig  # noqa: E402
+
+REPORT = "Nightly report\n- 2 PRs merged\n"
+BLOCK = (
+    "<question>\n"
+    "Merge PR #1827?\n"
+    "- \u2705 Yes (Recommended)\n"
+    "- \u23f8\ufe0f Not yet\n"
+    "</question>\n"
+)
+
+
+@pytest.fixture
+def store(monkeypatch, tmp_path):
+    """Pending-question store in a temp profile, never the developer's own."""
+    monkeypatch.setattr(questions_mod, "QUESTIONS_FILE", tmp_path / "cron" / "questions.db")
+    return questions_mod
+
+
+# ---------------------------------------------------------------------------
+# The markup contract
+# ---------------------------------------------------------------------------
+
+class TestParseQuestions:
+    def test_block_becomes_a_question_and_leaves_the_body(self):
+        body, questions = parse_questions(REPORT + BLOCK)
+
+        assert questions == [Question(
+            text="Merge PR #1827?",
+            options=[
+                QuestionOption(label="\u2705 Yes", recommended=True),
+                QuestionOption(label="\u23f8\ufe0f Not yet", recommended=False),
+            ],
+        )]
+        assert questions[0].options[0].recommended is True
+        assert "<question>" not in body
+        assert "Merge PR #1827?" not in body
+        # The report itself survives untouched.
+        assert "2 PRs merged" in body
+
+    @pytest.mark.parametrize("text", [
+        "no markup at all",
+        "<question>\nOnly a question, no options\n</question>",
+        "<question>\nPick one\n- a\nand some prose\n- b\n</question>",
+        "<question>\nUnterminated\n- a\n- b\n",
+        "<question>\nToo many\n" + "".join(f"- option {i}\n" for i in range(MAX_OPTIONS + 1)) + "</question>",
+    ])
+    def test_unparseable_input_is_returned_verbatim(self, text):
+        """A block that is not the documented shape must never disappear."""
+        body, questions = parse_questions(text)
+
+        assert questions == []
+        assert body == text
+
+    def test_multiple_blocks_are_all_extracted(self):
+        body, questions = parse_questions(
+            REPORT + BLOCK + "\n<question>\nShip it?\n- yes\n- no\n</question>\n")
+
+        assert [q.text for q in questions] == ["Merge PR #1827?", "Ship it?"]
+        assert "<question>" not in body
+
+    def test_button_rows_carry_a_token_per_question_not_per_report(self):
+        _, questions = parse_questions(BLOCK + "\n<question>\nShip it?\n- yes\n- no\n</question>\n")
+        payload = to_payload(questions, ["aaaa", "bbbb"])
+
+        rows = questions_mod.button_rows(payload)
+
+        assert rows[0][0]["callback_data"] == build_callback_data("aaaa", 0)
+        # Second question's options are numbered so a row is never ambiguous.
+        assert rows[2][0]["label"].startswith("2. ")
+        assert rows[2][0]["callback_data"] == build_callback_data("bbbb", 0)
+
+    def test_callback_data_round_trips_within_telegram_budget(self):
+        token = "0123456789ab"
+        data = build_callback_data(token, 3)
+
+        assert parse_callback_data(data) == (token, 3)
+        assert len(data.encode("utf-8")) <= questions_mod.MAX_CALLBACK_DATA_BYTES
+        assert parse_callback_data("cl:" + token + ":0") is None
+        assert parse_callback_data("cq:" + token) is None
+
+
+# ---------------------------------------------------------------------------
+# The pending-question store
+# ---------------------------------------------------------------------------
+
+class TestPendingQuestionStore:
+    def _question(self):
+        return [Question(text="Merge?", options=[QuestionOption("yes"), QuestionOption("no")])]
+
+    def test_answer_is_recorded_once_and_replays_are_reported(self, store):
+        (token,) = record_questions("job1", "telegram", "-100", self._question())
+
+        first = claim_answer(token, 0)
+        replay = claim_answer(token, 1)
+
+        assert first["status"] == "answered"
+        assert first["answer_text"] == "yes"
+        assert first["job_id"] == "job1"
+        assert replay["status"] == "already_answered"
+        # First write wins: the replay must not overwrite the recorded answer.
+        assert replay["answer_text"] == "yes"
+        assert get_question(token)["answer_text"] == "yes"
+
+    def test_unknown_token_and_out_of_range_option_are_reported_not_raised(self, store):
+        (token,) = record_questions("job1", "telegram", "-100", self._question())
+
+        assert claim_answer("deadbeefdead", 0)["status"] == "unknown"
+        assert claim_answer(token, 7)["status"] == "invalid_option"
+        assert get_question(token)["answered_at"] is None
+
+    def test_forget_questions_drops_buttons_that_never_shipped(self, store):
+        tokens = record_questions("job1", "telegram", "-100", self._question())
+
+        assert forget_questions(tokens) == 1
+        assert get_question(tokens[0]) is None
+
+    def test_stale_unanswered_rows_are_pruned_but_fresh_ones_survive(self, store, monkeypatch):
+        """A job whose questions are never answered must not grow a row per run forever."""
+        from datetime import timedelta
+
+        from hermes_time import now as real_now
+
+        monkeypatch.setattr(
+            store, "_hermes_now", lambda: real_now() - timedelta(days=store.MAX_PENDING_AGE_DAYS + 1))
+        (stale,) = record_questions("job1", "telegram", "-100", self._question())
+        monkeypatch.setattr(store, "_hermes_now", real_now)
+        (fresh,) = record_questions("job1", "telegram", "-100", self._question())
+
+        assert get_question(stale) is None
+        assert get_question(fresh) is not None
+
+
+# ---------------------------------------------------------------------------
+# The delivery lane
+# ---------------------------------------------------------------------------
+
+CHAT_ID = "-1001234567890"
+
+
+def _job():
+    return {
+        "id": "qbjob1",
+        "name": "Nightly",
+        "deliver": "origin",
+        "origin": {"platform": "telegram", "chat_id": CHAT_ID},
+    }
+
+
+def _run_delivery(content, *, live=True, cron_cfg=None):
+    """Drive ``_deliver_result`` over the live lane with a stubbed router.
+
+    Returns ``(body_sent, question_calls, standalone_calls)``.
+    """
+    adapter = MagicMock()
+    question_calls = []
+
+    async def _send_cron_questions(chat_id, payload, metadata=None):
+        question_calls.append({"chat_id": chat_id, "payload": payload, "metadata": metadata})
+        return {"success": True, "message_id": "42"}
+
+    adapter.send_cron_questions = _send_cron_questions
+
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    # live=False: no running gateway loop, so the standalone sender lane is the only one.
+    loop = loop if live else None
+
+    def fake_schedule(coro, _loop):
+        future = Future()
+        try:
+            future.set_result(asyncio.run(coro))
+        except BaseException as exc:  # noqa: BLE001
+            future.set_exception(exc)
+        return future
+
+    bodies = []
+    router = MagicMock()
+
+    async def _deliver_to_platform(target, text, metadata):
+        bodies.append(text)
+        return {"success": True, "message_id": "41"}
+
+    router._deliver_to_platform = _deliver_to_platform
+
+    standalone = []
+
+    async def _fake_send_to_platform(platform, pconfig, chat_id, text, **kwargs):
+        standalone.append(text)
+        return {}
+
+    config = MagicMock()
+    config.platforms = {Platform.TELEGRAM: PlatformConfig(enabled=True)}
+    config.get_home_channel = lambda platform: None
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+            patch("cron.scheduler.load_config",
+                  return_value={"cron": {"wrap_response": False, **(cron_cfg or {})}}), \
+            patch("gateway.delivery.DeliveryRouter", return_value=router), \
+            patch("tools.send_message_tool._send_to_platform", _fake_send_to_platform), \
+            patch("asyncio.run_coroutine_threadsafe", side_effect=fake_schedule), \
+            patch("cron.scheduler_delivery._record_delivery_verification"):
+        error = _deliver_result(
+            _job(), content, adapters={Platform.TELEGRAM: adapter}, loop=loop)
+    assert error is None
+    return (bodies[0] if bodies else None), question_calls, standalone
+
+
+class TestDeliveryLane:
+    def test_questions_become_buttons_and_leave_the_body(self, store):
+        body, question_calls, _ = _run_delivery(REPORT + BLOCK)
+
+        assert "<question>" not in body
+        assert "Merge PR #1827?" not in body
+        assert len(question_calls) == 1
+        payload = question_calls[0]["payload"]
+        assert [item.question for item in payload] == ["Merge PR #1827?"]
+        assert payload[0].options == ["\u2705 Yes", "\u23f8\ufe0f Not yet"]
+        assert question_calls[0]["chat_id"] == CHAT_ID
+        # The delivered button is answerable: its token is in the durable store.
+        assert get_question(payload[0].token)["job_id"] == "qbjob1"
+
+    def test_reports_without_markup_are_delivered_byte_identically(self, store):
+        body, question_calls, _ = _run_delivery(REPORT)
+
+        assert body == REPORT.rstrip("\n")
+        assert question_calls == []
+
+    def test_lane_without_buttons_keeps_the_questions_in_the_body(self, store):
+        """Standalone senders have no reply_markup path: keep the text, lose nothing."""
+        body, question_calls, standalone = _run_delivery(REPORT + BLOCK, live=False)
+
+        assert body is None  # the live lane never ran
+        assert question_calls == []
+        assert standalone and "<question>" in standalone[0]
+        assert "Merge PR #1827?" in standalone[0]
+
+    def test_question_buttons_can_be_switched_off(self, store):
+        body, question_calls, _ = _run_delivery(
+            REPORT + BLOCK, cron_cfg={"question_buttons": False})
+
+        assert "<question>" in body
+        assert question_calls == []

--- a/tests/gateway/test_telegram_cron_question_buttons.py
+++ b/tests/gateway/test_telegram_cron_question_buttons.py
@@ -1,0 +1,251 @@
+"""Telegram rendering + routing for cron report questions (#107138).
+
+``send_cron_questions`` mirrors ``send_clarify``'s shape but must NOT block: the
+report is already delivered, so a tap is recorded in the durable store and then
+handed to the conversation as an ordinary user turn. These tests pin the render,
+the ``cq:`` callback contract, and the replay/unauthorized paths.
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+from cron.questions import (  # noqa: E402
+    PendingQuestion,
+    Question,
+    QuestionOption,
+    get_question,
+    record_questions,
+)
+from gateway.config import PlatformConfig  # noqa: E402
+from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+
+
+@pytest.fixture
+def store(monkeypatch, tmp_path):
+    import cron.questions as questions_mod
+
+    monkeypatch.setattr(questions_mod, "QUESTIONS_FILE", tmp_path / "cron" / "questions.db")
+    return questions_mod
+
+
+def _make_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token", extra={}))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+def _question():
+    return Question(
+        text="Merge PR #1827?",
+        options=[QuestionOption("\u2705 Yes", recommended=True), QuestionOption("\u23f8\ufe0f Not yet")],
+    )
+
+
+def _query(data, *, user_id="777", chat_id=12345):
+    query = AsyncMock()
+    query.data = data
+    query.message = MagicMock()
+    query.message.chat_id = chat_id
+    query.message.message_id = 500
+    query.message.chat.id = chat_id
+    query.message.chat.type = "private"
+    query.message.text = "Merge PR #1827?"
+    query.from_user = MagicMock()
+    query.from_user.id = user_id
+    query.from_user.first_name = "Tester"
+    query.from_user.full_name = "Tester Person"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+    update = MagicMock()
+    update.callback_query = query
+    return query, update
+
+
+async def _tap(adapter, data, *, user_id="777", chat_id=12345, allowed="*"):
+    """Drive ``_handle_callback_query`` with a button tap on ``data``."""
+    query, update = _query(data, user_id=user_id, chat_id=chat_id)
+    # The env gate is read while the handler runs, not when the coroutine is built.
+    with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": allowed}, clear=False):
+        await adapter._handle_callback_query(update, MagicMock())
+    return query
+
+
+def _buttons_sent():
+    """``(label, callback_data)`` for every button the adapter built (PTB is a MagicMock here)."""
+    from telegram import InlineKeyboardButton
+
+    return [
+        (call.args[0] if call.args else None, call.kwargs.get("callback_data"))
+        for call in InlineKeyboardButton.call_args_list
+    ]
+
+
+class TestSendCronQuestions:
+    @pytest.mark.asyncio
+    async def test_one_button_per_option_carrying_its_token(self):
+        from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+        InlineKeyboardButton.reset_mock()
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=100))
+
+        result = await adapter.send_cron_questions(
+            "12345", [PendingQuestion(token="tok1", question="Merge PR #1827?", options=["\u2705 Yes", "\u23f8\ufe0f Not yet"])])
+
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert "Merge PR #1827?" in kwargs["text"]
+        # One option per row, carrying the token the tap resolves through.
+        rows = InlineKeyboardMarkup.call_args[0][0]
+        assert all(len(row) == 1 for row in rows)
+        assert _buttons_sent() == [("\u2705 Yes", "cq:tok1:0"), ("\u23f8\ufe0f Not yet", "cq:tok1:1")]
+
+    @pytest.mark.asyncio
+    async def test_multiple_questions_number_their_rows(self):
+        from telegram import InlineKeyboardButton
+
+        InlineKeyboardButton.reset_mock()
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=101))
+
+        await adapter.send_cron_questions("12345", [
+            PendingQuestion(token="tokA", question="Merge?", options=["yes", "no"]),
+            PendingQuestion(token="tokB", question="Deploy?", options=["now", "later"]),
+        ])
+
+        assert [label for label, _ in _buttons_sent()] == [
+            "1. yes", "1. no", "2. now", "2. later"]
+        assert [data for _, data in _buttons_sent()] == [
+            "cq:tokA:0", "cq:tokA:1", "cq:tokB:0", "cq:tokB:1"]
+
+    @pytest.mark.asyncio
+    async def test_question_text_is_html_escaped(self):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=102))
+
+        await adapter.send_cron_questions(
+            "12345", [PendingQuestion(token="tokC", question="<script>x</script>", options=["ok"])])
+
+        text = adapter._bot.send_message.call_args[1]["text"]
+        assert "<script>" not in text
+        assert "&lt;script&gt;" in text
+
+
+class TestCronQuestionCallback:
+    @pytest.mark.asyncio
+    async def test_tap_records_the_answer_and_reinjects_it_as_a_user_turn(self, store):
+        adapter = _make_adapter()
+        (token,) = record_questions("job9", "telegram", "12345", [_question()])
+        injected = []
+
+        async def _handle(event):
+            injected.append(event)
+
+        adapter.handle_message = _handle
+        adapter._message_handler = AsyncMock()
+        query = await _tap(adapter, f"cq:{token}:0")
+
+        assert get_question(token)["answer_text"] == "\u2705 Yes"
+        query.answer.assert_awaited()
+        assert len(injected) == 1
+        event = injected[0]
+        assert "Merge PR #1827?" in event.text
+        assert "\u2705 Yes" in event.text
+        # The answer re-enters as the tapping user, in the chat the report was delivered to.
+        assert event.source.chat_id == "12345"
+        assert event.source.user_id == "777"
+        assert event.reply_to_is_own_message is True
+        # A button label is not a command surface.
+        assert event.allow_gateway_control is False
+
+    @pytest.mark.asyncio
+    async def test_second_tap_does_not_answer_twice(self, store):
+        adapter = _make_adapter()
+        (token,) = record_questions("job9", "telegram", "12345", [_question()])
+        injected = []
+
+        async def _handle(event):
+            injected.append(event)
+
+        adapter.handle_message = _handle
+        adapter._message_handler = AsyncMock()
+        await _tap(adapter, f"cq:{token}:0")
+        second_query = await _tap(adapter, f"cq:{token}:1")
+
+        assert len(injected) == 1
+        assert get_question(token)["answer_text"] == "\u2705 Yes"
+        assert "Already answered" in second_query.answer.call_args[1]["text"]
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_tap_changes_nothing(self, store):
+        adapter = _make_adapter()
+        (token,) = record_questions("job9", "telegram", "12345", [_question()])
+        adapter.handle_message = AsyncMock()
+        adapter._message_handler = AsyncMock()
+
+        query = await _tap(adapter, f"cq:{token}:0", user_id="999", allowed="777")
+
+        assert get_question(token)["answered_at"] is None
+        adapter.handle_message.assert_not_awaited()
+        assert "not authorized" in query.answer.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_expired_token_is_reported_not_swallowed(self, store):
+        adapter = _make_adapter()
+        adapter.handle_message = AsyncMock()
+
+        query = await _tap(adapter, "cq:deadbeefdead:0")
+
+        adapter.handle_message.assert_not_awaited()
+        assert "no longer available" in query.answer.call_args[1]["text"]
+
+    @pytest.mark.asyncio
+    async def test_other_prefixes_are_not_hijacked(self, store):
+        adapter = _make_adapter()
+        adapter.handle_message = AsyncMock()
+
+        await _tap(adapter, "cl:someid:0")
+
+        adapter.handle_message.assert_not_awaited()
+
+
+class TestBaseAdapterFallback:
+    @pytest.mark.asyncio
+    async def test_buttonless_adapter_renders_numbered_text(self):
+        from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+        class _Stub(BasePlatformAdapter):
+            name = "stub"
+
+            def __init__(self):
+                self.sent = []
+
+            async def connect(self, *, is_reconnect: bool = False): pass
+            async def disconnect(self): pass
+
+            async def send(self, chat_id, content, **kw):
+                self.sent.append(content)
+                return SendResult(success=True, message_id="1")
+
+            async def edit(self, *a, **k): return SendResult(success=False)
+            async def get_history(self, *a, **k): return []
+            async def get_chat_info(self, *a, **k): return {}
+
+        adapter = _Stub()
+        result = await adapter.send_cron_questions(
+            "c", [PendingQuestion(token="t", question="Merge PR #1827?", options=["Yes", "Not yet"])])
+
+        assert result.success is True
+        text = adapter.sent[0]
+        assert "Merge PR #1827?" in text
+        assert "1. Yes" in text
+        assert "2. Not yet" in text

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -296,6 +296,26 @@ By default (`cron.wrap_response: true`), cron deliveries are wrapped with:
 
 The `[SILENT]` prefix in a cron response suppresses delivery entirely — useful for jobs that only need to write to files or perform side effects.
 
+### Question buttons
+
+`cron/questions.py` owns the `<question>` markup contract (`parse_questions`), the
+button/callback shapes (`button_rows`, `build_callback_data`/`parse_callback_data`)
+and the durable pending-question store (`cron/questions.db`, same ledger helpers as
+`cron/notepad.db`). `scheduler_delivery._parse_delivery_questions` splits the run's
+final response; the body goes out without the blocks and the questions ride a second
+send through `BasePlatformAdapter.send_cron_questions` (Telegram overrides it with an
+inline keyboard). A tap (`cq:<token>:<idx>`) claims the answer first-write-wins and
+then re-enters the conversation as a user turn.
+
+Two invariants:
+
+- **Lossless parsing.** A block that does not match the contract stays in the text,
+  and the delivery layer only strips the markup on a target whose live adapter is
+  ready — the standalone sender and relay-fronted lanes keep the questions inline.
+  Answers are only ever sent after the body was confirmed delivered.
+- **The run never blocks.** Nothing here waits for input; the store exists because
+  the tap can arrive days later, from a gateway that restarted in between.
+
 ### Session Isolation
 
 Cron deliveries are NOT mirrored into gateway session conversation history. They exist only in the cron job's own session. This prevents message alternation violations in the target chat's conversation.

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -527,6 +527,45 @@ cron:
   wrap_response: false
 ```
 
+### Decisions as inline buttons
+
+A run cannot ask you a question: `clarify` blocks the agent, and an unattended job
+has nobody to answer it. Instead, a report can end with a **question block**, and
+the delivery layer — not the agent — turns it into buttons:
+
+```
+<question>
+Merge PR #1827?
+- ✅ Yes (Recommended)
+- ⏸️ Not yet
+</question>
+```
+
+The block is removed from the delivered text and sent as its own message with one
+button per option (Telegram). Tapping a button records the answer and re-enters it
+into the conversation as if you had typed it, so a continuable job keeps going with
+the answer in context. Nothing waits: the scheduled run finished long before you tap.
+
+Rules of the markup:
+
+- The first line inside the block is the question; every following line that starts
+  with `-`, `*`, `•` or `1.` is an option.
+- Up to 8 options per question, and several questions per report.
+- A block that breaks these rules (no options, too many, prose mixed into the
+  options, unterminated tag) is delivered verbatim as text — the parser never
+  swallows part of a report.
+- Platforms without inline buttons get a numbered list instead, and a run that
+  cannot reach a live gateway (plain `hermes cron run`, relay-fronted platforms)
+  keeps the questions inline in the report text.
+
+To turn the whole behaviour off:
+
+```yaml
+# ~/.hermes/config.yaml
+cron:
+  question_buttons: false   # default: true
+```
+
 ### Push notifications (`cron.delivery.notify`)
 
 Cron output is a *final* delivery, not a progress message, so by default it is


### PR DESCRIPTION
## What Problem This Solves

Cron reports routinely end with a decision the user has to make ("do I merge PR #1827?" → ✅ Oui / ⏸️ Plus tard). Those decisions arrived as **plain text** and were unusable: the agent cannot call `clarify` during a cron run (it blocks the run awaiting input), so the question had no way to be answered — every scheduled report's decision was dead text.

This PR lets a job's **final response** carry its decisions as a documented `<question>` block. The **delivery layer** — not the agent — parses the blocks, strips them from the body, and sends them as inline-keyboard buttons. Nothing blocks: the run finishes normally and the question sits in the delivered message until the user taps, however much later.

```
<question>
Merge PR #1827?
- ✅ Yes (Recommended)
- ⏸️ Not yet
</question>
```

### How it works

- **Markup → buttons.** `cron/questions.py` (`parse_questions`) owns the markup contract: first line inside the block is the question, each following `-`/`*`/`•`/`1.` line is an option, up to 8 options per question and several questions per report. `(Recommended)` is recognized and stripped into a flag (the button keeps the plain label).
- **Delivery, not the agent.** `scheduler_delivery._deliver_result` splits the response, delivers the body without the blocks, and then sends the questions through `BasePlatformAdapter.send_cron_questions` — a new adapter hook modelled on `send_clarify`. Telegram overrides it with an inline keyboard (`cq:<token>:<idx>`); every other adapter gets the numbered-text default, and the *body* is only stripped on a target whose live adapter is actually reached.
- **Tapping is async, and one-shot.** The answer row is written to a durable profile-local store (`cron/questions.db`) *before* the buttons go out, and `claim_answer` is first-write-wins, so a double tap (or a replayed update) cannot answer twice. The tap then re-enters the conversation as an ordinary user turn quoting the question and the answer, which composes with the existing continuable-job machinery (`attach_to_session`) — the next turn sees the answer in context.
- **Opt-in and lossless.** The job opts in by emitting the markup; jobs that never emit it are byte-identically unaffected. `cron.question_buttons: false` disables the parsing process-wide (the prompt hint mirrors that switch, so the model is never asked for markup the delivery layer will not render). A block that does not match the contract — no options, too many, prose mixed into the options, unterminated tag — is left verbatim in the text, and a lane that cannot render buttons (standalone `hermes cron run`, relay-fronted platforms, no live gateway) keeps the questions inline instead of dropping them.
- **Nothing is swallowed.** If the button send fails after the body went out, the run records a delivery error naming how many questions were dropped, and the tokens are discarded only when no button can exist.

## Evidence

Real terminal output, unmodified except for the paths (temp dirs) and the token hex.

**Pre-fix (baseline `origin/main`, `git stash` + same script):** the markup is delivered verbatim and no adapter is asked for buttons.

```
$ python -P verify_question_buttons.py baseline
delivery error: None
--- body an adapter received ---
Nightly report
- 2 PRs merged, 1 CI failure

<question>
Merge PR #1827?
- ✅ Yes (Recommended)
- ⏸️ Not yet
</question>
--- question message ---
[]
pending store row: <unavailable: No module named 'cron.questions'>
--- checks (baseline) ---
PASS: markup delivered verbatim as dead text
PASS: the question text reaches the user as plain text
PASS: no buttons reach the adapter
```

**Post-fix (same script, same job, same stubbed `DeliveryRouter`):** the body is clean, the adapter receives the questions with a token, and the token is durable.

```
$ python -P verify_question_buttons.py fixed
delivery error: None
--- body an adapter received ---
Nightly report
- 2 PRs merged, 1 CI failure
--- question message ---
[{'chat_id': '-1001234567890', 'questions': [PendingQuestion(token='f23a494f25d2', question='Merge PR #1827?', options=['✅ Yes', '⏸️ Not yet'], recommended_index=0)], 'metadata': {'job_id': 'qbjob1', 'notify': True, 'question_tokens': ['f23a494f25d2']}}]
pending store row: {'token': 'f23a494f25d2', 'job_id': 'qbjob1', 'platform': 'telegram', 'chat_id': '-1001234567890', 'question': 'Merge PR #1827?', 'options_json': '["✅ Yes", "⏸️ Not yet"]', 'created_at': '2026-09-11T21:48:31.322425+08:00', 'answered_at': None, 'answer_index': None, 'answer_text': None}
--- checks (fixed) ---
PASS: markup stripped from the delivered body
PASS: question text kept out of the body
PASS: buttons handed to the adapter
```

**Regression tests** (`scripts/run_tests.sh`, never bare pytest):

```
tests/cron/test_cron_question_buttons.py .................          (17✓)
tests/gateway/test_telegram_cron_question_buttons.py .........     (9✓)
```

The 17 cover the parser contract (including 5 malformed-block shapes that must stay verbatim), the store (first-write-wins, unknown token, bounded retention for questions nobody ever answers), and the end-to-end delivery lane; the 9 cover Telegram rendering, the tap round-trip into the conversation, replay, unauthorized taps, and the button-less adapter fallback.

**Adjacent suites, all green:**

```
=== Summary: 6 files, 261 tests passed, 0 failed (100% complete) ===
  tests/gateway/test_telegram_clarify_buttons.py        (5✓)
  tests/gateway/test_telegram_cron_question_buttons.py  (9✓)
  tests/cron/test_cron_question_buttons.py              (17✓)
  tests/cron/test_cron_live_delivery_confirmation.py    (33✓)
  tests/hermes_cli/test_config.py                       (125✓)
  tests/tools/test_cronjob_tools.py                     (73✓)

=== Summary: 5 files, 77 tests passed, 0 failed (100% complete) ===
  tests/gateway/test_telegram_approval_buttons.py       (26✓)
  tests/gateway/test_telegram_thread_fallback.py
  tests/gateway/test_wisdom_mute_controls.py            (11✓)
  tests/gateway/test_allowed_channels_widening.py
  tests/gateway/test_multiplex_interactive_auth.py

=== Summary: 1 files, 12 tests passed, 0 failed (100% complete) ===
  tests/cron/test_cron_created_delivery.py              (12✓, 348.5s)
```

**Full `tests/cron/` on this Windows host** (`scripts/run_tests.sh -j 12 tests/cron/`): `1203 passed / 13 failed`. Every failure is pre-existing and environmental — reproduced unchanged on the unmodified baseline tree in the same session: `test_file_permissions` (6, Windows `chmod`), `test_lifecycle_guard_budget` (3, bash-wrapper walk on Windows), `test_media_delivery_parity` (1, Windows path backslash escaping in an env-var assertion), `test_cron_workdir` (1, `HOME`/`~` on Windows), `test_script_claim_heartbeat` (2, timing). `test_cron_created_delivery.py` hit the runner's 300s per-file cap at `-j 12` and passes at default parallelism.

## Scope

Covered: the markup contract, the parser and its losslessness, the durable pending-answer store, cron delivery wiring (strip + second send), the adapter hook with a Telegram inline-keyboard implementation, tap routing into the conversation, and the prompt hint that makes the markup discoverable to the model.

Not covered in this PR (say so rather than pretend): native buttons on non-Telegram adapters (Discord/Slack render the numbered-text fallback; the relay-fronted lane deliberately keeps the questions inline), an `Other (type answer)` row and multi-select, per-job opt-out via a job field (the markup itself is the per-job opt-in; `cron.question_buttons` is the global switch), and a `hermes cron` command to list or answer pending questions. Happy to follow up on any of these if the direction is right.

Partial fix for #107138 — the markup, delivery and answer round-trip are implemented and verified locally; the remaining adapters and UI polish above are follow-ups.
