### PR TITLE
fix(desktop): rearm voice conversation after stop (#108301)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => {
       resolveStreamStart?.()
       resolveStreamStart = null
     },
+    consumePendingResponse: vi.fn(),
     deferStreamStart() {
       deferStreamStart = true
     },
@@ -134,7 +135,7 @@ function renderRearmConversation(responseId: string, responseText: string) {
     ({ enabled }) =>
       useVoiceConversation({
         busy: false,
-        consumePendingResponse: vi.fn(),
+        consumePendingResponse: mocks.consumePendingResponse,
         enabled,
         onSubmit: async () => {
           response = { id: responseId, pending: false, text: responseText }
@@ -203,9 +204,11 @@ describe('useVoiceConversation playback rearm', () => {
       mocks.continueStreamStart()
     })
 
-    await waitFor(() => expect(hook.result.current.status).toBe('idle'))
+    // The reply is silenced, but the conversation stays live and re-listens.
+    await waitFor(() => expect(mocks.handle.start).toHaveBeenCalledTimes(2))
     expect(mocks.stopVoicePlayback).toHaveBeenCalledTimes(2)
-    expect(mocks.handle.start).toHaveBeenCalledTimes(1)
+    expect(mocks.consumePendingResponse).toHaveBeenCalledTimes(2)
+    expect(hook.result.current.status).toBe('listening')
   })
 
   it('does not start fallback playback after Stop during stream discovery', async () => {
@@ -221,12 +224,14 @@ describe('useVoiceConversation playback rearm', () => {
       mocks.continueStreamStart()
     })
 
-    await waitFor(() => expect(hook.result.current.status).toBe('idle'))
+    // No fallback playback, but the loop re-arms the mic instead of wedging.
+    await waitFor(() => expect(mocks.handle.start).toHaveBeenCalledTimes(2))
     expect(mocks.playSpeechText).not.toHaveBeenCalled()
-    expect(mocks.handle.start).toHaveBeenCalledTimes(1)
+    expect(mocks.consumePendingResponse).toHaveBeenCalledTimes(2)
+    expect(hook.result.current.status).toBe('listening')
   })
 
-  it('does not re-arm after an external Stop during streaming playback', async () => {
+  it('re-arms and consumes the pending response after an external Stop during streaming playback', async () => {
     const hook = renderRearmConversation('reply-stopped', 'Playing now')
 
     await beginReply(hook)
@@ -237,8 +242,9 @@ describe('useVoiceConversation playback rearm', () => {
       mocks.finishSpeech('done')
     })
 
-    await waitFor(() => expect(hook.result.current.status).toBe('idle'))
-    expect(mocks.handle.start).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(mocks.handle.start).toHaveBeenCalledTimes(2))
+    expect(mocks.consumePendingResponse).toHaveBeenCalledTimes(2)
+    expect(hook.result.current.status).toBe('listening')
   })
 
   it('re-arms the microphone after normal fallback playback completes', async () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -263,7 +263,11 @@ export function useVoiceConversation({
 
   const settleAfterSpeech = useCallback(
     (barged: boolean, stoppedDuringSetup = false) => {
-      if (barged || !awaitingSpokenResponseRef.current) {
+      const stoppedExternally =
+        stoppedDuringSetup ||
+        (speechStartSequenceRef.current > 0 && $voicePlayback.get().sequence > speechStartSequenceRef.current)
+
+      if (barged || stoppedExternally || !awaitingSpokenResponseRef.current) {
         awaitingSpokenResponseRef.current = false
         consumePendingResponse()
       }
@@ -282,16 +286,13 @@ export function useVoiceConversation({
 
       dropSpeechSession()
 
-      // If stopVoicePlayback() was called externally (Stop button, end), the
-      // voice-playback sequence has advanced past what we captured at speech
-      // start — don't auto-start the next sentence, the user chose to stop.
-      const stoppedByUser =
-        stoppedDuringSetup ||
-        (speechStartSequenceRef.current > 0 && $voicePlayback.get().sequence > speechStartSequenceRef.current)
-
+      // An external stopVoicePlayback() (Stop/Esc) silences the current reply;
+      // it does not end hands-free conversation mode. end() owns that path and
+      // clears pendingStartRef before disabling the loop. While still enabled,
+      // always re-arm so the user can speak immediately after cutting TTS.
       speechStartSequenceRef.current = 0
 
-      if (enabledRef.current && !stoppedByUser) {
+      if (enabledRef.current) {
         pendingStartRef.current = true
       }
 


### PR DESCRIPTION
## What

Fixes #108301.

Desktop voice conversation mode now treats Stop/Esc during read-aloud as a reply-only interruption, not as the end of hands-free mode:

- consumes the interrupted pending response when an external Stop is observed, so it cannot be replayed later;
- re-arms the microphone whenever the conversation is still enabled;
- preserves the barge-in capture early return so an active barge monitor still owns the mic instead of starting a second capture.

## Why

The previous `settleAfterSpeech()` path detected an external stop via the voice playback sequence and then skipped `pendingStartRef.current = true`. The UI remained in voice-conversation mode, but the mic never reopened. It also left the stopped pending response available to future playback consumers.

## Verification

Run from `apps/desktop` after rebasing onto current `upstream/main`:

- `npx vitest run --project ui src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx src/app/chat/composer/hooks/use-voice-conversation.test.tsx --reporter=default` → 2 files passed, 11 tests passed. Existing React `act(...)` warning in the barge-in suite is unchanged.
- `npx eslint src/app/chat/composer/hooks/use-voice-conversation.ts src/app/chat/composer/hooks/use-voice-conversation-rearm.test.tsx` → passed.
- `npm run typecheck` → passed.
- `git diff --check` → passed.

RED proof captured in `.automation/runs/20260911T1604Z/108301/fail-without-fix.txt`: 3 regression tests failed on the pre-fix production code, each with the mic start count stuck at 1 instead of re-arming to 2.

## Duplicate / competitor check

- Same-issue open PR search for `108301 in:title,body state:open`: none.
- Same-author open PR check for `Tranquil-Flow:fix/108301*`: none before publication.
- Topic-overlap PR #81176 was reviewed. It covers the basic re-arm symptom, but does not consume the interrupted pending response or cover the stale-replay layer from #108301; scored 6.5/10 under the pipeline duplicate policy, so it is not blocking.

Auto-published by Moonsong via Path B automated pipeline.
