### PR TITLE
fix(aux): do not fall back to a text-only main model for vision tasks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3916,6 +3916,16 @@ def _try_main_agent_model_fallback(
         main_provider, main_model = _agg_provider, _agg_model
     if not main_provider or not main_model or main_provider.lower() in {"auto", ""}:
         return None, None, ""
+    if task == "vision" and not _main_model_supports_vision(main_provider, main_model):
+        # A text-only main model cannot accept image content: keep the original
+        # provider error instead of surfacing a guaranteed 400 on the image block.
+        logger.debug(
+            "Auxiliary vision: main agent model %s (%s) takes no image input, "
+            "keeping the original error",
+            main_model,
+            main_provider,
+        )
+        return None, None, ""
     main_base_url = _custom_health_base_url(main_provider)
     if _failed_backend_skip(
             failed_provider, failed_model, failed_base_url=failed_base_url,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1993,6 +1993,46 @@ class TestTryMainAgentModelFallback:
         assert model == "anthropic/claude-sonnet-4"
         assert label == "main-agent(openrouter)"
 
+    def test_vision_task_skips_text_only_main_model(self):
+        """A vision call must not fall back to a main model that takes no image input."""
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+        with (
+            patch("agent.auxiliary_client._read_main_provider", return_value="zai"),
+            patch("agent.auxiliary_client._read_main_model", return_value="glm-5.3"),
+            patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False),
+            patch(
+                "agent.auxiliary_client._main_model_supports_vision", return_value=False
+            ),
+            patch("agent.auxiliary_client.resolve_provider_client") as mock_resolve,
+        ):
+            client, model, label = _try_main_agent_model_fallback("nous", task="vision")
+        assert client is None and model is None and label == ""
+        mock_resolve.assert_not_called()
+
+    def test_vision_task_allows_vision_capable_main_model(self):
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+        fake_client = MagicMock()
+        with (
+            patch(
+                "agent.auxiliary_client._read_main_provider", return_value="openrouter"
+            ),
+            patch(
+                "agent.auxiliary_client._read_main_model",
+                return_value="anthropic/claude-sonnet-4",
+            ),
+            patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False),
+            patch(
+                "agent.auxiliary_client._main_model_supports_vision", return_value=True
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fake_client, "anthropic/claude-sonnet-4"),
+            ),
+        ):
+            client, model, label = _try_main_agent_model_fallback("nous", task="vision")
+        assert client is fake_client
+        assert label == "main-agent(openrouter)"
+
 
 
 


### PR DESCRIPTION
Fixes #108349 (surface 1).

## Problem

When the pinned auxiliary vision provider returns a transient upstream-capacity 429, `_try_main_agent_model_fallback()` resolves the main agent provider+model and hands the client back for the vision call **without any vision-capability check**. With a text-only main model (e.g. `zai/glm-5.3`), the first image block then fails with `400 messages.content.type is invalid` (error 1210) — a guaranteed failure that masks the original, retryable 429.

The auto-route path (`_vision_main_provider_client`) already gates on `_main_model_supports_vision()` / `_PROVIDERS_WITHOUT_VISION` before building a client; the last-resort fallback path simply never got the same treatment.

## Fix

Gate `_try_main_agent_model_fallback` for `task == "vision"` with the same `_main_model_supports_vision()` check the auto-route path uses. When the main model is known text-only, return `(None, None, "")` so the original provider error (the retryable 429) surfaces to the caller instead of a guaranteed 400. Unknown capability still passes through (the helper fails open), so no existing vision-capable fallback is lost.

## Tests

Two twins in the existing `TestTryMainAgentModelFallback` class:

- `test_vision_task_skips_text_only_main_model` — text-only main model → no fallback client, `resolve_provider_client` never called, original error propagates (mutation-verified: removing the gate makes this test fail).
- `test_vision_task_allows_vision_capable_main_model` — vision-capable main model → fallback still returned, label intact.

## Scope

Surface 2 from the report (an upstream-capacity 429 whose body says "not your API key's rate limit" marking the chat credential-pool identity exhausted) is a separate policy call in the pool-rotation logic — I've kept it out of this PR rather than decide it silently in a patch, and flagged it on the issue for a maintainer call.
