### PR TITLE
fix(desktop): align compression activity heartbeat interval under websocket deadline (#108325)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -67,6 +67,7 @@ COMPACTION_STATUS = f"🗜️ {COMPACTION_STATUS_MARKER} — summarizing earlier
 COMPACTION_HEARTBEAT_STATUS = f"🗜️ {COMPACTION_STATUS_MARKER} — still summarizing earlier conversation so I can continue..."
 
 COMPACTION_DONE_STATUS = "✓ Context compaction complete — continuing turn..."
+DEFAULT_COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL: float = 15.0
 
 
 def _strip_marker_for_comparison(msgs: Any) -> Any:
@@ -1521,13 +1522,13 @@ class _CompressionActivityHeartbeat:
         # so a later UNKNOWN rewrite cannot re-arm a detached zombie heartbeat.
         self._suppressed = False
         if interval_seconds is None:
-            interval_seconds = getattr(agent, "_compression_activity_heartbeat_interval", 60.0)
+            interval_seconds = getattr(agent, "_compression_activity_heartbeat_interval", DEFAULT_COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL)
         try:
-            interval_seconds = float(interval_seconds or 60.0)
+            interval_seconds = float(interval_seconds or DEFAULT_COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL)
             if not math.isfinite(interval_seconds):
-                interval_seconds = 60.0
+                interval_seconds = DEFAULT_COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL
         except (TypeError, ValueError):
-            interval_seconds = 60.0
+            interval_seconds = DEFAULT_COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL
         self._interval_seconds = max(0.1, interval_seconds)
         # Only a compression that opened a VISIBLE compaction phase (the
         # routine start status was emitted) keeps it alive with heartbeats;
@@ -4028,6 +4029,7 @@ def try_shrink_image_parts_in_messages(api_messages: list, *, max_dimension: int
 
 __all__ = [
     "COMPACTION_STATUS", "COMPACTION_DONE_STATUS", "COMPACTION_HEARTBEAT_STATUS", "COMPACTION_STATUS_MARKER", "is_compaction_progress_status",
+    "DEFAULT_COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL",
     "check_compression_model_feasibility", "replay_compression_warning", "compress_context",
     "try_shrink_image_parts_in_messages",
 ]

--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -1,4 +1,4 @@
-import { JsonRpcGatewayClient } from '@hermes/shared'
+import { JsonRpcGatewayClient, type GatewayClientOptions } from '@hermes/shared'
 
 import type { HermesApiRequest } from '@/global'
 
@@ -26,13 +26,14 @@ const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 export const PROMPT_SUBMIT_REQUEST_TIMEOUT_MS = 1_800_000
 
 export class HermesGateway extends JsonRpcGatewayClient {
-  constructor() {
+  constructor(options?: Partial<GatewayClientOptions>) {
     super({
       closedErrorMessage: 'Hermes gateway connection closed',
       connectErrorMessage: 'Could not connect to Hermes gateway',
       createRequestId: nextId => nextId,
       notConnectedErrorMessage: 'Hermes gateway is not connected',
-      requestTimeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS
+      requestTimeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+      ...options
     })
   }
 }

--- a/apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts
@@ -128,4 +128,78 @@ describe('JsonRpcGatewayClient heartbeat recovery', () => {
     expect(socket.readyState).toBe(FakeSocket.OPEN)
     expect(socket.sent).toEqual([])
   })
+
+  it('keeps connection alive during long compaction when progress status events are emitted within deadline', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', { OPEN: FakeSocket.OPEN })
+    const socket = new FakeSocket()
+
+    const client = new JsonRpcGatewayClient({
+      heartbeatDeadlineMs: 45,
+      heartbeatIntervalMs: 15,
+      requestTimeoutMs: 120,
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const connected = client.connect('ws://gateway.test/api/ws')
+    socket.emit('open')
+    await connected
+    socket.message({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'gateway.ready', payload: { heartbeat: true } }
+    })
+
+    const reqPromise = client.request('agent.turn', { prompt: 'hello' }, 120)
+
+    // Backend emits periodic progress status every 15ms during a 90ms compaction
+    await vi.advanceTimersByTimeAsync(15)
+    socket.message({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'status.update', payload: { message: '📦 Compacting context...' } }
+    })
+
+    await vi.advanceTimersByTimeAsync(15)
+    socket.message({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'status.update', payload: { message: '📦 Compacting context...' } }
+    })
+
+    await vi.advanceTimersByTimeAsync(15)
+    socket.message({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'status.update', payload: { message: '📦 Compacting context...' } }
+    })
+
+    await vi.advanceTimersByTimeAsync(15)
+    socket.message({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'status.update', payload: { message: '📦 Compacting context...' } }
+    })
+
+    // Total elapsed: 60ms (exceeding initial 45ms deadline), connection must still be open
+    expect(client.connectionState).toBe('open')
+    expect(socket.readyState).toBe(FakeSocket.OPEN)
+
+    // Complete the turn at 80ms
+    await vi.advanceTimersByTimeAsync(20)
+    socket.message({
+      jsonrpc: '2.0',
+      id: 'r1',
+      result: { ok: true }
+    })
+
+    const result = await reqPromise
+    expect(result).toEqual({ ok: true })
+    expect(client.connectionState).toBe('open')
+
+    // After turn completes, idle silence past 45ms invalidates the socket
+    await vi.advanceTimersByTimeAsync(60)
+    expect(client.connectionState).toBe('closed')
+    expect(socket.readyState).toBe(FakeSocket.CLOSED)
+  })
 })

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -462,9 +462,11 @@ def test_compression_activity_heartbeat_nonfinite_interval_falls_back(tmp_path: 
 
     agent._touch_activity = _capture
 
+    from agent.conversation_compression import DEFAULT_COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL
+
     heartbeat = _CompressionActivityHeartbeat(agent, interval_seconds=float("inf"))
 
-    assert heartbeat._interval_seconds == 60.0
+    assert heartbeat._interval_seconds == DEFAULT_COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL
     heartbeat.start()
     heartbeat.stop()
     assert touch_calls == ["context compression started", "context compression completed"]


### PR DESCRIPTION
## Summary

Closes #108325.

### Root Cause
1. In `apps/shared/src/json-rpc-gateway.ts`, the desktop client WebSocket watchdog enforces a 45s heartbeat deadline (`DEFAULT_HEARTBEAT_DEADLINE_MS = 45_000`) without inbound frames before declaring the connection dead and tearing it down.
2. In `agent/conversation_compression.py`, `_CompressionActivityHeartbeat` is responsible for re-emitting progress status events (`COMPACTION_HEARTBEAT_STATUS`) during long-running context compaction. However, its default interval (`_compression_activity_heartbeat_interval`) was hard-coded to **60.0s** (`DEFAULT_COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL`).
3. During large-context preflight compaction (which can take 90–120s on large context windows), the client's 45s deadline elapsed before the 60s background heartbeat thread emitted its first progress frame. The client declared the connection dead with `WebSocket heartbeat acknowledgement timed out`, dropped the socket, and triggered a backend restart that killed the turn mid-flight.

### Fix
1. Reduced `DEFAULT_COMPRESSION_ACTIVITY_HEARTBEAT_INTERVAL` from 60.0s to 15.0s in `agent/conversation_compression.py`, ensuring compaction progress status frames are emitted every 15s to refresh `lastInboundAt` well within the desktop client's 45s deadline.
2. Allowed passing custom options (`GatewayClientOptions`) to `HermesGateway` constructor in `apps/desktop/src/api/client.ts` to allow caller-level customization.
3. Added unit tests in `apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts` and `tests/agent/test_compression_concurrent_fork.py`.

### Verification
- `npx vitest run apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts`: 3/3 passed (100%).
- `pytest tests/agent/test_compression_concurrent_fork.py`: 52/52 passed (100%).
- `npm --prefix apps/shared run typecheck`: Passed cleanly (0 errors).
