### PR TITLE
ci: pin wheel in build requires and harden workflow interpolations

### DIFF
--- a/.github/workflows/install-e2e-windows-run.yml
+++ b/.github/workflows/install-e2e-windows-run.yml
@@ -130,16 +130,16 @@ jobs:
 
       - name: Stage serve repo (main -> ${{ inputs.install-ref }})
         shell: powershell
-        run: powershell -NoProfile -ExecutionPolicy Bypass -File tests\install\windows-e2e.ps1 -Phase stage -InstallMethod "${{ inputs.install-method }}" -Route "${{ inputs.update-method }}" -InstallRef "${{ inputs.install-ref }}" -SetupExeUrl ${{ inputs.setup-exe-url }}
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File tests\install\windows-e2e.ps1 -Phase stage -InstallMethod "${{ inputs.install-method }}" -Route "${{ inputs.update-method }}" -InstallRef "${{ inputs.install-ref }}" -SetupExeUrl "${{ inputs.setup-exe-url }}"
 
       - name: Install ${{ inputs.install-ref }} (${{ inputs.install-method }})
         shell: powershell
-        run: powershell -NoProfile -ExecutionPolicy Bypass -File tests\install\windows-e2e.ps1 -Phase install -InstallMethod "${{ inputs.install-method }}" -Route "${{ inputs.update-method }}" -InstallRef "${{ inputs.install-ref }}" -SetupExeUrl ${{ inputs.setup-exe-url }}
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File tests\install\windows-e2e.ps1 -Phase install -InstallMethod "${{ inputs.install-method }}" -Route "${{ inputs.update-method }}" -InstallRef "${{ inputs.install-ref }}" -SetupExeUrl "${{ inputs.setup-exe-url }}"
 
       - name: Update ${{ inputs.install-ref }} -> HEAD (${{ inputs.update-method }})
         id: update
         shell: powershell
-        run: powershell -NoProfile -ExecutionPolicy Bypass -File tests\install\windows-e2e.ps1 -Phase update -InstallMethod "${{ inputs.install-method }}" -Route "${{ inputs.update-method }}" -InstallRef "${{ inputs.install-ref }}" -SetupExeUrl ${{ inputs.setup-exe-url }}
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File tests\install\windows-e2e.ps1 -Phase update -InstallMethod "${{ inputs.install-method }}" -Route "${{ inputs.update-method }}" -InstallRef "${{ inputs.install-ref }}" -SetupExeUrl "${{ inputs.setup-exe-url }}"
 
       - name: Stage known-failure receipt
         if: steps.update.outputs.known_failure != ''

--- a/.github/workflows/skills-index-freshness.yml
+++ b/.github/workflows/skills-index-freshness.yml
@@ -48,25 +48,32 @@ jobs:
           import json, sys
           from datetime import datetime, timezone
 
+          def clean(v):
+              """Single-line scalar for $GITHUB_OUTPUT: the fetched JSON is
+              remote data, so \r\n must never reach a key=value line."""
+              return str(v).replace("\r", " ").replace("\n", " ")
+
           try:
               with open("/tmp/skills-index.json") as f:
                   data = json.load(f)
           except Exception as e:
               print(f"status=parse-failed")
-              print(f"detail=JSON decode error: {e}")
+              print(f"detail=JSON decode error: {clean(e)}")
               sys.exit(0)
 
-          generated_at = data.get("generated_at", "")
+          generated_at = clean(data.get("generated_at", ""))
           total = data.get("skill_count", 0)
+          if not isinstance(total, int):
+              total = -1
           skills = data.get("skills", [])
           if not isinstance(skills, list):
               print("status=invalid-shape")
               print(f"detail=skills field is not a list (got {type(skills).__name__})")
               sys.exit(0)
 
-          # Per-source counts
+          # Per-source counts (keys are remote data; keep them single-line)
           from collections import Counter
-          by_src = Counter(s.get("source", "") for s in skills)
+          by_src = Counter(clean(s.get("source", "")) for s in skills if isinstance(s, dict))
 
           # Freshness
           age_hours = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -385,7 +385,7 @@ all = [
 # PEP 517 isolated builds (uv sync / uv pip install -e .). Without wheel in
 # requires, the isolation sandbox only gets setuptools and Windows installer
 # fails with ModuleNotFoundError: wheel.cli (#96488).
-requires = ["setuptools==83.0.0", "wheel"]
+requires = ["setuptools==83.0.0", "wheel==0.48.0"]
 build-backend = "setuptools.build_meta"
 
 [project.scripts]


### PR DESCRIPTION
## What does this PR do?

Three small CI/build hardening fixes:

- `build-system.requires` pinned `setuptools==83.0.0` exactly but left `wheel` floating to the newest PyPI release in every isolated build. Now `wheel==0.48.0`.
- `setup-exe-url` was interpolated bare into three PowerShell `run:` lines in the reusable install-e2e runner. Now quoted like the sibling args.
- `skills-index-freshness` printed live-JSON-derived values to `$GITHUB_OUTPUT` unsanitized. Values are flattened to single-line before printing, and a non-int `skill_count` coerces to `-1` so it trips the degraded floor instead of crashing the step.

## Related Issue

Fixes #108382

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `pyproject.toml`: `wheel` -> `wheel==0.48.0` in `[build-system] requires`.
- `.github/workflows/install-e2e-windows-run.yml`: quoted `${{ inputs.setup-exe-url }}` in the stage/install/update steps.
- `.github/workflows/skills-index-freshness.yml`: `clean()` flattens `\r\n` on every remote-derived value printed to `$GITHUB_OUTPUT`; `skill_count` coerces to `-1` when not an int.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `uv lock --check` passes.
2. Both workflows parse as YAML; the probe script's output was simulated locally with a forged `source` value containing `\nstatus=ok` and emits a single line.
3. The pin follows the existing `setuptools==83.0.0` precedent; `wheel 0.48.0` was published 2026-08-11.

Ran on Windows 11.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — or N/A (CI-only change)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A
