### PR TITLE
fix(plugins): make bundled validation recognize hook declarations

### DIFF
--- a/plugins/disk-cleanup/plugin.yaml
+++ b/plugins/disk-cleanup/plugin.yaml
@@ -2,6 +2,6 @@ name: disk-cleanup
 version: 2.0.0
 description: "Auto-track and clean up ephemeral files (test scripts, temp outputs, cron logs) created during Hermes sessions. Runs via plugin hooks — no agent action required."
 author: "@LVT382009 (original), NousResearch (plugin port)"
-hooks:
+provides_hooks:
   - post_tool_call
   - on_session_end

--- a/plugins/google_meet/plugin.yaml
+++ b/plugins/google_meet/plugin.yaml
@@ -12,5 +12,5 @@ provides_tools:
   - meet_status
   - meet_transcript
   - meet_say
-hooks:
+provides_hooks:
   - on_session_end

--- a/plugins/memory/byterover/plugin.yaml
+++ b/plugins/memory/byterover/plugin.yaml
@@ -5,5 +5,3 @@ external_dependencies:
   - name: brv
     install: "curl -fsSL https://byterover.dev/install.sh | sh"
     check: "brv --version"
-provides_hooks:
-  - on_pre_compress

--- a/plugins/memory/byterover/plugin.yaml
+++ b/plugins/memory/byterover/plugin.yaml
@@ -5,5 +5,5 @@ external_dependencies:
   - name: brv
     install: "curl -fsSL https://byterover.dev/install.sh | sh"
     check: "brv --version"
-hooks:
+provides_hooks:
   - on_pre_compress

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -4,5 +4,3 @@ description: "Hindsight — long-term memory with knowledge graph, entity resolu
 pip_dependencies:
   - "hindsight-client>=0.6.1"
 requires_env: []
-provides_hooks:
-  - on_session_end

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -4,5 +4,5 @@ description: "Hindsight — long-term memory with knowledge graph, entity resolu
 pip_dependencies:
   - "hindsight-client>=0.6.1"
 requires_env: []
-hooks:
+provides_hooks:
   - on_session_end

--- a/plugins/memory/holographic/plugin.yaml
+++ b/plugins/memory/holographic/plugin.yaml
@@ -1,5 +1,3 @@
 name: holographic
 version: 0.1.0
 description: "Holographic memory — local SQLite fact store with FTS5 search, trust scoring, and HRR-based compositional retrieval."
-provides_hooks:
-  - on_session_end

--- a/plugins/memory/holographic/plugin.yaml
+++ b/plugins/memory/holographic/plugin.yaml
@@ -1,5 +1,5 @@
 name: holographic
 version: 0.1.0
 description: "Holographic memory — local SQLite fact store with FTS5 search, trust scoring, and HRR-based compositional retrieval."
-hooks:
+provides_hooks:
   - on_session_end

--- a/plugins/memory/honcho/plugin.yaml
+++ b/plugins/memory/honcho/plugin.yaml
@@ -3,5 +3,5 @@ version: 1.0.0
 description: "Honcho AI-native memory — cross-session user modeling with dialectic Q&A, semantic search, and persistent conclusions."
 pip_dependencies:
   - honcho-ai
-hooks:
+provides_hooks:
   - on_session_end

--- a/plugins/memory/honcho/plugin.yaml
+++ b/plugins/memory/honcho/plugin.yaml
@@ -3,5 +3,3 @@ version: 1.0.0
 description: "Honcho AI-native memory — cross-session user modeling with dialectic Q&A, semantic search, and persistent conclusions."
 pip_dependencies:
   - honcho-ai
-provides_hooks:
-  - on_session_end

--- a/plugins/memory/openviking/plugin.yaml
+++ b/plugins/memory/openviking/plugin.yaml
@@ -4,5 +4,5 @@ description: "OpenViking context database — session-managed memory with automa
 pip_dependencies:
   - httpx
 requires_env: []
-hooks:
+provides_hooks:
   - on_session_end

--- a/plugins/memory/openviking/plugin.yaml
+++ b/plugins/memory/openviking/plugin.yaml
@@ -4,5 +4,3 @@ description: "OpenViking context database — session-managed memory with automa
 pip_dependencies:
   - httpx
 requires_env: []
-provides_hooks:
-  - on_session_end

--- a/plugins/observability/langfuse/plugin.yaml
+++ b/plugins/observability/langfuse/plugin.yaml
@@ -5,7 +5,7 @@ author: NousResearch
 requires_env:
   - HERMES_LANGFUSE_PUBLIC_KEY
   - HERMES_LANGFUSE_SECRET_KEY
-hooks:
+provides_hooks:
   - pre_api_request
   - post_api_request
   - api_request_error


### PR DESCRIPTION
## What does this PR do?

Three bundled plugins declare registered runtime hooks under an unconsumed `hooks` manifest key, so `hermes plugins validate` reports those registrations as undeclared and `hermes plugins doctor` emits warnings. Five memory-provider manifests also use that inert key for provider lifecycle methods that are not hook registrations. This change renames the three real hook declarations to `provides_hooks` and removes the five misleading lifecycle declarations.

**Trigger:** `hermes_cli/plugins_manifest.py:477` reads `provides_hooks`, while the affected bundled manifests use `hooks`.

**Causal chain:**
1. Plugin discovery loads an affected bundled manifest.
2. The unknown `hooks` key is ignored, leaving `PluginManifest.provides_hooks` empty.
3. Validation compares live hook registrations with that empty declaration and reports undeclared hooks.

**Working contrast:** Bundled manifests that declare tools already use the consumed `provides_tools` key. The corresponding hook capability key is `provides_hooks`.

**Ruled out:** The runtime hook registrations are not missing. Validation observes them and reports them specifically because their manifest declarations were not parsed.

## Related Issue

Closes #108371

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Rename `hooks` to `provides_hooks` for disk-cleanup, Google Meet, and Langfuse, preserving their registered hook values.
- Remove inert `hooks` declarations from five memory-provider manifests whose values name provider lifecycle methods rather than registered hooks.
- Leave `plugins/security-guidance/plugin.yaml` to its existing dedicated PR.

## How to Test

1. Validate each of the eight affected plugin directories with `validate_plugin_dir`; all eight pass.
2. Run the focused plugin manifest and validation tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_plugin_dev.py tests/hermes_cli/test_plugin_validate.py
```

Result: 18 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs to make sure this is not a duplicate.
- [x] This PR contains only changes related to this fix.
- [x] I ran the repository test entry on the focused tests and all tests pass.
- [x] Existing capability-validation tests cover the corrected manifest contract; no new runtime logic was introduced.
- [x] I tested on Windows 11.

### Documentation & Housekeeping

- [x] Documentation updates are not applicable because this corrects existing manifest declarations.
- [x] Config example updates are not applicable because no config key changes.
- [x] Architecture and workflow documentation updates are not applicable.
- [x] Cross-platform impact is limited to platform-independent YAML manifest parsing.
- [x] Tool descriptions and schemas are unchanged.
