### PR TITLE
fix(browser): don't report close-profile success when the process survives kill

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -543,7 +543,14 @@ def close_browser_holding_profile(src: str, timeout: float = 15.0) -> tuple[bool
     for p in alive:
         with contextlib.suppress(*gone_errs):
             p.kill()
-    psutil.wait_procs(alive, timeout=3.0)
+    still_alive = psutil.wait_procs(alive, timeout=3.0)[1]
+    if still_alive:
+        # _profile_is_locked() never trips on POSIX (see its docstring), so without this
+        # check a process that survived terminate()+kill() (e.g. AccessDenied swallowed
+        # above) would fall through to the lock poll below and be reported as closed.
+        return False, (
+            "could not terminate the browser process(es) holding the profile "
+            "— quit it manually and retry.")
     # The lock releases slightly after the process exits on Windows; poll.
     source_profile = _resolve_source_profile(src)[0] or _last_used_profile(src)
     deadline = time.monotonic() + timeout

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -972,6 +972,44 @@ class TestReviewRound3:
         assert matched[0].info["name"] == "chrome.exe"
         assert f"--user-data-dir={ud}" in " ".join(matched[0].info["cmdline"])
 
+    def test_close_fails_when_process_survives_kill(self, tmp_path, monkeypatch):
+        """On POSIX, _profile_is_locked() never trips (it only detects Windows'
+        deny-all-while-open semantics), so the success verdict must not rest on
+        it alone. A process that survives both terminate() and kill() (e.g. a
+        real-profile Chrome that AccessDenied silently swallowed) must make
+        close_browser_holding_profile report failure, not a false "closed"."""
+        import hermes_cli.browser_connect as bc
+
+        class FakeProc:
+            def children(self, recursive=True):
+                return []
+
+            def terminate(self):
+                pass  # process ignores SIGTERM
+
+            def kill(self):
+                pass  # kill() also has no effect (e.g. AccessDenied)
+
+        survivor = FakeProc()
+
+        class FakePsutil:
+            NoSuchProcess = type("E", (Exception,), {})
+            AccessDenied = type("E2", (Exception,), {})
+
+            def wait_procs(self, procs, timeout=None):
+                return [], list(procs)  # nothing ever exits
+
+        import sys as _sys
+        monkeypatch.setitem(_sys.modules, "psutil", FakePsutil())
+        monkeypatch.setattr(bc, "_processes_holding_profile", lambda src: iter([survivor]))
+        monkeypatch.setattr(bc, "_profile_is_locked", lambda s, p: False)  # never trips on POSIX
+        monkeypatch.setattr(bc, "_resolve_source_profile", lambda s: ("Default", None))
+        monkeypatch.setattr(bc, "_last_used_profile", lambda s: "Default")
+
+        closed, msg = bc.close_browser_holding_profile(str(tmp_path), timeout=0.1)
+        assert closed is False
+        assert "still running" in msg.lower() or "could not terminate" in msg.lower()
+
     def test_consent_off_triggers_cleanup(self, tmp_path, monkeypatch):
         called = {"n": 0}
         with patch.object(bt_cloud, "_use_real_profile", return_value=False), \


### PR DESCRIPTION
## What does this PR do?

Fixes a false-success report in `hermes browser close-profile` on macOS/Linux.

`close_browser_holding_profile()` (`hermes_cli/browser_connect.py`) terminates the
browser process(es) holding a real-profile's user-data-dir, then decides success by
polling `_profile_is_locked()`. That probe's own docstring says it is **"Always False
on POSIX"** — it only detects Windows' deny-all-while-open file semantics, since
opening a locked SQLite `Cookies` file for reading doesn't raise `PermissionError` on
macOS/Linux. So on POSIX, once any process was found to terminate, the function falls
straight through the lock-poll loop and reports "closed the browser and the profile
lock released" — even if `terminate()`/`kill()` silently failed (both exceptions are
swallowed by the existing `contextlib.suppress(psutil.NoSuchProcess,
psutil.AccessDenied)`) and the process tree is still running.

This is one of the adjacent, independently-reproduced defects reported in #108387
(the issue's headline macOS Chrome bundle-identity collision is a separate
needs-decision/structural question tracked upstream in #33155 and is out of scope for
this PR):

> `hermes browser close-profile` reports success while the browser stays open... the
> sanctioned recovery then printed `✓ closed the browser and the profile lock
> released.` while — minutes later — the identical Chrome tree (same PIDs) was still
> running... `close_browser_holding_profile()` gates its verdict on
> `_profile_is_locked()`, which by design "never trips on POSIX" — so on macOS the
> success check cannot detect the lock at all.

## Related Issue

Fixes #108387 (the "close-profile reports false success on POSIX" sub-issue)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/browser_connect.py`: `close_browser_holding_profile()` now checks
  `psutil.wait_procs()`'s post-kill "still alive" result and returns `(False, ...)`
  immediately if any target process survived `terminate()` + `kill()`, instead of
  falling through to the POSIX-blind `_profile_is_locked()` poll.
- `tests/tools/test_browser_real_profile.py`: added
  `test_close_fails_when_process_survives_kill`, which fakes a process that survives
  both `terminate()` and `kill()` (simulating e.g. a swallowed `AccessDenied`) with
  `_profile_is_locked` forced to `False` (its real POSIX behavior), and asserts
  `close_browser_holding_profile()` reports failure rather than a false "closed".

## How to Test

1. `git checkout HEAD~1 -- hermes_cli/browser_connect.py` (revert only the fix), then run:
   ```
   pytest tests/tools/test_browser_real_profile.py -k test_close_fails_when_process_survives_kill -v
   ```
   Fails on unmodified code: `assert closed is False` → `AssertionError: assert True is False`.
2. `git checkout HEAD -- hermes_cli/browser_connect.py` to restore the fix, re-run the
   same command → passes.
3. Full file: `pytest tests/tools/test_browser_real_profile.py -v` → 83 passed.
4. Related suites (unaffected):
   `pytest tests/hermes_cli/test_browser_connect_default_chromium.py tests/hermes_cli/test_browser_connect_dual_stack.py tests/tools/test_browser_real_profile_pin.py tests/cli/test_cli_browser_connect.py tests/hermes_cli/test_subcommands_final_batch.py -q`
   → 77 passed.
5. `ruff check hermes_cli/browser_connect.py tests/tools/test_browser_real_profile.py` → All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite for the touched module and related suites; all pass (full-repo `scripts/run_tests.sh` was not run due to environment constraints — see below)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (this fix is POSIX-specific; the failure mode it closes is macOS/Linux-only, Windows already had a working lock probe)

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, architecture, or tool-schema changes

## Notes

- This PR intentionally does **not** touch the macOS Chrome bundle-identity
  collision (silent Dock no-op) that is the main body of #108387 — that is a
  needs-decision/structural question already tracked at #33155 and requires a
  maintainer call between a documentation guardrail and structural profile isolation.
  It also does not touch the "stale CDP endpoint in long-lived daemons" observation
  from the same issue, which looks like the separate #100855 class.
- AI-assistance disclosure: this change was prepared with Claude Code (Anthropic), and
  the resulting diff/tests/verification steps above were reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
