### PR TITLE
fix(cli): count credential-pool entries as a configured API key in doctor, status and config show

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1160,35 +1160,52 @@ def _pool_entry_is_explicit(entry: Any) -> bool:
     return bool(source) and (source in _EXPLICIT_POOL_SOURCES or source.startswith("manual:"))
 
 
-def pool_credential_labels() -> Dict[str, str]:
-    """Map env var name -> credential-pool label for providers holding an explicit pool entry.
+def explicit_pool_providers() -> Dict[str, Dict[str, Any]]:
+    """Provider id -> its first EXPLICIT credential-pool entry.
 
-    ``hermes auth add`` persists to the pool in ``auth.json`` and never writes ``.env``, so any
-    display that resolves a provider from env vars alone reports "(not set)" for a provider that is
-    in fact authed and serving traffic. Keyed by env var so a display row matches without a
-    hand-maintained display-name -> provider-id table. Ambient borrowed sources (gh_cli /
-    claude_code / qwen-cli) are excluded by ``_pool_entry_is_explicit``, and the pooled secret is
-    never read — only its label — so no key material can reach a caller.
+    The shared primitive behind every "is this provider actually authed?" check. ``hermes auth add``
+    persists to the pool in ``auth.json`` and never writes ``.env``, so anything that judges auth
+    from env vars alone reports a missing key for a provider that is serving traffic. Ambient
+    borrowed sources (gh_cli / claude_code / qwen-cli) are excluded by ``_pool_entry_is_explicit``,
+    so a pool the user never set up cannot green-light a check.
 
-    Consumed by ``hermes status`` (``status_auth._render_api_keys``) and ``hermes config show``
-    (``config.show_config``). Never raises: an unreadable store yields what was collected so far.
+    Consumed by ``hermes doctor`` (``doctor_config.pooled_credential_providers``) and, via
+    :func:`pool_credential_labels`, by ``hermes status`` and ``hermes config show``.
+    Never raises: an unreadable store yields ``{}``.
     """
-    labels: Dict[str, str] = {}
+    found: Dict[str, Dict[str, Any]] = {}
     try:
         pool = read_credential_pool()
         for provider_id, entries in (pool.items() if isinstance(pool, dict) else ()):
-            explicit = [e for e in entries if _pool_entry_is_explicit(e)] if isinstance(entries, list) else []
-            if not explicit:
+            if not isinstance(entries, list):
                 continue
+            entry = next((e for e in entries if _pool_entry_is_explicit(e)), None)
+            if entry is not None:
+                found[provider_id] = entry
+    except Exception as e:
+        logger.debug("Could not read the credential pool: %s", e)
+    return found
+
+
+def pool_credential_labels() -> Dict[str, str]:
+    """Map env var name -> credential-pool label for providers holding an explicit pool entry.
+
+    Keyed by env var so a display row matches without a hand-maintained display-name ->
+    provider-id table. The pooled secret is never read — only its label — so no key material can
+    reach a caller. Never raises; a provider whose config cannot be resolved is skipped.
+    """
+    labels: Dict[str, str] = {}
+    for provider_id, entry in explicit_pool_providers().items():
+        try:
             pconfig = PROVIDER_REGISTRY.get(provider_id)
             if pconfig is None:
                 from hermes_cli.providers import get_provider
                 pconfig = get_provider(provider_id)
-            label = str(explicit[0].get("label") or provider_id).strip() or provider_id
+            label = str(entry.get("label") or provider_id).strip() or provider_id
             for env_var in getattr(pconfig, "api_key_env_vars", ()) or ():
                 labels.setdefault(env_var, label)
-    except Exception as e:
-        logger.debug("Could not read credential pool labels: %s", e)
+        except Exception as e:
+            logger.debug("Could not map pool labels for %s: %s", provider_id, e)
     return labels
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1160,6 +1160,38 @@ def _pool_entry_is_explicit(entry: Any) -> bool:
     return bool(source) and (source in _EXPLICIT_POOL_SOURCES or source.startswith("manual:"))
 
 
+def pool_credential_labels() -> Dict[str, str]:
+    """Map env var name -> credential-pool label for providers holding an explicit pool entry.
+
+    ``hermes auth add`` persists to the pool in ``auth.json`` and never writes ``.env``, so any
+    display that resolves a provider from env vars alone reports "(not set)" for a provider that is
+    in fact authed and serving traffic. Keyed by env var so a display row matches without a
+    hand-maintained display-name -> provider-id table. Ambient borrowed sources (gh_cli /
+    claude_code / qwen-cli) are excluded by ``_pool_entry_is_explicit``, and the pooled secret is
+    never read — only its label — so no key material can reach a caller.
+
+    Consumed by ``hermes status`` (``status_auth._render_api_keys``) and ``hermes config show``
+    (``config.show_config``). Never raises: an unreadable store yields what was collected so far.
+    """
+    labels: Dict[str, str] = {}
+    try:
+        pool = read_credential_pool()
+        for provider_id, entries in (pool.items() if isinstance(pool, dict) else ()):
+            explicit = [e for e in entries if _pool_entry_is_explicit(e)] if isinstance(entries, list) else []
+            if not explicit:
+                continue
+            pconfig = PROVIDER_REGISTRY.get(provider_id)
+            if pconfig is None:
+                from hermes_cli.providers import get_provider
+                pconfig = get_provider(provider_id)
+            label = str(explicit[0].get("label") or provider_id).strip() or provider_id
+            for env_var in getattr(pconfig, "api_key_env_vars", ()) or ():
+                labels.setdefault(env_var, label)
+    except Exception as e:
+        logger.debug("Could not read credential pool labels: %s", e)
+    return labels
+
+
 def _keyless_provider_has_explicit_config(normalized: str) -> bool:
     """Vertex / Bedrock count as explicit when Hermes-scoped routing config is present.
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2894,10 +2894,21 @@ def show_config():
     print(f"  Install:      {get_project_root()}")
 
     _section("API Keys")
+    from hermes_cli.auth import PROVIDER_REGISTRY, get_anthropic_key, pool_credential_labels
+    # A credential added via `hermes auth add` lives in the auth.json pool, not .env — without this
+    # fallback an authed provider prints "(not set)". Only the label is read, never the secret.
+    pool_labels = pool_credential_labels()
+
+    def _api_key_display(value: str, env_keys) -> str:
+        if value:
+            return redact_key(value)
+        label = next((pool_labels[k] for k in env_keys if k in pool_labels), "")
+        return f"credential pool ({label})" if label else redact_key("")
+
     for env_key, name in _SHOW_CONFIG_API_KEYS:
-        print(f"  {name:<14} {redact_key(get_env_value(env_key))}")
-    from hermes_cli.auth import get_anthropic_key
-    print(f"  {'Anthropic':<14} {redact_key(get_anthropic_key())}")
+        print(f"  {name:<14} {_api_key_display(get_env_value(env_key), (env_key,))}")
+    anthropic_env = PROVIDER_REGISTRY["anthropic"].api_key_env_vars
+    print(f"  {'Anthropic':<14} {_api_key_display(get_anthropic_key(), anthropic_env)}")
 
     _show_model_section(config)
     _show_display_section(config)

--- a/hermes_cli/doctor_config.py
+++ b/hermes_cli/doctor_config.py
@@ -17,6 +17,24 @@ def _has_provider_env_config(content: str) -> bool:
     return any(key in content for key in _PROVIDER_ENV_HINTS)
 
 
+def pooled_credential_providers() -> list[str]:
+    """Provider ids that hold an explicit credential-pool entry in ``auth.json``.
+
+    ``hermes auth add`` persists to the pool and never writes ``.env``, so a credential added that
+    way is invisible to :func:`_has_provider_env_config` and an env-only check reports a missing API
+    key on an install that is fully authed. Ambient borrowed sources (gh_cli / claude_code / qwen-cli)
+    are excluded by ``_pool_entry_is_explicit``, so this cannot green-light a pool the user never set
+    up. A store that fails to read degrades to "found nothing" rather than failing the check."""
+    providers: list[str] = []
+    with warn_on_error(""):
+        from hermes_cli.auth import _pool_entry_is_explicit, read_credential_pool
+        pool = read_credential_pool()
+        providers = sorted(
+            pid for pid, entries in (pool.items() if isinstance(pool, dict) else ())
+            if isinstance(entries, list) and any(_pool_entry_is_explicit(e) for e in entries))
+    return providers
+
+
 # Legacy config keys still read for back-compat: warn-only with the modern replacement, never auto-migrated
 # (migrations live in config.py). (section, key, replacement)
 _DEPRECATED_CONFIG_KEYS: tuple[tuple[str, str, str], ...] = (
@@ -141,7 +159,12 @@ def _check_env_file(should_fix: bool, f: Finding) -> None:
             content = env_path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             content = env_path.read_text(encoding="latin-1")
-        if not check_bool(_has_provider_env_config(content), "API key or custom endpoint configured", f"No API key found in {_DHH}/.env"):
+        if _has_provider_env_config(content):
+            check_ok("API key or custom endpoint configured")
+        elif pooled := pooled_credential_providers():
+            check_ok("API key configured in the credential pool", f"({', '.join(pooled)})")
+        else:
+            check_warn(f"No API key found in {_DHH}/.env or the credential pool")
             f.issues.append("Run 'hermes setup' to configure API keys")
     elif (PROJECT_ROOT / '.env').exists():  # project root as fallback
         check_ok(".env file exists (in project directory)")

--- a/hermes_cli/doctor_config.py
+++ b/hermes_cli/doctor_config.py
@@ -22,16 +22,13 @@ def pooled_credential_providers() -> list[str]:
 
     ``hermes auth add`` persists to the pool and never writes ``.env``, so a credential added that
     way is invisible to :func:`_has_provider_env_config` and an env-only check reports a missing API
-    key on an install that is fully authed. Ambient borrowed sources (gh_cli / claude_code / qwen-cli)
-    are excluded by ``_pool_entry_is_explicit``, so this cannot green-light a pool the user never set
-    up. A store that fails to read degrades to "found nothing" rather than failing the check."""
+    key on an install that is fully authed. Resolution (including the exclusion of ambient borrowed
+    sources) lives in ``auth.explicit_pool_providers``; a store that fails to read degrades to
+    "found nothing" rather than failing the check."""
     providers: list[str] = []
     with warn_on_error(""):
-        from hermes_cli.auth import _pool_entry_is_explicit, read_credential_pool
-        pool = read_credential_pool()
-        providers = sorted(
-            pid for pid, entries in (pool.items() if isinstance(pool, dict) else ())
-            if isinstance(entries, list) and any(_pool_entry_is_explicit(e) for e in entries))
+        from hermes_cli.auth import explicit_pool_providers
+        providers = sorted(explicit_pool_providers())
     return providers
 
 

--- a/hermes_cli/status_auth.py
+++ b/hermes_cli/status_auth.py
@@ -56,6 +56,49 @@ _API_KEYS: dict[str, str | tuple[str, ...]] = {
     "Browserbase": "BROWSERBASE_API_KEY",  # Optional — direct credentials only
     "FAL": "FAL_KEY", "ElevenLabs": "ELEVENLABS_API_KEY", "GitHub": "GITHUB_TOKEN"}
 
+def _pool_credential_labels() -> dict[str, str]:
+    """Map env var name -> credential-pool label for providers holding an explicit pool entry.
+
+    ``hermes auth add`` persists to the pool in ``auth.json`` and never writes ``.env``, so a row
+    resolved purely from env vars renders "(not set)" for a provider that is in fact authed and
+    serving traffic. Keyed by env var so a row matches without a hand-maintained display-name ->
+    provider-id table. Ambient borrowed sources (gh_cli / claude_code / qwen-cli) are excluded by
+    ``_pool_entry_is_explicit``, and the pooled secret itself is never read — only its label.
+    """
+    labels: dict[str, str] = {}
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY, _pool_entry_is_explicit, read_credential_pool
+        pool = read_credential_pool()
+        for provider_id, entries in (pool.items() if isinstance(pool, dict) else ()):
+            explicit = [e for e in entries if _pool_entry_is_explicit(e)] if isinstance(entries, list) else []
+            if not explicit:
+                continue
+            pconfig = PROVIDER_REGISTRY.get(provider_id)
+            if pconfig is None:
+                from hermes_cli.providers import get_provider
+                pconfig = get_provider(provider_id)
+            label = str(explicit[0].get("label") or provider_id).strip() or provider_id
+            for env_var in getattr(pconfig, "api_key_env_vars", ()) or ():
+                labels.setdefault(env_var, label)
+    except Exception:
+        pass  # a read-only status display must never fail on an unreadable auth store
+    return labels
+
+
+def _row_env_vars(name: str, env_ref) -> tuple[str, ...]:
+    """Env vars behind one API-key row. Anthropic resolves through ``get_anthropic_key``, so its
+    vars come from the registry the same way that helper reads them."""
+    if isinstance(env_ref, str):
+        return (env_ref,)
+    if isinstance(env_ref, (tuple, list)):
+        return tuple(env_ref)
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        return tuple(PROVIDER_REGISTRY["anthropic"].api_key_env_vars) if name == "Anthropic" else ()
+    except Exception:
+        return ()
+
+
 # OAuth detail rows: (label, status key, formatter, gate) — see _oauth_block.
 _FILE_REFRESH_ROWS = (
     ("Auth file:", "auth_store", None, None),
@@ -90,10 +133,16 @@ _FEATURE_STATES = (
 def _render_api_keys(ctx):
     _status._section("API Keys")
     from hermes_cli.auth import get_anthropic_key
+    pool_labels = _pool_credential_labels()
     # Anthropic uses the dedicated lookup (it also resolves OAuth tokens).
     for name, env_ref in (*_API_KEYS.items(), ("Anthropic", get_anthropic_key)):
         value = env_ref() if callable(env_ref) else _status._first_env_value(env_ref)
-        _status._row(name, bool(value), config.redact_key(value))
+        if value:
+            _status._row(name, True, config.redact_key(value))
+            continue
+        # No env credential: the provider may still be authed via the credential pool.
+        label = next((pool_labels[var] for var in _row_env_vars(name, env_ref) if var in pool_labels), "")
+        _status._row(name, bool(label), f"credential pool ({label})" if label else config.redact_key(""))
 
 
 def _render_auth_providers(ctx):

--- a/hermes_cli/status_auth.py
+++ b/hermes_cli/status_auth.py
@@ -4,7 +4,7 @@ module object so tests that monkeypatch that module keep working."""
 
 from datetime import datetime, timezone
 
-from hermes_cli.auth import AuthError
+from hermes_cli.auth import AuthError, pool_credential_labels
 from hermes_cli.nous_account import (
     format_nous_portal_entitlement_message, get_nous_portal_account_info)
 from hermes_cli.nous_subscription import get_nous_subscription_features
@@ -56,35 +56,6 @@ _API_KEYS: dict[str, str | tuple[str, ...]] = {
     "Browserbase": "BROWSERBASE_API_KEY",  # Optional — direct credentials only
     "FAL": "FAL_KEY", "ElevenLabs": "ELEVENLABS_API_KEY", "GitHub": "GITHUB_TOKEN"}
 
-def _pool_credential_labels() -> dict[str, str]:
-    """Map env var name -> credential-pool label for providers holding an explicit pool entry.
-
-    ``hermes auth add`` persists to the pool in ``auth.json`` and never writes ``.env``, so a row
-    resolved purely from env vars renders "(not set)" for a provider that is in fact authed and
-    serving traffic. Keyed by env var so a row matches without a hand-maintained display-name ->
-    provider-id table. Ambient borrowed sources (gh_cli / claude_code / qwen-cli) are excluded by
-    ``_pool_entry_is_explicit``, and the pooled secret itself is never read — only its label.
-    """
-    labels: dict[str, str] = {}
-    try:
-        from hermes_cli.auth import PROVIDER_REGISTRY, _pool_entry_is_explicit, read_credential_pool
-        pool = read_credential_pool()
-        for provider_id, entries in (pool.items() if isinstance(pool, dict) else ()):
-            explicit = [e for e in entries if _pool_entry_is_explicit(e)] if isinstance(entries, list) else []
-            if not explicit:
-                continue
-            pconfig = PROVIDER_REGISTRY.get(provider_id)
-            if pconfig is None:
-                from hermes_cli.providers import get_provider
-                pconfig = get_provider(provider_id)
-            label = str(explicit[0].get("label") or provider_id).strip() or provider_id
-            for env_var in getattr(pconfig, "api_key_env_vars", ()) or ():
-                labels.setdefault(env_var, label)
-    except Exception:
-        pass  # a read-only status display must never fail on an unreadable auth store
-    return labels
-
-
 def _row_env_vars(name: str, env_ref) -> tuple[str, ...]:
     """Env vars behind one API-key row. Anthropic resolves through ``get_anthropic_key``, so its
     vars come from the registry the same way that helper reads them."""
@@ -133,7 +104,7 @@ _FEATURE_STATES = (
 def _render_api_keys(ctx):
     _status._section("API Keys")
     from hermes_cli.auth import get_anthropic_key
-    pool_labels = _pool_credential_labels()
+    pool_labels = pool_credential_labels()
     # Anthropic uses the dedicated lookup (it also resolves OAuth tokens).
     for name, env_ref in (*_API_KEYS.items(), ("Anthropic", get_anthropic_key)):
         value = env_ref() if callable(env_ref) else _status._first_env_value(env_ref)

--- a/tests/hermes_cli/test_api_key_pool_display.py
+++ b/tests/hermes_cli/test_api_key_pool_display.py
@@ -5,7 +5,8 @@ Three displays resolved providers from env vars alone and so rendered "(not set)
 that was authed and serving traffic: ``hermes doctor`` (see tests/hermes_cli/test_doctor.py),
 ``hermes status`` (see tests/hermes_cli/test_status.py), and ``hermes config show`` here.
 
-``pool_credential_labels`` is the shared resolver behind the latter two.
+``auth.explicit_pool_providers`` is the one resolver behind all three; ``pool_credential_labels``
+adds the env-var keying the two display sites need.
 """
 
 import pytest
@@ -30,6 +31,67 @@ def _set_pool(monkeypatch, pool):
         monkeypatch.setattr(auth_mod, "read_credential_pool", boom)
     else:
         monkeypatch.setattr(auth_mod, "read_credential_pool", lambda provider_id=None: pool)
+
+
+class TestExplicitPoolProviders:
+    """The shared primitive: which providers hold a credential the user deliberately added."""
+
+    def test_returns_the_first_explicit_entry_per_provider(self, monkeypatch):
+        from hermes_cli.auth import explicit_pool_providers
+
+        _set_pool(monkeypatch, {"anthropic": [
+            {"source": "claude_code", "label": "Ambient"},
+            {"source": "manual", "label": "First explicit"},
+            {"source": "manual", "label": "Second explicit"}]})
+
+        assert explicit_pool_providers()["anthropic"]["label"] == "First explicit"
+
+    def test_providers_with_only_ambient_entries_are_omitted(self, monkeypatch):
+        from hermes_cli.auth import explicit_pool_providers
+
+        _set_pool(monkeypatch, {
+            "anthropic": [{"source": "claude_code"}], "copilot": [{"source": "gh_cli"}],
+            "zai": [{"source": "device_code"}]})
+
+        assert sorted(explicit_pool_providers()) == ["zai"]
+
+    def test_malformed_provider_slices_are_skipped(self, monkeypatch):
+        from hermes_cli.auth import explicit_pool_providers
+
+        _set_pool(monkeypatch, {"anthropic": "not-a-list", "zai": [{"source": "manual"}]})
+
+        assert sorted(explicit_pool_providers()) == ["zai"]
+
+    def test_unreadable_store_yields_nothing_instead_of_raising(self, monkeypatch):
+        from hermes_cli.auth import explicit_pool_providers
+
+        _set_pool(monkeypatch, OSError("auth.json unreadable"))
+
+        assert explicit_pool_providers() == {}
+
+
+class TestDoctorAndDisplaysShareOneResolver:
+    """doctor, status and config must agree — they now resolve through the same primitive."""
+
+    def test_doctor_sees_what_the_displays_see(self, monkeypatch):
+        from hermes_cli.auth import pool_credential_labels
+        from hermes_cli.doctor_config import pooled_credential_providers
+
+        _set_pool(monkeypatch, {
+            "anthropic": [{"source": "manual", "label": "Agentic"}],
+            "openrouter": [{"source": "claude_code", "label": "Ambient"}]})
+
+        assert pooled_credential_providers() == ["anthropic"]
+        assert pool_credential_labels()["ANTHROPIC_API_KEY"] == "Agentic"
+
+    def test_both_go_quiet_on_an_unreadable_store(self, monkeypatch):
+        from hermes_cli.auth import pool_credential_labels
+        from hermes_cli.doctor_config import pooled_credential_providers
+
+        _set_pool(monkeypatch, OSError("auth.json unreadable"))
+
+        assert pooled_credential_providers() == []
+        assert pool_credential_labels() == {}
 
 
 class TestPoolCredentialLabels:

--- a/tests/hermes_cli/test_api_key_pool_display.py
+++ b/tests/hermes_cli/test_api_key_pool_display.py
@@ -1,0 +1,130 @@
+"""API-key displays must count credential-pool entries, not just .env.
+
+``hermes auth add`` persists a credential to the pool in ``auth.json`` and never writes ``.env``.
+Three displays resolved providers from env vars alone and so rendered "(not set)" for a provider
+that was authed and serving traffic: ``hermes doctor`` (see tests/hermes_cli/test_doctor.py),
+``hermes status`` (see tests/hermes_cli/test_status.py), and ``hermes config show`` here.
+
+``pool_credential_labels`` is the shared resolver behind the latter two.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def clean_anthropic_env(monkeypatch, tmp_path):
+    """No Anthropic credential in either ``.env`` or the process env."""
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for var in PROVIDER_REGISTRY["anthropic"].api_key_env_vars:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _set_pool(monkeypatch, pool):
+    import hermes_cli.auth as auth_mod
+
+    if isinstance(pool, Exception):
+        def boom(provider_id=None):
+            raise pool
+        monkeypatch.setattr(auth_mod, "read_credential_pool", boom)
+    else:
+        monkeypatch.setattr(auth_mod, "read_credential_pool", lambda provider_id=None: pool)
+
+
+class TestPoolCredentialLabels:
+    def test_maps_provider_env_vars_to_its_pool_label(self, monkeypatch):
+        from hermes_cli.auth import pool_credential_labels
+
+        _set_pool(monkeypatch, {"anthropic": [{"source": "manual", "label": "Agentic"}]})
+
+        assert pool_credential_labels()["ANTHROPIC_API_KEY"] == "Agentic"
+
+    def test_falls_back_to_provider_id_when_entry_has_no_label(self, monkeypatch):
+        from hermes_cli.auth import pool_credential_labels
+
+        _set_pool(monkeypatch, {"anthropic": [{"source": "manual", "label": "   "}]})
+
+        assert pool_credential_labels()["ANTHROPIC_API_KEY"] == "anthropic"
+
+    def test_ambient_borrowed_entries_are_excluded(self, monkeypatch):
+        from hermes_cli.auth import pool_credential_labels
+
+        _set_pool(monkeypatch, {"anthropic": [{"source": "claude_code", "label": "Claude Code"}]})
+
+        assert pool_credential_labels() == {}
+
+    def test_first_explicit_entry_wins_for_a_shared_env_var(self, monkeypatch):
+        from hermes_cli.auth import pool_credential_labels
+
+        _set_pool(monkeypatch, {"anthropic": [
+            {"source": "manual", "label": "First"}, {"source": "manual", "label": "Second"}]})
+
+        assert pool_credential_labels()["ANTHROPIC_API_KEY"] == "First"
+
+    def test_unreadable_store_yields_no_labels_instead_of_raising(self, monkeypatch):
+        from hermes_cli.auth import pool_credential_labels
+
+        _set_pool(monkeypatch, OSError("auth.json unreadable"))
+
+        assert pool_credential_labels() == {}
+
+    def test_pooled_secret_is_never_returned(self, monkeypatch):
+        from hermes_cli.auth import pool_credential_labels
+
+        sentinel = "NONSECRET_SENTINEL_POOL_VALUE_DO_NOT_RETURN_123456"
+        _set_pool(monkeypatch, {
+            "anthropic": [{"source": "manual", "label": "Agentic", "api_key": sentinel}]})
+
+        assert sentinel not in str(pool_credential_labels())
+
+
+class TestShowConfigApiKeys:
+    """``hermes config show`` — the third copy of the env-only API-Keys rendering."""
+
+    @staticmethod
+    def _anthropic_row(out):
+        return next(line for line in out.splitlines() if "Anthropic" in line)
+
+    def test_pool_only_credential_renders_as_configured(
+            self, monkeypatch, capsys, clean_anthropic_env):
+        from hermes_cli.config import show_config
+
+        _set_pool(monkeypatch, {"anthropic": [{"source": "manual", "label": "Agentic"}]})
+        show_config()
+
+        row = self._anthropic_row(capsys.readouterr().out)
+        assert "credential pool (Agentic)" in row
+        assert "(not set)" not in row
+
+    def test_env_value_takes_precedence_over_pool_label(
+            self, monkeypatch, capsys, clean_anthropic_env):
+        from hermes_cli.config import show_config
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-env-value-not-a-real-key")
+        _set_pool(monkeypatch, {"anthropic": [{"source": "manual", "label": "Agentic"}]})
+        show_config()
+
+        row = self._anthropic_row(capsys.readouterr().out)
+        assert "credential pool" not in row
+        assert "sk-ant-env-value-not-a-real-key" not in row
+
+    def test_pooled_secret_value_is_never_printed(
+            self, monkeypatch, capsys, clean_anthropic_env):
+        from hermes_cli.config import show_config
+
+        sentinel = "NONSECRET_SENTINEL_POOL_VALUE_DO_NOT_PRINT_123456"
+        _set_pool(monkeypatch, {
+            "anthropic": [{"source": "manual", "label": "Agentic", "api_key": sentinel}]})
+        show_config()
+
+        assert sentinel not in capsys.readouterr().out
+
+    def test_unpooled_provider_still_reads_not_set(
+            self, monkeypatch, capsys, clean_anthropic_env):
+        from hermes_cli.config import show_config
+
+        _set_pool(monkeypatch, {})
+        show_config()
+
+        assert "(not set)" in self._anthropic_row(capsys.readouterr().out)

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -23,6 +23,7 @@ from hermes_cli import doctor_tools
 from hermes_cli import doctor_state
 from hermes_cli import doctor_platform
 from hermes_cli import doctor_config
+from hermes_cli import auth as auth_mod
 from tools import browser_tool_install as bt_install
 
 
@@ -75,6 +76,56 @@ class TestProviderEnvDetection:
     def test_returns_false_when_no_provider_settings(self):
         content = "TERMINAL_ENV=local\n"
         assert not _has_provider_env_config(content)
+
+
+class TestPooledCredentialDetection:
+    """`hermes auth add` persists to the auth.json credential pool and never writes .env, so the
+    env-only check used to report "No API key found" on a fully-authed install."""
+
+    def test_lists_providers_with_explicit_pool_entries(self, monkeypatch):
+        monkeypatch.setattr(auth_mod, "read_credential_pool", lambda provider_id=None: {
+            "zai": [{"source": "device_code"}],
+            "anthropic": [{"source": "manual", "label": "Agentic", "priority": 0}],
+        })
+
+        assert doctor_config.pooled_credential_providers() == ["anthropic", "zai"]
+
+    def test_ignores_ambient_borrowed_credentials(self, monkeypatch):
+        monkeypatch.setattr(auth_mod, "read_credential_pool", lambda provider_id=None: {
+            "anthropic": [{"source": "claude_code"}], "copilot": [{"source": "gh_cli"}],
+        })
+
+        assert doctor_config.pooled_credential_providers() == []
+
+    def test_unreadable_store_reports_nothing_instead_of_raising(self, monkeypatch):
+        def boom(provider_id=None):
+            raise OSError("auth.json unreadable")
+
+        monkeypatch.setattr(auth_mod, "read_credential_pool", boom)
+
+        assert doctor_config.pooled_credential_providers() == []
+
+    def test_env_check_accepts_a_pool_only_credential(self, monkeypatch, tmp_path, capsys):
+        (tmp_path / ".env").write_text("TERMINAL_ENV=local\n")
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", tmp_path)
+        monkeypatch.setattr(doctor_config, "pooled_credential_providers", lambda: ["anthropic"])
+
+        finding = doctor_config._check_env_file(False)
+
+        out = capsys.readouterr().out
+        assert "API key configured in the credential pool" in out
+        assert "No API key found" not in out
+        assert finding.issues == []
+
+    def test_env_check_still_warns_when_the_pool_is_empty_too(self, monkeypatch, tmp_path, capsys):
+        (tmp_path / ".env").write_text("TERMINAL_ENV=local\n")
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", tmp_path)
+        monkeypatch.setattr(doctor_config, "pooled_credential_providers", lambda: [])
+
+        finding = doctor_config._check_env_file(False)
+
+        assert "No API key found" in capsys.readouterr().out
+        assert finding.issues == ["Run 'hermes setup' to configure API keys"]
 
 
 class TestDoctorToolAvailabilitySummary:

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -250,3 +250,75 @@ def test_show_status_reports_gateway_session_last_activity(monkeypatch, capsys, 
     assert "Active:       2 session(s)" in output
     assert "Last activity:" in output
     assert "1m ago" in output
+
+
+class TestApiKeyCredentialPoolFallback:
+    """`hermes auth add` persists to the auth.json credential pool and never writes .env, so a row
+    resolved from env vars alone rendered "(not set)" for a provider that was actively serving."""
+
+    @staticmethod
+    def _clean_anthropic_env(monkeypatch, tmp_path):
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for var in PROVIDER_REGISTRY["anthropic"].api_key_env_vars:
+            monkeypatch.delenv(var, raising=False)
+
+    @staticmethod
+    def _render(monkeypatch, pool):
+        import hermes_cli.auth as auth_mod
+        from hermes_cli import status_auth
+
+        if isinstance(pool, Exception):
+            def boom(provider_id=None):
+                raise pool
+            monkeypatch.setattr(auth_mod, "read_credential_pool", boom)
+        else:
+            monkeypatch.setattr(auth_mod, "read_credential_pool", lambda provider_id=None: pool)
+        status_auth._render_api_keys(SimpleNamespace())
+
+    def _anthropic_row(self, out):
+        return next(line for line in out.splitlines() if "Anthropic" in line)
+
+    def test_pool_only_provider_renders_as_configured(self, monkeypatch, capsys, tmp_path):
+        self._clean_anthropic_env(monkeypatch, tmp_path)
+        self._render(monkeypatch, {"anthropic": [{"source": "manual", "label": "Agentic"}]})
+
+        row = self._anthropic_row(capsys.readouterr().out)
+        assert "credential pool (Agentic)" in row
+        assert "(not set)" not in row
+
+    def test_env_value_takes_precedence_over_pool_label(self, monkeypatch, capsys, tmp_path):
+        self._clean_anthropic_env(monkeypatch, tmp_path)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-env-value-not-a-real-key")
+        self._render(monkeypatch, {"anthropic": [{"source": "manual", "label": "Agentic"}]})
+
+        row = self._anthropic_row(capsys.readouterr().out)
+        assert "credential pool" not in row
+        assert "sk-ant-env-value-not-a-real-key" not in row
+
+    def test_ambient_borrowed_pool_entry_stays_not_set(self, monkeypatch, capsys, tmp_path):
+        self._clean_anthropic_env(monkeypatch, tmp_path)
+        self._render(monkeypatch, {"anthropic": [{"source": "claude_code", "label": "Claude Code"}]})
+
+        row = self._anthropic_row(capsys.readouterr().out)
+        assert "(not set)" in row
+        assert "credential pool" not in row
+
+    def test_pooled_secret_value_is_never_printed(self, monkeypatch, capsys, tmp_path):
+        self._clean_anthropic_env(monkeypatch, tmp_path)
+        sentinel = "NONSECRET_SENTINEL_POOL_VALUE_DO_NOT_PRINT_123456"
+        self._render(monkeypatch, {
+            "anthropic": [{"source": "manual", "label": "Agentic", "api_key": sentinel}]})
+
+        out = capsys.readouterr().out
+        assert "credential pool (Agentic)" in out
+        assert sentinel not in out
+
+    def test_unreadable_pool_does_not_break_the_section(self, monkeypatch, capsys, tmp_path):
+        self._clean_anthropic_env(monkeypatch, tmp_path)
+        self._render(monkeypatch, OSError("auth.json unreadable"))
+
+        out = capsys.readouterr().out
+        assert "API Keys" in out
+        assert "(not set)" in self._anthropic_row(out)


### PR DESCRIPTION
## Summary

`hermes auth add` persists a credential to the pool in `auth.json` and never writes `.env`. Three
displays resolved "is this provider configured?" from environment variables alone, so a provider
that was authed and actively serving traffic rendered as not configured:

- `hermes doctor` — `✗ No API key found in ~/.hermes/.env`, plus the misleading remediation
  "Run 'hermes setup' to configure API keys"
- `hermes status` — `Anthropic    ✗ (not set)`
- `hermes config show` — `Anthropic      (not set)`

`hermes doctor` is the worst of the three: it tells a correctly-configured user their install is
broken and sends them to re-run setup.

Reproduce on current `main` with a pool-only credential:

```bash
hermes auth add anthropic     # writes auth.json, not .env
grep ANTHROPIC ~/.hermes/.env # nothing
hermes auth list anthropic    # the credential is there and in use
hermes doctor                 # "No API key found"
hermes status                 # "Anthropic  ✗ (not set)"
hermes config show            # "Anthropic  (not set)"
```

## Where it manifests

| Site | Line before this PR |
|---|---|
| `hermes_cli/doctor_config.py` | `_check_env_file` judged auth from `_has_provider_env_config(content)` — a substring scan of `.env` text |
| `hermes_cli/status_auth.py` | `_render_api_keys` passed `bool(value)` from `_first_env_value(env_ref)` straight to `_row` |
| `hermes_cli/config.py` | `show_config` printed `redact_key(get_env_value(env_key))` per row |

Each one reads a different source and none of them consults the credential pool.

## Changes

One resolver, three consumers — rather than a pool lookup pasted into three call sites:

- `hermes_cli/auth.py` — `explicit_pool_providers()` maps provider id → its first *explicit* pool
  entry. `pool_credential_labels()` re-keys that by env var name, so a display row can match
  without a hand-maintained display-name → provider-id table.
- `hermes_cli/doctor_config.py` — `pooled_credential_providers()` wraps the resolver; the check
  now reports `API key configured in the credential pool (anthropic)` instead of warning.
- `hermes_cli/status_auth.py` and `hermes_cli/config.py` — fall back to the pool label only when
  no env credential exists.

Three properties worth calling out:

- **Ambient borrowed credentials cannot green-light a check.** `_pool_entry_is_explicit` already
  excludes `gh_cli` / `claude_code` / `qwen-cli` sources, so a pool the user never deliberately
  set up still reads as unconfigured. This is why the resolver reuses that predicate instead of
  testing for a non-empty pool.
- **No secret can reach a display.** Only `label` is read off the entry, never the key material.
  `test_pooled_secret_is_never_returned` and `test_pooled_secret_value_is_never_printed` pin this
  with a sentinel.
- **Env keeps precedence.** An env credential still renders its redacted value; the pool is a
  fallback, not an override.

## Tests

`tests/hermes_cli/test_api_key_pool_display.py` (new) plus additions to `test_doctor.py` and
`test_status.py`. All are behavior contracts, not snapshots — they assert how the pool store and
the rendered row relate, including that `doctor`, `status` and `config show` agree because they
share one resolver (`test_doctor_sees_what_the_displays_see`), and that all three degrade to
"found nothing" rather than raising on an unreadable `auth.json`.

```
$ scripts/run_tests.sh tests/hermes_cli/test_api_key_pool_display.py \
    tests/hermes_cli/test_doctor.py tests/hermes_cli/test_status.py tests/hermes_cli/test_config.py
=== Summary: 4 files, 229 tests passed, 0 failed, 4 skipped (100% complete) in 18.1s ===
```

The four new test classes were confirmed red on unfixed `main` before the fix: with only the test
files applied to `origin/main`, 20 of the new assertions fail (13 in
`test_api_key_pool_display.py`, 5 in `test_doctor.py::TestPooledCredentialDetection`, 2 in
`test_status.py::TestApiKeyCredentialPoolFallback`) while every pre-existing test in those files
still passes.

## Related

Fixes #60106 (the `hermes status` half of this, reported against OpenRouter).

#60135 is an earlier open PR covering the same issue for `status` only. It edits `hermes_cli/status.py`
(pre-decomposition), adds a `_pool_ids` display-name → provider-id table, and checks the pool
without the explicit/ambient distinction, so a borrowed `gh_cli` entry would report as configured.
This PR covers all three surfaces and routes them through one resolver; happy to defer or rebase
onto that work if the maintainers prefer it — @AlexFucuson9's report identified the bug first.

## Notes

Scope deliberately excludes a separate httpx2 security pin I also had locally, since #107441
already covers it as a strict superset (it also fixes `tools/lazy_deps.py`, which my local version
missed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
