### PR TITLE
fix(codex): emit approval lifecycle hooks

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -584,18 +584,30 @@ class CodexAppServerSession:
 
         Approval mode/timeout resolution lives upstream (codex_runtime.py derives the
         auto flags; the callback runs the shared gate). Do not re-read config here.
+
+        The prompt path wraps the callback in the documented observer hooks
+        (pre_approval_request / post_approval_response, see hooks.md) so a Codex approval is
+        observable like every other approval surface. The hooks cannot change the decision: the
+        returned choice is the callback's, and hook failures are swallowed. A callback that raises
+        produced no approval response at all, so its post event reports the documented no-decision
+        failure (``notify_failed``, same as a gateway notification that never arrived) rather than a
+        denial the user never gave.
         """
         if auto_approve:
             return "accept"
         if self._approval_callback is None:
             return "decline"
         command, description = prompt()
+        _fire_codex_approval_hook("pre_approval_request", command, description)
         try:
             choice = self._approval_callback(command, description, allow_permanent=False)
-            return _approval_choice_to_codex_decision(choice)
         except Exception:
             logger.exception("approval_callback raised on %s", log_label)
+            _fire_codex_approval_hook("post_approval_response", command, description,
+                                      choice="notify_failed")
             return "decline"
+        _fire_codex_approval_hook("post_approval_response", command, description, choice=choice)
+        return _approval_choice_to_codex_decision(choice)
 
     def _decide_exec_approval(self, params: dict) -> str:
         def prompt() -> tuple[str, str]:
@@ -679,6 +691,47 @@ def _apply_accounting_notification(result: TurnResult, note: dict) -> None:
 # Hermes approval choice -> codex decision (app-server-protocol v2). "deny" and
 # "timeout" both decline — codex has no "prompt expired" wire value.
 _APPROVAL_CHOICE_TO_DECISION = {"once": "accept", "session": "acceptForSession", "always": "acceptForSession"}
+
+
+# Synthetic pattern key for codex approvals: the transport asks about one concrete action (an exec
+# command or an apply_patch) that Hermes never matched a dangerous-command pattern against, so
+# observers get a stable key rather than an empty one — the same convention the other non-pattern
+# approval subjects use ("mcp_elicitation", "protected_instruction_file", "plugin_rule:<key>";
+# tools/approval*.py).
+_CODEX_APPROVAL_PATTERN_KEY = "codex_runtime"
+
+
+def _fire_codex_approval_hook(hook_name: str, command: str, description: str, **extra) -> None:
+    """Dispatch a documented approval lifecycle hook (pre_approval_request/post_approval_response).
+
+    Codex approvals are answered by the session's callback and never reach ``tools/approval*.py``,
+    so the pair is dispatched here — the transport's single approval seam — with the kwargs the
+    other surfaces send, letting an observer keyed on the hook see Codex approvals too.
+
+    Never raises, and never dispatches unredacted text: the approval decision is safety-critical,
+    plugin observability is not (same fail-closed rule as the plugin-transport presenter in
+    tools/approval_prompt.py). Observer return values are ignored — hooks cannot veto.
+    """
+    try:
+        from agent.redact import redact_sensitive_text
+        from tools.approval_context import _fire_approval_hook, get_current_session_key
+
+        _fire_approval_hook(
+            hook_name,
+            command=redact_sensitive_text(command, force=True),
+            description=redact_sensitive_text(description, force=True),
+            pattern_key=_CODEX_APPROVAL_PATTERN_KEY,
+            pattern_keys=[_CODEX_APPROVAL_PATTERN_KEY],
+            session_key=get_current_session_key(),
+            # The asking surface is the host prompt callback (``set_approval_callback`` — the
+            # interactive CLI/TUI/ACP prompt), which upstream's local prompt block reports as "cli"
+            # (tools/approval.py). ``surface`` names the surface that asks, never the runtime that
+            # raised the request, so the codex transport does not invent a value here.
+            surface="cli",
+            **extra,
+        )
+    except Exception:
+        logger.debug("codex approval hook %s dispatch failed", hook_name, exc_info=True)
 
 
 def _approval_choice_to_codex_decision(choice: str) -> str:

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -911,3 +911,196 @@ class TestClassifyOAuthFailure:
         assert _classify_oauth_failure("") is None
         assert _classify_oauth_failure("", None) is None  # type: ignore[arg-type]
 
+
+# ---- documented approval lifecycle hooks on the codex transport ----
+
+
+def _record_approval_hooks(monkeypatch) -> list[tuple[str, dict]]:
+    """Capture the approval lifecycle events a plugin would receive.
+
+    ``tools.approval_context._fire_approval_hook`` resolves ``invoke_hook`` at call time, so
+    patching the lifecycle module observes exactly what a registered plugin gets.
+    """
+    events: list[tuple[str, dict]] = []
+
+    def fake_invoke_hook(name: str, **kwargs):
+        events.append((name, kwargs))
+        return None
+
+    monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", fake_invoke_hook)
+    return events
+
+
+class TestApprovalLifecycleHooks:
+    """hooks.md documents ``pre_approval_request`` / ``post_approval_response`` as the observer pair
+    for an approval a human is asked about. Codex approvals never reach ``tools/approval*.py`` — the
+    transport asks its callback directly — so the pair has to be dispatched at the transport's
+    single approval seam, with the same payload shape and redaction as the other surfaces.
+    """
+
+    def _session_with_exec_request(self, client, callback, **session_kwargs):
+        client.queue_server_request(
+            "item/commandExecution/requestApproval", request_id="r1",
+            command="rm -rf /tmp/build", cwd="/tmp", reason="needs to clean the build dir",
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        return make_session(client, approval_callback=callback, **session_kwargs)
+
+    def test_exec_approval_dispatches_pre_hook_once(self, monkeypatch):
+        events = _record_approval_hooks(monkeypatch)
+        seen = {}
+
+        def cb(command, description, *, allow_permanent=True):
+            seen["command"] = command
+            return "once"
+
+        session = self._session_with_exec_request(FakeClient(), cb)
+        session.run_turn("hi", turn_timeout=1.0)
+
+        pre = [kw for name, kw in events if name == "pre_approval_request"]
+        assert len(pre) == 1, f"expected exactly one pre_approval_request, recorded: {events}"
+        assert pre[0]["command"] == "rm -rf /tmp/build"
+        assert pre[0]["pattern_key"] == "codex_runtime"
+        assert pre[0]["pattern_keys"] == ["codex_runtime"]
+        assert pre[0]["surface"] == "cli"
+        assert pre[0]["session_key"]  # observers scope their marks off this
+        assert seen["command"] == "rm -rf /tmp/build"
+
+    def test_exec_approval_dispatches_post_with_the_user_choice(self, monkeypatch):
+        events = _record_approval_hooks(monkeypatch)
+        session = self._session_with_exec_request(
+            FakeClient(), lambda command, description, **kw: "once")
+        session.run_turn("hi", turn_timeout=1.0)
+
+        assert [name for name, _ in events] == ["pre_approval_request", "post_approval_response"]
+        assert events[1][1]["choice"] == "once"
+        assert events[1][1]["command"] == "rm -rf /tmp/build"
+
+    def test_apply_patch_approval_dispatches_the_same_pair(self, monkeypatch):
+        events = _record_approval_hooks(monkeypatch)
+        client = FakeClient()
+        client.queue_notification(
+            "item/started",
+            item={"type": "fileChange", "id": "fc-1",
+                  "changes": [{"kind": {"type": "update"}, "path": "/tmp/a.py"}]},
+            threadId="t", turnId="tu1",
+        )
+        client.queue_server_request(
+            "item/fileChange/requestApproval", request_id="r2", itemId="fc-1",
+            threadId="t", turnId="tu1", startedAtMs=1234567890, reason="update a.py",
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        session = make_session(client, approval_callback=lambda command, description, **kw: "session")
+        session.run_turn("hi", turn_timeout=1.0)
+
+        assert [name for name, _ in events] == ["pre_approval_request", "post_approval_response"]
+        assert "apply_patch" in events[0][1]["command"]
+        assert events[1][1]["choice"] == "session"
+
+    @pytest.mark.parametrize("choice", ["once", "session", "always", "deny", "timeout"])
+    def test_one_request_is_exactly_one_pair_whatever_the_choice(self, monkeypatch, choice):
+        """A scope decision or a timeout is the same request's outcome, not a second event."""
+        events = _record_approval_hooks(monkeypatch)
+        session = self._session_with_exec_request(
+            FakeClient(), lambda command, description, **kw: choice)
+        session.run_turn("hi", turn_timeout=1.0)
+
+        assert [name for name, _ in events] == ["pre_approval_request", "post_approval_response"]
+        assert events[1][1]["choice"] == choice
+
+    def test_hook_return_value_cannot_veto_the_decision(self, monkeypatch):
+        """Observers are documented return-ignored (plugins.py); a plugin answering "deny" must not
+        change what the user's own approval produced."""
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", lambda name, **kwargs: "deny")
+        client = FakeClient()
+        session = self._session_with_exec_request(
+            client, lambda command, description, **kw: "once")
+        session.run_turn("hi", turn_timeout=1.0)
+
+        assert client.responses == [("r1", {"decision": "accept"})]
+
+    def test_hook_exception_cannot_break_the_approval(self, monkeypatch):
+        def exploding_invoke_hook(name, **kwargs):
+            raise RuntimeError("observer blew up")
+
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", exploding_invoke_hook)
+        client = FakeClient()
+        session = self._session_with_exec_request(
+            client, lambda command, description, **kw: "once")
+        session.run_turn("hi", turn_timeout=1.0)
+
+        assert client.responses == [("r1", {"decision": "accept"})]
+
+    def test_hook_payload_is_redacted_while_the_approval_sees_the_real_command(self, monkeypatch):
+        """hooks.md: an approval command may carry secrets. The observer payload must never carry
+        the raw text; the approval decision itself still sees what will run."""
+        secret = "sk-live-51H8xQ2eZvKYlo2Cabcdefgh"
+        events = _record_approval_hooks(monkeypatch)
+        seen = {}
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval", request_id="r1",
+            command=f"curl -H 'Authorization: Bearer {secret}' https://api.example.com",
+            cwd="/tmp",
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+
+        def cb(command, description, **kwargs):
+            seen["command"] = command
+            return "once"
+
+        session = make_session(client, approval_callback=cb)
+        session.run_turn("hi", turn_timeout=1.0)
+
+        assert secret in seen["command"]
+        pre = [kw for name, kw in events if name == "pre_approval_request"][0]
+        assert secret not in pre["command"], "the observer payload leaked the raw secret"
+        assert "***" in pre["command"]
+
+    def test_callback_exception_reports_no_decision_not_a_denial(self, monkeypatch):
+        """A raising callback obtained no approval response: the post event must carry the documented
+        no-decision failure, never ``deny`` — an exception is not a human denial."""
+        events = _record_approval_hooks(monkeypatch)
+
+        def exploding_callback(command, description, **kwargs):
+            raise RuntimeError("prompt UI blew up")
+
+        client = FakeClient()
+        session = self._session_with_exec_request(client, exploding_callback)
+        session.run_turn("hi", turn_timeout=1.0)
+
+        assert client.responses == [("r1", {"decision": "decline"})]
+        assert [name for name, _ in events] == ["pre_approval_request", "post_approval_response"]
+        post = events[1][1]
+        assert post["choice"] == "notify_failed"
+        assert post["choice"] not in {"once", "session", "always", "deny", "timeout"}
+
+    def test_no_hooks_when_no_human_is_asked(self, monkeypatch):
+        """Parity with the native gates: a bypassed approval and the fail-closed no-callback path
+        prompt nobody, so they must not emit lifecycle events."""
+        events = _record_approval_hooks(monkeypatch)
+
+        bypassed = FakeClient()
+        bypass_session = self._session_with_exec_request(
+            bypassed, None,
+            request_routing=_ServerRequestRouting(auto_approve_exec=True,
+                                                  auto_approve_apply_patch=True))
+        bypass_session.run_turn("hi", turn_timeout=1.0)
+        assert bypassed.responses == [("r1", {"decision": "accept"})]
+        assert events == []
+
+        headless = FakeClient()
+        headless_session = self._session_with_exec_request(headless, None)
+        headless_session.run_turn("hi", turn_timeout=1.0)
+        assert headless.responses == [("r1", {"decision": "decline"})]
+        assert events == []
+


### PR DESCRIPTION
## Summary

Fixes #108368.

Human-prompted approvals raised by the Codex app-server runtime currently bypass Hermes' normal approval hook lifecycle. The transport calls its approval callback directly, so observers that receive `pre_approval_request` / `post_approval_response` from the ordinary approval gate never see Codex approval prompts.

This change restores the existing observer lifecycle around the human-prompted Codex callback without changing authorization policy, timeout behavior, permanent-allow behavior, smart routing, or the Codex wire protocol.

## Behavior

For a Codex request that reaches the human approval callback, the session now:

1. emits exactly one `pre_approval_request`;
2. invokes the existing approval callback;
3. emits exactly one `post_approval_response` carrying the returned decision/outcome.

Paths that do not prompt a human remain silent, including auto-approved routing and no-callback fail-closed handling.

## Contract

This reuses existing approval-hook vocabulary and semantics:

- `surface="cli"` because the asking surface is the interactive CLI/TUI approval callback;
- `pattern_key="codex_runtime"` and `pattern_keys=["codex_runtime"]` as a synthetic non-command-pattern subject;
- callback failure closes the pre/post pair with `choice="notify_failed"` rather than inventing a new `error` value or misreporting the failure as a human denial;
- observer payloads are force-redacted;
- observer failures remain non-blocking and cannot alter the approval decision.

No new hook names or choice vocabulary are introduced.

## Tests

Focused verification against current upstream base `ad03f20dd61919ca2135d6904e787a94284aacaf`:

```text
48 passed in 25.42s
ruff check: clean
ruff check --select PLW1514: clean
ty: 9 diagnostics, matching the pristine upstream baseline (6 production + 3 test); no diagnostics introduced by this change
```

The same amended approval-lifecycle tests were previously run RED against pristine upstream and failed only on the missing-hook behavior.

Regression coverage includes:

- exactly one pre/post pair for a prompted request;
- `surface == "cli"`;
- synthetic `codex_runtime` pattern key(s);
- observer return values cannot alter the approval decision;
- sensitive command text is redacted in observer payloads;
- callback exception still fails closed while the post hook reports `notify_failed`, not a human denial;
- no duplicate dispatch;
- bypass / no-callback paths remain silent.

## Related work

No exact duplicate was found before filing #108368.

Related but distinct work:

- #79217 — missing approval-hook coverage in another prompted path;
- #63503 — precedent for fixing a missing approval lifecycle in smart verdicts;
- #70690 — Codex path bypassing a different hook;
- #83983 — bounded Codex app-server lifecycle observer hook, but not approval hooks;
- #67798 — broader proposal for shared lifecycle-hook ownership across execution surfaces.

If maintainers prefer to fold this narrow approval fix into #83983 or the broader #67798 design, this patch is intentionally isolated to the Codex approval seam and can be reconciled there.