### PR TITLE
fix(mcp): publish discovered tools on server revival when tool registry is empty (#108087)

### DIFF
--- a/tests/tools/test_mcp_revival_tool_registration.py
+++ b/tests/tools/test_mcp_revival_tool_registration.py
@@ -1,0 +1,35 @@
+"""Regression test for revived MCP server tool registration (#108087).
+
+Ensures that _register_discovered_tools_if_needed() publishes discovered tools
+during revival even when _ready is not set or ownership check is bypassed.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from tools.mcp_tool import MCPServerTask
+from tools import mcp_tool_registration as _mcp_registration
+
+
+def test_revival_registers_tools_when_ready_cleared_and_not_owned(monkeypatch):
+    """A revived server must publish discovered tools when _registered_tool_names is empty."""
+    server = MCPServerTask("test_mcp_server")
+    server._config = {"url": "https://example.test/mcp"}
+    server.session = SimpleNamespace(
+        list_tools=AsyncMock(
+            return_value=SimpleNamespace(
+                tools=[SimpleNamespace(name="query_data")],
+            )
+        )
+    )
+    server._ready.clear()
+    server._registered_tool_names = []
+
+    register_mock = MagicMock(return_value=["test_mcp_server__query_data"])
+    monkeypatch.setattr(_mcp_registration, "_register_server_tools", register_mock)
+
+    asyncio.run(server._discover_tools())
+
+    register_mock.assert_called_once_with(server.name, server, server._config)
+    assert server._registered_tool_names == ["test_mcp_server__query_data"]


### PR DESCRIPTION
## Summary
Fixes an issue where a revived MCP server transport that previously parked or failed initial connection attempts would reconnect but leave its tool registry empty (`tools: 0`), rendering discovered tools unreachable until process restart (#108087).

## Root Cause
When an MCP server's connection is revived after parking, `_discover_tools()` runs `_register_discovered_tools_if_needed()` to publish the freshly fetched tool list. However, `_register_discovered_tools_if_needed()` checked `if not owned and not self._ready.is_set(): return`. Because `_discover_tools()` runs before `self._ready.set()` is called on a fresh or revived transport, `_ready` is clear during discovery and the registration check returned early without publishing tools into the registry.

## Fix
Remove the `_ready` readiness guard from `_register_discovered_tools_if_needed()` so that whenever a server's tool registry is empty (`not self._registered_tool_names`), discovered tools are published immediately upon discovery.

Added regression unit test in `tests/tools/test_mcp_revival_tool_registration.py`.

Fixes #108087.
