### PR TITLE
fix(agent): recognize z.ai's 1210 wording as reasoning-mandatory

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -382,8 +382,12 @@ _V_OVERLOADED, _V_SERVER_ERROR, _V_TIMEOUT, _V_UNKNOWN = map(_v, (_R.overloaded,
 _V_IMAGE_TOO_LARGE, _V_IMAGE_CORRUPT = _v(_R.image_too_large), _v(_R.image_corrupt)
 _V_MULTIMODAL, _V_INVALID_ENCRYPTED = _v(_R.multimodal_tool_content_unsupported), _v(_R.invalid_encrypted_content)
 _V_REASONING_MANDATORY = _v(_R.reasoning_mandatory, should_compress=False, should_fallback=False)
-# A reasoning-mandatory route answering ``reasoning: {enabled: false}`` (Nous Portal + OpenRouter wording).
-_REASONING_MANDATORY_PATTERN = "reasoning is mandatory"
+# A reasoning-mandatory route answering ``reasoning: {enabled: false}`` (Nous Portal + OpenRouter wording,
+# plus z.ai's own code-1210 wording for GLM-5.2/5.3 rejecting ``thinking: {"type": "disabled"}``).
+_REASONING_MANDATORY_PATTERNS = (
+    "reasoning is mandatory",
+    "always engages in thinking and cannot be disabled",
+)
 
 
 def _billing_hints(error_msg: str) -> Verdict:
@@ -767,7 +771,7 @@ def _classify_400(c: _Ctx) -> Verdict:
     # Reasoning-mandatory route rejecting a disable (GLM-5.3 on Nous Portal / OpenRouter). Deterministic
     # for the request shape, but the only bad field is ``reasoning: {enabled: false}`` — the loop drops
     # the disable and retries once. Must precede request-validation, which would abort as format_error.
-    if _REASONING_MANDATORY_PATTERN in msg:
+    if any(p in msg for p in _REASONING_MANDATORY_PATTERNS):
         return _V_REASONING_MANDATORY
     # 400 blaming a field this route never sent (Codex OAuth injects then rejects
     # prompt_cache_retention ~20% of the time): transient, retry identical request.

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -822,6 +822,20 @@ class TestClassifyApiError:
         assert result.should_fallback is False
         assert result.should_compress is False
 
+    def test_zai_1210_disable_rejection_is_reasoning_mandatory(self):
+        """z.ai's own wording for the same disable-rejection (#108311), distinct from the Nous
+        Portal/OpenRouter phrasing covered above."""
+        e = MockAPIError(
+            "Error code: 400 - {'error': {'code': '1210', 'message': 'This model always engages "
+            "in thinking and cannot be disabled; please use low, high, or max'}}",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="zai", model="glm-5.3-flash")
+        assert result.reason == FailoverReason.reasoning_mandatory
+        assert result.retryable is True
+        assert result.should_fallback is False
+        assert result.should_compress is False
+
     # ── Provider-specific: llama.cpp grammar-parse ──
 
     def test_llama_cpp_unable_to_generate_parser_template(self):


### PR DESCRIPTION
Fixes #108311.

## What changed and why

When the zai provider profile sends `thinking: {"type": "disabled"}` to
GLM-5.3 on `api.z.ai`, the endpoint rejects it with HTTP 400 code 1210:

```
Error code: 400 - {'error': {'code': '1210', 'message': 'This model always
engages in thinking and cannot be disabled; please use low, high, or max'}}
```

`agent/error_classifier.py` only matched the Nous Portal / OpenRouter wording
("reasoning is mandatory") for this same class of failure — a route rejecting
a reasoning disable. Z.ai's message doesn't contain that substring, so the
error fell through to `format_error` (non-retryable) instead of
`reasoning_mandatory`, and the existing recovery in
`agent/turn_recovery.py::_handle_reasoning_mandatory` (drop the disable for
the session, retry) never fired. The turn dead-ends with a generic "model
provider failed after retries" instead of recovering.

This makes `_classify_400`'s reasoning-mandatory check match either wording
by turning the single pattern into a tuple checked with `any()`.

## How to test

```python
from agent.error_classifier import classify_api_error

class MockAPIError(Exception):
    def __init__(self, message, status_code=None):
        super().__init__(message)
        self.status_code = status_code
        self.body = {}

e = MockAPIError(
    "Error code: 400 - {'error': {'code': '1210', 'message': 'This model "
    "always engages in thinking and cannot be disabled; please use low, "
    "high, or max'}}",
    status_code=400,
)
classify_api_error(e, provider="zai", model="glm-5.3-flash").reason
# before: FailoverReason.format_error
# after:  FailoverReason.reasoning_mandatory
```

Added `test_zai_1210_disable_rejection_is_reasoning_mandatory` to
`tests/agent/test_error_classifier.py`, next to the existing
`test_reasoning_mandatory_400_is_retryable_not_format_error` test that covers
the Nous Portal/OpenRouter wording.

Verified the new test fails without the fix (checked out the pre-fix
`agent/error_classifier.py` with the test present):

```
FAILED tests/agent/test_error_classifier.py::TestClassifyApiError::test_zai_1210_disable_rejection_is_reasoning_mandatory
assert <FailoverReason.format_error: 'format_error'> == <FailoverReason.reasoning_mandatory: 'reasoning_mandatory'>
```

And passes with the fix, along with the full existing suite in this file:

```
$ pytest tests/agent/test_error_classifier.py -v
...
154 passed in 15.51s
```

`ruff check agent/error_classifier.py tests/agent/test_error_classifier.py`
— all checks passed.

## What platforms tested

Linux (CI sandbox). No platform-specific code touched.

## AI assistance disclosure

This patch was written by an AI coding agent (Claude Code) working from the
issue's own detailed root-cause analysis and suggested fix, then verified
against the existing test suite and a red/green test run as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
