### PR TITLE
fix(cron): multiplexed cron fires and delivers for every served profile — restart-safe scope, guild-scoped shared routes, Desktop ticker allowlist, idle-exit (#107399, #89302, salvage #107413/#104979/#103844/#103742)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3065,7 +3065,13 @@ def _launch_external_cron_worker(job: dict) -> bool:
         str(ack_path),
     ]
 
-    from agent.secret_scope import is_multiplex_active
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        is_multiplex_active,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+    from hermes_cli.env_loader import hydrate_profile_secret_sources
     from tools.environments.local import build_subprocess_env
     from tools.process_registry import (
         restart_safe_gateway_child_argv,
@@ -3107,11 +3113,17 @@ def _launch_external_cron_worker(job: dict) -> bool:
         payload_path.unlink(missing_ok=True)
         raise
 
-    worker_env = build_subprocess_env(
-        scrub_secrets=multiplex_active,
-        inherit_profile_home=True,
-        extra={"HERMES_HOME": str(_get_hermes_home().resolve())},
-    )
+    profile_home = _get_hermes_home().resolve()
+    hydrate_profile_secret_sources(profile_home)
+    secret_token = set_secret_scope(build_profile_secret_scope(profile_home))
+    try:
+        worker_env = build_subprocess_env(
+            scrub_secrets=multiplex_active,
+            inherit_profile_home=True,
+            extra={"HERMES_HOME": str(profile_home)},
+        )
+    finally:
+        reset_secret_scope(secret_token)
     worker_env = systemd_user_bus_env(worker_env)
     try:
         process = subprocess.Popen(

--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -1133,15 +1133,28 @@ def _resolve_target_transport(
     """Resolve ``(transport, pconfig, runtime_adapter, target_adapters)`` for one target, or
     ``(None, error)`` when it cannot be served (relay-fronted with no live transport, or not
     configured/enabled)."""
-    from gateway.delivery import resolve_delivery_transport
+    from gateway.delivery import DeliveryTransport, resolve_delivery_transport
     target_adapters = adapters
+    transport = None
     if isinstance(adapters, _preflight.SharedRouteAdapters):
         # Credentialless satellite: the primary adapter serves THIS target only when an exact
         # primary route maps it to this profile; a miss fails closed below.
         # See #101113.
         shared = adapters.get(platform, target)
         target_adapters = {platform: shared} if shared is not None else {}
-    transport = resolve_delivery_transport(platform, config, target_adapters)
+        if shared is not None:
+            # The PRIMARY's route authorized this exact native adapter. The satellite's own
+            # ``platforms.<p>`` block describes a connector it never runs (no credential), so
+            # neither its absence nor ``enabled: false`` may veto the shared transport; only its
+            # non-credential settings (continuable surface, reply mode) are kept (#89302, #103701).
+            from dataclasses import replace
+            from gateway.config import PlatformConfig
+            own = config.platforms.get(platform)
+            transport = DeliveryTransport(
+                shared, replace(own, enabled=True) if own is not None else PlatformConfig(enabled=True),
+                platform)
+    if transport is None:
+        transport = resolve_delivery_transport(platform, config, target_adapters)
     if transport is not None:
         pconfig = transport.config
         runtime_adapter = transport.adapter
@@ -1159,9 +1172,11 @@ def _resolve_target_transport(
         pconfig = config.platforms.get(platform)
         runtime_adapter = None
 
-    if transport is not None and transport.is_relay:
-        # Relay transport carries the RELAY adapter's config (enablement already checked). The
-        # logical platform is deliberately NOT natively enabled, so the native gate must not apply.
+    if transport is not None and (transport.is_relay or pconfig is None):
+        # Relay transport carries the RELAY adapter's config (enablement already checked): the
+        # logical platform is deliberately NOT natively enabled. A live NATIVE adapter with no
+        # ``platforms.<p>`` block is the same shape — the owning process already authorized the
+        # adapter; "no config" is not "disabled" (#89302).
         if pconfig is None:
             from gateway.config import PlatformConfig
             pconfig = PlatformConfig(enabled=True)

--- a/cron/scheduler_preflight.py
+++ b/cron/scheduler_preflight.py
@@ -198,12 +198,17 @@ class SharedRouteAdapters:
         chat_id = str(target.get("chat_id") or "") or None
         thread_id = target.get("thread_id")
         thread_id = str(thread_id) if thread_id else None
+        # A cron target carries no inbound guild anchor, so a route's guild_id is matched against
+        # itself — the target-exact discriminators (chat_id/thread_id) authorize the send. Without
+        # this the documented ``guild_id + chat_id`` Discord route never authorized cron output.
         for route in self._routes:
             if str(route.platform).lower() != platform_key:
                 continue
             if not (route.chat_id or route.thread_id):
                 continue  # guild-only routes are not target-exact
-            if route.matches(str(route.platform), chat_id=chat_id, thread_id=thread_id):
+            if route.matches(
+                str(route.platform), guild_id=route.guild_id, chat_id=chat_id, thread_id=thread_id,
+            ):
                 return adapter
         return default
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1645,6 +1645,23 @@ def _multiplex_profile_homes(config: object) -> list[tuple[str, "Path"]]:
         multiplex=True, profile_allowlist=getattr(config, "multiplex_profile_allowlist", None)))
 
 
+def _cron_tick_profile_homes(config: object) -> list[tuple[str, "Path"]]:
+    """Profile homes the in-process ticker visits under multiplex: the served set PLUS the
+    process-active profile. ``profiles_to_serve`` starts at default + allowlist, so a
+    ``--profile <name>`` multiplexer was omitted unless allowlisted — and allowlisting it would
+    start a second adapter on its own bot token. Adapter startup already skips ``active``."""
+    from hermes_cli.profiles import get_active_profile_name, get_profile_dir
+
+    homes = _multiplex_profile_homes(config)
+    active = get_active_profile_name() or "default"
+    if any(name == active for name, _home in homes):
+        return homes
+    try:
+        return homes + [(active, get_profile_dir(active))]
+    except Exception:
+        return homes
+
+
 def _enable_multiplex_log_routing(config: object) -> bool:
     """Route agent.log/errors.log/gateway.log records to their owning profile (inert single-profile).
     ``setup_logging(mode="gateway")`` binds file handlers to the launch home, so under multiplexing
@@ -5091,17 +5108,19 @@ def _start_gateway_start_cron_and_housekeeping(runner):
         resolve_cron_scheduler(), multiplex_profiles=multiplex_cron)
     cron_start_kwargs: Dict[str, Any] = {"adapters": runner.adapters, "loop": asyncio.get_running_loop()}
 
-    # Multiplex: tell the ticker which profile homes to tick, else secondary profiles' jobs never run.
+    # Multiplex: tell the ticker which profile homes to tick (else secondary profiles' jobs never
+    # run, #69377), including a ``--profile <name>`` multiplexer's OWN store.
     if isinstance(cron_provider, InProcessCronScheduler) and multiplex_cron:
         try:
-            profile_homes = _multiplex_profile_homes(runner.config)
+            profile_homes = _cron_tick_profile_homes(runner.config)
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
                 # Per-profile adapters so each profile's cron output goes via its own bot, not the default's.
                 cron_start_kwargs["profile_adapters"] = getattr(runner, "_profile_adapters", None)
-                # runner.adapters belongs to "default"; naming it keeps the ticker from routing a secondary's
-                # cron through the default bot (even before that profile's adapter connects).
-                cron_start_kwargs["default_profile"] = "default"
+                # runner.adapters belongs to the LAUNCH profile (``default``, or the ``--profile``
+                # name); naming it keeps the ticker from routing a secondary's cron through that bot
+                # and lets a named multiplexer's own jobs reuse its live adapters.
+                cron_start_kwargs["default_profile"] = runner._primary_profile_name
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s", len(profile_homes),
                     [p[0] if isinstance(p, tuple) else p for p in profile_homes])

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -98,19 +98,25 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     start_kwargs: dict = {"interval": interval}
     if isinstance(provider, InProcessCronScheduler):
         try:
-            from hermes_cli.profiles import profiles_to_serve
+            from hermes_cli.profiles import (
+                _check_gateway_running, _served_by_running_multiplexer, profiles_to_serve)
+            from hermes_cli.web_server_cron import _default_multiplex_profile_allowlist
 
-            profile_homes = list(profiles_to_serve(multiplex=True))
+            # Same served set as the multiplexer (allowlist honoured): a profile the default
+            # gateway deliberately does not serve must not be ticked from the Desktop either.
+            profile_homes = list(profiles_to_serve(
+                multiplex=True, profile_allowlist=_default_multiplex_profile_allowlist()))
             if profile_homes:
                 # Even one profile needs the per-tick gateway gate; otherwise
                 # Desktop races its dedicated gateway for the same cron store.
                 start_kwargs["profile_homes"] = profile_homes
-                # Stand down, per tick, for a profile whose OWN gateway runs:
-                # it ticks with live adapters, and the tick-lock race would
-                # otherwise deliver through the standalone path (#100489).
-                from hermes_cli.profiles import _check_gateway_running
-
-                start_kwargs["profile_gate"] = lambda _name, home: not _check_gateway_running(Path(home))
+                # Stand down, per tick, for a profile already owned by a gateway — its OWN
+                # process, or the live default multiplexer (a served satellite has no gateway.pid
+                # of its own). That gateway ticks with live adapters; winning the tick-lock race
+                # here would deliver through the standalone path (#100489, #107485).
+                start_kwargs["profile_gate"] = lambda name, home: not (
+                    _check_gateway_running(Path(home))
+                    or (name != "default" and _served_by_running_multiplexer(name)))
                 from hermes_logging import enable_profile_log_routing
 
                 enable_profile_log_routing(profile_homes)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -101,7 +101,9 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
             from hermes_cli.profiles import profiles_to_serve
 
             profile_homes = list(profiles_to_serve(multiplex=True))
-            if len(profile_homes) > 1:
+            if profile_homes:
+                # Even one profile needs the per-tick gateway gate; otherwise
+                # Desktop races its dedicated gateway for the same cron store.
                 start_kwargs["profile_homes"] = profile_homes
                 # Stand down, per tick, for a profile whose OWN gateway runs:
                 # it ticks with live adapters, and the tick-lock race would

--- a/hermes_cli/web_server_cron.py
+++ b/hermes_cli/web_server_cron.py
@@ -79,6 +79,23 @@ def _validate_dashboard_cron_context_from(refs: Optional[List[str]], profile_nam
                 detail=f"context_from job '{ref}' not found in profile '{profile_name}'")
 
 
+def _default_multiplex_profile_allowlist() -> "list[str] | None":
+    """``gateway.multiplex_profile_allowlist`` as the DEFAULT profile's config declares it (the
+    multiplexer's served set), so the Desktop ticker mirrors ``gateway/run.py::_multiplex_profile_homes``
+    instead of ticking every installed profile. ``None`` = serve all (historical behavior)."""
+    from gateway.config import _normalize_multiplex_profile_allowlist
+    from hermes_cli.config import read_user_config_raw
+    from hermes_constants import get_default_hermes_root
+
+    cfg_path = get_default_hermes_root() / "config.yaml"
+    if not cfg_path.exists():
+        return None
+    cfg = read_user_config_raw(cfg_path) or {}
+    raw = cfg.get("multiplex_profile_allowlist") if "multiplex_profile_allowlist" in cfg else (
+        cfg.get("gateway") or {}).get("multiplex_profile_allowlist")
+    return _normalize_multiplex_profile_allowlist(raw)
+
+
 def _cron_profile_dicts() -> List[Dict[str, Any]]:
     """Minimal profile records (callers only consume ``name``); avoids ``list_profiles()``,
     whose config parsing, gateway probes and skill counts are GIL pressure on large pools."""

--- a/hermes_cli/web_server_idle_exit.py
+++ b/hermes_cli/web_server_idle_exit.py
@@ -95,15 +95,22 @@ _probe_failure_logged = False
 
 
 def turn_in_flight() -> Optional[bool]:
-    """True/False from the gateway's running-session table; None when it cannot be read. The table
-    lives on ``tui_gateway.server`` (the voice mixin's helper is bound into that namespace). None
-    keeps the backend alive forever, so the cause is logged once — a silent never-exits would be
-    the original bug with a new face."""
+    """True/False from the gateway's running-session table OR the in-process cron scheduler; None
+    when neither can be read. The session table lives on ``tui_gateway.server`` (the voice mixin's
+    helper is bound into that namespace). Cron runs live outside that table
+    (``cron.scheduler.get_running_job_ids``, the same ledger the gateway shutdown drain reads):
+    without it a daily job mid-run reported "no turn" and the exit killed it (#107485). None keeps
+    the backend alive forever, so the cause is logged once — a silent never-exits would be the
+    original bug with a new face."""
     global _probe_failure_logged
     try:
         import tui_gateway.server as gateway
         with gateway._sessions_lock:
-            return any(s.get("running") for s in gateway._sessions.values())
+            running = any(s.get("running") for s in gateway._sessions.values())
+        if running:
+            return True
+        from cron.scheduler import get_running_job_ids
+        return bool(get_running_job_ids())
     except Exception:
         if not _probe_failure_logged:
             _probe_failure_logged = True

--- a/tests/cron/test_cron_multiplex_desktop_ticker_scope.py
+++ b/tests/cron/test_cron_multiplex_desktop_ticker_scope.py
@@ -115,11 +115,12 @@ def test_desktop_ticker_gates_on_profile_gateway_running(tmp_path, monkeypatch, 
     homes = [("default", tmp_path / "default"), ("ops", tmp_path / "ops")][:profile_count]
     running = {homes[-1][1]}
     monkeypatch.setattr(
-        "hermes_cli.profiles.profiles_to_serve", lambda multiplex=False: list(homes)
+        "hermes_cli.profiles.profiles_to_serve", lambda multiplex=False, profile_allowlist=None: list(homes)
     )
     monkeypatch.setattr(
         "hermes_cli.profiles._check_gateway_running", lambda home: home in running
     )
+    monkeypatch.setattr("hermes_cli.profiles._served_by_running_multiplexer", lambda name: False)
     captured = {}
 
     class _Provider:

--- a/tests/cron/test_cron_multiplex_desktop_ticker_scope.py
+++ b/tests/cron/test_cron_multiplex_desktop_ticker_scope.py
@@ -15,6 +15,8 @@ import asyncio
 import threading
 from unittest.mock import patch
 
+import pytest
+
 
 
 def test_standalone_fallback_pool_keeps_profile_scope(tmp_path, monkeypatch):
@@ -105,16 +107,18 @@ def test_multiplex_ticker_profile_gate_skips_rejected_profile(tmp_path):
     assert (orphan / "cron" / "ticker_last_success").exists()
 
 
-def test_desktop_ticker_gates_on_profile_gateway_running(tmp_path, monkeypatch):
-    """The desktop ticker wires the gate to ``_check_gateway_running``."""
+@pytest.mark.parametrize("profile_count", [1, 2])
+def test_desktop_ticker_gates_on_profile_gateway_running(tmp_path, monkeypatch, profile_count):
+    """Desktop yields to each live gateway, including a single-profile install."""
     from hermes_cli import web_server
 
-    homes = [("default", tmp_path / "default"), ("ops", tmp_path / "ops")]
+    homes = [("default", tmp_path / "default"), ("ops", tmp_path / "ops")][:profile_count]
+    running = {homes[-1][1]}
     monkeypatch.setattr(
         "hermes_cli.profiles.profiles_to_serve", lambda multiplex=False: list(homes)
     )
     monkeypatch.setattr(
-        "hermes_cli.profiles._check_gateway_running", lambda home: home.name == "ops"
+        "hermes_cli.profiles._check_gateway_running", lambda home: home in running
     )
     captured = {}
 
@@ -133,7 +137,15 @@ def test_desktop_ticker_gates_on_profile_gateway_running(tmp_path, monkeypatch):
 
     web_server._start_desktop_cron_ticker(threading.Event(), interval=0)
 
+    assert captured.get("profile_homes") == homes
     gate = captured.get("profile_gate")
     assert gate is not None, "desktop ticker did not install a profile gate"
-    assert gate("default", tmp_path / "default") is True
-    assert gate("ops", tmp_path / "ops") is False
+    for name, home in homes:
+        assert gate(name, home) is (home not in running)
+
+    # Re-evaluate on each tick: Desktop resumes fallback after gateway exit
+    # and stands down again if a gateway starts later.
+    running.clear()
+    assert all(gate(name, home) for name, home in homes)
+    running.update(home for _, home in homes)
+    assert not any(gate(name, home) for name, home in homes)

--- a/tests/cron/test_cron_multiplex_shared_route_delivery.py
+++ b/tests/cron/test_cron_multiplex_shared_route_delivery.py
@@ -107,3 +107,56 @@ def test_satellite_routes_exact_target_through_primary_adapter(tmp_path, monkeyp
 def test_shared_view_is_falsy_without_routes_or_primary_adapters():
     assert not SharedRouteAdapters({}, [])
     assert SharedRouteAdapters({Platform.DISCORD: object()}, []).get(Platform.DISCORD) is None
+
+
+def test_guild_scoped_route_authorizes_cron_target_even_when_satellite_has_no_platform_block(
+    tmp_path, monkeypatch,
+):
+    """The documented Discord route shape is ``guild_id + chat_id``. A cron target carries no guild
+    anchor, so the route must be matched on its target-exact discriminators; and the satellite's
+    missing/disabled ``platforms.discord`` block must not veto the PRIMARY's authorized transport
+    (#89302 sibling) — before, both fell to standalone "DISCORD_BOT_TOKEN is not set"."""
+    root = tmp_path / "root"
+    sat_home = root / "profiles" / "fitness"
+    sat_home.mkdir(parents=True)
+    (root / "config.yaml").write_text(yaml.safe_dump({
+        "gateway": {"multiplex_profiles": True, "profile_routes": [
+            {"platform": "discord", "guild_id": "G1", "chat_id": "C1", "profile": "fitness"}]},
+    }), encoding="utf-8")
+    monkeypatch.setattr("hermes_constants.get_default_hermes_root", lambda: root)
+    primary = _primary_adapter()
+
+    token = set_hermes_home_override(str(sat_home))
+    try:
+        shared = SharedRouteAdapters({Platform.DISCORD: primary}, _primary_profile_routes_for_current_home())
+        for satellite_platforms in ({}, {Platform.DISCORD: PlatformConfig(enabled=False)}):
+            primary.sent.clear()
+            config = MagicMock()
+            config.platforms = satellite_platforms
+            config.get_home_channel = lambda p: None
+            with patch("gateway.config.load_gateway_config", return_value=config):
+                error, standalone = _run(_job("C1"), shared)
+            assert error is None, error
+            assert primary.sent == ["C1"] and standalone == []
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_live_native_adapter_without_platform_block_is_not_treated_as_disabled():
+    """#89302: a live native adapter handed in by the gateway is the authorization; an absent
+    ``platforms.<p>`` block in the firing profile means "no config", not "disabled"."""
+    from cron.scheduler_delivery import _resolve_target_transport
+
+    config = MagicMock()
+    config.platforms = {}
+    adapter = object()
+    resolved, err = _resolve_target_transport(
+        {"id": "j"}, Platform.DISCORD, "discord", {"platform": "discord", "chat_id": "C1"},
+        {Platform.DISCORD: adapter}, config)
+    assert err is None and resolved[2] is adapter and resolved[1].enabled
+    # an explicitly disabled block still vetoes
+    config.platforms = {Platform.DISCORD: PlatformConfig(enabled=False)}
+    resolved, err = _resolve_target_transport(
+        {"id": "j"}, Platform.DISCORD, "discord", {"platform": "discord", "chat_id": "C1"},
+        {Platform.DISCORD: adapter}, config)
+    assert resolved is None and "not configured/enabled" in err

--- a/tests/cron/test_restart_safe_worker.py
+++ b/tests/cron/test_restart_safe_worker.py
@@ -188,9 +188,14 @@ def test_launch_external_worker_uses_restart_safe_scope_and_acknowledges(
     tmp_path, monkeypatch
 ):
     import cron.scheduler as scheduler
+    from tools.env_passthrough import clear_env_passthrough, register_env_passthrough
 
     job = {"id": "job-1", "execution_id": "exec-1", "prompt": "work"}
     monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: tmp_path)
+    (tmp_path / ".env").write_text(
+        "SERVICE_TOKEN=target-profile-token\n", encoding="utf-8"
+    )
+    register_env_passthrough(["SERVICE_TOKEN"])
     wrapped_commands = []
 
     def wrap(command, *, unit_suffix):
@@ -239,17 +244,20 @@ def test_launch_external_worker_uses_restart_safe_scope_and_acknowledges(
     get = Mock(side_effect=lambda _execution_id: next(observed_statuses))
     monkeypatch.setattr(scheduler, "get_execution", get)
     monkeypatch.setenv("ANTHROPIC_API_KEY", "should-not-cross-profile")
+    monkeypatch.setenv("SERVICE_TOKEN", "default-profile-token")
     from agent.secret_scope import set_multiplex_active
 
     set_multiplex_active(True)
     try:
         assert scheduler._launch_external_cron_worker(job) is True
     finally:
+        clear_env_passthrough()
         set_multiplex_active(False)
     assert wrapped_commands[0][1] == "cron-job-1-exec-exec-1"
     assert spawned[0][0][0:2] == ["scope", "--"]
     assert spawned[0][1]["start_new_session"] is True
     assert "ANTHROPIC_API_KEY" not in spawned[0][1]["env"]
+    assert spawned[0][1]["env"]["SERVICE_TOKEN"] == "target-profile-token"
     handoff.assert_called_once_with("exec-1")
     assert get.call_count == 2
     assert payloads[0]["multiplex_active"] is True

--- a/tests/gateway/test_multiplex_lifecycle.py
+++ b/tests/gateway/test_multiplex_lifecycle.py
@@ -41,6 +41,34 @@ def test_cron_profile_homes_follow_allowlist(tmp_path, monkeypatch):
     assert [name for name, _home in homes] == ["default", "worker"]
 
 
+def test_cron_tick_homes_include_active_named_host(tmp_path, monkeypatch):
+    """Named-profile gateway + allowlist must still tick the host store.
+
+    Adapter homes stay allowlist-only so the host is not started a second
+    time as a secondary (same bot token). Cron unions the active profile.
+    """
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    for name in ("host", "worker"):
+        (default_home / "profiles" / name).mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home / "profiles" / "host"))
+
+    import gateway.run as gateway_run
+
+    cfg = GatewayConfig(
+        multiplex_profiles=True,
+        multiplex_profile_allowlist=["worker"],
+    )
+    adapter_names = [name for name, _home in gateway_run._multiplex_profile_homes(cfg)]
+    cron_homes = gateway_run._cron_tick_profile_homes(cfg)
+    cron_names = [name for name, _home in cron_homes]
+    cron_by_name = dict(cron_homes)
+
+    assert adapter_names == ["default", "worker"]
+    assert cron_names == ["default", "worker", "host"]
+    assert cron_by_name["host"] == default_home / "profiles" / "host"
+
+
 class TestNamedProfileMultiplexerGuard:
     """_guard_named_profile_under_multiplexer is inert unless all conditions hold."""
 

--- a/tests/gateway/test_multiplex_phase0.py
+++ b/tests/gateway/test_multiplex_phase0.py
@@ -67,6 +67,36 @@ class TestSessionKeyNamespacedWhenOn:
 class TestMultiplexConfigFlag:
     """gateway.multiplex_profiles defaults off and round-trips."""
 
+    def test_cron_shared_adapter_owner_is_the_launch_profile(self, monkeypatch, tmp_path):
+        """A ``--profile rex`` multiplexer owns ``runner.adapters``; its ticker must name rex (not the
+        literal ``default``) as the shared-adapter owner or rex's own jobs fall to the fail-closed map."""
+        import asyncio
+        from types import SimpleNamespace
+        from gateway import run as run_mod
+        from cron.scheduler_provider import InProcessCronScheduler
+
+        captured = {}
+
+        class _Ticker(InProcessCronScheduler):
+            def start(self, stop_event, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("cron.scheduler_provider.resolve_cron_scheduler", lambda: _Ticker())
+        monkeypatch.setattr(run_mod, "_cron_tick_profile_homes", lambda cfg: [("rex", tmp_path)])
+        monkeypatch.setattr(run_mod, "_start_gateway_housekeeping", lambda *a, **k: None)
+        runner = SimpleNamespace(
+            config=GatewayConfig(multiplex_profiles=True), adapters={}, _profile_adapters={},
+            _primary_profile_name="rex", _draining=False, _external_drain_active=False)
+
+        async def _go():
+            return run_mod._start_gateway_start_cron_and_housekeeping(runner)
+
+        cron_stop, _provider, cron_thread, hk = asyncio.run(_go())
+        cron_stop.set()
+        cron_thread.join(timeout=5)
+        hk.join(timeout=5)
+        assert captured["default_profile"] == "rex"
+
     def test_default_is_false(self):
         assert GatewayConfig().multiplex_profiles is False
 

--- a/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
+++ b/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
@@ -130,3 +130,30 @@ def test_external_provider_never_gets_profile_homes(monkeypatch, tmp_path):
     ws._start_desktop_cron_ticker(threading.Event(), interval=13)
 
     assert external.start_kwargs == {"interval": 13}
+
+
+def test_desktop_ticker_honours_allowlist_and_yields_to_default_multiplexer(monkeypatch, _providers, tmp_path):
+    """The Desktop ticker mirrors the multiplexer's served set (allowlist) and stands down for a
+    satellite the live default multiplexer already ticks — that profile has no gateway.pid of its
+    own, so the per-home liveness check alone lets both tickers race for its fires (#107485)."""
+    import hermes_cli.profiles as profiles_mod
+    import yaml
+
+    _sp, builtin = _providers
+    root = tmp_path / ".hermes"
+    for name in ("worker", "guest"):
+        (root / "profiles" / name).mkdir(parents=True)
+    (root / "config.yaml").write_text(yaml.safe_dump(
+        {"gateway": {"multiplex_profiles": True, "multiplex_profile_allowlist": ["worker"]}}))
+    monkeypatch.setattr("hermes_constants.get_default_hermes_root", lambda: root)
+    monkeypatch.setattr(profiles_mod, "_get_default_hermes_home", lambda: root)
+    monkeypatch.setattr(profiles_mod, "_get_profiles_root", lambda: root / "profiles")
+    monkeypatch.setattr(profiles_mod, "_check_gateway_running", lambda home: False)
+    monkeypatch.setattr(profiles_mod, "_served_by_running_multiplexer", lambda name: name == "worker")
+
+    ws._start_desktop_cron_ticker(threading.Event(), interval=0)
+
+    assert [name for name, _ in builtin.start_kwargs["profile_homes"]] == ["default", "worker"]
+    gate = builtin.start_kwargs["profile_gate"]
+    assert gate("default", root) is True
+    assert gate("worker", root / "profiles" / "worker") is False

--- a/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
+++ b/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
@@ -70,19 +70,31 @@ def test_multi_profile_homes_passed_to_builtin(monkeypatch, _providers, tmp_path
     assert builtin.start_kwargs["profile_homes"] == homes
 
 
-def test_single_profile_keeps_legacy_path(monkeypatch, _providers, tmp_path):
-    _sp, builtin = _providers
+@pytest.mark.parametrize("gateway_running", [True, False])
+def test_single_profile_ticks_only_without_gateway(monkeypatch, tmp_path, gateway_running):
+    """Exercise Desktop startup through the real built-in scheduler loop."""
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_constants import get_hermes_home
     import hermes_cli.profiles as profiles_mod
 
+    home = tmp_path / "root"
+    home.mkdir()
+    monkeypatch.setattr(profiles_mod, "profiles_to_serve", lambda **_kw: [("default", home)])
+    monkeypatch.setattr(profiles_mod, "_check_gateway_running", lambda _home: gateway_running)
     monkeypatch.setattr(
-        profiles_mod,
-        "profiles_to_serve",
-        lambda **_kw: [("default", tmp_path / "root")],
+        "cron.scheduler_provider.resolve_cron_scheduler", InProcessCronScheduler
     )
+    ticked = []
+    monkeypatch.setattr(
+        "cron.scheduler.tick", lambda **_kw: ticked.append(get_hermes_home())
+    )
+    stop = threading.Event()
+    # One real scheduler cycle, with no wall-clock wait or job dispatch.
+    monkeypatch.setattr(stop, "wait", lambda _timeout: stop.set())
 
-    ws._start_desktop_cron_ticker(threading.Event(), interval=9)
+    ws._start_desktop_cron_ticker(stop, interval=0)
 
-    assert builtin.start_kwargs == {"interval": 9}
+    assert ticked == ([] if gateway_running else [home])
 
 
 def test_enumeration_failure_fails_open(monkeypatch, _providers):

--- a/tests/hermes_cli/test_web_server_idle_exit.py
+++ b/tests/hermes_cli/test_web_server_idle_exit.py
@@ -78,3 +78,19 @@ def test_watchdog_sets_should_exit_and_only_arms_for_ssh_isolated_backends(monke
         assert isinstance(ws_mod.app.state.ssh_isolated_clients, IdleClientTracker)
     finally:
         ws_mod.app.state._state.pop("ssh_isolated_clients", None)  # process-global app: never leak the tracker
+
+
+def test_turn_probe_counts_in_flight_cron_execution():
+    """#107485: a cron job mid-run must keep the SSH-isolated backend alive; the run lives outside
+    the dashboard session table, in the scheduler's running-job ledger."""
+    import cron.scheduler as scheduler
+    from hermes_cli.web_server_idle_exit import turn_in_flight
+
+    assert turn_in_flight() is False
+    with scheduler._running_lock:
+        scheduler._running_job_ids.add("idle-exit-probe-job")
+    try:
+        assert turn_in_flight() is True
+    finally:
+        with scheduler._running_lock:
+            scheduler._running_job_ids.discard("idle-exit-probe-job")

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -274,8 +274,11 @@ non-list value fails safely to default-only.
 
 The resulting served set also controls `/p/<profile>/` API and webhook prefixes,
 runtime status, profile-route eligibility, and which profiles the in-process
-cron scheduler ticks. A named profile outside the allowlist may still run its
-own standalone gateway.
+cron scheduler ticks (the Desktop backend's ticker follows the same allowlist and
+stands down for any profile a running multiplexer already serves). A multiplexer
+started as `hermes -p <name> gateway run` always ticks its own profile's cron store
+as well. A named profile outside the allowlist may still run its own standalone
+gateway.
 
 ### Routing shared-bot chats to profiles (`profile_routes`)
 
@@ -343,9 +346,12 @@ default-profile behavior.
 
 Cron jobs owned by a routed profile deliver through the shared bot too, but
 only to targets an enabled route with a `chat_id`/`thread_id` maps to that
-profile — a routed profile's job targeting an unrouted chat (or a chat routed
-to another profile) is never sent through the shared bot. Guild-only routes do
-not qualify a cron target; add a `chat_id` route for the delivery channel.
+profile (a `guild_id + chat_id` route qualifies its channel) — a routed
+profile's job targeting an unrouted chat (or a chat routed to another profile)
+is never sent through the shared bot. Guild-only routes do not qualify a cron
+target; add a `chat_id` route for the delivery channel. The routed profile does
+not need its own `platforms.<platform>` block for this: the shared bot's
+authorization comes from the route, not from the satellite's config.
 
 ## Start, stop, or restart all gateways at once
 


### PR DESCRIPTION
Under `gateway.multiplex_profiles`, cron jobs now actually fire and deliver for every served profile: the systemd restart-safe handoff no longer dies on `UnscopedSecretError`, routed satellites deliver through the shared bot for the documented `guild_id + chat_id` route shape (and without a `platforms:` block), the Desktop/serve ticker honours the allowlist and yields to the multiplexer, and the SSH-isolated idle-exit no longer kills a running cron job.

## Changes

- **Restart-safe fire (#107399)** — `cron/scheduler.py::_launch_external_cron_worker` builds the worker env inside the firing profile's hydrated secret scope, so a `terminal.env_passthrough` key present in the gateway process env resolves to the PROFILE's value instead of raising. Salvaged as-is from #107413 (first commit; the later commits adding a process-env fallback and a per-home passthrough cache were left out — the fallback re-introduces the environ leak the scope exists to prevent).
- **Routed delivery (startup F5, routing F10)** — `cron/scheduler_preflight.py::SharedRouteAdapters.get` passes the route's own `guild_id` to `ProfileRoute.matches` (a cron target has no inbound guild anchor; the target-exact `chat_id`/`thread_id` authorize). `cron/scheduler_delivery.py::_resolve_target_transport` builds the shared transport from the route-authorized adapter directly, so the satellite's absent or `enabled: false` `platforms.<p>` block (a connector it never runs) no longer vetoes it.
- **#89302** — a live native adapter with no `platforms.<p>` config block is normalized to `PlatformConfig(enabled=True)` like the relay path already was; an explicit `enabled: false` still vetoes.
- **Desktop/serve ticker (startup F6)** — `hermes_cli/web_server.py::_start_desktop_cron_ticker` reads the default profile's `multiplex_profile_allowlist` (`web_server_cron.py::_default_multiplex_profile_allowlist`) and its per-tick gate also consults `named_profile_served_by_running_multiplexer`, so a satellite the live multiplexer ticks is never raced by the adapter-less Desktop ticker. Single-profile installs get the gate too (salvaged #104979).
- **Idle-exit (startup F7, #107485)** — `hermes_cli/web_server_idle_exit.py::turn_in_flight` also consults `cron.scheduler.get_running_job_ids()` (the ledger the gateway shutdown drain already reads).
- **Named-profile multiplexer** — `gateway/run.py::_cron_tick_profile_homes` unions the launch profile into the ticker's home list, and the shared-adapter owner passed to the ticker is `runner._primary_profile_name`, not the literal `"default"` (salvaged #103844 + #103742, trimmed to one helper).
- Docs: `website/docs/user-guide/multi-profile-gateways.md` (allowlist/ticker, named multiplexer, guild-scoped route delivery).

## Root cause (one line each)

F3: the handoff ran before `_run_one_job_body` installs the fire scope. F5: `route.matches(...)` was called without `guild_id`, so any route declaring one returned False. F10/#89302: `_resolve_target_transport` applied the *satellite's* native enabled gate to a transport the *primary* authorized. F6: `profiles_to_serve(multiplex=True)` without the allowlist + a pid-only gate. F7: the idle probe read only the dashboard session table. Named: `profiles_to_serve` yields default + allowlist, never the `-p` launch profile.

## Live repro

Script: `/tmp/mux_audit/fix-cron-multiplex/repro.py` (temp `HERMES_HOME`, real imports, `profiles/worker`, `profiles/guest`, allowlist `[worker]`, routes `{guild G1, chat C1}` and `{chat C2}`, `env_passthrough: [BW_SESSION]`).

**Before (origin/main `ad03f20dd61`):**
```
F3     FIRE: UnscopedSecretError: get_secret('BW_SESSION') called with no profile secret scope active while multiplexing is
F5     FIRE: guild+chat route -> None; chat-only route -> adapter
F10    FIRE: platform 'discord' not configured/enabled
89302  FIRE: platform 'discord' not configured/enabled
F6     FIRE: ticked profiles=['default', 'guest', 'worker']; gate(worker served by multiplexer) -> True
F7     FIRE: turn_in_flight() with a running cron job -> False
named  FIRE: -p guest multiplexer ticks ['default', 'worker']
```
**After:**
```
F3     clean: launch -> True, BW_SESSION in worker env: 'profile-value'
F5     clean: guild+chat route -> adapter; chat-only route -> adapter
F10    clean: shared transport resolved
89302  clean: native transport resolved
F6     clean: ticked profiles=['default', 'worker']; gate(worker served by multiplexer) -> False
F7     clean: turn_in_flight() with a running cron job -> True
named  clean: -p guest multiplexer ticks ['default', 'worker', 'guest']
```
E2E (`e2e_delivery.py`, real config loader + DeliveryRouter + `_deliver_result`, satellite with NO `platforms:` block): before `routed C1 -> "platform 'discord' not configured/enabled"`; after `routed C1 -> error=None, primary sent ['C1']`, unrouted `C9` still fails closed (never the primary bot).

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/cron/` | 101 files, 1238 passed, 0 failed |
| `scripts/run_tests.sh tests/hermes_cli/` | 893 files, 9443 passed, 1 failed — `test_update_head_moved_gate.py::test_update_success_when_head_moves`, fails identically on unmodified `origin/main` (pre-existing, unrelated `hermes update` test) |
| `scripts/run_tests.sh tests/gateway/` | 824 files, 8383 passed, 0 failed |
| New tests red on base | 8/8 red on `origin/main` (`tests_red_on_base.txt`) |
| ruff / windows-footguns / compat pointers / subprocess-stdin / `git diff --check` | clean |

Tests added: `test_guild_scoped_route_authorizes_cron_target_even_when_satellite_has_no_platform_block`, `test_live_native_adapter_without_platform_block_is_not_treated_as_disabled`, `test_turn_probe_counts_in_flight_cron_execution`, `test_desktop_ticker_honours_allowlist_and_yields_to_default_multiplexer`, `test_cron_shared_adapter_owner_is_the_launch_profile` (+ salvaged `test_cron_tick_homes_include_active_named_host`, `test_single_profile_ticks_only_without_gateway`, `test_launch_external_worker_uses_restart_safe_scope_and_acknowledges` extension).

## Credits

- @zicochaos — reporter #107399; @Cloud-Ops-Dev — reporter #89302; @GJMcClintock — reporter #107485
- @fangliquanflq — #107413 (cherry-picked `e57f719f942`, the scope fix) and #102174 (multiplexer stand-down direction; co-authored)
- @MichaelNewham — #106050, earliest fix for #107399 (superseded by the narrower scope placement in #107413)
- @tachyon-r — #104979 (cherry-picked)
- @web3blind — #103701 (enabled-gate direction; co-authored)
- @pincente — #103844 (cherry-picked, trimmed); @r3x443 — #103742 (co-authored, reimplemented at the runner seam)

## Not done / design call

- **#107485 fully**: the probe fix keeps a running job alive, but a job whose scheduled instant lands in a restart gap still loses its slot (`tick()` advances `next_run_at` before the run). Missed-window catch-up on restart is a lifecycle-contract change — reported, not implemented.
- #107413's later commits (process-env passthrough fallback, per-home passthrough allowlist cache) intentionally not taken; the cache is a separate, real gap (`tools/env_passthrough.py::_config_passthrough` is process-wide).

Fixes #107399
Fixes #89302
Addresses #107485
Addresses #94590

## Infographic

![infographic](https://v3b.fal.media/files/b/0aaa049b/8uV-X7zWTJG5fzljXWJgY_ic2muHwM.png)
