### PR TITLE
Matrix: make attach_to_session / session handoff work (thread anchor + thread keying)

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2064,6 +2064,15 @@ class MatrixAdapter(BasePlatformAdapter):
             if synthetic:
                 thread_id = event_id
         display_name = await self._get_display_name(room_id, sender)
+        # Key an in-thread (non-DM) message with chat_type="thread" so a human
+        # reply resumes the SAME session the seed created. Handoff/cron seeds
+        # (and Telegram/Discord/Slack) key the first-class "thread" lane; without
+        # this Matrix keys "group" and the reply lands in a different session,
+        # silently dropping the seeded context. DM threads keep "dm", which the
+        # seed already matches; build_session_key drops user_id for threads, so
+        # chat_type is the only remaining divergent slot.
+        if thread_id and not is_dm:
+            chat_type = "thread"
         source = self.build_source(
             chat_id=room_id, chat_name=identity.display_name, chat_type=chat_type, user_id=sender,
             user_name=display_name, thread_id=thread_id, chat_topic=identity.room_topic,

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1399,6 +1399,40 @@ class MatrixAdapter(BasePlatformAdapter):
             self._client.send_message_event(RoomID(chat_id), EventType.ROOM_MESSAGE, msg_content), timeout=45)
         return str(event_id)
 
+    async def create_handoff_thread(
+        self,
+        parent_chat_id: str,
+        name: str,
+    ) -> Optional[str]:
+        """Create a Matrix thread anchor for a session handoff.
+
+        Matrix has no channel-level "create thread" API — a thread is just
+        events whose ``m.relates_to``/``rel_type: m.thread`` reference a root
+        event's ``event_id`` (the same model Slack uses with ``thread_ts``).
+        So post a seed/root message into ``parent_chat_id`` and return its
+        ``event_id``: the handoff watcher / cron scheduler uses that as the
+        ``thread_id`` for subsequent sends, and ``_apply_relation_metadata``
+        already threads them off it.
+
+        Returns the seed event id as a string, or ``None`` if the client is
+        unavailable or the seed send failed (callers fall back to
+        ``parent_chat_id`` directly).
+        """
+        if self._client is None:
+            return None
+        seed_text = (name or "").strip() or "Hermes session"
+        result = await self.send(parent_chat_id, seed_text)
+        root = result.message_id if (result and result.success) else None
+        if not root:
+            return None
+        try:
+            # Register the root so inbound replies in this thread are
+            # recognised as participated (mirrors inbound thread handling).
+            self._threads.mark(str(root))
+        except Exception:  # pragma: no cover - defensive
+            pass
+        return str(root)
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         identity = await self._resolve_room_identity(chat_id)
         return {"name": identity.display_name, "type": "dm" if identity.chat_type == "dm" else "group"}

--- a/tests/gateway/test_matrix_handoff_thread.py
+++ b/tests/gateway/test_matrix_handoff_thread.py
@@ -1,0 +1,81 @@
+"""Tests for MatrixAdapter.create_handoff_thread.
+
+Matrix has no channel-level "create thread" API, so the adapter seeds a root
+message and returns its event_id as the thread handle (Slack-style — mirrors
+``tests/gateway/test_slack_sdk_response.py::TestHandoffThread``). These tests
+cover: the seed event id becomes the thread id (and the root is registered as a
+participated thread), a blank name falls back to a default seed, and ``None`` is
+returned when the client is absent or the seed send fails.
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+
+
+def _make_adapter():
+    """Create a MatrixAdapter with mocked config (no live client)."""
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test_token",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@hermes:example.org",
+        },
+    )
+    adapter = MatrixAdapter(config)
+    adapter._startup_ts = time.time() - 10
+    return adapter
+
+
+class TestHandoffThread:
+    """``create_handoff_thread`` anchors a session on the seed event's id."""
+
+    def test_seed_event_becomes_the_thread_id(self):
+        adapter = _make_adapter()
+        adapter._client = MagicMock()  # truthy: a client is connected
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="$root_evt"))
+
+        thread_id = asyncio.run(adapter.create_handoff_thread("!room1:example.org", "Hermes — daily brief"))
+
+        assert thread_id == "$root_evt"
+        adapter.send.assert_awaited_once_with("!room1:example.org", "Hermes — daily brief")
+        # Root registered so inbound replies in this thread are recognised.
+        assert "$root_evt" in adapter._threads
+
+    def test_blank_name_falls_back_to_default_seed(self):
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="$root2"))
+
+        thread_id = asyncio.run(adapter.create_handoff_thread("!room1:example.org", "   "))
+
+        assert thread_id == "$root2"
+        adapter.send.assert_awaited_once_with("!room1:example.org", "Hermes session")
+
+    def test_no_client_yields_no_thread(self):
+        adapter = _make_adapter()
+        adapter._client = None
+        adapter.send = AsyncMock()
+
+        assert asyncio.run(adapter.create_handoff_thread("!room1:example.org", "x")) is None
+        adapter.send.assert_not_awaited()
+
+    def test_failed_seed_send_yields_no_thread(self):
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter.send = AsyncMock(return_value=SendResult(success=False, error="boom"))
+
+        assert asyncio.run(adapter.create_handoff_thread("!room1:example.org", "x")) is None
+
+    def test_seed_send_without_event_id_yields_no_thread(self):
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id=None))
+
+        assert asyncio.run(adapter.create_handoff_thread("!room1:example.org", "x")) is None

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -287,6 +287,64 @@ async def test_auto_thread_skips_dm(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Thread session-keying: in-thread messages key chat_type="thread"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_in_thread_message_keys_chat_type_thread(monkeypatch):
+    """An in-thread (non-DM) message must key chat_type="thread" so a reply
+    resumes the SAME session a handoff/cron seed created (which keys the
+    first-class "thread" lane, like Telegram/Discord/Slack)."""
+    monkeypatch.setenv("MATRIX_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("MATRIX_AUTO_THREAD", raising=False)
+
+    adapter = _make_adapter()
+    adapter._threads.mark("$thread_root")
+    event = _make_event("reply in thread", thread_id="$thread_root")
+
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.source.thread_id == "$thread_root"
+    assert msg.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_in_thread_dm_keeps_chat_type_dm(monkeypatch):
+    """A DM thread keeps chat_type="dm" — the seed already keys DMs that way."""
+    monkeypatch.setenv("MATRIX_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("MATRIX_AUTO_THREAD", raising=False)
+
+    adapter = _make_adapter()
+    _set_dm(adapter)
+    adapter._threads.mark("$thread_root")
+    event = _make_event("reply in dm thread", thread_id="$thread_root", event_id="$dm2")
+
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.source.thread_id == "$thread_root"
+    assert msg.source.chat_type == "dm"
+
+
+@pytest.mark.asyncio
+async def test_non_thread_room_message_keeps_chat_type_group(monkeypatch):
+    """A non-threaded room message is unaffected — still chat_type="group"."""
+    monkeypatch.setenv("MATRIX_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    event = _make_event("plain room message")
+
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.source.thread_id is None
+    assert msg.source.chat_type == "group"
+
+
+# ---------------------------------------------------------------------------
 # Thread persistence
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# Matrix: make `attach_to_session` / session handoff work (thread anchor + thread keying)

Two related changes that together make cron `attach_to_session` and the gateway
handoff watcher actually work on Matrix, matching Telegram/Discord/Slack.

Fixes #112918

### 1. `feat(matrix): implement create_handoff_thread`

`MatrixAdapter` inherited the base `create_handoff_thread(parent_chat_id, name)
-> Optional[str]`, which returns `None`. Telegram, Discord and Slack override it;
Matrix did not. So cron `attach_to_session` and the gateway handoff watcher
**silently no-op on Matrix** — the alert/handoff is delivered flat instead of as a
replyable thread, and the scheduler logs `thread_id=None` → `Mirror: no session
found`.

Implemented **Slack-style**: Matrix has no channel-level "create thread" API — a
thread is just events whose `m.relates_to`/`rel_type: m.thread` reference a root
event's `event_id` — so seed a root message and return its `event_id` as the
thread handle. The implementation reuses the adapter's own `send()` (chunking +
E2EE retry + formatting) and registers the root with `self._threads.mark()`;
`_apply_relation_metadata` already threads later sends off a supplied `thread_id`,
so the returned id is immediately usable. Returns `None` when the client is
unavailable or the seed send fails (callers fall back to `parent_chat_id`).

### 2. `fix(matrix): key in-thread messages as chat_type="thread"`

An in-thread (non-DM) Matrix message was keyed with the **room's** `chat_type`
(`"group"`) plus a `thread_id`, so `build_session_key` produced
`…:group:<room>:<thread>`, while the handoff/cron thread seed (and
Telegram/Discord/Slack) use the first-class `"thread"` `chat_type` →
`…:thread:<room>:<thread>`. That one-slot divergence lands the seeded brief and
the user's in-thread reply in **different sessions** — so even with fix #1 the
thread's replies start a blank session and the seeded context is silently dropped.

Switch `chat_type` to `"thread"` for in-thread non-DM messages so Matrix keys the
shared thread lane like every other platform. `build_session_key` already drops
`user_id` for any threaded message, so `chat_type` is the only remaining divergent
slot; DM threads keep `"dm"`, which the seed already matches.

> This second fix is independent of cron — it also corrects session keying for the
> gateway handoff watcher and for manual Matrix threads — but it's required for
> `attach_to_session` to work end-to-end, so both ship together.

### Tests

- `tests/gateway/test_matrix_handoff_thread.py` — `create_handoff_thread`: seed
  event id becomes the thread id (and the root is registered); blank name falls
  back to a default seed; `None` on no client, failed send, and missing event id.
  (Mirrors `tests/gateway/test_slack_sdk_response.py::TestHandoffThread`.)
- `tests/gateway/test_matrix_mention.py` — keying: in-thread room → `"thread"`,
  DM thread → `"dm"`, non-thread room → `"group"` (unchanged).

All additive (no deletions). `pytest tests/gateway/test_matrix_handoff_thread.py
tests/gateway/test_matrix_mention.py` → 25 passed.