### PR TITLE
fix(browser): resolve the Nous gateway from the picker selection, not only use_gateway

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -573,6 +573,42 @@ class TestBackendCdpResolution:
         assert bu_cli._resolve_backend_cdp(env, "t1", session_name="r7k2") is None
         assert "BU_CDP_WS" not in env and "BU_CDP_URL" not in env
 
+    def test_picker_managed_selection_resolves_gateway_provider(self, monkeypatch):
+        """``cloud_provider: nous`` (the `hermes tools` managed row) must resolve through the
+        provider: the picker never writes the legacy ``use_gateway`` flag, and the direct-API
+        branch leaves browser_exec with no CDP endpoint at all (#108310)."""
+        import tools.browser_tool as bt  # noqa: F401 — imported for parity with sibling tests
+
+        class _BUProvider:
+            name = "browser-use"
+
+        monkeypatch.setattr("tools.browser_tool_cdp._get_cdp_override", lambda: "")
+        monkeypatch.setattr(bt_cloud, "_get_cloud_provider", lambda: _BUProvider())
+        monkeypatch.setattr(
+            bt_session, "_get_session_info",
+            lambda task_id: {"cdp_url": "wss://gateway.example/cdp/managed"},
+        )
+        monkeypatch.setattr(bu_cli, "_read_browser_cfg", lambda: {"cloud_provider": "nous"})
+        env = {}
+        assert bu_cli._resolve_backend_cdp(env, "t1") is None
+        assert env["BU_CDP_WS"] == "wss://gateway.example/cdp/managed"
+
+    def test_legacy_use_gateway_flag_still_resolves_gateway_provider(self, monkeypatch):
+        """Regression guard for the pre-picker shape of the same selection."""
+        class _BUProvider:
+            name = "browser-use"
+
+        monkeypatch.setattr("tools.browser_tool_cdp._get_cdp_override", lambda: "")
+        monkeypatch.setattr(bt_cloud, "_get_cloud_provider", lambda: _BUProvider())
+        monkeypatch.setattr(
+            bt_session, "_get_session_info",
+            lambda task_id: {"cdp_url": "wss://gateway.example/cdp/legacy"},
+        )
+        monkeypatch.setattr(bu_cli, "_read_browser_cfg", lambda: {"use_gateway": True})
+        env = {}
+        assert bu_cli._resolve_backend_cdp(env, "t1") is None
+        assert env["BU_CDP_WS"] == "wss://gateway.example/cdp/legacy"
+
 
 class TestOwnTabPreamble:
     """Named sessions on SHARED browsers (a /browser connect CDP override) get the own-tab preamble

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -179,7 +179,17 @@ def _read_browser_cfg() -> dict:
 
 
 def _use_gateway(browser_cfg: dict) -> bool:
-    return is_truthy_value(browser_cfg.get("use_gateway"), default=False)
+    """True when the browser section selects the Nous Tool Gateway — by the current ``hermes tools``
+    picker row (``cloud_provider: nous``) or the pre-picker ``use_gateway: true`` flag. Reading only
+    the legacy flag missed every picker-configured gateway, and the direct-API branch it fell into
+    holds no credentials in managed mode (#108310)."""
+    if is_truthy_value(browser_cfg.get("use_gateway"), default=False):
+        return True
+    try:
+        from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER
+    except Exception:  # pragma: no cover — helper ships with the package
+        return False
+    return str(browser_cfg.get("cloud_provider") or "").strip().lower() == NOUS_MANAGED_PROVIDER
 
 
 def get_browser_backend() -> str:
@@ -434,8 +444,9 @@ def _resolve_backend_cdp(env: dict, task_id: Optional[str], session_name: str = 
         return _resolve_local_engine_cdp(env, task_id, session_name)
 
     # Browser Use direct-API configs: the CLI talks to BU cloud natively (BU_AUTOSPAWN / auth login) — the
-    # legacy provider would create a second, redundant session. The Nous-gateway variant (use_gateway: true)
-    # DOES resolve through the provider: the gateway provisions the browser server-side and returns its CDP URL.
+    # legacy provider would create a second, redundant session. Nous-gateway configs (cloud_provider: nous
+    # from the picker, or the pre-picker use_gateway: true) DO resolve through the provider: the gateway
+    # provisions the browser server-side and returns its CDP URL.
     provider_key = str(getattr(provider, "name", "") or "").strip().lower()
     if provider_key == _BACKEND_KEY and not _use_gateway(_read_browser_cfg()):
         env[_PRIVATE_BROWSER_SENTINEL] = "1"  # named BU cloud browsers are exclusive to their daemon


### PR DESCRIPTION
## What

`browser_exec` with the **managed Nous Tool Gateway** (`browser.cloud_provider: nous`, the row the `hermes tools` picker writes) never reached the gateway's CDP endpoint: it fell into the direct-API Browser Use branch, which needs `BROWSER_USE_API_KEY` / a BU login that managed mode does not have, and then died with `fatal: chrome-not-running`.

## Why

`_resolve_backend_cdp()` deliberately skips the provider for Browser Use **direct-API** configs, and it gated that decision on `_use_gateway(_read_browser_cfg())` — a helper that only knew the pre-picker flag:

```python
def _use_gateway(browser_cfg: dict) -> bool:
    return is_truthy_value(browser_cfg.get("use_gateway"), default=False)
```

The picker writes `browser.cloud_provider: nous` (`_select_into(config, "browser", "cloud_provider", bp, managed_feature)` in `hermes_cli/tools_config_providers.py`) and never sets the legacy flag, so the managed gateway was invisible to this branch. Every plugin resolves that same selection through `read_selection(section) == NOUS_MANAGED_PROVIDER`, and `read_selection` already maps `use_gateway: true` → `"nous"` — the flag was a strict subset of the real selection, so the branch was reading the wrong source.

## Change

`_use_gateway()` now recognizes **both** shapes of the same selection: the legacy flag still returns `True`, and `cloud_provider: nous` (`NOUS_MANAGED_PROVIDER`, read from the section the function is handed — no new global state, no signature change) counts as the gateway. Direct-API configs (`cloud_provider: browser-use`) are untouched and keep the native named-daemon path, so no second session and no double billing.

Scope note: this is the **routing** half of the report (Failure 1). Failure 2 — the real-profile copy-browser dying before agent-browser attaches under `local=true` — is environment-specific and is not touched here.

## Tests

`tests/tools/test_browser_use_cli.py` (behavioural, through `_resolve_backend_cdp`):

- `test_picker_managed_selection_resolves_gateway_provider` — **RED before the change** (`KeyError: 'BU_CDP_WS'`: provider skipped, no CDP resolved), GREEN after: the provider's session CDP is exported to `BU_CDP_WS`.
- `test_legacy_use_gateway_flag_still_resolves_gateway_provider` — the pre-picker shape keeps working.
- `test_named_session_direct_api_bu_cloud_still_skips_provider` (existing) still passes: BYO BU cloud keeps the native path.

```
scripts/run_tests.sh tests/tools/test_browser_use_cli.py tests/tools/test_strict_provider_selection.py \
  tests/tools/test_managed_browserbase_and_modal.py
→ 3 files, 161 tests passed, 0 failed
```

Fixes #108310
