### PR TITLE
fix(tools): exclude WSL launcher bash from Windows bash candidates (#108165)

### DIFF
--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -332,3 +332,24 @@ class TestWrapCommandWindowsNativeCwd:
         script = captured["script"]
         assert "/c/Users/Alexander/AppData/Local/Temp/hermes-snap-deadbeef.sh" in script
         assert r"C:\Users\Alexander\AppData" not in script
+
+
+class TestIsWslBash:
+    def test_detects_system32_wsl_bash(self, monkeypatch):
+        from tools.environments.local import _is_wsl_bash
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setenv("SystemRoot", r"C:\Windows")
+
+        assert _is_wsl_bash(r"C:\Windows\System32\bash.exe") is True
+        assert _is_wsl_bash(r"c:\windows\system32\bash.EXE") is True
+        assert _is_wsl_bash(r"C:\Program Files\Git\bin\bash.exe") is False
+
+    def test_windows_bash_candidates_excludes_wsl(self, monkeypatch):
+        from tools.environments.local import _windows_bash_candidates
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setenv("SystemRoot", r"C:\Windows")
+        monkeypatch.setattr(local_mod.shutil, "which", lambda cmd: r"C:\Windows\System32\bash.exe")
+
+        candidates = _windows_bash_candidates(None)
+        assert r"C:\Windows\System32\bash.exe" not in candidates
+

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -338,24 +338,48 @@ def build_subprocess_env(
 
 
 # --- Shell discovery ---
+def _is_wsl_bash(path: str) -> bool:
+    """Return True if path points to Windows/WSL launcher bash.exe (System32\\bash.exe)."""
+    if not path or not _IS_WINDOWS:
+        return False
+    norm = os.path.normpath(path).lower()
+    system_root = os.path.normpath(os.environ.get("SystemRoot", r"C:\Windows")).lower()
+    return (
+        norm.startswith(os.path.join(system_root, "system32"))
+        or norm.startswith(os.path.join(system_root, "syswow64"))
+        or norm.startswith(os.path.join(system_root, "windowsapps"))
+    )
+
+
 def _windows_bash_candidates(custom: "str | None") -> list[str]:
     """Ordered bash.exe candidates on Windows: HERMES_GIT_BASH_PATH, our portable Git
     under %LOCALAPPDATA%\\hermes\\git (PortableGit ``bin`` and MinGit ``usr\\bin``),
-    known Git-for-Windows dirs, then PATH last — ``shutil.which`` may return WSL's
-    bash, which fails silently on Windows paths."""
+    known Git-for-Windows dirs, then non-WSL PATH candidates — ``shutil.which`` may return WSL's
+    bash (System32\\bash.exe), which fails silently on Windows paths."""
     getenv = os.environ.get
     lad = getenv("LOCALAPPDATA", "")
+    pf = getenv("ProgramFiles", r"C:\Program Files")
+    pf86 = getenv("ProgramFiles(x86)", r"C:\Program Files (x86)")
+    sys_drive = getenv("SystemDrive", "C:")
+    user_prof = getenv("USERPROFILE", "")
     roots = [
         lad and os.path.join(lad, "hermes", "git", "bin"),
         lad and os.path.join(lad, "hermes", "git", "usr", "bin"),
-        os.path.join(getenv("ProgramFiles", r"C:\Program Files"), "Git", "bin"),
-        os.path.join(getenv("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "bin"),
+        os.path.join(pf, "Git", "bin"),
+        os.path.join(pf, "Git", "usr", "bin"),
+        os.path.join(pf86, "Git", "bin"),
+        os.path.join(pf86, "Git", "usr", "bin"),
         lad and os.path.join(lad, "Programs", "Git", "bin"),
+        lad and os.path.join(lad, "Programs", "Git", "usr", "bin"),
+        os.path.join(sys_drive, "Git", "bin"),
+        os.path.join(sys_drive, "Git", "usr", "bin"),
+        user_prof and os.path.join(user_prof, "scoop", "apps", "git", "current", "bin"),
+        user_prof and os.path.join(user_prof, "scoop", "apps", "git", "current", "usr", "bin"),
     ]
     raw = [custom or "", *(os.path.join(r, "bash.exe") for r in roots if r)]
     candidates = list(dict.fromkeys(c for c in raw if c and os.path.isfile(c)))
     found = shutil.which("bash")
-    if found and found not in candidates:
+    if found and found not in candidates and not _is_wsl_bash(found):
         candidates.append(found)
     return candidates
 


### PR DESCRIPTION
## Summary
Fixes #108165.

On Windows hosts where both Git for Windows and WSL are installed, `_windows_bash_candidates()` in `tools/environments/local.py` could resolve to WSL launcher `C:\Windows\System32\bash.exe` via `shutil.which("bash")`. Because WSL bash expects Linux path structures, Windows terminal tool calls using Windows path formatting failed with `/bin/bash: line 2: cd: C:\Users\...: No such file or directory` (exit code 126).

This PR:
1. Adds `_is_wsl_bash(path: str)` to identify Windows WSL launcher binaries under `System32`, `SysWOW64`, and `WindowsApps`.
2. Updates `_windows_bash_candidates()` to filter out WSL launcher `bash.exe` from `shutil.which("bash")` candidates so healthy Git for Windows candidates are chosen.
3. Expands search candidate paths for Git for Windows (including Scoop and SystemDrive Git installations).
4. Adds unit tests in `tests/tools/test_local_env_windows_msys.py`.

## Verification
- Ran `pytest tests/tools/test_local_env_windows_msys.py -k TestIsWslBash -v` - 100% passed.
