### PR TITLE
Refresh dashboard plugins before the auth gate

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2505,7 +2505,9 @@ def _dashboard_prepare_runtime(args, headless_backend) -> bool:
     # dashboard_auth, …).
     try:
         from hermes_cli.plugins import discover_plugins
-        discover_plugins()
+        # Dashboard auth settings may have changed after an earlier discovery
+        # pass in this process. Refresh before the fail-closed gate reads them.
+        discover_plugins(force=True)
     except Exception as exc:
         # Must not block startup; the gate's fail-closed branch surfaces a
         # missing provider if it matters.

--- a/tests/hermes_cli/test_dashboard_startup_invariants.py
+++ b/tests/hermes_cli/test_dashboard_startup_invariants.py
@@ -1,0 +1,45 @@
+"""Dashboard startup invariant for plugin resolution."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def test_dashboard_runtime_refreshes_plugins_before_auth_gate(tmp_path, monkeypatch):
+    """Startup must rescan when an earlier discovery used stale configuration."""
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    config_path = home / "config.yaml"
+    config_path.write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import hermes_cli.plugins as plugins_mod
+    from hermes_cli.dashboard_auth import clear_providers, list_providers
+    from hermes_cli import main as cli_main
+
+    plugins_mod._reset_plugin_managers_for_tests()
+    clear_providers()
+    try:
+        plugins_mod.discover_plugins()
+        assert not any(provider.name == "basic" for provider in list_providers())
+
+        config_path.write_text(
+            "dashboard:\n"
+            "  basic_auth:\n"
+            "    username: test-user\n"
+            "    password_hash: unused-test-hash\n"
+            "    secret: test-only-signing-secret-not-a-real-key\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(cli_main, "_sync_bundled_skills_quietly", lambda: None)
+        monkeypatch.setattr(cli_main, "_resolve_dashboard_web_dist", lambda *_: None)
+        from hermes_cli import config as config_mod, mcp_startup
+        monkeypatch.setattr(config_mod, "apply_terminal_config_to_env", lambda: None)
+        monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", lambda **_: None)
+
+        cli_main._dashboard_prepare_runtime(SimpleNamespace(), headless_backend=False)
+
+        assert any(provider.name == "basic" for provider in list_providers())
+    finally:
+        plugins_mod._reset_plugin_managers_for_tests()
+        clear_providers()


### PR DESCRIPTION
<!-- Suggested title: Refresh dashboard plugins before the auth gate -->

## What does this PR do?

Refreshes plugin discovery immediately before dashboard startup hands control to the fail-closed authentication gate. An earlier discovery pass can cache plugin state before `dashboard.basic_auth` is written, so the existing idempotent call can otherwise leave the newly configured `basic` provider unregistered.

## Related Issue

Related to #98624 and #102613.

- #75109 separately addresses the `python -m hermes_cli.main` module re-execution and profile issue. This branch does not include or duplicate its module-alias commits.
- #67048 proposes a different guard for that same profile issue. This branch contains no profile logic.
- #98624 addresses discovery before the dashboard auth gate. Current `main` already has that call; this change makes the existing call a forced rescan so an earlier cached discovery cannot hide configuration written later in the same process.
- #102613 addresses general `serve` and dashboard startup discovery so plugin hooks fire on web turns. This change does not add or move broad server discovery. It only refreshes dashboard plugin registration before the auth gate reads providers.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Updates `_dashboard_prepare_runtime()` to call `discover_plugins(force=True)` at its existing pre-auth-gate registration boundary.
- Adds one startup invariant that performs an initial discovery, writes basic-auth configuration, prepares the dashboard runtime, and observes that the `basic` provider is registered.

## How to Test

1. In a temporary worktree at base `ad03f20dd61919ca2135d6904e787a94284aacaf`, restore only `tests/hermes_cli/test_dashboard_startup_invariants.py` from `f32ddbedeebc8bd52c85d2679dd3e3924bbddced`, then run `TMP=/tmp scripts/run_tests.sh tests/hermes_cli/test_dashboard_startup_invariants.py -q`. The test fails at the final provider assertion.
2. On this branch, run `TMP=/tmp scripts/run_tests.sh tests/hermes_cli/test_dashboard_startup_invariants.py -q`. Expected result: 1 passed.
3. Run the dashboard-auth and plugin neighbors with `scripts/run_tests.sh`, then run Ruff, `scripts/check-windows-footguns.py --diff origin/main`, and `scripts/check_compat_pointers.py`.

Local verification on Linux x86_64 with Python 3.11 produced 1 focused pass and 162 neighboring passes. Two fixed-port cases were excluded from the final neighbor command because port 9119 was already occupied; all other cases in that file passed. Ruff, Python compilation, Windows-footgun, compatibility-pointer, and diff checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64, Python 3.11

### Documentation & Housekeeping

- [x] Relevant documentation, N/A. This changes startup refresh timing without changing configuration or user-facing behavior.
- [x] `cli-config.yaml.example`, N/A. No configuration keys changed.
- [x] `CONTRIBUTING.md` or `AGENTS.md`, N/A. No architecture or workflow changed.
- [x] Cross-platform impact considered. The change uses the existing pure-Python discovery API.
- [x] Tool descriptions and schemas, N/A. No model tool changed.

## Screenshots / Logs

The exact-base run reports 1 failed because no provider named `basic` appears after the configuration change. The final branch reports 1 passed with the same test and runner.

## Model Used

Prepared and verified with OpenAI Codex GPT-5.6 SOL. Earlier visible Paseo subagent attempts contributed no code to this focused branch. No subagent was launched for this revision.
