### PR TITLE
fix(tools): preserve managed FAL billing error diagnostics on HTTP 409 (#106469)

### DIFF
--- a/tests/tools/test_fal_common.py
+++ b/tests/tools/test_fal_common.py
@@ -642,3 +642,42 @@ class TestManagedFalSyncClientSubmit:
         client._add_timeout_header.assert_called_once()
         headers = client._maybe_retry_request.call_args[1]["headers"]
         assert headers["X-Custom"] == "val"
+
+
+class TestManagedFalBillingErrorExtra:
+    def test_unsupported_pricing_meter_payload(self):
+        from tools.fal_common import _managed_fal_billing_error
+        exc = MagicMock()
+        exc.response = MagicMock()
+        exc.response.json.return_value = {
+            "code": "BILLING_ERROR",
+            "message": "Unsupported resolver usage meter",
+            "details": {
+                "chargeIntentErrorCode": "unsupported_pricing_meter",
+                "upstreamPayload": {
+                    "code": "unsupported_pricing_meter",
+                    "error": "Unsupported resolver usage meter"
+                }
+            }
+        }
+        err = _managed_fal_billing_error(exc, "model")
+        assert err is not None
+        assert "Unsupported resolver usage meter" in err
+        assert "unsupported_pricing_meter" in err
+
+    def test_root_error_string_billing_error(self):
+        from tools.fal_common import _managed_fal_billing_error
+        exc = MagicMock()
+        exc.response = MagicMock()
+        exc.response.json.return_value = {
+            "error": "BILLING_ERROR",
+            "message": "Unsupported pricing meter",
+            "details": {
+                "chargeIntentErrorCode": "unsupported_pricing_meter"
+            }
+        }
+        err = _managed_fal_billing_error(exc, "endpoint")
+        assert err is not None
+        assert "Unsupported pricing meter" in err
+        assert "unsupported_pricing_meter" in err
+

--- a/tools/fal_common.py
+++ b/tools/fal_common.py
@@ -59,15 +59,33 @@ def _managed_fal_billing_error(exc: BaseException, what: str) -> Optional[str]:
         payload = response.json()
     except Exception:  # noqa: BLE001 — diagnostics must not mask the provider error
         return None
-    error = payload.get("error") if isinstance(payload, dict) else None
-    if not isinstance(error, dict) or error.get("code") != "BILLING_ERROR":
+    if not isinstance(payload, dict):
         return None
-    details = error.get("details") if isinstance(error.get("details"), dict) else {}
+
+    raw_error = payload.get("error")
+    error_dict = raw_error if isinstance(raw_error, dict) else payload
+
+    code_val = error_dict.get("code") or payload.get("code") or (raw_error if isinstance(raw_error, str) else None)
+    details = error_dict.get("details") if isinstance(error_dict.get("details"), dict) else (
+        payload.get("details") if isinstance(payload.get("details"), dict) else {})
+
+    charge_intent_code = details.get("chargeIntentErrorCode")
+    is_billing_error = (
+        code_val == "BILLING_ERROR"
+        or raw_error == "BILLING_ERROR"
+        or payload.get("code") == "BILLING_ERROR"
+        or charge_intent_code is not None
+    )
+    if not is_billing_error:
+        return None
+
     upstream = details.get("upstreamPayload") if isinstance(details.get("upstreamPayload"), dict) else {}
-    code = upstream.get("code") or details.get("chargeIntentErrorCode") or "billing_error"
-    detail = upstream.get("error") or "Nous Portal rejected the charge authorization"
+    code = upstream.get("code") or charge_intent_code or code_val or "billing_error"
+    msg = error_dict.get("message") or payload.get("message") or "Charge authorization failed"
+    detail = upstream.get("error") or details.get("error") or details.get("detail") or msg or "Nous Portal rejected the charge authorization"
+
     return (
-        f"{error.get('message') or 'Charge authorization failed'} (BILLING_ERROR; {code}: {detail}). "
+        f"{msg} (BILLING_ERROR; {code}: {detail}). "
         "This is a Nous Portal billing configuration issue, not a missing local API key. "
         f"The managed route cannot run this {what} until Nous enables its billing meter; "
         "a direct FAL_KEY is an optional bypass."


### PR DESCRIPTION
## Summary
Fixes #106469.

When Nous managed FAL gateway returns a 409 billing error (such as `BILLING_ERROR` with `unsupported_pricing_meter` for GPT Image 2.5), `_managed_fal_billing_error` in `tools/fal_common.py` returned `None` due to rigid checking on `payload.get("error")` being a dict.

This change:
1. Updates `_managed_fal_billing_error` to handle root `code: "BILLING_ERROR"`, string `error: "BILLING_ERROR"`, and `details.chargeIntentErrorCode` payloads robustly.
2. Ensures specific billing error messages (e.g. `Unsupported resolver usage meter (BILLING_ERROR; unsupported_pricing_meter: ...)`) are preserved and reported clearly.
3. Adds test cases in `tests/tools/test_fal_common.py`.

## Verification
- Ran `pytest tests/tools/test_fal_common.py -v` - 45/45 tests passed.
