### PR TITLE
fix(desktop): unpin a Pinned-row under every stored identity

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -179,7 +179,7 @@ import {
   SidebarPinnedEmptyState,
   SidebarSessionSkeletons
 } from './section-states'
-import { buildSessionByAnyId, resolvePinnedSessions } from './session-index'
+import { buildSessionByAnyId, resolvePinnedSessions, unpinIdentities } from './session-index'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
 import { useEnteredProjectSessions } from './use-entered-project-sessions'
@@ -601,6 +601,18 @@ export function ChatSidebar({
         unconfirmedPinWrites
       ),
     [pinnedSessionIds, sessionByAnyId, visibleSessions, cronSessions, messagingSessions, unconfirmedPinWrites]
+  )
+
+  // Unpin a Pinned-section row under EVERY id it is reachable under — see
+  // `unpinIdentities` in session-index.ts for why the exact-id filter in
+  // `unpinSession` can otherwise silently no-op.
+  const unpinPinnedRow = useCallback(
+    (pinId: string) => {
+      for (const id of unpinIdentities(pinId, sessionByAnyId)) {
+        unpinSession(id)
+      }
+    },
+    [sessionByAnyId]
   )
 
   // Every id a pin is reachable under: the raw stored ids, plus BOTH identities
@@ -1662,7 +1674,7 @@ export function ChatSidebar({
                 onReorderSessions={reorderPinned}
                 onResumeSession={onResumeSession}
                 onToggle={() => setSidebarPinsOpen(!pinsOpen)}
-                onTogglePin={unpinSession}
+                onTogglePin={unpinPinnedRow}
                 onToggleUnread={toggleUnread}
                 open={pinsOpen}
                 pinned

--- a/apps/desktop/src/app/chat/sidebar/session-index.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { SessionInfo } from '@/types/hermes'
 
-import { buildSessionByAnyId, resolvePinnedSessions } from './session-index'
+import { buildSessionByAnyId, resolvePinnedSessions, unpinIdentities } from './session-index'
 
 const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
   ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
@@ -153,5 +153,27 @@ describe('resolvePinnedSessions', () => {
     const index = buildSessionByAnyId(sessions, [], [])
 
     expect(resolvePinnedSessions([], index, sessions, settled)).toEqual([])
+  })
+})
+
+describe('unpinIdentities', () => {
+  // The stored pin may predate lineage keying: the set holds the OLD tip id
+  // while the menu hands us the lineage root (or vice versa). `unpinSession`
+  // filters by exact id, so a single-identity unpin silently removes nothing
+  // and the row stays pinned forever. The unpin must cover every identity.
+  it('covers a legacy tip-id pin when the menu passes the lineage root', () => {
+    const index = buildSessionByAnyId([], [], [row('tip_102151', { _lineage_root_id: 'root_080244' })])
+
+    expect(unpinIdentities('root_080244', index)).toEqual(['root_080244', 'tip_102151'])
+  })
+
+  it('covers a root-id pin when the menu passes the live tip', () => {
+    const index = buildSessionByAnyId([], [], [row('tip', { _lineage_root_id: 'root' })])
+
+    expect(unpinIdentities('tip', index)).toEqual(['tip', 'root'])
+  })
+
+  it('degrades to the bare id for an unindexed row', () => {
+    expect(unpinIdentities('unknown', new Map())).toEqual(['unknown'])
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-index.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-index.ts
@@ -33,6 +33,22 @@ export function buildSessionByAnyId(
 }
 
 /**
+ * Every id an unpin of *pinId* must drop from the local pin set.
+ *
+ * The menu hands us the canonical pin id (`sessionPinId` = lineage root), but
+ * the set may hold a DIFFERENT identity of the same conversation — a tip id
+ * captured before pins were lineage-keyed, or the row's live id. `unpinSession`
+ * filters by exact id, so a mismatch silently removes nothing: no state change,
+ * no PATCH, and the row stays pinned forever. Unpin under every identity the
+ * resolved row is reachable under.
+ */
+export function unpinIdentities(pinId: string, sessionByAnyId: Map<string, SessionInfo>): string[] {
+  const session = sessionByAnyId.get(pinId)
+
+  return [...new Set([pinId, session?.id, session?._lineage_root_id].filter((id): id is string => Boolean(id)))]
+}
+
+/**
  * Resolve the Pinned section's rows: the locally stored pin ids first (in the
  * user's hand-picked order), then any row the SERVER flags `pinned` that the
  * local set doesn't know about yet.


### PR DESCRIPTION
## The bugA pinned conversation could not be unpinned from the sidebar - clicking unpin did nothing, and the row came back pinned after every restart.Root cause (verified on a live install):1. The session had gone through context compression, producing a lineage: root A -> children B and C (a fork). One pin writes `pinned=1` across the whole lineage (`set_session_pinned` -> `_set_lineage_column`).2. The Pinned section menu calls `onTogglePin(sessionPinId(session))`, and `sessionPinId` returns the **lineage root** (A).3. The local pin set (`$pinnedSessionIds`) stored a **different identity** - the tip id C, captured before pins were lineage-keyed.4. `unpinSession` filters the set by **exact id**: removing A from a set that holds C is a silent no-op. `setOrderIds` skips identical arrays, so no atom change fires, the pin-sync reconcile never runs, and **no `PATCH pinned=false` is ever issued**. The row stays pinned forever.Confirmed against the backend `state.db`: all three lineage rows kept `pinned=1` after repeated unpin attempts - zero writes had landed.## The fixNew pure helper `unpinIdentities(pinId, sessionByAnyId)` in `session-index.ts`: resolve the row through the any-id index and return every id it is reachable under (the passed id + `session.id` + `_lineage_root_id`). The Pinned section now unpins through it, so a pin is removed no matter which identity the set holds.## Tests3 invariant tests in `session-index.test.ts` covering both mismatch directions (root->tip and tip->root) plus the unindexed-row fallback. `npx vitest run src/app/chat/sidebar/` -> 32 files / 261 tests pass; `tsc --noEmit` clean.