### PR TITLE
fix(gateway): timing-safe webhook secret compare and uniform 404 on bad signature

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -2,6 +2,7 @@
 inbound webhooks (text, media attachments, typing indicators, read receipts)."""
 
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -560,7 +561,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     async def _handle_webhook(self, request):
         from aiohttp import web
 
-        if self._webhook_token(request) != self.password:
+        token = self._webhook_token(request)
+        # Timing-safe compare as UTF-8 bytes (compare_digest raises on
+        # non-ASCII str, and the supplied token is attacker-controlled).
+        if not hmac.compare_digest(str(token).encode(), str(self.password).encode()):
             return web.json_response({"error": "unauthorized"}, status=401)
         try:
             payload = self._parse_webhook_body(await request.read())

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -435,7 +435,9 @@ class WebhookAdapter(BasePlatformAdapter):
             return None, _json_error("Webhook route is missing an HMAC secret", 403)
         if secret != _INSECURE_NO_AUTH and not self._validate_signature(request, raw_body, secret):
             logger.warning("[webhook] Invalid signature for route %s", route_name)
-            return None, _json_error("Invalid signature", 401)
+            # Same 404 as unknown-route so a bad signature cannot enumerate
+            # configured route names via the status split.
+            return None, _json_error(f"Unknown route: {route_name}", 404)
         return raw_body, None
 
     @staticmethod

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -215,13 +215,13 @@ class TestDeliverOnlySecurityInvariants:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            # No signature header → reject
+            # No signature header → reject (404, same as an unknown route)
             resp = await cli.post(
                 "/webhooks/r",
                 json={},
                 headers={"X-GitHub-Delivery": "d-noauth-1"},
             )
-            assert resp.status == 401
+            assert resp.status == 404
 
         # Target never called
         mock_target.send.assert_not_awaited()

--- a/tests/gateway/test_webhook_signature_rate_limit.py
+++ b/tests/gateway/test_webhook_signature_rate_limit.py
@@ -8,7 +8,8 @@ with 429.
 
 The correct order is:
 1. Read body
-2. Validate HMAC signature (reject 401 if invalid)
+2. Validate HMAC signature (reject 404 if invalid - same as unknown
+   route so a bad signature cannot enumerate configured route names)
 3. Rate limit check (reject 429 if over limit)
 4. Process the webhook
 """
@@ -66,7 +67,7 @@ class TestSignatureBeforeRateLimit:
 
         BEFORE FIX: Invalid signatures consume the rate limit bucket, so
         after 'rate_limit' bad requests the valid one would get 429.
-        AFTER FIX: Invalid signatures are rejected with 401 first (before
+        AFTER FIX: Invalid signatures are rejected first (before
         rate limiting), so the rate limit bucket is untouched. The valid
         request after many bad ones still succeeds.
         """
@@ -106,10 +107,13 @@ class TestSignatureBeforeRateLimit:
                         "X-GitHub-Delivery": f"bad-{i}",
                     },
                 )
-                # Each invalid signature should be rejected with 401
-                assert resp.status == 401, (
-                    f"Expected 401 for invalid signature, got {resp.status}"
+                # Each invalid signature is rejected with the same 404 an
+                # unknown route gets (no route-existence leak).
+                assert resp.status == 404, (
+                    f"Expected 404 for invalid signature, got {resp.status}"
                 )
+                data_out = await resp.json()
+                assert data_out["error"] == f"Unknown route: {route_name}"
 
             # Now send a valid-signed request — it MUST succeed (202)
             # BEFORE FIX: This would return 429 because the 5 bad requests


### PR DESCRIPTION
## What does this PR do?

Two webhook auth hardening fixes:

- `bluebubbles` compared the inbound token with `!=`; now `hmac.compare_digest` on UTF-8 bytes, matching `_hmac_str_equal` in `webhook.py`.
- The generic webhook adapter returned 404 for unknown routes but 401 for a bad signature on a real route, so route names were enumerable. A bad signature now returns the same 404, matching the profile-mismatch path's existing convention.

Note: the 401-to-404 change intentionally updates two tests that pinned the old status.

## Related Issue

Fixes #108388

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `gateway/platforms/bluebubbles.py`: `compare_digest(str(token).encode(), str(self.password).encode())`.
- `gateway/platforms/webhook.py`: invalid signature returns `Unknown route` 404.
- `tests/gateway/test_webhook_signature_rate_limit.py`, `test_webhook_deliver_only.py`: updated to the 404 contract; the rate-limit test also asserts the body matches the unknown-route shape.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `scripts/run_tests.sh tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_signature_rate_limit.py tests/gateway/test_webhook_deliver_only.py tests/gateway/test_bluebubbles.py -q`
2. `POST /webhooks/<real-route>` with a bad signature and `POST /webhooks/<bogus>` now return identical 404s.
3. The cron-fire webhook (`/api/cron/fire`) is a different adapter and keeps its 401 contract; `test_cron_fire_webhook.py` still passes.

Ran on Windows 11: 86 passed.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A
