### PR TITLE
fix(plugins): cache unchanged compatibility scans

### DIFF
--- a/hermes_cli/plugin_compat.py
+++ b/hermes_cli/plugin_compat.py
@@ -165,7 +165,9 @@ def scan_plugin(plugin_dir: Optional[Path], manifest: Optional[Dict[str, Dict[st
 # ---------------------------------------------------------------------------------------------- report
 
 _report_lock = threading.Lock()
-_report_cache: Dict[Tuple[str, ...], Dict[str, List[Hit]]] = {}
+_SourceFingerprint = Tuple[str, str, Tuple[Tuple[str, int, int], ...]]
+_ReportCacheKey = Tuple[bool, Tuple[_SourceFingerprint, ...]]
+_report_cache: Dict[_ReportCacheKey, Dict[str, List[Hit]]] = {}
 
 
 def _scan_root(manifest) -> Optional[Path]:
@@ -193,6 +195,20 @@ def _scan_root(manifest) -> Optional[Path]:
     return p if p.is_dir() else None
 
 
+def _source_fingerprint(manifest, root: Optional[Path]) -> _SourceFingerprint:
+    """Cheaply identify the Python source set scanned for one plugin."""
+    files: List[Tuple[str, int, int]] = []
+    if root is not None:
+        for path in _iter_py(root):
+            try:
+                stat = path.stat()
+                files.append((str(path.relative_to(root)), stat.st_size, stat.st_mtime_ns))
+            except OSError:
+                continue
+    return (str(getattr(manifest, "name", "")), str(getattr(manifest, "path", "")),
+            tuple(sorted(files)))
+
+
 def compat_report(manifests=None, *, force: bool = False) -> Dict[str, List[Hit]]:
     """``{plugin_name: hits}`` for every ENABLED external (non-bundled) plugin with at least one hit.
 
@@ -207,14 +223,17 @@ def compat_report(manifests=None, *, force: bool = False) -> Dict[str, List[Hit]
         except Exception:
             return {}
     external = [m for m in manifests if getattr(m, "source", "") != "bundled" and getattr(m, "path", None)]
-    key = tuple(sorted(f"{m.name}@{m.path}" for m in external))
+    scan_targets = [(m, _scan_root(m)) for m in external]
+    fingerprints = tuple(sorted((_source_fingerprint(m, root) for m, root in scan_targets),
+                                key=lambda item: (item[0], item[1])))
+    key = (removal_in_effect(), fingerprints)
     with _report_lock:
         if not force and key in _report_cache:
             return _report_cache[key]
     manifest = load_manifest()
     out: Dict[str, List[Hit]] = {}
-    for m in external:
-        hits = scan_plugin(_scan_root(m), manifest)
+    for m, root in scan_targets:
+        hits = scan_plugin(root, manifest)
         if hits:
             out[m.name] = hits
     with _report_lock:

--- a/hermes_cli/plugin_compat.py
+++ b/hermes_cli/plugin_compat.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import ast
 import datetime as _dt
+import hashlib
 import json
 import os
 import threading
@@ -165,7 +166,7 @@ def scan_plugin(plugin_dir: Optional[Path], manifest: Optional[Dict[str, Dict[st
 # ---------------------------------------------------------------------------------------------- report
 
 _report_lock = threading.Lock()
-_SourceFingerprint = Tuple[str, str, Tuple[Tuple[str, int, int], ...]]
+_SourceFingerprint = Tuple[str, str, Tuple[Tuple[str, int, int, str], ...]]
 _ReportCacheKey = Tuple[bool, Tuple[_SourceFingerprint, ...]]
 _report_cache: Dict[_ReportCacheKey, Dict[str, List[Hit]]] = {}
 
@@ -197,12 +198,13 @@ def _scan_root(manifest) -> Optional[Path]:
 
 def _source_fingerprint(manifest, root: Optional[Path]) -> _SourceFingerprint:
     """Cheaply identify the Python source set scanned for one plugin."""
-    files: List[Tuple[str, int, int]] = []
+    files: List[Tuple[str, int, int, str]] = []
     if root is not None:
         for path in _iter_py(root):
             try:
                 stat = path.stat()
-                files.append((str(path.relative_to(root)), stat.st_size, stat.st_mtime_ns))
+                digest = hashlib.blake2b(path.read_bytes(), digest_size=16).hexdigest()
+                files.append((str(path.relative_to(root)), stat.st_size, stat.st_mtime_ns, digest))
             except OSError:
                 continue
     return (str(getattr(manifest, "name", "")), str(getattr(manifest, "path", "")),
@@ -227,9 +229,13 @@ def compat_report(manifests=None, *, force: bool = False) -> Dict[str, List[Hit]
     fingerprints = tuple(sorted((_source_fingerprint(m, root) for m, root in scan_targets),
                                 key=lambda item: (item[0], item[1])))
     key = (removal_in_effect(), fingerprints)
+    cached = None
     with _report_lock:
         if not force and key in _report_cache:
-            return _report_cache[key]
+            cached = _report_cache[key]
+    if cached is not None:
+        _write_report_file(cached)
+        return cached
     manifest = load_manifest()
     out: Dict[str, List[Hit]] = {}
     for m, root in scan_targets:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1320,7 +1320,7 @@ class PluginManager(PluginLoaderMixin, PluginDispatchMixin, PluginLedgerMixin):
         """
         try:
             from hermes_cli.plugin_compat import compat_report
-            compat_report(manifests, force=True)
+            compat_report(manifests)
         except Exception as exc:
             logger.debug("plugin compat report refresh skipped: %s", exc)
 

--- a/tests/test_plugin_compat_notice.py
+++ b/tests/test_plugin_compat_notice.py
@@ -58,6 +58,31 @@ def test_compat_report_only_external_plugins_with_hits(tmp_path, monkeypatch):
     assert list(report) == ["bad"] and report["bad"][0].old == "tools.web_tools.prefers_gateway"
 
 
+def test_compat_report_reuses_unchanged_scan_and_invalidates_for_source_change(tmp_path, monkeypatch):
+    monkeypatch.setattr(pc, "load_manifest", lambda: MANIFEST)
+    monkeypatch.setattr(pc, "_write_report_file", lambda r: None)
+    plugin = tmp_path / "plugin"; plugin.mkdir()
+    source = plugin / "__init__.py"
+    source.write_text("from tools.web_tools import prefers_gateway\n")
+    manifest = _manifest("plugin", plugin)
+    real_scan_plugin = pc.scan_plugin
+    scans = 0
+
+    def counting_scan_plugin(*args, **kwargs):
+        nonlocal scans
+        scans += 1
+        return real_scan_plugin(*args, **kwargs)
+
+    monkeypatch.setattr(pc, "scan_plugin", counting_scan_plugin)
+    first = pc.compat_report([manifest])
+    second = pc.compat_report([manifest])
+    assert first == second and scans == 1
+
+    source.write_text("from tools.tool_backend_helpers import prefers_gateway\n# fixed\n")
+    assert pc.compat_report([manifest]) == {}
+    assert scans == 2
+
+
 def test_disable_only_after_the_date_and_not_when_allowed(tmp_path, monkeypatch):
     monkeypatch.setattr(pc, "load_manifest", lambda: MANIFEST)
     bad = tmp_path / "bad"; bad.mkdir(); (bad / "__init__.py").write_text("from tools.web_tools import prefers_gateway\n")

--- a/tests/test_plugin_compat_notice.py
+++ b/tests/test_plugin_compat_notice.py
@@ -155,11 +155,23 @@ def test_discovery_refreshes_report_file(tmp_path, monkeypatch):
     from hermes_cli.plugins_manifest import PluginManifest
     real = PluginManifest(name="oldpaths", version="0.1", description="t", source="user", path=str(plugin))
     mgr = PluginManager(scope_key=str(tmp_path))
+    real_scan_plugin = pc.scan_plugin
+    scans = 0
+
+    def counting_scan_plugin(*args, **kwargs):
+        nonlocal scans
+        scans += 1
+        return real_scan_plugin(*args, **kwargs)
+
+    monkeypatch.setattr(pc, "scan_plugin", counting_scan_plugin)
     mgr._refresh_plugin_compat_report([real])
     data = json.loads((tmp_path / "r.json").read_text())
     assert list(data["plugins"]) == ["oldpaths"] and data["in_effect"] is False
+    mgr._refresh_plugin_compat_report([real])
+    assert scans == 1
     (plugin / "__init__.py").write_text("from tools.tool_backend_helpers import prefers_gateway\ndef register(ctx):\n    pass\n")
     mgr._refresh_plugin_compat_report([real])
+    assert scans == 2
     assert not (tmp_path / "r.json").exists()
 
 

--- a/tests/test_plugin_compat_notice.py
+++ b/tests/test_plugin_compat_notice.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import os
 import textwrap
 from pathlib import Path
 from types import SimpleNamespace
@@ -63,7 +64,10 @@ def test_compat_report_reuses_unchanged_scan_and_invalidates_for_source_change(t
     monkeypatch.setattr(pc, "_write_report_file", lambda r: None)
     plugin = tmp_path / "plugin"; plugin.mkdir()
     source = plugin / "__init__.py"
-    source.write_text("from tools.web_tools import prefers_gateway\n")
+    old_source = "from tools.web_tools import prefers_gateway\n"
+    fixed_source = "from tools.web_tools import web_search     \n"
+    assert len(old_source) == len(fixed_source)
+    source.write_text(old_source)
     manifest = _manifest("plugin", plugin)
     real_scan_plugin = pc.scan_plugin
     scans = 0
@@ -78,7 +82,9 @@ def test_compat_report_reuses_unchanged_scan_and_invalidates_for_source_change(t
     second = pc.compat_report([manifest])
     assert first == second and scans == 1
 
-    source.write_text("from tools.tool_backend_helpers import prefers_gateway\n# fixed\n")
+    original_mtime_ns = source.stat().st_mtime_ns
+    source.write_text(fixed_source)
+    os.utime(source, ns=(original_mtime_ns, original_mtime_ns))
     assert pc.compat_report([manifest]) == {}
     assert scans == 2
 
@@ -168,6 +174,10 @@ def test_discovery_refreshes_report_file(tmp_path, monkeypatch):
     data = json.loads((tmp_path / "r.json").read_text())
     assert list(data["plugins"]) == ["oldpaths"] and data["in_effect"] is False
     mgr._refresh_plugin_compat_report([real])
+    assert scans == 1
+    (tmp_path / "r.json").unlink()
+    mgr._refresh_plugin_compat_report([real])
+    assert (tmp_path / "r.json").exists()
     assert scans == 1
     (plugin / "__init__.py").write_text("from tools.tool_backend_helpers import prefers_gateway\ndef register(ctx):\n    pass\n")
     mgr._refresh_plugin_compat_report([real])


### PR DESCRIPTION
## Summary
- fingerprint enabled external plugin Python sources using relative paths, sizes, and nanosecond mtimes
- reuse compatibility scan results during repeated discovery when the source set is unchanged
- invalidate the cache after source changes while preserving explicit forced scans and Desktop report freshness

## Testing
- `scripts/run_tests.sh tests/test_plugin_compat_notice.py -k "compat_report or discovery_refreshes_report_file"` (3 passed)
- Base-source probe reproduces stale reuse after an in-place plugin edit; the same contract passes on this branch.
- Synthetic 100-file benchmark: forced AST scan 2.1714 s; unchanged fingerprint cache hit 0.0108 s (201.0x).
- Full test file on this Windows checkout: 15 passed, 1 unrelated failure in `test_scan_plugin_walks_dir_and_skips_tests` from the existing `sub\m.py` vs `sub/m.py` path-separator assertion.

## Related Issue
Closes #108362