### PR TITLE
fix(desktop): define --titlebar-height at app shell and stylesheet default (#108181)

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -139,6 +139,7 @@ import { PluginInstallModal } from '../settings/plugin-install-modal'
 import { useOverlayRouting } from '../shell/hooks/use-overlay-routing'
 import { useWindowControlsOverlayWidth } from '../shell/hooks/use-window-controls-overlay-width'
 import {
+  TITLEBAR_HEIGHT,
   titlebarControlsPosition,
   titlebarControlsYNudge,
   titlebarToolsRightCss,
@@ -1238,6 +1239,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         className="contents"
         style={
           {
+            '--titlebar-height': `${TITLEBAR_HEIGHT}px`,
             '--titlebar-controls-left': `${controlsPos.left}px`,
             '--titlebar-controls-top': `${controlsPos.top}px`,
             '--titlebar-controls-width': leftToolsWidth,

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -521,6 +521,7 @@
 
     --sidebar-width: 14.8125rem;
     --chat-min-width: 28rem;
+    --titlebar-height: 34px;
     --titlebar-control-size: 24px;
     --titlebar-control-height: 24px;
     --titlebar-icon-size: 13.9px;


### PR DESCRIPTION
Fixes #108181

The titlebar header sizes via `h-(--titlebar-height)`. `ContribWiring` set every other titlebar CSS var (`--titlebar-controls-left`, `--titlebar-tools-right`, etc.) but never defined `--titlebar-height` itself, and `styles.css` had no default. When no ancestor provides the var the header's height evaluates to an invalid/auto value and the 34px chrome collapses to near-zero — traffic lights, tab title and toolbar icons stack/overlap, notification badge floats unanchored, and the tab indicator's border stretches as a stray blue line. Persisted across restarts because it is a layout invariant, not a runtime state.

- Define `--titlebar-height: 34px` (`TITLEBAR_HEIGHT`) in `ContribWiring`'s root `contents` div so every pane/zone subtree inherits the correct height.
- Add `--titlebar-height: 34px` default in `styles.css` `:root` so early paint, HUD/browser popouts and any subtree outside the shell still sizes correctly before JS hydrates.
