### PR TITLE
fix(tools): scope process_manage session actions to the caller

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1280,6 +1280,66 @@ class TestProcessToolHandler:
         assert "error" in result
 
 
+class TestSessionActionOwnership:
+    """process_manage session actions are scoped to the caller's identity.
+
+    A session id is not a capability: another conversation that learns a live
+    id must not poll, kill, or write to it. The caller matches when it owns the
+    process (owner_task_id/task_id) or shares its gateway session_key.
+    """
+
+    def _setup(self, monkeypatch, owner_task_id="task-a", session_key="key-a"):
+        import tools.approval_context as ac
+        from tools import process_registry as pr
+        reg = ProcessRegistry()
+        sess = _make_session(sid="proc_owned1", task_id="container-a")
+        sess.owner_task_id = owner_task_id
+        sess.session_key = session_key
+        sess.exited = True
+        sess.exit_code = 0
+        reg._finished[sess.id] = sess
+        monkeypatch.setattr(pr, "process_registry", reg)
+        return pr, ac, sess
+
+    def _call(self, pr, ac, monkeypatch, task_id, session_key):
+        monkeypatch.setattr(ac, "get_current_session_key", lambda default="": session_key)
+        return json.loads(pr._handle_process(
+            {"action": "poll", "session_id": "proc_owned1"}, task_id=task_id))
+
+    def test_owner_task_id_may_poll(self, monkeypatch):
+        pr, ac, _ = self._setup(monkeypatch)
+        out = self._call(pr, ac, monkeypatch, task_id="task-a", session_key="")
+        assert out["status"] != "not_found"
+
+    def test_foreign_task_gets_not_found(self, monkeypatch):
+        pr, ac, _ = self._setup(monkeypatch)
+        out = self._call(pr, ac, monkeypatch, task_id="task-b", session_key="key-b")
+        assert out["status"] == "not_found"
+
+    def test_same_session_key_may_poll_across_tasks(self, monkeypatch):
+        """A session-scoped process started by a sibling task is still ours (#29177)."""
+        pr, ac, _ = self._setup(monkeypatch)
+        out = self._call(pr, ac, monkeypatch, task_id="task-b", session_key="key-a")
+        assert out["status"] != "not_found"
+
+    def test_container_task_id_may_poll(self, monkeypatch):
+        pr, ac, _ = self._setup(monkeypatch)
+        out = self._call(pr, ac, monkeypatch, task_id="container-a", session_key="")
+        assert out["status"] != "not_found"
+
+    def test_unidentified_caller_passes(self, monkeypatch):
+        """Internal plumbing calls the handler without task_id/session_key."""
+        pr, ac, _ = self._setup(monkeypatch)
+        out = self._call(pr, ac, monkeypatch, task_id="", session_key="")
+        assert out["status"] != "not_found"
+
+    def test_unowned_session_is_actionable(self, monkeypatch):
+        pr, ac, _ = self._setup(monkeypatch, owner_task_id="", session_key="")
+        pr.process_registry._finished["proc_owned1"].task_id = ""
+        out = self._call(pr, ac, monkeypatch, task_id="task-b", session_key="key-b")
+        assert out["status"] != "not_found"
+
+
 # =========================================================================
 # format_process_notification + drain_notifications (shared helpers)
 # =========================================================================

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2120,6 +2120,37 @@ def _list_processes(task_id) -> dict:
             task_id=task_id, session_key=session_key or None, include_retained=True)]}
 
 
+def _caller_session_key() -> str:
+    with suppress(Exception):
+        # See #29177.
+        from tools.approval_context import get_current_session_key
+        return get_current_session_key(default="") or ""
+    return ""
+
+
+def _session_action_allowed(session: "ProcessSession", task_id: str, session_key: str) -> bool:
+    """Whether the caller may poll/log/wait/kill/write/submit/close ``session``.
+
+    Ownership is the spawning task (``owner_task_id``, or the container
+    ``task_id`` it collapsed to) or the gateway ``session_key`` — a
+    session-scoped process started by a sibling task is still this
+    conversation's to manage (#29177), including through a compression resume.
+    A caller carrying no identity at all is trusted internal plumbing rather
+    than a model call (model calls always pass task_id); a session carrying no
+    identity (unowned/detached) has no owner to violate.
+    """
+    owner = session.owner_task_id or session.task_id
+    if task_id and task_id in (owner, session.task_id):
+        return True
+    if session_key and session.session_key:
+        if session_key == session.session_key:
+            return True
+        from tools.process_registry_results import _owns_result
+        if _owns_result(session_key, session.session_key):
+            return True
+    return not (task_id or session_key) or not (owner or session.session_key)
+
+
 # action -> (handler(session_id, args) -> dict, redact output?). Output-bearing
 # actions are redacted; stdin actions return only status.
 _SESSION_ACTIONS = {
@@ -2187,6 +2218,12 @@ def _handle_process(args, **kw):
     if action in _SESSION_ACTIONS:
         if not session_id:
             return tool_error(f"session_id is required for {action}")
+        session = process_registry.get(session_id)
+        if session is not None and not _session_action_allowed(
+                session, str(kw.get("task_id") or ""), _caller_session_key()):
+            # Same shape as a miss so another conversation's live ids are not
+            # enumerable through the status split.
+            return json.dumps(_not_found(session_id), ensure_ascii=False)
         handler, redact = _SESSION_ACTIONS[action]
         result = handler(session_id, args)
         return json.dumps(_redact_process_result(result) if redact else result, ensure_ascii=False)


### PR DESCRIPTION
## What does this PR do?

`process_manage`'s session actions resolved any `session_id` process-wide, so a conversation that learned another's process id could read its output, kill it, or write to its stdin. The handler now gates on the same ownership model `transfer_ownership` and the retained-result loader already use:

- caller task id matches `owner_task_id` or the container `task_id`, or
- caller shares the process's `session_key` (session-scoped processes, #29177), including the compression-tip ancestor allowance via `_owns_result`.

Mismatches return the same `not_found` shape as a miss, so foreign ids stay unenumerable. Callers carrying no identity (internal plumbing; model calls always pass task_id) and sessions carrying none (unowned/detached) are unchanged.

## Related Issue

Fixes #108413

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `tools/process_registry.py`: `_session_action_allowed` + `_caller_session_key`; `_handle_process` resolves the session once and refuses non-owners before dispatching.
- `tests/tools/test_process_registry.py`: `TestSessionActionOwnership` covers owner, foreign, shared-session-key, container-id, no-identity, and unowned cases.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `scripts/run_tests.sh tests/tools/test_process_registry.py -q`
2. `test_foreign_task_gets_not_found` covers the cross-conversation kill/write surface.

Ran on Windows 11: 110 passed; 6 pre-existing failures in PTY/POSIX/detached-path tests that don't touch the handler.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A
