### PR TITLE
fix(desktop): keep long compaction turns connected

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1508,6 +1508,9 @@ def _supported_compression_kwargs(
     return {name: value for name, value in candidates.items() if name in parameters}
 
 
+_COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL_SECONDS = 30.0
+
+
 class _CompressionActivityHeartbeat:
     """Refresh the agent inactivity tracker while compression blocks in an aux call."""
 
@@ -1521,13 +1524,19 @@ class _CompressionActivityHeartbeat:
         # so a later UNKNOWN rewrite cannot re-arm a detached zombie heartbeat.
         self._suppressed = False
         if interval_seconds is None:
-            interval_seconds = getattr(agent, "_compression_activity_heartbeat_interval", 60.0)
+            interval_seconds = getattr(
+                agent,
+                "_compression_activity_heartbeat_interval",
+                _COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL_SECONDS,
+            )
         try:
-            interval_seconds = float(interval_seconds or 60.0)
+            interval_seconds = float(
+                interval_seconds or _COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL_SECONDS
+            )
             if not math.isfinite(interval_seconds):
-                interval_seconds = 60.0
+                interval_seconds = _COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL_SECONDS
         except (TypeError, ValueError):
-            interval_seconds = 60.0
+            interval_seconds = _COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL_SECONDS
         self._interval_seconds = max(0.1, interval_seconds)
         # Only a compression that opened a VISIBLE compaction phase (the
         # routine start status was emitted) keeps it alive with heartbeats;

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -464,7 +464,7 @@ def test_compression_activity_heartbeat_nonfinite_interval_falls_back(tmp_path: 
 
     heartbeat = _CompressionActivityHeartbeat(agent, interval_seconds=float("inf"))
 
-    assert heartbeat._interval_seconds == 60.0
+    assert heartbeat._interval_seconds == _CompressionActivityHeartbeat(agent)._interval_seconds
     heartbeat.start()
     heartbeat.stop()
     assert touch_calls == ["context compression started", "context compression completed"]
@@ -474,6 +474,17 @@ def test_compression_activity_heartbeat_nonfinite_interval_falls_back(tmp_path: 
         ActivityProvenance.AGENT_COMPRESSION,
         ActivityProvenance.AGENT_COMPRESSION,
     ]
+
+
+def test_compression_heartbeat_default_beats_client_silence_deadline() -> None:
+    """Busy compression must emit before the shared client's 45s silence deadline."""
+    from types import SimpleNamespace
+
+    from agent.conversation_compression import _CompressionActivityHeartbeat
+
+    heartbeat = _CompressionActivityHeartbeat(SimpleNamespace())
+
+    assert heartbeat._interval_seconds < 45.0
 
 
 def test_compression_heartbeat_stop_persists_completed_over_in_progress(


### PR DESCRIPTION
## What does this PR do?

Long context compaction can keep the backend busy for 90 seconds or more, but the shared JSON-RPC client closes a connection after 45 seconds without an inbound frame. This change makes the existing compression progress heartbeat run every 30 seconds by default, so Desktop receives liveness before its silence deadline and does not kill a healthy in-flight turn.

### Symptom

A large session enters preflight compaction, then Desktop reports `WebSocket heartbeat acknowledgement timed out`, reconnects, and restarts the backend before compaction finishes.

### Impact

Affected sessions can repeatedly restart at the compaction threshold, interrupting every attempted turn and making the conversation unusable.

### Bug Cause

**Trigger:** `agent/conversation_compression.py:1527` / `_CompressionActivityHeartbeat.__init__`

**Causal chain:**
1. Preflight compression emits its start status and begins a long auxiliary model call.
2. The compression progress heartbeat waits 60 seconds before emitting its first status frame, while the blocked gateway loop cannot answer `gateway.ping`.
3. `JsonRpcGatewayClient` reaches its 45 second inbound-silence deadline first, closes the socket, and Desktop restarts the backend during the turn.

**Why it is wrong:** The server already emits transport-visible compression liveness, but its default cadence is longer than the shortest client deadline it must keep alive.

**Working sibling / contrast:** Normal streaming turns continuously produce inbound delta and tool frames, so they refresh the same client timestamp before the deadline.

**Ruled out:** The WebSocket send deadline is not the trigger; logs show the client initiates the disconnect after receiving no frame, and the compression heartbeat's first scheduled event is already 15 seconds too late.

### Fix

Use a named 30 second default for compression activity heartbeats and all invalid-value fallbacks. Preserve explicit per-agent intervals and the quiet context-engine contract. Add a behavior-contract test that requires the default heartbeat to beat the shared client's 45 second silence deadline.

## Related Issue
N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py` - emit default compression liveness every 30 seconds instead of every 60 seconds.
- `tests/agent/test_compression_concurrent_fork.py` - cover the client-deadline relationship and invalid interval fallback.

## How to Test

1. Start a Desktop turn whose preflight context compaction takes longer than 45 seconds.
2. Confirm `status.update` compaction frames arrive every 30 seconds and the WebSocket remains connected.
3. Run the focused automated checks:

```bash
scripts/run_tests.sh tests/agent/test_compression_concurrent_fork.py -k 'compression_activity_heartbeat_nonfinite_interval_falls_back or compression_heartbeat_default_beats_client_silence_deadline or compression_activity_heartbeat_emits_client_status_events or compression_activity_heartbeat_touches_agent_during_long_compress'
scripts/run_tests.sh tests/gateway/test_compaction_heartbeat_gateway_filter.py
```

Result: 7 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - this is a transport liveness timing fix.
