### PR TITLE
fix(cli): pin recovery commands to profiles

### DIFF
--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -864,7 +864,7 @@ class GatewayNotificationsMixin:
                 "⚠️ Session database reported a corruption error confined to the search index "
                 "(FTS5); the message tables are not damaged. Messages may not be persisted until "
                 f"it is repaired: run `hermes {profile_arg}doctor --fix`, then restart the gateway. Do not run "
-                "recovery tools or restore a backup unless `hermes doctor` confirms damage."
+                f"recovery tools or restore a backup unless `hermes {profile_arg}doctor` confirms damage."
             )
         else:
             message = (

--- a/hermes_cli/web_routers/_common.py
+++ b/hermes_cli/web_routers/_common.py
@@ -89,8 +89,23 @@ _corrupt_store_warned_at: Dict[str, float] = {}  # {db path: monotonic}
 
 CORRUPT_STORE_DETAIL = {
     "error": "state_db_corrupt",
-    "message": "state.db corrupt — run `hermes doctor` (then `hermes doctor --fix` or `hermes sessions repair`).",
 }
+
+
+def _corrupt_store_detail(db_path):
+    """Return recovery guidance pinned to the profile that owns ``db_path``."""
+    from hermes_constants import profile_name_for_home
+
+    profile = profile_name_for_home(db_path.parent)
+    profile_arg = f"-p {profile} " if profile else ""
+    return {
+        **CORRUPT_STORE_DETAIL,
+        "message": (
+            f"state.db corrupt — run `hermes {profile_arg}doctor` "
+            f"(then `hermes {profile_arg}doctor --fix` or "
+            f"`hermes {profile_arg}sessions repair`)."
+        ),
+    }
 
 
 @contextlib.contextmanager
@@ -106,11 +121,12 @@ def corrupt_store_as_status(db_path):
         if not is_malformed_db_error(exc):
             raise
         key, now = str(db_path), time.monotonic()
+        detail = _corrupt_store_detail(db_path)
         last = _corrupt_store_warned_at.get(key)
         if last is None or now - last >= _CORRUPT_STORE_WARN_INTERVAL_S:
             _corrupt_store_warned_at[key] = now
             log.warning("state.db at %s is corrupt (%s); dashboard reads return a status payload until it is "
-                        "repaired — run `hermes doctor`", db_path, exc)
+                        "repaired; %s", db_path, exc, detail["message"])
         else:
             log.debug("state.db at %s still corrupt: %s", db_path, exc)
-        raise HTTPException(status_code=503, detail={**CORRUPT_STORE_DETAIL, "path": key}) from exc
+        raise HTTPException(status_code=503, detail={**detail, "path": key}) from exc

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -773,11 +773,12 @@ def display_hermes_home() -> str:
 
 def profile_cli_selector() -> str:
     """``-p <name> `` (trailing space) pinning copy-pasteable ``hermes ...`` guidance to the
-    active NAMED profile, else ``""``: a bare ``hermes`` follows the sticky ``active_profile``
-    file, which can name a different database than the one that failed (#105887). A custom
-    home outside the profile tree has no selector (only HERMES_HOME names it)."""
+    active profile, else ``""``: a bare ``hermes`` follows the sticky ``active_profile`` file,
+    which can name a different database than the one that failed (#105887). This includes the
+    default profile. A custom home outside the profile tree has no selector (only HERMES_HOME
+    names it)."""
     name = profile_name_for_home(get_hermes_home())
-    return f"-p {name} " if name and name != "default" else ""
+    return f"-p {name} " if name else ""
 
 
 def secure_parent_dir(path: Path) -> None:

--- a/tests/hermes_cli/test_web_analytics_corrupt_store.py
+++ b/tests/hermes_cli/test_web_analytics_corrupt_store.py
@@ -43,7 +43,7 @@ def test_corrupt_store_polls_return_status_and_warn_once_per_interval(tmp_path, 
     for resp in (first, second, third):
         assert resp.status_code == 503
         assert resp.json()["detail"]["error"] == "state_db_corrupt"
-        assert "hermes doctor" in resp.json()["detail"]["message"]
+        assert "hermes -p default doctor" in resp.json()["detail"]["message"]
     # Only the dashboard's own warning counts: hermes_state logs an unrelated
     # once-per-process SQLite-version advisory on some interpreters (CI's 3.50.4).
     warnings = [
@@ -63,3 +63,39 @@ def test_corrupt_store_polls_return_status_and_warn_once_per_interval(tmp_path, 
         r.levelno >= logging.WARNING and r.name.startswith("hermes_cli.web_server")
         for r in caplog.records
     ) == 1
+
+
+@pytest.mark.parametrize("endpoint", ["usage", "models"])
+def test_corrupt_store_guidance_pins_requested_profile(
+    endpoint, tmp_path, monkeypatch, caplog
+):
+    root = tmp_path / "hermes"
+    profile_home = root / "profiles" / "research"
+    profile_home.mkdir(parents=True)
+    (root / "active_profile").write_text("other\n")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    db_path = _malformed_state_db(profile_home)
+    monkeypatch.setattr(_common, "_corrupt_store_warned_at", {})
+    app = FastAPI()
+    app.include_router(analytics.router)
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.web_server"):
+        response = TestClient(app).get(
+            f"/api/analytics/{endpoint}?days=7&profile=research"
+        )
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert detail["path"] == str(db_path)
+    assert detail["message"] == (
+        "state.db corrupt — run `hermes -p research doctor` "
+        "(then `hermes -p research doctor --fix` or "
+        "`hermes -p research sessions repair`)."
+    )
+    warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name.startswith("hermes_cli.web_server")
+        and record.levelno >= logging.WARNING
+    ]
+    assert any("`hermes -p research doctor`" in warning for warning in warnings)

--- a/tests/run_agent/test_corruption_recovery_guidance.py
+++ b/tests/run_agent/test_corruption_recovery_guidance.py
@@ -15,7 +15,18 @@ The fix adds:
    with the full recovery path (hermes doctor, sqlite3 .recover, backups)
 """
 
+import re
+
 from pytest import fixture
+
+
+def _assert_profile_pinned_commands(message, profile, expected_count):
+    commands = re.findall(
+        r"\bhermes(?:\s+-p\s+\S+)?\s+(?:doctor|sessions)\b",
+        message,
+    )
+    assert len(commands) == expected_count, commands
+    assert all(command.startswith(f"hermes -p {profile} ") for command in commands), commands
 
 
 def test_format_turn_completion_corrupt_includes_recovery_options():
@@ -25,7 +36,7 @@ def test_format_turn_completion_corrupt_includes_recovery_options():
     explanation = AIAgent._format_turn_completion_explanation(
         "session_persistence_failed", "corrupt"
     )
-    assert "hermes doctor" in explanation
+    assert "hermes -p default doctor" in explanation
     assert ".recover" in explanation
     assert "backups" in explanation
     assert "Freeing disk space will not help" in explanation
@@ -101,7 +112,7 @@ def test_format_turn_completion_corrupt_never_names_the_live_db():
     assert "sessions recover" in explanation
     assert 'sqlite3 ~/.hermes/state.db ".recover"' not in explanation
     # The replacement guidance names the safe command.
-    assert "hermes sessions recover --source" in explanation
+    assert "hermes -p default sessions recover --source" in explanation
 
 
 def test_format_turn_completion_disk_still_advises_space():
@@ -167,3 +178,78 @@ def test_corrupt_guidance_pins_the_failing_profile(tmp_path, monkeypatch):
 
     exhausted = _persistent_repair_exhausted_error(home / "state.db")
     assert "`hermes -p research sessions recover --source" in exhausted
+
+
+def test_corrupt_guidance_explicitly_pins_the_default_profile(tmp_path, monkeypatch):
+    """Default-profile recovery commands must not follow a different sticky active profile."""
+    import asyncio
+
+    import gateway.run as gateway_run
+    from hermes_cli.doctor_report import Finding
+    from hermes_cli.doctor_state import _repair_state_db
+    from hermes_state_repair import _persistent_repair_exhausted_error
+    from run_agent import AIAgent
+
+    root = tmp_path / "hermes"
+    root.mkdir()
+    (root / "config.yaml").write_text("")
+    (root / "active_profile").write_text("other\n")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    explanation = AIAgent._format_turn_completion_explanation(
+        "session_persistence_failed", "corrupt"
+    )
+    _assert_profile_pinned_commands(explanation, "default", 3)
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_db_init_error = "database disk image is malformed"
+    sent = []
+    monkeypatch.setattr(
+        runner, "_home_channel_transports", lambda: [("telegram", {}, "home-chat", object())]
+    )
+
+    async def _capture_send(_platform, _home, _transport, message, _log_fmt):
+        sent.append(message)
+
+    monkeypatch.setattr(runner, "_send_home_channel_message", _capture_send)
+    asyncio.run(runner._send_session_db_warning_notifications())
+    _assert_profile_pinned_commands(sent[0], "default", 4)
+
+    exhausted = _persistent_repair_exhausted_error(root / "state.db")
+    _assert_profile_pinned_commands(exhausted, "default", 2)
+
+    finding = Finding()
+    _repair_state_db(finding, True, root / "state.db", "structural")
+    (structural_guidance,) = finding.manual_issues
+    _assert_profile_pinned_commands(structural_guidance, "default", 2)
+
+
+def test_gateway_fts_notice_pins_both_doctor_commands(tmp_path, monkeypatch):
+    """The confirmation command must target the same profile as the FTS repair command."""
+    import asyncio
+
+    import gateway.run as gateway_run
+
+    root = tmp_path / "hermes"
+    home = root / "profiles" / "research"
+    home.mkdir(parents=True)
+    (root / "config.yaml").write_text("")
+    (root / "active_profile").write_text("other\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_db_init_error = "malformed inverted index for FTS5 table main.messages_fts"
+    sent = []
+    monkeypatch.setattr(
+        runner, "_home_channel_transports", lambda: [("telegram", {}, "home-chat", object())]
+    )
+
+    async def _capture_send(_platform, _home, _transport, message, _log_fmt):
+        sent.append(message)
+
+    monkeypatch.setattr(runner, "_send_home_channel_message", _capture_send)
+    asyncio.run(runner._send_session_db_warning_notifications())
+
+    assert len(sent) == 1
+    _assert_profile_pinned_commands(sent[0], "research", 2)
+    assert "unless `hermes -p research doctor` confirms damage" in sent[0]


### PR DESCRIPTION
## What does this PR do?

Pins corruption recovery commands to the profile that owns the failing database. Bare commands follow the sticky `active_profile` file, so guidance for the default profile or an explicitly requested analytics profile could repair a different database.

Default-profile command surfaces now render `-p default`. Dashboard analytics responses and warning logs derive the selector from the failing `state.db` path. Custom homes outside the profile tree keep the existing bare guidance because only `HERMES_HOME` identifies them.

## Related Issue

Refs #108130
Related to #105887

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Render an explicit selector for the default profile.
- Pin both doctor commands in gateway FTS notifications.
- Build analytics recovery guidance from the failing database path.
- Reuse the same profile-aware guidance in HTTP responses and warning logs.
- Cover default, named, and custom-home recovery command surfaces.

## How to Test

1. Run `HERMES_PYTHON=/path/to/python scripts/run_tests.sh tests/run_agent/test_corruption_recovery_guidance.py tests/hermes_cli/test_web_analytics_corrupt_store.py -q`.
2. Confirm 12 tests pass.
3. Run `ruff check gateway/run_notifications.py hermes_cli/web_routers/_common.py hermes_constants.py tests/hermes_cli/test_web_analytics_corrupt_store.py tests/run_agent/test_corruption_recovery_guidance.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A