### PR TITLE
fix(desktop): wire local media-range so chat audio/video can seek

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -262,6 +262,7 @@ import {
 } from './managed-ssh-update'
 import { registerMcpOauthCallbackIpc } from './mcp-oauth-callback-ipc'
 import { createMediaProtocolHandler, MEDIA_PROTOCOL } from './media-protocol'
+import { fetchLocalMedia } from './media-range'
 import { createNativeAccessTokenCoordinator, NativeAuthChangedError } from './native-access-token'
 import { oauthSessionIsLive, resolveJsonBody, resolveReadinessProbeAuth } from './native-auth-decisions'
 import {
@@ -1366,13 +1367,10 @@ protocol.registerSchemesAsPrivileged([
 function registerMediaProtocol() {
   const handler = createMediaProtocolHandler({
     ensureRemoteBearer: baseUrl => ensureNativeAccessToken(baseUrl),
-    fetchLocal: (resolvedPath, headers, method) =>
-      electronNet.fetch(pathToFileURL(resolvedPath).toString(), {
-        bypassCustomProtocolHandlers: true,
-        credentials: 'omit',
-        headers,
-        method
-      }),
+    // Answer local files ourselves: Electron's file:// loader ignores Range and
+    // returns the whole body as 200 without Accept-Ranges, which makes <video>
+    // unseekable (seekable=[0,0]).
+    fetchLocal: fetchLocalMedia,
     fetchRemote: (url, headers, method) =>
       electronNet.fetch(url, {
         bypassCustomProtocolHandlers: true,

--- a/apps/desktop/electron/media-protocol.test.ts
+++ b/apps/desktop/electron/media-protocol.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
 import { describe, expect, it, vi } from 'vitest'
 
 import {
@@ -7,6 +11,7 @@ import {
   mediaRequestHeaders,
   remoteMediaEndpoint
 } from './media-protocol'
+import { fetchLocalMedia } from './media-range'
 
 function dependencies(overrides: Partial<MediaProtocolDependencies> = {}) {
   return {
@@ -72,6 +77,28 @@ describe('createMediaProtocolHandler', () => {
       const response = await createMediaProtocolHandler(deps)(request('hermes-media://remote/%2Ftmp%2Fclip.mp4'))
       expect(response.status).toBe(cookieStatus === 401 || cookieStatus === 403 ? 502 : cookieStatus)
     }
+  })
+
+  it('serves a 206 byte range through the production local fetch (seeking)', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'media-protocol-range-'))
+    const file = path.join(dir, 'clip.mp4')
+    const bytes = Buffer.from(Array.from({ length: 100 }, (_, i) => i))
+
+    await writeFile(file, bytes)
+
+    const deps = dependencies({
+      fetchLocal: fetchLocalMedia,
+      resolveLocalFile: vi.fn(async () => file)
+    })
+
+    const response = await createMediaProtocolHandler(deps)(
+      request(`hermes-media://stream/${encodeURIComponent(file)}`, { Range: 'bytes=10-19' })
+    )
+
+    expect(response.status).toBe(206)
+    expect(response.headers.get('content-range')).toBe('bytes 10-19/100')
+    expect(response.headers.get('accept-ranges')).toBe('bytes')
+    expect(Buffer.from(await response.arrayBuffer()).equals(bytes.subarray(10, 20))).toBe(true)
   })
 
   it('streams local media through the resolved local-file dependency', async () => {

--- a/apps/desktop/electron/media-range.ts
+++ b/apps/desktop/electron/media-range.ts
@@ -174,3 +174,20 @@ export async function buildLocalMediaResponse(
 
   return new Response(stream({ end: range.end, start: range.start }), { headers, status: 206 })
 }
+
+/**
+ * Production `fetchLocal` for `hermes-media://stream/…`.
+ *
+ * Electron's `file://` loader ignores `Range` and answers `200` with the whole body, so Chromium
+ * reports `video.seekable` as `[0, 0]`. Pass this into the media-protocol handler instead.
+ */
+export function fetchLocalMedia(
+  resolvedPath: string,
+  headers: Headers,
+  method: string
+): Promise<Response> {
+  return buildLocalMediaResponse(resolvedPath, {
+    method,
+    rangeHeader: headers.get('range')
+  })
+}


### PR DESCRIPTION
## Summary
- #108194 landed `media-range.ts` but `registerMediaProtocol`'s `fetchLocal` still delegated to Electron `net.fetch(file://…)`, which ignores `Range`. Long local clips stay unseekable (`video.seekable = [0,0]`; scrub snaps to 0).
- Wire `fetchLocal` through `fetchLocalMedia` / `buildLocalMediaResponse` (the hookup from #92707).
- Completes the seeking half of #108194. The fullscreen permission path is already confirmed working.

## Test plan
- [x] `vitest run --project electron electron/media-range.test.ts electron/media-protocol.test.ts` (25 passed)
- [ ] Desktop: play a long local chat video/audio, drag the progress bar — should land mid-clip instead of snapping to 0
- [ ] Native fullscreen button still works (unchanged)