### PR TITLE
fix(minimax): register minimax-portal and minimax-global provider aliases

### DIFF
--- a/plugins/model-providers/minimax/__init__.py
+++ b/plugins/model-providers/minimax/__init__.py
@@ -49,7 +49,8 @@ minimax_cn = MiniMaxProfile(
 )
 
 minimax_oauth = MiniMaxProfile(
-    name="minimax-oauth", aliases=("minimax_oauth", "minimax-oauth-io"), api_mode="anthropic_messages",
+    name="minimax-oauth", aliases=("minimax_oauth", "minimax-oauth-io", "minimax-portal", "minimax-global"),
+    api_mode="anthropic_messages",
     display_name="MiniMax (OAuth)", description="MiniMax via OAuth browser flow — no API key required",
     signup_url="https://api.minimax.io/",
     env_vars=(),  # OAuth — tokens in auth.json, not env

--- a/tests/plugins/model_providers/test_minimax_profile.py
+++ b/tests/plugins/model_providers/test_minimax_profile.py
@@ -120,6 +120,37 @@ class TestMinimaxAuxModelNotHighspeed:
         )
 
 
+class TestMinimaxOauthDocumentedAliases:
+    """``minimax-oauth`` must resolve every alias advertised in the user guide.
+
+    ``website/docs/guides/minimax-oauth.md`` documents four resolvable provider
+    ids: the canonical ``minimax-oauth``, the underscore form
+    ``minimax_oauth``, and two friendlier aliases ``minimax-portal`` and
+    ``minimax-global``. The profile's ``aliases=`` tuple previously only
+    registered the underscore form (plus an undocumented ``minimax-oauth-io``),
+    so ``--provider minimax-portal`` / ``--provider minimax-global`` failed
+    with "unknown provider" despite being documented as working.
+
+    Refs: Issue #107928.
+    """
+
+    @pytest.mark.parametrize(
+        "alias",
+        ["minimax-oauth", "minimax_oauth", "minimax-oauth-io", "minimax-portal", "minimax-global"],
+    )
+    def test_documented_and_legacy_aliases_resolve_to_minimax_oauth(self, alias):
+        import model_tools  # noqa: F401
+        import providers
+
+        canonical = providers.get_provider_profile("minimax-oauth")
+        resolved = providers.get_provider_profile(alias)
+        assert resolved is not None, f"{alias!r} does not resolve to any provider profile"
+        assert resolved is canonical, (
+            f"{alias!r} resolved to a different profile than the canonical "
+            "'minimax-oauth' id — aliases must point at the same registered profile"
+        )
+
+
 class TestMinimaxM3OpenAIReasoningWireShape:
     """MiniMax-M3 on api.minimax.io/v1 gets MiniMax's OpenAI-compatible knobs."""
 


### PR DESCRIPTION
## What does this PR do?

`website/docs/guides/minimax-oauth.md` (lines 143-146) documents four resolvable provider ids for `minimax-oauth`:

```
hermes --provider minimax-oauth    # canonical
hermes --provider minimax-portal   # alias
hermes --provider minimax-global   # alias
hermes --provider minimax_oauth    # alias (underscore form)
```

But `plugins/model-providers/minimax/__init__.py` only registered two of them in the profile's `aliases=` tuple (`minimax_oauth`, plus the undocumented `minimax-oauth-io`). `hermes --provider minimax-portal` and `hermes --provider minimax-global` failed with "unknown provider", contradicting the user guide.

This adds `minimax-portal` and `minimax-global` to the `aliases=` tuple so they resolve to the same registered profile as the canonical `minimax-oauth` id.

## Related Issue

Fixes #107928

## Testing

- Added `TestMinimaxOauthDocumentedAliases` to the existing `tests/plugins/model_providers/test_minimax_profile.py`, parametrized over all five known aliases (documented + legacy), asserting each resolves via `providers.get_provider_profile()` to the same profile object as the canonical id.
- `scripts/run_tests.sh tests/plugins/model_providers/test_minimax_profile.py -q` — 19/19 passed (14 pre-existing + 5 new).
- No new OAuth scopes, no behavior change for any existing alias/id — purely additive to the `aliases` tuple.