### PR TITLE
fix(state): fail closed for unknown integrity trees

### DIFF
--- a/hermes_state_repair.py
+++ b/hermes_state_repair.py
@@ -712,7 +712,9 @@ def integrity_damage_is_structural(integrity_lines, master_rows) -> bool:
         tree = _INTEGRITY_TREE_RE.search(text)
         if tree:
             name = name_by_rootpage.get(int(tree.group(1)), "")
-            if name and not _FTS_OBJECT_RE.fullmatch(name):
+            # Only a positively identified Hermes FTS object is safe to rebuild
+            # in place. A missing rootpage mapping cannot prove FTS ownership.
+            if not name or not _FTS_OBJECT_RE.fullmatch(name):
                 return True
         missing = _INTEGRITY_MISSING_INDEX_RE.search(text)
         if missing and not _FTS_OBJECT_RE.fullmatch(missing.group(1)):

--- a/tests/hermes_cli/test_doctor_structural_corruption.py
+++ b/tests/hermes_cli/test_doctor_structural_corruption.py
@@ -33,8 +33,8 @@ def test_integrity_damage_classifier_maps_tree_ids_through_rootpage():
     assert integrity_damage_is_structural(["Tree 40 page 40: btreeInitPage() returns error code 11"], master)
     assert integrity_damage_is_structural(["row 1 missing from index sqlite_autoindex_delivery_obligations_1"], master)
     assert integrity_damage_is_structural(["Freelist: invalid page number 167772160"], master)
-    # Unparseable / unknown-tree lines keep the FTS wording (incomplete, never wrong).
-    assert integrity_damage_is_structural(["Tree 999 page 1: garbage", "*** in database main ***"], master) is False
+    # An unknown tree cannot be proven to be derived FTS state, so fail closed.
+    assert integrity_damage_is_structural(["Tree 999 page 1: garbage", "*** in database main ***"], master) is True
 
 
 def _seed(tmp_path, rows=120):


### PR DESCRIPTION
## What does this PR do?

Treats integrity-check damage in an unmapped SQLite tree as structural corruption. The existing classifier only returned structural when a tree ID mapped to a known non-FTS object. An unknown tree therefore fell through to FTS-only recovery even though Hermes could not prove that the damage belonged to a rebuildable FTS object.

Known Hermes FTS tree mappings remain eligible for in-place FTS rebuild. Unknown tree IDs now fail closed and follow the structural recovery path.

## Related Issue

Refs #108130
Related to #97940

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Require a positive mapping to a Hermes FTS object before classifying tree damage as FTS-only.
- Keep known FTS tree behavior unchanged.
- Update the structural corruption regression for an unmapped tree ID.

## How to Test

1. Run `HERMES_PYTHON=/path/to/python scripts/run_tests.sh tests/hermes_cli/test_doctor_structural_corruption.py -q`.
2. Confirm 2 tests pass.
3. Run `ruff check hermes_state_repair.py tests/hermes_cli/test_doctor_structural_corruption.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A