### PR TITLE
fix(agent): screen vision capabilities in aux fallbacks and protect pool on upstream capacity 429 (fixes #108349)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3042,6 +3042,17 @@ _RATE_LIMIT_BILLING_KEYWORDS = (
     "out of funds", "run out of funds", "balance_depleted", "no usable credits",
     "model_not_supported_on_free_tier", "not available on the free tier", "isn't available on the free tier",
 )
+_UPSTREAM_CAPACITY_KEYWORDS = (
+    "temporarily at capacity", "at capacity", "over capacity",
+    "not your api key's rate limit", "not your api key",
+    "upstream overloaded", "server overloaded", "model is overloaded",
+)
+
+
+def _is_upstream_capacity_error(exc: Exception) -> bool:
+    """True when 429/503 signals an upstream server/model capacity overload rather than an account rate limit."""
+    err_lower = str(exc).lower()
+    return _contains_any(err_lower, _UPSTREAM_CAPACITY_KEYWORDS)
 
 
 def _is_rate_limit_error(exc: Exception) -> bool:
@@ -3394,6 +3405,8 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
     if _is_payment_error(exc):
         return _rotate(402)
     if _is_rate_limit_error(exc):
+        if _is_upstream_capacity_error(exc):
+            return False
         return _rotate(429)
     return False
 
@@ -3916,6 +3929,13 @@ def _try_main_agent_model_fallback(
         main_provider, main_model = _agg_provider, _agg_model
     if not main_provider or not main_model or main_provider.lower() in {"auto", ""}:
         return None, None, ""
+    if task == "vision":
+        if main_provider in _PROVIDERS_WITHOUT_VISION:
+            return None, None, ""
+        provider_vision_default = _resolve_provider_vision_default(main_provider)
+        check_model = provider_vision_default or main_model
+        if not _main_model_supports_vision(main_provider, check_model):
+            return None, None, ""
     main_base_url = _custom_health_base_url(main_provider)
     if _failed_backend_skip(
             failed_provider, failed_model, failed_base_url=failed_base_url,
@@ -4025,6 +4045,10 @@ def _try_configured_fallback_chain(
         except Exception:
             fb_client, resolved_model = None, None
         if fb_client is not None:
+            if task == "vision":
+                if fb_provider in _PROVIDERS_WITHOUT_VISION or not _main_model_supports_vision(fb_provider, resolved_model or fb_model):
+                    tried.append(f"{label} (no vision support)")
+                    continue
             too_small = _context_too_small(
                 entry, fb_provider, resolved_model, min_ctx, task=task, label=label, name_model=True,
             ) if resolved_model else None
@@ -4117,6 +4141,10 @@ def _try_main_fallback_chain(
             logger.debug("Auxiliary %s: main fallback %s failed to resolve: %s", task or "call", label, exc)
             fb_client, resolved_model = None, None
         if fb_client is not None:
+            if task == "vision":
+                if fb_norm in _PROVIDERS_WITHOUT_VISION or not _main_model_supports_vision(fb_provider, resolved_model or fb_model):
+                    tried.append(f"{label} (no vision support)")
+                    continue
             too_small = _context_too_small(
                 entry, fb_provider, resolved_model or fb_model, min_ctx, task=task, label=label,
             )

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1223,6 +1223,58 @@ class TestVisionClientFallback:
 
         assert "anthropic" in backends
 
+    def test_vision_main_fallback_skips_text_only_model(self):
+        """When falling back for vision, text-only main models are skipped."""
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+
+        with (
+            patch("agent.auxiliary_client._read_main_provider", return_value="zai"),
+            patch("agent.auxiliary_client._read_main_model", return_value="glm-5.3"),
+            patch("agent.auxiliary_client._main_model_supports_vision", return_value=False),
+            patch("agent.auxiliary_client._resolve_provider_vision_default", return_value=None),
+        ):
+            client, model, label = _try_main_agent_model_fallback("nous", task="vision")
+            assert client is None
+            assert model is None
+            assert label == ""
+
+    def test_vision_configured_fallback_skips_text_only_model(self):
+        """When falling back for vision, fallback_chain entries without vision are skipped."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        fake_client = MagicMock()
+        with (
+            patch(
+                "agent.auxiliary_client._get_auxiliary_task_config",
+                return_value={"fallback_chain": [{"provider": "zai", "model": "glm-5.3"}]},
+            ),
+            patch("agent.auxiliary_client._resolve_fallback_entry", return_value=(fake_client, "glm-5.3")),
+            patch("agent.auxiliary_client._main_model_supports_vision", return_value=False),
+        ):
+            client, model, label = _try_configured_fallback_chain("vision", "nous")
+            assert client is None
+            assert model is None
+            assert label == ""
+
+    def test_upstream_capacity_429_does_not_rotate_credential_pool(self):
+        """A 429 carrying upstream capacity wording must not rotate/exhaust the credential pool."""
+        from agent.auxiliary_client import _is_upstream_capacity_error, _recover_provider_pool
+
+        class _RateLimit429(Exception):
+            status_code = 429
+
+        exc = _RateLimit429(
+            "The requested model is temporarily at capacity upstream. "
+            "This is not your API key's rate limit — please retry shortly."
+        )
+        assert _is_upstream_capacity_error(exc) is True
+
+        mock_pool = MagicMock()
+        mock_pool.has_credentials.return_value = True
+        with patch("agent.auxiliary_client.load_pool", return_value=mock_pool):
+            recovered = _recover_provider_pool("nous", exc)
+            assert recovered is False
+            mock_pool.mark_exhausted_and_rotate.assert_not_called()
 
     def test_anthropic_auxiliary_client_aggregates_stream_response(self):
         from agent.auxiliary_client import AnthropicAuxiliaryClient


### PR DESCRIPTION
Fixes #108349.

### Root Cause
1. In `agent/auxiliary_client.py`, `_try_main_agent_model_fallback()`, `_try_configured_fallback_chain()`, and `_try_main_fallback_chain()` resolved fallback providers/models for auxiliary tasks without screening whether the fallback model supports vision when `task == "vision"`. When a multimodal aux call (e.g. Nous) encountered a failure, it would fall back to a text-only main or fallback model (e.g. `zai / glm-5.3`), causing the provider to reject the image payload with error 400 (`messages.content.type is invalid, allowed values: ['text']`).
2. When an auxiliary provider returned a transient upstream capacity 429 (e.g. `The requested model is temporarily at capacity upstream. This is not your API key's rate limit — please retry shortly.`), `_recover_provider_pool()` treated it as an account rate limit, rotating and marking the credential identity exhausted.

### Fix
- Added capability screening via `_main_model_supports_vision()` and `_PROVIDERS_WITHOUT_VISION` to `_try_main_agent_model_fallback()`, `_try_configured_fallback_chain()`, and `_try_main_fallback_chain()` when `task == "vision"` so text-only models are never handed image payloads.
- Added `_is_upstream_capacity_error()` in `agent/auxiliary_client.py` and updated `_recover_provider_pool()` to avoid exhausting/rotating credential pool entries on upstream capacity overloads.
- Added regression test suite in `tests/agent/test_auxiliary_client.py` verifying that text-only models are skipped during vision fallback and upstream-capacity 429s preserve credential pool identities.
