### PR TITLE
fix(desktop): preserve owner for unlisted profile tabs

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -67,7 +67,12 @@ import {
 } from '@/store/session'
 import { $removedSessionIds, $sessionMutationsInFlight } from '@/store/session-removal'
 import { requestForSessionProfile, type SessionProfileRoute } from '@/store/session-request-router'
-import { $sessionTiles, sessionTileOwnerRoute } from '@/store/session-states'
+import {
+  $sessionTiles,
+  knownOwnerForSession,
+  requestForOwnedSession,
+  sessionTileOwnerRoute
+} from '@/store/session-states'
 import { $sessionSeenCounts, $unreadFinishedMarkers } from '@/store/session-unread'
 
 import sessionResumeActiveTurn from '../../../../../../tests/fixtures/session-resume-active-turn.json'
@@ -4096,8 +4101,12 @@ describe('createBackendSessionForSend workspace target', () => {
 describe('openNewSessionTile workspace target', () => {
   afterEach(() => {
     cleanup()
+    $profiles.set([])
     $projectScope.set(ALL_PROJECTS)
     $projectTree.set([])
+    $sessionTiles.set([])
+    setConnection(null)
+    setSessions([])
     vi.restoreAllMocks()
   })
 
@@ -4138,6 +4147,52 @@ describe('openNewSessionTile workspace target', () => {
     })
 
     expect(createParams).not.toHaveProperty('cwd')
+  })
+
+  it('keeps an unlisted named local legacy-profile tile owned by its bare profile', async () => {
+    const storedSessionId = 'stored-unlisted-omar'
+    $profiles.set([{ name: 'default' }, { name: 'omar' }] as never)
+    setConnection({ mode: 'local' } as never)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        return {
+          info: { cwd: '', model: 'test-model', tools: {}, skills: {} },
+          session_id: RUNTIME_SESSION_ID,
+          stored_session_id: storedSessionId
+        } as never
+      }
+
+      throw new Error(`Unexpected ambient RPC: ${method}`)
+    })
+    vi.mocked(requestGatewayForProfile).mockResolvedValue({ control: {} } as never)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.openNewSessionTile('center', { listed: false, profile: 'omar' })
+    })
+
+    expect(requestGateway).toHaveBeenCalledWith('session.create', expect.any(Object))
+    expect(vi.mocked(requestGatewayForAgent)).not.toHaveBeenCalled()
+    expect($sessions.get().some(session => sessionMatchesStoredId(session, storedSessionId))).toBe(false)
+    expect($sessionTiles.get()).toContainEqual(expect.objectContaining({ ownerProfile: 'omar', storedSessionId }))
+    expect(knownOwnerForSession(storedSessionId)).toBe('omar')
+
+    await expect(
+      requestForOwnedSession(storedSessionId, requestGateway, 'session.control.read', {
+        session_id: RUNTIME_SESSION_ID
+      })
+    ).resolves.toEqual({ control: {} })
+    expect(requestGatewayForProfile).toHaveBeenCalledWith(
+      'omar',
+      'session.control.read',
+      { session_id: RUNTIME_SESSION_ID },
+      undefined,
+      undefined
+    )
   })
 })
 describe('selectSidebarItem', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -768,7 +768,27 @@ export function useSessionActions({
         // occupied (openTab path for "New session in Home").
         const capturedRoute = options?.route !== undefined ? options.route : resolveNewChatOwnerRoute(options?.profile)
 
-        const workspaceScope = options?.workspaceScope ?? { workspaceMode: 'sessions' }
+        // A named local profile deliberately uses the legacy profile-only
+        // transport, so it has no connectionId to capture. For an explicit,
+        // unique non-default profile from the active local roster, the bare
+        // profile is still an authoritative pool owner. Keep every other null
+        // route unresolved: explicit null, default, remote, missing or
+        // duplicate profile intent retains its prior behavior.
+        const requestedProfile = typeof options?.profile === 'string' ? normalizeProfileKey(options.profile) : null
+        const legacyOwnerProfile =
+          options?.route === undefined &&
+          !capturedRoute &&
+          requestedProfile !== null &&
+          requestedProfile !== 'default' &&
+          $connection.get()?.mode !== 'remote' &&
+          $profiles.get().filter(profile => normalizeProfileKey(profile.name) === requestedProfile).length === 1
+            ? requestedProfile
+            : undefined
+
+        const workspaceScope: SessionTileWorkspaceScope = {
+          ...(options?.workspaceScope ?? { workspaceMode: 'sessions' }),
+          ...(legacyOwnerProfile ? { ownerProfile: legacyOwnerProfile } : {})
+        }
 
         const cwd =
           options?.cwd === null ? '' : typeof options?.cwd === 'string' ? options.cwd.trim() : resolveNewSessionCwd()
@@ -806,6 +826,10 @@ export function useSessionActions({
             // moment on, and its socket stays pinned until the tile mounts.
             setSessionOwnerHint(stored, capturedRoute)
             holdSessionOwnerUntilForeground(stored, capturedRoute)
+          } else if (stored && legacyOwnerProfile) {
+            // The tile below persists this bare owner as the stored-id hint;
+            // bridge the create-to-mount gap with the same profile pool.
+            holdSessionOwnerUntilForeground(stored, legacyOwnerProfile)
           }
         } finally {
           releaseCreateLease()

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -272,6 +272,10 @@ export function foregroundSessionScopes(): Set<string> {
   for (const tile of $sessionTiles.get()) {
     addRuntimeScope(tile.runtimeId)
     addRouteScope(tile.ownerRoute)
+
+    if (!tile.ownerRoute && tile.ownerProfile) {
+      scopes.add(normalizeProfileKey(tile.ownerProfile))
+    }
   }
 
   // Create → foreground holds. A hold whose scope the rungs above already
@@ -769,6 +773,8 @@ export interface SessionTile {
   workspaceMode?: WorkspaceMode
   /** Exact opaque owner key for Bot Mode tabs. */
   workspaceOwnerKey?: string
+  /** Legacy profile-pool owner when no registry connection identifies the route. */
+  ownerProfile?: string
   /** Credential-free exact route used to resume this tab after relaunch. */
   ownerRoute?: SessionOwnerRoute
   /** Stable title for hidden relationship chats absent from the Sessions list. */
@@ -776,6 +782,7 @@ export interface SessionTile {
 }
 
 export interface SessionTileWorkspaceScope {
+  ownerProfile?: string
   ownerRoute?: SessionOwnerRoute
   workspaceMode: WorkspaceMode
   workspaceOwnerKey?: string
@@ -801,6 +808,7 @@ type StoredTile = Pick<
   | 'anchor'
   | 'before'
   | 'dir'
+  | 'ownerProfile'
   | 'ownerRoute'
   | 'storedSessionId'
   | 'workspaceMode'
@@ -812,6 +820,7 @@ const toStored = (t: SessionTile): StoredTile => ({
   anchor: t.anchor,
   before: t.before,
   dir: t.dir,
+  ...(t.ownerProfile ? { ownerProfile: t.ownerProfile } : {}),
   ...(t.ownerRoute ? { ownerRoute: t.ownerRoute } : {}),
   storedSessionId: t.storedSessionId,
   ...(t.workspaceMode ? { workspaceMode: t.workspaceMode } : {}),
@@ -830,6 +839,7 @@ function parseTileList(value: unknown): StoredTile[] {
             anchor: typeof raw.anchor === 'string' ? raw.anchor : undefined,
             before: typeof raw.before === 'string' || raw.before === null ? raw.before : undefined,
             dir: raw.dir,
+            ownerProfile: typeof raw.ownerProfile === 'string' ? normalizeProfileKey(raw.ownerProfile) : undefined,
             ownerRoute:
               raw.ownerRoute &&
               typeof raw.ownerRoute.connectionId === 'string' &&
@@ -968,6 +978,12 @@ export function sessionTileOwnerRoute(storedSessionId: string): SessionOwnerRout
   return $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)?.ownerRoute
 }
 
+function sessionTileOwner(storedSessionId: string): SessionOwnerScope {
+  const tile = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
+
+  return tile?.ownerRoute ?? tile?.ownerProfile
+}
+
 /**
  * Gateway keep-set scopes for currently open tiles. Bot chats (and any other
  * owner-routed tile) hold a secondary socket even while chrome stays on the
@@ -984,6 +1000,10 @@ export function openTileGatewayScopes(): Set<string> {
     const route = tile.ownerRoute
 
     if (!route) {
+      if (tile.ownerProfile) {
+        scopes.add(normalizeProfileKey(tile.ownerProfile))
+      }
+
       continue
     }
 
@@ -1033,7 +1053,7 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
   const storedSessionId = storedSessionIdForRuntimeId(sessionId) ?? sessionId
 
   return (
-    sessionTileOwnerRoute(storedSessionId) ??
+    sessionTileOwner(storedSessionId) ??
     getSessionOwnerHint(storedSessionId) ??
     knownSessionOwner(ownerLookupSessionRows(), storedSessionId) ??
     sessionOwnerByRuntimeId.get(sessionId)
@@ -1196,12 +1216,14 @@ export function setSessionTileWorkspaceScope(storedSessionId: string, scope: Ses
   // plain re-open can't unpin the owning socket. Bot scopes stay authoritative
   // both ways: they always name their route explicitly.
   const ownerRoute = scope.workspaceMode === 'bots' ? scope.ownerRoute : (scope.ownerRoute ?? tile?.ownerRoute)
+  const ownerProfile = scope.workspaceMode === 'bots' ? undefined : (scope.ownerProfile ?? tile?.ownerProfile)
   const workspaceTabTitle = scope.workspaceMode === 'bots' ? scope.workspaceTabTitle : undefined
 
   if (
     !tile ||
     ((tile.workspaceMode ?? 'sessions') === scope.workspaceMode &&
       tile.workspaceOwnerKey === workspaceOwnerKey &&
+      tile.ownerProfile === ownerProfile &&
       tile.ownerRoute?.connectionId === ownerRoute?.connectionId &&
       tile.ownerRoute?.profile === ownerRoute?.profile &&
       tile.ownerRoute?.targetProfile === ownerRoute?.targetProfile &&
@@ -1211,6 +1233,7 @@ export function setSessionTileWorkspaceScope(storedSessionId: string, scope: Ses
   }
 
   patchSessionTile(storedSessionId, {
+    ownerProfile,
     ownerRoute,
     workspaceMode: scope.workspaceMode,
     workspaceOwnerKey,
@@ -1484,6 +1507,7 @@ export function openSessionTile(
         // draft runtime is otherwise orphan-reaped the moment the pruner
         // closes the unpinned socket (the resume/reclaim flicker loop,
         // #93892 shape).
+        ownerProfile: workspaceScope.ownerProfile,
         ownerRoute: workspaceScope.ownerRoute,
         storedSessionId,
         workspaceMode: workspaceScope.workspaceMode,


### PR DESCRIPTION
## What does this PR do?

- preserve the bare local-profile owner when the tab-strip creates an unlisted session through the legacy profile pool - persist that owner with the tile so session-scoped RPCs and gateway keep-scopes continue to resolve it after the create handoff - keep the draft out of the Sessions sidebar until its first persisted turn Named profiles on the local legacy transport intentionally produce no connection-qualified owner route. Listed creates remain routable because their optimistic session row carries the profile, but `listed: false` suppresses that row.

### Symptom

- preserve the bare local-profile owner when the tab-strip creates an unlisted session through the legacy profile pool
- persist that owner with the tile so session-scoped RPCs and gateway keep-scopes continue to resolve it after the create handoff
- keep the draft out of the Sessions sidebar until its first persisted turn


Named profiles on the local legacy transport intentionally produce no connection-qualified owner route. Listed creates remain routable because their optimistic session row carries the profile, but `listed: false` suppresses that row. The new tab therefore had neither a row nor tile owner metadata, and `session.control.read` correctly failed closed rather than guessing the active gateway.

The fix records a bare `ownerProfile` only when the requested profile is explicit, unique, non-default, local, and no exact route exists. Exact routes continue to win, while unresolved/default/remote cases preserve their previous behavior.


Focused test:

```text
/opt/homebrew/Cellar/node@24/24.20.0/bin/node node_modules/vitest/vitest.mjs run --project ui src/app/session/hooks/use-session-actions.test.tsx
```

Before the implementation, the new regression test failed while the other 97 tests passed because the unlisted tile had no `ownerProfile`.

After the implementation:

```text
Test Files 1 passed (1)
Tests 98 passed (98)
```

`git diff --check` also passes.


The owner inference is deliberately narrow. If the profile is missing, duplicated, default, remote,

### Impact

- preserve the bare local-profile owner when the tab-strip creates an unlisted session through the legacy profile pool - persist that owner with the tile so session-scoped RPCs and gateway keep-scopes continue to resolve it after the create handoff - keep the draft out of the Sessions sidebar until its first persisted turn Named profiles on the local legacy transport intentionally produce no connection-qualified owner route. Listed creates remain routable because their optimistic session row carries the profile, but `listed: false` suppresses that row.

### Bug Cause

Named profiles on the local legacy transport intentionally produce no connection-qualified owner route. Listed creates remain routable because their optimistic session row carries the profile, but `listed: false` suppresses that row. The new tab therefore had neither a row nor tile owner metadata, and `session.control.read` correctly failed closed rather than guessing the active gateway.

The fix records a bare `ownerProfile` only when the requested profile is explicit, unique, non-default, local, and no exact route exists. Exact routes continue to win, while unresolved/default/remote cases preserve their previous behavior.

### Fix

- preserve the bare local-profile owner when the tab-strip creates an unlisted session through the legacy profile pool - persist that owner with the tile so session-scoped RPCs and gateway keep-scopes continue to resolve it after the create handoff - keep the draft out of the Sessions sidebar until its first persisted turn Named profiles on the local legacy transport intentionally produce no connection-qualified owner route. Listed creates remain routable because their optimistic session row carries the profile, but `listed: false` suppresses that row. The new tab therefore had neither a row nor tile owner metadata, and `session.control.read` correctly failed closed rather than guessing the active gateway.

## Related Issue

Fixes #108369

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See Fix; production and test files are in the diff

## How to Test

- ✅ `scripts/run_tests.sh` on the files in Changes Made — focused verification
- ✅ Focused verification completed on this branch

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

