### PR TITLE
fix(vault): include vault in 1Password item reads

### DIFF
--- a/agent/vault_backends/onepassword.py
+++ b/agent/vault_backends/onepassword.py
@@ -4,7 +4,7 @@ Unlock: ``op signin --raw`` with the master password on stdin (desktop-app
 integration or account-level auth) mints an ``OP_SESSION_<account>`` token.
 A configured service-account token skips the prompt entirely (headless).
 List: ``op item list --categories Login --format json`` → title, urls,
-username. Resolve: ``op item get <id> --fields label=password --reveal``.
+username, and vault ID. Resolve: ``op item get <id> --vault <vault-id> ...``.
 """
 
 from __future__ import annotations
@@ -109,8 +109,12 @@ class OnePasswordLoginBackend(LoginBackend):
             if not origin:
                 continue
             username = str(item.get("additional_information") or "").strip() or None
+            item_id = str(item.get("id") or "")
+            vault = item.get("vault") if isinstance(item.get("vault"), dict) else {}
+            vault_id = str(vault.get("id") or "")
+            opaque_id = f"{vault_id}:{item_id}" if vault_id else item_id
             out.append(VaultItemMeta(
-                id=f"{self.prefix}{item.get('id')}", kind="login", label=str(item.get("title") or origin),
+                id=f"{self.prefix}{opaque_id}", kind="login", label=str(item.get("title") or origin),
                 origin=origin, created_at=str(item.get("created_at") or ""),
                 identifier_type="username" if username else None, identifier=username))
         return out
@@ -119,16 +123,25 @@ class OnePasswordLoginBackend(LoginBackend):
         return next((m for m in self.list_items() if m.id == handle), None)
 
     def resolve_password(self, handle: str) -> str:
-        item_id = handle[len(self.prefix):]
-        return self._run("item", "get", item_id, "--fields", "label=password", "--reveal").rstrip("\r\n")
+        return self._run("item", "get", *_item_selector(handle, self.prefix),
+                         "--fields", "label=password", "--reveal").rstrip("\r\n")
 
     def resolve_otp(self, handle: str) -> Optional[str]:
         # `--otp` mints the current TOTP from the item's one-time-password field; items without one error out.
         try:
-            code = self._run("item", "get", handle[len(self.prefix):], "--otp").strip()
+            code = self._run("item", "get", *_item_selector(handle, self.prefix), "--otp").strip()
         except Exception:
             return None
         return code if code.isdigit() else None
+
+
+def _item_selector(handle: str, prefix: str) -> List[str]:
+    """Recover the item and vault IDs carried by a model-opaque backend handle."""
+    opaque_id = handle[len(prefix):]
+    vault_id, separator, item_id = opaque_id.partition(":")
+    if separator and vault_id and item_id:
+        return [item_id, "--vault", vault_id]
+    return [opaque_id]
 
 
 def _first_origin(urls: List[str]) -> Optional[str]:

--- a/tests/agent/test_vault_backend_onepassword.py
+++ b/tests/agent/test_vault_backend_onepassword.py
@@ -1,0 +1,37 @@
+"""1Password browser-vault backend command contracts."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock, patch
+
+from agent.vault_backends.onepassword import OnePasswordLoginBackend
+
+
+def test_service_account_item_reads_keep_vault_in_opaque_handle():
+    with patch("agent.secret_scope.get_secret", return_value="service-token"):
+        backend = OnePasswordLoginBackend()
+
+    backend._run = Mock(side_effect=[
+        json.dumps([{
+            "id": "item-id",
+            "title": "Example",
+            "vault": {"id": "vault-id", "name": "Private"},
+            "urls": [{"href": "https://example.com/login"}],
+        }]),
+        "password\n",
+        "123456\n",
+    ])
+
+    [item] = backend.list_items()
+    assert item.id == "op:vault-id:item-id"
+    assert "Private" not in item.id
+    assert backend.resolve_password(item.id) == "password"
+    assert backend.resolve_otp(item.id) == "123456"
+    assert backend._run.call_args_list[1].args == (
+        "item", "get", "item-id", "--vault", "vault-id",
+        "--fields", "label=password", "--reveal",
+    )
+    assert backend._run.call_args_list[2].args == (
+        "item", "get", "item-id", "--vault", "vault-id", "--otp",
+    )


### PR DESCRIPTION
## Summary

Fix 1Password service-account browser-vault fills by carrying each item's vault ID inside its opaque `op:` handle and passing that vault ID to server-side `op item get` calls.

The same selector is applied to password and OTP reads, so both item-resolution paths satisfy the 1Password CLI service-account contract without exposing a password or vault name to the model or chat logs.

## Why this PR vs existing PR #108339

PR #108339 adds one global `vault.onepassword.vault` setting. That still requires every affected user to discover and configure the workaround, and it can address only one vault at a time.

This PR instead uses the vault ID already returned with each `op item list` record. The backend carries that ID in the existing opaque handle and supplies the matching `--vault` automatically at fill time. This supports items from multiple accessible vaults in one listing while keeping vault selection in the server-side resolution path.

## Changes

- Include the per-item 1Password vault ID in generated opaque handles.
- Recover the item and vault IDs when resolving passwords and OTPs.
- Preserve legacy `op:<item-id>` parsing for handles without a vault component.
- Add a regression test for metadata-to-handle-to-command propagation and password/OTP command shapes.

## Tests

- `scripts/run_tests.sh tests/agent/test_vault_backend_onepassword.py tests/agent/test_vault_backends.py` (1 passed, 3 skipped on Windows)

## Related Issue

Closes #108335
