### PR TITLE
fix(mcp-oauth): relay RFC 9207 iss through client-local callbacks

### DIFF
--- a/apps/desktop/electron/mcp-oauth-callback-ipc.test.ts
+++ b/apps/desktop/electron/mcp-oauth-callback-ipc.test.ts
@@ -41,10 +41,14 @@ test('listen binds a loopback listener and wait resolves with the redirect param
   const waitPromise = invoke('hermes:mcp-oauth:wait', id, 5000) as Promise<{
     code: null | string
     error: null | string
+    iss: null | string
     state: null | string
   }>
 
-  const res = await fetch(`${redirectUri}?code=abc123&state=st-1`)
+  // RFC 9207: authorization servers that advertise
+  // authorization_response_iss_parameter_supported send `iss` on the redirect;
+  // the relay must forward it or the strict MCP client rejects the code grant.
+  const res = await fetch(`${redirectUri}?code=abc123&state=st-1&iss=${encodeURIComponent('https://as.example.com')}`)
 
   assert.equal(res.status, 200)
   assert.match(await res.text(), /return to Hermes/)
@@ -54,6 +58,7 @@ test('listen binds a loopback listener and wait resolves with the redirect param
   assert.equal(result.code, 'abc123')
   assert.equal(result.state, 'st-1')
   assert.equal(result.error, null)
+  assert.equal(result.iss, 'https://as.example.com')
 
   // Listener is one-shot: the port must be closed after the callback.
   await assert.rejects(fetch(`${redirectUri}?code=again&state=st-1`))

--- a/apps/desktop/electron/mcp-oauth-callback-ipc.ts
+++ b/apps/desktop/electron/mcp-oauth-callback-ipc.ts
@@ -41,6 +41,7 @@ const DONE_HTML =
 interface CallbackResult {
   code: null | string
   error: null | string
+  iss: null | string
   state: null | string
 }
 
@@ -83,7 +84,7 @@ function dispose(id: string) {
   }
 
   if (!entry.settled) {
-    settle(id, { code: null, error: 'cancelled', state: null })
+    settle(id, { code: null, error: 'cancelled', iss: null, state: null })
   }
 
   pending.delete(id)
@@ -112,6 +113,7 @@ export function registerMcpOauthCallbackIpc() {
       let code: null | string = null
       let state: null | string = null
       let error: null | string = null
+      let iss: null | string = null
 
       try {
         const parsed = new URL(url, 'http://127.0.0.1')
@@ -119,11 +121,12 @@ export function registerMcpOauthCallbackIpc() {
         code = parsed.searchParams.get('code')
         state = parsed.searchParams.get('state')
         error = parsed.searchParams.get('error')
+        iss = parsed.searchParams.get('iss')
       } catch {
         error = 'unparseable callback URL'
       }
 
-      settle(id, { code, error, state })
+      settle(id, { code, error, iss, state })
     })
 
     await new Promise<void>((resolve, reject) => {
@@ -143,7 +146,7 @@ export function registerMcpOauthCallbackIpc() {
     const entry = pending.get(String(id || ''))
 
     if (!entry) {
-      return { code: null, error: 'listener not found', state: null }
+      return { code: null, error: 'listener not found', iss: null, state: null }
     }
 
     if (entry.result) {
@@ -158,7 +161,7 @@ export function registerMcpOauthCallbackIpc() {
 
     const result = await new Promise<CallbackResult>(resolve => {
       const timer = setTimeout(() => {
-        settle(String(id), { code: null, error: 'timeout waiting for OAuth callback', state: null })
+        settle(String(id), { code: null, error: 'timeout waiting for OAuth callback', iss: null, state: null })
       }, timeout)
 
       entry.waiters.push(value => {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -308,7 +308,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   mcpOauth: {
     // One-shot loopback listener for MCP OAuth against remote backends: bind
     // on this machine, hand redirectUri to mcp.servers.oauth.start, then wait
-    // for the provider redirect and relay code/state via oauth.callback.
+    // for the provider redirect and relay code/state/iss via oauth.callback.
     listen: () => ipcRenderer.invoke('hermes:mcp-oauth:listen'),
     wait: (id, timeoutMs) => ipcRenderer.invoke('hermes:mcp-oauth:wait', id, timeoutMs),
     cancel: id => ipcRenderer.invoke('hermes:mcp-oauth:cancel', id)

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -370,7 +370,7 @@ declare global {
         wait: (
           id: string,
           timeoutMs?: number
-        ) => Promise<{ code: null | string; error: null | string; state: null | string }>
+        ) => Promise<{ code: null | string; error: null | string; iss: null | string; state: null | string }>
         cancel: (id: string) => Promise<boolean>
       }
       openPreviewInBrowser?: (url: string) => Promise<void>

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -276,6 +276,7 @@ async def mcp_oauth_callback(
     code: Optional[str] = None,
     state: Optional[str] = None,
     error: Optional[str] = None,
+    iss: Optional[str] = None,
 ):
     _gc_mcp_oauth_flows()
     with _mcp_oauth_flows_lock:
@@ -291,7 +292,7 @@ async def mcp_oauth_callback(
     if flow is None:
         return HTMLResponse("<h1>OAuth flow expired</h1><p>Return to Hermes and try again.</p>", status_code=404)
     try:
-        flow.deliver_callback(code=code, state=state, error=error)
+        flow.deliver_callback(code=code, state=state, error=error, iss=iss)
     except ValueError as exc:
         return HTMLResponse(
             "<h1>OAuth callback rejected</h1><p>The callback was invalid or already used.</p>",

--- a/tests/hermes_cli/test_mcp_dashboard_oauth.py
+++ b/tests/hermes_cli/test_mcp_dashboard_oauth.py
@@ -85,7 +85,7 @@ def test_hosted_callback_bypasses_gated_cookie_auth(monkeypatch):
     )
 
     assert response.status_code == 200
-    assert flow._callback == ("abc", "expected")
+    assert (flow._callback.code, flow._callback.state, flow._callback.iss) == ("abc", "expected", None)
 
 
 def test_hosted_auth_allows_same_server_name_in_different_profiles(tmp_path, monkeypatch):

--- a/tests/tools/test_mcp_dashboard_oauth.py
+++ b/tests/tools/test_mcp_dashboard_oauth.py
@@ -27,7 +27,31 @@ def test_dashboard_flow_exposes_authorization_url_and_accepts_callback():
     }
 
     flow.deliver_callback(code="code-1", state="s1", error=None)
-    assert asyncio.run(flow.wait_for_callback()) == ("code-1", "s1")
+    callback = asyncio.run(flow.wait_for_callback())
+    assert (callback.code, callback.state, callback.iss) == ("code-1", "s1", None)
+
+
+def test_dashboard_flow_preserves_iss_parameter():
+    """RFC 9207: the dashboard bridge must hand the SDK the provider's ``iss``.
+
+    Authorization servers that advertise ``authorization_response_iss_parameter_supported``
+    send ``iss`` on the redirect; the MCP SDK client rejects the authorization response
+    when a bridge drops it. The callback dataclass must carry it end to end.
+    """
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-iss",
+        server_name="reports",
+        profile=None,
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="https://agent.example/mcp/oauth/callback/flow-iss",
+    )
+    asyncio.run(flow.publish_authorization_url("https://idp.example/authorize?state=s9"))
+
+    flow.deliver_callback(code="code-9", state="s9", error=None, iss="https://idp.example")
+    callback = asyncio.run(flow.wait_for_callback())
+    assert callback.iss == "https://idp.example"
 
 
 def test_dashboard_flow_accepts_only_one_concurrent_callback():
@@ -96,6 +120,7 @@ def test_mcp_oauth_helpers_use_dashboard_flow_without_loopback_port():
         # AuthorizationCodeResult, not the legacy (code, state) tuple.
         result = asyncio.run(_make_callback_waiter(0)())
         assert (result.code, result.state) == ("code-4", "state-4")
+        assert result.iss is None
 
     assert flow.authorization_url == "https://idp.example/authorize?state=state-4"
 

--- a/tests/tui_gateway/test_mcp_oauth_client_callback.py
+++ b/tests/tui_gateway/test_mcp_oauth_client_callback.py
@@ -186,7 +186,26 @@ def test_deliver_callback_accepts_matching_state():
     flow = _make_session()
     out = deliver_callback_flow("sess-relay-1", "hosp", code="abc", state="s3cr3tstate")
     assert out == {"ok": True, "session_id": "sess-relay-1"}
-    assert flow._callback == ("abc", "s3cr3tstate")
+    assert (flow._callback.code, flow._callback.state, flow._callback.iss) == ("abc", "s3cr3tstate", None)
+
+
+def test_deliver_callback_preserves_iss():
+    """RFC 9207: a relayed authorization response must keep its ``iss``.
+
+    Authorization servers that advertise
+    ``authorization_response_iss_parameter_supported`` (e.g. Clerk) send
+    ``iss`` on the redirect; the strict SDK client rejects the code grant
+    when a client-relayed callback drops it. The relay must forward what
+    the provider sent, unchanged — no synthesis, no stripping.
+    """
+    flow = _make_session()
+    out = deliver_callback_flow(
+        "sess-relay-1", "hosp",
+        code="abc", state="s3cr3tstate", iss="https://as.example.com",
+    )
+    assert out == {"ok": True, "session_id": "sess-relay-1"}
+    assert flow._callback is not None
+    assert flow._callback.iss == "https://as.example.com"
 
 
 def test_deliver_callback_rejects_state_mismatch():

--- a/tools/mcp_dashboard_oauth.py
+++ b/tools/mcp_dashboard_oauth.py
@@ -29,6 +29,16 @@ def _event_field():
     return field(default_factory=threading.Event, init=False, repr=False)
 
 
+@dataclass(frozen=True)
+class DashboardOAuthCallback:
+    """Authorization response fields required by the MCP OAuth client."""
+
+    code: str
+    state: str | None
+    error: str | None
+    iss: str | None = None
+
+
 @dataclass
 class DashboardOAuthFlow:
     flow_id: str
@@ -43,7 +53,7 @@ class DashboardOAuthFlow:
     error: str | None = None
     tools: list[dict] = field(default_factory=list)
     expected_state: str | None = field(default=None, init=False)
-    _callback: tuple[str, str | None] | None = field(default=None, init=False, repr=False)
+    _callback: DashboardOAuthCallback | None = field(default=None, init=False, repr=False)
     _callback_error: str | None = field(default=None, init=False, repr=False)
     _authorization_ready: threading.Event = _event_field()
     _callback_ready: threading.Event = _event_field()
@@ -70,7 +80,7 @@ class DashboardOAuthFlow:
             raise RuntimeError(self.error or "MCP OAuth flow ended before authorization")
         return self.authorization_url
 
-    def deliver_callback(self, *, code: str | None, state: str | None, error: str | None) -> None:
+    def deliver_callback(self, *, code: str | None, state: str | None, error: str | None, iss: str | None = None) -> None:
         """Hand the browser redirect to the waiting flow; ``state`` must match exactly."""
         with self._lock:
             if self._callback_ready.is_set():
@@ -80,12 +90,12 @@ class DashboardOAuthFlow:
             if error:
                 self._callback_error = error
             elif code:
-                self._callback = (code, state)
+                self._callback = DashboardOAuthCallback(code=code, state=state, error=None, iss=iss)
             else:
                 self._callback_error = "OAuth callback did not include code or error"
             self._callback_ready.set()
 
-    async def wait_for_callback(self, timeout: float = 300.0) -> tuple[str, str | None]:
+    async def wait_for_callback(self, timeout: float = 300.0) -> DashboardOAuthCallback:
         if not await asyncio.to_thread(self._callback_ready.wait, timeout):
             raise TimeoutError("Timed out waiting for MCP OAuth callback")
         if self._callback_error:

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -646,8 +646,15 @@ def _make_callback_waiter(port: int, cimd_url: str | None = None, timeout: float
     async def _wait():
         dashboard_flow = get_dashboard_oauth_flow()
         if dashboard_flow is not None:
-            # Dashboard flow speaks the legacy tuple; normalize to one shape.
-            return _authorization_code_result(*await dashboard_flow.wait_for_callback())
+            # Preserve every authorization-response field needed by the SDK,
+            # including RFC 9207 ``iss``. Dropping it here makes strict clients
+            # reject providers that advertise issuer-response support.
+            dashboard_callback = await dashboard_flow.wait_for_callback()
+            return _authorization_code_result(
+                dashboard_callback.code,
+                dashboard_callback.state,
+                dashboard_callback.iss,
+            )
         # The SDK entered the authorization-code flow, so any cached token is unusable. Reject BEFORE
         # binding: binding would block for the full timeout and collide with the TIME_WAIT port on retry.
         # Reject before binding the callback listener in non-interactive contexts. Reaching here means the

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -61,7 +61,7 @@ def _start_loopback_listener(flow) -> "http.server.HTTPServer":
             status = 200
             try:
                 flow.deliver_callback(
-                    **{k: (qs.get(k) or [None])[0] for k in ("code", "state", "error")})
+                    **{k: (qs.get(k) or [None])[0] for k in ("code", "state", "error", "iss")})
             except Exception:
                 body = b"<h1>OAuth callback rejected</h1><p>The callback was invalid or already used.</p>"
                 status = 400
@@ -255,15 +255,17 @@ def cancel_flow(session_id: str, server_name: str, hermes_home: str) -> Dict[str
 
 def deliver_callback_flow(
     session_id: str, server_name: str, *, code: Optional[str], state: Optional[str],
-    error: Optional[str] = None) -> Dict[str, Any]:
+    error: Optional[str] = None, iss: Optional[str] = None) -> Dict[str, Any]:
     """Relay a client-captured OAuth redirect into a session's flow (remote-backend companion
     to ``start_flow(client_redirect_uri=...)``); ``deliver_callback`` still verifies ``state``
-    and rejects replays. Returns ``{ok: true}`` or ``{ok: false, error_message}``."""
+    and rejects replays, and forwards the RFC 9207 ``iss`` parameter so strict clients accept
+    authorization servers that advertise issuer-response support. Returns ``{ok: true}`` or
+    ``{ok: false, error_message}``."""
     rec, err = _lookup(session_id, server_name)
     if rec is None:
         return {"ok": False, "error_message": err}
     try:
-        rec["flow"].deliver_callback(code=code, state=state, error=error)
+        rec["flow"].deliver_callback(code=code, state=state, error=error, iss=iss)
     except ValueError as exc:
         return {"ok": False, "error_message": str(exc)}
     return {"ok": True, "session_id": session_id}

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1336,11 +1336,14 @@ def _(rid, params: dict) -> dict:
 
 @_mcp_rpc("oauth.callback", _NAME_SESSION)
 def _(rid, params: dict) -> dict:
-    """Relay a client-captured redirect (``code``/``state``/``error``) into a ``client_redirect_uri`` flow."""
-    code, state, error = (str(params.get(k) or "") or None for k in ("code", "state", "error"))
+    """Relay a client-captured redirect (``code``/``state``/``error``/``iss``) into a
+    ``client_redirect_uri`` flow; ``iss`` (RFC 9207) must survive the relay because strict
+    clients reject ``iss``-advertising servers whose callbacks drop it."""
+    code, state, error, iss = (str(params.get(k) or "") or None for k in ("code", "state", "error", "iss"))
     deliver = _tools_mod("tui_gateway.mcp_oauth_sessions").deliver_callback_flow
     return _ok(rid, deliver(
-        _str_arg(params, "session_id"), _str_arg(params, "name"), code=code, state=state, error=error))
+        _str_arg(params, "session_id"), _str_arg(params, "name"),
+        code=code, state=state, error=error, iss=iss))
 
 
 # ─── Plugins ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

MCP OAuth logins from the Desktop app fail against authorization servers that advertise `authorization_response_iss_parameter_supported` (e.g. Clerk, which fronts TinyFish):

```
OAuthFlowError: Authorization response missing iss parameter advertised by the authorization server
```

The SDK's RFC 9207 validation is correct — the server promises `iss` on the authorization response, the callback must carry it. The loopback CLI path and the HTTP callback handler already preserve it, but every relay that moves the redirect from the *user's machine* to the gateway strips it:

1. **Electron client-local listener** (`apps/desktop/electron/mcp-oauth-callback-ipc.ts`) — captures only `code`/`state`/`error`
2. **`oauth.callback` RPC** (`tui_gateway/methods_tools.py`) — reads only those three
3. **`deliver_callback_flow`** (`tui_gateway/mcp_oauth_sessions.py`) — no `iss` parameter
4. **`DashboardOAuthFlow`** waited as a legacy `(code, state)` tuple, dropping `iss` at `wait_for_callback()`
5. **dashboard HTTP callback route** (`hermes_cli/web_routers/mcp.py`) never read the `iss` query param
6. **tui_gateway loopback listener** passed only `code`/`state`/`error` into `deliver_callback`

Once #0f5dd5c46e / #e3ba651b6d made Desktop host the callback listener locally (the right fix for remote backends — the gateway's loopback is unreachable from the user's browser), every Desktop OAuth login against an `iss`-advertising server parked the MCP server with the error above.

## Fix

Forward the provider's `iss` unchanged through every relay link. No synthesis: the SDK compares `iss` against the discovered issuer and rejects mismatches, so a stripped value must surface as absent, never fabricated.

- `CallbackResult` carries `iss`; the Electron listener captures it from the redirect, and cancel/timeout/not-found settle it `null`
- `oauth.callback` RPC accepts and forwards `iss`
- `deliver_callback_flow` gains keyword-only `iss`, forwarded to `DashboardOAuthFlow.deliver_callback`
- `DashboardOAuthFlow` stores a frozen `DashboardOAuthCallback` dataclass (`code`/`state`/`error`/`iss`); `wait_for_callback()` returns it; `_make_callback_waiter` unpacks all three fields instead of splatting the legacy tuple
- dashboard HTTP callback route reads `iss`
- tui_gateway loopback listener delivers `iss`
- renderer `wait()` type + preload comment updated; the desktop relay spreads the captured callback into `oauth.callback` unchanged

## Verification

- New invariant tests: relayed callback preserves provider `iss` (red before the fix — `deliver_callback_flow()` rejected the keyword); dashboard flow carries `iss` end to end; Electron IPC test sends and asserts `iss` through a real loopback fetch
- `scripts/run_tests.sh tests/tui_gateway/ tests/tools/test_mcp_oauth.py tests/tools/test_mcp_dashboard_oauth.py tests/hermes_cli/test_mcp_dashboard_oauth.py tests/hermes_cli/web_routers/` → 136 files, 1198 passed, 0 failed
- `apps/desktop`: `vitest run electron/mcp-oauth-callback-ipc.test.ts src/lib/mcp-dashboard-oauth.test.ts` → 9 passed; `npm run typecheck` clean; eslint clean
- Live: TinyFish (Clerer AS, `authorization_response_iss_parameter_supported: true`) re-authenticated; MCP server revived from parked to connected