### PR TITLE
fix(relay): include cwd in session and turn scopes

### DIFF
--- a/agent/relay_cwd.py
+++ b/agent/relay_cwd.py
@@ -1,0 +1,88 @@
+"""Resolve logical working directories for Hermes-owned Relay scopes."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_CWD_SENTINELS = frozenset({"", ".", "./", "auto", "cwd"})
+
+
+def _clean_cwd(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    value = value.strip()
+    return "" if value.lower() in _CWD_SENTINELS else value
+
+
+def _recorded_cwd(key: str) -> str:
+    if not key:
+        return ""
+    from tools.terminal_tool import get_session_cwd
+
+    return _clean_cwd(get_session_cwd(key))
+
+
+def resolve_relay_scope_cwds(
+    agent: Any, task_id: str, session_id: str, platform: str
+) -> tuple[str, str]:
+    """Return logical ``(session_cwd, turn_cwd)`` for Relay scope input.
+
+    A task may use a worktree distinct from its owning session. Preserve remote paths as
+    declared and omit unknown paths instead of substituting the Hermes host's cwd.
+    """
+    try:
+        task_cwd = _recorded_cwd(task_id)
+    except Exception:
+        logger.debug("Unable to read the Relay turn cwd", exc_info=True)
+        task_cwd = ""
+
+    session_cwd = ""
+    try:
+        from agent.runtime_cwd import scoped_session_cwd
+
+        session_cwd = _clean_cwd(scoped_session_cwd())
+    except Exception:
+        logger.debug("Unable to read the scoped Relay session cwd", exc_info=True)
+
+    if not session_cwd:
+        try:
+            from gateway.session_context import get_session_env
+
+            session_key = get_session_env("HERMES_SESSION_KEY", "")
+            for key in dict.fromkeys(key for key in (session_key, session_id) if key):
+                if recorded := _recorded_cwd(key):
+                    session_cwd = recorded
+                    break
+        except Exception:
+            logger.debug("Unable to read the recorded Relay session cwd", exc_info=True)
+
+    if not session_cwd:
+        session_cwd = _clean_cwd(getattr(agent, "session_cwd", None))
+
+    backend = ""
+    if not session_cwd:
+        try:
+            from tools.terminal_scope import terminal_env
+
+            backend = terminal_env("TERMINAL_ENV", "local").strip().lower()
+            session_cwd = _clean_cwd(terminal_env("TERMINAL_CWD", ""))
+        except Exception:
+            logger.debug(
+                "Unable to read the configured Relay session cwd", exc_info=True
+            )
+
+    if not session_cwd and platform == "cli" and backend in {"", "local"}:
+        try:
+            from agent.runtime_cwd import resolve_agent_cwd
+
+            session_cwd = _clean_cwd(str(resolve_agent_cwd()))
+        except Exception:
+            logger.debug("Unable to resolve the local Relay session cwd", exc_info=True)
+
+    turn_cwd = task_cwd or session_cwd
+    if platform in {"subagent", "cron"} and task_cwd:
+        session_cwd = task_cwd
+    return session_cwd or turn_cwd, turn_cwd

--- a/agent/relay_cwd.py
+++ b/agent/relay_cwd.py
@@ -74,11 +74,14 @@ def resolve_relay_scope_cwds(
                 "Unable to read the configured Relay session cwd", exc_info=True
             )
 
-    if not session_cwd and platform == "cli" and backend in {"", "local"}:
+    if not session_cwd and platform in {"", "cli"} and backend in {"", "local"}:
         try:
             from agent.runtime_cwd import resolve_agent_cwd
 
-            session_cwd = _clean_cwd(str(resolve_agent_cwd()))
+            resolved = resolve_agent_cwd()
+            session_cwd = _clean_cwd(
+                str(resolved if resolved.is_absolute() else resolved.resolve())
+            )
         except Exception:
             logger.debug("Unable to resolve the local Relay session cwd", exc_info=True)
 

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -813,8 +813,9 @@ class ConversationLease:
     host: RelayHost
     session: RelaySession | None
     parent_session_id: str = ""
-    turn_cwd: str = ""
     released: bool = False
+    # Keep new fields after the pre-existing positional constructor fields.
+    turn_cwd: str = ""
 
     def live_runtime(self) -> RelayRuntime | None:
         """Return the real Relay host when this lease owns an open session."""

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -73,6 +73,11 @@ def runtime_metadata(runtime_id: str, **extra: Any) -> dict[str, Any]:
     return {RUNTIME_SCHEMA_KEY: RUNTIME_SCHEMA_VERSION, RUNTIME_INSTANCE_KEY: runtime_id, **extra}
 
 
+def _scope_input(cwd: Any = None) -> dict[str, str]:
+    """Return Relay scope input for a known logical working directory."""
+    return {"cwd": cwd.strip()} if isinstance(cwd, str) and cwd.strip() else {}
+
+
 def _run_on_daemon_thread(
     fn: Callable[[], Any], *, name: str, timeout: float | None = None, timeout_message: str = ""
 ) -> Any:
@@ -154,6 +159,7 @@ class RelaySession:
     segment_turns: int = 0  # turns completed within the current segment
     rotate_pending: bool = False  # consumed at next begin_turn
     close_pending: bool = False  # rotating compaction hit a live turn; end_turn consumes it
+    cwd: str = ""  # latest logical working directory; reused when a session segment rotates
 
 
 def _load_segments_config() -> dict[str, Any]:
@@ -387,7 +393,7 @@ class RelayRuntime:
             scope_metadata["nemo_relay_scope_role"] = "subagent"
         context = contextvars.Context()
         args = (self.relay.scope.push, SESSION_SCOPE, self.relay.ScopeType.Agent)
-        push_kwargs.update(handle=parent_handle, metadata=scope_metadata, input={})
+        push_kwargs.update(handle=parent_handle, metadata=scope_metadata, input=_scope_input(session.cwd))
         try:
             future = _scope_op_executor().submit(context.run, *args, **push_kwargs)
             session.handle = future.result(timeout=_SCOPE_OP_TIMEOUT)
@@ -398,7 +404,12 @@ class RelayRuntime:
         session.context = context
 
     def ensure_session(
-        self, event: dict[str, Any], *, data: Any = None, metadata: dict[str, Any] | None = None
+        self,
+        event: dict[str, Any],
+        *,
+        data: Any = None,
+        metadata: dict[str, Any] | None = None,
+        cwd: str | None = None,
     ) -> RelaySession | None:
         """Return the existing session scope or create it once."""
         session_id = _session_id(event)
@@ -415,6 +426,8 @@ class RelayRuntime:
         with session.lock:
             if session.closing:
                 return None
+            if isinstance(cwd, str) and cwd.strip():
+                session.cwd = cwd.strip()
             if session.handle is None:
                 self._open_session_scope(
                     session, {**(metadata or {}), **runtime_metadata(self.runtime_id)},
@@ -455,7 +468,8 @@ class RelayRuntime:
                 )
 
     def register_subagent(
-        self, event: dict[str, Any], *, metadata: dict[str, Any] | None = None
+        self, event: dict[str, Any], *, metadata: dict[str, Any] | None = None,
+        cwd: str | None = None,
     ) -> RelaySession | None:
         """Open a child Agent scope under its spawning turn when available."""
         parent_session_id = str(event.get("parent_session_id") or "")
@@ -473,7 +487,7 @@ class RelayRuntime:
             self._subagent_parents[child_session_id] = parent_session_id
             if parent_handle is not None:
                 self._subagent_parent_handles[child_session_id] = parent_handle
-        return self.ensure_session({"session_id": child_session_id}, metadata=metadata)
+        return self.ensure_session({"session_id": child_session_id}, metadata=metadata, cwd=cwd)
 
     def unregister_subagent(self, event: dict[str, Any]) -> None:
         """Close a delegated session and forget its parent relationship."""
@@ -799,6 +813,7 @@ class ConversationLease:
     host: RelayHost
     session: RelaySession | None
     parent_session_id: str = ""
+    turn_cwd: str = ""
     released: bool = False
 
     def live_runtime(self) -> RelayRuntime | None:
@@ -898,29 +913,44 @@ class RelaySessionCoordinator:
                 logger.warning("Hermes Relay session initializer failed: %s", name, exc_info=True)
 
     def acquire_conversation(
-        self, *, profile_key: str, session_id: str, platform: str, parent_session_id: str = "", model: str = "",
+        self,
+        *,
+        profile_key: str,
+        session_id: str,
+        platform: str,
+        parent_session_id: str = "",
+        model: str = "",
+        session_cwd: str | None = None,
+        turn_cwd: str | None = None,
     ) -> ConversationLease:
         host = self.registry.for_profile(profile_key) or NoopRelayRuntime(profile_key, "Relay host creation was disabled")
         session = None
         if isinstance(host, RelayRuntime):
             context = {
                 "profile_key": profile_key, "session_id": session_id, "platform": platform,
-                "parent_session_id": parent_session_id, "model": model,
+                "parent_session_id": parent_session_id, "model": model, "cwd": session_cwd,
             }
             session = _warn_on_error("conversation initialization", self._open_conversation_session, host, context)
+        effective_turn_cwd = (
+            _scope_input(turn_cwd).get("cwd") or _scope_input(session_cwd).get("cwd") or ""
+        )
+        if not effective_turn_cwd and session is not None:
+            with session.lock:
+                effective_turn_cwd = session.cwd
         return ConversationLease(
             profile_key=profile_key, session_id=session_id, platform=platform, host=host,
-            session=session, parent_session_id=parent_session_id,
+            session=session, parent_session_id=parent_session_id, turn_cwd=effective_turn_cwd,
         )
 
     def _open_conversation_session(self, host: RelayRuntime, context: dict[str, Any]) -> RelaySession | None:
         self._prepare_session(host, context)
         session_id, parent_session_id = context["session_id"], context["parent_session_id"]
         metadata = {"hermes.execution_surface": context["platform"] or "unknown"}
+        cwd = context.get("cwd")
         if parent_session_id and parent_session_id != session_id:
             event = {"parent_session_id": parent_session_id, "child_session_id": session_id}
-            return host.register_subagent(event, metadata=metadata)
-        return host.ensure_session({"session_id": session_id}, metadata=metadata)
+            return host.register_subagent(event, metadata=metadata, cwd=cwd)
+        return host.ensure_session({"session_id": session_id}, metadata=metadata, cwd=cwd)
 
     def begin_turn(self, lease: ConversationLease, *, turn_id: str, task_id: str) -> RelayTurnContext:
         if lease.released:
@@ -944,7 +974,8 @@ class RelaySessionCoordinator:
             _warn_on_error("segment rotation", self._maybe_rotate_segment, host, lease.session)
             turn.handle = _warn_on_error(
                 "turn initialization", host.run_in_session, lease.session, host.relay.scope.push,
-                TURN_SCOPE, host.relay.ScopeType.Function, handle=lease.session.handle, input={},
+                TURN_SCOPE, host.relay.ScopeType.Function, handle=lease.session.handle,
+                input=_scope_input(lease.turn_cwd),
                 metadata=runtime_metadata(host.runtime_id, **{"hermes.execution_surface": lease.platform or "unknown"}),
                 timeout=_SCOPE_OP_TIMEOUT,
             )

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -44,6 +44,16 @@ def clear_session_cwd() -> None:
     _SESSION_CWD.set("")
 
 
+def scoped_session_cwd() -> str:
+    """Return the current session's declared cwd without local path validation.
+
+    Remote and container paths may not exist on the Hermes host. Callers that only need
+    logical workspace identity should preserve the declared value instead of resolving it.
+    """
+    value = _SESSION_CWD.get()
+    return "" if value is _UNSET else str(value).strip()
+
+
 def scope_terminal_cwd() -> str:
     """Scope-aware TERMINAL_CWD value (may be empty) — every cwd consumer reads through this.
 

--- a/agent/turn_facade.py
+++ b/agent/turn_facade.py
@@ -46,6 +46,7 @@ class TurnFacadeMixin:
             set_conversation_context,
         )
         from agent.prompt_cache_scope import declared_conversation_scope_safe
+        from agent.relay_cwd import resolve_relay_scope_cwds
         from agent.review_idle_queue import QUEUE as _review_queue
         from agent.subagent_lifecycle import bind_subagent_parent
         from agent.interrupt_scope import track_in_interrupt_scope
@@ -88,11 +89,16 @@ class TurnFacadeMixin:
             lease = admission.lease
             conversation_history = admission.conversation_history
 
+            relay_session_cwd, relay_turn_cwd = resolve_relay_scope_cwds(
+                self, effective_task_id, session_id, task_context["platform"]
+            )
             relay_lease = relay_runtime.SESSION_COORDINATOR.acquire_conversation(
                 profile_key=relay_runtime.current_profile_key(),
                 session_id=task_context["session_id"], platform=task_context["platform"],
                 parent_session_id=relay_parent_session_id,
                 model=str(getattr(self, "model", None) or ""),
+                session_cwd=relay_session_cwd,
+                turn_cwd=relay_turn_cwd,
             )
             relay_turn = relay_runtime.SESSION_COORDINATOR.begin_turn(
                 relay_lease, turn_id=relay_turn_id, task_id=effective_task_id

--- a/docs/observability/relay-shared-metrics.md
+++ b/docs/observability/relay-shared-metrics.md
@@ -94,6 +94,20 @@ Both defaults preserve one session scope for the full session. Rotated spans
 retain the same `session_id` and add `hermes.session.segment` plus
 `hermes.session.segment_reason` (`compaction` or `max_turns`).
 
+## Working-Directory Scope Data
+
+When Hermes knows a session or task's logical working directory, its
+`hermes.session` and `hermes.turn` start scopes include it as `data.cwd` in
+ATOF. A turn running in a task worktree can therefore differ from its owning
+session. Unknown directories are omitted, and scope-end data remains reserved
+for the outcome.
+
+The working directory is Relay scope input, so it is visible to every enabled
+Relay subscriber, not only ATOF. Paths can reveal usernames, repository names,
+or mount layouts. Relay does not filter events by working directory; if a path
+must not leave the host, use a trusted local collector or do not enable a remote
+exporter for that process.
+
 ## Process-Wide Plugin Policy and Profile Isolation
 
 Relay plugin configuration is a process-level deployment choice, not a Hermes

--- a/tests/agent/test_relay_atof_cwd.py
+++ b/tests/agent/test_relay_atof_cwd.py
@@ -1,0 +1,109 @@
+"""Hermes scope cwd export through the real NeMo Relay ATOF plugin."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def test_run_conversation_exports_session_and_turn_cwds(tmp_path, monkeypatch):
+    relay = pytest.importorskip("nemo_relay")
+    if getattr(relay, "_native", None) is None:
+        pytest.skip("NeMo Relay native binding is unavailable on this platform")
+
+    from agent import relay_runtime
+    from hermes_cli.lifecycle import finalize_session
+    from run_agent import AIAgent
+    from tools.terminal_tool import clear_session_cwd, record_session_cwd
+
+    hermes_home = tmp_path / "hermes-home"
+    session_cwd = tmp_path / "session"
+    turn_cwd = tmp_path / "task"
+    atof_dir = tmp_path / "atof"
+    for directory in (hermes_home, session_cwd, turn_cwd, atof_dir):
+        directory.mkdir()
+
+    config = tmp_path / "plugins.toml"
+    config.write_text(
+        f"""version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+
+[components.config]
+version = 4
+
+[components.config.atof]
+enabled = true
+
+[[components.config.atof.sinks]]
+type = "file"
+output_directory = {json.dumps(str(atof_dir))}
+filename = "events.jsonl"
+mode = "overwrite"
+""",
+        encoding="utf-8",
+    )
+    session_id = "cwd-e2e-session"
+    task_id = "cwd-e2e-task"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv(relay_runtime.RELAY_PLUGINS_CONFIG_ENV, str(config))
+    monkeypatch.chdir(session_cwd)
+    monkeypatch.setattr(
+        "agent.conversation_loop.run_conversation",
+        lambda *_args, **_kwargs: {"final_response": "ok", "completed": True},
+    )
+
+    relay_runtime._reset_for_tests()
+    relay.plugin.clear()
+    record_session_cwd(task_id, str(turn_cwd))
+    agent = None
+    try:
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            provider="openai",
+            model="test-model",
+            session_id=session_id,
+            platform="cli",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            disabled_toolsets=["*"],
+        )
+        result = agent.run_conversation("hello", task_id=task_id)
+        assert result["final_response"] == "ok"
+        finalize_session(session_id=session_id)
+    finally:
+        if agent is not None:
+            agent.close()
+        clear_session_cwd(task_id)
+        relay_runtime._reset_for_tests()
+
+    events = [
+        json.loads(line)
+        for line in (atof_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+    def only_event(name: str, category: str) -> dict:
+        matches = [
+            event
+            for event in events
+            if event.get("name") == name and event.get("scope_category") == category
+        ]
+        assert len(matches) == 1
+        return matches[0]
+
+    session_start = only_event("hermes.session", "start")
+    turn_start = only_event("hermes.turn", "start")
+    session_end = only_event("hermes.session", "end")
+    turn_end = only_event("hermes.turn", "end")
+
+    assert session_start["data"] == {"cwd": str(session_cwd)}
+    assert turn_start["data"] == {"cwd": str(turn_cwd)}
+    assert turn_start["parent_uuid"] == session_start["uuid"]
+    assert "cwd" not in session_end["data"]
+    assert "cwd" not in turn_end["data"]

--- a/tests/agent/test_relay_atof_cwd.py
+++ b/tests/agent/test_relay_atof_cwd.py
@@ -67,7 +67,6 @@ mode = "overwrite"
             provider="openai",
             model="test-model",
             session_id=session_id,
-            platform="cli",
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,

--- a/tests/agent/test_relay_cwd.py
+++ b/tests/agent/test_relay_cwd.py
@@ -1,7 +1,21 @@
 """Logical working directories attached to Hermes-owned Relay scopes."""
 
+from pathlib import Path
+
+import pytest
+
 from agent import relay_cwd, runtime_cwd
+from agent.relay_runtime import ConversationLease
 from tools.terminal_tool import clear_session_cwd, record_session_cwd
+
+
+def test_conversation_lease_keeps_released_in_its_original_position():
+    lease = ConversationLease(
+        "profile", "session", "cli", object(), None, "parent", True
+    )
+
+    assert lease.released is True
+    assert lease.turn_cwd == ""
 
 
 def test_session_context_and_task_record_remain_distinct(monkeypatch):
@@ -22,8 +36,13 @@ def test_session_context_and_task_record_remain_distinct(monkeypatch):
         runtime_cwd._SESSION_CWD.reset(token)
 
 
-def test_remote_scoped_cwd_is_preserved_without_host_resolution(monkeypatch):
-    token = runtime_cwd.set_session_cwd("~/remote-project")
+@pytest.mark.parametrize(
+    "logical_cwd", ["~/remote-project", r"C:\work\project", r"\\server\share\project"]
+)
+def test_remote_scoped_cwd_is_preserved_without_host_resolution(
+    monkeypatch, logical_cwd
+):
+    token = runtime_cwd.set_session_cwd(logical_cwd)
     monkeypatch.setattr("tools.terminal_tool.get_session_cwd", lambda _key: None)
     monkeypatch.setattr(
         runtime_cwd,
@@ -33,7 +52,7 @@ def test_remote_scoped_cwd_is_preserved_without_host_resolution(monkeypatch):
     try:
         assert relay_cwd.resolve_relay_scope_cwds(
             object(), "task-1", "session-1", "gateway"
-        ) == ("~/remote-project", "~/remote-project")
+        ) == (logical_cwd, logical_cwd)
     finally:
         runtime_cwd._SESSION_CWD.reset(token)
 
@@ -59,3 +78,54 @@ def test_gateway_session_key_uses_its_recorded_cwd(monkeypatch):
     finally:
         clear_session_cwd("gateway-key")
         runtime_cwd._SESSION_CWD.reset(token)
+
+
+@pytest.mark.parametrize(
+    ("platform", "backend", "resolved", "expected", "uses_host"),
+    [
+        ("cli", "local", Path("/workspace"), "/workspace", True),
+        ("", "local", Path("."), str(Path.cwd().resolve()), True),
+        ("cli", "ssh", Path("/host"), "", False),
+        ("gateway", "local", Path("/host"), "", False),
+    ],
+)
+def test_only_local_cli_uses_host_cwd(
+    monkeypatch, platform, backend, resolved, expected, uses_host
+):
+    token = runtime_cwd.set_session_cwd(None)
+    host_lookups = []
+
+    def resolve_host_cwd():
+        host_lookups.append(True)
+        return resolved
+
+    monkeypatch.setattr("tools.terminal_tool.get_session_cwd", lambda _key: None)
+    monkeypatch.setattr(
+        "gateway.session_context.get_session_env", lambda _name, default: default
+    )
+    monkeypatch.setattr(
+        "tools.terminal_scope.terminal_env",
+        lambda name, default: backend if name == "TERMINAL_ENV" else default,
+    )
+    monkeypatch.setattr(runtime_cwd, "resolve_agent_cwd", resolve_host_cwd)
+    try:
+        assert relay_cwd.resolve_relay_scope_cwds(
+            object(), "task-1", "session-1", platform
+        ) == (expected, expected)
+        assert bool(host_lookups) is uses_host
+    finally:
+        runtime_cwd._SESSION_CWD.reset(token)
+
+
+def test_cwd_lookup_failures_do_not_break_the_turn(monkeypatch):
+    def unavailable(*_args):
+        raise RuntimeError("unavailable")
+
+    monkeypatch.setattr("tools.terminal_tool.get_session_cwd", unavailable)
+    monkeypatch.setattr(runtime_cwd, "scoped_session_cwd", unavailable)
+    monkeypatch.setattr("gateway.session_context.get_session_env", unavailable)
+    monkeypatch.setattr("tools.terminal_scope.terminal_env", unavailable)
+
+    assert relay_cwd.resolve_relay_scope_cwds(
+        object(), "task-1", "session-1", "gateway"
+    ) == ("", "")

--- a/tests/agent/test_relay_cwd.py
+++ b/tests/agent/test_relay_cwd.py
@@ -1,0 +1,61 @@
+"""Logical working directories attached to Hermes-owned Relay scopes."""
+
+from agent import relay_cwd, runtime_cwd
+from tools.terminal_tool import clear_session_cwd, record_session_cwd
+
+
+def test_session_context_and_task_record_remain_distinct(monkeypatch):
+    token = runtime_cwd.set_session_cwd("/workspace/session")
+    record_session_cwd("task-1", "/workspace/task")
+    monkeypatch.setattr(
+        "gateway.session_context.get_session_env", lambda _name, _default: ""
+    )
+    try:
+        assert relay_cwd.resolve_relay_scope_cwds(
+            object(), "task-1", "session-1", "cli"
+        ) == ("/workspace/session", "/workspace/task")
+        assert relay_cwd.resolve_relay_scope_cwds(
+            object(), "task-1", "session-1", "subagent"
+        ) == ("/workspace/task", "/workspace/task")
+    finally:
+        clear_session_cwd("task-1")
+        runtime_cwd._SESSION_CWD.reset(token)
+
+
+def test_remote_scoped_cwd_is_preserved_without_host_resolution(monkeypatch):
+    token = runtime_cwd.set_session_cwd("~/remote-project")
+    monkeypatch.setattr("tools.terminal_tool.get_session_cwd", lambda _key: None)
+    monkeypatch.setattr(
+        runtime_cwd,
+        "resolve_agent_cwd",
+        lambda: (_ for _ in ()).throw(AssertionError("must not resolve on this host")),
+    )
+    try:
+        assert relay_cwd.resolve_relay_scope_cwds(
+            object(), "task-1", "session-1", "gateway"
+        ) == ("~/remote-project", "~/remote-project")
+    finally:
+        runtime_cwd._SESSION_CWD.reset(token)
+
+
+def test_gateway_session_key_uses_its_recorded_cwd(monkeypatch):
+    token = runtime_cwd.set_session_cwd(None)
+    record_session_cwd("gateway-key", "/remote/gateway-workspace")
+    monkeypatch.setattr(
+        "gateway.session_context.get_session_env",
+        lambda name, default: (
+            "gateway-key" if name == "HERMES_SESSION_KEY" else default
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_cwd,
+        "resolve_agent_cwd",
+        lambda: (_ for _ in ()).throw(AssertionError("must not resolve on this host")),
+    )
+    try:
+        assert relay_cwd.resolve_relay_scope_cwds(
+            object(), "task-1", "session-1", "gateway"
+        ) == ("/remote/gateway-workspace", "/remote/gateway-workspace")
+    finally:
+        clear_session_cwd("gateway-key")
+        runtime_cwd._SESSION_CWD.reset(token)

--- a/tests/agent/test_relay_session_segments.py
+++ b/tests/agent/test_relay_session_segments.py
@@ -39,7 +39,7 @@ class _FakeScopeModule:
     def __init__(self, wedge_pop: threading.Event | None = None) -> None:
         self._wedge = wedge_pop
         self._seq = 0
-        self.pushes: list[dict[str, Any]] = []  # {name, metadata, handle}
+        self.pushes: list[dict[str, Any]] = []  # {name, metadata, handle, input}
         self.pops: list[_ScopeHandle] = []
 
     def push(self, name: str, scope_type: Any, **kwargs: Any) -> _ScopeHandle:
@@ -49,6 +49,7 @@ class _FakeScopeModule:
                 "name": name,
                 "metadata": dict(kwargs.get("metadata") or {}),
                 "parent": kwargs.get("handle"),
+                "input": dict(kwargs.get("input") or {}),
                 "seq": self._seq,
             }
         )
@@ -143,7 +144,7 @@ def coordinator() -> RelaySessionCoordinator:
     return RelaySessionCoordinator()
 
 
-def _acquire(coordinator, runtime, session_id="sess-1"):
+def _acquire(coordinator, runtime, session_id="sess-1", **kwargs):
     class _Registry:
         def for_profile(self, key):
             return runtime
@@ -154,6 +155,7 @@ def _acquire(coordinator, runtime, session_id="sess-1"):
         profile_key=runtime.profile_key,
         session_id=session_id,
         platform="test",
+        **kwargs,
     )
 
 
@@ -184,6 +186,33 @@ class TestDefaultsNeverRotate:
             "defaults off must never rotate the session scope — "
             "today's behavior is the contract"
         )
+
+
+class TestCwdProjection:
+    def test_distinct_session_and_turn_cwds_survive_segment_rotation(self, coordinator):
+        fake = _FakeRelay()
+        runtime = _make_runtime(fake)
+        lease = _acquire(
+            coordinator, runtime,
+            session_cwd="/workspace/session", turn_cwd="/workspace/task",
+        )
+
+        turn = coordinator.begin_turn(lease, turn_id="t1", task_id="task1")
+
+        assert _session_pushes(fake)[-1]["input"] == {"cwd": "/workspace/session"}
+        assert fake.scope.pushes[-1]["input"] == {"cwd": "/workspace/task"}
+        coordinator.end_turn(turn, outcome="success")
+
+        lease = _acquire(
+            coordinator, runtime,
+            session_cwd="/workspace/moved", turn_cwd="/workspace/next-task",
+        )
+        runtime.rotate_session_scope(lease.session, reason="compaction")
+        turn = coordinator.begin_turn(lease, turn_id="t2", task_id="task2")
+
+        assert _session_pushes(fake)[-1]["input"] == {"cwd": "/workspace/moved"}
+        assert fake.scope.pushes[-1]["input"] == {"cwd": "/workspace/next-task"}
+        coordinator.end_turn(turn, outcome="success")
 
 
 class TestCompactionRotation:


### PR DESCRIPTION
## What does this PR do?

Hermes opens `hermes.session` and `hermes.turn` Relay scopes without working-directory input. As a result, ATOF and other configured Relay subscribers cannot tell which workspace a session or turn belongs to.

This change passes Hermes's known logical cwd into those scope-start events. Session and turn paths remain separate because a task may run in a worktree or delegated workspace. Unknown paths are omitted, and remote/container paths are preserved without checking them against the Hermes host.

This builds on the report in #107752 and the initial implementation in #107763 by @KoNit-K. I independently reproduced the issue and added coverage for local CLI sessions, task worktrees, gateway session keys, remote paths, and session-segment rotation.

## Related Issue

Fixes #107752

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Resolve session and task cwd from Hermes's existing scope-aware cwd sources.
- Add cwd to Relay session and turn scope input, which becomes `data.cwd` in ATOF.
- Retain the latest session cwd when a long-running session rotates its Relay segment.
- Preserve remote paths as logical identifiers instead of resolving them on the Hermes host.
- Document that cwd is visible to every enabled Relay subscriber and may contain sensitive path information.
- Add a real `AIAgent` → Relay 0.8.3 → ATOF file-export regression test.

The cwd is observability context, not a security boundary. Relay does not currently filter events by cwd before export.

## How to Test

1. Configure Relay's ATOF file exporter through `HERMES_NEMO_RELAY_PLUGINS_TOML`.
2. Run a Hermes turn from one session directory with a different task/worktree directory.
3. Confirm the `hermes.session` start event contains the session path and the `hermes.turn` start event contains the task path.

Validated locally on macOS Apple silicon with Relay 0.8.3:

```text
hermes.session start  {"cwd": ".../session"}
hermes.turn    start  {"cwd": ".../task"}
```

End-user smoke: ran the actual `hermes --oneshot` CLI against a deterministic
streaming OpenAI-compatible endpoint with the Relay observability plugin active
and ATOF file and HTTP stream sinks enabled together. On current `main`, both
scope-start events had `data: {}`. On this PR, both contained the resolved
workspace cwd. The turn completed successfully, each sink received the same
nine events, and the session/turn parent relationship was preserved. Only the
model endpoint was local; Hermes, Relay 0.8.3, streaming, plugin activation, and
both exporters were the production paths.

- Focused Relay cwd/session/ATOF suite after merging current main: 29 passed.
- Gateway API regression suite: 125 passed (154 tests total across the targeted runs).
- `ruff check`: passed.
- `git diff --check`: passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and credited the related work above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run the full `pytest tests/ -q` suite
- [x] I've added tests for my changes
- [x] I've tested on macOS Apple silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` update is not applicable
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are not applicable
- [x] I've considered cross-platform impact; paths remain opaque strings and no platform path APIs are used for remote values
- [x] Tool descriptions and schemas are not applicable

## Screenshots / Logs

The checked-in regression test exercises the production ATOF file sink and verifies both cwd values, parent lineage, and that cwd is not repeated on scope-end events.

