### PR TITLE
fix(cron): prevent HERMES_CRON_SESSION leak into gateway messages (#108121)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2046,6 +2046,7 @@ class _CronRunScope:
             # #53027, #63142.
             async_delivery=False,
             cwd=self.workdir or "",
+            cron_session="",
         )
         for name in _CRON_DELIVERY_VARS:
             _VAR_MAP[name].set("")
@@ -2069,7 +2070,7 @@ class _CronRunScope:
         self._non_dispatcher_token = enter_non_dispatcher_owned_context()
 
     def exit(self) -> None:
-        from gateway.session_context import clear_session_vars
+        from gateway.session_context import clear_session_vars, reset_session_vars
         from tools.terminal_tool import clear_session_cwd
 
         clear_session_cwd(self.task_id)
@@ -2080,6 +2081,7 @@ class _CronRunScope:
             exit_non_dispatcher_owned_context(self._non_dispatcher_token)
         for name in _CRON_DELIVERY_VARS:
             self._var_map[name].set("")
+        reset_session_vars()
 
 
 def _reload_dotenv_and_publish_delivery_target(job: dict) -> None:

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -132,6 +132,8 @@ def set_session_vars(
     cannot grant wake authority."""
     global _session_context_engaged
     _session_context_engaged = True
+    if cron_session is _UNSET:
+        cron_session = ""
     values = (
         platform, source, chat_id, chat_type, chat_name, thread_id, user_id, user_id_alt,
         user_name, scope_id, session_key, session_id, ui_session_id, message_id, profile,

--- a/tests/cron/test_hermes_cron_session_gateway_leak.py
+++ b/tests/cron/test_hermes_cron_session_gateway_leak.py
@@ -1,0 +1,56 @@
+"""Regression tests for HERMES_CRON_SESSION environment leak into gateway turns (#108121).
+
+Ensures that ambient or process-global HERMES_CRON_SESSION env vars do not bleed
+into subsequent Discord/Telegram/Gateway sessions when set_session_vars() is called.
+"""
+
+import os
+import pytest
+from gateway.session_context import (
+    clear_session_vars,
+    get_session_env,
+    reset_session_vars,
+    set_session_vars,
+)
+from tools.approval_context import _is_cron_approval_context
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_env(monkeypatch):
+    reset_session_vars()
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    yield
+    reset_session_vars()
+
+
+def test_set_session_vars_defaults_cron_session_to_empty_string(monkeypatch):
+    """When os.environ has HERMES_CRON_SESSION=1, set_session_vars without cron_session masks it."""
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+
+    # Before binding, process env would fall back to "1"
+    assert get_session_env("HERMES_CRON_SESSION") == "1"
+
+    # Gateway message arrives and binds session context without specifying cron_session
+    tokens = set_session_vars(platform="discord", chat_id="456", session_key="disc-1")
+    try:
+        assert get_session_env("HERMES_CRON_SESSION") == ""
+        assert _is_cron_approval_context() is False
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_cron_run_scope_binds_cron_session(monkeypatch):
+    """Cron scope sets cron_session=1 during execution and clears upon exit."""
+    from cron.scheduler import _CronRunScope
+
+    scope = _CronRunScope(job={"id": "test_job"}, job_id="test_job", execution_id="exec-1")
+    try:
+        scope.enter()
+        assert get_session_env("HERMES_CRON_SESSION") == "1"
+        assert _is_cron_approval_context() is True
+    finally:
+        scope.exit()
+
+    # After exit, session context is cleared
+    assert get_session_env("HERMES_CRON_SESSION") == ""
+    assert _is_cron_approval_context() is False


### PR DESCRIPTION
## Summary
Fixes an issue where `HERMES_CRON_SESSION` environment variables or ambient session states leaked into subsequent Gateway message turns (e.g. Discord, Telegram), causing `execute_code` turns to be improperly blocked by `approvals.cron_mode: deny` (#108121).

## Root Cause
1. `set_session_vars()` previously left `cron_session` defaulted to `_UNSET`. When a gateway session was bound without an explicit `cron_session=""` parameter, `_CRON_SESSION` remained `_UNSET`, causing `_session_env("HERMES_CRON_SESSION")` to fall back to `os.getenv("HERMES_CRON_SESSION")`.
2. Any process-global or ambient `HERMES_CRON_SESSION` env var set during a cron run persisted in fallback reads for unbound or default-bound sessions.
3. `_CronRunScope` did not initialize `cron_session` to `""` before calling `enter()`, leaving `reset()` on scope exit to restore an `_UNSET` state rather than an explicit non-cron state.

## Fix
1. Default unsupplied `cron_session` in `set_session_vars()` to `""` (non-cron) when `_UNSET`, ensuring bound sessions explicitly mask process environment fallback.
2. Update `_CronRunScope.__init__` to initialize `cron_session=""` before `enter()` sets `"1"`, and call `reset_session_vars()` upon scope exit so the task context returns to a clean un-bound state.
3. Added unit tests in `tests/cron/test_hermes_cron_session_gateway_leak.py` verifying context masking and scope behavior.

Fixes #108121.
