### PR TITLE
fix(cron): renew fire-claim heartbeat without fire-fence timeout (fixes #108341)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2592,11 +2592,16 @@ def claim_job_for_fire(
 
 def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
     """Refresh an active ``fire_claim`` without extending another owner's lease: an execution may
-    outlive the TTL, and the owner check stops a stale runner from refreshing a recovered claim."""
+    outlive the TTL, and the owner check stops a stale runner from refreshing a recovered claim.
+    
+    Uses ``_with_job`` (which acquires the global jobs store lock) rather than ``_under_fire_fence``,
+    because the per-job fire fence is held across long side effects by the worker thread running the
+    job; acquiring it here from the background heartbeat thread would time out and falsely report
+    ownership loss."""
     def apply(jobs, _i, job):
         return _refresh_claim(jobs, job.get("fire_claim"), expected_owner)
 
-    return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
+    return _with_job(job_id, apply, False)
 
 
 # Completed one-shots are retained in jobs.json (final status stays inspectable) and pruned by

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -325,3 +325,46 @@ def test_fresh_claim_from_a_dead_same_host_owner_is_reclaimable(temp_home):
     job["fire_claim"]["by"] = f"{socket.gethostname()}:{child.pid}:tok"
     save_jobs(jobs)
     assert claim_job_for_fire(jid) is True
+
+
+def test_heartbeat_fire_claim_succeeds_concurrently_while_fire_fence_held(temp_home):
+    """Heartbeating a fire claim from a background thread while a worker thread holds the
+    per-job fire fence must succeed immediately without deadlocking or timing out on the fence."""
+    import threading
+    from cron.jobs import claim_job_for_fire, create_job, fire_claim_fence, get_job, heartbeat_fire_claim
+
+    job = create_job(prompt="x", schedule="every 5m", name="heartbeat-fence")
+    job_id = job["id"]
+    assert claim_job_for_fire(job_id) is True
+    claimed = dict(get_job(job_id)["fire_claim"])
+    owner = claimed["by"]
+
+    heartbeat_result = None
+    heartbeat_error = None
+    fence_entered = threading.Event()
+    heartbeat_done = threading.Event()
+
+    def _worker():
+        with fire_claim_fence(job_id, expected_owner=owner) as acquired:
+            assert acquired is True
+            fence_entered.set()
+            assert heartbeat_done.wait(timeout=10.0)
+
+    worker_thread = threading.Thread(target=_worker)
+    worker_thread.start()
+    assert fence_entered.wait(timeout=5.0)
+
+    try:
+        # Separate thread attempts heartbeat while worker holds fire fence
+        heartbeat_result = heartbeat_fire_claim(job_id, expected_owner=owner)
+    except Exception as e:
+        heartbeat_error = e
+    finally:
+        heartbeat_done.set()
+        worker_thread.join(timeout=5.0)
+
+    assert heartbeat_error is None
+    assert heartbeat_result is True
+    updated = get_job(job_id)["fire_claim"]
+    assert updated["by"] == owner
+


### PR DESCRIPTION
Fixes #108341.

### Root Cause
During job execution (such as slow external message delivery or long agent turns), _run_with_fire_claim_heartbeat runs a background thread cron-fire-claim-heartbeat to renew the job's ire_claim every 60s via heartbeat_fire_claim(job_id, expected_owner=owner).
Previously, heartbeat_fire_claim was wrapped in _under_fire_fence(job_id, ...). Because the executing worker thread holds _fire_job_lock(job_id) across the entire run/delivery duration, the background heartbeat thread failed to acquire the same per-job local lock within _JOBS_LOCK_TIMEOUT_SECONDS (30s), logging a timeout and failing closed (False). The heartbeat loop treated this timeout as ownership loss, prematurely marking the run as failed (Fire claim ownership lost; stale result was discarded.) even though delivery succeeded.

### Fix
- Updated heartbeat_fire_claim in cron/jobs.py to invoke _with_job directly (matching heartbeat_run_claim) rather than re-acquiring _under_fire_fence. _with_job safely serializes the read-compare-update of jobs.json under _jobs_lock().
- Added a regression test 	est_heartbeat_fire_claim_succeeds_concurrently_while_fire_fence_held in 	ests/cron/test_claim_job_for_fire.py verifying that heartbeat_fire_claim succeeds concurrently from a separate thread while ire_claim_fence is held.