### PR TITLE
fix(tools): run read denylist before document extraction

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -864,5 +864,26 @@ class TestWriteInvalidatesDedup(unittest.TestCase):
         self.assertEqual(_read_tracker["t"]["dedup"], {})
 
 
+# ---------------------------------------------------------------------------
+# Denylist runs before document extraction
+# ---------------------------------------------------------------------------
+
+class TestDenylistBeforeExtraction(unittest.TestCase):
+    """A document inside a read-denied dir must hit the denylist, not the
+    extractor - extraction can still leak bytes through a parse error or
+    partial render."""
+
+    def test_document_inside_mcp_tokens_dir_is_denied(self):
+        with tempfile.TemporaryDirectory() as td:
+            tokens_dir = os.path.join(td, "mcp-tokens")
+            os.makedirs(tokens_dir)
+            doc = os.path.join(tokens_dir, "report.docx")
+            with open(doc, "wb") as fh:
+                fh.write(b"not a real docx")
+            with patch.dict(os.environ, {"HERMES_HOME": td}):
+                result = json.loads(read_file_tool(doc, task_id="deny_extract"))
+            self.assertIn("cannot be read directly", result.get("error", ""))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -541,8 +541,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = DEFAULT_READ_LIMIT, 
     """Read a file with pagination and line numbers.
 
     Guard order: device-path blocklist (no I/O) → stat-based special-file
-    guard (host only) → document extraction → binary-extension guard → Hermes
-    internal denylist → negative-result cache → dedup stub → real read.
+    guard (host only) → Hermes internal denylist → document extraction →
+    binary-extension guard → negative-result cache → dedup stub → real read.
     """
     try:
         offset, limit = normalize_read_pagination(offset, limit)
@@ -567,6 +567,14 @@ def read_file_tool(path: str, offset: int = 1, limit: int = DEFAULT_READ_LIMIT, 
                         "attempted. Use terminal utilities if you need to "
                         "interact with it.")})
 
+        # Hermes internal denylist (prompt injection via catalog metadata,
+        # credential stores). Runs before extraction: a denylisted path must
+        # never reach an extractor. Pass the RESOLVED path: the denylist's own
+        # resolve() uses the process cwd and would miss a relative "auth.json".
+        block_error = get_read_block_error(str(_resolved))
+        if block_error:
+            return tool_error(block_error)
+
         extracted = _read_extracted_document(path, _resolved, offset, limit, task_id)
         if extracted is not None:
             return extracted
@@ -577,13 +585,6 @@ def read_file_tool(path: str, offset: int = 1, limit: int = DEFAULT_READ_LIMIT, 
             return tool_error(
                 f"Cannot read binary file '{path}' ({_resolved.suffix.lower()}). "
                 "Use vision_analyze for images, or terminal to inspect binary files.")
-
-        # Hermes internal denylist (prompt injection via catalog metadata,
-        # credential stores). Pass the RESOLVED path: the denylist's own
-        # resolve() uses the process cwd and would miss a relative "auth.json".
-        block_error = get_read_block_error(str(_resolved))
-        if block_error:
-            return tool_error(block_error)
 
         resolved_str = str(_resolved)
         cached_not_found = _check_not_found_cache("read", resolved_str, task_id)


### PR DESCRIPTION
## What does this PR do?

`read_file` ran `_read_extracted_document` before `get_read_block_error`, so an extractable file inside a read-denied directory (`mcp-tokens/`, `vault/`, `browser-profile/`, `skills/.hub/`) reached the parser and could leak bytes through a partial render or an extraction error. The denylist now runs first. No behavior change for non-denied paths: extraction and the binary-extension guard keep their relative order.

## Related Issue

Fixes #108375

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `tools/file_tools.py`: `get_read_block_error` moved ahead of `_read_extracted_document` and the binary-extension guard; guard-order docstring updated.
- `tests/tools/test_file_read_guards.py`: a `.docx` inside `mcp-tokens/` now returns the denylist error instead of an extraction error (verified to fail on the pre-fix order).

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `scripts/run_tests.sh tests/tools/test_file_read_guards.py tests/tools/test_read_extract.py tests/tools/test_credential_files.py -q`
2. Reading `$HERMES_HOME/mcp-tokens/<anything>.docx` returns "cannot be read directly" without touching the extractor.

Ran on Windows 11: new test passes; the two `TestIterSkillsFiles` failures in `test_credential_files.py` are pre-existing path-separator issues on Windows and reproduce on the base commit.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A
