### PR TITLE
fix(process_registry): persist the finished-process receipt outside the registry lock

### DIFF
--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -10,6 +10,7 @@ Covers:
 
 import json
 import os
+import threading
 import time
 import pytest
 from unittest.mock import MagicMock, patch
@@ -441,3 +442,108 @@ def test_non_ci_background_command_does_not_emit_homebrew_hint(monkeypatch, tmp_
     assert "hint" not in result, (
         f"Non-CI command using awk must not be flagged as homebrew CI poller, got: {result.get('hint')!r}"
     )
+
+
+# =========================================================================
+# Receipt-write lock scope (#108327)
+# =========================================================================
+
+class TestReceiptWriteLockScope:
+    """_move_to_finished must not hold the registry lock across the durable
+    receipt write: the gateway event loop polls get() under the same lock, so
+    a stalled save_completed_result (antivirus scan, slow disk) blocks the
+    whole loop until the shutdown watchdog kills the gateway with exit 75."""
+
+    def test_get_does_not_block_on_receipt_write(self, registry):
+        """get() keeps answering while the receipt write is still in flight."""
+        release = threading.Event()
+        started = threading.Event()
+        writes = []
+
+        def slow_save(session):
+            started.set()
+            writes.append(session.id)
+            assert release.wait(timeout=10)
+
+        s = _make_session(sid="proc_slow_disk", notify_on_complete=True, output="done")
+        s.exited = True
+        s.exit_code = 0
+        registry._running[s.id] = s
+
+        with patch.object(registry, "_write_checkpoint"), \
+             patch("tools.process_registry.save_completed_result", slow_save):
+            mover = threading.Thread(target=registry._move_to_finished, args=(s,))
+            mover.start()
+            assert started.wait(timeout=5), "receipt write never started"
+            # The write runs outside the lock: the watcher's get() poll must
+            # return immediately instead of waiting on the disk I/O.
+            t0 = time.monotonic()
+            found = registry.get("proc_slow_disk")
+            elapsed = time.monotonic() - t0
+            release.set()
+            mover.join(timeout=10)
+
+        assert found is s
+        assert elapsed < 1.0, f"get() blocked {elapsed:.2f}s behind the receipt write"
+        assert writes == ["proc_slow_disk"]
+        # Durable-before-visible still holds: the session only becomes finished
+        # once its receipt has been persisted.
+        assert registry._finished[s.id] is s
+        assert registry.completion_queue.qsize() == 1
+
+    def test_completion_notice_waits_for_durable_receipt(self, registry):
+        """Neither the completion event nor the notice fire before the write ends."""
+        release = threading.Event()
+        started = threading.Event()
+
+        def slow_save(session):
+            started.set()
+            assert release.wait(timeout=10)
+
+        s = _make_session(sid="proc_durable_order", notify_on_complete=True, output="done")
+        s.exited = True
+        s.exit_code = 0
+        registry._running[s.id] = s
+
+        with patch.object(registry, "_write_checkpoint"), \
+             patch("tools.process_registry.save_completed_result", slow_save):
+            mover = threading.Thread(target=registry._move_to_finished, args=(s,))
+            mover.start()
+            assert started.wait(timeout=5), "receipt write never started"
+            assert registry.completion_queue.empty()
+            assert not s._completion_event.is_set()
+            release.set()
+            mover.join(timeout=10)
+
+        assert s._completion_event.is_set()
+        assert registry.completion_queue.qsize() == 1
+
+    def test_concurrent_move_skips_in_flight_finalize(self, registry):
+        """A raced second move (reader vs kill) neither duplicates the receipt
+        write nor enqueues a second completion notice."""
+        release = threading.Event()
+        started = threading.Event()
+        writes = []
+
+        def slow_save(session):
+            started.set()
+            writes.append(session.id)
+            assert release.wait(timeout=10)
+
+        s = _make_session(sid="proc_race", notify_on_complete=True, output="done")
+        s.exited = True
+        s.exit_code = 0
+        registry._running[s.id] = s
+
+        with patch.object(registry, "_write_checkpoint"), \
+             patch("tools.process_registry.save_completed_result", slow_save):
+            mover = threading.Thread(target=registry._move_to_finished, args=(s,))
+            mover.start()
+            assert started.wait(timeout=5), "receipt write never started"
+            registry._move_to_finished(s)  # kill/reader race against the in-flight move
+            release.set()
+            mover.join(timeout=10)
+
+        assert writes == ["proc_race"]
+        assert registry.completion_queue.qsize() == 1
+        assert registry._finished[s.id] is s

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -469,6 +469,10 @@ class ProcessRegistry(ProcessCheckpointMixin):
     def __init__(self):
         self._running: Dict[str, ProcessSession] = {}
         self._finished: Dict[str, ProcessSession] = {}
+        # Sessions whose result receipt is being persisted (between leaving
+        # _running and entering _finished). Readers must still see them; the
+        # slow disk write itself happens outside _lock (see _move_to_finished).
+        self._finalizing: Dict[str, ProcessSession] = {}
         self._lock = threading.Lock()
         # Side-channel for check_interval watchers (gateway reads after agent run)
         self.pending_watchers: List[Dict[str, Any]] = []
@@ -1258,13 +1262,28 @@ class ProcessRegistry(ProcessCheckpointMixin):
         Idempotent: kill_process() and the reader thread can both call this; only
         the FIRST move enqueues the completion notification, so no duplicates."""
         with self._lock:
+            if session.id in self._finalizing:
+                # A concurrent move (reader vs kill race) already owns the
+                # durable-then-visible transition and its completion notice.
+                return
             was_running = session.id in self._running
             if was_running:
-                # Keep the session tracked until its result is durable. A finite
-                # parent must not observe completion and exit during this write.
-                save_completed_result(session)
                 self._running.pop(session.id)
-            self._finished[session.id] = session
+                self._finalizing[session.id] = session
+            else:
+                self._finished[session.id] = session
+        if was_running:
+            try:
+                # Keep the session tracked until its result is durable. A finite
+                # parent must not observe completion and exit during this write —
+                # but the write must not hold _lock: the gateway event loop polls
+                # get() under the same lock, and a stalled receipt write here
+                # blocks the loop until the shutdown watchdog kills the gateway.
+                save_completed_result(session)
+            finally:
+                with self._lock:
+                    self._finalizing.pop(session.id, None)
+                    self._finished[session.id] = session
         self._write_checkpoint()
         if was_running and session.notify_on_complete:
             notification = {
@@ -1337,7 +1356,7 @@ class ProcessRegistry(ProcessCheckpointMixin):
         result: dict = {"waited": [], "completed": [], "timed_out": []}
         with self._lock:
             pending = [
-                s for s in self._running.values()
+                s for s in [*self._running.values(), *self._finalizing.values()]
                 if s.notify_on_complete and not s._completion_event.is_set() and (task_id is None or s.task_id == task_id)
             ]
         if not pending or timeout <= 0:
@@ -1495,7 +1514,11 @@ class ProcessRegistry(ProcessCheckpointMixin):
         if not isinstance(session_id, str) or not session_id:
             return None
         with self._lock:
-            session = self._running.get(session_id) or self._finished.get(session_id)
+            session = (
+                self._running.get(session_id)
+                or self._finished.get(session_id)
+                or self._finalizing.get(session_id)
+            )
         if session is None:
             session = load_completed_results(session_id).get(session_id)
         return self._refresh_detached_session(session if session is not None else self._resolve_prefix(session_id))
@@ -1513,7 +1536,7 @@ class ProcessRegistry(ProcessCheckpointMixin):
         matches = load_completed_results(query)
         with self._lock:
             matches.update({
-                sid: s for store in (self._running, self._finished)
+                sid: s for store in (self._running, self._finished, self._finalizing)
                 for sid, s in store.items() if sid.startswith(query)
             })
         return next(iter(matches.values())) if len(matches) == 1 else None
@@ -1884,6 +1907,7 @@ class ProcessRegistry(ProcessCheckpointMixin):
         with self._lock:
             sessions.update(self._finished)
             sessions.update(self._running)
+            sessions.update(self._finalizing)
         all_sessions = [self._refresh_detached_session(s) for s in sessions.values()]
         if task_id or session_key:
             all_sessions = [
@@ -2020,7 +2044,7 @@ class ProcessRegistry(ProcessCheckpointMixin):
             del self._finished[sid]
         # Belt-and-suspenders against module-lifetime growth: forget consumed /
         # poll-observed marks for any session no longer tracked at all.
-        tracked = self._running.keys() | self._finished.keys()
+        tracked = self._running.keys() | self._finished.keys() | self._finalizing.keys()
         self._completion_consumed &= tracked
         self._poll_observed &= tracked
 


### PR DESCRIPTION
## What does this PR do?

`_move_to_finished` held `self._lock` across `save_completed_result(session)` — synchronous disk I/O (`mkstemp` + atomic write + receipt pruning). The gateway asyncio event loop polls `process_registry.get()` under that same lock from `_run_process_watcher`, so a slow or stalled receipt write (antivirus scan, heavy I/O, Windows file locking) blocked the entire event loop until `gateway.shutdown_watchdog` missed 3 liveness probes and killed the gateway with exit code 75 (#108327).

This moves the receipt write out of the lock while preserving the durable-before-visible contract:

- The registry lock now covers only the in-memory transition: the session leaves `_running` and parks in a new `_finalizing` store while its receipt is persisted, and only enters `_finished` once the write completes. The session is invisible as "finished" during the write, so a finite parent still cannot consume completion and exit before the result is durable.
- The completion notification and `session._completion_event` keep firing strictly after `save_completed_result`, exactly as before.
- Readers that must not lose the session mid-write now also consult `_finalizing`: `get()`, `_resolve_prefix()`, `list_sessions()`, `wait_for_pending_completions()` (the one-shot linger keeps waiting for the durable result), and `_prune_if_needed()`'s tracked-key set. Queries filtering on `not exited` are unaffected — the session is already marked exited when `_move_to_finished` runs.
- A concurrent second move (reader vs kill race) sees the session in `_finalizing` and returns immediately instead of duplicating the receipt write or the completion notice — the old code serialized this behind the lock, the lock-free window now has an explicit owner.

Note on the one observable difference: during the (normally millisecond) receipt write, a `get()`/`poll()` caller can now observe `exited=True` immediately instead of blocking until the write finishes. This is safe because `save_completed_result` already treats disk failure as non-fatal ("Preserve live delivery on disk failure") — the completion contract channels (notice + event) remain strictly durable-ordered.

## Related Issue

Fixes #108327

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py` — `_move_to_finished`: split the lock scope; in-memory `_running` → `_finalizing` transition under the lock, `save_completed_result` outside it, `_finished` insertion after the write (guarded by `finally`), early return for a concurrent in-flight move.
- `tools/process_registry.py` — `get()`, `_resolve_prefix()`, `list_sessions()`, `wait_for_pending_completions()`, `_prune_if_needed()` also consult the `_finalizing` store.
- `tests/tools/test_notify_on_complete.py` — regression tests: `get()` does not block behind the receipt write; the completion event/notice only fire after the write; a raced concurrent move neither duplicates the write nor the notice.

## How to Test

1. `python -m pytest tests/tools/test_notify_on_complete.py -q` — should pass (22 passed, includes the 3 new `TestReceiptWriteLockScope` tests).
2. `python -m pytest tests/tools/test_process_registry.py tests/tools/test_completed_process_results.py tests/tools/test_process_wait_clarity.py tests/tools/test_subagent_process_handoff.py tests/tools/test_delegate_control_actions.py tests/tools/test_zombie_process_cleanup.py tests/tools/test_threaded_process_handle.py tests/tools/test_watch_patterns.py tests/tools/test_process_schema_diet.py -q` — should pass (197 passed, 15 platform-skipped).
3. `python -m pytest tests/gateway/test_background_process_notifications.py tests/gateway/test_gateway_process_exit.py tests/gateway/test_abandoned_turn_process_cleanup.py -q` — should pass (37 passed).
4. `TestReceiptWriteLockScope.test_get_does_not_block_on_receipt_write` reproduces the watchdog scenario in miniature: a stalled `save_completed_result` holds no lock, so the watcher-path `get()` returns in under a second; Observed result: passes, and the session only lands in `_finished` plus the completion queue after the write is released.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 arm64

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Faulthandler evidence from the issue (main thread blocked on the lock while the reader thread writes the receipt):

```text
Thread 0x00013744: tools/process_registry.py line 1497 in get        # event loop, waiting on _lock
  ← gateway/run_notifications.py line 1617 in _run_process_watcher
Thread 0x000126ac: Lib/tempfile.py line 256 in _mkstemp_inner         # reader thread, holds _lock
  ← tools/process_registry_results.py line 61 in save_completed_result
  ← tools/process_registry.py line 1265 in _move_to_finished
```