### PR TITLE
feat(desktop): report recovered concurrent-render errors instead of an anonymous #520

### DIFF
--- a/apps/desktop/src/lib/recoverable-error-report.test.ts
+++ b/apps/desktop/src/lib/recoverable-error-report.test.ts
@@ -1,0 +1,72 @@
+import type { ErrorInfo } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildRecoverableErrorReport,
+  describeRecoverableError,
+  RECOVERABLE_BOUNDARY
+} from './recoverable-error-report'
+
+const REACT_WRAPPER = 'There was an error during concurrent rendering but React was able to recover'
+
+const lookupError = () => new Error('useClientLookup: Index 6 out of bounds (length: 2)')
+
+describe('describeRecoverableError', () => {
+  it('names the cause that actually threw, not just React recovery wrapper', () => {
+    const message = describeRecoverableError(new Error(REACT_WRAPPER, { cause: lookupError() }))
+
+    expect(message).toContain(REACT_WRAPPER)
+    expect(message).toContain('← caused by: Error: useClientLookup: Index 6 out of bounds (length: 2)')
+  })
+
+  it('walks a nested cause chain in order', () => {
+    const message = describeRecoverableError(
+      new Error('outer', { cause: new Error('middle', { cause: new Error('inner') }) })
+    )
+
+    expect(message.indexOf('middle')).toBeLessThan(message.indexOf('inner'))
+  })
+
+  it('reports an error with no cause without inventing one', () => {
+    expect(describeRecoverableError(new Error('lonely'))).toBe('Error: lonely')
+  })
+
+  it('survives a thrown non-Error value', () => {
+    expect(describeRecoverableError('boom')).toBe('boom')
+    expect(describeRecoverableError(undefined)).toBe('(undefined thrown)')
+  })
+
+  it('bounds the message even when the cause chain is long and chatty', () => {
+    const message = describeRecoverableError(new Error('x'.repeat(5000), { cause: new Error('y'.repeat(5000)) }))
+
+    expect(message.length).toBeLessThanOrEqual(2000)
+  })
+})
+
+describe('buildRecoverableErrorReport', () => {
+  it('marks the report as a concurrent-render recovery and keeps the component stack', () => {
+    const report = buildRecoverableErrorReport(
+      new Error(REACT_WRAPPER, { cause: lookupError() }),
+      { componentStack: '\n    at Thread\n    at App\n' } as ErrorInfo,
+      'main'
+    )
+
+    expect(report.boundary).toBe(RECOVERABLE_BOUNDARY)
+    expect(report.label).toBe('main')
+    expect(report.message).toContain('useClientLookup')
+    expect(report.componentStack).toBe('at Thread\n    at App')
+  })
+
+  it('falls back to the main label and an empty stack when React supplies neither', () => {
+    const report = buildRecoverableErrorReport(new Error('boom'), undefined, '')
+
+    expect(report.label).toBe('main')
+    expect(report.componentStack).toBe('')
+  })
+
+  it('clamps a hostile component stack', () => {
+    const report = buildRecoverableErrorReport(new Error('boom'), { componentStack: 'a'.repeat(9000) } as ErrorInfo, 'main')
+
+    expect(report.componentStack.length).toBeLessThanOrEqual(4000)
+  })
+})

--- a/apps/desktop/src/lib/recoverable-error-report.ts
+++ b/apps/desktop/src/lib/recoverable-error-report.ts
@@ -1,0 +1,82 @@
+import type { ErrorInfo } from 'react'
+
+/**
+ * React 19 recovers from an error thrown during a concurrent render by re-rendering the
+ * whole root synchronously — the "Minified React error #520" line. Recovery involves no
+ * error-boundary catch, and the console line carries only React's own message, so the
+ * error that actually threw survives solely as `error.cause`: nothing reads it, and every
+ * occurrence is unattributable in desktop.log.
+ *
+ * These helpers turn that recovered error into the report the existing renderer-crash
+ * channel (`window.hermesDesktop.reportRendererError`) persists, naming the cause.
+ */
+
+export interface RecoverableErrorReport {
+  label: string
+  boundary: string
+  message: string
+  componentStack: string
+}
+
+/** Distinct from an `error-boundary:` catch: this is React's concurrent-render recovery. */
+export const RECOVERABLE_BOUNDARY = 'recoverable-concurrent-render'
+
+const MESSAGE_MAX = 2000
+const STACK_MAX = 4000
+const MAX_CAUSES = 3
+const CAUSE_FRAME_MAX = 160
+
+const clamp = (value: unknown, max: number): string => String(value ?? '').slice(0, max)
+
+/** First frame of a cause's stack — enough to tell which module threw, cheap enough to log. */
+const firstFrame = (error: unknown): string => {
+  if (!(error instanceof Error) || typeof error.stack !== 'string') {
+    return ''
+  }
+
+  const frame = error.stack
+    .split('\n')
+    .slice(1)
+    .map(line => line.trim())
+    .find(line => line.startsWith('at '))
+
+  return frame ? ` (${clamp(frame, CAUSE_FRAME_MAX)})` : ''
+}
+
+const describe = (value: unknown): string => {
+  if (value instanceof Error) {
+    return `${value.name || 'Error'}: ${value.message || '(no message)'}`
+  }
+
+  return clamp(value === undefined ? '(undefined thrown)' : String(value), MESSAGE_MAX)
+}
+
+/**
+ * "<thrown message> ← caused by: <cause message> (at <frame>)".
+ * React's wrapper message comes first because that is what the console shows; each cause
+ * follows because that is what threw. The chain is bounded — a cyclic `cause` cannot hang it.
+ */
+export function describeRecoverableError(error: unknown): string {
+  const parts = [describe(error)]
+  let cause: unknown = error instanceof Error ? error.cause : undefined
+
+  for (let depth = 0; depth < MAX_CAUSES && cause !== undefined && cause !== null; depth += 1) {
+    parts.push(`← caused by: ${describe(cause)}${firstFrame(cause)}`)
+    cause = cause instanceof Error ? cause.cause : undefined
+  }
+
+  return clamp(parts.join(' '), MESSAGE_MAX)
+}
+
+export function buildRecoverableErrorReport(
+  error: unknown,
+  errorInfo: ErrorInfo | undefined,
+  label: string
+): RecoverableErrorReport {
+  return {
+    label: label || 'main',
+    boundary: RECOVERABLE_BOUNDARY,
+    message: describeRecoverableError(error),
+    componentStack: clamp(errorInfo?.componentStack ?? '', STACK_MAX).trim()
+  }
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -27,6 +27,7 @@ import { RootTooltipProvider } from './components/ui/tooltip'
 import { I18nProvider } from './i18n'
 import { installClipboardShim } from './lib/clipboard'
 import { queryClient } from './lib/query-client'
+import { buildRecoverableErrorReport } from './lib/recoverable-error-report'
 import { installRendererAnimationPauseState } from './lib/renderer-loop-pause'
 import { installSelectionCopyColorGuard } from './lib/selection-copy-colors'
 import { ThemeProvider } from './themes/context'
@@ -86,7 +87,27 @@ if (winParam === 'overlay') {
   // animations stop producing frames when nobody can see them.
   installRendererAnimationPauseState()
 
-  createRoot(document.getElementById('root')!).render(
+  createRoot(document.getElementById('root')!, {
+    /* React 19 recovers from an error thrown during a concurrent render by re-rendering the
+       whole root synchronously ("Minified React error #520"). Recovery involves no boundary
+       catch and the console line is minified, so the error that actually threw survives only
+       as `error.cause` — the class is invisible in desktop.log and every occurrence is
+       unattributable. Report it through the renderer-crash channel (#79428) before React
+       discards it. Logging must never take the root down with it. */
+    onRecoverableError: (error, errorInfo) => {
+      try {
+        window.hermesDesktop?.reportRendererError?.(
+          buildRecoverableErrorReport(
+            error,
+            errorInfo,
+            new URLSearchParams(window.location.search).get('win') ?? 'main'
+          )
+        )
+      } catch {
+        // Reporting is best-effort only.
+      }
+    }
+  }).render(
     <StrictMode>
       <RootErrorBoundary>
         <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## What does this PR do?

Makes React 19's concurrent-render recoveries ("Minified React error #520") attributable in `desktop.log`.

React recovers from an error thrown during a concurrent render by re-rendering the whole root synchronously. That recovery produces **no error-boundary catch**, and in a production build the console line carries only React's own message — the error that actually threw survives solely as the wrapper's `error.cause` (React builds it as `Error(i(520), {cause: r})`), which nothing reads. So every occurrence reaches a user's log as an anonymous:

```
[renderer console:main] Uncaught Error: Minified React error #520; visit https://react.dev/errors/520 ...
```

…with no cause, no component stack, and no crash report. That is why live reports like #45125 and #90795 can't be triaged from a user's logs.

This PR passes `onRecoverableError` to the root and reports the wrapper **and its cause chain** through the existing renderer-crash channel from #79428, so a recurrence lands as:

```
[renderer crash:main] [error-boundary:recoverable-concurrent-render] <thrown> ← caused by: <cause> (at <frame>)
<React component stack>
```

Scope is deliberately narrow: it does **not** claim to fix the underlying render race — it supplies the evidence needed to find it (cause + component stack), which today is discarded. It does not change boundary behaviour, and it cannot turn a recovery into a crash: reporting is wrapped and best-effort, and the message/stack are clamped (max 3 causes) so a chatty or cyclic `cause` cannot bloat the log.

## Related Issue

Relates to #45125 and #90795 — both are renderer `#520` reports that currently arrive with no cause and no component stack. This PR closes neither; it makes the next occurrence diagnosable.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality) — diagnostics: a new report on the existing renderer-crash channel
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/main.tsx` — pass `onRecoverableError` to the root `createRoot`, reporting through `window.hermesDesktop.reportRendererError` (the same channel the error boundaries already use, so no new IPC surface).
- `apps/desktop/src/lib/recoverable-error-report.ts` (new) — pure helpers. `describeRecoverableError` names the chain (`<thrown> ← caused by: <cause> (at <frame>)`, walking up to 3 causes); `buildRecoverableErrorReport` builds the IPC payload with clamped message/stack and a `recoverable-concurrent-render` boundary label so these are distinguishable from real boundary catches.
- `apps/desktop/src/lib/recoverable-error-report.test.ts` (new) — 8 tests: cause naming, nested chains, error-with-no-cause, non-Error throw values (string/undefined), message clamping, component-stack clamping, label/stack fallbacks.

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/lib/recoverable-error-report.test.ts` → 8 passed.
2. `npx vitest run --project electron electron/renderer-log.test.ts` → 7 passed (the formatting path this feeds).
3. `npx eslint src/main.tsx src/lib/recoverable-error-report.ts src/lib/recoverable-error-report.test.ts` → clean; `npx tsc -p . --noEmit` → clean.
4. Live reproduction of the gap this closes: on a packaged macOS build, three `#520` lines appeared in `~/.hermes/logs/desktop.log` (React 19.2.7) with no accompanying `reportRendererError` report and no component stack — and they correlated with remote-backend state changes (a failed turn, then `Reaping idle profile backend`), i.e. a render touching a runtime view whose client had just gone away. With this change, the next occurrence is persisted by `formatRendererBoundaryReport` with the cause and component stack.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no PR touches `onRecoverableError` / the renderer-crash channel)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: no Python is touched (TS-only change); ran vitest (`--project ui`, `--project electron`), `tsc --noEmit`, and eslint on the touched files instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2 (arm64), packaged desktop build

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A: no user-facing docs cover `desktop.log` internals; the payload reuses the documented #79428 renderer-crash channel
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A: renderer-side only, no platform-specific API (`URLSearchParams`, `reportRendererError` are platform-neutral; the label falls back to `main` when `?win=` is absent)

---

Produced with Hermes Agent while diagnosing these `#520` lines on macOS (the agent's own desktop app). Human-reviewed before submission.
