### PR TITLE
fix(windows): add CREATE_BREAKAWAY_FROM_JOB to windows_hide_flags()

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -173,8 +173,23 @@ def windows_hide_flags() -> int:
     For short-lived synchronous helpers (``taskkill``, ``where``, version probes): no flash, but the
     child stays in the parent's process group and job so Ctrl+C and job teardown still propagate.
     Stdio is inherited, so ``capture_output=True`` works.
+
+    Includes ``CREATE_BREAKAWAY_FROM_JOB``. Electron/Tauri desktop wrappers (Hermes Desktop) put
+    every child process -- including the local terminal backend's ``bash.exe`` spawn
+    (``tools/environments/local.py``) -- inside a Windows Job Object. Win32 silently ignores
+    ``CREATE_NO_WINDOW`` for a child inside a job it does not own unless the child also carries
+    ``CREATE_BREAKAWAY_FROM_JOB``: the console still allocates and is briefly visible before the
+    app's own job teardown catches up, reproducing the exact flash this helper exists to prevent.
+    ``windows_detach_flags()`` above already carries this bit for the same reason (PR #40909); this
+    function was never updated to match, and the gap was reported multiple times (#54323, #55604)
+    without ever landing here. Job objects created without ``JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK``
+    (or via legacy job nesting) can reject breakaway with ``PermissionError`` in rare cases --
+    callers of this hide-only helper already tolerate a failed spawn via their own exception
+    handling, same as ``windows_detach_flags()`` callers do.
     """
-    return _CREATE_NO_WINDOW if IS_WINDOWS else 0
+    if not IS_WINDOWS:
+        return 0
+    return _CREATE_NO_WINDOW | _CREATE_BREAKAWAY_FROM_JOB
 
 
 def suppress_platform_ver_console() -> None:

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -484,7 +484,7 @@ class TestSubprocessCompatHelpers:
         CREATE_BREAKAWAY_FROM_JOB with ERROR_ACCESS_DENIED.  Callers
         catch ``OSError`` and retry with this payload (see
         ``gateway_windows._spawn_detached`` for the canonical pattern).
-        It must drop ONLY the breakaway bit — DETACHED_PROCESS et al.
+        It must drop ONLY the breakaway bit -- DETACHED_PROCESS et al.
         are still required for the child to survive the parent's exit.
         """
         from hermes_cli import _subprocess_compat as sc
@@ -493,10 +493,65 @@ class TestSubprocessCompatHelpers:
         # Fallback equals full minus the breakaway bit, nothing else changed.
         assert fallback == full & ~0x01000000
         # And the detach bits we still need are present (hidden console, own
-        # process group — NOT console-less DETACHED_PROCESS, see
+        # process group -- NOT console-less DETACHED_PROCESS, see
         # test_windows_detach_flags_exclude_detached_process).
         assert fallback & 0x00000200, "fallback missing CREATE_NEW_PROCESS_GROUP"
         assert fallback & 0x08000000, "fallback missing CREATE_NO_WINDOW"
+
+    @pytest.mark.windows_only
+    def test_windows_hide_flags_includes_breakaway_from_job(self):
+        """CREATE_BREAKAWAY_FROM_JOB is load-bearing for windows_hide_flags()
+        too, not just windows_detach_flags() -- same root cause, different
+        caller shape.
+
+        windows_hide_flags() backs every short-lived synchronous helper
+        (subprocess.run for git/gh/taskkill/version probes, the local
+        terminal backend's bash spawn in tools/environments/local.py, ...).
+        The Desktop app (Electron) wraps ALL of its child processes --
+        including the terminal tool's bash.exe -- in a Windows Job Object.
+        Win32 silently ignores CREATE_NO_WINDOW for a process inside a job
+        it does not own unless that process also carries
+        CREATE_BREAKAWAY_FROM_JOB: the console still allocates and is
+        visible for a frame before the app's own job teardown catches up,
+        reproducing the exact flash windows_hide_flags() exists to prevent.
+
+        windows_detach_flags() already carries this bit (see
+        test_windows_detach_flags_includes_breakaway_from_job above,
+        PR #40909) -- windows_hide_flags() was never updated to match, and
+        this exact one-line gap was reported multiple times (#54323,
+        #55604) but never actually landed on this function. Regression
+        guard against re-dropping it once fixed.
+        """
+        from hermes_cli import _subprocess_compat as sc
+        assert sc.windows_hide_flags() & 0x01000000, (
+            "CREATE_BREAKAWAY_FROM_JOB (0x01000000) must be present in "
+            "windows_hide_flags() so short-lived hidden spawns (git, gh, "
+            "the local terminal backend's bash.exe, ...) don't flash a "
+            "console for a frame when the parent is inside an Electron/"
+            "Tauri Windows Job Object (Hermes Desktop)."
+        )
+
+    @pytest.mark.windows_only
+    def test_windows_hide_flags_excludes_detached_process(self):
+        """windows_hide_flags() must never include DETACHED_PROCESS.
+
+        Unlike windows_detach_flags(), this helper is documented (its own
+        docstring) as hiding the console WITHOUT detaching -- callers using
+        subprocess.run() need stdio inherited/piped and the child to stay
+        in the parent's process group so Ctrl+C and job teardown still
+        propagate. DETACHED_PROCESS would also silently neutralize
+        CREATE_NO_WINDOW (MSDN: ignored when combined with
+        CREATE_NEW_CONSOLE or DETACHED_PROCESS), re-creating the exact
+        console-flash bug class this helper exists to prevent.
+        """
+        from hermes_cli import _subprocess_compat as sc
+        assert not sc.windows_hide_flags() & 0x00000008, (
+            "DETACHED_PROCESS must not be in windows_hide_flags(): it "
+            "both breaks the documented non-detaching contract and makes "
+            "CREATE_NO_WINDOW a no-op (#54220/#56747)."
+        )
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`windows_hide_flags()` in `hermes_cli/_subprocess_compat.py` only returned `CREATE_NO_WINDOW`. Its sibling `windows_detach_flags()` already includes `CREATE_BREAKAWAY_FROM_JOB` (added in #40909 for the identical underlying reason) — this function was never updated to match.

## Root cause

Electron/Tauri desktop wrappers (Hermes Desktop) put every child process they spawn — including the local terminal backend's `bash.exe` spawn in `tools/environments/local.py` — inside a Windows Job Object. Win32 silently ignores `CREATE_NO_WINDOW` for a child inside a job it does not own unless that child also carries `CREATE_BREAKAWAY_FROM_JOB`: the console still allocates and is visible for a frame before the app's own job teardown catches up, reproducing the exact flash `windows_hide_flags()` exists to prevent.

This exact one-line gap was reported multiple times (#54323, #55604) but was consolidated into the #54220 umbrella tracker each time without the fix ever actually landing on this function. Confirmed still present on current `main` (`0b8daf30`+).

## Verification (real Windows 11 + real Hermes Desktop, not just unit tests)

Reproduced live: every terminal tool call from the Desktop app flashed a console window (`bash.exe` → `conhost.exe`/`OpenConsole.exe`) despite `windows_hide_flags()` already being wired into `tools/environments/local.py`'s `Popen` call. After adding the missing bit:
- Ran several real terminal commands (git, gh, python) back-to-back through the live Desktop app.
- Queried every `conhost`/`OpenConsole`/`cmd`/`git`/`gh` process via `user32.IsWindowVisible()` immediately after: **0 visible windows**, vs. the flash being directly observed before the fix.

## Tests

Two new regression tests in `TestSubprocessCompatHelpers` (`tests/tools/test_windows_native_support.py`), mirroring the existing `windows_detach_flags()` tests exactly:
- `test_windows_hide_flags_includes_breakaway_from_job` — the bit must be present.
- `test_windows_hide_flags_excludes_detached_process` — must never regress toward `DETACHED_PROCESS`, which MSDN documents as silently neutralizing `CREATE_NO_WINDOW` (the #54220/#56747 bug class).

Ran on real Windows 11 (not mocked `sys.platform`) against the actual venv: both new tests pass, plus all 5 existing `TestSubprocessCompatHelpers` tests and all 10 tests in `tests/test_windows_subprocess_no_window_flags.py` — no regressions. (One unrelated pre-existing failure, `TestWindowlessGatewayRestartSpec::test_noop_on_non_windows`, reproduces identically on unpatched `main` in this same environment — a "non-Windows" test asserting an empty cwd while genuinely running on Windows; unrelated to this change.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

Fixes #54323
Fixes #55604