### PR TITLE
fix(state): guard orphan FTS repair admission

### DIFF
--- a/hermes_state_fts.py
+++ b/hermes_state_fts.py
@@ -131,6 +131,27 @@ def load_fts5_cjk_extension(conn: sqlite3.Connection) -> bool:
 _FTS5_SHADOW_SUFFIXES = ("content", "data", "docsize", "idx", "config")
 
 
+def _orphan_fts_shadow_families(cursor: sqlite3.Cursor, families: Sequence[str]) -> list[str]:
+    """Return families that have shadows but no live virtual table.
+
+    This is only an admission hint. The destructive helper rechecks the live schema
+    after the caller acquires FTS rebuild authority.
+    """
+    orphaned: list[str] = []
+    for family in families:
+        shadows = [f"{family}_{suffix}" for suffix in _FTS5_SHADOW_SUFFIXES]
+        if cursor.execute(
+            f"SELECT 1 FROM sqlite_master AS shadow WHERE shadow.type = 'table' "
+            f"AND shadow.name IN ({','.join('?' for _ in shadows)}) "
+            "AND NOT EXISTS (SELECT 1 FROM sqlite_master AS vtable "
+            "WHERE vtable.type = 'table' AND vtable.name = ? "
+            "AND vtable.sql LIKE 'CREATE VIRTUAL TABLE%') LIMIT 1",
+            (*shadows, family),
+        ).fetchone():
+            orphaned.append(family)
+    return orphaned
+
+
 def _drop_orphan_fts_shadow_tables(cursor: sqlite3.Cursor, families: Sequence[str]) -> list[str]:
     """Drop, per family, shadow tables whose virtual table row is absent from sqlite_master.
 

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -26,7 +26,7 @@ from hermes_state_common import (
     LEGACY_FTS_TRIGRAM_SQL, SCHEMA_SQL,
     SCHEMA_VERSION, _FTS_CJK_TRIGGERS, _FTS_TRIGGERS, _ephemeral_child_sql, _sql_json_extract, fts_rebuild_admission,
 )
-from hermes_state_fts import _drop_orphan_fts_shadow_tables
+from hermes_state_fts import _drop_orphan_fts_shadow_tables, _orphan_fts_shadow_families
 from hermes_state_holders import _read_proc_argv
 
 # Pre-split logger identity so log filtering/capture is unchanged.
@@ -606,9 +606,6 @@ class SessionSchemaMixin:
                 legacy = self._db_has_legacy_inline_fts(cursor)
                 recovered = self._recover_stale_fts(cursor, legacy=legacy, timeout_seconds=0.0)
                 if recovered:
-                    # CJK was detached alongside the base indexes; its own ensure path
-                    # decides when it comes back online.
-                    self._ensure_fts_cjk_schema(cursor)
                     self._fts_stale_retry_interval = 0.0
                 with contextlib.suppress(sqlite3.Error):
                     self._conn.commit()
@@ -622,6 +619,9 @@ class SessionSchemaMixin:
     def _recover_stale_fts_locked(self, cursor: sqlite3.Cursor, *, legacy: bool) -> bool:
         """Body of :meth:`_recover_stale_fts`; caller holds rebuild authority. One write
         transaction, so no canonical writer slips between rebuild and trigger restoration."""
+        _drop_orphan_fts_shadow_tables(
+            cursor, ("messages_fts", "messages_fts_trigram", "messages_fts_cjk"),
+        )
         try:
             trigram_present = self._fts_table_probe(cursor, "messages_fts_trigram") is True
         except (sqlite3.DatabaseError, UnicodeDecodeError):
@@ -665,6 +665,10 @@ class SessionSchemaMixin:
         self._fts_stale = False
         self._fts_enabled = True
         self._trigram_available = include_trigram
+        if not legacy:
+            # Keep CJK orphan cleanup and recreation inside the same admission
+            # lifetime as the base/trigram recovery.
+            self._ensure_fts_cjk_schema(cursor)
         logger.warning("Rebuilt stale state.db FTS indexes from canonical messages and restored sync triggers.")
         return True
 
@@ -1129,41 +1133,49 @@ class SessionSchemaMixin:
         vtable exists so CREATE TRIGGER IF NOT EXISTS repairs trigger-only degradation.
         OPT-IN v23 boundary: a legacy v22 inline install keeps its inline schema + triggers
         (the v23 DDL would create the trigram source VIEW and leave a mixed state)."""
+        families = ("messages_fts", "messages_fts_trigram", "messages_fts_cjk")
         legacy_fts = self._db_has_legacy_inline_fts(cursor)
         # A `.recover`-restored image keeps the shadow tables but not the vtable rows; the DDL
-        # below would fail on the first shadow. Drop only orphaned families, then rebuild the
-        # recreated (empty) index like a missing-trigger repair (#103840).
-        orphan_repaired = _drop_orphan_fts_shadow_tables(
-            cursor, ("messages_fts", "messages_fts_trigram", "messages_fts_cjk"),
-        )
+        # below would fail on the first shadow. The preflight only selects the guarded path.
+        # The destructive helper rechecks and drops under rebuild admission so a stale snapshot
+        # cannot delete a family that another opener recreated (#103840).
+        orphan_families = set(_orphan_fts_shadow_families(cursor, families))
         if not self._fts_stale:
             self._migrate_bounded_tool_fts_triggers(cursor, legacy=legacy_fts)
         if self._fts_stale:
-            if self._recover_stale_fts(cursor, legacy=legacy_fts):
-                # CJK was detached alongside the base indexes; its ensure path decides when it returns.
-                self._ensure_fts_cjk_schema(cursor)
-            else:
+            if not self._recover_stale_fts(cursor, legacy=legacy_fts):
                 self._fts_enabled = self._trigram_available = self._fts_cjk_available = False
         else:
             base_sql, trigram_sql = _FTS_DDL[legacy_fts]
             # Measure before any DDL. Publishing missing base triggers before rebuild admission lets
             # another process write through an index whose bootstrap/repair has no owner (#105790).
             base_triggers_missing = self._fts_triggers_missing(cursor, _FTS_BASE_TRIGGERS) or getattr(
-                self, "_fts_tool_prefix_migration_requires_rebuild", False) or "messages_fts" in orphan_repaired
+                self, "_fts_tool_prefix_migration_requires_rebuild", False
+            ) or "messages_fts" in orphan_families
+            trigram_orphaned = "messages_fts_trigram" in orphan_families
+            cjk_orphaned = "messages_fts_cjk" in orphan_families
             trigram_triggers_missing = (
-                self._fts_triggers_missing(cursor, _FTS_TRIGRAM_TRIGGERS) or "messages_fts_trigram" in orphan_repaired
+                self._fts_triggers_missing(cursor, _FTS_TRIGRAM_TRIGGERS) or trigram_orphaned
             )
 
             def ensure_and_rebuild() -> None:
+                if orphan_families:
+                    _drop_orphan_fts_shadow_tables(cursor, families)
                 self._fts_enabled = self._ensure_fts_schema(cursor, "messages_fts", base_sql)
                 if not self._fts_enabled:
                     return
                 self._trigram_available = self._ensure_fts_schema(cursor, "messages_fts_trigram", trigram_sql)
+                if trigram_orphaned and not self._trigram_available:
+                    for trigger in _FTS_TRIGRAM_TRIGGERS:
+                        cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
                 self._rebuild_fts_indexes(
                     cursor, legacy=legacy_fts, include_trigram=self._trigram_available,
                 )
                 if not legacy_fts:
                     self._ensure_fts_cjk_schema(cursor)
+                    if cjk_orphaned and not self._fts_cjk_available:
+                        for trigger in _FTS_CJK_TRIGGERS:
+                            cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
 
             if base_triggers_missing:
                 # The authority covers the whole first-publication sequence, not merely the final rebuild.
@@ -1173,10 +1185,28 @@ class SessionSchemaMixin:
             else:
                 self._fts_enabled = self._ensure_fts_schema(cursor, "messages_fts", base_sql)
                 if self._fts_enabled:
-                    # Trigram is optional; without it CJK search falls back to LIKE.
-                    trigram_enabled = self._ensure_fts_schema(cursor, "messages_fts_trigram", trigram_sql)
-                    self._trigram_available = trigram_enabled
-                    if trigram_enabled and trigram_triggers_missing:
+                    if trigram_orphaned:
+                        def ensure_trigram_and_rebuild() -> None:
+                            _drop_orphan_fts_shadow_tables(cursor, families)
+                            self._trigram_available = self._ensure_fts_schema(
+                                cursor, "messages_fts_trigram", trigram_sql,
+                            )
+                            if self._trigram_available:
+                                self._rebuild_fts_indexes(
+                                    cursor, legacy=legacy_fts, include_trigram=True,
+                                )
+                            else:
+                                for trigger in _FTS_TRIGRAM_TRIGGERS:
+                                    cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+
+                        self._run_admitted_startup_rebuild(cursor, ensure_trigram_and_rebuild)
+                    else:
+                        # Trigram is optional; without it CJK search falls back to LIKE.
+                        trigram_enabled = self._ensure_fts_schema(
+                            cursor, "messages_fts_trigram", trigram_sql,
+                        )
+                        self._trigram_available = trigram_enabled
+                    if not trigram_orphaned and trigram_enabled and trigram_triggers_missing:
                         self._run_admitted_startup_rebuild(
                             cursor,
                             lambda: self._rebuild_fts_indexes(
@@ -1185,7 +1215,21 @@ class SessionSchemaMixin:
                         )
             if self._fts_enabled and not legacy_fts and not base_triggers_missing:
                 # CJK-bigram index: strictly additive, gated on the loadable tokenizer.
-                self._ensure_fts_cjk_schema(cursor)
+                if cjk_orphaned:
+                    with fts_rebuild_admission(self.db_path) as admitted:
+                        if admitted:
+                            _drop_orphan_fts_shadow_tables(cursor, families)
+                            self._ensure_fts_cjk_schema(cursor)
+                            if not self._fts_cjk_available:
+                                for trigger in _FTS_CJK_TRIGGERS:
+                                    cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+                        else:
+                            cursor.execute(_STALE_KEY_UPSERT_SQL, (FTS_CJK_STALE_KEY,))
+                            for trigger in _FTS_CJK_TRIGGERS:
+                                cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+                            self._fts_cjk_available = False
+                else:
+                    self._ensure_fts_cjk_schema(cursor)
         # IF NOT EXISTS cannot rewrite pre-existing broad AFTER UPDATE triggers.
         if self._fts_enabled:
             self._migrate_broad_fts_update_triggers(cursor)

--- a/tests/state/test_fts_orphan_shadow_repair.py
+++ b/tests/state/test_fts_orphan_shadow_repair.py
@@ -6,8 +6,13 @@ shadows must survive untouched.
 """
 
 import sqlite3
+import threading
+from contextlib import contextmanager
 
+import hermes_state
+import hermes_state_schema
 from hermes_state import SessionDB
+from hermes_state_common import FTS_STALE_KEY, fts_rebuild_admission
 
 
 def _orphan_family(db_path, family: str) -> None:
@@ -65,3 +70,253 @@ def test_orphaned_base_family_is_repaired_and_healthy_trigram_untouched(tmp_path
         reopened.close()
     # Same rowids: the healthy family was neither dropped nor recreated.
     assert _fts_master_rows(db_path, "messages_fts_trigram") == trigram_before
+
+
+def test_concurrent_orphan_repair_does_not_drop_recreated_fts_family(
+    tmp_path, monkeypatch
+):
+    """A stale orphan snapshot must not drop a family recreated by another opener."""
+    db_path = tmp_path / "state.db"
+    seed = SessionDB(db_path=db_path)
+    seed.create_session("s1", source="cli", model="m")
+    seed.append_message("s1", "user", "concurrent orphan repair")
+    seed.close()
+    _orphan_family(db_path, "messages_fts")
+
+    selected = threading.Event()
+    release = threading.Event()
+    state = threading.local()
+
+    class CoordinatedCursor(sqlite3.Cursor):
+        _selected_base_orphans = False
+
+        def execute(self, sql, parameters=()):
+            self._selected_base_orphans = (
+                getattr(state, "opener", None) == "stale"
+                and "messages_fts_data" in parameters
+                and (
+                    "SELECT name FROM sqlite_master" in sql
+                    or "SELECT 1 FROM sqlite_master AS shadow" in sql
+                )
+            )
+            return super().execute(sql, parameters)
+
+        def fetchall(self):
+            rows = super().fetchall()
+            if self._selected_base_orphans:
+                selected.set()
+                with fts_rebuild_admission(db_path, timeout_seconds=0) as admitted:
+                    snapshot_is_unguarded = admitted
+                if snapshot_is_unguarded:
+                    assert release.wait(timeout=10), "competing opener did not finish"
+            return rows
+
+    class CoordinatedConnection(sqlite3.Connection):
+        def cursor(self, *args, **kwargs):
+            kwargs.setdefault("factory", CoordinatedCursor)
+            return super().cursor(*args, **kwargs)
+
+    real_connect = hermes_state._connect_tracked_db
+
+    def coordinated_connect(path, tracking_path=None, **kwargs):
+        kwargs["factory"] = CoordinatedConnection
+        return real_connect(path, tracking_path=tracking_path, **kwargs)
+
+    monkeypatch.setattr(hermes_state, "_connect_tracked_db", coordinated_connect)
+
+    opened = {}
+    errors = {}
+
+    def open_db(name):
+        state.opener = name
+        try:
+            opened[name] = SessionDB(db_path=db_path)
+        except BaseException as exc:
+            errors[name] = exc
+        finally:
+            if name == "fresh":
+                release.set()
+
+    stale_thread = threading.Thread(target=open_db, args=("stale",), daemon=True)
+    fresh_thread = threading.Thread(target=open_db, args=("fresh",), daemon=True)
+    fresh_started = False
+    stale_thread.start()
+    try:
+        assert selected.wait(timeout=10), "stale opener did not snapshot orphan shadows"
+        fresh_thread.start()
+        fresh_started = True
+        fresh_thread.join(timeout=15)
+        stale_thread.join(timeout=15)
+        assert not fresh_thread.is_alive(), "competing opener did not terminate"
+        assert not stale_thread.is_alive(), "stale opener did not terminate"
+        assert errors == {}
+
+        db = opened["fresh"]
+        with db._lock:
+            hits = db._conn.execute(
+                "SELECT count(*) FROM messages_fts "
+                "WHERE messages_fts MATCH 'concurrent'"
+            ).fetchone()[0]
+        assert hits == 1
+    finally:
+        release.set()
+        stale_thread.join(timeout=5)
+        if fresh_started:
+            fresh_thread.join(timeout=5)
+        for db in opened.values():
+            db.close()
+
+
+def _seed_cjk_orphan_with_trigger(db_path):
+    seed = SessionDB(db_path=db_path)
+    seed.close()
+
+    raw = sqlite3.connect(db_path)
+    raw.executescript(
+        "CREATE TABLE messages_fts_cjk_data(id INTEGER PRIMARY KEY);"
+        "CREATE TRIGGER messages_fts_cjk_insert AFTER INSERT ON messages BEGIN "
+        "INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls) "
+        "VALUES (new.id, new.content, new.tool_name, new.tool_calls); END;"
+    )
+    raw.close()
+
+
+def _assert_cjk_trigger_detached_and_append_survives(db_path):
+    reopened = SessionDB(db_path=db_path)
+    try:
+        trigger = reopened._conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'trigger' "
+            "AND name = 'messages_fts_cjk_insert'"
+        ).fetchone()
+        assert trigger is None
+        reopened.create_session("s1", source="cli", model="m")
+        reopened.append_message("s1", "user", "canonical write survives")
+    finally:
+        reopened.close()
+
+
+def test_cjk_orphan_without_tokenizer_drops_broken_sync_triggers(
+    tmp_path, monkeypatch
+):
+    """An unavailable optional tokenizer must not leave a trigger targeting no table."""
+    db_path = tmp_path / "state.db"
+    _seed_cjk_orphan_with_trigger(db_path)
+    monkeypatch.setattr(hermes_state, "load_fts5_cjk_extension", lambda _conn: False)
+
+    _assert_cjk_trigger_detached_and_append_survives(db_path)
+
+
+def test_cjk_orphan_repair_deferral_drops_broken_sync_triggers(tmp_path, monkeypatch):
+    """Lost admission must leave canonical writes independent of a missing CJK table."""
+    db_path = tmp_path / "state.db"
+    _seed_cjk_orphan_with_trigger(db_path)
+
+    @contextmanager
+    def deny_admission(*_args, **_kwargs):
+        yield False
+
+    monkeypatch.setattr(hermes_state_schema, "fts_rebuild_admission", deny_admission)
+    _assert_cjk_trigger_detached_and_append_survives(db_path)
+
+
+def test_trigram_orphan_without_tokenizer_drops_broken_sync_triggers(
+    tmp_path, monkeypatch
+):
+    """A missing optional tokenizer must detach triggers for the absent trigram table."""
+    db_path = tmp_path / "state.db"
+    seed = SessionDB(db_path=db_path)
+    seed.close()
+    _orphan_family(db_path, "messages_fts_trigram")
+
+    real_ensure = SessionDB._ensure_fts_schema
+
+    def ensure_without_trigram(self, cursor, table_name, ddl):
+        if table_name == "messages_fts_trigram":
+            return False
+        return real_ensure(self, cursor, table_name, ddl)
+
+    monkeypatch.setattr(SessionDB, "_ensure_fts_schema", ensure_without_trigram)
+    reopened = SessionDB(db_path=db_path)
+    try:
+        triggers = reopened._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'trigger' "
+            "AND name LIKE 'messages_fts_trigram_%'"
+        ).fetchall()
+        assert triggers == []
+        reopened.create_session("s1", source="cli", model="m")
+        reopened.append_message("s1", "user", "canonical write survives")
+    finally:
+        reopened.close()
+
+
+def test_stale_recovery_keeps_admission_through_cjk_ensure(tmp_path, monkeypatch):
+    """CJK recreation must not run after releasing the orphan-repair authority."""
+    db_path = tmp_path / "state.db"
+    seed = SessionDB(db_path=db_path)
+    seed.close()
+    raw = sqlite3.connect(db_path)
+    raw.execute(
+        "INSERT INTO state_meta(key, value) VALUES (?, '1') "
+        "ON CONFLICT(key) DO UPDATE SET value = '1'",
+        (FTS_STALE_KEY,),
+    )
+    raw.execute("CREATE TABLE IF NOT EXISTS messages_fts_cjk_data(id INTEGER PRIMARY KEY)")
+    raw.commit()
+    raw.close()
+
+    entered = threading.Event()
+    original_ensure = SessionDB._ensure_fts_cjk_schema
+
+    def ensure_while_admitted(self, cursor):
+        with fts_rebuild_admission(db_path, timeout_seconds=0) as admitted:
+            assert not admitted, "CJK ensure ran after rebuild admission was released"
+        entered.set()
+        return original_ensure(self, cursor)
+
+    monkeypatch.setattr(SessionDB, "_ensure_fts_cjk_schema", ensure_while_admitted)
+    reopened = SessionDB(db_path=db_path)
+    try:
+        assert entered.is_set()
+    finally:
+        reopened.close()
+
+
+def test_base_and_trigram_orphans_without_tokenizer_detach_trigram(
+    tmp_path, monkeypatch
+):
+    """Base repair must fail closed when an orphaned trigram sibling cannot return."""
+    db_path = tmp_path / "state.db"
+    seed = SessionDB(db_path=db_path)
+    seed.close()
+    _orphan_family(db_path, "messages_fts")
+    _orphan_family(db_path, "messages_fts_trigram")
+
+    real_ensure = SessionDB._ensure_fts_schema
+
+    def ensure_without_trigram(self, cursor, table_name, ddl):
+        if table_name == "messages_fts_trigram":
+            return False
+        return real_ensure(self, cursor, table_name, ddl)
+
+    monkeypatch.setattr(SessionDB, "_ensure_fts_schema", ensure_without_trigram)
+    reopened = SessionDB(db_path=db_path)
+    try:
+        triggers = reopened._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'trigger' "
+            "AND name LIKE 'messages_fts_trigram_%'"
+        ).fetchall()
+        assert triggers == []
+        reopened.create_session("s1", source="cli", model="m")
+        reopened.append_message("s1", "user", "canonical write survives")
+    finally:
+        reopened.close()
+
+
+def test_base_and_cjk_orphans_without_tokenizer_detach_cjk(tmp_path, monkeypatch):
+    """Base repair must fail closed when an orphaned CJK sibling cannot return."""
+    db_path = tmp_path / "state.db"
+    _seed_cjk_orphan_with_trigger(db_path)
+    _orphan_family(db_path, "messages_fts")
+    monkeypatch.setattr(hermes_state, "load_fts5_cjk_extension", lambda _conn: False)
+
+    _assert_cjk_trigger_detached_and_append_survives(db_path)


### PR DESCRIPTION
## What does this PR do?

Prevents orphan FTS shadow repair from deleting a virtual table that another process recreated after a stale preflight check. The preflight now only selects the guarded path. Destructive orphan detection and cleanup run after FTS rebuild admission is acquired.

The repair remains family-specific. Base, trigram, and CJK indexes are rebuilt only when needed. If an optional tokenizer is unavailable or CJK admission is denied, its sync triggers are removed so canonical message writes do not target a missing table. Stale recovery also keeps CJK recreation inside the same admission lifetime.

## Related Issue

Refs #108130
Related to #103840

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a read-only orphan-family preflight in `hermes_state_fts.py`.
- Recheck and remove orphan shadows only while holding FTS rebuild admission.
- Preserve independent base, trigram, and CJK recovery behavior.
- Fail closed by removing optional-family triggers when recreation cannot complete.
- Add concurrency, admission, tokenizer, stale-recovery, and combined-family regressions.

## How to Test

1. Run `HERMES_PYTHON=/path/to/python scripts/run_tests.sh tests/state/test_fts_orphan_shadow_repair.py tests/state/test_fts_fresh_bootstrap_admission.py tests/state/test_fts_holder_instance_scope.py tests/state/test_fts_index_fail_open.py tests/state/test_fts_rebuild_admission.py tests/state/test_fts_runtime_rebuild.py tests/state/test_fts_trigram_cron_exclusion.py tests/state/test_fts_trigram_subagent_exclusion.py tests/test_fts_cjk_bigram.py tests/test_fts_update_of_narrowing.py tests/test_state_db_fts_segment_collision_probe.py tests/test_state_db_malformed_repair.py -q`.
2. Confirm 145 tests pass. Six Linux-only tests are skipped on macOS.
3. Run `ruff check hermes_state_fts.py hermes_state_schema.py tests/state/test_fts_orphan_shadow_repair.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A