### PR TITLE
fix(profiles): reject traversal-shaped profile names in get_profile_dir

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -235,15 +235,25 @@ def get_profile_dir(name: str) -> Path:
     canon = normalize_profile_name(name)
     if canon == "default":
         return _get_default_hermes_home()
+    # The name becomes a path component under profiles/; refuse anything that
+    # is not a valid profile id so every caller (WS params, /p/<profile>/
+    # prefixes, tool args) fails closed instead of escaping the root. The
+    # regex only, not _RESERVED_NAMES: a pre-reserved-list dir like
+    # profiles/hermes may still exist and must keep resolving.
+    if not _PROFILE_ID_RE.match(canon):
+        raise ValueError(f"Invalid profile name {canon!r}. Must match [a-z0-9][a-z0-9_-]{{0,63}}")
     return _get_profiles_root() / canon
 
 
 def profile_exists(name: str) -> bool:
     """Check whether a live (non-tombstoned) profile directory exists."""
-    canon = normalize_profile_name(name)
+    try:
+        canon = normalize_profile_name(name)
+        profile_dir = get_profile_dir(canon)
+    except ValueError:
+        return False
     if canon == "default":
         return True
-    profile_dir = get_profile_dir(canon)
     return profile_dir.is_dir() and not named_profile_is_deleted(profile_dir)
 
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -105,6 +105,20 @@ class TestGetProfileDir:
         result = get_profile_dir("default")
         assert result == tmp_path / ".hermes"
 
+    def test_valid_name_resolves_under_profiles_root(self, profile_env):
+        assert get_profile_dir("coder") == _get_profiles_root() / "coder"
+
+    @pytest.mark.parametrize("name", ["..", "../outside", "../../tmp", "a/b", "a\\b", ".hidden", "has space"])
+    def test_traversal_and_invalid_names_rejected(self, name, profile_env):
+        # The name becomes a path component under profiles/; invalid ids must
+        # raise instead of escaping the root.
+        with pytest.raises(ValueError):
+            get_profile_dir(name)
+
+    @pytest.mark.parametrize("name", ["..", "../outside", "a/b"])
+    def test_profile_exists_false_for_invalid_names(self, name, profile_env):
+        assert profiles.profile_exists(name) is False
+
 
 # ===================================================================
 # TestCreateProfile

--- a/tests/tui_gateway/test_profile_target_unavailable.py
+++ b/tests/tui_gateway/test_profile_target_unavailable.py
@@ -57,3 +57,24 @@ def test_custom_root_basename_target_fails_closed_when_unavailable(tmp_path, mon
     with pytest.raises(FileNotFoundError):
         with server._profile_db({"profile": "customer-data"}):
             pass
+
+
+@pytest.mark.parametrize("name", ["..", "../outside", "../../tmp", "a/b", "a\\b", ".hidden"])
+def test_profile_param_traversal_fails_closed(tmp_path, monkeypatch, name):
+    """A traversal-shaped ``profile`` param must never resolve outside profiles/."""
+    from tui_gateway import server
+
+    home = tmp_path / ".hermes"
+    outside = tmp_path / "outside"
+    outside.mkdir(parents=True)   # a real directory the traversal could land on
+    home.mkdir()
+    (home / "config.yaml").write_text("terminal:\n  cwd: /launch\n")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(server, "_hermes_home", home)
+
+    with pytest.raises(FileNotFoundError):
+        server._profile_home(name)
+    with pytest.raises(FileNotFoundError):
+        with server._profile_db({"profile": name}):
+            pass

--- a/tui_gateway/mcp_rpc_helpers.py
+++ b/tui_gateway/mcp_rpc_helpers.py
@@ -67,7 +67,10 @@ def resolve_profile(rid, params, err_fn) -> Tuple[Optional[Any], Optional[dict]]
     from hermes_cli.profiles import get_profile_dir
     from hermes_constants import set_hermes_home_override
 
-    profile_dir = get_profile_dir(profile)
+    try:
+        profile_dir = get_profile_dir(profile)
+    except ValueError:
+        return None, err_fn(rid, 4064, f"profile '{profile}' not found")
     if not profile_dir or not profile_dir.is_dir():
         return None, err_fn(rid, 4064, f"profile '{profile}' not found")
     return set_hermes_home_override(str(profile_dir)), None

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -72,7 +72,10 @@ def _resolve_profile(rid, params):
     if not name:
         return name, None, _err(rid, 4063, "name required")
     from hermes_cli.profiles import get_profile_dir
-    profile_dir = Path(get_profile_dir(name))
+    try:
+        profile_dir = Path(get_profile_dir(name))
+    except ValueError:
+        return name, None, _err(rid, 4064, f"profile '{name}' not found")
     if not profile_dir.is_dir():
         return name, None, _err(rid, 4064, f"profile '{name}' not found")
     return name, profile_dir, None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -463,7 +463,9 @@ def _canonical_profile_request(name: str) -> str:
     """
     if name.casefold() in {".hermes", "hermes"}:
         from hermes_cli import profiles as profiles_mod
-        if not Path(profiles_mod.get_profile_dir(name)).is_dir():
+        # Check the profiles root directly: get_profile_dir rejects "hermes" as a
+        # reserved name, but a pre-reserved-list install may still carry that dir.
+        if not (profiles_mod._get_profiles_root() / profiles_mod.normalize_profile_name(name)).is_dir():
             return "default"
     return name
 
@@ -486,8 +488,11 @@ def _profile_home(profile: str | None) -> Path | None:
     if not (name := _canonical_profile_request((profile or "").strip())):
         return None
     from hermes_cli import profiles as profiles_mod
-    home = Path(profiles_mod.get_profile_dir(name))
-    if not home.is_dir():
+    try:
+        home = Path(profiles_mod.get_profile_dir(name))
+    except ValueError:
+        home = None
+    if home is None or not home.is_dir():
         raise FileNotFoundError(f"Profile '{name}' does not exist.")
     if home.resolve() == Path(_hermes_home).resolve():
         return None  # already the launch profile (no override needed)


### PR DESCRIPTION
## What does this PR do?

`get_profile_dir` normalized profile names but never validated them, so a `profile` RPC param like `../../existing-dir` resolved outside `profiles/` and was served as a profile home. This PR validates the canonical name against the profile id regex inside `get_profile_dir`, so every caller fails closed at the same point.

The check is the id regex only, not `validate_profile_name`, so pre-reserved-list directories like `profiles/hermes` keep resolving. Boundary callers that probe existence map the `ValueError` to their existing "not found" path.

## Related Issue

Fixes #108346

Fixes #90699

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `hermes_cli/profiles.py`: `get_profile_dir` rejects non-id names with `ValueError`; `profile_exists` returns `False` for them.
- `tui_gateway/server.py`: `_profile_home` maps `ValueError` to its existing `FileNotFoundError` contract; `_canonical_profile_request` checks the legacy `hermes` basename directly so reserved-name validation cannot break it.
- `tui_gateway/methods_profiles.py`, `tui_gateway/mcp_rpc_helpers.py`: invalid names return the existing 4064 "profile not found" error.
- `tests/hermes_cli/test_profiles.py`, `tests/tui_gateway/test_profile_target_unavailable.py`: traversal names rejected and fail closed.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `scripts/run_tests.sh tests/hermes_cli/test_profiles.py tests/tui_gateway/test_profile_target_unavailable.py -q`
2. `session.create` with `{"profile": "../../existing-dir"}` now errors instead of binding that directory.
3. Regression check: `tests/tui_gateway/test_default_profile_session_name.py` (legacy `hermes` basename still resolves).

Ran on Windows 11: all new tests pass; the four unrelated Windows-only failures in `test_profiles.py` (posix mode bits, `.bat` wrapper naming) reproduce identically on the base commit.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A


