### PR TITLE
fix(docker): resolve non-root user home directory when HOME is unset (#107295)

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -42,13 +42,39 @@ def get_hermes_home_override() -> str | None:
     return str(override) if override is not _UNSET and override else None
 
 
+def _get_user_home() -> Path:
+    """Resolve current user's home directory safely.
+
+    If HOME is unset or resolves to /root when running under a non-root UID on Unix,
+    queries pwd.getpwuid(os.getuid()) or falls back to /tmp.
+    """
+    try:
+        home = Path.home()
+    except Exception:
+        home = None
+
+    if sys.platform != "win32" and hasattr(os, "getuid"):
+        uid = os.getuid()
+        if uid != 0:
+            if home is None or home == Path("/root") or str(home).startswith("/root/"):
+                try:
+                    import pwd
+                    pw_dir = pwd.getpwuid(uid).pw_dir
+                    if pw_dir and pw_dir != "/root" and os.access(pw_dir, os.W_OK):
+                        return Path(pw_dir)
+                except Exception:
+                    pass
+                return Path("/tmp")
+    return home if home is not None else (Path("/tmp") if sys.platform != "win32" else Path("C:/"))
+
+
 def _get_platform_default_hermes_home() -> Path:
     """Return the platform-native default Hermes home path."""
     if sys.platform == "win32":
         local_appdata = os.environ.get("LOCALAPPDATA", "").strip()
-        base = Path(local_appdata) if local_appdata else Path.home() / "AppData" / "Local"
+        base = Path(local_appdata) if local_appdata else _get_user_home() / "AppData" / "Local"
         return base / "hermes"
-    return Path.home() / ".hermes"
+    return _get_user_home() / ".hermes"
 
 
 def _warn_profile_fallback_once() -> None:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -1,6 +1,7 @@
 """Tests for hermes_constants module."""
 
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -28,6 +29,35 @@ from hermes_constants import (
     set_hermes_home_override,
     with_hermes_node_path,
 )
+
+
+class TestGetUserHome:
+    def test_get_user_home_non_root_fallback(self, monkeypatch):
+        from hermes_constants import _get_user_home
+        monkeypatch.setattr(hermes_constants.sys, "platform", "linux")
+        monkeypatch.setattr(os, "getuid", lambda: 1000, raising=False)
+        monkeypatch.setattr(Path, "home", lambda: Path("/root"))
+
+        class FakePwd:
+            pw_dir = "/home/hermes"
+        monkeypatch.setitem(sys.modules, "pwd", SimpleNamespace(getpwuid=lambda uid: FakePwd()))
+        monkeypatch.setattr(os, "access", lambda path, mode: True)
+
+        home = _get_user_home()
+        assert home == Path("/home/hermes")
+
+    def test_get_user_home_fallback_to_tmp(self, monkeypatch):
+        from hermes_constants import _get_user_home
+        monkeypatch.setattr(hermes_constants.sys, "platform", "linux")
+        monkeypatch.setattr(os, "getuid", lambda: 1000, raising=False)
+        monkeypatch.setattr(Path, "home", lambda: Path("/root"))
+
+        def fake_getpwuid(uid):
+            raise KeyError("no user entry")
+        monkeypatch.setitem(sys.modules, "pwd", SimpleNamespace(getpwuid=fake_getpwuid))
+
+        home = _get_user_home()
+        assert home == Path("/tmp")
 
 
 class TestGetDefaultHermesRoot:


### PR DESCRIPTION
## Summary
Fixes #107295.

In minimal Docker/Kubernetes environments running under a non-root UID where `HOME` environment variable is unset or empty, `Path.home()` can resolve to `/root`. This resulted in `PermissionError: [Errno 13] Permission denied: '/root/.hermes'` when non-root processes attempted to create default home configuration directories.

This PR:
1. Adds `_get_user_home()` helper in `hermes_constants.py` to inspect `pwd.getpwuid(os.getuid())` and verify write access when running under a non-root UID on Unix if `HOME` is unset or resolves to `/root`.
2. Falls back safely to `/tmp` if no user home entry is found, avoiding hardcoded `/root` permission errors for non-root containers.
3. Added unit tests `TestGetUserHome` in `tests/test_hermes_constants.py`.

## Verification
- Ran `pytest tests/test_hermes_constants.py -k TestGetUserHome -v` - 100% passed.
