### PR TITLE
fix(codex-runtime): preserve user-owned root default_permissions

### DIFF
--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -29,6 +29,7 @@ class MigrationReport:
     migrated_plugins: list[str] = field(default_factory=list)
     plugin_query_error: Optional[str] = None
     wrote_permissions_default: Optional[str] = None
+    preserved_permissions_default: Optional[str] = None
     errors: list[str] = field(default_factory=list)
     written: bool = False
     dry_run: bool = False
@@ -54,6 +55,10 @@ class MigrationReport:
             lines.append(f"Codex plugin discovery skipped: {self.plugin_query_error}")
         if self.wrote_permissions_default:
             lines.append(f"Wrote default_permissions = {self.wrote_permissions_default!r}")
+        if self.preserved_permissions_default:
+            lines.append(
+                f"Kept your root default_permissions = {self.preserved_permissions_default!r} "
+                "(managed default not written)")
         lines.extend(f"⚠ {err}" for err in self.errors)
         return "\n".join(lines)
 
@@ -274,6 +279,39 @@ def _strip_existing_managed_block(toml_text: str) -> str:
     return "".join(out)
 
 
+def _find_root_level_key(toml_text: str, key: str) -> Optional[str]:
+    """Return the value of a document-root ``key = ...`` assignment, or None when there is none.
+
+    Only lines above the first ``[table]`` header are at the document root — TOML has no way back
+    to the root after a header, so a ``default_permissions`` inside ``[permissions]`` is a
+    different key. A quoted ``#`` is part of the value, an unquoted one starts a comment, and
+    surrounding quotes are stripped so the result reads like the bare value it holds.
+    """
+    for line in toml_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if _looks_like_table_header(stripped):
+            return None
+        found, sep, value = stripped.partition("=")
+        if not sep or found.strip() != key:
+            continue
+        quote = ""
+        for idx, char in enumerate(value):
+            if quote:
+                quote = "" if char == quote else quote
+            elif char in "\"'":
+                quote = char
+            elif char == "#":
+                value = value[:idx]
+                break
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+            value = value[1:-1]
+        return value
+    return None
+
+
 def _query_codex_plugins(
     codex_home: Optional[Path] = None, timeout: float = 8.0) -> tuple[list[dict], Optional[str]]:
     """Spawn ``codex app-server`` briefly and return ``(installed plugins, error)`` from
@@ -400,7 +438,9 @@ def migrate(
     ``discover_plugins`` spawns the live codex CLI (set False in tests); discovery is best-effort
     and never blocks the migration. ``default_permission_profile`` (default ":workspace"; built-ins
     carry a leading ":", user profiles do not; None leaves codex's read-only default) avoids an
-    approval prompt on every write. ``expose_hermes_tools`` registers Hermes' own tool surface
+    approval prompt on every write; a root-level ``default_permissions`` the user owns outside the
+    managed block is kept instead and reported as ``preserved_permissions_default``.
+    ``expose_hermes_tools`` registers Hermes' own tool surface
     (agent/transports/hermes_tools_mcp_server.py, launched on demand by codex over stdio) as an MCP
     server so the codex subprocess can call back for tools it lacks.
     """
@@ -434,6 +474,24 @@ def migrate(
         # re-render and may strip pre-existing tables outside the managed block.
         plugin_query_succeeded = not plugin_err
         report.migrated_plugins += [f"{p['name']}@{p['marketplace']}" for p in plugins]
+    # Read the user's config BEFORE rendering: a root-level ``default_permissions`` they wrote
+    # outside the managed block is theirs. The docs promise that override survives re-migration,
+    # and emitting our default as well would put two root keys in the file — codex then refuses to
+    # load it ("Cannot overwrite a value") while this migration still reports success.
+    user_text: Optional[str] = None
+    if target.exists():
+        try:
+            existing = target.read_text(encoding="utf-8")
+        except Exception as exc:
+            report.errors.append(f"could not read {target}: {exc}")
+            return report
+        user_text = _strip_existing_managed_block(existing)
+        if plugin_query_succeeded:
+            user_text = _strip_unmanaged_plugin_tables(user_text)
+        user_owned_permissions = _find_root_level_key(user_text, "default_permissions")
+        if default_permission_profile and user_owned_permissions is not None:
+            report.preserved_permissions_default = user_owned_permissions
+            default_permission_profile = None
     if default_permission_profile:
         report.wrote_permissions_default = default_permission_profile
     if expose_hermes_tools:
@@ -442,17 +500,8 @@ def migrate(
             report.migrated.append("hermes-tools")
     managed_block = render_codex_toml_section(
         translated, plugins=plugins, default_permission_profile=default_permission_profile)
-    new_text = managed_block
-    if target.exists():
-        try:
-            existing = target.read_text(encoding="utf-8")
-        except Exception as exc:
-            report.errors.append(f"could not read {target}: {exc}")
-            return report
-        without_managed = _strip_existing_managed_block(existing)
-        if plugin_query_succeeded:
-            without_managed = _strip_unmanaged_plugin_tables(without_managed)
-        new_text = _insert_managed_block_at_top_level(without_managed, managed_block)
+    new_text = managed_block if user_text is None else _insert_managed_block_at_top_level(
+        user_text, managed_block)
     if dry_run:
         return report
     try:

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tomllib
 
 import pytest
 
@@ -378,6 +379,94 @@ class TestStripUnmanagedPluginTables:
         # File parses cleanly as TOML (the original duplicate-key error is gone).
         import tomllib
         tomllib.loads(new_text)
+
+
+# ---- root-level default_permissions ownership ----
+#
+# The documented override path (website/docs/user-guide/features/codex-app-server-runtime.md) is a
+# root-level ``default_permissions`` OUTSIDE the managed block — "Hermes will preserve your
+# override on re-migration as long as it lives outside the `# managed by hermes-agent` markers."
+# The migration preserved the user's *line* but still emitted its own root key, so the file ended
+# up with two ``default_permissions`` keys at the document root: codex then refuses to load it
+# (``TOMLDecodeError: Cannot overwrite a value``) and the migration still reported success.
+
+
+class TestUserOwnedRootDefaultPermissions:
+    """A root key the user owns outside the managed block stays the only one after migration."""
+
+    @staticmethod
+    def _config_text(tmp_path) -> str:
+        return (tmp_path / "config.toml").read_text(encoding="utf-8")
+
+    def test_user_override_is_preserved_and_not_duplicated(self, tmp_path):
+        (tmp_path / "config.toml").write_text(
+            "# my codex config\n"
+            'default_permissions = ":read-only"\n'
+            "\n"
+            "[features]\n"
+            "some_feature = true\n",
+            encoding="utf-8",
+        )
+
+        report = migrate({}, codex_home=tmp_path, discover_plugins=False,
+                         expose_hermes_tools=False)
+
+        text = self._config_text(tmp_path)
+        assert text.count("default_permissions") == 1
+        # The generated file has to be loadable — this is what codex does on startup.
+        assert tomllib.loads(text)["default_permissions"] == ":read-only"
+        assert report.preserved_permissions_default == ":read-only"
+        assert report.wrote_permissions_default is None
+
+    def test_user_override_is_idempotent_across_re_migrations(self, tmp_path):
+        (tmp_path / "config.toml").write_text(
+            'default_permissions = "hermes-obsidian"\n', encoding="utf-8")
+
+        first = migrate({}, codex_home=tmp_path, discover_plugins=False,
+                        expose_hermes_tools=False)
+        after_first = self._config_text(tmp_path)
+        second = migrate({}, codex_home=tmp_path, discover_plugins=False,
+                         expose_hermes_tools=False)
+
+        assert self._config_text(tmp_path) == after_first
+        assert tomllib.loads(after_first)["default_permissions"] == "hermes-obsidian"
+        assert first.preserved_permissions_default == "hermes-obsidian"
+        assert second.preserved_permissions_default == "hermes-obsidian"
+
+    def test_without_user_override_the_managed_default_is_written(self, tmp_path):
+        report = migrate({}, codex_home=tmp_path, discover_plugins=False,
+                         expose_hermes_tools=False)
+
+        assert tomllib.loads(self._config_text(tmp_path))["default_permissions"] == ":workspace"
+        assert report.wrote_permissions_default == ":workspace"
+
+    def test_managed_key_is_rewritten_not_treated_as_a_user_override(self, tmp_path):
+        """The key inside the managed block is Hermes' own ("anything you add inside the managed
+        block gets clobbered"), so re-migration updates it instead of freezing the old value."""
+        migrate({}, codex_home=tmp_path, discover_plugins=False, expose_hermes_tools=False,
+                default_permission_profile=":read-only")
+        report = migrate({}, codex_home=tmp_path, discover_plugins=False,
+                         expose_hermes_tools=False,
+                         default_permission_profile=":workspace")
+
+        assert tomllib.loads(self._config_text(tmp_path))["default_permissions"] == ":workspace"
+        assert report.wrote_permissions_default == ":workspace"
+
+    def test_key_inside_a_table_is_not_a_root_override(self, tmp_path):
+        """``[permissions.<name>] default_permissions`` is a table key, not the document-root
+        setting, so it must not suppress the managed root key."""
+        (tmp_path / "config.toml").write_text(
+            "[permissions.hermes-obsidian]\n"
+            'default_permissions = ":read-only"\n',
+            encoding="utf-8",
+        )
+
+        report = migrate({}, codex_home=tmp_path, discover_plugins=False,
+                         expose_hermes_tools=False)
+
+        parsed = tomllib.loads(self._config_text(tmp_path))
+        assert parsed["default_permissions"] == ":workspace"
+        assert parsed["permissions"]["hermes-obsidian"]["default_permissions"] == ":read-only"
 
 
 # ---- Bug C: HERMES_HOME tempdir leak into ~/.codex/config.toml ----


### PR DESCRIPTION
## Summary

Fixes #108278.

Codex runtime migration currently emits its managed `default_permissions` even when the user already owns a root-level `default_permissions` outside Hermes' managed block. That produces duplicate root keys and invalid TOML.

This change preserves the user-owned root key and suppresses the managed duplicate. If no user-owned root key exists, current behavior is unchanged and Hermes still writes its normal managed default.

## Behavior

Before migration:

```toml
default_permissions = "hermes-obsidian"
```

Previously, migration could produce:

```toml
default_permissions = "hermes-obsidian"

# managed by hermes-agent ...
default_permissions = ":workspace"
...
# end hermes-agent managed section
```

which fails TOML parsing with `TOMLDecodeError: Cannot overwrite a value`.

After this change, the user-owned root value is left in place and the managed block omits a second `default_permissions` key.

## Implementation

- read the existing config before rendering the managed block;
- detect an unmanaged root-level `default_permissions` that survives managed-block / plugin-table stripping;
- preserve that value instead of emitting the managed default;
- expose the preserved value in `MigrationReport` so the migration summary reports what happened;
- retain existing behavior when no user-owned root key exists.

The ownership rule is deliberately value-agnostic: a user-owned root key is preserved whether it names a custom profile such as `hermes-obsidian` or uses another valid value.

## Tests

Regression coverage includes:

- no user root key -> managed default still written;
- user root key outside the managed block -> exact value preserved;
- no duplicate root key emitted;
- resulting TOML parses successfully;
- table-level keys are not mistaken for root-level keys;
- re-migration remains stable.

Local verification on the prepared patch:

```text
44 passed, 0 failed
ruff check: clean
ruff check --select PLW1514: clean
ty check: clean
```

The failing behavior was reproduced RED against pristine upstream before applying the fix.

## Relationship to #27764

This overlaps mechanically with #27764 but addresses a distinct ownership case.

#27764 preserves selected full-access values during re-migration and re-emits them in Hermes' managed block. This change preserves any user-owned root-level `default_permissions` outside the managed block and therefore also covers named profiles and other values not handled by #27764.

Because both changes touch the migration tail, there may be a merge/reconciliation conflict if #27764 lands first. Semantically, the rule here is: if the root key is user-owned outside Hermes' managed block, Hermes should not emit a duplicate managed root key.