### PR TITLE
fix(gateway): multiplex routes, busy follow-ups, mid-turn authz and completions stay in the admitting profile (#104933, #103717, salvage #105040 #103764 #105357 #96370)

### DIFF
--- a/contributors/emails/hermes@turpaud.com
+++ b/contributors/emails/hermes@turpaud.com
@@ -1,0 +1,2 @@
+remi-td
+# PR #105357 salvage

--- a/contributors/emails/nmediaie@gmail.com
+++ b/contributors/emails/nmediaie@gmail.com
@@ -1,0 +1,2 @@
+nmediaie
+# PR #96370 salvage

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -11,6 +11,7 @@ import contextlib
 import logging
 import os
 import threading
+from pathlib import Path
 from typing import Optional
 
 from gateway.bot_loop_guard import BotLoopGuard
@@ -238,13 +239,38 @@ class GatewayAuthorizationMixin:
             return self._primary_adapters()
         profile_adapters = self._profile_adapters_map()
         if profile_name in profile_adapters:
-            return profile_adapters[profile_name]
+            adapters = profile_adapters[profile_name]
+            if adapters or not self._is_shared_bot_satellite(profile_name):
+                return adapters
+            return self._primary_adapters()
         # Identity captured at construction, not the per-turn HERMES_HOME-derived name.
         primary_profile = getattr(self, "_primary_profile_name", None)
         if not primary_profile:
             with contextlib.suppress(Exception):
                 primary_profile = self._active_profile_name()
         return self._primary_adapters() if profile_name == primary_profile else {}
+
+    def _is_shared_bot_satellite(self, profile_name: str) -> bool:
+        """A served profile with NO adapter of its own that a ``profile_routes`` entry targets through the
+        default profile's bot: it drains through the primary's adapters (gateway/AGENTS.md). Its
+        ``_profile_adapters`` entry is the ``{}`` startup placeholder; a secondary connected on ANY
+        platform is its own credential boundary and never borrows the primary. Restored/cached sources
+        carry no transport ref, so this is what keeps heartbeats, completions and goal notices for such a
+        profile deliverable after a restart (the same rule ``kanban_watchers_notifier`` and cron apply)."""
+        config = getattr(self, "config", None)
+        if not getattr(config, "multiplex_profiles", False):
+            return False
+        # A bot that failed to connect is queued for reconnect: that profile owns a credential.
+        if (getattr(self, "_profile_failed_platforms", None) or {}).get(profile_name):
+            return False
+        routes = getattr(config, "profile_routes", None) or []
+        if not any(r.enabled and r.profile == profile_name and r.bot_profile is None for r in routes):
+            return False
+        from gateway.run import _multiplex_profile_homes
+        try:
+            return profile_name in {name for name, _home in _multiplex_profile_homes(config)}
+        except Exception:
+            return False
 
     def _adapter_for_source(self, source: Optional[SessionSource]):
         """Resolve the live adapter for an inbound ``SessionSource``."""
@@ -284,6 +310,29 @@ class GatewayAuthorizationMixin:
             return None
         registered, profile = self._owning_profile(adapter, platform)
         return (adapter, profile) if registered else None
+
+    def _authorization_home_for_source(self, source: SessionSource):
+        """HERMES_HOME whose allowlist admits *source*: the ingress-stamped transport home, else the home of
+        the profile owning the adapter that delivers it. ``None`` = authorize in the ambient scope
+        (multiplex off, or no live adapter — the check then fails closed on its own).
+
+        Inside a routed satellite's turn the ambient scope is the satellite's, whose ``.env`` has no
+        token/allowlist; every authorization decision made mid-turn (``/topic``, sibling ``/stop``, plugin
+        injection, voice, auto-resume) must read the admitting bot's allowlist instead."""
+        stamped = getattr(source, "_authorization_profile_home", None)
+        if stamped is not None:
+            return Path(stamped)
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            return None
+        adapter = self._adapter_for_source(source)
+        if adapter is None:
+            return None
+        _registered, profile = self._owning_profile(adapter, getattr(source, "platform", None))
+        if profile is None:
+            from hermes_constants import get_process_hermes_home
+            return get_process_hermes_home()  # the primary bot's home, never the per-turn override
+        from hermes_cli.profiles import get_profile_dir
+        return get_profile_dir(profile)
 
     def _adapter_profile_for_source(self, source: SessionSource) -> Optional[str]:
         """Resolve the transport-owning profile for adapter policy lookups."""

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3558,17 +3558,21 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
 
     @staticmethod
     def _bind_api_server_session(
-        *, chat_id: str = "", session_key: str = "", session_id: str = "",
+        *, chat_id: str = "", session_key: str = "", session_id: str = "", profile: str = "",
         browser_control_principal: str = "", browser_control_transport_family: str = "",
         session_history_delivery: str = "") -> list:
         """Bind an API turn with push disabled and history delivery default-denied.
 
         Only routes whose continuation reads SessionDB may pass "1". An omitted
-        declaration or fingerprint-derived identity keeps delegation synchronous."""
+        declaration or fingerprint-derived identity keeps delegation synchronous.
+
+        ``profile`` is the ``/p/<profile>/`` prefix serving the request (``""`` = default). It must
+        reach ``HERMES_SESSION_PROFILE``: the persistent-Docker container key is derived from it, so an
+        unbound profile collapses every profile's turns onto the default sandbox (#96370)."""
         from gateway.session_context import set_session_vars
         return set_session_vars(
             platform="api_server", chat_id=chat_id, session_key=session_key, session_id=session_id,
-            browser_control_principal=browser_control_principal,
+            profile=profile, browser_control_principal=browser_control_principal,
             browser_control_transport_family=browser_control_transport_family,
             async_delivery=False, cron_session="", session_history_delivery=session_history_delivery)
 
@@ -3665,7 +3669,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             with self._profile_scope(request_profile):
                 tokens = self._bind_api_server_session(
                     chat_id=session_id or "", session_key=gateway_session_key or session_id or "",
-                    session_id=session_id or "",
+                    session_id=session_id or "", profile=request_profile or "",
                     browser_control_principal=request_browser_control_principal,
                     browser_control_transport_family=request_browser_control_transport_family,
                     session_history_delivery=session_history_delivery)

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -529,6 +529,7 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
             # tools.async_delegation sees no HERMES_SESSION_CHAT_ID and forces delegations sync.
             session_tokens = self._bind_api_server_session(
                 chat_id=session_id or "", session_key=run.approval_session_key, session_id=session_id or "",
+                profile=run.request_profile or "",
                 browser_control_principal=run.browser_control_principal,
                 browser_control_transport_family=run.browser_control_transport_family,
                 # #98619 audited opt-in: the /v1/runs session id is wake-capable only when its

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4174,11 +4174,15 @@ class BasePlatformAdapter(ABC):
             chat_id_alt=chat_id_alt, is_bot=is_bot, scope_id=_opt(scope_id),
             guild_id=_opt(guild_id), parent_chat_id=_opt(parent_chat_id),
             message_id=_opt(message_id))
-        profile, profile_route_rejected = None, False  # profile from configured routes, if any
+        # Profile from configured routes, else the owning profile of a dedicated secondary bot (so no
+        # later ``source.profile``-less fallback can re-route the message through the default bot's routes).
+        owner_profile = getattr(self, "_owner_profile", None)
+        profile, profile_route_rejected = owner_profile, False
         if self.gateway_runner is not None:
             from gateway.profile_routing import ProfileRouteRejected
             try:
-                profile = self.gateway_runner._profile_name_for_source(SessionSource(**fields))
+                profile = self.gateway_runner._profile_name_for_source(
+                    SessionSource(**fields), adapter_profile=owner_profile) or owner_profile
             except ProfileRouteRejected:
                 profile_route_rejected = True
             except Exception:

--- a/gateway/profile_routing.py
+++ b/gateway/profile_routing.py
@@ -4,6 +4,11 @@ Matching priority, most specific first (``gateway.profile_routes`` in config.yam
 platform + chat_id + thread_id (14) → platform + chat_id (6) → platform + guild_id (2)
 → default profile. For Discord threads/forum posts ``parent_chat_id`` carries the
 direct parent, so a channel route also matches any thread/post under it.
+
+A route applies only to messages received by the bot of its ``bot_profile`` (default: the
+default profile's shared bot). Telegram DM ``chat_id == user_id`` for EVERY bot, so without
+this a ``chat_id`` route meant for the shared bot would re-home the same user's DM with a
+dedicated secondary bot into another profile (#104933).
 """
 
 from __future__ import annotations
@@ -58,6 +63,7 @@ class ProfileRoute:
     chat_id: Optional[str] = None
     thread_id: Optional[str] = None
     enabled: bool = True
+    bot_profile: Optional[str] = None  # None = the default profile's bot
 
     @property
     def specificity(self) -> int:
@@ -67,13 +73,18 @@ class ProfileRoute:
     def matches(
         self, platform: str, guild_id: Optional[str] = None, chat_id: Optional[str] = None,
         thread_id: Optional[str] = None, parent_chat_id: Optional[str] = None,
+        adapter_profile: Optional[str] = None,
     ) -> bool:
         """True if every discriminator the route declares holds (AND).
 
         ``chat_id`` matches the channel directly or as the parent of a thread/forum post; WhatsApp
         ``chat_id`` also matches across number/JID/LID after the exact check (groups/broadcasts stay exact-only).
+        ``adapter_profile`` is the profile owning the receiving bot (``None`` = default); it must equal
+        the route's ``bot_profile``.
         """
         if not self.enabled or self.platform != platform:
+            return False
+        if _bot_profile_key(self.bot_profile) != _bot_profile_key(adapter_profile):
             return False
         if self.thread_id and self.thread_id != thread_id:
             return False
@@ -85,6 +96,12 @@ class ProfileRoute:
         ):
             return False
         return not (self.guild_id and self.guild_id != guild_id)
+
+
+def _bot_profile_key(name: Optional[str]) -> Optional[str]:
+    """``None`` for the default profile, else the profile name (mirrors ``set_owner_profile``)."""
+    name = (name or "").strip()
+    return None if not name or name == "default" else name
 
 
 def _coerce_route_id(value: Any) -> Optional[str]:
@@ -139,6 +156,7 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
             chat_id=_coerce_route_id(entry.get("chat_id")),
             thread_id=_coerce_route_id(entry.get("thread_id")),
             enabled=entry.get("enabled", True),
+            bot_profile=_bot_profile_key(entry.get("bot_profile")),
         ))
     routes.sort(key=lambda r: r.specificity, reverse=True)
     logger.debug("Loaded %d profile routes (most-specific-first)", len(routes))
@@ -148,9 +166,11 @@ def parse_profile_routes(raw: Optional[List[Dict[str, Any]]]) -> List[ProfileRou
 def match_profile_route(
     routes: List[ProfileRoute], platform: str, guild_id: Optional[str] = None, chat_id: Optional[str] = None,
     thread_id: Optional[str] = None, parent_chat_id: Optional[str] = None,
+    adapter_profile: Optional[str] = None,
 ) -> Optional[ProfileRoute]:
     """Return the first (most specific) matching route, or None."""
     for route in routes:
-        if route.matches(platform, guild_id=guild_id, chat_id=chat_id, thread_id=thread_id, parent_chat_id=parent_chat_id):
+        if route.matches(platform, guild_id=guild_id, chat_id=chat_id, thread_id=thread_id,
+                         parent_chat_id=parent_chat_id, adapter_profile=adapter_profile):
             return route
     return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3972,9 +3972,8 @@ class GatewayRunner(
         config all read the transport profile's ``gateway.bot_loop_guard``."""
         return self._under_authorization_profile(source, lambda: self._admit_bot_message(source))
 
-    @staticmethod
-    def _under_authorization_profile(source: SessionSource, check):
-        authorization_home = getattr(source, "_authorization_profile_home", None)
+    def _under_authorization_profile(self, source: SessionSource, check):
+        authorization_home = self._authorization_home_for_source(source)
         if authorization_home is None:
             return check()
         with _profile_runtime_scope(Path(authorization_home)):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4268,23 +4268,32 @@ class GatewayRunner(
                 agent._last_flushed_db_idx = 0
         agent._api_call_count = 0
 
-    def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
+    def _profile_name_for_source(
+        self, source: SessionSource, adapter_profile: Optional[str] = None,
+    ) -> Optional[str]:
         """Resolve the profile name for an inbound source via configured routes (most specific wins).
-        ``None`` = default/active profile. Gated on ``multiplex_profiles``, since the scoped run only
-        activates under multiplexing; otherwise keys would be profile-namespaced while the agent ran in
-        ``agent:main``."""
+        ``None`` = default/active profile (or, for a secondary adapter, its own profile — the caller
+        stamps it). Gated on ``multiplex_profiles``, since the scoped run only activates under
+        multiplexing; otherwise keys would be profile-namespaced while the agent ran in ``agent:main``.
+        ``adapter_profile`` is the profile owning the receiving bot; only routes declaring it as
+        ``bot_profile`` apply (#104933)."""
         config = getattr(self, "config", None)
         if not getattr(config, "multiplex_profiles", False):
             return None
         routes = getattr(config, "profile_routes", None)
         if not routes:
             return None
+        if adapter_profile is None:
+            # Sources built outside ``build_source`` may still carry the receiving adapter as provenance.
+            owner = self._transport_owner(source) if callable(getattr(source, "_transport_adapter_ref", None)) else None
+            if isinstance(owner, tuple):
+                adapter_profile = owner[1]
         from gateway.profile_routing import ProfileRouteRejected, match_profile_route
         try:
             matched = match_profile_route(
                 routes, platform=source.platform.value, guild_id=getattr(source, "guild_id", None),
                 chat_id=source.chat_id, thread_id=getattr(source, "thread_id", None),
-                parent_chat_id=getattr(source, "parent_chat_id", None))
+                parent_chat_id=getattr(source, "parent_chat_id", None), adapter_profile=adapter_profile)
         except Exception:
             logger.warning(
                 "Profile route matching failed for %s/%s, falling back to default",

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -1304,10 +1304,15 @@ class GatewayAdapterLifecycleMixin:
         return _handler
 
     def _make_profile_busy_session_handler(self, profile_name: str):
-        """Stamp an owning adapter's profile before resolving busy policy."""
+        """Stamp an owning adapter's profile, then resolve busy policy under the profile scope
+        (auth runs against the profile's own allowlist, same as the cold-path message handler)."""
+        from gateway.run import _async_profile_runtime_scope
+        profile_home = self._profile_home_or_none(profile_name)
+
         async def _handler(event, _session_key):
             self._stamp_event_profile(event, profile_name)
-            return await self._handle_active_session_busy_message(event, self._session_key_for_source(event.source))
+            async with self._scope_or_null(_async_profile_runtime_scope, profile_home):
+                return await self._handle_active_session_busy_message(event, self._session_key_for_source(event.source))
 
         return _handler
 

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -1039,7 +1039,7 @@ class GatewayAdapterLifecycleMixin:
         adapter.set_message_handler(message_handler or self._primary_message_handler())
         adapter.set_fatal_error_handler(fatal_error_handler or self._handle_adapter_fatal_error)
         adapter.set_session_store(self.session_store)
-        adapter.set_busy_session_handler(busy_session_handler or self._handle_active_session_busy_message)
+        adapter.set_busy_session_handler(busy_session_handler or self._primary_busy_session_handler())
         _set_reaction = getattr(adapter, "set_reaction_handler", None)
         if callable(_set_reaction):
             _set_reaction(self._handle_reaction_event)
@@ -1342,6 +1342,38 @@ class GatewayAdapterLifecycleMixin:
 
         return _handler
 
+    def _make_default_profile_busy_session_handler(self):
+        """Scope primary busy messages like normal routed messages.
+
+        A primary adapter admits a message under its own allowlist, while a
+        multiplex route can run its session under a secondary profile. Busy
+        callbacks bypass the normal handler, so carry both identities here.
+        """
+        from gateway.run import _async_profile_runtime_scope, get_hermes_home
+        default_home = Path(get_hermes_home())
+
+        async def _handler(event, _session_key):
+            source = event.source
+            source._authorization_profile_home = default_home
+            if (
+                not getattr(source, "profile", None)
+                and getattr(source, "profile_route_rejected", False) is not True
+                and not self._stamp_routed_profile(source)
+            ):
+                source.profile_route_rejected = True
+            if getattr(source, "profile_route_rejected", False) is True:
+                return True
+            profile_home = (
+                self._resolve_profile_home_for_source(source)
+                if getattr(source, "profile", None) else default_home
+            )
+            async with _async_profile_runtime_scope(profile_home):
+                return await self._handle_active_session_busy_message(
+                    event, self._session_key_for_source(source)
+                )
+
+        return _handler
+
     def _stamp_routed_profile(self, source) -> bool:
         """Stamp ``source.profile`` from ``profile_routes``; False when the route is rejected."""
         from gateway.profile_routing import ProfileRouteRejected
@@ -1354,6 +1386,13 @@ class GatewayAdapterLifecycleMixin:
     def _primary_message_handler(self):
         """Return the correctly scoped handler for a primary adapter."""
         return self._make_default_profile_message_handler() if self._multiplex_on() else self._handle_message
+
+    def _primary_busy_session_handler(self):
+        """Return the correctly scoped busy-session handler for a primary adapter."""
+        return (
+            self._make_default_profile_busy_session_handler()
+            if self._multiplex_on() else self._handle_active_session_busy_message
+        )
 
     def _multiplex_on(self) -> bool:
         return bool(getattr(self.config, "multiplex_profiles", False))

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -853,6 +853,7 @@ class GatewayAdapterLifecycleMixin:
             except Exception as e:
                 logger.error("Failed to start adapters for profile '%s': %s", profile_name, e, exc_info=True)
         self._record_served_profiles(active, profile_homes)
+        self._restore_secondary_completion_ledgers(profile_homes)
         return connected
 
     def _primary_resource_claims(self, active: str) -> Dict[tuple, str]:

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -1323,56 +1323,50 @@ class GatewayAdapterLifecycleMixin:
         default_home = Path(get_hermes_home())
 
         async def _handler(event):
-            source = event.source
-            # In-process only (serialization ignores dynamic attrs); route ≠ admitting bot.
-            source._authorization_profile_home = default_home
-            if (
-                not getattr(source, "profile", None)
-                and getattr(source, "profile_route_rejected", False) is not True
-                and not self._stamp_routed_profile(source)
-            ):
-                # Read by the ``_handle_message`` ingress gate, which drops fail-closed.
-                source.profile_route_rejected = True
-            profile_home = (
-                self._resolve_profile_home_for_source(source)
-                if getattr(source, "profile", None) else default_home
-            )
+            # A rejected route still enters ``_handle_message``, whose ingress gate drops it fail-closed.
+            profile_home = self._admit_primary_source(event.source, default_home) or default_home
             async with _async_profile_runtime_scope(profile_home):
                 return await self._handle_message(event)
 
         return _handler
 
     def _make_default_profile_busy_session_handler(self):
-        """Scope primary busy messages like normal routed messages.
-
-        A primary adapter admits a message under its own allowlist, while a
-        multiplex route can run its session under a secondary profile. Busy
-        callbacks bypass the normal handler, so carry both identities here.
-        """
+        """Busy-path twin of ``_make_default_profile_message_handler``: busy callbacks bypass the message
+        handler, so the routed scope and transport-home authorization must be re-established here or the
+        follow-up is authorized in whatever scope is ambient (#103717)."""
         from gateway.run import _async_profile_runtime_scope, get_hermes_home
         default_home = Path(get_hermes_home())
 
         async def _handler(event, _session_key):
             source = event.source
-            source._authorization_profile_home = default_home
-            if (
-                not getattr(source, "profile", None)
-                and getattr(source, "profile_route_rejected", False) is not True
-                and not self._stamp_routed_profile(source)
-            ):
-                source.profile_route_rejected = True
-            if getattr(source, "profile_route_rejected", False) is True:
-                return True
-            profile_home = (
-                self._resolve_profile_home_for_source(source)
-                if getattr(source, "profile", None) else default_home
-            )
+            profile_home = self._admit_primary_source(source, default_home)
+            if profile_home is None:
+                return True  # rejected route: swallow, same disposition as the ingress gate
             async with _async_profile_runtime_scope(profile_home):
                 return await self._handle_active_session_busy_message(
                     event, self._session_key_for_source(source)
                 )
 
         return _handler
+
+    def _admit_primary_source(self, source, default_home: Path) -> Optional[Path]:
+        """Stamp the transport home (authorization) and routed profile on a primary-adapter source and
+        return the runtime home to scope the turn under; ``None`` when the route targets an unserved
+        profile. ``_authorization_profile_home`` is in-process only (serialization ignores dynamic attrs);
+        route ≠ admitting bot."""
+        source._authorization_profile_home = default_home
+        if (
+            not getattr(source, "profile", None)
+            and getattr(source, "profile_route_rejected", False) is not True
+            and not self._stamp_routed_profile(source)
+        ):
+            source.profile_route_rejected = True
+        if getattr(source, "profile_route_rejected", False) is True:
+            return None
+        return (
+            self._resolve_profile_home_for_source(source)
+            if getattr(source, "profile", None) else default_home
+        )
 
     def _stamp_routed_profile(self, source) -> bool:
         """Stamp ``source.profile`` from ``profile_routes``; False when the route is rejected."""

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -665,8 +665,9 @@ class GatewayBusySessionMixin:
         # Same authorization gate as the cold path, else unauthorized users in shared threads
         # inject messages into a session they don't own.
         from gateway.run import _AGENT_PENDING_SENTINEL
-        # See #17775.
-        if not self._is_user_authorized(event.source):
+        # See #17775. A primary transport can route a turn into a secondary
+        # profile, so authorize in the stamped transport scope.
+        if not self._is_user_authorized_for_source(event.source):
             logger.warning(
                 "Dropping message from unauthorized user in active session: "
                 "user=%s (%s), platform=%s, session=%s", event.source.user_id, event.source.user_name,

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1791,7 +1791,7 @@ class GatewayInboundMixin:
 
         source = dataclasses.replace(entry.origin)
         try:
-            authorized = self._is_user_authorized(source, allow_adapter_delegation=False)
+            authorized = self._is_user_authorized_for_source(source, allow_adapter_delegation=False)
         except Exception:
             logger.warning(
                 "Plugin message injection authorization check failed: plugin=%s session=%s",

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -8,6 +8,7 @@ so ``patch("gateway.run.X")`` keeps intercepting them at call time.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import dataclasses
 import json
 import logging
@@ -1279,6 +1280,25 @@ class GatewayNotificationsMixin:
             claim.proceed, claim.early_result = False, False
         return claim
 
+    def _completion_event_scope(self, evt: dict):
+        """Profile runtime scope of the session a completion event targets (a no-op context when the
+        event is the default profile's or the scope is already installed).
+
+        The pre-flight (``_classify_completion_target`` → ``_session_db``) and every durable-ledger op
+        (``tools.async_delegation`` → ``get_hermes_home()/state.db``) resolve from the ambient scope.
+        The supervised ``_async_delegation_watcher`` and startup-recovered process watchers run under
+        the ROOT scope, so a secondary profile's completion was looked up in the DEFAULT profile's
+        state.db — classified ``terminal`` and dropped, its ledger row stranded ``pending`` forever."""
+        from gateway.run import _async_profile_runtime_scope
+        from hermes_constants import get_hermes_home_override
+        source = self._build_process_event_source(evt)
+        if source is None or not getattr(source, "profile", None):
+            return contextlib.nullcontext()
+        profile_home = self._resolve_profile_home_for_source(source)
+        if get_hermes_home_override() == str(profile_home):
+            return contextlib.nullcontext()
+        return _async_profile_runtime_scope(profile_home)
+
     async def _deliver_completion_notification(
         self, synth_text: str, evt: dict, *, sibling_claims=(),
     ) -> Optional[bool]:
@@ -1287,6 +1307,13 @@ class GatewayNotificationsMixin:
         True means adapter admission, not model execution; None means deduplicated or
         terminal. False remains retryable. Claims are settled together for every sibling.
         """
+        async with self._completion_event_scope(evt):
+            return await self._deliver_completion_notification_scoped(
+                synth_text, evt, sibling_claims=sibling_claims)
+
+    async def _deliver_completion_notification_scoped(
+        self, synth_text: str, evt: dict, *, sibling_claims=(),
+    ) -> Optional[bool]:
         from gateway.wake import WakeNotAccepted
         identity = self._completion_delivery_identity(evt)
         claim = self._CompletionClaim()
@@ -1476,6 +1503,11 @@ class GatewayNotificationsMixin:
         consolidated text of every sibling THIS runner claimed (siblings owned elsewhere are excluded;
         their claims are acked only after adapter acceptance). True after acceptance, False to requeue
         the group, None when nothing is deliverable here (retry siblings requeued)."""
+        # The group shares one session_key, hence one profile: scope the pre-checks and sibling claims too.
+        async with self._completion_event_scope(group[0]):
+            return await self._deliver_async_delegation_group_scoped(group)
+
+    async def _deliver_async_delegation_group_scoped(self, group: list[dict]) -> Optional[bool]:
         from gateway.run import _format_gateway_process_notification
         from tools.process_registry import process_registry as _pr
         # API delivery does not start a model turn, so there is nothing to coalesce.
@@ -1534,6 +1566,26 @@ class GatewayNotificationsMixin:
             for evt, _claim_id in siblings:
                 _pr.completion_queue.put(evt)
         return delivered
+
+    def _restore_secondary_completion_ledgers(self, profile_homes) -> None:
+        """Re-queue undelivered async completions from every SECONDARY profile's ledger. The process
+        registry restores only the launch profile's ``state.db`` at import; a secondary's rows would
+        otherwise never be replayed after a restart."""
+        from gateway.run import _profile_runtime_scope
+        from tools.async_delegation import restore_undelivered_completions
+        from tools.process_registry import process_registry as _pr
+        primary = getattr(self, "_primary_profile_name", None)
+        for profile_name, profile_home in profile_homes:
+            if profile_name == primary:
+                continue
+            try:
+                with _profile_runtime_scope(Path(profile_home), {}):
+                    restored = restore_undelivered_completions(_pr.completion_queue)
+            except Exception:
+                logger.warning("Could not restore async completions for profile %r", profile_name, exc_info=True)
+                continue
+            if restored:
+                logger.info("Restored %d undelivered async completion(s) for profile %r", restored, profile_name)
 
     async def _async_delegation_watcher(self, interval: float = 2.0) -> None:
         """Drain async completions and pattern notifications even while sessions are idle.

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -1011,10 +1011,9 @@ class GatewayNotificationsMixin:
                 return owner[0]
             if getattr(source, "delivered_via_upstream_relay", False) is True:
                 return self.adapters.get(Platform.RELAY)
-        profile = getattr(source, "profile", None)
-        adapters = self.adapters
-        if profile and profile not in ("default", getattr(self, "_primary_profile_name", None)):
-            adapters = (getattr(self, "_profile_adapters", None) or {}).get(profile, {})
+        # One resolver with authz/kanban/cron: a secondary's own map, or the primary's for a
+        # shared-bot satellite; a disconnected secondary fails closed to ``{}``.
+        adapters = self._adapters_for_profile(getattr(source, "profile", None))
         try:
             _transport = resolve_delivery_transport(Platform(platform_name), self.config, adapters)
         except Exception:

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -501,7 +501,7 @@ class GatewayStartupMixin:
         allowlist existed (or whose owner was since removed) must not silently receive a full agent
         response just because it carries a resume marker."""
         try:
-            if self._is_user_authorized(source):
+            if self._is_user_authorized_for_source(source):
                 return True
             logger.warning(
                 "Skipping auto-resume for %s: session owner is no "

--- a/gateway/run_voice.py
+++ b/gateway/run_voice.py
@@ -249,7 +249,7 @@ class GatewayVoiceMixin:
         # before TELEGRAM_ALLOWED_USERS (or equivalent) was configured, or before the owner was removed from
         # it, must not silently receive a full agent response on gateway restart just because it has a
         # resume-pending marker (issue #23778).
-        if not self._is_user_authorized(source):
+        if not self._is_user_authorized_for_source(source):
             logger.debug("Unauthorized voice input from user %d, ignoring", user_id)
             return
         if self._is_duplicate_voice_transcript(guild_id, user_id, transcript):

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -439,7 +439,7 @@ class GatewaySlashCommandsMixin(
         # run another user started lives under a different key, yet authorized users must still be
         # able to /stop it: fall back to sibling runs in this thread, gated on authorization.
         sibling_keys = self._sibling_thread_run_keys(source, session_key)
-        if sibling_keys and self._is_user_authorized(source):
+        if sibling_keys and self._is_user_authorized_for_source(source):
             for sibling_key in sibling_keys:
                 await _stop(sibling_key, "stop_command_thread_sibling")
             logger.info("STOP (thread sibling) by %s — interrupted %d run(s) in thread: %s",

--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -669,7 +669,7 @@ class GatewaySessionCommandsMixin:
 
         # Defense in depth: /topic mutates SQLite side tables, so re-check the allowlist here.
         try:
-            if not self._is_user_authorized(source):
+            if not self._is_user_authorized_for_source(source):
                 return t("gateway.topic.unauthorized")
         except Exception:
             logger.debug("Topic auth check failed", exc_info=True)

--- a/tests/gateway/test_64674_multiplex_primary_token_scope.py
+++ b/tests/gateway/test_64674_multiplex_primary_token_scope.py
@@ -267,6 +267,66 @@ class TestPrimaryMessageRuntimeScope:
         with pytest.raises(secret_scope.UnscopedSecretError):
             secret_scope.get_secret("DISCORD_BOT_TOKEN")
 
+    @pytest.mark.asyncio
+    async def test_primary_busy_path_authorizes_in_transport_scope(
+        self, tmp_path, monkeypatch
+    ):
+        """Routed busy messages must read the admitting adapter's allowlist.
+
+        Signal on Rémi's host is a primary/default transport that routes turns
+        into Sharik via gateway.profile_routes.  A follow-up can arrive while
+        the Sharik agent is still busy; that busy callback used to skip the
+        default-profile scoping wrapper and check SIGNAL_ALLOWED_USERS inside
+        Sharik's unrelated secret scope.
+        """
+        from agent import secret_scope
+        from gateway import run as run_mod
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / ".env").write_text(
+            "SIGNAL_ALLOWED_USERS=+15550001111\n"
+            "SIGNAL_ALLOW_ALL_USERS=false\n",
+            encoding="utf-8",
+        )
+        sharik = tmp_path / "profiles" / "sharik"
+        sharik.mkdir(parents=True)
+        (sharik / ".env").write_text("# no Signal allowlist here\n", encoding="utf-8")
+        (sharik / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+        monkeypatch.setattr(run_mod, "get_hermes_home", lambda: home)
+        secret_scope.set_multiplex_active(True)
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._resolve_profile_home_for_source = lambda _source: sharik  # type: ignore[method-assign]
+        runner._session_key_for_source = lambda source: f"agent:{source.profile}:signal:dm:{source.chat_id}"  # type: ignore[method-assign]
+        runner._is_user_authorized_for_source = GatewayRunner._is_user_authorized_for_source.__get__(runner)  # type: ignore[method-assign]
+
+        async def _busy(event, session_key):
+            assert session_key == "agent:sharik:signal:dm:+15550001111"
+            # This is what _handle_active_session_busy_message now calls.
+            return runner._is_user_authorized_for_source(event.source)
+
+        runner._handle_active_session_busy_message = _busy  # type: ignore[method-assign]
+        handler = runner._primary_busy_session_handler()
+        event = SimpleNamespace(
+            source=SessionSource(
+                platform=Platform.SIGNAL,
+                chat_id="+15550001111",
+                chat_type="dm",
+                user_id="+15550001111",
+                user_name="Remi",
+                profile="sharik",
+            )
+        )
+
+        assert await handler(event, "stale-unrouted-key") is True
+        with pytest.raises(secret_scope.UnscopedSecretError):
+            secret_scope.get_secret("SIGNAL_ALLOWED_USERS")
+
 
 class TestReconnectDropsEmptyToken:
     @pytest.mark.asyncio

--- a/tests/gateway/test_busy_session_profile_scope.py
+++ b/tests/gateway/test_busy_session_profile_scope.py
@@ -1,0 +1,88 @@
+"""Regression for #103717: a secondary multiplex profile's busy-session
+follow-ups must authorize against THAT profile's allowlist, not whatever
+``os.environ`` happens to hold (the primary profile's first-writer-bridged
+value under multiplex).
+
+``_make_profile_message_handler`` (the cold path) wraps ``_handle_message``
+in ``_async_profile_runtime_scope`` before authorization runs. Until this
+fix, ``_make_profile_busy_session_handler`` (the busy path) stamped
+``source.profile`` but never entered that scope, so ``_is_user_authorized``
+fell through to ``os.environ`` and read the wrong profile's
+``FEISHU_ALLOWED_USERS``.
+"""
+from pathlib import Path
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.pairing import PairingStore
+from gateway.session import SessionSource
+
+
+@pytest.fixture
+def mux_home(tmp_path, monkeypatch):
+    from agent import secret_scope
+
+    home = tmp_path / "hh"
+    (home / "profiles" / "secondary").mkdir(parents=True)
+    (home / ".env").write_text("FEISHU_ALLOWED_USERS=primary-user\n")
+    (home / "profiles" / "secondary" / ".env").write_text(
+        "FEISHU_ALLOWED_USERS=secondary-user\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for key in ("FEISHU_ALLOWED_USERS", "GATEWAY_ALLOW_ALL_USERS", "GATEWAY_ALLOWED_USERS"):
+        monkeypatch.delenv(key, raising=False)
+    prev = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    yield home
+    secret_scope.set_multiplex_active(prev)
+
+
+def _runner(home):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.config.platforms = {Platform.FEISHU: PlatformConfig(enabled=True, extra={})}
+    runner.pairing_store = PairingStore(profile="default")
+    runner.pairing_stores = {"default": runner.pairing_store}
+    runner._profile_adapters = {"secondary": {}}
+    runner.adapters = {}
+    return runner
+
+
+def _feishu_event(user_id):
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        user_id=user_id,
+        user_name=user_id,
+        chat_id="oc_dm",
+        chat_type="dm",
+        profile=None,
+    )
+    return MessageEvent(text="follow-up", message_type=MessageType.TEXT, source=source, message_id="m1")
+
+
+@pytest.mark.asyncio
+async def test_busy_handler_authorizes_against_secondary_profile_allowlist(mux_home):
+    """Secondary profile owner's follow-up while their session is busy must be
+    authorized against the SECONDARY profile's own allowlist."""
+    runner = _runner(mux_home)
+
+    # Isolate exactly the authorization decision the busy path gates on
+    # (see gateway/run_busy.py::_handle_active_session_busy_message's first
+    # check) without pulling in queueing/steer machinery unrelated to the bug.
+    async def _stub_busy_message(event, session_key):
+        return runner._is_user_authorized(event.source)
+
+    runner._handle_active_session_busy_message = _stub_busy_message
+
+    handler = runner._make_profile_busy_session_handler("secondary")
+
+    authorized_event = _feishu_event("secondary-user")
+    assert await handler(authorized_event, "sk") is True
+
+    intruder_event = _feishu_event("primary-user")
+    assert await handler(intruder_event, "sk") is False

--- a/tests/gateway/test_multiplex_api_server_routing.py
+++ b/tests/gateway/test_multiplex_api_server_routing.py
@@ -93,3 +93,49 @@ class TestApiServerModelsUnderProfile:
             assert adapter._resolve_model_name("") == "coder"
         finally:
             _api_request_profile.reset(token_prof)
+
+
+class TestApiServerSessionProfileBinding:
+    """HERMES_SESSION_PROFILE must be bound per /p/<profile>/ request.
+
+    Regression guard for cross-profile sandbox reuse: before the fix,
+    _bind_api_server_session never passed ``profile`` to set_session_vars,
+    so every API-server turn bound HERMES_SESSION_PROFILE="" and the
+    terminal tool collapsed ALL api_server sessions (default AND org
+    profiles) onto the shared "default" container key — letting org-profile
+    turns reuse the default profile's sandbox (SSH key / secrets exposure).
+    """
+
+    def test_profile_is_bound_into_session_vars(self):
+        from gateway.session_context import clear_session_vars, get_session_env
+
+        adapter = _make_adapter(multiplex=True)
+        tokens = adapter._bind_api_server_session(
+            chat_id="chat",
+            session_key="key",
+            session_id="sess",
+            profile="nm-media",
+        )
+        try:
+            assert get_session_env("HERMES_SESSION_PROFILE") == "nm-media"
+        finally:
+            clear_session_vars(tokens)
+
+    def test_bound_profile_selects_profile_scoped_container_key(self, monkeypatch):
+        """Persistent-Docker container keys honour the api_server-bound profile (real resolver chain)."""
+        import tools.terminal_tool as tt
+        from gateway.session_context import clear_session_vars
+
+        adapter = _make_adapter(multiplex=True)
+        monkeypatch.setattr(tt, "_ensure_terminal_env_bridged", lambda: None)
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "true")
+        monkeypatch.delenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", raising=False)
+
+        tokens = adapter._bind_api_server_session(
+            chat_id="chat", session_key="key", session_id="sess", profile="nm-media",
+        )
+        try:
+            assert tt._resolve_container_task_id(None) == "profile:nm-media"
+        finally:
+            clear_session_vars(tokens)

--- a/tests/gateway/test_multiplex_interactive_auth.py
+++ b/tests/gateway/test_multiplex_interactive_auth.py
@@ -203,12 +203,14 @@ def test_slack_interactive_auth_prefers_wired_profile_check(mux_home, monkeypatc
 def test_authorization_adapter_ignores_per_turn_active_profile(mux_home):
     """#87240 egress half: inside a secondary profile's runtime scope the
     default bot must not be handed to that profile (fail-closed None); the
-    launch profile still resolves ``self.adapters``."""
+    launch profile still resolves ``self.adapters``. The secondary's own bot
+    is down (reconnect pending), so it is not a route-only satellite."""
     from gateway.run import _profile_runtime_scope
 
     runner = _runner(mux_home)
     default_bot = object()
     runner.adapters = {Platform.TELEGRAM: default_bot}
+    runner._profile_failed_platforms = {"secondary": {Platform.TELEGRAM: object()}}
 
     with _profile_runtime_scope(mux_home / "profiles" / "secondary"):
         assert runner._authorization_adapter(Platform.TELEGRAM, profile="secondary") is None

--- a/tests/gateway/test_multiplex_routing_authz.py
+++ b/tests/gateway/test_multiplex_routing_authz.py
@@ -1,0 +1,153 @@
+"""Routing/authorization invariants for a multiplexed gateway (#104933, #103717).
+
+Every test builds a bare ``GatewayRunner`` with stub adapters against a temp ``HERMES_HOME`` and
+exercises the real resolvers (no patched predicates).
+"""
+
+import asyncio
+import threading
+import weakref
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.pairing import PairingStore
+from gateway.platforms.base import BasePlatformAdapter
+from gateway.profile_routing import parse_profile_routes
+from gateway.session import SessionSource
+
+
+class _Stub(BasePlatformAdapter):
+    pass
+
+
+_Stub.__abstractmethods__ = frozenset()
+
+
+def _stub(platform, runner, label):
+    adapter = _Stub.__new__(_Stub)
+    adapter.platform, adapter.gateway_runner, adapter.label = platform, runner, label
+    adapter._pending_messages, adapter._active_sessions = {}, {}
+    return adapter
+
+
+@pytest.fixture
+def mux(tmp_path, monkeypatch):
+    """Default home allows user 777; profile ``ops`` is a shared-bot satellite; ``team_b`` owns a bot."""
+    from agent import secret_scope
+    from gateway.run import GatewayRunner
+
+    home = tmp_path / "hh"
+    for name in ("ops", "team_b"):
+        (home / "profiles" / name).mkdir(parents=True)
+    (home / ".env").write_text("TELEGRAM_ALLOWED_USERS=777\n")
+    (home / "profiles" / "team_b" / ".env").write_text("TELEGRAM_ALLOWED_USERS=72719239\n")
+    (home / "profiles" / "ops" / ".env").write_text("")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for key in ("TELEGRAM_ALLOWED_USERS", "GATEWAY_ALLOW_ALL_USERS", "GATEWAY_ALLOWED_USERS"):
+        monkeypatch.delenv(key, raising=False)
+    prev = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner.config.platforms = {Platform.TELEGRAM: PlatformConfig(enabled=True, extra={})}
+    runner.config.profile_routes = parse_profile_routes(
+        [{"name": "admin-dm", "platform": "telegram", "profile": "ops", "chat_id": "72719239"}])
+    runner.pairing_store = PairingStore(profile="default")
+    runner.pairing_stores = {}
+    runner._primary_profile_name = "default"
+    primary = _stub(Platform.TELEGRAM, runner, "PRIMARY")
+    team_b = _stub(Platform.TELEGRAM, runner, "TEAM_B")
+    team_b.set_owner_profile("team_b")
+    runner.adapters = {Platform.TELEGRAM: primary}
+    runner._profile_adapters = {"team_b": {Platform.TELEGRAM: team_b}, "ops": {}}
+    served = [("default", home), ("ops", home / "profiles" / "ops"), ("team_b", home / "profiles" / "team_b")]
+    with patch("hermes_cli.profiles.profiles_to_serve", return_value=served), \
+            patch("hermes_cli.profiles.get_profile_dir", side_effect=lambda n: home / "profiles" / n), \
+            patch("hermes_cli.profiles.profile_exists", return_value=True):
+        yield SimpleNamespace(runner=runner, home=home, primary=primary, team_b=team_b)
+    secret_scope.set_multiplex_active(prev)
+
+
+def test_shared_bot_route_does_not_hijack_dedicated_secondary_bot(mux):
+    """A chat_id route for the shared bot must not re-home the same user's DM with team_b's own bot;
+    the same DM to the shared bot still routes to ``ops`` (#104933)."""
+    via_team_b = mux.team_b.build_source(chat_id="72719239", chat_type="dm", user_id="72719239")
+    assert via_team_b.profile == "team_b"
+    assert mux.runner._session_key_for_source(via_team_b) == "agent:team_b:telegram:dm:72719239"
+    via_primary = mux.primary.build_source(chat_id="72719239", chat_type="dm", user_id="72719239")
+    assert via_primary.profile == "ops"
+
+
+def test_secondary_busy_followup_authorized_against_its_own_allowlist(mux):
+    """The busy-session handler of a secondary adapter must run under that profile's scope, so its
+    owner (absent from the default allowlist) is admitted (#103717)."""
+    from agent import secret_scope
+
+    seen = {}
+
+    async def _busy(event, session_key):
+        seen["scoped"] = secret_scope.current_secret_scope() is not None
+        return mux.runner._is_user_authorized(event.source)
+
+    mux.runner._handle_active_session_busy_message = _busy
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="72719239", chat_type="dm", user_id="72719239")
+    source._transport_adapter_ref = weakref.ref(mux.team_b)
+    handler = mux.runner._make_profile_busy_session_handler("team_b")
+    assert asyncio.run(handler(SimpleNamespace(source=source), "k")) is True
+    assert seen["scoped"] is True
+
+
+def test_mid_turn_authorization_reads_admitting_transport_allowlist(mux):
+    """Inside a routed satellite's turn (its scope has no allowlist) ``_is_user_authorized_for_source``
+    must admit the shared bot's owner without an ingress stamp — the seam /topic, sibling /stop, plugin
+    injection, voice and auto-resume now use."""
+    from gateway.run import _profile_runtime_scope
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="777", chat_type="dm", user_id="777", profile="ops")
+    source._transport_adapter_ref = weakref.ref(mux.primary)
+    with _profile_runtime_scope(mux.home / "profiles" / "ops"):
+        assert mux.runner._is_user_authorized(source) is False  # the bug the call sites had
+        assert mux.runner._is_user_authorized_for_source(source) is True
+    stranger = SessionSource(platform=Platform.TELEGRAM, chat_id="1", chat_type="dm", user_id="1", profile="ops")
+    stranger._transport_adapter_ref = weakref.ref(mux.primary)
+    with _profile_runtime_scope(mux.home / "profiles" / "ops"):
+        assert mux.runner._is_user_authorized_for_source(stranger) is False
+
+
+def test_shared_bot_satellite_resolves_primary_transport_for_restored_sources(mux):
+    """A routed satellite with no bot of its own drains through the primary for restored/cached
+    sources (no transport ref); a disconnected secondary that owns a credential stays fail-closed."""
+    restored = SessionSource(platform=Platform.TELEGRAM, chat_id="72719239", chat_type="dm", user_id="7", profile="ops")
+    assert mux.runner._authorization_adapter(Platform.TELEGRAM, "ops") is mux.primary
+    assert mux.runner._adapter_for_source(restored) is mux.primary
+    assert mux.runner._resolve_injection_adapter("telegram", restored) is mux.primary
+    mux.runner._profile_adapters["team_b"] = {}  # team_b's bot is down: never borrow the primary
+    assert mux.runner._authorization_adapter(Platform.TELEGRAM, "team_b") is None
+
+
+def test_completion_preflight_runs_in_target_profile_scope(mux):
+    """An async-delegation completion for a secondary session must be classified against THAT
+    profile's state.db (the watcher runs unscoped, where the row does not exist → ``terminal``)."""
+    from gateway import run as run_module
+    from hermes_state import SessionDB
+
+    db_home = mux.home / "profiles" / "team_b"
+    SessionDB(db_path=db_home / "state.db").create_session(
+        session_id="sess-b", source="telegram", session_key="agent:team_b:telegram:dm:1", profile_name="team_b")
+    runner = mux.runner
+    runner._session_db_pinned = run_module._SESSION_DB_UNPINNED
+    runner._session_db_handles, runner._session_db_handles_lock = {}, threading.Lock()
+    runner.session_store, runner._session_sources = None, {}
+    evt = {"type": "async_delegation", "session_key": "agent:team_b:telegram:dm:1", "parent_session_id": "sess-b"}
+
+    async def _run():
+        unscoped = await runner._classify_completion_target("sess-b")
+        async with runner._completion_event_scope(evt):
+            scoped = await runner._classify_completion_target("sess-b")
+        return unscoped, scoped
+
+    assert asyncio.run(_run()) == ("terminal", "deliver")

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -322,6 +322,29 @@ no route stay on the default/active profile. The routed profile gets the full
 per-profile isolation described above (config, skills, memory, credentials,
 session namespace). Routing works on every platform adapter, not just Discord.
 
+A route applies only to messages received by the **default profile's bot**
+unless it names another bot with `bot_profile: <profile>`. Telegram DMs use the
+same `chat_id` for every bot (the user's id), so without this a
+`chat_id` route meant for the shared bot would also capture that user's DMs
+with a secondary profile's dedicated bot. Messages arriving at a secondary
+profile's own bot stay in that profile:
+
+```yaml
+    # Pin one user's DM with team_b's OWN bot to a third profile
+    - name: teamb-owner-dm
+      platform: telegram
+      bot_profile: team_b
+      chat_id: "72719239"
+      profile: ops-for-team-b
+```
+
+Authorization for a routed message is always decided by the **receiving bot's
+profile** (its token and allowlist), including follow-ups sent while the agent
+is busy and mid-turn checks such as `/topic` or `/stop`; the routed profile
+itself needs no copy of the allowlist. A routed profile without a bot of its
+own also receives background notifications (process completions, heartbeats,
+async delegation results) through the shared bot after a gateway restart.
+
 On WhatsApp and WhatsApp Cloud, a `chat_id` route matches across user-identity
 forms: a bare phone number (`15551234567`), a JID
 (`15551234567@s.whatsapp.net`), and a LID (`…@lid`) all refer to the same


### PR DESCRIPTION
Under `gateway.multiplex_profiles`, a message that reaches a secondary profile's own bot, a follow-up sent while that bot is busy, a mid-turn `/topic`/`/stop`, a background completion for a secondary session, and an API request under `/p/<profile>/` all now stay in — and are authorized by — the profile they actually belong to.

## Changes

- **`profile_routes` scoped to the receiving bot** (#104933, salvage #105040 / #105049): `ProfileRoute.bot_profile` (default = the shared default-profile bot) must equal the receiving adapter's owner profile. A `chat_id` route for the shared bot no longer re-homes the same user's DM with a dedicated secondary bot; secondary→secondary routes remain possible by naming `bot_profile`. `build_source` falls back to the adapter's own profile. Docs updated.
- **Busy-session handlers scoped like the cold path** (#103717, salvage #103764 + #105357): the secondary busy handler enters `_async_profile_runtime_scope`; the primary gets `_make_default_profile_busy_session_handler` (transport-home stamp + routed scope) sharing `_admit_primary_source` with the message handler; the busy gate uses `_is_user_authorized_for_source`.
- **Mid-turn authorization reads the admitting bot's allowlist**: `/topic`, sibling-thread `/stop`, plugin message injection, Discord voice transcripts and startup auto-resume switch to `_is_user_authorized_for_source`; `_under_authorization_profile` derives the transport home from the delivering adapter's owner when ingress did not stamp one (restored/cached sources).
- **Shared-bot satellites keep a transport after restart**: `_adapters_for_profile` (behind `_authorization_adapter`, `_adapter_for_source`, `_resolve_injection_adapter`) returns the primary map for a served, route-only profile with the `{}` placeholder and no reconnect pending — the rule kanban and cron already apply. A secondary that owns a credential stays fail-closed.
- **Async completions delivered in their own profile** (builds on #107247): pre-flight classify, durable claim/complete/release and inject all run inside `_completion_event_scope(evt)`; `_restore_secondary_completion_ledgers` replays every secondary's pending rows at multiplex startup.
- **api_server binds `HERMES_SESSION_PROFILE`** (#96370, salvage): `_bind_api_server_session(profile=…)` in both callers (`/v1/runs` uses `run.request_profile` — the executor thread has no contextvar), so persistent-Docker container keys become `profile:<name>` instead of collapsing onto `default`.

## Root cause

Route matching, busy handling, five mid-turn authorization checks, the completion watcher and the api_server session bind all ignored *which bot/profile admitted the request*, reading whatever scope was ambient (root, or the routed satellite's empty one).

## Validation

| Check | Before (origin/main) | After |
|---|---|---|
| DM to `team_b` bot with `chat_id` route → `ops` | `source.profile = ops`, key `agent:ops:…`, turn home `ops` | `source.profile = team_b`, key `agent:team_b:…`, turn home `team_b` |
| Secondary busy handler, owner in `team_b/.env` only | `scope_installed = False`, `authorized = False` | `True` / `True` |
| Inside routed satellite turn, shared-bot owner | `_is_user_authorized = False` (the 5 call sites) | `_is_user_authorized_for_source = True`, stranger `False` |
| Satellite restored source | `_authorization_adapter/_adapter_for_source/_resolve_injection_adapter = None` (kanban said PRIMARY) | all three → PRIMARY; downed secondary still `None` |
| Secondary completion pre-flight | root scope: `terminal`, ledger row `pending` forever | scoped: `deliver`, claim+complete `True`, row `delivered` |
| `/p/sec/` container key | `default` | `profile:sec` |

- Live repro scripts + before/after outputs: `/tmp/mux_audit/fix-routing-authz/{before,after,e2e_out}.txt` (20/20 E2E checks with real imports against a temp `HERMES_HOME`, positive and negative cases).
- New invariant tests (`tests/gateway/test_multiplex_routing_authz.py`, 5 tests; salvaged tests trimmed to ≤2 per PR) — all red on base, green here.
- `scripts/run_tests.sh tests/gateway/ tests/hermes_cli/test_kanban_notify.py tests/hermes_cli/test_platform_actions.py tests/tools/test_async_delegation*.py` → 8479 passed, 0 failed.

## Credits

- @0xalydev (#105040) and @Ahmett101 (#105049) — bot discriminator (co-authored on the routing commit)
- @chelsealong (#103764) — secondary busy-handler scope (cherry-picked)
- @remi-td (#105357) — primary busy-handler scope + `_is_user_authorized_for_source` gate (cherry-picked)
- @nmediaie (#96370) — api_server `HERMES_SESSION_PROFILE` bind (cherry-picked)
- @tensorbit89-netizen (#107247) — classify-only half of the completion scope
- Reporters: #104933, #103717, #96370

Fixes #104933
Fixes #103717
Addresses #88715

## Infographic

![infographic](https://v3b.fal.media/files/b/0aaa0446/wIqzVS0gMJ9Ni7vpwNJlL_WPFg0R3x.png)
