### PR TITLE
fix(gateway): trust SQLite codes for FTS recovery

### DIFF
--- a/gateway/session_transcript.py
+++ b/gateway/session_transcript.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import re
 import threading
 from agent.turn_context import extract_api_content_sidecar
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -15,6 +16,9 @@ if TYPE_CHECKING:
 
 # Log-record parity with the origin module.
 logger = logging.getLogger("gateway.session")
+_MISSING_HERMES_FTS_TABLE_RE = re.compile(
+    r"no such table:\s+(?:main\.)?messages_fts(?:_trigram|_cjk)?$"
+)
 
 
 class TranscriptReadError(RuntimeError):
@@ -366,10 +370,18 @@ class SessionTranscriptMixin:
         canonical B-trees, not just the FTS shadow tables — treating it as FTS-only here made the store
         rebuild the index and retry transcript writes against a structurally corrupt database (#97940).
         """
-        if "messages_fts" in str(exc).lower():
-            return True
         import sqlite3
         from hermes_state import SessionDB
+        text = str(exc).lower()
+        if _MISSING_HERMES_FTS_TABLE_RE.fullmatch(text.strip()):
+            return True
+        # A live SQLite result code is stronger provenance than prose. In
+        # particular, a constraint failure can include an FTS table name
+        # without proving that the index itself is corrupt.
+        if getattr(exc, "sqlite_errorcode", None) is not None:
+            return isinstance(exc, sqlite3.DatabaseError) and SessionDB._is_fts_write_corruption_error(exc)
+        if "messages_fts" in text:
+            return True
         return isinstance(exc, sqlite3.DatabaseError) and SessionDB._is_fts_write_corruption_error(exc)
 
     def _rebuild_fts_once(self) -> bool:

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1560,11 +1560,41 @@ class TestGatewaySessionDbRecovery:
         assert SessionStore._is_fts_corruption_error(
             RuntimeError("no such table: messages_fts")
         )
+        missing_fts = sqlite3.connect(":memory:")
+        try:
+            missing_fts.executescript(
+                "CREATE TABLE messages(content TEXT);"
+                "CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN "
+                "INSERT INTO messages_fts(content) VALUES (new.content); END;"
+            )
+            with pytest.raises(sqlite3.OperationalError) as missing:
+                missing_fts.execute("INSERT INTO messages(content) VALUES ('hello')")
+        finally:
+            missing_fts.close()
+        assert "no such table: main.messages_fts" in str(missing.value).lower()
+        assert SessionStore._is_fts_corruption_error(missing.value)
+        lookalike = sqlite3.connect(":memory:")
+        try:
+            lookalike.executescript(
+                "CREATE TABLE messages(content TEXT);"
+                "CREATE TRIGGER messages_fts_archive_insert AFTER INSERT ON messages BEGIN "
+                "INSERT INTO messages_fts_archive(content) VALUES (new.content); END;"
+            )
+            with pytest.raises(sqlite3.OperationalError) as missing_archive:
+                lookalike.execute("INSERT INTO messages(content) VALUES ('hello')")
+        finally:
+            lookalike.close()
+        assert not SessionStore._is_fts_corruption_error(missing_archive.value)
         assert SessionStore._is_fts_corruption_error(
             sqlite3.DatabaseError(
                 'fts5: corrupt structure record for table "messages_fts"'
             )
         )
+        contradictory = sqlite3.IntegrityError(
+            'fts5: corrupt structure record for table "messages_fts"'
+        )
+        contradictory.sqlite_errorcode = sqlite3.SQLITE_CONSTRAINT_TRIGGER
+        assert not SessionStore._is_fts_corruption_error(contradictory)
         assert not SessionStore._is_fts_corruption_error(
             RuntimeError("shifts were applied")
         )


### PR DESCRIPTION
## What does this PR do?

Uses SQLite result codes as the authoritative signal when gateway transcript writes decide whether to rebuild FTS and retry. The existing substring check treated any exception text containing `messages_fts` as FTS corruption, including constraint failures that should not trigger recovery.

Explicit missing-table recovery remains supported for the three Hermes FTS tables because SQLite reports those trigger failures as `SQLITE_ERROR`. The missing-table match is exact and accepts the schema-qualified `main.messages_fts` form emitted by real triggers without accepting lookalike table names.

## Related Issue

Refs #108130
Related to #97940

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Classify exceptions with live SQLite result codes through the shared corruption classifier.
- Preserve recovery for exact missing base, trigram, and CJK FTS tables.
- Accept real schema-qualified trigger errors.
- Reject lookalike table names and contradictory constraint result codes.

## How to Test

1. Run `HERMES_PYTHON=/path/to/python scripts/run_tests.sh tests/gateway/test_session.py -q`.
2. Confirm 65 tests pass.
3. Run `ruff check gateway/session_transcript.py tests/gateway/test_session.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A