### PR TITLE
fix(tools): include hunk numbers in V4A patch errors

### DIFF
--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -11,6 +11,7 @@ asserts zero contamination from shell noise via _assert_clean().
 import pytest
 
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -198,6 +199,75 @@ class TestPatchReplace:
         result = ops.patch_replace(path, "line2", "REPLACED")
         assert result.error is None
         assert Path(path).read_text() == "line1\nREPLACED\nline3\n"
+
+
+class TestPatchV4AHunkErrors:
+    @pytest.mark.parametrize(
+        "hint, reason",
+        [("absent-marker", "not found"), ("anchor", "ambiguous (2 occurrences)")],
+    )
+    def test_validation_error_identifies_addition_only_hunk(
+        self, ops, tmp_path, monkeypatch, hint, reason
+    ):
+        """A bad hunk names its position in its file and prevents all writes."""
+        import tools.file_tools as file_tools
+        from tools.registry import registry
+
+        monkeypatch.setattr(file_tools, "_get_file_ops", lambda task_id: ops)
+        first = tmp_path / "first.txt"
+        target = tmp_path / "target.txt"
+        original = "old\nanchor\nbody\nanchor\n"
+        first.write_text("before\n")
+        target.write_text(original)
+        patch = (
+            "*** Begin Patch\n"
+            f"*** Update File: {first}\n@@\n-before\n+after\n"
+            f"*** Update File: {target}\n@@\n-old\n+new\n"
+            f"@@ {hint} @@\n+inserted\n"
+            "*** End Patch\n"
+        )
+
+        result = json.loads(registry.dispatch("patch", {"mode": "patch", "patch": patch}))
+
+        assert result["success"] is False
+        assert "Patch validation failed" in result["error"]
+        assert first.read_text() == "before\n"
+        assert target.read_text() == original
+        assert str(target) in result["error"]
+        assert hint in result["error"]
+        assert reason in result["error"]
+        assert "addition-only hunk 2" in result["error"]
+
+    @pytest.mark.parametrize(
+        "second_hunk",
+        ["@@ anchor @@\n+inserted\n", "@@\n-anchor\n+replacement\n"],
+        ids=["addition-only", "replacement"],
+    )
+    def test_apply_error_identifies_hunk(self, ops, tmp_path, monkeypatch, second_hunk):
+        """If earlier additions make a later hunk ambiguous, identify that hunk."""
+        import tools.file_tools as file_tools
+        from tools.registry import registry
+
+        monkeypatch.setattr(file_tools, "_get_file_ops", lambda task_id: ops)
+        target = tmp_path / "target.txt"
+        original = "start\nanchor\nend\n"
+        target.write_text(original)
+        # Validation currently does not simulate addition-only hunks, so this
+        # exercises apply-phase errors. The diagnostic contract also holds if
+        # validation starts detecting the duplicate earlier.
+        patch = (
+            "*** Begin Patch\n"
+            f"*** Update File: {target}\n@@ start @@\n+anchor\n"
+            f"{second_hunk}"
+            "*** End Patch\n"
+        )
+
+        result = json.loads(registry.dispatch("patch", {"mode": "patch", "patch": patch}))
+
+        assert result["success"] is False
+        assert str(target) in result["error"]
+        assert target.read_text() == original
+        assert "hunk 2" in result["error"]
 
 
 # ── search ───────────────────────────────────────────────────────────────

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -179,10 +179,10 @@ def _validate_operations(operations: List[PatchOperation], file_ops: Any) -> Lis
                 if hunk.context_hint:
                     occurrences, ambiguous = _hint_ambiguity(simulated, hunk.context_hint)
                     if occurrences == 0:
-                        errors.append(f"{op.file_path}: addition-only hunk context hint "
+                        errors.append(f"{op.file_path}: addition-only hunk {hunk_index} context hint "
                                       f"'{hunk.context_hint}' not found")
                     elif ambiguous:
-                        errors.append(f"{op.file_path}: addition-only hunk {ambiguous}")
+                        errors.append(f"{op.file_path}: addition-only hunk {hunk_index} {ambiguous}")
                 continue
             search_pattern, replacement = '\n'.join(search_lines), '\n'.join(replace_lines)
             new_simulated, count, _strategy, match_error = fuzzy_find_and_replace(
@@ -337,7 +337,7 @@ def _insert_addition_only(new_content: str, hunk: Hunk, insert_text: str) -> Tup
         occurrences, ambiguous = _hint_ambiguity(
             new_content, hunk.context_hint, " — provide a more unique hint")
         if ambiguous:
-            return None, f"Addition-only hunk: {ambiguous}"
+            return None, ambiguous
         if occurrences == 1:
             eol = new_content.find('\n', new_content.find(hunk.context_hint))
             if eol == -1:
@@ -354,7 +354,7 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> ApplyResult:
     if read_result.error:
         return _fail(f"Cannot read file: {read_result.error}")
     current_content = new_content = read_result.content
-    for hunk in op.hunks:
+    for hunk_index, hunk in enumerate(op.hunks, start=1):
         search_lines, replace_lines = _split_hunk(hunk)
         if search_lines and search_lines == replace_lines:
             continue
@@ -362,7 +362,7 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> ApplyResult:
         if not search_lines:
             new_content, err = _insert_addition_only(new_content, hunk, replacement)
             if err:
-                return _fail(err)
+                return _fail(f"Addition-only hunk {hunk_index}: {err}")
             continue
         new_content, count, _strategy, error = fuzzy_find_and_replace(
             new_content, search_pattern, replacement, replace_all=False)
@@ -383,7 +383,7 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> ApplyResult:
             if is_already_applied(new_content, search_pattern, replacement):
                 continue
             hint = _no_match_hint(error, search_pattern, new_content)
-            return _fail(f"Could not apply hunk: {error}" + hint)
+            return _fail(f"Could not apply hunk {hunk_index}: {error}" + hint)
     # Pass pre_content to skip a redundant re-read inside write_file when supported.
     extra = {"pre_content": current_content} if _write_file_accepts_pre_content(file_ops) else {}
     write_result = file_ops.write_file(op.file_path, new_content, **extra)


### PR DESCRIPTION
## What does this PR do?

When the second hunk in a V4A update has a missing or ambiguous addition-only context hint, the error names the file and hint but omits the hunk number. Include the 1-based hunk number so callers can locate the failing block in a multi-hunk patch. Apply-phase addition and replacement failures now carry the same position information.

For example, `example.txt: addition-only hunk context hint 'anchor' is ambiguous (2 occurrences)` becomes `example.txt: addition-only hunk 2 context hint 'anchor' is ambiguous (2 occurrences)`.

## Related Issue

Relates to #93699 (the remaining diagnostic gap). This preserves the current matching, validation, and write behavior; it does not add partial application of valid hunks.

## Type of Change

- [x] Bug fix

## Changes Made

- `tools/patch_parser.py`: include hunk indices in addition-only validation errors and in both apply-phase hunk error paths.
- `tests/tools/test_file_tools_live.py`: two parametrized regression tests, covering four cases through registry dispatch and a real `LocalEnvironment`/`ShellFileOperations` backend. They verify file-local numbering, error propagation, and preservation of file contents on failure.

## How to Test

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
  tests/tools/test_file_tools_live.py \
  tests/tools/test_patch_parser.py \
  tests/tools/test_patch_already_applied.py \
  tests/tools/test_patch_v4a_gate.py \
  tests/tools/test_patch_multimatch_locations.py \
  tests/tools/test_patch_ws_diagnosis.py \
  tests/tools/test_patch_failure_tracking.py -j 4 -q --tb=short

ruff check tools/patch_parser.py tests/tools/test_file_tools_live.py
git diff --check
```

For an external development venv, set `HERMES_PYTHON` to its Python executable before running the wrapper.

Validation on macOS 26.6.2 arm64, Python 3.12.14, with core and `[dev]` dependencies:

- Before the source fix, all four new cases failed on `ad03f20dd61919ca2135d6904e787a94284aacaf`, specifically because the hunk number was absent. All preceding file-preservation and error-reason assertions passed.
- After the fix: **93 passed, 0 failed** across the seven files above, with file retries disabled.
- Ruff and whitespace checks passed.
- Manually dispatched V4A patches against real temporary files with an isolated `HERMES_HOME`: missing and duplicate hints reported hunk 2 and left the file unchanged; correcting the hint applied both hunks successfully.

## Checklist

### Code

- [x] I've read the Contributing Guide and applicable `AGENTS.md` files.
- [x] My commit follows Conventional Commits.
- [x] I searched existing PRs for duplicates.
- [x] This PR contains only changes related to this fix.
- [ ] Full test suite passes — the completed local run has failures documented below; upstream CI awaits approval.
- [x] I've added regression tests and demonstrated failure on the base code.
- [x] I've tested on macOS 26.6.2 arm64.

### Documentation & Housekeeping

- [x] Documentation/configuration/architecture updates: N/A; this only adds position information to existing errors.
- [x] Cross-platform impact considered: no platform-specific behavior was added. Linux and Windows were not run locally.
- [x] Tool descriptions/schemas: N/A.

## Full-suite follow-up (2026-09-12)

This PR is now **Draft** pending upstream CI approval and successful checks.

Ran the canonical full suite on macOS 26.6.2 arm64 with Python 3.11.14, uv 0.9.28, and the exact locked dependency/extras selection from `.github/workflows/tests.yml`:

```bash
uv sync --locked --python 3.11 --extra all --extra dev --extra anthropic \
  --extra mistral --extra fal --extra modal --extra daytona --extra hindsight --extra parallel-web
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j 8 -q --tb=short
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/e2e -j 2 -q --tb=short
```

- **Default full suite: 4,049 files; 48,663 passed, 53 failed, 582 skipped; exit 1; 965.7 seconds.** Also reported 3 xfailed and 1 xpassed; no collection errors.
- **E2E: 5 files; 63 passed, 0 failed, 7 skipped; exit 0; 11.1 seconds.** The seven skips require the Matrix test homeserver.
- All **93 tests** in the seven patch-related files above also passed within this full run.
- Re-ran all 32 failing files on the unmodified base `ad03f20dd61919ca2135d6904e787a94284aacaf` in a separate worktree with the same environment: **1,024 passed, 50 failed, 60 skipped**. The 50 failing test IDs match failures from the PR run.
- The remaining three failures (`test_timeout_kills_descendants`, `test_literal_newline_in_pattern_matches`, and `test_native_search_never_touches_the_shell_and_matches_shell_results`) passed in isolated runs on both base and PR code. Their first-run timeout/process-cleanup failures remain recorded; the full-run result above is unchanged.

No new reproducible failure was identified by this comparison. **The local full suite is not green**, and the all-tests-pass checklist remains unchecked. Reproduced baseline failures include macOS `/tmp` versus `/private/tmp` and filename-case assumptions, a CUA test fixture that assumes a Linux-style executable path, DNS answers in `198.18.x.x` rejected by URL safety checks, and existing runtime/CLI/optional-feature assertions. No source changes were made to those unrelated areas.

The default runner excludes `tests/e2e`, `tests/integration`, and `tests/docker`; E2E was run separately as shown. Linux, Windows, Docker, and Nix were not run locally. An initial sandbox-limited attempt was stopped after local server binds were denied; the completed run above allowed the test servers and used the CI venv first on `PATH`.

<details>
<summary>Failure counts by file: full PR run versus isolated base runs</summary>

| Test file | PR failures | Base failures |
|---|---:|---:|
| `tests/agent/test_shell_hooks_tree_kill.py` | 1 | 0 |
| `tests/computer_use/test_cua_no_overlay.py` | 1 | 1 |
| `tests/cron/test_file_permissions.py` | 1 | 1 |
| `tests/gateway/test_feishu.py` | 1 | 1 |
| `tests/gateway/test_media_download_retry.py` | 4 | 4 |
| `tests/gateway/test_slack.py` | 1 | 1 |
| `tests/gateway/test_telegram_media_read_timeout.py` | 2 | 2 |
| `tests/gateway/test_telegram_thread_fallback.py` | 1 | 1 |
| `tests/gateway/test_wecom.py` | 1 | 1 |
| `tests/hermes_cli/test_local_quickstart.py` | 2 | 2 |
| `tests/hermes_cli/test_session_recovery_lost_and_found.py` | 1 | 1 |
| `tests/hermes_cli/test_update_autostash.py` | 9 | 9 |
| `tests/hermes_cli/test_update_head_moved_gate.py` | 1 | 1 |
| `tests/hermes_cli/test_update_launchd_fleet_restart.py` | 2 | 2 |
| `tests/plugins/memory/test_openviking_optional_peer.py` | 1 | 1 |
| `tests/scripts/test_contributor_map.py` | 1 | 1 |
| `tests/test_guest_durability_barriers.py` | 1 | 1 |
| `tests/test_model_tools_async_bridge.py` | 2 | 2 |
| `tests/tools/test_approval.py` | 1 | 1 |
| `tests/tools/test_browser_hybrid_routing.py` | 1 | 1 |
| `tests/tools/test_browser_secret_exfil.py` | 1 | 1 |
| `tests/tools/test_code_kernel.py` | 1 | 1 |
| `tests/tools/test_delegate.py` | 1 | 1 |
| `tests/tools/test_execution_flag_detection.py` | 3 | 3 |
| `tests/tools/test_file_tools.py` | 2 | 2 |
| `tests/tools/test_read_file_utf8_binary_regression.py` | 1 | 1 |
| `tests/tools/test_search_auto_multiline.py` | 1 | 0 |
| `tests/tools/test_search_native_rg.py` | 1 | 0 |
| `tests/tools/test_transcription_tools.py` | 1 | 1 |
| `tests/tools/test_voice_mode.py` | 4 | 4 |
| `tests/tools/test_wake_word.py` | 1 | 1 |
| `tests/tools/test_web_tools_perplexity.py` | 1 | 1 |

The three rows with zero baseline failures also passed when re-run separately on the PR commit.

</details>

### Root-cause follow-up (2026-09-12)

The local failures are not all environment-only failures. All 53 original failure IDs were classified; 32 passed under targeted environment/fixture controls, without changes to this PR's source code:

- 6 passed after disabling macOS system-proxy discovery for the test process. A further 10 HTTP-mocked tests passed when supplied with a public DNS fixture; this host resolves public names to `198.18.x.x`/private IPv6 addresses. The real SSRF checks remained enabled.
- 10 update tests passed after completing the empty-launchd-fleet fixture and preserving it across module reloads. 2 Quickstart tests passed with a sufficient hardware-budget fixture; the real catalog preflight rejects this 24 GiB host.
- 2 Unix-socket tests passed with a short dedicated temporary path. 1 permissions test passed using canonical `TMPDIR`; 1 SQLite recovery test passed after clearing the stale CLI-refusal fixture state.

The remaining failures include platform-specific assertions/command-line assumptions and process cleanup/timing risks. In particular, native `rg` cleanup has an existing exit race: the CJK search case still raises `PermissionError` during group cleanup, then reports child exit code 0 and a vanished process group. Two other searches initially reported `ProcessLookupError`; the hook timeout case has a 1-second startup budget. These are not evidence that this PR's hunk-number change caused a regression, but they prevent a promise that Linux CI will pass.

Using the repository's actual macOS CI file selector and `-m "macos_only and not integration"`, the unmodified tests completed with **42 passed, 1 skipped, 0 failed** across 24 files. The default full suite runs on Linux upstream. No Linux full-suite result is claimed here; the PR remains Draft awaiting maintainer approval and successful required CI. Controlled fixture experiments do not replace the original full-run failures or check the all-tests-pass box.

