### PR TITLE
fix(desktop): stamp profile-only owner on unlisted + tabs

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -4140,6 +4140,123 @@ describe('openNewSessionTile workspace target', () => {
     expect(createParams).not.toHaveProperty('cwd')
   })
 })
+
+describe('openNewSessionTile unlisted named-profile owner stamp', () => {
+  const STORED = 'stored-unlisted-named'
+  const RUNTIME = 'rt-unlisted-named'
+
+  afterEach(() => {
+    cleanup()
+    $newChatProfile.set(null)
+    $newChatRoute.set(null)
+    $activeGatewayProfile.set('default')
+    $profiles.set([])
+    $sessionTiles.set([])
+    setSessions([])
+    vi.restoreAllMocks()
+  })
+
+  async function createUnlistedNamedProfileTab() {
+    $profiles.set([{ name: 'default' } as never, { name: 'winefox' } as never])
+    $activeGatewayProfile.set('winefox')
+    $newChatProfile.set('winefox')
+    $newChatRoute.set(null)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        return {
+          info: { cwd: '', model: 'test-model', tools: {}, skills: {} },
+          session_id: RUNTIME,
+          stored_session_id: STORED
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.openNewSessionTile('center', { listed: false })
+    })
+
+    return requestGateway
+  }
+
+  it('stamps a bare profile owner on an unlisted + tab without listing it in the sidebar', async () => {
+    const { knownOwnerForSession } = await import('@/store/session-states')
+
+    await createUnlistedNamedProfileTab()
+
+    expect($sessions.get().some(session => session.id === STORED)).toBe(false)
+    expect(getSessionOwnerHint(STORED)).toBeUndefined()
+    expect(sessionTileOwnerRoute(STORED)?.connectionId).toBeUndefined()
+    expect(knownOwnerForSession(STORED)).toBe('winefox')
+    expect(knownOwnerForSession(RUNTIME)).toBe('winefox')
+  })
+
+  it('keeps session-scoped RPCs on the profile door instead of failing closed', async () => {
+    const { knownOwnerForSession, requestForOwnedSession } = await import('@/store/session-states')
+    const { isSessionOwnerResolutionError } = await import('@/store/session-owner-resolution')
+
+    await createUnlistedNamedProfileTab()
+
+    const ambient = vi.fn(async () => {
+      throw new Error('ambient must not receive session-scoped RPCs for a known owner')
+    })
+
+    await expect(
+      requestForOwnedSession(RUNTIME, ambient as never, 'session.control.read', { session_id: RUNTIME })
+    ).resolves.toBeUndefined()
+    expect(isSessionOwnerResolutionError(null)).toBe(false)
+    expect(knownOwnerForSession(RUNTIME)).toBe('winefox')
+    expect(ambient).not.toHaveBeenCalled()
+    expect(vi.mocked(requestGatewayForProfile).mock.calls[0].slice(0, 3)).toEqual([
+      'winefox',
+      'session.control.read',
+      { session_id: RUNTIME }
+    ])
+  })
+
+  it('keeps an explicit create route as the exact owner when the tab is unlisted', async () => {
+    const route = { connectionId: 'homelab', profile: 'omar' }
+    $profiles.set([{ name: 'default' } as never, { name: 'omar' } as never])
+    $activeGatewayProfile.set('default')
+    $newChatProfile.set('omar')
+    $newChatRoute.set(route)
+
+    vi.mocked(requestGatewayForAgent).mockImplementation(async (_connectionId, _profile, method) => {
+      if (method === 'session.create') {
+        return {
+          info: { cwd: '', model: 'test-model', tools: {}, skills: {} },
+          session_id: RUNTIME,
+          stored_session_id: STORED
+        } as never
+      }
+
+      return {} as never
+    })
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.openNewSessionTile('center', { listed: false })
+    })
+
+    const { knownOwnerForSession } = await import('@/store/session-states')
+
+    expect($sessions.get().some(session => session.id === STORED)).toBe(false)
+    expect(getSessionOwnerHint(STORED)).toEqual(expect.objectContaining(route))
+    expect(knownOwnerForSession(STORED)).toEqual(expect.objectContaining(route))
+    expect(requestGateway).not.toHaveBeenCalledWith('session.create', expect.anything())
+  })
+})
+
 describe('selectSidebarItem', () => {
   it('fronts the workspace pane when navigating to a sidebar route (issue #72602)', async () => {
     const navigate = vi.fn()

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -117,6 +117,7 @@ import {
   patchSessionTile,
   publishSessionState,
   releaseSessionOwnerHold,
+  rememberProfileOnlySessionOwner,
   type SessionTileWorkspaceScope,
   type TileDock
 } from '@/store/session-states'
@@ -806,6 +807,18 @@ export function useSessionActions({
             // moment on, and its socket stays pinned until the tile mounts.
             setSessionOwnerHint(stored, capturedRoute)
             holdSessionOwnerUntilForeground(stored, capturedRoute)
+          } else if (stored) {
+            // Legacy profile-only door (named profile on explicit `local`):
+            // create rode ambient and left no exact route. Unlisted "+" tabs
+            // also skip the optimistic sidebar row, so stamp the bare profile
+            // on stored + runtime ids — otherwise session.resume /
+            // session.control.read fail closed in multi-profile installs.
+            const profileOnlyOwner = normalizeProfileKey(
+              $newChatProfile.get() || $activeGatewayProfile.get()
+            )
+            rememberProfileOnlySessionOwner(stored, profileOnlyOwner)
+            rememberProfileOnlySessionOwner(created.session_id, profileOnlyOwner)
+            holdSessionOwnerUntilForeground(stored, profileOnlyOwner)
           }
         } finally {
           releaseCreateLease()

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -25,6 +25,7 @@ import {
   focusedSessionNeedsRoute,
   focusOpenSession,
   focusWorkspaceOwnerSessionTile,
+  forgetProfileOnlyRuntimeOwners,
   foregroundSessionScopes,
   isSessionRemote,
   knownOwnerForSession,
@@ -35,6 +36,7 @@ import {
   patchSessionTile,
   recordSessionEventScope,
   releaseSessionTranscript,
+  rememberProfileOnlySessionOwner,
   requestForOwnedSession,
   resetTileRuntimeBindings,
   selectionHomesToWorkspace,
@@ -1291,6 +1293,48 @@ describe('knownOwnerForSession / requestForOwnedSession (#91684 client half)', (
 
     expect(ambient).toHaveBeenCalledTimes(1)
     expect(ambient.mock.calls[0]).toEqual(['approval.respond', { choice: 'once', session_id: 'unknown-session' }])
+  })
+})
+
+describe('rememberProfileOnlySessionOwner (unlisted named-profile mint)', () => {
+  beforeEach(() => {
+    $activeGatewayProfile.set('default')
+    $sessionTiles.set([])
+  })
+  afterEach(() => {
+    forgetProfileOnlyRuntimeOwners('winefox')
+    $sessionTiles.set([])
+    setSessions([])
+  })
+
+  it('makes knownOwnerForSession resolve a bare profile with no row or tile route', () => {
+    rememberProfileOnlySessionOwner('stored-draft', 'winefox')
+    rememberProfileOnlySessionOwner('rt-draft', 'winefox')
+
+    expect(sessionTileOwnerRoute('stored-draft')).toBeUndefined()
+    expect(knownOwnerForSession('stored-draft')).toBe('winefox')
+    expect(knownOwnerForSession('rt-draft')).toBe('winefox')
+  })
+
+  it('lets a runtime id resolve via its stored-id ledger entry', () => {
+    $sessionTiles.set([{ runtimeId: 'rt-draft', storedSessionId: 'stored-draft' }])
+    rememberProfileOnlySessionOwner('stored-draft', 'winefox')
+
+    expect(knownOwnerForSession('rt-draft')).toBe('winefox')
+  })
+
+  it('does not outrank an exact tile owner route', () => {
+    $sessionTiles.set([
+      {
+        ownerRoute: { connectionId: 'homelab', profile: 'winefox' },
+        runtimeId: 'rt-1',
+        storedSessionId: 'stored-1'
+      }
+    ])
+    rememberProfileOnlySessionOwner('stored-1', 'winefox')
+    rememberProfileOnlySessionOwner('rt-1', 'winefox')
+
+    expect(knownOwnerForSession('rt-1')).toEqual({ connectionId: 'homelab', profile: 'winefox' })
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -118,6 +118,30 @@ export function recordSessionEventScope(event: { connectionId?: string; profile?
   }
 }
 
+/**
+ * Stamp a legacy profile-only owner on a runtime and/or stored id.
+ *
+ * Used when session.create rode the ambient / profile-only door (named
+ * profile on the explicit `local` source: `resolveNewChatOwnerRoute()` is
+ * null) and the surface will not upsert a sidebar row — unlisted tab-strip
+ * "+" / ⌘T drafts. Without this stamp every later session-scoped RPC
+ * (`session.resume`, `session.control.read`) fails closed in multi-profile
+ * topology. A bare profile keeps the profile-pool door (remote override
+ * included) instead of inventing `{ connectionId: 'local', … }`, which
+ * would dial `requestGatewayForAgent` and skip that door.
+ *
+ * Exact connection routes still outrank this ledger in `knownOwnerForSession`.
+ */
+export function rememberProfileOnlySessionOwner(sessionId: string, profile: string): void {
+  const id = sessionId.trim()
+
+  if (!id) {
+    return
+  }
+
+  sessionOwnerByRuntimeId.set(id, normalizeProfileKey(profile))
+}
+
 /** Forget only profile-pool runtime owners during permanent LOCAL profile
  * teardown. These string routes came exclusively from the legacy secondary
  * producer; exact connection descriptors must survive a same-named remote
@@ -1018,10 +1042,14 @@ export function openTileGatewayScopes(): Set<string> {
  * Last rung: the owner recorded from the inbound runtime event itself
  * (sessionOwnerByRuntimeId, #97511) — an orphan runtime whose tile/hint/row
  * binding is absent or stale still routes through the exact
- * (connectionId, profile) or secondary socket's proven local profile. Every
- * durable rung above keeps outranking it, so a stored-id collision never
- * inherits a stale runtime ledger entry. Unproven profile fields record
- * nothing, so unknown owners in multi-profile topology still fail closed.
+ * (connectionId, profile) or secondary socket's proven local profile. The
+ * ledger is also how an unlisted profile-only mint (tab-strip "+" on a named
+ * local profile) names its owner before a sidebar row exists. Lookup tries
+ * the caller id then the translated stored id so a runtime control.read
+ * still hits a stored-id stamp. Every durable rung above keeps outranking
+ * it, so a stored-id collision never inherits a stale runtime ledger entry.
+ * Unproven profile fields record nothing, so unknown owners in multi-profile
+ * topology still fail closed.
  * Returns undefined when no owner is known — the caller fails closed
  * (assertSessionOwnerResolved), never falls to "active".
  */
@@ -1036,7 +1064,8 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
     sessionTileOwnerRoute(storedSessionId) ??
     getSessionOwnerHint(storedSessionId) ??
     knownSessionOwner(ownerLookupSessionRows(), storedSessionId) ??
-    sessionOwnerByRuntimeId.get(sessionId)
+    sessionOwnerByRuntimeId.get(sessionId) ??
+    sessionOwnerByRuntimeId.get(storedSessionId)
   )
 }
 


### PR DESCRIPTION
## Bug Description

On multi-profile Desktop, tab-strip **`+` / ⌘T** while on a **named (non-`default`) local profile** mints a draft session with **no owner metadata**. Session-scoped RPCs then fail closed:

- **#108369** — composer banner `Session controls unavailable` (`session.control.read`)
- **#102792** — tile dead-end `Couldn't open this session` (`session.resume`)

Same create path: `resolveNewChatOwnerRoute()` is null on the legacy profile-only door, and `listed: false` skips the optimistic sidebar row.

Fixes #108369
Fixes #102792

## Root Cause

`openNewSessionTile` only called `setSessionOwnerHint` when `capturedRoute` was set. Named profiles on This-device / `local` deliberately return **null** from `profilePickConnectionId` (legacy profile-pool door, including per-profile remote override). Combined with `listed: false`, every owner-ladder rung missed:

tile route → hint → session row → runtime ledger

`assertSessionOwnerResolved` then threw `SessionOwnerResolutionError` instead of guessing the ambient gateway.

Inventing `{ connectionId: 'local', profile }` would have been wrong: `requestGatewayForAgent('local', name)` does **not** collapse to the profile-pool door (`registryBackendScopeKey` keeps explicit `local`).

## Fix

When create returns a stored id **without** an exact route, stamp a **bare profile** (`$newChatProfile` / `$activeGatewayProfile`) on both the stored id and the runtime id via `rememberProfileOnlySessionOwner`, and hold that owner until the tile is foregrounded.

- `knownOwnerForSession` already accepts a string as the legacy profile door (`requestGatewayForProfile`)
- Exact `capturedRoute` path is unchanged (hint + hold)
- Unlisted drafts still stay out of `$sessions` / the sidebar
- Last-rung lookup also tries the translated stored id so a runtime `session.control.read` hits a stored-id stamp

## How to Verify

1. Desktop, local connection, ≥2 profiles.
2. Switch to a named profile (not `default`).
3. Click tab-strip `+` (or ⌘T) with another chat already open.
4. New tab should **not** show `Session controls unavailable` / `Couldn't open this session`.
5. Repeat on `default` — still fine.
6. Unlisted tab still does not appear in the sidebar until the first turn.

## Test Plan

- [x] Regression: unlisted named-profile `+` stamps bare profile, not listed in sidebar
- [x] `session.control.read` routes to `requestGatewayForProfile`, not ambient
- [x] Explicit `$newChatRoute` unlisted tab still keeps the exact connection owner
- [x] Tile exact route still outranks the profile-only ledger
- [x] Related suites: `use-session-actions`, `session-states`, owner-resolution, profile-select-source, session-rpc-dispatcher, read-only-transcript (230 tests)

## Risk Assessment

**Low** — Desktop renderer only. No gateway/TUI/CLI/tool changes. Create RPC routing (`profilePickConnectionId`) is untouched. Fail-closed for *unknown* owners remains. Profile-only stamp uses the same ledger `forgetProfileOnlyRuntimeOwners` already clears.
