### PR TITLE
fix(cron): distinguish fire fence contention from ownership loss

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -350,6 +350,16 @@ def _under_fire_fence(job_id: str, fn: Callable[[], Any]) -> Any:
         return fn()
 
 
+class _LocalFireFenceUnavailable:
+    """Distinct, falsey result for a heartbeat that could not inspect ownership locally."""
+
+    def __bool__(self) -> bool:
+        return False
+
+
+LOCAL_FIRE_FENCE_UNAVAILABLE = _LocalFireFenceUnavailable()
+
+
 @contextlib.contextmanager
 def fire_claim_fence(job_id: str, *, expected_owner: str):
     """Hold a per-job fence while an owner performs an external side effect."""
@@ -2590,13 +2600,18 @@ def claim_job_for_fire(
     return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
 
 
-def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
+def heartbeat_fire_claim(
+    job_id: str, *, expected_owner: str
+) -> Union[bool, _LocalFireFenceUnavailable]:
     """Refresh an active ``fire_claim`` without extending another owner's lease: an execution may
     outlive the TTL, and the owner check stops a stale runner from refreshing a recovered claim."""
     def apply(jobs, _i, job):
         return _refresh_claim(jobs, job.get("fire_claim"), expected_owner)
 
-    return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
+    with _fire_job_lock(job_id) as acquired:
+        if not acquired:
+            return LOCAL_FIRE_FENCE_UNAVAILABLE
+        return _with_job(job_id, apply, False)
 
 
 # Completed one-shots are retained in jobs.json (final status stays inspectable) and pruned by

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -461,9 +461,9 @@ def _resolve_job_reasoning_config(job: dict, cfg: dict, model: str) -> dict | No
 
 
 from cron.jobs import (
-    _ensure_cron_dir, advance_next_runs, claim_dispatch, claim_job_for_fire, fire_claim_fence,
-    clear_run_claim, get_due_jobs, heartbeat_fire_claim, heartbeat_run_claim, mark_job_run,
-    save_job_output, use_cron_store)
+    LOCAL_FIRE_FENCE_UNAVAILABLE, _ensure_cron_dir, advance_next_runs, claim_dispatch,
+    claim_job_for_fire, fire_claim_fence, clear_run_claim, get_due_jobs, heartbeat_fire_claim,
+    heartbeat_run_claim, mark_job_run, save_job_output, use_cron_store)
 from cron.executions import (
     _TERMINAL_STATES, create_execution, finish_execution, get_execution,
     mark_execution_handoff_pending, mark_execution_running, recover_interrupted_executions)
@@ -2374,18 +2374,43 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
         logger.warning("Job '%s': fire claim ownership was already lost before execution", job_id)
         _finish_unstarted("Fire claim ownership lost before execution started.")
         return True
+    if owns_fire_claim is not True and owns_fire_claim is not LOCAL_FIRE_FENCE_UNAVAILABLE:
+        logger.warning("Job '%s': initial fire_claim validation returned an unknown state", job_id)
+        _finish_unstarted("Fire claim ownership could not be validated before execution started.")
+        return True
 
     def _heartbeat_loop() -> None:
         last_confirmed = time.monotonic()
         while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
             try:
-                if not heartbeat_fire_claim(job_id, expected_owner=owner):
+                heartbeat_result = heartbeat_fire_claim(job_id, expected_owner=owner)
+                if heartbeat_result is False:
                     lost_ownership.set()
                     logger.warning(
                         "Job '%s': fire claim ownership lost; interrupting stale run",
                         job_id)
                     return
-                last_confirmed = time.monotonic()
+                if heartbeat_result is True:
+                    last_confirmed = time.monotonic()
+                    continue
+                if heartbeat_result is not LOCAL_FIRE_FENCE_UNAVAILABLE:
+                    lost_ownership.set()
+                    logger.warning(
+                        "Job '%s': fire_claim heartbeat returned an unknown state; "
+                        "interrupting uncertain run",
+                        job_id)
+                    return
+                if (
+                    time.monotonic() - last_confirmed
+                    >= _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS
+                ):
+                    lost_ownership.set()
+                    logger.warning(
+                        "Job '%s': local fire fence remained unavailable for %.1fs; "
+                        "interrupting uncertain run",
+                        job_id,
+                        _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS)
+                    return
             except Exception:
                 logger.debug("Job '%s': fire_claim heartbeat failed", job_id, exc_info=True)
                 if (
@@ -2497,7 +2522,10 @@ def _record_fire_ownership_lost(job_id: str, fire_owner: Optional[str], executio
     """Bookkeeping after fire-claim ownership loss. A transport-level cancel (dashboard drain) is
     not a real loss — we still own the claim, so record the interruption via the owner-fenced
     terminal write instead of leaving fire_claim/last_status stale; otherwise discard."""
-    if fire_owner is not None and heartbeat_fire_claim(job_id, expected_owner=fire_owner):
+    if (
+        fire_owner is not None
+        and heartbeat_fire_claim(job_id, expected_owner=fire_owner) is True
+    ):
         mark_job_run(job_id, False, _OWNERSHIP_LOST_INTERRUPTED, expected_fire_owner=fire_owner)
         finish_execution(execution_id, success=False, error=_OWNERSHIP_LOST_INTERRUPTED)
     else:
@@ -2587,7 +2615,7 @@ class _FireOwnership:
         if self.owner is None:
             return False
         try:
-            if heartbeat_fire_claim(self.job["id"], expected_owner=self.owner):
+            if heartbeat_fire_claim(self.job["id"], expected_owner=self.owner) is True:
                 return False
         except Exception:
             logger.debug(

--- a/tests/cron/test_script_claim_heartbeat.py
+++ b/tests/cron/test_script_claim_heartbeat.py
@@ -360,6 +360,84 @@ def test_run_one_job_refreshes_fire_claim_in_profile_store(tmp_path, monkeypatch
     assert refreshed["by"] == original_claim["by"]
 
 
+def test_local_fire_fence_timeout_during_slow_delivery_does_not_fake_owner_loss(
+    tmp_path, monkeypatch
+):
+    """A notifying run survives heartbeat contention with its own delivery fence."""
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+    from cron import scheduler_script as sched_script
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    with jobs.use_cron_store(profile_home):
+        job = jobs.create_job(
+            prompt="x", schedule="every 5m", name="slow notify", deliver="telegram"
+        )
+        assert jobs.claim_job_for_fire(job["id"]) is True
+        claimed_job = jobs.get_job(job["id"])
+
+    heartbeat_waiting_on_delivery = threading.Event()
+    heartbeat_finished_waiting = threading.Event()
+    real_heartbeat = jobs.heartbeat_fire_claim
+
+    def _observed_heartbeat(job_id: str, *, expected_owner: str):
+        is_heartbeat_thread = threading.current_thread().name == "cron-fire-claim-heartbeat"
+        if is_heartbeat_thread:
+            heartbeat_waiting_on_delivery.set()
+        result = real_heartbeat(job_id, expected_owner=expected_owner)
+        if is_heartbeat_thread:
+            heartbeat_finished_waiting.set()
+        return result
+
+    def _slow_delivery(*_args, **_kwargs):
+        assert heartbeat_waiting_on_delivery.wait(timeout=1)
+        assert heartbeat_finished_waiting.wait(timeout=1)
+        return None
+
+    mark_run = MagicMock(return_value=True)
+    finish = MagicMock()
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.02)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.005)
+    monkeypatch.setattr(scheduler, "_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS", 0.2)
+    monkeypatch.setattr(scheduler, "heartbeat_fire_claim", _observed_heartbeat)
+    monkeypatch.setattr(scheduler, "_launch_external_cron_worker", lambda _job: False)
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda _execution_id: {})
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda *_args, **_kwargs: (True, "output", "notification", None),
+    )
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_args: "output.md")
+    monkeypatch.setattr(scheduler, "_deliver_result", _slow_delivery)
+    monkeypatch.setattr(scheduler, "mark_job_run", mark_run)
+    monkeypatch.setattr(scheduler, "finish_execution", finish)
+
+    claimed_job["execution_id"] = "slow-notify-execution"
+    with (
+        jobs.use_cron_store(profile_home),
+        patch("agent.secret_scope.set_secret_scope", return_value=None),
+        patch("agent.secret_scope.build_profile_secret_scope", return_value=None),
+        patch("agent.secret_scope.reset_secret_scope"),
+    ):
+        assert scheduler.run_one_job(claimed_job) is True
+
+    mark_run.assert_called_once_with(
+        claimed_job["id"],
+        True,
+        None,
+        delivery_error=None,
+        expected_fire_owner=claimed_job["fire_claim"]["by"],
+    )
+    finish.assert_called_once_with(
+        "slow-notify-execution",
+        success=True,
+        error=None,
+        delivery_outcome="delivered",
+    )
+
+
 def test_lost_fire_claim_stops_stale_delivery(monkeypatch):
     """A runner that loses its durable owner must not deliver its stale result."""
     import cron.scheduler as scheduler


### PR DESCRIPTION
## What does this PR do?

Distinguishes a local per-job fire-fence timeout from confirmed fire-claim ownership loss.

Previously, `heartbeat_fire_claim()` returned `False` for both cases. During a slow notifying delivery, the delivery thread legitimately holds the fire fence, so the heartbeat thread could time out locally and cause the scheduler to interrupt and record an otherwise successful run as failed.

The heartbeat now returns a dedicated local-unavailable signal. The scheduler treats that signal as transient only within the existing heartbeat grace period, while a real owner mismatch still immediately cancels and discards the stale run. Unknown results remain fail-closed.

## Related Issue

Fixes #108341

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/jobs.py`: return a distinct sentinel when the local fire fence cannot be acquired.
- `cron/scheduler.py`: distinguish confirmed ownership loss, transient fence contention, and unknown heartbeat states without changing timeout or grace constants.
- `tests/cron/test_script_claim_heartbeat.py`: exercise the real profile store and local fence during a slow notifying delivery; retain the true stale-owner cancellation control.

## How to Test

1. Run `scripts/run_tests.sh tests/cron/test_script_claim_heartbeat.py -k 'local_fire_fence_timeout_during_slow_delivery_does_not_fake_owner_loss or lost_fire_claim_stops_stale_delivery' -q`.
2. Confirm both the local-contention regression and stale-owner control pass (`2 passed`).
3. Run `scripts/run_tests.sh tests/cron/test_claim_job_for_fire.py -q` and confirm all claim-store tests pass (`17 passed`).

Proof receipt: the new regression failed on `ad03f20dd61919ca2135d6904e787a94284aacaf` because the local fence timeout was interpreted as ownership loss and terminal bookkeeping recorded an interruption. It passes with this patch, together with the stale-owner control. An independent P0-only review found P0=0. `ruff` and `git diff --check` also pass.

The expanded heartbeat file run had 30 passing tests and two unrelated local failures where the repository live-system guard blocked `os.killpg`; no process-management code is changed here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is scheduler ownership bookkeeping with automated regression coverage.
