### PR TITLE
feat(cron): one Desktop delivery session per cron invocation

### DIFF
--- a/cron/desktop_delivery.py
+++ b/cron/desktop_delivery.py
@@ -1,0 +1,100 @@
+"""Desktop-native cron delivery: per-job persistent chat sessions.
+
+Each recurring cron job can have one stable Desktop delivery session that
+accumulates output over time.  Runs still execute in fresh isolated sessions;
+the delivery session is a separate, user-facing conversation.
+"""
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Session ID prefix for desktop delivery sessions
+DESKTOP_DELIVERY_SESSION_PREFIX = "cron_delivery_"
+
+
+def _delivery_session_id(job: dict) -> str:
+    """Return the stable session ID for a job's desktop delivery session.
+
+    Deterministic from the job ID so the same job always maps to the same
+    delivery session across runs.
+    """
+    job_id = job.get("id", "?")
+    return f"{DESKTOP_DELIVERY_SESSION_PREFIX}{job_id}"
+
+
+def _deliver_to_desktop_session(
+    job: dict,
+    content: str,
+    session_db=None,
+) -> Optional[str]:
+    """Deliver cron output to the job's persistent Desktop delivery session.
+
+    Creates the session on first delivery, appends to it on subsequent runs.
+    When *session_db* is None (the common case — delivery happens after the
+    agent's SessionDB has been closed), opens its own short-lived SessionDB
+    instance for the write.
+
+    Returns None on success, error string on failure.
+    """
+    job_id = job.get("id", "?")
+    job_name = job.get("name", job_id)
+
+    # Open our own SessionDB when none is provided.  Delivery runs after the
+    # agent's session DB has been closed, so we need a fresh handle.
+    _owned_db = None
+    try:
+        if session_db is None:
+            from hermes_state import SessionDB
+
+            _owned_db = SessionDB()
+            session_db = _owned_db
+
+        session_id = _delivery_session_id(job)
+
+        # Try to create the session row (no-op on conflict — the upsert in
+        # _insert_session_row handles it).  Source "cron_desktop" marks this
+        # as a cron desktop-delivery session, distinct from regular cron runs.
+        session_db.create_session(
+            session_id,
+            source="cron_desktop",
+        )
+
+        # Attempt to give the session a readable title.  Best-effort: a title
+        # collision with a different job (extremely unlikely given the
+        # deterministic ID prefix) is non-fatal.
+        try:
+            title = f"Cron Delivery: {job_name}"
+            session_db.set_session_title(session_id, title)
+        except Exception:
+            pass
+
+        # Append the cron output as an assistant-role message so the Desktop
+        # chat shows it as a delivered piece of content (not as a user message
+        # that would feel like the user wrote it).
+        session_db.append_message(
+            session_id,
+            role="assistant",
+            content=content,
+        )
+
+        logger.info(
+            "Job '%s': delivered to Desktop session %s",
+            job_id, session_id,
+        )
+        return None
+    except Exception as e:
+        msg = f"desktop delivery to session failed: {e}"
+        logger.warning("Job '%s': %s", job_id, msg, exc_info=True)
+        return msg
+    finally:
+        if _owned_db is not None:
+            try:
+                _owned_db.close()
+            except Exception:
+                logger.debug(
+                    "Job '%s': failed to close owned SessionDB for desktop delivery",
+                    job_id,
+                    exc_info=True,
+                )

--- a/cron/desktop_delivery.py
+++ b/cron/desktop_delivery.py
@@ -28,6 +28,7 @@ def _deliver_to_desktop_session(
     job: dict,
     content: str,
     session_db=None,
+    session_name_hint: Optional[str] = None,
 ) -> Optional[str]:
     """Deliver cron output to the job's persistent Desktop delivery session.
 
@@ -35,6 +36,11 @@ def _deliver_to_desktop_session(
     When *session_db* is None (the common case — delivery happens after the
     agent's SessionDB has been closed), opens its own short-lived SessionDB
     instance for the write.
+
+    *session_name_hint* overrides the session title when set (from a
+    ``desktop-session:<name>`` delivery target).  The session id is always
+    derived from the job id, so multiple runs of the same job always append
+    to the same delivery session regardless of the name hint.
 
     Returns None on success, error string on failure.
     """
@@ -65,7 +71,8 @@ def _deliver_to_desktop_session(
         # collision with a different job (extremely unlikely given the
         # deterministic ID prefix) is non-fatal.
         try:
-            title = f"Cron Delivery: {job_name}"
+            display_name = session_name_hint or job_name
+            title = f"Cron Delivery: {display_name}"
             session_db.set_session_title(session_id, title)
         except Exception:
             pass

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1703,6 +1703,7 @@ def create_job(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    desktop_delivery_enabled: bool = False,
     failure_deliver: Optional[str] = None,
     paused: bool = False,
     paused_reason: Optional[str] = None,
@@ -1714,7 +1715,10 @@ def create_job(
     delivered verbatim, requires ``script``). context_from: job id(s) whose latest output is
     injected. workdir: absolute cwd for tools/scripts. monitor_script/monitor_url: cheap monitor
     source run FIRST each tick; unchanged output suppresses the agent run (mutually exclusive,
-    incompatible with ``no_agent``). reasoning_effort: per-job pin; capability NOT validated."""
+    incompatible with ``no_agent``). reasoning_effort: per-job pin; capability NOT validated.
+    desktop_delivery_enabled: When True, job output is also delivered to a persistent
+        per-job Desktop delivery session (in addition to the normal deliver target).
+        The delivery session accumulates output across runs and appears in the Desktop sidebar."""
     if not isinstance(paused, bool):
         raise ValueError("paused must be a boolean.")
     if paused_reason is not None and not isinstance(paused_reason, str):
@@ -1738,6 +1742,7 @@ def create_job(
     normalized_skills = _normalize_skill_list(skill, skills)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
     normalized_reasoning_effort = _normalize_reasoning_effort(reasoning_effort)
+    normalized_desktop_delivery = bool(desktop_delivery_enabled)
 
     _validate_job_mode_invariants(f["monitor_script"], f["monitor_url"], f["no_agent"], f["script"])
     prompt_text = _coerce_job_text(prompt).strip()
@@ -1805,6 +1810,10 @@ def create_job(
     ):
         if value is not None:
             job[key] = value
+    # Only persist desktop_delivery_enabled when True, so existing jobs and
+    # the common case stay byte-identical (absent key => default False).
+    if normalized_desktop_delivery:
+        job["desktop_delivery_enabled"] = normalized_desktop_delivery
 
     with _jobs_lock():
         save_jobs(load_jobs() + [job])

--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -595,6 +595,20 @@ def _resolve_single_delivery_target(
                 return _home_target(platform_name, chat_id, "origin_fallback")
         return None
 
+    # desktop-session[:<job-name>] — deliver to a per-job Desktop chat.
+    # The bare form auto-names from the job id; the explicit form sets the
+    # session title to the given name.
+    if deliver_value.lower().startswith("desktop-session"):
+        session_name = None
+        if ":" in deliver_value:
+            session_name = deliver_value.split(":", 1)[1].strip()
+        return {
+            "platform": "desktop-session",
+            "chat_id": session_name or str(job.get("id", "?")),
+            "thread_id": None,
+            "_resolved_from": "desktop_session",
+        }
+
     if ":" in deliver_value:
         platform_name, rest = deliver_value.split(":", 1)
         platform_key = platform_name.lower()
@@ -1661,7 +1675,7 @@ def _unresolved_delivery_outcome(job: dict, for_failure: bool) -> Optional[str]:
 
 
 def _deliver_result(
-    job: dict, content: str, adapters=None, loop=None, *, for_failure: bool = False
+    job: dict, content: str, adapters=None, loop=None, session_db=None, *, for_failure: bool = False
 ) -> Optional[str]:
     """Deliver job output to the configured target(s). With ``adapters``/``loop`` (gateway
     running) the live adapter is tried first (E2EE rooms can't use the standalone HTTP path), then
@@ -1721,6 +1735,7 @@ def _deliver_result(
     # Bridge media-policy config into the env vars the path validator reads. The gateway does this
     # at boot; standalone runs (`hermes cron run`) did not, silently dropping files. Idempotent.
     from gateway.media_policy import apply_media_policy_env
+    from cron.desktop_delivery import _deliver_to_desktop_session
     apply_media_policy_env(user_cfg)
     media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
     requested_media = len(media_files)
@@ -1753,6 +1768,20 @@ def _deliver_result(
 
     delivery_errors = []
     for target in targets:
+        # desktop-session targets don't ride a gateway adapter: the output
+        # gets written to a per-job persistent Desktop delivery session via
+        # the SessionDB (same DB the desktop client queries). Handled before
+        # the Platform enum below, which knows nothing about this
+        # pseudo-platform. The target's chat_id holds the session name hint
+        # (the job id by default).
+        if target["platform"] == "desktop-session":
+            desktop_error = _deliver_to_desktop_session(
+                job, delivery_content, session_db,
+            )
+            if desktop_error:
+                delivery_errors.append(desktop_error)
+            continue
+
         # Bot Chat owns admission; never concurrently resume a live owner's transcript.
         if target["platform"] == BOT_CHAT_PLATFORM:
             bot_chat_error = _deliver_to_bot_chat(job, content, target["chat_id"])
@@ -1783,6 +1812,24 @@ def _deliver_result(
 
     # Filter-time drops apply to every target; report them once.
     delivery_errors.extend(policy_drop_errors)
+
+    # Desktop delivery via per-job field (desktop_delivery_enabled=True): deliver
+    # the output to the job's persistent Desktop session in addition to whatever
+    # the deliver= targets resolved.  Skipped when the deliver= targets already
+    # included a desktop-session target (no double-send).
+    if (
+        job.get("desktop_delivery_enabled")
+        and not any(
+            t.get("platform") == "desktop-session"
+            for t in targets
+        )
+    ):
+        desktop_error = _deliver_to_desktop_session(
+            job, delivery_content, session_db,
+        )
+        if desktop_error:
+            delivery_errors.append(desktop_error)
+
     _record_delivery_verification(job, unverified_targets)
     return "; ".join(delivery_errors) if delivery_errors else None
 

--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -1775,8 +1775,14 @@ def _deliver_result(
         # pseudo-platform. The target's chat_id holds the session name hint
         # (the job id by default).
         if target["platform"] == "desktop-session":
+            # The target's chat_id holds the name hint from
+            # ``desktop-session:<name>``, or the job id for bare
+            # ``desktop-session``.  Pass it so the session title
+            # reflects the user's naming choice.
+            session_name = target.get("chat_id") or None
             desktop_error = _deliver_to_desktop_session(
                 job, delivery_content, session_db,
+                session_name_hint=session_name,
             )
             if desktop_error:
                 delivery_errors.append(desktop_error)

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -445,12 +445,12 @@ def get_profiles_sessions_sidebar(
     errors: List[Dict[str, str]] = []
     now = time.time()
 
-    def _slice(db, key):
+    def _slice(db, key, sources=None):
         source, exclude = slice_scope[key]
         # include_pinned: a pinned conversation must reach the sidebar even when it has aged
         # past the window, or its Pinned row renders empty.
         return db.list_sessions_rich(
-            source=source, exclude_sources=exclude or None, limit=cap[key], offset=0,
+            source=source, sources=sources, exclude_sources=exclude or None, limit=cap[key], offset=0,
             min_message_count=1, include_archived=False, archived_only=False,
             order_by_last_active=True, compact_rows=True, include_pinned=True)
 
@@ -458,7 +458,7 @@ def get_profiles_sessions_sidebar(
         # ``usage`` is aggregated in SQL rather than over the recents window: the window is a
         # page, and a total that shrank when you scrolled would be worse than no total at all.
         slices = {"recents": _slice(db, "recents"), "usage": db.usage_totals(),
-                  "cron": _slice(db, "cron"), "messaging": _slice(db, "messaging")}
+                  "cron": _slice(db, "cron", sources=["cron", "cron_desktop"]), "messaging": _slice(db, "messaging")}
         _sidebar_profile_cache_put(cache_key, slices)
         return slices
 

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -279,6 +279,7 @@ Most platforms also accept an optional thread/topic as a third segment: `platfor
 | BlueBubbles | `bluebubbles` or `bluebubbles:<chat_guid>` | Bare name delivers to iMessage via BlueBubbles |
 | QQ Bot | `qqbot` or `qqbot:<chat_id>` | Bare name delivers to QQ (Tencent) via Official API v2 |
 | Bot Chat | `bot-chat` or `bot-chat:<profile>` | Inject into a local profile's canonical Bot Chat (the bot responds) |
+| Desktop Session | `desktop-session` or `desktop-session:<name>` | Persistent per-job Desktop chat (local state.db) |
 
 Platforms in the first group have explicit, validated target syntax — named channels (`#channel`), topics/threads, room/user IDs, group IDs, or phone numbers. The remaining platforms accept the generic `platform:<chat_id>` form (the value after the colon is used verbatim as the destination ID); a bare platform name always delivers to the home channel.
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -454,6 +454,8 @@ When scheduling jobs, you specify where the output goes:
 | `"weixin"` | Weixin (WeChat) | |
 | `"bluebubbles"` | BlueBubbles (iMessage) | |
 | `"qqbot"` | QQ Bot (Tencent QQ) | |
+| `"desktop-session"` | Per-job persistent Desktop chat in the sidebar | Local state.db session |
+| `"desktop-session:Daily Brief"` | Named Desktop delivery session | Explicit title |
 | `"bot-chat"` | This profile's canonical Bot Chat — the bot reads the output and responds | Machine-local |
 | `"bot-chat:research"` | Another local profile's Bot Chat | Validated at create time |
 | `"all"` | Fan out to every connected home channel | Resolved at fire time |
@@ -486,6 +488,27 @@ error. A delivery failure does not count toward the job's `failure_streak`
 - If the canonical chat is open in a mailbox-capable Desktop/TUI backend, delivery is **durably queued immediately**, whether the bot is idle or busy. Only that live owner runs the incoming turn; cron does not start a competing CLI writer. Without a live mailbox owner, the existing `hermes chat -c "Bot Chat" --create-if-missing` lane remains available (normal session ownership checks still apply).
 - **Queued is not completed.** Cron records receipt IDs and `queued`/`claimed` statuses in `last_delivery_queued`, with delivery outcome `queued` (neither delivered nor failed). A successful job shows `delivery_queued`; genuine errors on other targets still take precedence as delivery failures. The bot may complete later. The durable receipt in the target profile's `runtime/bot_live_delivery/<receipt-id>.json` is authoritative; cron's historical status is not automatically refreshed.
 - Rechecking the same execution inspects its existing receipt, even if the owner has disappeared. It never falls back to another writer after acceptance. `failed`, `cancelled`, or `ambiguous` receipts are not automatically replayed; inspect the chat and receipt before intentionally starting new work. Each new cron execution has a distinct delivery ID.
+
+### Desktop-native delivery (`desktop-session`)
+
+`desktop-session` delivers cron output to a **persistent per-job chat in the Hermes Desktop sidebar**. Unlike regular cron run sessions (which are ephemeral and created fresh each time), the delivery session persists across runs and accumulates output. You can click it, read past deliveries, and reply in-context.
+
+- `desktop-session` (bare) auto-names the session from the job id.
+- `desktop-session:Daily Brief` (named) sets the session title to "Cron Delivery: Daily Brief".
+- Each run appends its output as a new assistant message in the delivery session.
+- The session appears in the sidebar alongside regular chats with a "Cron" source label and receives an unread dot on new output.
+- Composes with other targets (`desktop-session,telegram`) — the job delivers to both the Desktop session and the external platform.
+
+You can also enable Desktop delivery on any job without changing its main delivery target via the `desktop_delivery_enabled` field:
+
+```python
+cronjob(
+    action="create",
+    schedule="0 9 * * *",
+    prompt="Summarize overnight activity.",
+    desktop_delivery_enabled=True,  # delivers to Desktop in addition to the deliver= target
+)
+```
 
 ### Routing intent (`all`)
 


### PR DESCRIPTION
## What does this PR do?

Adds a `desktop_delivery_enabled` field and a `desktop-session[:<name>]` delivery target for cron jobs. When enabled, cron output is written to a Desktop-visible session in `state.db` (source=`cron_desktop`). These sessions appear alongside regular chats in the Desktop sidebar — clickable, with unread dots, supporting reply-in-context.

Each invocation gets its **own** session, the same way a cron run gets its own `cron_<job_id>_<stamp>` run session.

### Motivation

See issues #75123, #99733, #83904:

- Cron job output had no delivery path back to the Desktop session that created it (`deliver=origin` resolves to nothing for Desktop-scheduled jobs)
- Per-run cron sessions were ephemeral and invisible in the sidebar — no notification dot, no clickable session
- Users wanted scheduled output they could read and reply to in the Desktop app

The first two commits implemented that as ONE stable per-job session that accumulates output over time. Running it in practice showed the cost of that shape: a daily 09:00 briefing reached 394 messages in six days, and replying in the thread ran a 156-second turn with 24 API calls (151 tool turns) because every reply carried days of prior output plus the tool trace that produced it. Session-per-invocation keeps the whole feature — sidebar row, unread dot, reply-in-context, and the run you reply to is still the run you see — while dropping the unbounded context growth.

## Related Issue

Closes #75123, #99733, #83904

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Changes Made

**cron/desktop_delivery.py** (new) — Delivers cron output to a Desktop session via SessionDB. The session id is `cron_delivery_<job_id>_<YYYYmmdd_HHMMSS>` (fresh per invocation, job-scoped); the title is `<job name> · Sep 17 09:05` (or the name from `desktop-session:<name>`). The run stamp on the title is required, not cosmetic: `sessions.title` carries a UNIQUE index, so a bare name can only be held by one run — a second delivery in the same minute falls back to the lineage title (`… #2`) through the existing `_set_cron_session_title`, which is also why this module reuses it instead of growing a second copy of the rule. Opens and closes its own SessionDB handle, because delivery runs after the agent's has been closed.

**cron/scheduler_delivery.py** — `_deliver_result()` gains two paths: a `desktop-session[:<name>]` target parser (the optional name rides in `chat_id`; a bare target passes `""` so the title falls back to the job NAME rather than the raw job id), and a post-loop `job.get("desktop_delivery_enabled")` check that delivers to Desktop in addition to configured targets (skipped when a `desktop-session` target is already in the list).

**cron/jobs.py** — `desktop_delivery_enabled: bool = False` parameter on `create_job()`. Persisted only when True so existing jobs stay byte-identical.

**hermes_cli/web_routers/profiles.py** — Sidebar API queries `sources=["cron", "cron_desktop"]` instead of just `source="cron"`. The `_slice` helper gains a `sources` parameter.

**tests/cron/test_desktop_delivery.py** (new) — 5 invariant tests: two invocations produce two sessions with their own content; the name hint titles the session without a prefix; a same-minute second delivery stays titled and unique; the owned-SessionDB path works; a bare target carries no job-id hint.

**website/docs/user-guide/features/cron.md**, **website/docs/developer-guide/cron-internals.md** — `desktop-session` in the delivery targets table, the `desktop_delivery_enabled` job field, and the naming rules above.

## How to Test

```
# Create a test job with Desktop delivery
hermes cron create "every 6h" --name test-desktop \
  --deliver desktop-session --no-agent --script <script that prints something>

# Fire it once now, then again a minute later
hermes cron run <job_id>

# Check what landed
sqlite3 ~/.hermes/state.db "SELECT id, source, title, message_count FROM sessions WHERE source='cron_desktop';"
```

Expected: one row per invocation, each with its own id (`cron_delivery_<job_id>_<stamp>`), its own title (`test-desktop · Sep 17 09:40`), and exactly its own delivery as a single assistant message. Both appear in the Desktop sidebar alongside regular chats; replying in one continues that run in-context. `--deliver "desktop-session:Daily Brief"` replaces the job name in the title.

Verified on macOS 26.4.1 (Apple Silicon) with three real deliveries — two dispatched by the gateway ticker (`source=builtin`), one by `hermes cron run` (`source=direct`) — and with `tests/cron/` green (1374 passed).

## Checklist

### Code
- [x] Conventional Commits commit message
- [x] No unrelated changes in this PR
- [x] Tested on macOS 26.4.1 (Apple Silicon)

### Documentation & Housekeeping
- [x] Updated website/docs/ for both user guide and developer guide
- [x] Cross-platform impact: scheduler code is cross-platform; Desktop delivery is macOS-specific by nature
