### PR TITLE
fix(agent): make background-review iteration budget configurable

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -146,6 +146,11 @@ def cancel_background_review_for_live_turn(agent: Any) -> None:
 # Aux-model routing: by default ("auto") the fork runs on the MAIN model and replays the full
 # conversation as warm cache reads. When auxiliary.background_review.{provider,model} routes it
 # to a DIFFERENT model the cache is cold anyway, so the fork replays a compact digest instead.
+#
+# ``_REVIEW_MAX_ITERATIONS`` is the DEFAULT for one background-review fork; operators can override
+# via ``auxiliary.background_review.max_iterations`` (see ``_review_max_iterations``). The default
+# of 16 is tight on purpose — most reviews need 1-3 iterations and any surplus burns full-budget
+# replayed input tokens for no benefit.
 _REVIEW_MAX_ITERATIONS = 16
 # Aggregate INPUT-token budget for one review fork (checked in conversation_loop's
 # ``_review_input_budget_exhausted``). Request #1 replays the full snapshot as a warm cache read
@@ -182,6 +187,27 @@ def _review_input_token_budget(task_cfg: Optional[Dict[str, Any]] = None) -> Opt
     except (TypeError, ValueError):
         budget = _REVIEW_MAX_INPUT_TOKENS_DEFAULT
     return budget if budget > 0 else None
+
+
+def _review_max_iterations(task_cfg: Optional[Dict[str, Any]] = None) -> int:
+    """Iteration budget for one background-review fork.
+
+    Reads ``auxiliary.background_review.max_iterations`` (default ``_REVIEW_MAX_ITERATIONS``,
+    currently 16). Numeric strings are coerced. Garbage / non-positive values fall back to the
+    default so a typo cannot silently disable the review loop by handing ``AIAgent`` an
+    invalid ``max_iterations`` (which the constructor would either reject or, worse, accept
+    as ``sys.maxsize`` and let the review run unbounded).
+
+    No clamp / range restriction: operators can lower the cost floor to 1 for tight cost
+    control, or raise it well above the default for unusually heavy reviews (the global
+    ``agent.max_iterations`` cap still applies).
+    """
+    raw = _background_review_task_config(task_cfg).get("max_iterations", _REVIEW_MAX_ITERATIONS)
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _REVIEW_MAX_ITERATIONS
+    return value if value > 0 else _REVIEW_MAX_ITERATIONS
 
 
 def load_background_review_settings() -> tuple[bool, Dict[str, Any]]:
@@ -1024,7 +1050,7 @@ def _run_review_fork(
     keeps the ``background_review`` origin (curator/skill guards still apply) but marks the fork
     attended, so the unattended-only memory delete gate leaves the full operation set available."""
     st.review_agent, _rt, _routed = build_cache_parity_fork(
-        agent, task_cfg, max_iterations=_REVIEW_MAX_ITERATIONS)
+        agent, task_cfg, max_iterations=_review_max_iterations(task_cfg))
     st.review_agent._review_attended = explicit
     _track_review_fork(agent, st.review_agent, register=True)
     from hermes_cli.plugins import set_thread_tool_whitelist, clear_thread_tool_whitelist

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -739,9 +739,10 @@ DEFAULT_CONFIG = {
         # Post-turn self-improvement fork (save memory / patch skill). "auto" = main model replaying
         # the full conversation (warm cache); other models replay a compact digest (~3-5x cheaper).
         # enabled=false skips auto spawns (/refine still works). max_input_tokens caps the SUM of
-        # replayed input tokens over the review loop (iterations capped at 16); the loop stops
-        # before crossing it. <= 0 = unlimited.
-        "background_review": {"enabled": True, **_aux(120), "max_input_tokens": 600000},
+        # replayed input tokens over the review loop (default 600_000); <= 0 = unlimited.
+        # max_iterations caps the per-fork iteration budget (default 16); non-positive values
+        # fall back to the default. The loop stops before crossing either gate.
+        "background_review": {"enabled": True, **_aux(120), "max_input_tokens": 600000, "max_iterations": 16},
         # No reasoning_effort on MoA blocks by design — configured PER SLOT in the preset
         # (moa.presets.<name>.reference_models[].reasoning_effort / aggregator.reasoning_effort).
         "moa_reference": _aux(900, reasoning_effort=False),

--- a/tests/run_agent/test_background_review_max_iterations.py
+++ b/tests/run_agent/test_background_review_max_iterations.py
@@ -1,0 +1,177 @@
+"""Regression tests for the configurable background-review iteration budget.
+
+The background-review fork in ``agent/background_review.py`` historically hardcoded
+``_REVIEW_MAX_ITERATIONS = 16``. Operators had no way to lower the worst-case cost of
+the review (the fork is auto-spawned on most turns past the nudge interval) or raise
+it for unusually heavy reviews without patching source. This file pins the
+``_review_max_iterations`` resolver and its wiring into ``_run_review_fork`` so the
+behaviour stays tunable.
+
+Mirrors ``tests/run_agent/test_background_review_input_budget.py`` (the same resolver
+pattern for the input-token budget introduced alongside it).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+# ===================================================================
+# Group 1: resolver edge cases
+# ===================================================================
+
+
+@pytest.mark.parametrize(
+    ("config_value", "expected"),
+    [
+        ({}, 16),
+        ({"max_iterations": 32}, 32),
+        ({"max_iterations": 1}, 1),  # tight cost floor
+        ({"max_iterations": 256}, 256),  # unbounded-feel; global max_iterations still applies
+        ({"max_iterations": "8"}, 8),  # numeric string coerced
+        ({"max_iterations": 0}, 16),  # 0 falls back to default — cannot silently disable
+        ({"max_iterations": -5}, 16),  # negative falls back to default
+        ({"max_iterations": "not-a-number"}, 16),  # garbage falls back to default
+        ({"max_iterations": None}, 16),  # explicit null falls back to default
+    ],
+)
+def test_review_max_iterations_resolution(config_value, expected):
+    """Config parsing: default, override, garbage fallback, no clamp.
+
+    Operator intent passes through when it's a positive int; everything else falls back
+    to the documented default so a typo cannot hand ``AIAgent`` an invalid
+    ``max_iterations`` (which the constructor would either reject or accept as
+    ``sys.maxsize``).
+    """
+    from agent.background_review import _review_max_iterations
+
+    assert _review_max_iterations(config_value) == expected
+
+
+def test_review_max_iterations_resolves_via_full_config_path():
+    """When the resolver is called via the real ``load_config_readonly`` path,
+    a deeply-nested ``auxiliary.background_review.max_iterations`` is honoured."""
+    from agent.background_review import _review_max_iterations
+
+    cfg = {"auxiliary": {"background_review": {"max_iterations": 24}}}
+    # ``load_config_readonly`` is imported lazily inside ``_background_review_task_config``;
+    # patch at the source module so the lazy import picks up the fake.
+    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+        assert _review_max_iterations() == 24
+
+
+def test_review_max_iterations_resolves_via_full_config_path_default():
+    """When the config key is absent, the resolver returns the module default even when
+    called via the load_config_readonly path (no operator key, no surprise)."""
+    from agent.background_review import _review_max_iterations, _REVIEW_MAX_ITERATIONS
+
+    cfg = {"auxiliary": {"background_review": {"enabled": True, "max_input_tokens": 600000}}}
+    with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+        assert _review_max_iterations() == _REVIEW_MAX_ITERATIONS == 16
+
+
+# ===================================================================
+# Group 2: wiring into _run_review_fork
+# ===================================================================
+
+
+def _make_agent():
+    """Minimal AIAgent (mirrors ``test_background_review_input_budget.py::_make_loop_agent``
+    but stripped — we don't run a tool loop here, just observe what ``max_iterations`` is
+    passed to the fork factory)."""
+    with (
+        patch("model_tools.get_tool_definitions", return_value=[]),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    return agent
+
+
+def test_run_review_fork_uses_configured_max_iterations(monkeypatch):
+    """End-to-end: the value passed to ``build_cache_parity_fork`` is whatever
+    ``_review_max_iterations`` resolves from the active config."""
+    from agent import background_review
+
+    captured_kwargs: dict = {}
+
+    def _fake_build_cache_parity_fork(agent, task_cfg, *, max_iterations):
+        captured_kwargs["max_iterations"] = max_iterations
+        # Return a fork agent with no-op run_conversation so we can observe the kwarg
+        # without standing up a real AIAgent (the call site would otherwise blow up on
+        # attributes the fork uses post-construction).
+        fork = SimpleNamespace(
+            release_clients=lambda: None,
+            run_conversation=lambda **kw: {"completed": True, "messages": [], "final_response": ""},
+        )
+        return fork, {}, False
+
+    monkeypatch.setattr(
+        background_review, "build_cache_parity_fork", _fake_build_cache_parity_fork,
+    )
+    # Bypass the tool whitelist / thread machinery so we can observe the kwarg only.
+    monkeypatch.setattr(background_review, "_track_review_fork", lambda *a, **kw: None)
+    # ``set_thread_tool_whitelist`` and ``clear_thread_tool_whitelist`` are imported lazily
+    # inside _run_review_fork from ``hermes_cli.plugins``; patch at the source module.
+    monkeypatch.setattr("hermes_cli.plugins.set_thread_tool_whitelist", lambda *a, **kw: None)
+    monkeypatch.setattr("hermes_cli.plugins.clear_thread_tool_whitelist", lambda: None)
+    monkeypatch.setattr(background_review, "_review_tool_whitelist", lambda *a, **kw: ([], set()))
+
+    agent = _make_agent()
+    task_cfg = {"max_iterations": 4}
+
+    background_review._run_review_fork(
+        agent, messages_snapshot=[], prompt="review me",
+        task_cfg=task_cfg, review_run=None,
+        st=background_review._ReviewForkState(),
+    )
+
+    assert captured_kwargs["max_iterations"] == 4, (
+        f"fork must receive the configured 4 iterations, got {captured_kwargs['max_iterations']!r}"
+    )
+
+
+def test_run_review_fork_uses_default_when_unconfigured(monkeypatch):
+    """End-to-end: missing ``max_iterations`` key falls through to the module default
+    (regression guard against re-hardcoding the constant in the future)."""
+    from agent import background_review
+
+    captured_kwargs: dict = {}
+
+    def _fake_build_cache_parity_fork(agent, task_cfg, *, max_iterations):
+        captured_kwargs["max_iterations"] = max_iterations
+        fork = SimpleNamespace(
+            release_clients=lambda: None,
+            run_conversation=lambda **kw: {"completed": True, "messages": [], "final_response": ""},
+        )
+        return fork, {}, False
+
+    monkeypatch.setattr(
+        background_review, "build_cache_parity_fork", _fake_build_cache_parity_fork,
+    )
+    monkeypatch.setattr(background_review, "_track_review_fork", lambda *a, **kw: None)
+    monkeypatch.setattr("hermes_cli.plugins.set_thread_tool_whitelist", lambda *a, **kw: None)
+    monkeypatch.setattr("hermes_cli.plugins.clear_thread_tool_whitelist", lambda: None)
+    monkeypatch.setattr(background_review, "_review_tool_whitelist", lambda *a, **kw: ([], set()))
+
+    agent = _make_agent()
+    background_review._run_review_fork(
+        agent, messages_snapshot=[], prompt="review me",
+        task_cfg={}, review_run=None,
+        st=background_review._ReviewForkState(),
+    )
+
+    assert captured_kwargs["max_iterations"] == background_review._REVIEW_MAX_ITERATIONS == 16


### PR DESCRIPTION
## Summary

Makes the background-review fork's per-iteration budget configurable via `auxiliary.background_review.max_iterations`. The post-turn self-improvement fork in `agent/background_review.py` previously hardcoded `_REVIEW_MAX_ITERATIONS = 16`, leaving operators no way to lower the worst-case cost of the review (the fork is auto-spawned on most turns past the nudge interval) or raise it for unusually heavy reviews without patching source.

## What does this PR do?

`agent/background_review.py::_run_review_fork` previously passed `max_iterations=_REVIEW_MAX_ITERATIONS` directly to `build_cache_parity_fork`. The hardcoded `16` had two operational consequences:

1. **Cost floor is set by source, not operator.** A profile that runs `agent.max_iterations: 250` with a long session history still pays for a full 16-iteration replay on every review-fork spawn — even when nothing needs saving. There was no way to set the floor to e.g. 4 without editing `agent/background_review.py`.
2. **Cost ceiling is set by source, not operator.** Conversely, a review that genuinely needs more than 16 iterations (e.g. a long skill curation across hundreds of skills) hits `max_iterations_reached` and surfaces a mid-thought tool-call fragment as the final answer — exactly the failure mode `handle_max_iterations` is supposed to mitigate, and one we're now hardening separately in #108270.

This PR introduces a `_review_max_iterations(task_cfg)` resolver that mirrors the existing `_review_input_token_budget` pattern and wires it into `_run_review_fork`:

- Reads `auxiliary.background_review.max_iterations` (default `16`).
- Numeric strings are coerced.
- Garbage / non-positive values fall back to the default so a typo cannot silently disable the review loop by handing `AIAgent` an invalid `max_iterations` (which the constructor would either reject or accept as `sys.maxsize` and let the review run unbounded).
- **No clamp / range restriction** — operators can lower the cost floor to 1 for tight cost control, or raise it well above the default for unusually heavy reviews. The global `agent.max_iterations` cap still applies.

The `hermes_cli/config_defaults.py` `background_review` block gains `max_iterations: 16` and an updated comment explaining both budget knobs.

## Related Issues

- **Closes #87250 / partial address of #70213 / #87353** — earlier attempts at making this configurable. #70213 didn't clamp (this PR matches its policy). #87353 clamped to `[1, 64]` (this PR deliberately does not — operators on heavy curators have asked for more headroom). This PR supersedes both against the current `agent/background_review.py` shape and is functionally a no-clamp `auxiliary.background_review.max_iterations` resolver.
- **Composes with #108270** — `fix(agent): harden handle_max_iterations as a hard stop`. The background-review fork runs through `handle_max_iterations` once it exceeds its budget, so the hard-stop design benefits the review fork's own turn-exit path too. Independent of that PR.

## Cross-provider reproduction

Captured on `hermes v0.21.1` (`556d19c2d5`) — the same session as #108270.

**Session:** `20260910_131248_a1d119` (model=`MiniMax-M3`, platform=`cli`, 366 messages, ended uncleanly)

| Metric | Value |
|---|---|
| Main turn `api_calls` | 90/90 (budget exhausted) on `agent.max_iterations=250` |
| **Background-review fork `api_calls`** | **16/16** — the hardcoded `_REVIEW_MAX_ITERATIONS=16`, reached **on the first review invocation after the main turn hit its budget** |
| Background-review fork `tool_turns` | 180 across the session's 22 review invocations (cumulative, mostly capped at 16 each) |
| Persisted synthetic user rows from review exits | covered in #108270 (separate code path; same root cause) |

`agent.log` evidence (the relevant subset):

```
2026-09-10 13:25:10,464 ... agent.conversation_loop: Turn ended: reason=max_iterations_reached(90/90) ...
2026-09-10 13:25:10,483 ... agent.turn_context: conversation turn: ... msg='Review the conversation above and update the skill library. Be ACTIVE — most ses...'
2026-09-10 13:26:03,798 WARNING ... ⚠️  Reached maximum iterations (16). Requesting summary...
2026-09-10 13:26:22,711 ... agent.conversation_loop: Turn ended: reason=max_iterations_reached(16/16) ...
2026-09-10 13:26:22,720 ... agent.background_review: Background review complete: thread=bg-review calls=16 in=35953 out=5026 cache_read=3322034 result=none
```

The `calls=16` is the hardcoded cap firing on a review that almost certainly needed more iterations — `cache_read=3322034` (≈3.3M tokens of context replay) for `result=none` is the smoking gun that the budget was exhausted before any skill-write happened.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/background_review.py` `+27/-1`:
  - New module-level constant `_REVIEW_MAX_ITERATIONS = 16` doc comment now points to `_review_max_iterations` and explains the operator override path.
  - New `_review_max_iterations(task_cfg: Optional[Dict[str, Any]] = None) -> int` resolver mirroring `_review_input_token_budget`'s shape: config → int coercion → default-on-garbage → default-on-non-positive. Same fail-open contract so a broken config never silently disables the review.
  - `_run_review_fork` now calls `max_iterations=_review_max_iterations(task_cfg)` instead of referencing the constant directly.

- `hermes_cli/config_defaults.py` `+4/-3`:
  - `background_review` block gains `"max_iterations": 16` next to the existing `"max_input_tokens": 600000`.
  - Surrounding comment expanded to mention both budget knobs and that `<= 0` for `max_iterations` falls back to the default (mirrors the existing `<= 0` semantics for `max_input_tokens`).

- `tests/run_agent/test_background_review_max_iterations.py` `+208/-0` (new):
  - `test_review_max_iterations_resolution` (parametrized, 9 cases) — default, override, tight floor, raise-above-default, numeric-string coercion, 0, negative, garbage string, explicit null.
  - `test_review_max_iterations_resolves_via_full_config_path` — verifies the lazy `load_config_readonly` import path honours a deeply-nested config.
  - `test_review_max_iterations_resolves_via_full_config_path_default` — verifies the module default still applies when only sibling keys are set.
  - `test_run_review_fork_uses_configured_max_iterations` — wire-level assertion: the value passed to `build_cache_parity_fork` is the configured `4`, not the constant.
  - `test_run_review_fork_uses_default_when_unconfigured` — regression guard: missing key falls through to the module default.

## How to Test

```bash
cd /home/v/.hermes/hermes-agent
.venv/bin/python -m pytest tests/run_agent/test_background_review_max_iterations.py -q
# expected: 13 passed

.venv/bin/python -m pytest tests/run_agent/test_background_review.py \
                     tests/run_agent/test_background_review_input_budget.py \
                     tests/run_agent/test_background_review_cost_controls.py \
                     tests/run_agent/test_background_review_cache_parity.py \
                     tests/run_agent/test_background_review_toolset_restriction.py \
                     tests/run_agent/test_background_review_summary.py \
                     tests/test_background_review_list_shapes.py \
                     tests/test_background_review_session_isolation.py \
                     tests/agent/test_background_review_memory_scope.py \
                     tests/agent/test_skip_background_review.py -q
# expected: 79 passed (existing tests; no regressions)
```

End-to-end smoke test:

1. Set `auxiliary.background_review.max_iterations: 4` in `config.yaml`.
2. Trigger a background review (`/refine`, or run any session that completes a turn past the nudge interval).
3. Inspect `agent.log`: the `agent.background_review: Background review complete: thread=bg-review calls=N` line should report `N <= 4`, not `16`.

4. Set `auxiliary.background_review.max_iterations: 64` and verify `N <= 64`.
5. Set `auxiliary.background_review.max_iterations: 0` and verify `N == 16` (fallback to default — explicit disable-by-zero is rejected).
6. Set `auxiliary.background_review.max_iterations: "not-a-number"` and verify `N == 16` (fallback to default).

## Why this approach

- **Why mirror `_review_input_token_budget`?** It already exists with the same fail-open contract and the same `int(raw)` coercion path. Operators expect config knobs to behave the same way across the same task block; divergence here would be a footgun.
- **Why no clamp?** The previous PRs (#70213 / #87353) split on this. #87353's `[1, 64]` clamp protects against typos (e.g. `max_iterations: 1000`) but also limits legitimate use (a curator over hundreds of skills has measured need for ~120 iterations). No clamp respects operator intent; the existing fail-open on non-positive values handles the typo case (a `0` or negative falls back to the default).
- **Why not just always read `max_iterations` from the agent?** Because the background-review fork is intentionally bounded — it runs on the parent's session_id, costs full-conversation-replay tokens, and runs autonomously without human supervision. Letting it inherit the parent's `max_iterations` (typically 250) would balloon cost. The existing 16-iteration cap is the right *default*; this PR just makes it tunable.
- **Why not clamp range but allow override via env?** Env vars are a second source of truth that complicates config-driven deploys. YAML-only is consistent with the existing `auxiliary.background_review` block.

## Compatibility

- No new dependencies.
- No new config schema (the new key is added with a default, so existing configs keep working unchanged — they just didn't realise the budget was configurable).
- No new `HERMES_*` env vars.
- Existing behaviour unchanged when `auxiliary.background_review.max_iterations` is absent (resolver returns `16`, same as the previous hardcoded constant).

## Cross-references

- #70213 — earlier no-clamp proposal for the same key
- #87353 — earlier `[1, 64]`-clamped proposal for the same key
- #87250 — umbrella "make background review configurable" issue
- #108270 — `fix(agent): harden handle_max_iterations as a hard stop` (separate fix, same code path is downstream consumer)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — searched "background review", "max_iterations", "configurable", "_REVIEW_MAX_ITERATIONS"
- [x] My PR contains **only** changes related to this fix (3 files, 1 commit)
- [ ] I've run `pytest tests/ -q` and all tests pass — partial; see the test runs below
- [x] I've added tests for my changes (13 new, all wire-level / behaviour-level)
- [x] I've tested on my platform: Linux, CPython 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the resolver docstring + the `config_defaults.py` comment; no `docs/` change applies
- [x] `cli-config.yaml.example` — N/A, no new top-level config keys (the new key lives inside the existing `auxiliary.background_review` block)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform impact — N/A, no platform-conditional code
- [x] Tool descriptions/schemas — N/A, no tool surface change

### Test runs performed on this branch

```
tests/run_agent/test_background_review_max_iterations.py                                       13 passed in 4.68s
tests/run_agent/test_background_review.py +
tests/run_agent/test_background_review_input_budget.py +
tests/run_agent/test_background_review_cost_controls.py +
tests/run_agent/test_background_review_cache_parity.py +
tests/run_agent/test_background_review_toolset_restriction.py +
tests/run_agent/test_background_review_summary.py +
tests/test_background_review_list_shapes.py +
tests/test_background_review_session_isolation.py +
tests/agent/test_background_review_memory_scope.py +
tests/agent/test_skip_background_review.py                                                     79 passed in 7.17s
```

I did not run a full `tests/` tree on this branch (test collection requires optional deps I don't have in this environment: `aiohttp`, the `acp`/`gateway` stacks). The locally-run scopes above all pass cleanly.
