### PR TITLE
fix(agent): count Responses tool output images correctly

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2099,6 +2099,10 @@ def _count_image_tokens(msg: Dict[str, Any], cost_per_image: int) -> int:
         return 0
     content = msg.get("content")
     count = _count_parts(content, {"image", "image_url", "input_image"})
+    if msg.get("type") == "function_call_output":
+        output = msg.get("output")
+        if isinstance(output, list):
+            count += sum(1 for part in output if isinstance(part, dict) and part.get("type") == "input_image")
     count += _count_parts(msg.get("_anthropic_content_blocks"), {"image"})
     # Multimodal tool results that haven't been converted yet.
     if isinstance(content, dict) and content.get("_multimodal"):
@@ -2151,6 +2155,12 @@ def _wire_message_shadow(msg: Dict[str, Any]) -> Dict[str, Any]:
             ]
         elif k == "content" and isinstance(v, dict) and v.get("_multimodal"):
             shadow[k] = v.get("text_summary", "")
+        elif k == "output" and msg.get("type") == "function_call_output" and isinstance(v, list):
+            shadow[k] = [
+                {"type": part.get("type"), "image": "[stripped]"}
+                if isinstance(part, dict) and part.get("type") == "input_image" else part
+                for part in v
+            ]
         elif k == "codex_reasoning_items":
             shadow[k] = strip_opaque_replay_items(v)
         elif k == "encrypted_content":  # a Responses reasoning/compaction item passed as a row

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -162,6 +162,18 @@ class TestEstimateMessagesTokensRough:
         # Raw base64 would be ~100K tokens; the flat per-image model is ~1.5K.
         assert estimate_messages_tokens_rough([msg]) < 5_000
 
+    def test_responses_function_call_output_image_uses_flat_cost(self):
+        item = {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": [{
+                "type": "input_image",
+                "image_url": "data:image/png;base64," + "A" * 300_000,
+            }],
+        }
+
+        assert 1_500 <= estimate_messages_tokens_rough([item]) < 2_000
+
 
 
 class TestEstimateRequestTokensRough:


### PR DESCRIPTION
## Summary

- count `input_image` parts carried by Responses `function_call_output.output` at the estimator's flat per-image cost
- strip those image payloads from the wire-message shadow so embedded base64 data is not also counted as text
- preserve conservative text counting for unrelated or malformed output shapes

## Related issue

Fixes #108320

## Changes

- `agent/model_metadata.py`: extend image counting and payload stripping to the Responses tool-output wire shape
- `tests/agent/test_model_metadata.py`: add a focused regression with a 300,000-character data URL

## Proof receipt

The same focused test was run before and after the production change:

```bash
HERMES_PYTHON=/path/to/hermes-agent/.venv/bin/python \
  scripts/run_tests.sh tests/agent/test_model_metadata.py \
  -k test_responses_function_call_output_image_uses_flat_cost -q
```

Before the fix:

```text
AssertionError: assert 75033 < 2000
1 failed, 121 deselected
```

After the fix:

```text
1 passed, 0 failed
```

`git diff --check` also passes.

## Scope and risk

The change is limited to the existing token-estimation helpers and one regression test. It does not alter Responses conversion or provider request payloads. Only the focused regression was run; the complete model-metadata suite was not run.

P0 self-review: 0 outstanding.
