### PR TITLE
fix(vault): pass --vault to op item get for service-account 1Password auth

### DIFF
--- a/agent/vault_backends/onepassword.py
+++ b/agent/vault_backends/onepassword.py
@@ -118,14 +118,21 @@ class OnePasswordLoginBackend(LoginBackend):
     def get_meta(self, handle: str) -> Optional[VaultItemMeta]:
         return next((m for m in self.list_items() if m.id == handle), None)
 
+    def _vault_args(self) -> List[str]:
+        # A service-account token has no default vault, so `op item get` rejects it with
+        # "a vault query must be provided" unless --vault is given explicitly (item list is unaffected).
+        vault = str(self.cfg.get("vault") or "")
+        return ["--vault", vault] if vault else []
+
     def resolve_password(self, handle: str) -> str:
         item_id = handle[len(self.prefix):]
-        return self._run("item", "get", item_id, "--fields", "label=password", "--reveal").rstrip("\r\n")
+        return self._run("item", "get", item_id, *self._vault_args(),
+                          "--fields", "label=password", "--reveal").rstrip("\r\n")
 
     def resolve_otp(self, handle: str) -> Optional[str]:
         # `--otp` mints the current TOTP from the item's one-time-password field; items without one error out.
         try:
-            code = self._run("item", "get", handle[len(self.prefix):], "--otp").strip()
+            code = self._run("item", "get", handle[len(self.prefix):], *self._vault_args(), "--otp").strip()
         except Exception:
             return None
         return code if code.isdigit() else None

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2200,6 +2200,9 @@ DEFAULT_CONFIG = {
             "binary_path": "",      # absolute path to op; empty = PATH.
             # Env var holding a service-account token (headless auth, no unlock prompt). Unset = prompt.
             "service_account_token_env": "OP_SERVICE_ACCOUNT_TOKEN",
+            # Vault name/ID passed as `--vault` on item reads; required by service-account tokens,
+            # which have no default vault. Empty = omit (fine for account/session auth).
+            "vault": "",
         },
         "bitwarden": {
             "enabled": False,       # `bw` CLI (Password Manager, not Secrets Manager); run `bw login` once first.

--- a/tests/agent/test_vault_backends.py
+++ b/tests/agent/test_vault_backends.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import os
 import stat
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -168,3 +169,52 @@ def test_lock_during_unlock_wins_and_only_the_owning_session_release_drops_a_tok
         unlock_mod.release_session("sess-A")
         assert not backend.is_unlocked()
         unlock_mod.set_current_session_id(None)
+
+
+class TestOnePasswordServiceAccountVault:
+    """A service-account token has no default vault: `op item get` rejects it with
+    'a vault query must be provided ...' unless --vault is given explicitly (unlike `item list`,
+    which succeeds without one). vault.onepassword.vault must reach both item-get reads."""
+
+    @pytest.fixture
+    def backend(self, monkeypatch):
+        from pathlib import Path
+
+        from agent.vault_backends.onepassword import OnePasswordLoginBackend
+
+        monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "svc-token")
+        monkeypatch.setattr("agent.vault_backends.onepassword.find_op", lambda *_a, **_kw: Path("/usr/bin/op"))
+
+        def make(cfg):
+            return OnePasswordLoginBackend(cfg)
+
+        return make
+
+    def _fake_run_cli(self, monkeypatch, stdout="the-password\n"):
+        calls = []
+
+        def fake(argv, **_kwargs):
+            calls.append(list(argv))
+            return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr("agent.vault_backends.onepassword.run_cli", fake)
+        return calls
+
+    def test_resolve_password_passes_configured_vault(self, backend, monkeypatch):
+        calls = self._fake_run_cli(monkeypatch)
+        result = backend({"vault": "Shared Website Logins"}).resolve_password("op:item1")
+        assert result == "the-password"
+        assert calls[-1][1:] == ["item", "get", "item1", "--vault", "Shared Website Logins",
+                                 "--fields", "label=password", "--reveal"]
+
+    def test_resolve_otp_passes_configured_vault(self, backend, monkeypatch):
+        calls = self._fake_run_cli(monkeypatch, stdout="123456\n")
+        result = backend({"vault": "Shared Website Logins"}).resolve_otp("op:item1")
+        assert result == "123456"
+        assert calls[-1][1:] == ["item", "get", "item1", "--vault", "Shared Website Logins", "--otp"]
+
+    def test_no_vault_configured_omits_the_flag(self, backend, monkeypatch):
+        calls = self._fake_run_cli(monkeypatch)
+        backend({}).resolve_password("op:item1")
+        assert calls[-1][1:] == ["item", "get", "item1", "--fields", "label=password", "--reveal"]
+        assert "--vault" not in calls[-1]

--- a/website/docs/user-guide/features/credential-vault.md
+++ b/website/docs/user-guide/features/credential-vault.md
@@ -92,7 +92,10 @@ Cron jobs, webhooks, the API server and `hermes chat -q` have nobody to answer a
 prompt. Saved local logins keep working there; a locked password manager reports
 `unavailable_in_this_session` and a missing login reports `prompt_unavailable`.
 Unlock or save from an interactive session first, or give 1Password a service
-account token (`OP_SERVICE_ACCOUNT_TOKEN`).
+account token (`OP_SERVICE_ACCOUNT_TOKEN`). A service account has no default
+vault, so filling a login also needs `vault` set to the vault it was granted
+access to — otherwise `op` rejects the read with "a vault query must be
+provided when this command is called by a service account".
 
 ```yaml
 vault:
@@ -100,6 +103,7 @@ vault:
     enabled: false          # opt OUT of a detected manager (default: on when installed)
     account: ""             # `op --account` shorthand; empty = default
     service_account_token_env: OP_SERVICE_ACCOUNT_TOKEN
+    vault: ""               # vault name/ID for `op --vault`; required by a service account
   bitwarden:
     enabled: false
 ```


### PR DESCRIPTION
## What does this PR do?

Fixes the 1Password browser-vault backend so a service-account token can actually fill a saved login, not just list it.

`OnePasswordLoginBackend._run("item", "get", ...)` (used by both `resolve_password()` and `resolve_otp()`) never passed a vault selector. `op item list` succeeds without one, but `op item get` rejects a service-account-authenticated call with:

```
op failed: a vault query must be provided when this command is called by a service account. Please specify one either through the --vault flag or through piped input
```

So `hermes vault list` shows the item fine, but `browser_vault_fill` fails at the moment it actually needs the password.

Added a `vault.onepassword.vault` config setting (vault name/ID) and a `_vault_args()` helper on the backend that appends `--vault <name>` to both `item get` calls when it's set. Empty (the default) omits the flag entirely, so account/session-token auth is unaffected. The vault selection stays server-side in the existing opaque-handle path — no new argv path exposes the password to the model or chat logs.

## Related Issue

Fixes #108335

## Changes Made

- `agent/vault_backends/onepassword.py` — add `_vault_args()`, thread it through `resolve_password()` and `resolve_otp()`
- `hermes_cli/config_defaults.py` — add `vault.onepassword.vault` (default `""`)
- `website/docs/user-guide/features/credential-vault.md` — document the new setting next to the existing service-account note
- `tests/agent/test_vault_backends.py` — regression tests for the `--vault` argv shape

## How to Test

1. `hermes config set vault.onepassword.enabled true` and `vault.onepassword.vault <vault-name>` with a service-account token exported as `OP_SERVICE_ACCOUNT_TOKEN`.
2. `hermes vault list` shows the item (unaffected — `item list` never needed `--vault`).
3. `browser_vault_fill` on the matching `op:` handle now succeeds instead of failing with the service-account vault error.

### Automated test run

```
$ python -m pytest tests/agent/test_vault_backends.py -k OnePassword -v
tests/agent/test_vault_backends.py::TestOnePasswordServiceAccountVault::test_resolve_password_passes_configured_vault PASSED
tests/agent/test_vault_backends.py::TestOnePasswordServiceAccountVault::test_resolve_otp_passes_configured_vault PASSED
tests/agent/test_vault_backends.py::TestOnePasswordServiceAccountVault::test_no_vault_configured_omits_the_flag PASSED
3 passed, 3 deselected in 0.66s
```

Confirmed these two new tests fail without the fix (checked out `agent/vault_backends/onepassword.py` at the parent commit and reran):

```
FAILED test_resolve_password_passes_configured_vault - AssertionError: ... '--fields' != '--vault' ...
FAILED test_resolve_otp_passes_configured_vault - AssertionError: ... '--otp' != '--vault' ...
2 failed, 1 passed, 3 deselected
```

Also ran the full existing suite for this area to check for regressions:

```
$ python -m pytest tests/agent/test_vault_backends.py tests/test_browser_vault.py tests/test_onepassword_secrets.py
65 passed, 3 failed
```

The 3 remaining failures (`test_check_fn_follows_the_browser_not_the_item_count`, `test_secret_eval_fails_closed_without_supervisor`, `test_nonsecret_eval_fallback_still_works`) are pre-existing `AttributeError: module 'tools' has no attribute 'browser_tool...'` collection issues in this sandbox, reproduced identically on the unmodified base commit — unrelated to this change.

`ruff check` on the touched files passes clean.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the test suite for the touched area and all relevant tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — sandboxed CI-only environment, no macOS/Windows available

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/credential-vault.md`)
- [ ] `cli-config.yaml.example` — N/A: the `vault:` backend section (unlike `secrets:`) isn't documented there at all yet, for any of its existing keys
- [ ] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture/workflow change
- [x] Cross-platform impact considered — pure argv construction, no OS-specific behavior
- [ ] Tool descriptions/schemas — N/A, no tool-facing behavior change

## AI assistance disclosure

This PR was prepared with AI assistance (Claude Code), with the diff reviewed by the author before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
