### PR TITLE
fix(tts): make the provider HTTP timeout configurable

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -998,6 +998,10 @@ DEFAULT_CONFIG = {
         # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" |
         # "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local)
         "provider": "edge",
+        # Seconds to wait for a provider's HTTP response. Generation time scales
+        # with script length, so long-form speech can exceed the 60s default and
+        # fail with "Read timed out" after the provider already did the work.
+        "request_timeout": 60,
         "edge": {
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
             "voice": "en-US-AriaNeural",

--- a/tests/tools/test_tts_request_timeout.py
+++ b/tests/tools/test_tts_request_timeout.py
@@ -1,0 +1,31 @@
+"""Behaviour contract for ``tts.request_timeout``.
+
+Generation time scales with script length, so long-form speech can exceed a
+fixed 60s read timeout and fail with ``Read timed out`` *after* the provider has
+already done (and billed) the work. The timeout must therefore be configurable —
+and must stay enabled when the config value is nonsense, since a disabled
+timeout hangs a turn forever.
+"""
+
+from tools.tts_tool_providers import (
+    DEFAULT_TTS_REQUEST_TIMEOUT,
+    _resolve_request_timeout,
+)
+
+
+def test_configured_timeout_reaches_the_request():
+    """A positive ``tts.request_timeout`` overrides the default."""
+    assert _resolve_request_timeout({"request_timeout": 180}) == 180
+    assert _resolve_request_timeout({}) == DEFAULT_TTS_REQUEST_TIMEOUT
+
+
+def test_unusable_values_keep_a_live_timeout():
+    """Garbage must fall back to the default, never to "no timeout".
+
+    ``True`` is included deliberately: ``isinstance(True, int)`` is True in
+    Python, so a bare int check would accept it and set a 1-second timeout.
+    """
+    for bad in (0, -5, True, "180", None, 1.5):
+        resolved = _resolve_request_timeout({"request_timeout": bad})
+        assert resolved == DEFAULT_TTS_REQUEST_TIMEOUT, bad
+        assert resolved > 0

--- a/tools/tts_tool_providers.py
+++ b/tools/tts_tool_providers.py
@@ -149,10 +149,31 @@ def _write_bytes(output_path: str, audio_bytes: bytes) -> str:
     return output_path
 
 
-def _post_json(url: str, payload: Dict[str, Any], headers: Dict[str, str], **extra: Any):
-    """Streaming ``requests.post`` with the shared 60s timeout (body read via the bounded readers)."""
+DEFAULT_TTS_REQUEST_TIMEOUT = 60
+
+
+def _resolve_request_timeout(tts_config: Optional[Dict[str, Any]] = None) -> int:
+    """Read timeout for a TTS HTTP request: ``tts.request_timeout``, else 60s.
+
+    Generation time scales with script length, so a legitimately long reply can
+    exceed a fixed 60s and fail with ``Read timed out`` after the provider has
+    already been billed for the work. Configurable so long-form speech is a
+    setting rather than a rebuild. Non-positive / non-int values fall through to
+    the default so a broken config cannot disable the timeout entirely.
+    """
+    value = (tts_config or {}).get("request_timeout")
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return DEFAULT_TTS_REQUEST_TIMEOUT
+
+
+def _post_json(url: str, payload: Dict[str, Any], headers: Dict[str, str],
+               *, timeout: Optional[int] = None, **extra: Any):
+    """Streaming ``requests.post`` (body read via the bounded readers)."""
     import requests
-    return requests.post(url, headers=headers, json=payload, timeout=60, stream=True, **extra)
+    return requests.post(url, headers=headers, json=payload,
+                         timeout=timeout or DEFAULT_TTS_REQUEST_TIMEOUT,
+                         stream=True, **extra)
 
 
 # --- Auxiliary-model speech-tag rewrites ---
@@ -335,7 +356,8 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
         payload["text_normalization"] = True
     response = _post_json(f"{base_url}/tts", payload, {
         "Authorization": f"Bearer {api_key}", "Content-Type": "application/json",
-        "User-Agent": hermes_xai_user_agent()})
+        "User-Agent": hermes_xai_user_agent()},
+        timeout=_resolve_request_timeout(tts_config))
     response.raise_for_status()
     return _write_bytes(output_path, _read_tts_response_bytes(response, label="xAI TTS"))
 
@@ -419,7 +441,8 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     else:
         payload = {"model": model, "text": text, "voice_id": voice_id}
     response = _post_json(base_url, payload, {
-        "Content-Type": "application/json", "Authorization": f"Bearer {runtime.api_key}"})
+        "Content-Type": "application/json", "Authorization": f"Bearer {runtime.api_key}"},
+        timeout=_resolve_request_timeout(tts_config))
     if is_t2a_v2:
         response.raise_for_status()
         result = _read_tts_response_json(response, label="MiniMax TTS")
@@ -595,7 +618,8 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         except Exception:
             version = "0.0.0"
         headers["X-Goog-Api-Client"] = f"hermes-agent/{version}"  # partner-integration guidance
-    response = _post_json(f"{base_url}/models/{model}:generateContent", payload, headers, params={"key": api_key})
+    response = _post_json(f"{base_url}/models/{model}:generateContent", payload, headers,
+                          timeout=_resolve_request_timeout(tts_config), params={"key": api_key})
     if response.status_code != 200:
         raise RuntimeError(f"Gemini TTS API error (HTTP {response.status_code}): {_gemini_error_detail(response)}")
     try:


### PR DESCRIPTION
## The bug

`_post_json` in `tools/tts_tool_providers.py` hardcodes `timeout=60`. TTS generation time scales with script length, so a long reply legitimately takes more than 60 seconds to synthesize — and the request is aborted with `Read timed out` *after* the provider has already done and billed the work. No audio is delivered; the gateway logs `Auto voice reply TTS failed` and sends text only, so it reads to the user as "voice randomly stopped working."

Measured on `gemini-2.5-flash-preview-tts` over a single day: **12 failures in 132 calls**, every one on a long script.

```
15:30:05 INFO  Generating speech with Google Gemini TTS...
15:31:05 ERROR TTS generation failed (gemini): HTTPSConnectionPool(...): Read timed out. (read timeout=60)
15:31:05 WARN  Auto voice reply TTS failed
```

## The fix

Adds `tts.request_timeout` (default `60`, so existing behaviour is byte-identical unless set) and threads it through the three providers sharing `_post_json`: Gemini, xAI, MiniMax.

Per the config policy this is a behavioural setting, so it lands in `config.yaml`/`DEFAULT_CONFIG` rather than an env var. No `_config_version` bump — new keys deep-merge.

## Why the validation is shaped this way

`isinstance(True, int)` is `True` in Python, so a bare int check would accept `request_timeout: true` and set a **1-second** timeout. Non-positive and non-int values therefore fall through to the default rather than disabling the timeout — a disabled timeout hangs a turn forever, which is worse than the bug being fixed.

## Tests

`tests/tools/test_tts_request_timeout.py` — two invariant tests: a configured value reaches the request, and unusable values keep a live (>0) timeout. Not snapshots; they assert the contract between config input and resolved timeout.

```
scripts/run_tests.sh tests/tools/test_tts_request_timeout.py
  2 passed

scripts/run_tests.sh tests/tools/ -k tts
  299 passed, 0 failed, 3 skipped
```

## Related, not fixed here

`tts.<provider>.max_text_length` is used both as the chunk size *and* as the ceiling check on the composed prompt in `_generate_gemini_tts`. When a persona prompt is configured (`tts.gemini.persona_prompt_file`), its length is added to every chunk, so any value low enough to chunk usefully also fails its own ceiling check and raises instead of splitting:

```
persona overhead: 2,106 chars, paid on EVERY chunk
cap=900   -> 4 chunks, worst composed 3,007 -> raises
cap=1500  -> 2 chunks, worst composed 3,607 -> raises
```

That means chunking is not currently a workaround for long-form TTS with a persona. Happy to open a separate issue or PR if maintainers agree it is a bug.