### PR TITLE
fix(gateway): let Dashboard chat start with custom providers

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1408,6 +1408,10 @@ def _config_model_provider() -> Tuple[Any, Optional[str]]:
         if provider.startswith("custom:"):
             from hermes_cli.runtime_provider_custom import has_named_custom_provider
             return model_cfg, (provider if has_named_custom_provider(provider) else None)
+        if not _optional_base_url(model_cfg.get("base_url")):
+            from hermes_cli.local_runtime.endpoint import LLAMACPP_ALIASES, llamacpp_route_available
+            if provider in LLAMACPP_ALIASES:
+                return model_cfg, (provider if llamacpp_route_available(config) else None)
         try:
             resolved = resolve_provider(provider)
         except AuthError:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1393,16 +1393,28 @@ def _logged_in_oauth_active_provider(*, skip_free_tier: bool = False) -> Optiona
 
 
 def _config_model_provider() -> Tuple[Any, Optional[str]]:
-    """``(model_cfg, provider)`` when ``model.provider`` names a routable provider.
+    """``(model_cfg, provider)`` when ``model.provider`` names a configured route.
 
     The normal chat/gateway path resolves config.provider upstream in resolve_requested_provider();
     this is the safety net for the lone direct caller (main.py resolve_provider("auto"))."""
     try:
         from hermes_cli.config import load_config
-        model_cfg = (load_config() or {}).get("model")
+        config = load_config() or {}
+        model_cfg = config.get("model")
         provider = model_cfg.get("provider") if isinstance(model_cfg, dict) else None
         provider = provider.strip().lower() if isinstance(provider, str) else ""
-        return model_cfg, (provider if provider != "auto" and is_runtime_provider_routable(provider) else None)
+        if not provider or provider == "auto":
+            return model_cfg, None
+        if provider.startswith("custom:"):
+            from hermes_cli.runtime_provider_custom import has_named_custom_provider
+            return model_cfg, (provider if has_named_custom_provider(provider) else None)
+        try:
+            resolved = resolve_provider(provider)
+        except AuthError:
+            return model_cfg, None
+        if resolved == "custom" and not _optional_base_url(model_cfg.get("base_url")):
+            return model_cfg, None
+        return model_cfg, (provider if is_runtime_provider_routable(provider) else None)
     except Exception as e:
         logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)
         return None, None

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1393,7 +1393,7 @@ def _logged_in_oauth_active_provider(*, skip_free_tier: bool = False) -> Optiona
 
 
 def _config_model_provider() -> Tuple[Any, Optional[str]]:
-    """``(model_cfg, provider)`` from config.yaml when ``model.provider`` names a registry provider.
+    """``(model_cfg, provider)`` when ``model.provider`` names a routable provider.
 
     The normal chat/gateway path resolves config.provider upstream in resolve_requested_provider();
     this is the safety net for the lone direct caller (main.py resolve_provider("auto"))."""
@@ -1402,7 +1402,7 @@ def _config_model_provider() -> Tuple[Any, Optional[str]]:
         model_cfg = (load_config() or {}).get("model")
         provider = model_cfg.get("provider") if isinstance(model_cfg, dict) else None
         provider = provider.strip().lower() if isinstance(provider, str) else ""
-        return model_cfg, (provider if provider in PROVIDER_REGISTRY else None)
+        return model_cfg, (provider if provider != "auto" and is_runtime_provider_routable(provider) else None)
     except Exception as e:
         logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)
         return None, None

--- a/hermes_cli/local_runtime/endpoint.py
+++ b/hermes_cli/local_runtime/endpoint.py
@@ -108,6 +108,17 @@ def resolve_llamacpp_endpoint(config: dict | None = None,
     return None
 
 
+def llamacpp_route_available(config: dict | None = None) -> bool:
+    """Whether a llamacpp alias has a usable or booting managed route.
+
+    Readiness callers must not wait for startup, but they must keep the route
+    configured while an enabled, installed managed runtime is booting.
+    """
+    if _boot_in_flight(config):
+        return True
+    return resolve_llamacpp_endpoint(config=config, wait_for_boot_s=0) is not None
+
+
 _KICK_LOCK = threading.Lock()
 
 

--- a/tests/hermes_cli/test_anon_auth_core.py
+++ b/tests/hermes_cli/test_anon_auth_core.py
@@ -397,7 +397,8 @@ class TestBootstrapIsTheOneCreator:
         fb.reset_for_tests()
         return fb
 
-    def test_bootstrap_mints_once_records_and_a_second_run_is_free(self, portal):
+    def test_bootstrap_mints_once_records_and_a_second_run_is_free(self, portal, monkeypatch):
+        monkeypatch.setattr("agent.bedrock_adapter.has_aws_credentials", lambda: False)
         fb = self._fresh()
         record = fb.run_bootstrap()
         assert record.free_tier and record.has_identity and record.provider_configured

--- a/tests/hermes_cli/test_provider_precedence.py
+++ b/tests/hermes_cli/test_provider_precedence.py
@@ -43,19 +43,15 @@ class TestProviderPrecedence:
         _config(monkeypatch, {"provider": "zai", "default": "glm-4.6"})
         assert resolve_provider("auto") == "zai"
 
-    @pytest.mark.parametrize("provider", ["custom", "custom:llama-local"])
-    def test_config_custom_provider_counts_as_inference_route(self, monkeypatch, provider):
-        """Dashboard setup readiness must accept custom routes outside the auth registry."""
+    def test_config_runtime_provider_counts_as_inference_route(self, monkeypatch):
+        """Dashboard readiness accepts custom routes but keeps the auto sentinel unresolved."""
         _clear_provider_env(monkeypatch)
         _no_aws(monkeypatch)
         _logged_out(monkeypatch)
-        _config(monkeypatch, {"provider": provider, "default": "local-model"})
-        assert resolve_provider("auto", skip_free_tier=True) == provider
+        for provider in ("custom", "custom:llama-local"):
+            _config(monkeypatch, {"provider": provider, "default": "local-model"})
+            assert resolve_provider("auto", skip_free_tier=True) == provider
 
-    def test_config_auto_provider_continues_resolution(self, monkeypatch):
-        """The auto sentinel is not itself a resolved inference route."""
-        _clear_provider_env(monkeypatch)
-        _no_aws(monkeypatch)
         _login(monkeypatch, "anthropic")
         _config(monkeypatch, {"provider": "auto", "default": "some-model"})
         assert resolve_provider("auto") == "anthropic"

--- a/tests/hermes_cli/test_provider_precedence.py
+++ b/tests/hermes_cli/test_provider_precedence.py
@@ -19,8 +19,8 @@ def _login(monkeypatch, provider_id):
                         lambda p: {"logged_in": p == provider_id})
 
 
-def _config(monkeypatch, model_cfg):
-    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": model_cfg})
+def _config(monkeypatch, model_cfg, **extra):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": model_cfg, **extra})
 
 
 def _no_aws(monkeypatch):
@@ -48,13 +48,35 @@ class TestProviderPrecedence:
         _clear_provider_env(monkeypatch)
         _no_aws(monkeypatch)
         _logged_out(monkeypatch)
-        for provider in ("custom", "custom:llama-local"):
-            _config(monkeypatch, {"provider": provider, "default": "local-model"})
-            assert resolve_provider("auto", skip_free_tier=True) == provider
+        _config(monkeypatch, {
+            "provider": "custom", "default": "local-model", "base_url": "http://127.0.0.1:8080/v1",
+        })
+        assert resolve_provider("auto", skip_free_tier=True) == "custom"
+
+        _config(
+            monkeypatch,
+            {"provider": "custom:llama-local", "default": "local-model"},
+            providers={"llama-local": {"base_url": "http://127.0.0.1:8080/v1"}},
+        )
+        assert resolve_provider("auto", skip_free_tier=True) == "custom:llama-local"
 
         _login(monkeypatch, "anthropic")
         _config(monkeypatch, {"provider": "auto", "default": "some-model"})
         assert resolve_provider("auto") == "anthropic"
+
+    @pytest.mark.parametrize("model_cfg", [
+        {"provider": "custom", "default": "local-model"},
+        {"provider": "custom:missing", "default": "local-model"},
+    ])
+    def test_incomplete_custom_provider_is_not_an_inference_route(self, monkeypatch, model_cfg):
+        """Bootstrap readiness rejects custom identities that runtime resolution cannot build."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _logged_out(monkeypatch)
+        _config(monkeypatch, model_cfg, providers={})
+
+        with pytest.raises(AuthError, match="No inference provider configured"):
+            resolve_provider("auto", skip_free_tier=True)
 
     def test_env_key_beats_stale_oauth(self, monkeypatch):
         """An exported provider API key wins over a logged-in OAuth active_provider."""

--- a/tests/hermes_cli/test_provider_precedence.py
+++ b/tests/hermes_cli/test_provider_precedence.py
@@ -78,6 +78,28 @@ class TestProviderPrecedence:
         with pytest.raises(AuthError, match="No inference provider configured"):
             resolve_provider("auto", skip_free_tier=True)
 
+    @pytest.mark.parametrize(("route_available", "enabled"), [(True, True), (False, False)])
+    def test_managed_llamacpp_route_controls_readiness(self, monkeypatch, route_available, enabled):
+        """A base-URL-free llamacpp alias is ready exactly when its managed route is available."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _logged_out(monkeypatch)
+        _config(
+            monkeypatch,
+            {"provider": "llamacpp", "default": "local-model"},
+            local_runtime={"enabled": enabled},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.local_runtime.endpoint.llamacpp_route_available",
+            lambda config: route_available,
+        )
+
+        if route_available:
+            assert resolve_provider("auto", skip_free_tier=True) == "llamacpp"
+        else:
+            with pytest.raises(AuthError, match="No inference provider configured"):
+                resolve_provider("auto", skip_free_tier=True)
+
     def test_env_key_beats_stale_oauth(self, monkeypatch):
         """An exported provider API key wins over a logged-in OAuth active_provider."""
         _clear_provider_env(monkeypatch)

--- a/tests/hermes_cli/test_provider_precedence.py
+++ b/tests/hermes_cli/test_provider_precedence.py
@@ -43,6 +43,23 @@ class TestProviderPrecedence:
         _config(monkeypatch, {"provider": "zai", "default": "glm-4.6"})
         assert resolve_provider("auto") == "zai"
 
+    @pytest.mark.parametrize("provider", ["custom", "custom:llama-local"])
+    def test_config_custom_provider_counts_as_inference_route(self, monkeypatch, provider):
+        """Dashboard setup readiness must accept custom routes outside the auth registry."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _logged_out(monkeypatch)
+        _config(monkeypatch, {"provider": provider, "default": "local-model"})
+        assert resolve_provider("auto", skip_free_tier=True) == provider
+
+    def test_config_auto_provider_continues_resolution(self, monkeypatch):
+        """The auto sentinel is not itself a resolved inference route."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _login(monkeypatch, "anthropic")
+        _config(monkeypatch, {"provider": "auto", "default": "some-model"})
+        assert resolve_provider("auto") == "anthropic"
+
     def test_env_key_beats_stale_oauth(self, monkeypatch):
         """An exported provider API key wins over a logged-in OAuth active_provider."""
         _clear_provider_env(monkeypatch)


### PR DESCRIPTION
## What does this PR do?

Dashboard Chat no longer reports "Setup Required" and leaves prompts queued when the configured inference route is a custom OpenAI-compatible provider. The setup readiness check now recognizes every provider identity accepted by runtime routing instead of limiting config-backed providers to the authentication registry.

### Symptom

A configured custom provider works through `hermes chat`, but `/chat` stops before `session.create`, displays "Setup Required", and never dispatches queued prompts.

### Impact

Dashboard Chat is unusable for affected custom-provider installations even though the same model and configuration work through the CLI.

### Bug Cause

**Trigger:** `hermes_cli/auth.py:1395` / `_config_model_provider()` when `model.provider` is `custom` or `custom:<name>`.

**Causal chain:**
1. Dashboard startup records setup readiness through `free_tier_bootstrap._inventory_other_providers()` and `resolve_provider("auto", skip_free_tier=True)`.
2. `_config_model_provider()` accepts only entries in `PROVIDER_REGISTRY`, while custom providers intentionally live outside that authentication registry.
3. The boot record says no provider is configured, so the TUI's pre-session `setup.status` gate refuses to call `session.create` and the chat never builds an agent.

**Why it is wrong:** Runtime routing explicitly supports bare and named custom provider identities, so setup readiness disagrees with the route that successfully powers normal CLI turns.

**Working sibling / contrast:** The normal chat runtime uses `resolve_requested_provider()` and the runtime provider ladder, which preserve the custom provider configured in `model.provider`.

**Ruled out:** The WebSocket and PTY handshake are not the blocker because both are accepted before the client-side setup gate stops session creation.

### Fix

Use the existing runtime-routability predicate for config-backed provider readiness while keeping the `auto` sentinel unresolved. Add regression coverage for bare custom providers, named custom providers, and the `auto` fallback path.

## Related Issue

Fixes #108383

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py` - recognize configured provider identities supported by runtime routing during automatic provider resolution.
- `tests/hermes_cli/test_provider_precedence.py` - cover custom-provider readiness and preserve `auto` fallback behavior.
- `tests/hermes_cli/test_anon_auth_core.py` - isolate the bootstrap inventory contract from ambient AWS credentials.

## How to Test

1. Configure `model.provider` as `custom` or `custom:<name>` with a local OpenAI-compatible endpoint.
2. Start the dashboard and open `/chat`; verify a new session starts instead of displaying "Setup Required".
3. Run the focused provider precedence tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_provider_precedence.py tests/hermes_cli/test_anon_auth_core.py -k 'TestProviderPrecedence or TestBootstrapIsTheOneCreator'
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)

### Documentation & Housekeeping

- [x] Documentation update is not applicable; this fixes provider readiness without changing user-facing configuration.
- [x] `cli-config.yaml.example` update is not applicable; no config keys changed.
- [x] `CONTRIBUTING.md` or `AGENTS.md` update is not applicable; no architecture or workflow changed.
- [x] I've considered cross-platform impact; the provider resolution path is platform-independent.
- [x] Tool description/schema updates are not applicable; no tool behavior changed.

## Screenshots / Logs

Not applicable; the regression is covered at the provider readiness boundary.
