### PR TITLE
fix(connections): report unavailable connector service without inventing state

### DIFF
--- a/tests/tools/test_connections_tool.py
+++ b/tests/tools/test_connections_tool.py
@@ -308,6 +308,27 @@ def test_wait_tolerates_transient_gateway_blips_but_not_a_dead_gateway(no_sleep)
     assert dead.polls == 3  # gave up on the third consecutive failure
 
 
+def test_wait_propagates_dark_gateway_as_unavailable():
+    client = WaitClient(flips_on=None)
+    client.on_poll = lambda _n: (_ for _ in ()).throw(
+        GatewayUnavailable("route concealed", code="NOT_FOUND", status=404)
+    )
+
+    out = _wait(client, timeout_seconds=180)
+
+    assert out == {
+        "status": "unavailable",
+        "code": "CONNECTORS_UNAVAILABLE",
+        "connectors": [],
+        "message": "Connector service is not available for this account or session.",
+        "hint": (
+            "Do not infer connection state or retry automatically. "
+            "The user can manage connections in the Nous Portal."
+        ),
+    }
+    assert client.polls == 1
+
+
 def test_wait_interrupted_mid_wait_reports_interrupted_not_an_error(no_sleep):
     from tools.interrupt import set_interrupt
 

--- a/tests/tools/test_connections_tool.py
+++ b/tests/tools/test_connections_tool.py
@@ -12,6 +12,7 @@ import pytest
 
 import tools.connections_tool  # registers the tool
 from tools.connections_tool import MANAGE_CONNECTIONS_SCHEMA, manage_connections
+from tools.tool_gateway.errors import GatewayUnavailable
 
 
 class FakeClient:
@@ -130,6 +131,26 @@ def test_gateway_failure_is_a_model_actionable_error():
         manage_connections({"action": "status"}, client_factory=exploding)
     )
     assert "connector gateway request failed" in out["error"]
+
+
+def test_dark_gateway_is_an_unavailable_state_not_disconnected_inventory():
+    def dark():
+        raise GatewayUnavailable("route concealed", code="NOT_FOUND", status=404)
+
+    out = json.loads(
+        manage_connections({"action": "status"}, client_factory=dark)
+    )
+
+    assert out == {
+        "status": "unavailable",
+        "code": "CONNECTORS_UNAVAILABLE",
+        "connectors": [],
+        "message": "Connector service is not available for this account or session.",
+        "hint": (
+            "Do not infer connection state or retry automatically. "
+            "The user can manage connections in the Nous Portal."
+        ),
+    }
 
 
 def test_mcp_actions_are_not_this_tools_business():

--- a/tools/connections_tool.py
+++ b/tools/connections_tool.py
@@ -39,6 +39,7 @@ import time
 from typing import Any, Callable, Dict, List, Optional
 
 from tools.registry import registry, tool_error
+from tools.tool_gateway.errors import GatewayUnavailable
 
 logger = logging.getLogger(__name__)
 
@@ -427,6 +428,27 @@ def manage_connections(
             results.append(out)
         return json.dumps(
             {"results": results, "summary": response.get("summary", {})},
+            ensure_ascii=False,
+        )
+    except GatewayUnavailable:
+        # The connector deployment deliberately answers 404 when its routes
+        # are dark for this principal. That is an availability state, not
+        # proof that the user's connectors are disconnected and not a
+        # transient gateway failure. Keep the shape action-independent so a
+        # caller can branch on it without parsing prose.
+        return json.dumps(
+            {
+                "status": "unavailable",
+                "code": "CONNECTORS_UNAVAILABLE",
+                "connectors": [],
+                "message": (
+                    "Connector service is not available for this account or session."
+                ),
+                "hint": (
+                    "Do not infer connection state or retry automatically. "
+                    "The user can manage connections in the Nous Portal."
+                ),
+            },
             ensure_ascii=False,
         )
     except Exception as exc:

--- a/tools/connections_tool.py
+++ b/tools/connections_tool.py
@@ -223,6 +223,8 @@ def _wait_for_connections(
         poll_started = time.monotonic()
         try:
             items = client.list_connectors()
+        except GatewayUnavailable:
+            raise
         except Exception:
             # A transient gateway blip costs one poll, never the whole wait.
             # Three in a row means the gateway is genuinely down mid-wait —

--- a/tools/tool_gateway/errors.py
+++ b/tools/tool_gateway/errors.py
@@ -59,8 +59,9 @@ class GatewayAuthError(ToolGatewayError):
 class GatewayUnavailable(ToolGatewayError):
     """404 from any connector route — connectors are dark for this principal.
 
-    This is the silent-degradation signal: callers fall back to local-only
-    behavior and the model never sees a connector error.
+    Search and describe use this as a silent-degradation signal; the explicit
+    connection-management surface renders it as a machine-readable unavailable
+    state rather than pretending the connector inventory is known.
     """
 
 


### PR DESCRIPTION
## What does this PR do?

`manage_connections` currently exposes an authenticated connector-route 404 as a generic gateway failure. This change renders the gateway's existing typed dark-route signal as a stable, machine-readable unavailable state, so callers do not mistake unknown inventory for disconnected connectors or retry an account-level unavailable route as a transient outage.

### Symptom

A signed-in account can receive `The connector gateway request failed: tool gateway request failed with status 404` from `manage_connections(action="status")` even though local availability admitted the tool.

### Impact

Affected users cannot determine whether connectors are disconnected, connected, or unavailable for their account. The generic failure also gives the model no stable discriminator between an account/session availability state and a transient gateway fault.

### Bug Cause

**Trigger:** `tools/connections_tool.py:manage_connections` catches the `GatewayUnavailable` raised for connector-route 404 responses in its generic exception branch.

**Causal chain:**
1. The broad session availability gate exposes `manage_connections`, then the connector service conceals unavailable routes with an authenticated 404.
2. `ConnectorClient` correctly maps that response to `GatewayUnavailable`, but `manage_connections` erases the typed distinction by catching every exception together.
3. The model receives a generic gateway failure and cannot distinguish unavailable inventory from a transient outage.

**Why it is wrong:** A dark connector route means the inventory is unknowable for this principal. It does not prove an empty or disconnected inventory, and the client already has a dedicated exception for this contract.

**Working sibling / contrast:** Connector search and schema lookup already catch `GatewayUnavailable` separately and degrade to local-only results. Other exceptions still use their genuine failure path.

**Ruled out:** The route path is not stale or status-specific. The same current client contract reaches list, search, and schema routes, and the reported authenticated 404 differs from the unauthenticated 401 response.

### Fix

Catch `GatewayUnavailable` before the generic failure branch and return `status: unavailable` with the stable `CONNECTORS_UNAVAILABLE` code. The response carries no fabricated inventory and explicitly tells callers not to infer connection state or retry automatically. Transport, 5xx, malformed-response, and unexpected failures remain model-visible gateway errors.

## Related Issue

Closes #108412

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/connections_tool.py` - render dark connector routes as a stable unavailable state.
- `tools/tool_gateway/errors.py` - document the explicit management-surface contract for `GatewayUnavailable`.
- `tests/tools/test_connections_tool.py` - cover the unavailable state while preserving the generic failure contrast.

## How to Test

1. Run the focused connection-management tests:

```bash
scripts/run_tests.sh tests/tools/test_connections_tool.py
```

Result: 40 passed across `tests/tools/test_connections_tool.py` and `tests/tools/test_tool_gateway_client.py`.

2. Confirm a fake `GatewayUnavailable` returns `status: unavailable` and `code: CONNECTORS_UNAVAILABLE` without claiming disconnected inventory.
3. Confirm an unrelated runtime failure still returns the existing connector gateway error.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry point on the relevant tests and all 40 pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant docstrings
- [x] `cli-config.yaml.example`: N/A, no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md`: N/A, no architecture or workflow change
- [x] I've considered cross-platform impact: the Python-only exception classification is platform-neutral
- [x] Tool descriptions/schemas: N/A, no input schema or action semantics changed